### PR TITLE
fix(ui): contain optional lazy-load failures

### DIFF
--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.test.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockInnerState = vi.hoisted(() => ({
+  error: new Error('Unset emoji picker test error'),
+}));
+
+vi.mock('./AgorEmojiPickerInner', () => ({
+  default: function MockAgorEmojiPickerInner(): never {
+    throw mockInnerState.error;
+  },
+}));
+
+import { AgorEmojiPicker, EmojiPickerErrorFallback } from './EmojiPickerInput';
+
+const dynamicImportError = new TypeError(
+  'Failed to fetch dynamically imported module: http://localhost/AgorEmojiPickerInner.tsx'
+);
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EmojiPickerErrorFallback', () => {
+  it('offers a page reload after a dynamic-import load failure', () => {
+    const onReload = vi.fn();
+
+    render(
+      <EmojiPickerErrorFallback
+        error={
+          new TypeError(
+            'Failed to fetch dynamically imported module: http://localhost/AgorEmojiPickerInner.tsx'
+          )
+        }
+        onReload={onReload}
+      />
+    );
+
+    expect(screen.getByText("Couldn't load the emoji picker.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Reload page' }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it('uses a neutral contained fallback for programming errors', () => {
+    render(<EmojiPickerErrorFallback error={new Error('Module initialization failed')} />);
+
+    expect(screen.getByText('The emoji picker is unavailable.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reload page' })).not.toBeInTheDocument();
+  });
+});
+
+describe('AgorEmojiPicker', () => {
+  it('contains a lazy-module load failure without replacing its surrounding flow', async () => {
+    mockInnerState.error = dynamicImportError;
+
+    render(
+      <div>
+        <span>Onboarding remains available</span>
+        <AgorEmojiPicker onEmojiClick={() => {}} />
+      </div>
+    );
+
+    expect(await screen.findByText("Couldn't load the emoji picker.")).toBeInTheDocument();
+    expect(screen.getByText('Onboarding remains available')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload page' })).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -1,11 +1,14 @@
-import { SmileOutlined } from '@ant-design/icons';
+import { ReloadOutlined, SmileOutlined } from '@ant-design/icons';
 import { Button, Flex, Form, Input, Popover, Typography } from 'antd';
 import type { EmojiClickData, PickerProps } from 'emoji-picker-react';
 import { lazy, Suspense, useState } from 'react';
+import { ErrorBoundary, isDynamicImportLoadError } from '../ErrorBoundary';
 
 // Lazy-load the emoji-picker-react render (~60KB) so the library is fetched
 // only when a picker is first opened, not at app mount. Types above are
 // `import type` and erase at compile time, so they don't pull the library in.
+// A failed native import cannot be retried in the same document, so the local
+// boundary below contains the failure and offers a full-page reload instead.
 const AgorEmojiPickerInner = lazy(() => import('./AgorEmojiPickerInner'));
 
 /**
@@ -18,6 +21,32 @@ const EmojiPickerFallback: React.FC = () => (
   </Flex>
 );
 
+export const EmojiPickerErrorFallback: React.FC<{
+  error: Error;
+  onReload?: () => void;
+}> = ({ error, onReload = () => window.location.reload() }) => {
+  const isLoadError = isDynamicImportLoadError(error);
+
+  return (
+    <Flex vertical align="center" justify="center" gap="small" style={{ width: 350, height: 400 }}>
+      <Typography.Text type="secondary">
+        {isLoadError ? "Couldn't load the emoji picker." : 'The emoji picker is unavailable.'}
+      </Typography.Text>
+      {isLoadError ? (
+        <Button size="small" icon={<ReloadOutlined />} aria-label="Reload page" onClick={onReload}>
+          Reload page
+        </Button>
+      ) : null}
+    </Flex>
+  );
+};
+
+const EmojiPickerBoundary: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <ErrorBoundary fallbackRender={({ error }) => <EmojiPickerErrorFallback error={error} />}>
+    {children}
+  </ErrorBoundary>
+);
+
 /**
  * Shared <EmojiPicker /> wrapper that pins CSP-safe and visually-consistent
  * defaults. Always use this instead of importing EmojiPicker directly — the
@@ -25,9 +54,11 @@ const EmojiPickerFallback: React.FC = () => (
  * cdn.jsdelivr.net, blocked by Agor's default img-src CSP.
  */
 export const AgorEmojiPicker: React.FC<Pick<PickerProps, 'onEmojiClick'>> = ({ onEmojiClick }) => (
-  <Suspense fallback={<EmojiPickerFallback />}>
-    <AgorEmojiPickerInner onEmojiClick={onEmojiClick} />
-  </Suspense>
+  <EmojiPickerBoundary>
+    <Suspense fallback={<EmojiPickerFallback />}>
+      <AgorEmojiPickerInner onEmojiClick={onEmojiClick} />
+    </Suspense>
+  </EmojiPickerBoundary>
 );
 
 interface EmojiPickerInputProps {

--- a/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -12,11 +12,19 @@ interface ErrorBoundaryProps {
   //     entire app.
   variant?: 'scoped' | 'global';
   fallbackTitle?: ReactNode;
+  // Optional component-specific fallback. This keeps failures isolated without
+  // forcing every surface into the generic Alert or global crash screen.
+  fallbackRender?: (props: ErrorBoundaryFallbackRenderProps) => ReactNode;
   // When this value changes, the boundary clears its error state and re-renders
   // children. Useful when fresh data may unblock the failed render (e.g. a
   // logs refresh after a transient bad payload). The global variant doesn't
   // typically use this — the user reloads instead.
   resetKey?: unknown;
+}
+
+export interface ErrorBoundaryFallbackRenderProps {
+  error: Error;
+  errorInfo: ErrorInfo | null;
 }
 
 interface ErrorBoundaryState {
@@ -53,9 +61,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   render() {
     const { error, errorInfo } = this.state;
-    const { variant = 'scoped', fallbackTitle, children } = this.props;
+    const { variant = 'scoped', fallbackTitle, fallbackRender, children } = this.props;
 
     if (error) {
+      if (fallbackRender) {
+        return fallbackRender({ error, errorInfo });
+      }
       if (variant === 'global') {
         return <GlobalCrashScreen error={error} errorInfo={errorInfo} />;
       }

--- a/apps/agor-ui/src/components/ErrorBoundary/dynamicImportError.test.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/dynamicImportError.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isDynamicImportLoadError } from './dynamicImportError';
+
+describe('isDynamicImportLoadError', () => {
+  it.each([
+    'Failed to fetch dynamically imported module: http://localhost/chunk.tsx',
+    'Importing a module script failed.',
+    'error loading dynamically imported module',
+    'ChunkLoadError: Loading chunk 42 failed',
+    'Unable to preload CSS for /assets/chunk.css',
+  ])('recognizes browser and bundler load failures: %s', (message) => {
+    expect(isDynamicImportLoadError(new TypeError(message))).toBe(true);
+  });
+
+  it('does not classify module programming errors as load failures', () => {
+    expect(isDynamicImportLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+  });
+});

--- a/apps/agor-ui/src/components/ErrorBoundary/dynamicImportError.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/dynamicImportError.ts
@@ -1,0 +1,18 @@
+const DYNAMIC_IMPORT_LOAD_ERROR_PATTERNS = [
+  /failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+  /chunkloaderror/i,
+  /loading chunk \S+ failed/i,
+  /unable to preload css for/i,
+];
+
+/**
+ * Browsers use different messages for network/asset failures from import().
+ * Keep this deliberately narrow so module evaluation and component render
+ * errors can use a different fallback from recoverable document-load errors.
+ */
+export function isDynamicImportLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return DYNAMIC_IMPORT_LOAD_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}

--- a/apps/agor-ui/src/components/ErrorBoundary/index.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/index.ts
@@ -1,3 +1,4 @@
 export { getCrashContext, setCrashContext } from './crashContext';
-export { ErrorBoundary } from './ErrorBoundary';
+export { isDynamicImportLoadError } from './dynamicImportError';
+export { ErrorBoundary, type ErrorBoundaryFallbackRenderProps } from './ErrorBoundary';
 export { GlobalCrashScreen } from './GlobalCrashScreen';

--- a/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.error.test.tsx
+++ b/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.error.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./ThemedSyntaxHighlighter.inner', () => ({
+  default: function MockThemedSyntaxHighlighterInner(): never {
+    throw new TypeError(
+      'Failed to fetch dynamically imported module: http://localhost/ThemedSyntaxHighlighter.inner.tsx'
+    );
+  },
+}));
+
+import { ThemedSyntaxHighlighter } from './ThemedSyntaxHighlighter';
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ThemedSyntaxHighlighter lazy-load failure', () => {
+  it('falls back to plain code without replacing the surrounding conversation', async () => {
+    const { container } = render(
+      <div>
+        <span>Conversation remains available</span>
+        <ThemedSyntaxHighlighter language="typescript">
+          {'const answer = 42;'}
+        </ThemedSyntaxHighlighter>
+      </div>
+    );
+
+    expect(await screen.findByText('const answer = 42;')).toBeInTheDocument();
+    expect(screen.getByText('Conversation remains available')).toBeInTheDocument();
+    expect(container.querySelector('pre')).toHaveTextContent('const answer = 42;');
+  });
+});

--- a/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.tsx
+++ b/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.tsx
@@ -24,6 +24,7 @@
 
 import { theme } from 'antd';
 import { lazy, Suspense } from 'react';
+import { ErrorBoundary } from '../ErrorBoundary';
 import type { ThemedSyntaxHighlighterProps } from './ThemedSyntaxHighlighter.inner';
 
 export type { ThemedSyntaxHighlighterProps };
@@ -59,7 +60,9 @@ const PlainCodeFallback: React.FC<ThemedSyntaxHighlighterProps> = ({
 };
 
 export const ThemedSyntaxHighlighter: React.FC<ThemedSyntaxHighlighterProps> = (props) => (
-  <Suspense fallback={<PlainCodeFallback {...props} />}>
-    <ThemedSyntaxHighlighterInner {...props} />
-  </Suspense>
+  <ErrorBoundary fallbackRender={() => <PlainCodeFallback {...props} />}>
+    <Suspense fallback={<PlainCodeFallback {...props} />}>
+      <ThemedSyntaxHighlighterInner {...props} />
+    </Suspense>
+  </ErrorBoundary>
 );


### PR DESCRIPTION
## Summary

- contain emoji-picker dynamic-import failures inside the picker popover instead of escalating to the global crash screen
- preserve the intentional lazy splits; for the emoji picker, offer a full-page reload because failed native imports cannot be retried in the same document
- degrade syntax highlighting to the existing plain-code fallback if its optional Prism chunk fails, keeping the conversation usable
- extend the shared `ErrorBoundary` with a component-specific fallback renderer and centralize cross-browser dynamic-import error classification
- use a neutral contained fallback for emoji module evaluation or render errors

## Root cause

Both reports came from raw Vite development module URLs, first for the emoji picker and later for the syntax highlighter. In each case the exact module existed and served valid transformed JavaScript shortly after the crash, and neither reported build SHA changed the failing component. This is consistent with a transient Vite dev-server/HMR or network fetch window rather than a persistent missing module or incomplete production bundle.

`React.lazy` propagates a rejected import past `Suspense` to the nearest error boundary. These optional components had no local boundary, so the top-level boundary replaced onboarding/the conversation with the global crash screen.

## Verification

- `pnpm exec vitest run src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.test.tsx src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.error.test.tsx src/components/ErrorBoundary/dynamicImportError.test.ts src/components/EmojiPickerInput/EmojiPickerInput.test.tsx src/components/OnboardingWizard/OnboardingWizard.test.tsx` — 39 passed
- Biome on all changed files
- UI source-condition typecheck
- Three Codex review passes were clean before the syntax-highlighter follow-up; follow-up review requested

Closes #2008
