### PR TITLE
fix(ui): onboarding wizard reuses existing board via server fetch

### DIFF
--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -357,6 +357,63 @@ describe('OnboardingWizard', () => {
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
   });
 
+  it('reuses existing board via server fetch when boardById store is empty (restart onboarding)', async () => {
+    const serverBoard = makeBoard({ board_id: 'board-existing', name: 'My board' });
+    const boardsService = {
+      create: vi.fn(async () => ({ board_id: 'board-new', created_by: 'user-1' })),
+      get: vi.fn(async () => serverBoard),
+    };
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => (name === 'boards' ? boardsService : {})),
+    };
+
+    renderWizard({
+      initialStep: 'workspace',
+      client: client as never,
+      user: makeUser({ preferences: { mainBoardId: 'board-existing' } } as Partial<User>),
+      // No boardById — store is empty (the bug scenario)
+    });
+
+    await waitFor(() => expect(boardsService.get).toHaveBeenCalledWith('board-existing'));
+    expect(await screen.findByText('Board already set up')).toBeInTheDocument();
+    expect(screen.getByText('My board')).toBeInTheDocument();
+
+    clickButton(/keep going/i);
+    expect(boardsService.create).not.toHaveBeenCalled();
+    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+  });
+
+  it('creates a new board when mainBoardId points to a deleted board', async () => {
+    const boardsService = {
+      create: vi.fn(async () => ({ board_id: 'board-new', created_by: 'user-1' })),
+      get: vi.fn(async () => {
+        throw new Error('Not found');
+      }),
+    };
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => (name === 'boards' ? boardsService : {})),
+    };
+
+    renderWizard({
+      initialStep: 'workspace',
+      client: client as never,
+      user: makeUser({ preferences: { mainBoardId: 'board-deleted' } } as Partial<User>),
+    });
+
+    await waitFor(() => expect(boardsService.get).toHaveBeenCalledWith('board-deleted'));
+    // Board not found — user can name a new teammate and create a board
+    await waitFor(() => expect(screen.getByText('Name your AI teammate')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Ada' } });
+    clickButton(/^continue →/i);
+
+    await waitFor(() => {
+      expect(boardsService.create).toHaveBeenCalledWith({ name: 'Ada', icon: '🤖' });
+    });
+  });
+
   it('integrations step shows persona-tailored MCP recommendations', async () => {
     renderWizard({ initialStep: 'integrations' });
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,6 +9,7 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
+  Board,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -568,6 +569,10 @@ export function OnboardingWizard({
   const [createdBoardId, setCreatedBoardId] = useState<string | null>(null);
   const [boardCreating, setBoardCreating] = useState(false);
   const [boardError, setBoardError] = useState<string | null>(null);
+  // Server-verified board: populated by a one-shot fetch so the board-reuse
+  // check doesn't depend on Zustand store hydration timing.
+  const [verifiedBoard, setVerifiedBoard] = useState<Board | null>(null);
+  const [boardVerifying, setBoardVerifying] = useState(false);
 
   // ── Step 4: integrations ─────────────────────────────────────────────────
 
@@ -595,6 +600,8 @@ export function OnboardingWizard({
     setCreatedBoardId(null);
     setBoardError(null);
     setBoardCreating(false);
+    setVerifiedBoard(null);
+    setBoardVerifying(false);
     setCompleting(false);
     // Force seed effect to re-run on every open for the same user
     userSeedRef.current = null;
@@ -638,10 +645,6 @@ export function OnboardingWizard({
     } else {
       setSelectedAgent(null);
     }
-    // Teammate name is personal ("Rusty", "Ada"…) so we leave it empty and let
-    // the placeholder guide the user. Never seed createdBoardId from preferences
-    // because the preference may point to a deleted board (stale mainBoardId).
-    // hasExistingBoard uses boardById to verify the board actually exists.
     setTeammateName('');
     setCreatedBoardId(null);
   }, [open, user]);
@@ -727,7 +730,39 @@ export function OnboardingWizard({
   const existingBoard = useAgorStore((store) =>
     existingBoardId ? (store.boardById.get(existingBoardId) ?? null) : null
   );
-  const hasExistingBoard = !!(existingBoard || createdBoardId);
+
+  // Server-verify the user's mainBoardId. The Zustand boardById store may not be
+  // hydrated when onboarding runs (fresh session or restart-onboarding), so a
+  // direct server fetch avoids the false-negative that creates a duplicate board.
+  useEffect(() => {
+    if (!open || !existingBoardId || !client) {
+      setVerifiedBoard(null);
+      setBoardVerifying(false);
+      return;
+    }
+    if (existingBoard) {
+      setVerifiedBoard(existingBoard);
+      setBoardVerifying(false);
+      return;
+    }
+    setBoardVerifying(true);
+    let cancelled = false;
+    (client.service('boards').get(existingBoardId) as Promise<Board>)
+      .then((board) => {
+        if (!cancelled) setVerifiedBoard(board);
+      })
+      .catch(() => {
+        // Board deleted or inaccessible — fall through to creating a new one
+      })
+      .finally(() => {
+        if (!cancelled) setBoardVerifying(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, existingBoardId, client, existingBoard]);
+
+  const hasExistingBoard = !!(verifiedBoard || createdBoardId);
 
   const primaryEnabled = useMemo(() => {
     switch (currentStep) {
@@ -755,6 +790,7 @@ export function OnboardingWizard({
         return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
       }
       case 'workspace':
+        if (boardVerifying) return false;
         return hasExistingBoard || teammateName.trim().length > 0;
       case 'integrations':
         return true;
@@ -770,6 +806,7 @@ export function OnboardingWizard({
     llmAuthVerified,
     apiKey,
     authMethod,
+    boardVerifying,
     hasExistingBoard,
     teammateName,
   ]);
@@ -798,6 +835,7 @@ export function OnboardingWizard({
         return err ?? null;
       }
       case 'workspace':
+        if (boardVerifying) return null;
         if (hasExistingBoard) return null;
         return teammateName.trim().length === 0 ? 'Name your AI teammate to continue' : null;
       default:
@@ -812,6 +850,7 @@ export function OnboardingWizard({
     llmAuthVerified,
     apiKey,
     authMethod,
+    boardVerifying,
     hasExistingBoard,
     teammateName,
     llmSaving,
@@ -1011,8 +1050,7 @@ export function OnboardingWizard({
         break;
       }
       case 'done': {
-        // existingBoard is null if mainBoardId points to a deleted board — don't pass stale IDs
-        const boardIdToUse = createdBoardId || (existingBoard ? existingBoardId : '') || '';
+        const boardIdToUse = createdBoardId || verifiedBoard?.board_id || '';
         // Suggested MCP integrations for the chosen persona (same set shown on
         // the integrations step) — threaded into the teammate's bootstrap prompt.
         const recs = PERSONA_MCP_RECS[selectedPersona ?? '_default'] ?? PERSONA_MCP_RECS._default;
@@ -1057,8 +1095,7 @@ export function OnboardingWizard({
     teammateEmoji,
     saveOnboardingProgress,
     createdBoardId,
-    existingBoardId,
-    existingBoard,
+    verifiedBoard,
     onComplete,
     goToStep,
   ]);
@@ -1619,7 +1656,7 @@ export function OnboardingWizard({
             </Text>
             <div>
               <Text style={{ color: TEXT_SECONDARY, fontSize: 12 }}>
-                {existingBoard?.name || 'Your board is ready.'}
+                {verifiedBoard?.name || 'Your board is ready.'}
               </Text>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- The onboarding wizard's board-reuse check relied on `boardById` from the Zustand store, which may not be hydrated at the time onboarding runs (fresh session, or after "Restart Onboarding" from user settings). When `boardById.get(mainBoardId)` returned `undefined`, the ownership check silently failed and the wizard fell through to creating a brand-new board — producing board clutter and a disorienting "random new board" experience.
- Fix: when `mainBoardId` is set, fetch the board directly from the server (`boards.get`) to verify it exists, rather than trusting the client-side cache. Only fall through to creating a new board if the fetch fails (board deleted/archived/not found). The Continue button is disabled during the brief verification window to prevent races.
- Scoped to `OnboardingWizard.tsx` — no changes to `App.tsx` (the `handleOnboardingComplete` navigation logic is already correct: it navigates to the session path when a session is seeded, or to the board path using the board ID directly, neither of which depends on store hydration).

## Changes

**`OnboardingWizard.tsx`**
- Added `verifiedBoard` / `boardVerifying` state
- Added a `useEffect` that fetches the board from the server when `existingBoardId` is set and the store doesn't have it yet; uses the store value as a shortcut when available
- `hasExistingBoard` now uses `verifiedBoard` instead of the store-derived `existingBoard`
- `primaryEnabled` gates on `boardVerifying` to prevent the user from creating a duplicate while verification is in flight
- The 'done' step's `boardIdToUse` uses `verifiedBoard?.board_id` instead of the store-dependent conditional

**`OnboardingWizard.test.tsx`**
- Added: "reuses existing board via server fetch when boardById store is empty (restart onboarding)" — the core bug scenario
- Added: "creates a new board when mainBoardId points to a deleted board" — the fallback path

## Test plan

- [x] All 1039 existing tests pass (including the 21 existing onboarding wizard tests)
- [x] 2 new tests cover the bug scenario and the deleted-board fallback
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome lint passes (pre-commit hook)
- [ ] Manual: restart onboarding for a user with an existing `mainBoardId`, confirm the wizard shows "Board already set up" on the workspace step and reuses that board on completion
- [ ] Manual: delete a user's board, restart onboarding, confirm the wizard lets them create a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)