### PR TITLE
fix(executor): deliver Stop over task-scoped socket

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -26,6 +26,7 @@ function ctx(overrides: Partial<HookContext>): HookContext {
 describe('executorRuntimeScopeGuard', () => {
   it.each([
     'connectExecutor',
+    'reportTerminationComplete',
     'reportRuntimeTelemetry',
     'reportSdkHealthFailure',
   ])('accepts scoped %s and rejects a different task', async (method) => {

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -131,6 +131,10 @@ export interface SessionsServiceImpl
  */
 export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersParams> {
   connectExecutor(data: { task_id: string }, params?: FeathersParams): Promise<Task>;
+  reportTerminationComplete(
+    data: import('@agor/core/types').ExecutorTerminationCompleteInput,
+    params?: FeathersParams
+  ): Promise<Task>;
   recordExecutorStartupWarning(
     taskId: string,
     warning: string,

--- a/apps/agor-daemon/src/executor-tracking.ts
+++ b/apps/agor-daemon/src/executor-tracking.ts
@@ -106,7 +106,13 @@ export function getTrackedExecutor(sessionId: string): Readonly<TrackedExecutor>
 export async function containExecutorProcess(
   sessionId: string,
   taskId: string,
-  options: { termGraceMs?: number; killGraceMs?: number; pollMs?: number } = {}
+  options: {
+    /** Give a cooperatively quiesced wrapper a brief chance to exit itself. */
+    preSignalGraceMs?: number;
+    termGraceMs?: number;
+    killGraceMs?: number;
+    pollMs?: number;
+  } = {}
 ): Promise<ContainmentResult> {
   const tracked = executorProcesses.get(sessionId);
   if (!tracked || tracked.taskId !== taskId) {
@@ -136,6 +142,18 @@ export async function containExecutorProcess(
         reason: 'Executor process identity changed or is unreadable.',
       };
     }
+  }
+
+  if (
+    options.preSignalGraceMs &&
+    (await waitForAbsence(
+      tracked.pgid,
+      options.preSignalGraceMs,
+      options.pollMs ?? 50,
+      tracked.asUser
+    ))
+  ) {
+    return { status: 'verified_absent' };
   }
 
   const signal = (value: NodeJS.Signals): ContainmentResult | undefined => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -3031,6 +3031,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       connectExecutor: [requireExecutorRuntimeToken()],
+      reportTerminationComplete: [requireExecutorRuntimeToken()],
       reportRuntimeTelemetry: [requireExecutorRuntimeToken()],
       reportSdkHealthFailure: [requireExecutorRuntimeToken()],
       remove: [

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -1,19 +1,48 @@
-import { readFileSync } from 'node:fs';
+import {
+  createTenantScopedDatabaseProxy,
+  MissingTenantDatabaseScopeError,
+  runWithTenantContext,
+} from '@agor/core/db';
 import { describe, expect, it } from 'vitest';
+import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 
 describe('Stop route transaction scope', () => {
-  it('does not hold a tenant DB transaction while awaiting executor acknowledgement', () => {
-    const source = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
-    const stopSection = source.slice(
-      source.indexOf('// Stop endpoint'),
-      source.indexOf('// Queue listing', source.indexOf('// Stop endpoint'))
+  it('gives normal Stop and force-unverified ownership checks short guarded DB scopes', async () => {
+    const transaction = async (work: (tx: unknown) => Promise<unknown>) =>
+      work({
+        execute: async () => [],
+        marker: () => 'scoped',
+      });
+    const rawDb = {
+      transaction,
+      marker: () => 'scoped',
+    };
+    const guardedDb = createTenantScopedDatabaseProxy(rawDb as never, {
+      requireScope: true,
+      label: 'Stop test DB',
+    });
+    const repositories = bindStopRouteRepositories(guardedDb, {
+      taskRepo: {
+        async findQueued() {
+          return (guardedDb as unknown as { marker(): string }).marker() === 'scoped' ? [] : [];
+        },
+      },
+      branchRepo: {
+        async isOwner() {
+          return (guardedDb as unknown as { marker(): string }).marker() === 'scoped';
+        },
+      },
+    });
+
+    expect(() => (guardedDb as unknown as { marker(): string }).marker()).toThrow(
+      MissingTenantDatabaseScopeError
     );
 
-    expect(stopSection).toContain(
-      "registerLongAuthenticatedRoute(\n    app,\n    '/sessions/:id/stop'"
-    );
-    expect(stopSection).not.toContain(
-      "registerAuthenticatedRoute(\n    app,\n    '/sessions/:id/stop'"
-    );
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(repositories.taskRepo.findQueued('session-a')).resolves.toEqual([]);
+      await expect(
+        repositories.branchRepo.isOwner('branch-a' as never, 'user-a' as never)
+      ).resolves.toBe(true);
+    });
   });
 });

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Stop route transaction scope', () => {
+  it('does not hold a tenant DB transaction while awaiting executor acknowledgement', () => {
+    const source = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
+    const stopSection = source.slice(
+      source.indexOf('// Stop endpoint'),
+      source.indexOf('// Queue listing', source.indexOf('// Stop endpoint'))
+    );
+
+    expect(stopSection).toContain(
+      "registerLongAuthenticatedRoute(\n    app,\n    '/sessions/:id/stop'"
+    );
+    expect(stopSection).not.toContain(
+      "registerAuthenticatedRoute(\n    app,\n    '/sessions/:id/stop'"
+    );
+  });
+});

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -144,6 +144,7 @@ import {
 } from './utils/session-task-state.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
+import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
@@ -355,6 +356,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       ...options,
       around: [tenantIdentityAround, ...(options.around ?? [])],
     });
+
+  // Long routes carry tenant identity without holding a route-wide database
+  // transaction. Bind direct repository dependencies to short units of work;
+  // hooked service calls establish their own scopes.
+  const stopRouteRepositories = bindStopRouteRepositories(db, {
+    taskRepo: new TaskRepository(db),
+    branchRepo: branchRepository,
+  });
 
   // Helper: safely get a service (returns undefined if not registered due to tier=off)
   const safeService = (path: string) => {
@@ -2270,7 +2279,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             const userId = params.user?.user_id;
             const isAdmin = hasMinimumRole(params.user?.role, ROLES.ADMIN);
             const isOwner =
-              !!userId && (await branchRepository.isOwner(session.branch_id, userId as UUID));
+              !!userId &&
+              (await stopRouteRepositories.branchRepo.isOwner(session.branch_id, userId as UUID));
             if (!isAdmin && !isOwner) {
               throw new Forbidden('Only a branch owner or administrator may force-fail a Task.');
             }
@@ -2298,7 +2308,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           stopSessionPreserveQueue(
             {
               app,
-              taskRepo: new TaskRepository(db),
+              taskRepo: stopRouteRepositories.taskRepo,
               sessionsService: sessionsServiceWithHooks,
             },
             id as SessionID,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2231,7 +2231,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Stop endpoint
   // ============================================================================
 
-  registerAuthenticatedRoute(
+  // Stop coordinates durable state with an external executor and may wait for
+  // its socket acknowledgement. It must not hold the route-wide tenant DB
+  // transaction while waiting: emitServiceEvent correctly defers realtime
+  // publication until commit, so a long transaction here would withhold the
+  // Stop event until after the cooperative grace expired and containment had
+  // already fallen back to SIGTERM. Internal service calls still use their
+  // normal short tenant transactions.
+  registerLongAuthenticatedRoute(
     app,
     '/sessions/:id/stop',
     {

--- a/apps/agor-daemon/src/register-services.tasks-events.test.ts
+++ b/apps/agor-daemon/src/register-services.tasks-events.test.ts
@@ -1,0 +1,32 @@
+import { feathers } from '@agor/core/feathers';
+import { describe, expect, it } from 'vitest';
+import { TASKS_SERVICE_CUSTOM_EVENTS } from './services/tasks-events.js';
+
+describe('Tasks service transport events', () => {
+  it('registers termination_requested at the Feathers transport boundary', () => {
+    const app = feathers();
+    app.use(
+      'tasks',
+      {
+        async get() {
+          return {};
+        },
+      },
+      {
+        methods: ['get'],
+        events: [...TASKS_SERVICE_CUSTOM_EVENTS],
+      }
+    );
+
+    const service = app.service('tasks') as unknown as Record<PropertyKey, unknown>;
+    const options = Object.getOwnPropertySymbols(service)
+      .map((symbol) => service[symbol])
+      .find(
+        (value): value is { events: string[]; serviceEvents: string[] } =>
+          !!value && typeof value === 'object' && 'events' in value && 'serviceEvents' in value
+      );
+    if (!options) throw new Error('Feathers service registration options were not installed');
+    expect(options.events).toContain('termination_requested');
+    expect(options.serviceEvents).toContain('termination_requested');
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -123,6 +123,7 @@ import { createSessionMCPServersService } from './services/session-mcp-servers.j
 import { createSessionStreamsService } from './services/session-streams.js';
 import { createSessionsService } from './services/sessions.js';
 import { createTasksService } from './services/tasks.js';
+import { TASKS_SERVICE_CUSTOM_EVENTS } from './services/tasks-events.js';
 import { createTemplatesService } from './services/templates.js';
 import { createTenantAgenticToolSettingsService } from './services/tenant-agentic-tools.js';
 import { TerminalsService } from './services/terminals.js';
@@ -267,7 +268,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     //      task.
     //   - 'tool:start' / 'tool:complete' / 'thinking:chunk': forwarded from
     //      the executor for live tool/thinking visualization.
-    events: ['queued', 'tool:start', 'tool:complete', 'thinking:chunk', 'failed'],
+    events: [...TASKS_SERVICE_CUSTOM_EVENTS],
   });
   app.use('/leaderboard', createLeaderboardService(db));
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -252,6 +252,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       'patch',
       'remove',
       'connectExecutor',
+      'reportTerminationComplete',
       'reportRuntimeTelemetry',
       'reportSdkHealthFailure',
     ],

--- a/apps/agor-daemon/src/services/tasks-events.ts
+++ b/apps/agor-daemon/src/services/tasks-events.ts
@@ -1,0 +1,14 @@
+/**
+ * Custom task events that must cross the Feathers transport boundary.
+ *
+ * Keep this list in sync with every custom `tasks.emit(...)` call. Standard
+ * service events such as `patched` are registered by Feathers automatically.
+ */
+export const TASKS_SERVICE_CUSTOM_EVENTS = [
+  'queued',
+  'tool:start',
+  'tool:complete',
+  'thinking:chunk',
+  'failed',
+  'termination_requested',
+] as const;

--- a/apps/agor-daemon/src/services/tasks.termination-report.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-report.test.ts
@@ -1,0 +1,52 @@
+import type { Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+
+const requestExecutorTermination = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+vi.mock('../termination-coordinator.js', () => ({
+  beginExecutorTermination: vi.fn(),
+  requestExecutorTermination,
+}));
+
+import { TasksService } from './tasks';
+
+describe('TasksService executor termination report', () => {
+  it('persists and publishes quiescence before coordinating asynchronously', async () => {
+    const requestedAt = '2026-07-23T12:00:00.000Z';
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: requestedAt,
+        executor_quiesced_at: '2026-07-23T12:00:00.125Z',
+      },
+    } as Task;
+    const recordExecutorQuiescence = vi.fn().mockResolvedValue(task);
+    const emit = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService;
+    Reflect.set(service, 'taskRepo', { recordExecutorQuiescence });
+    Reflect.set(service, 'app', { service: () => ({ emit }) });
+
+    await expect(
+      service.reportTerminationComplete({
+        task_id: task.task_id,
+        requested_at: requestedAt,
+      })
+    ).resolves.toBe(task);
+
+    expect(recordExecutorQuiescence).toHaveBeenCalledWith({
+      task_id: task.task_id,
+      requested_at: requestedAt,
+    });
+    expect(emit).toHaveBeenCalledWith('patched', task, expect.objectContaining({ path: 'tasks' }));
+    expect(requestExecutorTermination).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.task_id,
+        cause: 'user_stop',
+        params: expect.objectContaining({ provider: undefined }),
+      })
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.termination-report.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-report.test.ts
@@ -3,15 +3,32 @@ import { TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 
 const requestExecutorTermination = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+const deferred = vi.hoisted(
+  () =>
+    ({ work: undefined as (() => Promise<void>) | undefined, schedule: vi.fn() }) as {
+      work: (() => Promise<void>) | undefined;
+      schedule: ReturnType<typeof vi.fn>;
+    }
+);
 vi.mock('../termination-coordinator.js', () => ({
   beginExecutorTermination: vi.fn(),
   requestExecutorTermination,
+}));
+vi.mock('../utils/tenant-db-scope.js', () => ({
+  deferWithTenantContext: (
+    params: unknown,
+    work: () => Promise<void>,
+    onError?: (error: unknown) => void
+  ) => {
+    deferred.work = work;
+    deferred.schedule(params, onError);
+  },
 }));
 
 import { TasksService } from './tasks';
 
 describe('TasksService executor termination report', () => {
-  it('persists and publishes quiescence before coordinating asynchronously', async () => {
+  it('persists and publishes quiescence before coordinating after the service transaction', async () => {
     const requestedAt = '2026-07-23T12:00:00.000Z';
     const task = {
       task_id: '018f0000-0000-7000-8000-000000000001',
@@ -30,10 +47,13 @@ describe('TasksService executor termination report', () => {
     Reflect.set(service, 'app', { service: () => ({ emit }) });
 
     await expect(
-      service.reportTerminationComplete({
-        task_id: task.task_id,
-        requested_at: requestedAt,
-      })
+      service.reportTerminationComplete(
+        {
+          task_id: task.task_id,
+          requested_at: requestedAt,
+        },
+        { tenant: { tenant_id: 'tenant-a' } } as never
+      )
     ).resolves.toBe(task);
 
     expect(recordExecutorQuiescence).toHaveBeenCalledWith({
@@ -41,6 +61,14 @@ describe('TasksService executor termination report', () => {
       requested_at: requestedAt,
     });
     expect(emit).toHaveBeenCalledWith('patched', task, expect.objectContaining({ path: 'tasks' }));
+    expect(deferred.schedule).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant: { tenant_id: 'tenant-a' } }),
+      expect.any(Function)
+    );
+    expect(requestExecutorTermination).not.toHaveBeenCalled();
+
+    await deferred.work?.();
+
     expect(requestExecutorTermination).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: task.task_id,

--- a/apps/agor-daemon/src/services/tasks.termination-request.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-request.test.ts
@@ -51,4 +51,71 @@ describe('TasksService termination request publication', () => {
       expect.objectContaining({ provider: undefined })
     );
   });
+
+  it('re-publishes an unchanged active request without pretending the Task was patched', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    } as Task;
+    const claimTermination = vi.fn().mockResolvedValue({ outcome: 'unchanged', task });
+    const emit = vi.fn();
+    const patchSession = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService;
+    Reflect.set(service, 'taskRepo', { claimTermination });
+    Reflect.set(service, 'app', {
+      service(path: string) {
+        if (path === 'tasks') return { emit };
+        if (path === 'sessions') return { patch: patchSession };
+        throw new Error(`Unexpected service ${path}`);
+      },
+    });
+
+    await expect(
+      service.claimTermination({
+        taskId: task.task_id,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user.',
+      })
+    ).resolves.toEqual({ outcome: 'unchanged', task });
+
+    expect(emit).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith(
+      'termination_requested',
+      task,
+      expect.objectContaining({ path: 'tasks', method: 'patch' })
+    );
+    expect(patchSession).not.toHaveBeenCalled();
+  });
+
+  it('does not re-publish after the executor has already reported quiescence', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+        executor_quiesced_at: '2026-07-23T12:00:00.125Z',
+      },
+    } as Task;
+    const emit = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService;
+    Reflect.set(service, 'taskRepo', {
+      claimTermination: vi.fn().mockResolvedValue({ outcome: 'unchanged', task }),
+    });
+    Reflect.set(service, 'app', { service: () => ({ emit }) });
+
+    await service.claimTermination({
+      taskId: task.task_id,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user.',
+    });
+
+    expect(emit).not.toHaveBeenCalled();
+  });
 });

--- a/apps/agor-daemon/src/services/tasks.termination-request.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-request.test.ts
@@ -1,0 +1,54 @@
+import type { Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+describe('TasksService termination request publication', () => {
+  it('publishes durable state and the task-scoped executor control event', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    } as Task;
+    const claimTermination = vi.fn().mockResolvedValue({ outcome: 'claimed', task });
+    const emit = vi.fn();
+    const patchSession = vi.fn().mockResolvedValue({});
+    const service = Object.create(TasksService.prototype) as TasksService;
+    Reflect.set(service, 'taskRepo', { claimTermination });
+    Reflect.set(service, 'app', {
+      service(path: string) {
+        if (path === 'tasks') return { emit };
+        if (path === 'sessions') return { patch: patchSession };
+        throw new Error(`Unexpected service ${path}`);
+      },
+    });
+
+    await service.claimTermination({
+      taskId: task.task_id,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user.',
+    });
+
+    expect(emit).toHaveBeenNthCalledWith(
+      1,
+      'patched',
+      task,
+      expect.objectContaining({ path: 'tasks', method: 'patch' })
+    );
+    expect(emit).toHaveBeenNthCalledWith(
+      2,
+      'termination_requested',
+      task,
+      expect.objectContaining({ path: 'tasks', method: 'patch' })
+    );
+    expect(patchSession).toHaveBeenCalledWith(
+      task.session_id,
+      { status: 'stopping', ready_for_prompt: false },
+      expect.objectContaining({ provider: undefined })
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -29,6 +29,7 @@ import { type Application, BadRequest, Conflict } from '@agor/core/feathers';
 import { deriveTitleFromPrompt } from '@agor/core/sessions';
 import type {
   ContentBlock,
+  ExecutorTerminationCompleteInput,
   Paginated,
   QueryParams,
   RuntimeTelemetryInput,
@@ -49,7 +50,10 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
-import { beginExecutorTermination } from '../termination-coordinator.js';
+import {
+  beginExecutorTermination,
+  requestExecutorTermination,
+} from '../termination-coordinator.js';
 import { appendSystemMessage } from '../utils/append-system-message.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import {
@@ -1160,6 +1164,45 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       });
     }
     return connection.task;
+  }
+
+  async reportTerminationComplete(
+    data: ExecutorTerminationCompleteInput,
+    params?: TaskParams
+  ): Promise<Task> {
+    const task = await this.taskRepo.recordExecutorQuiescence(data);
+    if (!task?.termination_request) {
+      throw new Conflict(
+        `Task ${shortId(data.task_id)} has no matching active termination request`
+      );
+    }
+
+    emitServiceEvent(this.app, {
+      path: 'tasks',
+      event: 'patched',
+      data: task,
+      id: task.task_id,
+      params,
+    });
+
+    // Do not await containment here. A local executor must receive this RPC
+    // response before it can exit, while the coordinator verifies that process
+    // group only after the wrapper exits. The durable quiescence timestamp
+    // wakes an existing coordinator and also makes this restart/retry safe.
+    void requestExecutorTermination({
+      app: this.app,
+      taskId: task.task_id,
+      cause: task.termination_request.cause,
+      errorMessage: task.termination_request.error_message ?? 'Executor stopped cooperatively.',
+      params: { ...(params ?? {}), provider: undefined },
+    }).catch((error) =>
+      console.error(
+        `[termination] Failed to settle executor report for Task ${shortId(task.task_id)}:`,
+        error
+      )
+    );
+
+    return task;
   }
 
   async recordExecutorStartupWarning(

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -316,15 +316,26 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     params?: TaskParams
   ): Promise<TerminationClaimResult> {
     const result = await this.taskRepo.claimTermination(input);
-    if (result.outcome !== 'claimed') return result;
+    const claimed = result.outcome === 'claimed';
+    const retryingActiveRequest =
+      result.outcome === 'unchanged' &&
+      result.task.status === TaskStatus.STOPPING &&
+      !!result.task.termination_request &&
+      !result.task.termination_request.executor_quiesced_at;
+    if (!claimed && !retryingActiveRequest) return result;
 
-    emitServiceEvent(this.app, {
-      path: 'tasks',
-      event: 'patched',
-      data: result.task,
-      id: result.task.task_id,
-      params,
-    });
+    if (claimed) {
+      emitServiceEvent(this.app, {
+        path: 'tasks',
+        event: 'patched',
+        data: result.task,
+        id: result.task.task_id,
+        params,
+      });
+    }
+    // A repeated claim keeps the original requested_at fence but re-publishes
+    // the private control event. This makes Stop retryable after a lost socket
+    // delivery without creating a new cancellation epoch.
     emitServiceEvent(this.app, {
       path: 'tasks',
       event: 'termination_requested',
@@ -333,6 +344,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       method: 'patch',
       params,
     });
+    if (!claimed) return result;
+
     try {
       await this.app
         .service('sessions')

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -324,6 +324,14 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       id: result.task.task_id,
       params,
     });
+    emitServiceEvent(this.app, {
+      path: 'tasks',
+      event: 'termination_requested',
+      data: result.task,
+      id: result.task.task_id,
+      method: 'patch',
+      params,
+    });
     try {
       await this.app
         .service('sessions')

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -61,6 +61,7 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
+import { deferWithTenantContext } from '../utils/tenant-db-scope.js';
 import type { SessionsService } from './sessions';
 
 /**
@@ -1184,6 +1185,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         `Task ${shortId(data.task_id)} has no matching active termination request`
       );
     }
+    const terminationRequest = task.termination_request;
 
     emitServiceEvent(this.app, {
       path: 'tasks',
@@ -1195,19 +1197,25 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
     // Do not await containment here. A local executor must receive this RPC
     // response before it can exit, while the coordinator verifies that process
-    // group only after the wrapper exits. The durable quiescence timestamp
-    // wakes an existing coordinator and also makes this restart/retry safe.
-    void requestExecutorTermination({
-      app: this.app,
-      taskId: task.task_id,
-      cause: task.termination_request.cause,
-      errorMessage: task.termination_request.error_message ?? 'Executor stopped cooperatively.',
-      params: { ...(params ?? {}), provider: undefined },
-    }).catch((error) =>
-      console.error(
-        `[termination] Failed to settle executor report for Task ${shortId(task.task_id)}:`,
-        error
-      )
+    // group only after the wrapper exits. Start recovery after this service
+    // transaction commits and outside its ALS database scope; the durable
+    // quiescence timestamp makes the deferred recovery restart/retry safe.
+    const coordinatorParams = { ...(params ?? {}), provider: undefined };
+    deferWithTenantContext(
+      params,
+      () =>
+        requestExecutorTermination({
+          app: this.app,
+          taskId: task.task_id,
+          cause: terminationRequest.cause,
+          errorMessage: terminationRequest.error_message ?? 'Executor stopped cooperatively.',
+          params: coordinatorParams,
+        }).then(() => undefined),
+      (error) =>
+        console.error(
+          `[termination] Failed to settle executor report for Task ${shortId(task.task_id)}:`,
+          error
+        )
     );
 
     return task;

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -24,6 +24,7 @@
 import type { Application } from '@agor/core/feathers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
+import { executorTaskChannelName } from '../utils/realtime-publish';
 import {
   boardPresenceRoomName,
   configureChannels,
@@ -946,6 +947,9 @@ describe('configureChannels tenant isolation', () => {
     const joins = new Map<string, unknown[]>();
     const leaves = new Map<string, unknown[]>();
     const app = {
+      get channels() {
+        return [...new Set([...joins.keys(), ...leaves.keys()])];
+      },
       on(event: string, fn: (...args: any[]) => void) {
         handlers.set(event, fn);
       },
@@ -1064,6 +1068,81 @@ describe('configureChannels tenant isolation', () => {
     );
 
     expect(joins.get('authenticated')).toEqual([connection]);
+  });
+
+  it('joins only the Task room proven by a verified executor-session login', () => {
+    const { app, handlers, joins } = makeChannelHarness();
+    configureChannels(app);
+    const connection = { data: {} } as any;
+
+    handlers.get('login')?.(
+      {
+        user: { user_id: ALICE },
+        task_id: 'task-1',
+        authentication: {
+          payload: {
+            type: 'executor-session',
+            purpose: 'executor-task',
+            task_id: 'task-1',
+            session_id: 'session-1',
+          },
+        },
+      },
+      { connection }
+    );
+
+    expect(joins.get(executorTaskChannelName('task-1'))).toEqual([connection]);
+  });
+
+  it('does not trust an unscoped login or mismatched result task claim', () => {
+    const { app, handlers, joins } = makeChannelHarness();
+    configureChannels(app);
+    const connection = { data: {} } as any;
+
+    handlers.get('login')?.(
+      {
+        user: { user_id: ALICE },
+        task_id: 'task-2',
+        authentication: {
+          payload: {
+            type: 'executor-session',
+            purpose: 'executor-task',
+            task_id: 'task-1',
+          },
+        },
+      },
+      { connection }
+    );
+
+    expect(joins.has(executorTaskChannelName('task-1'))).toBe(false);
+    expect(joins.has(executorTaskChannelName('task-2'))).toBe(false);
+  });
+
+  it('drops the prior Task room before replacing socket authentication', () => {
+    const { app, handlers, joins, leaves } = makeChannelHarness();
+    configureChannels(app);
+    const connection = { data: {} } as any;
+    const login = (taskId: string) =>
+      handlers.get('login')?.(
+        {
+          user: { user_id: ALICE },
+          task_id: taskId,
+          authentication: {
+            payload: {
+              type: 'executor-session',
+              purpose: 'executor-task',
+              task_id: taskId,
+            },
+          },
+        },
+        { connection }
+      );
+
+    login('task-1');
+    login('task-2');
+
+    expect(joins.get(executorTaskChannelName('task-2'))).toEqual([connection]);
+    expect(leaves.get(executorTaskChannelName('task-1'))).toEqual([connection]);
   });
 
   it('leaves tenant-scoped channels on logout', () => {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -744,6 +744,18 @@ describe('terminal:* handler authorization', () => {
       expect(s.joined.size).toBe(0);
     });
 
+    it('does not expose executor control rooms through the client join event', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      const room = executorTaskChannelName('tenant-a', 'task-1');
+
+      s.handlers.get('join')?.(room);
+
+      expect(s.joined.has(room)).toBe(false);
+    });
+
     it("rejects a user joining another user's terminal channel", () => {
       const { io } = buildHarness();
       const s = makeSocket('alice-sock');
@@ -1072,7 +1084,13 @@ describe('configureChannels tenant isolation', () => {
 
   it('joins only the Task room proven by a verified executor-session login', () => {
     const { app, handlers, joins } = makeChannelHarness();
-    configureChannels(app);
+    configureChannels(app, {
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    });
     const connection = { data: {} } as any;
 
     handlers.get('login')?.(
@@ -1085,18 +1103,21 @@ describe('configureChannels tenant isolation', () => {
             purpose: 'executor-task',
             task_id: 'task-1',
             session_id: 'session-1',
+            tenant_id: 'tenant-a',
           },
         },
       },
       { connection }
     );
 
-    expect(joins.get(executorTaskChannelName('task-1'))).toEqual([connection]);
+    expect(joins.get(executorTaskChannelName('tenant-a', 'task-1'))).toEqual([connection]);
   });
 
   it('does not trust an unscoped login or mismatched result task claim', () => {
     const { app, handlers, joins } = makeChannelHarness();
-    configureChannels(app);
+    configureChannels(app, {
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+    });
     const connection = { data: {} } as any;
 
     handlers.get('login')?.(
@@ -1114,13 +1135,15 @@ describe('configureChannels tenant isolation', () => {
       { connection }
     );
 
-    expect(joins.has(executorTaskChannelName('task-1'))).toBe(false);
-    expect(joins.has(executorTaskChannelName('task-2'))).toBe(false);
+    expect(joins.has(executorTaskChannelName('tenant-a', 'task-1'))).toBe(false);
+    expect(joins.has(executorTaskChannelName('tenant-a', 'task-2'))).toBe(false);
   });
 
   it('drops the prior Task room before replacing socket authentication', () => {
     const { app, handlers, joins, leaves } = makeChannelHarness();
-    configureChannels(app);
+    configureChannels(app, {
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+    });
     const connection = { data: {} } as any;
     const login = (taskId: string) =>
       handlers.get('login')?.(
@@ -1141,8 +1164,8 @@ describe('configureChannels tenant isolation', () => {
     login('task-1');
     login('task-2');
 
-    expect(joins.get(executorTaskChannelName('task-2'))).toEqual([connection]);
-    expect(leaves.get(executorTaskChannelName('task-1'))).toEqual([connection]);
+    expect(joins.get(executorTaskChannelName('tenant-a', 'task-2'))).toEqual([connection]);
+    expect(leaves.get(executorTaskChannelName('tenant-a', 'task-1'))).toEqual([connection]);
   });
 
   it('leaves tenant-scoped channels on logout', () => {

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -1019,9 +1019,14 @@ export function configureChannels(
         executorPayload.task_id.length > 0 &&
         result.task_id === executorPayload.task_id
       ) {
-        joinExecutorTaskChannel(app, executorPayload.task_id, context.connection);
+        // A signed task claim is necessary but not sufficient: namespace the
+        // private room by the tenant resolved from that same authenticated
+        // login, preventing even a pathological cross-tenant Task-ID collision
+        // from crossing the control-plane boundary.
+        if (!tenant) return;
+        joinExecutorTaskChannel(app, tenant.tenant_id, executorPayload.task_id, context.connection);
         console.debug(
-          `🎯 Executor connection joined task control room: ${executorTaskChannelName(executorPayload.task_id)}`
+          `🎯 Executor connection joined task control room: ${executorTaskChannelName(tenant.tenant_id, executorPayload.task_id)}`
         );
       }
     }

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -27,9 +27,15 @@ import type {
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import type { Server, Socket } from 'socket.io';
+import { isExecutorSessionTokenPayload } from '../auth/executor-session-token.js';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 import { isTerminalExecutorIdentity } from '../auth/terminal-executor-guard.js';
-import { leaveAllSessionStreamChannels } from '../utils/realtime-publish.js';
+import {
+  executorTaskChannelName,
+  joinExecutorTaskChannel,
+  leaveAllExecutorTaskChannels,
+  leaveAllSessionStreamChannels,
+} from '../utils/realtime-publish.js';
 import type { BuildInfo } from './build-info.js';
 import type { CorsOrigin } from './cors.js';
 
@@ -953,8 +959,14 @@ export function configureChannels(
       const result = authResult as {
         user?: { user_id?: string; email?: string; tenant_id?: string };
         authentication?: { payload?: unknown };
+        task_id?: string;
       };
       console.debug('✅ Login event fired:', result.user?.user_id, result.user?.email);
+
+      // Authentication can be replaced on an already-open socket. Remove any
+      // prior executor capability before considering the new signed claims, so
+      // a socket can never accumulate control rooms across Tasks.
+      leaveAllExecutorTaskChannels(app, context.connection);
 
       // A terminal-executor identity must NOT receive broadcast events. It only
       // consumes raw `terminal:*` events on its own `user/<id>/terminal` room,
@@ -999,6 +1011,19 @@ export function configureChannels(
             .join(context.connection as never);
         }
       }
+
+      const executorPayload = result.authentication?.payload;
+      if (
+        isExecutorSessionTokenPayload(executorPayload) &&
+        typeof executorPayload.task_id === 'string' &&
+        executorPayload.task_id.length > 0 &&
+        result.task_id === executorPayload.task_id
+      ) {
+        joinExecutorTaskChannel(app, executorPayload.task_id, context.connection);
+        console.debug(
+          `🎯 Executor connection joined task control room: ${executorTaskChannelName(executorPayload.task_id)}`
+        );
+      }
     }
   });
 
@@ -1013,6 +1038,7 @@ export function configureChannels(
 
       // Remove from authenticated channel - no more broadcast events
       app.channel('authenticated').leave(context.connection as never);
+      leaveAllExecutorTaskChannels(app, context.connection);
       if (tenant) {
         app.channel(tenantChannelName(tenant.tenant_id)).leave(context.connection as never);
         if (userId) {

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -41,7 +41,10 @@ function appDouble(tool = 'codex') {
       return { outcome, task: value };
     });
   };
-  return { app, claim, settle, claimTermination, settleTermination, sessionGet };
+  const setCurrent = (value: ReturnType<typeof task>) => {
+    current = value;
+  };
+  return { app, claim, settle, setCurrent, claimTermination, settleTermination, sessionGet };
 }
 
 const stopping = (cause: 'user_stop' | 'sdk_health_failure' | 'heartbeat_lost') =>
@@ -84,6 +87,80 @@ describe('termination coordinator', () => {
       task: { status: TaskStatus.STOPPED },
     });
     expect(untrackExecutorProcess).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a scoped remote executor quiescence report without local signaling', async () => {
+    const state = appDouble();
+    const remoteStopping = {
+      ...stopping('user_stop'),
+      executor_mode: 'templated',
+      executor_connected_at: '2026-01-01T00:00:00.000Z',
+      termination_request: {
+        ...stopping('user_stop').termination_request,
+        executor_quiesced_at: '2026-01-01T00:00:01.100Z',
+      },
+    };
+    state.claim(remoteStopping);
+    state.settle(task(TaskStatus.STOPPED));
+
+    await expect(request(state.app, 'user_stop')).resolves.toMatchObject({
+      status: 'terminal',
+      task: { status: TaskStatus.STOPPED },
+    });
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+  });
+
+  it('observes a remote socket-stop report during the cooperative grace window', async () => {
+    const state = appDouble();
+    const remoteStopping = {
+      ...stopping('user_stop'),
+      executor_mode: 'templated',
+      executor_connected_at: '2026-01-01T00:00:00.000Z',
+    };
+    state.claim(remoteStopping);
+    state.settle(task(TaskStatus.STOPPED));
+
+    const result = requestExecutorTermination({
+      app: state.app,
+      taskId,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user',
+      cooperativeGraceMs: 100,
+    });
+    setTimeout(() => {
+      state.setCurrent({
+        ...remoteStopping,
+        termination_request: {
+          ...remoteStopping.termination_request,
+          executor_quiesced_at: '2026-01-01T00:00:01.100Z',
+        },
+      });
+    }, 5);
+
+    await expect(result).resolves.toMatchObject({ status: 'terminal' });
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+  });
+
+  it('still verifies local process absence after executor quiescence', async () => {
+    containExecutorProcess.mockResolvedValue({ status: 'verified_absent' });
+    const state = appDouble();
+    const localStopping = {
+      ...stopping('user_stop'),
+      executor_mode: 'local',
+      executor_connected_at: '2026-01-01T00:00:00.000Z',
+      termination_request: {
+        ...stopping('user_stop').termination_request,
+        executor_quiesced_at: '2026-01-01T00:00:01.100Z',
+      },
+    };
+    state.claim(localStopping);
+    state.settle(task(TaskStatus.STOPPED));
+
+    await request(state.app, 'user_stop');
+
+    expect(containExecutorProcess).toHaveBeenCalledWith(sessionId, taskId, {
+      preSignalGraceMs: 250,
+    });
   });
 
   it('contains a terminal task before releasing its tracked executor', async () => {

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -25,6 +25,8 @@ export interface TerminationInput {
   errorMessage: string;
   params?: Params;
   signalDelayMs?: number;
+  /** Test/configuration seam for the cooperative socket-stop grace window. */
+  cooperativeGraceMs?: number;
   absenceVerified?: boolean;
   sdkFailure?: SdkFailure;
   expectedStatus?: Task['status'];
@@ -34,6 +36,9 @@ export interface TerminationInput {
 }
 
 const operations = new Map<string, Promise<TerminationResult>>();
+const DEFAULT_COOPERATIVE_GRACE_MS = 1000;
+const COOPERATIVE_POLL_MS = 25;
+const LOCAL_WRAPPER_EXIT_GRACE_MS = 250;
 
 function internalParams(params?: Params): Params {
   return { ...(params ?? {}), provider: undefined };
@@ -72,24 +77,72 @@ async function loadAgenticTool(input: TerminationInput): Promise<AgenticToolName
   return session.agentic_tool;
 }
 
+async function waitForExecutorQuiescence(input: TerminationInput, requested: Task): Promise<Task> {
+  if (
+    !requested.executor_connected_at ||
+    requested.termination_request?.executor_quiesced_at ||
+    isTerminalTaskStatus(requested.status)
+  ) {
+    return requested;
+  }
+
+  const graceMs = input.signalDelayMs ?? input.cooperativeGraceMs ?? DEFAULT_COOPERATIVE_GRACE_MS;
+  if (graceMs <= 0) return requested;
+
+  const tasks = input.app.service('tasks');
+  const requestedAt = requested.termination_request?.requested_at;
+  const deadline = Date.now() + graceMs;
+  let current = requested;
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, Math.min(COOPERATIVE_POLL_MS, Math.max(0, deadline - Date.now())))
+    );
+    current = await tasks.get(requested.task_id, internalParams(input.params));
+    if (
+      isTerminalTaskStatus(current.status) ||
+      current.status !== TaskStatus.STOPPING ||
+      current.termination_request?.requested_at !== requestedAt ||
+      current.termination_request?.executor_quiesced_at
+    ) {
+      return current;
+    }
+  }
+  return current;
+}
+
 async function runContainment(
   input: TerminationInput,
   requested: Task,
   tool: AgenticToolName
 ): Promise<TerminationResult> {
   const tasks = input.app.service('tasks') as unknown as TasksServiceImpl;
-  if (input.signalDelayMs) {
-    await new Promise<void>((resolve) => setTimeout(resolve, input.signalDelayMs));
+  const current = await waitForExecutorQuiescence(input, requested);
+  if (
+    current.status !== requested.status &&
+    current.status !== TaskStatus.STOPPING &&
+    !isTerminalTaskStatus(current.status)
+  ) {
+    return { status: 'condition_changed', task: current };
   }
+  const executorQuiesced = !!current.termination_request?.executor_quiesced_at;
+  // A scoped remote executor is the only component able to authoritatively
+  // quiesce its SDK runtime. Local mode additionally verifies PGID absence.
+  const remoteCooperativeContainment = current.executor_mode === 'templated' && executorQuiesced;
   const containment = input.absenceVerified
     ? ({ status: 'verified_absent' } as const)
-    : await containExecutorProcess(requested.session_id, requested.task_id);
-  if (isTerminalTaskStatus(requested.status)) {
+    : remoteCooperativeContainment
+      ? ({ status: 'verified_absent' } as const)
+      : executorQuiesced
+        ? await containExecutorProcess(current.session_id, current.task_id, {
+            preSignalGraceMs: LOCAL_WRAPPER_EXIT_GRACE_MS,
+          })
+        : await containExecutorProcess(current.session_id, current.task_id);
+  if (isTerminalTaskStatus(current.status)) {
     if (containment.status === 'unverified') {
-      return { status: 'unverified', task: requested, reason: containment.reason };
+      return { status: 'unverified', task: current, reason: containment.reason };
     }
-    untrackExecutorProcess(requested.session_id, requested.task_id);
-    return { status: 'terminal', task: requested };
+    untrackExecutorProcess(current.session_id, current.task_id);
+    return { status: 'terminal', task: current };
   }
   const providerUnverified = tool === 'opencode';
   if (containment.status === 'unverified' || providerUnverified) {
@@ -97,21 +150,21 @@ async function runContainment(
       containment.status === 'unverified'
         ? containment.reason
         : 'OpenCode server-side execution termination is not verified.';
-    const diagnosis: SdkFailure = requested.sdk_failure
-      ? { ...requested.sdk_failure, termination: 'unverified' }
+    const diagnosis: SdkFailure = current.sdk_failure
+      ? { ...current.sdk_failure, termination: 'unverified' }
       : {
           reason: 'termination_unverified',
           detected_at: new Date().toISOString(),
           tool,
-          last_pulse: requested.latest_executor_pulse,
+          last_pulse: current.latest_executor_pulse,
           termination: 'unverified',
         };
     const settlement = await tasks.settleTermination(
       {
-        taskId: requested.task_id,
+        taskId: current.task_id,
         outcome: 'unverified',
         sdkFailure: diagnosis,
-        errorMessage: unverifiedMessage(requested.task_id, reason),
+        errorMessage: unverifiedMessage(current.task_id, reason),
       },
       { ...internalParams(input.params), suppressTerminalQueueProcessing: true } as Params
     );
@@ -126,7 +179,7 @@ async function runContainment(
 
   const settlement = await tasks.settleTermination(
     {
-      taskId: requested.task_id,
+      taskId: current.task_id,
       outcome: 'verified_absent',
       errorMessage: input.errorMessage,
     },

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -80,13 +80,14 @@ describe('configureRealtimePublish executor control scope', () => {
   it('routes termination only to the private room for that Task', async () => {
     const browser = { user: user('browser') };
     const executor = { user: user('executor') };
-    const room = executorTaskChannelName('task-1');
+    const room = executorTaskChannelName('tenant-a', 'task-1');
     const app = makeApp([browser, executor], {}, { [room]: [executor] });
     configureRealtimePublish({
       app,
       branchRbacEnabled: false,
       branchRepository: {} as never,
       sessionsRepository: {} as never,
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
     });
 
     const result = (await app.runPublish(
@@ -110,6 +111,7 @@ describe('configureRealtimePublish executor control scope', () => {
       branchRbacEnabled: false,
       branchRepository: {} as never,
       sessionsRepository: {} as never,
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
     });
 
     await expect(
@@ -123,7 +125,32 @@ describe('configureRealtimePublish executor control scope', () => {
         }
       )
     ).resolves.toEqual([]);
-    expect(app.channels).not.toContain(executorTaskChannelName('task-1'));
+    expect(app.channels).not.toContain(executorTaskChannelName('tenant-a', 'task-1'));
+  });
+
+  it('does not deliver a tenant A Stop to the same Task room in tenant B', async () => {
+    const tenantBExecutor = { user: user('executor-b') };
+    const tenantBRoom = executorTaskChannelName('tenant-b', 'task-1');
+    const app = makeApp([tenantBExecutor], {}, { [tenantBRoom]: [tenantBExecutor] });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      branchRepository: {} as never,
+      sessionsRepository: {} as never,
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+    });
+
+    await expect(
+      app.runPublish(
+        { task_id: 'task-1', status: 'stopping' },
+        {
+          path: 'tasks',
+          method: 'patch',
+          event: 'termination_requested',
+          params: {},
+        }
+      )
+    ).resolves.toEqual([]);
   });
 });
 

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -12,6 +12,7 @@ import type {
 } from './realtime-access-cache';
 import {
   configureRealtimePublish,
+  executorTaskChannelName,
   leaveAllSessionStreamChannels,
   markConnectionSessionStreamsAware,
 } from './realtime-publish';
@@ -74,6 +75,57 @@ function session(id: string, branchId: string): Session {
 }
 
 const scopeOnlyDb = { run: vi.fn() } as unknown as TenantScopeAwareDatabase;
+
+describe('configureRealtimePublish executor control scope', () => {
+  it('routes termination only to the private room for that Task', async () => {
+    const browser = { user: user('browser') };
+    const executor = { user: user('executor') };
+    const room = executorTaskChannelName('task-1');
+    const app = makeApp([browser, executor], {}, { [room]: [executor] });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      branchRepository: {} as never,
+      sessionsRepository: {} as never,
+    });
+
+    const result = (await app.runPublish(
+      { task_id: 'task-1', status: 'stopping' },
+      {
+        path: 'tasks',
+        method: 'patch',
+        event: 'termination_requested',
+        params: {},
+      }
+    )) as unknown as FakeChannel[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.connections).toEqual([executor]);
+  });
+
+  it('does not materialize a room when Stop wins before executor connect', async () => {
+    const app = makeApp([]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      branchRepository: {} as never,
+      sessionsRepository: {} as never,
+    });
+
+    await expect(
+      app.runPublish(
+        { task_id: 'task-1', status: 'stopping' },
+        {
+          path: 'tasks',
+          method: 'patch',
+          event: 'termination_requested',
+          params: {},
+        }
+      )
+    ).resolves.toEqual([]);
+    expect(app.channels).not.toContain(executorTaskChannelName('task-1'));
+  });
+});
 
 function repos(options: {
   branch: Branch;

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -40,8 +40,8 @@ const EXECUTOR_TASK_CHANNEL_PREFIX = 'executor-task:';
  * an `executor-session` token whose signed `task_id` matches the room. There is
  * no client-callable subscribe method.
  */
-export function executorTaskChannelName(taskId: string): string {
-  return `${EXECUTOR_TASK_CHANNEL_PREFIX}${taskId}`;
+export function executorTaskChannelName(tenantId: string, taskId: string): string {
+  return `${EXECUTOR_TASK_CHANNEL_PREFIX}${tenantId}:${taskId}`;
 }
 
 export function sessionStreamChannelName(sessionId: string): string {
@@ -76,10 +76,11 @@ export function leaveAllExecutorTaskChannels(app: Application, connection: unkno
 /** Join the private executor control room after the signed task claim is verified. */
 export function joinExecutorTaskChannel(
   app: Application,
+  tenantId: string,
   taskId: string,
   connection: unknown
 ): void {
-  app.channel(executorTaskChannelName(taskId)).join(connection as never);
+  app.channel(executorTaskChannelName(tenantId, taskId)).join(connection as never);
 }
 
 /**
@@ -628,17 +629,11 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     // from a server-verified executor-session JWT. Do not materialize an empty
     // room on publish: a Stop before executor connect is recovered from the
     // durable Task state when connectExecutor/reauthentication runs.
-    if (context.path === 'tasks' && context.event === 'termination_requested') {
-      const taskId = extractTaskId(data);
-      if (!taskId) return [];
-      const room = existingChannel(app, executorTaskChannelName(taskId));
-      return room ? [room] : [];
-    }
-
     let tenantScoped = authenticated;
+    let tenantId: string | undefined;
     if (multiTenancy) {
       try {
-        const tenantId = resolveRealtimeTenantId(multiTenancy, context);
+        tenantId = resolveRealtimeTenantId(multiTenancy, context);
         tenantScoped = app.channel(tenantChannelName(tenantId));
       } catch (error) {
         if (error instanceof TenantResolutionError) {
@@ -651,6 +646,16 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
         }
         throw error;
       }
+    }
+
+    if (context.path === 'tasks' && context.event === 'termination_requested') {
+      const taskId = extractTaskId(data);
+      // Production always supplies resolved multi-tenancy config. Fail closed
+      // rather than falling back to a cross-tenant task-only room if either
+      // identity is unexpectedly absent.
+      if (!tenantId || !taskId) return [];
+      const room = existingChannel(app, executorTaskChannelName(tenantId, taskId));
+      return room ? [room] : [];
     }
     const resolveDelivery = async () => {
       // Streaming events are routed to session subscribers (plus service and
@@ -708,7 +713,6 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     // active by the time RBAC visibility repositories run. Re-enter the scope
     // resolved for channel routing so the authorization lookup and delivery
     // decision use the same tenant as the event.
-    const tenantId = multiTenancy ? resolveRealtimeTenantId(multiTenancy, context) : undefined;
     return db && tenantId
       ? runWithTenantDatabaseScope(db, tenantId, resolveDelivery)
       : resolveDelivery();

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -30,6 +30,19 @@ function tenantChannelName(tenantId: string): string {
  * `sessions.get`.
  */
 const SESSION_STREAM_CHANNEL_PREFIX = 'session-stream:';
+const EXECUTOR_TASK_CHANNEL_PREFIX = 'executor-task:';
+
+/**
+ * Private control-plane room for the one executor JWT scoped to a Task.
+ *
+ * Unlike normal Task events, membership is not derived from branch visibility:
+ * configureChannels joins this room only after ServiceJWTStrategy has verified
+ * an `executor-session` token whose signed `task_id` matches the room. There is
+ * no client-callable subscribe method.
+ */
+export function executorTaskChannelName(taskId: string): string {
+  return `${EXECUTOR_TASK_CHANNEL_PREFIX}${taskId}`;
+}
 
 export function sessionStreamChannelName(sessionId: string): string {
   return `${SESSION_STREAM_CHANNEL_PREFIX}${sessionId}`;
@@ -49,6 +62,24 @@ export function leaveAllSessionStreamChannels(app: Application, connection: unkn
       app.channel(name).leave(connection as never);
     }
   }
+}
+
+/** Drop task-control capability on logout or before replacing socket auth. */
+export function leaveAllExecutorTaskChannels(app: Application, connection: unknown): void {
+  for (const name of app.channels ?? []) {
+    if (name.startsWith(EXECUTOR_TASK_CHANNEL_PREFIX)) {
+      app.channel(name).leave(connection as never);
+    }
+  }
+}
+
+/** Join the private executor control room after the signed task claim is verified. */
+export function joinExecutorTaskChannel(
+  app: Application,
+  taskId: string,
+  connection: unknown
+): void {
+  app.channel(executorTaskChannelName(taskId)).join(connection as never);
 }
 
 /**
@@ -591,6 +622,19 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     }
 
     const authenticated = app.channel('authenticated');
+
+    // This is an executor control-plane event, not a branch-visible data
+    // broadcast. The only possible recipients are sockets placed in this room
+    // from a server-verified executor-session JWT. Do not materialize an empty
+    // room on publish: a Stop before executor connect is recovered from the
+    // durable Task state when connectExecutor/reauthentication runs.
+    if (context.path === 'tasks' && context.event === 'termination_requested') {
+      const taskId = extractTaskId(data);
+      if (!taskId) return [];
+      const room = existingChannel(app, executorTaskChannelName(taskId));
+      return room ? [room] : [];
+    }
+
     let tenantScoped = authenticated;
     if (multiTenancy) {
       try {

--- a/apps/agor-daemon/src/utils/stop-route-repositories.ts
+++ b/apps/agor-daemon/src/utils/stop-route-repositories.ts
@@ -1,0 +1,28 @@
+import {
+  type BranchRepository,
+  bindRepositoryToTenantUnitOfWork,
+  type TaskRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+
+export interface StopRouteRepositories {
+  taskRepo: Pick<TaskRepository, 'findQueued'>;
+  branchRepo: Pick<BranchRepository, 'isOwner'>;
+}
+
+/**
+ * Direct repository access used by the identity-only Stop route.
+ *
+ * Service calls establish tenant scopes through their hooks. These repository
+ * calls do not, so each must run in its own short tenant unit of work rather
+ * than relying on a route-wide transaction.
+ */
+export function bindStopRouteRepositories(
+  db: TenantScopeAwareDatabase,
+  repositories: StopRouteRepositories
+): StopRouteRepositories {
+  return {
+    taskRepo: bindRepositoryToTenantUnitOfWork(db, repositories.taskRepo),
+    branchRepo: bindRepositoryToTenantUnitOfWork(db, repositories.branchRepo),
+  };
+}

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -1045,13 +1045,23 @@ SDK activity facts share the existing executor heartbeat transport. Disabling
 diagnostics and the stale-wrapper backstop, but the executor-local watchdog and
 its direct failure report remain active.
 
-For locally spawned executors, enforced failures and user Stop wait for bounded
-process-group termination and absence verification before the session becomes
-promptable. This can add the configured grace and signal-escalation latency.
-Templated/remote execution that cannot prove absence remains visible and blocked
-until a branch owner or administrator explicitly force-fails it. After an abrupt
-daemon restart, Agor keeps its existing orphan cleanup behavior; diagnostics
-disclose that logical release does not prove remote process termination.
+User Stop first persists the Task's `stopping` state. That normal realtime Task
+patch travels over the executor's authenticated WebSocket, so the executor can
+abort its SDK and run provider cleanup regardless of which host or pod runs the
+daemon. Reconnecting executors read the durable Task state instead of relying on
+an ephemeral cancellation event. The executor reports quiescence only after its
+SDK and stop hooks return.
+
+For locally spawned executors, Agor additionally verifies process-group absence
+before the session becomes promptable; a short cooperative grace is followed by
+SIGTERM/SIGKILL only when the wrapper does not exit itself. A scoped remote
+executor's quiescence report is the authoritative cooperative result because
+the daemon cannot inspect a process group on another host. Missing reports still
+flow through the heartbeat supervisor and remain visible and blocked rather
+than being treated as proof of termination. OpenCode server-side execution also
+remains unverified. After an abrupt daemon restart, Agor keeps its existing
+orphan cleanup behavior; diagnostics disclose that logical release does not
+prove remote process termination.
 
 ### Step 5: Test Single Executor
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -130,6 +130,16 @@ describe('SessionFooter', () => {
     expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
   });
 
+  it('shows stopping feedback immediately while the Stop request is in flight', () => {
+    const { container } = render(
+      <SessionFooter {...baseProps} isRunning={true} stopRequestInFlight={true} />,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByRole('button', { name: /stop/i })).toBeDisabled();
+    expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+    expect(container.querySelector('[data-icon="stop"]')).not.toBeInTheDocument();
+  });
+
   it('Model chip is hidden when no model is present', () => {
     render(
       <SessionFooter

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1240,7 +1240,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   );
 
   const stopTooltip = stopRequestInFlight
-    ? 'Sending stop request...'
+    ? 'Stopping...'
     : isStopping
       ? 'Stopping... (Click again to retry if stuck)'
       : 'Stop Execution';
@@ -1607,7 +1607,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                   danger
                   size="small"
                   icon={
-                    isStopping && !stopRequestInFlight ? <Spin size="small" /> : <StopOutlined />
+                    stopRequestInFlight || isStopping ? <Spin size="small" /> : <StopOutlined />
                   }
                   onClick={onStop}
                   disabled={!isRunning || stopRequestInFlight}

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -623,6 +623,7 @@ describe('createClient', () => {
       };
       expect(tasksService.methods).toHaveBeenCalledWith(
         'connectExecutor',
+        'reportTerminationComplete',
         'reportRuntimeTelemetry',
         'reportSdkHealthFailure'
       );

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -328,6 +328,11 @@ export interface SessionsService extends AgorService<Session, CreatePayload<Crea
 export interface TasksService extends AgorService<Task> {
   /** Claim a daemon-dispatched task after executor authentication. */
   connectExecutor(data: { task_id: string }, params?: Params): Promise<Task>;
+  /** Report that a requested cooperative stop has fully quiesced SDK work. */
+  reportTerminationComplete(
+    data: import('../types/task').ExecutorTerminationCompleteInput,
+    params?: Params
+  ): Promise<Task>;
   /** Report daemon-stamped wrapper liveness and the latest coalesced SDK pulse. */
   reportRuntimeTelemetry(data: RuntimeTelemetryInput, params?: Params): Promise<Task>;
   /** Report a daemon-authorized SDK watchdog decision. */
@@ -918,7 +923,12 @@ function extendTasksService(client: AgorClient): void {
   };
   if (tasksService[TASKS_SERVICE_EXTENDED]) return;
   if (typeof tasksService.methods === 'function') {
-    tasksService.methods('connectExecutor', 'reportRuntimeTelemetry', 'reportSdkHealthFailure');
+    tasksService.methods(
+      'connectExecutor',
+      'reportTerminationComplete',
+      'reportRuntimeTelemetry',
+      'reportSdkHealthFailure'
+    );
   }
   tasksService[TASKS_SERVICE_EXTENDED] = true;
 }

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1261,6 +1261,50 @@ describe('TaskRepository.update', () => {
     ).toBe('terminal');
   });
 
+  dbTest('records only the current termination request as executor-quiesced', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const task = await taskRepo.create(
+      createTaskData({
+        session_id: sessionId,
+        status: TaskStatus.RUNNING,
+        executor_connected_at: '2026-07-10T20:00:00.000Z',
+      })
+    );
+    const claim = await taskRepo.claimTermination({
+      taskId: task.task_id,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user',
+      now: new Date('2026-07-10T20:01:00.000Z'),
+    });
+    const requestedAt = claim.task.termination_request!.requested_at;
+
+    expect(
+      await taskRepo.recordExecutorQuiescence({
+        task_id: task.task_id,
+        requested_at: '2026-07-10T19:59:00.000Z',
+      })
+    ).toBeNull();
+
+    const reported = await taskRepo.recordExecutorQuiescence(
+      { task_id: task.task_id, requested_at: requestedAt },
+      new Date('2026-07-10T20:01:00.125Z')
+    );
+    expect(reported).toMatchObject({
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        requested_at: requestedAt,
+        executor_quiesced_at: '2026-07-10T20:01:00.125Z',
+      },
+    });
+    expect(
+      await taskRepo.recordExecutorQuiescence(
+        { task_id: task.task_id, requested_at: requestedAt },
+        new Date('2026-07-10T20:01:01.000Z')
+      )
+    ).toEqual(reported);
+  });
+
   dbTest(
     'releases a stopping task after restart without claiming verified absence',
     async ({ db }) => {

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -6,6 +6,7 @@
 
 import type {
   ExecutorPulse,
+  ExecutorTerminationCompleteInput,
   SdkFailure,
   SessionID,
   Task,
@@ -576,6 +577,40 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     });
   }
 
+  /**
+   * Persist the scoped executor's cooperative-stop completion.
+   *
+   * The request timestamp fences delayed reports, while the row lock makes the
+   * report idempotent against duplicate socket delivery/reconnect recovery.
+   */
+  async recordExecutorQuiescence(
+    input: ExecutorTerminationCompleteInput,
+    observedAt = new Date()
+  ): Promise<Task | null> {
+    return this.mutateLockedTask(input.task_id, async (txDb, row, fullId) => {
+      const current = this.rowToTask(row);
+      const request = current.termination_request;
+      if (
+        current.status !== TaskStatus.STOPPING ||
+        !request ||
+        request.requested_at !== input.requested_at
+      ) {
+        return null;
+      }
+      if (request.executor_quiesced_at) return current;
+
+      const data = {
+        ...row.data,
+        termination_request: {
+          ...request,
+          executor_quiesced_at: observedAt.toISOString(),
+        },
+      };
+      await update(txDb, tasks).set({ data }).where(eq(tasks.task_id, fullId)).run();
+      return this.rowToTask({ ...row, data });
+    });
+  }
+
   /** Record observe-only SDK health evidence only while the executor still owns the task. */
   async recordSdkHealthObservation(id: string, failure: SdkFailure): Promise<Task | null> {
     return this.mutateLockedTask(id, async (txDb, row, fullId) => {
@@ -622,6 +657,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
           cause === input.cause
             ? input.errorMessage
             : (existing?.error_message ?? input.errorMessage),
+        ...(existing?.executor_quiesced_at
+          ? { executor_quiesced_at: existing.executor_quiesced_at }
+          : {}),
       };
       const sdkFailure = incomingWins
         ? (input.sdkFailure ?? current.sdk_failure)

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -86,6 +86,19 @@ export interface TerminationRequest {
   requested_at: string;
   /** Failure/stop reason captured with the winning claim. */
   error_message?: string;
+  /**
+   * Daemon-authored time at which the scoped executor reported that its SDK
+   * work and stop hooks had fully quiesced. For remote executors this is the
+   * authoritative cooperative-containment result; local executors still get
+   * process-group absence verification before the session becomes promptable.
+   */
+  executor_quiesced_at?: string;
+}
+
+export interface ExecutorTerminationCompleteInput {
+  task_id: string;
+  /** Fences a late report from a previous termination request. */
+  requested_at: string;
 }
 
 /**

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -115,6 +115,9 @@ describe('executeToolTask credential preflight', () => {
         if (name === 'sessions') {
           return { get: vi.fn().mockRejectedValue(new Error('no git state in unit test')) };
         }
+        if (name === 'messages' || name === 'tasks' || name === '/tasks/streaming') {
+          return {};
+        }
         throw new Error(`unexpected service ${name}`);
       },
     } as never;
@@ -143,6 +146,54 @@ describe('executeToolTask credential preflight', () => {
         },
       })
     );
+  });
+
+  it('does not launch provider work when cancellation arrives before tool execution', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const stopTask = vi.fn().mockResolvedValue({ success: true });
+    const executePromptWithStreaming = vi.fn();
+    const createTool = vi.fn(() => ({
+      stopTask,
+      executePromptWithStreaming,
+    }));
+    const client = {
+      service(name: string) {
+        if (name === 'config/resolve-api-key') {
+          return {
+            create: vi.fn().mockResolvedValue({
+              apiKey: 'daemon-key',
+              source: 'user',
+              useNativeAuth: false,
+            }),
+          };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn().mockRejectedValue(new Error('no git state in unit test')) };
+        }
+        if (name === 'messages' || name === 'tasks' || name === '/tasks/streaming') {
+          return {};
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      executeToolTask({
+        client,
+        sessionId: 'session-1' as never,
+        taskId: 'task-1' as never,
+        prompt: 'hello',
+        abortController,
+        apiKeyEnvVar: 'GEMINI_API_KEY',
+        toolName: 'gemini',
+        createTool,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(createTool).toHaveBeenCalledOnce();
+    expect(stopTask).toHaveBeenCalledWith('session-1', 'task-1');
+    expect(executePromptWithStreaming).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -27,9 +27,8 @@ import { createFeathersBackedRepositories } from '../../db/feathers-repositories
 import { getCurrentBranch, getGitState } from '../../git/index.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
-import { isSdkHealthAbort } from '../../sdk-watchdog.js';
 import type { AgorClient } from '../../services/feathers-client.js';
-import { isCoordinatorTerminationAbort } from '../../termination-state.js';
+import { isDaemonOwnedAbort } from '../../termination-state.js';
 import { configureSessionGitSafeDirectories } from './git-safe-directory.js';
 
 const DEBUG_SDK_EXECUTOR =
@@ -421,9 +420,7 @@ export async function executeToolTask(params: {
 }): Promise<void> {
   const { client, sessionId, taskId, prompt, permissionMode, apiKeyEnvVar, toolName, createTool } =
     params;
-  const coordinatorOwnsTerminality = () =>
-    isSdkHealthAbort(params.abortController) ||
-    isCoordinatorTerminationAbort(params.abortController);
+  const daemonOwnsTerminality = () => isDaemonOwnedAbort(params.abortController);
 
   console.log(`[${toolName}] Executing task ${shortId(taskId)}...`);
 
@@ -505,6 +502,10 @@ export async function executeToolTask(params: {
     // Handle race condition: if signal is already aborted, call handler immediately
     if (params.abortController.signal.aborted) {
       await abortHandler();
+      // Cancellation may arrive during git setup or credential resolution,
+      // before the provider has registered any active work for stopTask().
+      // Never launch fresh SDK work after that durable cancellation.
+      return;
     }
 
     // Listen for abort signal
@@ -522,7 +523,7 @@ export async function executeToolTask(params: {
       params.messageSource
     );
 
-    if (coordinatorOwnsTerminality()) return;
+    if (daemonOwnsTerminality()) return;
 
     console.log(
       `[${toolName}] Execution completed: user=${result.userMessageId}, assistant=${result.assistantMessageIds.length} messages`
@@ -633,7 +634,7 @@ export async function executeToolTask(params: {
     // The tasks.ts patch hook guards against double-updates (wasAlreadyTerminal check).
     await client.service('tasks').patch(taskId, patchData);
   } catch (error) {
-    if (coordinatorOwnsTerminality()) return;
+    if (daemonOwnsTerminality()) return;
     const err = error instanceof Error ? error : new Error(String(error));
     console.error(`[${toolName}] Execution failed:`, err);
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -29,6 +29,7 @@ import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import { isSdkHealthAbort } from '../../sdk-watchdog.js';
 import type { AgorClient } from '../../services/feathers-client.js';
+import { isCoordinatorTerminationAbort } from '../../termination-state.js';
 import { configureSessionGitSafeDirectories } from './git-safe-directory.js';
 
 const DEBUG_SDK_EXECUTOR =
@@ -420,11 +421,14 @@ export async function executeToolTask(params: {
 }): Promise<void> {
   const { client, sessionId, taskId, prompt, permissionMode, apiKeyEnvVar, toolName, createTool } =
     params;
-  const coordinatorOwnsTerminality = () => isSdkHealthAbort(params.abortController);
+  const coordinatorOwnsTerminality = () =>
+    isSdkHealthAbort(params.abortController) ||
+    isCoordinatorTerminationAbort(params.abortController);
 
   console.log(`[${toolName}] Executing task ${shortId(taskId)}...`);
 
   let abortHandler: (() => Promise<void>) | undefined;
+  let abortCompletion: Promise<void> | undefined;
 
   try {
     // Ensure plain git commands launched by the agent SDK inherit safe.directory
@@ -475,24 +479,27 @@ export async function executeToolTask(params: {
     // Pass the resolved key (or empty string) and useNativeAuth flag
     const tool = createTool(ctx.repos, resolution.apiKey || '', resolution.useNativeAuth);
 
-    // Wire up abort signal to tool's stopTask method.
-    // Triggered by SIGTERM handler calling abortController.abort().
-    abortHandler = async () => {
-      console.log(`[${toolName}] Abort signal received, calling tool.stopTask()...`);
-      if (tool.stopTask) {
-        try {
-          const stopResult = await tool.stopTask(sessionId, taskId);
-          if (stopResult.success) {
-            console.log(`[${toolName}] Tool stopped successfully`);
-          } else {
-            console.warn(`[${toolName}] Tool stop failed: ${stopResult.reason}`);
+    // Wire up abort signal to tool's stopTask method. The primary path is a
+    // durable STOPPING patch over the socket; SIGTERM remains a fallback.
+    abortHandler = () => {
+      abortCompletion ??= (async () => {
+        console.log(`[${toolName}] Abort signal received, calling tool.stopTask()...`);
+        if (tool.stopTask) {
+          try {
+            const stopResult = await tool.stopTask(sessionId, taskId);
+            if (stopResult.success) {
+              console.log(`[${toolName}] Tool stopped successfully`);
+            } else {
+              console.warn(`[${toolName}] Tool stop failed: ${stopResult.reason}`);
+            }
+          } catch (error) {
+            console.error(`[${toolName}] Error calling stopTask:`, error);
           }
-        } catch (error) {
-          console.error(`[${toolName}] Error calling stopTask:`, error);
+        } else {
+          console.warn(`[${toolName}] Tool does not implement stopTask method`);
         }
-      } else {
-        console.warn(`[${toolName}] Tool does not implement stopTask method`);
-      }
+      })();
+      return abortCompletion;
     };
 
     // Handle race condition: if signal is already aborted, call handler immediately
@@ -691,5 +698,8 @@ export async function executeToolTask(params: {
     if (abortHandler) {
       params.abortController.signal.removeEventListener('abort', abortHandler);
     }
+    // AbortSignal dispatch does not await async listeners. Do not report the
+    // executor quiesced until the provider-specific stop hook has completed.
+    await abortCompletion;
   }
 }

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -189,6 +189,14 @@ describe('AgorExecutor watchdog handoff', () => {
         requested_at: '2026-07-23T12:00:00.000Z',
       },
     });
+    listeners.get('tasks:termination_requested')?.({
+      task_id: 'task-1',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
 
     expect(executor.abortController.signal.aborted).toBe(true);
     expect(heartbeatStop).toHaveBeenCalledOnce();

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -148,4 +148,49 @@ describe('AgorExecutor watchdog handoff', () => {
       requested_at: '2026-07-23T12:00:00.000Z',
     });
   });
+
+  it('handles the private task-scoped termination socket event', () => {
+    const listeners = new Map<string, (data: unknown) => void>();
+    const heartbeatStop = vi.fn();
+    const executor = new AgorExecutor({
+      sessionToken: 'token',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      prompt: 'prompt',
+      tool: 'codex',
+      daemonUrl: 'http://daemon',
+    }) as unknown as {
+      client: {
+        service(path: string): {
+          on(event: string, listener: (data: unknown) => void): void;
+        };
+      };
+      heartbeat: { stop: typeof heartbeatStop } | null;
+      abortController: AbortController;
+      setupEventListeners(): void;
+    };
+    executor.client = {
+      service(path) {
+        return {
+          on(event, listener) {
+            listeners.set(`${path}:${event}`, listener);
+          },
+        };
+      },
+    };
+    executor.heartbeat = { stop: heartbeatStop };
+    executor.setupEventListeners();
+
+    listeners.get('tasks:termination_requested')?.({
+      task_id: 'task-1',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
+
+    expect(executor.abortController.signal.aborted).toBe(true);
+    expect(heartbeatStop).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -108,4 +108,44 @@ describe('AgorExecutor watchdog handoff', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(exit).toHaveBeenCalledWith(70);
   });
+
+  it('aborts immediately on the durable stopping patch and reports quiescence', async () => {
+    const reportTerminationComplete = vi.fn().mockResolvedValue({});
+    const heartbeatStop = vi.fn();
+    const executor = new AgorExecutor({
+      sessionToken: 'token',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      prompt: 'prompt',
+      tool: 'codex',
+      daemonUrl: 'http://daemon',
+    }) as unknown as {
+      client: {
+        service: () => { reportTerminationComplete: typeof reportTerminationComplete };
+      };
+      heartbeat: { stop: typeof heartbeatStop } | null;
+      abortController: AbortController;
+      handleTaskLifecycleUpdate(task: unknown): void;
+      reportTerminationComplete(): Promise<void>;
+    };
+    executor.client = { service: () => ({ reportTerminationComplete }) };
+    executor.heartbeat = { stop: heartbeatStop };
+
+    executor.handleTaskLifecycleUpdate({
+      task_id: 'task-1',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
+
+    expect(executor.abortController.signal.aborted).toBe(true);
+    expect(heartbeatStop).toHaveBeenCalledOnce();
+    await executor.reportTerminationComplete();
+    expect(reportTerminationComplete).toHaveBeenCalledWith({
+      task_id: 'task-1',
+      requested_at: '2026-07-23T12:00:00.000Z',
+    });
+  });
 });

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -4,8 +4,12 @@
  * Ephemeral executor that:
  * 1. Connects to daemon via Feathers/WebSocket
  * 2. Executes exactly one task
- * 3. Listens for stop events while running
+ * 3. Receives realtime permission resolutions while running
  * 4. Exits when task completes
+ *
+ * User Stop is delivered out-of-band via Unix process-group signals. The
+ * authenticated WebSocket carries task telemetry and service events, not a
+ * cancellation command.
  */
 
 import { resolveSdkWatchdogConfig } from '@agor/core/config';

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -5,10 +5,11 @@
  * 1. Connects to daemon via Feathers/WebSocket
  * 2. Executes exactly one task
  * 3. Receives realtime permission resolutions while running
- * 4. Receives durable Task STOPPING transitions over that socket
+ * 4. Receives task-scoped Stop control events over that socket
  * 5. Exits when task completes
  *
- * The daemon persists Stop before publishing the normal Task patch. The
+ * The daemon persists Stop before publishing a private task-scoped control
+ * event. The durable Task patch/read remains reconnect and race recovery. The
  * executor cooperatively aborts its SDK and reports quiescence; local process
  * signals and remote heartbeat recovery remain containment fallbacks.
  */
@@ -151,6 +152,9 @@ export class AgorExecutor {
     if (!this.client) return;
 
     this.client.service('tasks').on('patched', (data: unknown) => {
+      this.handleTaskLifecycleUpdate(data as Task);
+    });
+    this.client.service('tasks').on('termination_requested', (data: unknown) => {
       this.handleTaskLifecycleUpdate(data as Task);
     });
 

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -5,11 +5,12 @@
  * 1. Connects to daemon via Feathers/WebSocket
  * 2. Executes exactly one task
  * 3. Receives realtime permission resolutions while running
- * 4. Exits when task completes
+ * 4. Receives durable Task STOPPING transitions over that socket
+ * 5. Exits when task completes
  *
- * User Stop is delivered out-of-band via Unix process-group signals. The
- * authenticated WebSocket carries task telemetry and service events, not a
- * cancellation command.
+ * The daemon persists Stop before publishing the normal Task patch. The
+ * executor cooperatively aborts its SDK and reports quiescence; local process
+ * signals and remote heartbeat recovery remain containment fallbacks.
  */
 
 import { resolveSdkWatchdogConfig } from '@agor/core/config';
@@ -19,6 +20,7 @@ import type {
   PermissionMode,
   PermissionScope,
   SessionID,
+  Task,
   TaskID,
 } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
@@ -34,6 +36,7 @@ import {
 } from './sdk-watchdog.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
+import { markCoordinatorTerminationAbort } from './termination-state.js';
 
 patchConsole();
 
@@ -65,6 +68,8 @@ export class AgorExecutor {
   private isRunning = false;
   private heartbeat: ExecutorHeartbeatHandle | null = null;
   private watchdog: SdkWatchdog | null = null;
+  private terminationRequest: Task['termination_request'];
+  private terminationReport: Promise<void> | null = null;
 
   constructor(private config: ExecutorConfig) {
     this.abortController = new AbortController();
@@ -96,27 +101,37 @@ export class AgorExecutor {
     try {
       // Connect to daemon via Feathers/WebSocket
       executorDebug('[executor] Connecting to daemon via Feathers...');
-      this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken);
+      this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken, {
+        onReauthenticated: () => this.refreshTerminationState(),
+      });
       executorDebug('[executor] Connected to daemon');
+
+      // Register before claiming so Stop cannot fall into the connect → listen
+      // gap. The durable-state refresh in the catch path covers Stop that won
+      // before this socket authenticated.
+      this.setupEventListeners();
+      this.setupShutdownHandlers();
 
       // Authentication is complete. Atomically claim the daemon-dispatched task
       // before starting heartbeats or SDK work; a late executor cannot revive a
       // stopped or terminal task.
-      await this.client.service('tasks').connectExecutor({ task_id: this.config.taskId });
-
-      // Setup event listeners
-      this.setupEventListeners();
-
-      // Setup graceful shutdown handlers
-      this.setupShutdownHandlers();
+      const connectedTask = await this.client
+        .service('tasks')
+        .connectExecutor({ task_id: this.config.taskId });
+      this.handleTaskLifecycleUpdate(connectedTask);
 
       // Execute the task
-      await this.executeTask();
+      if (!this.terminationRequest) await this.executeTask();
+      await this.reportTerminationComplete();
 
       // Exit successfully
       console.log('[executor] Task completed, exiting');
       process.exit(0);
     } catch (error) {
+      if (await this.recoverTerminationBeforeStart()) {
+        process.exit(0);
+        return;
+      }
       console.error('[executor] Fatal error:', error);
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
@@ -129,12 +144,15 @@ export class AgorExecutor {
   /**
    * Setup event listeners for WebSocket events
    *
-   * Stop signaling is handled via Unix signals (SIGTERM/SIGKILL) from the daemon,
-   * not WebSocket events. The SIGTERM handler in setupShutdownHandlers() calls
-   * abortController.abort() for graceful shutdown.
+   * Task lifecycle patches are already durable and realtime, so Stop needs no
+   * second ephemeral command channel. Reconnect recovery reads the same Task.
    */
   private setupEventListeners(): void {
     if (!this.client) return;
+
+    this.client.service('tasks').on('patched', (data: unknown) => {
+      this.handleTaskLifecycleUpdate(data as Task);
+    });
 
     // Listen for permission_resolved events
     this.client.service('messages').on('permission_resolved', (data: unknown) => {
@@ -167,6 +185,67 @@ export class AgorExecutor {
     executorDebug('[executor] Event listeners registered');
   }
 
+  private handleTaskLifecycleUpdate(task: Task): void {
+    if (
+      task.task_id !== this.config.taskId ||
+      task.status !== TaskStatus.STOPPING ||
+      !task.termination_request
+    ) {
+      return;
+    }
+    if (this.terminationRequest?.requested_at === task.termination_request.requested_at) return;
+
+    this.terminationRequest = task.termination_request;
+    console.log(
+      `[executor] Received ${task.termination_request.cause} termination request; stopping SDK`
+    );
+    markCoordinatorTerminationAbort(this.abortController);
+    this.heartbeat?.stop();
+    this.heartbeat = null;
+    this.watchdog?.stop();
+    this.watchdog = null;
+    this.abortController.abort();
+  }
+
+  private async refreshTerminationState(): Promise<void> {
+    if (!this.client) return;
+    const task = (await this.client.service('tasks').get(this.config.taskId)) as Task;
+    this.handleTaskLifecycleUpdate(task);
+  }
+
+  private async reportTerminationComplete(): Promise<void> {
+    if (!this.client || !this.terminationRequest) return;
+    if (!this.terminationReport) {
+      const report = this.client
+        .service('tasks')
+        .reportTerminationComplete({
+          task_id: this.config.taskId,
+          requested_at: this.terminationRequest.requested_at,
+        })
+        .then(() => {
+          console.log('[executor] Cooperative termination complete');
+        });
+      this.terminationReport = report;
+      void report.catch(() => {
+        if (this.terminationReport === report) this.terminationReport = null;
+      });
+    }
+    await this.terminationReport;
+  }
+
+  /** Handle Stop that atomically beat connectExecutor() without starting SDK work. */
+  private async recoverTerminationBeforeStart(): Promise<boolean> {
+    if (!this.client) return false;
+    try {
+      await this.refreshTerminationState();
+      if (!this.terminationRequest) return false;
+      await this.reportTerminationComplete();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * Execute the task using the appropriate SDK
    */
@@ -174,6 +253,7 @@ export class AgorExecutor {
     if (!this.client) {
       throw new Error('Feathers client not initialized');
     }
+    if (this.terminationRequest || this.abortController.signal.aborted) return;
 
     this.isRunning = true;
 
@@ -244,8 +324,9 @@ export class AgorExecutor {
     const report = this.client
       .service('tasks')
       .reportSdkHealthFailure({ ...evidence, task_id: this.config.taskId })
-      .then(() => {
+      .then((task) => {
         acknowledged = true;
+        this.handleTaskLifecycleUpdate(task);
       })
       .catch((error) => console.error('[executor] Failed to report SDK health:', error));
     if (evidence.watchdog_action !== 'enforced') {

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -29,15 +29,10 @@ import { patchConsole } from '@agor/core/utils/logger';
 import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
-import {
-  getSdkActivityVersion,
-  isSdkHealthAbort,
-  markSdkHealthAbort,
-  SdkWatchdog,
-} from './sdk-watchdog.js';
+import { getSdkActivityVersion, markSdkHealthAbort, SdkWatchdog } from './sdk-watchdog.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
-import { markCoordinatorTerminationAbort } from './termination-state.js';
+import { isDaemonOwnedAbort, markCoordinatorTerminationAbort } from './termination-state.js';
 
 patchConsole();
 
@@ -85,7 +80,7 @@ export class AgorExecutor {
     status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
     errorMessage?: string
   ): Promise<void> {
-    if (!this.client || isSdkHealthAbort(this.abortController)) return;
+    if (!this.client || isDaemonOwnedAbort(this.abortController)) return;
     await tryMarkTaskTerminal(this.client, this.config.taskId, status, errorMessage);
   }
 

--- a/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
+++ b/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
@@ -176,7 +176,8 @@ export class GeminiTool implements ITool {
       prompt,
       taskId,
       permissionMode,
-      streamingCallbacks?.onPulse
+      streamingCallbacks?.onPulse,
+      abortController?.signal
     )) {
       // Capture resolved model from partial/complete events
       if (!resolvedModel) {

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.test.ts
@@ -99,6 +99,46 @@ describe('GeminiPromptService', () => {
   describe('Task Management', () => {
     const sessionId = 'test-session-id-123' as SessionID;
 
+    it('does not start a provider request when stopped during initialization', async () => {
+      const sendMessageStream = vi.fn();
+      let finishInitialization!: (client: { sendMessageStream: typeof sendMessageStream }) => void;
+      const initialization = new Promise<{ sendMessageStream: typeof sendMessageStream }>(
+        (resolve) => {
+          finishInitialization = resolve;
+        }
+      );
+      const getOrCreateClient = vi.fn().mockReturnValue(initialization);
+      (
+        service as unknown as {
+          getOrCreateClient: typeof getOrCreateClient;
+        }
+      ).getOrCreateClient = getOrCreateClient;
+      vi.mocked(mockSessionsRepo.findById).mockResolvedValue({
+        created_by: 'user-1',
+        model_config: null,
+      } as never);
+
+      const outerAbortController = new AbortController();
+      const nextEvent = service
+        .promptSessionStreaming(
+          sessionId,
+          'test prompt',
+          undefined,
+          undefined,
+          undefined,
+          outerAbortController.signal
+        )
+        .next();
+
+      await vi.waitFor(() => expect(getOrCreateClient).toHaveBeenCalledOnce());
+      outerAbortController.abort();
+      expect(service.stopTask(sessionId)).toEqual({ success: true });
+      finishInitialization({ sendMessageStream });
+
+      await expect(nextEvent).resolves.toMatchObject({ done: true });
+      expect(sendMessageStream).not.toHaveBeenCalled();
+    });
+
     it('should return failure when stopping non-existent task', () => {
       const result = service.stopTask(sessionId);
       expect(result.success).toBe(false);

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -137,45 +137,58 @@ export class GeminiPromptService {
     prompt: string,
     taskId?: TaskID,
     permissionMode?: PermissionMode,
-    onActivity?: SdkActivityCallback
+    onActivity?: SdkActivityCallback,
+    outerAbortSignal?: AbortSignal
   ): AsyncGenerator<GeminiStreamEvent> {
-    // Get session metadata for model
-    const session = await this.sessionsRepo.findById(sessionId);
-    if (!session) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
-
-    // Context user for per-user OAuth/API-key resolution — the task creator
-    // (prompter) when known, else the session owner.
-    const contextUserId = await resolveContextUserId({
-      session,
-      taskId,
-      tasksService: this.tasksService,
-    });
-
-    // Get or create Gemini client for this session
-    const client = await this.getOrCreateClient(sessionId, permissionMode, contextUserId);
-
-    // For recording on stream events. SDK invocation uses the model bound
-    // on the cached client (see getOrCreateClient).
-    const configuredModel = session.model_config?.model;
-
-    // Prepare initial prompt (just text for now - can enhance with file paths later)
-    let parts: Part[] = [{ text: prompt }];
-
-    // Create abort controller for cancellation support
+    // Register cancellation before any asynchronous initialization. Stop can
+    // otherwise arrive while credentials/client configuration is loading,
+    // before Gemini has an active SDK request to abort.
     const abortController = new AbortController();
+    const forwardOuterAbort = () => abortController.abort(outerAbortSignal?.reason);
+    if (outerAbortSignal?.aborted) {
+      forwardOuterAbort();
+    } else {
+      outerAbortSignal?.addEventListener('abort', forwardOuterAbort, { once: true });
+    }
     this.activeControllers.set(sessionId, abortController);
 
-    // Generate unique prompt ID for this turn
-    const promptId = `${sessionId}-${Date.now()}`;
-
     try {
+      // Get session metadata for model
+      const session = await this.sessionsRepo.findById(sessionId);
+      if (!session) {
+        throw new Error(`Session ${sessionId} not found`);
+      }
+
+      // Context user for per-user OAuth/API-key resolution — the task creator
+      // (prompter) when known, else the session owner.
+      const contextUserId = await resolveContextUserId({
+        session,
+        taskId,
+        tasksService: this.tasksService,
+      });
+
+      // Get or create Gemini client for this session
+      const client = await this.getOrCreateClient(sessionId, permissionMode, contextUserId);
+
+      // For recording on stream events. SDK invocation uses the model bound
+      // on the cached client (see getOrCreateClient).
+      const configuredModel = session.model_config?.model;
+
+      // Prepare initial prompt (just text for now - can enhance with file paths later)
+      let parts: Part[] = [{ text: prompt }];
+
+      // Generate unique prompt ID for this turn
+      const promptId = `${sessionId}-${Date.now()}`;
+
       // Tool execution loop - keep going until no more tool calls
       let loopCount = 0;
       const MAX_LOOPS = 50; // Safety limit to prevent infinite loops
 
       while (loopCount < MAX_LOOPS) {
+        // Initialization and tool execution can both outlive the original Stop
+        // callback. Never submit another provider request after cancellation.
+        if (abortController.signal.aborted) return;
+
         loopCount++;
         console.debug(`[Gemini Loop ${loopCount}] Starting turn with ${parts.length} parts`);
 
@@ -498,8 +511,10 @@ export class GeminiPromptService {
       console.error('Gemini streaming error:', error);
       throw error;
     } finally {
-      // Clean up abort controller
-      this.activeControllers.delete(sessionId);
+      outerAbortSignal?.removeEventListener('abort', forwardOuterAbort);
+      if (this.activeControllers.get(sessionId) === abortController) {
+        this.activeControllers.delete(sessionId);
+      }
     }
   }
 

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -1,5 +1,6 @@
 import type { ResolvedSdkWatchdogConfig } from '@agor/core/config';
 import type { ExecutorPulseKind, SdkHealthFailureInput } from '@agor/core/types';
+import { hasAgorAbortCause, markAgorAbortCause } from './termination-state.js';
 
 export type SdkActivityAdapter = 'claude-code' | 'codex' | 'gemini' | 'copilot' | 'opencode';
 export type SdkActivityCallback = (kind: ExecutorPulseKind, detail?: string) => void;
@@ -90,15 +91,13 @@ export function reportSdkActivity(
 }
 
 type WatchdogEvidence = Omit<SdkHealthFailureInput, 'task_id'>;
-type AbortControllerWithCause = AbortController & { agorAbortCause?: string };
-
 export function markSdkHealthAbort(controller: AbortController): void {
-  (controller as AbortControllerWithCause).agorAbortCause = 'sdk_health_failure';
+  markAgorAbortCause(controller, 'sdk_health_failure');
   controller.abort();
 }
 
 export function isSdkHealthAbort(controller: AbortController): boolean {
-  return (controller as AbortControllerWithCause).agorAbortCause === 'sdk_health_failure';
+  return hasAgorAbortCause(controller, 'sdk_health_failure');
 }
 
 interface WatchdogState {

--- a/packages/executor/src/termination-state.ts
+++ b/packages/executor/src/termination-state.ts
@@ -1,0 +1,10 @@
+const coordinatorTerminationAborts = new WeakSet<AbortController>();
+
+/** Mark an abort whose terminal task transition is owned by the daemon. */
+export function markCoordinatorTerminationAbort(controller: AbortController): void {
+  coordinatorTerminationAborts.add(controller);
+}
+
+export function isCoordinatorTerminationAbort(controller: AbortController): boolean {
+  return coordinatorTerminationAborts.has(controller);
+}

--- a/packages/executor/src/termination-state.ts
+++ b/packages/executor/src/termination-state.ts
@@ -1,10 +1,25 @@
-const coordinatorTerminationAborts = new WeakSet<AbortController>();
+export type AgorAbortCause = 'coordinator_termination' | 'sdk_health_failure';
 
-/** Mark an abort whose terminal task transition is owned by the daemon. */
+const abortCauses = new WeakMap<AbortController, AgorAbortCause>();
+
+export function markAgorAbortCause(controller: AbortController, cause: AgorAbortCause): void {
+  abortCauses.set(controller, cause);
+}
+
+export function hasAgorAbortCause(controller: AbortController, cause: AgorAbortCause): boolean {
+  return abortCauses.get(controller) === cause;
+}
+
+/** Mark an abort whose terminal task transition is owned by the daemon coordinator. */
 export function markCoordinatorTerminationAbort(controller: AbortController): void {
-  coordinatorTerminationAborts.add(controller);
+  markAgorAbortCause(controller, 'coordinator_termination');
 }
 
 export function isCoordinatorTerminationAbort(controller: AbortController): boolean {
-  return coordinatorTerminationAborts.has(controller);
+  return hasAgorAbortCause(controller, 'coordinator_termination');
+}
+
+/** Whether a daemon workflow, rather than the executor fail-safe, owns terminality. */
+export function isDaemonOwnedAbort(controller: AbortController): boolean {
+  return abortCauses.has(controller);
 }

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -48,10 +48,12 @@ const checks = [
       // Claude CLI launch and Stop target only the owning user's terminal room.
       'apps/agor-daemon/src/services/claude-cli-integration.ts': 4,
       // The tenant-aware realtime facade: tenant/session channel join, the
-      // publish handler, session-stream join, the existence-gated room lookup
-      // (existingChannel — used by publish + leave paths so they never
-      // materialize a room), and leave-all all live here on purpose.
-      'apps/agor-daemon/src/utils/realtime-publish.ts': 7,
+      // publish handler, session-stream and tenant+task executor-control joins,
+      // the existence-gated room lookup (existingChannel — used by publish +
+      // leave paths so they never materialize a room), and both leave-all
+      // helpers live here on purpose. Executor control rooms are explicitly
+      // tenant-namespaced and can only be joined from a verified scoped JWT.
+      'apps/agor-daemon/src/utils/realtime-publish.ts': 9,
       'apps/agor-daemon/src/setup/socketio.ts': 17,
     },
   },


### PR DESCRIPTION
## Summary

- make executor Stop socket-first instead of waiting for local process signaling
- persist `Task.status = stopping` before publishing a private executor control event
- abort the provider SDK inside the executor and report durable quiescence before terminalizing the task/session
- retain local process-group containment and heartbeat recovery as safety fallbacks
- show immediate stopping feedback in the UI while preserving queued work and promptability fencing

## Root cause

The Stop route held a tenant database transaction while waiting for the executor. Manual realtime events are correctly deferred until commit, so the executor notification was withheld until the cooperative grace expired. Local mode then fell back to `SIGTERM`, which made Stop appear to take several seconds and could not work as the primary mechanism for a remote/Kubernetes executor.

The Stop route now carries tenant identity without holding a route-long transaction. Its individual service writes still use short tenant transactions, so the durable stopping transition commits before realtime publication and acknowledgement waiting begins.

## Socket control path

1. The daemon atomically claims termination and persists the stopping request.
2. After commit, it publishes `termination_requested` to a private room named `executor-task:<tenant_id>:<task_id>`.
3. Only a connection authenticated with a verified `executor-session` JWT carrying matching tenant/session/branch/task claims can join that room. There is no client-callable subscription path.
4. The executor aborts its SDK, awaits provider-specific cleanup, and reports quiescence fenced by `requested_at`.
5. Remote templated execution accepts the scoped executor report; local execution additionally verifies process-group absence.
6. Only after containment is verified does the task become stopped and the session become idle/promptable.

Repeated Stop/containment claims while the same request is still active re-publish the original fenced control event without rewriting `requested_at`. Executors ignore duplicate delivery after accepting that request, while a previously missed delivery is handled normally. Gemini links the outer executor abort signal before asynchronous client initialization and fences every provider submission, so Stop cannot land in an unarmed initialization window.

The normal durable Task patch/read remains as reconnect and connect-race recovery. Heartbeat supervision remains the dead-executor recovery path, not normal Stop delivery.

## Security and containment

- control rooms are namespaced by tenant and task
- authentication replacement removes previous task-room membership
- logout/disconnect removes membership
- browsers cannot join executor control rooms or relay Stop events
- mismatched JWT task claims fail closed
- cross-tenant delivery is covered by focused tests
- fallback containment remains enabled; latency is not improved by prematurely terminalizing a live workload

## Observed result

A managed-environment run showed the cooperative path with no daemon `SIGTERM` fallback:

- Stop request to executor quiescence report: **~35 ms**
- Stop request to terminal Task state: **~102 ms**
- Stop request to idle/promptable Session: **~127 ms**

## Validation

- `pnpm i`
- `pnpm check`
- core task repository tests: **93 passed**, PostgreSQL variant skipped by its normal environment gate
- daemon termination/socket/heartbeat/session-stop tests: **150 passed**
- focused executor lifecycle/Gemini tests: **41 passed**
- UI stopping/session tests: **29 passed**

`pnpm check` completes successfully; Biome reports only existing repository warnings.

## Deployment note

A remote executor should connect over HTTPS/WSS (or service-mesh TLS). Multi-daemon deployments still require sticky routing or a shared Socket.IO adapter/control bus so Stop reaches the daemon replica that owns the executor socket.


