### PR TITLE
feat(codex): expose reasoning effort configuration

### DIFF
--- a/apps/agor-docs/content/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/content/guide/rich-chat-ux.mdx
@@ -42,13 +42,14 @@ Combined with **per-user analytics** (Settings → Analytics), this gives you a 
 
 ## 🧠 Model Selector & Effort
 
-**Switch models and reasoning depth mid-session.** A model selector and effort dropdown sit in the session panel footer.
+**Switch models and reasoning depth mid-session.** Claude and Codex sessions expose a model selector and effort dropdown in the session panel footer. Codex shows **Inherited** until Agor stores an explicit override.
 
 | Effort   | When                                         |
 | -------- | -------------------------------------------- |
 | `low`    | Quick lookups, simple edits                  |
 | `medium` | Balanced speed/quality                       |
-| `high`   | Default (complex coding, reviews)            |
+| `high`   | Deep reasoning for complex coding and reviews |
+| `xhigh`  | Extra reasoning depth for supported runtimes |
 | `max`    | Critical decisions, architecture (Opus only) |
 
 Models with the `[1m]` suffix (e.g., `claude-sonnet-4-6[1m]`) enable Anthropic's 1M-token extended context window. They appear as separate dropdown entries.

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -203,7 +203,7 @@ Each level delegates to specialized agents. Each session has a focused context w
 A session has more knobs than a CLI invocation:
 
 - **Model**: Switch model mid-session from the panel footer
-- **Effort**: `low` / `medium` / `high` / `xhigh` / `max` reasoning depth
+- **Effort**: Explicit reasoning depth for Claude and Codex sessions. Unset Codex sessions inherit the runtime's project, user, or model default.
 - **Permissions**: How tool calls are gated (auto-approve, supervised, manual)
 - **MCP servers**: Which tool sets are attached
 - **Effort and 1M context**: Models with `[1m]` enable extended context

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../store/agorStore', () => ({
     selector({
       agenticToolSettingsByName: new Map([
         ['claude-code', { inline_configuration_allowed: storeSettings.inlineAllowed }],
+        ['codex', { inline_configuration_allowed: storeSettings.inlineAllowed }],
       ]),
     }),
 }));
@@ -52,7 +53,23 @@ vi.mock('../PermissionModeSelector', async () => {
     ),
   };
 });
-vi.mock('../EffortSelector', () => ({ EffortSelector: () => <div data-testid="effort-select" /> }));
+vi.mock('../EffortSelector', () => ({
+  EffortSelector: ({
+    value,
+    onChange,
+    allowInherited,
+    levels,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    allowInherited?: boolean;
+    levels?: readonly string[];
+  }) => (
+    <button type="button" data-testid="effort-select" onClick={() => onChange?.('medium')}>
+      {value ?? 'Inherited'}|{allowInherited ? 'clearable' : 'fixed'}|{levels?.join(',')}
+    </button>
+  ),
+}));
 vi.mock('../MCPServerSelect', () => ({ MCPServerSelect: () => <div data-testid="mcp-select" /> }));
 
 const makeClient = () =>
@@ -75,16 +92,18 @@ function Harness({
   user,
   client = makeClient(),
   initialSource,
+  tool = 'claude-code',
 }: {
   user: User;
   client?: AgorClient | null;
   initialSource?: string;
+  tool?: 'claude-code' | 'codex' | 'gemini';
 }) {
   const [form] = Form.useForm();
   return (
     <Form form={form} initialValues={{ agenticToolPresetId: initialSource }}>
       <AgenticConfigChipRow
-        tool="claude-code"
+        tool={tool}
         client={client}
         mcpServerById={new Map()}
         currentUser={user}
@@ -97,6 +116,7 @@ function Harness({
               src: form.getFieldValue('agenticToolPresetId'),
               model: (form.getFieldValue('modelConfig') as { model?: string } | undefined)?.model,
               perm: form.getFieldValue('permissionMode'),
+              effort: form.getFieldValue('effort'),
             })}
           </span>
         )}
@@ -212,6 +232,39 @@ describe('AgenticConfigChipRow', () => {
     fireEvent.click(await screen.findByTestId('advisor-select'));
 
     await waitFor(() => expect(chip).toHaveTextContent('Advisor: advisor-model'));
+  });
+
+  it('shows inherited Codex effort and turns an explicit selection into a custom override', async () => {
+    const codexUser = {
+      user_id: 'codex-user',
+      default_agentic_config: {
+        codex: {
+          modelConfig: { model: 'gpt-5.6-sol' },
+          permissionMode: 'allow-all',
+        },
+      },
+    } as unknown as User;
+
+    render(<Harness user={codexUser} tool="codex" />);
+
+    const effortChip = await screen.findByTestId('effort-chip');
+    expect(effortChip).toHaveTextContent('Effort: Inherited');
+    expect(screen.queryByTestId('advisor-chip')).not.toBeInTheDocument();
+
+    fireEvent.click(effortChip);
+    const selector = await screen.findByTestId('effort-select');
+    expect(selector).toHaveTextContent('Inherited|clearable|low,medium,high,xhigh');
+    fireEvent.click(selector);
+
+    await waitFor(() => expect(screen.getByText('Custom')).toBeInTheDocument());
+    expect(screen.getByTestId('effort-chip')).toHaveTextContent('Effort: Medium');
+    expect(JSON.parse(screen.getByTestId('state').textContent || '{}').effort).toBe('medium');
+  });
+
+  it('does not render effort for unsupported tools', async () => {
+    render(<Harness user={{ user_id: 'gemini-user' } as User} tool="gemini" />);
+    await screen.findByTestId('permission-chip');
+    expect(screen.queryByTestId('effort-chip')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -50,6 +50,8 @@ export interface AgenticConfigChipRowProps {
   fieldName?: string;
   /** Offer "Save as my default" under the chips while Custom is active. */
   enableSaveAsDefault?: boolean;
+  /** Hide effort where changes cannot affect the active runtime. */
+  showEffort?: boolean;
   /**
    * Reports the same source validity enforced by the registered form field so
    * callers can disable submission proactively. `reason` explains why.
@@ -94,6 +96,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   currentUser,
   fieldName = 'agenticToolPresetId',
   enableSaveAsDefault = false,
+  showEffort = true,
   onConfigValidityChange,
 }) => {
   const { token } = theme.useToken();
@@ -101,7 +104,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const isClaude = CLAUDE_TOOLS.has(tool);
   const toolCapabilities = AGENTIC_TOOL_CAPABILITIES[tool];
   const effortLevels = toolCapabilities.reasoningEffortLevels;
-  const supportsEffort = Boolean(effortLevels?.length);
+  const supportsEffort = showEffort && Boolean(effortLevels?.length);
   const {
     inlineAllowed,
     loading,

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -7,7 +7,11 @@ import type {
   PermissionMode,
   User,
 } from '@agor-live/client';
-import { getDefaultModelForTool, getDefaultPermissionMode } from '@agor-live/client';
+import {
+  AGENTIC_TOOL_CAPABILITIES,
+  getDefaultModelForTool,
+  getDefaultPermissionMode,
+} from '@agor-live/client';
 import {
   ApiOutlined,
   ExperimentOutlined,
@@ -61,10 +65,6 @@ const EFFORT_LABELS: Record<EffortLevel, string> = {
   max: 'Max',
 };
 
-// The daemon treats an unset effort as "high" (see resolve-session-defaults),
-// so the chip resolves to that effective value rather than showing "default".
-const DEFAULT_EFFORT: EffortLevel = 'high';
-
 const CLAUDE_TOOLS = new Set<AgenticToolName>(['claude-code', 'claude-code-cli']);
 
 /**
@@ -99,6 +99,9 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const { token } = theme.useToken();
   const form = Form.useFormInstance();
   const isClaude = CLAUDE_TOOLS.has(tool);
+  const toolCapabilities = AGENTIC_TOOL_CAPABILITIES[tool];
+  const effortLevels = toolCapabilities.reasoningEffortLevels;
+  const supportsEffort = Boolean(effortLevels?.length);
   const {
     inlineAllowed,
     loading,
@@ -144,7 +147,8 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const resolved = configForSource(source);
   const resolvedModel = resolved.modelConfig?.model || getDefaultModelForTool(tool) || '';
   const resolvedPermission = resolved.permissionMode || getDefaultPermissionMode(tool);
-  const resolvedEffort = (isInline ? formEffort : resolved.modelConfig?.effort) ?? DEFAULT_EFFORT;
+  const explicitEffort = isInline ? formEffort : resolved.modelConfig?.effort;
+  const resolvedEffort = explicitEffort ?? toolCapabilities.defaultReasoningEffort;
   const advisorModel = isInline ? formModelConfig?.advisorModel : undefined;
   const mcpCount = formMcp?.length ?? 0;
 
@@ -176,7 +180,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
     ensureCustom();
     form.setFieldValue('permissionMode', mode);
   };
-  const onEffortChange = (effort: EffortLevel) => {
+  const onEffortChange = (effort: EffortLevel | undefined) => {
     ensureCustom();
     form.setFieldValue('effort', effort);
   };
@@ -299,10 +303,10 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
           )}
         />
 
-        {isClaude && (
+        {supportsEffort && (
           <EditableChip
             icon={<ExperimentOutlined />}
-            label={`Effort: ${EFFORT_LABELS[resolvedEffort]}`}
+            label={`Effort: ${resolvedEffort ? EFFORT_LABELS[resolvedEffort] : 'Inherited'}`}
             title="Reasoning effort"
             editable={inlineAllowed}
             managedNote={managedNote}
@@ -311,6 +315,9 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
             renderContent={(close) => (
               <EffortSelector
                 value={resolvedEffort}
+                levels={effortLevels}
+                fallbackValue={toolCapabilities.defaultReasoningEffort}
+                allowInherited={!toolCapabilities.defaultReasoningEffort}
                 onChange={(effort) => {
                   onEffortChange(effort);
                   close();

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.test.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { AgenticToolConfigForm } from './AgenticToolConfigForm';
+
+vi.mock('../ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector" />,
+}));
+vi.mock('../PermissionModeSelector', () => ({
+  CODEX_APPROVAL_POLICIES: [],
+  CODEX_SANDBOX_MODES: [],
+  PermissionModeSelector: () => <div data-testid="permission-selector" />,
+}));
+vi.mock('../CodexNetworkAccessToggle', () => ({
+  CodexNetworkAccessToggle: () => <div data-testid="network-toggle" />,
+}));
+vi.mock('../EffortSelector', () => ({
+  EffortSelector: ({
+    levels,
+    allowInherited,
+  }: {
+    levels?: readonly string[];
+    allowInherited?: boolean;
+  }) => (
+    <div data-testid="effort-selector">
+      {levels?.join(',')}|{allowInherited ? 'inherited' : 'fixed'}
+    </div>
+  ),
+}));
+
+function renderForm(agenticTool: 'codex' | 'gemini') {
+  render(
+    <Form>
+      <AgenticToolConfigForm agenticTool={agenticTool} />
+    </Form>
+  );
+}
+
+describe('AgenticToolConfigForm reasoning effort', () => {
+  it('renders truthful Codex levels with inherited runtime configuration', () => {
+    renderForm('codex');
+    expect(screen.getByTestId('effort-selector')).toHaveTextContent(
+      'low,medium,high,xhigh|inherited'
+    );
+  });
+
+  it('omits the control for unsupported tools', () => {
+    renderForm('gemini');
+    expect(screen.queryByTestId('effort-selector')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { AgenticToolName, AgorClient } from '@agor-live/client';
-import { DEFAULT_CLAUDE_MODEL } from '@agor-live/client';
+import { AGENTIC_TOOL_CAPABILITIES, DEFAULT_CLAUDE_MODEL } from '@agor-live/client';
 import { Form, Select } from 'antd';
 import { CodexNetworkAccessToggle } from '../CodexNetworkAccessToggle';
 import { EffortSelector } from '../EffortSelector';
@@ -69,6 +69,8 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
 }) => {
   const modelLabel = MODEL_LABELS[agenticTool] ?? 'Claude Model';
   const showCodexFields = agenticTool === 'codex' && !compact;
+  const toolCapabilities = AGENTIC_TOOL_CAPABILITIES[agenticTool];
+  const effortLevels = toolCapabilities.reasoningEffortLevels;
 
   return (
     <>
@@ -92,17 +94,23 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
         <PermissionModeSelector agentic_tool={agenticTool} compact={compact} fullWidth />
       </Form.Item>
 
-      {(agenticTool === 'claude-code' || agenticTool === 'claude-code-cli') && (
+      {effortLevels && (
         <Form.Item
           name="effort"
           label="Reasoning Effort"
           help={
             showHelpText
-              ? 'Control how much reasoning Claude applies (low = fast, high = thorough, max = Opus only)'
+              ? toolCapabilities.defaultReasoningEffort
+                ? 'Control how much reasoning the agent applies'
+                : 'Control how much reasoning the agent applies; inherited uses the runtime configuration'
               : undefined
           }
         >
-          <EffortSelector />
+          <EffortSelector
+            levels={effortLevels}
+            fallbackValue={toolCapabilities.defaultReasoningEffort}
+            allowInherited={!toolCapabilities.defaultReasoningEffort}
+          />
         </Form.Item>
       )}
 

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
@@ -3,7 +3,17 @@ import { describe, expect, it } from 'vitest';
 import {
   buildModelConfigFromFormValues,
   buildScheduleConfigFromFormValues,
+  getFormValuesFromConfig,
 } from './agenticConfigHelpers';
+
+describe('getFormValuesFromConfig', () => {
+  it('explicitly clears merged model fields when a tool has no stored config', () => {
+    const values = getFormValuesFromConfig('codex');
+
+    expect(values).toHaveProperty('modelConfig', undefined);
+    expect(values).toHaveProperty('effort', undefined);
+  });
+});
 
 describe('buildModelConfigFromFormValues', () => {
   it('stores an explicit effort beside the selected model', () => {

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
@@ -1,6 +1,29 @@
 import type { ScheduleAgenticToolConfig } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
-import { buildScheduleConfigFromFormValues } from './agenticConfigHelpers';
+import {
+  buildModelConfigFromFormValues,
+  buildScheduleConfigFromFormValues,
+} from './agenticConfigHelpers';
+
+describe('buildModelConfigFromFormValues', () => {
+  it('stores an explicit effort beside the selected model', () => {
+    expect(
+      buildModelConfigFromFormValues({
+        modelConfig: { model: 'gpt-5.6-sol' },
+        effort: 'medium',
+      })
+    ).toEqual({ model: 'gpt-5.6-sol', effort: 'medium' });
+  });
+
+  it('removes a stale nested effort when the form returns to inherited', () => {
+    expect(
+      buildModelConfigFromFormValues({
+        modelConfig: { model: 'gpt-5.6-sol', effort: 'high' },
+        effort: undefined,
+      })
+    ).toEqual({ model: 'gpt-5.6-sol' });
+  });
+});
 
 describe('buildScheduleConfigFromFormValues', () => {
   it('detaches a previous preset when switching a schedule to inline configuration', () => {

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
@@ -54,20 +54,14 @@ export function getFormValuesFromConfig(
   tool: AgenticToolName,
   config?: DefaultAgenticToolConfig
 ): AgenticFormValues {
-  if (!config) {
-    return {
-      permissionMode: getDefaultPermissionMode(tool),
-    };
-  }
-
   return {
-    modelConfig: config.modelConfig,
-    effort: config.modelConfig?.effort,
-    permissionMode: config.permissionMode || getDefaultPermissionMode(tool),
+    modelConfig: config?.modelConfig,
+    effort: config?.modelConfig?.effort,
+    permissionMode: config?.permissionMode || getDefaultPermissionMode(tool),
     ...(tool === 'codex' && {
-      codexSandboxMode: config.codexSandboxMode,
-      codexApprovalPolicy: config.codexApprovalPolicy,
-      codexNetworkAccess: config.codexNetworkAccess,
+      codexSandboxMode: config?.codexSandboxMode,
+      codexApprovalPolicy: config?.codexApprovalPolicy,
+      codexNetworkAccess: config?.codexNetworkAccess,
     }),
   };
 }

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
@@ -34,6 +34,18 @@ export interface AgenticFormValues {
   codexNetworkAccess?: boolean;
 }
 
+/** Fold the standalone form field into the canonical model config without retaining stale effort. */
+export function buildModelConfigFromFormValues(
+  values: Pick<AgenticFormValues, 'modelConfig' | 'effort'>
+): DefaultModelConfig | undefined {
+  const { effort: _storedEffort, ...modelConfig } = values.modelConfig ?? {};
+  if (Object.keys(modelConfig).length === 0 && values.effort === undefined) return undefined;
+  return {
+    ...modelConfig,
+    ...(values.effort !== undefined ? { effort: values.effort } : {}),
+  };
+}
+
 /**
  * Convert a stored DefaultAgenticToolConfig into form field values.
  * Returns sensible defaults when config is undefined.
@@ -68,12 +80,7 @@ export function buildConfigFromFormValues(
   tool: AgenticToolName,
   values: AgenticFormValues
 ): DefaultAgenticToolConfig {
-  // Merge effort back into modelConfig
-  const modelConfig = values.modelConfig
-    ? { ...values.modelConfig, effort: values.effort }
-    : values.effort
-      ? { effort: values.effort }
-      : undefined;
+  const modelConfig = buildModelConfigFromFormValues(values);
 
   return {
     modelConfig,

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/index.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/index.ts
@@ -3,6 +3,7 @@ export { AgenticToolConfigForm } from './AgenticToolConfigForm';
 export type { AgenticFormValues } from './agenticConfigHelpers';
 export {
   buildConfigFromFormValues,
+  buildModelConfigFromFormValues,
   buildScheduleConfigFromFormValues,
   getClearedFormValues,
   getFormValuesFromConfig,

--- a/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.tsx
@@ -18,7 +18,7 @@ import { slugify } from '@/utils/repoSlug';
 import { useEnsureFrameworkRepo } from '../../../hooks/useEnsureFrameworkRepo';
 import { useTeammateForm } from '../../../hooks/useTeammateForm';
 import type { AgenticToolOption } from '../../../types';
-import { getFormValuesFromConfig } from '../../AgenticToolConfigForm';
+import { buildConfigFromFormValues, getFormValuesFromConfig } from '../../AgenticToolConfigForm';
 import {
   AgenticToolConfigurationPicker,
   INLINE_AGENTIC_CONFIGURATION,
@@ -111,6 +111,18 @@ export const TeammateTab: React.FC<TeammateTabProps> = ({
         agentDefaults?.permissionMode ??
         getDefaultPermissionMode(selectedAgent);
 
+      const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+      const inlineAgentConfig = isInline
+        ? buildConfigFromFormValues(selectedAgent, {
+            modelConfig: values.modelConfig,
+            effort: values.effort,
+            permissionMode: values.permissionMode,
+            codexSandboxMode: values.codexSandboxMode,
+            codexApprovalPolicy: values.codexApprovalPolicy,
+            codexNetworkAccess: values.codexNetworkAccess,
+          })
+        : undefined;
+
       const result: TeammateTabResult = {
         displayName: values.displayName.trim(),
         description: values.description || undefined,
@@ -119,12 +131,13 @@ export const TeammateTab: React.FC<TeammateTabProps> = ({
         branchName: values.name || `private-${slugify(values.displayName)}`,
         sourceBranch: values.sourceBranch || 'main',
         agent: selectedAgent,
-        agenticToolPresetId:
-          values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION
-            ? undefined
-            : values.agenticToolPresetId,
-        modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
-        effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
+        agenticToolPresetId: isInline ? undefined : values.agenticToolPresetId,
+        modelConfig: isInline
+          ? inlineAgentConfig?.modelConfig
+          : (values.modelConfig ?? agentDefaults?.modelConfig),
+        effort: isInline
+          ? undefined
+          : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
         mcpServerIds: values.mcpServerIds ?? currentUser?.default_mcp_server_ids,
         permissionMode,
       };

--- a/apps/agor-ui/src/components/EffortSelector/EffortSelector.test.tsx
+++ b/apps/agor-ui/src/components/EffortSelector/EffortSelector.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EffortSelector } from './EffortSelector';
+
+describe('EffortSelector', () => {
+  it('shows inherited when unset and only offers supported levels', () => {
+    render(
+      <EffortSelector
+        allowInherited
+        levels={['low', 'medium', 'high', 'xhigh']}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Inherited')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    const listbox = screen.getByRole('listbox');
+    expect(within(listbox).getByText('X-High')).toBeInTheDocument();
+    expect(within(listbox).queryByText('Maximum')).not.toBeInTheDocument();
+    expect(within(listbox).queryByText(/default/i)).not.toBeInTheDocument();
+  });
+
+  it('uses the caller-provided fallback instead of owning a default', () => {
+    render(<EffortSelector fallbackValue="medium" levels={['low', 'medium', 'high']} />);
+    expect(screen.getByRole('combobox').parentElement).toHaveTextContent('Medium effort');
+  });
+
+  it('clears an explicit override back to inherited', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <EffortSelector
+        value="medium"
+        allowInherited
+        levels={['low', 'medium', 'high', 'xhigh']}
+        onChange={onChange}
+      />
+    );
+
+    const select = container.querySelector('.ant-select') as Element;
+    fireEvent.mouseEnter(select);
+    fireEvent.mouseDown(container.querySelector('.ant-select-clear') as Element);
+    expect(onChange.mock.calls.at(-1)?.[0]).toBeUndefined();
+  });
+});

--- a/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
+++ b/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
@@ -2,12 +2,12 @@
  * EffortSelector - Compact selector for reasoning effort level
  *
  * Effort controls how much reasoning the agent applies to responses.
- * Maps to the SDK's effort parameter (output_config.effort in the API).
+ * Runtime adapters map the shared value to their native effort option.
  *
  * Levels:
  * - Low: Minimal thinking, fastest responses
  * - Medium: Moderate thinking
- * - High: Deep reasoning (default)
+ * - High: Deep reasoning
  * - X-High: Extra reasoning depth, below maximum
  * - Max: Highest effort level (model-dependent)
  */
@@ -19,7 +19,10 @@ import type React from 'react';
 
 interface EffortSelectorProps {
   value?: EffortLevel;
-  onChange?: (effort: EffortLevel) => void;
+  onChange?: (effort: EffortLevel | undefined) => void;
+  levels?: readonly EffortLevel[];
+  fallbackValue?: EffortLevel;
+  allowInherited?: boolean;
   size?: 'small' | 'middle' | 'large';
   compact?: boolean;
   plain?: boolean;
@@ -39,7 +42,7 @@ const EFFORT_OPTIONS: {
     description: 'Minimal thinking, fastest responses',
   },
   { value: 'medium', shortLabel: 'Md', label: 'Medium', description: 'Moderate thinking' },
-  { value: 'high', shortLabel: 'Hi', label: 'High', description: 'Deep reasoning (default)' },
+  { value: 'high', shortLabel: 'Hi', label: 'High', description: 'Deep reasoning' },
   {
     value: 'xhigh',
     shortLabel: 'Xh',
@@ -55,23 +58,32 @@ const EFFORT_OPTIONS: {
 ];
 
 /**
- * EffortSelector - Dropdown for selecting Claude reasoning effort level
+ * EffortSelector - Dropdown for selecting a supported reasoning effort level
  */
 export const EffortSelector: React.FC<EffortSelectorProps> = ({
-  value = 'high',
+  value,
   onChange,
+  levels,
+  fallbackValue,
+  allowInherited = false,
   size = 'middle',
   compact = false,
   plain = false,
   fullWidth = false,
 }) => {
   const { token } = theme.useToken();
+  const options = levels
+    ? EFFORT_OPTIONS.filter((option) => levels.includes(option.value))
+    : EFFORT_OPTIONS;
+  const resolvedValue = value ?? fallbackValue;
 
   return (
     <Tooltip title="Reasoning effort level">
       <Select
-        value={value}
+        value={resolvedValue}
         onChange={onChange}
+        allowClear={allowInherited}
+        placeholder={allowInherited ? 'Inherited' : undefined}
         size={size}
         style={{
           width: fullWidth ? '100%' : compact ? undefined : 160,
@@ -79,7 +91,7 @@ export const EffortSelector: React.FC<EffortSelectorProps> = ({
         }}
         popupMatchSelectWidth={false}
         optionLabelProp="label"
-        options={EFFORT_OPTIONS.map((opt) => ({
+        options={options.map((opt) => ({
           value: opt.value,
           label: plain ? (
             opt.label
@@ -96,7 +108,7 @@ export const EffortSelector: React.FC<EffortSelectorProps> = ({
           ),
         }))}
         optionRender={(option) => {
-          const opt = EFFORT_OPTIONS.find((o) => o.value === option.value);
+          const opt = options.find((o) => o.value === option.value);
           return (
             <Space size={6} align="start">
               <BulbOutlined style={{ marginTop: 3 }} />

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -17,6 +17,7 @@ import { getDefaultPermissionMode } from '@agor-live/client';
 import { Checkbox, Form, Modal, Radio, Typography, theme } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
 import { AgenticConfigChipRow } from '../AgenticConfigChipRow';
+import { buildModelConfigFromFormValues } from '../AgenticToolConfigForm/agenticConfigHelpers';
 import { INLINE_AGENTIC_CONFIGURATION } from '../AgenticToolConfigurationPicker';
 import {
   getUserAgenticToolDefault,
@@ -180,12 +181,10 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
             spawnConfig.presetId = values.agenticToolPresetId;
           } else {
             spawnConfig.permissionMode = values.permissionMode;
-            // Fold the standalone effort field back into model_config.
-            spawnConfig.modelConfig = values.modelConfig
-              ? { ...values.modelConfig, ...(values.effort ? { effort: values.effort } : {}) }
-              : values.effort
-                ? { effort: values.effort }
-                : undefined;
+            spawnConfig.modelConfig = buildModelConfigFromFormValues({
+              modelConfig: values.modelConfig,
+              effort: values.effort,
+            });
             spawnConfig.codexSandboxMode = values.codexSandboxMode;
             spawnConfig.codexApprovalPolicy = values.codexApprovalPolicy;
             spawnConfig.codexNetworkAccess = values.codexNetworkAccess;

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -17,7 +17,7 @@ import { selectMcpServerById, selectUserById } from '../../store/selectors';
 import { useThemedMessage } from '../../utils/message';
 import { AgenticConfigChipRow } from '../AgenticConfigChipRow';
 import type { AgenticFormValues } from '../AgenticToolConfigForm';
-import { getFormValuesFromConfig } from '../AgenticToolConfigForm';
+import { buildConfigFromFormValues, getFormValuesFromConfig } from '../AgenticToolConfigForm';
 import {
   INLINE_AGENTIC_CONFIGURATION,
   persistUserDefaultFromForm,
@@ -210,6 +210,16 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         getDefaultPermissionMode(selectedAgent as AgenticToolName);
 
       const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+      const inlineAgentConfig = isInline
+        ? buildConfigFromFormValues(selectedAgent as AgenticToolName, {
+            modelConfig: values.modelConfig,
+            effort: values.effort,
+            permissionMode: values.permissionMode,
+            codexSandboxMode: values.codexSandboxMode,
+            codexApprovalPolicy: values.codexApprovalPolicy,
+            codexNetworkAccess: values.codexNetworkAccess,
+          })
+        : undefined;
 
       // Promote the inline config to the user's default when requested. Fire and
       // forget — session creation shouldn't block on the profile patch.
@@ -237,8 +247,12 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         title: values.title,
         initialPrompt: values.initialPrompt,
         // Daemon's applySessionConfigDefaults hook fills the tool default.
-        modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
-        effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
+        modelConfig: isInline
+          ? inlineAgentConfig?.modelConfig
+          : (values.modelConfig ?? agentDefaults?.modelConfig),
+        effort: isInline
+          ? undefined
+          : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
         mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
         permissionMode,
         envVarNames: envVarNames.length > 0 ? envVarNames : undefined,

--- a/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
+++ b/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
@@ -143,7 +143,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
   const [form] = Form.useForm<ScheduleFormValues>();
 
   // Agent picker is controlled via local state because it drives which
-  // fields AgenticToolConfigForm shows (e.g., effort for Claude only).
+  // fields AgenticToolConfigForm shows (for example runtime-supported effort).
   // The selected value is mirrored into the form as `agenticTool` so save
   // can read it consistently with the rest of the form.
   const [agentTool, setAgentTool] = useState<AgenticToolName>(

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -133,6 +133,89 @@ describe('ZoneTriggerModal smart-default session selection', () => {
 });
 
 describe('ZoneTriggerModal reasoning effort', () => {
+  it('does not inherit model or effort from another agent while preserving MCP inheritance', async () => {
+    const claudeSession = {
+      ...makeSession('s-claude', 'completed', '2026-06-20T00:00:00.000Z', 'Claude session'),
+      agentic_tool: 'claude-code',
+      model_config: { mode: 'alias', model: 'claude-opus-4-8', effort: 'max' },
+      permission_config: { mode: 'bypassPermissions' },
+    } as unknown as Session;
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ZoneTriggerModal
+        open
+        onCancel={() => {}}
+        client={null}
+        branchId={BRANCH_ID}
+        branch={{ mcp_server_ids: ['branch-mcp'] } as never}
+        sessionsByBranch={new Map([[BRANCH_ID, [claudeSession]]])}
+        zoneName="Zone"
+        trigger={{ template: 'prompt' } as never}
+        availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
+        mcpServerById={new Map()}
+        onExecute={onExecute}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Create a new session'));
+    fireEvent.click(screen.getByRole('button', { name: 'codex' }));
+    fireEvent.click(screen.getByText('Agentic Tool Configuration (optional)'));
+    await waitFor(() => expect(screen.getByLabelText('zone-effort')).toHaveValue(''));
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() =>
+      expect(onExecute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: 'codex',
+          modelConfig: undefined,
+          permissionMode: undefined,
+          mcpServerIds: ['branch-mcp'],
+        })
+      )
+    );
+  });
+
+  it('inherits model and effort from the newest session for the selected agent', async () => {
+    const codexSession = {
+      ...makeSession('s-codex', 'completed', '2026-06-20T00:00:00.000Z', 'Codex session'),
+      agentic_tool: 'codex',
+      model_config: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+      permission_config: { mode: 'allow-all' },
+    } as unknown as Session;
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ZoneTriggerModal
+        open
+        onCancel={() => {}}
+        client={null}
+        branchId={BRANCH_ID}
+        branch={undefined}
+        sessionsByBranch={new Map([[BRANCH_ID, [codexSession]]])}
+        zoneName="Zone"
+        trigger={{ template: 'prompt' } as never}
+        availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
+        mcpServerById={new Map()}
+        onExecute={onExecute}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Create a new session'));
+    fireEvent.click(screen.getByRole('button', { name: 'codex' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() =>
+      expect(onExecute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: 'codex',
+          modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+          permissionMode: 'allow-all',
+        })
+      )
+    );
+  });
+
   it('folds an explicit Codex effort into a new session model config', async () => {
     const onExecute = vi.fn().mockResolvedValue(undefined);
     render(

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -3,6 +3,26 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ZoneTriggerModal } from './ZoneTriggerModal';
 
+function EffortField({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange?: (value: string | undefined) => void;
+}) {
+  return (
+    <select
+      aria-label="zone-effort"
+      value={value ?? ''}
+      onChange={(event) => onChange?.(event.target.value || undefined)}
+    >
+      <option value="">Inherited</option>
+      <option value="medium">Medium</option>
+      <option value="xhigh">X-High</option>
+    </select>
+  );
+}
+
 // Isolate the modal's own smart-default selection logic from its heavy config
 // children — the regression lives entirely in ZoneTriggerModal's render-time
 // useMemo, which runs regardless of what these children render.
@@ -28,23 +48,6 @@ vi.mock('../../AgenticToolConfigForm', async () => {
     '../../AgenticToolConfigForm'
   );
   const { Form } = await vi.importActual<typeof import('antd')>('antd');
-  const EffortField = ({
-    value,
-    onChange,
-  }: {
-    value?: string;
-    onChange?: (value: string | undefined) => void;
-  }) => (
-    <select
-      aria-label="zone-effort"
-      value={value ?? ''}
-      onChange={(event) => onChange?.(event.target.value || undefined)}
-    >
-      <option value="">Inherited</option>
-      <option value="medium">Medium</option>
-      <option value="xhigh">X-High</option>
-    </select>
-  );
   return {
     ...actual,
     AgenticToolConfigForm: () => (
@@ -56,23 +59,6 @@ vi.mock('../../AgenticToolConfigForm', async () => {
 });
 vi.mock('../../AgenticToolConfigurationPicker', async () => {
   const { Form } = await vi.importActual<typeof import('antd')>('antd');
-  const EffortField = ({
-    value,
-    onChange,
-  }: {
-    value?: string;
-    onChange?: (value: string | undefined) => void;
-  }) => (
-    <select
-      aria-label="zone-effort"
-      value={value ?? ''}
-      onChange={(event) => onChange?.(event.target.value || undefined)}
-    >
-      <option value="">Inherited</option>
-      <option value="medium">Medium</option>
-      <option value="xhigh">X-High</option>
-    </select>
-  );
   return {
     INLINE_AGENTIC_CONFIGURATION: '__inline__',
     AgenticToolConfigurationPicker: () => (

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -1,5 +1,5 @@
 import type { BranchID, Session } from '@agor-live/client';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ZoneTriggerModal } from './ZoneTriggerModal';
 
@@ -7,11 +7,81 @@ import { ZoneTriggerModal } from './ZoneTriggerModal';
 // children — the regression lives entirely in ZoneTriggerModal's render-time
 // useMemo, which runs regardless of what these children render.
 vi.mock('../../AgentSelectionGrid', () => ({
-  AgentSelectionGrid: () => null,
+  AgentSelectionGrid: ({
+    agents,
+    onSelect,
+  }: {
+    agents: { id: string }[];
+    onSelect: (agent: string) => void;
+  }) => (
+    <>
+      {agents.map((agent) => (
+        <button key={agent.id} type="button" onClick={() => onSelect(agent.id)}>
+          {agent.id}
+        </button>
+      ))}
+    </>
+  ),
 }));
-vi.mock('../../AgenticToolConfigForm', () => ({
-  AgenticToolConfigForm: () => null,
-}));
+vi.mock('../../AgenticToolConfigForm', async () => {
+  const actual = await vi.importActual<typeof import('../../AgenticToolConfigForm')>(
+    '../../AgenticToolConfigForm'
+  );
+  const { Form } = await vi.importActual<typeof import('antd')>('antd');
+  const EffortField = ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange?: (value: string | undefined) => void;
+  }) => (
+    <select
+      aria-label="zone-effort"
+      value={value ?? ''}
+      onChange={(event) => onChange?.(event.target.value || undefined)}
+    >
+      <option value="">Inherited</option>
+      <option value="medium">Medium</option>
+      <option value="xhigh">X-High</option>
+    </select>
+  );
+  return {
+    ...actual,
+    AgenticToolConfigForm: () => (
+      <Form.Item name="effort" noStyle>
+        <EffortField />
+      </Form.Item>
+    ),
+  };
+});
+vi.mock('../../AgenticToolConfigurationPicker', async () => {
+  const { Form } = await vi.importActual<typeof import('antd')>('antd');
+  const EffortField = ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange?: (value: string | undefined) => void;
+  }) => (
+    <select
+      aria-label="zone-effort"
+      value={value ?? ''}
+      onChange={(event) => onChange?.(event.target.value || undefined)}
+    >
+      <option value="">Inherited</option>
+      <option value="medium">Medium</option>
+      <option value="xhigh">X-High</option>
+    </select>
+  );
+  return {
+    INLINE_AGENTIC_CONFIGURATION: '__inline__',
+    AgenticToolConfigurationPicker: () => (
+      <Form.Item name="effort" noStyle>
+        <EffortField />
+      </Form.Item>
+    ),
+  };
+});
 
 const BRANCH_ID = 'branch-1' as BranchID;
 
@@ -59,5 +129,97 @@ describe('ZoneTriggerModal smart-default session selection', () => {
     // session — surfaced as the closed Select's selected value.
     expect(document.body.textContent).toContain('Newer session');
     expect(document.body.textContent).not.toContain('Older session');
+  });
+});
+
+describe('ZoneTriggerModal reasoning effort', () => {
+  it('folds an explicit Codex effort into a new session model config', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ZoneTriggerModal
+        open
+        onCancel={() => {}}
+        client={null}
+        branchId={BRANCH_ID}
+        branch={undefined}
+        sessionsByBranch={new Map()}
+        zoneName="Zone"
+        trigger={{ template: 'prompt' } as never}
+        availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
+        mcpServerById={new Map()}
+        currentUser={
+          {
+            default_agentic_config: {
+              codex: {
+                modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+              },
+            },
+          } as never
+        }
+        onExecute={onExecute}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'codex' }));
+    fireEvent.click(screen.getByText('Agentic Tool Configuration (optional)'));
+    const effort = await screen.findByLabelText('zone-effort');
+    await waitFor(() => expect(effort).toHaveValue('medium'));
+    fireEvent.change(effort, { target: { value: 'xhigh' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() =>
+      expect(onExecute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: 'codex',
+          modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'xhigh' },
+        })
+      )
+    );
+  });
+
+  it.each([
+    'fork',
+    'spawn',
+  ] as const)('folds an explicit effort into a reused session %s config', async (action) => {
+    const session = {
+      ...makeSession('s-codex', 'completed', '2026-06-20T00:00:00.000Z', 'Codex session'),
+      agentic_tool: 'codex',
+      model_config: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+      permission_config: { mode: 'allow-all' },
+    } as unknown as Session;
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ZoneTriggerModal
+        open
+        onCancel={() => {}}
+        client={null}
+        branchId={BRANCH_ID}
+        branch={undefined}
+        sessionsByBranch={new Map([[BRANCH_ID, [session]]])}
+        zoneName="Zone"
+        trigger={{ template: 'prompt' } as never}
+        availableAgents={[]}
+        mcpServerById={new Map()}
+        onExecute={onExecute}
+      />
+    );
+
+    fireEvent.click(screen.getByText(new RegExp(`^${action}`, 'i')));
+    fireEvent.click(screen.getByText('Session Configuration (codex)'));
+    const effort = await screen.findByLabelText('zone-effort');
+    await waitFor(() => expect(effort).toHaveValue('medium'));
+    fireEvent.change(effort, { target: { value: 'xhigh' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() =>
+      expect(onExecute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 's-codex',
+          action,
+          modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'xhigh' },
+        })
+      )
+    );
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -174,6 +174,8 @@ export const ZoneTriggerModal = ({
 
       // Get user defaults for this agent as fallback
       const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
+      const recentAgentSession =
+        mostRecentSession?.agentic_tool === selectedAgent ? mostRecentSession : undefined;
 
       // MCP inheritance: branch config > user defaults
       const effectiveMcpServerIds =
@@ -183,9 +185,10 @@ export const ZoneTriggerModal = ({
 
       // Calculate config values (priority: most recent session > user defaults)
       const configValues = {
-        permissionMode: mostRecentSession?.permission_config?.mode || agentDefaults?.permissionMode,
-        modelConfig: mostRecentSession?.model_config || agentDefaults?.modelConfig,
-        effort: mostRecentSession?.model_config?.effort ?? agentDefaults?.modelConfig?.effort,
+        permissionMode:
+          recentAgentSession?.permission_config?.mode || agentDefaults?.permissionMode,
+        modelConfig: recentAgentSession?.model_config || agentDefaults?.modelConfig,
+        effort: recentAgentSession?.model_config?.effort ?? agentDefaults?.modelConfig?.effort,
         mcpServerIds: form.getFieldValue('mcpServerIds') ?? effectiveMcpServerIds,
       };
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -10,6 +10,8 @@ import type {
   AgorClient,
   Branch,
   BranchID,
+  DefaultModelConfig,
+  EffortLevel,
   MCPServer,
   PermissionMode,
   Session,
@@ -29,13 +31,12 @@ import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
 // Async server-side renderer — keeps Handlebars out of the browser bundle so
 // the page doesn't need CSP `script-src 'unsafe-eval'`.
 import { renderTemplate } from '../../../utils/templates';
-import { AgenticToolConfigForm } from '../../AgenticToolConfigForm';
+import { AgenticToolConfigForm, buildModelConfigFromFormValues } from '../../AgenticToolConfigForm';
 import {
   AgenticToolConfigurationPicker,
   INLINE_AGENTIC_CONFIGURATION,
 } from '../../AgenticToolConfigurationPicker';
 import { AgentSelectionGrid } from '../../AgentSelectionGrid';
-import type { ModelConfig } from '../../ModelSelector';
 
 interface ZoneTriggerModalProps {
   open: boolean;
@@ -59,7 +60,7 @@ interface ZoneTriggerModalProps {
     // New session config (only when sessionId === 'new')
     agent?: string;
     agenticToolPresetId?: string;
-    modelConfig?: ModelConfig;
+    modelConfig?: DefaultModelConfig;
     permissionMode?: PermissionMode;
     mcpServerIds?: string[];
   }) => Promise<void>;
@@ -106,7 +107,8 @@ export const ZoneTriggerModal = ({
   // Explicit state for session config (survives form mount/unmount cycles)
   const [sessionConfig, setSessionConfig] = useState<{
     agenticToolPresetId?: string;
-    modelConfig?: ModelConfig;
+    modelConfig?: DefaultModelConfig;
+    effort?: EffortLevel;
     permissionMode?: PermissionMode;
     mcpServerIds?: string[];
   }>({});
@@ -182,9 +184,8 @@ export const ZoneTriggerModal = ({
       // Calculate config values (priority: most recent session > user defaults)
       const configValues = {
         permissionMode: mostRecentSession?.permission_config?.mode || agentDefaults?.permissionMode,
-        modelConfig:
-          mostRecentSession?.model_config ||
-          (agentDefaults?.modelConfig as ModelConfig | undefined),
+        modelConfig: mostRecentSession?.model_config || agentDefaults?.modelConfig,
+        effort: mostRecentSession?.model_config?.effort ?? agentDefaults?.modelConfig?.effort,
         mcpServerIds: form.getFieldValue('mcpServerIds') ?? effectiveMcpServerIds,
       };
 
@@ -202,6 +203,7 @@ export const ZoneTriggerModal = ({
         agent: selectedSession.agentic_tool,
         permissionMode: selectedSession.permission_config?.mode,
         modelConfig: selectedSession.model_config,
+        effort: selectedSession.model_config?.effort,
         // Note: mcpServerIds would need to be fetched separately if we want to show them
       });
     }
@@ -276,7 +278,7 @@ export const ZoneTriggerModal = ({
           sessionConfig.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION
             ? undefined
             : sessionConfig.agenticToolPresetId,
-        modelConfig: sessionConfig.modelConfig,
+        modelConfig: buildModelConfigFromFormValues(sessionConfig),
         permissionMode: sessionConfig.permissionMode,
         mcpServerIds: sessionConfig.mcpServerIds,
       });
@@ -297,7 +299,10 @@ export const ZoneTriggerModal = ({
       if (selectedAction === 'fork' || selectedAction === 'spawn') {
         // Include additional config for fork/spawn (eventual support for changing config)
         params.agent = formValues.agent || selectedSession?.agentic_tool;
-        params.modelConfig = formValues.modelConfig;
+        params.modelConfig = buildModelConfigFromFormValues({
+          modelConfig: formValues.modelConfig,
+          effort: formValues.effort,
+        });
         params.mcpServerIds = formValues.mcpServerIds;
       }
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -251,6 +251,22 @@ describe('SessionFooter', () => {
     expect(within(overflowOptions).getByText('Effort')).toBeInTheDocument();
     expect(within(overflowOptions).getByText('Inherited')).toBeInTheDocument();
   });
+
+  it('does not expose live reasoning effort for Claude Code CLI sessions', async () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        session={{ ...baseSession, agentic_tool: 'claude-code-cli' } as Session}
+        toolCaps={AGENTIC_TOOL_CAPABILITIES['claude-code-cli']}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    const overflowOptions = await screen.findByRole('group', { name: 'More options' });
+    expect(within(overflowOptions).queryByText('Effort')).not.toBeInTheDocument();
+    expect(within(overflowOptions).queryByTestId('effort-selector-stub')).not.toBeInTheDocument();
+  });
 });
 
 describe('useFooterPreferences', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -5,6 +5,7 @@ import type {
   PermissionMode,
   Session,
 } from '@agor-live/client';
+import { AGENTIC_TOOL_CAPABILITIES } from '@agor-live/client';
 import { act, fireEvent, render, renderHook, screen, within } from '@testing-library/react';
 import { App, ConfigProvider } from 'antd';
 import type React from 'react';
@@ -15,6 +16,11 @@ import { SessionFooter } from './SessionFooter';
 // ModelSelector makes async network calls — replace with a stub
 vi.mock('../ModelSelector', () => ({
   ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+vi.mock('../EffortSelector', () => ({
+  EffortSelector: ({ value }: { value?: EffortLevel }) => (
+    <div data-testid="effort-selector-stub">{value ?? 'Inherited'}</div>
+  ),
 }));
 
 // TimerPill uses complex internal state not needed for footer layout tests
@@ -227,6 +233,23 @@ describe('SessionFooter', () => {
 
     expect(await screen.findByText('Session MCP servers')).toBeInTheDocument();
     expect(screen.queryByText('Open session settings')).not.toBeInTheDocument();
+  });
+
+  it('shows inherited reasoning effort for Codex in session settings', async () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        session={{ ...baseSession, agentic_tool: 'codex' } as Session}
+        toolCaps={AGENTIC_TOOL_CAPABILITIES.codex}
+        effortLevel={undefined}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    const overflowOptions = await screen.findByRole('group', { name: 'More options' });
+    expect(within(overflowOptions).getByText('Effort')).toBeInTheDocument();
+    expect(within(overflowOptions).getByText('Inherited')).toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgenticToolCapabilities,
   AgorClient,
   CodexApprovalPolicy,
   CodexSandboxMode,
@@ -69,9 +70,9 @@ export interface SessionFooterProps {
   composerAttachmentsPresent?: boolean;
   composerAttachmentUploading?: boolean;
   connectionDisabled: boolean;
-  toolCaps?: { supportsSessionFork?: boolean; supportsChildSpawn?: boolean };
+  toolCaps?: AgenticToolCapabilities;
   // Settings state
-  effortLevel: EffortLevel;
+  effortLevel?: EffortLevel;
   permissionMode: PermissionMode;
   codexSandboxMode: CodexSandboxMode;
   codexApprovalPolicy: CodexApprovalPolicy;
@@ -89,7 +90,7 @@ export interface SessionFooterProps {
   onSpawnOpen: () => void;
   onAttachFiles: () => void;
   onUploadOpen: () => void;
-  onEffortChange: (v: EffortLevel) => void;
+  onEffortChange: (v: EffortLevel | undefined) => void;
   onPermissionModeChange: (v: PermissionMode) => void;
   onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
   // Prompt textarea rendered between the two bars
@@ -281,8 +282,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
         </div>
       </div>
 
-      {/* Effort — only for claude-code */}
-      {session.agentic_tool === 'claude-code' && (
+      {toolCaps?.reasoningEffortLevels && (
         <div style={{ ...overflowRowStyle, cursor: 'default' }}>
           <PercentageOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
@@ -309,6 +309,9 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
             <EffortSelector
               value={effortLevel}
               onChange={onEffortChange}
+              levels={toolCaps.reasoningEffortLevels}
+              fallbackValue={toolCaps.defaultReasoningEffort}
+              allowInherited={!toolCaps.defaultReasoningEffort}
               size="small"
               compact
               plain

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -143,6 +143,8 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   promptInputSlot,
 }) => {
   const managedByPreset = Boolean(session.agentic_tool_preset_id);
+  const supportsLiveEffort =
+    session.agentic_tool === 'claude-code' || session.agentic_tool === 'codex';
   const { token } = theme.useToken();
   const [moreOpen, setMoreOpen] = React.useState(false);
   const [prefs, setPref] = useFooterPreferences();
@@ -282,7 +284,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
         </div>
       </div>
 
-      {toolCaps?.reasoningEffortLevels && (
+      {supportsLiveEffort && toolCaps?.reasoningEffortLevels && (
         <div style={{ ...overflowRowStyle, cursor: 'default' }}>
           <PercentageOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -9,6 +9,7 @@ import type {
   Session,
   Task,
 } from '@agor-live/client';
+import { usesExecutorRuntime } from '@agor-live/client';
 import {
   BranchesOutlined,
   ClockCircleOutlined,
@@ -143,8 +144,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   promptInputSlot,
 }) => {
   const managedByPreset = Boolean(session.agentic_tool_preset_id);
-  const supportsLiveEffort =
-    session.agentic_tool === 'claude-code' || session.agentic_tool === 'codex';
+  const supportsLiveEffort = usesExecutorRuntime(session.agentic_tool);
   const { token } = theme.useToken();
   const [moreOpen, setMoreOpen] = React.useState(false);
   const [prefs, setPref] = useFooterPreferences();

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -457,8 +457,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [codexApprovalPolicy, setCodexApprovalPolicy] = React.useState<CodexApprovalPolicy>(
     session?.permission_config?.codex?.approvalPolicy ?? initialCodexDefaults.approvalPolicy
   );
-  const [effortLevel, setEffortLevel] = React.useState<EffortLevel>(
-    session?.model_config?.effort || 'high'
+  const [effortLevel, setEffortLevel] = React.useState<EffortLevel | undefined>(
+    session?.model_config?.effort ?? toolCaps?.defaultReasoningEffort
   );
   /**
    * Claude Code CLI view toggle: 'terminal' shows the embedded `claude`
@@ -716,10 +716,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   }, [session?.permission_config?.mode, session?.permission_config?.codex, session?.agentic_tool]);
 
-  // Update effort level when session changes (default to 'high' for sessions without effort config)
+  // Keep explicit overrides distinct from runtime-owned defaults (for example Codex config.toml).
   React.useEffect(() => {
-    setEffortLevel(session?.model_config?.effort || 'high');
-  }, [session?.model_config?.effort]);
+    setEffortLevel(session?.model_config?.effort ?? toolCaps?.defaultReasoningEffort);
+  }, [session?.model_config?.effort, toolCaps?.defaultReasoningEffort]);
 
   React.useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -769,7 +769,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     onSpawnOpen: () => void;
     onAttachFiles: () => void;
     onUploadOpen: () => void;
-    onEffortChange: (v: EffortLevel) => void;
+    onEffortChange: (v: EffortLevel | undefined) => void;
     onPermissionModeChange: (v: PermissionMode) => void;
     onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
   } | null>(null);
@@ -784,7 +784,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       onSpawnOpen: () => footerHandlersRef.current?.onSpawnOpen(),
       onAttachFiles: () => footerHandlersRef.current?.onAttachFiles(),
       onUploadOpen: () => footerHandlersRef.current?.onUploadOpen(),
-      onEffortChange: (v: EffortLevel) => footerHandlersRef.current?.onEffortChange(v),
+      onEffortChange: (v: EffortLevel | undefined) => footerHandlersRef.current?.onEffortChange(v),
       onPermissionModeChange: (v: PermissionMode) =>
         footerHandlersRef.current?.onPermissionModeChange(v),
       onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) =>
@@ -1274,18 +1274,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const handleEffortChange = (newEffort: EffortLevel) => {
+  const handleEffortChange = (newEffort: EffortLevel | undefined) => {
     setEffortLevel(newEffort);
 
-    if (session && onUpdateSession) {
-      if (session.model_config) {
-        onUpdateSession(session.session_id, {
-          model_config: {
-            ...session.model_config,
-            effort: newEffort,
-          },
-        });
-      }
+    if (session?.model_config && onUpdateSession) {
+      const nextModelConfig = {
+        ...session.model_config,
+        updated_at: new Date().toISOString(),
+      };
+      if (newEffort) nextModelConfig.effort = newEffort;
+      else delete nextModelConfig.effort;
+      onUpdateSession(session.session_id, { model_config: nextModelConfig });
     }
   };
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
@@ -21,8 +21,8 @@ export interface SessionRunSettingsPopoverProps {
   modelLabel?: string;
   modelConfig?: ModelConfig;
   onModelConfigChange: (config: ModelConfig) => void;
-  effortLevel: EffortLevel;
-  onEffortChange: (effort: EffortLevel) => void;
+  effortLevel?: EffortLevel;
+  onEffortChange: (effort: EffortLevel | undefined) => void;
   permissionMode: PermissionMode;
   onPermissionModeChange: (mode: PermissionMode) => void;
   codexSandboxMode: CodexSandboxMode;

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
@@ -22,10 +22,11 @@ vi.mock('../AgenticToolConfigurationPicker', () => ({
 }));
 // Chip-row stub that drives the shared `agenticToolPresetId` field.
 vi.mock('../AgenticConfigChipRow', () => ({
-  AgenticConfigChipRow: () => {
+  AgenticConfigChipRow: ({ showEffort = true }: { showEffort?: boolean }) => {
     const form = Form.useFormInstance();
     return (
       <div>
+        {showEffort && <div data-testid="effort-chip" />}
         <Form.Item name="agenticToolPresetId" hidden>
           <input />
         </Form.Item>
@@ -91,6 +92,20 @@ const codexSession = {
 } as unknown as Session;
 
 describe('SessionSettingsModal configuration', { timeout: 10_000 }, () => {
+  it('does not expose effort changes for an active Claude Code CLI session', () => {
+    render(
+      <SessionSettingsModal
+        open
+        onClose={vi.fn()}
+        session={{ ...claudeSession, agentic_tool: 'claude-code-cli' } as Session}
+        client={null}
+        currentUser={null}
+      />
+    );
+
+    expect(screen.queryByTestId('effort-chip')).not.toBeInTheDocument();
+  });
+
   it('persists MCP changes while a preset is selected', async () => {
     const onUpdateSessionMcpServers = vi.fn();
     render(

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -35,6 +35,7 @@ import { useThemedMessage } from '../../utils/message';
 import { AdvancedSettingsForm } from '../AdvancedSettingsForm';
 import { AgenticConfigChipRow } from '../AgenticConfigChipRow';
 import type { AgenticFormValues } from '../AgenticToolConfigForm';
+import { buildModelConfigFromFormValues } from '../AgenticToolConfigForm';
 import {
   INLINE_AGENTIC_CONFIGURATION,
   persistUserDefaultFromForm,
@@ -132,11 +133,14 @@ function buildUpdates(values: FormValues, session: Session): Partial<Session> {
   }
 
   if (!presetId && values.modelConfig) {
+    const modelConfig = buildModelConfigFromFormValues({
+      modelConfig: values.modelConfig,
+      effort: values.effort,
+    });
     updates.model_config = {
-      ...values.modelConfig,
-      ...(values.effort ? { effort: values.effort } : {}),
+      ...modelConfig,
       updated_at: new Date().toISOString(),
-    };
+    } as NonNullable<Session['model_config']>;
   }
 
   if (!presetId && values.permissionMode) {

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -436,6 +436,7 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
           currentUser={currentUser}
           client={client ?? null}
           enableSaveAsDefault
+          showEffort={session.agentic_tool !== 'claude-code-cli'}
         />
 
         {/* SECONDARY ZONE — niche settings, collapsed by default */}

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -24,7 +24,11 @@ import type {
   Session,
   User,
 } from '@agor-live/client';
-import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live/client';
+import {
+  getDefaultPermissionMode,
+  mapToCodexPermissionConfig,
+  usesExecutorRuntime,
+} from '@agor-live/client';
 import { DownOutlined, KeyOutlined, SettingOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import type { CollapseProps } from 'antd';
 import { Collapse, Divider, Form, Modal, Typography, theme } from 'antd';
@@ -436,7 +440,7 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
           currentUser={currentUser}
           client={client ?? null}
           enableSaveAsDefault
-          showEffort={session.agentic_tool !== 'claude-code-cli'}
+          showEffort={usesExecutorRuntime(session.agentic_tool)}
         />
 
         {/* SECONDARY ZONE — niche settings, collapsed by default */}

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -47,13 +47,45 @@ vi.mock('../AgentSelectionGrid', () => ({
     </div>
   ),
 }));
-vi.mock('../AgenticToolConfigForm', () => ({
-  AgenticToolConfigForm: () => <div data-testid="agent-config" />,
-}));
-vi.mock('../AgenticToolConfigurationPicker', () => ({
-  INLINE_AGENTIC_CONFIGURATION: '__inline__',
-  AgenticToolConfigurationPicker: () => <div data-testid="agent-config" />,
-}));
+vi.mock('../AgenticToolConfigForm', async () => {
+  const actual = await vi.importActual<typeof import('../AgenticToolConfigForm')>(
+    '../AgenticToolConfigForm'
+  );
+  return {
+    ...actual,
+    AgenticToolConfigForm: () => <div data-testid="agent-config" />,
+  };
+});
+vi.mock('../AgenticToolConfigurationPicker', async () => {
+  const { Form } = await vi.importActual<typeof import('antd')>('antd');
+  const EffortField = ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange?: (value: string | undefined) => void;
+  }) => (
+    <select
+      aria-label="gateway-effort"
+      value={value ?? ''}
+      onChange={(event) => onChange?.(event.target.value || undefined)}
+    >
+      <option value="">Inherited</option>
+      <option value="medium">Medium</option>
+      <option value="xhigh">X-High</option>
+    </select>
+  );
+  return {
+    INLINE_AGENTIC_CONFIGURATION: '__inline__',
+    AgenticToolConfigurationPicker: () => (
+      <div data-testid="agent-config">
+        <Form.Item name="effort" noStyle>
+          <EffortField />
+        </Form.Item>
+      </div>
+    ),
+  };
+});
 
 function renderWithProviders(ui: React.ReactElement) {
   return render(
@@ -637,6 +669,33 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
     expect(onUpdate.mock.calls[0][1]).toMatchObject({
       mcp_server_ids: ['mcp-server-1'],
+    });
+  });
+
+  it('rehydrates and persists a Codex reasoning-effort override', async () => {
+    const channel = {
+      ...makeSlackChannel(),
+      agentic_config: {
+        agent: 'codex',
+        modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+      },
+    } as unknown as GatewayChannel;
+    const onUpdate = vi.fn();
+
+    renderEditTable(null, channel, { onUpdate });
+    expandPanel('Agent Configuration');
+
+    const effort = screen.getByLabelText('gateway-effort');
+    expect(effort).toHaveValue('medium');
+    fireEvent.change(effort, { target: { value: 'xhigh' } });
+    clickButton(/^Save$/);
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][1]).toMatchObject({
+      agentic_config: {
+        agent: 'codex',
+        modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'xhigh' },
+      },
     });
   });
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -699,6 +699,29 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     });
   });
 
+  it('clears stale model and effort fields when switching to an agent without defaults', async () => {
+    const channel = {
+      ...makeSlackChannel(),
+      agentic_config: {
+        agent: 'codex',
+        modelConfig: { mode: 'alias', model: 'gpt-5.6-sol', effort: 'medium' },
+      },
+      mcp_server_ids: ['mcp-server-1'],
+    } as unknown as GatewayChannel;
+    const onUpdate = vi.fn();
+
+    renderEditTable(null, channel, { currentUser: makeUser(), onUpdate });
+    expandPanel('Agent Configuration');
+    clickButton(/^claude-code$/);
+    await waitFor(() => expect(screen.getByLabelText('gateway-effort')).toHaveValue(''));
+    clickButton(/^Save$/);
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    const update = onUpdate.mock.calls[0][1];
+    expect(update.agentic_config).not.toHaveProperty('modelConfig');
+    expect(update.mcp_server_ids).toEqual(['mcp-server-1']);
+  });
+
   it("applies the target agent's defaults when switching agents and back, instead of silently keeping stale fields", async () => {
     // A value-based guard (selectedAgent === persisted agent) would treat
     // switching away and back as "no-op" and skip re-applying defaults,

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -80,7 +80,7 @@ import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ACCESS_TOKEN_KEY } from '@/utils/tokenRefresh';
-import { buildModelConfigFromFormValues } from '../AgenticToolConfigForm';
+import { buildModelConfigFromFormValues, getFormValuesFromConfig } from '../AgenticToolConfigForm';
 import {
   AgenticToolConfigurationPicker,
   INLINE_AGENTIC_CONFIGURATION,
@@ -3214,17 +3214,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       return;
     }
     const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
-    if (agentDefaults) {
-      const activeForm = editModalOpen ? editForm : createForm;
-      activeForm.setFieldsValue({
-        permissionMode: agentDefaults.permissionMode,
-        modelConfig: agentDefaults.modelConfig,
-        effort: agentDefaults.modelConfig?.effort,
-        codexSandboxMode: agentDefaults.codexSandboxMode,
-        codexApprovalPolicy: agentDefaults.codexApprovalPolicy,
-        codexNetworkAccess: agentDefaults.codexNetworkAccess,
-      });
-    }
+    const activeForm = editModalOpen ? editForm : createForm;
+    activeForm.setFieldsValue(
+      getFormValuesFromConfig(selectedAgent as AgenticToolName, agentDefaults)
+    );
   }, [selectedAgent, currentUser, createForm, editForm, editModalOpen]);
 
   const extractFormData = (

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -14,6 +14,8 @@ import type {
   AgorClient,
   Branch,
   ChannelType,
+  DefaultModelConfig,
+  EffortLevel,
   GatewayAgenticConfig,
   GatewayChannel,
   GatewayConnectionTestResult,
@@ -78,6 +80,7 @@ import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ACCESS_TOKEN_KEY } from '@/utils/tokenRefresh';
+import { buildModelConfigFromFormValues } from '../AgenticToolConfigForm';
 import {
   AgenticToolConfigurationPicker,
   INLINE_AGENTIC_CONFIGURATION,
@@ -3216,6 +3219,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       activeForm.setFieldsValue({
         permissionMode: agentDefaults.permissionMode,
         modelConfig: agentDefaults.modelConfig,
+        effort: agentDefaults.modelConfig?.effort,
         codexSandboxMode: agentDefaults.codexSandboxMode,
         codexApprovalPolicy: agentDefaults.codexApprovalPolicy,
         codexNetworkAccess: agentDefaults.codexNetworkAccess,
@@ -3337,15 +3341,19 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       values.agenticToolPresetId && values.agenticToolPresetId !== INLINE_AGENTIC_CONFIGURATION
         ? (values.agenticToolPresetId as GatewayAgenticConfig['presetId'])
         : undefined;
+    const modelConfig = !presetId
+      ? buildModelConfigFromFormValues({
+          modelConfig: values.modelConfig as DefaultModelConfig | undefined,
+          effort: values.effort as EffortLevel | undefined,
+        })
+      : undefined;
     const agenticConfig: GatewayAgenticConfig = {
       agent: (agent || 'claude-code') as AgenticToolName,
       ...(presetId ? { presetId } : {}),
       ...(!presetId && values.permissionMode
         ? { permissionMode: values.permissionMode as PermissionMode }
         : {}),
-      ...(!presetId && values.modelConfig
-        ? { modelConfig: values.modelConfig as GatewayAgenticConfig['modelConfig'] }
-        : {}),
+      ...(modelConfig ? { modelConfig } : {}),
       ...(!presetId && values.codexSandboxMode
         ? { codexSandboxMode: values.codexSandboxMode as GatewayAgenticConfig['codexSandboxMode'] }
         : {}),
@@ -3500,6 +3508,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       // Agentic config fields
       permissionMode: channel.agentic_config?.permissionMode,
       modelConfig: channel.agentic_config?.modelConfig,
+      effort: channel.agentic_config?.modelConfig?.effort,
       mcpServerIds: channel.mcp_server_ids ?? [],
       codexSandboxMode: channel.agentic_config?.codexSandboxMode,
       codexApprovalPolicy: channel.agentic_config?.codexApprovalPolicy,

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -169,6 +169,27 @@ describe('resolveSessionDefaults', () => {
       expect(r.model_config).toBeUndefined();
     });
 
+    it('leaves Codex effort unset when no Agor override is configured', () => {
+      const r = resolveSessionDefaults({ agenticTool: 'codex', now });
+      expect(r.model_config).toMatchObject({
+        mode: 'alias',
+        model: 'gpt-5.6-sol',
+      });
+      expect(r.model_config).not.toHaveProperty('effort');
+    });
+
+    it('preserves an explicit Codex effort override', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        overrides: { modelConfig: { effort: 'xhigh' } },
+        now,
+      });
+      expect(r.model_config).toMatchObject({
+        model: 'gpt-5.6-sol',
+        effort: 'xhigh',
+      });
+    });
+
     it("uses the user's tool default model when present", () => {
       const r = resolveSessionDefaults({
         agenticTool: 'claude-code',

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -1,6 +1,7 @@
 // src/types/agentic-tool.ts
 
 import type { AgenticToolID } from './id';
+import type { EffortLevel } from './session';
 
 /**
  * The set of credential env-var names the resolver knows how to look up.
@@ -195,6 +196,16 @@ export interface AgenticToolCapabilities {
   supportsSessionImport: boolean;
   /** Supports stateless filesystem mode (session state serialized to DB) */
   supportsStatelessFsMode: boolean;
+  /**
+   * Supported reasoning-effort overrides. Absent when the runtime has no
+   * effort control.
+   */
+  reasoningEffortLevels?: readonly EffortLevel[];
+  /**
+   * Effective effort when Agor does not store an override. Absent means the
+   * underlying runtime owns the default.
+   */
+  defaultReasoningEffort?: EffortLevel;
 }
 
 /**
@@ -319,6 +330,8 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     supportsChildSpawn: true,
     supportsSessionImport: true,
     supportsStatelessFsMode: true,
+    reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    defaultReasoningEffort: 'high',
   },
   'claude-code-cli': {
     // First-class CLI flag: `claude --resume <id> --fork-session`
@@ -331,12 +344,15 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     // CLI sessions live in long-running PTYs; state is on disk in the JSONL,
     // not a serializable filesystem snapshot the daemon manages.
     supportsStatelessFsMode: false,
+    reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    defaultReasoningEffort: 'high',
   },
   codex: {
     supportsSessionFork: true,
     supportsChildSpawn: true,
     supportsSessionImport: false,
     supportsStatelessFsMode: true,
+    reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh'],
   },
   gemini: {
     supportsSessionFork: false,

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -1,8 +1,8 @@
 // src/types/session.ts
 
 /**
- * Effort level controls how much reasoning Claude applies.
- * Maps to Claude API's output_config.effort and the Claude Code CLI's --effort flag.
+ * Effort level controls how much reasoning a supported agent applies.
+ * Runtime adapters map this shared value to their native effort option.
  */
 export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
@@ -257,7 +257,7 @@ export interface Session {
     updated_at: string;
     /** Optional user notes about why this model was selected */
     notes?: string;
-    /** Effort level for reasoning depth (default: high) */
+    /** Optional session override for reasoning depth; unset delegates to the runtime default. */
     effort?: EffortLevel;
     /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable'); unset means no session override */
     advisorModel?: string;

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -50,6 +50,8 @@ let mockInstanceConfigs: Array<unknown> = [];
 let mockClosedInstanceIds: number[] = [];
 let mockStreamEvents: Array<Record<string, unknown>> = [];
 let mockStartThreadId: string | undefined = 'mock-thread-id';
+let mockStartThreadOptions: unknown[] = [];
+let mockResumeThreadOptions: unknown[] = [];
 
 async function* streamMockEvents() {
   for (const event of mockStreamEvents) {
@@ -81,7 +83,8 @@ vi.mock('@agor/core/sdk', () => {
       mockClosedInstanceIds.push(this.instanceId);
     }
 
-    startThread() {
+    startThread(options: unknown) {
+      mockStartThreadOptions.push(options);
       return {
         id: mockStartThreadId,
         run: vi.fn(),
@@ -89,7 +92,8 @@ vi.mock('@agor/core/sdk', () => {
       };
     }
 
-    resumeThread(threadId: string) {
+    resumeThread(threadId: string, options: unknown) {
+      mockResumeThreadOptions.push(options);
       return {
         id: threadId,
         run: vi.fn(),
@@ -127,6 +131,8 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
     mockStartThreadId = 'mock-thread-id';
+    mockStartThreadOptions = [];
+    mockResumeThreadOptions = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
@@ -317,6 +323,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     mockInstanceConfigs = [];
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
+    mockStartThreadOptions = [];
+    mockResumeThreadOptions = [];
     delete process.env.OPENAI_BASE_URL;
     delete process.env.AGOR_CODEX_SANDBOX_MODE;
     vi.clearAllMocks();
@@ -483,7 +491,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
         ...(persistedPermissionMode ? { mode: persistedPermissionMode } : {}),
         codex: codexPermissions,
       },
-      model_config: {},
+      model_config: { effort: 'medium' },
       mcp_token: 'test-token',
     });
     mockSessionsRepo.update.mockResolvedValue(undefined);
@@ -524,6 +532,9 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     ]);
     expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
       threadId: 'mock-thread-id',
+    });
+    expect(mockStartThreadOptions.at(-1)).toMatchObject({
+      modelReasoningEffort: 'medium',
     });
   });
 
@@ -604,6 +615,8 @@ describe('CodexPromptService - forked sessions', () => {
     mockInstanceConfigs = [];
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
+    mockStartThreadOptions = [];
+    mockResumeThreadOptions = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
@@ -640,7 +653,7 @@ describe('CodexPromptService - forked sessions', () => {
       sdk_session_id: null,
       genealogy: { forked_from_session_id: 'parent-session' },
       permission_config: { codex: {} },
-      model_config: {},
+      model_config: { effort: 'max' },
       mcp_token: 'test-token',
     };
     const parentSession = {
@@ -686,6 +699,9 @@ describe('CodexPromptService - forked sessions', () => {
     });
     expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
       threadId: 'forked-thread-id',
+    });
+    expect(mockResumeThreadOptions.at(-1)).toMatchObject({
+      modelReasoningEffort: 'xhigh',
     });
   });
 });


### PR DESCRIPTION
## Linked issue

Fixes #2014

## Summary

- Expose reasoning-effort controls for Codex across shared configuration surfaces.
- Preserve an unset Codex effort as inherited runtime configuration.
- Reuse the existing effort selector and model configuration persistence paths for sessions, defaults, schedules, gateways, and fork/spawn flows.

## Why / context

Codex already accepts per-thread reasoning-effort overrides, but Agor only exposed the shared effort control for Claude. Users could not see or configure whether a Codex session inherited its runtime default or used an explicit override.

## Screenshot
<img width="605" height="410" alt="Screenshot 2026-07-24 at 12 16 45" src="https://github.com/user-attachments/assets/9fa9dcb1-b127-4ac6-9a07-2b1eabd810b4" />


## Implementation notes

- Define supported effort levels and default ownership in the existing agent capability map.
- Extend the shared selector with tool-specific levels and an explicit inherited state.
- Centralize form-to-model serialization so clearing an override removes stale effort values without changing the selected model or other configuration.
- Keep Claude behavior unchanged and omit the control for unsupported tools.
- No schema migration or new API field is introduced.

## Validation / test plan

- [x] `pnpm --filter agor-ui test` — 170 files, 1,110 tests passed
- [x] Core session-default resolver tests — 29 passed
- [x] Codex prompt-service tests — 50 passed
- [x] Biome checks passed for the changed files
- [x] Manually created and resumed a Codex session, changed the effort from inherited to low, and verified the stored session configuration and runtime turn metadata both reported `low`

## Screenshots / demos

- Manually verified the Codex effort selector in the new-session and active-session flows.

## Risks / rollout / rollback

The change uses existing session configuration fields and executor plumbing, so rollout requires no migration. The main compatibility risk is accidentally persisting an inherited value or changing Claude behavior; focused coverage exercises both boundaries. Rollback is a normal revert of this commit.

## Out of scope / follow-ups

- Reading or exposing arbitrary Codex configuration files.
- Inferring the runtime's resolved default when Agor sends no override.
- Adding effort controls to runtimes that do not expose compatible support.
