### PR TITLE
Move Knowledge semantic settings to tenant scope

### DIFF
--- a/apps/agor-daemon/src/knowledge/embeddings.ts
+++ b/apps/agor-daemon/src/knowledge/embeddings.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY } from '@agor/core/types';
 
 export interface EmbeddingInput {
   id: string;
@@ -26,32 +27,12 @@ export interface EmbeddingProvider {
   embed(inputs: EmbeddingInput[], options: EmbeddingOptions): Promise<EmbeddingResult[]>;
 }
 
-export const KNOWLEDGE_EMBEDDINGS_NAMESPACE = 'knowledge.embeddings';
-export const KNOWLEDGE_EMBEDDINGS_API_KEY = 'api_key';
-export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
-export const DEFAULT_OPENAI_EMBEDDING_DIMENSIONS = 1536;
+export const DEFAULT_OPENAI_EMBEDDING_MODEL = DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.model;
+export const DEFAULT_OPENAI_EMBEDDING_DIMENSIONS = DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.dimensions;
 export const SUPPORTED_OPENAI_EMBEDDING_MODELS = new Set([
   'text-embedding-3-small',
   'text-embedding-3-large',
 ]);
-
-export const DEFAULT_KNOWLEDGE_CHUNKING = {
-  target_tokens: 850,
-  max_tokens: 1200,
-  overlap_tokens: 100,
-  min_tokens: 80,
-};
-
-export const DEFAULT_KNOWLEDGE_INDEXING = {
-  paused: false,
-  batch_size: 32,
-  concurrency: 1,
-};
-
-export function normalizeKnowledgeEmbeddingApiKey(value: string | null | undefined): string | null {
-  const trimmed = value?.trim() ?? '';
-  return trimmed.length > 0 ? trimmed : null;
-}
 
 export function isUsableOpenAIEmbeddingConfig(
   semantic: {

--- a/apps/agor-daemon/src/knowledge/embeddings.ts
+++ b/apps/agor-daemon/src/knowledge/embeddings.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'node:crypto';
-import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY } from '@agor/core/types';
+import {
+  DEFAULT_KNOWLEDGE_SEMANTIC_POLICY,
+  KNOWLEDGE_OPENAI_EMBEDDING_MODELS,
+} from '@agor/core/types';
 
 export interface EmbeddingInput {
   id: string;
@@ -29,10 +32,7 @@ export interface EmbeddingProvider {
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.model;
 export const DEFAULT_OPENAI_EMBEDDING_DIMENSIONS = DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.dimensions;
-export const SUPPORTED_OPENAI_EMBEDDING_MODELS = new Set([
-  'text-embedding-3-small',
-  'text-embedding-3-large',
-]);
+export const SUPPORTED_OPENAI_EMBEDDING_MODELS = new Set<string>(KNOWLEDGE_OPENAI_EMBEDDING_MODELS);
 
 export function isUsableOpenAIEmbeddingConfig(
   semantic: {

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -1,4 +1,12 @@
-import { executeRaw, isPostgresDatabase, sql, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  executeRaw,
+  isPostgresDatabase,
+  sql,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+
+type KnowledgeTenantDatabase = TenantScopeAwareDatabase | TenantScopedDatabase;
 
 export interface KnowledgePgvectorCapability {
   available: boolean;
@@ -32,7 +40,7 @@ export function semanticUnavailableMessage(reason?: string | null): string {
   return `Semantic Knowledge search is unavailable${reason ? `: ${reason}` : ''}. ${SETUP_HINT}`;
 }
 
-async function ensureEmbeddingTenantIsolation(db: TenantScopeAwareDatabase): Promise<void> {
+async function ensureEmbeddingTenantIsolation(db: KnowledgeTenantDatabase): Promise<void> {
   await executeRaw(
     db,
     sql`ALTER TABLE kb_unit_embeddings ADD COLUMN IF NOT EXISTS tenant_id text DEFAULT 'default' NOT NULL`
@@ -55,9 +63,7 @@ async function ensureEmbeddingTenantIsolation(db: TenantScopeAwareDatabase): Pro
   );
 }
 
-async function readCapability(
-  db: TenantScopeAwareDatabase
-): Promise<KnowledgePgvectorStorageState> {
+async function readCapability(db: KnowledgeTenantDatabase): Promise<KnowledgePgvectorStorageState> {
   if (!isPostgresDatabase(db)) {
     return {
       available: false,
@@ -123,13 +129,13 @@ async function readCapability(
 }
 
 export async function getKnowledgePgvectorCapability(
-  db: TenantScopeAwareDatabase
+  db: KnowledgeTenantDatabase
 ): Promise<KnowledgePgvectorCapability> {
   return readCapability(db);
 }
 
 export async function ensureKnowledgePgvectorStorage(
-  db: TenantScopeAwareDatabase
+  db: KnowledgeTenantDatabase
 ): Promise<KnowledgePgvectorCapability> {
   if (!isPostgresDatabase(db)) return readCapability(db);
 

--- a/apps/agor-daemon/src/knowledge/policy-transaction.ts
+++ b/apps/agor-daemon/src/knowledge/policy-transaction.ts
@@ -1,0 +1,39 @@
+import {
+  getCurrentTenantDatabase,
+  isPostgresDatabase,
+  isSQLiteDatabase,
+  runDatabaseTransaction,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+
+/**
+ * Run a short Knowledge policy/materialization unit of work in the active
+ * tenant transaction, or create the equivalent direct-call transaction.
+ * SQLite uses IMMEDIATE with bounded busy retries so its database-wide write
+ * lock provides the same serialization boundary as the PostgreSQL policy row.
+ */
+export async function runKnowledgePolicyTransaction<T>(
+  db: TenantScopeAwareDatabase,
+  work: (tx: TenantScopedDatabase) => Promise<T>
+): Promise<T> {
+  const ambientDb = getCurrentTenantDatabase();
+  if (ambientDb && isPostgresDatabase(ambientDb)) {
+    return work(ambientDb as TenantScopedDatabase);
+  }
+
+  if (isSQLiteDatabase(db)) {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await runDatabaseTransaction(db, (tx) => work(tx as TenantScopedDatabase), {
+          sqliteImmediate: true,
+        });
+      } catch (error) {
+        if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+      }
+    }
+  }
+
+  return runDatabaseTransaction(db, (tx) => work(tx as TenantScopedDatabase));
+}

--- a/apps/agor-daemon/src/knowledge/units.ts
+++ b/apps/agor-daemon/src/knowledge/units.ts
@@ -1,4 +1,3 @@
-import type { AgorConfig } from '@agor/core/config';
 import {
   and,
   eq,
@@ -10,17 +9,18 @@ import {
   select,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import type { KnowledgeDocumentVersionID } from '@agor/core/types';
-import { DEFAULT_KNOWLEDGE_CHUNKING } from './embeddings.js';
+import type { KnowledgeDocumentVersionID, KnowledgeSemanticPolicy } from '@agor/core/types';
 import { chunkMarkdownForKnowledge, type MarkdownChunkerOptions } from './markdown-chunker.js';
 
-export function knowledgeChunkerOptionsFromConfig(config: AgorConfig): MarkdownChunkerOptions {
-  const chunking = config.knowledge?.semantic_search?.chunking ?? {};
+export function knowledgeChunkerOptionsFromSettings(
+  settings: KnowledgeSemanticPolicy
+): MarkdownChunkerOptions {
+  const { chunking } = settings;
   return {
-    targetTokens: chunking.target_tokens ?? DEFAULT_KNOWLEDGE_CHUNKING.target_tokens,
-    maxTokens: chunking.max_tokens ?? DEFAULT_KNOWLEDGE_CHUNKING.max_tokens,
-    overlapTokens: chunking.overlap_tokens ?? DEFAULT_KNOWLEDGE_CHUNKING.overlap_tokens,
-    minTokens: chunking.min_tokens ?? DEFAULT_KNOWLEDGE_CHUNKING.min_tokens,
+    targetTokens: chunking.target_tokens,
+    maxTokens: chunking.max_tokens,
+    overlapTokens: chunking.overlap_tokens,
+    minTokens: chunking.min_tokens,
   };
 }
 
@@ -48,7 +48,7 @@ export function knowledgeUnitsForMarkdown(
 
 export async function rebuildCurrentKnowledgeUnits(
   db: TenantScopeAwareDatabase,
-  config: AgorConfig,
+  settings: KnowledgeSemanticPolicy,
   options: { embeddingConfigured: boolean }
 ): Promise<number> {
   const rows = (await select(db)
@@ -62,7 +62,7 @@ export async function rebuildCurrentKnowledgeUnits(
     .all()) as Array<Record<string, unknown>>;
 
   const documents = new KnowledgeDocumentRepository(db);
-  const chunkerOptions = knowledgeChunkerOptionsFromConfig(config);
+  const chunkerOptions = knowledgeChunkerOptionsFromSettings(settings);
   let queued = 0;
   for (const row of rows) {
     const document = row.kb_documents as typeof kbDocuments.$inferSelect;

--- a/apps/agor-daemon/src/knowledge/units.ts
+++ b/apps/agor-daemon/src/knowledge/units.ts
@@ -8,6 +8,7 @@ import {
   type ReplaceKnowledgeUnitInput,
   select,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
 } from '@agor/core/db';
 import type { KnowledgeDocumentVersionID, KnowledgeSemanticPolicy } from '@agor/core/types';
 import { chunkMarkdownForKnowledge, type MarkdownChunkerOptions } from './markdown-chunker.js';
@@ -47,7 +48,7 @@ export function knowledgeUnitsForMarkdown(
 }
 
 export async function rebuildCurrentKnowledgeUnits(
-  db: TenantScopeAwareDatabase,
+  db: TenantScopeAwareDatabase | TenantScopedDatabase,
   settings: KnowledgeSemanticPolicy,
   options: { embeddingConfigured: boolean }
 ): Promise<number> {
@@ -69,7 +70,8 @@ export async function rebuildCurrentKnowledgeUnits(
     const version = row.kb_document_versions as typeof kbDocumentVersions.$inferSelect;
     if (!document.current_version_id || typeof version.content_text !== 'string') continue;
     const units = knowledgeUnitsForMarkdown(document.path, version.content_text, chunkerOptions);
-    await documents.replaceUnitsForVersion(
+    await documents.replaceUnitsForVersionInTransaction(
+      db,
       document.current_version_id as KnowledgeDocumentVersionID,
       units,
       {

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -241,6 +241,12 @@ describe('tenant-owned service registration', () => {
       ])
     );
   });
+
+  it('wraps Knowledge policy and indexing admin services in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
+      expect.arrayContaining(['kb/settings', 'kb/indexing/status', 'kb/indexing/reindex'])
+    );
+  });
 });
 
 describe('shouldValidateRepoEnvironmentPayload', () => {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -8,16 +8,13 @@
 import { PAGINATION } from '@agor/core/config';
 import {
   type CreateKnowledgeDocumentInput,
-  getCurrentTenantDatabase,
   isPostgresDatabase,
-  isSQLiteDatabase,
   type KnowledgeDocumentFilters,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
   KnowledgeGraphRepository,
   KnowledgeNamespaceRepository,
   KnowledgeSemanticSettingsRepository,
-  runDatabaseTransaction,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
   type UpdateKnowledgeDocumentInput,
@@ -44,6 +41,7 @@ import {
 import { DrizzleService } from '../adapters/drizzle';
 import { isUsableOpenAIEmbeddingConfig } from '../knowledge/embeddings.js';
 import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
+import { runKnowledgePolicyTransaction } from '../knowledge/policy-transaction.js';
 import {
   knowledgeChunkerOptionsFromSettings,
   knowledgeUnitsForMarkdown,
@@ -159,34 +157,14 @@ export class KnowledgeDocumentsService extends DrizzleService<
   private async runPolicyDependentWrite<T>(
     work: (service: KnowledgeDocumentsService) => Promise<T>
   ): Promise<T> {
-    const ambientDb = getCurrentTenantDatabase();
-    if (ambientDb && isPostgresDatabase(ambientDb)) {
-      await this.semanticSettings.lockAggregateForUpdate(ambientDb);
-      return work(this);
-    }
-
-    const apply = async (tx: TenantScopedDatabase): Promise<T> => {
+    return runKnowledgePolicyTransaction(this.db, async (tx: TenantScopedDatabase) => {
       const service = new KnowledgeDocumentsService(
         tx as unknown as TenantScopeAwareDatabase,
         this.app
       );
       await service.semanticSettings.lockAggregateForUpdate(tx);
       return work(service);
-    };
-
-    if (isSQLiteDatabase(this.db)) {
-      for (let attempt = 0; ; attempt++) {
-        try {
-          return await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase), {
-            sqliteImmediate: true,
-          });
-        } catch (error) {
-          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
-          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
-        }
-      }
-    }
-    return runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
+    });
   }
 
   private isAdmin(user?: User): boolean {
@@ -513,14 +491,16 @@ export class KnowledgeDocumentsService extends DrizzleService<
     data: KnowledgeDocumentWriteData,
     params?: KnowledgeDocumentParams
   ): Promise<KnowledgeDocument> {
-    const result = await this.runPolicyDependentWrite((service) =>
-      service.putDocumentInTransaction(data, params)
-    );
+    const write = (service: KnowledgeDocumentsService) => service.writePutDocument(data, params);
+    const result =
+      typeof data.content_text === 'string'
+        ? await this.runPolicyDependentWrite(write)
+        : await write(this);
     if (typeof data.content_text === 'string') this.wakeIndexer();
     return result;
   }
 
-  private async putDocumentInTransaction(
+  private async writePutDocument(
     data: KnowledgeDocumentWriteData,
     params?: KnowledgeDocumentParams
   ): Promise<KnowledgeDocument> {
@@ -645,18 +625,19 @@ export class KnowledgeDocumentsService extends DrizzleService<
       | Array<CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput>,
     params?: KnowledgeDocumentParams
   ): Promise<KnowledgeDocument | KnowledgeDocument[]> {
-    const result = await this.runPolicyDependentWrite(async (service) => {
+    const write = async (service: KnowledgeDocumentsService) => {
       if (!Array.isArray(data)) return service.createOne(data, params);
       const created: KnowledgeDocument[] = [];
       for (const item of data) created.push(await service.createOne(item, params));
       return created;
-    });
-    if (
+    };
+    const materializesUnits =
       (Array.isArray(data) && data.some((item) => typeof item.content_text === 'string')) ||
-      (!Array.isArray(data) && typeof data.content_text === 'string')
-    ) {
-      this.wakeIndexer();
-    }
+      (!Array.isArray(data) && typeof data.content_text === 'string');
+    const result = materializesUnits
+      ? await this.runPolicyDependentWrite(write)
+      : await write(this);
+    if (materializesUnits) this.wakeIndexer();
     return result;
   }
 
@@ -665,14 +646,16 @@ export class KnowledgeDocumentsService extends DrizzleService<
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams
   ) {
-    const result = await this.runPolicyDependentWrite((service) =>
-      service.patchInTransaction(id, data, params)
-    );
+    const write = (service: KnowledgeDocumentsService) => service.writePatch(id, data, params);
+    const result =
+      typeof data.content_text === 'string'
+        ? await this.runPolicyDependentWrite(write)
+        : await write(this);
     if (typeof data.content_text === 'string') this.wakeIndexer();
     return result;
   }
 
-  private async patchInTransaction(
+  private async writePatch(
     id: NullableId,
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams
@@ -707,14 +690,16 @@ export class KnowledgeDocumentsService extends DrizzleService<
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams
   ) {
-    const result = await this.runPolicyDependentWrite((service) =>
-      service.updateInTransaction(id, data, params)
-    );
+    const write = (service: KnowledgeDocumentsService) => service.writeUpdate(id, data, params);
+    const result =
+      typeof data.content_text === 'string'
+        ? await this.runPolicyDependentWrite(write)
+        : await write(this);
     if (typeof data.content_text === 'string') this.wakeIndexer();
     return result;
   }
 
-  private async updateInTransaction(
+  private async writeUpdate(
     id: Id,
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -8,14 +8,18 @@
 import { PAGINATION } from '@agor/core/config';
 import {
   type CreateKnowledgeDocumentInput,
+  getCurrentTenantDatabase,
   isPostgresDatabase,
+  isSQLiteDatabase,
   type KnowledgeDocumentFilters,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
   KnowledgeGraphRepository,
   KnowledgeNamespaceRepository,
   KnowledgeSemanticSettingsRepository,
+  runDatabaseTransaction,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   type UpdateKnowledgeDocumentInput,
 } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
@@ -144,6 +148,45 @@ export class KnowledgeDocumentsService extends DrizzleService<
     this.versions = new KnowledgeDocumentVersionRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
     this.graph = new KnowledgeGraphRepository(db);
+  }
+
+  /**
+   * Serialize document/unit writes with semantic policy mutations. PostgreSQL
+   * requests normally arrive inside the tenant hook's transaction; direct
+   * calls and SQLite use an explicit transaction so the aggregate lock, the
+   * document version, and its derived units share one commit boundary.
+   */
+  private async runPolicyDependentWrite<T>(
+    work: (service: KnowledgeDocumentsService) => Promise<T>
+  ): Promise<T> {
+    const ambientDb = getCurrentTenantDatabase();
+    if (ambientDb && isPostgresDatabase(ambientDb)) {
+      await this.semanticSettings.lockAggregateForUpdate(ambientDb);
+      return work(this);
+    }
+
+    const apply = async (tx: TenantScopedDatabase): Promise<T> => {
+      const service = new KnowledgeDocumentsService(
+        tx as unknown as TenantScopeAwareDatabase,
+        this.app
+      );
+      await service.semanticSettings.lockAggregateForUpdate(tx);
+      return work(service);
+    };
+
+    if (isSQLiteDatabase(this.db)) {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          return await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase), {
+            sqliteImmediate: true,
+          });
+        } catch (error) {
+          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+        }
+      }
+    }
+    return runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
   }
 
   private isAdmin(user?: User): boolean {
@@ -279,9 +322,12 @@ export class KnowledgeDocumentsService extends DrizzleService<
       content,
       knowledgeChunkerOptionsFromSettings(settings)
     );
-    await this.repo.replaceUnitsForVersion(doc.current_version_id, chunks, {
+    await this.repo.replaceUnitsForVersionInTransaction(this.db, doc.current_version_id, chunks, {
       embeddingConfigured: await this.isEmbeddingConfigured(),
     });
+  }
+
+  private wakeIndexer(): void {
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'
     ) as { wake?: () => void } | undefined;
@@ -467,6 +513,17 @@ export class KnowledgeDocumentsService extends DrizzleService<
     data: KnowledgeDocumentWriteData,
     params?: KnowledgeDocumentParams
   ): Promise<KnowledgeDocument> {
+    const result = await this.runPolicyDependentWrite((service) =>
+      service.putDocumentInTransaction(data, params)
+    );
+    if (typeof data.content_text === 'string') this.wakeIndexer();
+    return result;
+  }
+
+  private async putDocumentInTransaction(
+    data: KnowledgeDocumentWriteData,
+    params?: KnowledgeDocumentParams
+  ): Promise<KnowledgeDocument> {
     const userId = this.attributionUserId(params, data.created_by);
 
     const parsed = parseKnowledgeUri(data.uri);
@@ -588,13 +645,34 @@ export class KnowledgeDocumentsService extends DrizzleService<
       | Array<CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput>,
     params?: KnowledgeDocumentParams
   ): Promise<KnowledgeDocument | KnowledgeDocument[]> {
-    if (Array.isArray(data)) {
-      return Promise.all(data.map((item) => this.createOne(item, params)));
+    const result = await this.runPolicyDependentWrite(async (service) => {
+      if (!Array.isArray(data)) return service.createOne(data, params);
+      const created: KnowledgeDocument[] = [];
+      for (const item of data) created.push(await service.createOne(item, params));
+      return created;
+    });
+    if (
+      (Array.isArray(data) && data.some((item) => typeof item.content_text === 'string')) ||
+      (!Array.isArray(data) && typeof data.content_text === 'string')
+    ) {
+      this.wakeIndexer();
     }
-    return this.createOne(data, params);
+    return result;
   }
 
   async patch(
+    id: NullableId,
+    data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
+    params?: KnowledgeDocumentParams
+  ) {
+    const result = await this.runPolicyDependentWrite((service) =>
+      service.patchInTransaction(id, data, params)
+    );
+    if (typeof data.content_text === 'string') this.wakeIndexer();
+    return result;
+  }
+
+  private async patchInTransaction(
     id: NullableId,
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams
@@ -625,6 +703,18 @@ export class KnowledgeDocumentsService extends DrizzleService<
   }
 
   async update(
+    id: Id,
+    data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
+    params?: KnowledgeDocumentParams
+  ) {
+    const result = await this.runPolicyDependentWrite((service) =>
+      service.updateInTransaction(id, data, params)
+    );
+    if (typeof data.content_text === 'string') this.wakeIndexer();
+    return result;
+  }
+
+  private async updateInTransaction(
     id: Id,
     data: CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput,
     params?: KnowledgeDocumentParams

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -5,9 +5,8 @@
  * immutable document version and advances `current_version_id`.
  */
 
-import { loadConfig, PAGINATION } from '@agor/core/config';
+import { PAGINATION } from '@agor/core/config';
 import {
-  AppVariableRepository,
   type CreateKnowledgeDocumentInput,
   isPostgresDatabase,
   type KnowledgeDocumentFilters,
@@ -15,6 +14,7 @@ import {
   KnowledgeDocumentVersionRepository,
   KnowledgeGraphRepository,
   KnowledgeNamespaceRepository,
+  KnowledgeSemanticSettingsRepository,
   type TenantScopeAwareDatabase,
   type UpdateKnowledgeDocumentInput,
 } from '@agor/core/db';
@@ -38,14 +38,10 @@ import {
   titleFromKnowledgeContent,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
-import {
-  isUsableOpenAIEmbeddingConfig,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-} from '../knowledge/embeddings.js';
+import { isUsableOpenAIEmbeddingConfig } from '../knowledge/embeddings.js';
 import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
 import {
-  knowledgeChunkerOptionsFromConfig,
+  knowledgeChunkerOptionsFromSettings,
   knowledgeUnitsForMarkdown,
 } from '../knowledge/units.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
@@ -125,7 +121,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
   KnowledgeDocumentParams
 > {
   private repo: KnowledgeDocumentRepository;
-  private variables: AppVariableRepository;
+  private semanticSettings: KnowledgeSemanticSettingsRepository;
   private versions: KnowledgeDocumentVersionRepository;
   private namespaces: KnowledgeNamespaceRepository;
   private graph: KnowledgeGraphRepository;
@@ -144,7 +140,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       },
     });
     this.repo = repo;
-    this.variables = new AppVariableRepository(db);
+    this.semanticSettings = new KnowledgeSemanticSettingsRepository(db);
     this.versions = new KnowledgeDocumentVersionRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
     this.graph = new KnowledgeGraphRepository(db);
@@ -264,17 +260,11 @@ export class KnowledgeDocumentsService extends DrizzleService<
    */
 
   private async isEmbeddingConfigured(): Promise<boolean> {
-    const config = await loadConfig();
     if (!isPostgresDatabase(this.db)) return false;
-    const apiKey = await this.variables.find(
-      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-      KNOWLEDGE_EMBEDDINGS_API_KEY
-    );
+    const settings = await this.semanticSettings.find();
     return (
-      isUsableOpenAIEmbeddingConfig(
-        config.knowledge?.semantic_search ?? {},
-        Boolean(apiKey?.value_encrypted)
-      ) && (await ensureKnowledgePgvectorStorage(this.db)).available
+      isUsableOpenAIEmbeddingConfig(settings, settings.api_key_configured) &&
+      (await ensureKnowledgePgvectorStorage(this.db)).available
     );
   }
 
@@ -283,11 +273,11 @@ export class KnowledgeDocumentsService extends DrizzleService<
     content?: string | null
   ): Promise<void> {
     if (typeof content !== 'string' || !doc.current_version_id) return;
-    const config = await loadConfig();
+    const settings = await this.semanticSettings.findPolicy();
     const chunks = knowledgeUnitsForMarkdown(
       doc.path,
       content,
-      knowledgeChunkerOptionsFromConfig(config)
+      knowledgeChunkerOptionsFromSettings(settings)
     );
     await this.repo.replaceUnitsForVersion(doc.current_version_id, chunks, {
       embeddingConfigured: await this.isEmbeddingConfigured(),

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
@@ -4,13 +4,55 @@ import {
   runWithTenantContext,
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
+import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import {
   buildKnowledgeEmbeddingReuseSql,
+  isKnowledgeEmbeddingMaterializationSnapshotCurrent,
   KnowledgeEmbeddingIndexer,
   mergeEmbeddingReuseIntoNextMetadata,
 } from './knowledge-embedding-indexer';
+
+describe('isKnowledgeEmbeddingMaterializationSnapshotCurrent', () => {
+  it('rejects policy, credential, and chunking changes but ignores batch-size tuning', () => {
+    const snapshot = DEFAULT_KNOWLEDGE_SEMANTIC_POLICY;
+
+    expect(
+      isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+        snapshot,
+        { ...snapshot, model: 'text-embedding-3-large' },
+        'key-a',
+        'key-a'
+      )
+    ).toBe(false);
+    expect(
+      isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+        snapshot,
+        {
+          ...snapshot,
+          chunking: { ...snapshot.chunking, target_tokens: 640 },
+        },
+        'key-a',
+        'key-a'
+      )
+    ).toBe(false);
+    expect(
+      isKnowledgeEmbeddingMaterializationSnapshotCurrent(snapshot, snapshot, 'key-a', 'key-b')
+    ).toBe(false);
+    expect(
+      isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+        snapshot,
+        {
+          ...snapshot,
+          indexing: { ...snapshot.indexing, batch_size: 64 },
+        },
+        'key-a',
+        'key-a'
+      )
+    ).toBe(true);
+  });
+});
 
 function sqlText(query: { queryChunks?: unknown[] }): string {
   return (query.queryChunks ?? [])
@@ -169,6 +211,41 @@ describe('KnowledgeEmbeddingIndexer wake scheduling', () => {
 
       await vi.runAllTimersAsync();
       expect(tick).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  dbTest('reruns after a wake arrives during an active tick', async ({ db }) => {
+    vi.useFakeTimers();
+    try {
+      const indexer = new KnowledgeEmbeddingIndexer(db, { tenantId: 'bootstrap-tenant' });
+      let releaseFirst!: () => void;
+      let signalStarted!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        signalStarted = resolve;
+      });
+      const holdFirst = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let calls = 0;
+      indexer.indexBatch = vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          signalStarted();
+          await holdFirst;
+        }
+        return 0;
+      });
+
+      const firstTick = indexer.tick();
+      await firstStarted;
+      indexer.wake();
+      releaseFirst();
+      await firstTick;
+      await vi.runAllTimersAsync();
+
+      expect(indexer.indexBatch).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import {
+  getCurrentTenantDatabase,
+  getCurrentTenantId,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
+import { describe, expect, it, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import {
   buildKnowledgeEmbeddingReuseSql,
+  KnowledgeEmbeddingIndexer,
   mergeEmbeddingReuseIntoNextMetadata,
 } from './knowledge-embedding-indexer';
 
@@ -110,5 +118,59 @@ describe('mergeEmbeddingReuseIntoNextMetadata', () => {
       total_chunks: 27,
       updated_at: '2026-06-08T00:01:00.000Z',
     });
+  });
+});
+
+describe('KnowledgeEmbeddingIndexer wake scheduling', () => {
+  dbTest('runs only after commit with request tenant scopes detached', async ({ db }) => {
+    vi.useFakeTimers();
+    try {
+      const indexer = new KnowledgeEmbeddingIndexer(db, { tenantId: 'bootstrap-tenant' });
+      const observedScopes: Array<{ tenantId: string | undefined; hasDatabase: boolean }> = [];
+      const tick = vi.fn(async () => {
+        observedScopes.push({
+          tenantId: getCurrentTenantId() as string | undefined,
+          hasDatabase: Boolean(getCurrentTenantDatabase()),
+        });
+      });
+      indexer.tick = tick;
+
+      await runWithTenantContext('request-tenant', () =>
+        runWithTenantDatabaseScope(db, 'request-tenant', async () => {
+          indexer.wake();
+          expect(tick).not.toHaveBeenCalled();
+        })
+      );
+
+      expect(tick).not.toHaveBeenCalled();
+      await vi.runAllTimersAsync();
+      expect(tick).toHaveBeenCalledTimes(1);
+      expect(observedScopes).toEqual([{ tenantId: undefined, hasDatabase: false }]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  dbTest('does not wake when the surrounding tenant transaction rolls back', async ({ db }) => {
+    vi.useFakeTimers();
+    try {
+      const indexer = new KnowledgeEmbeddingIndexer(db, { tenantId: 'bootstrap-tenant' });
+      const tick = vi.fn(async () => {});
+      indexer.tick = tick;
+
+      await expect(
+        runWithTenantContext('request-tenant', () =>
+          runWithTenantDatabaseScope(db, 'request-tenant', async () => {
+            indexer.wake();
+            throw new Error('rollback');
+          })
+        )
+      ).rejects.toThrow('rollback');
+
+      await vi.runAllTimersAsync();
+      expect(tick).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -20,7 +20,7 @@ import {
   type TenantScopeAwareDatabase,
   update,
 } from '@agor/core/db';
-import type { KnowledgeDocumentUnitID, TenantID } from '@agor/core/types';
+import type { KnowledgeDocumentUnitID, KnowledgeSemanticPolicy, TenantID } from '@agor/core/types';
 import {
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
   embeddingToPgvector,
@@ -37,6 +37,12 @@ interface PendingUnitRow {
   document_id: string;
   content_text: string | null;
   content_md5: string | null;
+}
+
+interface CurrentUnitRow {
+  unit_id: string;
+  content_md5: string | null;
+  embedding_status: string;
 }
 
 interface ReusedEmbeddingRow {
@@ -74,6 +80,23 @@ function sameEmbeddingReuseScope(
     existing.provider === update.provider &&
     existing.model === update.model &&
     existing.dimensions === update.dimensions
+  );
+}
+
+export function isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+  snapshot: KnowledgeSemanticPolicy,
+  current: KnowledgeSemanticPolicy,
+  snapshotApiKey: string,
+  currentApiKey: string | null
+): boolean {
+  return (
+    snapshotApiKey === currentApiKey &&
+    snapshot.enabled === current.enabled &&
+    snapshot.provider === current.provider &&
+    snapshot.model === current.model &&
+    snapshot.dimensions === current.dimensions &&
+    snapshot.indexing.paused === current.indexing.paused &&
+    JSON.stringify(snapshot.chunking) === JSON.stringify(current.chunking)
   );
 }
 
@@ -191,6 +214,7 @@ export class KnowledgeEmbeddingIndexer {
   private intervalHandle?: NodeJS.Timeout;
   private running = false;
   private wakeScheduled = false;
+  private rerunRequested = false;
   private settings: KnowledgeSemanticSettingsRepository;
   private provider = new OpenAIEmbeddingProvider();
   private lastErrorByTenant = new Map<string, string | null>();
@@ -230,6 +254,10 @@ export class KnowledgeEmbeddingIndexer {
       // indexer establishes its own tenant context in tick().
       runWithoutTenantContext(() => {
         runWithoutTenantDatabaseScope(() => {
+          if (this.running) {
+            this.rerunRequested = true;
+            return;
+          }
           if (this.wakeScheduled) return;
           this.wakeScheduled = true;
           setTimeout(() => {
@@ -424,6 +452,10 @@ export class KnowledgeEmbeddingIndexer {
       throw error;
     } finally {
       this.running = false;
+      if (this.rerunRequested) {
+        this.rerunRequested = false;
+        this.wake();
+      }
     }
   }
 
@@ -453,6 +485,19 @@ export class KnowledgeEmbeddingIndexer {
     const batchSize = Math.min(Math.max(semantic.indexing.batch_size, 1), 128);
     this.lastErrorByTenant.set(this.currentTenantKey(), null);
     const prepared = await this.withTenantDatabase(async () => {
+      const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+      const currentApiKey = await this.settings.getApiKey();
+      if (
+        !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+          semantic,
+          currentSemantic,
+          apiKey,
+          currentApiKey
+        )
+      ) {
+        return { kind: 'obsolete' as const };
+      }
+
       // Hot idle path: avoid provider setup/work when no units are pending.
       const pending = (await select(this.db, { unit_id: kbDocumentUnits.unit_id })
         .from(kbDocumentUnits)
@@ -500,6 +545,7 @@ export class KnowledgeEmbeddingIndexer {
         .all()) as PendingUnitRow[];
       return { kind: 'ready' as const, embeddingSpaceId, reused, rows };
     });
+    if (prepared.kind === 'obsolete') return 0;
     if (prepared.kind === 'idle') return this.idle();
     if (prepared.kind === 'unavailable') {
       this.lastErrorByTenant.set(this.currentTenantKey(), prepared.reason);
@@ -541,26 +587,53 @@ export class KnowledgeEmbeddingIndexer {
         { apiKey, model, dimensions }
       );
     } catch (error) {
-      await this.withTenantDatabase(() =>
-        update(this.db, kbDocumentUnits)
+      const recorded = await this.withTenantDatabase(async () => {
+        const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+        const currentApiKey = await this.settings.getApiKey();
+        if (
+          !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+            semantic,
+            currentSemantic,
+            apiKey,
+            currentApiKey
+          )
+        ) {
+          return false;
+        }
+        const eligibleIds = await this.eligibleResultUnitIds(rows);
+        if (eligibleIds.length === 0) return false;
+        await update(this.db, kbDocumentUnits)
           .set({
             embedding_status: 'error',
             embedding_error: error instanceof Error ? error.message : String(error),
             updated_at: new Date(),
           })
-          .where(
-            inArray(
-              kbDocumentUnits.unit_id,
-              rows.map((row) => row.unit_id as KnowledgeDocumentUnitID)
-            )
-          )
-          .run()
-      );
+          .where(inArray(kbDocumentUnits.unit_id, eligibleIds as KnowledgeDocumentUnitID[]))
+          .run();
+        return true;
+      });
+      if (!recorded) return 0;
       throw error;
     }
 
-    await this.withTenantDatabase(async () => {
-      for (const result of results) {
+    const committed = await this.withTenantDatabase(async () => {
+      const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+      const currentApiKey = await this.settings.getApiKey();
+      if (
+        !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
+          semantic,
+          currentSemantic,
+          apiKey,
+          currentApiKey
+        )
+      ) {
+        return 0;
+      }
+
+      const eligibleIds = new Set(await this.eligibleResultUnitIds(rows));
+      const currentResults = results.filter((result) => eligibleIds.has(result.id));
+      if (currentResults.length === 0) return 0;
+      for (const result of currentResults) {
         const source = rows.find((row) => row.unit_id === result.id);
         const content = source?.content_text ?? '';
         const vector = embeddingToPgvector(result.embedding);
@@ -588,13 +661,42 @@ export class KnowledgeEmbeddingIndexer {
         .where(
           inArray(
             kbDocumentUnits.unit_id,
-            results.map((result) => result.id as KnowledgeDocumentUnitID)
+            currentResults.map((result) => result.id as KnowledgeDocumentUnitID)
           )
         )
         .run();
+      return currentResults.length;
     });
 
+    if (committed === 0) return 0;
     this.lastIndexedAtByTenant.set(this.currentTenantKey(), new Date());
-    return reused + results.length;
+    return reused + committed;
+  }
+
+  private async eligibleResultUnitIds(rows: PendingUnitRow[]): Promise<string[]> {
+    if (rows.length === 0) return [];
+    const currentRows = (await select(this.db, {
+      unit_id: kbDocumentUnits.unit_id,
+      content_md5: kbDocumentUnits.content_md5,
+      embedding_status: kbDocumentUnits.embedding_status,
+    })
+      .from(kbDocumentUnits)
+      .where(
+        inArray(
+          kbDocumentUnits.unit_id,
+          rows.map((row) => row.unit_id as KnowledgeDocumentUnitID)
+        )
+      )
+      .all()) as CurrentUnitRow[];
+    const sourceById = new Map(rows.map((row) => [row.unit_id, row]));
+    return currentRows
+      .filter((row) => {
+        const source = sourceById.get(row.unit_id);
+        return (
+          source?.content_md5 === row.content_md5 &&
+          (row.embedding_status === 'pending' || row.embedding_status === 'stale')
+        );
+      })
+      .map((row) => row.unit_id);
   }
 }

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -1,12 +1,11 @@
-import { loadConfig } from '@agor/core/config';
 import {
-  AppVariableRepository,
   executeRaw,
   generateId,
   getCurrentTenantId,
   inArray,
   insert,
   isPostgresDatabase,
+  KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
   kbDocumentVersions,
   kbEmbeddingSpaces,
@@ -21,10 +20,7 @@ import {
 import type { KnowledgeDocumentUnitID, TenantID } from '@agor/core/types';
 import {
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-  DEFAULT_OPENAI_EMBEDDING_MODEL,
   embeddingToPgvector,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
   OpenAIEmbeddingProvider,
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
   sha256Text,
@@ -192,17 +188,17 @@ export class KnowledgeEmbeddingIndexer {
   private intervalHandle?: NodeJS.Timeout;
   private running = false;
   private wakeScheduled = false;
-  private variables: AppVariableRepository;
+  private settings: KnowledgeSemanticSettingsRepository;
   private provider = new OpenAIEmbeddingProvider();
-  private lastError: string | null = null;
-  private lastIndexedAt: Date | null = null;
+  private lastErrorByTenant = new Map<string, string | null>();
+  private lastIndexedAtByTenant = new Map<string, Date>();
   private pgvectorStorageReady = false;
 
   constructor(
     private db: TenantScopeAwareDatabase,
     private options: { tenantId?: TenantID | string } = {}
   ) {
-    this.variables = new AppVariableRepository(db);
+    this.settings = new KnowledgeSemanticSettingsRepository(db);
   }
 
   private withTenantDatabase<T>(work: () => Promise<T>): Promise<T> {
@@ -235,16 +231,20 @@ export class KnowledgeEmbeddingIndexer {
     }, 0);
   }
 
-  getLastError(): string | null {
-    return this.lastError;
+  private currentTenantKey(): string {
+    return String(getCurrentTenantId() ?? this.options.tenantId ?? 'default');
   }
 
-  getLastIndexedAt(): Date | null {
-    return this.lastIndexedAt;
+  getLastError(tenantId?: TenantID | string): string | null {
+    return this.lastErrorByTenant.get(String(tenantId ?? this.currentTenantKey())) ?? null;
+  }
+
+  getLastIndexedAt(tenantId?: TenantID | string): Date | null {
+    return this.lastIndexedAtByTenant.get(String(tenantId ?? this.currentTenantKey())) ?? null;
   }
 
   private idle(): 0 {
-    this.lastError = null;
+    this.lastErrorByTenant.set(this.currentTenantKey(), null);
     return 0;
   }
 
@@ -396,9 +396,14 @@ export class KnowledgeEmbeddingIndexer {
     this.running = true;
     try {
       const indexed = await this.indexBatch();
-      if (indexed > 0 || !this.lastError) this.lastError = null;
+      if (indexed > 0 || !this.getLastError()) {
+        this.lastErrorByTenant.set(this.currentTenantKey(), null);
+      }
     } catch (error) {
-      this.lastError = error instanceof Error ? error.message : String(error);
+      this.lastErrorByTenant.set(
+        this.currentTenantKey(),
+        error instanceof Error ? error.message : String(error)
+      );
       throw error;
     } finally {
       this.running = false;
@@ -406,32 +411,30 @@ export class KnowledgeEmbeddingIndexer {
   }
 
   async indexBatch(): Promise<number> {
-    const config = await loadConfig();
-    const semantic = config.knowledge?.semantic_search;
-    if (semantic?.enabled !== true) return this.idle();
-    if (semantic.indexing?.paused === true) return this.idle();
+    const { semantic, apiKey } = await this.withTenantDatabase(async () => ({
+      semantic: await this.settings.findPolicy(),
+      apiKey: await this.settings.getApiKey(),
+    }));
+    if (!semantic.enabled) return this.idle();
+    if (semantic.indexing.paused) return this.idle();
     if (!isPostgresDatabase(this.db)) return this.idle();
-    const provider = semantic.provider ?? 'openai';
+    const provider = semantic.provider;
     if (provider !== 'openai') return this.idle();
-
-    const apiKey = await this.withTenantDatabase(() =>
-      this.variables.getPlain(KNOWLEDGE_EMBEDDINGS_NAMESPACE, KNOWLEDGE_EMBEDDINGS_API_KEY)
-    );
     if (!apiKey) return this.idle();
 
-    const model = semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL;
+    const model = semantic.model;
     if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(model)) {
       throw new Error(`Unsupported OpenAI embedding model: ${model}`);
     }
-    const dimensions = semantic.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS;
+    const dimensions = semantic.dimensions;
     if (dimensions !== DEFAULT_OPENAI_EMBEDDING_DIMENSIONS) {
       throw new Error(
         'Only 1536-dimensional OpenAI embeddings are supported by the V1 vector table'
       );
     }
 
-    const batchSize = Math.min(Math.max(semantic.indexing?.batch_size ?? 32, 1), 128);
-    this.lastError = null;
+    const batchSize = Math.min(Math.max(semantic.indexing.batch_size, 1), 128);
+    this.lastErrorByTenant.set(this.currentTenantKey(), null);
     const prepared = await this.withTenantDatabase(async () => {
       // Hot idle path: avoid provider setup/work when no units are pending.
       const pending = (await select(this.db, { unit_id: kbDocumentUnits.unit_id })
@@ -482,13 +485,13 @@ export class KnowledgeEmbeddingIndexer {
     });
     if (prepared.kind === 'idle') return this.idle();
     if (prepared.kind === 'unavailable') {
-      this.lastError = prepared.reason;
+      this.lastErrorByTenant.set(this.currentTenantKey(), prepared.reason);
       return 0;
     }
     const { embeddingSpaceId, reused, rows } = prepared;
     if (rows.length === 0) {
       if (reused === 0) return this.idle();
-      this.lastIndexedAt = new Date();
+      this.lastIndexedAtByTenant.set(this.currentTenantKey(), new Date());
       return reused;
     }
 
@@ -574,7 +577,7 @@ export class KnowledgeEmbeddingIndexer {
         .run();
     });
 
-    this.lastIndexedAt = new Date();
+    this.lastIndexedAtByTenant.set(this.currentTenantKey(), new Date());
     return reused + results.length;
   }
 }

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -18,6 +18,7 @@ import {
   shortId,
   sql,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   update,
 } from '@agor/core/db';
 import type { KnowledgeDocumentUnitID, KnowledgeSemanticPolicy, TenantID } from '@agor/core/types';
@@ -41,6 +42,7 @@ interface PendingUnitRow {
 
 interface CurrentUnitRow {
   unit_id: string;
+  content_text: string | null;
   content_md5: string | null;
   embedding_status: string;
 }
@@ -228,7 +230,7 @@ export class KnowledgeEmbeddingIndexer {
     this.settings = new KnowledgeSemanticSettingsRepository(db);
   }
 
-  private withTenantDatabase<T>(work: () => Promise<T>): Promise<T> {
+  private withTenantDatabase<T>(work: (db: TenantScopedDatabase) => Promise<T>): Promise<T> {
     return runWithTenantDatabaseScope(this.db, getCurrentTenantId(), work);
   }
 
@@ -484,8 +486,8 @@ export class KnowledgeEmbeddingIndexer {
 
     const batchSize = Math.min(Math.max(semantic.indexing.batch_size, 1), 128);
     this.lastErrorByTenant.set(this.currentTenantKey(), null);
-    const prepared = await this.withTenantDatabase(async () => {
-      const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+    const prepared = await this.withTenantDatabase(async (tx) => {
+      const currentSemantic = await this.settings.lockAggregateForUpdate(tx);
       const currentApiKey = await this.settings.getApiKey();
       if (
         !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
@@ -587,8 +589,8 @@ export class KnowledgeEmbeddingIndexer {
         { apiKey, model, dimensions }
       );
     } catch (error) {
-      const recorded = await this.withTenantDatabase(async () => {
-        const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+      const recorded = await this.withTenantDatabase(async (tx) => {
+        const currentSemantic = await this.settings.lockAggregateForUpdate(tx);
         const currentApiKey = await this.settings.getApiKey();
         if (
           !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
@@ -616,8 +618,8 @@ export class KnowledgeEmbeddingIndexer {
       throw error;
     }
 
-    const committed = await this.withTenantDatabase(async () => {
-      const currentSemantic = await this.settings.lockAggregateForUpdate(this.db);
+    const committed = await this.withTenantDatabase(async (tx) => {
+      const currentSemantic = await this.settings.lockAggregateForUpdate(tx);
       const currentApiKey = await this.settings.getApiKey();
       if (
         !isKnowledgeEmbeddingMaterializationSnapshotCurrent(
@@ -677,6 +679,7 @@ export class KnowledgeEmbeddingIndexer {
     if (rows.length === 0) return [];
     const currentRows = (await select(this.db, {
       unit_id: kbDocumentUnits.unit_id,
+      content_text: kbDocumentUnits.content_text,
       content_md5: kbDocumentUnits.content_md5,
       embedding_status: kbDocumentUnits.embedding_status,
     })
@@ -693,7 +696,9 @@ export class KnowledgeEmbeddingIndexer {
       .filter((row) => {
         const source = sourceById.get(row.unit_id);
         return (
-          source?.content_md5 === row.content_md5 &&
+          source !== undefined &&
+          source.content_text === row.content_text &&
+          source.content_md5 === row.content_md5 &&
           (row.embedding_status === 'pending' || row.embedding_status === 'stale')
         );
       })

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -1,4 +1,5 @@
 import {
+  enqueueAfterTenantDatabaseCommit,
   executeRaw,
   generateId,
   getCurrentTenantId,
@@ -9,6 +10,8 @@ import {
   kbDocumentUnits,
   kbDocumentVersions,
   kbEmbeddingSpaces,
+  runWithoutTenantContext,
+  runWithoutTenantDatabaseScope,
   runWithTenantContext,
   runWithTenantDatabaseScope,
   select,
@@ -221,14 +224,28 @@ export class KnowledgeEmbeddingIndexer {
   }
 
   wake(): void {
-    if (this.wakeScheduled) return;
-    this.wakeScheduled = true;
-    setTimeout(() => {
-      this.wakeScheduled = false;
-      this.tick().catch((error) => {
-        console.error('[knowledge-indexer] wake failed:', error);
+    const schedule = () => {
+      // Timers inherit AsyncLocalStorage. Explicitly detach both the request's
+      // operation identity and its (possibly committed) transaction before the
+      // indexer establishes its own tenant context in tick().
+      runWithoutTenantContext(() => {
+        runWithoutTenantDatabaseScope(() => {
+          if (this.wakeScheduled) return;
+          this.wakeScheduled = true;
+          setTimeout(() => {
+            this.wakeScheduled = false;
+            this.tick().catch((error) => {
+              console.error('[knowledge-indexer] wake failed:', error);
+            });
+          }, 0);
+        });
       });
-    }, 0);
+    };
+
+    // A settings/document mutation can call wake from an outer tenant
+    // transaction. Never let the indexer observe work until that transaction
+    // commits; rollback discards the callback.
+    if (!enqueueAfterTenantDatabaseCommit(schedule)) schedule();
   }
 
   private currentTenantKey(): string {

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -1,7 +1,7 @@
-import { loadConfig } from '@agor/core/config';
 import {
-  AppVariableRepository,
+  getCurrentTenantId,
   isPostgresDatabase,
+  KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
   select,
   sql,
@@ -14,13 +14,7 @@ import type {
   KnowledgeIndexingStatus,
   Params,
 } from '@agor/core/types';
-import {
-  DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-  DEFAULT_OPENAI_EMBEDDING_MODEL,
-  isUsableOpenAIEmbeddingConfig,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-} from '../knowledge/embeddings.js';
+import { isUsableOpenAIEmbeddingConfig } from '../knowledge/embeddings.js';
 import { getKnowledgePgvectorCapability } from '../knowledge/pgvector.js';
 
 const STATUSES: KnowledgeEmbeddingStatus[] = [
@@ -34,22 +28,17 @@ const STATUSES: KnowledgeEmbeddingStatus[] = [
 export type KnowledgeIndexingParams = Params & AuthenticatedParams;
 
 export class KnowledgeIndexingStatusService {
-  private variables: AppVariableRepository;
+  private settings: KnowledgeSemanticSettingsRepository;
 
   constructor(
     private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
-    this.variables = new AppVariableRepository(db);
+    this.settings = new KnowledgeSemanticSettingsRepository(db);
   }
 
   async find(_params?: KnowledgeIndexingParams): Promise<KnowledgeIndexingStatus> {
-    const config = await loadConfig();
-    const semantic = config.knowledge?.semantic_search ?? {};
-    const apiKey = await this.variables.find(
-      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-      KNOWLEDGE_EMBEDDINGS_API_KEY
-    );
+    const semantic = await this.settings.find();
     const counts = Object.fromEntries(STATUSES.map((status) => [status, 0])) as Record<
       KnowledgeEmbeddingStatus,
       number
@@ -67,18 +56,24 @@ export class KnowledgeIndexingStatusService {
     }
 
     const pgvector = await getKnowledgePgvectorCapability(this.db);
-    const semanticEnabled = semantic.enabled === true;
+    const semanticEnabled = semantic.enabled;
     const embeddingConfigUsable = isUsableOpenAIEmbeddingConfig(
       semantic,
-      Boolean(apiKey?.value_encrypted)
+      semantic.api_key_configured
     );
     const configured = isPostgresDatabase(this.db) && pgvector.available && embeddingConfigUsable;
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'
-    ) as { getLastIndexedAt?: () => Date | null; getLastError?: () => string | null } | undefined;
+    ) as
+      | {
+          getLastIndexedAt?: (tenantId?: string) => Date | null;
+          getLastError?: (tenantId?: string) => string | null;
+        }
+      | undefined;
+    const tenantId = String(getCurrentTenantId() ?? 'default');
     const lastError = semanticEnabled
-      ? ((configured ? indexer?.getLastError?.() : null) ??
+      ? ((configured ? indexer?.getLastError?.(tenantId) : null) ??
         (!pgvector.available ? pgvector.reason : null))
       : null;
 
@@ -91,12 +86,12 @@ export class KnowledgeIndexingStatusService {
       pgvector_storage_ready: pgvector.storageReady,
       pgvector_reason: pgvector.reason,
       pgvector_setup_hint: pgvector.setupHint,
-      provider: semantic.provider ?? 'openai',
-      model: semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
-      dimensions: semantic.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
+      provider: semantic.provider,
+      model: semantic.model,
+      dimensions: semantic.dimensions,
       chunks: counts,
       queue_depth: counts.pending + counts.stale,
-      last_indexed_at: indexer?.getLastIndexedAt?.() ?? null,
+      last_indexed_at: indexer?.getLastIndexedAt?.(tenantId) ?? null,
       last_error: lastError,
     };
   }

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -1,9 +1,6 @@
 import {
-  getCurrentTenantDatabase,
   isPostgresDatabase,
-  isSQLiteDatabase,
   KnowledgeSemanticSettingsRepository,
-  runDatabaseTransaction,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
 } from '@agor/core/db';
@@ -11,6 +8,7 @@ import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, KnowledgeEmbeddingStatus, Params } from '@agor/core/types';
 import { isUsableOpenAIEmbeddingConfig } from '../knowledge/embeddings.js';
 import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
+import { runKnowledgePolicyTransaction } from '../knowledge/policy-transaction.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
 export interface KnowledgeReindexResult {
@@ -40,29 +38,9 @@ export class KnowledgeReindexService {
   }
 
   async create(_data?: unknown, _params?: KnowledgeReindexParams): Promise<KnowledgeReindexResult> {
-    const ambientDb = getCurrentTenantDatabase();
-    let result: KnowledgeReindexResult;
-    if (ambientDb && isPostgresDatabase(ambientDb)) {
-      result = await this.reindexInTransaction(ambientDb as TenantScopedDatabase);
-    } else if (isSQLiteDatabase(this.db)) {
-      for (let attempt = 0; ; attempt++) {
-        try {
-          result = await runDatabaseTransaction(
-            this.db,
-            (tx) => this.reindexInTransaction(tx as TenantScopedDatabase),
-            { sqliteImmediate: true }
-          );
-          break;
-        } catch (error) {
-          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
-          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
-        }
-      }
-    } else {
-      result = await runDatabaseTransaction(this.db, (tx) =>
-        this.reindexInTransaction(tx as TenantScopedDatabase)
-      );
-    }
+    const result = await runKnowledgePolicyTransaction(this.db, (tx) =>
+      this.reindexInTransaction(tx)
+    );
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -1,16 +1,11 @@
-import { loadConfig } from '@agor/core/config';
 import {
-  AppVariableRepository,
   isPostgresDatabase,
+  KnowledgeSemanticSettingsRepository,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, KnowledgeEmbeddingStatus, Params } from '@agor/core/types';
-import {
-  isUsableOpenAIEmbeddingConfig,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-} from '../knowledge/embeddings.js';
+import { isUsableOpenAIEmbeddingConfig } from '../knowledge/embeddings.js';
 import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
@@ -22,29 +17,24 @@ export interface KnowledgeReindexResult {
 export type KnowledgeReindexParams = Params & AuthenticatedParams;
 
 export class KnowledgeReindexService {
-  private variables: AppVariableRepository;
+  private settings: KnowledgeSemanticSettingsRepository;
 
   constructor(
     private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
-    this.variables = new AppVariableRepository(db);
+    this.settings = new KnowledgeSemanticSettingsRepository(db);
   }
 
   async create(_data?: unknown, _params?: KnowledgeReindexParams): Promise<KnowledgeReindexResult> {
-    const config = await loadConfig();
-    const semantic = config.knowledge?.semantic_search ?? {};
-    const apiKey = await this.variables.find(
-      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-      KNOWLEDGE_EMBEDDINGS_API_KEY
-    );
+    const semantic = await this.settings.find();
     const embeddingConfigured =
       isPostgresDatabase(this.db) &&
-      isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted)) &&
+      isUsableOpenAIEmbeddingConfig(semantic, semantic.api_key_configured) &&
       (await ensureKnowledgePgvectorStorage(this.db)).available;
     const status: KnowledgeEmbeddingStatus = embeddingConfigured ? 'pending' : 'not_configured';
 
-    const queued = await rebuildCurrentKnowledgeUnits(this.db, config, { embeddingConfigured });
+    const queued = await rebuildCurrentKnowledgeUnits(this.db, semantic, { embeddingConfigured });
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -1,7 +1,11 @@
 import {
+  getCurrentTenantDatabase,
   isPostgresDatabase,
+  isSQLiteDatabase,
   KnowledgeSemanticSettingsRepository,
+  runDatabaseTransaction,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, KnowledgeEmbeddingStatus, Params } from '@agor/core/types';
@@ -17,31 +21,55 @@ export interface KnowledgeReindexResult {
 export type KnowledgeReindexParams = Params & AuthenticatedParams;
 
 export class KnowledgeReindexService {
-  private settings: KnowledgeSemanticSettingsRepository;
-
   constructor(
     private db: TenantScopeAwareDatabase,
     private app?: Application
-  ) {
-    this.settings = new KnowledgeSemanticSettingsRepository(db);
+  ) {}
+
+  private async reindexInTransaction(db: TenantScopedDatabase): Promise<KnowledgeReindexResult> {
+    const semantic = await new KnowledgeSemanticSettingsRepository(db).lockAggregateForUpdate(db);
+    const embeddingConfigured =
+      isPostgresDatabase(db) &&
+      isUsableOpenAIEmbeddingConfig(semantic, semantic.api_key_configured) &&
+      (await ensureKnowledgePgvectorStorage(db)).available;
+    const status: KnowledgeEmbeddingStatus = embeddingConfigured ? 'pending' : 'not_configured';
+
+    const queued = await rebuildCurrentKnowledgeUnits(db, semantic, { embeddingConfigured });
+
+    return { queued, status };
   }
 
   async create(_data?: unknown, _params?: KnowledgeReindexParams): Promise<KnowledgeReindexResult> {
-    const semantic = await this.settings.find();
-    const embeddingConfigured =
-      isPostgresDatabase(this.db) &&
-      isUsableOpenAIEmbeddingConfig(semantic, semantic.api_key_configured) &&
-      (await ensureKnowledgePgvectorStorage(this.db)).available;
-    const status: KnowledgeEmbeddingStatus = embeddingConfigured ? 'pending' : 'not_configured';
-
-    const queued = await rebuildCurrentKnowledgeUnits(this.db, semantic, { embeddingConfigured });
+    const ambientDb = getCurrentTenantDatabase();
+    let result: KnowledgeReindexResult;
+    if (ambientDb && isPostgresDatabase(ambientDb)) {
+      result = await this.reindexInTransaction(ambientDb as TenantScopedDatabase);
+    } else if (isSQLiteDatabase(this.db)) {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          result = await runDatabaseTransaction(
+            this.db,
+            (tx) => this.reindexInTransaction(tx as TenantScopedDatabase),
+            { sqliteImmediate: true }
+          );
+          break;
+        } catch (error) {
+          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+        }
+      }
+    } else {
+      result = await runDatabaseTransaction(this.db, (tx) =>
+        this.reindexInTransaction(tx as TenantScopedDatabase)
+      );
+    }
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'
     ) as { wake?: () => void } | undefined;
-    if (embeddingConfigured && queued > 0) indexer?.wake?.();
+    if (result.status === 'pending' && result.queued > 0) indexer?.wake?.();
 
-    return { queued, status };
+    return result;
   }
 }
 

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -2,15 +2,15 @@
  * Knowledge search service
  */
 
-import { getBaseUrl, loadConfig } from '@agor/core/config';
+import { getBaseUrl } from '@agor/core/config';
 import {
-  AppVariableRepository,
   executeRaw,
   isPostgresDatabase,
   KnowledgeDocumentRepository,
   KnowledgeNamespaceRepository,
   type KnowledgeSearchQuery,
   KnowledgeSearchRepository,
+  KnowledgeSemanticSettingsRepository,
   sql,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
@@ -26,10 +26,7 @@ import {
 import { getKnowledgeUrl } from '@agor/core/utils/url';
 import {
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-  DEFAULT_OPENAI_EMBEDDING_MODEL,
   embeddingToPgvector,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
   OpenAIEmbeddingProvider,
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
 } from '../knowledge/embeddings.js';
@@ -45,14 +42,14 @@ export class KnowledgeSearchService {
   private repo: KnowledgeSearchRepository;
   private documents: KnowledgeDocumentRepository;
   private namespaces: KnowledgeNamespaceRepository;
-  private variables: AppVariableRepository;
+  private semanticSettings: KnowledgeSemanticSettingsRepository;
   private embeddingProvider = new OpenAIEmbeddingProvider();
 
   constructor(private db: TenantScopeAwareDatabase) {
     this.repo = new KnowledgeSearchRepository(db);
     this.documents = new KnowledgeDocumentRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
-    this.variables = new AppVariableRepository(db);
+    this.semanticSettings = new KnowledgeSemanticSettingsRepository(db);
   }
 
   private async canRead(
@@ -155,26 +152,22 @@ export class KnowledgeSearchService {
         setup_hint: pgvector.setupHint,
       });
     }
-    const config = await loadConfig();
-    const semantic = config.knowledge?.semantic_search ?? {};
-    if (semantic.enabled !== true) {
+    const semantic = await this.semanticSettings.findPolicy();
+    if (!semantic.enabled) {
       throw new BadRequest(
         'Semantic Knowledge search is disabled. Enable it in Knowledge settings.'
       );
     }
-    const provider = semantic.provider ?? 'openai';
+    const provider = semantic.provider;
     if (provider !== 'openai') throw new BadRequest('Only OpenAI embeddings are implemented');
-    const apiKey = await this.variables.getPlain(
-      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-      KNOWLEDGE_EMBEDDINGS_API_KEY
-    );
+    const apiKey = await this.semanticSettings.getApiKey();
     if (!apiKey) throw new BadRequest('Knowledge embedding API key is not configured');
 
-    const model = semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL;
+    const model = semantic.model;
     if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(model)) {
       throw new BadRequest(`Unsupported OpenAI embedding model: ${model}`);
     }
-    const dimensions = semantic.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS;
+    const dimensions = semantic.dimensions;
     if (dimensions !== DEFAULT_OPENAI_EMBEDDING_DIMENSIONS) {
       throw new BadRequest(
         'Only 1536-dimensional OpenAI embeddings are supported by the V1 vector table'

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -181,11 +181,13 @@ export class KnowledgeSettingsService {
     const updatedBy = (user?.user_id as UserID | undefined) ?? null;
     const apply = async (
       db: KnowledgeSettingsDatabase
-    ): Promise<KnowledgeSemanticSettingsPublic> => {
+    ): Promise<{ saved: KnowledgeSemanticSettingsPublic; shouldWake: boolean }> => {
       const settings = new KnowledgeSemanticSettingsRepository(db);
-      const current = await settings.find();
-      const saved = await settings.patchInTransaction(db, data, updatedBy, (policy) =>
-        this.validateProviderCapability(policy)
+      const { previous: current, saved } = await settings.patchInTransaction(
+        db,
+        data,
+        updatedBy,
+        (policy) => this.validateProviderCapability(policy)
       );
       const identityChanged =
         current.enabled !== saved.enabled ||
@@ -205,29 +207,39 @@ export class KnowledgeSettingsService {
               embeddingConfigured: configured,
             })
           : await this.markCurrentUnitsForEmbedding(db, configured ? 'pending' : 'not_configured');
-        if (queued > 0 && configured) this.wakeIndexer();
+        return { saved, shouldWake: queued > 0 && configured };
       }
 
-      return saved;
+      return { saved, shouldWake: false };
     };
 
     try {
+      let result: { saved: KnowledgeSemanticSettingsPublic; shouldWake: boolean };
       if (!isSQLiteDatabase(this.db)) {
         const ambientDb = getCurrentTenantDatabase();
-        return ambientDb && isPostgresDatabase(ambientDb)
-          ? await apply(this.db)
-          : await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
-      }
-      for (let attempt = 0; ; attempt++) {
-        try {
-          return await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase), {
-            sqliteImmediate: true,
-          });
-        } catch (error) {
-          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
-          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+        result =
+          ambientDb && isPostgresDatabase(ambientDb)
+            ? await apply(this.db)
+            : await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
+      } else {
+        for (let attempt = 0; ; attempt++) {
+          try {
+            result = await runDatabaseTransaction(
+              this.db,
+              (tx) => apply(tx as TenantScopedDatabase),
+              {
+                sqliteImmediate: true,
+              }
+            );
+            break;
+          } catch (error) {
+            if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+            await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+          }
         }
       }
+      if (result.shouldWake) this.wakeIndexer();
+      return result.saved;
     } catch (error) {
       if (error instanceof KnowledgeSemanticPolicyValidationError) {
         throw new BadRequest(error.message);

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -1,8 +1,7 @@
-import { type AgorKnowledgeSettings, loadConfig, saveConfig } from '@agor/core/config';
 import {
-  AppVariableRepository,
   executeRaw,
   isPostgresDatabase,
+  KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
   sql,
   type TenantScopeAwareDatabase,
@@ -12,22 +11,17 @@ import type { Application } from '@agor/core/feathers';
 import { BadRequest } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
-  KnowledgeEmbeddingProvider,
   KnowledgeEmbeddingStatus,
+  KnowledgeSemanticPolicy,
+  KnowledgeSemanticSettingsPatch,
   KnowledgeSemanticSettingsPublic,
   Params,
   User,
   UserID,
 } from '@agor/core/types';
 import {
-  DEFAULT_KNOWLEDGE_CHUNKING,
-  DEFAULT_KNOWLEDGE_INDEXING,
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-  DEFAULT_OPENAI_EMBEDDING_MODEL,
   isUsableOpenAIEmbeddingConfig,
-  KNOWLEDGE_EMBEDDINGS_API_KEY,
-  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-  normalizeKnowledgeEmbeddingApiKey,
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
 } from '../knowledge/embeddings.js';
 import {
@@ -36,53 +30,25 @@ import {
 } from '../knowledge/pgvector.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
-const DEFAULT_PROVIDER: KnowledgeEmbeddingProvider = 'openai';
-
-type KnowledgeSemanticSearchSettings = NonNullable<AgorKnowledgeSettings['semantic_search']>;
-type KnowledgeChunkingSettings = NonNullable<KnowledgeSemanticSearchSettings['chunking']>;
-
-export interface KnowledgeSettingsPatch {
-  enabled?: boolean;
-  provider?: KnowledgeEmbeddingProvider;
-  model?: string | null;
-  dimensions?: number | null;
-  api_key?: string | null;
-  chunking?: KnowledgeSemanticSearchSettings['chunking'];
-  indexing?: KnowledgeSemanticSearchSettings['indexing'];
-}
+export type KnowledgeSettingsPatch = KnowledgeSemanticSettingsPatch;
 
 export type KnowledgeSettingsParams = Params & AuthenticatedParams;
 
 export class KnowledgeSettingsService {
-  private variables: AppVariableRepository;
+  private settings: KnowledgeSemanticSettingsRepository;
 
   constructor(
     private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
-    this.variables = new AppVariableRepository(db);
+    this.settings = new KnowledgeSemanticSettingsRepository(db);
   }
 
   private async publicSettings(): Promise<KnowledgeSemanticSettingsPublic> {
-    const config = await loadConfig();
-    const settings = config.knowledge?.semantic_search ?? {};
-    const apiKey = await this.variables.find(
-      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-      KNOWLEDGE_EMBEDDINGS_API_KEY
-    );
-    return {
-      enabled: settings.enabled === true,
-      provider: settings.provider ?? DEFAULT_PROVIDER,
-      model: settings.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
-      dimensions: settings.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-      api_key_configured: Boolean(apiKey?.value_encrypted),
-      chunking: { ...DEFAULT_KNOWLEDGE_CHUNKING, ...(settings.chunking ?? {}) },
-      indexing: { ...DEFAULT_KNOWLEDGE_INDEXING, ...(settings.indexing ?? {}) },
-    };
+    return this.settings.find();
   }
 
-  private validateChunking(chunking?: KnowledgeChunkingSettings): void {
-    if (!chunking) return;
+  private validateChunking(chunking: KnowledgeSemanticPolicy['chunking']): void {
     const entries = [
       ['target_tokens', chunking.target_tokens],
       ['max_tokens', chunking.max_tokens],
@@ -90,7 +56,6 @@ export class KnowledgeSettingsService {
       ['min_tokens', chunking.min_tokens],
     ] as const;
     for (const [name, value] of entries) {
-      if (value === undefined) continue;
       if (!Number.isInteger(value) || value < 0) {
         throw new BadRequest(`Knowledge chunking ${name} must be a non-negative integer`);
       }
@@ -99,25 +64,125 @@ export class KnowledgeSettingsService {
       }
     }
 
-    const merged = { ...DEFAULT_KNOWLEDGE_CHUNKING, ...chunking };
-    if (merged.min_tokens <= 0) {
+    if (chunking.min_tokens <= 0) {
       throw new BadRequest('Knowledge chunking min_tokens must be greater than 0');
     }
-    if (merged.target_tokens <= 0) {
+    if (chunking.target_tokens <= 0) {
       throw new BadRequest('Knowledge chunking target_tokens must be greater than 0');
     }
-    if (merged.max_tokens < merged.min_tokens) {
+    if (chunking.max_tokens < chunking.min_tokens) {
       throw new BadRequest(
         'Knowledge chunking max_tokens must be greater than or equal to min_tokens'
       );
     }
-    if (merged.target_tokens > merged.max_tokens) {
+    if (chunking.target_tokens > chunking.max_tokens) {
       throw new BadRequest(
         'Knowledge chunking target_tokens must be less than or equal to max_tokens'
       );
     }
-    if (merged.overlap_tokens >= merged.max_tokens) {
+    if (chunking.overlap_tokens >= chunking.max_tokens) {
       throw new BadRequest('Knowledge chunking overlap_tokens must be less than max_tokens');
+    }
+  }
+
+  private validateIndexing(indexing: KnowledgeSemanticPolicy['indexing']): void {
+    if (typeof indexing.paused !== 'boolean') {
+      throw new BadRequest('Knowledge indexing paused must be a boolean');
+    }
+    if (
+      !Number.isInteger(indexing.batch_size) ||
+      indexing.batch_size < 1 ||
+      indexing.batch_size > 128
+    ) {
+      throw new BadRequest('Knowledge indexing batch_size must be an integer between 1 and 128');
+    }
+    if (
+      !Number.isInteger(indexing.concurrency) ||
+      indexing.concurrency < 1 ||
+      indexing.concurrency > 32
+    ) {
+      throw new BadRequest('Knowledge indexing concurrency must be an integer between 1 and 32');
+    }
+  }
+
+  private validatePolicy(policy: KnowledgeSemanticPolicy): void {
+    if (policy.provider !== 'openai') {
+      throw new BadRequest('Knowledge semantic search currently supports only OpenAI embeddings');
+    }
+    this.validateChunking(policy.chunking);
+    this.validateIndexing(policy.indexing);
+    if (!Number.isInteger(policy.dimensions) || policy.dimensions <= 0) {
+      throw new BadRequest('Knowledge embedding dimensions must be a positive integer');
+    }
+    if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(policy.model)) {
+      throw new BadRequest(`Unsupported OpenAI embedding model: ${policy.model}`);
+    }
+    if (policy.dimensions !== DEFAULT_OPENAI_EMBEDDING_DIMENSIONS) {
+      throw new BadRequest(
+        'Knowledge semantic search currently supports 1536-dimensional OpenAI embeddings'
+      );
+    }
+  }
+
+  private validatePatchShape(data: KnowledgeSettingsPatch): void {
+    const allowedFields = new Set([
+      'enabled',
+      'provider',
+      'model',
+      'dimensions',
+      'api_key',
+      'chunking',
+      'indexing',
+    ]);
+    const unknownField = Object.keys(data).find((field) => !allowedFields.has(field));
+    if (unknownField) {
+      throw new BadRequest(`Unknown Knowledge semantic-search setting: ${unknownField}`);
+    }
+    if (data.enabled !== undefined && typeof data.enabled !== 'boolean') {
+      throw new BadRequest('Knowledge semantic search enabled must be a boolean');
+    }
+    if (
+      data.provider !== undefined &&
+      data.provider !== null &&
+      typeof data.provider !== 'string'
+    ) {
+      throw new BadRequest('Knowledge embedding provider must be a string');
+    }
+    if (data.model !== undefined && data.model !== null && typeof data.model !== 'string') {
+      throw new BadRequest('Knowledge embedding model must be a string');
+    }
+    if (
+      data.dimensions !== undefined &&
+      data.dimensions !== null &&
+      typeof data.dimensions !== 'number'
+    ) {
+      throw new BadRequest('Knowledge embedding dimensions must be a number');
+    }
+    if (data.api_key !== undefined && data.api_key !== null && typeof data.api_key !== 'string') {
+      throw new BadRequest('Knowledge embedding API key must be a string or null');
+    }
+    for (const [section, value] of [
+      ['chunking', data.chunking],
+      ['indexing', data.indexing],
+    ] as const) {
+      if (
+        value !== undefined &&
+        value !== null &&
+        (!value || typeof value !== 'object' || Array.isArray(value))
+      ) {
+        throw new BadRequest(`Knowledge ${section} settings must be an object or null`);
+      }
+      const allowedSectionFields =
+        section === 'chunking'
+          ? new Set(['target_tokens', 'max_tokens', 'overlap_tokens', 'min_tokens'])
+          : new Set(['paused', 'batch_size', 'concurrency']);
+      const unknownSectionField =
+        value && typeof value === 'object' && !Array.isArray(value)
+          ? Object.keys(value).find((field) => !allowedSectionFields.has(field))
+          : undefined;
+      if (unknownSectionField) {
+        throw new BadRequest(`Unknown Knowledge ${section} setting: ${unknownSectionField}`);
+      }
     }
   }
 
@@ -164,92 +229,37 @@ export class KnowledgeSettingsService {
     data: KnowledgeSettingsPatch,
     params?: KnowledgeSettingsParams
   ): Promise<KnowledgeSemanticSettingsPublic> {
-    const config = await loadConfig();
-    const current = config.knowledge?.semantic_search ?? {};
-    const next = {
-      ...current,
-      ...(data.enabled !== undefined ? { enabled: data.enabled } : {}),
-      ...(data.provider !== undefined ? { provider: data.provider } : {}),
-      ...(data.model !== undefined ? { model: data.model ?? undefined } : {}),
-      ...(data.dimensions !== undefined ? { dimensions: data.dimensions ?? undefined } : {}),
-      ...(data.chunking !== undefined ? { chunking: data.chunking } : {}),
-      ...(data.indexing !== undefined ? { indexing: data.indexing } : {}),
-    };
+    this.validatePatchShape(data);
+    const current = await this.publicSettings();
 
-    if ((next.provider ?? DEFAULT_PROVIDER) !== 'openai') {
-      throw new BadRequest('Knowledge semantic search currently supports only OpenAI embeddings');
-    }
-    this.validateChunking(next.chunking);
-    if (
-      next.dimensions !== undefined &&
-      (!Number.isInteger(next.dimensions) || next.dimensions <= 0)
-    ) {
-      throw new BadRequest('Knowledge embedding dimensions must be a positive integer');
-    }
-    if ((next.provider ?? DEFAULT_PROVIDER) === 'openai') {
-      const model = next.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL;
-      if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(model)) {
-        throw new BadRequest(`Unsupported OpenAI embedding model: ${model}`);
-      }
-      if (
-        (next.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS) !==
-        DEFAULT_OPENAI_EMBEDDING_DIMENSIONS
-      ) {
-        throw new BadRequest(
-          'Knowledge semantic search currently supports 1536-dimensional OpenAI embeddings'
-        );
-      }
-    }
-
-    const previousIdentity = {
-      enabled: current.enabled === true,
-      provider: current.provider ?? DEFAULT_PROVIDER,
-      model: current.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
-      dimensions: current.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-    };
-    const nextIdentity = {
-      enabled: next.enabled === true,
-      provider: next.provider ?? DEFAULT_PROVIDER,
-      model: next.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
-      dimensions: next.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
-    };
+    const user = params?.user as User | undefined;
+    const saved = await this.settings.patch(
+      data,
+      (user?.user_id as UserID | undefined) ?? null,
+      (policy) => this.validatePolicy(policy)
+    );
     const identityChanged =
-      previousIdentity.enabled !== nextIdentity.enabled ||
-      previousIdentity.provider !== nextIdentity.provider ||
-      previousIdentity.model !== nextIdentity.model ||
-      previousIdentity.dimensions !== nextIdentity.dimensions ||
+      current.enabled !== saved.enabled ||
+      current.provider !== saved.provider ||
+      current.model !== saved.model ||
+      current.dimensions !== saved.dimensions ||
       data.api_key !== undefined;
-    const chunkingChanged = data.chunking !== undefined;
-
-    config.knowledge = { ...(config.knowledge ?? {}), semantic_search: next };
-    await saveConfig(config);
-
-    if (data.api_key !== undefined) {
-      const user = params?.user as User | undefined;
-      await this.variables.setEncrypted(
-        KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-        KNOWLEDGE_EMBEDDINGS_API_KEY,
-        normalizeKnowledgeEmbeddingApiKey(data.api_key),
-        (user?.user_id as UserID | undefined) ?? null
-      );
-    }
+    const chunkingChanged = JSON.stringify(current.chunking) !== JSON.stringify(saved.chunking);
 
     if (identityChanged || chunkingChanged) {
-      const apiKey = await this.variables.find(
-        KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-        KNOWLEDGE_EMBEDDINGS_API_KEY
-      );
       const configured =
         isPostgresDatabase(this.db) &&
-        isUsableOpenAIEmbeddingConfig(next, Boolean(apiKey?.value_encrypted)) &&
+        isUsableOpenAIEmbeddingConfig(saved, saved.api_key_configured) &&
         (await ensureKnowledgePgvectorStorage(this.db)).available;
       const queued = chunkingChanged
-        ? await rebuildCurrentKnowledgeUnits(this.db, config, { embeddingConfigured: configured })
+        ? await rebuildCurrentKnowledgeUnits(this.db, saved, {
+            embeddingConfigured: configured,
+          })
         : await this.markCurrentUnitsForEmbedding(configured ? 'pending' : 'not_configured');
       if (queued > 0 && configured) this.wakeIndexer();
     }
 
-    return this.publicSettings();
+    return saved;
   }
 
   async create(data: KnowledgeSettingsPatch, params?: KnowledgeSettingsParams) {

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -1,10 +1,14 @@
 import {
   executeRaw,
+  getCurrentTenantDatabase,
   isPostgresDatabase,
+  isSQLiteDatabase,
   KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
+  runDatabaseTransaction,
   sql,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   update,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
@@ -19,6 +23,7 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
+import { KnowledgeSemanticPolicyValidationError } from '@agor/core/types';
 import {
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
   isUsableOpenAIEmbeddingConfig,
@@ -33,6 +38,7 @@ import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 export type KnowledgeSettingsPatch = KnowledgeSemanticSettingsPatch;
 
 export type KnowledgeSettingsParams = Params & AuthenticatedParams;
+type KnowledgeSettingsDatabase = TenantScopeAwareDatabase | TenantScopedDatabase;
 
 export class KnowledgeSettingsService {
   private settings: KnowledgeSemanticSettingsRepository;
@@ -48,71 +54,9 @@ export class KnowledgeSettingsService {
     return this.settings.find();
   }
 
-  private validateChunking(chunking: KnowledgeSemanticPolicy['chunking']): void {
-    const entries = [
-      ['target_tokens', chunking.target_tokens],
-      ['max_tokens', chunking.max_tokens],
-      ['overlap_tokens', chunking.overlap_tokens],
-      ['min_tokens', chunking.min_tokens],
-    ] as const;
-    for (const [name, value] of entries) {
-      if (!Number.isInteger(value) || value < 0) {
-        throw new BadRequest(`Knowledge chunking ${name} must be a non-negative integer`);
-      }
-      if (value > 8000) {
-        throw new BadRequest(`Knowledge chunking ${name} must be 8000 or less`);
-      }
-    }
-
-    if (chunking.min_tokens <= 0) {
-      throw new BadRequest('Knowledge chunking min_tokens must be greater than 0');
-    }
-    if (chunking.target_tokens <= 0) {
-      throw new BadRequest('Knowledge chunking target_tokens must be greater than 0');
-    }
-    if (chunking.max_tokens < chunking.min_tokens) {
-      throw new BadRequest(
-        'Knowledge chunking max_tokens must be greater than or equal to min_tokens'
-      );
-    }
-    if (chunking.target_tokens > chunking.max_tokens) {
-      throw new BadRequest(
-        'Knowledge chunking target_tokens must be less than or equal to max_tokens'
-      );
-    }
-    if (chunking.overlap_tokens >= chunking.max_tokens) {
-      throw new BadRequest('Knowledge chunking overlap_tokens must be less than max_tokens');
-    }
-  }
-
-  private validateIndexing(indexing: KnowledgeSemanticPolicy['indexing']): void {
-    if (typeof indexing.paused !== 'boolean') {
-      throw new BadRequest('Knowledge indexing paused must be a boolean');
-    }
-    if (
-      !Number.isInteger(indexing.batch_size) ||
-      indexing.batch_size < 1 ||
-      indexing.batch_size > 128
-    ) {
-      throw new BadRequest('Knowledge indexing batch_size must be an integer between 1 and 128');
-    }
-    if (
-      !Number.isInteger(indexing.concurrency) ||
-      indexing.concurrency < 1 ||
-      indexing.concurrency > 32
-    ) {
-      throw new BadRequest('Knowledge indexing concurrency must be an integer between 1 and 32');
-    }
-  }
-
-  private validatePolicy(policy: KnowledgeSemanticPolicy): void {
+  private validateProviderCapability(policy: KnowledgeSemanticPolicy): void {
     if (policy.provider !== 'openai') {
       throw new BadRequest('Knowledge semantic search currently supports only OpenAI embeddings');
-    }
-    this.validateChunking(policy.chunking);
-    this.validateIndexing(policy.indexing);
-    if (!Number.isInteger(policy.dimensions) || policy.dimensions <= 0) {
-      throw new BadRequest('Knowledge embedding dimensions must be a positive integer');
     }
     if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(policy.model)) {
       throw new BadRequest(`Unsupported OpenAI embedding model: ${policy.model}`);
@@ -175,7 +119,7 @@ export class KnowledgeSettingsService {
       const allowedSectionFields =
         section === 'chunking'
           ? new Set(['target_tokens', 'max_tokens', 'overlap_tokens', 'min_tokens'])
-          : new Set(['paused', 'batch_size', 'concurrency']);
+          : new Set(['paused', 'batch_size']);
       const unknownSectionField =
         value && typeof value === 'object' && !Array.isArray(value)
           ? Object.keys(value).find((field) => !allowedSectionFields.has(field))
@@ -186,8 +130,11 @@ export class KnowledgeSettingsService {
     }
   }
 
-  private async markCurrentUnitsForEmbedding(status: KnowledgeEmbeddingStatus): Promise<number> {
-    const rows = await update(this.db, kbDocumentUnits)
+  private async markCurrentUnitsForEmbedding(
+    db: KnowledgeSettingsDatabase,
+    status: KnowledgeEmbeddingStatus
+  ): Promise<number> {
+    const rows = await update(db, kbDocumentUnits)
       .set({
         embedding_status: status,
         embedding_model: null,
@@ -201,11 +148,11 @@ export class KnowledgeSettingsService {
       .returning({ unit_id: kbDocumentUnits.unit_id })
       .all();
 
-    if (isPostgresDatabase(this.db) && rows.length > 0) {
-      const pgvector = await getKnowledgePgvectorCapability(this.db);
+    if (isPostgresDatabase(db) && rows.length > 0) {
+      const pgvector = await getKnowledgePgvectorCapability(db);
       if (pgvector.storageReady) {
         await executeRaw(
-          this.db,
+          db,
           sql`DELETE FROM kb_unit_embeddings WHERE unit_id IN (SELECT unit_id FROM kb_document_units WHERE version_id IN (SELECT current_version_id FROM kb_documents WHERE current_version_id IS NOT NULL AND archived = false))`
         );
       }
@@ -230,36 +177,63 @@ export class KnowledgeSettingsService {
     params?: KnowledgeSettingsParams
   ): Promise<KnowledgeSemanticSettingsPublic> {
     this.validatePatchShape(data);
-    const current = await this.publicSettings();
-
     const user = params?.user as User | undefined;
-    const saved = await this.settings.patch(
-      data,
-      (user?.user_id as UserID | undefined) ?? null,
-      (policy) => this.validatePolicy(policy)
-    );
-    const identityChanged =
-      current.enabled !== saved.enabled ||
-      current.provider !== saved.provider ||
-      current.model !== saved.model ||
-      current.dimensions !== saved.dimensions ||
-      data.api_key !== undefined;
-    const chunkingChanged = JSON.stringify(current.chunking) !== JSON.stringify(saved.chunking);
+    const updatedBy = (user?.user_id as UserID | undefined) ?? null;
+    const apply = async (
+      db: KnowledgeSettingsDatabase
+    ): Promise<KnowledgeSemanticSettingsPublic> => {
+      const settings = new KnowledgeSemanticSettingsRepository(db);
+      const current = await settings.find();
+      const saved = await settings.patchInTransaction(db, data, updatedBy, (policy) =>
+        this.validateProviderCapability(policy)
+      );
+      const identityChanged =
+        current.enabled !== saved.enabled ||
+        current.provider !== saved.provider ||
+        current.model !== saved.model ||
+        current.dimensions !== saved.dimensions ||
+        data.api_key !== undefined;
+      const chunkingChanged = JSON.stringify(current.chunking) !== JSON.stringify(saved.chunking);
 
-    if (identityChanged || chunkingChanged) {
-      const configured =
-        isPostgresDatabase(this.db) &&
-        isUsableOpenAIEmbeddingConfig(saved, saved.api_key_configured) &&
-        (await ensureKnowledgePgvectorStorage(this.db)).available;
-      const queued = chunkingChanged
-        ? await rebuildCurrentKnowledgeUnits(this.db, saved, {
-            embeddingConfigured: configured,
-          })
-        : await this.markCurrentUnitsForEmbedding(configured ? 'pending' : 'not_configured');
-      if (queued > 0 && configured) this.wakeIndexer();
+      if (identityChanged || chunkingChanged) {
+        const configured =
+          isPostgresDatabase(db) &&
+          isUsableOpenAIEmbeddingConfig(saved, saved.api_key_configured) &&
+          (await ensureKnowledgePgvectorStorage(db)).available;
+        const queued = chunkingChanged
+          ? await rebuildCurrentKnowledgeUnits(db, saved, {
+              embeddingConfigured: configured,
+            })
+          : await this.markCurrentUnitsForEmbedding(db, configured ? 'pending' : 'not_configured');
+        if (queued > 0 && configured) this.wakeIndexer();
+      }
+
+      return saved;
+    };
+
+    try {
+      if (!isSQLiteDatabase(this.db)) {
+        const ambientDb = getCurrentTenantDatabase();
+        return ambientDb && isPostgresDatabase(ambientDb)
+          ? await apply(this.db)
+          : await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
+      }
+      for (let attempt = 0; ; attempt++) {
+        try {
+          return await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase), {
+            sqliteImmediate: true,
+          });
+        } catch (error) {
+          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+        }
+      }
+    } catch (error) {
+      if (error instanceof KnowledgeSemanticPolicyValidationError) {
+        throw new BadRequest(error.message);
+      }
+      throw error;
     }
-
-    return saved;
   }
 
   async create(data: KnowledgeSettingsPatch, params?: KnowledgeSettingsParams) {

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -1,11 +1,8 @@
 import {
   executeRaw,
-  getCurrentTenantDatabase,
   isPostgresDatabase,
-  isSQLiteDatabase,
   KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
-  runDatabaseTransaction,
   sql,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
@@ -33,6 +30,7 @@ import {
   ensureKnowledgePgvectorStorage,
   getKnowledgePgvectorCapability,
 } from '../knowledge/pgvector.js';
+import { runKnowledgePolicyTransaction } from '../knowledge/policy-transaction.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
 export type KnowledgeSettingsPatch = KnowledgeSemanticSettingsPatch;
@@ -180,7 +178,7 @@ export class KnowledgeSettingsService {
     const user = params?.user as User | undefined;
     const updatedBy = (user?.user_id as UserID | undefined) ?? null;
     const apply = async (
-      db: KnowledgeSettingsDatabase
+      db: TenantScopedDatabase
     ): Promise<{ saved: KnowledgeSemanticSettingsPublic; shouldWake: boolean }> => {
       const settings = new KnowledgeSemanticSettingsRepository(db);
       const { previous: current, saved } = await settings.patchInTransaction(
@@ -214,30 +212,7 @@ export class KnowledgeSettingsService {
     };
 
     try {
-      let result: { saved: KnowledgeSemanticSettingsPublic; shouldWake: boolean };
-      if (!isSQLiteDatabase(this.db)) {
-        const ambientDb = getCurrentTenantDatabase();
-        result =
-          ambientDb && isPostgresDatabase(ambientDb)
-            ? await apply(this.db)
-            : await runDatabaseTransaction(this.db, (tx) => apply(tx as TenantScopedDatabase));
-      } else {
-        for (let attempt = 0; ; attempt++) {
-          try {
-            result = await runDatabaseTransaction(
-              this.db,
-              (tx) => apply(tx as TenantScopedDatabase),
-              {
-                sqliteImmediate: true,
-              }
-            );
-            break;
-          } catch (error) {
-            if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
-            await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
-          }
-        }
-      }
+      const result = await runKnowledgePolicyTransaction(this.db, apply);
       if (result.shouldWake) this.wakeIndexer();
       return result.saved;
     } catch (error) {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -751,6 +751,67 @@ describe('Knowledge semantic indexing lifecycle', () => {
     }
   );
 
+  dbTest(
+    'serializes document-unit writes with concurrent chunking policy changes on SQLite',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'document-policy-owner');
+      const original = await seedDocument(db, owner, { content_text: '# Original\n\nshort' });
+      const content = `# Updated\n\n${Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')}`;
+      const documents = new KnowledgeDocumentsService(db);
+      const settings = new KnowledgeSettingsService(db);
+
+      await Promise.all([
+        documents.patch(original.document_id, { content_text: content }, params(owner)),
+        settings.patch(null, {
+          chunking: { target_tokens: 40, max_tokens: 60, overlap_tokens: 0, min_tokens: 1 },
+        }),
+      ]);
+
+      const saved = await settings.find();
+      const document = await documents.get(original.document_id, params(owner));
+      const units = await select(db)
+        .from(kbDocumentUnits)
+        .where(eq(kbDocumentUnits.version_id, document.current_version_id))
+        .all();
+      const expected = knowledgeUnitsForMarkdown(
+        document.path,
+        content,
+        knowledgeChunkerOptionsFromSettings(saved)
+      );
+      expect(units.map((unit) => unit.content_md5).sort()).toEqual(
+        expected.map((unit) => unit.content_md5).sort()
+      );
+    }
+  );
+
+  dbTest('serializes manual reindex with chunking policy changes on SQLite', async ({ db }) => {
+    const owner = await seedUser(db, 'reindex-policy-owner');
+    const content = `# Reindex\n\n${Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')}`;
+    const document = await seedDocument(db, owner, { content_text: content });
+    const settings = new KnowledgeSettingsService(db);
+
+    await Promise.all([
+      new KnowledgeReindexService(db).create(),
+      settings.patch(null, {
+        chunking: { target_tokens: 40, max_tokens: 60, overlap_tokens: 0, min_tokens: 1 },
+      }),
+    ]);
+
+    const saved = await settings.find();
+    const units = await select(db)
+      .from(kbDocumentUnits)
+      .where(eq(kbDocumentUnits.version_id, document.current_version_id))
+      .all();
+    const expected = knowledgeUnitsForMarkdown(
+      document.path,
+      content,
+      knowledgeChunkerOptionsFromSettings(saved)
+    );
+    expect(units.map((unit) => unit.content_md5).sort()).toEqual(
+      expected.map((unit) => unit.content_md5).sort()
+    );
+  });
+
   dbTest('indexing status separates pgvector extension from usable storage', async ({ db }) => {
     await withTempConfig({}, async () => {
       await new KnowledgeSettingsService(db).patch(null, {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -23,6 +23,7 @@ import type { KnowledgeDocument, User, UserID } from '@agor/core/types';
 import { parseKnowledgeUri, ROLES } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { knowledgeChunkerOptionsFromSettings, knowledgeUnitsForMarkdown } from '../knowledge/units';
 import { KnowledgeDocumentsService } from './knowledge-documents';
 import { KnowledgeEmbeddingIndexer } from './knowledge-embedding-indexer';
 import { KnowledgeGraphService } from './knowledge-graph';
@@ -716,6 +717,39 @@ describe('Knowledge semantic indexing lifecycle', () => {
       );
     });
   });
+
+  dbTest(
+    'commits concurrent chunking policy and rebuilt units atomically on SQLite',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'chunk-policy-owner');
+      const content = `# Big\n\n${Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')}`;
+      const doc = await seedDocument(db, owner, { content_text: content });
+      const settings = new KnowledgeSettingsService(db);
+
+      await Promise.all([
+        settings.patch(null, {
+          chunking: { target_tokens: 40, max_tokens: 60, overlap_tokens: 0, min_tokens: 1 },
+        }),
+        settings.patch(null, {
+          chunking: { target_tokens: 80, max_tokens: 100, overlap_tokens: 10, min_tokens: 1 },
+        }),
+      ]);
+
+      const saved = await settings.find();
+      const units = await select(db)
+        .from(kbDocumentUnits)
+        .where(eq(kbDocumentUnits.version_id, doc.current_version_id))
+        .all();
+      const expected = knowledgeUnitsForMarkdown(
+        doc.path,
+        content,
+        knowledgeChunkerOptionsFromSettings(saved)
+      );
+      expect(units.map((unit) => unit.content_md5).sort()).toEqual(
+        expected.map((unit) => unit.content_md5).sort()
+      );
+    }
+  );
 
   dbTest('indexing status separates pgvector extension from usable storage', async ({ db }) => {
     await withTempConfig({}, async () => {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { __resetConfigCacheForTests, type AgorConfig, saveConfig } from '@agor/core/config';
+import {
+  __resetConfigCacheForTests,
+  type AgorConfig,
+  loadConfig,
+  saveConfig,
+} from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import {
   eq,
@@ -661,9 +666,10 @@ describe('KnowledgeDocumentsService permissions', () => {
 
 describe('Knowledge semantic indexing lifecycle', () => {
   dbTest('rejects unsupported providers and normalizes blank API keys', async ({ db }) => {
-    await withTempConfig({}, async () => {
+    await withTempConfig({ daemon: { port: 4321 } }, async () => {
       const admin = await seedUser(db, 'admin', ROLES.ADMIN);
       const settings = new KnowledgeSettingsService(db);
+      const configBefore = await loadConfig();
 
       await expect(
         settings.patch(null, { provider: 'voyage' as never }, params(admin))
@@ -675,59 +681,55 @@ describe('Knowledge semantic indexing lifecycle', () => {
         params(admin)
       );
       expect(saved.api_key_configured).toBe(false);
+      expect(await loadConfig()).toEqual(configBefore);
     });
   });
 
   dbTest('reindex rebuilds chunks from current document content on SQLite', async ({ db }) => {
-    await withTempConfig(
-      {
-        knowledge: {
-          semantic_search: {
-            enabled: true,
-            provider: 'openai',
-            chunking: {
-              target_tokens: 40,
-              max_tokens: 60,
-              overlap_tokens: 0,
-              min_tokens: 1,
-            },
-          },
+    await withTempConfig({}, async () => {
+      await new KnowledgeSettingsService(db).patch(null, {
+        enabled: true,
+        provider: 'openai',
+        chunking: {
+          target_tokens: 40,
+          max_tokens: 60,
+          overlap_tokens: 0,
+          min_tokens: 1,
         },
-      },
-      async () => {
-        const owner = await seedUser(db, 'owner');
-        const doc = await seedDocument(db, owner, {
-          content_text: `# Big\n\n${Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')}`,
-        });
+      });
+      const owner = await seedUser(db, 'owner');
+      const doc = await seedDocument(db, owner, {
+        content_text: `# Big\n\n${Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')}`,
+      });
 
-        const result = await new KnowledgeReindexService(db).create();
-        expect(result.status).toBe('not_configured');
-        expect(result.queued).toBeGreaterThan(1);
+      const result = await new KnowledgeReindexService(db).create();
+      expect(result.status).toBe('not_configured');
+      expect(result.queued).toBeGreaterThan(1);
 
-        const units = await select(db)
-          .from(kbDocumentUnits)
-          .where(eq(kbDocumentUnits.version_id, doc.current_version_id))
-          .all();
-        expect(units).toHaveLength(result.queued);
-        expect(new Set(units.map((unit) => unit.embedding_status))).toEqual(
-          new Set(['not_configured'])
-        );
-      }
-    );
+      const units = await select(db)
+        .from(kbDocumentUnits)
+        .where(eq(kbDocumentUnits.version_id, doc.current_version_id))
+        .all();
+      expect(units).toHaveLength(result.queued);
+      expect(new Set(units.map((unit) => unit.embedding_status))).toEqual(
+        new Set(['not_configured'])
+      );
+    });
   });
 
   dbTest('indexing status separates pgvector extension from usable storage', async ({ db }) => {
-    await withTempConfig(
-      { knowledge: { semantic_search: { enabled: true, provider: 'openai' } } },
-      async () => {
-        const status = await new KnowledgeIndexingStatusService(db).find();
+    await withTempConfig({}, async () => {
+      await new KnowledgeSettingsService(db).patch(null, {
+        enabled: true,
+        provider: 'openai',
+      });
+      const status = await new KnowledgeIndexingStatusService(db).find();
 
-        expect(status.pgvector_available).toBe(false);
-        expect(status.pgvector_extension_installed).toBe(false);
-        expect(status.pgvector_storage_ready).toBe(false);
-        expect(status.last_error).toContain('not PostgreSQL');
-      }
-    );
+      expect(status.pgvector_available).toBe(false);
+      expect(status.pgvector_extension_installed).toBe(false);
+      expect(status.pgvector_storage_ready).toBe(false);
+      expect(status.last_error).toContain('not PostgreSQL');
+    });
   });
 
   dbTest(
@@ -754,10 +756,13 @@ describe('Knowledge semantic indexing lifecycle', () => {
     async ({ db }) => {
       await withTempConfig({}, async () => {
         const indexer = new KnowledgeEmbeddingIndexer(db);
-        (indexer as unknown as { lastError: string | null }).lastError = 'old pgvector error';
+        (
+          indexer as unknown as { lastErrorByTenant: Map<string, string | null> }
+        ).lastErrorByTenant.set('default', 'old pgvector error');
 
         await expect(indexer.indexBatch()).resolves.toBe(0);
         expect(indexer.getLastError()).toBeNull();
+        expect(indexer.getLastError('another-tenant')).toBeNull();
       });
     }
   );

--- a/apps/agor-docs/content/guide/knowledge.mdx
+++ b/apps/agor-docs/content/guide/knowledge.mdx
@@ -85,6 +85,10 @@ Semantic-search policy is workspace-scoped. Admins choose the enabled state, Ope
 
 The deployment still supplies the underlying capability. Vector search requires PostgreSQL with pgvector available; SQLite can retain workspace settings and build text-search units, but it cannot perform semantic or hybrid vector search.
 
+> **Upgrading from YAML-based semantic settings:** Before restarting Agor, record any values under `knowledge.semantic_search`, then remove the entire top-level `knowledge:` block from `config.yaml`. Agor rejects that removed configuration instead of silently applying one operator policy to every workspace. After startup, a workspace admin can re-enter the policy in **Knowledge → Settings → Semantic search**. Existing encrypted workspace embedding API keys remain stored and do not need to be copied into YAML.
+
+> **Multi-tenant indexer limitation:** In `required_from_auth` deployments, semantic policy and queued units are isolated correctly per workspace, but the singleton background indexer currently drains only the startup/bootstrap tenant. Other workspaces can safely configure semantic search and queue work, but automatic all-tenant queue discovery is still pending. Static/single-workspace deployments are unaffected.
+
 ---
 
 ## Graph and links

--- a/apps/agor-docs/content/guide/knowledge.mdx
+++ b/apps/agor-docs/content/guide/knowledge.mdx
@@ -71,7 +71,7 @@ Each content update creates an immutable version, so the page can evolve without
 
 ## Search
 
-Text search is always available. Optional semantic and hybrid search become available when the instance is configured for Knowledge embeddings.
+Text search is always available. Optional semantic and hybrid search become available when a workspace admin enables embeddings in **Knowledge → Settings → Semantic search**.
 
 | Mode         | Use it for                                                     | Requirements                                         |
 | ------------ | -------------------------------------------------------------- | ---------------------------------------------------- |
@@ -80,6 +80,10 @@ Text search is always available. Optional semantic and hybrid search become avai
 | **Hybrid**   | Blend keyword precision with semantic recall                   | Same as semantic                                     |
 
 Semantic search is intentionally optional: the Knowledge base still works without it, but embeddings make it much more powerful as the corpus grows.
+
+Semantic-search policy is workspace-scoped. Admins choose the enabled state, OpenAI model, chunking, and indexing settings in the Knowledge UI; the provider API key is stored encrypted and is never returned to the browser. Operators do not configure this policy in `config.yaml`.
+
+The deployment still supplies the underlying capability. Vector search requires PostgreSQL with pgvector available; SQLite can retain workspace settings and build text-search units, but it cannot perform semantic or hybrid vector search.
 
 ---
 
@@ -122,7 +126,7 @@ This makes Knowledge a natural companion to [Teammates](/guide/teammates): teamm
 
 ## Permissions and control plane fit
 
-Knowledge is tied into Agor's existing role-based control plane. Members can create and work with documents and namespaces, admins manage namespace governance and semantic-search settings, and each document carries visibility and edit-policy controls.
+Knowledge is tied into Agor's existing role-based control plane. Members can create and work with documents and namespaces, workspace admins manage semantic-search settings, and namespace owners/admins manage namespace governance. Each document also carries visibility and edit-policy controls.
 
 In practice, that means Knowledge follows the same posture as the rest of Agor: humans and agents collaborate in one system, with view/edit boundaries enforced by the daemon rather than scattered across ad hoc files and local MCP servers.
 

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -16,6 +16,7 @@ import type {
 import {
   hasMinimumRole,
   KNOWLEDGE_DOCUMENT_KINDS,
+  KNOWLEDGE_OPENAI_EMBEDDING_MODELS,
   normalizeKnowledgeDocumentIconEmoji,
   normalizeKnowledgeFolderPath,
   ROLES,
@@ -222,16 +223,15 @@ const clampPercent = (value: number, min: number, max: number) =>
 const widthToPercent = (widthPx: number, viewportWidth: number) =>
   (widthPx / Math.max(viewportWidth, 1)) * 100;
 
-const OPENAI_EMBEDDING_MODEL_OPTIONS = [
-  {
-    label: 'text-embedding-3-small — recommended',
-    value: 'text-embedding-3-small',
-  },
-  {
-    label: 'text-embedding-3-large — higher quality',
-    value: 'text-embedding-3-large',
-  },
-];
+const OPENAI_EMBEDDING_MODEL_LABELS = {
+  'text-embedding-3-small': 'text-embedding-3-small — recommended',
+  'text-embedding-3-large': 'text-embedding-3-large — higher quality',
+} satisfies Record<(typeof KNOWLEDGE_OPENAI_EMBEDDING_MODELS)[number], string>;
+
+const OPENAI_EMBEDDING_MODEL_OPTIONS = KNOWLEDGE_OPENAI_EMBEDDING_MODELS.map((model) => ({
+  label: OPENAI_EMBEDDING_MODEL_LABELS[model],
+  value: model,
+}));
 
 const kindLabels: Record<KnowledgeDocumentKind, string> = {
   doc: 'Page',
@@ -1313,11 +1313,9 @@ export function KnowledgePage({
         client.service('kb/settings').find(),
         client.service('kb/indexing/status').find(),
       ]);
-      const nextSettings = normalizeKnowledgeSemanticSettings(
-        settings as unknown as KnowledgeSemanticSettingsPublic
-      );
+      const nextSettings = normalizeKnowledgeSemanticSettings(settings);
       setKnowledgeSettings(nextSettings);
-      setIndexingStatus(status as unknown as KnowledgeIndexingStatus);
+      setIndexingStatus(status);
       settingsForm.setFieldsValue(nextSettings);
     } catch (err) {
       console.error('Failed to load Knowledge semantic settings:', err);
@@ -1373,7 +1371,7 @@ export function KnowledgePage({
         settingsClearApiKey
       );
       const next = await client.service('kb/settings').create(patch);
-      setKnowledgeSettings(next as KnowledgeSemanticSettingsPublic);
+      setKnowledgeSettings(next);
       setSettingsApiKeyDraft('');
       setSettingsClearApiKey(false);
       await refreshKnowledgeSettings();

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -3978,6 +3978,13 @@ export function KnowledgePage({
                         >
                           <InputNumber min={1} max={128} precision={0} style={{ width: '100%' }} />
                         </Form.Item>
+                        <Form.Item
+                          name={['indexing', 'paused']}
+                          label="Pause indexing"
+                          valuePropName="checked"
+                        >
+                          <Switch />
+                        </Form.Item>
                       </Flex>
                     </Form>
                     <Flex justify="space-between" align="center">

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -113,6 +113,11 @@ import {
 import { useThemedModal } from '../utils/modal';
 import { slugify } from '../utils/repoSlug';
 import { searchableSelectProps } from '../utils/selectSearch';
+import {
+  buildKnowledgeSemanticSettingsPatch,
+  DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+  normalizeKnowledgeSemanticSettings,
+} from './knowledgeSemanticSettings';
 
 const { Header, Content } = Layout;
 const { Text, Title } = Typography;
@@ -156,7 +161,7 @@ interface KnowledgeEmbeddingReuseIntoNext {
   updatedAt?: string;
 }
 
-type KnowledgeSemanticSettings = KnowledgeSemanticSettingsPublic & { api_key?: string | null };
+type KnowledgeSemanticSettings = KnowledgeSemanticSettingsPublic;
 
 type KnowledgeNamespaceAclEntry = Pick<
   CoreKnowledgeNamespaceAclEntry,
@@ -205,24 +210,6 @@ const DEFAULT_MARKDOWN = `# New Knowledge Page\n\nWrite markdown here.\n`;
 const DRAFT_DOCUMENT_ID = '__knowledge_draft__' as CoreKnowledgeDocument['document_id'];
 const ROOT_FOLDER = '';
 const DEFAULT_FOLDERS = ['pages', 'skills', 'memories'];
-const DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS: KnowledgeSemanticSettings = {
-  enabled: false,
-  provider: 'openai',
-  model: 'text-embedding-3-small',
-  dimensions: 1536,
-  api_key_configured: false,
-  chunking: {
-    target_tokens: 850,
-    max_tokens: 1200,
-    overlap_tokens: 100,
-    min_tokens: 80,
-  },
-  indexing: {
-    paused: false,
-    batch_size: 32,
-    concurrency: 1,
-  },
-};
 
 const KNOWLEDGE_SIDEBAR_MIN_WIDTH_PX = 280;
 const KNOWLEDGE_SIDEBAR_MAX_WIDTH_PX = 780;
@@ -814,6 +801,7 @@ export function KnowledgePage({
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsApiKeyDraft, setSettingsApiKeyDraft] = useState('');
+  const [settingsClearApiKey, setSettingsClearApiKey] = useState(false);
   const [settingsForm] = Form.useForm<KnowledgeSemanticSettings>();
   const [namespaceEditorOpen, setNamespaceEditorOpen] = useState(false);
   const [namespaceEditing, setNamespaceEditing] = useState<KnowledgeNamespace | null>(null);
@@ -1325,18 +1313,9 @@ export function KnowledgePage({
         client.service('kb/settings').find(),
         client.service('kb/indexing/status').find(),
       ]);
-      const nextSettings = {
-        ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
-        ...(settings as unknown as KnowledgeSemanticSettingsPublic),
-        chunking: {
-          ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.chunking,
-          ...((settings as unknown as KnowledgeSemanticSettingsPublic).chunking ?? {}),
-        },
-        indexing: {
-          ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.indexing,
-          ...((settings as unknown as KnowledgeSemanticSettingsPublic).indexing ?? {}),
-        },
-      };
+      const nextSettings = normalizeKnowledgeSemanticSettings(
+        settings as unknown as KnowledgeSemanticSettingsPublic
+      );
       setKnowledgeSettings(nextSettings);
       setIndexingStatus(status as unknown as KnowledgeIndexingStatus);
       settingsForm.setFieldsValue(nextSettings);
@@ -1373,6 +1352,7 @@ export function KnowledgePage({
   const openKnowledgeSettings = useCallback(() => {
     setKnowledgeSettingsOpen(true);
     setSettingsApiKeyDraft('');
+    setSettingsClearApiKey(false);
     setSettingsError(null);
     setNamespaceError(null);
     void refreshKnowledgeSettings();
@@ -1387,24 +1367,15 @@ export function KnowledgePage({
     setSettingsError(null);
     try {
       const values = await settingsForm.validateFields();
-      const patch: Record<string, unknown> = {
-        enabled: values.enabled ?? DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.enabled,
-        provider: values.provider ?? DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.provider,
-        model: values.model || DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.model,
-        dimensions: values.dimensions ?? DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.dimensions,
-        chunking: {
-          ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.chunking,
-          ...(values.chunking ?? {}),
-        },
-        indexing: {
-          ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.indexing,
-          ...(values.indexing ?? {}),
-        },
-      };
-      if (settingsApiKeyDraft.trim()) patch.api_key = settingsApiKeyDraft.trim();
+      const patch = buildKnowledgeSemanticSettingsPatch(
+        values,
+        settingsApiKeyDraft,
+        settingsClearApiKey
+      );
       const next = await client.service('kb/settings').create(patch);
       setKnowledgeSettings(next as KnowledgeSemanticSettingsPublic);
       setSettingsApiKeyDraft('');
+      setSettingsClearApiKey(false);
       await refreshKnowledgeSettings();
       setKnowledgeSettingsOpen(false);
     } catch (err) {
@@ -1413,7 +1384,7 @@ export function KnowledgePage({
     } finally {
       setSettingsSaving(false);
     }
-  }, [client, refreshKnowledgeSettings, settingsApiKeyDraft, settingsForm]);
+  }, [client, refreshKnowledgeSettings, settingsApiKeyDraft, settingsClearApiKey, settingsForm]);
 
   const reindexKnowledge = useCallback(async () => {
     if (!client) return;
@@ -3941,16 +3912,37 @@ export function KnowledgePage({
                         </Form.Item>
                       </Flex>
                       <Form.Item label="OpenAI API key">
-                        <Input.Password
-                          value={settingsApiKeyDraft}
-                          onChange={(event) => setSettingsApiKeyDraft(event.target.value)}
-                          placeholder={
-                            knowledgeSettings?.api_key_configured
-                              ? 'Configured — enter a new key to replace'
-                              : 'sk-...'
-                          }
-                          autoComplete="off"
-                        />
+                        <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                          <Input.Password
+                            value={settingsApiKeyDraft}
+                            disabled={settingsClearApiKey}
+                            onChange={(event) => {
+                              setSettingsApiKeyDraft(event.target.value);
+                              setSettingsClearApiKey(false);
+                            }}
+                            placeholder={
+                              knowledgeSettings?.api_key_configured
+                                ? 'Configured — enter a new key to replace'
+                                : 'sk-...'
+                            }
+                            autoComplete="off"
+                          />
+                          {knowledgeSettings?.api_key_configured && (
+                            <Button
+                              danger
+                              size="small"
+                              type={settingsClearApiKey ? 'primary' : 'default'}
+                              onClick={() => {
+                                setSettingsClearApiKey((current) => !current);
+                                setSettingsApiKeyDraft('');
+                              }}
+                            >
+                              {settingsClearApiKey
+                                ? 'API key will be removed on save'
+                                : 'Remove configured API key'}
+                            </Button>
+                          )}
+                        </Space>
                       </Form.Item>
                       <Flex gap={12} wrap="wrap">
                         <Form.Item
@@ -3986,7 +3978,7 @@ export function KnowledgePage({
                           label="Batch size"
                           style={{ width: 130 }}
                         >
-                          <InputNumber min={1} max={256} precision={0} style={{ width: '100%' }} />
+                          <InputNumber min={1} max={128} precision={0} style={{ width: '100%' }} />
                         </Form.Item>
                       </Flex>
                     </Form>

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildKnowledgeSemanticSettingsPatch,
+  DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+  normalizeKnowledgeSemanticSettings,
+} from './knowledgeSemanticSettings';
+
+describe('Knowledge semantic settings UI helpers', () => {
+  it('fills absent server fields from the typed tenant defaults', () => {
+    expect(
+      normalizeKnowledgeSemanticSettings({
+        enabled: true,
+        chunking: { ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.chunking, target_tokens: 640 },
+      })
+    ).toMatchObject({
+      enabled: true,
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+      chunking: { target_tokens: 640, max_tokens: 1200 },
+      indexing: { paused: false, batch_size: 32, concurrency: 1 },
+    });
+  });
+
+  it('keeps a configured key when the replacement field is blank', () => {
+    const patch = buildKnowledgeSemanticSettingsPatch(
+      { ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS, api_key_configured: true },
+      '   ',
+      false
+    );
+    expect(patch).not.toHaveProperty('api_key');
+  });
+
+  it('uses explicit null only when an admin requests key removal', () => {
+    const patch = buildKnowledgeSemanticSettingsPatch(
+      DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+      'ignored-replacement',
+      true
+    );
+    expect(patch.api_key).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
@@ -18,7 +18,7 @@ describe('Knowledge semantic settings UI helpers', () => {
       model: 'text-embedding-3-small',
       dimensions: 1536,
       chunking: { target_tokens: 640, max_tokens: 1200 },
-      indexing: { paused: false, batch_size: 32, concurrency: 1 },
+      indexing: { paused: false, batch_size: 32 },
     });
   });
 

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
@@ -39,4 +39,20 @@ describe('Knowledge semantic settings UI helpers', () => {
     );
     expect(patch.api_key).toBeNull();
   });
+
+  it('preserves a paused indexing policy when saving other settings', () => {
+    const patch = buildKnowledgeSemanticSettingsPatch(
+      {
+        ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+        indexing: {
+          ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.indexing,
+          paused: true,
+        },
+      },
+      '',
+      false
+    );
+
+    expect(patch.indexing).toEqual({ paused: true, batch_size: 32 });
+  });
 });

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.ts
@@ -1,0 +1,47 @@
+import type {
+  KnowledgeSemanticSettingsPatch,
+  KnowledgeSemanticSettingsPublic,
+} from '@agor/core/types';
+import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY } from '@agor/core/types';
+
+export const DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS: KnowledgeSemanticSettingsPublic = {
+  ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY,
+  chunking: { ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.chunking },
+  indexing: { ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.indexing },
+  api_key_configured: false,
+};
+
+export function normalizeKnowledgeSemanticSettings(
+  settings?: Partial<KnowledgeSemanticSettingsPublic> | null
+): KnowledgeSemanticSettingsPublic {
+  return {
+    ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+    ...(settings ?? {}),
+    chunking: {
+      ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.chunking,
+      ...(settings?.chunking ?? {}),
+    },
+    indexing: {
+      ...DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS.indexing,
+      ...(settings?.indexing ?? {}),
+    },
+  };
+}
+
+export function buildKnowledgeSemanticSettingsPatch(
+  values: Partial<KnowledgeSemanticSettingsPublic>,
+  apiKeyDraft: string,
+  clearApiKey: boolean
+): KnowledgeSemanticSettingsPatch {
+  const settings = normalizeKnowledgeSemanticSettings(values);
+  const trimmedApiKey = apiKeyDraft.trim();
+  return {
+    enabled: settings.enabled,
+    provider: settings.provider,
+    model: settings.model,
+    dimensions: settings.dimensions,
+    chunking: { ...settings.chunking },
+    indexing: { ...settings.indexing },
+    ...(clearApiKey ? { api_key: null } : trimmedApiKey ? { api_key: trimmedApiKey } : {}),
+  };
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -30,6 +30,7 @@ import type {
   KnowledgeNamespace,
   KnowledgeNamespaceGraph,
   KnowledgeSearchResult,
+  KnowledgeSemanticSettingsPatch,
   KnowledgeSemanticSettingsPublic,
   MCPServer,
   Message,
@@ -265,6 +266,13 @@ export type AgenticToolPresetsService = AgorService<
   CreateAgenticToolPreset,
   never,
   PatchAgenticToolPreset
+>;
+
+export type KnowledgeSettingsService = AgorService<
+  KnowledgeSemanticSettingsPublic,
+  KnowledgeSemanticSettingsPatch,
+  never,
+  never
 >;
 
 /**
@@ -597,6 +605,7 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'repos/local'): ReposLocalService;
   service(path: 'branches'): BranchesService;
   service(path: 'boards'): BoardsService;
+  service(path: 'kb/settings'): KnowledgeSettingsService;
   service(path: 'agentic-tool-settings'): AgenticToolSettingsService;
   service(path: 'agentic-tool-presets'): AgenticToolPresetsService;
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -268,12 +268,32 @@ export type AgenticToolPresetsService = AgorService<
   PatchAgenticToolPreset
 >;
 
-export type KnowledgeSettingsService = AgorService<
-  KnowledgeSemanticSettingsPublic,
-  KnowledgeSemanticSettingsPatch,
-  never,
-  never
->;
+/** Singleton workspace Knowledge semantic-search settings endpoint. */
+export interface KnowledgeSettingsService {
+  find(params?: Params): Promise<KnowledgeSemanticSettingsPublic>;
+  create(
+    data: KnowledgeSemanticSettingsPatch,
+    params?: Params
+  ): Promise<KnowledgeSemanticSettingsPublic>;
+  patch(
+    id: null,
+    data: KnowledgeSemanticSettingsPatch,
+    params?: Params
+  ): Promise<KnowledgeSemanticSettingsPublic>;
+}
+
+/** Singleton workspace Knowledge indexing status endpoint. */
+export interface KnowledgeIndexingStatusService {
+  find(params?: Params): Promise<KnowledgeIndexingStatus>;
+}
+
+/** Workspace-wide Knowledge reindex command endpoint. */
+export interface KnowledgeReindexService {
+  create(
+    data?: Record<string, never>,
+    params?: Params
+  ): Promise<{ queued: number; status: KnowledgeEmbeddingStatus }>;
+}
 
 /**
  * Sessions service with custom methods for forking, spawning, and genealogy
@@ -606,6 +626,8 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'branches'): BranchesService;
   service(path: 'boards'): BoardsService;
   service(path: 'kb/settings'): KnowledgeSettingsService;
+  service(path: 'kb/indexing/status'): KnowledgeIndexingStatusService;
+  service(path: 'kb/indexing/reindex'): KnowledgeReindexService;
   service(path: 'agentic-tool-settings'): AgenticToolSettingsService;
   service(path: 'agentic-tool-presets'): AgenticToolPresetsService;
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -225,6 +225,7 @@ describe('loadConfig', () => {
     'credentials',
     'opencode',
     'codex',
+    'knowledge',
   ])('rejects the removed %s config surface', async (key) => {
     const agorDir = path.join(tempDir, '.agor');
     const configPath = path.join(agorDir, 'config.yaml');

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -233,6 +233,7 @@ function validateConfig(config: AgorConfig): void {
     credentials?: unknown;
     opencode?: unknown;
     codex?: unknown;
+    knowledge?: unknown;
     execution?: AgorConfig['execution'] & { cursor_sdk_enabled?: unknown };
   };
   if (removedProviderConfig.credentials !== undefined) {
@@ -250,6 +251,11 @@ function validateConfig(config: AgorConfig): void {
   if (removedProviderConfig.codex !== undefined) {
     throw new Error(
       "Config error: 'codex' has been removed. Codex home directories are managed per-session automatically."
+    );
+  }
+  if (removedProviderConfig.knowledge !== undefined) {
+    throw new Error(
+      "Config error: 'knowledge' has been removed. Configure semantic search in workspace Knowledge settings."
     );
   }
   if (removedProviderConfig.execution?.cursor_sdk_enabled !== undefined) {
@@ -272,7 +278,6 @@ function validateConfig(config: AgorConfig): void {
     'paths',
     'analytics',
     'telemetry',
-    'knowledge',
     'onboarding',
     'multi_tenancy',
     'proxies',
@@ -467,26 +472,6 @@ function validateConfig(config: AgorConfig): void {
   only(legacyConfig.onboarding, 'onboarding', [
     ...RETIRED_CONFIG_KEYS.onboarding,
     'frameworkRepoUrl',
-  ]);
-  only(config.knowledge, 'knowledge', ['semantic_search']);
-  only(config.knowledge?.semantic_search, 'knowledge.semantic_search', [
-    'enabled',
-    'provider',
-    'model',
-    'dimensions',
-    'chunking',
-    'indexing',
-  ]);
-  only(config.knowledge?.semantic_search?.chunking, 'knowledge.semantic_search.chunking', [
-    'target_tokens',
-    'max_tokens',
-    'overlap_tokens',
-    'min_tokens',
-  ]);
-  only(config.knowledge?.semantic_search?.indexing, 'knowledge.semantic_search.indexing', [
-    'paused',
-    'batch_size',
-    'concurrency',
   ]);
   only(config.multi_tenancy, 'multi_tenancy', [
     'mode',

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -964,30 +964,6 @@ export interface AgorProxyConfig {
 }
 
 /**
- * Knowledge Base semantic search settings. Secrets are stored separately in the
- * encrypted app_variables table; this config only carries non-secret defaults.
- */
-export interface AgorKnowledgeSettings {
-  semantic_search?: {
-    enabled?: boolean;
-    provider?: 'openai' | 'voyage' | 'openai-compatible';
-    model?: string;
-    dimensions?: number;
-    chunking?: {
-      target_tokens?: number;
-      max_tokens?: number;
-      overlap_tokens?: number;
-      min_tokens?: number;
-    };
-    indexing?: {
-      paused?: boolean;
-      batch_size?: number;
-      concurrency?: number;
-    };
-  };
-}
-
-/**
  * App-level multi-tenancy settings.
  *
  * `static` preserves today's single-tenant behavior: every request belongs to
@@ -1044,9 +1020,6 @@ export interface AgorConfig {
   /** Public open-source telemetry settings. */
   telemetry?: AgorTelemetrySettings;
 
-  /** Knowledge Base semantic search settings. */
-  knowledge?: AgorKnowledgeSettings;
-
   /** App-level multi-tenancy settings. Defaults to static/default tenant. */
   multi_tenancy?: AgorMultiTenancySettings;
 
@@ -1074,5 +1047,4 @@ export type ConfigKey =
   | `teammates.${keyof AgorTeammateSettings}`
   | `paths.${keyof AgorPathSettings}`
   | `analytics.${keyof AgorAnalyticsSettings}`
-  | `telemetry.${keyof AgorTelemetrySettings}`
-  | `knowledge.${keyof AgorKnowledgeSettings}`;
+  | `telemetry.${keyof AgorTelemetrySettings}`;

--- a/packages/core/src/db/repositories/app-variables.ts
+++ b/packages/core/src/db/repositories/app-variables.ts
@@ -5,7 +5,7 @@ import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { decryptApiKey, encryptApiKey } from '../encryption';
 import { type AppVariableInsert, type AppVariableRow, appVariables } from '../schema';
-import { RepositoryError } from './base';
+import { currentTenantInsert, RepositoryError } from './base';
 
 export interface AppVariable {
   variable_id: string;
@@ -104,6 +104,7 @@ export class AppVariableRepository {
     }
 
     const insertRow: AppVariableInsert = {
+      ...currentTenantInsert(),
       variable_id: generateId(),
       namespace: data.namespace,
       key: data.key,
@@ -125,6 +126,7 @@ export class AppVariableRepository {
     const now = new Date();
     const encrypted = data.encrypted === true;
     const insertRow: AppVariableInsert = {
+      ...currentTenantInsert(),
       variable_id: generateId(),
       namespace: data.namespace,
       key: data.key,

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -18,6 +18,7 @@ export * from './gateway-channels';
 export * from './gateway-outbound-messages';
 export * from './groups';
 export * from './knowledge';
+export * from './knowledge-semantic-settings';
 export * from './mcp-servers';
 export * from './messages';
 export * from './repos';

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDatabase, type Database } from '../client';
+import { isPostgresDatabase } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { KnowledgeSemanticSettingsRepository } from './knowledge-semantic-settings';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'KnowledgeSemanticSettingsRepository PostgreSQL RLS',
+  () => {
+    let db: Database;
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tenantA = `knowledge-settings-a-${suffix}`;
+    const tenantB = `knowledge-settings-b-${suffix}`;
+
+    beforeAll(async () => {
+      process.env.AGOR_MASTER_SECRET ||= 'knowledge-semantic-settings-postgres-test-secret';
+      db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(db);
+      if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+    });
+
+    afterAll(async () => {
+      await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('isolates typed policy and encrypted credentials between tenants', async () => {
+      await runWithTenantDatabaseScope(db, tenantA, async (tenantDb) => {
+        await new KnowledgeSemanticSettingsRepository(tenantDb).patch({
+          enabled: true,
+          model: 'text-embedding-3-large',
+          api_key: 'tenant-a-secret',
+          chunking: { target_tokens: 640 },
+        });
+      });
+      await runWithTenantDatabaseScope(db, tenantB, async (tenantDb) => {
+        await new KnowledgeSemanticSettingsRepository(tenantDb).patch({
+          enabled: false,
+          api_key: 'tenant-b-secret',
+          chunking: { target_tokens: 720 },
+        });
+      });
+
+      await runWithTenantDatabaseScope(db, tenantA, async (tenantDb) => {
+        const repository = new KnowledgeSemanticSettingsRepository(tenantDb);
+        await expect(repository.find()).resolves.toMatchObject({
+          enabled: true,
+          model: 'text-embedding-3-large',
+          api_key_configured: true,
+          chunking: { target_tokens: 640 },
+        });
+        await expect(repository.getApiKey()).resolves.toBe('tenant-a-secret');
+      });
+      await runWithTenantDatabaseScope(db, tenantB, async (tenantDb) => {
+        const repository = new KnowledgeSemanticSettingsRepository(tenantDb);
+        await expect(repository.find()).resolves.toMatchObject({
+          enabled: false,
+          model: 'text-embedding-3-small',
+          api_key_configured: true,
+          chunking: { target_tokens: 720 },
+        });
+        await expect(repository.getApiKey()).resolves.toBe('tenant-b-secret');
+      });
+    });
+  }
+);

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
@@ -91,5 +91,41 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         await expect(repository.getApiKey()).resolves.toBe('concurrent-secret');
       });
     });
+
+    it('blocks credential-only mutation behind the tenant aggregate guard', async () => {
+      const tenant = `knowledge-settings-guard-${suffix}`;
+      let releaseGuard!: () => void;
+      let signalLocked!: () => void;
+      const guardLocked = new Promise<void>((resolve) => {
+        signalLocked = resolve;
+      });
+      const holdGuard = new Promise<void>((resolve) => {
+        releaseGuard = resolve;
+      });
+
+      const holder = runWithTenantDatabaseScope(db, tenant, async (tenantDb) => {
+        await new KnowledgeSemanticSettingsRepository(tenantDb).lockAggregateForUpdate(tenantDb);
+        signalLocked();
+        await holdGuard;
+      });
+      await guardLocked;
+
+      let mutationCompleted = false;
+      const mutation = runWithTenantDatabaseScope(db, tenant, async (tenantDb) => {
+        await new KnowledgeSemanticSettingsRepository(tenantDb).patch({
+          api_key: 'guarded-secret',
+        });
+        mutationCompleted = true;
+      });
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(mutationCompleted).toBe(false);
+      } finally {
+        releaseGuard();
+      }
+      await Promise.all([holder, mutation]);
+      expect(mutationCompleted).toBe(true);
+    });
   }
 );

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.postgres.test.ts
@@ -65,5 +65,31 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         await expect(repository.getApiKey()).resolves.toBe('tenant-b-secret');
       });
     });
+
+    it('serializes credential-only and policy-only patches through one tenant lock', async () => {
+      const tenant = `knowledge-settings-concurrent-${suffix}`;
+
+      await Promise.all([
+        runWithTenantDatabaseScope(db, tenant, async (tenantDb) => {
+          await new KnowledgeSemanticSettingsRepository(tenantDb).patch({
+            api_key: 'concurrent-secret',
+          });
+        }),
+        runWithTenantDatabaseScope(db, tenant, async (tenantDb) => {
+          await new KnowledgeSemanticSettingsRepository(tenantDb).patch({
+            enabled: true,
+          });
+        }),
+      ]);
+
+      await runWithTenantDatabaseScope(db, tenant, async (tenantDb) => {
+        const repository = new KnowledgeSemanticSettingsRepository(tenantDb);
+        await expect(repository.find()).resolves.toMatchObject({
+          enabled: true,
+          api_key_configured: true,
+        });
+        await expect(repository.getApiKey()).resolves.toBe('concurrent-secret');
+      });
+    });
   }
 );

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
@@ -1,0 +1,134 @@
+import { beforeAll, describe, expect } from 'vitest';
+import { dbTest } from '../test-helpers';
+import { AppVariableRepository } from './app-variables';
+import {
+  KNOWLEDGE_EMBEDDINGS_API_KEY,
+  KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+  KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+  KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+  KnowledgeSemanticSettingsRepository,
+} from './knowledge-semantic-settings';
+
+beforeAll(() => {
+  process.env.AGOR_MASTER_SECRET ||= 'knowledge-semantic-settings-test-secret';
+});
+
+describe('KnowledgeSemanticSettingsRepository', () => {
+  dbTest(
+    'resolves an absent tenant policy to safe defaults without materializing state',
+    async ({ db }) => {
+      const repository = new KnowledgeSemanticSettingsRepository(db);
+      await expect(repository.find()).resolves.toEqual({
+        enabled: false,
+        provider: 'openai',
+        model: 'text-embedding-3-small',
+        dimensions: 1536,
+        api_key_configured: false,
+        chunking: {
+          target_tokens: 850,
+          max_tokens: 1200,
+          overlap_tokens: 100,
+          min_tokens: 80,
+        },
+        indexing: { paused: false, batch_size: 32, concurrency: 1 },
+      });
+
+      await expect(
+        new AppVariableRepository(db).find(
+          KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+          KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+        )
+      ).resolves.toBeNull();
+    }
+  );
+
+  dbTest('stores typed tenant policy separately from the encrypted API key', async ({ db }) => {
+    const repository = new KnowledgeSemanticSettingsRepository(db);
+    await repository.patch({
+      enabled: true,
+      model: 'text-embedding-3-large',
+      api_key: '  workspace-secret  ',
+      chunking: { target_tokens: 640 },
+    });
+
+    await expect(repository.find()).resolves.toMatchObject({
+      enabled: true,
+      model: 'text-embedding-3-large',
+      api_key_configured: true,
+      chunking: { target_tokens: 640, max_tokens: 1200 },
+    });
+    await expect(repository.getApiKey()).resolves.toBe('workspace-secret');
+
+    const variables = new AppVariableRepository(db);
+    const policy = await variables.find(
+      KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+      KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+    );
+    expect(policy).toMatchObject({
+      is_encrypted: false,
+      content_type: 'application/json',
+    });
+    expect(JSON.parse(policy?.value_text ?? '')).toEqual({
+      enabled: true,
+      model: 'text-embedding-3-large',
+      chunking: { target_tokens: 640 },
+    });
+
+    const secret = await variables.find(
+      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+      KNOWLEDGE_EMBEDDINGS_API_KEY
+    );
+    expect(secret?.value_text).toBeNull();
+    expect(secret?.value_encrypted).toBeTruthy();
+    expect(secret?.value_encrypted).not.toContain('workspace-secret');
+  });
+
+  dbTest('distinguishes omitted fields from explicit null resets', async ({ db }) => {
+    const repository = new KnowledgeSemanticSettingsRepository(db);
+    await repository.patch({
+      enabled: true,
+      model: 'text-embedding-3-large',
+      api_key: 'workspace-secret',
+      chunking: { target_tokens: 640 },
+    });
+    await repository.patch({});
+    await expect(repository.find()).resolves.toMatchObject({
+      enabled: true,
+      model: 'text-embedding-3-large',
+      api_key_configured: true,
+      chunking: { target_tokens: 640 },
+    });
+
+    await repository.patch({
+      enabled: false,
+      model: null,
+      api_key: null,
+      chunking: { target_tokens: null },
+    });
+    await expect(repository.find()).resolves.toMatchObject({
+      enabled: false,
+      model: 'text-embedding-3-small',
+      api_key_configured: false,
+      chunking: { target_tokens: 850 },
+    });
+    await expect(
+      new AppVariableRepository(db).find(
+        KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+        KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+      )
+    ).resolves.toBeNull();
+  });
+
+  dbTest('fails closed on malformed stored policy JSON', async ({ db }) => {
+    await new AppVariableRepository(db).set({
+      namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+      key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+      value: JSON.stringify({ enabled: 'yes' }),
+      content_type: 'application/json',
+    });
+
+    await expect(new KnowledgeSemanticSettingsRepository(db).findPolicy()).rejects.toThrow(
+      'Invalid stored Knowledge semantic-search enabled value'
+    );
+  });
+});

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
@@ -30,7 +30,7 @@ describe('KnowledgeSemanticSettingsRepository', () => {
           overlap_tokens: 100,
           min_tokens: 80,
         },
-        indexing: { paused: false, batch_size: 32, concurrency: 1 },
+        indexing: { paused: false, batch_size: 32 },
       });
 
       await expect(
@@ -120,7 +120,8 @@ describe('KnowledgeSemanticSettingsRepository', () => {
   });
 
   dbTest('fails closed on malformed stored policy JSON', async ({ db }) => {
-    await new AppVariableRepository(db).set({
+    const variables = new AppVariableRepository(db);
+    await variables.set({
       namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
       key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
       value: JSON.stringify({ enabled: 'yes' }),
@@ -130,5 +131,62 @@ describe('KnowledgeSemanticSettingsRepository', () => {
     await expect(new KnowledgeSemanticSettingsRepository(db).findPolicy()).rejects.toThrow(
       'Invalid stored Knowledge semantic-search enabled value'
     );
+
+    await variables.set({
+      namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+      key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+      value: JSON.stringify({ chunking: { target_tokens: 1300, max_tokens: 1200 } }),
+      content_type: 'application/json',
+    });
+    await expect(new KnowledgeSemanticSettingsRepository(db).findPolicy()).rejects.toThrow(
+      'Knowledge chunking target_tokens must be less than or equal to max_tokens'
+    );
+  });
+
+  dbTest('enforces portable policy invariants for direct repository callers', async ({ db }) => {
+    const repository = new KnowledgeSemanticSettingsRepository(db);
+
+    await expect(
+      repository.patch({
+        chunking: { target_tokens: 1300, max_tokens: 1200 },
+      })
+    ).rejects.toThrow('Knowledge chunking target_tokens must be less than or equal to max_tokens');
+
+    await expect(repository.find()).resolves.toMatchObject({
+      enabled: false,
+      chunking: { target_tokens: 850, max_tokens: 1200 },
+    });
+    await expect(
+      new AppVariableRepository(db).find(
+        KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+        KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+      )
+    ).resolves.toBeNull();
+  });
+
+  dbTest('serializes concurrent first writes and partial policy patches', async ({ db }) => {
+    const repository = new KnowledgeSemanticSettingsRepository(db);
+
+    await Promise.all([
+      repository.patch({ api_key: 'workspace-secret-a' }),
+      repository.patch({ api_key: 'workspace-secret-b' }),
+      repository.patch({ model: 'text-embedding-3-large' }),
+      repository.patch({ chunking: { target_tokens: 640 } }),
+    ]);
+
+    await expect(repository.find()).resolves.toMatchObject({
+      model: 'text-embedding-3-large',
+      api_key_configured: true,
+      chunking: { target_tokens: 640 },
+    });
+    await expect(repository.getApiKey()).resolves.toMatch(/^workspace-secret-[ab]$/);
+
+    const variables = new AppVariableRepository(db);
+    await expect(
+      variables.find(KNOWLEDGE_EMBEDDINGS_NAMESPACE, KNOWLEDGE_EMBEDDINGS_API_KEY)
+    ).resolves.toMatchObject({
+      is_encrypted: true,
+      value_text: null,
+    });
   });
 });

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.test.ts
@@ -116,7 +116,7 @@ describe('KnowledgeSemanticSettingsRepository', () => {
         KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
         KNOWLEDGE_SEMANTIC_SETTINGS_KEY
       )
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({ value_text: '{}' });
   });
 
   dbTest('fails closed on malformed stored policy JSON', async ({ db }) => {

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_KNOWLEDGE_SEMANTIC_POLICY,
   KNOWLEDGE_EMBEDDING_PROVIDERS,
 } from '../../types';
-import type { Database } from '../client';
+import type { Database, TenantScopedDatabase } from '../client';
 import {
   isPostgresDatabase,
   isSQLiteDatabase,
@@ -292,7 +292,7 @@ export class KnowledgeSemanticSettingsRepository {
    * their active transaction and retain it for all dependent writes.
    */
   async lockAggregateForUpdate(
-    txDb: Database,
+    txDb: TenantScopedDatabase,
     updatedBy?: UserID | null
   ): Promise<KnowledgeSemanticSettingsPublic> {
     const variables = new AppVariableRepository(txDb);
@@ -330,7 +330,7 @@ export class KnowledgeSemanticSettingsRepository {
    * settings write and dependent Knowledge-unit updates must commit together.
    */
   async patchInTransaction(
-    txDb: Database,
+    txDb: TenantScopedDatabase,
     patch: KnowledgeSemanticSettingsPatch,
     updatedBy?: UserID | null,
     validate?: (policy: KnowledgeSemanticPolicy) => void
@@ -407,7 +407,8 @@ export class KnowledgeSemanticSettingsRepository {
     validate?: (policy: KnowledgeSemanticPolicy) => void
   ): Promise<KnowledgeSemanticSettingsPublic> {
     const apply = async (txDb: Database) =>
-      (await this.patchInTransaction(txDb, patch, updatedBy, validate)).saved;
+      (await this.patchInTransaction(txDb as TenantScopedDatabase, patch, updatedBy, validate))
+        .saved;
 
     const ambientDb = getCurrentTenantDatabase();
     if (ambientDb && isPostgresDatabase(ambientDb)) return apply(ambientDb);

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.ts
@@ -287,22 +287,15 @@ export class KnowledgeSemanticSettingsRepository {
   }
 
   /**
-   * Apply a patch inside a caller-owned transaction. This is used when the
-   * settings write and dependent Knowledge-unit updates must commit together.
+   * Acquire the stable tenant aggregate lock used by every operation that
+   * materializes state derived from semantic-search policy. Callers must pass
+   * their active transaction and retain it for all dependent writes.
    */
-  async patchInTransaction(
+  async lockAggregateForUpdate(
     txDb: Database,
-    patch: KnowledgeSemanticSettingsPatch,
-    updatedBy?: UserID | null,
-    validate?: (policy: KnowledgeSemanticPolicy) => void
-  ): Promise<KnowledgeSemanticSettingsMutation> {
-    const hasPolicyPatch = POLICY_FIELDS.some((field) => Object.hasOwn(patch, field));
+    updatedBy?: UserID | null
+  ): Promise<KnowledgeSemanticSettingsPublic> {
     const variables = new AppVariableRepository(txDb);
-
-    // The policy row is the stable aggregate lock for both policy and
-    // credential mutations. Every patch takes it before reading the combined
-    // state so sparse concurrent patches cannot derive side effects from
-    // different snapshots.
     await variables.setIfAbsent({
       namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
       key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
@@ -320,19 +313,38 @@ export class KnowledgeSemanticSettingsRepository {
       )!
     );
 
-    const currentStored = await this.findStoredWith(variables);
-    const currentPolicy = resolveKnowledgeSemanticPolicy(currentStored);
-    assertValidKnowledgeSemanticPolicy(currentPolicy);
-    const currentApiKey = await variables.find(
+    const policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(variables));
+    assertValidKnowledgeSemanticPolicy(policy);
+    const apiKey = await variables.find(
       KNOWLEDGE_EMBEDDINGS_NAMESPACE,
       KNOWLEDGE_EMBEDDINGS_API_KEY
     );
-    const previous: KnowledgeSemanticSettingsPublic = {
-      ...currentPolicy,
-      api_key_configured: Boolean(currentApiKey?.is_encrypted && currentApiKey.value_encrypted),
+    return {
+      ...policy,
+      api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
     };
+  }
 
-    let policy = currentPolicy;
+  /**
+   * Apply a patch inside a caller-owned transaction. This is used when the
+   * settings write and dependent Knowledge-unit updates must commit together.
+   */
+  async patchInTransaction(
+    txDb: Database,
+    patch: KnowledgeSemanticSettingsPatch,
+    updatedBy?: UserID | null,
+    validate?: (policy: KnowledgeSemanticPolicy) => void
+  ): Promise<KnowledgeSemanticSettingsMutation> {
+    const hasPolicyPatch = POLICY_FIELDS.some((field) => Object.hasOwn(patch, field));
+    const variables = new AppVariableRepository(txDb);
+
+    // The policy row is the stable aggregate lock for both policy and
+    // credential mutations. Every patch takes it before reading the combined
+    // state so sparse concurrent patches cannot derive side effects from
+    // different snapshots.
+    const previous = await this.lockAggregateForUpdate(txDb, updatedBy);
+    const currentStored = await this.findStoredWith(variables);
+    let policy: KnowledgeSemanticPolicy = previous;
     if (hasPolicyPatch) {
       const next = applyKnowledgeSemanticPolicyPatch(currentStored, patch);
       policy = resolveKnowledgeSemanticPolicy(next);

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.ts
@@ -1,0 +1,361 @@
+import { and, eq } from 'drizzle-orm';
+import type {
+  KnowledgeSemanticPolicy,
+  KnowledgeSemanticSettingsPatch,
+  KnowledgeSemanticSettingsPublic,
+  StoredKnowledgeSemanticPolicy,
+  UserID,
+} from '../../types';
+import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY, KNOWLEDGE_EMBEDDING_PROVIDERS } from '../../types';
+import type { Database } from '../client';
+import {
+  isPostgresDatabase,
+  isSQLiteDatabase,
+  lockRowForUpdate,
+  runDatabaseTransaction,
+} from '../database-wrapper';
+import { appVariables } from '../schema';
+import { getCurrentTenantDatabase } from '../tenant-scope';
+import { AppVariableRepository } from './app-variables';
+
+export const KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE = 'knowledge.semantic_search';
+export const KNOWLEDGE_SEMANTIC_SETTINGS_KEY = 'policy';
+export const KNOWLEDGE_EMBEDDINGS_NAMESPACE = 'knowledge.embeddings';
+export const KNOWLEDGE_EMBEDDINGS_API_KEY = 'api_key';
+
+const POLICY_FIELDS = [
+  'enabled',
+  'provider',
+  'model',
+  'dimensions',
+  'chunking',
+  'indexing',
+] as const;
+const CHUNKING_FIELDS = ['target_tokens', 'max_tokens', 'overlap_tokens', 'min_tokens'] as const;
+const INDEXING_FIELDS = ['paused', 'batch_size', 'concurrency'] as const;
+
+function assertRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid stored ${label}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertOnlyFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  label: string
+): void {
+  const unknown = Object.keys(value).filter((key) => !fields.includes(key));
+  if (unknown.length > 0) throw new Error(`Invalid stored ${label} field: ${unknown[0]}`);
+}
+
+function parseInteger(value: unknown, label: string): number {
+  if (!Number.isInteger(value)) throw new Error(`Invalid stored ${label}`);
+  return value as number;
+}
+
+export function parseStoredKnowledgeSemanticPolicy(value: string): StoredKnowledgeSemanticPolicy {
+  const input = assertRecord(JSON.parse(value) as unknown, 'Knowledge semantic-search policy');
+  assertOnlyFields(input, POLICY_FIELDS, 'Knowledge semantic-search policy');
+
+  if (input.enabled !== undefined && input.enabled !== true) {
+    throw new Error('Invalid stored Knowledge semantic-search enabled value');
+  }
+  if (
+    input.provider !== undefined &&
+    !(KNOWLEDGE_EMBEDDING_PROVIDERS as readonly unknown[]).includes(input.provider)
+  ) {
+    throw new Error('Invalid stored Knowledge semantic-search provider');
+  }
+  if (
+    input.model !== undefined &&
+    (typeof input.model !== 'string' || input.model.trim().length === 0)
+  ) {
+    throw new Error('Invalid stored Knowledge semantic-search model');
+  }
+
+  const chunking =
+    input.chunking === undefined
+      ? undefined
+      : assertRecord(input.chunking, 'Knowledge semantic-search chunking');
+  if (chunking) assertOnlyFields(chunking, CHUNKING_FIELDS, 'Knowledge semantic-search chunking');
+  const indexing =
+    input.indexing === undefined
+      ? undefined
+      : assertRecord(input.indexing, 'Knowledge semantic-search indexing');
+  if (indexing) assertOnlyFields(indexing, INDEXING_FIELDS, 'Knowledge semantic-search indexing');
+  if (indexing?.paused !== undefined && typeof indexing.paused !== 'boolean') {
+    throw new Error('Invalid stored Knowledge semantic-search indexing.paused');
+  }
+
+  return {
+    ...(input.enabled === true ? { enabled: true as const } : {}),
+    ...(input.provider !== undefined
+      ? { provider: input.provider as StoredKnowledgeSemanticPolicy['provider'] }
+      : {}),
+    ...(input.model !== undefined ? { model: input.model.trim() } : {}),
+    ...(input.dimensions !== undefined
+      ? {
+          dimensions: parseInteger(
+            input.dimensions,
+            'Knowledge semantic-search embedding dimensions'
+          ),
+        }
+      : {}),
+    ...(chunking
+      ? {
+          chunking: Object.fromEntries(
+            CHUNKING_FIELDS.filter((field) => chunking[field] !== undefined).map((field) => [
+              field,
+              parseInteger(chunking[field], `Knowledge semantic-search chunking.${field}`),
+            ])
+          ),
+        }
+      : {}),
+    ...(indexing
+      ? {
+          indexing: {
+            ...(indexing.paused !== undefined ? { paused: indexing.paused as boolean } : {}),
+            ...Object.fromEntries(
+              INDEXING_FIELDS.filter(
+                (field) => field !== 'paused' && indexing[field] !== undefined
+              ).map((field) => [
+                field,
+                parseInteger(indexing[field], `Knowledge semantic-search indexing.${field}`),
+              ])
+            ),
+          },
+        }
+      : {}),
+  };
+}
+
+export function resolveKnowledgeSemanticPolicy(
+  stored: StoredKnowledgeSemanticPolicy = {}
+): KnowledgeSemanticPolicy {
+  return {
+    enabled: stored.enabled === true,
+    provider: stored.provider ?? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.provider,
+    model: stored.model ?? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.model,
+    dimensions: stored.dimensions ?? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.dimensions,
+    chunking: {
+      ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.chunking,
+      ...(stored.chunking ?? {}),
+    },
+    indexing: {
+      ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.indexing,
+      ...(stored.indexing ?? {}),
+    },
+  };
+}
+
+function storeNonDefaultPolicy(policy: KnowledgeSemanticPolicy): StoredKnowledgeSemanticPolicy {
+  const chunking = Object.fromEntries(
+    CHUNKING_FIELDS.filter(
+      (field) => policy.chunking[field] !== DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.chunking[field]
+    ).map((field) => [field, policy.chunking[field]])
+  );
+  const indexing = Object.fromEntries(
+    INDEXING_FIELDS.filter(
+      (field) => policy.indexing[field] !== DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.indexing[field]
+    ).map((field) => [field, policy.indexing[field]])
+  );
+  return {
+    ...(policy.enabled ? { enabled: true as const } : {}),
+    ...(policy.provider !== DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.provider
+      ? { provider: policy.provider }
+      : {}),
+    ...(policy.model !== DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.model ? { model: policy.model } : {}),
+    ...(policy.dimensions !== DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.dimensions
+      ? { dimensions: policy.dimensions }
+      : {}),
+    ...(Object.keys(chunking).length > 0 ? { chunking } : {}),
+    ...(Object.keys(indexing).length > 0 ? { indexing } : {}),
+  };
+}
+
+export function applyKnowledgeSemanticPolicyPatch(
+  stored: StoredKnowledgeSemanticPolicy,
+  patch: KnowledgeSemanticSettingsPatch
+): StoredKnowledgeSemanticPolicy {
+  const current = resolveKnowledgeSemanticPolicy(stored);
+  const applyNestedPatch = <T extends object>(
+    currentValue: T,
+    defaultValue: T,
+    nestedPatch: { [K in keyof T]?: T[K] | null } | null | undefined,
+    fields: readonly (keyof T)[]
+  ): T => {
+    if (nestedPatch === null) return { ...defaultValue };
+    const next = { ...currentValue };
+    if (!nestedPatch) return next;
+    for (const field of fields) {
+      const value = nestedPatch[field];
+      if (value !== undefined) next[field] = value === null ? defaultValue[field] : value;
+    }
+    return next;
+  };
+  const chunking = applyNestedPatch(
+    current.chunking,
+    DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.chunking,
+    patch.chunking,
+    CHUNKING_FIELDS
+  );
+  const indexing = applyNestedPatch(
+    current.indexing,
+    DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.indexing,
+    patch.indexing,
+    INDEXING_FIELDS
+  );
+
+  return storeNonDefaultPolicy({
+    enabled: patch.enabled ?? current.enabled,
+    provider:
+      patch.provider === null
+        ? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.provider
+        : (patch.provider ?? current.provider),
+    model:
+      patch.model === null
+        ? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.model
+        : (patch.model?.trim() ?? current.model),
+    dimensions:
+      patch.dimensions === null
+        ? DEFAULT_KNOWLEDGE_SEMANTIC_POLICY.dimensions
+        : (patch.dimensions ?? current.dimensions),
+    chunking,
+    indexing,
+  });
+}
+
+function normalizeApiKey(value: string | null): string | null {
+  const trimmed = value?.trim() ?? '';
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Typed tenant-owned Knowledge semantic-search policy and encrypted provider
+ * credential. Tenant identity comes from the ambient database scope.
+ */
+export class KnowledgeSemanticSettingsRepository {
+  private variables: AppVariableRepository;
+
+  constructor(private db: Database) {
+    this.variables = new AppVariableRepository(db);
+  }
+
+  private async findStoredWith(
+    variables: AppVariableRepository
+  ): Promise<StoredKnowledgeSemanticPolicy> {
+    const value = await variables.getPlain(
+      KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+      KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+    );
+    return value ? parseStoredKnowledgeSemanticPolicy(value) : {};
+  }
+
+  async findPolicy(): Promise<KnowledgeSemanticPolicy> {
+    return resolveKnowledgeSemanticPolicy(await this.findStoredWith(this.variables));
+  }
+
+  async hasApiKey(): Promise<boolean> {
+    const value = await this.variables.find(
+      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+      KNOWLEDGE_EMBEDDINGS_API_KEY
+    );
+    return Boolean(value?.is_encrypted && value.value_encrypted);
+  }
+
+  async getApiKey(): Promise<string | null> {
+    return this.variables.getPlain(KNOWLEDGE_EMBEDDINGS_NAMESPACE, KNOWLEDGE_EMBEDDINGS_API_KEY);
+  }
+
+  async find(): Promise<KnowledgeSemanticSettingsPublic> {
+    const policy = await this.findPolicy();
+    const apiKeyConfigured = await this.hasApiKey();
+    return { ...policy, api_key_configured: apiKeyConfigured };
+  }
+
+  async patch(
+    patch: KnowledgeSemanticSettingsPatch,
+    updatedBy?: UserID | null,
+    validate?: (policy: KnowledgeSemanticPolicy) => void
+  ): Promise<KnowledgeSemanticSettingsPublic> {
+    const hasPolicyPatch = POLICY_FIELDS.some((field) => Object.hasOwn(patch, field));
+
+    const apply = async (txDb: Database) => {
+      const variables = new AppVariableRepository(txDb);
+      let policy: KnowledgeSemanticPolicy;
+      if (hasPolicyPatch) {
+        await variables.setIfAbsent({
+          namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+          key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+          value: '{}',
+          content_type: 'application/json',
+          updated_by: updatedBy ?? null,
+        });
+        await lockRowForUpdate(
+          txDb,
+          this.db,
+          appVariables,
+          and(
+            eq(appVariables.namespace, KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE),
+            eq(appVariables.key, KNOWLEDGE_SEMANTIC_SETTINGS_KEY)
+          )!
+        );
+        const current = await this.findStoredWith(variables);
+        const next = applyKnowledgeSemanticPolicyPatch(current, patch);
+        policy = resolveKnowledgeSemanticPolicy(next);
+        validate?.(policy);
+        if (Object.keys(next).length === 0) {
+          await variables.delete(
+            KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+            KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+          );
+        } else {
+          await variables.set({
+            namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+            key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+            value: JSON.stringify(next),
+            content_type: 'application/json',
+            updated_by: updatedBy ?? null,
+          });
+        }
+      } else {
+        policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(variables));
+        validate?.(policy);
+      }
+
+      if (patch.api_key !== undefined) {
+        await variables.setEncrypted(
+          KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+          KNOWLEDGE_EMBEDDINGS_API_KEY,
+          normalizeApiKey(patch.api_key),
+          updatedBy ?? null
+        );
+      }
+
+      const apiKey = await variables.find(
+        KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+        KNOWLEDGE_EMBEDDINGS_API_KEY
+      );
+      return {
+        ...policy,
+        api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
+      };
+    };
+
+    const ambientDb = getCurrentTenantDatabase();
+    if (ambientDb && isPostgresDatabase(ambientDb)) return apply(ambientDb);
+    if (isSQLiteDatabase(this.db)) {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          return await runDatabaseTransaction(this.db, apply, { sqliteImmediate: true });
+        } catch (error) {
+          if ((error as { code?: string }).code !== 'SQLITE_BUSY' || attempt >= 9) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+        }
+      }
+    }
+    return runDatabaseTransaction(this.db, apply);
+  }
+}

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.ts
@@ -6,7 +6,11 @@ import type {
   StoredKnowledgeSemanticPolicy,
   UserID,
 } from '../../types';
-import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY, KNOWLEDGE_EMBEDDING_PROVIDERS } from '../../types';
+import {
+  assertValidKnowledgeSemanticPolicy,
+  DEFAULT_KNOWLEDGE_SEMANTIC_POLICY,
+  KNOWLEDGE_EMBEDDING_PROVIDERS,
+} from '../../types';
 import type { Database } from '../client';
 import {
   isPostgresDatabase,
@@ -32,7 +36,7 @@ const POLICY_FIELDS = [
   'indexing',
 ] as const;
 const CHUNKING_FIELDS = ['target_tokens', 'max_tokens', 'overlap_tokens', 'min_tokens'] as const;
-const INDEXING_FIELDS = ['paused', 'batch_size', 'concurrency'] as const;
+const INDEXING_FIELDS = ['paused', 'batch_size'] as const;
 
 function assertRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -254,7 +258,9 @@ export class KnowledgeSemanticSettingsRepository {
   }
 
   async findPolicy(): Promise<KnowledgeSemanticPolicy> {
-    return resolveKnowledgeSemanticPolicy(await this.findStoredWith(this.variables));
+    const policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(this.variables));
+    assertValidKnowledgeSemanticPolicy(policy);
+    return policy;
   }
 
   async hasApiKey(): Promise<boolean> {
@@ -275,74 +281,102 @@ export class KnowledgeSemanticSettingsRepository {
     return { ...policy, api_key_configured: apiKeyConfigured };
   }
 
-  async patch(
+  /**
+   * Apply a patch inside a caller-owned transaction. This is used when the
+   * settings write and dependent Knowledge-unit updates must commit together.
+   */
+  async patchInTransaction(
+    txDb: Database,
     patch: KnowledgeSemanticSettingsPatch,
     updatedBy?: UserID | null,
     validate?: (policy: KnowledgeSemanticPolicy) => void
   ): Promise<KnowledgeSemanticSettingsPublic> {
     const hasPolicyPatch = POLICY_FIELDS.some((field) => Object.hasOwn(patch, field));
-
-    const apply = async (txDb: Database) => {
-      const variables = new AppVariableRepository(txDb);
-      let policy: KnowledgeSemanticPolicy;
-      if (hasPolicyPatch) {
-        await variables.setIfAbsent({
+    const variables = new AppVariableRepository(txDb);
+    let policy: KnowledgeSemanticPolicy;
+    if (hasPolicyPatch) {
+      await variables.setIfAbsent({
+        namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+        key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+        value: '{}',
+        content_type: 'application/json',
+        updated_by: updatedBy ?? null,
+      });
+      await lockRowForUpdate(
+        txDb,
+        this.db,
+        appVariables,
+        and(
+          eq(appVariables.namespace, KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE),
+          eq(appVariables.key, KNOWLEDGE_SEMANTIC_SETTINGS_KEY)
+        )!
+      );
+      const current = await this.findStoredWith(variables);
+      const next = applyKnowledgeSemanticPolicyPatch(current, patch);
+      policy = resolveKnowledgeSemanticPolicy(next);
+      assertValidKnowledgeSemanticPolicy(policy);
+      validate?.(policy);
+      if (Object.keys(next).length === 0) {
+        await variables.delete(
+          KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+          KNOWLEDGE_SEMANTIC_SETTINGS_KEY
+        );
+      } else {
+        await variables.set({
           namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
           key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
-          value: '{}',
+          value: JSON.stringify(next),
           content_type: 'application/json',
           updated_by: updatedBy ?? null,
         });
-        await lockRowForUpdate(
-          txDb,
-          this.db,
-          appVariables,
-          and(
-            eq(appVariables.namespace, KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE),
-            eq(appVariables.key, KNOWLEDGE_SEMANTIC_SETTINGS_KEY)
-          )!
-        );
-        const current = await this.findStoredWith(variables);
-        const next = applyKnowledgeSemanticPolicyPatch(current, patch);
-        policy = resolveKnowledgeSemanticPolicy(next);
-        validate?.(policy);
-        if (Object.keys(next).length === 0) {
-          await variables.delete(
-            KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
-            KNOWLEDGE_SEMANTIC_SETTINGS_KEY
-          );
-        } else {
-          await variables.set({
-            namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
-            key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
-            value: JSON.stringify(next),
-            content_type: 'application/json',
-            updated_by: updatedBy ?? null,
-          });
-        }
-      } else {
-        policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(variables));
-        validate?.(policy);
       }
+    } else {
+      policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(variables));
+      assertValidKnowledgeSemanticPolicy(policy);
+      validate?.(policy);
+    }
 
-      if (patch.api_key !== undefined) {
-        await variables.setEncrypted(
-          KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-          KNOWLEDGE_EMBEDDINGS_API_KEY,
-          normalizeApiKey(patch.api_key),
-          updatedBy ?? null
-        );
-      }
-
-      const apiKey = await variables.find(
-        KNOWLEDGE_EMBEDDINGS_NAMESPACE,
-        KNOWLEDGE_EMBEDDINGS_API_KEY
+    if (patch.api_key !== undefined) {
+      await variables.setIfAbsent({
+        namespace: KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+        key: KNOWLEDGE_EMBEDDINGS_API_KEY,
+        value: null,
+        encrypted: true,
+        updated_by: updatedBy ?? null,
+      });
+      await lockRowForUpdate(
+        txDb,
+        this.db,
+        appVariables,
+        and(
+          eq(appVariables.namespace, KNOWLEDGE_EMBEDDINGS_NAMESPACE),
+          eq(appVariables.key, KNOWLEDGE_EMBEDDINGS_API_KEY)
+        )!
       );
-      return {
-        ...policy,
-        api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
-      };
+      await variables.setEncrypted(
+        KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+        KNOWLEDGE_EMBEDDINGS_API_KEY,
+        normalizeApiKey(patch.api_key),
+        updatedBy ?? null
+      );
+    }
+
+    const apiKey = await variables.find(
+      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+      KNOWLEDGE_EMBEDDINGS_API_KEY
+    );
+    return {
+      ...policy,
+      api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
     };
+  }
+
+  async patch(
+    patch: KnowledgeSemanticSettingsPatch,
+    updatedBy?: UserID | null,
+    validate?: (policy: KnowledgeSemanticPolicy) => void
+  ): Promise<KnowledgeSemanticSettingsPublic> {
+    const apply = (txDb: Database) => this.patchInTransaction(txDb, patch, updatedBy, validate);
 
     const ambientDb = getCurrentTenantDatabase();
     if (ambientDb && isPostgresDatabase(ambientDb)) return apply(ambientDb);

--- a/packages/core/src/db/repositories/knowledge-semantic-settings.ts
+++ b/packages/core/src/db/repositories/knowledge-semantic-settings.ts
@@ -27,6 +27,11 @@ export const KNOWLEDGE_SEMANTIC_SETTINGS_KEY = 'policy';
 export const KNOWLEDGE_EMBEDDINGS_NAMESPACE = 'knowledge.embeddings';
 export const KNOWLEDGE_EMBEDDINGS_API_KEY = 'api_key';
 
+export interface KnowledgeSemanticSettingsMutation {
+  previous: KnowledgeSemanticSettingsPublic;
+  saved: KnowledgeSemanticSettingsPublic;
+}
+
 const POLICY_FIELDS = [
   'enabled',
   'provider',
@@ -290,49 +295,59 @@ export class KnowledgeSemanticSettingsRepository {
     patch: KnowledgeSemanticSettingsPatch,
     updatedBy?: UserID | null,
     validate?: (policy: KnowledgeSemanticPolicy) => void
-  ): Promise<KnowledgeSemanticSettingsPublic> {
+  ): Promise<KnowledgeSemanticSettingsMutation> {
     const hasPolicyPatch = POLICY_FIELDS.some((field) => Object.hasOwn(patch, field));
     const variables = new AppVariableRepository(txDb);
-    let policy: KnowledgeSemanticPolicy;
+
+    // The policy row is the stable aggregate lock for both policy and
+    // credential mutations. Every patch takes it before reading the combined
+    // state so sparse concurrent patches cannot derive side effects from
+    // different snapshots.
+    await variables.setIfAbsent({
+      namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+      key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+      value: '{}',
+      content_type: 'application/json',
+      updated_by: updatedBy ?? null,
+    });
+    await lockRowForUpdate(
+      txDb,
+      this.db,
+      appVariables,
+      and(
+        eq(appVariables.namespace, KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE),
+        eq(appVariables.key, KNOWLEDGE_SEMANTIC_SETTINGS_KEY)
+      )!
+    );
+
+    const currentStored = await this.findStoredWith(variables);
+    const currentPolicy = resolveKnowledgeSemanticPolicy(currentStored);
+    assertValidKnowledgeSemanticPolicy(currentPolicy);
+    const currentApiKey = await variables.find(
+      KNOWLEDGE_EMBEDDINGS_NAMESPACE,
+      KNOWLEDGE_EMBEDDINGS_API_KEY
+    );
+    const previous: KnowledgeSemanticSettingsPublic = {
+      ...currentPolicy,
+      api_key_configured: Boolean(currentApiKey?.is_encrypted && currentApiKey.value_encrypted),
+    };
+
+    let policy = currentPolicy;
     if (hasPolicyPatch) {
-      await variables.setIfAbsent({
-        namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
-        key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
-        value: '{}',
-        content_type: 'application/json',
-        updated_by: updatedBy ?? null,
-      });
-      await lockRowForUpdate(
-        txDb,
-        this.db,
-        appVariables,
-        and(
-          eq(appVariables.namespace, KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE),
-          eq(appVariables.key, KNOWLEDGE_SEMANTIC_SETTINGS_KEY)
-        )!
-      );
-      const current = await this.findStoredWith(variables);
-      const next = applyKnowledgeSemanticPolicyPatch(current, patch);
+      const next = applyKnowledgeSemanticPolicyPatch(currentStored, patch);
       policy = resolveKnowledgeSemanticPolicy(next);
       assertValidKnowledgeSemanticPolicy(policy);
       validate?.(policy);
-      if (Object.keys(next).length === 0) {
-        await variables.delete(
-          KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
-          KNOWLEDGE_SEMANTIC_SETTINGS_KEY
-        );
-      } else {
-        await variables.set({
-          namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
-          key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
-          value: JSON.stringify(next),
-          content_type: 'application/json',
-          updated_by: updatedBy ?? null,
-        });
-      }
+      // Keep the default-valued row as the aggregate mutation lock. Reads do
+      // not materialize it; the first write does.
+      await variables.set({
+        namespace: KNOWLEDGE_SEMANTIC_SETTINGS_NAMESPACE,
+        key: KNOWLEDGE_SEMANTIC_SETTINGS_KEY,
+        value: JSON.stringify(next),
+        content_type: 'application/json',
+        updated_by: updatedBy ?? null,
+      });
     } else {
-      policy = resolveKnowledgeSemanticPolicy(await this.findStoredWith(variables));
-      assertValidKnowledgeSemanticPolicy(policy);
       validate?.(policy);
     }
 
@@ -366,8 +381,11 @@ export class KnowledgeSemanticSettingsRepository {
       KNOWLEDGE_EMBEDDINGS_API_KEY
     );
     return {
-      ...policy,
-      api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
+      previous,
+      saved: {
+        ...policy,
+        api_key_configured: Boolean(apiKey?.is_encrypted && apiKey.value_encrypted),
+      },
     };
   }
 
@@ -376,7 +394,8 @@ export class KnowledgeSemanticSettingsRepository {
     updatedBy?: UserID | null,
     validate?: (policy: KnowledgeSemanticPolicy) => void
   ): Promise<KnowledgeSemanticSettingsPublic> {
-    const apply = (txDb: Database) => this.patchInTransaction(txDb, patch, updatedBy, validate);
+    const apply = async (txDb: Database) =>
+      (await this.patchInTransaction(txDb, patch, updatedBy, validate)).saved;
 
     const ambientDb = getCurrentTenantDatabase();
     if (ambientDb && isPostgresDatabase(ambientDb)) return apply(ambientDb);

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -1370,41 +1370,48 @@ export class KnowledgeDocumentRepository
     units: ReplaceKnowledgeUnitInput[],
     options: { embeddingConfigured?: boolean } = {}
   ): Promise<void> {
-    const version = await new KnowledgeDocumentVersionRepository(this.db).findById(versionId);
+    await this.db.transaction((tx) =>
+      this.replaceUnitsForVersionInTransaction(txAsDb(tx), versionId, units, options)
+    );
+  }
+
+  /** Replace units inside a caller-owned transaction. */
+  async replaceUnitsForVersionInTransaction(
+    txDb: Database,
+    versionId: KnowledgeDocumentVersionID,
+    units: ReplaceKnowledgeUnitInput[],
+    options: { embeddingConfigured?: boolean } = {}
+  ): Promise<void> {
+    const version = await new KnowledgeDocumentVersionRepository(txDb).findById(versionId);
     if (!version) throw new EntityNotFoundError('KnowledgeDocumentVersion', versionId);
-    await this.db.transaction(async (tx) => {
-      const txDb = txAsDb(tx);
-      await deleteFrom(txDb, kbDocumentUnits)
-        .where(eq(kbDocumentUnits.version_id, versionId))
-        .run();
-      if (units.length === 0) return;
-      await insert(txDb, kbDocumentUnits)
-        .values(
-          units.map((unit) => ({
-            unit_id: deterministicKnowledgeUnitId(version.version_id, unit),
-            document_id: version.document_id,
-            version_id: version.version_id,
-            kind: unit.kind,
-            ordinal: unit.ordinal,
-            path_anchor: unit.path_anchor ?? null,
-            heading_path: unit.heading_path ?? null,
-            source_path: unit.source_path ?? null,
-            content_text: unit.content_text,
-            content_md5: unit.content_md5,
-            start_offset: unit.start_offset ?? null,
-            end_offset: unit.end_offset ?? null,
-            embedding_status: options.embeddingConfigured ? 'pending' : 'not_configured',
-            embedding_model: null,
-            embedding_dimensions: null,
-            embedding_hash: null,
-            embedding_error: null,
-            metadata: unit.metadata ?? null,
-            created_at: new Date(),
-            updated_at: new Date(),
-          }))
-        )
-        .run();
-    });
+    await deleteFrom(txDb, kbDocumentUnits).where(eq(kbDocumentUnits.version_id, versionId)).run();
+    if (units.length === 0) return;
+    await insert(txDb, kbDocumentUnits)
+      .values(
+        units.map((unit) => ({
+          unit_id: deterministicKnowledgeUnitId(version.version_id, unit),
+          document_id: version.document_id,
+          version_id: version.version_id,
+          kind: unit.kind,
+          ordinal: unit.ordinal,
+          path_anchor: unit.path_anchor ?? null,
+          heading_path: unit.heading_path ?? null,
+          source_path: unit.source_path ?? null,
+          content_text: unit.content_text,
+          content_md5: unit.content_md5,
+          start_offset: unit.start_offset ?? null,
+          end_offset: unit.end_offset ?? null,
+          embedding_status: options.embeddingConfigured ? 'pending' : 'not_configured',
+          embedding_model: null,
+          embedding_dimensions: null,
+          embedding_hash: null,
+          embedding_error: null,
+          metadata: unit.metadata ?? null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        }))
+      )
+      .run();
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -121,6 +121,69 @@ export type KnowledgeSearchMode = (typeof KNOWLEDGE_SEARCH_MODES)[number];
 export const KNOWLEDGE_EMBEDDING_PROVIDERS = ['openai', 'voyage', 'openai-compatible'] as const;
 export type KnowledgeEmbeddingProvider = (typeof KNOWLEDGE_EMBEDDING_PROVIDERS)[number];
 
+export interface KnowledgeSemanticChunkingSettings {
+  target_tokens: number;
+  max_tokens: number;
+  overlap_tokens: number;
+  min_tokens: number;
+}
+
+export interface KnowledgeSemanticIndexingSettings {
+  paused: boolean;
+  batch_size: number;
+  concurrency: number;
+}
+
+export interface KnowledgeSemanticPolicy {
+  enabled: boolean;
+  provider: KnowledgeEmbeddingProvider;
+  model: string;
+  dimensions: number;
+  chunking: KnowledgeSemanticChunkingSettings;
+  indexing: KnowledgeSemanticIndexingSettings;
+}
+
+export interface StoredKnowledgeSemanticPolicy {
+  enabled?: true;
+  provider?: KnowledgeEmbeddingProvider;
+  model?: string;
+  dimensions?: number;
+  chunking?: Partial<KnowledgeSemanticChunkingSettings>;
+  indexing?: Partial<KnowledgeSemanticIndexingSettings>;
+}
+
+type NullableSettingsPatch<T> = {
+  [K in keyof T]?: T[K] | null;
+};
+
+export interface KnowledgeSemanticSettingsPatch {
+  enabled?: boolean;
+  provider?: KnowledgeEmbeddingProvider | null;
+  model?: string | null;
+  dimensions?: number | null;
+  api_key?: string | null;
+  chunking?: NullableSettingsPatch<KnowledgeSemanticChunkingSettings> | null;
+  indexing?: NullableSettingsPatch<KnowledgeSemanticIndexingSettings> | null;
+}
+
+export const DEFAULT_KNOWLEDGE_SEMANTIC_POLICY: KnowledgeSemanticPolicy = {
+  enabled: false,
+  provider: 'openai',
+  model: 'text-embedding-3-small',
+  dimensions: 1536,
+  chunking: {
+    target_tokens: 850,
+    max_tokens: 1200,
+    overlap_tokens: 100,
+    min_tokens: 80,
+  },
+  indexing: {
+    paused: false,
+    batch_size: 32,
+    concurrency: 1,
+  },
+};
+
 export const KNOWLEDGE_VECTOR_STORAGE_TYPES = ['vector', 'halfvec', 'bit', 'sparsevec'] as const;
 export type KnowledgeVectorStorageType = (typeof KNOWLEDGE_VECTOR_STORAGE_TYPES)[number];
 
@@ -575,21 +638,12 @@ export interface KnowledgeIndexingStatus {
 
 export interface KnowledgeSemanticSettingsPublic {
   enabled: boolean;
-  provider?: KnowledgeEmbeddingProvider | null;
-  model?: string | null;
-  dimensions?: number | null;
+  provider: KnowledgeEmbeddingProvider;
+  model: string;
+  dimensions: number;
   api_key_configured: boolean;
-  chunking?: {
-    target_tokens?: number;
-    max_tokens?: number;
-    overlap_tokens?: number;
-    min_tokens?: number;
-  };
-  indexing?: {
-    paused?: boolean;
-    batch_size?: number;
-    concurrency?: number;
-  };
+  chunking: KnowledgeSemanticChunkingSettings;
+  indexing: KnowledgeSemanticIndexingSettings;
 }
 
 export interface KnowledgeGraphNode {

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -121,6 +121,12 @@ export type KnowledgeSearchMode = (typeof KNOWLEDGE_SEARCH_MODES)[number];
 export const KNOWLEDGE_EMBEDDING_PROVIDERS = ['openai', 'voyage', 'openai-compatible'] as const;
 export type KnowledgeEmbeddingProvider = (typeof KNOWLEDGE_EMBEDDING_PROVIDERS)[number];
 
+export const KNOWLEDGE_OPENAI_EMBEDDING_MODELS = [
+  'text-embedding-3-small',
+  'text-embedding-3-large',
+] as const;
+export type KnowledgeOpenAIEmbeddingModel = (typeof KNOWLEDGE_OPENAI_EMBEDDING_MODELS)[number];
+
 export interface KnowledgeSemanticChunkingSettings {
   target_tokens: number;
   max_tokens: number;
@@ -131,7 +137,6 @@ export interface KnowledgeSemanticChunkingSettings {
 export interface KnowledgeSemanticIndexingSettings {
   paused: boolean;
   batch_size: number;
-  concurrency: number;
 }
 
 export interface KnowledgeSemanticPolicy {
@@ -180,9 +185,99 @@ export const DEFAULT_KNOWLEDGE_SEMANTIC_POLICY: KnowledgeSemanticPolicy = {
   indexing: {
     paused: false,
     batch_size: 32,
-    concurrency: 1,
   },
 };
+
+export class KnowledgeSemanticPolicyValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KnowledgeSemanticPolicyValidationError';
+  }
+}
+
+/**
+ * Validate portable semantic-policy invariants at the persistence boundary.
+ * Provider capabilities (currently supported provider/model/dimensions) remain
+ * a daemon concern because they depend on deployed infrastructure.
+ */
+export function assertValidKnowledgeSemanticPolicy(policy: KnowledgeSemanticPolicy): void {
+  if (typeof policy.enabled !== 'boolean') {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge semantic search enabled must be a boolean'
+    );
+  }
+  if (!(KNOWLEDGE_EMBEDDING_PROVIDERS as readonly unknown[]).includes(policy.provider)) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge embedding provider is not supported'
+    );
+  }
+  if (typeof policy.model !== 'string' || policy.model.trim().length === 0) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge embedding model must be a non-empty string'
+    );
+  }
+  if (!Number.isInteger(policy.dimensions) || policy.dimensions <= 0) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge embedding dimensions must be a positive integer'
+    );
+  }
+
+  const chunkEntries = [
+    ['target_tokens', policy.chunking.target_tokens],
+    ['max_tokens', policy.chunking.max_tokens],
+    ['overlap_tokens', policy.chunking.overlap_tokens],
+    ['min_tokens', policy.chunking.min_tokens],
+  ] as const;
+  for (const [name, value] of chunkEntries) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new KnowledgeSemanticPolicyValidationError(
+        `Knowledge chunking ${name} must be a non-negative integer`
+      );
+    }
+    if (value > 8000) {
+      throw new KnowledgeSemanticPolicyValidationError(
+        `Knowledge chunking ${name} must be 8000 or less`
+      );
+    }
+  }
+  if (policy.chunking.min_tokens <= 0) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge chunking min_tokens must be greater than 0'
+    );
+  }
+  if (policy.chunking.target_tokens <= 0) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge chunking target_tokens must be greater than 0'
+    );
+  }
+  if (policy.chunking.max_tokens < policy.chunking.min_tokens) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge chunking max_tokens must be greater than or equal to min_tokens'
+    );
+  }
+  if (policy.chunking.target_tokens > policy.chunking.max_tokens) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge chunking target_tokens must be less than or equal to max_tokens'
+    );
+  }
+  if (policy.chunking.overlap_tokens >= policy.chunking.max_tokens) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge chunking overlap_tokens must be less than max_tokens'
+    );
+  }
+  if (typeof policy.indexing.paused !== 'boolean') {
+    throw new KnowledgeSemanticPolicyValidationError('Knowledge indexing paused must be a boolean');
+  }
+  if (
+    !Number.isInteger(policy.indexing.batch_size) ||
+    policy.indexing.batch_size < 1 ||
+    policy.indexing.batch_size > 128
+  ) {
+    throw new KnowledgeSemanticPolicyValidationError(
+      'Knowledge indexing batch_size must be an integer between 1 and 128'
+    );
+  }
+}
 
 export const KNOWLEDGE_VECTOR_STORAGE_TYPES = ['vector', 'halfvec', 'bit', 'sparsevec'] as const;
 export type KnowledgeVectorStorageType = (typeof KNOWLEDGE_VECTOR_STORAGE_TYPES)[number];


### PR DESCRIPTION
## Summary

- remove `knowledge.semantic_search.*` from operator-owned `config.yaml`
- make the existing Knowledge settings API/UI the authoritative typed, tenant-scoped policy surface
- preserve encrypted tenant embedding API-key storage while moving enabled state, provider/model, dimensions, chunking, and indexing policy into tenant-scoped `app_variables`
- update search, chunking, reindex, status, and background indexing paths to resolve workspace policy from the tenant repository
- keep workspace-admin authorization and Postgres RLS / SQLite-static behavior aligned

## Migration and defaults

- legacy top-level `knowledge:` YAML is rejected with guidance to use workspace Knowledge settings
- a workspace with no stored policy resolves to semantic search disabled and the existing semantic defaults
- absent patch fields preserve current values; `null` resets supported policy fields or sections to defaults
- the repository stores only non-default typed policy overrides; after the first mutation, an empty policy row remains as the stable per-tenant mutation lock
- no database migration is required because this uses the established tenant-scoped, RLS-protected `app_variables` table
- existing encrypted `knowledge.embeddings/api_key` values remain in place; blank UI input preserves the key and the explicit removal action clears it
- Postgres/pgvector availability remains an operator/infrastructure capability rather than tenant policy

## Verification

- `pnpm i`
- `pnpm check` (passes; 10 pre-existing lint warnings)
- core suite — 2,888 passed, 5 skipped; the conditional Postgres test remains skipped without `AGOR_TEST_POSTGRES_URL`
- daemon suite — 1,974 passed, 31 skipped
- UI suite — 1,093 passed

## Follow-up

Required-from-auth deployments still need a separate all-tenant background indexer discovery design. This PR deliberately does not conflate that work: the singleton startup indexer continues to drain only the startup/bootstrap tenant, although other tenants can safely configure policy and queue work without leaking settings or status across tenants.

## AI review follow-up

Independent Codex review prompted two focused follow-up commits.

Commit `4656b5af`:

- models singleton settings/status/reindex client signatures exactly and removes UI casts
- centralizes supported OpenAI embedding models and portable policy invariants in core
- serializes first credential writes and makes settings plus dependent unit rebuilds atomic
- stamps internal app-variable inserts with the active tenant for Postgres RLS
- removes the unused tenant `indexing.concurrency` field rather than exposing inert policy
- adds concurrent SQLite coverage, conditional Postgres/RLS tenant-isolation coverage, and explicit upgrade/indexer-limitation docs

Commit `c0c5565f`:

- uses the tenant policy row as a stable aggregate lock for every settings mutation and returns the locked previous/saved combined state for dependent unit updates
- schedules indexer wakes only after commit and detaches inherited database and operation tenant scopes; rollback drops the wake
- exposes `indexing.paused` in the settings UI so unrelated saves preserve it
- adds wake commit/rollback/scope tests, paused-policy UI coverage, and conditional Postgres concurrent credential/policy coverage


Commit `2d175545`:

- extends the stable aggregate guard to document/unit writes and manual reindex, with explicit SQLite immediate transactions and the existing Postgres tenant transaction
- reacquires the guard after provider work and validates policy, credential, unit identity, and content hash before committing embeddings or error status
- preserves wake requests arriving during an active indexer tick through a rerun flag
- adds deterministic Postgres guard-blocking coverage, SQLite document/reindex coordination tests, stale materialization-snapshot validation, and active-tick wake coverage


Commit `72ee341a`:

- brands aggregate-lock and in-transaction patch inputs as `TenantScopedDatabase`, encoding the active-transaction requirement in core signatures
- centralizes Knowledge policy transaction, SQLite immediate-lock retry, and ambient Postgres reuse in one daemon helper
- binds document materialization directly to the scoped transaction while avoiding the aggregate guard for metadata-only document writes
- passes the exact scoped database through indexer aggregate-lock callbacks
- compares exact provider input text as well as its hash before accepting delayed embedding results
