### PR TITLE
feat(executor): expose tenant_id to the executor command template

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -34,7 +34,6 @@ import { ensureCanPromptTargetSession } from '../../utils/branch-authorization.j
 import { inspectBranchViaExecutor } from '../../utils/branch-inspect.js';
 import { emitServiceEvent } from '../../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../../utils/executor-read-impersonation.js';
-import { serviceTokenScopeForParams } from '../../utils/spawn-executor.js';
 import {
   resolveBoardId,
   resolveBranchId,
@@ -989,7 +988,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const { currentSha, currentRef } = await inspectBranchViaExecutor(ctx.app, branch.branch_id, {
         asUser,
         logPrefix: `[mcp.sessions.create ${branch.name}]`,
-        serviceTokenScope: serviceTokenScopeForParams(ctx.baseServiceParams),
+        params: ctx.baseServiceParams,
       });
 
       // Resolve permission_config / model_config / inherited mcp_server_ids

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -754,7 +754,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           ...(options?.delete ? { delete: true } : {}),
         },
       },
-      { logPrefix }
+      { logPrefix, params }
     );
   };
 
@@ -789,7 +789,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           daemonUser: config.daemon?.unix_user,
         },
       },
-      { logPrefix }
+      { logPrefix, params }
     );
   };
 
@@ -2321,7 +2321,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 configureGitSafeDirectory: isUnixImpersonationEnabled(), // Configure git when impersonating
               },
             },
-            { logPrefix: '[Executor/user.create]' }
+            {
+              logPrefix: '[Executor/user.create]',
+              params: context.params as Partial<AuthenticatedParams>,
+            }
           );
 
           return context;
@@ -2394,7 +2397,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 configureGitSafeDirectory: isUnixImpersonationEnabled(), // Configure git when impersonating
               },
             },
-            { logPrefix: '[Executor/user.patch]' }
+            {
+              logPrefix: '[Executor/user.patch]',
+              params: context.params as Partial<AuthenticatedParams>,
+            }
           );
 
           return context;
@@ -2531,9 +2537,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                             | undefined
                         ),
                         logPrefix: `[sessions.create ${branch.name}]`,
-                        serviceTokenScope: serviceTokenScopeForParams(
-                          context.params as AuthenticatedParams
-                        ),
+                        params: context.params as AuthenticatedParams,
                       }
                     );
                     (context.data as Record<string, unknown>).git_state = {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1011,6 +1011,7 @@ function createExecuteHandler(
       asUser: executorUnixUser || undefined,
       preparedEnv: executorEnv,
       logPrefix,
+      params,
       templateVariables: {
         session_id: sessionId,
         task_id: taskId,

--- a/apps/agor-daemon/src/services/branch-owners.test.ts
+++ b/apps/agor-daemon/src/services/branch-owners.test.ts
@@ -86,7 +86,12 @@ describe('setupBranchOwnersService Unix sync hooks', () => {
         sessionToken: 'service-token',
         params: expect.objectContaining({ branchId: 'branch-1', daemonUser: 'agor' }),
       }),
-      { logPrefix: '[Executor/branch-owners.create]' }
+      expect.objectContaining({
+        logPrefix: '[Executor/branch-owners.create]',
+        // The authenticated params are threaded through so `{tenant_id}` can be
+        // derived for the executor command template.
+        params: expect.objectContaining({ tenant: { tenant_id: 'tenant-a' } }),
+      })
     );
   });
 });

--- a/apps/agor-daemon/src/services/branch-owners.ts
+++ b/apps/agor-daemon/src/services/branch-owners.ts
@@ -274,7 +274,10 @@ export function setupBranchOwnersService(
                 daemonUser: config.daemonUser,
               },
             },
-            { logPrefix: '[Executor/branch-owners.create]' }
+            {
+              logPrefix: '[Executor/branch-owners.create]',
+              params: context.params as Partial<AuthenticatedParams>,
+            }
           );
 
           return context;
@@ -309,7 +312,10 @@ export function setupBranchOwnersService(
                 daemonUser: config.daemonUser,
               },
             },
-            { logPrefix: '[Executor/branch-owners.remove]' }
+            {
+              logPrefix: '[Executor/branch-owners.remove]',
+              params: context.params as Partial<AuthenticatedParams>,
+            }
           );
 
           return context;

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -444,6 +444,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           logPrefix,
           asUser,
           preparedEnv: env,
+          params,
           templateVariables: {
             branch_id: branch.branch_id,
           },
@@ -478,13 +479,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     action: EnvironmentLifecycleAction;
     params?: BranchParams;
   }): Promise<void> {
-    const { branch, action } = options;
+    const { branch, action, params } = options;
     const { payload, asUser, env } = await this.createEnvironmentExecutorPayload(options);
 
     const result = await runExecutorCommand(payload, {
       logPrefix: `[Environment.${action} ${branch.name}]`,
       asUser,
       preparedEnv: env,
+      params,
       // Mixed webhook/shell restart needs the daemon to wait for shell stop
       // before it invokes the daemon-owned webhook start. Keep this generous
       // enough for docker compose down while still bounding the request.
@@ -546,6 +548,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         logPrefix: `[Environment.logs ${branch.name}]`,
         asUser,
         preparedEnv: env,
+        params,
         timeoutMs: ENVIRONMENT.LOGS_TIMEOUT_MS,
         templateVariables: {
           branch_id: branch.branch_id,
@@ -1332,6 +1335,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             {
               logPrefix: `[BranchesService.remove ${branch.name}]`,
               asUser, // Run as resolved user (fresh groups via sudo -u)
+              params,
             }
           );
         })
@@ -1417,6 +1421,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             },
             {
               logPrefix: `[BranchesService.clean ${branch.name}]`,
+              params,
             }
           );
         })
@@ -1465,6 +1470,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             },
             {
               logPrefix: `[BranchesService.delete ${branch.name}]`,
+              params,
             }
           );
         })
@@ -1681,6 +1687,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           },
           {
             logPrefix: `[BranchesService.unarchive ${branch.name}]`,
+            params,
           }
         );
       } catch (error) {

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -124,6 +124,7 @@ export class FilesService {
         },
         {
           logPrefix: `[FilesService ${sessionId}]`,
+          params,
           // In strict mode, autocomplete runs as the requesting Unix user.
           // In simple/insulated mode this stays undefined so default installs
           // do not require sudo and configured executor defaults can apply.

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -301,6 +301,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       {
         logPrefix: `[clone ${slug}]`,
         asUser, // Run as resolved user (fresh groups via sudo -u)
+        params,
         onExit: (code) => {
           if (code !== 0 && code !== null) {
             // Broadcast clone failure to all connected clients (the existing
@@ -968,6 +969,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         {
           logPrefix: `[ReposService.createBranch ${data.name}]`,
           asUser, // Run as resolved user (fresh groups via sudo -u)
+          params,
         }
       );
     } catch (error) {
@@ -1033,6 +1035,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       {
         logPrefix: `[${command} ${repo.slug}/${branch.name}]`,
         asUser,
+        params: serviceParams,
       }
     );
   }
@@ -1214,6 +1217,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         {
           logPrefix: `[repo.delete ${repo.slug}]`,
           timeoutMs: 5 * 60_000,
+          params,
         }
       );
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -1019,6 +1019,7 @@ export class TerminalsService {
           logPrefix: `[TerminalsService.executor ${shortId(userId)}]`,
           asUser: finalUnixUser || undefined,
           env: executorEnv,
+          params,
           // Clean up map when executor exits (handles crashes too)
           onExit: () => this.handleExecutorExit(userId),
         }

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -18,7 +18,6 @@ import { buildZoneTriggerContext } from '@agor/core/templates/zone-trigger-conte
 import type { AgenticToolName, Branch, Session, Task, User } from '@agor/core/types';
 import { inspectBranchViaExecutor } from '../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
-import { serviceTokenScopeForParams } from '../utils/spawn-executor.js';
 
 export interface FireAlwaysNewZoneTriggerInput {
   // biome-ignore lint/suspicious/noExplicitAny: Feathers app type varies across callers
@@ -94,7 +93,7 @@ export async function fireAlwaysNewZoneTrigger(
   const { currentSha, currentRef } = await inspectBranchViaExecutor(app, branch.branch_id, {
     asUser,
     logPrefix: `[zone-trigger ${branch.name}]`,
-    serviceTokenScope: serviceTokenScopeForParams(params),
+    params,
   });
 
   const newSession: Session = await app.service('sessions').create(

--- a/apps/agor-daemon/src/utils/branch-inspect.ts
+++ b/apps/agor-daemon/src/utils/branch-inspect.ts
@@ -1,6 +1,11 @@
 import type { Application } from '@agor/core/feathers';
-import type { BranchID } from '@agor/core/types';
-import { generateSessionToken, getDaemonUrl, runExecutorCommand } from './spawn-executor.js';
+import type { AuthenticatedParams, BranchID } from '@agor/core/types';
+import {
+  generateSessionToken,
+  getDaemonUrl,
+  runExecutorCommand,
+  serviceTokenScopeForParams,
+} from './spawn-executor.js';
 
 export interface BranchInspectResult {
   currentSha: string;
@@ -22,12 +27,13 @@ export async function inspectBranchViaExecutor(
   options: {
     asUser?: string | null;
     logPrefix?: string;
-    serviceTokenScope?: Record<string, unknown>;
+    /** Authenticated request params; used for token scope and template substitution. */
+    params?: Partial<AuthenticatedParams>;
   } = {}
 ): Promise<BranchInspectResult> {
   const sessionToken = generateSessionToken(
     app as unknown as { settings: { authentication?: { secret?: string } } },
-    options.serviceTokenScope
+    serviceTokenScopeForParams(options.params)
   );
 
   const result = await runExecutorCommand(
@@ -40,6 +46,7 @@ export async function inspectBranchViaExecutor(
     {
       logPrefix: options.logPrefix ?? `[branch.inspect ${branchId}]`,
       asUser: options.asUser ?? undefined,
+      params: options.params,
     }
   );
 

--- a/apps/agor-daemon/src/utils/realign-repo-origin.ts
+++ b/apps/agor-daemon/src/utils/realign-repo-origin.ts
@@ -55,6 +55,7 @@ export async function ensureRepoOriginAlignedForRepo(
     },
     {
       logPrefix: `[git.repo.realign-origin ${repo.slug}]`,
+      params,
     }
   );
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -173,6 +173,67 @@ describe('configured executor spawning', () => {
     );
   });
 
+  it('substitutes {tenant_id} from the request tenant params for templated spawns', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor(
+      { command: 'git.clone' },
+      {
+        executorCommandTemplate: 'launch --tenant-id {tenant_id} -- {command}',
+        params: { tenant: { tenant_id: 'tenant-abc' as never, source: 'auth_claim' } },
+      }
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'launch --tenant-id tenant-abc -- git.clone'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('leaves {tenant_id} unsubstituted when the request has no resolved tenant', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor(
+      { command: 'git.clone' },
+      { executorCommandTemplate: 'launch --tenant-id {tenant_id} -- {command}' }
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'launch --tenant-id {tenant_id} -- git.clone'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('substitutes {tenant_id} from the request tenant params for templated runExecutorCommand', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { runExecutorCommand } = await import('./spawn-executor');
+
+    const resultPromise = runExecutorCommand(
+      { command: 'branch.inspect' },
+      {
+        executorCommandTemplate: 'launch --tenant-id {tenant_id} -- {command}',
+        params: { tenant: { tenant_id: 'tenant-abc' as never, source: 'auth_claim' } },
+      }
+    );
+    // Settle the awaited command so no timer/promise dangles.
+    proc.stdout.emit('data', Buffer.from(JSON.stringify({ success: true, data: {} })));
+    proc.emit('exit', 0);
+    await resultPromise;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'launch --tenant-id tenant-abc -- branch.inspect'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+  });
+
   it('propagates an explicit LOG_LEVEL to local executor processes at startup', async () => {
     const proc = createMockProcess();
     spawnMock.mockReturnValue(proc);
@@ -264,5 +325,28 @@ describe('configured executor spawning', () => {
         process.env.AGOR_EXECUTOR_PATH = previous;
       }
     }
+  });
+});
+
+describe('substituteTemplateVariables', () => {
+  it('substitutes a {tenant_id} placeholder with the provided tenant', async () => {
+    const { substituteTemplateVariables } = await import('./spawn-executor');
+
+    const result = substituteTemplateVariables('launch --tenant-id {tenant_id} -- {command}', {
+      tenant_id: 'tenant-xyz',
+      command: 'git.clone',
+    });
+
+    expect(result).toBe('launch --tenant-id tenant-xyz -- git.clone');
+  });
+
+  it('leaves {tenant_id} as-is when no tenant is provided', async () => {
+    const { substituteTemplateVariables } = await import('./spawn-executor');
+
+    const result = substituteTemplateVariables('launch --tenant-id {tenant_id} -- {command}', {
+      command: 'git.clone',
+    });
+
+    expect(result).toBe('launch --tenant-id {tenant_id} -- git.clone');
   });
 });

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -91,6 +91,15 @@ export interface ExecutorTemplateVariables {
   session_id?: string;
   branch_id?: string;
   log_level?: string;
+  /**
+   * The tenant that owns this request, as resolved from the request's auth
+   * claim (`params.tenant`). Exposed as a general `{tenant_id}` placeholder so
+   * operator-supplied command templates can forward it (for example, a launcher
+   * that attributes each run to its tenant). Left as-is when absent
+   * (single-tenant / unauthenticated paths). This is the runtime's own generic
+   * tenant primitive and introduces no other identifiers.
+   */
+  tenant_id?: string;
 }
 
 export type ExecutorSpawnMode = 'local' | 'templated';
@@ -108,6 +117,13 @@ export interface SpawnExecutorOptions {
   /** When set, uses template substitution instead of local subprocess. */
   executorCommandTemplate?: string | null;
   templateVariables?: ExecutorTemplateVariables;
+  /**
+   * Authenticated request params. Only consumed to derive the `{tenant_id}`
+   * template variable in one place (via `tenantIdForParams`) so call sites
+   * don't each re-derive it. Optional: paths without a resolved tenant simply
+   * leave `{tenant_id}` unsubstituted.
+   */
+  params?: Partial<AuthenticatedParams>;
   onExit?: (code: number | null, context: ExecutorSpawnContext) => void;
   /** Fired after spawn, before stdin is written. Works for both local and templated paths. */
   onSpawn?: (child: ChildProcess, context: ExecutorSpawnContext) => void;
@@ -158,6 +174,7 @@ export function substituteTemplateVariables(
     session_id: variables.session_id,
     branch_id: variables.branch_id,
     log_level: variables.log_level,
+    tenant_id: variables.tenant_id,
   };
 
   for (const [key, value] of Object.entries(substitutions)) {
@@ -251,6 +268,7 @@ export function spawnExecutor(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
+        tenant_id: tenantIdForParams(options.params),
         ...templateVariables,
       },
       logPrefix,
@@ -547,6 +565,7 @@ export async function runExecutorCommand(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
+        tenant_id: tenantIdForParams(options.params),
         ...templateVariables,
       },
       logPrefix,
@@ -858,8 +877,17 @@ export function createServiceToken(
 export function serviceTokenScopeForParams(
   params?: Partial<AuthenticatedParams>
 ): Record<string, unknown> {
-  const tenantId = params?.tenant?.tenant_id ?? params?.tenant_id ?? params?.user?.tenant_id;
+  const tenantId = tenantIdForParams(params);
   return tenantId ? { tenant_id: tenantId } : {};
+}
+
+/**
+ * Resolve the tenant id from authenticated params, if any. Single source of
+ * truth for token scoping and executor command-template substitution, so both
+ * derive the tenant the same way. Returns undefined for tenant-less requests.
+ */
+export function tenantIdForParams(params?: Partial<AuthenticatedParams>): string | undefined {
+  return params?.tenant?.tenant_id ?? params?.tenant_id ?? params?.user?.tenant_id;
 }
 
 /**


### PR DESCRIPTION
## What

Adds a general `tenant_id` variable to the daemon's executor command-template substitution, so an operator-supplied `executor_command_template` can forward the per-request tenant to the launcher — e.g. `… --tenant-id {tenant_id} …`.

- `ExecutorTemplateVariables` gains a `tenant_id?: string` field and the `substituteTemplateVariables` map substitutes `{tenant_id}`.
- The tenant is derived in **one place** (inside `spawnExecutor` / `runExecutorCommand`) via a small typed `tenantIdForParams(params)` helper, from the `params.tenant` the daemon already resolves from the request's auth claim. Call sites forward their authenticated `params` through the new optional `SpawnExecutorOptions.params` rather than each re-deriving the tenant.
- `inspectBranchViaExecutor` was refactored to take `params` too, deriving its token scope internally and forwarding `params` to the executor — removing duplicated derivation at its callers.
- Unknown/absent tenants keep existing behavior: `{tenant_id}` is left unsubstituted on single-tenant / unauthenticated paths.

## Why

A single daemon can serve many tenants, so the tenant that owns a run must be delivered **per request**. The daemon already resolves it (`params.tenant.tenant_id`, used today to scope the executor's service token) but never surfaced it as a template field — it only reached the executor buried inside the session-token JWT. Exposing a generic `{tenant_id}` placeholder lets an operator's launch template attribute each run to its tenant. This is the runtime's own generic tenant primitive and introduces no other identifiers.

## Tests

- Unit tests for `substituteTemplateVariables`: `{tenant_id}` round-trips when a tenant is present and is left as-is when absent.
- Integration tests through both `spawnExecutor` and `runExecutorCommand`: `params.tenant` is substituted into a `{tenant_id}` template, and left literal when no tenant is resolved.
- Updated the branch-owners hook test to assert the authenticated params (tenant) are threaded to the spawn.

Typecheck (all packages), Biome lint, and the multitenancy-boundary guard all pass.
