### PR TITLE
Fix environment pill clickable cursor

### DIFF
--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -76,6 +76,28 @@ const defaultProps = {
 };
 
 describe('EnvironmentPill', () => {
+  it('shows a pointer only when the environment label links to a running app', () => {
+    const { rerender } = render(
+      <EnvironmentPill
+        {...defaultProps}
+        branch={
+          {
+            ...branch,
+            app_url: 'https://example.test',
+            environment_instance: { status: 'running' },
+          } as Branch
+        }
+      />
+    );
+
+    expect(screen.getByRole('link')).toHaveStyle({ cursor: 'pointer' });
+
+    rerender(<EnvironmentPill {...defaultProps} />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('env').parentElement).toHaveStyle({ cursor: 'default' });
+  });
+
   it('can hide only the destructive nuke action while preserving other controls', () => {
     render(<EnvironmentPill {...defaultProps} showNukeEnvironment={false} />);
 

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -192,6 +192,7 @@ export function EnvironmentPill({
                 padding: '0 7px',
                 textDecoration: 'none',
                 height: '22px',
+                cursor: 'pointer',
               }}
             >
               <Space size={4} align="center">
@@ -208,6 +209,7 @@ export function EnvironmentPill({
                 height: '22px',
                 display: 'inline-flex',
                 alignItems: 'center',
+                cursor: 'default',
               }}
             >
               <Space size={4} align="center">


### PR DESCRIPTION
## Summary

- show the pointer cursor across the environment label only when it links to a running app
- preserve the default cursor for inactive environment labels
- add focused coverage for clickable and non-clickable states

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- src/components/EnvironmentPill/EnvironmentPill.test.tsx` (170 files, 1,112 tests passed)
