### PR TITLE
Add effort settings and latest Codex model support

### DIFF
--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -91,20 +91,17 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
       >
         <PermissionModeSelector agentic_tool={agenticTool} compact={compact} fullWidth />
       </Form.Item>
-
-      {(agenticTool === 'claude-code' || agenticTool === 'claude-code-cli') && (
-        <Form.Item
-          name="effort"
-          label="Reasoning Effort"
-          help={
-            showHelpText
-              ? 'Control how much reasoning Claude applies (low = fast, high = thorough, max = Opus only)'
-              : undefined
-          }
-        >
-          <EffortSelector />
-        </Form.Item>
-      )}
+      <Form.Item
+        name="effort"
+        label="Reasoning Effort"
+        help={
+          showHelpText
+            ? 'Control reasoning depth (low = fast, high = thorough, max = model-dependent)'
+            : undefined
+        }
+      >
+        <EffortSelector />
+      </Form.Item>
 
       {showCodexFields && (
         <Form.Item

--- a/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
+++ b/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
@@ -55,7 +55,7 @@ const EFFORT_OPTIONS: {
 ];
 
 /**
- * EffortSelector - Dropdown for selecting Claude reasoning effort level
+ * EffortSelector - Dropdown for selecting reasoning effort level
  */
 export const EffortSelector: React.FC<EffortSelectorProps> = ({
   value = 'high',

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -277,41 +277,39 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
         </div>
       </div>
 
-      {/* Effort — only for claude-code */}
-      {session.agentic_tool === 'claude-code' && (
-        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
-          <PercentageOutlined
-            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+      {/* Effort */}
+      <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+        <PercentageOutlined
+          style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+        />
+        <Typography.Text
+          style={{
+            fontSize: 12,
+            flex: 1,
+            color: token.colorTextSecondary,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+        >
+          Effort
+        </Typography.Text>
+        <div
+          style={{
+            pointerEvents: managedByPreset ? 'none' : undefined,
+            opacity: managedByPreset ? 0.65 : undefined,
+          }}
+        >
+          <EffortSelector
+            value={effortLevel}
+            onChange={onEffortChange}
+            size="small"
+            compact
+            plain
           />
-          <Typography.Text
-            style={{
-              fontSize: 12,
-              flex: 1,
-              color: token.colorTextSecondary,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              minWidth: 0,
-            }}
-          >
-            Effort
-          </Typography.Text>
-          <div
-            style={{
-              pointerEvents: managedByPreset ? 'none' : undefined,
-              opacity: managedByPreset ? 0.65 : undefined,
-            }}
-          >
-            <EffortSelector
-              value={effortLevel}
-              onChange={onEffortChange}
-              size="small"
-              compact
-              plain
-            />
-          </div>
         </div>
-      )}
+      </div>
 
       {/* Permissions */}
       <div style={{ ...overflowRowStyle, cursor: 'default' }}>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1277,15 +1277,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const handleEffortChange = (newEffort: EffortLevel) => {
     setEffortLevel(newEffort);
 
-    if (session && onUpdateSession) {
-      if (session.model_config) {
-        onUpdateSession(session.session_id, {
-          model_config: {
-            ...session.model_config,
-            effort: newEffort,
-          },
-        });
-      }
+    const currentModelConfig = session?.model_config;
+    if (onUpdateSession && currentModelConfig?.mode && currentModelConfig.model) {
+      onUpdateSession(session.session_id, {
+        model_config: {
+          ...currentModelConfig,
+          mode: currentModelConfig.mode,
+          model: currentModelConfig.model,
+          effort: newEffort,
+          updated_at: new Date().toISOString(),
+        },
+      });
     }
   };
 

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -69,7 +69,7 @@
     "@oclif/plugin-help": "^6.2.53",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.144.0",
+    "@openai/codex-sdk": "^0.145.0",
     "@opencode-ai/sdk": "^1.2.20",
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.22.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -414,7 +414,7 @@
     "@libsql/client": "^0.17.4",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.144.0",
+    "@openai/codex-sdk": "^0.145.0",
     "@opencode-ai/sdk": "^1.2.20",
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.22.0",

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -6,7 +6,7 @@ export type SdkActivityCallback = (kind: ExecutorPulseKind, detail?: string) => 
 
 export const SDK_ACTIVITY_VERSION_MANIFEST: Record<SdkActivityAdapter, string> = {
   'claude-code': '@anthropic-ai/claude-agent-sdk@0.3.197',
-  codex: '@openai/codex-sdk@0.144.0',
+  codex: '@openai/codex-sdk@0.145.0',
   gemini: '@google/gemini-cli-core@0.31.0',
   copilot: '@github/copilot-sdk@0.2.2',
   opencode: '@opencode-ai/sdk@1.14.33',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,8 +584,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.144.0
-        version: 0.144.0
+        specifier: ^0.145.0
+        version: 0.145.0
       '@opencode-ai/sdk':
         specifier: ^1.2.20
         version: 1.14.33
@@ -819,8 +819,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.144.0
-        version: 0.144.0
+        specifier: ^0.145.0
+        version: 0.145.0
       '@opencode-ai/sdk':
         specifier: ^1.2.20
         version: 1.14.33
@@ -2957,47 +2957,47 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
-  '@openai/codex-sdk@0.144.0':
-    resolution: {integrity: sha512-Avk4tZxfhNfwMhLoD9P+1aFlgaK2Mv11ouy+z9ImkgOKRHDMhDPFw1CbsNECfGNWJix7T0EG9TAU1XVkEKW3DQ==}
+  '@openai/codex-sdk@0.145.0':
+    resolution: {integrity: sha512-lBviqBKnomEXNpdjfDzUoz/H+VZuK75m2oR8dQSmL2zUpnklfAsTneuaSg23NOoE+vw/Qhbxp8ePy9te973yfw==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.144.0':
-    resolution: {integrity: sha512-QFh6f+v5QUx/Vg0HjIl9HB94p7aDLBDkZjc4IXX5RXUcXHPVCZNb6Hl2R49Og/fqW7orgZkeDcgWfRANUa1WoQ==}
+  '@openai/codex@0.145.0':
+    resolution: {integrity: sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.0-darwin-arm64':
-    resolution: {integrity: sha512-rqFAJdOa2I0VRgepVsSZeLxs96+Y+LXTjccOOvH6894FyaFAYPZ/o+6hgpB1iGHxxdoY/DsGa8jrJC8Leqn9Kg==}
+  '@openai/codex@0.145.0-darwin-arm64':
+    resolution: {integrity: sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.0-darwin-x64':
-    resolution: {integrity: sha512-4p2jxRbN+Khg5UQzpkzT9upFj+qkEF/abmdvrtflkkWmVKP6Nt+yi8ospdqv9PDqvQ9SotPvX7iXaFaeUTrtmA==}
+  '@openai/codex@0.145.0-darwin-x64':
+    resolution: {integrity: sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.0-linux-arm64':
-    resolution: {integrity: sha512-k++xhZrn9P3laO00Q92APG6mdOFDD66nUBo+8ExCa1NXi2pjLEMLC4+UNJTUUtUT1PEflOZ5pDKxPXgzaiFFFg==}
+  '@openai/codex@0.145.0-linux-arm64':
+    resolution: {integrity: sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.0-linux-x64':
-    resolution: {integrity: sha512-GmKtQeX+cO9lN7mQD1FEVcXYEMLMgMByHwZdvlluH0bj/+c2ind3hwbRtE3eECFDekNhEiB80Ez0FfbkyFQqoA==}
+  '@openai/codex@0.145.0-linux-x64':
+    resolution: {integrity: sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.0-win32-arm64':
-    resolution: {integrity: sha512-e2yGSgwdzrT1SoJMoOzWD58WBEsIaAMZpEchuV2VGkE2T955SG7dn7EyVQTQcy7/rdpE8aEDktZ/1eQQfjkdtQ==}
+  '@openai/codex@0.145.0-win32-arm64':
+    resolution: {integrity: sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.0-win32-x64':
-    resolution: {integrity: sha512-QiholLCYqNeYvNM77HOmPtrOFrY0rQc/N9nXt+sQGXO3rEGmcWjpLzujY4Oegl3CLRHoieWqlep3EqEvFBjoIA==}
+  '@openai/codex@0.145.0-win32-x64':
+    resolution: {integrity: sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -12351,35 +12351,35 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@openai/codex-sdk@0.144.0':
+  '@openai/codex-sdk@0.145.0':
     dependencies:
-      '@openai/codex': 0.144.0
+      '@openai/codex': 0.145.0
 
-  '@openai/codex@0.144.0':
+  '@openai/codex@0.145.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.145.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.145.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.145.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.145.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.145.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.145.0-win32-x64'
 
-  '@openai/codex@0.144.0-darwin-arm64':
+  '@openai/codex@0.145.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-darwin-x64':
+  '@openai/codex@0.145.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.0-linux-arm64':
+  '@openai/codex@0.145.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-linux-x64':
+  '@openai/codex@0.145.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.0-win32-arm64':
+  '@openai/codex@0.145.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-win32-x64':
+  '@openai/codex@0.145.0-win32-x64':
     optional: true
 
   '@opencode-ai/sdk@1.14.33':


### PR DESCRIPTION
## Summary

- Upgrade `@openai/codex-sdk` to `0.145.0`, enabling current Codex model metadata and newer model requests.
- Add **effort selection** to all relevant session settings surfaces:
  - user defaults
  - zone templates
  - new session creation
  - fork/spawn session
  - session footer settings
- Persist selected effort in `model_config` while preserving existing model, mode, provider, and advisor settings.
- Keep existing Codex permissions and production configuration behavior unchanged.

## Validation

- Agor UI typecheck passes.
- Focused new-session test passes.
- Biome and commit checks pass.
- Fixed required `model_config.mode` and `model_config.model` typing exposed by CI.

Single squashed commit based on latest upstream `main`.