### PR TITLE
fix: restore MCP token issuance for static tenants

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,4 +1,5 @@
 import { request as httpRequest } from 'node:http';
+import { resolveMultiTenancyConfig } from '@agor/core/config';
 import { getCurrentTenantId } from '@agor/core/db';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -242,7 +243,10 @@ describe('POST /mcp token source', () => {
   });
 
   it('rejects an internal MCP token replayed under a conflicting trusted tenant', async () => {
-    initMcpTokens({ db: testSqliteDb() });
+    initMcpTokens({
+      db: testSqliteDb(),
+      multiTenancy: resolveMultiTenancyConfig({}),
+    });
     const now = Math.floor(Date.now() / 1000);
     const token = jwt.sign(
       {

--- a/apps/agor-daemon/src/mcp/tokens.test.ts
+++ b/apps/agor-daemon/src/mcp/tokens.test.ts
@@ -13,6 +13,7 @@
  *   - pre-rollout tokens (no jti/exp) → rejected
  */
 
+import { resolveMultiTenancyConfig } from '@agor/core/config';
 import {
   branches,
   type Database,
@@ -50,6 +51,25 @@ const JWT_SECRET = 'test-jwt-secret-do-not-use-in-production';
  */
 function makeApp(): any {
   return { settings: { authentication: { secret: JWT_SECRET } } };
+}
+
+function initTestMcpTokens(
+  db: Database,
+  options: {
+    expirationMs?: number;
+    now?: () => number;
+    multiTenancy?: Parameters<typeof resolveMultiTenancyConfig>[0];
+  } = {}
+): void {
+  const multiTenancyConfig = options.multiTenancy ?? {
+    multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+  };
+  initMcpTokens({
+    db,
+    multiTenancy: resolveMultiTenancyConfig(multiTenancyConfig),
+    ...(options.expirationMs === undefined ? {} : { expirationMs: options.expirationMs }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
 }
 
 function mintSessionToken(
@@ -116,7 +136,7 @@ afterEach(() => {
 
 describe('generateSessionToken', () => {
   dbTest('issues a token with jti, exp, iat, aud, iss claims', async ({ db }) => {
-    initMcpTokens({ db, expirationMs: 60_000 });
+    initTestMcpTokens(db, { expirationMs: 60_000 });
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
     const app = makeApp();
 
@@ -142,7 +162,7 @@ describe('generateSessionToken', () => {
     const baseMs = Date.now();
     vi.useFakeTimers({ now: baseMs, shouldAdvanceTime: false });
     try {
-      initMcpTokens({ db, expirationMs: 60_000 });
+      initTestMcpTokens(db, { expirationMs: 60_000 });
       const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
       const t1 = await mintSessionToken(makeApp(), sessionId, 'u' as UserID);
@@ -163,15 +183,78 @@ describe('generateSessionToken', () => {
   });
 
   dbTest('throws when the session does not exist', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const missingSessionId = generateId() as SessionID;
     await expect(mintSessionToken(makeApp(), missingSessionId, 'u1' as UserID)).rejects.toThrow(
       /not found/
     );
   });
 
-  dbTest('fails closed when issuance has no tenant context', async ({ db }) => {
-    initMcpTokens({ db });
+  dbTest(
+    'uses the default static tenant for request-less/background issuance with no config block',
+    async ({ db }) => {
+      initTestMcpTokens(db, { multiTenancy: {} });
+      const sessionId = await seedSession(db);
+
+      const token = await generateSessionToken(makeApp(), sessionId, 'u1' as UserID);
+
+      expect((jwt.decode(token) as { tid?: string }).tid).toBe('default');
+    }
+  );
+
+  dbTest('uses a custom configured static tenant without ambient scope', async ({ db }) => {
+    initTestMcpTokens(db, {
+      multiTenancy: {
+        multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-static' },
+      },
+    });
+    const sessionId = await seedSession(db);
+
+    const token = await generateSessionToken(makeApp(), sessionId, 'u1' as UserID);
+
+    expect((jwt.decode(token) as { tid?: string }).tid).toBe('tenant-static');
+  });
+
+  dbTest('keeps an agreeing ambient static tenant authoritative', async ({ db }) => {
+    initTestMcpTokens(db, {
+      multiTenancy: {
+        multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-static' },
+      },
+    });
+    const sessionId = await seedSession(db);
+
+    const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-static');
+
+    expect((jwt.decode(token) as { tid?: string }).tid).toBe('tenant-static');
+  });
+
+  dbTest('rejects an ambient tenant that conflicts with static configuration', async ({ db }) => {
+    initTestMcpTokens(db, {
+      multiTenancy: {
+        multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-static' },
+      },
+    });
+    const sessionId = await seedSession(db);
+
+    await expect(
+      mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-other')
+    ).rejects.toThrow(/Conflicting tenant identities/);
+  });
+
+  dbTest(
+    'rejects malformed ambient tenant identity instead of using static fallback',
+    async ({ db }) => {
+      initTestMcpTokens(db, { multiTenancy: {} });
+      const sessionId = await seedSession(db);
+
+      await expect(
+        mintSessionToken(makeApp(), sessionId, 'u1' as UserID, '  default  ')
+      ).rejects.toThrow(/Invalid ambient tenant identity/);
+    }
+  );
+
+  dbTest('fails closed in required_from_auth mode without ambient scope', async ({ db }) => {
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db);
 
     await expect(generateSessionToken(makeApp(), sessionId, 'u1' as UserID)).rejects.toThrow(
@@ -179,8 +262,17 @@ describe('generateSessionToken', () => {
     );
   });
 
+  dbTest('issues in required_from_auth mode with an ambient tenant scope', async ({ db }) => {
+    initTestMcpTokens(db);
+    const sessionId = await seedSession(db);
+
+    const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-required');
+
+    expect((jwt.decode(token) as { tid?: string }).tid).toBe('tenant-required');
+  });
+
   dbTest('keeps cached tokens distinct across tenant bindings', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db);
 
     const tenantA = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-a');
@@ -198,7 +290,7 @@ describe('generateSessionToken', () => {
 
 describe('validateSessionToken', () => {
   dbTest('accepts a freshly minted token', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
     const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
@@ -218,7 +310,7 @@ describe('validateSessionToken', () => {
     const baseMs = Date.now();
     vi.useFakeTimers({ now: baseMs, shouldAdvanceTime: false });
     try {
-      initMcpTokens({ db, expirationMs: 60_000 });
+      initTestMcpTokens(db, { expirationMs: 60_000 });
       const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
       const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
@@ -235,7 +327,7 @@ describe('validateSessionToken', () => {
   });
 
   dbTest('rejects tokens for sessions that have been deleted', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
     const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
@@ -247,7 +339,7 @@ describe('validateSessionToken', () => {
   });
 
   dbTest('rejects a post-rollout token with the wrong issuer', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
     // Hand-mint a token that has every other claim right but a bogus `iss`.
@@ -271,7 +363,7 @@ describe('validateSessionToken', () => {
   });
 
   dbTest('rejects a pre-rollout token missing jti/exp', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
     // Pre-rollout tokens were minted without `jti` or `exp` (and no `iss`).
@@ -293,7 +385,7 @@ describe('validateSessionToken', () => {
     // when the claim is present. A forged-but-signature-valid token without
     // `exp` would otherwise pass verify and be replayable forever. Confirm
     // the explicit `payload.exp === undefined` check rejects it.
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
     const forged = jwt.sign(
@@ -314,7 +406,7 @@ describe('validateSessionToken', () => {
   });
 
   dbTest('rejects a signature-valid token that has an exp but is missing jti', async ({ db }) => {
-    initMcpTokens({ db });
+    initTestMcpTokens(db);
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
     const nowSec = Math.floor(Date.now() / 1000);
@@ -339,7 +431,7 @@ describe('validateSessionToken', () => {
   dbTest(
     'rejects replay against a different expected tenant before session lookup',
     async ({ db }) => {
-      initMcpTokens({ db });
+      initTestMcpTokens(db);
       const sessionId = await seedSession(db);
       const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-a');
 

--- a/apps/agor-daemon/src/mcp/tokens.ts
+++ b/apps/agor-daemon/src/mcp/tokens.ts
@@ -25,10 +25,15 @@
  * for deleted sessions are rejected even if they haven't yet hit their `exp`.
  */
 
-import { MCP_TOKEN } from '@agor/core/config';
+import {
+  MCP_TOKEN,
+  type ResolvedMultiTenancyConfig,
+  resolveTenantContext,
+  TenantResolutionError,
+} from '@agor/core/config';
 import {
   generateId,
-  requireCurrentTenantId,
+  getCurrentTenantId,
   runWithTenantContext,
   runWithTenantDatabaseScope,
   SessionRepository,
@@ -81,6 +86,11 @@ export interface McpTokenContext {
 
 export interface McpTokenInitOptions {
   db: TenantScopeAwareDatabase;
+  /**
+   * Resolved daemon tenant policy. Issuance may use the configured tenant only
+   * in static mode; required_from_auth still needs an ambient tenant identity.
+   */
+  multiTenancy: ResolvedMultiTenancyConfig;
   /** Token lifetime in ms. Falls back to `MCP_TOKEN.DEFAULT_EXPIRATION_MS` (24h). */
   expirationMs?: number;
   /** Override `Date.now()` for tests. */
@@ -94,6 +104,7 @@ export interface McpTokenInitOptions {
 interface ModuleState {
   db: TenantScopeAwareDatabase;
   sessionRepo: SessionRepository;
+  multiTenancy: ResolvedMultiTenancyConfig;
   expirationMs: number;
   now: () => number;
   tokenCache: Map<string, CachedMcpToken>;
@@ -131,6 +142,7 @@ export function initMcpTokens(options: McpTokenInitOptions): void {
   _state = {
     db: options.db,
     sessionRepo: new SessionRepository(options.db),
+    multiTenancy: options.multiTenancy,
     expirationMs,
     now,
     tokenCache: new Map(),
@@ -152,6 +164,44 @@ export function shutdownMcpTokens(): void {
 // ============================================================================
 
 /**
+ * Resolve the tenant binding for a new token through the canonical config
+ * resolver. Ambient identity is passed as an explicit trusted daemon signal:
+ *
+ * - static mode falls back to its configured tenant when ambient identity is
+ *   absent;
+ * - an ambient identity must agree with the configured static tenant;
+ * - required_from_auth accepts an ambient identity but fails closed without
+ *   one.
+ */
+function resolveIssuanceTenantId(state: ModuleState): TenantID {
+  const ambientTenantId = getCurrentTenantId();
+  try {
+    if (
+      ambientTenantId !== undefined &&
+      (!ambientTenantId.trim() || ambientTenantId.trim() !== ambientTenantId)
+    ) {
+      throw new TenantResolutionError('Invalid ambient tenant identity');
+    }
+    return resolveTenantContext(
+      state.multiTenancy,
+      ambientTenantId
+        ? {
+            params: { tenant_id: ambientTenantId },
+          }
+        : undefined
+    ).tenant_id;
+  } catch (error) {
+    if (error instanceof TenantResolutionError) {
+      const message = error.message.startsWith('Missing tenant context')
+        ? 'missing active tenant context'
+        : error.message;
+      throw new Error(`MCP token generation failed: ${message}`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+/**
  * Mint or reuse an MCP token for a session.
  *
  * @throws if the module isn't initialized, the session doesn't exist, or the
@@ -169,9 +219,7 @@ export async function generateSessionToken(
   }
 
   const nowMs = s.now();
-  const tenantId = requireCurrentTenantId(
-    'MCP token generation failed: missing active tenant context'
-  ) as TenantID;
+  const tenantId = resolveIssuanceTenantId(s);
   if (nowMs - s.lastCachePruneAtMs > 5 * 60 * 1000) {
     for (const [key, entry] of s.tokenCache) {
       if (entry.expiresAtMs <= nowMs) {

--- a/apps/agor-daemon/src/register-hooks.tenant-identity.test.ts
+++ b/apps/agor-daemon/src/register-hooks.tenant-identity.test.ts
@@ -2,19 +2,16 @@
  * Regression: tenant-owned services must carry ambient tenant identity even
  * without tenant columns (SQLite / single-tenant default).
  *
- * PR #1942 made MCP session-token minting (mcp/tokens.ts) call
- * `requireCurrentTenantId()`, which throws when no tenant context is active.
- * register-hooks.ts only registered the tenant around-hook when tenant columns
- * were enabled (PostgreSQL), so on the default SQLite deployment `sessions`
- * had no around-hook, no ambient tenant, and every `sessions.create` /
- * `sessions.get` 500'd with "missing active tenant context" — surfaced in the
- * UI as "Failed to create session".
+ * Tenant-aware service code should observe the configured static tenant even
+ * when tenant columns are absent. MCP token issuance can independently resolve
+ * the configured tenant in static mode, but other service code still relies on
+ * this ambient identity and required_from_auth must never receive a static
+ * fallback.
  *
  * The fix registers the identity-only around hook (no data stamping, no RLS
  * transaction) for tenant-owned services in SQLite mode. This test drives that
  * exact hook through its Feathers `(context, next)` contract and proves the
- * wrapped service body runs with the static tenant active — which is what lets
- * `generateSessionToken` succeed downstream instead of throwing.
+ * wrapped service body runs with the static tenant active.
  */
 
 import { DEFAULT_STATIC_TENANT_ID } from '@agor/core/config';
@@ -50,7 +47,7 @@ describe('tenant identity for owned services (SQLite / static mode)', () => {
   it('activates the static tenant while the wrapped service body runs', async () => {
     let observed: string | undefined = 'sentinel';
     await identityAround(makeContext(), async () => {
-      // Stand-in for the after-hook (mcp/tokens.ts) reading the active tenant.
+      // Stand-in for tenant-aware service code reading the active tenant.
       observed = getCurrentTenantId();
     });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -139,7 +139,6 @@ import {
   redactMCPServerSecrets,
   shouldExposeMCPServerSecrets,
 } from './utils/mcp-header-secrets.js';
-import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
 import {
   type RealtimeAccessBranchRepository,
@@ -153,6 +152,7 @@ import {
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './utils/schedule-hooks.js';
+import { createSessionMcpTokenHook } from './utils/session-mcp-token-hook.js';
 import { deferWithSessionQueueTenantScope } from './utils/session-queue-tenant-scope.js';
 import {
   isTerminalQueueProcessingSuppressed,
@@ -572,6 +572,18 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const multiTenancy = resolveMultiTenancyConfig(config);
   const tenantColumnsEnabled = resolveMultiTenancyDatabaseDialect(config) === 'postgresql';
   const executionMode = resolveExecutionSecurityMode(config);
+  const attachMcpTokenAfterGet = createSessionMcpTokenHook({
+    app,
+    config,
+    onAttached: (session) =>
+      mcpTokenDebug(`🔄 Resolved MCP token for session ${shortId(session.session_id)}`),
+  });
+  const attachMcpTokenAfterCreate = createSessionMcpTokenHook({
+    app,
+    config,
+    onAttached: (session) =>
+      console.log(`🎫 MCP token issued for session ${shortId(session.session_id)}`),
+  });
 
   const tenantOwnedServicePaths = TENANT_OWNED_SERVICE_PATHS;
 
@@ -2616,53 +2628,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           return context;
         },
       ],
-      get: [
-        async (context) => {
-          // Attach an MCP token for fetched session (cached/reused when still valid).
-          if (config.daemon?.mcpEnabled === false) {
-            return context;
-          }
-
-          const session = context.result as Session;
-          const callerUser = (context.params as AuthenticatedParams).user;
-
-          // Rationale for the narrow gate lives on canReceiveMcpTokenForSession.
-          if (
-            !canReceiveMcpTokenForSession({
-              callerUserId: callerUser?.user_id,
-              callerRole: callerUser?.role,
-            })
-          ) {
-            return context;
-          }
-
-          const { generateSessionToken } = await import('./mcp/tokens.js');
-          const userId = callerUser?.user_id;
-          if (!userId) {
-            return context;
-          }
-
-          const jwtSecret = app.settings.authentication?.secret;
-          if (!jwtSecret) {
-            console.error('❌ JWT secret not configured - cannot generate MCP token');
-            return context;
-          }
-
-          const mcpToken = await generateSessionToken(
-            app,
-            session.session_id,
-            userId as import('@agor/core/types').UserID
-          );
-
-          mcpTokenDebug(`🔄 Resolved MCP token for session ${shortId(session.session_id)}`);
-
-          // Add token to result. Tokens are not stored on the session row; the
-          // token module may reuse a still-valid issued token or mint a new one.
-          context.result = { ...session, mcp_token: mcpToken };
-
-          return context;
-        },
-      ],
+      get: [attachMcpTokenAfterGet],
       create: [
         async (context) => {
           const session = context.result as Session;
@@ -2673,57 +2639,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           );
           return context;
         },
-        async (context) => {
-          // Skip MCP setup if MCP server is disabled
-          if (config.daemon?.mcpEnabled === false) {
-            return context;
-          }
-
-          // Gate MCP token issuance through the same caller-scoped policy as `after:get`.
-          const callerUser = (context.params as AuthenticatedParams).user;
-          if (
-            !canReceiveMcpTokenForSession({
-              callerUserId: callerUser?.user_id,
-              callerRole: callerUser?.role,
-            })
-          ) {
-            return context;
-          }
-
-          // Resolve MCP token for this session (cached/reused when still valid).
-          // Mint it for the active caller, not for an inherited/parent creator.
-          const { generateSessionToken } = await import('./mcp/tokens.js');
-          const session = context.result as Session;
-          const userId = callerUser?.user_id;
-          if (!userId) {
-            return context;
-          }
-
-          // Get JWT secret from app settings
-          const jwtSecret = app.settings.authentication?.secret;
-          if (!jwtSecret) {
-            console.error('❌ JWT secret not configured - cannot generate MCP token');
-            return context;
-          }
-
-          const mcpToken = await generateSessionToken(
-            app,
-            session.session_id,
-            userId as import('@agor/core/types').UserID
-          );
-
-          console.log(`🎫 MCP token issued for session ${shortId(session.session_id)}`);
-
-          // Note: We no longer auto-attach global MCP servers to sessions.
-          // Instead, getMcpServersForSession() will automatically provide ALL
-          // global servers plus any session-specific servers assigned to this
-          // session. This avoids polluting the session_mcp_servers junction table.
-
-          // Update context.result to include the token
-          context.result = { ...session, mcp_token: mcpToken };
-
-          return context;
-        },
+        attachMcpTokenAfterCreate,
         // TODO: OpenCode session creation moved to executor - implement via IPC if needed
 
         // Unix Integration: When a non-owner creates a session in a branch with

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -152,7 +152,7 @@ import {
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './utils/schedule-hooks.js';
-import { createSessionMcpTokenHook } from './utils/session-mcp-token-hook.js';
+import { createSessionMcpTokenAfterHooks } from './utils/session-mcp-token-hook.js';
 import { deferWithSessionQueueTenantScope } from './utils/session-queue-tenant-scope.js';
 import {
   isTerminalQueueProcessingSuppressed,
@@ -572,16 +572,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const multiTenancy = resolveMultiTenancyConfig(config);
   const tenantColumnsEnabled = resolveMultiTenancyDatabaseDialect(config) === 'postgresql';
   const executionMode = resolveExecutionSecurityMode(config);
-  const attachMcpTokenAfterGet = createSessionMcpTokenHook({
+  const sessionMcpTokenAfterHooks = createSessionMcpTokenAfterHooks({
     app,
     config,
-    onAttached: (session) =>
+    onGetAttached: (session) =>
       mcpTokenDebug(`🔄 Resolved MCP token for session ${shortId(session.session_id)}`),
-  });
-  const attachMcpTokenAfterCreate = createSessionMcpTokenHook({
-    app,
-    config,
-    onAttached: (session) =>
+    onCreateAttached: (session) =>
       console.log(`🎫 MCP token issued for session ${shortId(session.session_id)}`),
   });
 
@@ -682,10 +678,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   // Without tenant columns (SQLite / single-tenant), tenant-owned services skip
   // the full RLS-transaction hooks — but they must still carry ambient tenant
-  // identity so tenant-aware call sites (e.g. MCP session-token minting in
-  // mcp/tokens.ts) can resolve the active tenant instead of throwing "missing
-  // active tenant context". Identity only: no data stamping or DB transaction,
-  // which are Postgres tenant-column mechanics.
+  // identity for tenant-aware call sites. MCP session-token issuance can
+  // resolve the configured tenant without ambient identity in static mode,
+  // while required_from_auth remains fail-closed. Identity only: no data
+  // stamping or DB transaction, which are Postgres tenant-column mechanics.
   const registerTenantIdentityForOwnedServices = (): void => {
     for (const path of tenantOwnedServicePaths) {
       safeService(path)?.hooks({ around: { all: [tenantIdentityAround] } });
@@ -2628,7 +2624,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           return context;
         },
       ],
-      get: [attachMcpTokenAfterGet],
+      get: [sessionMcpTokenAfterHooks.get],
       create: [
         async (context) => {
           const session = context.result as Session;
@@ -2639,7 +2635,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           );
           return context;
         },
-        attachMcpTokenAfterCreate,
+        sessionMcpTokenAfterHooks.create,
         // TODO: OpenCode session creation moved to executor - implement via IPC if needed
 
         // Unix Integration: When a non-owner creates a session in a branch with

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -10,6 +10,7 @@ import {
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
   resolveExecutionSecurityMode,
+  resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
   and,
@@ -207,6 +208,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const { initMcpTokens } = await import('./mcp/tokens.js');
   initMcpTokens({
     db,
+    multiTenancy: resolveMultiTenancyConfig(config),
     expirationMs: config.execution?.mcp_token_expiration_ms,
   });
 

--- a/apps/agor-daemon/src/utils/session-mcp-token-hook.test.ts
+++ b/apps/agor-daemon/src/utils/session-mcp-token-hook.test.ts
@@ -8,19 +8,38 @@ import {
   sessions,
   shortId,
 } from '@agor/core/db';
-import type { HookContext, Session, SessionID } from '@agor/core/types';
+import { feathers } from '@agor/core/feathers';
+import type { Session, SessionID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { afterEach, describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { initMcpTokens, shutdownMcpTokens } from '../mcp/tokens.js';
-import { createSessionMcpTokenHook } from './session-mcp-token-hook.js';
+import { createSessionMcpTokenAfterHooks } from './session-mcp-token-hook.js';
 
 const JWT_SECRET = 'session-mcp-hook-test-secret';
 
-function makeApp() {
-  return {
-    settings: { authentication: { secret: JWT_SECRET } },
-  } as never;
+function makeApp(session: Session) {
+  const app = feathers();
+  app.set('authentication', { secret: JWT_SECRET });
+  app.use('sessions', {
+    async create() {
+      return { ...session };
+    },
+    async get() {
+      return { ...session };
+    },
+  });
+  const hooks = createSessionMcpTokenAfterHooks({
+    app: app as never,
+    config: {},
+  });
+  app.service('sessions').hooks({
+    after: {
+      create: [hooks.create],
+      get: [hooks.get],
+    },
+  });
+  return app;
 }
 
 async function seedSession(db: Database): Promise<Session> {
@@ -81,38 +100,36 @@ describe('sessions MCP-token after hook', () => {
       multiTenancy: resolveMultiTenancyConfig({}),
     });
     const session = await seedSession(db);
-    const hook = createSessionMcpTokenHook({
-      app: makeApp(),
-      config: {},
-    });
-    const context = {
-      method,
-      result: session,
-      params: {
-        // No provider, request tenant params, or ambient ALS: this models the
-        // executor/background fetches that exposed issue #2003.
-        user,
-      },
-    } as unknown as HookContext;
+    const service = makeApp(session).service('sessions');
+    const params = {
+      // No provider, request tenant params, or ambient ALS: this models the
+      // executor/background fetches that exposed issue #2003.
+      user,
+    };
+    const result =
+      method === 'create'
+        ? await service.create({}, params as never)
+        : await service.get(session.session_id, params as never);
 
-    await hook(context);
-
-    const token = (context.result as Session).mcp_token;
+    const token = (result as Session).mcp_token;
     expect(token).toEqual(expect.any(String));
     expect((jwt.verify(token!, JWT_SECRET) as { tid?: string }).tid).toBe('default');
   }
 
-  dbTest('attaches a default-static token on request-less after:create', async ({ db }) => {
+  dbTest('attaches a default-static token through Feathers sessions.create', async ({ db }) => {
     await expectDefaultStaticToken(db, 'create', {
       user_id: 'member-user',
       role: 'member',
     });
   });
 
-  dbTest('attaches a default-static token on executor/background after:get', async ({ db }) => {
-    await expectDefaultStaticToken(db, 'get', {
-      user_id: 'executor-service',
-      role: 'service',
-    });
-  });
+  dbTest(
+    'attaches a default-static token through executor/background Feathers sessions.get',
+    async ({ db }) => {
+      await expectDefaultStaticToken(db, 'get', {
+        user_id: 'executor-service',
+        role: 'service',
+      });
+    }
+  );
 });

--- a/apps/agor-daemon/src/utils/session-mcp-token-hook.test.ts
+++ b/apps/agor-daemon/src/utils/session-mcp-token-hook.test.ts
@@ -1,0 +1,118 @@
+import { resolveMultiTenancyConfig } from '@agor/core/config';
+import {
+  branches,
+  type Database,
+  generateId,
+  insert,
+  RepoRepository,
+  sessions,
+  shortId,
+} from '@agor/core/db';
+import type { HookContext, Session, SessionID } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import { afterEach, describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { initMcpTokens, shutdownMcpTokens } from '../mcp/tokens.js';
+import { createSessionMcpTokenHook } from './session-mcp-token-hook.js';
+
+const JWT_SECRET = 'session-mcp-hook-test-secret';
+
+function makeApp() {
+  return {
+    settings: { authentication: { secret: JWT_SECRET } },
+  } as never;
+}
+
+async function seedSession(db: Database): Promise<Session> {
+  const sessionId = generateId() as SessionID;
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `slug-${shortId(sessionId)}`,
+    name: 'Hook Test Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/test.git',
+    local_path: '/tmp/test',
+    default_branch: 'main',
+  });
+  const branchId = generateId();
+  await insert(db, branches)
+    .values({
+      branch_id: branchId,
+      repo_id: repo.repo_id,
+      created_at: new Date(),
+      created_by: 'test-user',
+      name: 'main',
+      ref: 'main',
+      branch_unique_id: 1,
+      data: { path: '/tmp/test/wt', git_state: { ref_at_start: 'main' } },
+    })
+    .run();
+  await insert(db, sessions)
+    .values({
+      session_id: sessionId,
+      created_at: new Date(),
+      status: 'idle',
+      agentic_tool: 'claude-code',
+      branch_id: branchId,
+      created_by: 'test-user',
+      data: { genealogy: { children: [] }, contextFiles: [], tasks: [], git_state: {} },
+    })
+    .run();
+
+  return {
+    session_id: sessionId,
+    branch_id: branchId,
+    created_by: 'test-user',
+    status: 'idle',
+    agentic_tool: 'claude-code',
+  } as Session;
+}
+
+afterEach(() => shutdownMcpTokens());
+
+describe('sessions MCP-token after hook', () => {
+  async function expectDefaultStaticToken(
+    db: Database,
+    method: 'create' | 'get',
+    user: { user_id: string; role: string }
+  ) {
+    initMcpTokens({
+      db,
+      multiTenancy: resolveMultiTenancyConfig({}),
+    });
+    const session = await seedSession(db);
+    const hook = createSessionMcpTokenHook({
+      app: makeApp(),
+      config: {},
+    });
+    const context = {
+      method,
+      result: session,
+      params: {
+        // No provider, request tenant params, or ambient ALS: this models the
+        // executor/background fetches that exposed issue #2003.
+        user,
+      },
+    } as unknown as HookContext;
+
+    await hook(context);
+
+    const token = (context.result as Session).mcp_token;
+    expect(token).toEqual(expect.any(String));
+    expect((jwt.verify(token!, JWT_SECRET) as { tid?: string }).tid).toBe('default');
+  }
+
+  dbTest('attaches a default-static token on request-less after:create', async ({ db }) => {
+    await expectDefaultStaticToken(db, 'create', {
+      user_id: 'member-user',
+      role: 'member',
+    });
+  });
+
+  dbTest('attaches a default-static token on executor/background after:get', async ({ db }) => {
+    await expectDefaultStaticToken(db, 'get', {
+      user_id: 'executor-service',
+      role: 'service',
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/session-mcp-token-hook.ts
+++ b/apps/agor-daemon/src/utils/session-mcp-token-hook.ts
@@ -10,6 +10,12 @@ export interface SessionMcpTokenHookOptions {
   onAttached?: (session: Session) => void;
 }
 
+export interface SessionMcpTokenAfterHooksOptions
+  extends Omit<SessionMcpTokenHookOptions, 'onAttached'> {
+  onGetAttached?: (session: Session) => void;
+  onCreateAttached?: (session: Session) => void;
+}
+
 /**
  * Build the shared sessions after:get / after:create MCP-token hook.
  *
@@ -45,5 +51,27 @@ export function createSessionMcpTokenHook(options: SessionMcpTokenHookOptions) {
     context.result = { ...session, mcp_token: mcpToken };
     options.onAttached?.(session);
     return context;
+  };
+}
+
+/**
+ * Build the paired hooks registered on the sessions service.
+ *
+ * Keeping the method mapping beside the shared hook implementation makes it
+ * harder for create/get behavior to drift and gives integration tests one
+ * canonical registration shape to exercise through Feathers.
+ */
+export function createSessionMcpTokenAfterHooks(options: SessionMcpTokenAfterHooksOptions) {
+  return {
+    get: createSessionMcpTokenHook({
+      app: options.app,
+      config: options.config,
+      onAttached: options.onGetAttached,
+    }),
+    create: createSessionMcpTokenHook({
+      app: options.app,
+      config: options.config,
+      onAttached: options.onCreateAttached,
+    }),
   };
 }

--- a/apps/agor-daemon/src/utils/session-mcp-token-hook.ts
+++ b/apps/agor-daemon/src/utils/session-mcp-token-hook.ts
@@ -1,0 +1,49 @@
+import type { AgorConfig } from '@agor/core/config';
+import type { Application } from '@agor/core/feathers';
+import type { AuthenticatedParams, HookContext, Session, UserID } from '@agor/core/types';
+import { generateSessionToken } from '../mcp/tokens.js';
+import { canReceiveMcpTokenForSession } from './mcp-token-authorization.js';
+
+export interface SessionMcpTokenHookOptions {
+  app: Application;
+  config: AgorConfig;
+  onAttached?: (session: Session) => void;
+}
+
+/**
+ * Build the shared sessions after:get / after:create MCP-token hook.
+ *
+ * Token issuance owns tenant binding semantics; this hook owns only caller
+ * authorization and response enrichment. Keeping both session paths on this
+ * function prevents request and background fetch behavior from drifting.
+ */
+export function createSessionMcpTokenHook(options: SessionMcpTokenHookOptions) {
+  return async (context: HookContext): Promise<HookContext> => {
+    if (options.config.daemon?.mcpEnabled === false) return context;
+
+    const callerUser = (context.params as AuthenticatedParams).user;
+    if (
+      !canReceiveMcpTokenForSession({
+        callerUserId: callerUser?.user_id,
+        callerRole: callerUser?.role,
+      })
+    ) {
+      return context;
+    }
+
+    const userId = callerUser?.user_id;
+    if (!userId) return context;
+
+    if (!options.app.settings.authentication?.secret) {
+      console.error('❌ JWT secret not configured - cannot generate MCP token');
+      return context;
+    }
+
+    const session = context.result as Session;
+    const mcpToken = await generateSessionToken(options.app, session.session_id, userId as UserID);
+
+    context.result = { ...session, mcp_token: mcpToken };
+    options.onAttached?.(session);
+    return context;
+  };
+}

--- a/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
+++ b/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
@@ -75,9 +75,11 @@ raw connection or a superuser/BYPASSRLS daemon role.
    trusted header; unlike internal JWTs, existing opaque keys contain no signed
    tenant claim.
 3. **Tenant-bound internal tokens:** every newly issued internal MCP JWT signs a
-   non-empty tenant id. Issuance requires an active tenant; cache keys include
-   it; validation rejects legacy/unbound tokens and checks session existence
-   inside the signed tenant.
+   non-empty tenant id. Static mode may use its configured tenant when no
+   ambient identity exists; `required_from_auth` requires an active tenant.
+   Any configured/ambient conflict fails closed. Cache keys include the tenant;
+   validation rejects legacy/unbound tokens and checks session existence inside
+   the signed tenant.
 4. **Immutable stateful binding:** an MCP Streamable HTTP session is bound at
    initialize time to `(tenant, user, optional Agor session)`. Every subsequent
    request re-authenticates; tenant and user must match. The optional Agor

--- a/packages/agor-live/package-lock.json
+++ b/packages/agor-live/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agor-live",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agor-live",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- resolve MCP token tenant binding from the daemon's canonical multitenancy policy
- allow request-less token issuance only in static mode, using the configured `static_tenant_id`
- keep ambient tenant identity authoritative and reject malformed or conflicting scopes
- keep `required_from_auth` fail-closed when no ambient tenant is available
- centralize session `after:get` / `after:create` MCP token response enrichment
- bump `agor-live` and `@agor-live/client` to `0.23.4`

## Root cause

Commit `31613d403` changed MCP token issuance to require an ambient tenant context. Static single-tenant installations can legitimately reach session hooks and executor/background fetches without request-scoped tenant state, so issuance failed before the configured static tenant could be resolved.

The token issuer now receives the resolved multitenancy policy at initialization and delegates binding to `resolveTenantContext()`. This preserves the isolation guarantees from #1942: required-from-auth mode still requires ambient identity, and explicit/static conflicts are rejected rather than hidden.

## Coverage

- implicit static configuration resolves to `default`
- custom `static_tenant_id`
- agreeing and conflicting ambient static identity
- malformed ambient identity
- required-from-auth with and without ambient identity
- tenant-separated token caching
- request-less session `after:create`
- executor/background-style session `after:get`

## Verification

- `pnpm i`
- `pnpm check`
- focused daemon tenant/MCP tests: 70 passed
- core multitenancy tests: 40 passed
- full daemon suite: 2019 passed, 31 skipped

Fixes #2003.
