### PR TITLE
fix: validate Codex model selections before session creation

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1337,11 +1337,17 @@ describe('agor_models_list', () => {
     expect(parsed.codex.note).toContain('omit modelConfig');
 
     const codexIds = parsed.codex.models.map((m: { id: string }) => m.id);
-    expect(codexIds).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
-    expect(codexIds).not.toContain('gpt-5.5');
-    expect(codexIds).not.toContain('gpt-5.4-mini');
-    expect(codexIds).not.toContain('gpt-5.4');
+    expect(codexIds.slice(0, 3)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+    expect(codexIds).toContain('gpt-5.5');
+    expect(codexIds).toContain('gpt-5.4-mini');
+    expect(codexIds).toContain('gpt-5.4');
     expect(codexIds).not.toContain('gpt-5-codex');
+    expect(
+      parsed.codex.models.find((model: { id: string }) => model.id === 'gpt-5.5')
+    ).toMatchObject({
+      status: 'known',
+      availability: 'provider-dependent',
+    });
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1583,9 +1583,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   //
   // Discovery tool so MCP-driven agents can find valid `model` strings without
   // having to scrape tool descriptions. Sourced from the same in-process model
-  // registries the UI uses (packages/core/src/models/*), so when a new model
-  // ships and the registry is updated, this tool returns it on the very next
-  // call — no MCP-tool-description redeploy needed.
+  // registries the UI uses (packages/core/src/models/*). This reads the
+  // registry loaded by the running daemon; it is not provider discovery.
   //
   // Caveats:
   //   - Gemini's authoritative list is fetched live from the Google API per
@@ -1599,7 +1598,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_models_list',
     {
       description:
-        'List valid model IDs grouped by agenticTool. Use this to discover what to pass for `modelConfig` (or its string shorthand) in agor_sessions_create / spawn / prompt. Sourced live from the daemon model registry — when new models ship and the registry is updated, this tool returns them on the next call.',
+        'List selectable model aliases grouped by agenticTool. Use this to discover what to pass for `modelConfig` (or its string shorthand) in agor_sessions_create / spawn / prompt. Lists the registry loaded by the running daemon; provider-specific exact IDs may be account-dependent.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         agenticTool: z
@@ -1620,6 +1619,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         id,
         displayName: meta.name,
         description: meta.description,
+        status: meta.status,
+        availability: meta.availability,
       }));
 
       const copilotModels = Object.entries(COPILOT_MODEL_METADATA).map(([id, meta]) => ({
@@ -1648,7 +1649,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         codex: {
           default: DEFAULT_CODEX_MODEL,
           models: codexModels,
-          note: 'Codex defaults to gpt-5.6-sol; omit modelConfig unless a specific model is required. Use gpt-5.6-terra for balanced everyday work or gpt-5.6-luna for clear, high-volume tasks. Legacy Codex aliases are intentionally omitted from this selectable list.',
+          note: 'Latest models are listed first; omit modelConfig to use the default. Current models are supported defaults; older entries marked provider-dependent may vary by Codex account and are checked by Codex at startup. This is Agor’s known-model registry, not a dynamic Codex CLI/provider listing. Provider-specific IDs absent from this list must be passed with mode "exact". Known unsupported legacy aliases are omitted.',
         },
         gemini: {
           default: DEFAULT_GEMINI_MODEL,

--- a/apps/agor-daemon/src/services/sessions.materialize-agentic-tool-preset.test.ts
+++ b/apps/agor-daemon/src/services/sessions.materialize-agentic-tool-preset.test.ts
@@ -21,7 +21,13 @@ import { SessionsService } from './sessions';
 const STUB_APP = {} as Application;
 const ACTOR_ID = '00000000-0000-7000-8000-000000000001' as UserID;
 
-async function seedPresetSession(db: Database) {
+async function seedPresetSession(
+  db: Database,
+  modelConfig: { mode: 'alias' | 'exact'; model: string } = {
+    mode: 'exact',
+    model: 'gpt-5.4',
+  }
+) {
   const repo = await new RepoRepository(db).create({
     repo_id: generateId(),
     slug: `repo-${generateId()}`,
@@ -46,7 +52,7 @@ async function seedPresetSession(db: Database) {
     {
       tool: 'codex',
       name: 'Task start preset',
-      configuration: { modelConfig: { mode: 'exact', model: 'gpt-5.4' } },
+      configuration: { modelConfig },
     },
     ACTOR_ID
   );
@@ -66,6 +72,24 @@ async function seedPresetSession(db: Database) {
 }
 
 describe('SessionsService.materializeAgenticToolPreset tenant scope', () => {
+  dbTest(
+    'rejects a preset alias that is no longer selectable before executor startup',
+    async ({ db }) => {
+      const session = await seedPresetSession(db, {
+        mode: 'alias',
+        model: 'gpt-5.6-codex',
+      });
+      const service = new SessionsService(db, STUB_APP);
+      const sessionRepo = (service as unknown as { sessionRepo: SessionRepository }).sessionRepo;
+      const update = vi.spyOn(sessionRepo, 'update');
+
+      await expect(
+        runWithTenantContext('tenant-x', () => service.materializeAgenticToolPreset(session))
+      ).rejects.toThrow('agor_models_list');
+      expect(update).not.toHaveBeenCalled();
+    }
+  );
+
   dbTest('opens a tenant unit of work from identity-only context', async ({ db }) => {
     const session = await seedPresetSession(db);
     const guardedDb = createTenantScopedDatabaseProxy(db, {

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -214,7 +214,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   private db: TenantScopeAwareDatabase;
 
   private assertSupportedModelConfig(
-    agenticTool: AgenticToolName,
+    agenticTool: Session['agentic_tool'],
     modelConfig: Session['model_config'] | undefined
   ): void {
     if (agenticTool !== 'codex' || !modelConfig) return;

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -35,9 +35,8 @@ import {
 } from '@agor/core/feathers';
 import {
   formatModelToolMismatchWarning,
-  formatUnsupportedAgorCodexModelMessage,
+  getCodexModelSelectionError,
   isResolvedModelConfig,
-  isUnsupportedAgorCodexModel,
   lintModelToolMatch,
 } from '@agor/core/models';
 import { resolveChildSessionConfig } from '@agor/core/sessions';
@@ -218,13 +217,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     agenticTool: AgenticToolName,
     modelConfig: Session['model_config'] | undefined
   ): void {
-    if (
-      agenticTool === 'codex' &&
-      modelConfig?.model &&
-      isUnsupportedAgorCodexModel(modelConfig.model)
-    ) {
-      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(modelConfig.model));
-    }
+    if (agenticTool !== 'codex' || !modelConfig) return;
+    const modelError = getCodexModelSelectionError(modelConfig);
+    if (modelError) throw new BadRequest(modelError);
   }
 
   constructor(db: TenantScopeAwareDatabase, app: Application) {
@@ -332,6 +327,10 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         model_config: modelConfig,
       };
     }
+    this.assertSupportedModelConfig(
+      (createData.agentic_tool ?? agenticTool) as Session['agentic_tool'],
+      createData.model_config
+    );
     const created = await super.create(createData, params);
     if (Array.isArray(created)) {
       throw new Error('Single-session creation returned multiple sessions');
@@ -357,11 +356,11 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         agenticTool,
         session.agentic_tool_preset_id
       );
-      return this.sessionRepo.update(
-        session.session_id,
-        presetConfigurationToSessionPatch(agenticTool, preset.configuration),
-        { replaceAgenticConfig: true }
-      );
+      const materialized = presetConfigurationToSessionPatch(agenticTool, preset.configuration);
+      this.assertSupportedModelConfig(agenticTool, materialized.model_config);
+      return this.sessionRepo.update(session.session_id, materialized, {
+        replaceAgenticConfig: true,
+      });
     });
   }
 
@@ -1285,6 +1284,18 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         await assertInlineAgenticConfigurationAllowed(
           this.db,
           requireActiveAgenticTool(data.agentic_tool ?? current.agentic_tool)
+        );
+      }
+      // Validate only a newly selected/effective model. Existing persisted
+      // sessions remain patchable when the curated registry changes.
+      if (
+        data.model_config !== undefined ||
+        data.agentic_tool !== undefined ||
+        data.agentic_tool_preset_id !== undefined
+      ) {
+        this.assertSupportedModelConfig(
+          data.agentic_tool ?? current.agentic_tool,
+          data.model_config === undefined ? current.model_config : data.model_config
         );
       }
     }

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -111,6 +111,40 @@ describe('applySessionConfigDefaults', () => {
     await expect(hook(ctx)).rejects.toThrow('gpt-5-codex');
   });
 
+  it('rejects an unknown Codex alias before create', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'codex',
+        created_by: ALICE,
+        permission_config: { mode: 'acceptEdits' },
+        model_config: { mode: 'alias', model: 'gpt-5.6-codex', updated_at: 'now' },
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+
+    await expect(hook(ctx)).rejects.toThrow('agor_models_list');
+  });
+
+  it('allows an explicit exact Codex provider model ID', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'codex',
+        created_by: ALICE,
+        permission_config: { mode: 'acceptEdits' },
+        model_config: { mode: 'exact', model: 'account-preview-model', updated_at: 'now' },
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+
+    await expect(hook(ctx)).resolves.toBe(ctx);
+  });
+
   it('does not reapply user defaults after an internal caller fully resolves configuration', async () => {
     const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
     const ctx = makeContext({
@@ -254,7 +288,7 @@ describe('applySessionConfigDefaults', () => {
         agentic_tool: 'codex',
         created_by: ALICE,
         permission_config: { mode: 'acceptEdits' },
-        model_config: { model: 'gpt-5.4', notes: 'Use this model for consistency' },
+        model_config: { model: 'gpt-5.6-sol', notes: 'Use this model for consistency' },
       },
       users: { [ALICE]: { user_id: ALICE } },
     });
@@ -263,7 +297,7 @@ describe('applySessionConfigDefaults', () => {
 
     expect(ctx.data?.model_config).toMatchObject({
       mode: 'alias',
-      model: 'gpt-5.4',
+      model: 'gpt-5.6-sol',
       notes: 'Use this model for consistency',
       updated_at: expect.any(String),
     });

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
@@ -39,11 +39,7 @@
  */
 
 import { BadRequest } from '@agor/core/feathers';
-import {
-  formatUnsupportedAgorCodexModelMessage,
-  isResolvedModelConfig,
-  isUnsupportedAgorCodexModel,
-} from '@agor/core/models';
+import { getCodexModelSelectionError, isResolvedModelConfig } from '@agor/core/models';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type { CreateSessionInput, HookContext, User } from '@agor/core/types';
 import { isAgenticToolName } from '@agor/core/types';
@@ -82,12 +78,9 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
       throw new BadRequest(`Unsupported agentic tool: ${String(agenticTool)}`);
     }
 
-    if (
-      agenticTool === 'codex' &&
-      data.model_config?.model &&
-      isUnsupportedAgorCodexModel(data.model_config.model)
-    ) {
-      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(data.model_config.model));
+    if (agenticTool === 'codex' && isResolvedModelConfig(data.model_config)) {
+      const modelError = getCodexModelSelectionError(data.model_config);
+      if (modelError) throw new BadRequest(modelError);
     }
 
     if (
@@ -127,12 +120,9 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
       user,
       overrides: { modelConfig: data.model_config ?? undefined },
     });
-    if (
-      resolved.model_config?.model &&
-      agenticTool === 'codex' &&
-      isUnsupportedAgorCodexModel(resolved.model_config.model)
-    ) {
-      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(resolved.model_config.model));
+    if (agenticTool === 'codex' && resolved.model_config) {
+      const modelError = getCodexModelSelectionError(resolved.model_config);
+      if (modelError) throw new BadRequest(modelError);
     }
 
     if (!hasPermission) {

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ModelSelector } from './ModelSelector';
 
 describe('ModelSelector (Claude)', () => {
-  it('renders curated aliases by display name and offers a pin affordance', () => {
+  it('renders aliases by display name and offers a pin affordance', () => {
     render(
       <ModelSelector
         agentic_tool="claude-code"
@@ -91,6 +91,21 @@ describe('ModelSelector (Claude)', () => {
     expect(screen.getByText(/Frontier model for complex reasoning/)).toHaveStyle({
       whiteSpace: 'normal',
     });
+  });
+
+  it('offers previous aliases alongside the preferred models', () => {
+    render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'alias', model: 'claude-sonnet-5' }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+
+    expect(screen.getByText('Claude Opus 4.7')).toBeInTheDocument();
+    expect(screen.getByText('Claude Sonnet 4.6')).toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
@@ -93,3 +93,13 @@ describe('ModelSelector (Claude)', () => {
     });
   });
 });
+
+describe('ModelSelector (Codex)', () => {
+  it('marks older aliases whose availability depends on the provider account', () => {
+    render(<ModelSelector agentic_tool="codex" value={{ mode: 'alias', model: 'gpt-5.6-sol' }} />);
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+
+    expect(screen.getAllByText('account-dependent').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -72,6 +72,7 @@ const CODEX_MODEL_OPTIONS = Object.entries(CODEX_MODEL_METADATA).map(([modelId, 
   id: modelId,
   label: meta.name,
   description: meta.description,
+  availability: meta.availability,
 }));
 
 // Gemini model options (convert from GEMINI_MODELS metadata)
@@ -333,8 +334,10 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     value: m.id,
     label: m.displayName,
     description: m.description,
+    availability: m.availability,
     isDefault: m.id === fallbackModel,
-    searchText: `${m.displayName} ${m.id} ${m.description ?? ''}`.toLowerCase(),
+    searchText:
+      `${m.displayName} ${m.id} ${m.description ?? ''} ${m.availability ?? ''}`.toLowerCase(),
   }));
   if (!pinned && currentModel && !aliasOptions.some((o) => o.value === currentModel)) {
     const norm = normalizedList.find((m) => m.id === currentModel);
@@ -342,6 +345,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       value: currentModel,
       label: norm?.displayName ?? getModelDisplayName(effectiveTool, currentModel),
       description: norm?.description,
+      availability: norm?.availability,
       isDefault: false,
       searchText: currentModel.toLowerCase(),
     });
@@ -361,11 +365,18 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             </Typography.Text>
           )}
         </div>
-        {data?.isDefault && (
-          <Tag bordered={false} color="blue" style={{ marginInlineEnd: 0, fontSize: 10 }}>
-            default
-          </Tag>
-        )}
+        <Space size={4}>
+          {data?.availability === 'provider-dependent' && (
+            <Tag bordered={false} color="gold" style={{ marginInlineEnd: 0, fontSize: 10 }}>
+              account-dependent
+            </Tag>
+          )}
+          {data?.isDefault && (
+            <Tag bordered={false} color="blue" style={{ marginInlineEnd: 0, fontSize: 10 }}>
+              default
+            </Tag>
+          )}
+        </Space>
       </Flex>
     );
   };
@@ -374,7 +385,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   if (compact) {
     const compactOptions = aliasOptions.map((o) => ({
       value: o.value,
-      label: o.label,
+      label: o.availability === 'provider-dependent' ? `${o.label} (account-dependent)` : o.label,
       searchText: o.searchText,
     }));
     // Compact has no pin toggle, so an exact/pinned current value would be

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -121,9 +121,10 @@ const PIN_PLACEHOLDERS: Record<string, string> = {
 /**
  * Model Selector Component
  *
- * Presents a curated, richly-labelled list of model aliases (latest per family)
- * and a "Pin a specific version…" affordance for exact model IDs. Picking from
- * the list maps to `mode: 'alias'`; a pinned/custom ID maps to `mode: 'exact'`.
+ * Presents the complete discovered, richly-labelled list of model aliases with
+ * the default first, plus a "Pin a specific version…" affordance for exact
+ * model IDs. Picking from the list maps to `mode: 'alias'`; a pinned/custom ID
+ * maps to `mode: 'exact'`.
  */
 export const ModelSelector: React.FC<ModelSelectorProps> = ({
   value,
@@ -265,7 +266,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
               : (claudeServerOptions ?? AVAILABLE_CLAUDE_MODEL_ALIASES);
 
   // Pin mode reflects the stored config: an exact ID is an explicitly-pinned
-  // version, anything else is a curated alias selection.
+  // version, anything else is a discovered alias selection.
   const [pinned, setPinned] = useState(value?.mode === 'exact');
   useEffect(() => {
     setPinned(value?.mode === 'exact');
@@ -328,8 +329,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     selectAlias(curated.some((m) => m.id === currentModel) ? currentModel : fallbackModel);
   };
 
-  // Alias options: curated list, with the currently-selected alias preserved
-  // even if curation would otherwise hide it (e.g. a superseded version).
+  // Preserve the currently-selected alias even if it is absent from the latest
+  // discovery result.
   const aliasOptions = curated.map((m) => ({
     value: m.id,
     label: m.displayName,
@@ -389,7 +390,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       searchText: o.searchText,
     }));
     // Compact has no pin toggle, so an exact/pinned current value would be
-    // absent from the curated list — always surface the current selection.
+    // absent from the discovered list — always surface the current selection.
     if (currentModel && !compactOptions.some((o) => o.value === currentModel)) {
       const norm = normalizedList.find((m) => m.id === currentModel);
       compactOptions.unshift({

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
@@ -49,21 +49,21 @@ describe('getModelSelectorFallbackModel', () => {
 describe('curateModelOptions (Claude)', () => {
   const normalized = AVAILABLE_CLAUDE_MODEL_ALIASES.map(normalizeModelOption);
 
-  it('keeps only the latest alias per model line and drops [1m]/legacy versions', () => {
+  it('keeps preferred and previous aliases available', () => {
     const ids = curateModelOptions('claude-code', normalized, DEFAULT_CLAUDE_MODEL).map(
       (m) => m.id
     );
-    // Exactly one entry per line: the newest Opus/Sonnet/Haiku/Fable.
+
     expect(ids).toContain('claude-opus-5');
     expect(ids).toContain('claude-sonnet-5');
     expect(ids).toContain('claude-haiku-4-5');
     expect(ids).toContain('claude-fable-5');
-    // Superseded, dated, and 1M variants are excluded from the top-level list.
-    expect(ids).not.toContain('claude-opus-4-8');
-    expect(ids).not.toContain('claude-opus-4-7');
-    expect(ids).not.toContain('claude-sonnet-4-6');
-    expect(ids).not.toContain('claude-opus-4-1');
-    expect(ids.some((id) => id.includes('[1m]'))).toBe(false);
+    expect(ids).toContain('claude-opus-4-8');
+    expect(ids).toContain('claude-opus-4-7');
+    expect(ids).toContain('claude-sonnet-4-6');
+    expect(ids).toContain('claude-opus-4-1');
+    expect(ids).toContain('claude-sonnet-4-5[1m]');
+    expect(ids).toHaveLength(normalized.length);
   });
 
   it('surfaces the default/recommended model first', () => {
@@ -73,10 +73,10 @@ describe('curateModelOptions (Claude)', () => {
     expect(ids[0]).toBe(DEFAULT_CLAUDE_MODEL);
   });
 
-  it('never drops the current default even if it is a superseded version', () => {
+  it('surfaces a previous alias first when it is the configured default', () => {
     const ids = curateModelOptions('claude-code', normalized, 'claude-sonnet-4-5').map((m) => m.id);
-    expect(ids).toContain('claude-sonnet-4-5');
     expect(ids[0]).toBe('claude-sonnet-4-5');
+    expect(ids).toHaveLength(normalized.length);
   });
 
   it('passes non-Claude lists through unchanged aside from default-first ordering', () => {

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
@@ -89,6 +89,22 @@ describe('curateModelOptions (Claude)', () => {
   });
 });
 
+describe('normalizeModelOption', () => {
+  it('preserves provider availability metadata for picker presentation', () => {
+    expect(
+      normalizeModelOption({
+        id: 'older-model',
+        label: 'Older model',
+        availability: 'provider-dependent',
+      })
+    ).toMatchObject({
+      id: 'older-model',
+      displayName: 'Older model',
+      availability: 'provider-dependent',
+    });
+  });
+});
+
 describe('getModelDisplayName', () => {
   it('resolves Claude ids to their friendly display name', () => {
     expect(getModelDisplayName('claude-code', 'claude-sonnet-5')).toBe('Claude Sonnet 5');

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
@@ -23,6 +23,7 @@ export interface NormalizedModelOption {
   id: string;
   displayName: string;
   description?: string;
+  availability?: 'supported' | 'provider-dependent' | 'unsupported';
 }
 
 /** The picker's upstream lists disagree on the name field (`displayName` vs `label`). */
@@ -31,6 +32,7 @@ type LooseModelOption = {
   displayName?: string;
   label?: string;
   description?: string;
+  availability?: 'supported' | 'provider-dependent' | 'unsupported';
 };
 
 export function normalizeModelOption(model: LooseModelOption): NormalizedModelOption {
@@ -38,6 +40,7 @@ export function normalizeModelOption(model: LooseModelOption): NormalizedModelOp
     id: model.id,
     displayName: model.displayName ?? model.label ?? model.id,
     description: model.description,
+    availability: model.availability,
   };
 }
 

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
@@ -44,59 +44,26 @@ export function normalizeModelOption(model: LooseModelOption): NormalizedModelOp
   };
 }
 
-const CLAUDE_ALIAS_PATTERN = /^claude-([a-z]+)-(\d+)(?:-(\d+))?$/;
-
-/** Parse a Claude alias id into its model line and a comparable version number. */
-function parseClaudeAlias(id: string): { line: string; version: number } | null {
-  const match = CLAUDE_ALIAS_PATTERN.exec(id);
-  if (!match) return null;
-  const [, line, major, minor] = match;
-  return { line, version: Number(major) + (minor ? Number(minor) / 100 : 0) };
-}
-
 /**
- * Curate the top-level model list: for Claude keep only the latest alias per
- * model line (Opus/Sonnet/Haiku/Fable), dropping dated snapshots, `[1m]`
- * variants, and superseded versions. The default/recommended model is surfaced
- * first. Non-Claude tools ship short curated lists already, so they pass
- * through unchanged (order preserved, default first).
+ * Preserve the complete selectable alias list supplied by the tool's static or
+ * dynamic discovery source, surfacing the default/recommended model first.
+ *
+ * Provider discovery is responsible for excluding unsuitable entries such as
+ * Claude's dated snapshots. Users can still pin an unlisted provider model ID
+ * through exact mode.
  */
 export function curateModelOptions(
-  tool: AgenticToolName,
+  _tool: AgenticToolName,
   models: NormalizedModelOption[],
   defaultModel: string
 ): NormalizedModelOption[] {
-  let curated = models;
-
-  if (CLAUDE_TOOLS.has(tool)) {
-    const latestByLine = new Map<string, { option: NormalizedModelOption; version: number }>();
-    for (const option of models) {
-      if (option.id.includes('[1m]')) continue;
-      const parsed = parseClaudeAlias(option.id);
-      if (!parsed) continue;
-      const existing = latestByLine.get(parsed.line);
-      if (!existing || parsed.version > existing.version) {
-        latestByLine.set(parsed.line, { option, version: parsed.version });
-      }
-    }
-    const keep = new Set([...latestByLine.values()].map((entry) => entry.option.id));
-    curated = models.filter((model) => keep.has(model.id));
-    // Never drop the current runtime default, even if it fails to parse.
-    if (defaultModel && !curated.some((model) => model.id === defaultModel)) {
-      const fallback = models.find((model) => model.id === defaultModel);
-      if (fallback) curated = [fallback, ...curated];
-    }
-  }
-
-  const defaultIndex = curated.findIndex((model) => model.id === defaultModel);
-  if (defaultIndex > 0) {
-    curated = [
-      curated[defaultIndex],
-      ...curated.slice(0, defaultIndex),
-      ...curated.slice(defaultIndex + 1),
-    ];
-  }
-  return curated;
+  const defaultIndex = models.findIndex((model) => model.id === defaultModel);
+  if (defaultIndex <= 0) return models;
+  return [
+    models[defaultIndex],
+    ...models.slice(0, defaultIndex),
+    ...models.slice(defaultIndex + 1),
+  ];
 }
 
 /** Resolve a stored model id to its friendly display name for inline summaries. */

--- a/packages/core/src/models/codex.test.ts
+++ b/packages/core/src/models/codex.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CODEX_MODEL,
   formatUnsupportedAgorCodexModelMessage,
   getCodexModelLifecycle,
+  getCodexModelSelectionError,
   isUnsupportedAgorCodexModel,
 } from './codex.js';
 
@@ -15,14 +16,15 @@ describe('Codex model registry', () => {
     expect(CODEX_MINI_MODEL).toBe('gpt-5.6-terra');
   });
 
-  it('surfaces only selectable models to callers', () => {
+  it('surfaces supported and provider-dependent models newest-first', () => {
     const selectableIds = Object.keys(CODEX_MODEL_METADATA);
 
-    expect(selectableIds).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
-    expect(selectableIds).not.toContain('gpt-5.5');
-    expect(selectableIds).not.toContain('gpt-5.4-mini');
-    expect(selectableIds).not.toContain('gpt-5.4');
+    expect(selectableIds.slice(0, 3)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+    expect(selectableIds).toContain('gpt-5.5');
+    expect(selectableIds).toContain('gpt-5.4-mini');
+    expect(selectableIds).toContain('gpt-5.4');
     expect(selectableIds).not.toContain('gpt-5-codex');
+    expect(CODEX_MODEL_METADATA['gpt-5.5'].availability).toBe('provider-dependent');
   });
 
   it('keeps legacy aliases in the lifecycle registry for diagnostics', () => {
@@ -63,5 +65,27 @@ describe('Codex model registry', () => {
     expect(message).toContain('gpt-5.6-sol');
     expect(message).toContain('user defaults');
     expect(message).toContain('omit modelConfig');
+  });
+
+  it('accepts curated aliases and rejects unknown alias selections actionably', () => {
+    expect(getCodexModelSelectionError({ mode: 'alias', model: 'gpt-5.6-sol' })).toBeUndefined();
+    expect(getCodexModelSelectionError({ mode: 'alias', model: 'gpt-5.4' })).toBeUndefined();
+
+    const error = getCodexModelSelectionError({
+      mode: 'alias',
+      model: 'gpt-5.6-codex',
+    });
+    expect(error).toContain('gpt-5.6-codex');
+    expect(error).toContain('agor_models_list');
+    expect(error).toContain('mode "exact"');
+  });
+
+  it('allows unknown exact provider IDs but still rejects known unsupported aliases', () => {
+    expect(
+      getCodexModelSelectionError({ mode: 'exact', model: 'account-preview-model' })
+    ).toBeUndefined();
+    expect(getCodexModelSelectionError({ mode: 'exact', model: 'gpt-5-codex' })).toContain(
+      'legacy alias'
+    );
   });
 });

--- a/packages/core/src/models/codex.test.ts
+++ b/packages/core/src/models/codex.test.ts
@@ -89,6 +89,17 @@ describe('Codex model registry', () => {
     expect(getCodexModelSelectionError({ mode: 'exact', model: snapshot })).toBeUndefined();
   });
 
+  it('rejects non-canonical alias casing instead of persisting it unchanged', () => {
+    const error = getCodexModelSelectionError({
+      mode: 'alias',
+      model: 'GPT-5.6-SOL',
+    });
+
+    expect(error).toContain('canonical registry casing');
+    expect(error).toContain('"gpt-5.6-sol"');
+    expect(getCodexModelSelectionError({ mode: 'exact', model: 'GPT-5.6-SOL' })).toBeUndefined();
+  });
+
   it('allows unknown exact provider IDs but still rejects known unsupported aliases', () => {
     expect(
       getCodexModelSelectionError({ mode: 'exact', model: 'account-preview-model' })

--- a/packages/core/src/models/codex.test.ts
+++ b/packages/core/src/models/codex.test.ts
@@ -80,6 +80,15 @@ describe('Codex model registry', () => {
     expect(error).toContain('mode "exact"');
   });
 
+  it('requires dated provider snapshots to use exact mode', () => {
+    const snapshot = 'gpt-5.6-sol-2026-07-09';
+
+    expect(getCodexModelSelectionError({ mode: 'alias', model: snapshot })).toContain(
+      'mode "exact"'
+    );
+    expect(getCodexModelSelectionError({ mode: 'exact', model: snapshot })).toBeUndefined();
+  });
+
   it('allows unknown exact provider IDs but still rejects known unsupported aliases', () => {
     expect(
       getCodexModelSelectionError({ mode: 'exact', model: 'account-preview-model' })

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
 export const CODEX_MINI_MODEL = 'gpt-5.6-terra';
 
 export type CodexModelStatus = 'current' | 'known';
-export type CodexModelAvailability = 'supported' | 'not-selectable' | 'unsupported';
+export type CodexModelAvailability = 'supported' | 'provider-dependent' | 'unsupported';
 
 export type CodexModelLifecycleMetadata = {
   name: string;
@@ -56,8 +56,8 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5.6',
     description: 'Alias that routes to GPT-5.6 Sol',
     status: 'current',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-5.5 models
@@ -66,16 +66,16 @@ const _CODEX_MODEL_REGISTRY = {
     description:
       'Previous frontier model for complex coding, computer use, knowledge work, and research workflows in Codex.',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.5-pro': {
     name: 'GPT-5.5 Pro',
     description: 'Higher-compute GPT-5.5 variant for the toughest professional work',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-5.4 models
@@ -83,32 +83,32 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5.4',
     description: 'Frontier model for professional work with strong coding and agentic workflows',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.4-pro': {
     name: 'GPT-5.4 Pro',
     description: 'Higher-compute GPT-5.4 variant for difficult reasoning tasks',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.4-mini': {
     name: 'GPT-5.4 Mini',
     description: 'Fast, efficient model for responsive coding tasks and subagents',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
   'gpt-5.4-nano': {
     name: 'GPT-5.4 Nano',
     description: 'Lowest-cost GPT-5.4-class model for simple high-volume tasks and subagents',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.3 models
@@ -116,16 +116,16 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5.3 Codex',
     description: 'Previous Codex coding model.',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.3-codex-spark': {
     name: 'GPT-5.3 Codex Spark',
     description: 'Real-time coding model, 1000+ tokens/sec (Pro users)',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.2 models
@@ -133,32 +133,32 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5.2 Codex',
     description: 'Previous coding model optimized for agentic tasks - 400k context',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2': {
     name: 'GPT-5.2',
     description: 'Previous frontier model for complex tasks - 400k context, thinking mode',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2-pro': {
     name: 'GPT-5.2 Pro',
     description: 'Highest accuracy, xhigh reasoning for difficult problems',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2-instant': {
     name: 'GPT-5.2 Instant',
     description: 'Faster model for writing and information seeking',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.1 models
@@ -166,32 +166,32 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5.1 Codex Max',
     description: 'Previous model optimized for long-horizon agentic coding',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.1-codex': {
     name: 'GPT-5.1 Codex',
     description: 'Previous model optimized for agentic coding tasks',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.1-codex-mini': {
     name: 'GPT-5.1 Codex Mini',
     description: 'Previous cost-effective Codex variant',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
   'gpt-5.1': {
     name: 'GPT-5.1',
     description: 'General purpose GPT-5.1 model',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-5 models (legacy)
@@ -215,8 +215,8 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-5',
     description: 'Legacy general purpose model',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-4o models
@@ -224,16 +224,16 @@ const _CODEX_MODEL_REGISTRY = {
     name: 'GPT-4o',
     description: 'General purpose model',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-4o-mini': {
     name: 'GPT-4o Mini',
     description: 'Smaller, faster model',
     status: 'known',
-    selectable: false,
-    availability: 'not-selectable',
+    selectable: true,
+    availability: 'provider-dependent',
     replacement: CODEX_MINI_MODEL,
   },
 } as const satisfies Record<string, CodexModelLifecycleMetadata>;
@@ -243,13 +243,23 @@ export const CODEX_MODEL_REGISTRY = _CODEX_MODEL_REGISTRY;
 export const CODEX_MODEL_METADATA = Object.fromEntries(
   Object.entries(CODEX_MODEL_REGISTRY)
     .filter(([, meta]) => meta.selectable)
-    .map(([id, meta]) => [id, { name: meta.name, description: meta.description }])
+    .map(([id, meta]) => [
+      id,
+      {
+        name: meta.name,
+        description: meta.description,
+        status: meta.status,
+        availability: meta.availability,
+      },
+    ])
 ) as PickSelectableCodexModelMetadata<typeof CODEX_MODEL_REGISTRY>;
 
 type PickSelectableCodexModelMetadata<T extends Record<string, CodexModelLifecycleMetadata>> = {
   [K in keyof T as T[K]['selectable'] extends true ? K : never]: {
     name: T[K]['name'];
     description: T[K]['description'];
+    status: T[K]['status'];
+    availability: T[K]['availability'];
   };
 };
 
@@ -273,7 +283,10 @@ export function getCodexModelLifecycle(model?: string): CodexModelLifecycleMetad
     ([a], [b]) => b.length - a.length
   );
   for (const [id, meta] of longestFirstEntries) {
-    if (normalized.startsWith(`${id}-`)) {
+    const suffix = normalized.slice(id.length + 1);
+    // Recognize dated provider snapshots without treating an arbitrary,
+    // guessed suffix (for example gpt-5.6-codex) as a valid known alias.
+    if (normalized.startsWith(`${id}-`) && /^\d{4}-\d{2}-\d{2}(?:$|-)/.test(suffix)) {
       return meta;
     }
   }
@@ -283,6 +296,50 @@ export function getCodexModelLifecycle(model?: string): CodexModelLifecycleMetad
 
 export function isUnsupportedAgorCodexModel(model?: string): boolean {
   return getCodexModelLifecycle(model)?.availability === 'unsupported';
+}
+
+export type CodexModelSelection = {
+  mode: 'alias' | 'exact';
+  model: string;
+};
+
+/**
+ * Validate a newly selected Codex model.
+ *
+ * `alias` is Agor's known-model selection mode, so only entries exposed by
+ * CODEX_MODEL_METADATA are accepted. Some older entries are provider-dependent
+ * and can still be rejected for a particular account. `exact` is an explicit provider model
+ * ID escape hatch: unknown IDs are allowed because availability is
+ * account-specific and can change independently of an Agor release. Known
+ * aliases marked unsupported are rejected in either mode.
+ *
+ * This is selection-time validation. Persisted sessions are not scanned or
+ * invalidated when the registry changes; the provider remains authoritative
+ * at dispatch time.
+ */
+export function getCodexModelSelectionError(
+  selection: CodexModelSelection | null | undefined
+): string | undefined {
+  if (!selection?.model) return undefined;
+
+  const lifecycle = getCodexModelLifecycle(selection.model);
+  if (lifecycle?.availability === 'unsupported') {
+    return formatUnsupportedAgorCodexModelMessage(selection.model);
+  }
+  if (selection.mode === 'exact') return undefined;
+  if (lifecycle?.selectable) return undefined;
+
+  const replacement = lifecycle?.replacement ?? DEFAULT_CODEX_MODEL;
+  const reason = lifecycle
+    ? 'is known but is not selectable'
+    : 'is not a selectable Agor Codex alias';
+  return (
+    `Codex model "${selection.model}" ${reason}. ` +
+    `Call agor_models_list for current selectable aliases, omit modelConfig to use the default ` +
+    `(${DEFAULT_CODEX_MODEL}), or use "${replacement}". ` +
+    'If this is an intentional provider-specific model ID, pass modelConfig with mode "exact"; ' +
+    'provider/account availability will then be checked when Codex starts.'
+  );
 }
 
 export function formatUnsupportedAgorCodexModelMessage(model: string): string {

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -328,7 +328,14 @@ export function getCodexModelSelectionError(
   }
   if (selection.mode === 'exact') return undefined;
   const normalized = selection.model.toLowerCase();
-  if (Object.hasOwn(CODEX_MODEL_METADATA, normalized)) return undefined;
+  if (Object.hasOwn(CODEX_MODEL_METADATA, normalized)) {
+    if (selection.model === normalized) return undefined;
+    return (
+      `Codex model alias "${selection.model}" must use its canonical registry casing: ` +
+      `"${normalized}". Use that value, or pass mode "exact" for an intentional ` +
+      'provider-specific model ID.'
+    );
+  }
 
   const replacement = lifecycle?.replacement ?? DEFAULT_CODEX_MODEL;
   return (

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -327,14 +327,12 @@ export function getCodexModelSelectionError(
     return formatUnsupportedAgorCodexModelMessage(selection.model);
   }
   if (selection.mode === 'exact') return undefined;
-  if (lifecycle?.selectable) return undefined;
+  const normalized = selection.model.toLowerCase();
+  if (Object.hasOwn(CODEX_MODEL_METADATA, normalized)) return undefined;
 
   const replacement = lifecycle?.replacement ?? DEFAULT_CODEX_MODEL;
-  const reason = lifecycle
-    ? 'is known but is not selectable'
-    : 'is not a selectable Agor Codex alias';
   return (
-    `Codex model "${selection.model}" ${reason}. ` +
+    `Codex model "${selection.model}" is not a selectable Agor Codex alias. ` +
     `Call agor_models_list for current selectable aliases, omit modelConfig to use the default ` +
     `(${DEFAULT_CODEX_MODEL}), or use "${replacement}". ` +
     'If this is an intentional provider-specific model ID, pass modelConfig with mode "exact"; ' +


### PR DESCRIPTION
## Summary

- reject unknown or known-unsupported Codex aliases before a session is persisted
- validate model selections consistently across direct creates, defaults, presets, forks/spawns, and session configuration updates
- expose the full known Codex model registry newest-first, marking older entries as provider-dependent
- clarify that `agor_models_list` is Agor registry discovery rather than dynamic Codex account discovery
- preserve `mode: "exact"` as the escape hatch for account-specific provider model IDs

## Root cause

`agor_sessions_create` normalized any non-empty model string as an alias. The existing guard rejected only two explicitly unsupported legacy aliases, so the guessed `gpt-5.6-codex` value was persisted and its initial task dispatched. The Codex SDK then passed it directly to Codex CLI via `--model`; Codex emitted a missing-metadata warning and the ChatGPT-backed provider rejected it asynchronously.

The lifecycle lookup also treated every hyphen suffix as a snapshot, causing `gpt-5.6-codex` to partially match `gpt-5.6`. Snapshot matching is now limited to dated suffixes.

## Model contract

- `alias`: must be present in Agor's known Codex registry
- current aliases: supported defaults
- older known aliases: selectable but provider-dependent, since account availability may differ
- known unsupported aliases: rejected synchronously
- `exact`: permits account/provider-specific IDs and defers availability to Codex startup

Existing persisted sessions are not globally invalidated and remain patchable for unrelated settings. Live preset configuration is revalidated before executor startup so registry changes do not launch a known-invalid model.

## Validation

- `pnpm i`
- `pnpm check`
- `packages/core/node_modules/.bin/vitest run packages/core/src/models/codex.test.ts packages/executor/src/sdk-handlers/codex/models.test.ts`
- `apps/agor-daemon/node_modules/.bin/vitest run src/utils/apply-session-config-defaults.test.ts src/mcp/tools/sessions.test.ts src/services/sessions.materialize-agentic-tool-preset.test.ts`

Relevant tests: 74 passed.

<img width="642" height="377" alt="Screenshot 2026-07-28 at 10 38 19 AM" src="https://github.com/user-attachments/assets/d355d575-c2fc-45e0-9f69-62e00a6f016d" />



## Claude model picker behavior

This PR also removes the UI-only “latest alias per family” filter introduced by #1923. Claude discovery already returns alias-style models while excluding dated snapshots; the picker now preserves that complete dynamic/static alias list, moves the configured default to the top, and leaves unlisted snapshots/provider IDs to exact pin mode. Regression coverage keeps previous Opus/Sonnet aliases and `[1m]` variants visible while preserving default-first ordering.

## Review follow-up

Alias validation now requires canonical registry casing before persistence. For example, `GPT-5.6-SOL` is rejected with guidance to use `gpt-5.6-sol`; callers intentionally passing a provider-specific case-sensitive ID can still use `mode: "exact"`.
