### PR TITLE
Add session settings to conversation footer menu

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -5,7 +5,7 @@ import type {
   PermissionMode,
   Session,
 } from '@agor-live/client';
-import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, within } from '@testing-library/react';
 import { App, ConfigProvider } from 'antd';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -208,10 +208,12 @@ describe('SessionFooter', () => {
       wrapper: Wrapper,
     });
 
-    fireEvent.click(screen.getByRole('img', { name: 'ellipsis' }).closest('button')!);
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    const overflowOptions = await screen.findByRole('group', { name: 'More options' });
     const settingsButton = await screen.findByRole('button', { name: 'Session settings' });
+    const overflowButtons = within(overflowOptions).getAllByRole('button');
 
-    expect(settingsButton.parentElement?.lastElementChild).toBe(settingsButton);
+    expect(overflowButtons[overflowButtons.length - 1]).toBe(settingsButton);
     fireEvent.click(settingsButton);
     expect(onOpenSessionSettings).toHaveBeenCalledWith('test-session-123');
   });

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -5,7 +5,7 @@ import type {
   PermissionMode,
   Session,
 } from '@agor-live/client';
-import { act, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { App, ConfigProvider } from 'antd';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -53,6 +53,7 @@ const baseProps = {
   sessionMcpServerIds: [] as string[],
   unauthedMcpServers: [],
   mcpServerById: new Map(),
+  userAuthenticatedMcpServerIds: new Set<string>(),
   isRunning: false,
   isStopping: false,
   stopRequestInFlight: false,
@@ -199,6 +200,31 @@ describe('SessionFooter', () => {
     const chip = screen.getByTitle(/3 MCP servers need attention/);
     expect(chip).toBeInTheDocument();
     expect(chip.textContent).toContain('3');
+  });
+
+  it('opens session settings from the final footer overflow action', async () => {
+    const onOpenSessionSettings = vi.fn();
+    render(<SessionFooter {...baseProps} onOpenSessionSettings={onOpenSessionSettings} />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.click(screen.getByRole('img', { name: 'ellipsis' }).closest('button')!);
+    const settingsButton = await screen.findByRole('button', { name: 'Session settings' });
+
+    expect(settingsButton.parentElement?.lastElementChild).toBe(settingsButton);
+    fireEvent.click(settingsButton);
+    expect(onOpenSessionSettings).toHaveBeenCalledWith('test-session-123');
+  });
+
+  it('does not expose session settings from the MCP control', async () => {
+    render(<SessionFooter {...baseProps} onOpenSessionSettings={vi.fn()} />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.click(screen.getByTitle(/No MCP servers attached/));
+
+    expect(await screen.findByText('Session MCP servers')).toBeInTheDocument();
+    expect(screen.queryByText('Open session settings')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -225,7 +225,10 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   };
 
   const moreContent = (
-    <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>
+    <fieldset
+      aria-label="More options"
+      style={{ width: 260, padding: '6px 0', margin: 0, border: 0 }}
+    >
       {/* === Section: Settings === */}
       <div style={sectionHeaderStyle}>Settings</div>
 
@@ -1228,7 +1231,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
           </Button>
         </>
       )}
-    </div>
+    </fieldset>
   );
 
   const stopTooltip = stopRequestInFlight

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -23,6 +23,7 @@ import {
   QuestionCircleOutlined,
   RobotOutlined,
   SendOutlined,
+  SettingOutlined,
   StopOutlined,
   ToolOutlined,
   UploadOutlined,
@@ -1203,6 +1204,30 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
           </Tooltip>
         </div>
       </Popover>
+
+      {onOpenSessionSettings && (
+        <>
+          <Divider style={{ margin: '4px 0' }} />
+          <Button
+            block
+            type="text"
+            icon={<SettingOutlined />}
+            aria-label="Session settings"
+            style={{
+              height: 32,
+              justifyContent: 'flex-start',
+              paddingInline: 12,
+              fontSize: 13,
+            }}
+            onClick={() => {
+              setMoreOpen(false);
+              onOpenSessionSettings(session.session_id);
+            }}
+          >
+            Session settings
+          </Button>
+        </>
+      )}
     </div>
   );
 
@@ -1297,7 +1322,6 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                 sessionMcpServerIds={sessionMcpServerIds}
                 mcpServerById={mcpServerById}
                 userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
-                onOpenSessionSettings={onOpenSessionSettings}
               />
             )}
 
@@ -1554,7 +1578,12 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
               title={null}
             >
               <Tooltip title="More options">
-                <Button size="small" type="text" icon={<EllipsisOutlined />} />
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<EllipsisOutlined />}
+                  aria-label="More options"
+                />
               </Tooltip>
             </Popover>
           </Space>

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
-import { ApiOutlined, SettingOutlined } from '@ant-design/icons';
-import { Tag as AntTag, Button, Divider, Popover, Space, Typography, theme } from 'antd';
+import { ApiOutlined } from '@ant-design/icons';
+import { Tag as AntTag, Popover, Space, Typography, theme } from 'antd';
 import React from 'react';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -16,7 +16,6 @@ export interface SessionMcpFooterControlProps {
   sessionMcpServerIds: string[];
   mcpServerById: Map<string, MCPServer>;
   userAuthenticatedMcpServerIds: Set<string>;
-  onOpenSessionSettings?: (sessionId: string) => void;
 }
 
 export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
@@ -25,7 +24,6 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
   sessionMcpServerIds,
   mcpServerById,
   userAuthenticatedMcpServerIds,
-  onOpenSessionSettings,
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
@@ -93,18 +91,6 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           disabled={!client || saving}
           style={{ width: '100%' }}
         />
-
-        <Divider style={{ margin: `${token.sizeUnit}px 0` }} />
-        <Button
-          block
-          icon={<SettingOutlined />}
-          onClick={() => {
-            setOpen(false);
-            onOpenSessionSettings?.(sessionId);
-          }}
-        >
-          Open session settings
-        </Button>
       </Space>
     </div>
   );

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -27,7 +27,6 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
-  const [open, setOpen] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
 
   const summary = React.useMemo(
@@ -97,8 +96,6 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
 
   return (
     <Popover
-      open={open}
-      onOpenChange={setOpen}
       trigger="click"
       placement="top"
       getPopupContainer={(trigger) => trigger.parentElement ?? document.body}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -977,7 +977,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           {
             key: 'settings',
             icon: <SettingOutlined />,
-            label: 'Session Settings',
+            label: 'Session settings',
             onClick: () => onOpenSettings(session.session_id),
           },
         ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,13 @@ services:
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     environment:
+      # The development image tag is shared across branch projects, so a manual
+      # `docker compose up` can briefly reuse an older image/entrypoint. Keep
+      # pnpm startup safeguards at the Compose boundary too: current source must
+      # never hang on an interactive node_modules purge, even with a stale image.
+      - CI=true
+      - pnpm_config_verify_deps_before_run=false
+
       # Daemon configuration
       - NODE_ENV=development
       - DAEMON_PORT=${DAEMON_PORT:-3030}

--- a/docker/README.md
+++ b/docker/README.md
@@ -174,16 +174,16 @@ docker compose -f docker-compose.prod.yml build
 
 Each git branch can run its own isolated Docker environment with:
 
-- **Separate images** (tagged per project name)
+- **A shared development image** (`agor-dev:latest`)
 - **Separate volumes** (node_modules, database, config)
 - **Separate ports** (using unique_id offset)
-- **Automatic dependency sync** (based on each branch's pnpm-lock.yaml)
+- **Prebuilt dependencies** from the image
 
 This is configured in `.agor.yml`:
 
 ```yaml
 environment:
-  start: DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000 branch.unique_id}} docker compose -p agor-{{branch.name}} up -d
+  start: DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000 branch.unique_id}} docker compose -p agor-{{branch.name}} up -d --build
   stop: docker compose -p agor-{{branch.name}} down
 ```
 
@@ -192,25 +192,24 @@ Manual example:
 ```bash
 # Branch 1 (postgres-support branch)
 cd ~/.agor/worktrees/preset-io/agor/postgres-support
-DAEMON_PORT=3001 UI_PORT=5001 docker compose -p agor-postgres-support up -d
+DAEMON_PORT=3001 UI_PORT=5001 docker compose -p agor-postgres-support up -d --build
 
 # Branch 2 (main branch)
 cd ~/.agor/worktrees/preset-io/agor/main
-DAEMON_PORT=3002 UI_PORT=5002 docker compose -p agor-main up -d
+DAEMON_PORT=3002 UI_PORT=5002 docker compose -p agor-main up -d --build
 ```
 
 **How it works:**
 
-1. **Image isolation**: `${COMPOSE_PROJECT_NAME}-agor-dev` means each `-p` project builds its own image
+1. **Shared image**: all branch projects reuse `agor-dev:latest`; `--build` refreshes it from the current checkout
 2. **Volume isolation**: Docker Compose creates separate volumes per project (named volumes + anonymous volumes for node_modules)
-3. **Dependency sync**: Entrypoint runs `pnpm install` on startup, syncing to the mounted branch's `pnpm-lock.yaml`
-4. **No conflicts**: Branch A with PostgreSQL deps won't conflict with Branch B without them
+3. **Prebuilt dependencies**: the image build runs `pnpm install`; startup uses those dependencies without reinstalling
+4. **Non-interactive startup**: Compose and the entrypoint disable pnpm's workspace verification/purge prompts
 
 **Benefits:**
 
 - Work on multiple branches simultaneously
-- Each branch has correct dependencies (even if branches diverge)
-- No manual dependency management needed
+- Refresh dependencies explicitly with `docker compose up --build` when a branch changes the lockfile
 - Clean separation of databases and configs
 
 ### SSH Key Authentication (Dev)

--- a/docker/README.md
+++ b/docker/README.md
@@ -192,16 +192,16 @@ Manual example:
 ```bash
 # Branch 1 (postgres-support branch)
 cd ~/.agor/worktrees/preset-io/agor/postgres-support
-DAEMON_PORT=3001 UI_PORT=5001 docker compose -p agor-postgres-support up -d --build
+DAEMON_PORT=3001 UI_PORT=5001 docker compose -p agor-postgres-support up -d
 
 # Branch 2 (main branch)
 cd ~/.agor/worktrees/preset-io/agor/main
-DAEMON_PORT=3002 UI_PORT=5002 docker compose -p agor-main up -d --build
+DAEMON_PORT=3002 UI_PORT=5002 docker compose -p agor-main up -d
 ```
 
 **How it works:**
 
-1. **Shared image**: all branch projects reuse `agor-dev:latest`; `--build` refreshes it from the current checkout
+1. **Shared image**: all branch projects reuse `agor-dev:latest`; the managed `.agor.yml` workflow rebuilds it from the current checkout
 2. **Volume isolation**: Docker Compose creates separate volumes per project (named volumes + anonymous volumes for node_modules)
 3. **Prebuilt dependencies**: the image build runs `pnpm install`; startup uses those dependencies without reinstalling
 4. **Non-interactive startup**: Compose and the entrypoint disable pnpm's workspace verification/purge prompts
@@ -209,7 +209,7 @@ DAEMON_PORT=3002 UI_PORT=5002 docker compose -p agor-main up -d --build
 **Benefits:**
 
 - Work on multiple branches simultaneously
-- Refresh dependencies explicitly with `docker compose up --build` when a branch changes the lockfile
+- Rebuild explicitly with `docker compose up --build` when the Dockerfile or lockfile changes
 - Clean separation of databases and configs
 
 ### SSH Key Authentication (Dev)


### PR DESCRIPTION
## Linked issue

No linked issue.

## Summary

- Add **Session settings** as the final, separated action in the conversation footer overflow menu.
- Reuse the existing session-settings callback and modal behavior shared with the header menu.
- Remove the redundant session-settings shortcut from the MCP-specific popover.
- Standardize the header menu label and add focused accessibility/behavior coverage.
- Prevent stale shared Docker development images from triggering pnpm's interactive modules-purge prompt.
- Correct the Docker guide to reflect the shared-image, prebuilt-dependency workflow.

## Why / context

Session settings were available from the conversation header and indirectly through the MCP footer popover, but not from the footer overflow menu where users already manage conversation controls. Adding a direct footer entry makes the information architecture consistent. Removing the MCP shortcut keeps that popover focused on MCP server configuration and avoids an unrelated duplicate path.

As bycatch, all Compose projects share `agor-dev:latest`. A manual `docker compose up` can therefore reuse an older image and entrypoint from another checkout. Passing the existing pnpm startup safeguards at the Compose boundary prevents that stale-image path from launching a workspace reinstall and blocking on an interactive purge prompt.

## Implementation notes

- The footer action calls the existing `onOpenSettings` path; no settings modal or persistence logic is duplicated.
- The action is visually separated and remains the final footer overflow item.
- The header and footer use consistent sentence-case copy: **Session settings**.
- Compose passes `CI=true` and `pnpm_config_verify_deps_before_run=false`, matching the current entrypoint while also protecting older shared images.
- Docker documentation now describes the actual shared image, prebuilt dependencies, and `docker compose up --build` workflow.

## Validation / test plan

- [x] `pnpm i`
- [x] `pnpm check`
- [x] `pnpm exec vitest run src/components/SessionPanel/SessionFooter.test.tsx src/components/SessionPanel/SessionPanel.test.tsx`
- [x] `sh -n docker/docker-entrypoint.sh`
- [x] `docker compose config --quiet`
- [x] Assert the rendered Compose environment contains both pnpm safeguards
- [x] `pnpm exec prettier --check docker-compose.yml docker/README.md`
- [x] `git diff --check`

## Screenshots / demos

Not included. The UI change is a focused menu-entry relocation using existing Ant Design menu and popover styling.

## Risks / rollout / rollback

Low risk. The UI reuses the existing settings action. The Compose variables duplicate values already exported by the current entrypoint, so behavior only differs when an older shared image is reused. Reverting the relevant commits restores the previous behavior.
