### PR TITLE
fix(ui): fire streaming capability announce after authenticate()

### DIFF
--- a/apps/agor-ui/src/hooks/sessionStreamsCapability.test.ts
+++ b/apps/agor-ui/src/hooks/sessionStreamsCapability.test.ts
@@ -1,87 +1,31 @@
 import type { AgorClient } from '@agor-live/client';
 import { describe, expect, it, vi } from 'vitest';
-import { ensureSessionStreamsCapabilityAnnounce } from './sessionStreamsCapability';
+import { announceSessionStreamsCapability } from './sessionStreamsCapability';
 
-function makeAnnounceClient() {
-  const ioHandlers: Record<string, Array<() => void>> = {};
-  const appHandlers: Record<string, Array<() => void>> = {};
-  const create = vi.fn(async () => ({ session_id: '', subscribed: false }));
+function makeAnnounceClient(create = vi.fn(async () => ({ session_id: '', subscribed: false }))) {
   const client = {
-    io: {
-      connected: false,
-      on: vi.fn((event: string, handler: () => void) => {
-        const handlers = ioHandlers[event] ?? [];
-        handlers.push(handler);
-        ioHandlers[event] = handlers;
-      }),
-      off: vi.fn(),
-    },
-    on: vi.fn((event: string, handler: () => void) => {
-      const handlers = appHandlers[event] ?? [];
-      handlers.push(handler);
-      appHandlers[event] = handlers;
-    }),
-    off: vi.fn(),
     service: vi.fn((name: string) => {
       if (name === 'session-streams') return { create };
       throw new Error(`Unexpected service: ${name}`);
     }),
   } as unknown as AgorClient;
-  const fireIo = (event: string) => {
-    for (const handler of [...(ioHandlers[event] ?? [])]) handler();
-  };
-  // Feathers emits 'authenticated' on the app after every authenticate().
-  const fireAuth = () => {
-    for (const handler of [...(appHandlers.authenticated ?? [])]) handler();
-  };
-  return { client, create, fireIo, fireAuth };
+  return { client, create };
 }
 
-describe('ensureSessionStreamsCapabilityAnnounce', () => {
-  it('announces capability after authentication and again on re-auth', async () => {
-    const { client, create, fireAuth } = makeAnnounceClient();
-    ensureSessionStreamsCapabilityAnnounce(client);
-
-    // Not authenticated yet → no announce.
-    expect(create).not.toHaveBeenCalled();
-
-    fireAuth();
+describe('announceSessionStreamsCapability', () => {
+  it('creates the session-streams capability marker', async () => {
+    const { client, create } = makeAnnounceClient();
+    announceSessionStreamsCapability(client);
     await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(1));
-    // Reconnect re-auth is a fresh authenticate() → re-announce.
-    fireAuth();
-    await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(2));
-
-    for (const call of create.mock.calls) {
-      expect(call[0]).toEqual({ capability: true });
-    }
-  });
-
-  it('does not announce on a pre-auth raw connect', () => {
-    const { client, create, fireIo } = makeAnnounceClient();
-    ensureSessionStreamsCapabilityAnnounce(client);
-
-    // A raw socket connect precedes auth; announcing here would 401.
-    fireIo('connect');
-    expect(create).not.toHaveBeenCalled();
-  });
-
-  it('wires the authenticated listener at most once per client', () => {
-    const { client } = makeAnnounceClient();
-    ensureSessionStreamsCapabilityAnnounce(client);
-    ensureSessionStreamsCapabilityAnnounce(client);
-
-    const authRegistrations = (
-      client.on as unknown as { mock: { calls: unknown[][] } }
-    ).mock.calls.filter((call) => call[0] === 'authenticated');
-    expect(authRegistrations).toHaveLength(1);
+    expect(create).toHaveBeenCalledWith({ capability: true });
   });
 
   it('swallows a create rejection (stale daemon / mid-connect auth refresh)', async () => {
-    const { client, create, fireAuth } = makeAnnounceClient();
-    create.mockRejectedValue(new Error('NotAuthenticated'));
-    ensureSessionStreamsCapabilityAnnounce(client);
-
-    expect(() => fireAuth()).not.toThrow();
+    const create = vi.fn(async () => {
+      throw new Error('NotAuthenticated');
+    });
+    const { client } = makeAnnounceClient(create);
+    expect(() => announceSessionStreamsCapability(client)).not.toThrow();
     await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/agor-ui/src/hooks/sessionStreamsCapability.ts
+++ b/apps/agor-ui/src/hooks/sessionStreamsCapability.ts
@@ -5,30 +5,20 @@ interface SessionStreamsCapabilityAnnounce {
   capability: true;
 }
 
-const CAPABILITY_ANNOUNCED_CLIENTS = new WeakSet<AgorClient>();
-
 /**
  * Mark this connection session-streams aware so the daemon's owner fallback
- * skips it — even idle tabs that never open a transcript. Fires after
- * authentication (initial and every reconnect re-auth); idempotent per client.
+ * skips it — even idle tabs that never open a transcript. Fires post-auth (a
+ * pre-auth call 401s + triggers refresh churn); invoked explicitly by
+ * useAgorClient after authenticate() because the client emits no usable
+ * post-auth event. Best-effort: a rejection just leaves this connection on the
+ * owner fallback.
  */
-export function ensureSessionStreamsCapabilityAnnounce(client: AgorClient): void {
-  if (CAPABILITY_ANNOUNCED_CLIENTS.has(client)) return;
-  CAPABILITY_ANNOUNCED_CLIENTS.add(client);
-
-  const announce = () => {
-    // Best-effort: a rejection just leaves this connection on the owner fallback.
-    void (
-      client.service('session-streams') as {
-        create: (data: SessionStreamsCapabilityAnnounce) => Promise<unknown>;
-      }
-    )
-      .create({ capability: true })
-      .catch(() => {});
-  };
-
-  // Announce post-auth, not on raw `connect`: session-streams.create requires
-  // auth, so a pre-auth call would 401 and needlessly refresh+retry. Feathers
-  // emits `authenticated` after every authenticate() (initial + reconnects).
-  client.on('authenticated', announce);
+export function announceSessionStreamsCapability(client: AgorClient): void {
+  void (
+    client.service('session-streams') as {
+      create: (data: SessionStreamsCapabilityAnnounce) => Promise<unknown>;
+    }
+  )
+    .create({ capability: true })
+    .catch(() => {});
 }

--- a/apps/agor-ui/src/hooks/useAgorClient.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorClient.test.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@agor-live/client';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import { useAgorClient } from './useAgorClient';
 
 // Keep every real export; only stub the client factory so the hook wires a
@@ -8,6 +9,14 @@ import { useAgorClient } from './useAgorClient';
 vi.mock('@agor-live/client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agor-live/client')>()),
   createClient: vi.fn(),
+}));
+
+// Mock only refreshAndReauthenticate so the reconnect refresh-fallback path is
+// drivable; keep the event name + error class real for the other paths.
+const { refreshMock } = vi.hoisted(() => ({ refreshMock: vi.fn() }));
+vi.mock('../utils/singleFlightRefresh', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/singleFlightRefresh')>()),
+  refreshAndReauthenticate: refreshMock,
 }));
 
 function makeDeferred<T>() {
@@ -21,13 +30,13 @@ function makeDeferred<T>() {
 }
 
 // Mock client that drives the REAL connect→authenticate flow: io.connect()
-// marks the socket connected so connect()'s wait-promise resolves, then
-// authenticate() returns a deferred we control to observe pre/post-auth timing.
-// Unknown property access resolves to a no-op fn so the rest of connect()
-// can't throw.
+// marks the socket connected so connect()'s wait-promise resolves; io 'connect'
+// handlers are captured so reconnects can be fired; authenticate() resolves by
+// default and can be overridden per-call. Unknown property access resolves to a
+// no-op fn so the rest of connect() can't throw.
 function makeSeamClient() {
   const create = vi.fn(async () => ({ session_id: '', subscribed: false }));
-  const authDeferred = makeDeferred<Record<string, unknown>>();
+  const ioHandlers: Record<string, Array<(...a: unknown[]) => void>> = {};
 
   const permissive = (target: Record<string, unknown>) =>
     new Proxy(target, {
@@ -41,7 +50,11 @@ function makeSeamClient() {
 
   const io = permissive({
     connected: false,
-    on: vi.fn(),
+    on: vi.fn((event: string, handler: (...a: unknown[]) => void) => {
+      const handlers = ioHandlers[event] ?? [];
+      handlers.push(handler);
+      ioHandlers[event] = handlers;
+    }),
     once: vi.fn(),
     off: vi.fn(),
     connect: vi.fn(() => {
@@ -55,19 +68,25 @@ function makeSeamClient() {
     off: vi.fn(),
     hooks: vi.fn(),
     service: vi.fn((name: string) => (name === 'session-streams' ? { create } : permissive({}))),
-    authenticate: vi.fn(() => authDeferred.promise),
+    authenticate: vi.fn(() => Promise.resolve({})),
   });
 
-  return { client, create, authDeferred };
+  const fireIo = (event: string) => {
+    for (const handler of [...(ioHandlers[event] ?? [])]) handler();
+  };
+  return { client, create, fireIo };
 }
 
 describe('useAgorClient session-streams announce seam', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    refreshMock.mockReset();
   });
 
   it('announces session-streams capability only after authenticate() resolves', async () => {
-    const { client, create, authDeferred } = makeSeamClient();
+    const { client, create } = makeSeamClient();
+    const authDeferred = makeDeferred<Record<string, unknown>>();
+    client.authenticate.mockReturnValue(authDeferred.promise);
     vi.mocked(createClient).mockReturnValue(client as never);
 
     renderHook(() => useAgorClient({ url: 'http://daemon.test', accessToken: 'access-token' }));
@@ -81,5 +100,53 @@ describe('useAgorClient session-streams announce seam', () => {
     authDeferred.resolve({});
     await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
     expect(create).toHaveBeenCalledWith({ capability: true });
+  });
+
+  it('re-announces on reconnect direct re-auth', async () => {
+    const { client, create, fireIo } = makeSeamClient();
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    renderHook(() => useAgorClient({ url: 'http://daemon.test', accessToken: 'access-token' }));
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1)); // initial auth
+
+    // First connect marks hasConnectedOnce; the second runs the reconnect
+    // handler (isReconnect=true) → direct authenticate() resolves → announce.
+    fireIo('connect');
+    fireIo('connect');
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    expect(create).toHaveBeenLastCalledWith({ capability: true });
+  });
+
+  it('re-announces on reconnect refresh-fallback', async () => {
+    const { client, create, fireIo } = makeSeamClient();
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    renderHook(() => useAgorClient({ url: 'http://daemon.test', accessToken: 'access-token' }));
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1)); // initial auth
+
+    fireIo('connect'); // marks hasConnectedOnce
+    // Reconnect: direct authenticate() rejects, refresh succeeds → announce.
+    client.authenticate.mockRejectedValueOnce(new Error('jwt expired'));
+    refreshMock.mockResolvedValue({ accessToken: 'fresh', refreshToken: 'r' });
+    fireIo('connect');
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    expect(create).toHaveBeenLastCalledWith({ capability: true });
+  });
+
+  it('re-announces on in-place token-refresh reauth', async () => {
+    const { client, create } = makeSeamClient();
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    renderHook(() => useAgorClient({ url: 'http://daemon.test', accessToken: 'access-token' }));
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1)); // initial auth
+
+    // Token replacement on the live socket → in-place authenticate() resolves → announce.
+    window.dispatchEvent(
+      new CustomEvent(TOKENS_REFRESHED_EVENT, {
+        detail: { accessToken: 'fresh', refreshToken: 'r' },
+      })
+    );
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    expect(create).toHaveBeenLastCalledWith({ capability: true });
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorClient.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorClient.test.tsx
@@ -1,5 +1,5 @@
 import { createClient } from '@agor-live/client';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useAgorClient } from './useAgorClient';
 
@@ -10,12 +10,24 @@ vi.mock('@agor-live/client', async (importOriginal) => ({
   createClient: vi.fn(),
 }));
 
-// A mock Feathers client with just enough surface for connect()'s synchronous
-// prefix (hooks/io/service) plus a captured `authenticated` listener. Unknown
-// property access resolves to a no-op fn so the rest of connect() can't throw.
+function makeDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Mock client that drives the REAL connect→authenticate flow: io.connect()
+// marks the socket connected so connect()'s wait-promise resolves, then
+// authenticate() returns a deferred we control to observe pre/post-auth timing.
+// Unknown property access resolves to a no-op fn so the rest of connect()
+// can't throw.
 function makeSeamClient() {
-  const authHandlers: Array<() => void> = [];
   const create = vi.fn(async () => ({ session_id: '', subscribed: false }));
+  const authDeferred = makeDeferred<Record<string, unknown>>();
 
   const permissive = (target: Record<string, unknown>) =>
     new Proxy(target, {
@@ -28,30 +40,25 @@ function makeSeamClient() {
     });
 
   const io = permissive({
-    connected: true, // wait-for-connection resolves immediately
+    connected: false,
     on: vi.fn(),
     once: vi.fn(),
     off: vi.fn(),
+    connect: vi.fn(() => {
+      io.connected = true; // wait-for-connection resolves on next check
+    }),
   });
 
   const client = permissive({
     io,
-    on: vi.fn((event: string, handler: () => void) => {
-      if (event === 'authenticated') authHandlers.push(handler);
-    }),
+    on: vi.fn(),
     off: vi.fn(),
     hooks: vi.fn(),
     service: vi.fn((name: string) => (name === 'session-streams' ? { create } : permissive({}))),
-    authenticate: vi.fn(async () => ({})),
+    authenticate: vi.fn(() => authDeferred.promise),
   });
 
-  return {
-    client,
-    create,
-    fireAuth: () => {
-      for (const handler of [...authHandlers]) handler();
-    },
-  };
+  return { client, create, authDeferred };
 }
 
 describe('useAgorClient session-streams announce seam', () => {
@@ -59,19 +66,20 @@ describe('useAgorClient session-streams announce seam', () => {
     vi.clearAllMocks();
   });
 
-  it('announces session-streams capability once the socket authenticates', async () => {
-    const { client, create, fireAuth } = makeSeamClient();
+  it('announces session-streams capability only after authenticate() resolves', async () => {
+    const { client, create, authDeferred } = makeSeamClient();
     vi.mocked(createClient).mockReturnValue(client as never);
 
     renderHook(() => useAgorClient({ url: 'http://daemon.test', accessToken: 'access-token' }));
 
-    // No announce before authentication.
+    // Drive the flow up to the pending authenticate() call.
+    await waitFor(() => expect(client.authenticate).toHaveBeenCalled());
+
+    // Pre-auth: announcing here would 401 — must NOT have fired yet.
     expect(create).not.toHaveBeenCalled();
 
-    // Feathers emits `authenticated` after authenticate() resolves.
-    fireAuth();
-    await Promise.resolve();
-
+    authDeferred.resolve({});
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
     expect(create).toHaveBeenCalledWith({ capability: true });
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -16,7 +16,7 @@ import {
   TOKENS_REFRESHED_EVENT,
 } from '../utils/singleFlightRefresh';
 import type { RefreshResult } from '../utils/tokenRefresh';
-import { ensureSessionStreamsCapabilityAnnounce } from './sessionStreamsCapability';
+import { announceSessionStreamsCapability } from './sessionStreamsCapability';
 
 interface UseAgorClientResult {
   client: AgorClient | null;
@@ -124,11 +124,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       // Create client (autoConnect: false, so we control connection timing)
       client = createClient(url, false);
       clientRef.current = client;
-
-      // UI-scoped: announce session-streams awareness post-auth so idle home /
-      // board tabs are excluded from the owner fallback. Left off the library
-      // (createClient) so bare raw-listener consumers keep the fallback.
-      ensureSessionStreamsCapabilityAnnounce(client);
 
       // Register an around-hook that transparently recovers from mid-session
       // access-token expiry. Any service call that fails with NotAuthenticated
@@ -250,6 +245,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                   strategy: 'jwt',
                   accessToken: currentAccessToken,
                 });
+                announceSessionStreamsCapability(client);
                 setConnected(true);
                 setConnecting(false);
                 setError(null);
@@ -262,6 +258,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                 try {
                   const refreshResult = await refreshAndReauthenticate(client);
                   if (refreshResult) {
+                    announceSessionStreamsCapability(client);
                     setConnected(true);
                     setConnecting(false);
                     setError(null);
@@ -441,6 +438,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
 
       // Authentication successful - connection is ready
       if (mounted) {
+        announceSessionStreamsCapability(client);
         setConnected(true);
         setConnecting(false);
         setError(null);
@@ -476,6 +474,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
           // was true at entry, (b) `authenticate()` just resolved, so the socket
           // is connected AND authenticated.
           if (!mounted) return;
+          announceSessionStreamsCapability(client);
           setConnected(true);
           setConnecting(false);
           setError(null);


### PR DESCRIPTION
The client-side session-streams capability announce was wired only to `client.on('authenticated')`, an event the real Feathers v5 client never emits (it emits `login`; `useBoardPresenceRoom` only survives because it *also* wires `client.io.on('connect')`, masking the same dead listener). Because the announce never fired in prod, no connection was ever marked session-streams aware, so #1896's daemon owner-fallback gate never engaged and idle home/board tabs kept receiving the full streaming firehose.

Fix: replace the listener with a plain `announceSessionStreamsCapability(client)` and fire it explicitly after **every** successful `authenticate()` — initial auth, reconnect re-auth, reconnect refresh-fallback, and in-place token-refresh reauth. Firing once per (re)auth is correct (each is a connection to mark aware; the server side is idempotent). The announce stays post-auth because a pre-auth call would 401 and trigger refresh churn.

Daemon gate unchanged — it is already correct and deployed. Proven in prod: manually firing the announce in a live idle tab dropped the streaming firehose from ~18 events/15s to 0.

Tests: the old test emitted a mock `authenticated` event, so the announce fired in-test and went green while prod was broken (false green). Replaced with (1) a unit test of `announceSessionStreamsCapability` and (2) a real `renderHook` seam test that drives the actual connect→authenticate flow with a controllable `authenticate()` promise, asserting the announce fires **after** authenticate resolves and **not before** (guards the pre-auth 401 regression). Verified this seam test goes red when the post-auth announce is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)