### PR TITLE
fix(executor): preserve Claude background task lifecycle

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import type { SDKMessage } from '@agor/core/sdk';
+import { describe, expect, it } from 'vitest';
+import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
+
+const message = (value: Record<string, unknown>) => value as SDKMessage;
+const started = (taskId: string, taskType = 'agent') =>
+  message({ type: 'system', subtype: 'task_started', task_id: taskId, task_type: taskType });
+const settled = (taskId: string, status: 'completed' | 'failed' | 'stopped' = 'completed') =>
+  message({ type: 'system', subtype: 'task_notification', task_id: taskId, status });
+const result = (subtype = 'success') => message({ type: 'result', subtype });
+
+describe('ClaudeBackgroundTaskLifecycle', () => {
+  it('keeps a Workflow alive across its parent result until its completion turn', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('workflow-1', 'local_workflow'));
+    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    lifecycle.observe(settled('workflow-1'));
+    expect(lifecycle.observe(result())).toBe('terminal');
+  });
+
+  it('preserves the parent result while an Agent completion notification is pending', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.activeTaskCount).toBe(1);
+    lifecycle.observe(settled('agent-1'));
+    expect(lifecycle.activeTaskCount).toBe(0);
+  });
+
+  it.each([
+    'completed',
+    'failed',
+    'stopped',
+  ] as const)('allows a terminal continuation after a %s task notification', (status) => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    lifecycle.observe(settled('agent-1', status));
+    expect(lifecycle.observe(result())).toBe('terminal');
+  });
+
+  it('waits for every background task before accepting a later result', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    lifecycle.observe(started('agent-2'));
+    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    lifecycle.observe(settled('agent-1'));
+    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    lifecycle.observe(settled('agent-2'));
+    expect(lifecycle.observe(result())).toBe('terminal');
+  });
+
+  it('ends ordinary turns immediately', () => {
+    expect(new ClaudeBackgroundTaskLifecycle().observe(result())).toBe('terminal');
+  });
+
+  it('ends error results even if a task never reports settlement', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    expect(lifecycle.observe(result('error_during_execution'))).toBe('terminal');
+  });
+
+  it('ignores duplicate and unknown settlement notifications', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    lifecycle.observe(settled('unknown'));
+    lifecycle.observe(settled('agent-1'));
+    lifecycle.observe(settled('agent-1'));
+    expect(lifecycle.activeTaskCount).toBe(0);
+    expect(lifecycle.observe(result())).toBe('terminal');
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -13,15 +13,15 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
   it('keeps a Workflow alive across its parent result until its completion turn', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('workflow-1', 'local_workflow'));
-    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     lifecycle.observe(settled('workflow-1'));
-    expect(lifecycle.observe(result())).toBe('terminal');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
   });
 
   it('preserves the parent result while an Agent completion notification is pending', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('agent-1'));
-    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     expect(lifecycle.activeTaskCount).toBe(1);
     lifecycle.observe(settled('agent-1'));
     expect(lifecycle.activeTaskCount).toBe(0);
@@ -34,30 +34,32 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
   ] as const)('allows a terminal continuation after a %s task notification', (status) => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('agent-1'));
-    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     lifecycle.observe(settled('agent-1', status));
-    expect(lifecycle.observe(result())).toBe('terminal');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
   });
 
   it('waits for every background task before accepting a later result', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('agent-1'));
     lifecycle.observe(started('agent-2'));
-    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     lifecycle.observe(settled('agent-1'));
-    expect(lifecycle.observe(result())).toBe('await-background-tasks');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     lifecycle.observe(settled('agent-2'));
-    expect(lifecycle.observe(result())).toBe('terminal');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
   });
 
   it('ends ordinary turns immediately', () => {
-    expect(new ClaudeBackgroundTaskLifecycle().observe(result())).toBe('terminal');
+    expect(new ClaudeBackgroundTaskLifecycle().observe(result()).resultDisposition).toBe(
+      'terminal'
+    );
   });
 
   it('ends error results even if a task never reports settlement', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('agent-1'));
-    expect(lifecycle.observe(result('error_during_execution'))).toBe('terminal');
+    expect(lifecycle.observe(result('error_during_execution')).resultDisposition).toBe('terminal');
   });
 
   it('ignores duplicate and unknown settlement notifications', () => {
@@ -67,6 +69,15 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     lifecycle.observe(settled('agent-1'));
     lifecycle.observe(settled('agent-1'));
     expect(lifecycle.activeTaskCount).toBe(0);
-    expect(lifecycle.observe(result())).toBe('terminal');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it('reports only real task transitions and can clear orphaned activity', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    expect(lifecycle.observe(started('agent-1')).taskTransition).toBe('started');
+    expect(lifecycle.observe(started('agent-1')).taskTransition).toBeUndefined();
+    expect(lifecycle.observe(settled('unknown')).taskTransition).toBeUndefined();
+    expect(lifecycle.clearActiveTasks()).toBe(1);
+    expect(lifecycle.clearActiveTasks()).toBe(0);
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -1,0 +1,36 @@
+import type { SDKMessage } from '@agor/core/sdk';
+
+export type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
+
+/**
+ * Tracks the documented Agent SDK task lifecycle within one streaming-input
+ * query. A `result` ends one model turn, but background tasks may subsequently
+ * emit task notifications and wake another model turn on the same query.
+ */
+export class ClaudeBackgroundTaskLifecycle {
+  private readonly activeTaskIds = new Set<string>();
+
+  observe(message: SDKMessage): ResultDisposition {
+    if (message.type === 'system' && message.subtype === 'task_started') {
+      this.activeTaskIds.add(message.task_id);
+      return 'not-result';
+    }
+
+    if (message.type === 'system' && message.subtype === 'task_notification') {
+      this.activeTaskIds.delete(message.task_id);
+      return 'not-result';
+    }
+
+    if (message.type !== 'result') return 'not-result';
+
+    // Error results cannot reliably produce later settlement notifications.
+    // Let the normal error/teardown path contain any remaining subprocess work.
+    if (message.subtype !== 'success') return 'terminal';
+
+    return this.activeTaskIds.size > 0 ? 'await-background-tasks' : 'terminal';
+  }
+
+  get activeTaskCount(): number {
+    return this.activeTaskIds.size;
+  }
+}

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -1,6 +1,11 @@
 import type { SDKMessage } from '@agor/core/sdk';
 
-export type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
+type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
+
+export interface ClaudeQueryLifecycleTransition {
+  resultDisposition: ResultDisposition;
+  taskTransition?: 'started' | 'settled';
+}
 
 /**
  * Tracks the documented Agent SDK task lifecycle within one streaming-input
@@ -10,27 +15,41 @@ export type ResultDisposition = 'not-result' | 'await-background-tasks' | 'termi
 export class ClaudeBackgroundTaskLifecycle {
   private readonly activeTaskIds = new Set<string>();
 
-  observe(message: SDKMessage): ResultDisposition {
+  observe(message: SDKMessage): ClaudeQueryLifecycleTransition {
     if (message.type === 'system' && message.subtype === 'task_started') {
+      const wasActive = this.activeTaskIds.has(message.task_id);
       this.activeTaskIds.add(message.task_id);
-      return 'not-result';
+      return {
+        resultDisposition: 'not-result',
+        taskTransition: wasActive ? undefined : 'started',
+      };
     }
 
     if (message.type === 'system' && message.subtype === 'task_notification') {
-      this.activeTaskIds.delete(message.task_id);
-      return 'not-result';
+      return {
+        resultDisposition: 'not-result',
+        taskTransition: this.activeTaskIds.delete(message.task_id) ? 'settled' : undefined,
+      };
     }
 
-    if (message.type !== 'result') return 'not-result';
+    if (message.type !== 'result') return { resultDisposition: 'not-result' };
 
     // Error results cannot reliably produce later settlement notifications.
     // Let the normal error/teardown path contain any remaining subprocess work.
-    if (message.subtype !== 'success') return 'terminal';
+    if (message.subtype !== 'success') return { resultDisposition: 'terminal' };
 
-    return this.activeTaskIds.size > 0 ? 'await-background-tasks' : 'terminal';
+    return {
+      resultDisposition: this.activeTaskIds.size > 0 ? 'await-background-tasks' : 'terminal',
+    };
   }
 
   get activeTaskCount(): number {
     return this.activeTaskIds.size;
+  }
+
+  clearActiveTasks(): number {
+    const count = this.activeTaskIds.size;
+    this.activeTaskIds.clear();
+    return count;
   }
 }

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -1,0 +1,175 @@
+import type { SDKMessage } from '@agor/core/sdk';
+import type { SessionID } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./query-builder.js', () => ({
+  setupQuery: vi.fn(),
+}));
+
+import { ClaudePromptService } from './prompt-service.js';
+import { setupQuery } from './query-builder.js';
+
+const sessionId = 'session-1' as SessionID;
+
+function sdkResult(uuid: string): SDKMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 1,
+    duration_api_ms: 1,
+    is_error: false,
+    num_turns: 1,
+    result: '',
+    stop_reason: null,
+    total_cost_usd: 0.01,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+      service_tier: 'standard',
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid,
+    session_id: 'sdk-session',
+  };
+}
+
+function fakeQuery(messages: SDKMessage[] | (() => AsyncGenerator<SDKMessage>)) {
+  const releaseInput = vi.fn();
+  const getContextUsage = vi.fn().mockResolvedValue({
+    totalTokens: 15,
+    maxTokens: 200_000,
+    percentage: 0.0075,
+  });
+  const generator =
+    typeof messages === 'function'
+      ? messages()
+      : (async function* () {
+          yield* messages;
+        })();
+  return Object.assign(generator, {
+    releaseInput,
+    getContextUsage,
+    interrupt: vi.fn(),
+  });
+}
+
+function service() {
+  return new ClaudePromptService(
+    {} as never,
+    {
+      findById: vi.fn().mockResolvedValue({
+        session_id: sessionId,
+        sdk_session_id: 'sdk-session',
+      }),
+    } as never
+  );
+}
+
+describe('ClaudePromptService background task query lifetime', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('retains the parent result and releases input only after the continuation result', async () => {
+    const query = fakeQuery([
+      {
+        type: 'system',
+        subtype: 'task_started',
+        task_id: 'task-1',
+        description: 'Explore',
+        uuid: 'start',
+        session_id: 'sdk-session',
+      },
+      sdkResult('parent-result'),
+      {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'task-1',
+        status: 'completed',
+        output_file: '/tmp/task-1',
+        summary: 'done',
+        uuid: 'notification',
+        session_id: 'sdk-session',
+      },
+      sdkResult('continuation-result'),
+    ]);
+    vi.mocked(setupQuery).mockResolvedValue({
+      query: query as never,
+      resolvedModel: 'claude-sonnet-4-6',
+      getStderr: () => '',
+    });
+    const activity = vi.fn();
+
+    const events = [];
+    for await (const event of service().promptSessionStreaming(
+      sessionId,
+      'prompt',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      activity
+    )) {
+      events.push(event);
+    }
+
+    expect(
+      events.filter((event) => event.type === 'result').map((event) => event.raw_sdk_message.uuid)
+    ).toEqual(['parent-result', 'continuation-result']);
+    // `end` is an internal processor sentinel and is never yielded upstream.
+    expect(events.filter((event) => event.type === 'end')).toHaveLength(0);
+    expect(events.filter((event) => event.type === 'context_usage')).toHaveLength(1);
+    expect(query.getContextUsage).toHaveBeenCalledTimes(1);
+    expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    const terminalResult = events.filter((event) => event.type === 'result').at(-1);
+    expect(terminalResult?.raw_sdk_message).toMatchObject({
+      total_cost_usd: 0.02,
+      num_turns: 2,
+      usage: { input_tokens: 20, output_tokens: 10 },
+    });
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.start');
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
+  });
+
+  it('releases input and balances watchdog activity when cancellation interrupts a task', async () => {
+    const query = fakeQuery(async function* () {
+      yield {
+        type: 'system',
+        subtype: 'task_started',
+        task_id: 'task-1',
+        description: 'Explore',
+        uuid: 'start',
+        session_id: 'sdk-session',
+      };
+      const error = new Error('aborted');
+      error.name = 'AbortError';
+      throw error;
+    });
+    vi.mocked(setupQuery).mockResolvedValue({
+      query: query as never,
+      resolvedModel: 'claude-sonnet-4-6',
+      getStderr: () => '',
+    });
+    const activity = vi.fn();
+
+    const events = [];
+    for await (const event of service().promptSessionStreaming(
+      sessionId,
+      'prompt',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      activity
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual({ type: 'stopped' });
+    expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.start');
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -21,6 +21,7 @@ import { reportSdkActivity, type SdkActivityCallback } from '../../sdk-watchdog.
 import type { SessionID, TaskID } from '../../types.js';
 import { MessageRole } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
+import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
 
@@ -213,6 +214,7 @@ If you continue to see authentication errors, please contact your Agor administr
       existingSdkSessionId,
       enableTokenStreaming: ClaudePromptService.ENABLE_TOKEN_STREAMING,
     });
+    const backgroundTasks = new ClaudeBackgroundTaskLifecycle();
 
     // With AbortController passed to SDK, cancellation is handled natively.
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
@@ -220,6 +222,24 @@ If you continue to see authentication errors, please contact your Agor administr
     try {
       for await (const msg of result) {
         reportSdkActivity(onActivity, 'claude-code', msg.type);
+        const activeTaskCountBefore = backgroundTasks.activeTaskCount;
+        const resultDisposition = backgroundTasks.observe(msg);
+        if (
+          msg.type === 'system' &&
+          msg.subtype === 'task_started' &&
+          backgroundTasks.activeTaskCount > activeTaskCountBefore
+        ) {
+          // Keep the SDK watchdog paused for the documented lifetime of the
+          // background task, not merely the Agent/Workflow launch tool call.
+          onActivity?.('progress', 'tool.start');
+        }
+        if (
+          msg.type === 'system' &&
+          msg.subtype === 'task_notification' &&
+          backgroundTasks.activeTaskCount < activeTaskCountBefore
+        ) {
+          onActivity?.('progress', 'tool.complete');
+        }
         // Process message through processor
         const events = await processor.process(msg);
 
@@ -247,6 +267,12 @@ If you continue to see authentication errors, please contact your Agor administr
           // (via a pending Promise) specifically so this control request can use
           // stdin.  We must release it afterward regardless of success/failure.
           if (event.type === 'result') {
+            if (resultDisposition === 'await-background-tasks') {
+              console.log(
+                `⏳ Parent turn ended with ${backgroundTasks.activeTaskCount} background task(s) still active; keeping SDK query alive`
+              );
+              continue;
+            }
             try {
               const contextUsage = await result.getContextUsage();
               console.log(
@@ -265,6 +291,9 @@ If you continue to see authentication errors, please contact your Agor administr
 
           // Handle end event
           if (event.type === 'end') {
+            if (resultDisposition === 'await-background-tasks') {
+              continue;
+            }
             console.log(`🏁 Conversation ended: ${event.reason}`);
             break; // Exit for-await loop
           }
@@ -274,7 +303,10 @@ If you continue to see authentication errors, please contact your Agor administr
         }
 
         // If we got an end event, break the outer loop
-        if (events.some((e) => e.type === 'end')) {
+        if (
+          resultDisposition !== 'await-background-tasks' &&
+          events.some((e) => e.type === 'end')
+        ) {
           break;
         }
       }

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -24,6 +24,7 @@ import type { MessagesService, SessionsPatchClient, TasksService } from '../base
 import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
+import { aggregateClaudeResults } from './result-aggregation.js';
 
 export interface PromptResult {
   /** Assistant messages (can be multiple: tool invocation, then response) */
@@ -215,6 +216,13 @@ If you continue to see authentication errors, please contact your Agor administr
       enableTokenStreaming: ClaudePromptService.ENABLE_TOKEN_STREAMING,
     });
     const backgroundTasks = new ClaudeBackgroundTaskLifecycle();
+    const sdkResults: SDKResultMessage[] = [];
+    const clearBackgroundTaskActivity = () => {
+      const activeTaskCount = backgroundTasks.clearActiveTasks();
+      for (let index = 0; index < activeTaskCount; index++) {
+        onActivity?.('progress', 'background_task.complete');
+      }
+    };
 
     // With AbortController passed to SDK, cancellation is handled natively.
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
@@ -222,23 +230,22 @@ If you continue to see authentication errors, please contact your Agor administr
     try {
       for await (const msg of result) {
         reportSdkActivity(onActivity, 'claude-code', msg.type);
-        const activeTaskCountBefore = backgroundTasks.activeTaskCount;
-        const resultDisposition = backgroundTasks.observe(msg);
+        const lifecycleTransition = backgroundTasks.observe(msg);
+        const { resultDisposition } = lifecycleTransition;
         if (
-          msg.type === 'system' &&
-          msg.subtype === 'task_started' &&
-          backgroundTasks.activeTaskCount > activeTaskCountBefore
+          msg.type === 'result' &&
+          msg.subtype !== 'success' &&
+          backgroundTasks.activeTaskCount > 0
         ) {
+          clearBackgroundTaskActivity();
+        }
+        if (lifecycleTransition.taskTransition === 'started') {
           // Keep the SDK watchdog paused for the documented lifetime of the
           // background task, not merely the Agent/Workflow launch tool call.
-          onActivity?.('progress', 'tool.start');
+          onActivity?.('progress', 'background_task.start');
         }
-        if (
-          msg.type === 'system' &&
-          msg.subtype === 'task_notification' &&
-          backgroundTasks.activeTaskCount < activeTaskCountBefore
-        ) {
-          onActivity?.('progress', 'tool.complete');
+        if (lifecycleTransition.taskTransition === 'settled') {
+          onActivity?.('progress', 'background_task.complete');
         }
         // Process message through processor
         const events = await processor.process(msg);
@@ -267,25 +274,27 @@ If you continue to see authentication errors, please contact your Agor administr
           // (via a pending Promise) specifically so this control request can use
           // stdin.  We must release it afterward regardless of success/failure.
           if (event.type === 'result') {
+            sdkResults.push(event.raw_sdk_message);
             if (resultDisposition === 'await-background-tasks') {
               console.log(
                 `⏳ Parent turn ended with ${backgroundTasks.activeTaskCount} background task(s) still active; keeping SDK query alive`
               );
-              continue;
-            }
-            try {
-              const contextUsage = await result.getContextUsage();
-              console.log(
-                `📊 SDK context usage: ${contextUsage.totalTokens}/${contextUsage.maxTokens} tokens (${contextUsage.percentage}%)`
-              );
-              yield { type: 'context_usage', contextUsage } as ProcessedEvent;
-            } catch (error) {
-              console.warn(
-                `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`
-              );
-            } finally {
-              // Release the held input iterable so the SDK can close stdin
-              result.releaseInput();
+            } else {
+              event.raw_sdk_message = aggregateClaudeResults(sdkResults);
+              try {
+                const contextUsage = await result.getContextUsage();
+                console.log(
+                  `📊 SDK context usage: ${contextUsage.totalTokens}/${contextUsage.maxTokens} tokens (${contextUsage.percentage}%)`
+                );
+                yield { type: 'context_usage', contextUsage } as ProcessedEvent;
+              } catch (error) {
+                console.warn(
+                  `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`
+                );
+              } finally {
+                // Release the held input iterable so the SDK can close stdin
+                result.releaseInput();
+              }
             }
           }
 
@@ -312,6 +321,7 @@ If you continue to see authentication errors, please contact your Agor administr
       }
     } catch (error) {
       // Ensure stdin is released on any error so the subprocess can exit cleanly
+      clearBackgroundTaskActivity();
       result.releaseInput();
 
       const state = processor.getState();

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
@@ -1,0 +1,70 @@
+import type { SDKResultMessage } from '@agor/core/sdk';
+import { describe, expect, it } from 'vitest';
+import { aggregateClaudeResults } from './result-aggregation.js';
+
+function result(uuid: string, inputTokens: number, cost: number): SDKResultMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 10,
+    duration_api_ms: 8,
+    is_error: false,
+    num_turns: 1,
+    result: '',
+    stop_reason: null,
+    total_cost_usd: cost,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: 2,
+      cache_creation_input_tokens: 3,
+      cache_read_input_tokens: 4,
+      server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+      service_tier: 'standard',
+    },
+    modelUsage: {
+      sonnet: {
+        inputTokens,
+        outputTokens: 2,
+        cacheReadInputTokens: 4,
+        cacheCreationInputTokens: 3,
+        webSearchRequests: 0,
+        costUSD: cost,
+        contextWindow: 200_000,
+        maxOutputTokens: 32_000,
+      },
+    },
+    permission_denials: [],
+    uuid,
+    session_id: 'sdk-session',
+  };
+}
+
+describe('aggregateClaudeResults', () => {
+  it('makes the terminal result an aggregate of every query turn', () => {
+    const aggregate = aggregateClaudeResults([
+      result('parent', 10, 0.01),
+      result('continuation', 20, 0.02),
+    ]);
+
+    expect(aggregate.uuid).toBe('continuation');
+    expect(aggregate.usage).toMatchObject({
+      input_tokens: 30,
+      output_tokens: 4,
+      cache_creation_input_tokens: 6,
+      cache_read_input_tokens: 8,
+    });
+    expect(aggregate.modelUsage.sonnet).toMatchObject({
+      inputTokens: 30,
+      outputTokens: 4,
+      contextWindow: 200_000,
+      maxOutputTokens: 32_000,
+      costUSD: 0.03,
+    });
+    expect(aggregate).toMatchObject({
+      duration_ms: 20,
+      duration_api_ms: 16,
+      num_turns: 2,
+      total_cost_usd: 0.03,
+    });
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
@@ -1,0 +1,67 @@
+import type { SDKResultMessage } from '@agor/core/sdk';
+
+const TOP_LEVEL_USAGE_COUNTERS = [
+  'input_tokens',
+  'output_tokens',
+  'cache_creation_input_tokens',
+  'cache_read_input_tokens',
+] as const;
+
+const MODEL_USAGE_COUNTERS = [
+  'inputTokens',
+  'outputTokens',
+  'cacheReadInputTokens',
+  'cacheCreationInputTokens',
+  'webSearchRequests',
+  'costUSD',
+] as const;
+
+/**
+ * Aggregate per-turn Agent SDK results into the terminal result consumed by
+ * ClaudeTool's task-level accounting. The individual results are still yielded
+ * upstream; this makes the last one an authoritative query-level summary.
+ */
+export function aggregateClaudeResults(results: SDKResultMessage[]): SDKResultMessage {
+  const terminal = results.at(-1);
+  if (!terminal || results.length === 1) return terminal!;
+
+  const usage = { ...terminal.usage };
+  for (const key of TOP_LEVEL_USAGE_COUNTERS) {
+    usage[key] = results.reduce((sum, result) => sum + (result.usage[key] ?? 0), 0);
+  }
+
+  const modelUsage: SDKResultMessage['modelUsage'] = {};
+  for (const result of results) {
+    for (const [modelId, current] of Object.entries(result.modelUsage)) {
+      const aggregate = modelUsage[modelId]
+        ? { ...modelUsage[modelId] }
+        : {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 0,
+            maxOutputTokens: 0,
+          };
+      for (const key of MODEL_USAGE_COUNTERS) {
+        aggregate[key] += current[key] ?? 0;
+      }
+      aggregate.contextWindow = Math.max(aggregate.contextWindow, current.contextWindow ?? 0);
+      aggregate.maxOutputTokens = Math.max(aggregate.maxOutputTokens, current.maxOutputTokens ?? 0);
+      modelUsage[modelId] = aggregate;
+    }
+  }
+
+  return {
+    ...terminal,
+    duration_ms: results.reduce((sum, result) => sum + result.duration_ms, 0),
+    duration_api_ms: results.reduce((sum, result) => sum + result.duration_api_ms, 0),
+    num_turns: results.reduce((sum, result) => sum + result.num_turns, 0),
+    total_cost_usd: results.reduce((sum, result) => sum + result.total_cost_usd, 0),
+    usage,
+    modelUsage,
+    permission_denials: results.flatMap((result) => result.permission_denials),
+  };
+}

--- a/packages/executor/src/sdk-watchdog.test.ts
+++ b/packages/executor/src/sdk-watchdog.test.ts
@@ -109,6 +109,20 @@ describe('SdkWatchdog', () => {
     expect(decisions[0]?.reason).toBe('progress_stalled');
   });
 
+  it('pauses Claude idle policy while an SDK background task is active', () => {
+    const { watchdog, decisions } = harness({}, 'claude-code');
+    watchdog.record('sdk_started');
+    watchdog.record('progress', 'assistant');
+    watchdog.record('progress', 'background_task.start');
+    vi.advanceTimersByTime(10_000);
+    expect(decisions).toEqual([]);
+    watchdog.record('progress', 'background_task.complete');
+    vi.advanceTimersByTime(1_999);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('progress_stalled');
+  });
+
   it('keeps Claude idle policy paused until every parallel tool completes', () => {
     const { watchdog, decisions } = harness({}, 'claude-code');
     watchdog.record('sdk_started');

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -208,8 +208,10 @@ export class SdkWatchdog {
     if (kind === 'progress') {
       this.state.firstProgressAt ??= now;
       this.state.idleAnchor = now;
-      if (detail === 'tool.start') this.state.activeToolCount++;
-      if (detail === 'tool.complete') {
+      if (detail === 'tool.start' || detail === 'background_task.start') {
+        this.state.activeToolCount++;
+      }
+      if (detail === 'tool.complete' || detail === 'background_task.complete') {
         this.state.activeToolCount = Math.max(0, this.state.activeToolCount - 1);
       }
     }


### PR DESCRIPTION
## Summary

- keep Claude Agent SDK streaming queries alive after a parent `result` while documented background tasks remain active
- track `system/task_started` and terminal `system/task_notification` events for Agent and Workflow tasks
- extend SDK watchdog tool accounting across the real background-task lifetime
- add deterministic lifecycle coverage for Workflow, Agent completion, failure, cancellation, multiple tasks, duplicate notifications, and ordinary turns

## Root cause

Agor treated the first SDK `result` as both the end of the model turn and the end of the query. It then released the held input stream and stopped consuming the generator. Claude Code background Agents and Workflows can outlive that parent turn, so subprocess teardown aborted them. Resuming the session could subsequently surface a stale task-notification result instead of processing the next prompt.

The Agent SDK 0.3.197 contract distinguishes these boundaries: `task_started` identifies live background work, `task_notification` reports `completed`, `failed`, or `stopped`, and a later result closes the continuation turn.

## Design

A query-scoped lifecycle tracker records active SDK task IDs. Successful results are deferred while any tracked task remains active. Input is released only after all tasks settle and the SDK emits the subsequent result. SDK error results remain terminal so a missing notification cannot wedge the executor indefinitely.

Task lifecycle events are also mapped to watchdog `tool.start`/`tool.complete` activity. This prevents the Claude idle watchdog from terminating a healthy background task after the launch tool itself has returned.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/executor exec vitest run src/sdk-handlers/claude/background-task-lifecycle.test.ts src/sdk-handlers/claude/query-builder.test.ts src/sdk-handlers/claude/message-processor.test.ts src/sdk-watchdog.test.ts`

Closes #1852.
