### PR TITLE
fix: preserve Codex edit diffs and bound MCP lists

### DIFF
--- a/apps/agor-daemon/src/mcp/schema.test.ts
+++ b/apps/agor-daemon/src/mcp/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mcpLimit } from './schema.js';
+import { mcpLimit, mcpOffset, mcpPositiveIntWithDefault } from './schema.js';
 
 describe('mcpLimit', () => {
   it('applies the documented default when callers omit a limit', () => {
@@ -17,5 +17,18 @@ describe('mcpLimit', () => {
 
     expect(limit.safeParse(100).success).toBe(true);
     expect(limit.safeParse(101).success).toBe(false);
+  });
+
+  it('applies offset defaults consistently', () => {
+    expect(mcpOffset(0).parse(undefined)).toBe(0);
+  });
+
+  it('uses the caller field name in validation errors', () => {
+    const result = mcpPositiveIntWithDefault('max_results', 10).safeParse(0);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('max_results');
+    }
   });
 });

--- a/apps/agor-daemon/src/mcp/schema.test.ts
+++ b/apps/agor-daemon/src/mcp/schema.test.ts
@@ -31,4 +31,38 @@ describe('mcpLimit', () => {
       expect(result.error.issues[0]?.message).toContain('max_results');
     }
   });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects an invalid positive integer default (%s)', (defaultValue) => {
+    expect(() => mcpPositiveIntWithDefault('limit', defaultValue)).toThrow(
+      'default must be a positive safe integer'
+    );
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects an invalid positive integer maximum (%s)', (maxValue) => {
+    expect(() => mcpPositiveIntWithDefault('limit', 1, maxValue)).toThrow(
+      'maximum must be a positive safe integer'
+    );
+  });
+
+  it('rejects a default above the maximum', () => {
+    expect(() => mcpPositiveIntWithDefault('limit', 2, 1)).toThrow('exceeds maximum');
+  });
+
+  it.each([
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects an invalid offset default (%s)', (defaultValue) => {
+    expect(() => mcpOffset(defaultValue)).toThrow('default must be a non-negative safe integer');
+  });
 });

--- a/apps/agor-daemon/src/mcp/schema.test.ts
+++ b/apps/agor-daemon/src/mcp/schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { mcpLimit } from './schema.js';
+
+describe('mcpLimit', () => {
+  it('applies the documented default when callers omit a limit', () => {
+    expect(mcpLimit(50).parse(undefined)).toBe(50);
+  });
+
+  it('preserves permissive callers that enforce their own runtime cap', () => {
+    const limit = mcpLimit(50);
+
+    expect(limit.safeParse(500).success).toBe(true);
+  });
+
+  it('supports a lower tool-specific maximum', () => {
+    const limit = mcpLimit(50, 100);
+
+    expect(limit.safeParse(100).success).toBe(true);
+    expect(limit.safeParse(101).success).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -138,6 +138,12 @@ export function mcpPositiveIntWithDefault(
   defaultValue: number,
   maxValue?: number
 ) {
+  if (!Number.isSafeInteger(defaultValue) || defaultValue <= 0) {
+    throw new Error(`MCP ${fieldName} default must be a positive safe integer`);
+  }
+  if (maxValue !== undefined && (!Number.isSafeInteger(maxValue) || maxValue <= 0)) {
+    throw new Error(`MCP ${fieldName} maximum must be a positive safe integer`);
+  }
   if (maxValue !== undefined && defaultValue > maxValue) {
     throw new Error(`MCP ${fieldName} default ${defaultValue} exceeds maximum ${maxValue}`);
   }
@@ -165,6 +171,10 @@ export function mcpLimit(defaultValue = 50, maxValue?: number) {
 }
 
 export function mcpOffset(defaultValue = 0) {
+  if (!Number.isSafeInteger(defaultValue) || defaultValue < 0) {
+    throw new Error('MCP offset default must be a non-negative safe integer');
+  }
+
   return z
     .number({
       error: 'offset must be a non-negative integer when provided.',

--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -133,8 +133,30 @@ export function mcpOptionalNonNegativeInt(fieldName: string, description: string
     .describe(description);
 }
 
-export function mcpLimit(defaultValue = 50) {
-  return mcpOptionalPositiveInt('limit', `Maximum number of results (default: ${defaultValue})`);
+export function mcpLimit(defaultValue = 50, maxValue?: number) {
+  if (maxValue !== undefined && defaultValue > maxValue) {
+    throw new Error(`MCP limit default ${defaultValue} exceeds maximum ${maxValue}`);
+  }
+
+  const limit = z
+    .number({
+      error: 'limit must be a positive integer when provided.',
+    })
+    .int('limit must be an integer.')
+    .positive('limit must be greater than 0.');
+  const boundedLimit =
+    maxValue === undefined
+      ? limit
+      : limit.max(maxValue, `limit must be less than or equal to ${maxValue}.`);
+
+  return boundedLimit
+    .optional()
+    .default(defaultValue)
+    .describe(
+      `Maximum number of results (default: ${defaultValue}${
+        maxValue === undefined ? '' : `, max: ${maxValue}`
+      })`
+    );
 }
 
 export function mcpOffset(defaultValue = 0) {

--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -133,35 +133,45 @@ export function mcpOptionalNonNegativeInt(fieldName: string, description: string
     .describe(description);
 }
 
-export function mcpLimit(defaultValue = 50, maxValue?: number) {
+export function mcpPositiveIntWithDefault(
+  fieldName: string,
+  defaultValue: number,
+  maxValue?: number
+) {
   if (maxValue !== undefined && defaultValue > maxValue) {
-    throw new Error(`MCP limit default ${defaultValue} exceeds maximum ${maxValue}`);
+    throw new Error(`MCP ${fieldName} default ${defaultValue} exceeds maximum ${maxValue}`);
   }
 
   const limit = z
     .number({
-      error: 'limit must be a positive integer when provided.',
+      error: `${fieldName} must be a positive integer when provided.`,
     })
-    .int('limit must be an integer.')
-    .positive('limit must be greater than 0.');
+    .int(`${fieldName} must be an integer.`)
+    .positive(`${fieldName} must be greater than 0.`);
   const boundedLimit =
     maxValue === undefined
       ? limit
-      : limit.max(maxValue, `limit must be less than or equal to ${maxValue}.`);
+      : limit.max(maxValue, `${fieldName} must be less than or equal to ${maxValue}.`);
 
-  return boundedLimit
-    .optional()
-    .default(defaultValue)
-    .describe(
-      `Maximum number of results (default: ${defaultValue}${
-        maxValue === undefined ? '' : `, max: ${maxValue}`
-      })`
-    );
+  return boundedLimit.optional().default(defaultValue);
+}
+
+export function mcpLimit(defaultValue = 50, maxValue?: number) {
+  return mcpPositiveIntWithDefault('limit', defaultValue, maxValue).describe(
+    `Maximum number of results (default: ${defaultValue}${
+      maxValue === undefined ? '' : `, max: ${maxValue}`
+    })`
+  );
 }
 
 export function mcpOffset(defaultValue = 0) {
-  return mcpOptionalNonNegativeInt(
-    'offset',
-    `Number of results to skip (default: ${defaultValue})`
-  );
+  return z
+    .number({
+      error: 'offset must be a non-negative integer when provided.',
+    })
+    .int('offset must be an integer.')
+    .nonnegative('offset must be greater than or equal to 0.')
+    .optional()
+    .default(defaultValue)
+    .describe(`Number of results to skip (default: ${defaultValue})`);
 }

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -954,6 +954,52 @@ describe('agor_branches_list', () => {
     };
   }
 
+  it('uses a bounded default page and supports offsets', async () => {
+    const findFn = vi.fn(async () => ({
+      data: [],
+      total: 596,
+      limit: 50,
+      skip: 0,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { find: findFn };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await list({});
+    await list({ limit: 25, offset: 50 });
+
+    expect(findFn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        query: expect.objectContaining({ archived: false, $limit: 50, $skip: 0 }),
+      })
+    );
+    expect(findFn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        query: expect.objectContaining({ archived: false, $limit: 25, $skip: 50 }),
+      })
+    );
+  });
+
+  it('rejects branch list pages above 100 rows', () => {
+    const config = registerAndCaptureConfig('agor_branches_list', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(config.inputSchema?.safeParse({ limit: 100 }).success).toBe(true);
+    expect(config.inputSchema?.safeParse({ limit: 101 }).success).toBe(false);
+  });
+
   it('includes zone_id and zone_label from enriched branches', async () => {
     const enrichedBranches = {
       data: [

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -47,6 +47,8 @@ import { assertValidVariant } from './_environment-helpers.js';
 
 const BRANCH_NAME_PATTERN = /^[a-z0-9-]+$/;
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const BRANCH_LIST_DEFAULT_LIMIT = 50;
+const BRANCH_LIST_MAX_LIMIT = 100;
 const CLEANUP_CANDIDATE_DEFAULT_OLDER_THAN_DAYS = 7;
 const CLEANUP_CANDIDATE_SOURCE_PAGE_LIMIT = 10000;
 type CleanupCandidateFilesystemStatus = NonNullable<Branch['filesystem_status']>;
@@ -195,14 +197,16 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     'agor_branches_list',
     {
       description:
-        'List all branches in a repository. Each branch includes zone_id and zone_label when ' +
+        'List a paginated set of branches, optionally filtered by repository. Inspect total, ' +
+        'limit, and skip in the response, then advance offset until all desired pages have been read. ' +
+        'Each branch includes zone_id and zone_label when ' +
         'the branch is assigned to a board zone — use these fields directly to identify which ' +
         'zone a branch is in without extra agor_branches_get calls. Also includes ' +
         'pull_request_url, issue_url, board_object_id, and position when set.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: mcpOptionalId('repoId', 'Repository', 'Repository ID to filter by'),
-        limit: mcpLimit(50, 100),
+        limit: mcpLimit(BRANCH_LIST_DEFAULT_LIMIT, BRANCH_LIST_MAX_LIMIT),
         offset: mcpOffset(0),
         includeArchived: z
           .boolean()
@@ -230,7 +234,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // 10,000-row UI default. On large installations that aggregate response
       // can cross the Socket.IO 1 MB frame limit when Codex persists the tool
       // completion through the executor.
-      query.$limit = args.limit ?? 50;
+      query.$limit = args.limit ?? BRANCH_LIST_DEFAULT_LIMIT;
       query.$skip = args.offset ?? 0;
       if (args.archived === true) {
         query.archived = true;

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -32,6 +32,7 @@ import {
 } from '../resolve-ids.js';
 import {
   mcpLimit,
+  mcpOffset,
   mcpOptionalId,
   mcpOptionalNonNegativeInt,
   mcpOptionalPositiveInt,
@@ -201,7 +202,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: mcpOptionalId('repoId', 'Repository', 'Repository ID to filter by'),
-        limit: mcpLimit(50),
+        limit: mcpLimit(50, 100),
+        offset: mcpOffset(0),
         includeArchived: z
           .boolean()
           .optional()
@@ -224,7 +226,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const query: Record<string, unknown> = {};
       if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
-      if (args.limit) query.$limit = args.limit;
+      // Prevent no-argument MCP calls from inheriting the service's intentional
+      // 10,000-row UI default. On large installations that aggregate response
+      // can cross the Socket.IO 1 MB frame limit when Codex persists the tool
+      // completion through the executor.
+      query.$limit = args.limit ?? 50;
+      query.$skip = args.offset ?? 0;
       if (args.archived === true) {
         query.archived = true;
       } else if (!args.includeArchived) {

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { mcpLimit, mcpRequiredString } from '../schema.js';
+import { mcpPositiveIntWithDefault, mcpRequiredString } from '../schema.js';
 import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
 
@@ -126,7 +126,9 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
           ),
         read_only: z.boolean().optional().describe('Filter to read-only tools only'),
         destructive: z.boolean().optional().describe('Filter to destructive tools only'),
-        max_results: mcpLimit(10).describe('Max results to return (default: 10)'),
+        max_results: mcpPositiveIntWithDefault('max_results', 10).describe(
+          'Max results to return (default: 10)'
+        ),
       }),
       annotations: { readOnlyHint: true },
     },

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -271,6 +271,114 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('+export const value = "after";'))).toBe(true);
   });
 
+  it('preserves the turn baseline when file_change starts after the filesystem mutation', async () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'src', 'late-start.ts');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const value = "before";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-late-start' };
+    await registerEditFilesTurnBaseline(context);
+
+    // Codex can report item.started after apply_patch has already mutated disk.
+    fs.writeFileSync(filePath, 'export const value = "after";\n', 'utf-8');
+    registerToolInvocationStart(
+      'tool-codex-edit-files-late-start',
+      'edit_files',
+      { changes: [{ path: filePath, kind: 'update' }] },
+      context
+    );
+
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-late-start',
+        name: 'edit_files',
+        input: { changes: [{ path: filePath, kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-late-start',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    const lines = blocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-export const value = "before";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+export const value = "after";'))).toBe(true);
+  });
+
+  it('keeps rapid late-start edits scoped to the immediately preceding state', async () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'src', 'rapid-late-start.ts');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const value = "one";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-rapid-late-start' };
+    await registerEditFilesTurnBaseline(context);
+
+    fs.writeFileSync(filePath, 'export const value = "two";\n', 'utf-8');
+    registerToolInvocationStart(
+      'tool-codex-edit-files-rapid-late-start-1',
+      'edit_files',
+      { changes: [{ path: 'src/rapid-late-start.ts', kind: 'update' }] },
+      context
+    );
+    const firstBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-rapid-late-start-1',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/rapid-late-start.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-rapid-late-start-1',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(firstBlocks, context);
+
+    fs.writeFileSync(filePath, 'export const value = "three";\n', 'utf-8');
+    registerToolInvocationStart(
+      'tool-codex-edit-files-rapid-late-start-2',
+      'edit_files',
+      { changes: [{ path: 'src/rapid-late-start.ts', kind: 'update' }] },
+      context
+    );
+    const secondBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-rapid-late-start-2',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/rapid-late-start.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-rapid-late-start-2',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(secondBlocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    const firstLines = firstBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(firstLines.some((line) => line.includes('-export const value = "one";'))).toBe(true);
+    expect(firstLines.some((line) => line.includes('+export const value = "two";'))).toBe(true);
+
+    const secondLines = secondBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(secondLines.some((line) => line.includes('-export const value = "two";'))).toBe(true);
+    expect(secondLines.some((line) => line.includes('+export const value = "three";'))).toBe(true);
+    expect(secondLines.some((line) => line.includes('"one"'))).toBe(false);
+  });
+
   it('refreshes the Codex turn baseline after each edit_files result', async () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'src', 'twice.ts');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -313,6 +313,66 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('+export const value = "after";'))).toBe(true);
   });
 
+  it('falls back to the turn baseline independently for each file in a mixed snapshot', async () => {
+    const repoDir = createTempGitRepo();
+    const firstPath = path.join(repoDir, 'src', 'first.ts');
+    const secondPath = path.join(repoDir, 'src', 'second.ts');
+    fs.mkdirSync(path.dirname(firstPath), { recursive: true });
+    fs.writeFileSync(firstPath, 'export const first = "before";\n', 'utf-8');
+    fs.writeFileSync(secondPath, 'export const second = "before";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-mixed-start' };
+    await registerEditFilesTurnBaseline(context);
+
+    // Simulate Codex being between two filesystem mutations when item.started
+    // is observed: first.ts is already post-edit, while second.ts is pre-edit.
+    fs.writeFileSync(firstPath, 'export const first = "after";\n', 'utf-8');
+    const changes = [
+      { path: 'src/first.ts', kind: 'update' },
+      { path: 'src/second.ts', kind: 'update' },
+    ];
+    registerToolInvocationStart(
+      'tool-codex-edit-files-mixed-start',
+      'edit_files',
+      { changes },
+      context
+    );
+    fs.writeFileSync(secondPath, 'export const second = "after";\n', 'utf-8');
+
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-mixed-start',
+        name: 'edit_files',
+        input: { changes },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-mixed-start',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    expect(blocks[1].diff?.files).toHaveLength(2);
+    const firstLines =
+      blocks[1].diff?.files?.find((file) => file.path === 'src/first.ts')?.structuredPatch?.[0]
+        ?.lines ?? [];
+    const secondLines =
+      blocks[1].diff?.files?.find((file) => file.path === 'src/second.ts')?.structuredPatch?.[0]
+        ?.lines ?? [];
+    expect(firstLines.some((line) => line.includes('-export const first = "before";'))).toBe(true);
+    expect(firstLines.some((line) => line.includes('+export const first = "after";'))).toBe(true);
+    expect(secondLines.some((line) => line.includes('-export const second = "before";'))).toBe(
+      true
+    );
+    expect(secondLines.some((line) => line.includes('+export const second = "after";'))).toBe(true);
+  });
+
   it('keeps rapid late-start edits scoped to the immediately preceding state', async () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'src', 'rapid-late-start.ts');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -373,6 +373,49 @@ describe('diff enrichment', () => {
     expect(secondLines.some((line) => line.includes('+export const second = "after";'))).toBe(true);
   });
 
+  it('does not treat files beyond a truncated turn baseline as absent', async () => {
+    const repoDir = createTempGitRepo();
+    const bulkDir = path.join(repoDir, 'bulk');
+    fs.mkdirSync(bulkDir, { recursive: true });
+    for (let index = 0; index < 5_000; index += 1) {
+      fs.writeFileSync(path.join(bulkDir, `${String(index).padStart(4, '0')}.txt`), '');
+    }
+
+    // This sorts after the 5,000 bulk files and is therefore not enumerated in
+    // the bounded turn baseline.
+    const filePath = path.join(repoDir, 'target.ts');
+    fs.writeFileSync(filePath, 'export const value = "before";\n', 'utf-8');
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-truncated-baseline' };
+    await registerEditFilesTurnBaseline(context);
+
+    fs.writeFileSync(filePath, 'export const value = "after";\n', 'utf-8');
+    registerToolInvocationStart(
+      'tool-codex-edit-files-truncated-baseline',
+      'edit_files',
+      { changes: [{ path: 'target.ts', kind: 'update' }] },
+      context
+    );
+
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-truncated-baseline',
+        name: 'edit_files',
+        input: { changes: [{ path: 'target.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-truncated-baseline',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    expect(blocks[1].diff).toBeUndefined();
+  });
+
   it('keeps rapid late-start edits scoped to the immediately preceding state', async () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'src', 'rapid-late-start.ts');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -652,14 +652,18 @@ function enrichEditFilesResult(
 
   if (snapshots?.length) {
     const snapshotDiffs = enrichFromEditFilesSnapshots(snapshots);
-    refreshEditFilesBaselineFromSnapshots(context, snapshots);
     if (snapshotDiffs.length > 0) {
+      refreshEditFilesBaselineFromSnapshots(context, snapshots);
       block.diff = {
         structuredPatch: snapshotDiffs[0].structuredPatch,
         files: snapshotDiffs,
       };
       return;
     }
+    // Codex may emit file_change/item.started after apply_patch has already
+    // mutated the worktree. In that case these snapshots are post-edit and
+    // produce no diff. Keep the turn baseline intact so it can provide the
+    // actual pre-edit state below.
   }
 
   const baselineSnapshots = snapshotsFromEditFilesBaseline(changes, context);

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -649,46 +649,69 @@ function enrichEditFilesResult(
     pendingEditFilesSnapshots.delete(getSnapshotKey(toolUseId, context));
   }
   const snapshots = snapshotEntry?.snapshots;
-
-  if (snapshots?.length) {
-    const snapshotDiffs = enrichFromEditFilesSnapshots(snapshots);
-    if (snapshotDiffs.length > 0) {
-      refreshEditFilesBaselineFromSnapshots(context, snapshots);
-      block.diff = {
-        structuredPatch: snapshotDiffs[0].structuredPatch,
-        files: snapshotDiffs,
-      };
-      return;
-    }
-    // Codex may emit file_change/item.started after apply_patch has already
-    // mutated the worktree. In that case these snapshots are post-edit and
-    // produce no diff. Keep the turn baseline intact so it can provide the
-    // actual pre-edit state below.
-  }
-
   const baselineSnapshots = snapshotsFromEditFilesBaseline(changes, context);
-  if (baselineSnapshots.length > 0) {
-    const baselineDiffs = enrichFromEditFilesSnapshots(baselineSnapshots);
-    refreshEditFilesBaselineFromSnapshots(context, baselineSnapshots);
-    if (baselineDiffs.length > 0) {
-      block.diff = {
-        structuredPatch: baselineDiffs[0].structuredPatch,
-        files: baselineDiffs,
-      };
-      return;
-    }
-  }
-
-  // Find git root once for relative path resolution
-  const gitRoot = getGitRoot(workingDirectory);
+  const baseline = pendingEditFilesBaselines.get(getBaselineKey(context));
+  const gitRoot = baseline?.gitRoot ?? getGitRoot(workingDirectory);
   if (!gitRoot) return; // Not in a git repo or git unavailable
 
+  const invocationSnapshotsByPath = new Map<string, EditFilesSnapshot>();
+  for (const snapshot of snapshots ?? []) {
+    const relativePath = resolveRepoRelativePath(gitRoot, snapshot.absolutePath);
+    if (relativePath) invocationSnapshotsByPath.set(relativePath, snapshot);
+  }
+
+  const baselineSnapshotsByPath = new Map<string, EditFilesSnapshot>();
+  for (const snapshot of baselineSnapshots) {
+    const relativePath = resolveRepoRelativePath(gitRoot, snapshot.absolutePath);
+    if (relativePath) baselineSnapshotsByPath.set(relativePath, snapshot);
+  }
+
   const fileDiffs: FileDiff[] = [];
+  const refreshSnapshots: EditFilesSnapshot[] = [];
+  const processedPaths = new Set<string>();
 
   for (const change of changes) {
     if (!change.path) continue;
 
     const kind = normalizeChangeKind(change.kind);
+    const filePath = change.path;
+    const resolvedPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(workingDirectory || gitRoot, filePath);
+    const relativePath = resolveRepoRelativePath(gitRoot, resolvedPath);
+    if (!relativePath || processedPaths.has(relativePath)) continue;
+    processedPaths.add(relativePath);
+
+    const invocationSnapshot = invocationSnapshotsByPath.get(relativePath);
+    const baselineSnapshot = baselineSnapshotsByPath.get(relativePath);
+    const refreshSnapshot = baselineSnapshot ??
+      invocationSnapshot ?? {
+        path: relativePath,
+        kind,
+        absolutePath: resolvedPath,
+        beforeExists: false,
+      };
+    refreshSnapshots.push(refreshSnapshot);
+
+    // Resolve each file independently. A multi-file item can be observed while
+    // Codex is between mutations, leaving some invocation snapshots pre-edit
+    // and others post-edit. Prefer a valid invocation diff for this path, then
+    // fall back to the turn baseline only for this path.
+    const invocationDiff = invocationSnapshot
+      ? enrichFromEditFilesSnapshots([invocationSnapshot])[0]
+      : undefined;
+    if (invocationDiff) {
+      fileDiffs.push(invocationDiff);
+      continue;
+    }
+
+    const baselineDiff = baselineSnapshot
+      ? enrichFromEditFilesSnapshots([baselineSnapshot])[0]
+      : undefined;
+    if (baselineDiff) {
+      fileDiffs.push(baselineDiff);
+      continue;
+    }
 
     // Without a pre-edit snapshot, Codex SDK file_change items only tell us
     // path + kind. Diffing updates/deletes against HEAD is misleading in dirty
@@ -697,15 +720,7 @@ function enrichEditFilesResult(
     // trustworthy post-edit-only representation.
     if (kind !== 'add') continue;
 
-    const filePath = change.path;
-    const resolvedPath = path.isAbsolute(filePath)
-      ? filePath
-      : path.resolve(workingDirectory || gitRoot, filePath);
-
     try {
-      // Only render files inside the repo.
-      if (!resolveRepoRelativePath(gitRoot, resolvedPath)) continue;
-
       const after = readTextFileSnapshot(resolvedPath);
       if (!after.exists || after.content === undefined) continue;
       const content = after.content;
@@ -720,6 +735,11 @@ function enrichEditFilesResult(
       // Best effort — skip files that fail
     }
   }
+
+  // Advance the baseline once, after every file has been compared against its
+  // chosen pre-image. This prevents one path's late snapshot from destroying
+  // another path's still-needed turn baseline.
+  refreshEditFilesBaselineFromSnapshots(context, refreshSnapshots);
 
   if (fileDiffs.length > 0) {
     // Also set structuredPatch to the first file's hunks for backward compat

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -75,6 +75,7 @@ interface TextFileSnapshot {
 interface EditFilesBaselineEntry {
   gitRoot: string;
   files: Map<string, TextFileSnapshot>;
+  fileListComplete: boolean;
   createdAt: number;
 }
 
@@ -166,7 +167,9 @@ async function getGitRootFromGit(workingDirectory: string): Promise<string | nul
   }
 }
 
-async function listTurnBaselineFiles(gitRoot: string): Promise<string[]> {
+async function listTurnBaselineFiles(
+  gitRoot: string
+): Promise<{ files: string[]; complete: boolean }> {
   try {
     const { git } = createGit(gitRoot);
     const output = await git.raw(['ls-files', '--cached', '--others', '--exclude-standard', '-z']);
@@ -174,15 +177,17 @@ async function listTurnBaselineFiles(gitRoot: string): Promise<string[]> {
     const seen = new Set<string>();
 
     for (const rawPath of output.split('\0')) {
-      if (files.length >= MAX_TURN_BASELINE_FILES) break;
       if (!rawPath || seen.has(rawPath) || !isSafeRepoRelativePath(rawPath)) continue;
+      if (files.length >= MAX_TURN_BASELINE_FILES) {
+        return { files, complete: false };
+      }
       seen.add(rawPath);
       files.push(rawPath);
     }
 
-    return files;
+    return { files, complete: true };
   } catch {
-    return [];
+    return { files: [], complete: false };
   }
 }
 
@@ -339,9 +344,10 @@ export async function registerEditFilesTurnBaseline(
     const gitRoot = await getGitRootFromGit(workingDirectory);
     if (!gitRoot) return;
 
+    const listedFiles = await listTurnBaselineFiles(gitRoot);
     const files = new Map<string, TextFileSnapshot>();
     let totalBytes = 0;
-    for (const relativePath of await listTurnBaselineFiles(gitRoot)) {
+    for (const relativePath of listedFiles.files) {
       const absolutePath = path.join(gitRoot, relativePath);
       const snapshot = readTextFileSnapshot(absolutePath);
       if (snapshot.content !== undefined) {
@@ -358,6 +364,7 @@ export async function registerEditFilesTurnBaseline(
     pendingEditFilesBaselines.set(getBaselineKey(context), {
       gitRoot,
       files,
+      fileListComplete: listedFiles.complete,
       createdAt: Date.now(),
     });
   } catch {
@@ -856,13 +863,19 @@ function snapshotsFromEditFilesBaseline(
     const relativePath = resolveRepoRelativePath(baseline.gitRoot, absolutePath);
     if (!relativePath) continue;
 
-    const before = baseline.files.get(relativePath) ?? { exists: false };
+    const before = baseline.files.get(relativePath);
+    if (!before && !baseline.fileListComplete) {
+      // An absent entry is only authoritative when enumeration completed. If
+      // capture hit its file cap or failed, the path may already have existed.
+      // Omitting an uncertain diff is safer than fabricating a whole-file add.
+      continue;
+    }
     snapshots.push({
       path: relativePath,
       kind: normalizeChangeKind(change.kind),
       absolutePath,
-      beforeExists: before.exists,
-      beforeContent: before.content,
+      beforeExists: before?.exists ?? false,
+      beforeContent: before?.content,
     });
   }
 


### PR DESCRIPTION
## Summary

- preserve the Codex turn baseline when a per-invocation edit snapshot produces no diff
- recover edit diffs when Codex reports `file_change/item.started` after `apply_patch` has already mutated the worktree
- resolve mixed-boundary multi-file edits independently by canonical path
- apply documented MCP list defaults and bound `agor_branches_list` to paged responses
- add regression coverage for late/rapid edits, mixed multi-file timing, bounded baselines, and MCP pagination contracts

## Codex edit-diff root cause

Codex does not consistently report `file_change/item.started` before the filesystem mutation. When the start event arrives late, the targeted “before” snapshot already contains the post-edit state and produces an empty diff.

Agor previously refreshed the valid whole-turn baseline from that empty post-edit snapshot before trying the baseline fallback. The fallback consequently compared the post-edit file against itself and persisted a completed `edit_files` result without `diff` data.

The fix resolves each changed file independently: it prefers a valid targeted snapshot for that canonical path, falls back to the preserved turn baseline only for paths whose targeted snapshot is empty, merges the per-file results, and advances the baseline once after all comparisons. This also covers multi-file items observed between filesystem mutations.

Turn-baseline enumeration now records whether its 5,000-file scan completed. A path missing from a truncated or failed scan is treated as unknown rather than nonexistent, preventing uncertain late-start updates from being rendered as false whole-file additions.

## MCP payload reliability

The incidental `agor_branches_list` hang had a separate cause. `mcpLimit(50)` only described a default; it did not apply one. An omitted limit therefore fell through to the branch service's intentional 10,000-row UI default. On the affected installation, the tool returned all 596 branches in a roughly 1.1 MB Codex result. Persisting that completed tool call through the executor exceeded the daemon's 1 MB Socket.IO frame limit.

This PR now:

- makes shared MCP limit schemas apply their documented defaults
- validates helper defaults and maxima when schemas are constructed
- supports opt-in tool-specific maxima without changing intentionally permissive schemas
- defaults branch lists to 50 rows, caps them at 100, and adds `offset` paging
- documents the paginated response contract and centralizes branch-list bounds
- makes positive-integer defaults field-aware and applies offset defaults consistently

The Socket.IO limit is unchanged. Raising it would only move the failure threshold and increase unauthenticated frame-processing exposure; general oversized-result truncation/chunking remains a separate defense-in-depth follow-up.

## Tests

- `pnpm i`
- `pnpm check`
- `TMPDIR=<temp> pnpm --filter @agor/executor test` — 41 files, 559 tests passed
- `pnpm --filter @agor/daemon test` — 153 files passed, 1 skipped; 1,944 tests passed, 31 skipped
- focused executor diff-enrichment test — 22 tests passed
- focused MCP schema/branch/search tests — 64 tests passed

`pnpm check` completed successfully with 10 existing warning-level Biome diagnostics outside the changed files.
