### PR TITLE
Add HubSpot tracking loader to the docs site

### DIFF
--- a/apps/agor-docs/app/layout.tsx
+++ b/apps/agor-docs/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Head } from 'nextra/components';
 import 'nextra-theme-docs/style.css';
 import { Hanken_Grotesk, JetBrains_Mono, Space_Grotesk } from 'next/font/google';
+import Script from 'next/script';
 import type { ReactNode } from 'react';
 import { DocsAuroraBackground } from '../components/DocsAuroraBackground';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
@@ -129,6 +130,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <DocsAuroraBackground />
         {children}
+        {/* HubSpot tracking / embed loader (portal 246818610). */}
+        <Script
+          id="hs-script-loader"
+          strategy="afterInteractive"
+          src="https://js-na2.hs-scripts.com/246818610.js"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
Loads the HubSpot embed/tracking script (portal `246818610`) on every page of the docs site (agor.live).

- Added via `next/script` with `strategy="afterInteractive"` in the root layout, mirroring the existing HubSpot forms `Script` usage in `HubSpotForm.tsx`.
- Used an explicit `https://` src instead of the protocol-relative `//` from the HubSpot snippet.
- Verified: `pnpm build` succeeds and the loader is inlined into the static-export HTML across all pages (home page and 90 others).

```html
<!-- equivalent of the HubSpot embed code -->
<script id="hs-script-loader" async defer src="https://js-na2.hs-scripts.com/246818610.js"></script>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)