### PR TITLE
feat(runtime): tenant-aware data_home for multi-tenant cells

### DIFF
--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -15,6 +15,7 @@ import {
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
+  getCurrentTenantId,
   MessagesRepository,
   runWithTenantContext,
   runWithTenantDatabaseScope,
@@ -22,6 +23,7 @@ import {
   shortId,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
+import { setDataHomeTenantResolver } from '@agor/core/git/pure';
 import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
 import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
@@ -572,6 +574,13 @@ export async function startup(ctx: StartupContext): Promise<void> {
     getSocketServer,
     terminalsService,
   } = ctx;
+
+  // 0. Make the repo/worktree layout tenant-aware in this daemon process. The
+  // git package can't import @agor/core (cycle), so we inject the ambient tenant
+  // resolver here; every repo/branch path then lands under tenants/<id>/ for a
+  // resolved non-default tenant. The executor stays un-scoped and operates on the
+  // absolute paths this daemon hands it.
+  setDataHomeTenantResolver(getCurrentTenantId);
 
   // 1. Correct orphaned task/session state from previous daemon instance.
   // Keep this blocking so clients never see stale RUNNING/AWAITING states from

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -16,7 +16,7 @@ import {
   buildAuthHeaderEnv,
   buildGitConfigEnv,
   extractRepoName,
-  getBranchesDir,
+  getDataHomeRoot,
   getReposDir,
   gitUrlHasUserinfo,
   parseHostFromGitUrl,
@@ -1737,29 +1737,33 @@ export async function deleteRepoDirectory(repoPath: string): Promise<void> {
   const { realpathSync, existsSync } = await import('node:fs');
   const { resolve, relative } = await import('node:path');
 
-  // Safety check: ensure we're only deleting from ~/.agor/repos/
-  const reposDir = getReposDir();
+  // Safety check: ensure we're only deleting from within the data-home root.
+  // We validate against the un-scoped root (not getReposDir()) because this runs
+  // in the executor process, which has no ambient tenant context: a tenant-scoped
+  // repo path (root/tenants/<id>/repos/<slug>) is a sibling of the un-scoped
+  // root/repos, so containment only holds against the shared root.
+  const dataHomeRoot = getDataHomeRoot();
 
   // Use realpathSync to follow symlinks and canonicalize paths.
   // If the directory was already removed, fall back to resolving via parent.
-  const resolvedReposDir = realpathSync(reposDir);
+  const resolvedRoot = realpathSync(dataHomeRoot);
   const resolvedRepoPath = existsSync(repoPath)
     ? realpathSync(repoPath)
     : resolve(realpathSync(resolve(repoPath, '..')), resolve(repoPath).split('/').pop()!);
 
-  // Get relative path from reposDir to repoPath
-  const relativePath = relative(resolvedReposDir, resolvedRepoPath);
+  // Get relative path from the data-home root to repoPath
+  const relativePath = relative(resolvedRoot, resolvedRepoPath);
 
   // Check if relative path goes outside (starts with '..' or is absolute)
   if (relativePath.startsWith('..') || resolve(relativePath) === relativePath) {
     throw new Error(
-      `Safety check failed: Repository path must be inside ${reposDir}. Got: ${repoPath}`
+      `Safety check failed: Repository path must be inside ${dataHomeRoot}. Got: ${repoPath}`
     );
   }
 
-  // Additional safety: don't allow deleting the repos directory itself
-  if (resolvedRepoPath === resolvedReposDir || relativePath === '') {
-    throw new Error('Cannot delete the repos directory itself');
+  // Additional safety: don't allow deleting the data-home root itself
+  if (resolvedRepoPath === resolvedRoot || relativePath === '') {
+    throw new Error('Cannot delete the data-home root itself');
   }
 
   await rm(resolvedRepoPath, { recursive: true, force: true });
@@ -1778,30 +1782,34 @@ export async function deleteBranchDirectory(branchPath: string): Promise<void> {
   const { realpathSync, existsSync } = await import('node:fs');
   const { resolve, relative } = await import('node:path');
 
-  // Safety check: ensure we're only deleting from configured branches directory
-  const branchesDir = getBranchesDir();
+  // Safety check: ensure we're only deleting from within the data-home root.
+  // Validated against the un-scoped root (not getBranchesDir()) for the same
+  // reason as deleteRepoDirectory: this runs in the executor, which has no
+  // ambient tenant context, so a tenant-scoped branch path only stays contained
+  // relative to the shared root.
+  const dataHomeRoot = getDataHomeRoot();
 
   // Use realpathSync to follow symlinks and canonicalize paths.
   // If the branch directory was already removed (e.g. by `git worktree remove`),
   // fall back to resolve() — the safety check still works since the base dir exists.
-  const resolvedBranchesDir = realpathSync(branchesDir);
+  const resolvedRoot = realpathSync(dataHomeRoot);
   const resolvedBranchPath = existsSync(branchPath)
     ? realpathSync(branchPath)
     : resolve(realpathSync(resolve(branchPath, '..')), resolve(branchPath).split('/').pop()!);
 
-  // Get relative path from branchesDir to branchPath
-  const relativePath = relative(resolvedBranchesDir, resolvedBranchPath);
+  // Get relative path from the data-home root to branchPath
+  const relativePath = relative(resolvedRoot, resolvedBranchPath);
 
   // Check if relative path goes outside (starts with '..' or is absolute)
   if (relativePath.startsWith('..') || resolve(relativePath) === relativePath) {
     throw new Error(
-      `Safety check failed: Branch path must be inside ${branchesDir}. Got: ${branchPath}`
+      `Safety check failed: Branch path must be inside ${dataHomeRoot}. Got: ${branchPath}`
     );
   }
 
-  // Additional safety: don't allow deleting the branches directory itself
-  if (resolvedBranchPath === resolvedBranchesDir || relativePath === '') {
-    throw new Error('Cannot delete the branches directory itself');
+  // Additional safety: don't allow deleting the data-home root itself
+  if (resolvedBranchPath === resolvedRoot || relativePath === '') {
+    throw new Error('Cannot delete the data-home root itself');
   }
 
   await rm(resolvedBranchPath, { recursive: true, force: true });

--- a/packages/git/src/pure.test.ts
+++ b/packages/git/src/pure.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { getBranchPath, getDataHomeRoot, getReposDir, setDataHomeTenantResolver } from './pure';
+
+const BASE = '/data/agor';
+
+describe('tenant-aware data home', () => {
+  let prevDataHome: string | undefined;
+
+  beforeAll(() => {
+    prevDataHome = process.env.AGOR_DATA_HOME;
+    process.env.AGOR_DATA_HOME = BASE;
+  });
+
+  afterEach(() => {
+    setDataHomeTenantResolver(undefined);
+  });
+
+  afterAll(() => {
+    if (prevDataHome === undefined) delete process.env.AGOR_DATA_HOME;
+    else process.env.AGOR_DATA_HOME = prevDataHome;
+  });
+
+  it('uses the un-scoped root when no resolver is set (executor / OSS default)', () => {
+    expect(getDataHomeRoot()).toBe(BASE);
+    expect(getReposDir()).toBe(`${BASE}/repos`);
+    expect(getBranchPath('preset-io/agor', 'feat-x')).toBe(
+      `${BASE}/worktrees/preset-io/agor/feat-x`
+    );
+  });
+
+  it('stays un-scoped for the default tenant (zero migration for static installs)', () => {
+    setDataHomeTenantResolver(() => 'default');
+    expect(getReposDir()).toBe(`${BASE}/repos`);
+    // getDataHomeRoot never carries a tenant segment — the executor delete safety
+    // checks depend on it staying the shared root.
+    expect(getDataHomeRoot()).toBe(BASE);
+  });
+
+  it('nests under tenants/<id> for a resolved non-default tenant', () => {
+    setDataHomeTenantResolver(() => 'ws_abc123');
+    expect(getReposDir()).toBe(`${BASE}/tenants/ws_abc123/repos`);
+    expect(getBranchPath('preset-io/agor', 'feat-x')).toBe(
+      `${BASE}/tenants/ws_abc123/worktrees/preset-io/agor/feat-x`
+    );
+    // A tenant-scoped path is still contained by the un-scoped root, so the
+    // executor's containment check passes without ambient tenant context.
+    expect(getReposDir().startsWith(`${getDataHomeRoot()}/`)).toBe(true);
+  });
+});

--- a/packages/git/src/pure.ts
+++ b/packages/git/src/pure.ts
@@ -21,7 +21,28 @@ function getAgorHome(): string {
   return path.join(os.homedir(), '.agor');
 }
 
-function getDataHome(): string {
+/**
+ * Tenant resolver injected by the daemon so the repo/worktree layout becomes
+ * per-tenant in-process. The git package cannot import @agor/core (dependency
+ * cycle), so the daemon wires getCurrentTenantId in at startup via
+ * setDataHomeTenantResolver. The executor process never sets a resolver — it
+ * receives fully-resolved absolute paths from the daemon — so it stays on the
+ * un-scoped root (see getDataHomeRoot and the delete safety checks).
+ */
+type DataHomeTenantResolver = () => string | undefined;
+let dataHomeTenantResolver: DataHomeTenantResolver | undefined;
+
+export function setDataHomeTenantResolver(resolver: DataHomeTenantResolver | undefined): void {
+  dataHomeTenantResolver = resolver;
+}
+
+// Mirrors @agor/core's DEFAULT_STATIC_TENANT_ID. The single-tenant OSS/static
+// deployment stays on the historical un-scoped layout (zero migration); only a
+// resolved non-default tenant gets its own `tenants/<id>` subtree.
+const DEFAULT_TENANT_ID = 'default';
+
+/** The un-scoped data-home root, with no tenant segment. */
+export function getDataHomeRoot(): string {
   if (process.env.AGOR_DATA_HOME) return expandHomePath(process.env.AGOR_DATA_HOME);
   try {
     const raw = readFileSync(path.join(getAgorHome(), 'config.yaml'), 'utf-8');
@@ -33,6 +54,13 @@ function getDataHome(): string {
     // @agor/core's full config loader.
   }
   return getAgorHome();
+}
+
+function getDataHome(): string {
+  const root = getDataHomeRoot();
+  const tenantId = dataHomeTenantResolver?.();
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) return root;
+  return path.join(root, 'tenants', tenantId);
 }
 
 export function getReposDir(): string {


### PR DESCRIPTION
## Why

Agor Cloud is moving to **many tenants (workspaces) per Cell** on durable, shared per-Cell storage (EFS). Today the on-disk path helpers are process-global: `getDataHome()` / `getReposDir()` / `getBranchPath()` have no tenant segment, so two workspaces on the same daemon that add the same repo slug collide at `$DATA_HOME/repos/<slug>` and `$DATA_HOME/worktrees/<slug>/<branch>` (slugs are unique only within a tenant). This makes the runtime side of that model safe.

## What

Scope repos/worktrees by tenant, keyed off the **already-ambient** tenant context — no callsite signature changes.

- **`packages/git/src/pure.ts`** — `getDataHome()` nests under `tenants/<tenant_id>/` for a resolved non-default tenant, via an injected resolver (`setDataHomeTenantResolver`). The git package cannot import `@agor/core` (dependency cycle), so the daemon injects `getCurrentTenantId`. Adds exported `getDataHomeRoot()` (the un-scoped root).
- **`apps/agor-daemon/src/startup.ts`** — one line wiring `setDataHomeTenantResolver(getCurrentTenantId)`.
- **`packages/git/src/index.ts`** — the executor-side `deleteRepoDirectory` / `deleteBranchDirectory` safety checks now validate containment against the un-scoped `getDataHomeRoot()`. The executor process has no ambient tenant context and operates on daemon-supplied absolute paths, so a `tenants/<id>/…` path only stays contained relative to the shared root.

## Backward compatibility

The **default/static tenant emits no segment**, so existing single-tenant installs keep the historical `$DATA_HOME/{repos,worktrees}` layout — **no filesystem migration**. The tenant subtree only appears for a resolved non-default tenant (cloud `required_from_auth`).

## Net layout

`$DATA_HOME/tenants/<tenant_id>/{repos,worktrees}/…` for a resolved tenant; unchanged for the default tenant.

## Tests

Adds `packages/git/src/pure.test.ts` covering no-resolver (executor/OSS), default tenant (no segment), and non-default tenant (scoped, still contained by the root).

## Deploy

Deployable by its own SHA once CI publishes `docker.io/preset/agor:<sha>` — the Agor Cloud control-plane side (per-Cell durable EFS storage) pins Cells to that SHA.
