### PR TITLE
Scope filesystem data by tenant

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1186,7 +1186,7 @@ async function resolveGatewayUploadFilePath(
   if (!trimmed) throw new Error('path is required');
 
   if (path.isAbsolute(trimmed)) {
-    const uploadDir = getUploadDirectory();
+    const uploadDir = getUploadDirectory(ctx.baseServiceParams.tenant?.tenant_id);
     const uploadRoot = await realpath(uploadDir).catch(() => path.resolve(uploadDir));
     const canonical = await canonicalizeExistingPrefix(trimmed);
     if (!isPathInsideRoot(uploadRoot, canonical)) {
@@ -1723,7 +1723,11 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
       if (typeof botToken !== 'string' || !botToken) {
         throw new Error(`Gateway channel ${target.channel.id} has no bot token configured.`);
       }
-      const { paths } = await ingestInboundAttachments({ files: [file], botToken });
+      const { paths } = await ingestInboundAttachments({
+        files: [file],
+        botToken,
+        tenantId: ctx.baseServiceParams.tenant?.tenant_id,
+      });
       const storedPath = paths[0];
       if (!storedPath) {
         throw new Error(

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -12,6 +12,7 @@ import { analyticsLogger } from '@agor/core/analytics';
 import {
   createUserProcessEnvironment,
   ENVIRONMENT,
+  getBranchesDir,
   loadConfig,
   PAGINATION,
   resolveExecutionSecurityMode,
@@ -1281,6 +1282,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    */
   async remove(id: BranchID, params?: BranchParams): Promise<Branch> {
     const { deleteFromFilesystem } = params?.query || {};
+    const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
 
     // Get branch details before deletion
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
@@ -1319,6 +1321,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               params: {
                 branchId: branch.branch_id,
                 branchPath: branch.path,
+                branchesRoot: getBranchesDir(tenantId),
                 deleteDbRecord: false, // Already deleted above
                 // Clean up the branch if it was created by Agor
                 branch: branch.ref,
@@ -1428,6 +1431,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         });
     } else if (filesystemAction === 'deleted') {
       console.log(`🗑️  Spawning executor to delete branch from filesystem: ${branch.path}`);
+      const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
 
       // No user impersonation for infrastructure operations — the daemon user
       // owns all branches and impersonation would resolve getBranchesDir()
@@ -1454,6 +1458,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               params: {
                 branchId: branch.branch_id,
                 branchPath: branch.path,
+                branchesRoot: getBranchesDir(tenantId),
                 deleteDbRecord: false, // Daemon handles DB deletion separately
                 // Clean up the branch if it was created by Agor
                 branch: branch.ref,

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1148,18 +1148,21 @@ describe('GatewayService Slack attachment ingestion', () => {
       connector: {},
     });
 
-    const result = await service.create({
-      channel_key: 'slack-key',
-      thread_id: 'D123-100.000000',
-      text: 'what does this screenshot show?',
-      files: inboundFiles,
-      metadata: dmMetadata,
-    });
+    const result = await runWithTenantContext('tenant-channel', () =>
+      service.create({
+        channel_key: 'slack-key',
+        thread_id: 'D123-100.000000',
+        text: 'what does this screenshot show?',
+        files: inboundFiles,
+        metadata: dmMetadata,
+      })
+    );
 
     expect(result).toMatchObject({ success: true, sessionId: 'sess-1' });
     expect(ingestInboundAttachments).toHaveBeenCalledWith({
       files: inboundFiles,
       botToken: 'xoxb-test',
+      tenantId: 'tenant-channel',
     });
     const prompt = promptCreate.mock.calls[0][0].prompt as string;
     expect(prompt).toContain('Attached files:\n- /home/agor/.agor/uploads/screenshot_1.png');

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -2433,6 +2433,7 @@ export class GatewayService {
           const { paths, failed } = await ingestInboundAttachments({
             files: data.files,
             botToken,
+            tenantId: getCurrentTenantId(),
           });
           failedAttachments = failed;
           if (paths.length > 0) {

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -14,6 +14,9 @@ import path from 'node:path';
 import {
   ensureBranchStorageModeAllowed,
   extractSlugFromUrl,
+  getBranchesDir,
+  getBranchPath,
+  getReposDir,
   isValidGitUrl,
   isValidSlug,
   normalizeRepoUrl,
@@ -38,12 +41,7 @@ import {
   scanGitConfigRemoteCredentials,
   scrubGitConfigRemoteCredentials,
 } from '@agor/core/git/exec';
-import {
-  getBranchPath,
-  getReposDir,
-  redactGitUrlCredentials,
-  stripGitUrlCredentials,
-} from '@agor/core/git/pure';
+import { redactGitUrlCredentials, stripGitUrlCredentials } from '@agor/core/git/pure';
 import type {
   AuthenticatedParams,
   Branch,
@@ -255,7 +253,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // local_path is computed best-effort (mirrors what the executor will use).
     // Use the slug, not the URL basename, so two remotes with the same repo
     // name but distinct Agor slugs do not collide on disk.
-    const expectedLocalPath = path.join(getReposDir(), slug);
+    const tenantId = (params as AuthenticatedParams | undefined)?.tenant?.tenant_id;
+    const expectedLocalPath = path.join(getReposDir(tenantId), slug);
     const placeholder = (await this.create(
       {
         slug: slug as RepoSlug,
@@ -737,7 +736,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       }
     }
 
-    const branchPath = getBranchPath(repo.slug, data.name);
+    const tenantId = (params as AuthenticatedParams | undefined)?.tenant?.tenant_id;
+    const branchPath = getBranchPath(repo.slug, data.name, tenantId);
 
     // Path existence + branch-in-use checks have moved to the executor /
     // core git helpers — see the "filesystem preflights" note above. Both
@@ -1209,6 +1209,10 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           daemonUrl: getDaemonUrl(),
           params: {
             repoId: repo.repo_id,
+            reposRoot: getReposDir((params as AuthenticatedParams | undefined)?.tenant?.tenant_id),
+            branchesRoot: getBranchesDir(
+              (params as AuthenticatedParams | undefined)?.tenant?.tenant_id
+            ),
           },
         },
         {

--- a/apps/agor-daemon/src/utils/gateway-attachments.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.ts
@@ -157,9 +157,10 @@ export async function ingestInboundAttachments(args: {
   botToken: string;
   fetchImpl?: typeof fetch;
   uploadDir?: string;
+  tenantId?: string;
 }): Promise<AttachmentIngestResult> {
   const fetchImpl = args.fetchImpl ?? fetch;
-  const uploadDir = args.uploadDir ?? getUploadDirectory();
+  const uploadDir = args.uploadDir ?? getUploadDirectory(args.tenantId);
 
   const ingestable = args.files.filter(isIngestableFile);
   const paths: string[] = [];

--- a/apps/agor-daemon/src/utils/upload.ts
+++ b/apps/agor-daemon/src/utils/upload.ts
@@ -6,7 +6,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { getAgorHome } from '@agor/core/config';
+import { getTenantDataRoot } from '@agor/core/config';
 import type { NextFunction, Request, Response } from 'express';
 import multer from 'multer';
 
@@ -56,8 +56,8 @@ const LEGACY_IGNORED_UPLOAD_DESTINATIONS = new Set(['branch', 'global']);
 /**
  * Resolve the only supported daemon-side upload directory.
  */
-export function getUploadDirectory(): string {
-  return path.join(getAgorHome(), 'uploads');
+export function getUploadDirectory(tenantId?: string): string {
+  return path.join(getTenantDataRoot(tenantId), 'uploads');
 }
 
 export function validateUploadDestinationQuery(destination: unknown): void {
@@ -118,7 +118,9 @@ export function createUploadStorage() {
           );
         }
 
-        const dest = getUploadDirectory();
+        const tenantId = (req as Request & { feathers?: { tenant?: { tenant_id?: string } } })
+          .feathers?.tenant?.tenant_id;
+        const dest = getUploadDirectory(tenantId);
 
         if (DEBUG_UPLOAD) console.log(`📁 [Upload Storage] Target directory: ${dest}`);
 

--- a/apps/agor-docs/components/MermaidZoom.tsx
+++ b/apps/agor-docs/components/MermaidZoom.tsx
@@ -94,7 +94,6 @@ export function MermaidZoom() {
       onClick={close}
       onKeyDown={(e) => e.key === 'Escape' && close()}
     >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: buttons carry their own handlers; this only stops backdrop close */}
       <div className={styles.toolbar} onClick={(e) => e.stopPropagation()}>
         <button
           type="button"
@@ -117,7 +116,6 @@ export function MermaidZoom() {
           ✕
         </button>
       </div>
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop handles keys; this just stops propagation */}
       <div
         ref={viewportRef}
         className={styles.viewport}

--- a/apps/agor-docs/content/guide/_meta.ts
+++ b/apps/agor-docs/content/guide/_meta.ts
@@ -40,6 +40,7 @@ export default {
     type: 'separator',
     title: 'Deployment',
   },
+  'multi-tenant-filesystem': 'Multi-Tenant Filesystem',
   'multiplayer-unix-isolation': 'Full Multiplayer Mode',
   'containerized-execution': 'Containerized Execution',
 };

--- a/apps/agor-docs/content/guide/multi-tenant-filesystem.mdx
+++ b/apps/agor-docs/content/guide/multi-tenant-filesystem.mdx
@@ -1,0 +1,77 @@
+---
+title: Multi-Tenant Filesystem
+description: Configure tenant-isolated repositories, branches, and uploads for hosted Agor deployments.
+---
+
+# Multi-Tenant Filesystem
+
+Agor can partition tenant-owned files while keeping daemon state shared. This
+is intended for hosted deployments that resolve tenant identity from trusted
+authentication.
+
+## Configuration
+
+```yaml
+multi_tenancy:
+  mode: required_from_auth
+  auth_claim: tenant_id
+  filesystem_isolation_enabled: true
+  tenants_base_folder: ~/.agor/tenants
+```
+
+`filesystem_isolation_enabled` defaults to `false`, preserving the existing
+single-tenant layout. It is required when `mode` is `required_from_auth`; the
+daemon rejects that mode without filesystem isolation.
+
+`tenants_base_folder` may be absolute, such as `/data/agor-tenants`, or relative
+to the daemon home (`~/.agor`). Its default is `~/.agor/tenants`.
+
+## Filesystem layout
+
+With filesystem isolation enabled, Agor creates directories lazily:
+
+```text
+~/.agor/
+  tenants/
+    <tenant-id>/
+      repos/
+      worktrees/
+      uploads/
+  agor.db
+  config.yaml
+```
+
+Repository clones, branch directories, direct uploads, and gateway attachment
+uploads are tenant-scoped. `agor.db` and `config.yaml` remain shared daemon
+state under `~/.agor`.
+
+In the default single-tenant mode, paths remain unchanged:
+
+```text
+~/.agor/
+  repos/
+  worktrees/
+  uploads/
+  agor.db
+  config.yaml
+```
+
+## User homes and container mounts
+
+Agor does not provision or relocate Unix user home directories as part of this
+setting. In Kubernetes or another container scheduler, user-home persistence is
+an executor provisioning responsibility. A deployment may mount a stable home
+for the Agor user together with only the authorized branch paths, using
+read-only or read-write mounts according to its RBAC policy.
+
+Tenant filesystem isolation determines where daemon-managed data lives; it
+does not require mounting the entire tenant root into every executor.
+
+## Migration
+
+Enabling filesystem isolation does **not** move existing repositories,
+worktrees, or uploads. Configure it for a new multi-tenant deployment, or move
+existing tenant data into the target topology while the daemon is stopped.
+Database rows containing filesystem paths must agree with the resulting
+locations.
+

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs:dev": "pnpm --filter @agor/docs dev",
     "docs:build": "pnpm --filter @agor/docs build",
     "docs:generate": "pnpm --filter @agor/docs generate",
-    "lint": "biome check --diagnostic-level=warn . && node scripts/test-frontend-color-plugins.mjs",
+    "lint": "biome check --diagnostic-level=warn --error-on-warnings . && node scripts/test-frontend-color-plugins.mjs",
     "lint:fix": "biome check --write .",
     "format": "prettier --write .",
     "test": "turbo run test",

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -20,6 +20,7 @@ import {
   getDataHome,
   getDefaultConfig,
   getReposDir,
+  getTenantDataRoot,
   initConfig,
   isBranchRbacEnabled,
   isUnixGroupRefreshNeeded,
@@ -1322,6 +1323,82 @@ describe('getReposDir', () => {
 
     const reposDir = getReposDir();
     expect(reposDir).toBe('/env/data/repos');
+  });
+});
+
+describe('getTenantDataRoot', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-tenant-path-test-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+    delete process.env.AGOR_DATA_HOME;
+    __resetConfigCacheForTests();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    __resetConfigCacheForTests();
+  });
+
+  async function writeConfig(multi_tenancy: NonNullable<AgorConfig['multi_tenancy']>) {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(path.join(agorDir, 'config.yaml'), yaml.dump({ multi_tenancy }), 'utf-8');
+    __resetConfigCacheForTests();
+  }
+
+  it('preserves the flat data root when multi-tenancy is disabled', () => {
+    expect(getTenantDataRoot()).toBe(path.join(tempDir, '.agor'));
+  });
+
+  it('uses the default tenant base folder when enabled', async () => {
+    await writeConfig({ enabled: true });
+
+    expect(getTenantDataRoot('tenant-a')).toBe(path.join(tempDir, '.agor', 'tenants', 'tenant-a'));
+    expect(getReposDir('tenant-a')).toBe(
+      path.join(tempDir, '.agor', 'tenants', 'tenant-a', 'repos')
+    );
+    expect(getBranchPath('org/repo', 'feature', 'tenant-a')).toBe(
+      path.join(tempDir, '.agor', 'tenants', 'tenant-a', 'worktrees', 'org/repo', 'feature')
+    );
+  });
+
+  it('resolves relative tenant base folders from the daemon home', async () => {
+    await writeConfig({ enabled: true, tenants_base_folder: 'tenant-volume' });
+
+    expect(getTenantDataRoot('tenant-b')).toBe(
+      path.join(tempDir, '.agor', 'tenant-volume', 'tenant-b')
+    );
+  });
+
+  it('supports absolute and home-relative tenant base folders', async () => {
+    await writeConfig({ enabled: true, tenants_base_folder: '/data/agor-tenants' });
+    expect(getTenantDataRoot('tenant-c')).toBe('/data/agor-tenants/tenant-c');
+
+    await writeConfig({ enabled: true, tenants_base_folder: '~/mounted-tenants' });
+    expect(getTenantDataRoot('tenant-c')).toBe(path.join(tempDir, 'mounted-tenants', 'tenant-c'));
+  });
+
+  it('requires a safe tenant id when enabled', async () => {
+    await writeConfig({ enabled: true });
+
+    expect(() => getTenantDataRoot()).toThrow(/valid tenant id/i);
+    expect(() => getTenantDataRoot('../escape')).toThrow(/valid tenant id/i);
+  });
+
+  it('fails closed instead of falling back to shared storage when config is invalid', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agorDir, 'config.yaml'),
+      yaml.dump({ multi_tenancy: { enabled: true, unsupported_option: true } }),
+      'utf-8'
+    );
+    __resetConfigCacheForTests();
+
+    expect(() => getTenantDataRoot('tenant-a')).toThrow(/unrecognized/i);
   });
 });
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -1354,7 +1354,7 @@ describe('getTenantDataRoot', () => {
   });
 
   it('uses the default tenant base folder when enabled', async () => {
-    await writeConfig({ enabled: true });
+    await writeConfig({ filesystem_isolation_enabled: true });
 
     expect(getTenantDataRoot('tenant-a')).toBe(path.join(tempDir, '.agor', 'tenants', 'tenant-a'));
     expect(getReposDir('tenant-a')).toBe(
@@ -1366,7 +1366,10 @@ describe('getTenantDataRoot', () => {
   });
 
   it('resolves relative tenant base folders from the daemon home', async () => {
-    await writeConfig({ enabled: true, tenants_base_folder: 'tenant-volume' });
+    await writeConfig({
+      filesystem_isolation_enabled: true,
+      tenants_base_folder: 'tenant-volume',
+    });
 
     expect(getTenantDataRoot('tenant-b')).toBe(
       path.join(tempDir, '.agor', 'tenant-volume', 'tenant-b')
@@ -1374,15 +1377,21 @@ describe('getTenantDataRoot', () => {
   });
 
   it('supports absolute and home-relative tenant base folders', async () => {
-    await writeConfig({ enabled: true, tenants_base_folder: '/data/agor-tenants' });
+    await writeConfig({
+      filesystem_isolation_enabled: true,
+      tenants_base_folder: '/data/agor-tenants',
+    });
     expect(getTenantDataRoot('tenant-c')).toBe('/data/agor-tenants/tenant-c');
 
-    await writeConfig({ enabled: true, tenants_base_folder: '~/mounted-tenants' });
+    await writeConfig({
+      filesystem_isolation_enabled: true,
+      tenants_base_folder: '~/mounted-tenants',
+    });
     expect(getTenantDataRoot('tenant-c')).toBe(path.join(tempDir, 'mounted-tenants', 'tenant-c'));
   });
 
   it('requires a safe tenant id when enabled', async () => {
-    await writeConfig({ enabled: true });
+    await writeConfig({ filesystem_isolation_enabled: true });
 
     expect(() => getTenantDataRoot()).toThrow(/valid tenant id/i);
     expect(() => getTenantDataRoot('../escape')).toThrow(/valid tenant id/i);
@@ -1393,7 +1402,9 @@ describe('getTenantDataRoot', () => {
     await fs.mkdir(agorDir, { recursive: true });
     await fs.writeFile(
       path.join(agorDir, 'config.yaml'),
-      yaml.dump({ multi_tenancy: { enabled: true, unsupported_option: true } }),
+      yaml.dump({
+        multi_tenancy: { filesystem_isolation_enabled: true, unsupported_option: true },
+      }),
       'utf-8'
     );
     __resetConfigCacheForTests();

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -473,7 +473,7 @@ function validateConfig(config: AgorConfig): void {
     'frameworkRepoUrl',
   ]);
   only(config.multi_tenancy, 'multi_tenancy', [
-    'enabled',
+    'filesystem_isolation_enabled',
     'tenants_base_folder',
     'mode',
     'static_tenant_id',
@@ -707,7 +707,7 @@ export function getDefaultConfig(): AgorConfig {
     analytics: getDefaultAnalyticsConfig(),
     telemetry: {},
     multi_tenancy: {
-      enabled: false,
+      filesystem_isolation_enabled: false,
       tenants_base_folder: '~/.agor/tenants',
       mode: 'static',
       static_tenant_id: 'default',
@@ -1347,17 +1347,16 @@ export function getDataHome(): string {
 }
 
 /**
- * Resolve the root containing tenant-owned filesystem data.
- *
- * Single-tenant installs retain the historical data home. When filesystem
- * multi-tenancy is enabled, a tenant id is required and the result is
- * `<tenants_base_folder>/<tenantId>`.
+ * Pure tenant-data-root policy shared by sync and async config loaders.
  */
-export function getTenantDataRoot(tenantId?: string): string {
-  const config = loadConfigSync();
-
-  if (config.multi_tenancy?.enabled !== true) {
-    return getDataHome();
+function resolveTenantDataRoot(
+  config: AgorConfig,
+  dataHome: string,
+  agorHome: string,
+  tenantId?: string
+): string {
+  if (config.multi_tenancy?.filesystem_isolation_enabled !== true) {
+    return dataHome;
   }
 
   const normalizedTenantId = tenantId?.trim();
@@ -1368,15 +1367,28 @@ export function getTenantDataRoot(tenantId?: string): string {
     normalizedTenantId.includes('/') ||
     normalizedTenantId.includes('\\')
   ) {
-    throw new Error('A valid tenant id is required when multi_tenancy.enabled is true');
+    throw new Error(
+      'A valid tenant id is required when multi_tenancy.filesystem_isolation_enabled is true'
+    );
   }
 
   const configuredBase = config.multi_tenancy.tenants_base_folder || '~/.agor/tenants';
   const expandedBase = expandHomePath(configuredBase);
   const tenantsBase = path.isAbsolute(expandedBase)
     ? expandedBase
-    : path.resolve(getAgorHome(), expandedBase);
+    : path.resolve(agorHome, expandedBase);
   return path.join(tenantsBase, normalizedTenantId);
+}
+
+/**
+ * Resolve the root containing tenant-owned filesystem data.
+ *
+ * Single-tenant installs retain the historical data home. When filesystem
+ * multi-tenancy is enabled, a tenant id is required and the result is
+ * `<tenants_base_folder>/<tenantId>`.
+ */
+export function getTenantDataRoot(tenantId?: string): string {
+  return resolveTenantDataRoot(loadConfigSync(), getDataHome(), getAgorHome(), tenantId);
 }
 
 /**
@@ -1452,29 +1464,8 @@ export async function getDataHomeAsync(): Promise<string> {
 
 /** Async counterpart to {@link getTenantDataRoot}. */
 export async function getTenantDataRootAsync(tenantId?: string): Promise<string> {
-  const config = await loadConfig();
-
-  if (config.multi_tenancy?.enabled !== true) {
-    return getDataHomeAsync();
-  }
-
-  const normalizedTenantId = tenantId?.trim();
-  if (
-    !normalizedTenantId ||
-    normalizedTenantId === '.' ||
-    normalizedTenantId === '..' ||
-    normalizedTenantId.includes('/') ||
-    normalizedTenantId.includes('\\')
-  ) {
-    throw new Error('A valid tenant id is required when multi_tenancy.enabled is true');
-  }
-
-  const configuredBase = config.multi_tenancy.tenants_base_folder || '~/.agor/tenants';
-  const expandedBase = expandHomePath(configuredBase);
-  const tenantsBase = path.isAbsolute(expandedBase)
-    ? expandedBase
-    : path.resolve(getAgorHome(), expandedBase);
-  return path.join(tenantsBase, normalizedTenantId);
+  const [config, dataHome] = await Promise.all([loadConfig(), getDataHomeAsync()]);
+  return resolveTenantDataRoot(config, dataHome, getAgorHome(), tenantId);
 }
 
 /**

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -473,6 +473,8 @@ function validateConfig(config: AgorConfig): void {
     'frameworkRepoUrl',
   ]);
   only(config.multi_tenancy, 'multi_tenancy', [
+    'enabled',
+    'tenants_base_folder',
     'mode',
     'static_tenant_id',
     'auth_claim',
@@ -705,6 +707,8 @@ export function getDefaultConfig(): AgorConfig {
     analytics: getDefaultAnalyticsConfig(),
     telemetry: {},
     multi_tenancy: {
+      enabled: false,
+      tenants_base_folder: '~/.agor/tenants',
       mode: 'static',
       static_tenant_id: 'default',
     },
@@ -1343,14 +1347,47 @@ export function getDataHome(): string {
 }
 
 /**
+ * Resolve the root containing tenant-owned filesystem data.
+ *
+ * Single-tenant installs retain the historical data home. When filesystem
+ * multi-tenancy is enabled, a tenant id is required and the result is
+ * `<tenants_base_folder>/<tenantId>`.
+ */
+export function getTenantDataRoot(tenantId?: string): string {
+  const config = loadConfigSync();
+
+  if (config.multi_tenancy?.enabled !== true) {
+    return getDataHome();
+  }
+
+  const normalizedTenantId = tenantId?.trim();
+  if (
+    !normalizedTenantId ||
+    normalizedTenantId === '.' ||
+    normalizedTenantId === '..' ||
+    normalizedTenantId.includes('/') ||
+    normalizedTenantId.includes('\\')
+  ) {
+    throw new Error('A valid tenant id is required when multi_tenancy.enabled is true');
+  }
+
+  const configuredBase = config.multi_tenancy.tenants_base_folder || '~/.agor/tenants';
+  const expandedBase = expandHomePath(configuredBase);
+  const tenantsBase = path.isAbsolute(expandedBase)
+    ? expandedBase
+    : path.resolve(getAgorHome(), expandedBase);
+  return path.join(tenantsBase, normalizedTenantId);
+}
+
+/**
  * Get repos directory path
  *
  * Returns: $AGOR_DATA_HOME/repos
  *
  * @returns Absolute path to repos directory
  */
-export function getReposDir(): string {
-  return path.join(getDataHome(), 'repos');
+export function getReposDir(tenantId?: string): string {
+  return path.join(getTenantDataRoot(tenantId), 'repos');
 }
 
 /**
@@ -1366,8 +1403,8 @@ export function getReposDir(): string {
  *
  * @returns Absolute path to the branches directory
  */
-export function getBranchesDir(): string {
-  return path.join(getDataHome(), 'worktrees');
+export function getBranchesDir(tenantId?: string): string {
+  return path.join(getTenantDataRoot(tenantId), 'worktrees');
 }
 
 /**
@@ -1381,8 +1418,8 @@ export function getBranchesDir(): string {
  * @param branchName - Branch name (e.g., "feature-x")
  * @returns Absolute path to the branch
  */
-export function getBranchPath(repoSlug: string, branchName: string): string {
-  return path.join(getBranchesDir(), repoSlug, branchName);
+export function getBranchPath(repoSlug: string, branchName: string, tenantId?: string): string {
+  return path.join(getBranchesDir(tenantId), repoSlug, branchName);
 }
 
 /**
@@ -1413,13 +1450,40 @@ export async function getDataHomeAsync(): Promise<string> {
   return getAgorHome();
 }
 
+/** Async counterpart to {@link getTenantDataRoot}. */
+export async function getTenantDataRootAsync(tenantId?: string): Promise<string> {
+  const config = await loadConfig();
+
+  if (config.multi_tenancy?.enabled !== true) {
+    return getDataHomeAsync();
+  }
+
+  const normalizedTenantId = tenantId?.trim();
+  if (
+    !normalizedTenantId ||
+    normalizedTenantId === '.' ||
+    normalizedTenantId === '..' ||
+    normalizedTenantId.includes('/') ||
+    normalizedTenantId.includes('\\')
+  ) {
+    throw new Error('A valid tenant id is required when multi_tenancy.enabled is true');
+  }
+
+  const configuredBase = config.multi_tenancy.tenants_base_folder || '~/.agor/tenants';
+  const expandedBase = expandHomePath(configuredBase);
+  const tenantsBase = path.isAbsolute(expandedBase)
+    ? expandedBase
+    : path.resolve(getAgorHome(), expandedBase);
+  return path.join(tenantsBase, normalizedTenantId);
+}
+
 /**
  * Get repos directory path (async version)
  *
  * @returns Absolute path to repos directory
  */
-export async function getReposDirAsync(): Promise<string> {
-  return path.join(await getDataHomeAsync(), 'repos');
+export async function getReposDirAsync(tenantId?: string): Promise<string> {
+  return path.join(await getTenantDataRootAsync(tenantId), 'repos');
 }
 
 /**
@@ -1430,6 +1494,6 @@ export async function getReposDirAsync(): Promise<string> {
  *
  * @returns Absolute path to branches directory
  */
-export async function getBranchesDirAsync(): Promise<string> {
-  return path.join(await getDataHomeAsync(), 'worktrees');
+export async function getBranchesDirAsync(tenantId?: string): Promise<string> {
+  return path.join(await getTenantDataRootAsync(tenantId), 'worktrees');
 }

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -56,6 +56,22 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toThrow(/auth_claim or multi_tenancy\.trusted_header/);
   });
 
+  it('requires filesystem isolation in required_from_auth mode', () => {
+    vi.stubEnv('AGOR_DB_DIALECT', '');
+    vi.stubEnv('DATABASE_URL', '');
+
+    expect(() =>
+      assertValidMultiTenancyConfig({
+        database: { dialect: 'postgresql' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          auth_claim: 'tenant_id',
+          filesystem_isolation_enabled: false,
+        },
+      })
+    ).toThrow(/requires multi_tenancy\.filesystem_isolation_enabled: true/);
+  });
+
   it('rejects reserved JWT claims as the tenant auth claim', () => {
     vi.stubEnv('AGOR_DB_DIALECT', '');
     vi.stubEnv('DATABASE_URL', '');

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -147,6 +147,11 @@ export function assertValidMultiTenancyConfig(
         'Config error: multi_tenancy.required_from_auth requires multi_tenancy.auth_claim or multi_tenancy.trusted_header'
       );
     }
+    if (config.multi_tenancy?.filesystem_isolation_enabled !== true) {
+      throw new Error(
+        'Config error: multi_tenancy.required_from_auth requires multi_tenancy.filesystem_isolation_enabled: true'
+      );
+    }
   }
 }
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -961,6 +961,15 @@ export interface AgorKnowledgeSettings {
  * accessed.
  */
 export interface AgorMultiTenancySettings {
+  /** Store tenant-owned filesystem data below a tenant-specific root. Defaults to false. */
+  enabled?: boolean;
+
+  /**
+   * Parent directory for tenant data. Absolute paths and paths relative to
+   * `~/.agor` are supported. Defaults to `~/.agor/tenants`.
+   */
+  tenants_base_folder?: string;
+
   /** Multi-tenancy mode. Defaults to `static`. */
   mode?: 'static' | 'required_from_auth';
 
@@ -1025,4 +1034,5 @@ export type ConfigKey =
   | `teammates.${keyof AgorTeammateSettings}`
   | `paths.${keyof AgorPathSettings}`
   | `analytics.${keyof AgorAnalyticsSettings}`
-  | `telemetry.${keyof AgorTelemetrySettings}`;
+  | `telemetry.${keyof AgorTelemetrySettings}`
+  | `multi_tenancy.${keyof AgorMultiTenancySettings}`;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -962,7 +962,7 @@ export interface AgorKnowledgeSettings {
  */
 export interface AgorMultiTenancySettings {
   /** Store tenant-owned filesystem data below a tenant-specific root. Defaults to false. */
-  enabled?: boolean;
+  filesystem_isolation_enabled?: boolean;
 
   /**
    * Parent directory for tenant data. Absolute paths and paths relative to

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -41,6 +44,7 @@ import {
   handleBranchAgorYmlExport,
   handleBranchAgorYmlImport,
   handleBranchInspect,
+  handleGitBranchRemove,
   handleGitClone,
   handleGitRepoDelete,
 } from './git.js';
@@ -125,6 +129,35 @@ beforeEach(() => {
 });
 
 describe('managed executor git/fs commands', () => {
+  it('uses the daemon-provided tenant root when removing a branch directory', async () => {
+    const branchesRoot = await mkdtemp(join(tmpdir(), 'agor-tenant-worktrees-'));
+    const branchPath = join(branchesRoot, 'repo', 'feature');
+    await mkdir(branchPath, { recursive: true });
+    createClient({});
+
+    try {
+      const result = await handleGitBranchRemove(
+        {
+          command: 'git.branch.remove',
+          sessionToken: 'jwt',
+          params: {
+            branchId,
+            branchPath,
+            branchesRoot,
+            storageMode: 'clone',
+            deleteDbRecord: false,
+          },
+        },
+        {}
+      );
+
+      expect(result.success).toBe(true);
+      expect(mocks.deleteBranchDirectory).toHaveBeenCalledWith(branchPath, branchesRoot);
+    } finally {
+      await rm(branchesRoot, { recursive: true, force: true });
+    }
+  });
+
   it('derives git.repo.delete paths from daemon records instead of payload paths', async () => {
     createClient({
       repo: { repo_id: repoId, local_path: '/safe/repos/repo' },

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -47,6 +47,7 @@ import {
 
 const repoId = '550e8400-e29b-41d4-a716-446655440001';
 const branchId = '550e8400-e29b-41d4-a716-446655440002';
+const deleteRoots = { reposRoot: '/safe/repos', branchesRoot: '/safe/worktrees' };
 
 function createClient(records: {
   repo?: Record<string, unknown>;
@@ -131,13 +132,16 @@ describe('managed executor git/fs commands', () => {
     });
 
     const result = await handleGitRepoDelete(
-      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId } },
+      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId, ...deleteRoots } },
       {}
     );
 
     expect(result.success).toBe(true);
-    expect(mocks.deleteBranchDirectory).toHaveBeenCalledWith('/safe/worktrees/repo/feature');
-    expect(mocks.deleteRepoDirectory).toHaveBeenCalledWith('/safe/repos/repo');
+    expect(mocks.deleteBranchDirectory).toHaveBeenCalledWith(
+      '/safe/worktrees/repo/feature',
+      '/safe/worktrees'
+    );
+    expect(mocks.deleteRepoDirectory).toHaveBeenCalledWith('/safe/repos/repo', '/safe/repos');
   });
 
   it('uses slug-derived output paths for git.clone to avoid same-basename collisions', async () => {
@@ -225,7 +229,7 @@ describe('managed executor git/fs commands', () => {
     });
 
     const result = await handleGitRepoDelete(
-      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId } },
+      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId, ...deleteRoots } },
       {}
     );
 
@@ -233,9 +237,10 @@ describe('managed executor git/fs commands', () => {
     expect(mocks.deleteBranchDirectory).toHaveBeenCalledTimes(1002);
     expect(mocks.deleteBranchDirectory).toHaveBeenNthCalledWith(
       1001,
-      '/safe/worktrees/repo/branch-1000'
+      '/safe/worktrees/repo/branch-1000',
+      '/safe/worktrees'
     );
-    expect(mocks.deleteRepoDirectory).toHaveBeenCalledWith('/safe/repos/repo');
+    expect(mocks.deleteRepoDirectory).toHaveBeenCalledWith('/safe/repos/repo', '/safe/repos');
   });
 
   it('rejects git.repo.delete if branch query returns a foreign branch', async () => {
@@ -247,7 +252,7 @@ describe('managed executor git/fs commands', () => {
     });
 
     const result = await handleGitRepoDelete(
-      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId } },
+      { command: 'git.repo.delete', sessionToken: 'jwt', params: { repoId, ...deleteRoots } },
       {}
     );
 

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -623,12 +623,12 @@ export async function handleGitRepoDelete(
 
     for (const branch of branches) {
       if (!branch.path) continue;
-      await deleteBranchDirectory(branch.path);
+      await deleteBranchDirectory(branch.path, payload.params.branchesRoot);
       deletedPaths.push(branch.path);
       console.log(`🗑️  [git.repo.delete] Deleted branch directory: ${branch.path}`);
     }
 
-    await deleteRepoDirectory(repoPath);
+    await deleteRepoDirectory(repoPath, payload.params.reposRoot);
     deletedPaths.push(repoPath);
     console.log(`🗑️  [git.repo.delete] Deleted repository directory: ${repoPath}`);
 

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -1372,6 +1372,7 @@ export async function handleGitBranchRemove(
 
     const branchId = payload.params.branchId;
     const branchPath = payload.params.branchPath;
+    const branchesRoot = payload.params.branchesRoot;
     const storageMode = payload.params.storageMode ?? 'worktree';
 
     console.log(
@@ -1394,7 +1395,7 @@ export async function handleGitBranchRemove(
         console.log(
           `[git.branch.remove] Clone mode — removing self-standing directory ${branchPath}`
         );
-        await deleteBranchDirectory(branchPath);
+        await deleteBranchDirectory(branchPath, branchesRoot);
         filesystemRemoved = true;
       } else {
         console.log(
@@ -1415,7 +1416,7 @@ export async function handleGitBranchRemove(
         console.warn(
           `[git.branch.remove] DB says storage_mode='worktree' but ${gitPath} is a directory — treating as clone-mode removal`
         );
-        await deleteBranchDirectory(branchPath);
+        await deleteBranchDirectory(branchPath, branchesRoot);
         filesystemRemoved = true;
       } else {
         // Read .git file to find the main repo
@@ -1448,7 +1449,7 @@ export async function handleGitBranchRemove(
         // Fully delete the directory to reclaim all disk space.
         if (existsSync(branchPath)) {
           console.log(`[git.branch.remove] Directory still exists, removing residual files...`);
-          await deleteBranchDirectory(branchPath);
+          await deleteBranchDirectory(branchPath, branchesRoot);
           console.log(`[git.branch.remove] Directory fully removed`);
         }
 
@@ -1483,7 +1484,7 @@ export async function handleGitBranchRemove(
       console.log(
         '[git.branch.remove] No .git file but directory exists (orphaned), removing directory...'
       );
-      await deleteBranchDirectory(branchPath);
+      await deleteBranchDirectory(branchPath, branchesRoot);
       filesystemRemoved = true;
       console.log('[git.branch.remove] Orphaned directory removed');
     } else {

--- a/packages/executor/src/commands/index.test.ts
+++ b/packages/executor/src/commands/index.test.ts
@@ -284,7 +284,9 @@ describe('executeCommand - git.branch.remove', () => {
     command: 'git.branch.remove',
     sessionToken: 'jwt-token',
     params: {
+      branchId: '550e8400-e29b-41d4-a716-446655440002',
       branchPath: '/data/agor/worktrees/repo/feature-x',
+      branchesRoot: '/data/agor/worktrees',
     },
   };
 

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -399,6 +399,7 @@ describe('GitBranchRemovePayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         branchPath: '/data/agor/worktrees/user/repo/feature-x',
+        branchesRoot: '/data/agor/worktrees',
       },
     };
 
@@ -415,6 +416,7 @@ describe('GitBranchRemovePayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         branchPath: '/data/agor/worktrees/user/repo/feature-x',
+        branchesRoot: '/data/agor/worktrees',
         force: true,
       },
     };
@@ -593,6 +595,7 @@ describe('Type guards', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         branchPath: '/data/branches/feature',
+        branchesRoot: '/data/branches',
       },
     };
     expect(isGitBranchRemovePayload(payload)).toBe(true);

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -388,6 +388,9 @@ export const GitBranchRemovePayloadSchema = BasePayloadSchema.extend({
     /** Path to the branch to remove */
     branchPath: z.string(),
 
+    /** Tenant-aware root that must contain branchPath */
+    branchesRoot: z.string(),
+
     /** Force removal even if dirty */
     force: z.boolean().optional(),
 

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -662,8 +662,12 @@ export const GitRepoDeletePayloadSchema = BasePayloadSchema.extend({
   sessionToken: z.string(),
 
   params: z.object({
-    /** Repo being deleted; executor fetches/derives managed paths itself */
+    /** Repo being deleted; executor fetches the concrete managed paths itself. */
     repoId: z.string().uuid(),
+    /** Tenant-scoped root that is allowed to contain the managed repository. */
+    reposRoot: z.string().min(1),
+    /** Tenant-scoped root that is allowed to contain managed branches. */
+    branchesRoot: z.string().min(1),
   }),
 });
 

--- a/packages/git/src/delete-directories.test.ts
+++ b/packages/git/src/delete-directories.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { deleteBranchDirectory, deleteRepoDirectory } from './index';
+
+describe('managed directory deletion roots', () => {
+  let tempDir: string;
+  let tenantRoot: string;
+  let reposRoot: string;
+  let branchesRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-tenant-delete-'));
+    tenantRoot = path.join(tempDir, 'tenants', 'tenant-a');
+    reposRoot = path.join(tenantRoot, 'repos');
+    branchesRoot = path.join(tenantRoot, 'worktrees');
+    await fs.mkdir(reposRoot, { recursive: true });
+    await fs.mkdir(branchesRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('deletes paths inside explicitly supplied tenant roots', async () => {
+    const repoPath = path.join(reposRoot, 'org', 'repo');
+    const branchPath = path.join(branchesRoot, 'org', 'repo', 'feature');
+    await fs.mkdir(repoPath, { recursive: true });
+    await fs.mkdir(branchPath, { recursive: true });
+
+    await deleteBranchDirectory(branchPath, branchesRoot);
+    await deleteRepoDirectory(repoPath, reposRoot);
+
+    await expect(fs.access(branchPath)).rejects.toThrow();
+    await expect(fs.access(repoPath)).rejects.toThrow();
+  });
+
+  it('rejects paths belonging to another tenant', async () => {
+    const otherRepo = path.join(tempDir, 'tenants', 'tenant-b', 'repos', 'org', 'repo');
+    const otherBranch = path.join(
+      tempDir,
+      'tenants',
+      'tenant-b',
+      'worktrees',
+      'org',
+      'repo',
+      'feature'
+    );
+    await fs.mkdir(otherRepo, { recursive: true });
+    await fs.mkdir(otherBranch, { recursive: true });
+
+    await expect(deleteRepoDirectory(otherRepo, reposRoot)).rejects.toThrow(/Safety check failed/);
+    await expect(deleteBranchDirectory(otherBranch, branchesRoot)).rejects.toThrow(
+      /Safety check failed/
+    );
+  });
+});

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1730,15 +1730,19 @@ export async function getGitState(repoPath: string): Promise<string> {
  * This is typically used when deleting a remote repository that was cloned by Agor.
  *
  * @param repoPath - Absolute path to the repository directory
- * @throws Error if the path is not inside ~/.agor/repos/ (safety check)
+ * @param allowedReposDir - Explicit safety root (tenant-scoped when applicable)
+ * @throws Error if the path is not inside the allowed repositories root
  */
-export async function deleteRepoDirectory(repoPath: string): Promise<void> {
+export async function deleteRepoDirectory(
+  repoPath: string,
+  allowedReposDir: string = getReposDir()
+): Promise<void> {
   const { rm } = await import('node:fs/promises');
   const { realpathSync, existsSync } = await import('node:fs');
   const { resolve, relative } = await import('node:path');
 
   // Safety check: ensure we're only deleting from ~/.agor/repos/
-  const reposDir = getReposDir();
+  const reposDir = allowedReposDir;
 
   // Use realpathSync to follow symlinks and canonicalize paths.
   // If the directory was already removed, fall back to resolving via parent.
@@ -1771,15 +1775,19 @@ export async function deleteRepoDirectory(repoPath: string): Promise<void> {
  * Removes the branch directory and all its contents from the branches directory.
  *
  * @param branchPath - Absolute path to the branch directory
+ * @param allowedBranchesDir - Explicit safety root (tenant-scoped when applicable)
  * @throws Error if the path is not inside the configured branches directory (safety check)
  */
-export async function deleteBranchDirectory(branchPath: string): Promise<void> {
+export async function deleteBranchDirectory(
+  branchPath: string,
+  allowedBranchesDir: string = getBranchesDir()
+): Promise<void> {
   const { rm } = await import('node:fs/promises');
   const { realpathSync, existsSync } = await import('node:fs');
   const { resolve, relative } = await import('node:path');
 
   // Safety check: ensure we're only deleting from configured branches directory
-  const branchesDir = getBranchesDir();
+  const branchesDir = allowedBranchesDir;
 
   // Use realpathSync to follow symlinks and canonicalize paths.
   // If the branch directory was already removed (e.g. by `git worktree remove`),

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local", "pnpm-lock.yaml"],
+  "globalPassThroughEnv": ["AGOR_DB_DIALECT", "BIOME_BIN", "DATABASE_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- add tenant-aware filesystem roots under `multi_tenancy.tenants_base_folder`
- preserve the existing flat filesystem layout when multi-tenancy is disabled
- scope managed repositories, branch clones/worktrees, uploads, and gateway attachments by tenant
- pass tenant-specific safety roots to executor cleanup so repository deletion works without crossing tenant boundaries
- fail closed for invalid multi-tenant path configuration

## Configuration

```yaml
multi_tenancy:
  enabled: true
  tenants_base_folder: ~/.agor/tenants
```

Absolute paths, `~/...` paths, and paths relative to `~/.agor` are supported.

## Filesystem layout

```text
~/.agor/
  tenants/<tenant-id>/
    repos/
    worktrees/
    uploads/
  agor.db
  config.yaml
```

Single-tenant instances continue using the existing flat `repos/`, `worktrees/`, and `uploads/` directories.

## Validation

- `pnpm i`
- `pnpm check`
- core config tests: 127 passed
- git deletion tests: 2 passed
- executor payload/deletion tests: 44 passed
- daemon repo/upload/gateway tests: 126 passed
