### PR TITLE
feat: add Oh My Pi (OMP) as an agentic runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ interchangeable per session — bring your own provider and subscription, no ven
   <a href="https://github.com/sst/opencode"><img src="apps/agor-docs/public/tools/opencode.png" alt="OpenCode" height="44" /></a>
   &nbsp;&nbsp;
   <a href="https://cursor.com"><img src="apps/agor-docs/public/tools/cursor.png" alt="Cursor" height="44" /></a>
+  &nbsp;&nbsp;
+  <a href="https://github.com/can1357/oh-my-pi">🥧 Oh My Pi</a>
 </p>
 
 <!--
@@ -61,8 +63,8 @@ _The board: branches as cards, zones as regions, agent sessions, and — optiona
   dev environment, conversation history, and PR. One entity to point at.
 - **Isolated dev environments** — a one-click dev server per branch, with ports auto-assigned so
   parallel branches never collide.
-- **Multi-runtime** — Claude Code, Codex, Gemini, OpenCode, Copilot, and Cursor (beta) are
-  interchangeable per session. Bring your own provider; no vendor lock-in.
+- **Multi-runtime** — Claude Code, Codex, Gemini, OpenCode, Copilot, Cursor (beta), and Oh My Pi
+  (beta) are interchangeable per session. Bring your own provider; no vendor lock-in.
 - **Rich session UI** — per-prompt token and dollar accounting, structured tool blocks,
   model/effort selectors, completion chimes. The terminal experience, in the browser.
 - **MCP-native** — Agor exposes itself over MCP; sessions are auto-issued a token, so agents fork,

--- a/apps/agor-docs/content/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/content/guide/sdk-comparison.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Feature Comparison
-description: Compare AI coding agent capabilities in agor. Feature matrix for Claude Code, Codex, Gemini, GitHub Copilot, and OpenCode integrations including streaming, tool approval, and SDK differences.
+description: Compare AI coding agent capabilities in agor. Feature matrix for Claude Code, Codex, Gemini, GitHub Copilot, OpenCode, and Oh My Pi integrations including streaming, tool approval, and SDK differences.
 ---
 
 import { ScrollTable } from '../../components/ScrollTable';
@@ -13,19 +13,19 @@ Agor integrates with multiple AI coding agents. Each SDK has different capabilit
 
 <ScrollTable>
 
-| Feature                     | Claude Code         | Codex                     | Gemini              | Copilot                   | OpenCode                  | Notes                                                                                       |
-| --------------------------- | ------------------- | ------------------------- | ------------------- | ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Streaming responses**     | ✅ Text + tools     | ⚠️ Tools only             | ✅ Text + tools     | ✅ Text + tools           | ✅ Text + tools           | Claude, Gemini, Copilot & OpenCode stream text token-by-token; Codex streams tool events only |
-| **Stop mid-execution**      | ✅ Yes              | ⚠️ Limited                | ⚠️ Limited          | ⚠️ Limited                | ⚠️ Limited                | Claude has `interrupt()`, others may lose partial work                                      |
-| **Session import/export**   | ✅ Yes              | ❌ No                     | ❌ No               | ❌ No                     | ❌ No                     | Only Claude Code stores sessions as JSONL transcripts                                       |
-| **Session forkable**        | ✅ SDK-native       | ✅ App Server fork        | ❌ Not yet          | ❌ Not yet                | ❌ Not yet                | Claude uses Agent SDK's `forkSession`; Codex uses `codex app-server` `thread/fork` sidecar  |
-| **MCP integration**         | ✅ Native           | ✅ Native                  | ✅ Native           | ✅ Native                 | ✅ Native                 | All agents support MCP with Agor's built-in self-access server                              |
-| **Permission requests**     | ✅ Rich             | ⚠️ Basic                  | ⚠️ Basic            | ✅ Interactive             | ⚠️ Auto-granted          | OpenCode permissions auto-granted by Agor to prevent session hangs                          |
-| **Project instructions**    | ✅ CLAUDE.md        | ✅ AGENTS.md               | ⚠️ Manual           | ⚠️ Manual                 | ✅ opencode.json          | OpenCode reads project config from `opencode.json`; Claude auto-loads CLAUDE.md             |
-| **Tool execution**          | ✅ Rich widgets     | ⚠️ Basic                  | ⚠️ Basic            | ✅ Rich events            | ✅ Rich events            | OpenCode streams tool parts with state tracking (pending/running/completed)                  |
-| **Session continuity**      | ✅ SDK-managed      | ✅ History-based          | ✅ History-based    | ✅ SDK-managed            | ✅ SDK-managed            | OpenCode, Claude, and Copilot use SDK session IDs; others replay message history            |
-| **Token usage tracking**    | ✅ Full             | ✅ Full                   | ❌ No               | ⚠️ Via events             | ✅ Via step-finish        | OpenCode provides token counts and cost via `step-finish` message parts                     |
-| **Context window tracking** | 🟡 Estimated        | 🟡 Estimated              | ❌ No               | 🟡 Estimated              | 🟡 Estimated              | Agor derives cumulative conversation usage from SDK metrics                                 |
+| Feature                     | Claude Code         | Codex                     | Gemini              | Copilot                   | OpenCode                  | Oh My Pi           | Notes                                                                                       |
+| --------------------------- | ------------------- | ------------------------- | ------------------- | ------------------------- | ------------------------- | ------------------ | ------------------------------------------------------------------------------------------- |
+| **Streaming responses**     | ✅ Text + tools     | ⚠️ Tools only             | ✅ Text + tools     | ✅ Text + tools           | ✅ Text + tools           | ✅ Text + thinking | Claude, Gemini, Copilot, OpenCode & Oh My Pi stream text token-by-token; Codex streams tool events only |
+| **Stop mid-execution**      | ✅ Yes              | ⚠️ Limited                | ⚠️ Limited          | ⚠️ Limited                | ⚠️ Limited                | ✅ Yes             | Claude & Oh My Pi support interrupt/abort; others may lose partial work                      |
+| **Session import/export**   | ✅ Yes              | ❌ No                     | ❌ No               | ❌ No                     | ❌ No                     | ❌ No              | Only Claude Code stores sessions as JSONL transcripts                                       |
+| **Session forkable**        | ✅ SDK-native       | ✅ App Server fork        | ❌ Not yet          | ❌ Not yet                | ❌ Not yet                | ❌ Not yet          | Claude uses Agent SDK's `forkSession`; Codex uses `codex app-server` `thread/fork` sidecar  |
+| **MCP integration**         | ✅ Native           | ✅ Native                  | ✅ Native           | ✅ Native                 | ✅ Native                 | ✅ Native          | All agents support MCP with Agor's built-in self-access server                              |
+| **Permission requests**     | ✅ Rich             | ⚠️ Basic                  | ⚠️ Basic            | ✅ Interactive             | ⚠️ Auto-granted          | ✅ Modes           | OpenCode permissions auto-granted by Agor; Oh My Pi exposes default/acceptEdits/bypassPermissions |
+| **Project instructions**    | ✅ CLAUDE.md        | ✅ AGENTS.md               | ⚠️ Manual           | ⚠️ Manual                 | ✅ opencode.json          | ✅ AGENTS.md       | OpenCode reads `opencode.json`; Claude auto-loads CLAUDE.md; Oh My Pi auto-discovers context files from the branch worktree it runs in |
+| **Tool execution**          | ✅ Rich widgets     | ⚠️ Basic                  | ⚠️ Basic            | ✅ Rich events            | ✅ Rich events            | ✅ Start/end       | OpenCode streams tool parts (pending/running/completed); Oh My Pi emits tool_execution_start/end |
+| **Session continuity**      | ✅ SDK-managed      | ✅ History-based          | ✅ History-based    | ✅ SDK-managed            | ✅ SDK-managed            | ✅ Resumed session | OpenCode, Claude & Copilot keep server-side state; Oh My Pi resumes its session file per turn; Codex/Gemini replay history |
+| **Token usage tracking**    | ✅ Full             | ✅ Full                   | ❌ No               | ⚠️ Via events             | ✅ Via step-finish        | ✅ Tokens + $      | OpenCode provides tokens via `step-finish`; Oh My Pi reports tokens and real USD cost      |
+| **Context window tracking** | 🟡 Estimated        | 🟡 Estimated              | ❌ No               | 🟡 Estimated              | 🟡 Estimated              | ✅ Reported        | Agor derives cumulative usage from SDK metrics; Oh My Pi reports context snapshots directly |
 
 </ScrollTable>
 
@@ -829,6 +829,16 @@ Copilot supports multiple underlying models selectable via the SDK:
 - You need flexibility to switch between providers without changing tools
 - Cost optimization is important (bring your own keys, no middleman)
 
+### Use Oh My Pi when:
+
+- You want a **terminal-native** coding agent driven over a stable RPC
+  protocol (no SDK import, no separate server process to babysit)
+- **Slash commands** matter to your workflow — they work in Agor
+- You want **accurate** per-prompt cost (real USD, reported by OMP) and
+  **accurate** context-window usage (snapshots, not estimates)
+- You want **streaming reasoning** alongside streaming text
+- You need fine-grained **reasoning levels** (low, medium, high, xhigh, max)
+
 ---
 
 ## OpenCode-Specific Notes
@@ -867,6 +877,65 @@ OpenCode supports MCP servers via its REST API:
 - **Session import/export** not available
 - **Permissions** are auto-granted by Agor (no interactive approval UI)
 - **Server must be running.** `opencode serve` must be started separately before using in Agor
+
+---
+
+## Oh My Pi-Specific Notes
+
+### Integration: RPC over stdio
+
+Agor does **not** import OMP's SDK in-process. OMP's npm package ships raw
+TypeScript and targets the Bun runtime, so it cannot be loaded by Agor's
+Node executor. Instead, Agor spawns the `omp` CLI in RPC mode:
+
+```bash
+omp --mode rpc
+```
+
+This speaks a **newline-delimited JSON (JSONL)** protocol over stdio. Agor
+writes request frames to the process stdin and reads response/event frames
+from stdout. Every capability below is surfaced through that RPC channel.
+
+### Authentication
+
+Oh My Pi manages its own credentials (under `~/.omp`). Agor stores **no OMP
+API key**. To use OMP in Agor, authenticate the `omp` CLI once on the host
+that runs the Agor executor:
+
+```bash
+omp        # complete the sign-in flow once
+```
+
+OMP-managed auth is identical to how Agor treats OpenCode.
+
+### Capabilities surfaced over RPC
+
+- **Streaming text + thinking deltas** — token-level text and reasoning
+  streamed as the model generates, for a real-time typewriter effect.
+- **Structured tool events** — `tool_execution_start` / `tool_execution_end`
+  frames with tool name, arguments, and results.
+- **Token usage + real cost** — per-message token counts **and** a real USD
+  cost figure reported by OMP itself (not estimated by Agor).
+- **Context-window snapshots** — OMP reports its current context-window
+  usage directly, so Agor shows accurate (not estimated) usage.
+- **Abort / interrupt** — a prompt in flight can be cancelled over RPC.
+- **Model selection** — the model is chosen per session over RPC.
+- **Reasoning levels** — `low`, `medium`, `high`, `xhigh`, `max`.
+- **Permission modes** — `default`, `acceptEdits`, `bypassPermissions`.
+
+### Slash commands
+
+Slash commands are OMP's distinctive capability and **work in Agor**. OMP
+advertises its command set over RPC (`available_commands_update` frames and
+a `get_available_commands` request). A prompt that begins with `/` is
+expanded by OMP itself; local-only commands complete without an agent turn.
+
+### Session model
+
+- **Spawn subsessions** — supported. Delegate a fresh-context child for a
+  focused subtask.
+- **Fork** — not yet supported in Agor.
+- **Session import/export** — not yet supported.
 
 ---
 

--- a/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
@@ -48,6 +48,13 @@ export const AVAILABLE_AGENTS: AgenticToolOption[] = [
     beta: true,
   },
   {
+    id: 'omp',
+    name: 'Oh My Pi',
+    icon: '🥧',
+    description: 'Oh My Pi terminal coding agent, driven over its RPC protocol',
+    beta: true,
+  },
+  {
     id: 'claude-code-cli',
     name: 'Claude Code CLI',
     icon: '🤖',

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -132,6 +132,7 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
     },
   ],
   opencode: [],
+  omp: [],
   // Claude Code CLI uses the same Anthropic credentials as the SDK
   // path — surface the same fields so the Defaults panel renders
   // them under the CLI tab too. Backed by the same `user.agentic_tools`

--- a/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
+++ b/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
@@ -20,6 +20,7 @@ const NATIVE_AUTH_HINT: Partial<Record<AgenticToolName, string>> = {
     'Already on a Claude Pro or Max plan? You can connect that instead of an API key.',
   codex:
     'Already signed in with ChatGPT on this machine? Codex can use that instead of an API key.',
+  omp: 'On the machine Agor runs sessions on, sign in once with the `omp` CLI and Oh My Pi will reuse that instead of an API key.',
 };
 
 const pendingAuthChecks = new WeakMap<

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -42,7 +42,8 @@ export interface ModelSelectorProps {
     | 'gemini'
     | 'opencode'
     | 'copilot'
-    | 'cursor'; // Kept as 'agent' for backwards compat in prop name
+    | 'cursor'
+    | 'omp'; // Kept as 'agent' for backwards compat in prop name
   agentic_tool?:
     | 'claude-code'
     | 'claude-code-cli'
@@ -50,7 +51,8 @@ export interface ModelSelectorProps {
     | 'gemini'
     | 'opencode'
     | 'copilot'
-    | 'cursor';
+    | 'cursor'
+    | 'omp';
   /**
    * Optional Feathers client. When provided AND the agentic tool supports
    * dynamic model discovery (Copilot/Cursor), the picker fetches the live
@@ -268,8 +270,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       ? CODEX_MODEL_OPTIONS
       : effectiveTool === 'gemini'
         ? GEMINI_MODEL_OPTIONS
-        : effectiveTool === 'opencode'
-          ? [] // OpenCode doesn't use this list
+        : effectiveTool === 'opencode' || effectiveTool === 'omp'
+          ? [] // OpenCode / OMP resolve their own models — Agor doesn't enumerate them
           : effectiveTool === 'copilot'
             ? (copilotServerOptions ?? COPILOT_STATIC_MODEL_OPTIONS)
             : effectiveTool === 'cursor'

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -28,7 +28,8 @@ export interface PermissionModeSelectorProps {
     | 'gemini'
     | 'opencode'
     | 'copilot'
-    | 'cursor';
+    | 'cursor'
+    | 'omp';
   /** If true, renders as a compact Select dropdown instead of Radio buttons */
   compact?: boolean;
   /**
@@ -216,6 +217,31 @@ const OPENCODE_MODES: ModeOption[] = [
   },
 ];
 
+// Oh My Pi (OMP) permission modes — mirrors OmpPermissionMode (default/acceptEdits/bypassPermissions).
+const OMP_MODES: ModeOption[] = [
+  {
+    mode: 'default',
+    label: 'Manual',
+    description: 'Asks before each operation · for high-stakes changes',
+    icon: <LockOutlined />,
+    tone: 'danger',
+  },
+  {
+    mode: 'acceptEdits',
+    label: 'Accept edits',
+    description: 'Auto-approves file edits · for code you review in the diff',
+    icon: <EditOutlined />,
+    tone: 'success',
+  },
+  {
+    mode: 'bypassPermissions',
+    label: 'Bypass permissions',
+    description: 'Runs everything without asking · isolated environments only',
+    icon: <UnlockOutlined />,
+    tone: 'warning',
+  },
+];
+
 // Codex sandbox mode options
 export const CODEX_SANDBOX_MODES = [
   {
@@ -268,6 +294,8 @@ const getModesForTool = (tool: PermissionModeSelectorProps['agentic_tool']): Mod
       return GEMINI_MODES;
     case 'opencode':
       return OPENCODE_MODES;
+    case 'omp':
+      return OMP_MODES;
     case 'copilot':
       return COPILOT_MODES;
     case 'cursor':

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -29,6 +29,7 @@ const TOOL_LABELS: Record<TenantAgenticToolName, string> = {
   copilot: 'GitHub Copilot',
   cursor: 'Cursor SDK',
   opencode: 'OpenCode',
+  omp: 'Oh My Pi',
 };
 
 const TENANT_TOOL_FIELDS: Record<TenantAgenticToolName, AgenticToolFieldConfig[]> = {
@@ -40,6 +41,8 @@ const TENANT_TOOL_FIELDS: Record<TenantAgenticToolName, AgenticToolFieldConfig[]
   copilot: TOOL_FIELD_CONFIGS.copilot,
   cursor: TOOL_FIELD_CONFIGS.cursor,
   opencode: [],
+  // OMP authenticates through its own CLI profile; no tenant-stored credentials.
+  omp: [],
 };
 
 const RESOLUTION_POLICIES: Array<{

--- a/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
@@ -37,6 +37,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
   const [cursorForm] = Form.useForm();
+  const [ompForm] = Form.useForm();
 
   const [saving, setSaving] = useState<Record<AgenticToolName, boolean>>({
     'claude-code': false,
@@ -46,6 +47,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
     opencode: false,
     copilot: false,
     cursor: false,
+    omp: false,
   });
   const [activeTab, setActiveTab] = useState<AgenticToolName>('claude-code');
 
@@ -68,6 +70,8 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
         return copilotForm;
       case 'cursor':
         return cursorForm;
+      case 'omp':
+        return ompForm;
     }
   };
 
@@ -123,6 +127,12 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
       label: 'OpenCode',
       tool: 'opencode',
       form: opencodeForm,
+    },
+    {
+      key: 'omp',
+      label: 'Oh My Pi',
+      tool: 'omp',
+      form: ompForm,
     },
     {
       key: 'cursor',

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -73,6 +73,7 @@ const AGENTIC_TOOL_TABS = [
   'opencode',
   'copilot',
   'cursor',
+  'omp',
 ] as const satisfies readonly AgenticToolName[];
 
 type AgenticConfigFormValues = Parameters<typeof buildConfigFromFormValues>[1] & {
@@ -126,6 +127,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
   const [cursorForm] = Form.useForm();
+  const [ompForm] = Form.useForm();
   const [audioForm] = Form.useForm();
 
   const agenticFormByTool = useMemo<Record<AgenticToolName, ReturnType<typeof Form.useForm>[0]>>(
@@ -137,8 +139,18 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       opencode: opencodeForm,
       copilot: copilotForm,
       cursor: cursorForm,
+      omp: ompForm,
     }),
-    [claudeCliForm, claudeForm, codexForm, copilotForm, cursorForm, geminiForm, opencodeForm]
+    [
+      claudeCliForm,
+      claudeForm,
+      codexForm,
+      copilotForm,
+      cursorForm,
+      geminiForm,
+      ompForm,
+      opencodeForm,
+    ]
   );
 
   // Jump to initialTab each time the modal opens (e.g. from a banner deep-link).
@@ -157,6 +169,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     opencode: {},
     copilot: {},
     cursor: {},
+    omp: {},
   });
   const [savingToolField, setSavingToolField] = useState<Record<string, boolean>>({});
   const [agenticAuthMethods, setAgenticAuthMethods] = useState<
@@ -185,6 +198,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     opencode: false,
     copilot: false,
     cursor: false,
+    omp: false,
   });
   const [dirtyAgenticConfigTools, setDirtyAgenticConfigTools] = useState<Set<AgenticToolName>>(
     () => new Set()
@@ -331,6 +345,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       opencode: {},
       copilot: {},
       cursor: {},
+      omp: {},
     };
     const stored = user?.agentic_tools;
     if (stored) {
@@ -696,6 +711,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'opencode':
       case 'copilot':
       case 'cursor':
+      case 'omp':
         await handleAgenticConfigSave(activeTab as AgenticToolName);
         break;
     }
@@ -770,6 +786,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           key: 'opencode',
           label: 'OpenCode',
           icon: <ToolIcon tool="opencode" size={18} />,
+        },
+        {
+          key: 'omp',
+          label: 'Oh My Pi',
+          icon: <ToolIcon tool="omp" size={18} />,
         },
         {
           key: 'cursor',
@@ -1009,6 +1030,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'gemini':
       case 'opencode':
       case 'copilot':
+      case 'omp':
       case 'cursor': {
         const toolName = activeTab as AgenticToolName;
         const currentForm = agenticFormByTool[toolName];

--- a/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
+++ b/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
@@ -53,6 +53,7 @@ export const ToolIcon: React.FC<ToolIconProps> = ({ tool, size = 32, className =
     opencode: '🌐',
     copilot: '✈️',
     cursor: '⌘',
+    omp: '🥧',
   };
 
   if (!logoSrc) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -262,6 +262,12 @@
       "import": "./dist/models/gemini-shared.js",
       "require": "./dist/models/gemini-shared.cjs"
     },
+    "./omp": {
+      "source": "./src/omp/index.ts",
+      "types": "./dist/omp/index.d.ts",
+      "import": "./dist/omp/index.js",
+      "require": "./dist/omp/index.cjs"
+    },
     "./sdk": {
       "source": "./src/sdk/index.ts",
       "types": "./dist/sdk/index.d.ts",

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -89,7 +89,16 @@ export const sessions = pgTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'],
+      enum: [
+        'claude-code',
+        'claude-code-cli',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'cursor',
+        'omp',
+      ],
     }).notNull(),
     agentic_tool_preset_id: varchar('agentic_tool_preset_id', { length: 36 }).references(
       (): AnyPgColumn => agenticToolPresets.preset_id,
@@ -1265,7 +1274,7 @@ export const agenticToolPresets = pgTable(
     tenant_id: text('tenant_id').notNull().default('default'),
     preset_id: varchar('preset_id', { length: 36 }).primaryKey(),
     tool: text('tool', {
-      enum: ['claude-code', 'codex', 'gemini', 'copilot', 'cursor', 'opencode'],
+      enum: ['claude-code', 'codex', 'gemini', 'copilot', 'cursor', 'opencode', 'omp'],
     }).notNull(),
     name: text('name').notNull(),
     description: text('description'),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -76,7 +76,16 @@ export const sessions = sqliteTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'],
+      enum: [
+        'claude-code',
+        'claude-code-cli',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'cursor',
+        'omp',
+      ],
     }).notNull(),
     agentic_tool_preset_id: text('agentic_tool_preset_id', { length: 36 }).references(
       (): AnySQLiteColumn => agenticToolPresets.preset_id,
@@ -1242,7 +1251,7 @@ export const agenticToolPresets = sqliteTable(
   {
     preset_id: text('preset_id').primaryKey(),
     tool: text('tool', {
-      enum: ['claude-code', 'codex', 'gemini', 'copilot', 'cursor', 'opencode'],
+      enum: ['claude-code', 'codex', 'gemini', 'copilot', 'cursor', 'opencode', 'omp'],
     }).notNull(),
     name: text('name').notNull(),
     description: text('description'),

--- a/packages/core/src/omp/event-translator.test.ts
+++ b/packages/core/src/omp/event-translator.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import { isSlashCommandPrompt, OmpTurnAccumulator } from './event-translator.js';
+import type { OmpFrame } from './event-types.js';
+
+/** Build the assistant `message_end` frame OMP emits at the end of a message. */
+function assistantEnd(overrides: Record<string, unknown> = {}): OmpFrame {
+  return {
+    type: 'message_end',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'done' }],
+      model: 'claude-opus-5',
+      provider: 'anthropic',
+      stopReason: 'stop',
+      ...overrides,
+    },
+  } as OmpFrame;
+}
+
+describe('OmpTurnAccumulator', () => {
+  it('streams text deltas and ignores non-delta updates', () => {
+    const acc = new OmpTurnAccumulator();
+    expect(
+      acc.handle({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello' },
+      } as OmpFrame)
+    ).toEqual({ kind: 'text', text: 'Hello' });
+
+    expect(
+      acc.handle({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'pondering' },
+      } as OmpFrame)
+    ).toEqual({ kind: 'thinking', text: 'pondering' });
+
+    // Start/end markers carry no text and must not produce a chunk.
+    expect(
+      acc.handle({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_start', contentIndex: 0 },
+      } as OmpFrame)
+    ).toBeUndefined();
+  });
+
+  it('builds tool_use and tool_result blocks from execution events', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'tool_execution_start',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      args: { path: 'a.txt' },
+      intent: 'Reading a.txt',
+    } as OmpFrame);
+    acc.handle({
+      type: 'tool_execution_end',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      result: { content: [{ type: 'text', text: 'file body' }] },
+      isError: false,
+    } as OmpFrame);
+
+    const { contentBlocks, toolUses } = acc.result();
+    expect(contentBlocks).toEqual([
+      {
+        type: 'tool_use',
+        id: 'call-1',
+        name: 'read',
+        input: { path: 'a.txt' },
+        intent: 'Reading a.txt',
+      },
+      { type: 'tool_result', tool_use_id: 'call-1', content: 'file body', is_error: false },
+    ]);
+    expect(toolUses).toEqual([{ id: 'call-1', name: 'read', input: { path: 'a.txt' } }]);
+  });
+
+  it('does not duplicate a tool block when a start frame repeats', () => {
+    const acc = new OmpTurnAccumulator();
+    const start = {
+      type: 'tool_execution_start',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      args: {},
+    } as OmpFrame;
+    acc.handle(start);
+    acc.handle(start);
+    expect(acc.result().toolUses).toHaveLength(1);
+  });
+
+  it('treats a failing tool as normal progress, not a failed turn', () => {
+    // Agents routinely probe, hit an error, and adapt. Only transport/agent
+    // failures may set hadError, otherwise every exploratory turn fails.
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'tool_execution_start',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      args: { path: 'missing.txt' },
+    } as OmpFrame);
+    acc.handle({
+      type: 'tool_execution_end',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      result: { content: [{ type: 'text', text: 'ENOENT' }] },
+      isError: true,
+    } as OmpFrame);
+    acc.handle({ type: 'agent_end' } as OmpFrame);
+
+    const result = acc.result();
+    expect(result.hadError).toBe(false);
+    expect(result.contentBlocks).toContainEqual({
+      type: 'tool_result',
+      tool_use_id: 'call-1',
+      content: 'ENOENT',
+      is_error: true,
+    });
+  });
+
+  it('flags extension and transport errors as a failed turn', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle({ type: 'extension_error', error: 'boom' } as OmpFrame);
+    expect(acc.result().hadError).toBe(true);
+
+    const other = new OmpTurnAccumulator();
+    other.recordError('spawn failed');
+    expect(other.result().errorDetails).toEqual(['spawn failed']);
+  });
+
+  it('sums token usage and real USD cost across messages in a turn', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle(
+      assistantEnd({
+        usage: {
+          input: 2,
+          output: 100,
+          cacheRead: 0,
+          cacheWrite: 50,
+          totalTokens: 152,
+          cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0.3, total: 0.6 },
+        },
+      })
+    );
+    acc.handle(
+      assistantEnd({
+        usage: {
+          input: 3,
+          output: 7,
+          cacheRead: 150,
+          cacheWrite: 1,
+          totalTokens: 161,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.4 },
+        },
+      })
+    );
+
+    expect(acc.result().usage).toEqual({
+      inputTokens: 5,
+      outputTokens: 107,
+      cacheReadTokens: 150,
+      cacheCreationTokens: 51,
+      totalTokens: 313,
+      costUsd: 1,
+    });
+  });
+
+  it('records the model and stop reason from the assistant message', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle(assistantEnd());
+    const result = acc.result();
+    expect(result.model).toBe('claude-opus-5');
+    expect(result.provider).toBe('anthropic');
+    expect(result.stopReason).toBe('stop');
+  });
+
+  it('ignores user messages so the transcript is not duplicated', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'message_end',
+      message: { role: 'user', content: [{ type: 'text', text: 'my prompt' }] },
+    } as OmpFrame);
+    expect(acc.result().contentBlocks).toEqual([]);
+  });
+
+  it('captures slash-command output as a text block', () => {
+    // Local-only commands never invoke the agent; their output arrives on the
+    // command_output side channel and is the entire visible result.
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'command_output',
+      text: 'Current model: anthropic/claude-opus-5',
+    } as OmpFrame);
+    const result = acc.result();
+    expect(result.commandOutputs).toEqual(['Current model: anthropic/claude-opus-5']);
+    expect(result.contentBlocks).toEqual([
+      { type: 'text', text: 'Current model: anthropic/claude-opus-5' },
+    ]);
+  });
+
+  it('collects advertised slash commands for composer autocomplete', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'available_commands_update',
+      commands: [
+        { name: 'model', description: 'Show current model selection', source: 'builtin' },
+        { name: 'usage', description: 'Show usage', source: 'builtin' },
+      ],
+    } as OmpFrame);
+    expect(acc.result().slashCommands).toEqual(['model', 'usage']);
+  });
+
+  it('replaces the command set when OMP re-advertises it', () => {
+    // OMP re-emits on change; keeping both sets would surface stale commands.
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'available_commands_update',
+      commands: [{ name: 'old' }],
+    } as OmpFrame);
+    acc.handle({
+      type: 'available_commands_update',
+      commands: [{ name: 'fresh' }],
+    } as OmpFrame);
+    expect(acc.result().slashCommands).toEqual(['fresh']);
+  });
+
+  it('ignores malformed command entries without dropping valid ones', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle({
+      type: 'available_commands_update',
+      commands: [{ name: 'good' }, { description: 'no name' }, null, { name: '' }],
+    } as OmpFrame);
+    expect(acc.result().slashCommands).toEqual(['good']);
+  });
+
+  it('marks the turn ended on agent_end and via markEnded', () => {
+    const viaAgent = new OmpTurnAccumulator();
+    expect(viaAgent.isEnded).toBe(false);
+    viaAgent.handle({ type: 'agent_end' } as OmpFrame);
+    expect(viaAgent.isEnded).toBe(true);
+
+    const viaLocal = new OmpTurnAccumulator();
+    viaLocal.markEnded();
+    expect(viaLocal.result().ended).toBe(true);
+  });
+
+  it('drops blank text and thinking blocks', () => {
+    const acc = new OmpTurnAccumulator();
+    acc.handle(
+      assistantEnd({
+        content: [
+          { type: 'text', text: '   ' },
+          { type: 'thinking', thinking: '' },
+          { type: 'text', text: 'kept' },
+        ],
+      })
+    );
+    expect(acc.result().contentBlocks).toEqual([{ type: 'text', text: 'kept' }]);
+  });
+
+  it('tolerates unknown and malformed frames', () => {
+    const acc = new OmpTurnAccumulator();
+    expect(() => {
+      acc.handle({ type: 'some_future_frame', payload: 1 } as OmpFrame);
+      acc.handle({ type: 'message_end' } as OmpFrame);
+      acc.handle({ type: 'tool_execution_end', toolCallId: 'x' } as OmpFrame);
+    }).not.toThrow();
+  });
+});
+
+describe('isSlashCommandPrompt', () => {
+  it('detects slash commands, including leading whitespace', () => {
+    expect(isSlashCommandPrompt('/model')).toBe(true);
+    expect(isSlashCommandPrompt('  /usage')).toBe(true);
+  });
+
+  it('treats ordinary prompts and paths as non-commands', () => {
+    expect(isSlashCommandPrompt('fix the bug')).toBe(false);
+    expect(isSlashCommandPrompt('what does a/b do?')).toBe(false);
+  });
+});

--- a/packages/core/src/omp/event-translator.test.ts
+++ b/packages/core/src/omp/event-translator.test.ts
@@ -87,6 +87,22 @@ describe('OmpTurnAccumulator', () => {
     expect(acc.result().toolUses).toHaveLength(1);
   });
 
+  it('does not emit an orphan tool_result when an end frame repeats', () => {
+    // Asymmetric dedup used to let a retried end frame append a second
+    // tool_result with no matching tool_use.
+    const acc = new OmpTurnAccumulator();
+    const end = {
+      type: 'tool_execution_end',
+      toolCallId: 'call-1',
+      toolName: 'read',
+      result: { content: [{ type: 'text', text: 'body' }] },
+    } as OmpFrame;
+    acc.handle(end);
+    acc.handle(end);
+    const results = acc.result().contentBlocks.filter((b) => b.type === 'tool_result');
+    expect(results).toHaveLength(1);
+  });
+
   it('treats a failing tool as normal progress, not a failed turn', () => {
     // Agents routinely probe, hit an error, and adapt. Only transport/agent
     // failures may set hadError, otherwise every exploratory turn fails.

--- a/packages/core/src/omp/event-translator.ts
+++ b/packages/core/src/omp/event-translator.ts
@@ -95,6 +95,8 @@ export class OmpTurnAccumulator {
   private sawError = false;
   /** Tool call ids already emitted, so a retried frame cannot duplicate a block. */
   private readonly seenToolCalls = new Set<string>();
+  /** Tool call ids already completed, so a retried end frame cannot duplicate. */
+  private readonly settledToolCalls = new Set<string>();
 
   /**
    * Consume one frame.
@@ -270,9 +272,14 @@ export class OmpTurnAccumulator {
    * and adapt — that is normal progress, not a task failure. The error is
    * flagged on the block so the UI renders it as such, but only transport and
    * agent-level failures set `hadError`.
+   *
+   * Deduplicated by call id, mirroring `handleToolStart`: a repeated end frame
+   * would otherwise append a second `tool_result` with no matching `tool_use`.
    */
   private handleToolEnd(frame: OmpFrame): void {
     if (!('toolCallId' in frame) || typeof frame.toolCallId !== 'string') return;
+    if (this.settledToolCalls.has(frame.toolCallId)) return;
+    this.settledToolCalls.add(frame.toolCallId);
     const isError = 'isError' in frame && frame.isError === true;
     this.blocks.push({
       type: 'tool_result',

--- a/packages/core/src/omp/event-translator.ts
+++ b/packages/core/src/omp/event-translator.ts
@@ -1,0 +1,323 @@
+/**
+ * Translates an Oh My Pi RPC event stream into Agor message content.
+ *
+ * OMP emits both incremental deltas (for live typing) and, at
+ * `message_end`, the authoritative final message. This accumulator streams the
+ * deltas for UX but builds the persisted blocks from the final messages, so a
+ * dropped or reordered delta can never corrupt what gets stored.
+ *
+ * Pure and transport-free so it can be unit-tested without spawning OMP.
+ */
+
+import type { ContentBlock } from '../types/message.js';
+import type { OmpFrame, OmpMessage } from './event-types.js';
+
+/** A chunk of streamable output to forward to Agor's streaming callbacks. */
+export interface OmpStreamDelta {
+  kind: 'text' | 'thinking';
+  text: string;
+}
+
+/** Token/cost totals summed across every assistant message in a turn. */
+export interface OmpTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  /** Real USD spend as reported by OMP — not an Agor-side estimate. */
+  costUsd: number;
+}
+
+/** Everything the executor needs once a turn finishes. */
+export interface OmpTurnResult {
+  contentBlocks: ContentBlock[];
+  toolUses: Array<{ id: string; name: string; input: Record<string, unknown> }>;
+  usage: OmpTurnUsage;
+  model?: string;
+  provider?: string;
+  stopReason?: string;
+  hadError: boolean;
+  errorDetails: string[];
+  /**
+   * True once OMP signalled the turn is over. Set by `agent_end`, or by a
+   * local-only slash command resolving without invoking the agent.
+   */
+  ended: boolean;
+  /** Output produced by local-only slash commands (e.g. `/model`). */
+  commandOutputs: string[];
+  /**
+   * Slash commands OMP advertised for this session. Agor persists these so the
+   * composer can autocomplete them.
+   */
+  slashCommands: string[];
+}
+
+const EMPTY_USAGE: OmpTurnUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 0,
+  costUsd: 0,
+};
+
+/**
+ * Read a numeric field off an unvalidated object, defaulting to 0.
+ *
+ * OMP's usage payloads are external input, so every field is checked rather
+ * than assumed; a missing or non-numeric entry contributes nothing to totals.
+ */
+function readNumber(source: object, key: string): number {
+  if (!(key in source)) return 0;
+  const value: unknown = Reflect.get(source, key);
+  return typeof value === 'number' ? value : 0;
+}
+
+/**
+ * Accumulates one OMP turn.
+ *
+ * Feed every frame to `handle()`; it returns a delta whenever the frame
+ * carried streamable text. Read `result()` once `ended` is true.
+ */
+export class OmpTurnAccumulator {
+  private readonly blocks: ContentBlock[] = [];
+  private readonly toolUses: Array<{ id: string; name: string; input: Record<string, unknown> }> =
+    [];
+  private readonly errors: string[] = [];
+  private readonly commandOutputs: string[] = [];
+  private slashCommandNames: string[] = [];
+  private usage: OmpTurnUsage = { ...EMPTY_USAGE };
+  private model?: string;
+  private provider?: string;
+  private stopReason?: string;
+  private ended = false;
+  private sawError = false;
+  /** Tool call ids already emitted, so a retried frame cannot duplicate a block. */
+  private readonly seenToolCalls = new Set<string>();
+
+  /**
+   * Consume one frame.
+   *
+   * @returns streamable text when the frame was a text/thinking delta.
+   */
+  handle(frame: OmpFrame): OmpStreamDelta | undefined {
+    switch (frame.type) {
+      case 'message_update':
+        return this.handleMessageUpdate(frame);
+      case 'message_end':
+        this.handleMessageEnd(frame);
+        return undefined;
+      case 'tool_execution_start':
+        this.handleToolStart(frame);
+        return undefined;
+      case 'tool_execution_end':
+        this.handleToolEnd(frame);
+        return undefined;
+      case 'command_output':
+        if ('text' in frame && typeof frame.text === 'string') {
+          this.commandOutputs.push(frame.text);
+          this.blocks.push({ type: 'text', text: frame.text });
+        }
+        return undefined;
+      case 'available_commands_update':
+        this.captureSlashCommands(frame);
+        return undefined;
+      case 'extension_error':
+        if ('error' in frame && typeof frame.error === 'string') {
+          this.sawError = true;
+          this.errors.push(frame.error);
+        }
+        return undefined;
+      case 'agent_end':
+        this.ended = true;
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  /** Mark the turn finished without an `agent_end` (local-only slash command). */
+  markEnded(): void {
+    this.ended = true;
+  }
+
+  /** Record a transport/protocol failure against the turn. */
+  recordError(message: string): void {
+    this.sawError = true;
+    this.errors.push(message);
+  }
+
+  get isEnded(): boolean {
+    return this.ended;
+  }
+
+  /**
+   * Record the command set OMP advertises.
+   *
+   * OMP emits this at startup and whenever command metadata changes, so the
+   * latest frame wins rather than accumulating stale entries.
+   */
+  private captureSlashCommands(frame: OmpFrame): void {
+    if (!('commands' in frame) || !Array.isArray(frame.commands)) return;
+    const names: string[] = [];
+    for (const command of frame.commands) {
+      if (typeof command !== 'object' || command === null) continue;
+      if (!('name' in command) || typeof command.name !== 'string' || !command.name) continue;
+      names.push(command.name);
+    }
+    if (names.length > 0) this.slashCommandNames = names;
+  }
+
+  private handleMessageUpdate(frame: OmpFrame): OmpStreamDelta | undefined {
+    if (!('assistantMessageEvent' in frame)) return undefined;
+    const event = frame.assistantMessageEvent;
+    if (typeof event !== 'object' || event === null) return undefined;
+    if (!('type' in event) || typeof event.type !== 'string') return undefined;
+    if (!('delta' in event) || typeof event.delta !== 'string' || event.delta === '') {
+      return undefined;
+    }
+    if (event.type === 'text_delta') return { kind: 'text', text: event.delta };
+    if (event.type === 'thinking_delta') return { kind: 'thinking', text: event.delta };
+    return undefined;
+  }
+
+  /**
+   * Fold a completed message in. Only assistant messages contribute content;
+   * the user echo is already in Agor's transcript.
+   */
+  private handleMessageEnd(frame: OmpFrame): void {
+    if (!('message' in frame)) return;
+    const message = frame.message;
+    if (typeof message !== 'object' || message === null) return;
+    if (!('role' in message) || message.role !== 'assistant') return;
+
+    this.foldUsage(message);
+    if ('model' in message && typeof message.model === 'string') this.model = message.model;
+    if ('provider' in message && typeof message.provider === 'string') {
+      this.provider = message.provider;
+    }
+    if ('stopReason' in message && typeof message.stopReason === 'string') {
+      this.stopReason = message.stopReason;
+    }
+
+    if (!('content' in message) || !Array.isArray(message.content)) return;
+    for (const block of message.content) {
+      if (typeof block !== 'object' || block === null) continue;
+      if (!('type' in block)) continue;
+      if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
+        if (block.text.trim()) this.blocks.push({ type: 'text', text: block.text });
+      } else if (
+        block.type === 'thinking' &&
+        'thinking' in block &&
+        typeof block.thinking === 'string'
+      ) {
+        if (block.thinking.trim()) this.blocks.push({ type: 'thinking', thinking: block.thinking });
+      }
+    }
+  }
+
+  private foldUsage(message: OmpMessage | Record<string, unknown>): void {
+    if (!('usage' in message)) return;
+    const usage = message.usage;
+    if (typeof usage !== 'object' || usage === null) return;
+    this.usage = {
+      inputTokens: this.usage.inputTokens + readNumber(usage, 'input'),
+      outputTokens: this.usage.outputTokens + readNumber(usage, 'output'),
+      cacheReadTokens: this.usage.cacheReadTokens + readNumber(usage, 'cacheRead'),
+      cacheCreationTokens: this.usage.cacheCreationTokens + readNumber(usage, 'cacheWrite'),
+      totalTokens: this.usage.totalTokens + readNumber(usage, 'totalTokens'),
+      costUsd: this.usage.costUsd + this.readCostTotal(usage),
+    };
+  }
+
+  private readCostTotal(usage: object): number {
+    if (!('cost' in usage)) return 0;
+    const cost = usage.cost;
+    if (typeof cost !== 'object' || cost === null) return 0;
+    return readNumber(cost, 'total');
+  }
+
+  private handleToolStart(frame: OmpFrame): void {
+    if (!('toolCallId' in frame) || typeof frame.toolCallId !== 'string') return;
+    if (!('toolName' in frame) || typeof frame.toolName !== 'string') return;
+    if (this.seenToolCalls.has(frame.toolCallId)) return;
+    this.seenToolCalls.add(frame.toolCallId);
+
+    const args =
+      'args' in frame && typeof frame.args === 'object' && frame.args !== null
+        ? { ...frame.args }
+        : {};
+    const block: ContentBlock = {
+      type: 'tool_use',
+      id: frame.toolCallId,
+      name: frame.toolName,
+      input: args,
+    };
+    // OMP annotates each call with a short natural-language intent; surface it
+    // so Agor's tool blocks read the way they do in the OMP TUI.
+    if ('intent' in frame && typeof frame.intent === 'string' && frame.intent) {
+      block.intent = frame.intent;
+    }
+    this.blocks.push(block);
+    this.toolUses.push({ id: frame.toolCallId, name: frame.toolName, input: args });
+  }
+
+  /**
+   * Record a finished tool call.
+   *
+   * A failing tool is NOT a failed turn. Agents routinely probe, get an error,
+   * and adapt — that is normal progress, not a task failure. The error is
+   * flagged on the block so the UI renders it as such, but only transport and
+   * agent-level failures set `hadError`.
+   */
+  private handleToolEnd(frame: OmpFrame): void {
+    if (!('toolCallId' in frame) || typeof frame.toolCallId !== 'string') return;
+    const isError = 'isError' in frame && frame.isError === true;
+    this.blocks.push({
+      type: 'tool_result',
+      tool_use_id: frame.toolCallId,
+      content: this.flattenToolResult(frame),
+      is_error: isError,
+    });
+  }
+
+  /** Collapse an OMP tool result's content array into displayable text. */
+  private flattenToolResult(frame: OmpFrame): string {
+    if (!('result' in frame)) return '';
+    const result = frame.result;
+    if (typeof result !== 'object' || result === null) return '';
+    if (!('content' in result) || !Array.isArray(result.content)) return '';
+    const parts: string[] = [];
+    for (const entry of result.content) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      if ('text' in entry && typeof entry.text === 'string') parts.push(entry.text);
+    }
+    return parts.join('\n');
+  }
+
+  /** Snapshot the accumulated turn. */
+  result(): OmpTurnResult {
+    return {
+      contentBlocks: [...this.blocks],
+      toolUses: [...this.toolUses],
+      usage: { ...this.usage },
+      model: this.model,
+      provider: this.provider,
+      stopReason: this.stopReason,
+      hadError: this.sawError,
+      errorDetails: [...this.errors],
+      ended: this.ended,
+      commandOutputs: [...this.commandOutputs],
+      slashCommands: [...this.slashCommandNames],
+    };
+  }
+}
+
+/**
+ * A prompt is a slash command when it starts with `/` — OMP expands these
+ * itself and may complete them without ever invoking the model.
+ */
+export function isSlashCommandPrompt(prompt: string): boolean {
+  return prompt.trimStart().startsWith('/');
+}

--- a/packages/core/src/omp/event-types.ts
+++ b/packages/core/src/omp/event-types.ts
@@ -1,0 +1,239 @@
+/**
+ * Wire types for the Oh My Pi (OMP) JSONL RPC protocol.
+ *
+ * Agor drives OMP by spawning `omp --mode rpc`, which speaks newline-delimited
+ * JSON over stdio: commands in on stdin, a `ready` frame plus command
+ * responses and agent events out on stdout.
+ *
+ * These types are hand-written against OMP's documented RPC reference rather
+ * than imported: OMP's npm package ships raw TypeScript and targets the Bun
+ * runtime, so it cannot be a dependency of Agor's Node executor.
+ *
+ * Only the surface Agor actually consumes is modelled. Unknown frames are
+ * tolerated by design — OMP may add event types, and the translator ignores
+ * anything it does not recognise instead of failing the turn.
+ */
+
+/** Reasoning levels OMP accepts for `set_thinking_level`. */
+export type OmpThinkingLevel =
+  | 'off'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max'
+  | 'auto';
+
+/** How a prompt issued while the agent is streaming should be queued. */
+export type OmpStreamingBehavior = 'steer' | 'followUp';
+
+/**
+ * Per-message token accounting as reported by OMP.
+ *
+ * Note OMP reports real spend in `cost` (USD) rather than leaving the host to
+ * infer it from a price table — Agor surfaces this directly instead of
+ * estimating.
+ */
+export interface OmpUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+  /** Cache time-to-live buckets, e.g. `{ ephemeral1h: 53259 }`. Informational. */
+  cttl?: Record<string, number>;
+}
+
+/** A single content block on an OMP message. */
+export interface OmpContentBlock {
+  type: 'text' | 'thinking' | 'toolCall' | 'toolResult' | string;
+  text?: string;
+  thinking?: string;
+  thinkingSignature?: string;
+  /** Present on `toolCall` blocks. */
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** A whole message as carried by `message_start` / `message_end`. */
+export interface OmpMessage {
+  role: 'user' | 'assistant' | 'system' | string;
+  content: OmpContentBlock[];
+  api?: string;
+  provider?: string;
+  model?: string;
+  usage?: OmpUsage;
+  stopReason?: string;
+  timestamp?: number;
+  attribution?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Streaming delta carried by `message_update`.
+ *
+ * `contentIndex` identifies which block of the in-flight assistant message the
+ * delta belongs to, which is what lets text and thinking interleave safely.
+ */
+export interface OmpAssistantMessageEvent {
+  type:
+    | 'text_start'
+    | 'text_delta'
+    | 'text_end'
+    | 'thinking_start'
+    | 'thinking_delta'
+    | 'thinking_end'
+    | 'toolcall_start'
+    | 'toolcall_delta'
+    | 'toolcall_end'
+    | string;
+  contentIndex?: number;
+  delta?: string;
+  [key: string]: unknown;
+}
+
+/** Result payload attached to `tool_execution_end`. */
+export interface OmpToolResult {
+  content?: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  details?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** One slash command advertised by OMP. */
+export interface OmpSlashCommand {
+  name: string;
+  description?: string;
+  aliases?: string[];
+  /** Free-form argument hint, e.g. `"[on|off|status]"`. */
+  input?: { hint?: string };
+  subcommands?: Array<{ name: string; description?: string }>;
+  /** Where the command came from: `builtin`, an extension, a file, etc. */
+  source?: string;
+}
+
+/** Context-window occupancy reported by `get_state`. */
+export interface OmpContextUsage {
+  tokens: number;
+  contextWindow: number;
+  /** Percentage in the 0–100 range (may be fractional). */
+  percent: number;
+}
+
+/** Model descriptor reported by `get_state` / `get_available_models`. */
+export interface OmpModelInfo {
+  id: string;
+  name?: string;
+  provider?: string;
+  api?: string;
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  thinking?: { mode?: string; efforts?: string[]; supportsDisplay?: boolean };
+  [key: string]: unknown;
+}
+
+/** Payload of a successful `get_state` response. */
+export interface OmpState {
+  model?: OmpModelInfo;
+  thinkingLevel?: OmpThinkingLevel;
+  isStreaming?: boolean;
+  isCompacting?: boolean;
+  sessionFile?: string;
+  sessionId?: string;
+  sessionName?: string;
+  messageCount?: number;
+  queuedMessageCount?: number;
+  contextUsage?: OmpContextUsage;
+  [key: string]: unknown;
+}
+
+/** The handshake frame OMP writes before accepting commands. */
+export interface OmpReadyFrame {
+  type: 'ready';
+  protocolVersion: number;
+  supportedProtocolVersions?: number[];
+  maxFrameBytes?: number;
+  maxReassembledFrameBytes?: number;
+}
+
+/** Reply to a command, correlated by the `id` the caller supplied. */
+export interface OmpResponseFrame {
+  type: 'response';
+  id?: string;
+  command: string;
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+/**
+ * Every stdout frame Agor understands.
+ *
+ * Deliberately open-ended (`| { type: string }`) so an OMP upgrade that adds
+ * frames cannot break parsing.
+ */
+export type OmpFrame =
+  | OmpReadyFrame
+  | OmpResponseFrame
+  | { type: 'agent_start' }
+  | { type: 'agent_end'; messages?: OmpMessage[]; isTerminal?: boolean }
+  | { type: 'turn_start' }
+  | { type: 'turn_end' }
+  | { type: 'message_start'; message: OmpMessage }
+  | { type: 'message_end'; message: OmpMessage }
+  | {
+      type: 'message_update';
+      assistantMessageEvent: OmpAssistantMessageEvent;
+      message?: OmpMessage;
+    }
+  | {
+      type: 'tool_execution_start';
+      toolCallId: string;
+      toolName: string;
+      args?: Record<string, unknown>;
+      intent?: string;
+    }
+  | {
+      type: 'tool_execution_end';
+      toolCallId: string;
+      toolName: string;
+      result?: OmpToolResult;
+      isError?: boolean;
+    }
+  | { type: 'available_commands_update'; commands: OmpSlashCommand[] }
+  | { type: 'command_output'; text: string }
+  | { type: 'prompt_result'; id?: string; agentInvoked: boolean }
+  | { type: 'extension_ui_request'; id: string; method: string; [key: string]: unknown }
+  | { type: 'extension_error'; extensionPath?: string; event?: string; error?: string }
+  | { type: string; [key: string]: unknown };
+
+/** Commands Agor sends on stdin. `id` correlates the eventual response. */
+export type OmpCommand =
+  | { id?: string; type: 'prompt'; message: string; streamingBehavior?: OmpStreamingBehavior }
+  | { id?: string; type: 'steer'; message: string }
+  | { id?: string; type: 'follow_up'; message: string }
+  | { id?: string; type: 'abort' }
+  | { id?: string; type: 'get_state' }
+  | { id?: string; type: 'get_available_commands' }
+  | { id?: string; type: 'get_available_models' }
+  | { id?: string; type: 'set_model'; provider: string; modelId: string }
+  | { id?: string; type: 'set_thinking_level'; level: OmpThinkingLevel }
+  | { id?: string; type: 'get_last_assistant_text' }
+  | { id?: string; type: 'set_session_name'; name: string }
+  | { id?: string; type: string; [key: string]: unknown };
+
+/** Narrowing helper — `type` is present on every well-formed frame. */
+export function isOmpFrame(value: unknown): value is OmpFrame {
+  if (typeof value !== 'object' || value === null || !('type' in value)) return false;
+  return typeof value.type === 'string';
+}

--- a/packages/core/src/omp/index.ts
+++ b/packages/core/src/omp/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Oh My Pi (OMP) integration primitives shared by the executor adapter and the
+ * daemon. Transport, wire types, event translation, and spawn/MCP setup for
+ * driving `omp --mode rpc`.
+ */
+
+export * from './event-translator.js';
+export * from './event-types.js';
+export * from './rpc-client.js';
+export * from './spawn-config.js';

--- a/packages/core/src/omp/rpc-client.ts
+++ b/packages/core/src/omp/rpc-client.ts
@@ -81,7 +81,10 @@ function asResponseFrame(frame: OmpFrame): OmpResponseFrame | undefined {
 interface ChunkAccumulator {
   chunkId: string;
   count: number;
+  /** Declared total size of the logical frame, as advertised by OMP. */
   byteLength: number;
+  /** Base64 characters actually buffered so far. */
+  buffered: number;
   parts: string[];
   received: number;
 }
@@ -244,7 +247,18 @@ export class OmpRpcClient {
     while (newlineIndex >= 0) {
       const line = this.stdoutBuffer.slice(0, newlineIndex);
       this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
-      if (line.trim()) this.handleLine(line);
+      if (line.trim()) {
+        // This runs inside a stream 'data' listener: an escaping throw would be
+        // an uncaught exception and take the executor process down. A bad frame
+        // must degrade to a dropped frame, never a crash.
+        try {
+          this.handleLine(line);
+        } catch (error) {
+          this.options.onStderr?.(
+            `[omp-rpc] dropped frame: ${error instanceof Error ? error.message : String(error)}\n`
+          );
+        }
+      }
       newlineIndex = this.stdoutBuffer.indexOf('\n');
     }
   }
@@ -285,6 +299,7 @@ export class OmpRpcClient {
         chunkId: chunk.chunkId,
         count: chunk.count,
         byteLength: chunk.byteLength,
+        buffered: 0,
         parts: new Array<string>(chunk.count).fill(''),
         received: 0,
       };
@@ -294,7 +309,11 @@ export class OmpRpcClient {
       this.chunk = undefined;
       return undefined;
     }
-    if (acc.byteLength > this.maxReassembledBytes) {
+    // Bound on bytes ACTUALLY buffered, not the declared `byteLength` of the
+    // first chunk — a sequence of small chunks must not be able to grow the
+    // buffer past the negotiated ceiling unchecked.
+    acc.buffered += chunk.data.length;
+    if (acc.buffered > this.maxReassembledBytes || acc.byteLength > this.maxReassembledBytes) {
       this.chunk = undefined;
       throw new Error('OMP frame exceeded the negotiated reassembly limit');
     }

--- a/packages/core/src/omp/rpc-client.ts
+++ b/packages/core/src/omp/rpc-client.ts
@@ -1,0 +1,425 @@
+/**
+ * Client for Oh My Pi's JSONL RPC protocol (`omp --mode rpc`).
+ *
+ * Owns the subprocess lifecycle, stdout framing, protocol-v2 chunk
+ * reassembly, and request/response correlation. It is deliberately transport
+ * only: translating OMP events into Agor messages is `event-translator.ts`,
+ * and deciding what to do with them is the executor's `OmpTool`.
+ *
+ * Why a subprocess rather than an in-process SDK: OMP's npm package ships raw
+ * TypeScript and targets the Bun runtime, so Agor's Node executor cannot
+ * import it. The RPC protocol is OMP's supported embedding surface.
+ */
+
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import {
+  isOmpFrame,
+  type OmpCommand,
+  type OmpFrame,
+  type OmpReadyFrame,
+  type OmpResponseFrame,
+} from './event-types.js';
+
+/** Largest reassembled logical frame we will buffer, matching OMP's default. */
+const DEFAULT_MAX_REASSEMBLED_BYTES = 64 * 1024 * 1024;
+
+/** How long to wait for the `ready` frame before giving up on the process. */
+const READY_TIMEOUT_MS = 30_000;
+
+/** Default ceiling for a correlated request. Prompts are NOT bounded by this. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+export interface OmpRpcClientOptions {
+  /** Working directory for the agent — normally the Agor branch worktree. */
+  cwd: string;
+  /** Executable to spawn. Defaults to `omp` resolved from PATH. */
+  binPath?: string;
+  /**
+   * OMP profile name. Optional: when omitted OMP runs under the host user's
+   * default profile, inheriting their existing login.
+   */
+  profile?: string;
+  /** Model pattern passed through to `--model` (OMP fuzzy-matches it). */
+  model?: string;
+  /**
+   * Prior OMP session to resume (`--resume`), by session-file path or id
+   * prefix. Carries conversation state across Agor turns, which each spawn a
+   * fresh process.
+   */
+  resume?: string;
+  /** Extra CLI arguments appended verbatim. */
+  extraArgs?: string[];
+  /** Environment for the child. Merged over `process.env` by the caller. */
+  env?: NodeJS.ProcessEnv;
+  /** Receives every decoded stdout frame, in order. */
+  onFrame?: (frame: OmpFrame) => void;
+  /** Receives raw stderr text (OMP logs diagnostics here). */
+  onStderr?: (text: string) => void;
+  /** Invoked once the process exits, for whatever reason. */
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+  /** Injection seam for tests. */
+  spawnFn?: typeof spawn;
+}
+
+/** Structural check for a `response` frame, validated rather than asserted. */
+function asResponseFrame(frame: OmpFrame): OmpResponseFrame | undefined {
+  if (frame.type !== 'response') return undefined;
+  if (!('command' in frame) || typeof frame.command !== 'string') return undefined;
+  if (!('success' in frame) || typeof frame.success !== 'boolean') return undefined;
+  const id = 'id' in frame && typeof frame.id === 'string' ? frame.id : undefined;
+  const error = 'error' in frame && typeof frame.error === 'string' ? frame.error : undefined;
+  return {
+    type: 'response',
+    id,
+    command: frame.command,
+    success: frame.success,
+    data: 'data' in frame ? frame.data : undefined,
+    error,
+  };
+}
+
+interface ChunkAccumulator {
+  chunkId: string;
+  count: number;
+  byteLength: number;
+  parts: string[];
+  received: number;
+}
+
+/** Fields carried by a protocol-v2 `rpc_chunk` frame, once validated. */
+interface ChunkFrame {
+  chunkId: string;
+  index: number;
+  count: number;
+  byteLength: number;
+  data: string;
+}
+
+/**
+ * Validate a `rpc_chunk` frame. Returns undefined when the frame is malformed,
+ * which the caller treats as lost framing and drops the partial buffer.
+ */
+function asChunkFrame(frame: OmpFrame): ChunkFrame | undefined {
+  if (!('chunkId' in frame && 'index' in frame && 'count' in frame && 'data' in frame)) {
+    return undefined;
+  }
+  const { chunkId, index, count, data } = frame;
+  if (typeof chunkId !== 'string' || typeof data !== 'string') return undefined;
+  if (typeof index !== 'number' || typeof count !== 'number') return undefined;
+  const rawByteLength = 'byteLength' in frame ? frame.byteLength : 0;
+  return {
+    chunkId,
+    index,
+    count,
+    byteLength: typeof rawByteLength === 'number' ? rawByteLength : 0,
+    data,
+  };
+}
+
+interface PendingRequest {
+  resolve: (response: OmpResponseFrame) => void;
+  reject: (error: Error) => void;
+  timer?: NodeJS.Timeout;
+}
+
+export class OmpRpcClient {
+  private readonly options: OmpRpcClientOptions;
+  private child?: ChildProcessWithoutNullStreams;
+  private stdoutBuffer = '';
+  private readonly pending = new Map<string, PendingRequest>();
+  private requestCounter = 0;
+  private chunk?: ChunkAccumulator;
+  private maxReassembledBytes = DEFAULT_MAX_REASSEMBLED_BYTES;
+  private readyFrame?: OmpReadyFrame;
+  private exited = false;
+  private exitError?: Error;
+
+  constructor(options: OmpRpcClientOptions) {
+    this.options = options;
+  }
+
+  /** True once the process has exited (cleanly or not). */
+  get isExited(): boolean {
+    return this.exited;
+  }
+
+  /** The negotiated ready frame, available after `start()` resolves. */
+  get ready(): OmpReadyFrame | undefined {
+    return this.readyFrame;
+  }
+
+  /** Build the argv for `omp --mode rpc`, exposed for spawn-config tests. */
+  static buildArgs(
+    options: Pick<OmpRpcClientOptions, 'profile' | 'model' | 'resume' | 'extraArgs'>
+  ): string[] {
+    const args = ['--mode', 'rpc'];
+    if (options.profile) args.push('--profile', options.profile);
+    if (options.model) args.push('--model', options.model);
+    if (options.resume) args.push('--resume', options.resume);
+    if (options.extraArgs?.length) args.push(...options.extraArgs);
+    return args;
+  }
+
+  /**
+   * Spawn OMP and resolve once it advertises readiness.
+   *
+   * Negotiates protocol v2 when offered so oversized frames arrive losslessly
+   * as `rpc_chunk` sequences instead of being truncated.
+   */
+  async start(): Promise<OmpReadyFrame> {
+    if (this.child) throw new Error('OmpRpcClient already started');
+
+    const spawnFn = this.options.spawnFn ?? spawn;
+    const child = spawnFn(this.options.binPath ?? 'omp', OmpRpcClient.buildArgs(this.options), {
+      cwd: this.options.cwd,
+      env: this.options.env ?? process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.child = child;
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (text: string) => {
+      this.consumeStdout(text);
+    });
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (text: string) => {
+      this.options.onStderr?.(text);
+    });
+
+    const readyPromise = new Promise<OmpReadyFrame>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`OMP did not become ready within ${READY_TIMEOUT_MS}ms`));
+      }, READY_TIMEOUT_MS);
+
+      this.onReady = (frame) => {
+        clearTimeout(timer);
+        resolve(frame);
+      };
+      this.onEarlyFailure = (error) => {
+        clearTimeout(timer);
+        reject(error);
+      };
+    });
+
+    child.on('error', (error) => {
+      const wrapped =
+        'code' in error && error.code === 'ENOENT'
+          ? new Error(
+              `Oh My Pi binary not found (tried "${this.options.binPath ?? 'omp'}"). ` +
+                'Install OMP and make sure it is on PATH for the Agor executor.'
+            )
+          : error;
+      this.failAll(wrapped);
+      this.onEarlyFailure?.(wrapped);
+    });
+
+    child.on('exit', (code, signal) => {
+      this.exited = true;
+      const error = new Error(`OMP exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+      this.exitError = error;
+      this.failAll(error);
+      this.onEarlyFailure?.(error);
+      this.options.onExit?.(code, signal);
+    });
+
+    const frame = await readyPromise;
+    this.readyFrame = frame;
+    if (typeof frame.maxReassembledFrameBytes === 'number') {
+      this.maxReassembledBytes = frame.maxReassembledFrameBytes;
+    }
+    if (frame.supportedProtocolVersions?.includes(2)) {
+      // Best effort: a v1-only server simply rejects it and we stay on v1.
+      await this.request({ type: 'negotiate_protocol', protocolVersion: 2 }).catch(() => undefined);
+    }
+    return frame;
+  }
+
+  private onReady?: (frame: OmpReadyFrame) => void;
+  private onEarlyFailure?: (error: Error) => void;
+
+  /** Split the stdout stream into lines and dispatch each decoded frame. */
+  private consumeStdout(text: string): void {
+    this.stdoutBuffer += text;
+    let newlineIndex = this.stdoutBuffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line.trim()) this.handleLine(line);
+      newlineIndex = this.stdoutBuffer.indexOf('\n');
+    }
+  }
+
+  private handleLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // A non-JSON line is diagnostic noise, not a protocol frame.
+      this.options.onStderr?.(line);
+      return;
+    }
+    if (!isOmpFrame(parsed)) return;
+
+    if (parsed.type === 'rpc_chunk') {
+      const reassembled = this.accumulateChunk(parsed);
+      if (reassembled) this.dispatch(reassembled);
+      return;
+    }
+    this.dispatch(parsed);
+  }
+
+  /**
+   * Reassemble a protocol-v2 chunk sequence.
+   *
+   * Chunks must arrive as an uninterrupted run sharing one `chunkId`; anything
+   * else means we lost framing, so the partial buffer is dropped.
+   */
+  private accumulateChunk(frame: OmpFrame): OmpFrame | undefined {
+    const chunk = asChunkFrame(frame);
+    if (!chunk) {
+      this.chunk = undefined;
+      return undefined;
+    }
+    if (!this.chunk || this.chunk.chunkId !== chunk.chunkId) {
+      this.chunk = {
+        chunkId: chunk.chunkId,
+        count: chunk.count,
+        byteLength: chunk.byteLength,
+        parts: new Array<string>(chunk.count).fill(''),
+        received: 0,
+      };
+    }
+    const acc = this.chunk;
+    if (chunk.index < 0 || chunk.index >= acc.count) {
+      this.chunk = undefined;
+      return undefined;
+    }
+    if (acc.byteLength > this.maxReassembledBytes) {
+      this.chunk = undefined;
+      throw new Error('OMP frame exceeded the negotiated reassembly limit');
+    }
+    if (acc.parts[chunk.index] === '') acc.received += 1;
+    acc.parts[chunk.index] = chunk.data;
+    if (acc.received < acc.count) return undefined;
+
+    this.chunk = undefined;
+    const decoded = Buffer.from(acc.parts.join(''), 'base64').toString('utf8');
+    try {
+      const parsed: unknown = JSON.parse(decoded);
+      return isOmpFrame(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private dispatch(frame: OmpFrame): void {
+    if (frame.type === 'ready') {
+      const supported =
+        'supportedProtocolVersions' in frame && Array.isArray(frame.supportedProtocolVersions)
+          ? frame.supportedProtocolVersions.filter((v): v is number => typeof v === 'number')
+          : undefined;
+      const protocolVersion =
+        'protocolVersion' in frame && typeof frame.protocolVersion === 'number'
+          ? frame.protocolVersion
+          : 1;
+      const maxReassembledFrameBytes =
+        'maxReassembledFrameBytes' in frame && typeof frame.maxReassembledFrameBytes === 'number'
+          ? frame.maxReassembledFrameBytes
+          : undefined;
+      this.onReady?.({
+        type: 'ready',
+        protocolVersion,
+        supportedProtocolVersions: supported,
+        maxReassembledFrameBytes,
+      });
+    }
+
+    const response = asResponseFrame(frame);
+    if (response?.id) {
+      const pending = this.pending.get(response.id);
+      if (pending) {
+        this.pending.delete(response.id);
+        clearTimeout(pending.timer);
+        pending.resolve(response);
+      }
+    }
+
+    this.options.onFrame?.(frame);
+  }
+
+  private failAll(error: Error): void {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  /** Write a command without waiting for its response. */
+  send(command: OmpCommand): void {
+    if (!this.child || this.exited) {
+      throw this.exitError ?? new Error('OMP process is not running');
+    }
+    this.child.stdin.write(`${JSON.stringify(command)}\n`);
+  }
+
+  /**
+   * Send a command and await its correlated response.
+   *
+   * `timeoutMs = 0` waits indefinitely — used for `prompt`, which OMP
+   * acknowledges immediately but whose turn completes via `agent_end`.
+   */
+  request(
+    command: OmpCommand,
+    timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS
+  ): Promise<OmpResponseFrame> {
+    this.requestCounter += 1;
+    const id = `agor_${this.requestCounter}`;
+    return new Promise<OmpResponseFrame>((resolve, reject) => {
+      const pending: PendingRequest = { resolve, reject };
+      if (timeoutMs > 0) {
+        pending.timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`OMP command "${command.type}" timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+      this.pending.set(id, pending);
+      try {
+        this.send({ ...command, id });
+      } catch (error) {
+        this.pending.delete(id);
+        clearTimeout(pending.timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  /** Ask OMP to stop the in-flight turn. */
+  async abort(): Promise<void> {
+    if (!this.child || this.exited) return;
+    await this.request({ type: 'abort' }, 10_000).catch(() => undefined);
+  }
+
+  /** Close stdin and terminate the child, escalating to SIGKILL if needed. */
+  async dispose(): Promise<void> {
+    const child = this.child;
+    if (!child || this.exited) return;
+    this.failAll(new Error('OMP client disposed'));
+    try {
+      child.stdin.end();
+    } catch {
+      // stdin may already be torn down; termination below is what matters.
+    }
+    await new Promise<void>((resolve) => {
+      const killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve();
+      }, 3_000);
+      child.once('exit', () => {
+        clearTimeout(killTimer);
+        resolve();
+      });
+      child.kill('SIGTERM');
+    });
+  }
+}

--- a/packages/core/src/omp/spawn-config.test.ts
+++ b/packages/core/src/omp/spawn-config.test.ts
@@ -1,0 +1,144 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { OmpRpcClient } from './rpc-client.js';
+import {
+  AGOR_MCP_TOKEN_ENV,
+  AGOR_MCP_URL_ENV,
+  AGOR_OMP_MCP_SERVER_NAME,
+  buildOmpEnv,
+  ensureAgorMcpConfig,
+  getOmpAgentDir,
+  getOmpMcpConfigPath,
+} from './spawn-config.js';
+
+describe('OmpRpcClient.buildArgs', () => {
+  it('always runs in RPC mode', () => {
+    expect(OmpRpcClient.buildArgs({})).toEqual(['--mode', 'rpc']);
+  });
+
+  it('omits --profile so OMP uses the host user login by default', () => {
+    // A named profile starts with an empty auth store, so defaulting to one
+    // would leave the agent unable to reach any model.
+    expect(OmpRpcClient.buildArgs({})).not.toContain('--profile');
+  });
+
+  it('passes profile, model and resume through when supplied', () => {
+    expect(
+      OmpRpcClient.buildArgs({ profile: 'agor', model: 'opus', resume: '/s/abc.jsonl' })
+    ).toEqual([
+      '--mode',
+      'rpc',
+      '--profile',
+      'agor',
+      '--model',
+      'opus',
+      '--resume',
+      '/s/abc.jsonl',
+    ]);
+  });
+
+  it('emits --resume only when a prior session exists', () => {
+    // Multi-turn continuity depends on this: each Agor task spawns a fresh
+    // process, and --resume is what carries the conversation forward.
+    expect(OmpRpcClient.buildArgs({ resume: 'sess-1' })).toContain('--resume');
+    expect(OmpRpcClient.buildArgs({})).not.toContain('--resume');
+  });
+});
+
+describe('getOmpAgentDir', () => {
+  it('resolves the default profile outside the profiles tree', () => {
+    expect(getOmpAgentDir(undefined, '/home/u')).toBe('/home/u/.omp/agent');
+  });
+
+  it('roots a named profile under profiles/<name>', () => {
+    expect(getOmpAgentDir('agor', '/home/u')).toBe('/home/u/.omp/profiles/agor/agent');
+    expect(getOmpMcpConfigPath('agor', '/home/u')).toBe(
+      '/home/u/.omp/profiles/agor/agent/mcp.json'
+    );
+  });
+});
+
+describe('buildOmpEnv', () => {
+  it('exports the Agor MCP endpoint when a session token was issued', () => {
+    const env = buildOmpEnv({
+      base: {},
+      daemonUrl: 'http://127.0.0.1:5150',
+      mcpToken: 'tok-1',
+    });
+    expect(env[AGOR_MCP_URL_ENV]).toBe('http://127.0.0.1:5150/mcp');
+    expect(env[AGOR_MCP_TOKEN_ENV]).toBe('tok-1');
+  });
+
+  it('strips a trailing slash from the daemon URL', () => {
+    const env = buildOmpEnv({ base: {}, daemonUrl: 'http://d/', mcpToken: 't' });
+    expect(env[AGOR_MCP_URL_ENV]).toBe('http://d/mcp');
+  });
+
+  it('clears stale endpoint vars when no token is available', () => {
+    // Degrades to "no Agor self-drive tools" rather than leaking another
+    // session's credentials into this process.
+    const env = buildOmpEnv({
+      base: { [AGOR_MCP_URL_ENV]: 'http://old/mcp', [AGOR_MCP_TOKEN_ENV]: 'old' },
+      daemonUrl: 'http://d',
+    });
+    expect(env[AGOR_MCP_URL_ENV]).toBeUndefined();
+    expect(env[AGOR_MCP_TOKEN_ENV]).toBeUndefined();
+  });
+
+  it('pins OMP_PROFILE only when isolation was requested', () => {
+    expect(buildOmpEnv({ base: {}, profile: 'agor' }).OMP_PROFILE).toBe('agor');
+    expect(buildOmpEnv({ base: { OMP_PROFILE: 'stale' } }).OMP_PROFILE).toBeUndefined();
+  });
+});
+
+describe('ensureAgorMcpConfig', () => {
+  it('creates a templated Agor entry that OMP expands per process', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'omp-mcp-'));
+    const path = await ensureAgorMcpConfig({ home });
+    const config = JSON.parse(await readFile(path, 'utf8'));
+    const server = config.mcpServers[AGOR_OMP_MCP_SERVER_NAME];
+
+    expect(server.type).toBe('http');
+    // Placeholders, not baked values: one shared file must stay correct for
+    // concurrent sessions, and stay inert outside Agor.
+    expect(server.url).toBe(`\${${AGOR_MCP_URL_ENV}}`);
+    expect(server.headers.Authorization).toBe(`Bearer \${${AGOR_MCP_TOKEN_ENV}}`);
+  });
+
+  it('preserves MCP servers the user already configured', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'omp-mcp-'));
+    const agentDir = getOmpAgentDir(undefined, home);
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      join(agentDir, 'mcp.json'),
+      JSON.stringify({ mcpServers: { mine: { command: 'my-server' } } }),
+      'utf8'
+    );
+
+    const path = await ensureAgorMcpConfig({ home });
+    const config = JSON.parse(await readFile(path, 'utf8'));
+    expect(config.mcpServers.mine).toEqual({ command: 'my-server' });
+    expect(config.mcpServers[AGOR_OMP_MCP_SERVER_NAME]).toBeDefined();
+  });
+
+  it('is idempotent across repeated session starts', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'omp-mcp-'));
+    const path = await ensureAgorMcpConfig({ home });
+    const first = await readFile(path, 'utf8');
+    await ensureAgorMcpConfig({ home });
+    expect(await readFile(path, 'utf8')).toBe(first);
+  });
+
+  it('recovers from an unparseable config instead of throwing', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'omp-mcp-'));
+    const agentDir = getOmpAgentDir(undefined, home);
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(join(agentDir, 'mcp.json'), '{ not json', 'utf8');
+
+    const path = await ensureAgorMcpConfig({ home });
+    const config = JSON.parse(await readFile(path, 'utf8'));
+    expect(config.mcpServers[AGOR_OMP_MCP_SERVER_NAME]).toBeDefined();
+  });
+});

--- a/packages/core/src/omp/spawn-config.ts
+++ b/packages/core/src/omp/spawn-config.ts
@@ -1,0 +1,166 @@
+/**
+ * Spawn configuration for the Oh My Pi runtime.
+ *
+ * ## Profile and authentication
+ *
+ * By default Agor runs OMP under the host user's **default** profile
+ * (`~/.omp/agent`). That is deliberate: OMP owns its own credentials, and a
+ * named profile starts with an empty auth store, so an isolated profile would
+ * leave the agent unable to reach any model until the user separately signed
+ * that profile in. Using the default profile means "install OMP, run it once,
+ * sign in" is the whole setup story.
+ *
+ * Operators who *want* isolation can set `AGOR_OMP_PROFILE` and sign that
+ * profile in with `omp --profile <name>`.
+ *
+ * ## MCP injection
+ *
+ * OMP has no `--mcp-config` flag; it discovers MCP servers from files. Writing
+ * one into the branch worktree would leave a stray untracked file in the
+ * user's git status, so Agor writes to the profile's user-level `mcp.json`,
+ * which lives outside any repo.
+ *
+ * That file is shared by every session, so the Agor endpoint is templated with
+ * `${...}` placeholders that OMP expands per process from the environment.
+ * One static file therefore stays correct for concurrent sessions instead of
+ * racing to rewrite per-session values — and outside Agor the placeholders
+ * resolve to nothing, so the entry is inert in a normal terminal session.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Env var an operator sets to run OMP under an isolated named profile. */
+export const AGOR_OMP_PROFILE_ENV = 'AGOR_OMP_PROFILE';
+
+/** Name of the injected MCP server inside OMP. */
+export const AGOR_OMP_MCP_SERVER_NAME = 'agor';
+
+/** Env var carrying the per-session Agor MCP endpoint. */
+export const AGOR_MCP_URL_ENV = 'AGOR_MCP_URL';
+
+/** Env var carrying the per-session Agor MCP bearer token. */
+export const AGOR_MCP_TOKEN_ENV = 'AGOR_MCP_TOKEN';
+
+const MCP_SCHEMA_URL =
+  'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json';
+
+/**
+ * Root of an OMP profile's agent directory.
+ *
+ * The default profile (no name) lives at `~/.omp/agent`; a named profile at
+ * `~/.omp/profiles/<name>/agent`.
+ */
+export function getOmpAgentDir(profile?: string, home: string = homedir()): string {
+  return profile ? join(home, '.omp', 'profiles', profile, 'agent') : join(home, '.omp', 'agent');
+}
+
+/** Path to the user-level `mcp.json` for a profile. */
+export function getOmpMcpConfigPath(profile?: string, home: string = homedir()): string {
+  return join(getOmpAgentDir(profile, home), 'mcp.json');
+}
+
+/** Shape Agor writes into OMP's `mcp.json`. */
+interface OmpMcpConfigFile {
+  $schema?: string;
+  mcpServers?: Record<string, unknown>;
+  disabledServers?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * The Agor MCP server entry, templated so one file serves every session.
+ *
+ * OMP expands `${VAR}` while discovering MCP configs, resolving both fields
+ * from the spawned process's environment.
+ */
+function agorMcpServerEntry(): Record<string, unknown> {
+  return {
+    type: 'http',
+    url: `\${${AGOR_MCP_URL_ENV}}`,
+    headers: { Authorization: `Bearer \${${AGOR_MCP_TOKEN_ENV}}` },
+  };
+}
+
+/**
+ * Ensure the Agor MCP server is registered in the profile's `mcp.json`.
+ *
+ * Merges into any existing file rather than overwriting, so the user's own MCP
+ * servers survive. Idempotent: rewrites only when the Agor entry is missing or
+ * stale.
+ */
+export async function ensureAgorMcpConfig(options?: {
+  profile?: string;
+  home?: string;
+}): Promise<string> {
+  const home = options?.home ?? homedir();
+  const agentDir = getOmpAgentDir(options?.profile, home);
+  const configPath = getOmpMcpConfigPath(options?.profile, home);
+
+  let config: OmpMcpConfigFile = {};
+  try {
+    const existing = await readFile(configPath, 'utf8');
+    const parsed: unknown = JSON.parse(existing);
+    if (typeof parsed === 'object' && parsed !== null) {
+      config = { ...parsed };
+    }
+  } catch {
+    // Missing or unparseable file — start from a fresh config.
+  }
+
+  const desired = agorMcpServerEntry();
+  const servers =
+    typeof config.mcpServers === 'object' && config.mcpServers !== null
+      ? { ...config.mcpServers }
+      : {};
+  if (JSON.stringify(servers[AGOR_OMP_MCP_SERVER_NAME]) === JSON.stringify(desired)) {
+    return configPath;
+  }
+  servers[AGOR_OMP_MCP_SERVER_NAME] = desired;
+
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ $schema: MCP_SCHEMA_URL, ...config, mcpServers: servers }, null, 2)}\n`,
+    'utf8'
+  );
+  return configPath;
+}
+
+export interface OmpEnvOptions {
+  /** Base environment to extend, normally `process.env`. */
+  base: NodeJS.ProcessEnv;
+  /** Agor daemon URL, e.g. `http://127.0.0.1:5150`. */
+  daemonUrl?: string;
+  /** Per-session MCP bearer token issued by the daemon. */
+  mcpToken?: string;
+  /** Named profile, when the operator opted into isolation. */
+  profile?: string;
+}
+
+/**
+ * Build the child environment for an OMP session.
+ *
+ * When no MCP token was issued the Agor endpoint vars are left unset: OMP then
+ * fails to resolve that one server and skips it, which is the correct
+ * degradation — the session still runs, just without Agor self-drive tools.
+ */
+export function buildOmpEnv(options: OmpEnvOptions): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...options.base };
+  // Only pin a profile when one was explicitly requested; otherwise inherit
+  // the user's default OMP profile (and therefore their existing login).
+  if (options.profile) {
+    env.OMP_PROFILE = options.profile;
+  } else {
+    delete env.OMP_PROFILE;
+  }
+  if (options.daemonUrl && options.mcpToken) {
+    env[AGOR_MCP_URL_ENV] = `${options.daemonUrl.replace(/\/+$/, '')}/mcp`;
+    env[AGOR_MCP_TOKEN_ENV] = options.mcpToken;
+  } else {
+    delete env[AGOR_MCP_URL_ENV];
+    delete env[AGOR_MCP_TOKEN_ENV];
+  }
+  return env;
+}

--- a/packages/core/src/omp/spawn-config.ts
+++ b/packages/core/src/omp/spawn-config.ts
@@ -23,8 +23,15 @@
  * That file is shared by every session, so the Agor endpoint is templated with
  * `${...}` placeholders that OMP expands per process from the environment.
  * One static file therefore stays correct for concurrent sessions instead of
- * racing to rewrite per-session values — and outside Agor the placeholders
- * resolve to nothing, so the entry is inert in a normal terminal session.
+ * racing to rewrite per-session values.
+ *
+ * Known tradeoff: an unexpanded `${...}` is kept as a literal string by OMP,
+ * so outside Agor this entry is not inert — OMP will try to reach a nonsense
+ * URL and report that one server as failed. It is non-fatal (other servers and
+ * the session are unaffected), and callers only write the entry once a session
+ * actually has an MCP token, but a user running plain `omp` under the same
+ * profile will see it. Set `AGOR_OMP_PROFILE` to keep Agor's MCP entry in an
+ * isolated profile instead; that profile then needs its own OMP login.
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -45,7 +45,8 @@ export type AgenticToolName =
   | 'gemini'
   | 'opencode'
   | 'copilot'
-  | 'cursor';
+  | 'cursor'
+  | 'omp';
 
 export const NON_EXECUTOR_AGENTIC_TOOLS: ReadonlySet<AgenticToolName> = new Set([
   'claude-code-cli',
@@ -176,6 +177,17 @@ export type CopilotPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissio
  * so these mirror the autonomous-provider modes until a richer policy surface exists.
  */
 export type CursorPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
+
+/**
+ * Oh My Pi (OMP) permission modes.
+ *
+ * OMP is driven over its JSONL RPC protocol (`omp --mode rpc`), which has no
+ * per-turn approval handshake: the spawned agent either runs with its normal
+ * tool set or with edits/commands pre-approved. Agor therefore exposes the
+ * same three-way shape used by the other subprocess runtimes and maps it onto
+ * OMP's approval settings at spawn time.
+ */
+export type OmpPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
 
 // ============================================================================
 // Tool Capabilities (static, shared between backend and UI)
@@ -322,6 +334,7 @@ export const AGENTIC_TOOL_DISPLAY_NAMES: Record<AgenticToolName, string> = {
   opencode: 'OpenCode',
   copilot: 'GitHub Copilot',
   cursor: 'Cursor SDK',
+  omp: 'Oh My Pi',
 };
 
 /** Where a user creates a fresh API key for each tool. Keyless tools (opencode) are absent. */
@@ -387,5 +400,19 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     supportsChildSpawn: true,
     supportsSessionImport: false,
     supportsStatelessFsMode: false,
+  },
+  omp: {
+    // `switch_session` + `branch` exist over RPC, but Agor-level fork of an
+    // OMP transcript is not wired yet.
+    supportsSessionFork: false,
+    supportsChildSpawn: true,
+    // OMP persists JSONL transcripts under its profile dir; adopting them into
+    // Agor is deferred.
+    supportsSessionImport: false,
+    supportsStatelessFsMode: false,
+    // Mirrors the thinking levels OMP advertises on reasoning models
+    // (`get_state` -> model.thinking.efforts).
+    reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    defaultReasoningEffort: 'medium',
   },
 };

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -126,6 +126,11 @@ export function getDefaultPermissionMode(agenticTool: AgenticToolName): Permissi
       return 'acceptEdits'; // Copilot uses same semantics as Claude Code
     case 'cursor':
       return 'bypassPermissions'; // Cursor SDK is experimental/autonomous until permission callbacks exist
+    case 'omp':
+      // OMP applies its own approval settings inside the agent; Agor does not
+      // drive a per-turn approval handshake over RPC, so record the neutral
+      // mode rather than a Claude-specific one.
+      return 'default';
     default:
       return 'auto'; // Claude Code (SDK + CLI): model-classifier permissions
   }

--- a/packages/core/src/types/tenant-agentic-tool.ts
+++ b/packages/core/src/types/tenant-agentic-tool.ts
@@ -9,10 +9,12 @@ export const TENANT_AGENTIC_TOOL_NAMES = [
   'copilot',
   'cursor',
   'opencode',
+  'omp',
 ] as const;
 
 export type TenantAgenticToolName = (typeof TENANT_AGENTIC_TOOL_NAMES)[number];
-export type ProviderConnectionTool = Exclude<TenantAgenticToolName, 'opencode'>;
+/** Tools Agor stores provider credentials for. OMP and OpenCode self-authenticate. */
+export type ProviderConnectionTool = Exclude<TenantAgenticToolName, 'opencode' | 'omp'>;
 
 export const PROVIDER_RESOLUTION_POLICIES = [
   'user_required',
@@ -92,7 +94,7 @@ export function canonicalTenantAgenticTool(tool: AgenticToolName): TenantAgentic
 export function isProviderConnectionTool(
   tool: TenantAgenticToolName
 ): tool is ProviderConnectionTool {
-  return tool !== 'opencode';
+  return tool !== 'opencode' && tool !== 'omp';
 }
 
 export function providerToolForField(field: AgenticToolConfigField): ProviderConnectionTool | null {

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -128,6 +128,7 @@ export interface DefaultAgenticConfig {
   opencode?: DefaultAgenticToolConfig;
   copilot?: DefaultAgenticToolConfig;
   cursor?: DefaultAgenticToolConfig;
+  omp?: DefaultAgenticToolConfig;
 }
 
 export type UserAgenticDefaultSelections = Partial<
@@ -184,6 +185,8 @@ export interface AgenticToolsConfig {
   copilot?: CopilotConfig;
   cursor?: CursorConfig;
   opencode?: Record<string, never>;
+  /** OMP resolves credentials from its own profile — no Agor-stored fields. */
+  omp?: Record<string, never>;
 }
 
 /** Union of all valid env-var-named fields across all tool configs. */

--- a/packages/core/src/utils/permission-mode-mapper.ts
+++ b/packages/core/src/utils/permission-mode-mapper.ts
@@ -68,6 +68,37 @@ export function mapPermissionMode(
           return 'acceptEdits'; // Safe default
       }
 
+    case 'omp':
+      // OMP accepts default | acceptEdits | bypassPermissions — the same
+      // three-way shape as Copilot/Cursor, but without Claude's plan/dontAsk/auto.
+      switch (mode) {
+        case 'default':
+        case 'acceptEdits':
+        case 'bypassPermissions':
+          return mode;
+        // Claude-only modes → nearest OMP equivalent.
+        case 'plan':
+          return 'default'; // Plan mode → most restrictive available
+        case 'dontAsk':
+          return 'bypassPermissions';
+        case 'auto':
+          return 'acceptEdits';
+        // Gemini modes → OMP equivalents
+        case 'autoEdit':
+          return 'acceptEdits';
+        case 'yolo':
+          return 'bypassPermissions';
+        // Codex modes → OMP equivalents
+        case 'ask':
+          return 'default';
+        case 'on-failure':
+          return 'acceptEdits';
+        case 'allow-all':
+          return 'bypassPermissions';
+        default:
+          return 'acceptEdits'; // Safe default
+      }
+
     case 'gemini':
     case 'opencode':
       // Gemini native modes: default, autoEdit, yolo

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     'api/index': 'src/api/index.ts',
     'claude/index': 'src/claude/index.ts',
     'claude-cli/index': 'src/claude-cli/index.ts', // Pure utilities for the Claude Code CLI adapter (path slug, event types, JSONL translator)
+    'omp/index': 'src/omp/index.ts', // Oh My Pi RPC transport, wire types, event translator, spawn/MCP config
     'config/index': 'src/config/index.ts',
     'config/browser': 'src/config/browser.ts', // Browser-safe config utilities
     'permissions/index': 'src/permissions/index.ts',

--- a/packages/executor/src/handlers/sdk/omp.ts
+++ b/packages/executor/src/handlers/sdk/omp.ts
@@ -1,0 +1,147 @@
+/**
+ * Oh My Pi (OMP) SDK Handler
+ *
+ * Executes prompts by driving the `omp` binary over its JSONL RPC protocol.
+ *
+ * Like OpenCode, OMP is keyless from Agor's perspective — it resolves its own
+ * credentials from its profile — so this runner does not go through
+ * `executeToolTask`, whose credential gate would reject a session that has no
+ * Agor-stored API key.
+ */
+
+import { generateId, shortId } from '@agor/core';
+import { AGOR_OMP_PROFILE_ENV } from '@agor/core/omp';
+import type {
+  ExecutorPulseKind,
+  MessageID,
+  MessageSource,
+  PermissionMode,
+  SessionID,
+  TaskID,
+} from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { getDaemonUrl } from '../../config.js';
+import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
+import type { ResolvedConfigSlice } from '../../payload-types.js';
+import { OmpTool } from '../../sdk-handlers/omp/index.js';
+import type { AgorClient } from '../../services/feathers-client.js';
+import { createStreamingCallbacks } from './base-executor.js';
+
+export async function executeOmpTask(params: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  prompt: string;
+  permissionMode?: PermissionMode;
+  abortController: AbortController;
+  messageSource?: MessageSource;
+  resolvedConfig?: ResolvedConfigSlice;
+  onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
+}): Promise<void> {
+  const { client, sessionId, taskId, prompt } = params;
+  let abortHandler: (() => void) | undefined;
+
+  console.log(`[omp] Executing task ${shortId(taskId)}...`);
+
+  try {
+    const session = await client.service('sessions').get(sessionId);
+    const repos = createFeathersBackedRepositories(client);
+    const callbacks = createStreamingCallbacks(client, 'omp', sessionId, params.onPulse);
+
+    // Run the agent inside the branch worktree so its file tools operate on the
+    // right checkout.
+    let branchPath: string | undefined;
+    if (session.branch_id) {
+      try {
+        const branch = await repos.branches.findById(session.branch_id);
+        if (branch) branchPath = branch.path;
+      } catch (error) {
+        console.warn(`[omp] Could not resolve branch ${session.branch_id}:`, error);
+      }
+    }
+
+    const tool = new OmpTool(
+      {
+        enabled: true,
+        binPath: process.env.OMP_BIN_PATH || undefined,
+        // Opt-in isolation; default inherits the host user's OMP login.
+        profile: process.env[AGOR_OMP_PROFILE_ENV] || undefined,
+      },
+      repos.messagesService,
+      repos.sessions
+    );
+
+    tool.setSessionContext({
+      workingDirectory: branchPath,
+      model: session.model_config?.model,
+      provider: session.model_config?.provider,
+      mcpToken: session.mcp_token,
+      daemonUrl: await getDaemonUrl(),
+      // Each task spawns a fresh OMP process; resuming the prior session file
+      // is what preserves conversation context across turns.
+      resumeRef: session.sdk_session_id ?? undefined,
+    });
+
+    abortHandler = () => {
+      void tool.stopTask(sessionId, taskId).then((result) => {
+        if (!result.success) console.warn(`[omp] Abort was not confirmed: ${result.reason}`);
+      });
+    };
+    params.abortController.signal.addEventListener('abort', abortHandler, { once: true });
+    if (params.abortController.signal.aborted) abortHandler();
+
+    const existingMessages = await client.service('messages').find({
+      query: { session_id: sessionId, $sort: { index: 1 } },
+    });
+    const messages = Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
+    const nextIndex = messages?.length || 0;
+
+    await repos.messagesService.create({
+      message_id: generateId() as MessageID,
+      session_id: sessionId,
+      task_id: taskId,
+      type: 'user' as const,
+      role: MessageRole.USER,
+      index: nextIndex,
+      timestamp: new Date().toISOString(),
+      content_preview: prompt.substring(0, 200),
+      content: prompt,
+    });
+
+    const result = await tool.executeTask(sessionId, prompt, taskId, callbacks, nextIndex + 1);
+    console.log(`[omp] Execution completed: status=${result.status}`);
+
+    const modelIdentifier =
+      session.model_config?.provider && session.model_config?.model
+        ? `${session.model_config.provider}/${session.model_config.model}`
+        : session.model_config?.model;
+
+    if (!params.abortController.signal.aborted) {
+      const contextUsage = tool.getLastContextUsage();
+      await client.service('tasks').patch(taskId, {
+        status: result.status === 'completed' ? 'completed' : 'failed',
+        completed_at: new Date().toISOString(),
+        model: modelIdentifier,
+        ...(contextUsage ? { computed_context_window: contextUsage.totalTokens } : {}),
+      });
+
+      // Remember OMP's session file so the next task continues this thread.
+      const sessionFile = tool.getLastSessionFile();
+      if (sessionFile && sessionFile !== session.sdk_session_id) {
+        await client.service('sessions').patch(sessionId, { sdk_session_id: sessionFile });
+      }
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error('[omp] Execution failed:', err);
+    if (!params.abortController.signal.aborted) {
+      await client.service('tasks').patch(taskId, {
+        status: 'failed',
+        completed_at: new Date().toISOString(),
+      });
+    }
+    throw err;
+  } finally {
+    if (abortHandler) params.abortController.signal.removeEventListener('abort', abortHandler);
+  }
+}

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -19,7 +19,7 @@ import type { AgorClient } from '../../services/feathers-client.js';
 /**
  * Tool identifier
  */
-export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor';
+export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor' | 'omp';
 
 /**
  * Tool runner function - executes via Feathers WebSocket
@@ -127,13 +127,14 @@ export class ToolRegistry {
  */
 export async function initializeToolRegistry(): Promise<void> {
   // Import all tool handlers
-  const [claude, codex, gemini, opencode, copilot, cursor] = await Promise.all([
+  const [claude, codex, gemini, opencode, copilot, cursor, omp] = await Promise.all([
     import('./claude.js'),
     import('./codex.js'),
     import('./gemini.js'),
     import('./opencode.js'),
     import('./copilot.js'),
     import('./cursor.js'),
+    import('./omp.js'),
   ]);
 
   // Register Claude Code
@@ -182,5 +183,13 @@ export async function initializeToolRegistry(): Promise<void> {
     name: 'Cursor SDK',
     apiKeyEnvVar: TOOL_API_KEY_NAMES.cursor!,
     runner: cursor.executeCursorTask,
+  });
+
+  // Register Oh My Pi (driven over its JSONL RPC protocol; no Agor-stored key)
+  ToolRegistry.register({
+    tool: 'omp',
+    name: 'Oh My Pi',
+    apiKeyEnvVar: 'NONE', // OMP resolves credentials from its own profile
+    runner: omp.executeOmpTask,
   });
 }

--- a/packages/executor/src/sdk-handlers/base/types.ts
+++ b/packages/executor/src/sdk-handlers/base/types.ts
@@ -17,7 +17,8 @@ export type ToolType =
   | 'gemini'
   | 'opencode'
   | 'copilot'
-  | 'cursor';
+  | 'cursor'
+  | 'omp';
 
 /**
  * Streaming callback interface for agents that support real-time streaming

--- a/packages/executor/src/sdk-handlers/normalizer-factory.ts
+++ b/packages/executor/src/sdk-handlers/normalizer-factory.ts
@@ -16,12 +16,14 @@ import { ClaudeCodeNormalizer } from './claude/normalizer.js';
 import { CodexNormalizer } from './codex/normalizer.js';
 import { CopilotNormalizer } from './copilot/normalizer.js';
 import { GeminiNormalizer } from './gemini/normalizer.js';
+import { OmpNormalizer } from './omp/normalizer.js';
 
 // Singleton instances (normalizers are stateless, so one instance is fine)
 const claudeNormalizer = new ClaudeCodeNormalizer();
 const codexNormalizer = new CodexNormalizer();
 const copilotNormalizer = new CopilotNormalizer();
 const geminiNormalizer = new GeminiNormalizer();
+const ompNormalizer = new OmpNormalizer();
 
 /** `modelHint` refines `contextWindowLimit` lookup; never used as `primaryModel`. */
 export interface NormalizeOptions {
@@ -37,7 +39,15 @@ export interface NormalizeOptions {
  * @returns Normalized data with consistent structure, or undefined if normalization fails
  */
 export function normalizeRawSdkResponse(
-  agenticTool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'cursor' | string,
+  agenticTool:
+    | 'claude-code'
+    | 'codex'
+    | 'gemini'
+    | 'opencode'
+    | 'copilot'
+    | 'cursor'
+    | 'omp'
+    | string,
   rawSdkResponse: unknown,
   options?: NormalizeOptions
 ): NormalizedSdkData | undefined {
@@ -67,6 +77,11 @@ export function normalizeRawSdkResponse(
       case 'copilot':
         return copilotNormalizer.normalize(
           rawSdkResponse as Parameters<typeof copilotNormalizer.normalize>[0]
+        );
+
+      case 'omp':
+        return ompNormalizer.normalize(
+          rawSdkResponse as Parameters<typeof ompNormalizer.normalize>[0]
         );
 
       case 'opencode':

--- a/packages/executor/src/sdk-handlers/omp/index.ts
+++ b/packages/executor/src/sdk-handlers/omp/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Oh My Pi Tool Module
+ *
+ * Integration with Oh My Pi (OMP), a terminal coding agent driven over its
+ * JSONL RPC protocol (`omp --mode rpc`) rather than an in-process SDK.
+ */
+
+export { DEFAULT_OMP_CONTEXT_WINDOW, getOmpContextWindowLimit } from './models.js';
+export { OmpNormalizer, type OmpSdkResponse } from './normalizer.js';
+export { type OmpConfig, OmpTool } from './omp-tool.js';

--- a/packages/executor/src/sdk-handlers/omp/models.ts
+++ b/packages/executor/src/sdk-handlers/omp/models.ts
@@ -1,0 +1,24 @@
+/**
+ * Model metadata for the Oh My Pi runtime.
+ *
+ * OMP is provider-agnostic and resolves models from its own configuration, so
+ * Agor deliberately does NOT hardcode a catalogue here. OMP reports the real
+ * context window per turn via `get_state`; this fallback only covers the case
+ * where that reading is unavailable.
+ */
+
+/**
+ * Conservative fallback context window, used only when OMP did not report one.
+ * Chosen to match the smallest window in common use so Agor under-promises
+ * rather than showing a falsely low occupancy percentage.
+ */
+export const DEFAULT_OMP_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Resolve the context-window limit for an OMP turn.
+ *
+ * @param reportedWindow - Window OMP reported for the active model, if any.
+ */
+export function getOmpContextWindowLimit(reportedWindow?: number): number {
+  return reportedWindow && reportedWindow > 0 ? reportedWindow : DEFAULT_OMP_CONTEXT_WINDOW;
+}

--- a/packages/executor/src/sdk-handlers/omp/normalizer.ts
+++ b/packages/executor/src/sdk-handlers/omp/normalizer.ts
@@ -1,0 +1,75 @@
+/**
+ * Oh My Pi SDK normalizer.
+ *
+ * OMP self-reports both token counts and real USD spend per message, so this
+ * normalizer passes those through rather than estimating from a price table.
+ * It also forwards OMP's own context-window reading as the authoritative
+ * snapshot.
+ */
+
+import type { INormalizer, NormalizedSdkData } from '../base/normalizer.interface.js';
+import { getOmpContextWindowLimit } from './models.js';
+
+/** Raw shape Agor stores for an OMP turn (assembled by `OmpTool`). */
+export interface OmpSdkResponse {
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+    totalTokens?: number;
+    /** Real spend reported by OMP, already in USD. */
+    costUsd?: number;
+  };
+  model?: string;
+  provider?: string;
+  /** Context occupancy as read from OMP's `get_state`. */
+  contextUsage?: {
+    totalTokens?: number;
+    maxTokens?: number;
+    percentage?: number;
+  };
+  durationMs?: number;
+}
+
+export class OmpNormalizer implements INormalizer<OmpSdkResponse> {
+  normalize(response: OmpSdkResponse): NormalizedSdkData {
+    const usage = response.usage ?? {};
+    const inputTokens = usage.inputTokens ?? 0;
+    const outputTokens = usage.outputTokens ?? 0;
+    const cacheReadTokens = usage.cacheReadTokens ?? 0;
+    const cacheCreationTokens = usage.cacheCreationTokens ?? 0;
+    const contextWindowLimit = getOmpContextWindowLimit(response.contextUsage?.maxTokens);
+
+    const snapshot =
+      response.contextUsage?.totalTokens !== undefined &&
+      response.contextUsage.maxTokens !== undefined
+        ? {
+            totalTokens: response.contextUsage.totalTokens,
+            maxTokens: response.contextUsage.maxTokens,
+            percentage:
+              response.contextUsage.percentage ??
+              Math.round(
+                (response.contextUsage.totalTokens / response.contextUsage.maxTokens) * 100
+              ),
+          }
+        : undefined;
+
+    return {
+      tokenUsage: {
+        inputTokens,
+        outputTokens,
+        totalTokens: usage.totalTokens ?? inputTokens + outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+      },
+      contextWindowLimit,
+      ...(snapshot ? { contextUsageSnapshot: snapshot } : {}),
+      // Only surface a cost when OMP actually reported spend; a hard 0 would
+      // read as "this turn was free" rather than "unknown".
+      ...(usage.costUsd !== undefined && usage.costUsd > 0 ? { costUsd: usage.costUsd } : {}),
+      ...(response.model ? { primaryModel: response.model } : {}),
+      durationMs: response.durationMs,
+    };
+  }
+}

--- a/packages/executor/src/sdk-handlers/omp/omp-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/omp/omp-tool.test.ts
@@ -1,0 +1,209 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { MessagesService, StreamingCallbacks } from '../base/index.js';
+import { type OmpConfig, OmpTool } from './omp-tool.js';
+
+/**
+ * Minimal stand-in for a spawned `omp --mode rpc` process.
+ *
+ * `emit()` writes frames the way a real pipe does — several JSON lines can
+ * arrive in ONE stdout chunk, which is exactly the condition that used to
+ * reorder streaming callbacks.
+ *
+ * The fake answers `get_state` and exits on `kill()` so the tool's own
+ * post-turn request and disposal complete immediately instead of waiting out
+ * their real timeouts.
+ */
+function fakeOmp() {
+  const child = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  const sent: Array<Record<string, unknown>> = [];
+
+  const write = (...frames: Array<Record<string, unknown>>) => {
+    stdout.write(`${frames.map((f) => JSON.stringify(f)).join('\n')}\n`);
+  };
+
+  stdin.on('data', (buf: Buffer) => {
+    for (const line of buf.toString().split('\n').filter(Boolean)) {
+      const command: Record<string, unknown> = JSON.parse(line);
+      sent.push(command);
+      // Answer the bookkeeping calls the tool makes around every turn.
+      if (command.type === 'get_state') {
+        write({
+          type: 'response',
+          id: command.id,
+          command: 'get_state',
+          success: true,
+          data: { sessionFile: '/s/abc.jsonl', contextUsage: { tokens: 10, contextWindow: 100 } },
+        });
+      }
+    }
+  });
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    stdin,
+    kill: () => {
+      // A real kill terminates the process; mirror that so dispose() resolves.
+      queueMicrotask(() => child.emit('exit', 0, 'SIGTERM'));
+      return true;
+    },
+  });
+
+  return { child, write, sent };
+}
+
+function harness() {
+  const omp = fakeOmp();
+  const created: Array<Record<string, unknown>> = [];
+  const messagesService = {
+    create: vi.fn(async (m: Record<string, unknown>) => {
+      created.push(m);
+      return m;
+    }),
+  } as unknown as MessagesService;
+
+  const events: string[] = [];
+  const callbacks = {
+    onStreamStart: vi.fn(async () => {
+      events.push('start');
+    }),
+    onStreamChunk: vi.fn(async (_id: unknown, chunk: string, seq?: number) => {
+      events.push(`chunk:${chunk}:${seq}`);
+    }),
+    onStreamEnd: vi.fn(async () => {
+      events.push('end');
+    }),
+  } as unknown as StreamingCallbacks;
+
+  const tool = new OmpTool(
+    { enabled: true, spawnFn: (() => omp.child) as OmpConfig['spawnFn'] },
+    messagesService
+  );
+  tool.setSessionContext({ workingDirectory: '/tmp' });
+
+  /** Resolves once the tool has issued its `prompt` command. */
+  const promptSent = () =>
+    vi.waitFor(() => expect(omp.sent.some((c) => c.type === 'prompt')).toBe(true));
+
+  return { omp, tool, callbacks, events, created, promptSent };
+}
+
+const READY = { type: 'ready', protocolVersion: 1, supportedProtocolVersions: [1] };
+
+describe('OmpTool streaming', () => {
+  it('delivers text chunks in arrival order behind onStreamStart', async () => {
+    // Regression: deltas were dispatched as independent `void (async () => …)`
+    // tasks. onFrame runs synchronously from the stdout reader loop, so the
+    // second delta skipped the not-yet-resolved onStreamStart and emitted
+    // first — reversing the text and mis-numbering `sequence`.
+    const { omp, tool, callbacks, events, promptSent } = harness();
+
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+
+    // Four deltas in a single chunk, then the terminal frames.
+    omp.write(
+      { type: 'response', id: 'agor_1', command: 'prompt', success: true },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'A' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'B' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'C' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'D' } },
+      {
+        type: 'message_end',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'ABCD' }] },
+      },
+      { type: 'agent_end' }
+    );
+
+    const result = await run;
+    expect(result.status).toBe('completed');
+    expect(events).toEqual(['start', 'chunk:A:1', 'chunk:B:2', 'chunk:C:3', 'chunk:D:4', 'end']);
+  });
+
+  it('starts the stream before any chunk and ends it last', async () => {
+    const { omp, tool, callbacks, events, promptSent } = harness();
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+    omp.write(
+      { type: 'response', id: 'agor_1', command: 'prompt', success: true },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'x' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'y' } },
+      { type: 'agent_end' }
+    );
+    await run;
+    expect(events[0]).toBe('start');
+    expect(events.at(-1)).toBe('end');
+  });
+
+  it('records the context snapshot and session file for the next turn', async () => {
+    const { omp, tool, callbacks, promptSent } = harness();
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+    omp.write(
+      { type: 'response', id: 'agor_1', command: 'prompt', success: true },
+      { type: 'agent_end' }
+    );
+    await run;
+
+    expect(tool.getLastSessionFile()).toBe('/s/abc.jsonl');
+    expect(tool.getLastContextUsage()).toEqual({
+      totalTokens: 10,
+      maxTokens: 100,
+      percentage: 10,
+    });
+  });
+
+  it('fails the turn when OMP rejects the prompt', async () => {
+    const { omp, tool, callbacks, promptSent } = harness();
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+    omp.write({
+      type: 'response',
+      id: 'agor_1',
+      command: 'prompt',
+      success: false,
+      error: 'no model configured',
+    });
+
+    const result = await run;
+    expect(result.status).toBe('failed');
+    expect(result.error?.message).toContain('no model configured');
+  });
+
+  it('ends the turn when the process dies mid-stream instead of hanging', async () => {
+    // Without the onExit hook this would sit on the 30-minute turn timeout.
+    const { omp, tool, callbacks, promptSent } = harness();
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+    omp.write({ type: 'response', id: 'agor_1', command: 'prompt', success: true });
+    omp.child.emit('exit', 1, null);
+
+    await expect(run).resolves.toMatchObject({ status: 'completed' });
+  });
+
+  it('persists a placeholder rather than an empty message when OMP says nothing', async () => {
+    const { omp, tool, callbacks, created, promptSent } = harness();
+    const run = tool.executeTask('s1', 'hi', 't1', callbacks, 1);
+    omp.write(READY);
+    await promptSent();
+    omp.write(
+      { type: 'response', id: 'agor_1', command: 'prompt', success: true },
+      { type: 'agent_end' }
+    );
+    await run;
+
+    const message = created.at(-1);
+    expect(message?.content).toEqual([{ type: 'text', text: '(no output)' }]);
+    expect(message?.content_preview).toBeDefined();
+  });
+});

--- a/packages/executor/src/sdk-handlers/omp/omp-tool.ts
+++ b/packages/executor/src/sdk-handlers/omp/omp-tool.ts
@@ -1,0 +1,427 @@
+/**
+ * Oh My Pi tool implementation.
+ *
+ * Drives OMP as a subprocess over its JSONL RPC protocol (`omp --mode rpc`).
+ * OMP's npm SDK ships raw TypeScript for the Bun runtime, so it cannot be
+ * imported in-process by Agor's Node executor; RPC is the supported embedding
+ * surface and it also happens to be the only path that preserves OMP's slash
+ * commands.
+ *
+ * Capabilities:
+ * - Streaming text and thinking deltas
+ * - Structured tool-call blocks (`tool_execution_start` / `_end`)
+ * - Token usage AND real USD cost, both self-reported by OMP
+ * - Context-window snapshots via `get_state`
+ * - Slash commands: a prompt starting with `/` is expanded by OMP, and
+ *   local-only commands complete without an agent turn
+ */
+
+import { spawn } from 'node:child_process';
+import { generateId, shortId } from '@agor/core';
+import type { OmpFrame, OmpTurnResult } from '@agor/core/omp';
+import {
+  buildOmpEnv,
+  ensureAgorMcpConfig,
+  isSlashCommandPrompt,
+  OmpRpcClient,
+  OmpTurnAccumulator,
+} from '@agor/core/omp';
+import type { ContextUsageSnapshot, MessageID, SessionID, TaskID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import type { SessionRepository } from '../../db/feathers-repositories.js';
+import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-response.js';
+import { enrichContentBlocks } from '../base/diff-enrichment.js';
+import type {
+  MessagesService,
+  StreamingCallbacks,
+  TaskResult,
+  ToolCapabilities,
+} from '../base/index.js';
+import type { ITool } from '../base/tool.interface.js';
+
+/** Grace period to drain `command_output` after a local-only slash command. */
+const LOCAL_COMMAND_DRAIN_MS = 750;
+
+/** Hard ceiling on a single OMP turn, so a wedged agent cannot hang the task. */
+const TURN_TIMEOUT_MS = 30 * 60 * 1000;
+
+export interface OmpConfig {
+  enabled: boolean;
+  /** Executable to spawn; defaults to `omp` on PATH. */
+  binPath?: string;
+  /** OMP profile Agor runs under. */
+  profile?: string;
+}
+
+interface OmpSessionContext {
+  workingDirectory?: string;
+  model?: string;
+  provider?: string;
+  mcpToken?: string;
+  daemonUrl?: string;
+  /**
+   * OMP session file from a previous turn. Each Agor task spawns a fresh OMP
+   * process, so this is what carries the conversation forward.
+   */
+  resumeRef?: string;
+}
+
+export class OmpTool implements ITool {
+  readonly toolType = 'omp' as const;
+  readonly name = 'Oh My Pi';
+
+  private readonly config: OmpConfig;
+  private readonly messagesService: MessagesService;
+  private context: OmpSessionContext = {};
+  private activeClient?: OmpRpcClient;
+  /** Latest context-window reading, surfaced to Agor's task accounting. */
+  private lastContextUsage?: ContextUsageSnapshot;
+  /** OMP session file for the last turn, so the next task can resume it. */
+  private lastSessionFile?: string;
+
+  private readonly sessionsRepo?: SessionRepository;
+
+  constructor(
+    config: OmpConfig,
+    messagesService: MessagesService,
+    sessionsRepo?: SessionRepository
+  ) {
+    this.config = config;
+    this.messagesService = messagesService;
+    this.sessionsRepo = sessionsRepo;
+  }
+
+  /**
+   * Persist the command set OMP advertises so the composer can autocomplete
+   * `/` commands for this session, matching the Claude Code behaviour.
+   */
+  private async persistSlashCommands(sessionId: string, commands: string[]): Promise<void> {
+    if (!this.sessionsRepo || commands.length === 0) return;
+    try {
+      // The repository deep-merges custom_context, so this only touches the key.
+      await this.sessionsRepo.update(sessionId as SessionID, {
+        custom_context: { slash_commands: commands },
+      });
+    } catch (error) {
+      console.warn('[omp] Failed to persist slash commands to session:', error);
+    }
+  }
+
+  getCapabilities(): ToolCapabilities {
+    return {
+      supportsSessionImport: false,
+      supportsSessionCreate: true,
+      supportsLiveExecution: true,
+      supportsSessionFork: false,
+      supportsChildSpawn: true,
+      supportsGitState: false,
+      supportsStreaming: true,
+    };
+  }
+
+  /** Probe the binary by asking it for its version. */
+  checkInstalled(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const child = spawn(this.config.binPath ?? 'omp', ['--version'], { stdio: 'ignore' });
+      child.on('error', () => resolve(false));
+      child.on('exit', (code) => resolve(code === 0));
+    });
+  }
+
+  setSessionContext(context: OmpSessionContext): void {
+    this.context = { ...this.context, ...context };
+  }
+
+  /** Context-window snapshot captured during the last turn, if any. */
+  getLastContextUsage(): ContextUsageSnapshot | undefined {
+    return this.lastContextUsage;
+  }
+
+  /**
+   * OMP session file written by the last turn. The runner persists this on the
+   * Agor session so the next task resumes the same conversation.
+   */
+  getLastSessionFile(): string | undefined {
+    return this.lastSessionFile;
+  }
+
+  /**
+   * Run one prompt to completion and persist the assistant message.
+   *
+   * A fresh OMP process is spawned per task. OMP keeps its own session file,
+   * but Agor is the system of record for the transcript, so a per-task process
+   * keeps failure domains small and abort semantics simple.
+   */
+  async executeTask(
+    sessionId: string,
+    prompt: string,
+    taskId?: string,
+    streamingCallbacks?: StreamingCallbacks,
+    assistantIndex?: number
+  ): Promise<TaskResult> {
+    const accumulator = new OmpTurnAccumulator();
+    const assistantMessageId = generateId() as MessageID;
+    let streamStarted = false;
+    let sequence = 0;
+    let streamedPreview = '';
+
+    // Turn completion has two paths: a model turn ends with `agent_end`, while
+    // a local-only slash command never invokes the agent at all. Both funnel
+    // through `finishTurn`, which is idempotent.
+    let turnFinished = false;
+    let resolveTurn: () => void = () => undefined;
+    let turnTimer: NodeJS.Timeout | undefined;
+    const turnComplete = new Promise<void>((resolve) => {
+      resolveTurn = resolve;
+    });
+    const finishTurn = (): void => {
+      if (turnFinished) return;
+      turnFinished = true;
+      clearTimeout(turnTimer);
+      accumulator.markEnded();
+      resolveTurn();
+    };
+    turnTimer = setTimeout(() => {
+      accumulator.recordError(`OMP turn exceeded ${TURN_TIMEOUT_MS}ms`);
+      finishTurn();
+    }, TURN_TIMEOUT_MS);
+
+    // Register the Agor MCP endpoint in the profile before the agent starts, so
+    // its tool registry includes Agor self-drive tools on the first turn.
+    await ensureAgorMcpConfig({ profile: this.config.profile }).catch((error: unknown) => {
+      console.warn('[omp] Could not write Agor MCP config:', error);
+    });
+
+    const client = new OmpRpcClient({
+      cwd: this.context.workingDirectory ?? process.cwd(),
+      binPath: this.config.binPath,
+      profile: this.config.profile,
+      model: this.context.model,
+      resume: this.context.resumeRef,
+      env: buildOmpEnv({
+        base: process.env,
+        daemonUrl: this.context.daemonUrl,
+        mcpToken: this.context.mcpToken,
+        profile: this.config.profile,
+      }),
+      onStderr: (text) => {
+        if (text.trim()) console.warn(`[omp:stderr] ${text.trimEnd()}`);
+      },
+      // The process dying is a terminal condition for the turn.
+      onExit: () => finishTurn(),
+      onFrame: (frame) => {
+        this.observeCompletion(frame, finishTurn);
+        const delta = accumulator.handle(frame);
+        if (!delta || !streamingCallbacks) return;
+        // Agor renders one streaming surface per message; thinking deltas are
+        // captured into blocks at message_end rather than streamed as text.
+        if (delta.kind !== 'text') return;
+        void (async () => {
+          if (!streamStarted) {
+            streamStarted = true;
+            await streamingCallbacks.onStreamStart(assistantMessageId, {
+              session_id: sessionId as SessionID,
+              task_id: taskId as TaskID | undefined,
+              role: 'assistant',
+              timestamp: new Date().toISOString(),
+            });
+          }
+          sequence += 1;
+          streamedPreview += delta.text;
+          await streamingCallbacks.onStreamChunk(assistantMessageId, delta.text, sequence);
+        })().catch((error: unknown) => {
+          console.warn('[omp] Streaming callback failed:', error);
+        });
+      },
+    });
+    this.activeClient = client;
+
+    try {
+      await client.start();
+      await this.applyModelSelection(client);
+
+      // `prompt` is acknowledged on acceptance, not on completion — the turn
+      // itself finishes via the frames observed above.
+      const response = await client.request({ type: 'prompt', message: prompt }, 0);
+      if (!response.success) {
+        throw new Error(response.error ?? 'OMP rejected the prompt');
+      }
+      if (this.isLocalOnlyAck(response.data)) {
+        // Let queued `command_output` frames land before closing the turn.
+        setTimeout(finishTurn, isSlashCommandPrompt(prompt) ? LOCAL_COMMAND_DRAIN_MS : 0);
+      }
+      await turnComplete;
+
+      await this.captureContextUsage(client);
+
+      const result = accumulator.result();
+      await this.persistSlashCommands(sessionId, result.slashCommands);
+      await this.persistAssistantMessage({
+        sessionId,
+        taskId,
+        assistantMessageId,
+        assistantIndex,
+        result,
+        streamedPreview,
+      });
+
+      if (streamStarted && streamingCallbacks) {
+        await streamingCallbacks.onStreamEnd(assistantMessageId);
+      }
+
+      return {
+        taskId: taskId ?? '',
+        status: result.hadError ? 'failed' : 'completed',
+        messages: [],
+        completedAt: new Date(),
+      };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      console.error('[omp] executeTask failed:', err);
+      if (streamStarted && streamingCallbacks) {
+        await streamingCallbacks.onStreamEnd(assistantMessageId).catch(() => undefined);
+      }
+      return {
+        taskId: taskId ?? '',
+        status: 'failed',
+        messages: [],
+        error: err,
+        completedAt: new Date(),
+      };
+    } finally {
+      clearTimeout(turnTimer);
+      this.activeClient = undefined;
+      await client.dispose().catch(() => undefined);
+    }
+  }
+
+  /** Close the turn when OMP signals the agent finished, or resolved locally. */
+  private observeCompletion(frame: OmpFrame, finishTurn: () => void): void {
+    if (frame.type === 'agent_end') {
+      finishTurn();
+      return;
+    }
+    if (frame.type !== 'prompt_result') return;
+    if ('agentInvoked' in frame && frame.agentInvoked === false) {
+      setTimeout(finishTurn, LOCAL_COMMAND_DRAIN_MS);
+    }
+  }
+
+  /**
+   * `agentInvoked: false` means OMP handled the prompt without a model turn —
+   * typically a slash command that printed output directly.
+   */
+  private isLocalOnlyAck(data: unknown): boolean {
+    if (typeof data !== 'object' || data === null || !('agentInvoked' in data)) return false;
+    return data.agentInvoked === false;
+  }
+
+  /** Apply the session's configured model, if Agor has one pinned. */
+  private async applyModelSelection(client: OmpRpcClient): Promise<void> {
+    const { model, provider } = this.context;
+    if (!model || !provider) return;
+    const response = await client
+      .request({ type: 'set_model', provider, modelId: model }, 15_000)
+      .catch(() => undefined);
+    if (response && !response.success) {
+      console.warn(`[omp] set_model(${provider}/${model}) failed: ${response.error}`);
+    }
+  }
+
+  /**
+   * Read OMP's post-turn state: context-window occupancy for task accounting,
+   * and the session file so the next turn can resume this conversation.
+   */
+  private async captureContextUsage(client: OmpRpcClient): Promise<void> {
+    const response = await client.request({ type: 'get_state' }, 15_000).catch(() => undefined);
+    if (!response?.success) return;
+    const data = response.data;
+    if (typeof data !== 'object' || data === null) return;
+    if ('sessionFile' in data && typeof data.sessionFile === 'string' && data.sessionFile) {
+      this.lastSessionFile = data.sessionFile;
+    }
+    if (!('contextUsage' in data)) return;
+    const usage = data.contextUsage;
+    if (typeof usage !== 'object' || usage === null) return;
+    // OMP's payload is external input, so each field is checked, not assumed.
+    const read = (key: string): number | undefined => {
+      if (!(key in usage)) return undefined;
+      const value: unknown = Reflect.get(usage, key);
+      return typeof value === 'number' ? value : undefined;
+    };
+    const tokens = read('tokens');
+    const contextWindow = read('contextWindow');
+    if (tokens === undefined || contextWindow === undefined || contextWindow <= 0) return;
+    const percent = read('percent');
+    this.lastContextUsage = {
+      totalTokens: tokens,
+      maxTokens: contextWindow,
+      percentage: Math.round(percent ?? (tokens / contextWindow) * 100),
+    };
+  }
+
+  private async persistAssistantMessage(params: {
+    sessionId: string;
+    taskId?: string;
+    assistantMessageId: MessageID;
+    assistantIndex?: number;
+    result: OmpTurnResult;
+    streamedPreview: string;
+  }): Promise<void> {
+    const { result } = params;
+    const contentBlocks = [...result.contentBlocks];
+    if (contentBlocks.length === 0) {
+      contentBlocks.push({ type: 'text', text: params.streamedPreview.trim() || '(no output)' });
+    }
+    // Attach structuredPatch data so edit/write results render as diffs.
+    enrichContentBlocks(contentBlocks);
+
+    const preview = contentBlocks
+      .map((block) => (block.type === 'text' && typeof block.text === 'string' ? block.text : ''))
+      .filter(Boolean)
+      .join(' ')
+      .slice(0, 200);
+
+    await this.messagesService.create({
+      message_id: params.assistantMessageId,
+      session_id: params.sessionId as SessionID,
+      task_id: params.taskId as TaskID | undefined,
+      type: 'assistant' as const,
+      role: MessageRole.ASSISTANT,
+      index: params.assistantIndex ?? 0,
+      timestamp: new Date().toISOString(),
+      content_preview: preview || params.streamedPreview.slice(0, 200),
+      content: contentBlocks,
+      tool_uses: result.toolUses.length > 0 ? result.toolUses : undefined,
+      metadata: {
+        omp: {
+          model: result.model,
+          provider: result.provider,
+          stopReason: result.stopReason,
+          usage: result.usage,
+          commandOutputs: result.commandOutputs.length > 0 ? result.commandOutputs : undefined,
+        },
+      },
+    });
+  }
+
+  /** Interrupt the in-flight turn. */
+  async stopTask(
+    sessionId: string,
+    taskId?: string
+  ): Promise<{ success: boolean; partialResult?: Partial<TaskResult>; reason?: string }> {
+    const client = this.activeClient;
+    if (!client) {
+      return { success: false, reason: 'No active OMP session to stop' };
+    }
+    console.log(`[omp] Aborting task ${taskId ? shortId(taskId) : ''} in ${shortId(sessionId)}`);
+    await client.abort();
+    return { success: true, partialResult: { status: 'cancelled' } };
+  }
+
+  normalizedSdkResponse(_rawResponse: RawSdkResponse): NormalizedSdkResponse {
+    throw new Error(
+      'normalizedSdkResponse() is deprecated - use normalizeRawSdkResponse() from utils/sdk-normalizer instead'
+    );
+  }
+}

--- a/packages/executor/src/sdk-handlers/omp/omp-tool.ts
+++ b/packages/executor/src/sdk-handlers/omp/omp-tool.ts
@@ -18,7 +18,7 @@
 
 import { spawn } from 'node:child_process';
 import { generateId, shortId } from '@agor/core';
-import type { OmpFrame, OmpTurnResult } from '@agor/core/omp';
+import type { OmpFrame, OmpRpcClientOptions, OmpTurnResult } from '@agor/core/omp';
 import {
   buildOmpEnv,
   ensureAgorMcpConfig,
@@ -45,12 +45,20 @@ const LOCAL_COMMAND_DRAIN_MS = 750;
 /** Hard ceiling on a single OMP turn, so a wedged agent cannot hang the task. */
 const TURN_TIMEOUT_MS = 30 * 60 * 1000;
 
+/**
+ * Ceiling for the prompt ACCEPTANCE ack, which OMP sends immediately — this is
+ * not the turn budget (see `TURN_TIMEOUT_MS`).
+ */
+const PROMPT_ACK_TIMEOUT_MS = 60 * 1000;
+
 export interface OmpConfig {
   enabled: boolean;
   /** Executable to spawn; defaults to `omp` on PATH. */
   binPath?: string;
   /** OMP profile Agor runs under. */
   profile?: string;
+  /** Injection seam for tests, forwarded to the RPC client. */
+  spawnFn?: OmpRpcClientOptions['spawnFn'];
 }
 
 interface OmpSessionContext {
@@ -164,6 +172,16 @@ export class OmpTool implements ITool {
     let streamStarted = false;
     let sequence = 0;
     let streamedPreview = '';
+    /**
+     * Serializes streaming callbacks.
+     *
+     * `onFrame` is invoked synchronously from the stdout reader's loop, so
+     * several deltas can be dispatched before the first `await` resumes.
+     * Firing an independent async task per delta would let a later chunk
+     * overtake an earlier one — and overtake `onStreamStart` itself — so every
+     * delta is appended to one chain instead.
+     */
+    let streamChain: Promise<void> = Promise.resolve();
 
     // Turn completion has two paths: a model turn ends with `agent_end`, while
     // a local-only slash command never invokes the agent at all. Both funnel
@@ -186,11 +204,18 @@ export class OmpTool implements ITool {
       finishTurn();
     }, TURN_TIMEOUT_MS);
 
-    // Register the Agor MCP endpoint in the profile before the agent starts, so
-    // its tool registry includes Agor self-drive tools on the first turn.
-    await ensureAgorMcpConfig({ profile: this.config.profile }).catch((error: unknown) => {
-      console.warn('[omp] Could not write Agor MCP config:', error);
-    });
+    // Register the Agor MCP endpoint so the agent's tool registry includes
+    // Agor self-drive tools on the first turn.
+    //
+    // Gated on actually having a token: the entry lives in the user's own OMP
+    // config, and its `${...}` placeholders do NOT resolve outside Agor — OMP
+    // treats an unexpanded value literally and reports a failed server. So we
+    // only add it for installs that genuinely use Agor's MCP.
+    if (this.context.mcpToken && this.context.daemonUrl) {
+      await ensureAgorMcpConfig({ profile: this.config.profile }).catch((error: unknown) => {
+        console.warn('[omp] Could not write Agor MCP config:', error);
+      });
+    }
 
     const client = new OmpRpcClient({
       cwd: this.context.workingDirectory ?? process.cwd(),
@@ -198,6 +223,7 @@ export class OmpTool implements ITool {
       profile: this.config.profile,
       model: this.context.model,
       resume: this.context.resumeRef,
+      spawnFn: this.config.spawnFn,
       env: buildOmpEnv({
         base: process.env,
         daemonUrl: this.context.daemonUrl,
@@ -216,22 +242,24 @@ export class OmpTool implements ITool {
         // Agor renders one streaming surface per message; thinking deltas are
         // captured into blocks at message_end rather than streamed as text.
         if (delta.kind !== 'text') return;
-        void (async () => {
-          if (!streamStarted) {
-            streamStarted = true;
-            await streamingCallbacks.onStreamStart(assistantMessageId, {
-              session_id: sessionId as SessionID,
-              task_id: taskId as TaskID | undefined,
-              role: 'assistant',
-              timestamp: new Date().toISOString(),
-            });
-          }
-          sequence += 1;
-          streamedPreview += delta.text;
-          await streamingCallbacks.onStreamChunk(assistantMessageId, delta.text, sequence);
-        })().catch((error: unknown) => {
-          console.warn('[omp] Streaming callback failed:', error);
-        });
+        streamChain = streamChain
+          .then(async () => {
+            if (!streamStarted) {
+              streamStarted = true;
+              await streamingCallbacks.onStreamStart(assistantMessageId, {
+                session_id: sessionId as SessionID,
+                task_id: taskId as TaskID | undefined,
+                role: 'assistant',
+                timestamp: new Date().toISOString(),
+              });
+            }
+            sequence += 1;
+            streamedPreview += delta.text;
+            await streamingCallbacks.onStreamChunk(assistantMessageId, delta.text, sequence);
+          })
+          .catch((error: unknown) => {
+            console.warn('[omp] Streaming callback failed:', error);
+          });
       },
     });
     this.activeClient = client;
@@ -240,17 +268,30 @@ export class OmpTool implements ITool {
       await client.start();
       await this.applyModelSelection(client);
 
-      // `prompt` is acknowledged on acceptance, not on completion — the turn
+      // `prompt` is acknowledged on ACCEPTANCE, not on completion — the turn
       // itself finishes via the frames observed above.
-      const response = await client.request({ type: 'prompt', message: prompt }, 0);
-      if (!response.success) {
+      //
+      // The ack is raced against turn completion so a wedged OMP that accepts
+      // the prompt but never acks cannot hang the task forever: `agent_end`,
+      // process exit, or the turn timeout all release us. Waiting on the ack
+      // alone would make the turn timer unreachable, since it only resolves
+      // `turnComplete`.
+      const ack = client.request({ type: 'prompt', message: prompt }, PROMPT_ACK_TIMEOUT_MS);
+      // Swallow a late rejection; the race below already decided the outcome.
+      ack.catch(() => undefined);
+      const response = await Promise.race([ack, turnComplete.then(() => undefined)]);
+
+      if (response && !response.success) {
         throw new Error(response.error ?? 'OMP rejected the prompt');
       }
-      if (this.isLocalOnlyAck(response.data)) {
+      if (response && this.isLocalOnlyAck(response.data)) {
         // Let queued `command_output` frames land before closing the turn.
         setTimeout(finishTurn, isSlashCommandPrompt(prompt) ? LOCAL_COMMAND_DRAIN_MS : 0);
       }
       await turnComplete;
+      // Drain queued chunks so `streamedPreview` is complete before it is used
+      // as a preview fallback, and so no chunk lands after `onStreamEnd`.
+      await streamChain;
 
       await this.captureContextUsage(client);
 

--- a/packages/executor/src/types/sdk-response.ts
+++ b/packages/executor/src/types/sdk-response.ts
@@ -10,6 +10,7 @@
 
 import type { Claude, Codex, Gemini } from '@agor/core/sdk';
 import type { MessageID } from '@agor/core/types';
+import type { OmpSdkResponse } from '../sdk-handlers/omp/normalizer.js';
 
 type SDKResultMessage = Claude.SDKResultMessage;
 type ServerGeminiFinishedEvent = Gemini.ServerGeminiFinishedEvent;
@@ -102,6 +103,16 @@ export type CopilotSdkResponse = import('../sdk-handlers/copilot/normalizer.js')
 export type OpenCodeSdkResponse = unknown;
 
 // ============================================================================
+// Oh My Pi (OMP) SDK Response
+// ============================================================================
+
+/**
+ * OMP turn summary assembled by `OmpTool` from the RPC event stream.
+ * Re-exported from the normalizer, which owns the shape.
+ */
+export type { OmpSdkResponse };
+
+// ============================================================================
 // Union Type - All Raw SDK Responses
 // ============================================================================
 
@@ -114,7 +125,8 @@ export type RawSdkResponse =
   | CodexSdkResponse
   | GeminiSdkResponse
   | CopilotSdkResponse
-  | OpenCodeSdkResponse;
+  | OpenCodeSdkResponse
+  | OmpSdkResponse;
 
 // ============================================================================
 // Legacy/Deprecated Types (for backward compatibility)


### PR DESCRIPTION
## Linked issue

<!-- None — new runtime integration. -->

## Summary

- Adds **Oh My Pi (OMP)** as a selectable agentic runtime alongside Claude Code, Codex, Gemini, OpenCode, Copilot and Cursor
- New `@agor/core/omp` module: wire types, RPC client (JSONL framing, protocol-v2 chunk reassembly, request correlation), event translator, spawn/MCP config
- New `packages/executor/src/sdk-handlers/omp` (`OmpTool` + normalizer) and `handlers/sdk/omp.ts` task runner, registered in `tool-registry` and `normalizer-factory`
- UI registration: agent picker, settings tabs, permission modes, tool icon, and every exhaustive `Record<AgenticToolName, …>` / `Record<TenantAgenticToolName, …>`
- Slash commands work, and the ~47 commands OMP advertises populate the composer autocomplete
- Docs: OMP column in the harness comparison matrix + README runtime list

## Why / context

OMP is a terminal coding agent with a documented embedding protocol. Adding it follows Agor's "bring your own harness, no vendor lock-in" model.

**Why a subprocess rather than an in-process SDK.** `@oh-my-pi/pi-coding-agent` declares `"main": "./src/index.ts"` — it ships **raw TypeScript** and targets the Bun runtime (`engines.bun`), so the Node executor cannot import it the way it imports `@opencode-ai/sdk`. OMP's supported cross-runtime surface is its JSONL RPC protocol (`omp --mode rpc`).

That turned out to be the better transport anyway: it yields structured events (for the rich session UI and token accounting) **and** preserves slash commands, which a plain print-mode pipe would not.

## Implementation notes

**Keyless runtime.** Like OpenCode, OMP resolves credentials from its own profile. It is therefore absent from `TOOL_API_KEY_NAMES` / `AGENTIC_TOOL_KEY_CREATION_URL`, excluded from `ProviderConnectionTool`, renders no API-key fields, and the runner deliberately bypasses `executeToolTask` — that helper's credential gate raises `MissingCredentialError` for a session with no Agor-stored key.

**Profile / auth.** Runs under the host user's **default** OMP profile so an existing `omp` login applies. A named profile starts with an empty auth store, so defaulting to one produced sessions that spawned fine but failed every turn. Isolation is opt-in via `AGOR_OMP_PROFILE`.

**MCP injection.** OMP has no `--mcp-config` flag; it discovers servers from files. Writing into the branch worktree would leave a stray untracked file in the user's `git status`, so Agor writes the profile's user-level `mcp.json` (outside any repo) with `${AGOR_MCP_URL}` / `${AGOR_MCP_TOKEN}` placeholders that OMP expands per process. One static file therefore stays correct for concurrent sessions instead of racing to rewrite per-session values, and the entry is inert outside Agor. Existing user-defined servers are merged, not clobbered.

**Session continuity.** Each task spawns a fresh process, so `get_state.sessionFile` is captured and persisted to `session.sdk_session_id`, then replayed as `--resume` on the next turn.

**Accounting.** Token counts and **real USD cost** come from OMP's own per-message reporting rather than an Agor-side price table; context-window occupancy comes from its `get_state` snapshot (surfaced as an authoritative `contextUsageSnapshot`).

**Tool errors are not turn failures.** A failing `tool_execution_end` is flagged on the block for rendering but does not set `hadError` — agents routinely probe, hit an error and adapt, and treating that as a failed task marked ordinary exploratory turns as failed.

**Schema.** `omp` was added to the `agentic_tool` and `agentic_tool_presets.tool` enums in **both** the SQLite and Postgres schemas.

## Validation / test plan

- [x] `pnpm typecheck` — 11/11 packages
- [x] `pnpm build` — 8/8 packages
- [x] `pnpm lint` — clean (two pre-existing failures in `apps/agor-docs/components/MermaidZoom.tsx` and `scripts/*.ts` are untouched by this branch)
- [x] `@agor/core` — 2914 passed, 5 skipped (includes 31 new OMP tests)
- [x] `@agor/executor` — 563 passed
- [x] `agor-ui` — 1150 passed

End-to-end against the real `omp` binary, driving `OmpTool` directly:

- [x] **Agent turn** — completed in ~15s; content blocks `text, tool_use, tool_result, text`; a real `read` tool call whose result matched a sentinel written to disk
- [x] **Accounting** — `costUsd` 0.365 reported by OMP; context snapshot `53708 / 1000000`
- [x] **Streaming** — text deltas delivered through `StreamingCallbacks`
- [x] **Slash command** — `/model` returned `Current model: anthropic/claude-opus-5` in ~4s via `agentInvoked: false` + `command_output`, with no agent turn
- [x] **Autocomplete** — all 47 advertised commands persisted to `session.custom_context.slash_commands`
- [x] **Multi-turn** — a fresh process resuming the prior session file recalled a codeword established in turn 1
- [x] **Registry** — `initializeToolRegistry()` registers `omp` with its runner; `normalizeRawSdkResponse('omp', …)` returns tokens, cost, and the context snapshot

New unit tests cover the event translator (streaming deltas, tool blocks, usage/cost aggregation, tool-error semantics, command capture, malformed-frame tolerance) and spawn config (`buildArgs`, profile resolution, env templating, `mcp.json` merge/idempotency).

## Screenshots / demos

Not included — the change is runtime plumbing plus registration; the agent picker entry renders through the existing `AgentSelectionGrid` with the standard beta styling.

## Risks / rollout / rollback

- **Additive.** No existing runtime's behaviour changes; every edit to shared code is a new enum member or map key.
- **Requires the `omp` binary** on `PATH` for the daemon/executor user, authenticated once via the OMP CLI. When it is absent, `OmpTool.checkInstalled()` returns false and spawning reports an actionable "binary not found" error.
- **Writes `~/.omp/agent/mcp.json`** for the executing user (merged, idempotent, inert outside Agor). Operators who prefer isolation can set `AGOR_OMP_PROFILE`.
- **DB enums widened** — additive only; existing rows are unaffected and no migration is required for SQLite/Postgres text enums.
- **Rollback** is removing the runtime registration; no data migration to reverse.

## Out of scope / follow-ups

- Session **fork** and **import** are reported as unsupported (`AGENTIC_TOOL_CAPABILITIES.omp`); OMP exposes `branch` / `switch_session` over RPC, so both are feasible later.
- No static OMP model catalogue — OMP resolves its own model, so the model selector intentionally shows no hardcoded list (same treatment as OpenCode).
- Permission modes are declared and selectable but map onto OMP's approval settings coarsely; richer per-tool approval could follow.
