### PR TITLE
feat(ui): show active environment variant on branch card

### DIFF
--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -95,6 +95,14 @@ export function BranchHeaderPill({
   const env = branch.environment_instance;
   const inferredState = getEnvironmentState(env);
   const environmentUrl = branch.app_url;
+  // Surface the active environment variant name on the label instead of the
+  // generic "env" — only when the repo defines more than one variant to
+  // distinguish (single-variant / v1 repos stay quiet as "env"). Mirrors
+  // EnvironmentPill on the board card.
+  const variantCount = repo.environment ? Object.keys(repo.environment.variants ?? {}).length : 0;
+  const envLabel =
+    branch.environment_variant && variantCount > 1 ? branch.environment_variant : 'env';
+  const variantPrefix = envLabel !== 'env' ? `${envLabel} · ` : '';
   // If a parent has loaded effective branch access (e.g. BranchModal), honor
   // that explicit decision. Otherwise do not infer from direct ownership or
   // `others_can`: group grants are not present on this branch payload, and the
@@ -299,7 +307,7 @@ export function BranchHeaderPill({
             <>
               {/* Env label — clickable to env URL when running, otherwise opens env tab */}
               {isRunning && environmentUrl ? (
-                <Tooltip title={`Open ${environmentUrl}`}>
+                <Tooltip title={`${variantPrefix}Open ${environmentUrl}`}>
                   <a
                     href={environmentUrl}
                     target="_blank"
@@ -315,11 +323,13 @@ export function BranchHeaderPill({
                     }}
                   >
                     <EnvironmentStatusIcon state={inferredState} size={11} />
-                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>
+                      {envLabel}
+                    </span>
                   </a>
                 </Tooltip>
               ) : (
-                <Tooltip title={getEnvTooltip()}>
+                <Tooltip title={`${variantPrefix}${getEnvTooltip()}`}>
                   <button
                     type="button"
                     onClick={openTab('environment')}
@@ -336,7 +346,9 @@ export function BranchHeaderPill({
                     }}
                   >
                     <EnvironmentStatusIcon state={inferredState} size={11} />
-                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>
+                      {envLabel}
+                    </span>
                   </button>
                 </Tooltip>
               )}

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -112,4 +112,51 @@ describe('EnvironmentPill', () => {
 
     expect(screen.getByRole('button', { name: 'Nuke environment' })).toBeInTheDocument();
   });
+
+  it('surfaces the active variant name when the repo defines multiple variants', () => {
+    const multiVariantRepo = {
+      repo_id: 'repo-2',
+      slug: 'tzercin/agor',
+      environment: {
+        version: 2,
+        default: 'sqlite',
+        variants: {
+          sqlite: { start: 'pnpm dev', stop: 'pnpm stop' },
+          postgres: { start: 'pnpm dev:pg', stop: 'pnpm stop' },
+        },
+      },
+    } as unknown as Repo;
+    const pgBranch = {
+      ...branch,
+      environment_variant: 'postgres',
+    } as Branch;
+
+    render(<EnvironmentPill {...defaultProps} repo={multiVariantRepo} branch={pgBranch} />);
+
+    expect(screen.getByText('postgres')).toBeInTheDocument();
+    expect(screen.queryByText('env')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the generic "env" label when only one variant exists', () => {
+    const singleVariantRepo = {
+      repo_id: 'repo-3',
+      slug: 'tzercin/agor',
+      environment: {
+        version: 2,
+        default: 'default',
+        variants: {
+          default: { start: 'pnpm dev', stop: 'pnpm stop' },
+        },
+      },
+    } as unknown as Repo;
+    const singleBranch = {
+      ...branch,
+      environment_variant: 'default',
+    } as Branch;
+
+    render(<EnvironmentPill {...defaultProps} repo={singleVariantRepo} branch={singleBranch} />);
+
+    expect(screen.getByText('env')).toBeInTheDocument();
+    expect(screen.queryByText('default')).not.toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -57,6 +57,18 @@ export function EnvironmentPill({
   // Get static app_url (user-editable, initialized from template)
   const environmentUrl = branch.app_url;
 
+  // Surface the active environment variant name on the pill instead of the
+  // generic "env" label — but only when the repo actually defines more than one
+  // variant to distinguish. Single-variant repos (and v1 configs, whose lone
+  // variant is named "default") stay quiet as "env" to avoid noise, mirroring
+  // the StorageModePill "quiet default" philosophy.
+  const variantCount = repo.environment ? Object.keys(repo.environment.variants ?? {}).length : 0;
+  const activeVariant = branch.environment_variant;
+  const envLabel = activeVariant && variantCount > 1 ? activeVariant : 'env';
+  // When a specific variant is surfaced, prefix tooltips with its name so the
+  // hover text still explains what the (now variant-named) label represents.
+  const variantPrefix = envLabel !== 'env' ? `${envLabel} · ` : '';
+
   // Case 1: No config at all - show grayed discovery pill
   if (!hasConfig) {
     return (
@@ -179,7 +191,7 @@ export function EnvironmentPill({
       >
         {/* Left section - clickable to open URL (when running) */}
         {env?.status === 'running' && environmentUrl ? (
-          <Tooltip title={`Open environment - ${environmentUrl}`}>
+          <Tooltip title={`${variantPrefix}Open environment - ${environmentUrl}`}>
             <a
               href={environmentUrl}
               target="_blank"
@@ -197,12 +209,12 @@ export function EnvironmentPill({
             >
               <Space size={4} align="center">
                 <EnvironmentStatusIcon state={inferredState} size={12} />
-                <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>env</span>
+                <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>{envLabel}</span>
               </Space>
             </a>
           </Tooltip>
         ) : (
-          <Tooltip title={getTooltipText()}>
+          <Tooltip title={`${variantPrefix}${getTooltipText()}`}>
             <div
               style={{
                 padding: '0 7px',
@@ -214,7 +226,7 @@ export function EnvironmentPill({
             >
               <Space size={4} align="center">
                 <EnvironmentStatusIcon state={inferredState} size={12} />
-                <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>env</span>
+                <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>{envLabel}</span>
               </Space>
             </div>
           </Tooltip>


### PR DESCRIPTION
## Problem

When an environment is started on a branch, the board's branch card showed a generic pill labeled just **"env"** — it did not indicate which environment variant (e.g. `sqlite` / `postgres` / `full` / `docs`) was currently selected or running. Users couldn't tell at a glance which variant was active without opening the branch.

## Change

Surface `branch.environment_variant` as the pill label whenever the repo defines **more than one** variant to distinguish:

- **`EnvironmentPill`** (board branch card) and **`BranchHeaderPill`** now render the active variant name (e.g. `postgres`) in place of the generic `env` label.
- The running-vs-stopped state indicator (`EnvironmentStatusIcon`) is unchanged, so state is still visible alongside the variant name.
- Tooltips are prefixed with the variant name (`postgres · Open environment …`) so hover text still explains what the now variant-named label represents.

### Quiet default

Single-variant repos — and v1 configs whose lone variant is named `default` — stay quiet as `env` to avoid noise, mirroring the `StorageModePill` "quiet default" philosophy. The variant name only appears when there's an actual choice to disambiguate.

## Tests

Added `EnvironmentPill` cases covering:
- multi-variant repo → active variant name (`postgres`) is shown, generic `env` is not.
- single-variant repo → falls back to `env`, variant name (`default`) is not shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)