### PR TITLE
feat(db): audited, idempotent per-tenant data deletion

### DIFF
--- a/apps/agor-cli/src/commands/tenant/delete.test.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { tenantDeleteErrorMessage } from './delete';
+
+describe('tenantDeleteErrorMessage', () => {
+  it('redacts credentials from Error messages', () => {
+    expect(
+      tenantDeleteErrorMessage(
+        new Error('connect postgresql://operator:top-secret@db.example.test/agor failed')
+      )
+    ).toBe('connect postgresql://[redacted]@db.example.test/agor failed');
+  });
+
+  it('stringifies non-Error failures before redacting credentials', () => {
+    expect(
+      tenantDeleteErrorMessage(
+        'connect postgresql://operator:top-secret@db.example.test/agor failed'
+      )
+    ).toBe('connect postgresql://[redacted]@db.example.test/agor failed');
+  });
+});

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -1,12 +1,11 @@
 /**
  * `agor tenant delete` - Permanently delete all data for a single tenant.
  *
- * Operators of a multi-tenant Agor deployment use this to remove a tenant
- * entirely (offboarding, data-removal requests, regulatory erasure). It runs
- * non-interactively (container/Job friendly), talks straight to the database the
- * same way the rest of the runtime does (env/config), and prints a single stable
- * JSON object to stdout for external automation. Human audit logging goes to
- * stderr so stdout stays parseable.
+ * Operators of a standalone multi-tenant PostgreSQL runtime use this to remove
+ * a tenant entirely (offboarding, data-removal requests, regulatory erasure).
+ * It runs non-interactively (container/Job friendly), uses the runtime database
+ * configuration, and prints a single stable JSON object to stdout for external
+ * automation. Human audit logging goes to stderr so stdout stays parseable.
  */
 
 import {
@@ -48,9 +47,10 @@ function flushStderr(): Promise<void> {
 
 export default class TenantDelete extends Command {
   static override description =
-    'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified. ' +
-    'Precondition: quiesce the tenant first — stop new tenant-scoped work in the deployment BEFORE running. ' +
-    'This command verifies tenant state at scan time and does not by itself prevent a concurrent writer from recreating tenant rows after verification.';
+    'Permanently delete all data belonging to a single tenant in a standalone multi-tenant PostgreSQL runtime. Idempotent and verified. ' +
+    'Preconditions: quiesce tenant writes and schema changes for the entire operation, and ensure every foreign-key reference between tenant rows is tenant-consistent. ' +
+    'PostgreSQL row-level security neither enforces tenant equality when foreign keys are created nor constrains referential actions such as cascades. ' +
+    'This command cannot prevent a writer or schema change that occurs after final verification.';
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> --tenant-id acme-corp',

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -36,7 +36,9 @@ function redactSecrets(message: string): string {
 
 export default class TenantDelete extends Command {
   static override description =
-    'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified.';
+    'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified. ' +
+    'Precondition: quiesce the tenant first — stop new tenant-scoped work at the control/auth layer BEFORE running. ' +
+    'This command verifies tenant state at scan time and does not by itself prevent a concurrent writer from recreating tenant rows after verification.';
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> --tenant-id acme-corp',
@@ -85,7 +87,13 @@ export default class TenantDelete extends Command {
       });
 
       // Stable machine-readable contract on stdout — the only thing on stdout.
-      process.stdout.write(`${JSON.stringify(result)}\n`);
+      // Await the write so the payload is fully flushed to a pipe before the
+      // process.exit(0) below (needed to terminate the lingering postgres-js
+      // pool); process.exit can otherwise truncate an in-flight async write.
+      const json = `${JSON.stringify(result)}\n`;
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(json, (err) => (err ? reject(err) : resolve()));
+      });
 
       const totalRows = Object.values(result.rowCounts).reduce((sum, value) => sum + value, 0);
       this.logToStderr(

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -44,7 +44,7 @@ function flushStderr(): Promise<void> {
 export default class TenantDelete extends Command {
   static override description =
     'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified. ' +
-    'Precondition: quiesce the tenant first — stop new tenant-scoped work at the control/auth layer BEFORE running. ' +
+    'Precondition: quiesce the tenant first — stop new tenant-scoped work in the deployment BEFORE running. ' +
     'This command verifies tenant state at scan time and does not by itself prevent a concurrent writer from recreating tenant rows after verification.';
 
   static override examples = [

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -34,6 +34,13 @@ function redactSecrets(message: string): string {
   return message.replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, '$1[redacted]@');
 }
 
+/** Wait until every stderr write queued so far has completed. */
+function flushStderr(): Promise<void> {
+  return new Promise((resolve) => {
+    process.stderr.write('', () => resolve());
+  });
+}
+
 export default class TenantDelete extends Command {
   static override description =
     'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified. ' +
@@ -68,6 +75,7 @@ export default class TenantDelete extends Command {
     } catch (error) {
       if (error instanceof InvalidTenantIdError) {
         this.logToStderr(chalk.red(`✗ ${error.message}`));
+        await flushStderr();
         process.exit(EXIT_INVALID_INPUT);
       }
       throw error;
@@ -101,9 +109,10 @@ export default class TenantDelete extends Command {
           `✓ ${dryRun ? 'Dry run complete' : 'Tenant data deleted and verified'} — ${totalRows} row(s)`
         )
       );
+      await flushStderr();
       process.exit(0);
     } catch (error) {
-      const message = error instanceof Error ? redactSecrets(error.message) : String(error);
+      const message = redactSecrets(error instanceof Error ? error.message : String(error));
       this.logToStderr(chalk.red(`✗ ${message}`));
       if (error instanceof TenantDeletionVerificationError) {
         this.logToStderr(chalk.red(`  Remaining tables: ${error.tables.join(', ')}`));
@@ -115,6 +124,7 @@ export default class TenantDelete extends Command {
           )
         );
       }
+      await flushStderr();
       process.exit(EXIT_FAILURE);
     }
   }

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -1,0 +1,113 @@
+/**
+ * `agor tenant delete` - Permanently delete all data for a single tenant.
+ *
+ * Operators of a multi-tenant Agor deployment use this to remove a tenant
+ * entirely (offboarding, data-removal requests, regulatory erasure). It runs
+ * non-interactively (container/Job friendly), talks straight to the database the
+ * same way the rest of the runtime does (env/config), and prints a single stable
+ * JSON object to stdout for external automation. Human audit logging goes to
+ * stderr so stdout stays parseable.
+ */
+
+import {
+  assertValidTenantId,
+  createDatabase,
+  deleteTenantData,
+  getDatabaseUrl,
+  InvalidTenantIdError,
+  TenantDeletionUnsupportedError,
+  TenantDeletionVerificationError,
+} from '@agor/core/db';
+import { Command, Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+/** Exit code for a rejected / invalid `--tenant-id`. */
+const EXIT_INVALID_INPUT = 2;
+/** Exit code for any failure after input validation. */
+const EXIT_FAILURE = 1;
+
+/**
+ * Best-effort redaction of connection-string credentials from an error message
+ * before it is written to stderr, so an audit log never leaks a DB password.
+ */
+function redactSecrets(message: string): string {
+  return message.replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, '$1[redacted]@');
+}
+
+export default class TenantDelete extends Command {
+  static override description =
+    'Permanently delete all data belonging to a single tenant (PostgreSQL multi-tenant deployments). Idempotent and verified.';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> --tenant-id acme-corp',
+    '<%= config.bin %> <%= command.id %> --tenant-id acme-corp --dry-run',
+  ];
+
+  static override flags = {
+    'tenant-id': Flags.string({
+      description: 'Tenant id whose data will be permanently deleted',
+      required: true,
+    }),
+    'dry-run': Flags.boolean({
+      char: 'n',
+      description: 'Report the row counts that would be deleted without deleting anything',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(TenantDelete);
+    const tenantId = flags['tenant-id'];
+    const dryRun = flags['dry-run'];
+
+    // Validate before touching the database so bad input never opens a connection.
+    try {
+      assertValidTenantId(tenantId);
+    } catch (error) {
+      if (error instanceof InvalidTenantIdError) {
+        this.logToStderr(chalk.red(`✗ ${error.message}`));
+        process.exit(EXIT_INVALID_INPUT);
+      }
+      throw error;
+    }
+
+    try {
+      this.logToStderr(
+        chalk.bold(
+          `${dryRun ? '🔎 Dry run:' : '⚠️  Deleting'} all data for tenant ${chalk.cyan(tenantId)}`
+        )
+      );
+
+      const db = createDatabase({ url: getDatabaseUrl() });
+      const result = await deleteTenantData(db, tenantId, {
+        dryRun,
+        log: (message) => this.logToStderr(chalk.dim(`  ${message}`)),
+      });
+
+      // Stable machine-readable contract on stdout — the only thing on stdout.
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+
+      const totalRows = Object.values(result.rowCounts).reduce((sum, value) => sum + value, 0);
+      this.logToStderr(
+        chalk.green(
+          `✓ ${dryRun ? 'Dry run complete' : 'Tenant data deleted and verified'} — ${totalRows} row(s)`
+        )
+      );
+      process.exit(0);
+    } catch (error) {
+      const message = error instanceof Error ? redactSecrets(error.message) : String(error);
+      this.logToStderr(chalk.red(`✗ ${message}`));
+      if (error instanceof TenantDeletionVerificationError) {
+        this.logToStderr(chalk.red(`  Remaining tables: ${error.tables.join(', ')}`));
+      }
+      if (error instanceof TenantDeletionUnsupportedError) {
+        this.logToStderr(
+          chalk.dim(
+            '  Point the command at a PostgreSQL database (AGOR_DB_DIALECT=postgresql, DATABASE_URL=…).'
+          )
+        );
+      }
+      process.exit(EXIT_FAILURE);
+    }
+  }
+}

--- a/apps/agor-cli/src/commands/tenant/delete.ts
+++ b/apps/agor-cli/src/commands/tenant/delete.ts
@@ -34,6 +34,11 @@ function redactSecrets(message: string): string {
   return message.replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+@/gi, '$1[redacted]@');
 }
 
+/** Convert any thrown value to a secret-safe stderr message. */
+export function tenantDeleteErrorMessage(error: unknown): string {
+  return redactSecrets(error instanceof Error ? error.message : String(error));
+}
+
 /** Wait until every stderr write queued so far has completed. */
 function flushStderr(): Promise<void> {
   return new Promise((resolve) => {
@@ -112,7 +117,7 @@ export default class TenantDelete extends Command {
       await flushStderr();
       process.exit(0);
     } catch (error) {
-      const message = redactSecrets(error instanceof Error ? error.message : String(error));
+      const message = tenantDeleteErrorMessage(error);
       this.logToStderr(chalk.red(`✗ ${message}`));
       if (error instanceof TenantDeletionVerificationError) {
         this.logToStderr(chalk.red(`  Remaining tables: ${error.tables.join(', ')}`));

--- a/apps/agor-cli/src/lib/check-migrations.test.ts
+++ b/apps/agor-cli/src/lib/check-migrations.test.ts
@@ -37,6 +37,7 @@ describe('getPendingMigrationsInfo', () => {
       hasPending: false,
       pending: [],
       applied: ['0000_init'],
+      dbAheadOfBinary: false,
     });
 
     await expect(getPendingMigrationsInfo()).resolves.toBeNull();
@@ -47,6 +48,7 @@ describe('getPendingMigrationsInfo', () => {
       hasPending: true,
       pending: ['0005_add_widgets', '0006_add_gizmos'],
       applied: ['0000_init'],
+      dbAheadOfBinary: false,
     });
 
     const info = await getPendingMigrationsInfo();
@@ -65,6 +67,7 @@ describe('getPendingMigrationsInfo', () => {
       hasPending: true,
       pending: ['0001_thing'],
       applied: [],
+      dbAheadOfBinary: false,
     });
 
     const info = await getPendingMigrationsInfo('file:/tmp/agor-override.db');

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -50,6 +50,9 @@ export * from './repositories';
 export * from './schema';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';
+// Tenant deletion (permanent, audited, idempotent per-tenant erasure)
+export * from './tenant-deletion';
+export * from './tenant-deletion-manifest';
 export * from './tenant-scope';
 export * from './tenant-unit-of-work';
 // User utilities

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -53,6 +53,7 @@ export * from './session-guard';
 // Tenant deletion (permanent, audited, idempotent per-tenant erasure)
 export * from './tenant-deletion';
 export * from './tenant-deletion-manifest';
+export * from './tenant-imperative-tables';
 export * from './tenant-scope';
 export * from './tenant-unit-of-work';
 // User utilities

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -164,11 +164,21 @@ function getMigrationsFolder(db: Database): string {
  * folderMillis against the last applied migration's created_at, NOT hashes.
  * Hash-based checking breaks when migration files are modified after being applied.
  *
+ * `dbAheadOfBinary` is true when the database's max applied migration timestamp
+ * is NEWER than the newest entry in this binary's local journal — i.e. the
+ * database was migrated by a newer release than the one running now. This is the
+ * inverse of `hasPending` (binary ahead of DB) and cannot be detected from the
+ * journal alone, so consumers that require a complete, matching schema (e.g.
+ * tenant deletion) must check it explicitly.
+ *
  * @returns Object with hasPending flag and list of pending migration tags
  */
-export async function checkMigrationStatus(
-  db: Database
-): Promise<{ hasPending: boolean; pending: string[]; applied: string[] }> {
+export async function checkMigrationStatus(db: Database): Promise<{
+  hasPending: boolean;
+  pending: string[];
+  applied: string[];
+  dbAheadOfBinary: boolean;
+}> {
   try {
     const migrationsFolder = getMigrationsFolder(db);
 
@@ -180,6 +190,7 @@ export async function checkMigrationStatus(
     const journalEntries: { tag: string; when: number }[] = journal.entries.map(
       (e: { tag: string; when: number }) => ({ tag: e.tag, when: e.when })
     );
+    const journalMaxWhen = journalEntries.reduce((max, e) => Math.max(max, e.when), 0);
 
     // Get max applied timestamp from database (Drizzle's watermark)
     const hasTable = await hasMigrationsTable(db);
@@ -188,6 +199,7 @@ export async function checkMigrationStatus(
         hasPending: true,
         pending: journalEntries.map((e) => e.tag),
         applied: [],
+        dbAheadOfBinary: false,
       };
     }
 
@@ -208,10 +220,15 @@ export async function checkMigrationStatus(
     const pending = journalEntries.filter((e) => e.when > maxAppliedMillis).map((e) => e.tag);
     const applied = journalEntries.filter((e) => e.when <= maxAppliedMillis).map((e) => e.tag);
 
+    // The database has been migrated by a newer binary than this one when its
+    // watermark is past every migration this binary knows about.
+    const dbAheadOfBinary = maxAppliedMillis > journalMaxWhen;
+
     return {
       hasPending: pending.length > 0,
       pending,
       applied,
+      dbAheadOfBinary,
     };
   } catch (error) {
     const rootCause = getRootCause(error);

--- a/packages/core/src/db/tenant-deletion-manifest.test.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.test.ts
@@ -18,9 +18,14 @@ function allPostgresTableNames(): string[] {
   return names.sort();
 }
 
-/** Blocking `ON DELETE` actions constrain deletion order (see manifest module). */
-function isBlocking(onDelete: string | undefined): boolean {
-  return onDelete === undefined || onDelete === 'no action' || onDelete === 'restrict';
+/** Blocking and cascading actions constrain the defensive deletion order. */
+function isOrderingEdge(onDelete: string | undefined): boolean {
+  return (
+    onDelete === undefined ||
+    onDelete === 'no action' ||
+    onDelete === 'restrict' ||
+    onDelete === 'cascade'
+  );
 }
 
 describe('tenant deletion manifest classification', () => {
@@ -73,7 +78,7 @@ describe('tenant deletion manifest ordering', () => {
     }
   });
 
-  it('orders children before parents for every blocking foreign key', () => {
+  it('orders children before parents for every blocking or cascading foreign key', () => {
     for (const value of Object.values(postgresSchema)) {
       if (!is(value, PgTable)) continue;
       const config = getTableConfig(value);
@@ -81,7 +86,7 @@ describe('tenant deletion manifest ordering', () => {
       const childIndex = orderIndex.get(childName);
       if (childIndex === undefined) continue; // not a tenant-scoped table
       for (const fk of config.foreignKeys) {
-        if (!isBlocking(fk.onDelete)) continue;
+        if (!isOrderingEdge(fk.onDelete)) continue;
         const parentName = getTableConfig(fk.reference().foreignTable).name;
         if (parentName === childName) continue;
         const parentIndex = orderIndex.get(parentName);

--- a/packages/core/src/db/tenant-deletion-manifest.test.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.test.ts
@@ -1,0 +1,94 @@
+import { is } from 'drizzle-orm';
+import { getTableConfig, PgTable } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import * as postgresSchema from './schema.postgres';
+import {
+  buildTenantDeletionManifest,
+  classifyPostgresTables,
+  GLOBAL_TABLES,
+  TENANT_SCOPE_COLUMN,
+} from './tenant-deletion-manifest';
+
+/** All physical table names exported by the PostgreSQL schema. */
+function allPostgresTableNames(): string[] {
+  const names: string[] = [];
+  for (const value of Object.values(postgresSchema)) {
+    if (is(value, PgTable)) names.push(getTableConfig(value).name);
+  }
+  return names.sort();
+}
+
+/** Blocking `ON DELETE` actions constrain deletion order (see manifest module). */
+function isBlocking(onDelete: string | undefined): boolean {
+  return onDelete === undefined || onDelete === 'no action' || onDelete === 'restrict';
+}
+
+describe('tenant deletion manifest classification', () => {
+  it('classifies every schema table (nothing can silently escape deletion)', () => {
+    const { direct, transitive, global, unclassified } = classifyPostgresTables();
+
+    // The exhaustiveness guarantee: a future table that is neither tenant-scoped,
+    // transitively-scoped, nor explicitly declared global fails this assertion.
+    expect(unclassified).toEqual([]);
+
+    const covered = [...direct, ...transitive, ...global].sort();
+    expect(covered).toEqual(allPostgresTableNames());
+  });
+
+  it('treats every current application table as directly tenant-scoped', () => {
+    const { direct, transitive, global } = classifyPostgresTables();
+    // Every table in the PostgreSQL schema currently carries a tenant_id column.
+    expect(transitive).toEqual([]);
+    expect(global).toEqual([]);
+    expect(direct).toEqual(allPostgresTableNames());
+    // Spot-check a few tables spanning the FK hierarchy.
+    expect(direct).toContain('sessions');
+    expect(direct).toContain('users');
+    expect(direct).toContain('kb_graph_edges');
+  });
+
+  it('only lists real, tenant-free tables in GLOBAL_TABLES', () => {
+    const names = new Set(allPostgresTableNames());
+    for (const global of GLOBAL_TABLES) {
+      expect(names.has(global)).toBe(true);
+    }
+  });
+});
+
+describe('tenant deletion manifest ordering', () => {
+  const manifest = buildTenantDeletionManifest();
+  const orderIndex = new Map(manifest.map((entry, index) => [entry.name, index]));
+
+  it('includes exactly the tenant-scoped tables', () => {
+    const { direct, transitive } = classifyPostgresTables();
+    const expected = [...direct, ...transitive].sort();
+    expect(manifest.map((entry) => entry.name).sort()).toEqual(expected);
+  });
+
+  it('exposes a tenant column for every direct entry', () => {
+    for (const entry of manifest) {
+      if (entry.scope === 'direct') {
+        expect(entry.tenantColumn?.name).toBe(TENANT_SCOPE_COLUMN);
+      }
+    }
+  });
+
+  it('orders children before parents for every blocking foreign key', () => {
+    for (const value of Object.values(postgresSchema)) {
+      if (!is(value, PgTable)) continue;
+      const config = getTableConfig(value);
+      const childName = config.name;
+      const childIndex = orderIndex.get(childName);
+      if (childIndex === undefined) continue; // not a tenant-scoped table
+      for (const fk of config.foreignKeys) {
+        if (!isBlocking(fk.onDelete)) continue;
+        const parentName = getTableConfig(fk.reference().foreignTable).name;
+        if (parentName === childName) continue;
+        const parentIndex = orderIndex.get(parentName);
+        if (parentIndex === undefined) continue; // parent not in manifest
+        // The referencing (child) row must be deleted before the referenced row.
+        expect(childIndex).toBeLessThan(parentIndex);
+      }
+    }
+  });
+});

--- a/packages/core/src/db/tenant-deletion-manifest.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.ts
@@ -1,0 +1,366 @@
+/**
+ * Runtime-owned manifest of tenant-scoped database tables.
+ *
+ * Operators of a multi-tenant Agor deployment occasionally need to permanently
+ * remove every trace of a single tenant (offboarding, data-removal requests,
+ * regulatory erasure). Doing that safely requires an exhaustive, machine-derived
+ * list of which tables hold tenant data and in what order they must be deleted
+ * so foreign keys are never violated.
+ *
+ * This module derives that manifest directly from the PostgreSQL schema
+ * definitions (`schema.postgres.ts`) rather than hand-maintaining a list, so a
+ * newly added table is picked up automatically. Every table is classified as:
+ *
+ *   - `direct`     — carries a `tenant_id` column and is deleted with
+ *                    `WHERE tenant_id = $1`.
+ *   - `transitive` — has no `tenant_id` column but reaches a scoped table via a
+ *                    foreign-key chain; deleted with a subquery predicate that
+ *                    resolves down to a scoped ancestor.
+ *   - `global`     — explicitly declared as holding no tenant data (see
+ *                    {@link GLOBAL_TABLES}); left untouched.
+ *
+ * The companion exhaustiveness test fails the build if any schema table falls
+ * into none of those buckets, so a future table cannot silently escape
+ * tenant deletion.
+ *
+ * Multi-tenancy is a PostgreSQL-only feature in Agor (the SQLite schema is
+ * single-tenant and has no `tenant_id` columns), so this manifest is built from
+ * the PostgreSQL schema exclusively.
+ */
+
+import { eq, inArray, is, type SQL } from 'drizzle-orm';
+import { getTableConfig, type PgColumn, PgTable, type QueryBuilder } from 'drizzle-orm/pg-core';
+import * as postgresSchema from './schema.postgres';
+
+/** Name of the column that scopes a row to a tenant. */
+export const TENANT_SCOPE_COLUMN = 'tenant_id';
+
+/**
+ * Tables that legitimately hold no tenant-scoped data and must therefore be
+ * left untouched by tenant deletion.
+ *
+ * This list is intentionally explicit: the exhaustiveness test fails if a schema
+ * table is neither tenant-scoped, transitively tenant-scoped, nor named here, so
+ * a new global table cannot be introduced without a conscious decision recorded
+ * in this set. It is currently empty because every application table in the
+ * PostgreSQL schema carries a `tenant_id` column.
+ *
+ * Note: Drizzle's own migration bookkeeping table (`drizzle.__drizzle_migrations`)
+ * is not part of the application schema exports and is never enumerated by this
+ * manifest.
+ */
+export const GLOBAL_TABLES: ReadonlySet<string> = new Set<string>([]);
+
+/** How a table is tied to a tenant. */
+export type TenantTableScope = 'direct' | 'transitive';
+
+/** Full classification of a table, including non-tenant tables. */
+export type TableClassification = TenantTableScope | 'global';
+
+/** Link from a transitively-scoped child table to a scoped ancestor. */
+export interface TenantParentLink {
+  /** Single-column foreign key on the child table. */
+  fkColumn: PgColumn;
+  /** Physical name of the scoped (direct or transitive) parent table. */
+  parentTable: string;
+  /** Referenced primary/unique column on the parent table. */
+  parentPkColumn: PgColumn;
+}
+
+/** A table that holds tenant data and must be included in deletion. */
+export interface TenantDeletionTable {
+  /** Physical table name. */
+  name: string;
+  /** Drizzle table object, used to build type-safe queries. */
+  table: PgTable;
+  /** How the table is scoped to a tenant. */
+  scope: TenantTableScope;
+  /** Tenant column (present only for `direct` scope). */
+  tenantColumn?: PgColumn;
+  /** FK link to a scoped ancestor (present only for `transitive` scope). */
+  parentLink?: TenantParentLink;
+}
+
+interface ForeignKeyMeta {
+  fkColumns: PgColumn[];
+  parentTable: string;
+  parentColumns: PgColumn[];
+  onDelete?: string;
+}
+
+interface TableMeta {
+  name: string;
+  table: PgTable;
+  columns: PgColumn[];
+  foreignKeys: ForeignKeyMeta[];
+}
+
+/**
+ * An `ON DELETE` action blocks deletion of the referenced (parent) row while a
+ * referencing (child) row still exists. Only `restrict` and `no action` (the
+ * default when unspecified) block; `cascade`, `set null`, and `set default`
+ * never do. Blocking edges are the only ones that constrain deletion order.
+ */
+function isBlockingOnDelete(onDelete: string | undefined): boolean {
+  return onDelete === undefined || onDelete === 'no action' || onDelete === 'restrict';
+}
+
+let cachedTableMetas: Map<string, TableMeta> | null = null;
+
+function discoverTableMetas(): Map<string, TableMeta> {
+  if (cachedTableMetas) return cachedTableMetas;
+  const metas = new Map<string, TableMeta>();
+  for (const value of Object.values(postgresSchema)) {
+    if (!is(value, PgTable)) continue;
+    const config = getTableConfig(value);
+    const foreignKeys: ForeignKeyMeta[] = config.foreignKeys.map((fk) => {
+      const reference = fk.reference();
+      return {
+        fkColumns: reference.columns as PgColumn[],
+        parentTable: getTableConfig(reference.foreignTable).name,
+        parentColumns: reference.foreignColumns as PgColumn[],
+        onDelete: fk.onDelete,
+      };
+    });
+    metas.set(config.name, {
+      name: config.name,
+      table: value,
+      columns: config.columns as PgColumn[],
+      foreignKeys,
+    });
+  }
+  cachedTableMetas = metas;
+  return metas;
+}
+
+function hasTenantColumn(meta: TableMeta): boolean {
+  return meta.columns.some((column) => column.name === TENANT_SCOPE_COLUMN);
+}
+
+export interface TableClassificationResult {
+  direct: string[];
+  transitive: string[];
+  global: string[];
+  /** Tables that could not be classified — a bug that must fail the build. */
+  unclassified: string[];
+}
+
+/**
+ * Classify every PostgreSQL table into direct / transitive / global, computing
+ * the transitive set to a fixpoint over foreign-key chains.
+ */
+export function classifyPostgresTables(): TableClassificationResult {
+  const metas = discoverTableMetas();
+
+  const global = new Set<string>();
+  const direct = new Set<string>();
+  for (const [name, meta] of metas) {
+    if (GLOBAL_TABLES.has(name)) {
+      global.add(name);
+      continue;
+    }
+    if (hasTenantColumn(meta)) direct.add(name);
+  }
+
+  const transitive = new Set<string>();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [name, meta] of metas) {
+      if (global.has(name) || direct.has(name) || transitive.has(name)) continue;
+      const reachesScoped = meta.foreignKeys.some(
+        (fk) => direct.has(fk.parentTable) || transitive.has(fk.parentTable)
+      );
+      if (reachesScoped) {
+        transitive.add(name);
+        changed = true;
+      }
+    }
+  }
+
+  const unclassified: string[] = [];
+  for (const name of metas.keys()) {
+    if (!global.has(name) && !direct.has(name) && !transitive.has(name)) unclassified.push(name);
+  }
+
+  return {
+    direct: [...direct].sort(),
+    transitive: [...transitive].sort(),
+    global: [...global].sort(),
+    unclassified: unclassified.sort(),
+  };
+}
+
+function requireSingleColumn(columns: PgColumn[], context: string): PgColumn {
+  if (columns.length !== 1) {
+    throw new Error(
+      `Tenant deletion manifest cannot handle composite foreign key (${context}); expected a single column`
+    );
+  }
+  return columns[0];
+}
+
+function buildParentLink(
+  meta: TableMeta,
+  direct: Set<string>,
+  scoped: Set<string>
+): TenantParentLink {
+  // Prefer a foreign key to a directly-scoped parent for the shortest predicate,
+  // falling back to any scoped (transitive) parent.
+  const candidate =
+    meta.foreignKeys.find((fk) => direct.has(fk.parentTable)) ??
+    meta.foreignKeys.find((fk) => scoped.has(fk.parentTable));
+  if (!candidate) {
+    throw new Error(`Transitive table ${meta.name} has no foreign key to a scoped table`);
+  }
+  return {
+    fkColumn: requireSingleColumn(candidate.fkColumns, `${meta.name} -> ${candidate.parentTable}`),
+    parentTable: candidate.parentTable,
+    parentPkColumn: requireSingleColumn(
+      candidate.parentColumns,
+      `${candidate.parentTable} referenced by ${meta.name}`
+    ),
+  };
+}
+
+/**
+ * Order manifest tables children-first so that, for every blocking foreign key,
+ * the referencing table is deleted before the table it references. Implemented
+ * as a Kahn topological sort; deterministic via name-sorted tie-breaking.
+ */
+function orderChildrenFirst(
+  entries: TenantDeletionTable[],
+  metas: Map<string, TableMeta>
+): TenantDeletionTable[] {
+  const inManifest = new Set(entries.map((entry) => entry.name));
+  const byName = new Map(entries.map((entry) => [entry.name, entry]));
+  const indegree = new Map<string, number>();
+  for (const entry of entries) indegree.set(entry.name, 0);
+  // child -> parents that must be deleted after the child.
+  const childToParents = new Map<string, Set<string>>();
+
+  for (const entry of entries) {
+    const meta = metas.get(entry.name);
+    if (!meta) continue;
+    for (const fk of meta.foreignKeys) {
+      if (!isBlockingOnDelete(fk.onDelete)) continue;
+      const parent = fk.parentTable;
+      if (parent === entry.name) {
+        throw new Error(
+          `Self-referential blocking foreign key on ${entry.name}; tenant deletion order cannot be derived`
+        );
+      }
+      if (!inManifest.has(parent)) continue;
+      const parents = childToParents.get(entry.name) ?? new Set<string>();
+      if (!parents.has(parent)) {
+        parents.add(parent);
+        childToParents.set(entry.name, parents);
+        indegree.set(parent, (indegree.get(parent) ?? 0) + 1);
+      }
+    }
+  }
+
+  const ready = [...indegree]
+    .filter(([, degree]) => degree === 0)
+    .map(([name]) => name)
+    .sort();
+  const order: TenantDeletionTable[] = [];
+  while (ready.length > 0) {
+    ready.sort();
+    const name = ready.shift() as string;
+    const entry = byName.get(name);
+    if (entry) order.push(entry);
+    for (const parent of childToParents.get(name) ?? []) {
+      const next = (indegree.get(parent) ?? 0) - 1;
+      indegree.set(parent, next);
+      if (next === 0) ready.push(parent);
+    }
+  }
+
+  if (order.length !== entries.length) {
+    throw new Error(
+      'Cycle among blocking tenant foreign keys; cannot derive a safe deletion order'
+    );
+  }
+  return order;
+}
+
+let cachedManifest: TenantDeletionTable[] | null = null;
+
+/**
+ * Build the ordered tenant-deletion manifest: every direct- and
+ * transitively-scoped table, ordered so children are deleted before parents.
+ * The result is memoized because the schema is static at runtime.
+ */
+export function buildTenantDeletionManifest(): TenantDeletionTable[] {
+  if (cachedManifest) return cachedManifest;
+  const metas = discoverTableMetas();
+  const { direct, transitive } = classifyPostgresTables();
+  const directSet = new Set<string>(direct);
+  const scoped = new Set<string>([...direct, ...transitive]);
+
+  const entries: TenantDeletionTable[] = [];
+  for (const name of direct) {
+    const meta = metas.get(name);
+    if (!meta) continue;
+    const tenantColumn = meta.columns.find((column) => column.name === TENANT_SCOPE_COLUMN);
+    if (!tenantColumn) continue;
+    entries.push({ name, table: meta.table, scope: 'direct', tenantColumn });
+  }
+  for (const name of transitive) {
+    const meta = metas.get(name);
+    if (!meta) continue;
+    entries.push({
+      name,
+      table: meta.table,
+      scope: 'transitive',
+      parentLink: buildParentLink(meta, directSet, scoped),
+    });
+  }
+
+  cachedManifest = orderChildrenFirst(entries, metas);
+  return cachedManifest;
+}
+
+/** Index a manifest by table name (used when resolving transitive predicates). */
+export function indexManifest(manifest: TenantDeletionTable[]): Map<string, TenantDeletionTable> {
+  return new Map(manifest.map((entry) => [entry.name, entry]));
+}
+
+/**
+ * Build the boolean condition that scopes a table's rows to a single tenant.
+ * Direct tables use `tenant_id = $1`; transitive tables recurse into a subquery
+ * that resolves down to a scoped ancestor. The `queryBuilder` is used only to
+ * construct subqueries and carries no database connection, so this function is
+ * pure and can be rendered/asserted without a live database.
+ */
+export function buildTenantScopeCondition(
+  queryBuilder: QueryBuilder,
+  entry: TenantDeletionTable,
+  tenantId: string,
+  byName: Map<string, TenantDeletionTable>
+): SQL {
+  if (entry.scope === 'direct') {
+    if (!entry.tenantColumn) {
+      throw new Error(`Direct tenant table ${entry.name} is missing its tenant column`);
+    }
+    return eq(entry.tenantColumn, tenantId);
+  }
+
+  const link = entry.parentLink;
+  if (!link) {
+    throw new Error(`Transitive tenant table ${entry.name} is missing its parent link`);
+  }
+  const parent = byName.get(link.parentTable);
+  if (!parent) {
+    throw new Error(
+      `Transitive tenant table ${entry.name} references unknown parent ${link.parentTable}`
+    );
+  }
+  const parentCondition = buildTenantScopeCondition(queryBuilder, parent, tenantId, byName);
+  const subquery = queryBuilder
+    .select({ pk: link.parentPkColumn })
+    .from(parent.table)
+    .where(parentCondition);
+  return inArray(link.fkColumn, subquery);
+}

--- a/packages/core/src/db/tenant-deletion-manifest.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.ts
@@ -295,7 +295,35 @@ let cachedManifest: TenantDeletionTable[] | null = null;
 export function buildTenantDeletionManifest(): TenantDeletionTable[] {
   if (cachedManifest) return cachedManifest;
   const metas = discoverTableMetas();
-  const { direct, transitive } = classifyPostgresTables();
+  const { direct, transitive, unclassified } = classifyPostgresTables();
+
+  // Runtime exhaustiveness invariant: no schema table may silently escape
+  // deletion. This is the same guarantee the CI exhaustiveness test asserts,
+  // enforced here at runtime so a mis-deployed binary fails loudly instead of
+  // certifying an incomplete deletion.
+  if (unclassified.length > 0) {
+    throw new Error(
+      `Tenant deletion cannot classify table(s): ${unclassified.join(', ')}. ` +
+        'Every schema table must carry a tenant_id column, reach a scoped table ' +
+        'via a foreign key, or be declared in GLOBAL_TABLES.'
+    );
+  }
+
+  // The transitive deletion path is unproven: the child-first ordering picks a
+  // single parent FK, and phase-2 verification resolves scope through parent
+  // rows that phase-1 has already deleted, so a surviving transitive row
+  // (including ON DELETE SET NULL orphans) cannot be detected. Rather than
+  // half-delete such a table and self-certify success, refuse loudly. This
+  // branch is dormant today (every application table carries tenant_id) and
+  // guards against a future schema addition slipping through unverified.
+  if (transitive.length > 0) {
+    throw new Error(
+      `Tenant deletion does not yet support transitively-scoped tables (${transitive.join(', ')}). ` +
+        'Add a tenant_id column to these tables, or extend the deletion engine ' +
+        'with orphan-safe verification before deleting them.'
+    );
+  }
+
   const directSet = new Set<string>(direct);
   const scoped = new Set<string>([...direct, ...transitive]);
 

--- a/packages/core/src/db/tenant-deletion-manifest.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.ts
@@ -1,11 +1,16 @@
 /**
  * Runtime-owned manifest of tenant-scoped database tables.
  *
- * Operators of a multi-tenant Agor deployment occasionally need to permanently
- * remove every trace of a single tenant (offboarding, data-removal requests,
- * regulatory erasure). Doing that safely requires an exhaustive, machine-derived
- * list of which tables hold tenant data and in what order they must be deleted
- * so foreign keys are never violated.
+ * A standalone multi-tenant PostgreSQL runtime occasionally needs to
+ * permanently remove every trace of a single tenant (offboarding, data-removal
+ * requests, regulatory erasure). This module supplies an exhaustive,
+ * machine-derived list of tenant tables and a defensive order based on the
+ * compiled schema's foreign keys.
+ *
+ * The order is not proof of foreign-key tenant consistency. PostgreSQL RLS does
+ * not prevent a row from creating a cross-tenant reference and does not limit
+ * referential actions such as cascades. The live schema and data must maintain
+ * the deletion engine's tenant-consistent foreign-key precondition.
  *
  * This module derives that manifest directly from the PostgreSQL schema
  * definitions (`schema.postgres.ts`) rather than hand-maintaining a list, so a
@@ -28,8 +33,8 @@
  * the PostgreSQL schema exclusively.
  */
 
-import { eq, is, type SQL } from 'drizzle-orm';
-import { getTableConfig, type PgColumn, PgTable, type QueryBuilder } from 'drizzle-orm/pg-core';
+import { is } from 'drizzle-orm';
+import { getTableConfig, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
 import * as postgresSchema from './schema.postgres';
 
 /** Name of the column that scopes a row to a tenant. */
@@ -180,9 +185,10 @@ export function classifyPostgresTables(): TableClassificationResult {
 
 /**
  * Order manifest tables children-first so that, for every blocking or cascading
- * foreign key, the referencing table is deleted before the table it references.
- * Implemented as a Kahn topological sort; deterministic via name-sorted
- * tie-breaking.
+ * foreign key in the compiled schema, the referencing table is deleted before
+ * the table it references. Implemented as a Kahn topological sort;
+ * deterministic via name-sorted tie-breaking. This ordering does not validate
+ * row-level tenant equality across those references.
  */
 function orderChildrenFirst(
   entries: TenantDeletionTable[],
@@ -298,27 +304,4 @@ export function buildTenantDeletionManifest(): TenantDeletionTable[] {
 
   cachedManifest = orderChildrenFirst(entries, metas);
   return cachedManifest;
-}
-
-/** Index a manifest by table name. */
-export function indexManifest(manifest: TenantDeletionTable[]): Map<string, TenantDeletionTable> {
-  return new Map(manifest.map((entry) => [entry.name, entry]));
-}
-
-/**
- * Build the boolean condition that scopes a table's rows to a single tenant.
- *
- * The unused compatibility parameters can be removed with the executor call
- * sites; deletion entries themselves are direct-only.
- */
-export function buildTenantScopeCondition(
-  _queryBuilder: QueryBuilder,
-  entry: TenantDeletionTable,
-  tenantId: string,
-  _byName: Map<string, TenantDeletionTable>
-): SQL {
-  if (!entry.tenantColumn) {
-    throw new Error(`Direct tenant table ${entry.name} is missing its tenant column`);
-  }
-  return eq(entry.tenantColumn, tenantId);
 }

--- a/packages/core/src/db/tenant-deletion-manifest.ts
+++ b/packages/core/src/db/tenant-deletion-manifest.ts
@@ -14,8 +14,8 @@
  *   - `direct`     — carries a `tenant_id` column and is deleted with
  *                    `WHERE tenant_id = $1`.
  *   - `transitive` — has no `tenant_id` column but reaches a scoped table via a
- *                    foreign-key chain; deleted with a subquery predicate that
- *                    resolves down to a scoped ancestor.
+ *                    foreign-key chain; detected so deletion can fail closed
+ *                    until that shape has an orphan-safe implementation.
  *   - `global`     — explicitly declared as holding no tenant data (see
  *                    {@link GLOBAL_TABLES}); left untouched.
  *
@@ -28,7 +28,7 @@
  * the PostgreSQL schema exclusively.
  */
 
-import { eq, inArray, is, type SQL } from 'drizzle-orm';
+import { eq, is, type SQL } from 'drizzle-orm';
 import { getTableConfig, type PgColumn, PgTable, type QueryBuilder } from 'drizzle-orm/pg-core';
 import * as postgresSchema from './schema.postgres';
 
@@ -51,21 +51,8 @@ export const TENANT_SCOPE_COLUMN = 'tenant_id';
  */
 export const GLOBAL_TABLES: ReadonlySet<string> = new Set<string>([]);
 
-/** How a table is tied to a tenant. */
-export type TenantTableScope = 'direct' | 'transitive';
-
 /** Full classification of a table, including non-tenant tables. */
-export type TableClassification = TenantTableScope | 'global';
-
-/** Link from a transitively-scoped child table to a scoped ancestor. */
-export interface TenantParentLink {
-  /** Single-column foreign key on the child table. */
-  fkColumn: PgColumn;
-  /** Physical name of the scoped (direct or transitive) parent table. */
-  parentTable: string;
-  /** Referenced primary/unique column on the parent table. */
-  parentPkColumn: PgColumn;
-}
+export type TableClassification = 'direct' | 'transitive' | 'global';
 
 /** A table that holds tenant data and must be included in deletion. */
 export interface TenantDeletionTable {
@@ -73,23 +60,17 @@ export interface TenantDeletionTable {
   name: string;
   /** Drizzle table object, used to build type-safe queries. */
   table: PgTable;
-  /** How the table is scoped to a tenant. */
-  scope: TenantTableScope;
-  /** Tenant column (present only for `direct` scope). */
-  tenantColumn?: PgColumn;
-  /** FK link to a scoped ancestor (present only for `transitive` scope). */
-  parentLink?: TenantParentLink;
+  /** Deletion entries are always scoped directly by this tenant column. */
+  scope: 'direct';
+  tenantColumn: PgColumn;
 }
 
 interface ForeignKeyMeta {
-  fkColumns: PgColumn[];
   parentTable: string;
-  parentColumns: PgColumn[];
   onDelete?: string;
 }
 
 interface TableMeta {
-  name: string;
   table: PgTable;
   columns: PgColumn[];
   foreignKeys: ForeignKeyMeta[];
@@ -105,6 +86,15 @@ function isBlockingOnDelete(onDelete: string | undefined): boolean {
   return onDelete === undefined || onDelete === 'no action' || onDelete === 'restrict';
 }
 
+/**
+ * Blocking and cascading edges both order a child before its parent. SET NULL
+ * and SET DEFAULT edges are deliberately excluded: they do not block deletion,
+ * and the schema contains cycles through those actions.
+ */
+function isOrderingOnDelete(onDelete: string | undefined): boolean {
+  return isBlockingOnDelete(onDelete) || onDelete === 'cascade';
+}
+
 let cachedTableMetas: Map<string, TableMeta> | null = null;
 
 function discoverTableMetas(): Map<string, TableMeta> {
@@ -116,14 +106,11 @@ function discoverTableMetas(): Map<string, TableMeta> {
     const foreignKeys: ForeignKeyMeta[] = config.foreignKeys.map((fk) => {
       const reference = fk.reference();
       return {
-        fkColumns: reference.columns as PgColumn[],
         parentTable: getTableConfig(reference.foreignTable).name,
-        parentColumns: reference.foreignColumns as PgColumn[],
         onDelete: fk.onDelete,
       };
     });
     metas.set(config.name, {
-      name: config.name,
       table: value,
       columns: config.columns as PgColumn[],
       foreignKeys,
@@ -191,42 +178,11 @@ export function classifyPostgresTables(): TableClassificationResult {
   };
 }
 
-function requireSingleColumn(columns: PgColumn[], context: string): PgColumn {
-  if (columns.length !== 1) {
-    throw new Error(
-      `Tenant deletion manifest cannot handle composite foreign key (${context}); expected a single column`
-    );
-  }
-  return columns[0];
-}
-
-function buildParentLink(
-  meta: TableMeta,
-  direct: Set<string>,
-  scoped: Set<string>
-): TenantParentLink {
-  // Prefer a foreign key to a directly-scoped parent for the shortest predicate,
-  // falling back to any scoped (transitive) parent.
-  const candidate =
-    meta.foreignKeys.find((fk) => direct.has(fk.parentTable)) ??
-    meta.foreignKeys.find((fk) => scoped.has(fk.parentTable));
-  if (!candidate) {
-    throw new Error(`Transitive table ${meta.name} has no foreign key to a scoped table`);
-  }
-  return {
-    fkColumn: requireSingleColumn(candidate.fkColumns, `${meta.name} -> ${candidate.parentTable}`),
-    parentTable: candidate.parentTable,
-    parentPkColumn: requireSingleColumn(
-      candidate.parentColumns,
-      `${candidate.parentTable} referenced by ${meta.name}`
-    ),
-  };
-}
-
 /**
- * Order manifest tables children-first so that, for every blocking foreign key,
- * the referencing table is deleted before the table it references. Implemented
- * as a Kahn topological sort; deterministic via name-sorted tie-breaking.
+ * Order manifest tables children-first so that, for every blocking or cascading
+ * foreign key, the referencing table is deleted before the table it references.
+ * Implemented as a Kahn topological sort; deterministic via name-sorted
+ * tie-breaking.
  */
 function orderChildrenFirst(
   entries: TenantDeletionTable[],
@@ -243,11 +199,11 @@ function orderChildrenFirst(
     const meta = metas.get(entry.name);
     if (!meta) continue;
     for (const fk of meta.foreignKeys) {
-      if (!isBlockingOnDelete(fk.onDelete)) continue;
+      if (!isOrderingOnDelete(fk.onDelete)) continue;
       const parent = fk.parentTable;
       if (parent === entry.name) {
         throw new Error(
-          `Self-referential blocking foreign key on ${entry.name}; tenant deletion order cannot be derived`
+          `Self-referential blocking or cascading foreign key on ${entry.name}; tenant deletion order cannot be derived`
         );
       }
       if (!inManifest.has(parent)) continue;
@@ -279,7 +235,7 @@ function orderChildrenFirst(
 
   if (order.length !== entries.length) {
     throw new Error(
-      'Cycle among blocking tenant foreign keys; cannot derive a safe deletion order'
+      'Cycle among blocking or cascading tenant foreign keys; cannot derive a safe deletion order'
     );
   }
   return order;
@@ -288,9 +244,10 @@ function orderChildrenFirst(
 let cachedManifest: TenantDeletionTable[] | null = null;
 
 /**
- * Build the ordered tenant-deletion manifest: every direct- and
- * transitively-scoped table, ordered so children are deleted before parents.
- * The result is memoized because the schema is static at runtime.
+ * Build the ordered tenant-deletion manifest: every directly-scoped table,
+ * ordered so children are deleted before parents. Transitively-scoped tables
+ * are detected above and rejected until deletion can verify them safely. The
+ * result is memoized because the schema is static at runtime.
  */
 export function buildTenantDeletionManifest(): TenantDeletionTable[] {
   if (cachedManifest) return cachedManifest;
@@ -324,9 +281,6 @@ export function buildTenantDeletionManifest(): TenantDeletionTable[] {
     );
   }
 
-  const directSet = new Set<string>(direct);
-  const scoped = new Set<string>([...direct, ...transitive]);
-
   const entries: TenantDeletionTable[] = [];
   for (const name of direct) {
     const meta = metas.get(name);
@@ -335,60 +289,36 @@ export function buildTenantDeletionManifest(): TenantDeletionTable[] {
     if (!tenantColumn) continue;
     entries.push({ name, table: meta.table, scope: 'direct', tenantColumn });
   }
-  for (const name of transitive) {
-    const meta = metas.get(name);
-    if (!meta) continue;
-    entries.push({
-      name,
-      table: meta.table,
-      scope: 'transitive',
-      parentLink: buildParentLink(meta, directSet, scoped),
-    });
+
+  if (entries.length === 0) {
+    throw new Error(
+      'Tenant deletion manifest is empty; refusing to certify an empty deletion plan'
+    );
   }
 
   cachedManifest = orderChildrenFirst(entries, metas);
   return cachedManifest;
 }
 
-/** Index a manifest by table name (used when resolving transitive predicates). */
+/** Index a manifest by table name. */
 export function indexManifest(manifest: TenantDeletionTable[]): Map<string, TenantDeletionTable> {
   return new Map(manifest.map((entry) => [entry.name, entry]));
 }
 
 /**
  * Build the boolean condition that scopes a table's rows to a single tenant.
- * Direct tables use `tenant_id = $1`; transitive tables recurse into a subquery
- * that resolves down to a scoped ancestor. The `queryBuilder` is used only to
- * construct subqueries and carries no database connection, so this function is
- * pure and can be rendered/asserted without a live database.
+ *
+ * The unused compatibility parameters can be removed with the executor call
+ * sites; deletion entries themselves are direct-only.
  */
 export function buildTenantScopeCondition(
-  queryBuilder: QueryBuilder,
+  _queryBuilder: QueryBuilder,
   entry: TenantDeletionTable,
   tenantId: string,
-  byName: Map<string, TenantDeletionTable>
+  _byName: Map<string, TenantDeletionTable>
 ): SQL {
-  if (entry.scope === 'direct') {
-    if (!entry.tenantColumn) {
-      throw new Error(`Direct tenant table ${entry.name} is missing its tenant column`);
-    }
-    return eq(entry.tenantColumn, tenantId);
+  if (!entry.tenantColumn) {
+    throw new Error(`Direct tenant table ${entry.name} is missing its tenant column`);
   }
-
-  const link = entry.parentLink;
-  if (!link) {
-    throw new Error(`Transitive tenant table ${entry.name} is missing its parent link`);
-  }
-  const parent = byName.get(link.parentTable);
-  if (!parent) {
-    throw new Error(
-      `Transitive tenant table ${entry.name} references unknown parent ${link.parentTable}`
-    );
-  }
-  const parentCondition = buildTenantScopeCondition(queryBuilder, parent, tenantId, byName);
-  const subquery = queryBuilder
-    .select({ pk: link.parentPkColumn })
-    .from(parent.table)
-    .where(parentCondition);
-  return inArray(link.fkColumn, subquery);
+  return eq(entry.tenantColumn, tenantId);
 }

--- a/packages/core/src/db/tenant-deletion.postgres.test.ts
+++ b/packages/core/src/db/tenant-deletion.postgres.test.ts
@@ -1,0 +1,135 @@
+/**
+ * PostgreSQL integration for tenant deletion — exercises real RLS-scoped
+ * deletion, cross-tenant isolation, idempotency, the frozen output contract, and
+ * dry-run. Gated on an explicit test database, mirroring the repository
+ * PostgreSQL suites (`*.postgres.test.ts`); skipped in the SQLite fast-lane CI.
+ *
+ * Run with, e.g.:
+ *   AGOR_DB_DIALECT=postgresql \
+ *   AGOR_TEST_POSTGRES_URL=postgresql://user:pw@host:5432/db \
+ *   pnpm --filter @agor/core exec vitest run src/db/tenant-deletion.postgres.test.ts
+ */
+
+import { count, eq } from 'drizzle-orm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../lib/ids';
+import type { UUID } from '../types/id';
+import { createDatabase, type Database } from './client';
+import { isPostgresDatabase, select } from './database-wrapper';
+import { initializeDatabase } from './migrate';
+import { BranchRepository } from './repositories/branches';
+import { RepoRepository } from './repositories/repos';
+import { SessionRepository } from './repositories/sessions';
+import * as pg from './schema.postgres';
+import { deleteTenantData } from './tenant-deletion';
+import { runWithTenantDatabaseScope } from './tenant-scope';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+// int4 column; keep values small and monotonically unique across seeds.
+let branchUniqueSeq = Date.now() % 1_000_000;
+
+async function seedTenant(db: Database, tenantId: string): Promise<void> {
+  await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const repoId = generateId();
+    await new RepoRepository(scoped).create({
+      repo_id: repoId,
+      slug: `td-${tenantId}-${repoId}`,
+      name: `repo ${tenantId}`,
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/tenant-deletion.git',
+      local_path: `/tmp/${repoId}`,
+      default_branch: 'main',
+    });
+    const branchId = generateId();
+    await new BranchRepository(scoped).create({
+      branch_id: branchId,
+      repo_id: repoId,
+      name: `branch-${tenantId}`,
+      ref: 'main',
+      branch_unique_id: branchUniqueSeq++,
+      path: `/tmp/${branchId}`,
+      created_by: 'tenant-deletion-test-user' as UUID,
+    });
+    await new SessionRepository(scoped).create({
+      session_id: generateId(),
+      branch_id: branchId,
+      agentic_tool: 'claude-code',
+      created_by: 'tenant-deletion-test-user',
+    });
+  });
+}
+
+async function countTenantSessions(db: Database, tenantId: string): Promise<number> {
+  return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const rows = (await select(scoped, { n: count() })
+      .from(pg.sessions)
+      .where(eq(pg.sessions.tenant_id, tenantId))
+      .all()) as Array<{ n: number | string }>;
+    return Number(rows[0]?.n ?? 0);
+  });
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreSQL)', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    await initializeDatabase(db);
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+  });
+
+  it('deletes one tenant, leaves others intact, and is idempotent', async () => {
+    const tenantA = `tda-${generateId()}`;
+    const tenantB = `tdb-${generateId()}`;
+    await seedTenant(db, tenantA);
+    await seedTenant(db, tenantB);
+
+    expect(await countTenantSessions(db, tenantA)).toBe(1);
+    expect(await countTenantSessions(db, tenantB)).toBe(1);
+
+    const result = await deleteTenantData(db, tenantA);
+
+    // Frozen output contract: exactly these keys, all values numbers/strings/bools.
+    expect(Object.keys(result).sort()).toEqual(['rowCounts', 'schemaVersion', 'tenantDataDeleted']);
+    expect(result.tenantDataDeleted).toBe(true);
+    expect(typeof result.schemaVersion).toBe('string');
+    expect(result.schemaVersion.length).toBeGreaterThan(0);
+    expect(result.rowCounts.sessions).toBeGreaterThanOrEqual(1);
+    expect(result.rowCounts.repos).toBeGreaterThanOrEqual(1);
+    expect(result.rowCounts.branches).toBeGreaterThanOrEqual(1);
+    for (const value of Object.values(result.rowCounts)) {
+      expect(typeof value).toBe('number');
+    }
+
+    // Tenant A erased, tenant B untouched.
+    expect(await countTenantSessions(db, tenantA)).toBe(0);
+    expect(await countTenantSessions(db, tenantB)).toBe(1);
+
+    // Second run deletes nothing yet still reports success.
+    const second = await deleteTenantData(db, tenantA);
+    expect(second.tenantDataDeleted).toBe(true);
+    const secondTotal = Object.values(second.rowCounts).reduce((sum, value) => sum + value, 0);
+    expect(secondTotal).toBe(0);
+
+    await deleteTenantData(db, tenantB);
+    expect(await countTenantSessions(db, tenantB)).toBe(0);
+  });
+
+  it('dry-run reports counts without deleting', async () => {
+    const tenantC = `tdc-${generateId()}`;
+    await seedTenant(db, tenantC);
+
+    const dry = await deleteTenantData(db, tenantC, { dryRun: true });
+    expect(dry.tenantDataDeleted).toBe(false);
+    expect('dryRun' in dry && dry.dryRun).toBe(true);
+    expect(dry.rowCounts.sessions).toBeGreaterThanOrEqual(1);
+
+    // Nothing was actually deleted.
+    expect(await countTenantSessions(db, tenantC)).toBe(1);
+
+    await deleteTenantData(db, tenantC);
+    expect(await countTenantSessions(db, tenantC)).toBe(0);
+  });
+});

--- a/packages/core/src/db/tenant-deletion.postgres.test.ts
+++ b/packages/core/src/db/tenant-deletion.postgres.test.ts
@@ -10,12 +10,12 @@
  *   pnpm --filter @agor/core exec vitest run src/db/tenant-deletion.postgres.test.ts
  */
 
-import { count, eq } from 'drizzle-orm';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { count, eq, sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../lib/ids';
 import type { UUID } from '../types/id';
 import { createDatabase, type Database } from './client';
-import { isPostgresDatabase, select } from './database-wrapper';
+import { executeRaw, insert, isPostgresDatabase, select } from './database-wrapper';
 import { initializeDatabase } from './migrate';
 import { BranchRepository } from './repositories/branches';
 import { RepoRepository } from './repositories/repos';
@@ -71,6 +71,188 @@ async function countTenantSessions(db: Database, tenantId: string): Promise<numb
   });
 }
 
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+async function closePostgresDatabase(db: Database): Promise<void> {
+  await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+}
+
+function errorChainMessage(error: unknown): string {
+  const messages: string[] = [];
+  let current: unknown = error;
+  while (current) {
+    messages.push(current instanceof Error ? current.message : String(current));
+    current =
+      current && typeof current === 'object' && 'cause' in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return messages.join('\n');
+}
+
+async function ensureImperativeEmbeddingTable(db: Database): Promise<void> {
+  // The stock PostgreSQL test image does not ship pgvector. A text-backed domain
+  // lets this test use the runtime table DDL unchanged; deletion only depends on
+  // the tenant discriminator, foreign keys, and RLS contract.
+  await executeRaw(
+    db,
+    sql`
+      DO $block$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+          WHERE n.nspname = 'public' AND t.typname = 'vector'
+        ) THEN
+          CREATE DOMAIN public.vector AS text;
+        END IF;
+      END
+      $block$
+    `
+  );
+  await executeRaw(
+    db,
+    sql`
+      CREATE TABLE IF NOT EXISTS public.kb_unit_embeddings (
+        tenant_id text DEFAULT 'default' NOT NULL,
+        unit_id varchar(36) NOT NULL
+          REFERENCES public.kb_document_units(unit_id) ON DELETE cascade,
+        embedding_space_id varchar(36) NOT NULL
+          REFERENCES public.kb_embedding_spaces(embedding_space_id) ON DELETE cascade,
+        content_sha256 text NOT NULL,
+        embedding vector NOT NULL,
+        token_count integer,
+        created_at timestamp with time zone NOT NULL,
+        updated_at timestamp with time zone NOT NULL,
+        CONSTRAINT kb_unit_embeddings_unit_id_embedding_space_id_pk
+          PRIMARY KEY(unit_id, embedding_space_id)
+      )
+    `
+  );
+  await executeRaw(db, sql`ALTER TABLE public.kb_unit_embeddings ENABLE ROW LEVEL SECURITY`);
+  await executeRaw(db, sql`ALTER TABLE public.kb_unit_embeddings FORCE ROW LEVEL SECURITY`);
+  await executeRaw(
+    db,
+    sql`DROP POLICY IF EXISTS tenant_isolation_kb_unit_embeddings ON public.kb_unit_embeddings`
+  );
+  await executeRaw(
+    db,
+    sql`
+      CREATE POLICY tenant_isolation_kb_unit_embeddings ON public.kb_unit_embeddings
+        USING (
+          tenant_id = COALESCE(
+            NULLIF(current_setting('agor.tenant_id', true), ''),
+            'default'
+          )
+        )
+        WITH CHECK (
+          tenant_id = COALESCE(
+            NULLIF(current_setting('agor.tenant_id', true), ''),
+            'default'
+          )
+        )
+    `
+  );
+}
+
+async function seedEmbedding(db: Database, tenantId: string): Promise<void> {
+  const namespaceId = generateId();
+  const documentId = generateId();
+  const versionId = generateId();
+  const unitId = generateId();
+  const embeddingSpaceId = generateId();
+  const now = new Date();
+
+  await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    await insert(scoped, pg.kbNamespaces)
+      .values({
+        namespace_id: namespaceId,
+        slug: `td-${namespaceId}`,
+        display_name: `tenant deletion ${tenantId}`,
+        created_at: now,
+      })
+      .run();
+    await insert(scoped, pg.kbDocuments)
+      .values({
+        document_id: documentId,
+        namespace_id: namespaceId,
+        path: `${documentId}.md`,
+        uri: `agor://knowledge/${namespaceId}/${documentId}.md`,
+        title: `tenant deletion ${tenantId}`,
+        created_at: now,
+      })
+      .run();
+    await insert(scoped, pg.kbDocumentVersions)
+      .values({
+        version_id: versionId,
+        document_id: documentId,
+        version_number: 1,
+        content_text: tenantId,
+        content_sha256: `sha-${tenantId}`,
+        created_at: now,
+      })
+      .run();
+    await insert(scoped, pg.kbDocumentUnits)
+      .values({
+        unit_id: unitId,
+        document_id: documentId,
+        version_id: versionId,
+        content_text: tenantId,
+        created_at: now,
+      })
+      .run();
+    await insert(scoped, pg.kbEmbeddingSpaces)
+      .values({
+        embedding_space_id: embeddingSpaceId,
+        provider: 'test',
+        model: 'test',
+        dimensions: 3,
+        created_at: now,
+      })
+      .run();
+    await executeRaw(
+      scoped,
+      sql`
+        INSERT INTO public.kb_unit_embeddings (
+          tenant_id,
+          unit_id,
+          embedding_space_id,
+          content_sha256,
+          embedding,
+          token_count,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${tenantId},
+          ${unitId},
+          ${embeddingSpaceId},
+          ${`sha-${tenantId}`},
+          '[0,0,0]'::vector,
+          1,
+          ${now.toISOString()},
+          ${now.toISOString()}
+        )
+      `
+    );
+  });
+}
+
+async function countTenantEmbeddings(db: Database, tenantId: string): Promise<number> {
+  return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const result = await executeRaw(
+      scoped,
+      sql`SELECT count(*) AS n FROM public.kb_unit_embeddings WHERE tenant_id = ${tenantId}`
+    );
+    return Number(rowsOf(result)[0]?.n ?? 0);
+  });
+}
+
 describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreSQL)', () => {
   let db: Database;
 
@@ -78,6 +260,10 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
     db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
     await initializeDatabase(db);
     if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+  });
+
+  afterAll(async () => {
+    await closePostgresDatabase(db);
   });
 
   it('deletes one tenant, leaves others intact, and is idempotent', async () => {
@@ -131,5 +317,162 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
 
     await deleteTenantData(db, tenantC);
     expect(await countTenantSessions(db, tenantC)).toBe(0);
+  });
+
+  it('deletes and verifies the imperative embeddings table without touching another tenant', async () => {
+    await ensureImperativeEmbeddingTable(db);
+    const tenantA = `tde-a-${generateId()}`;
+    const tenantB = `tde-b-${generateId()}`;
+    await seedEmbedding(db, tenantA);
+    await seedEmbedding(db, tenantB);
+
+    expect(await countTenantEmbeddings(db, tenantA)).toBe(1);
+    expect(await countTenantEmbeddings(db, tenantB)).toBe(1);
+
+    const result = await deleteTenantData(db, tenantA);
+    expect(result.rowCounts.kb_unit_embeddings).toBe(1);
+    expect(await countTenantEmbeddings(db, tenantA)).toBe(0);
+    expect(await countTenantEmbeddings(db, tenantB)).toBe(1);
+
+    await deleteTenantData(db, tenantB);
+    expect(await countTenantEmbeddings(db, tenantB)).toBe(0);
+  });
+
+  it('fails closed when the live catalog contains an unplanned tenant table', async () => {
+    await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_unknown`);
+    await executeRaw(
+      db,
+      sql`
+        CREATE TABLE public.tenant_delete_unknown (
+          tenant_id text NOT NULL,
+          value text NOT NULL
+        )
+      `
+    );
+    await executeRaw(db, sql`ALTER TABLE public.tenant_delete_unknown ENABLE ROW LEVEL SECURITY`);
+    await executeRaw(db, sql`ALTER TABLE public.tenant_delete_unknown FORCE ROW LEVEL SECURITY`);
+    await executeRaw(
+      db,
+      sql`
+        CREATE POLICY tenant_isolation_tenant_delete_unknown
+          ON public.tenant_delete_unknown
+          USING (
+            tenant_id = COALESCE(
+              NULLIF(current_setting('agor.tenant_id', true), ''),
+              'default'
+            )
+          )
+          WITH CHECK (
+            tenant_id = COALESCE(
+              NULLIF(current_setting('agor.tenant_id', true), ''),
+              'default'
+            )
+          )
+      `
+    );
+
+    try {
+      await expect(
+        deleteTenantData(db, `td-unknown-${generateId()}`, { dryRun: true })
+      ).rejects.toThrow(/tenant_delete_unknown/);
+    } finally {
+      await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_unknown`);
+    }
+  });
+
+  it('fails closed when live-catalog discovery is empty', async () => {
+    const databaseName = `tdel_empty_${generateId().replaceAll('-', '').slice(0, 20)}`;
+    const databaseUrl = new URL(postgresUrl!);
+    databaseUrl.pathname = `/${databaseName}`;
+    let emptyDb: Database | undefined;
+
+    try {
+      const watermarkResult = await executeRaw(
+        db,
+        sql`SELECT max(created_at) AS max_ts FROM drizzle.__drizzle_migrations`
+      );
+      const watermark = rowsOf(watermarkResult)[0]?.max_ts;
+      if (watermark === undefined || watermark === null) {
+        throw new Error('Expected an applied migration watermark');
+      }
+
+      await executeRaw(db, sql`CREATE DATABASE ${sql.identifier(databaseName)}`);
+      emptyDb = createDatabase({ dialect: 'postgresql', url: databaseUrl.toString() });
+      await executeRaw(emptyDb, sql`CREATE SCHEMA drizzle`);
+      await executeRaw(
+        emptyDb,
+        sql`
+          CREATE TABLE drizzle.__drizzle_migrations (
+            id serial PRIMARY KEY,
+            hash text NOT NULL,
+            created_at bigint
+          )
+        `
+      );
+      await executeRaw(
+        emptyDb,
+        sql`
+          INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+          VALUES ('empty-catalog-test', ${watermark})
+        `
+      );
+
+      await expect(
+        deleteTenantData(emptyDb, `td-empty-${generateId()}`, { dryRun: true })
+      ).rejects.toThrow(/zero tenant-contract tables/);
+    } finally {
+      if (emptyDb) await closePostgresDatabase(emptyDb);
+      await executeRaw(
+        db,
+        sql`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${databaseName}`
+      );
+      await executeRaw(db, sql`DROP DATABASE IF EXISTS ${sql.identifier(databaseName)}`);
+    }
+  });
+
+  it('rolls back earlier table deletes when a later delete fails', async () => {
+    const tenantId = `td-rollback-${generateId()}`;
+    await seedTenant(db, tenantId);
+    await executeRaw(
+      db,
+      sql`
+        CREATE OR REPLACE FUNCTION public.tenant_delete_force_rollback()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+        BEGIN
+          RAISE EXCEPTION 'forced tenant deletion rollback';
+        END
+        $function$
+      `
+    );
+    await executeRaw(db, sql`DROP TRIGGER IF EXISTS tenant_delete_force_rollback ON public.repos`);
+    await executeRaw(
+      db,
+      sql`
+        CREATE TRIGGER tenant_delete_force_rollback
+        BEFORE DELETE ON public.repos
+        FOR EACH ROW
+        EXECUTE FUNCTION public.tenant_delete_force_rollback()
+      `
+    );
+
+    try {
+      let deletionError: unknown;
+      try {
+        await deleteTenantData(db, tenantId);
+      } catch (error) {
+        deletionError = error;
+      }
+      expect(errorChainMessage(deletionError)).toMatch(/forced tenant deletion rollback/);
+      expect(await countTenantSessions(db, tenantId)).toBe(1);
+    } finally {
+      await executeRaw(
+        db,
+        sql`DROP TRIGGER IF EXISTS tenant_delete_force_rollback ON public.repos`
+      );
+      await executeRaw(db, sql`DROP FUNCTION IF EXISTS public.tenant_delete_force_rollback()`);
+      await deleteTenantData(db, tenantId);
+    }
   });
 });

--- a/packages/core/src/db/tenant-deletion.postgres.test.ts
+++ b/packages/core/src/db/tenant-deletion.postgres.test.ts
@@ -21,7 +21,7 @@ import { BranchRepository } from './repositories/branches';
 import { RepoRepository } from './repositories/repos';
 import { SessionRepository } from './repositories/sessions';
 import * as pg from './schema.postgres';
-import { deleteTenantData } from './tenant-deletion';
+import { deleteTenantData, TenantDeletionCatalogError } from './tenant-deletion';
 import { runWithTenantDatabaseScope } from './tenant-scope';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
@@ -105,8 +105,8 @@ async function ensureImperativeEmbeddingTable(db: Database): Promise<void> {
       BEGIN
         IF NOT EXISTS (
           SELECT 1
-          FROM pg_type t
-          JOIN pg_namespace n ON n.oid = t.typnamespace
+          FROM pg_catalog.pg_type t
+          JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
           WHERE n.nspname = 'public' AND t.typname = 'vector'
         ) THEN
           CREATE DOMAIN public.vector AS text;
@@ -253,6 +253,33 @@ async function countTenantEmbeddings(db: Database, tenantId: string): Promise<nu
   });
 }
 
+async function installCanonicalTenantPolicy(db: Database, tableName: string): Promise<void> {
+  const table = sql`${sql.identifier('public')}.${sql.identifier(tableName)}`;
+  const policy = sql.identifier(`tenant_isolation_${tableName}`);
+  await executeRaw(db, sql`DROP POLICY IF EXISTS ${policy} ON ${table}`);
+  await executeRaw(
+    db,
+    sql`
+      CREATE POLICY ${policy} ON ${table}
+        AS PERMISSIVE
+        FOR ALL
+        TO PUBLIC
+        USING (
+          tenant_id = COALESCE(
+            NULLIF(current_setting('agor.tenant_id', true), ''),
+            'default'
+          )
+        )
+        WITH CHECK (
+          tenant_id = COALESCE(
+            NULLIF(current_setting('agor.tenant_id', true), ''),
+            'default'
+          )
+        )
+    `
+  );
+}
+
 describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreSQL)', () => {
   let db: Database;
 
@@ -338,6 +365,102 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
     expect(await countTenantEmbeddings(db, tenantB)).toBe(0);
   });
 
+  it('uses audited public relations when temporary tables shadow catalog and plan names', async () => {
+    const tenantId = `td-shadow-${generateId()}`;
+    await seedTenant(db, tenantId);
+    const shadowDb = createDatabase({
+      dialect: 'postgresql',
+      url: postgresUrl!,
+      pool: { max: 1 },
+    });
+
+    try {
+      await executeRaw(shadowDb, sql`CREATE TEMPORARY TABLE pg_class (marker text)`);
+      await executeRaw(
+        shadowDb,
+        sql`CREATE TEMPORARY TABLE sessions (tenant_id text NOT NULL, marker text NOT NULL)`
+      );
+      await executeRaw(
+        shadowDb,
+        sql`INSERT INTO sessions (tenant_id, marker) VALUES (${tenantId}, 'temporary-shadow')`
+      );
+      await executeRaw(shadowDb, sql`SET search_path TO pg_temp, public, pg_catalog`);
+
+      const result = await deleteTenantData(shadowDb, tenantId);
+
+      expect(result.rowCounts.sessions).toBeGreaterThanOrEqual(1);
+      expect(await countTenantSessions(db, tenantId)).toBe(0);
+      const temporaryRows = await executeRaw(
+        shadowDb,
+        sql`SELECT pg_catalog.count(*) AS n FROM sessions WHERE tenant_id = ${tenantId}`
+      );
+      expect(Number(rowsOf(temporaryRows)[0]?.n ?? 0)).toBe(1);
+    } finally {
+      await closePostgresDatabase(shadowDb);
+      if ((await countTenantSessions(db, tenantId)) > 0) {
+        await deleteTenantData(db, tenantId);
+      }
+    }
+  });
+
+  it('rejects an unexpected restrictive policy that could hide tenant rows', async () => {
+    await executeRaw(
+      db,
+      sql`
+        CREATE POLICY tenant_delete_restrictive_test ON public.sessions
+          AS RESTRICTIVE
+          FOR ALL
+          TO PUBLIC
+          USING (false)
+          WITH CHECK (false)
+      `
+    );
+
+    try {
+      await expect(
+        deleteTenantData(db, `td-restrictive-${generateId()}`, { dryRun: true })
+      ).rejects.toThrow(/restrictive.*tenant_delete_restrictive_test/i);
+    } finally {
+      await executeRaw(
+        db,
+        sql`DROP POLICY IF EXISTS tenant_delete_restrictive_test ON public.sessions`
+      );
+    }
+  });
+
+  it('rejects an inverted tenant isolation predicate', async () => {
+    await executeRaw(db, sql`DROP POLICY tenant_isolation_sessions ON public.sessions`);
+    await executeRaw(
+      db,
+      sql`
+        CREATE POLICY tenant_isolation_sessions ON public.sessions
+          AS PERMISSIVE
+          FOR ALL
+          TO PUBLIC
+          USING (
+            tenant_id <> COALESCE(
+              NULLIF(current_setting('agor.tenant_id', true), ''),
+              'default'
+            )
+          )
+          WITH CHECK (
+            tenant_id <> COALESCE(
+              NULLIF(current_setting('agor.tenant_id', true), ''),
+              'default'
+            )
+          )
+      `
+    );
+
+    try {
+      await expect(
+        deleteTenantData(db, `td-inverted-${generateId()}`, { dryRun: true })
+      ).rejects.toThrow(/canonical tenant_id equality/i);
+    } finally {
+      await installCanonicalTenantPolicy(db, 'sessions');
+    }
+  });
+
   it('fails closed when the live catalog contains an unplanned tenant table', async () => {
     await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_unknown`);
     await executeRaw(
@@ -377,6 +500,96 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
       ).rejects.toThrow(/tenant_delete_unknown/);
     } finally {
       await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_unknown`);
+    }
+  });
+
+  it('fails closed when a tenant table appears after phase-one reconciliation', async () => {
+    const tenantId = `td-late-${generateId()}`;
+    await seedTenant(db, tenantId);
+    await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_late`);
+    await executeRaw(
+      db,
+      sql`
+        CREATE OR REPLACE FUNCTION public.tenant_delete_create_late_table()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+        BEGIN
+          IF pg_catalog.to_regclass('public.tenant_delete_late') IS NULL THEN
+            CREATE TABLE public.tenant_delete_late (
+              tenant_id text NOT NULL,
+              value text NOT NULL
+            );
+            ALTER TABLE public.tenant_delete_late ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE public.tenant_delete_late FORCE ROW LEVEL SECURITY;
+            CREATE POLICY tenant_isolation_tenant_delete_late
+              ON public.tenant_delete_late
+              AS PERMISSIVE
+              FOR ALL
+              TO PUBLIC
+              USING (
+                tenant_id = COALESCE(
+                  NULLIF(current_setting('agor.tenant_id', true), ''),
+                  'default'
+                )
+              )
+              WITH CHECK (
+                tenant_id = COALESCE(
+                  NULLIF(current_setting('agor.tenant_id', true), ''),
+                  'default'
+                )
+              );
+            INSERT INTO public.tenant_delete_late (tenant_id, value)
+            VALUES (OLD.tenant_id, 'created after phase-one reconciliation');
+          END IF;
+          RETURN OLD;
+        END
+        $function$
+      `
+    );
+    await executeRaw(
+      db,
+      sql`
+        DROP TRIGGER IF EXISTS tenant_delete_create_late_table ON public.repos
+      `
+    );
+    await executeRaw(
+      db,
+      sql`
+        CREATE TRIGGER tenant_delete_create_late_table
+        BEFORE DELETE ON public.repos
+        FOR EACH ROW
+        EXECUTE FUNCTION public.tenant_delete_create_late_table()
+      `
+    );
+
+    try {
+      let deletionError: unknown;
+      try {
+        await deleteTenantData(db, tenantId);
+      } catch (error) {
+        deletionError = error;
+      }
+      expect(deletionError).toBeInstanceOf(TenantDeletionCatalogError);
+      expect(errorChainMessage(deletionError)).toMatch(/tenant_delete_late/);
+      expect(await countTenantSessions(db, tenantId)).toBe(0);
+      const lateRows = await runWithTenantDatabaseScope(db, tenantId, async (scoped) =>
+        executeRaw(
+          scoped,
+          sql`SELECT pg_catalog.count(*) AS n FROM public.tenant_delete_late WHERE tenant_id = ${tenantId}`
+        )
+      );
+      expect(Number(rowsOf(lateRows)[0]?.n ?? 0)).toBe(1);
+    } finally {
+      await executeRaw(
+        db,
+        sql`DROP TRIGGER IF EXISTS tenant_delete_create_late_table ON public.repos`
+      );
+      await executeRaw(db, sql`DROP FUNCTION IF EXISTS public.tenant_delete_create_late_table()`);
+      await executeRaw(db, sql`DROP TABLE IF EXISTS public.tenant_delete_late`);
+      if ((await countTenantSessions(db, tenantId)) > 0) {
+        await deleteTenantData(db, tenantId);
+      }
     }
   });
 
@@ -424,7 +637,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
       if (emptyDb) await closePostgresDatabase(emptyDb);
       await executeRaw(
         db,
-        sql`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ${databaseName}`
+        sql`SELECT pg_catalog.pg_terminate_backend(pid) FROM pg_catalog.pg_stat_activity WHERE datname = ${databaseName}`
       );
       await executeRaw(db, sql`DROP DATABASE IF EXISTS ${sql.identifier(databaseName)}`);
     }

--- a/packages/core/src/db/tenant-deletion.test.ts
+++ b/packages/core/src/db/tenant-deletion.test.ts
@@ -1,0 +1,119 @@
+import { getTableConfig, type PgColumn, PgDialect, QueryBuilder } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import * as pg from './schema.postgres';
+import {
+  assertNoRemainingTenantRows,
+  assertValidTenantId,
+  deleteTenantData,
+  InvalidTenantIdError,
+  TenantDeletionUnsupportedError,
+  TenantDeletionVerificationError,
+} from './tenant-deletion';
+import { buildTenantScopeCondition, type TenantDeletionTable } from './tenant-deletion-manifest';
+import { dbTest } from './test-helpers';
+
+describe('assertValidTenantId', () => {
+  it.each([
+    'acme-corp',
+    'default',
+    '0192f0c4-6f1e-7a2b-9c3d-4e5f60718293',
+    'tenant_42',
+  ])('accepts concrete id %s', (id) => {
+    expect(() => assertValidTenantId(id)).not.toThrow();
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'blank'],
+    [' padded', 'leading whitespace'],
+    ['padded ', 'trailing whitespace'],
+    ['*', 'wildcard star'],
+    ['%', 'wildcard percent'],
+    ['ten%ant', 'embedded percent'],
+    ['ten*ant', 'embedded star'],
+  ])('rejects %s (%s)', (id) => {
+    expect(() => assertValidTenantId(id)).toThrow(InvalidTenantIdError);
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => assertValidTenantId(undefined)).toThrow(InvalidTenantIdError);
+    expect(() => assertValidTenantId(123 as unknown)).toThrow(InvalidTenantIdError);
+  });
+});
+
+describe('assertNoRemainingTenantRows', () => {
+  it('does nothing when no rows remain', () => {
+    expect(() => assertNoRemainingTenantRows([])).not.toThrow();
+  });
+
+  it('throws a verification error carrying the offending table names', () => {
+    try {
+      assertNoRemainingTenantRows(['sessions', 'tasks']);
+      throw new Error('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TenantDeletionVerificationError);
+      expect((error as TenantDeletionVerificationError).tables).toEqual(['sessions', 'tasks']);
+    }
+  });
+});
+
+describe('buildTenantScopeCondition', () => {
+  const dialect = new PgDialect();
+  const queryBuilder = new QueryBuilder();
+
+  function column(table: unknown, name: string): PgColumn {
+    const found = getTableConfig(table as never).columns.find((c) => c.name === name);
+    if (!found) throw new Error(`missing column ${name}`);
+    return found as PgColumn;
+  }
+
+  const directEntry: TenantDeletionTable = {
+    name: 'sessions',
+    table: pg.sessions,
+    scope: 'direct',
+    tenantColumn: column(pg.sessions, 'tenant_id'),
+  };
+  // Synthetic transitive entry (tasks scoped via its session_id FK to sessions)
+  // exercises the recursive subquery predicate without needing such a table to
+  // actually exist in the schema.
+  const transitiveEntry: TenantDeletionTable = {
+    name: 'tasks',
+    table: pg.tasks,
+    scope: 'transitive',
+    parentLink: {
+      fkColumn: column(pg.tasks, 'session_id'),
+      parentTable: 'sessions',
+      parentPkColumn: column(pg.sessions, 'session_id'),
+    },
+  };
+  const byName = new Map<string, TenantDeletionTable>([
+    ['sessions', directEntry],
+    ['tasks', transitiveEntry],
+  ]);
+
+  it('scopes a direct table with tenant_id = $1', () => {
+    const { sql, params } = dialect.sqlToQuery(
+      buildTenantScopeCondition(queryBuilder, directEntry, 'acme', byName)
+    );
+    expect(sql).toContain('"sessions"."tenant_id" =');
+    expect(params).toEqual(['acme']);
+  });
+
+  it('scopes a transitive table via a subquery down to a scoped ancestor', () => {
+    const { sql, params } = dialect.sqlToQuery(
+      buildTenantScopeCondition(queryBuilder, transitiveEntry, 'acme', byName)
+    );
+    expect(sql).toContain('"tasks"."session_id" in (select');
+    expect(sql).toContain('from "sessions"');
+    expect(sql).toContain('"sessions"."tenant_id" =');
+    expect(params).toEqual(['acme']);
+  });
+});
+
+describe('deleteTenantData guards', () => {
+  dbTest('refuses to run against a single-tenant SQLite database', async ({ db }) => {
+    await expect(deleteTenantData(db, 'acme-corp')).rejects.toBeInstanceOf(
+      TenantDeletionUnsupportedError
+    );
+  });
+});

--- a/packages/core/src/db/tenant-deletion.test.ts
+++ b/packages/core/src/db/tenant-deletion.test.ts
@@ -10,6 +10,7 @@ import {
   TenantDeletionVerificationError,
 } from './tenant-deletion';
 import { buildTenantScopeCondition, type TenantDeletionTable } from './tenant-deletion-manifest';
+import { runWithTenantDatabaseScope } from './tenant-scope';
 import { dbTest } from './test-helpers';
 
 describe('assertValidTenantId', () => {
@@ -115,5 +116,13 @@ describe('deleteTenantData guards', () => {
     await expect(deleteTenantData(db, 'acme-corp')).rejects.toBeInstanceOf(
       TenantDeletionUnsupportedError
     );
+  });
+
+  dbTest('refuses to run inside an ambient tenant database scope', async ({ db }) => {
+    // runWithTenantDatabaseScope sets the scope store even on SQLite, so the
+    // ambient-scope guard fires before the PostgreSQL-only check.
+    await expect(
+      runWithTenantDatabaseScope(db, 'acme-corp', async () => deleteTenantData(db, 'acme-corp'))
+    ).rejects.toThrow(/fresh connection/);
   });
 });

--- a/packages/core/src/db/tenant-deletion.test.ts
+++ b/packages/core/src/db/tenant-deletion.test.ts
@@ -1,6 +1,4 @@
-import { getTableConfig, type PgColumn, PgDialect, QueryBuilder } from 'drizzle-orm/pg-core';
 import { describe, expect, it, vi } from 'vitest';
-import * as pg from './schema.postgres';
 import {
   assertNoRemainingTenantRows,
   assertValidTenantId,
@@ -9,7 +7,6 @@ import {
   TenantDeletionUnsupportedError,
   TenantDeletionVerificationError,
 } from './tenant-deletion';
-import { buildTenantScopeCondition, type TenantDeletionTable } from './tenant-deletion-manifest';
 import { runWithTenantDatabaseScope } from './tenant-scope';
 import { dbTest } from './test-helpers';
 
@@ -76,33 +73,6 @@ describe('assertNoRemainingTenantRows', () => {
       expect(error).toBeInstanceOf(TenantDeletionVerificationError);
       expect((error as TenantDeletionVerificationError).tables).toEqual(['sessions', 'tasks']);
     }
-  });
-});
-
-describe('buildTenantScopeCondition', () => {
-  const dialect = new PgDialect();
-  const queryBuilder = new QueryBuilder();
-
-  function column(table: unknown, name: string): PgColumn {
-    const found = getTableConfig(table as never).columns.find((c) => c.name === name);
-    if (!found) throw new Error(`missing column ${name}`);
-    return found as PgColumn;
-  }
-
-  const directEntry: TenantDeletionTable = {
-    name: 'sessions',
-    table: pg.sessions,
-    scope: 'direct',
-    tenantColumn: column(pg.sessions, 'tenant_id'),
-  };
-  const byName = new Map<string, TenantDeletionTable>([['sessions', directEntry]]);
-
-  it('scopes a direct table with tenant_id = $1', () => {
-    const { sql, params } = dialect.sqlToQuery(
-      buildTenantScopeCondition(queryBuilder, directEntry, 'acme', byName)
-    );
-    expect(sql).toContain('"sessions"."tenant_id" =');
-    expect(params).toEqual(['acme']);
   });
 });
 

--- a/packages/core/src/db/tenant-deletion.test.ts
+++ b/packages/core/src/db/tenant-deletion.test.ts
@@ -1,5 +1,5 @@
 import { getTableConfig, type PgColumn, PgDialect, QueryBuilder } from 'drizzle-orm/pg-core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as pg from './schema.postgres';
 import {
   assertNoRemainingTenantRows,
@@ -32,6 +32,13 @@ describe('assertValidTenantId', () => {
     ['%', 'wildcard percent'],
     ['ten%ant', 'embedded percent'],
     ['ten*ant', 'embedded star'],
+    ['line\nbreak', 'newline'],
+    ['carriage\rreturn', 'carriage return'],
+    ['tab\tcharacter', 'tab'],
+    ['nul\u0000character', 'NUL'],
+    ['escape\u001bcharacter', 'terminal escape'],
+    ['delete\u007fcharacter', 'DEL'],
+    ['bidi\u202eoverride', 'Unicode formatting control'],
   ])('rejects %s (%s)', (id) => {
     expect(() => assertValidTenantId(id)).toThrow(InvalidTenantIdError);
   });
@@ -39,6 +46,20 @@ describe('assertValidTenantId', () => {
   it('rejects non-string input', () => {
     expect(() => assertValidTenantId(undefined)).toThrow(InvalidTenantIdError);
     expect(() => assertValidTenantId(123 as unknown)).toThrow(InvalidTenantIdError);
+  });
+});
+
+describe('empty tenant deletion manifest', () => {
+  it('fails closed when schema discovery produces no entries', async () => {
+    vi.resetModules();
+    vi.doMock('./schema.postgres', () => ({}));
+    try {
+      const { buildTenantDeletionManifest } = await import('./tenant-deletion-manifest');
+      expect(() => buildTenantDeletionManifest()).toThrow(/manifest is empty/i);
+    } finally {
+      vi.doUnmock('./schema.postgres');
+      vi.resetModules();
+    }
   });
 });
 

--- a/packages/core/src/db/tenant-deletion.test.ts
+++ b/packages/core/src/db/tenant-deletion.test.ts
@@ -74,38 +74,12 @@ describe('buildTenantScopeCondition', () => {
     scope: 'direct',
     tenantColumn: column(pg.sessions, 'tenant_id'),
   };
-  // Synthetic transitive entry (tasks scoped via its session_id FK to sessions)
-  // exercises the recursive subquery predicate without needing such a table to
-  // actually exist in the schema.
-  const transitiveEntry: TenantDeletionTable = {
-    name: 'tasks',
-    table: pg.tasks,
-    scope: 'transitive',
-    parentLink: {
-      fkColumn: column(pg.tasks, 'session_id'),
-      parentTable: 'sessions',
-      parentPkColumn: column(pg.sessions, 'session_id'),
-    },
-  };
-  const byName = new Map<string, TenantDeletionTable>([
-    ['sessions', directEntry],
-    ['tasks', transitiveEntry],
-  ]);
+  const byName = new Map<string, TenantDeletionTable>([['sessions', directEntry]]);
 
   it('scopes a direct table with tenant_id = $1', () => {
     const { sql, params } = dialect.sqlToQuery(
       buildTenantScopeCondition(queryBuilder, directEntry, 'acme', byName)
     );
-    expect(sql).toContain('"sessions"."tenant_id" =');
-    expect(params).toEqual(['acme']);
-  });
-
-  it('scopes a transitive table via a subquery down to a scoped ancestor', () => {
-    const { sql, params } = dialect.sqlToQuery(
-      buildTenantScopeCondition(queryBuilder, transitiveEntry, 'acme', byName)
-    );
-    expect(sql).toContain('"tasks"."session_id" in (select');
-    expect(sql).toContain('from "sessions"');
     expect(sql).toContain('"sessions"."tenant_id" =');
     expect(params).toEqual(['acme']);
   });

--- a/packages/core/src/db/tenant-deletion.ts
+++ b/packages/core/src/db/tenant-deletion.ts
@@ -138,17 +138,36 @@ export function assertNoRemainingTenantRows(remaining: string[]): void {
 
 async function resolveSchemaVersion(db: Database): Promise<string> {
   const status = await checkMigrationStatus(db);
-  // Fail closed on DB-ahead-of-binary schema skew: if the database was migrated
-  // by a newer release, this binary's compiled schema (and thus the deletion
-  // manifest) omits tables the database now has. Deleting + verifying against an
-  // incomplete manifest would falsely certify success while tenant data
-  // survives in tables this binary cannot see. (`hasPending` catches only the
-  // opposite, binary-ahead-of-DB case, which already fails loudly.)
+  // Fail closed unless the schema is in lockstep in BOTH directions: the binary's
+  // compiled schema (and thus the deletion manifest) must match exactly the
+  // schema the database currently has applied. That requires !dbAheadOfBinary AND
+  // !hasPending.
+  //
+  // DB ahead of binary: the database was migrated by a newer release, so this
+  // binary's schema omits tables the database now has. Deleting + verifying
+  // against that incomplete manifest would falsely certify success while tenant
+  // data survives in tables this binary cannot see.
   if (status.dbAheadOfBinary) {
     throw new Error(
       'Database schema is newer than this binary: the database has migrations this release does not know about. ' +
         'Refusing to run tenant deletion because the deletion manifest may be incomplete and could falsely certify success. ' +
         'Upgrade this binary to match the database, then retry.'
+    );
+  }
+  // Binary ahead of DB (pending migrations): this binary has migrations the DB
+  // has not applied. If a pending migration DROPS or RENAMES a tenant-scoped
+  // table, the live database still holds that table with tenant data, but this
+  // binary's compiled schema no longer lists it under that name — so the manifest
+  // omits it, deletion skips it, and verification (scanning the same manifest)
+  // reports false success while tenant data survives. (The ADD-a-table case does
+  // fail loudly with 'relation does not exist', but the DROP/RENAME case does
+  // not — hence this guard.)
+  if (status.hasPending) {
+    throw new Error(
+      `Refusing to delete tenant data: the database has ${status.pending.length} pending migration(s); ` +
+        "the running binary's schema does not match the database. " +
+        'Run migrations so the binary and database schemas match before deleting a tenant ' +
+        '(a pending migration may drop or rename a tenant-scoped table, which would make deletion silently incomplete).'
     );
   }
   const applied = status.applied;

--- a/packages/core/src/db/tenant-deletion.ts
+++ b/packages/core/src/db/tenant-deletion.ts
@@ -17,6 +17,12 @@
  * and still reports success. Multi-tenancy is PostgreSQL-only, so the command
  * refuses to run against a SQLite database.
  *
+ * Precondition — quiesce the tenant first: this operation verifies tenant state
+ * at scan time; it does not by itself fence out a concurrent writer. The
+ * operator must disable/quiesce the tenant (stop new tenant-scoped work at the
+ * control/auth layer) BEFORE running, otherwise a writer active during or after
+ * verification can recreate tenant rows that the verification pass will not see.
+ *
  * The result object is a frozen machine-readable contract (see
  * {@link TenantDeletionResult}) intended to be parsed by external automation. It
  * contains only booleans, numbers, and identifier strings — never row content,
@@ -34,7 +40,7 @@ import {
   indexManifest,
   type TenantDeletionTable,
 } from './tenant-deletion-manifest';
-import { runWithTenantDatabaseScope } from './tenant-scope';
+import { getCurrentTenantDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
 
 /** Thrown when the supplied tenant id is empty, blank, or wildcard-like. */
 export class InvalidTenantIdError extends Error {
@@ -132,6 +138,19 @@ export function assertNoRemainingTenantRows(remaining: string[]): void {
 
 async function resolveSchemaVersion(db: Database): Promise<string> {
   const status = await checkMigrationStatus(db);
+  // Fail closed on DB-ahead-of-binary schema skew: if the database was migrated
+  // by a newer release, this binary's compiled schema (and thus the deletion
+  // manifest) omits tables the database now has. Deleting + verifying against an
+  // incomplete manifest would falsely certify success while tenant data
+  // survives in tables this binary cannot see. (`hasPending` catches only the
+  // opposite, binary-ahead-of-DB case, which already fails loudly.)
+  if (status.dbAheadOfBinary) {
+    throw new Error(
+      'Database schema is newer than this binary: the database has migrations this release does not know about. ' +
+        'Refusing to run tenant deletion because the deletion manifest may be incomplete and could falsely certify success. ' +
+        'Upgrade this binary to match the database, then retry.'
+    );
+  }
   const applied = status.applied;
   if (applied.length === 0) {
     throw new Error(
@@ -182,6 +201,19 @@ export async function deleteTenantData(
   options: TenantDeletionOptions = {}
 ): Promise<TenantDeletionResult | TenantDeletionDryRunResult> {
   assertValidTenantId(tenantId);
+
+  // Refuse to run inside an ambient tenant/system database scope. This routine
+  // relies on two independent transactions — phase 1 deletes and commits, phase
+  // 2 re-scans committed state. runWithTenantDatabaseScope JOINS an existing
+  // scope rather than opening a fresh transaction, so a caller that invokes us
+  // within an active scope would collapse both phases into their single
+  // uncommitted transaction: verification would then observe uncommitted state
+  // and could report success before the outer transaction commits or rolls back.
+  if (getCurrentTenantDatabaseScope()) {
+    throw new Error(
+      'deleteTenantData must run with its own fresh connection, not within an ambient tenant/system database scope.'
+    );
+  }
 
   if (!isPostgresDatabase(db)) {
     throw new TenantDeletionUnsupportedError(

--- a/packages/core/src/db/tenant-deletion.ts
+++ b/packages/core/src/db/tenant-deletion.ts
@@ -2,29 +2,37 @@
  * Permanent, audited, idempotent deletion of all data belonging to a single
  * tenant.
  *
- * Operators of a multi-tenant Agor deployment need a verifiable way to remove a
- * tenant entirely (offboarding, data-removal requests, regulatory erasure). This
- * module performs that removal against a deletion plan assembled from the
- * runtime-derived {@link buildTenantDeletionManifest tenant manifest} and the
- * registry of tenant tables created imperatively at runtime:
+ * Operators of a standalone multi-tenant PostgreSQL runtime need a verifiable
+ * way to remove a tenant entirely (offboarding, data-removal requests,
+ * regulatory erasure). This module performs that removal against a deletion
+ * plan assembled from the runtime-derived
+ * {@link buildTenantDeletionManifest tenant manifest} and the registry of
+ * tenant tables created imperatively at runtime:
  *
  *   1. Validate the tenant id (refuse empty / whitespace / wildcard values).
  *   2. Reconcile the plan against the live PostgreSQL catalog and fail closed if
  *      any tenant-contract table is missing or malformed.
  *   3. Delete every tenant-scoped row inside a single tenant-scoped transaction,
- *      children before parents, so foreign keys are never violated.
- *   4. Re-scan the whole plan in a fresh transaction and fail unless zero
- *      rows remain for the tenant.
+ *      following the compiled schema's defensive child-before-parent order.
+ *   4. Reconcile the live catalog again, independently rebuild the verification
+ *      plan, and re-scan committed state in a fresh transaction. Fail unless the
+ *      catalog contract is unchanged and zero tenant rows remain.
  *
  * Running it twice on the same tenant is safe: the second run deletes zero rows
  * and still reports success. Multi-tenancy is PostgreSQL-only, so the command
  * refuses to run against a SQLite database.
  *
- * Precondition — quiesce the tenant first: this operation verifies tenant state
- * at scan time; it does not by itself fence out a concurrent writer. The
- * operator must stop new tenant-scoped work in the deployment BEFORE running,
- * otherwise a writer active during or after verification can recreate tenant
- * rows that the verification pass will not see.
+ * Preconditions:
+ *
+ * - Quiesce tenant writes and relevant schema changes for the entire operation.
+ *   The table locks and second catalog scan narrow races but do not fence a
+ *   writer or DDL that commits after final verification.
+ * - Maintain a tenant-consistent foreign-key graph: every foreign-key reference
+ *   from a tenant-scoped row to another tenant-scoped row must connect rows with
+ *   the same tenant id. PostgreSQL row-level security does not enforce that
+ *   equality when a foreign key is created and does not constrain referential
+ *   actions such as cascades. This routine validates the supported RLS policy
+ *   contract, but it does not prove row-level foreign-key consistency.
  *
  * The result object is a frozen machine-readable contract (see
  * {@link TenantDeletionResult}) intended to be parsed by external automation. It
@@ -32,17 +40,11 @@
  * connection strings, or other secrets.
  */
 
-import { count, sql } from 'drizzle-orm';
-import { QueryBuilder } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import type { Database } from './client';
-import { deleteFrom, executeRaw, isPostgresDatabase, select } from './database-wrapper';
+import { executeRaw, isPostgresDatabase } from './database-wrapper';
 import { checkMigrationStatus } from './migrate';
-import {
-  buildTenantDeletionManifest,
-  buildTenantScopeCondition,
-  indexManifest,
-  type TenantDeletionTable,
-} from './tenant-deletion-manifest';
+import { buildTenantDeletionManifest, type TenantDeletionTable } from './tenant-deletion-manifest';
 import { IMPERATIVE_TENANT_TABLES, type ImperativeTenantTable } from './tenant-imperative-tables';
 import { getCurrentTenantDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
 
@@ -206,7 +208,20 @@ function boolValue(value: unknown): boolean {
   return value === true || value === 't' || value === 'true' || value === 1 || value === '1';
 }
 
+interface CatalogPolicy {
+  name: string;
+  command: string;
+  permissive: boolean;
+  publicOnly: boolean;
+  roles: string;
+  usingExpression: string | null;
+  checkExpression: string | null;
+  usingTree: string | null;
+  checkTree: string | null;
+}
+
 interface CatalogRelation {
+  relationId: string;
   schemaName: string;
   tableName: string;
   relkind: string;
@@ -214,29 +229,31 @@ interface CatalogRelation {
   rlsForced: boolean;
   hasTenantColumn: boolean;
   tenantColumnTextNotNull: boolean;
-  hasTenantPolicyMarker: boolean;
-  hasTenantIsolationPolicy: boolean;
   participatesInInheritance: boolean;
+  foreignKeyContract: string;
+  policies: CatalogPolicy[];
 }
 
 /**
  * Read every non-system ordinary or partitioned relation that claims some part
- * of the tenant contract. Catalog names are used for comparison and diagnostics
- * only; executed deletion SQL never uses them.
+ * of the tenant contract. Every system-catalog reference is explicitly
+ * pg_catalog-qualified so a hostile search_path or temporary relation cannot
+ * redirect the audit.
  */
 async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
   const result = await executeRaw(
     db,
     sql`
       SELECT
+        c.oid::pg_catalog.text AS relation_id,
         n.nspname AS schema_name,
         c.relname AS table_name,
-        c.relkind::text AS relkind,
+        c.relkind::pg_catalog.text AS relkind,
         c.relrowsecurity AS rls_enabled,
         c.relforcerowsecurity AS rls_forced,
         EXISTS (
           SELECT 1
-          FROM pg_attribute a
+          FROM pg_catalog.pg_attribute a
           WHERE a.attrelid = c.oid
             AND a.attname = 'tenant_id'
             AND a.attnum > 0
@@ -244,39 +261,50 @@ async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
         ) AS has_tenant_column,
         EXISTS (
           SELECT 1
-          FROM pg_attribute a
+          FROM pg_catalog.pg_attribute a
           WHERE a.attrelid = c.oid
             AND a.attname = 'tenant_id'
             AND a.attnum > 0
             AND NOT a.attisdropped
-            AND a.atttypid = 'text'::regtype
+            AND a.atttypid = 'pg_catalog.text'::pg_catalog.regtype
             AND a.attnotnull
         ) AS tenant_column_text_not_null,
         EXISTS (
           SELECT 1
-          FROM pg_policy p
-          WHERE p.polrelid = c.oid
-            AND (
-              p.polname LIKE 'tenant_isolation_%'
-              OR COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
-              OR COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
-            )
-        ) AS has_tenant_policy_marker,
-        EXISTS (
-          SELECT 1
-          FROM pg_policy p
-          WHERE p.polrelid = c.oid
-            AND p.polname LIKE 'tenant_isolation_%'
-            AND COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
-            AND COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
-        ) AS has_tenant_isolation_policy,
-        EXISTS (
-          SELECT 1
-          FROM pg_inherits i
+          FROM pg_catalog.pg_inherits i
           WHERE i.inhrelid = c.oid OR i.inhparent = c.oid
-        ) AS participates_in_inheritance
-      FROM pg_class c
-      JOIN pg_namespace n ON n.oid = c.relnamespace
+        ) AS participates_in_inheritance,
+        COALESCE(
+          (
+            SELECT pg_catalog.string_agg(
+              pg_catalog.concat_ws(
+                ':',
+                fk.oid::pg_catalog.text,
+                fk.conrelid::pg_catalog.text,
+                fk.confrelid::pg_catalog.text,
+                pg_catalog.pg_get_constraintdef(fk.oid, false)
+              ),
+              E'\n'
+              ORDER BY fk.oid
+            )
+            FROM pg_catalog.pg_constraint fk
+            WHERE fk.contype = 'f'
+              AND (fk.conrelid = c.oid OR fk.confrelid = c.oid)
+          ),
+          ''
+        ) AS foreign_key_contract,
+        p.polname AS policy_name,
+        p.polcmd::pg_catalog.text AS policy_command,
+        p.polpermissive AS policy_permissive,
+        p.polroles::pg_catalog.text AS policy_roles,
+        p.polroles = ARRAY[0::pg_catalog.oid] AS policy_public_only,
+        pg_catalog.pg_get_expr(p.polqual, p.polrelid) AS policy_using_expression,
+        pg_catalog.pg_get_expr(p.polwithcheck, p.polrelid) AS policy_check_expression,
+        p.polqual::pg_catalog.text AS policy_using_tree,
+        p.polwithcheck::pg_catalog.text AS policy_check_tree
+      FROM pg_catalog.pg_class c
+      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      LEFT JOIN pg_catalog.pg_policy p ON p.polrelid = c.oid
       WHERE c.relkind IN ('r', 'p')
         AND n.nspname <> 'information_schema'
         AND n.nspname NOT LIKE 'pg_%'
@@ -284,7 +312,7 @@ async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
           c.relforcerowsecurity
           OR EXISTS (
             SELECT 1
-            FROM pg_attribute a
+            FROM pg_catalog.pg_attribute a
             WHERE a.attrelid = c.oid
               AND a.attname = 'tenant_id'
               AND a.attnum > 0
@@ -292,30 +320,169 @@ async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
           )
           OR EXISTS (
             SELECT 1
-            FROM pg_policy p
-            WHERE p.polrelid = c.oid
+            FROM pg_catalog.pg_policy marker_policy
+            WHERE marker_policy.polrelid = c.oid
               AND (
-                p.polname LIKE 'tenant_isolation_%'
-                OR COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
-                OR COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
+                marker_policy.polname LIKE 'tenant_isolation_%'
+                OR COALESCE(
+                    pg_catalog.pg_get_expr(
+                      marker_policy.polqual,
+                      marker_policy.polrelid
+                    ),
+                    ''
+                  ) LIKE '%agor.tenant_id%'
+                OR COALESCE(
+                    pg_catalog.pg_get_expr(
+                      marker_policy.polwithcheck,
+                      marker_policy.polrelid
+                    ),
+                    ''
+                  ) LIKE '%agor.tenant_id%'
               )
           )
         )
+      ORDER BY n.nspname, c.relname, p.polname
     `
   );
 
-  return rowsOf(result).map((row) => ({
-    schemaName: String(row.schema_name),
-    tableName: String(row.table_name),
-    relkind: String(row.relkind),
-    rlsEnabled: boolValue(row.rls_enabled),
-    rlsForced: boolValue(row.rls_forced),
-    hasTenantColumn: boolValue(row.has_tenant_column),
-    tenantColumnTextNotNull: boolValue(row.tenant_column_text_not_null),
-    hasTenantPolicyMarker: boolValue(row.has_tenant_policy_marker),
-    hasTenantIsolationPolicy: boolValue(row.has_tenant_isolation_policy),
-    participatesInInheritance: boolValue(row.participates_in_inheritance),
-  }));
+  const relations = new Map<string, CatalogRelation>();
+  for (const row of rowsOf(result)) {
+    const relationId = String(row.relation_id);
+    let relation = relations.get(relationId);
+    if (!relation) {
+      relation = {
+        relationId,
+        schemaName: String(row.schema_name),
+        tableName: String(row.table_name),
+        relkind: String(row.relkind),
+        rlsEnabled: boolValue(row.rls_enabled),
+        rlsForced: boolValue(row.rls_forced),
+        hasTenantColumn: boolValue(row.has_tenant_column),
+        tenantColumnTextNotNull: boolValue(row.tenant_column_text_not_null),
+        participatesInInheritance: boolValue(row.participates_in_inheritance),
+        foreignKeyContract: String(row.foreign_key_contract),
+        policies: [],
+      };
+      relations.set(relationId, relation);
+    }
+    if (row.policy_name !== null && row.policy_name !== undefined) {
+      relation.policies.push({
+        name: String(row.policy_name),
+        command: String(row.policy_command),
+        permissive: boolValue(row.policy_permissive),
+        publicOnly: boolValue(row.policy_public_only),
+        roles: String(row.policy_roles),
+        usingExpression:
+          row.policy_using_expression === null || row.policy_using_expression === undefined
+            ? null
+            : String(row.policy_using_expression),
+        checkExpression:
+          row.policy_check_expression === null || row.policy_check_expression === undefined
+            ? null
+            : String(row.policy_check_expression),
+        usingTree:
+          row.policy_using_tree === null || row.policy_using_tree === undefined
+            ? null
+            : String(row.policy_using_tree),
+        checkTree:
+          row.policy_check_tree === null || row.policy_check_tree === undefined
+            ? null
+            : String(row.policy_check_tree),
+      });
+    }
+  }
+  return [...relations.values()];
+}
+
+const CANONICAL_TENANT_POLICY_EXPRESSION =
+  "tenant_id=coalesce(nullif(current_setting('agor.tenant_id',true),''),'default')";
+
+function stripOuterParentheses(expression: string): string {
+  let current = expression;
+  while (current.startsWith('(') && current.endsWith(')')) {
+    let depth = 0;
+    let closesAtEnd = true;
+    for (let index = 0; index < current.length; index += 1) {
+      const character = current[index];
+      if (character === '(') depth += 1;
+      if (character === ')') depth -= 1;
+      if (depth === 0 && index < current.length - 1) {
+        closesAtEnd = false;
+        break;
+      }
+    }
+    if (!closesAtEnd) break;
+    current = current.slice(1, -1);
+  }
+  return current;
+}
+
+/**
+ * pg_get_expr is the server's structural deparser. Normalize only formatting,
+ * identifier quoting, built-in qualification, and text casts that vary between
+ * supported PostgreSQL releases; do not reorder or simplify operators.
+ */
+function normalizePolicyExpression(expression: string | null): string | null {
+  if (expression === null) return null;
+  const normalized = expression
+    .replaceAll('"', '')
+    .replace(/::(?:pg_catalog\.)?text\b/gi, '')
+    .replace(/\bpg_catalog\.current_setting\b/gi, 'current_setting')
+    .replace(/\s+/g, '')
+    .toLowerCase();
+  return stripOuterParentheses(normalized);
+}
+
+function assertSupportedPolicies(relation: CatalogRelation): void {
+  const qualifiedName = `${relation.schemaName}.${relation.tableName}`;
+
+  const restrictive = relation.policies.filter((policy) => !policy.permissive);
+  if (restrictive.length > 0) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName} has unsupported restrictive row-security policy/policies: ${restrictive
+        .map((policy) => policy.name)
+        .sort()
+        .join(', ')}`
+    );
+  }
+
+  const expectedName = `tenant_isolation_${relation.tableName}`;
+  const isolationPolicies = relation.policies.filter((policy) => policy.name === expectedName);
+  if (isolationPolicies.length !== 1) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName} must have exactly one ${expectedName} policy`
+    );
+  }
+
+  const isolation = isolationPolicies[0];
+  if (isolation.command !== '*') {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName}.${expectedName} must apply to ALL commands`
+    );
+  }
+  if (!isolation.permissive) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName}.${expectedName} must be permissive`
+    );
+  }
+  if (!isolation.publicOnly) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName}.${expectedName} must apply only to PUBLIC`
+    );
+  }
+  if (
+    normalizePolicyExpression(isolation.usingExpression) !== CANONICAL_TENANT_POLICY_EXPRESSION ||
+    normalizePolicyExpression(isolation.checkExpression) !== CANONICAL_TENANT_POLICY_EXPRESSION
+  ) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: ${qualifiedName}.${expectedName} must use the canonical tenant_id equality for both USING and WITH CHECK`
+    );
+  }
+}
+
+interface CatalogAudit {
+  liveTenantTables: ReadonlySet<string>;
+  fingerprint: string;
 }
 
 /**
@@ -325,7 +492,7 @@ async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
 async function auditLiveTenantCatalog(
   db: Database,
   planNames: ReadonlySet<string>
-): Promise<ReadonlySet<string>> {
+): Promise<CatalogAudit> {
   const relations = await readTenantCatalog(db);
   const liveTenantTables = new Set<string>();
 
@@ -361,11 +528,7 @@ async function auditLiveTenantCatalog(
         `Refusing tenant deletion: ${qualifiedName} must enable and force row-level security`
       );
     }
-    if (!relation.hasTenantPolicyMarker || !relation.hasTenantIsolationPolicy) {
-      throw new TenantDeletionCatalogError(
-        `Refusing tenant deletion: ${qualifiedName} lacks a complete tenant_isolation_* policy referencing agor.tenant_id`
-      );
-    }
+    assertSupportedPolicies(relation);
     liveTenantTables.add(relation.tableName);
   }
 
@@ -382,38 +545,35 @@ async function auditLiveTenantCatalog(
     );
   }
 
-  return liveTenantTables;
-}
+  const fingerprint = JSON.stringify(
+    relations.map((relation) => ({
+      relationId: relation.relationId,
+      schemaName: relation.schemaName,
+      tableName: relation.tableName,
+      relkind: relation.relkind,
+      rlsEnabled: relation.rlsEnabled,
+      rlsForced: relation.rlsForced,
+      hasTenantColumn: relation.hasTenantColumn,
+      tenantColumnTextNotNull: relation.tenantColumnTextNotNull,
+      participatesInInheritance: relation.participatesInInheritance,
+      // Fingerprinting all incoming/outgoing FK definitions detects timing
+      // changes; it does not assert that row values are tenant-consistent.
+      foreignKeyContract: relation.foreignKeyContract,
+      policies: relation.policies.map((policy) => ({
+        name: policy.name,
+        command: policy.command,
+        permissive: policy.permissive,
+        publicOnly: policy.publicOnly,
+        roles: policy.roles,
+        // Internal parse trees are stable within this live server and avoid a
+        // search_path-sensitive deparse in the between-phase fingerprint.
+        usingTree: policy.usingTree,
+        checkTree: policy.checkTree,
+      })),
+    }))
+  );
 
-async function countTenantRows(
-  db: Database,
-  queryBuilder: QueryBuilder,
-  entry: TenantDeletionTable,
-  tenantId: string,
-  byName: Map<string, TenantDeletionTable>
-): Promise<number> {
-  const condition = buildTenantScopeCondition(queryBuilder, entry, tenantId, byName);
-  const rows = (await select(db, { n: count() })
-    .from(entry.table)
-    .where(condition)
-    .all()) as Array<{
-    n: number | string | bigint;
-  }>;
-  return Number(rows[0]?.n ?? 0);
-}
-
-async function deleteTenantRows(
-  db: Database,
-  queryBuilder: QueryBuilder,
-  entry: TenantDeletionTable,
-  tenantId: string,
-  byName: Map<string, TenantDeletionTable>
-): Promise<number> {
-  const condition = buildTenantScopeCondition(queryBuilder, entry, tenantId, byName);
-  const result = (await deleteFrom(db, entry.table).where(condition).run()) as {
-    rowsAffected?: number;
-  };
-  return Number(result?.rowsAffected ?? 0);
+  return { liveTenantTables, fingerprint };
 }
 
 interface DeletionStep {
@@ -422,29 +582,17 @@ interface DeletionStep {
   deleteRows(db: Database, tenantId: string): Promise<void>;
 }
 
-function buildManifestStep(
-  entry: TenantDeletionTable,
-  queryBuilder: QueryBuilder,
-  byName: Map<string, TenantDeletionTable>
-): DeletionStep {
-  return {
-    name: entry.name,
-    countRows: (db, tenantId) => countTenantRows(db, queryBuilder, entry, tenantId, byName),
-    deleteRows: async (db, tenantId) => {
-      await deleteTenantRows(db, queryBuilder, entry, tenantId, byName);
-    },
-  };
-}
+const TENANT_SCHEMA = 'public';
 
-function buildImperativeStep(table: ImperativeTenantTable): DeletionStep {
-  const tableIdentifier = sql.identifier(table.name);
-  const tenantColumnIdentifier = sql.identifier(table.tenantColumn);
+function buildQualifiedStep(name: string, tenantColumn: string): DeletionStep {
+  const tableIdentifier = sql`${sql.identifier(TENANT_SCHEMA)}.${sql.identifier(name)}`;
+  const tenantColumnIdentifier = sql.identifier(tenantColumn);
   return {
-    name: table.name,
+    name,
     countRows: async (db, tenantId) => {
       const result = await executeRaw(
         db,
-        sql`SELECT count(*) AS n FROM ${tableIdentifier} WHERE ${tenantColumnIdentifier} = ${tenantId}`
+        sql`SELECT pg_catalog.count(*) AS n FROM ${tableIdentifier} WHERE ${tenantColumnIdentifier} = ${tenantId}`
       );
       return Number(rowsOf(result)[0]?.n ?? 0);
     },
@@ -455,6 +603,87 @@ function buildImperativeStep(table: ImperativeTenantTable): DeletionStep {
       );
     },
   };
+}
+
+function buildManifestStep(entry: TenantDeletionTable): DeletionStep {
+  return buildQualifiedStep(entry.name, entry.tenantColumn.name);
+}
+
+function buildImperativeStep(table: ImperativeTenantTable): DeletionStep {
+  return buildQualifiedStep(table.name, table.tenantColumn);
+}
+
+interface DeletionPlan {
+  steps: DeletionStep[];
+  fingerprint: string;
+}
+
+async function buildDeletionPlan(
+  db: Database,
+  manifest: TenantDeletionTable[],
+  planNames: ReadonlySet<string>
+): Promise<DeletionPlan> {
+  const audit = await auditLiveTenantCatalog(db, planNames);
+  const presentImperativeTables = IMPERATIVE_TENANT_TABLES.filter((table) =>
+    audit.liveTenantTables.has(table.name)
+  );
+  // Imperative registry entries are deliberately limited to known leaf tables.
+  // Their row-level foreign-key consistency remains an operator/schema
+  // precondition; the registry does not claim to validate it.
+  const steps = [
+    ...presentImperativeTables.map(buildImperativeStep),
+    ...manifest.map(buildManifestStep),
+  ];
+  if (steps.length === 0) {
+    throw new TenantDeletionCatalogError(
+      'Refusing tenant deletion: the reconciled deletion plan is empty'
+    );
+  }
+  return {
+    steps,
+    fingerprint: JSON.stringify({
+      catalog: audit.fingerprint,
+      steps: steps.map((step) => step.name),
+    }),
+  };
+}
+
+async function lockDeletionPlan(db: Database, plan: DeletionPlan): Promise<void> {
+  for (const step of plan.steps) {
+    const tableIdentifier = sql`${sql.identifier(TENANT_SCHEMA)}.${sql.identifier(step.name)}`;
+    // SHARE ROW EXCLUSIVE blocks concurrent table writers and policy/DDL changes
+    // for the duration of this transaction. It cannot cover a table created
+    // after the scan, which is why phase two reconciles the catalog again and
+    // operator quiescence remains mandatory.
+    await executeRaw(db, sql`LOCK TABLE ${tableIdentifier} IN SHARE ROW EXCLUSIVE MODE`);
+  }
+}
+
+async function buildLockedDeletionPlan(
+  db: Database,
+  manifest: TenantDeletionTable[],
+  planNames: ReadonlySet<string>
+): Promise<DeletionPlan> {
+  const beforeLock = await buildDeletionPlan(db, manifest, planNames);
+  await lockDeletionPlan(db, beforeLock);
+  const afterLock = await buildDeletionPlan(db, manifest, planNames);
+  if (beforeLock.fingerprint !== afterLock.fingerprint) {
+    throw new TenantDeletionCatalogError(
+      'Refusing tenant deletion: the live tenant catalog changed while the deletion plan was being locked'
+    );
+  }
+  return afterLock;
+}
+
+async function hardenDeletionSearchPath(db: Database): Promise<void> {
+  // Transaction-local and repeated in both phases. Explicit public relation
+  // qualification remains the primary binding; this also ensures any incidental
+  // built-in function/operator/type resolution prefers pg_catalog and searches
+  // the temporary schema last.
+  await executeRaw(
+    db,
+    sql`SELECT pg_catalog.set_config('search_path', 'pg_catalog, public, pg_temp', true)`
+  );
 }
 
 /**
@@ -490,47 +719,37 @@ export async function deleteTenantData(
   const log = options.log ?? (() => {});
   const dryRun = options.dryRun ?? false;
   const manifest = buildTenantDeletionManifest();
-  const byName = indexManifest(manifest);
-  const queryBuilder = new QueryBuilder();
-  const schemaVersion = await resolveSchemaVersion(db);
   const planNames = new Set([
     ...manifest.map((entry) => entry.name),
     ...IMPERATIVE_TENANT_TABLES.map((table) => table.name),
   ]);
-  const liveTenantTables = await auditLiveTenantCatalog(db, planNames);
-  const presentImperativeTables = IMPERATIVE_TENANT_TABLES.filter((table) =>
-    liveTenantTables.has(table.name)
-  );
-  // Imperative registry entries are leaves whose cascade parents are in the
-  // typed manifest, so placing them first preserves children-before-parents.
-  const steps: DeletionStep[] = [
-    ...presentImperativeTables.map(buildImperativeStep),
-    ...manifest.map((entry) => buildManifestStep(entry, queryBuilder, byName)),
-  ];
-  if (steps.length === 0) {
-    throw new TenantDeletionCatalogError(
-      'Refusing tenant deletion: the reconciled deletion plan is empty'
-    );
-  }
   const startedAt = Date.now();
-
-  log(
-    `${dryRun ? 'dry-run: ' : ''}tenant deletion started (schemaVersion=${schemaVersion}, tables=${steps.length})`
-  );
-
   const rowCounts: Record<string, number> = {};
+  let schemaVersion = '';
+  let phaseOneFingerprint = '';
+  let phaseOneTableCount = 0;
 
   // Phase 1: snapshot per-table counts, then (unless this is a dry run) delete,
-  // all inside one tenant-scoped transaction so the deletion is atomic and RLS
-  // pins every statement to the tenant.
+  // all inside one tenant-scoped transaction so the deletion is atomic. Every
+  // statement also has an explicit tenant_id predicate and public-qualified
+  // relation; RLS is a separately audited defense, not a foreign-key boundary.
   //
   // Counts are captured up front, BEFORE any DELETE runs. This keeps the reported
   // rowCounts accurate even when an `ON DELETE CASCADE` from a parent table would
   // otherwise remove a child's rows before that child's own DELETE statement
-  // runs. Each row belongs to exactly one table, so the pre-deletion snapshot is
-  // precisely the set of rows the operation removes.
+  // runs. Under the tenant-consistent foreign-key precondition, each row belongs
+  // to exactly one table and tenant, so the pre-deletion snapshot is precisely
+  // the set of rows the operation removes.
   await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
-    for (const step of steps) {
+    await hardenDeletionSearchPath(scoped);
+    schemaVersion = await resolveSchemaVersion(scoped);
+    const phaseOnePlan = await buildLockedDeletionPlan(scoped, manifest, planNames);
+    phaseOneFingerprint = phaseOnePlan.fingerprint;
+    phaseOneTableCount = phaseOnePlan.steps.length;
+    log(
+      `${dryRun ? 'dry-run: ' : ''}tenant deletion started (schemaVersion=${schemaVersion}, tables=${phaseOneTableCount})`
+    );
+    for (const step of phaseOnePlan.steps) {
       rowCounts[step.name] = await step.countRows(scoped, tenantId);
       if (rowCounts[step.name] > 0) {
         log(
@@ -539,16 +758,38 @@ export async function deleteTenantData(
       }
     }
     if (dryRun) return;
-    for (const step of steps) {
+    for (const step of phaseOnePlan.steps) {
       await step.deleteRows(scoped, tenantId);
     }
   });
 
-  // Phase 2: verify committed state in a fresh transaction (skipped for dry-run).
+  if (!schemaVersion || !phaseOneFingerprint || phaseOneTableCount === 0) {
+    throw new TenantDeletionCatalogError(
+      'Refusing tenant deletion: phase-one catalog reconciliation did not produce a plan'
+    );
+  }
+
+  // Phase 2: independently reconcile and lock a fresh plan, compare its live
+  // catalog fingerprint to phase one, then verify committed state. Reusing the
+  // phase-one steps here would let a relation or policy added between phases
+  // escape verification.
   if (!dryRun) {
     const remaining = await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+      await hardenDeletionSearchPath(scoped);
+      const verificationSchemaVersion = await resolveSchemaVersion(scoped);
+      if (verificationSchemaVersion !== schemaVersion) {
+        throw new TenantDeletionCatalogError(
+          'Refusing to certify tenant deletion: the migration watermark changed between deletion and verification'
+        );
+      }
+      const verificationPlan = await buildLockedDeletionPlan(scoped, manifest, planNames);
+      if (verificationPlan.fingerprint !== phaseOneFingerprint) {
+        throw new TenantDeletionCatalogError(
+          'Refusing to certify tenant deletion: the live tenant catalog or verification plan changed after phase one'
+        );
+      }
       const offending: string[] = [];
-      for (const step of steps) {
+      for (const step of verificationPlan.steps) {
         const left = await step.countRows(scoped, tenantId);
         if (left > 0) offending.push(step.name);
       }
@@ -560,7 +801,7 @@ export async function deleteTenantData(
   const durationMs = Date.now() - startedAt;
   const totalRows = Object.values(rowCounts).reduce((sum, value) => sum + value, 0);
   log(
-    `${dryRun ? 'dry-run complete' : 'tenant deletion verified'} (${totalRows} row(s) across ${steps.length} tables in ${durationMs}ms)`
+    `${dryRun ? 'dry-run complete' : 'tenant deletion verified'} (${totalRows} row(s) across ${phaseOneTableCount} tables in ${durationMs}ms)`
   );
 
   if (dryRun) {

--- a/packages/core/src/db/tenant-deletion.ts
+++ b/packages/core/src/db/tenant-deletion.ts
@@ -4,13 +4,16 @@
  *
  * Operators of a multi-tenant Agor deployment need a verifiable way to remove a
  * tenant entirely (offboarding, data-removal requests, regulatory erasure). This
- * module performs that removal against the runtime-derived
- * {@link buildTenantDeletionManifest tenant manifest}:
+ * module performs that removal against a deletion plan assembled from the
+ * runtime-derived {@link buildTenantDeletionManifest tenant manifest} and the
+ * registry of tenant tables created imperatively at runtime:
  *
  *   1. Validate the tenant id (refuse empty / whitespace / wildcard values).
- *   2. Delete every tenant-scoped row inside a single tenant-scoped transaction,
+ *   2. Reconcile the plan against the live PostgreSQL catalog and fail closed if
+ *      any tenant-contract table is missing or malformed.
+ *   3. Delete every tenant-scoped row inside a single tenant-scoped transaction,
  *      children before parents, so foreign keys are never violated.
- *   3. Re-scan the whole manifest in a fresh transaction and fail unless zero
+ *   4. Re-scan the whole plan in a fresh transaction and fail unless zero
  *      rows remain for the tenant.
  *
  * Running it twice on the same tenant is safe: the second run deletes zero rows
@@ -19,9 +22,9 @@
  *
  * Precondition — quiesce the tenant first: this operation verifies tenant state
  * at scan time; it does not by itself fence out a concurrent writer. The
- * operator must disable/quiesce the tenant (stop new tenant-scoped work at the
- * control/auth layer) BEFORE running, otherwise a writer active during or after
- * verification can recreate tenant rows that the verification pass will not see.
+ * operator must stop new tenant-scoped work in the deployment BEFORE running,
+ * otherwise a writer active during or after verification can recreate tenant
+ * rows that the verification pass will not see.
  *
  * The result object is a frozen machine-readable contract (see
  * {@link TenantDeletionResult}) intended to be parsed by external automation. It
@@ -29,10 +32,10 @@
  * connection strings, or other secrets.
  */
 
-import { count } from 'drizzle-orm';
+import { count, sql } from 'drizzle-orm';
 import { QueryBuilder } from 'drizzle-orm/pg-core';
 import type { Database } from './client';
-import { deleteFrom, isPostgresDatabase, select } from './database-wrapper';
+import { deleteFrom, executeRaw, isPostgresDatabase, select } from './database-wrapper';
 import { checkMigrationStatus } from './migrate';
 import {
   buildTenantDeletionManifest,
@@ -40,6 +43,7 @@ import {
   indexManifest,
   type TenantDeletionTable,
 } from './tenant-deletion-manifest';
+import { IMPERATIVE_TENANT_TABLES, type ImperativeTenantTable } from './tenant-imperative-tables';
 import { getCurrentTenantDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
 
 /** Thrown when the supplied tenant id is empty, blank, or wildcard-like. */
@@ -55,6 +59,14 @@ export class TenantDeletionUnsupportedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'TenantDeletionUnsupportedError';
+  }
+}
+
+/** Thrown when the live catalog cannot prove that the deletion plan is exhaustive. */
+export class TenantDeletionCatalogError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TenantDeletionCatalogError';
   }
 }
 
@@ -80,7 +92,7 @@ export interface TenantDeletionResult {
   tenantDataDeleted: true;
   /** Current applied schema/migration version (last applied migration tag). */
   schemaVersion: string;
-  /** Rows deleted per table. Every manifest table is present, even at zero. */
+  /** Rows deleted per table. Every plan table is present, even at zero. */
   rowCounts: Record<string, number>;
 }
 
@@ -102,10 +114,13 @@ export interface TenantDeletionOptions {
 
 /** Wildcard-like characters that must never be accepted as a concrete tenant id. */
 const WILDCARD_CHARACTERS = /[%*]/;
+/** Unicode control and formatting characters can forge terminal or audit output. */
+const CONTROL_CHARACTERS = /[\p{Cc}\p{Cf}]/u;
 
 /**
  * Validate a tenant id, refusing empty, whitespace-only, whitespace-padded, and
- * wildcard-like values. A concrete id such as `default` or a UUID is accepted.
+ * wildcard-like or non-printable values. A concrete id such as `default` or a
+ * UUID is accepted.
  */
 export function assertValidTenantId(tenantId: unknown): asserts tenantId is string {
   if (typeof tenantId !== 'string') {
@@ -123,6 +138,9 @@ export function assertValidTenantId(tenantId: unknown): asserts tenantId is stri
   if (WILDCARD_CHARACTERS.test(tenantId)) {
     throw new InvalidTenantIdError('Tenant id must not contain wildcard characters ("%" or "*")');
   }
+  if (CONTROL_CHARACTERS.test(tenantId)) {
+    throw new InvalidTenantIdError('Tenant id must not contain control or formatting characters');
+  }
 }
 
 /**
@@ -138,10 +156,9 @@ export function assertNoRemainingTenantRows(remaining: string[]): void {
 
 async function resolveSchemaVersion(db: Database): Promise<string> {
   const status = await checkMigrationStatus(db);
-  // Fail closed unless the schema is in lockstep in BOTH directions: the binary's
-  // compiled schema (and thus the deletion manifest) must match exactly the
-  // schema the database currently has applied. That requires !dbAheadOfBinary AND
-  // !hasPending.
+  // This migration-watermark check is a conservative compatibility guard, not a
+  // proof that the compiled schema equals the live catalog. Exhaustiveness is
+  // established separately by the catalog reconciliation before any deletion.
   //
   // DB ahead of binary: the database was migrated by a newer release, so this
   // binary's schema omits tables the database now has. Deleting + verifying
@@ -165,8 +182,8 @@ async function resolveSchemaVersion(db: Database): Promise<string> {
   if (status.hasPending) {
     throw new Error(
       `Refusing to delete tenant data: the database has ${status.pending.length} pending migration(s); ` +
-        "the running binary's schema does not match the database. " +
-        'Run migrations so the binary and database schemas match before deleting a tenant ' +
+        "the running binary's migration watermark is not compatible with the database. " +
+        'Apply the pending migrations before deleting a tenant ' +
         '(a pending migration may drop or rename a tenant-scoped table, which would make deletion silently incomplete).'
     );
   }
@@ -177,6 +194,195 @@ async function resolveSchemaVersion(db: Database): Promise<string> {
     );
   }
   return applied[applied.length - 1];
+}
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+function boolValue(value: unknown): boolean {
+  return value === true || value === 't' || value === 'true' || value === 1 || value === '1';
+}
+
+interface CatalogRelation {
+  schemaName: string;
+  tableName: string;
+  relkind: string;
+  rlsEnabled: boolean;
+  rlsForced: boolean;
+  hasTenantColumn: boolean;
+  tenantColumnTextNotNull: boolean;
+  hasTenantPolicyMarker: boolean;
+  hasTenantIsolationPolicy: boolean;
+  participatesInInheritance: boolean;
+}
+
+/**
+ * Read every non-system ordinary or partitioned relation that claims some part
+ * of the tenant contract. Catalog names are used for comparison and diagnostics
+ * only; executed deletion SQL never uses them.
+ */
+async function readTenantCatalog(db: Database): Promise<CatalogRelation[]> {
+  const result = await executeRaw(
+    db,
+    sql`
+      SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        c.relkind::text AS relkind,
+        c.relrowsecurity AS rls_enabled,
+        c.relforcerowsecurity AS rls_forced,
+        EXISTS (
+          SELECT 1
+          FROM pg_attribute a
+          WHERE a.attrelid = c.oid
+            AND a.attname = 'tenant_id'
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+        ) AS has_tenant_column,
+        EXISTS (
+          SELECT 1
+          FROM pg_attribute a
+          WHERE a.attrelid = c.oid
+            AND a.attname = 'tenant_id'
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+            AND a.atttypid = 'text'::regtype
+            AND a.attnotnull
+        ) AS tenant_column_text_not_null,
+        EXISTS (
+          SELECT 1
+          FROM pg_policy p
+          WHERE p.polrelid = c.oid
+            AND (
+              p.polname LIKE 'tenant_isolation_%'
+              OR COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
+              OR COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
+            )
+        ) AS has_tenant_policy_marker,
+        EXISTS (
+          SELECT 1
+          FROM pg_policy p
+          WHERE p.polrelid = c.oid
+            AND p.polname LIKE 'tenant_isolation_%'
+            AND COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
+            AND COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
+        ) AS has_tenant_isolation_policy,
+        EXISTS (
+          SELECT 1
+          FROM pg_inherits i
+          WHERE i.inhrelid = c.oid OR i.inhparent = c.oid
+        ) AS participates_in_inheritance
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind IN ('r', 'p')
+        AND n.nspname <> 'information_schema'
+        AND n.nspname NOT LIKE 'pg_%'
+        AND (
+          c.relforcerowsecurity
+          OR EXISTS (
+            SELECT 1
+            FROM pg_attribute a
+            WHERE a.attrelid = c.oid
+              AND a.attname = 'tenant_id'
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM pg_policy p
+            WHERE p.polrelid = c.oid
+              AND (
+                p.polname LIKE 'tenant_isolation_%'
+                OR COALESCE(pg_get_expr(p.polqual, p.polrelid), '') LIKE '%agor.tenant_id%'
+                OR COALESCE(pg_get_expr(p.polwithcheck, p.polrelid), '') LIKE '%agor.tenant_id%'
+              )
+          )
+        )
+    `
+  );
+
+  return rowsOf(result).map((row) => ({
+    schemaName: String(row.schema_name),
+    tableName: String(row.table_name),
+    relkind: String(row.relkind),
+    rlsEnabled: boolValue(row.rls_enabled),
+    rlsForced: boolValue(row.rls_forced),
+    hasTenantColumn: boolValue(row.has_tenant_column),
+    tenantColumnTextNotNull: boolValue(row.tenant_column_text_not_null),
+    hasTenantPolicyMarker: boolValue(row.has_tenant_policy_marker),
+    hasTenantIsolationPolicy: boolValue(row.has_tenant_isolation_policy),
+    participatesInInheritance: boolValue(row.participates_in_inheritance),
+  }));
+}
+
+/**
+ * Assert the full contract for every catalog relation and reconcile the live set
+ * against the typed manifest plus the constant imperative-table registry.
+ */
+async function auditLiveTenantCatalog(
+  db: Database,
+  planNames: ReadonlySet<string>
+): Promise<ReadonlySet<string>> {
+  const relations = await readTenantCatalog(db);
+  const liveTenantTables = new Set<string>();
+
+  for (const relation of relations) {
+    const qualifiedName = `${relation.schemaName}.${relation.tableName}`;
+    if (relation.schemaName !== 'public') {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: tenant-contract relation ${qualifiedName} is outside the public schema`
+      );
+    }
+    if (relation.relkind === 'p') {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: tenant-contract relation ${qualifiedName} is partitioned`
+      );
+    }
+    if (relation.participatesInInheritance) {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: tenant-contract relation ${qualifiedName} participates in table inheritance`
+      );
+    }
+    if (!relation.hasTenantColumn) {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: ${qualifiedName} has forced row security or a tenant-isolation policy but no tenant_id column`
+      );
+    }
+    if (!relation.tenantColumnTextNotNull) {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: ${qualifiedName}.tenant_id must be a NOT NULL text column`
+      );
+    }
+    if (!relation.rlsEnabled || !relation.rlsForced) {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: ${qualifiedName} must enable and force row-level security`
+      );
+    }
+    if (!relation.hasTenantPolicyMarker || !relation.hasTenantIsolationPolicy) {
+      throw new TenantDeletionCatalogError(
+        `Refusing tenant deletion: ${qualifiedName} lacks a complete tenant_isolation_* policy referencing agor.tenant_id`
+      );
+    }
+    liveTenantTables.add(relation.tableName);
+  }
+
+  if (liveTenantTables.size === 0) {
+    throw new TenantDeletionCatalogError(
+      'Refusing tenant deletion: live-catalog discovery found zero tenant-contract tables'
+    );
+  }
+
+  const uncovered = [...liveTenantTables].filter((name) => !planNames.has(name)).sort();
+  if (uncovered.length > 0) {
+    throw new TenantDeletionCatalogError(
+      `Refusing tenant deletion: live tenant table(s) are not covered by the deletion plan: ${uncovered.join(', ')}`
+    );
+  }
+
+  return liveTenantTables;
 }
 
 async function countTenantRows(
@@ -208,6 +414,47 @@ async function deleteTenantRows(
     rowsAffected?: number;
   };
   return Number(result?.rowsAffected ?? 0);
+}
+
+interface DeletionStep {
+  name: string;
+  countRows(db: Database, tenantId: string): Promise<number>;
+  deleteRows(db: Database, tenantId: string): Promise<void>;
+}
+
+function buildManifestStep(
+  entry: TenantDeletionTable,
+  queryBuilder: QueryBuilder,
+  byName: Map<string, TenantDeletionTable>
+): DeletionStep {
+  return {
+    name: entry.name,
+    countRows: (db, tenantId) => countTenantRows(db, queryBuilder, entry, tenantId, byName),
+    deleteRows: async (db, tenantId) => {
+      await deleteTenantRows(db, queryBuilder, entry, tenantId, byName);
+    },
+  };
+}
+
+function buildImperativeStep(table: ImperativeTenantTable): DeletionStep {
+  const tableIdentifier = sql.identifier(table.name);
+  const tenantColumnIdentifier = sql.identifier(table.tenantColumn);
+  return {
+    name: table.name,
+    countRows: async (db, tenantId) => {
+      const result = await executeRaw(
+        db,
+        sql`SELECT count(*) AS n FROM ${tableIdentifier} WHERE ${tenantColumnIdentifier} = ${tenantId}`
+      );
+      return Number(rowsOf(result)[0]?.n ?? 0);
+    },
+    deleteRows: async (db, tenantId) => {
+      await executeRaw(
+        db,
+        sql`DELETE FROM ${tableIdentifier} WHERE ${tenantColumnIdentifier} = ${tenantId}`
+      );
+    },
+  };
 }
 
 /**
@@ -246,10 +493,29 @@ export async function deleteTenantData(
   const byName = indexManifest(manifest);
   const queryBuilder = new QueryBuilder();
   const schemaVersion = await resolveSchemaVersion(db);
+  const planNames = new Set([
+    ...manifest.map((entry) => entry.name),
+    ...IMPERATIVE_TENANT_TABLES.map((table) => table.name),
+  ]);
+  const liveTenantTables = await auditLiveTenantCatalog(db, planNames);
+  const presentImperativeTables = IMPERATIVE_TENANT_TABLES.filter((table) =>
+    liveTenantTables.has(table.name)
+  );
+  // Imperative registry entries are leaves whose cascade parents are in the
+  // typed manifest, so placing them first preserves children-before-parents.
+  const steps: DeletionStep[] = [
+    ...presentImperativeTables.map(buildImperativeStep),
+    ...manifest.map((entry) => buildManifestStep(entry, queryBuilder, byName)),
+  ];
+  if (steps.length === 0) {
+    throw new TenantDeletionCatalogError(
+      'Refusing tenant deletion: the reconciled deletion plan is empty'
+    );
+  }
   const startedAt = Date.now();
 
   log(
-    `${dryRun ? 'dry-run: ' : ''}tenant deletion started (schemaVersion=${schemaVersion}, tables=${manifest.length})`
+    `${dryRun ? 'dry-run: ' : ''}tenant deletion started (schemaVersion=${schemaVersion}, tables=${steps.length})`
   );
 
   const rowCounts: Record<string, number> = {};
@@ -260,22 +526,21 @@ export async function deleteTenantData(
   //
   // Counts are captured up front, BEFORE any DELETE runs. This keeps the reported
   // rowCounts accurate even when an `ON DELETE CASCADE` from a parent table would
-  // otherwise remove a child's rows before that child's own DELETE statement runs
-  // (deletion order only constrains blocking foreign keys, so a cascade parent can
-  // legitimately be deleted first). Each row belongs to exactly one table, so the
-  // pre-deletion snapshot is precisely the set of rows the operation removes.
+  // otherwise remove a child's rows before that child's own DELETE statement
+  // runs. Each row belongs to exactly one table, so the pre-deletion snapshot is
+  // precisely the set of rows the operation removes.
   await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
-    for (const entry of manifest) {
-      rowCounts[entry.name] = await countTenantRows(scoped, queryBuilder, entry, tenantId, byName);
-      if (rowCounts[entry.name] > 0) {
+    for (const step of steps) {
+      rowCounts[step.name] = await step.countRows(scoped, tenantId);
+      if (rowCounts[step.name] > 0) {
         log(
-          `${dryRun ? 'would delete' : 'deleting'} ${rowCounts[entry.name]} row(s) from ${entry.name}`
+          `${dryRun ? 'would delete' : 'deleting'} ${rowCounts[step.name]} row(s) from ${step.name}`
         );
       }
     }
     if (dryRun) return;
-    for (const entry of manifest) {
-      await deleteTenantRows(scoped, queryBuilder, entry, tenantId, byName);
+    for (const step of steps) {
+      await step.deleteRows(scoped, tenantId);
     }
   });
 
@@ -283,9 +548,9 @@ export async function deleteTenantData(
   if (!dryRun) {
     const remaining = await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
       const offending: string[] = [];
-      for (const entry of manifest) {
-        const left = await countTenantRows(scoped, queryBuilder, entry, tenantId, byName);
-        if (left > 0) offending.push(entry.name);
+      for (const step of steps) {
+        const left = await step.countRows(scoped, tenantId);
+        if (left > 0) offending.push(step.name);
       }
       return offending;
     });
@@ -295,7 +560,7 @@ export async function deleteTenantData(
   const durationMs = Date.now() - startedAt;
   const totalRows = Object.values(rowCounts).reduce((sum, value) => sum + value, 0);
   log(
-    `${dryRun ? 'dry-run complete' : 'tenant deletion verified'} (${totalRows} row(s) across ${manifest.length} tables in ${durationMs}ms)`
+    `${dryRun ? 'dry-run complete' : 'tenant deletion verified'} (${totalRows} row(s) across ${steps.length} tables in ${durationMs}ms)`
   );
 
   if (dryRun) {

--- a/packages/core/src/db/tenant-deletion.ts
+++ b/packages/core/src/db/tenant-deletion.ts
@@ -1,0 +1,254 @@
+/**
+ * Permanent, audited, idempotent deletion of all data belonging to a single
+ * tenant.
+ *
+ * Operators of a multi-tenant Agor deployment need a verifiable way to remove a
+ * tenant entirely (offboarding, data-removal requests, regulatory erasure). This
+ * module performs that removal against the runtime-derived
+ * {@link buildTenantDeletionManifest tenant manifest}:
+ *
+ *   1. Validate the tenant id (refuse empty / whitespace / wildcard values).
+ *   2. Delete every tenant-scoped row inside a single tenant-scoped transaction,
+ *      children before parents, so foreign keys are never violated.
+ *   3. Re-scan the whole manifest in a fresh transaction and fail unless zero
+ *      rows remain for the tenant.
+ *
+ * Running it twice on the same tenant is safe: the second run deletes zero rows
+ * and still reports success. Multi-tenancy is PostgreSQL-only, so the command
+ * refuses to run against a SQLite database.
+ *
+ * The result object is a frozen machine-readable contract (see
+ * {@link TenantDeletionResult}) intended to be parsed by external automation. It
+ * contains only booleans, numbers, and identifier strings — never row content,
+ * connection strings, or other secrets.
+ */
+
+import { count } from 'drizzle-orm';
+import { QueryBuilder } from 'drizzle-orm/pg-core';
+import type { Database } from './client';
+import { deleteFrom, isPostgresDatabase, select } from './database-wrapper';
+import { checkMigrationStatus } from './migrate';
+import {
+  buildTenantDeletionManifest,
+  buildTenantScopeCondition,
+  indexManifest,
+  type TenantDeletionTable,
+} from './tenant-deletion-manifest';
+import { runWithTenantDatabaseScope } from './tenant-scope';
+
+/** Thrown when the supplied tenant id is empty, blank, or wildcard-like. */
+export class InvalidTenantIdError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidTenantIdError';
+  }
+}
+
+/** Thrown when tenant deletion is attempted against a non-multi-tenant database. */
+export class TenantDeletionUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TenantDeletionUnsupportedError';
+  }
+}
+
+/** Thrown when post-deletion verification still finds tenant rows. */
+export class TenantDeletionVerificationError extends Error {
+  /** Names of tables that still contain rows for the tenant. */
+  readonly tables: string[];
+  constructor(tables: string[]) {
+    super(
+      `Tenant deletion verification failed: ${tables.length} table(s) still contain tenant rows`
+    );
+    this.name = 'TenantDeletionVerificationError';
+    this.tables = tables;
+  }
+}
+
+/**
+ * Stable machine-readable success contract. Key names are frozen — external
+ * automation parses them exactly. Only booleans, numbers, and identifier
+ * strings are ever emitted.
+ */
+export interface TenantDeletionResult {
+  tenantDataDeleted: true;
+  /** Current applied schema/migration version (last applied migration tag). */
+  schemaVersion: string;
+  /** Rows deleted per table. Every manifest table is present, even at zero. */
+  rowCounts: Record<string, number>;
+}
+
+/** Result of a `--dry-run`: reports would-be deletions without mutating data. */
+export interface TenantDeletionDryRunResult {
+  tenantDataDeleted: false;
+  dryRun: true;
+  schemaVersion: string;
+  /** Rows that WOULD be deleted per table. */
+  rowCounts: Record<string, number>;
+}
+
+export interface TenantDeletionOptions {
+  /** Report counts without deleting anything. */
+  dryRun?: boolean;
+  /** Human-readable audit sink (secret-safe). Defaults to a no-op. */
+  log?: (message: string) => void;
+}
+
+/** Wildcard-like characters that must never be accepted as a concrete tenant id. */
+const WILDCARD_CHARACTERS = /[%*]/;
+
+/**
+ * Validate a tenant id, refusing empty, whitespace-only, whitespace-padded, and
+ * wildcard-like values. A concrete id such as `default` or a UUID is accepted.
+ */
+export function assertValidTenantId(tenantId: unknown): asserts tenantId is string {
+  if (typeof tenantId !== 'string') {
+    throw new InvalidTenantIdError('A tenant id is required');
+  }
+  if (tenantId.length === 0) {
+    throw new InvalidTenantIdError('Tenant id must not be empty');
+  }
+  if (tenantId.trim().length === 0) {
+    throw new InvalidTenantIdError('Tenant id must not be blank');
+  }
+  if (tenantId.trim() !== tenantId) {
+    throw new InvalidTenantIdError('Tenant id must not have leading or trailing whitespace');
+  }
+  if (WILDCARD_CHARACTERS.test(tenantId)) {
+    throw new InvalidTenantIdError('Tenant id must not contain wildcard characters ("%" or "*")');
+  }
+}
+
+/**
+ * Convert the set of tables that still hold tenant rows after deletion into a
+ * thrown {@link TenantDeletionVerificationError}. Extracted so the failure path
+ * is unit-testable without a live database.
+ */
+export function assertNoRemainingTenantRows(remaining: string[]): void {
+  if (remaining.length > 0) {
+    throw new TenantDeletionVerificationError(remaining);
+  }
+}
+
+async function resolveSchemaVersion(db: Database): Promise<string> {
+  const status = await checkMigrationStatus(db);
+  const applied = status.applied;
+  if (applied.length === 0) {
+    throw new Error(
+      'Database has no applied migrations; refusing to run tenant deletion against an uninitialized schema'
+    );
+  }
+  return applied[applied.length - 1];
+}
+
+async function countTenantRows(
+  db: Database,
+  queryBuilder: QueryBuilder,
+  entry: TenantDeletionTable,
+  tenantId: string,
+  byName: Map<string, TenantDeletionTable>
+): Promise<number> {
+  const condition = buildTenantScopeCondition(queryBuilder, entry, tenantId, byName);
+  const rows = (await select(db, { n: count() })
+    .from(entry.table)
+    .where(condition)
+    .all()) as Array<{
+    n: number | string | bigint;
+  }>;
+  return Number(rows[0]?.n ?? 0);
+}
+
+async function deleteTenantRows(
+  db: Database,
+  queryBuilder: QueryBuilder,
+  entry: TenantDeletionTable,
+  tenantId: string,
+  byName: Map<string, TenantDeletionTable>
+): Promise<number> {
+  const condition = buildTenantScopeCondition(queryBuilder, entry, tenantId, byName);
+  const result = (await deleteFrom(db, entry.table).where(condition).run()) as {
+    rowsAffected?: number;
+  };
+  return Number(result?.rowsAffected ?? 0);
+}
+
+/**
+ * Permanently delete all data for a single tenant, or report what would be
+ * deleted when `dryRun` is set. Returns the frozen machine-readable result.
+ */
+export async function deleteTenantData(
+  db: Database,
+  tenantId: string,
+  options: TenantDeletionOptions = {}
+): Promise<TenantDeletionResult | TenantDeletionDryRunResult> {
+  assertValidTenantId(tenantId);
+
+  if (!isPostgresDatabase(db)) {
+    throw new TenantDeletionUnsupportedError(
+      'Tenant deletion requires a PostgreSQL (multi-tenant) database; the SQLite schema is single-tenant'
+    );
+  }
+
+  const log = options.log ?? (() => {});
+  const dryRun = options.dryRun ?? false;
+  const manifest = buildTenantDeletionManifest();
+  const byName = indexManifest(manifest);
+  const queryBuilder = new QueryBuilder();
+  const schemaVersion = await resolveSchemaVersion(db);
+  const startedAt = Date.now();
+
+  log(
+    `${dryRun ? 'dry-run: ' : ''}tenant deletion started (schemaVersion=${schemaVersion}, tables=${manifest.length})`
+  );
+
+  const rowCounts: Record<string, number> = {};
+
+  // Phase 1: snapshot per-table counts, then (unless this is a dry run) delete,
+  // all inside one tenant-scoped transaction so the deletion is atomic and RLS
+  // pins every statement to the tenant.
+  //
+  // Counts are captured up front, BEFORE any DELETE runs. This keeps the reported
+  // rowCounts accurate even when an `ON DELETE CASCADE` from a parent table would
+  // otherwise remove a child's rows before that child's own DELETE statement runs
+  // (deletion order only constrains blocking foreign keys, so a cascade parent can
+  // legitimately be deleted first). Each row belongs to exactly one table, so the
+  // pre-deletion snapshot is precisely the set of rows the operation removes.
+  await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    for (const entry of manifest) {
+      rowCounts[entry.name] = await countTenantRows(scoped, queryBuilder, entry, tenantId, byName);
+      if (rowCounts[entry.name] > 0) {
+        log(
+          `${dryRun ? 'would delete' : 'deleting'} ${rowCounts[entry.name]} row(s) from ${entry.name}`
+        );
+      }
+    }
+    if (dryRun) return;
+    for (const entry of manifest) {
+      await deleteTenantRows(scoped, queryBuilder, entry, tenantId, byName);
+    }
+  });
+
+  // Phase 2: verify committed state in a fresh transaction (skipped for dry-run).
+  if (!dryRun) {
+    const remaining = await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+      const offending: string[] = [];
+      for (const entry of manifest) {
+        const left = await countTenantRows(scoped, queryBuilder, entry, tenantId, byName);
+        if (left > 0) offending.push(entry.name);
+      }
+      return offending;
+    });
+    assertNoRemainingTenantRows(remaining);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const totalRows = Object.values(rowCounts).reduce((sum, value) => sum + value, 0);
+  log(
+    `${dryRun ? 'dry-run complete' : 'tenant deletion verified'} (${totalRows} row(s) across ${manifest.length} tables in ${durationMs}ms)`
+  );
+
+  if (dryRun) {
+    return { tenantDataDeleted: false, dryRun: true, schemaVersion, rowCounts };
+  }
+  return { tenantDataDeleted: true, schemaVersion, rowCounts };
+}

--- a/packages/core/src/db/tenant-imperative-tables.ts
+++ b/packages/core/src/db/tenant-imperative-tables.ts
@@ -28,34 +28,29 @@ export const IMPERATIVE_TENANT_SCOPE_COLUMN = 'tenant_id';
 
 /**
  * A tenant-scoped table created imperatively (outside the Drizzle schema) and
- * therefore not derivable from `schema.postgres.ts`.
+ * therefore not derivable from `schema.postgres.ts`. Entries describe only the
+ * relation used for explicit public-qualified tenant DML. They do not claim to
+ * validate row-level foreign-key tenant consistency.
  */
 export interface ImperativeTenantTable {
   /** Physical table name (constant — never sourced from the live catalog). */
   readonly name: string;
   /** Tenant discriminator column (always deleted with `WHERE <col> = $1`). */
   readonly tenantColumn: string;
-  /**
-   * Physical names of the tables this one references via `ON DELETE CASCADE`
-   * foreign keys. Recorded so the table orders as a leaf/child — it is deleted
-   * before any of these parents. Nothing references an imperative table, so
-   * each entry is a pure leaf and is safely deleted first.
-   */
-  readonly cascadeParents: readonly string[];
 }
 
 /**
  * The imperative tenant tables Agor may create at runtime.
  *
  * `kb_unit_embeddings` (Knowledge pgvector storage) is created lazily by
- * `ensureKnowledgePgvectorStorage`. Its two foreign keys — to `kb_document_units`
- * and `kb_embedding_spaces` — are both `ON DELETE CASCADE`, so it is a leaf and
- * is deleted before those parents.
+ * `ensureKnowledgePgvectorStorage`. The engine places registered imperative
+ * tables before the compiled manifest. The standalone PostgreSQL schema and its
+ * data must still satisfy the documented tenant-consistent foreign-key
+ * precondition.
  */
 export const IMPERATIVE_TENANT_TABLES: readonly ImperativeTenantTable[] = [
   {
     name: 'kb_unit_embeddings',
     tenantColumn: IMPERATIVE_TENANT_SCOPE_COLUMN,
-    cascadeParents: ['kb_document_units', 'kb_embedding_spaces'],
   },
 ];

--- a/packages/core/src/db/tenant-imperative-tables.ts
+++ b/packages/core/src/db/tenant-imperative-tables.ts
@@ -1,0 +1,61 @@
+/**
+ * Registry of tenant-scoped tables that are created *imperatively* at runtime
+ * rather than declared in the Drizzle schema (`schema.postgres.ts`).
+ *
+ * The Drizzle-derived {@link buildTenantDeletionManifest tenant manifest} only
+ * sees tables that are exported from the compiled schema. Some tenant-scoped
+ * tables, however, are created lazily by application code — most notably
+ * `kb_unit_embeddings`, which the Knowledge pgvector layer creates on demand
+ * (see `apps/agor-daemon/src/knowledge/pgvector.ts`). Such a table carries the
+ * full tenant contract (a `tenant_id` discriminator, FORCE ROW LEVEL SECURITY,
+ * and a `tenant_isolation_*` policy) but is invisible to the schema exports, so
+ * it would silently escape deletion and verification.
+ *
+ * This registry closes that gap by describing those tables by *name and
+ * contract only* — never by importing daemon code (core must not depend on the
+ * daemon). Each entry is included in the deletion plan, the pre-delete count
+ * snapshot, and phase-2 verification ONLY when the live catalog shows the table
+ * present with the full tenant contract (it may not exist yet, since it is
+ * created lazily).
+ *
+ * Because these tables are referenced by a constant name here — not by a
+ * catalog-sourced string — the executed DELETE/COUNT statements can safely quote
+ * the identifier (`sql.identifier`) and bind the tenant id as a parameter.
+ */
+
+/** The column that scopes an imperative table's rows to a tenant. */
+export const IMPERATIVE_TENANT_SCOPE_COLUMN = 'tenant_id';
+
+/**
+ * A tenant-scoped table created imperatively (outside the Drizzle schema) and
+ * therefore not derivable from `schema.postgres.ts`.
+ */
+export interface ImperativeTenantTable {
+  /** Physical table name (constant — never sourced from the live catalog). */
+  readonly name: string;
+  /** Tenant discriminator column (always deleted with `WHERE <col> = $1`). */
+  readonly tenantColumn: string;
+  /**
+   * Physical names of the tables this one references via `ON DELETE CASCADE`
+   * foreign keys. Recorded so the table orders as a leaf/child — it is deleted
+   * before any of these parents. Nothing references an imperative table, so
+   * each entry is a pure leaf and is safely deleted first.
+   */
+  readonly cascadeParents: readonly string[];
+}
+
+/**
+ * The imperative tenant tables Agor may create at runtime.
+ *
+ * `kb_unit_embeddings` (Knowledge pgvector storage) is created lazily by
+ * `ensureKnowledgePgvectorStorage`. Its two foreign keys — to `kb_document_units`
+ * and `kb_embedding_spaces` — are both `ON DELETE CASCADE`, so it is a leaf and
+ * is deleted before those parents.
+ */
+export const IMPERATIVE_TENANT_TABLES: readonly ImperativeTenantTable[] = [
+  {
+    name: 'kb_unit_embeddings',
+    tenantColumn: IMPERATIVE_TENANT_SCOPE_COLUMN,
+    cascadeParents: ['kb_document_units', 'kb_embedding_spaces'],
+  },
+];


### PR DESCRIPTION
## Linked issue

_None._

## Summary

- Adds `agor tenant delete --tenant-id <id>` (with `--dry-run`): an audited, idempotent admin command that **permanently deletes all data for exactly one tenant** from a multi-tenant (PostgreSQL) deployment.
- Introduces a runtime-owned, schema-derived **tenant table manifest** (`@agor/core/db`) with an **exhaustiveness test**, so no future table can silently escape tenant deletion.
- Emits a **stable machine-readable JSON contract** on stdout for automation; all human/audit logging goes to stderr.
- Hardened through adversarial review into a **fail-closed** tool: it refuses to run unless the binary's schema is provably in lockstep with the database, aborts loudly on unclassified/transitively-scoped tables rather than deleting partially, and cannot emit a truncated contract.

## Why / context

Operators of multi-tenant deployments need a safe, verifiable way to fully remove one tenant — offboarding, data-removal requests, GDPR-style erasure. Hand-written SQL is error-prone: it can miss a table, trip a foreign key, or leave orphaned rows and still look like it worked. This command makes tenant erasure exhaustive, FK-ordered, transactional, and self-verifying, and returns a result automation can assert on.

## Implementation notes

**Manifest (`tenant-deletion-manifest.ts`)** — derived directly from the PostgreSQL Drizzle schema (not a hand-maintained list). Every table is classified `direct` (`tenant_id` column), `transitive` (reaches a scoped table via an FK chain), or explicitly `global`. Deletion order is a topological sort over blocking foreign keys (children before parents). `buildTenantDeletionManifest()` throws at runtime if any table is `unclassified`, or if a `transitive` table is present — the transitive delete/verify path is not yet proven, so it fails loud instead of deleting partially.

**Deletion (`tenant-deletion.ts`)** — `deleteTenantData()`:
- Rejects empty / blank / whitespace-padded / wildcard tenant ids before opening a connection.
- Refuses non-PostgreSQL databases (multi-tenancy is PostgreSQL-only).
- **Fails closed on schema skew:** refuses unless the running binary's migrations match the database's applied set in both directions (`hasPending`, or a database migrated by a newer release) — a mismatched manifest could silently miss a renamed/dropped/added tenant table.
- Refuses to run inside an ambient tenant/system DB scope (which would collapse its delete and verify phases into one uncommitted transaction).
- Deletes all tenant rows inside a single tenant-scoped transaction. RLS (`FORCE ROW LEVEL SECURITY`) is pinned to the target via the `agor.tenant_id` GUC, and every statement also carries an explicit `tenant_id` predicate — defense-in-depth that holds whether or not the maintenance role bypasses RLS.
- Snapshots per-table counts **before** deleting, so `ON DELETE CASCADE` can't undercount.
- Re-scans the whole manifest in a fresh post-commit transaction and fails (non-zero) unless zero rows remain. **Idempotent:** a second run deletes nothing and still succeeds.

**CLI (`commands/tenant/delete.ts`)** — resolves the database exactly like the daemon (env/config); prints one JSON object to stdout — `{ tenantDataDeleted, schemaVersion, rowCounts }` (dry-run adds `dryRun: true`), values limited to booleans, numbers, and identifier strings; the payload is flushed before exit so a piped consumer can't get truncated output. Human logs and errors (credentials redacted) go to stderr. Exit codes: `0` verified success, `2` invalid input, `1` runtime failure.

This PR was hardened through an adversarial advocate/skeptic review on two independent model families. Fixes landed from that review: the fail-closed schema-lockstep guard, the ambient-scope guard, runtime `unclassified`/`transitive` guards, and the stdout-flush fix.

## Validation / test plan

- [x] `pnpm --filter @agor/core typecheck` — clean
- [x] `pnpm --filter @agor/cli typecheck` — clean
- [x] `pnpm --filter @agor/core test` — 2906 passed, 5 skipped
- [x] `biome check` — clean on all changed files
- [x] PostgreSQL integration suite (`tenant-deletion.postgres.test.ts`) run against a real PostgreSQL: scoped deletion, cross-tenant isolation, idempotency, frozen output contract, dry-run — all pass. Gated on `AGOR_TEST_POSTGRES_URL` + `AGOR_DB_DIALECT=postgresql`, mirroring the existing `*.postgres.test.ts` convention; skipped in the SQLite fast lane.
- [ ] CI does not yet run the PostgreSQL suite — see Out of scope.

Example success output (stdout):

```json
{"tenantDataDeleted":true,"schemaVersion":"0066_gateway_listener_discovery","rowCounts":{"sessions":3,"tasks":5,"messages":42,"branches":1,"repos":1}}
```

## Risks / rollout / rollback

- Destructive by design. Mitigations: strict id validation, schema-lockstep refusal, single atomic transaction (partial failure rolls back), and post-commit verification that fails loudly if anything survives. `--dry-run` previews counts without deleting.
- **Operational precondition:** the operator must quiesce/disable the tenant (stop new tenant-scoped work at the control/auth layer) before running. The command attests to state at scan time; it does not by itself prevent a concurrent writer from recreating rows after verification. This is documented in the CLI help and module doc.
- Purely additive: no schema migration, no change to existing runtime paths beyond three barrel exports and one additive field on `checkMigrationStatus`. Blast radius on existing deployments is zero until the command is invoked.

## Out of scope / follow-ups

- **Non-database tenant state** (per-branch worktrees, caches on disk) — keyed by branch, not tenant; safe reclamation is deployment-specific. This command is DB-only. Follow-up: enumerate a tenant's branches before deletion and reclaim their filesystem state with the same verify/report rigor.
- **Tenant admission/lifecycle fence** — a durable "tenant disabled" state that stops new tenant-scoped work belongs at the control/auth layer and is a separate change. This PR documents the precondition; it does not build the fence.
- **PostgreSQL CI job** — the integration suite (this one and the pre-existing `tasks.postgres.test.ts`) is env-gated and not exercised by current CI. Follow-up: add a Postgres-service job so the deletion path runs under `FORCE RLS` in CI.
- **Transitive-scope deletion** — currently refused at runtime; if a future table needs it, extend the engine with orphan-safe (post-parent-deletion) verification before enabling.
