### PR TITLE
feat(ui): add "All branches" tab to board assistant panel

### DIFF
--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -438,7 +438,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
           },
           {
             key: 'all-sessions',
-            label: 'All sessions',
+            label: 'Sessions',
             children: board ? (
               <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
                 {sessionDetailsHydrated ? (
@@ -462,7 +462,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
           },
           {
             key: 'all-branches',
-            label: 'All branches',
+            label: 'Branches',
             children: board ? (
               <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
                 {sessionDetailsHydrated ? (

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -28,13 +28,13 @@ import {
 import { mapToArray } from '../../utils/mapHelpers';
 import { BranchSessionSections } from '../BranchCard';
 import { BranchHeaderPill } from '../BranchHeaderPill';
-import { BoardSessionList } from '../BranchListDrawer';
+import { BoardBranchList, BoardSessionList } from '../BranchListDrawer';
 import { BranchMetadataRow } from '../BranchMetadataRow';
 import type { BranchModalTab } from '../BranchModal';
 import { CommentsPanel } from '../CommentsPanel';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 
-export type BoardTeammatePanelTab = 'teammate' | 'all-sessions' | 'comments';
+export type BoardTeammatePanelTab = 'teammate' | 'all-sessions' | 'all-branches' | 'comments';
 
 interface BoardTeammatePanelProps {
   board: Board | null;
@@ -450,6 +450,23 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
                     sessionsByBranch={sessionsByBranch}
                     onSessionClick={onSessionClick}
                   />
+                ) : (
+                  <div style={{ padding: 16 }}>
+                    <Skeleton active paragraph={{ rows: 4 }} title={false} />
+                  </div>
+                )}
+              </div>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No board selected" />
+            ),
+          },
+          {
+            key: 'all-branches',
+            label: 'All branches',
+            children: board ? (
+              <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
+                {sessionDetailsHydrated ? (
+                  <BoardBranchList board={board} repoById={repoById} client={client} />
                 ) : (
                   <div style={{ padding: 16 }}>
                     <Skeleton active paragraph={{ rows: 4 }} title={false} />

--- a/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.tsx
@@ -1,4 +1,9 @@
-import { CommentOutlined, RobotOutlined, UnorderedListOutlined } from '@ant-design/icons';
+import {
+  BranchesOutlined,
+  CommentOutlined,
+  RobotOutlined,
+  UnorderedListOutlined,
+} from '@ant-design/icons';
 import { Badge, theme } from 'antd';
 import type React from 'react';
 import { memo } from 'react';
@@ -13,6 +18,7 @@ interface RailItem {
 const RAIL_ITEMS: RailItem[] = [
   { key: 'teammate', label: 'Teammate', icon: <RobotOutlined /> },
   { key: 'all-sessions', label: 'Sessions', icon: <UnorderedListOutlined /> },
+  { key: 'all-branches', label: 'Branches', icon: <BranchesOutlined /> },
   { key: 'comments', label: 'Comments', icon: <CommentOutlined /> },
 ];
 

--- a/apps/agor-ui/src/components/BranchListDrawer/BoardBranchList.test.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BoardBranchList.test.tsx
@@ -1,0 +1,181 @@
+import type { AgorClient, Board, BoardEntityObject, Branch, Repo } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CanvasNavigationProvider,
+  useRegisterRecenter,
+} from '../../contexts/CanvasNavigationContext';
+import { BoardBranchList } from './BoardBranchList';
+
+const board = {
+  board_id: 'board-1',
+  name: 'Board 1',
+} as Board;
+
+const repo = {
+  repo_id: 'repo-1',
+  slug: 'preset-io/agor',
+} as Repo;
+
+const shownBranch = {
+  branch_id: 'branch-shown',
+  board_id: 'board-1',
+  repo_id: 'repo-1',
+  name: 'feature/visible',
+  archived: false,
+  last_used: '2026-05-31T00:00:00.000Z',
+  zone_label: 'In Review',
+} as unknown as Branch;
+
+const hiddenBranch = {
+  branch_id: 'branch-hidden',
+  board_id: 'board-1',
+  repo_id: 'repo-1',
+  name: 'feature/archived',
+  archived: true,
+  last_used: '2026-05-30T00:00:00.000Z',
+} as unknown as Branch;
+
+const makeClient = (branches: Branch[]): AgorClient => {
+  const service = {
+    findAll: vi.fn().mockResolvedValue(branches),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  };
+  return { service: vi.fn().mockReturnValue(service) } as unknown as AgorClient;
+};
+
+/**
+ * Client mock with a working event registry so tests can drive realtime
+ * refetches. Each service name gets its own handler map; `emit` invokes every
+ * handler registered for a given service+event.
+ */
+const makeEmittingClient = (branches: () => Branch[]) => {
+  const handlers = new Map<string, Map<string, Set<(payload: unknown) => void>>>();
+  const findAll = vi.fn().mockImplementation(() => Promise.resolve(branches()));
+
+  const serviceFor = (name: string) => {
+    const events = handlers.get(name) ?? new Map();
+    handlers.set(name, events);
+    return {
+      findAll,
+      on: (event: string, handler: (payload: unknown) => void) => {
+        const set = events.get(event) ?? new Set();
+        set.add(handler);
+        events.set(event, set);
+      },
+      removeListener: (event: string, handler: (payload: unknown) => void) => {
+        events.get(event)?.delete(handler);
+      },
+    };
+  };
+
+  const client = { service: vi.fn().mockImplementation(serviceFor) } as unknown as AgorClient;
+
+  const emit = (name: string, event: string, payload: unknown) => {
+    for (const handler of handlers.get(name)?.get(event) ?? []) handler(payload);
+  };
+
+  return { client, emit, findAll };
+};
+
+const renderList = (
+  client: AgorClient,
+  registerRecenter: (nodeId: string) => boolean = () => false
+) => {
+  const Harness: React.FC = () => {
+    // Register a fake canvas recenter so we can assert pan-to calls.
+    useRegisterRecenter(registerRecenter);
+    return (
+      <BoardBranchList board={board} repoById={new Map([[repo.repo_id, repo]])} client={client} />
+    );
+  };
+
+  return render(
+    <CanvasNavigationProvider>
+      <Harness />
+    </CanvasNavigationProvider>
+  );
+};
+
+describe('BoardBranchList', () => {
+  it('lists both shown and hidden (archived) branches with their zone label', async () => {
+    renderList(makeClient([shownBranch, hiddenBranch]));
+
+    expect(await screen.findByText('feature/visible')).toBeInTheDocument();
+    // Hidden/archived branch is included (no visibility filtering).
+    expect(screen.getByText('feature/archived')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+    // Zone pinning label from the enriched branch list API is surfaced.
+    expect(screen.getByText('In Review')).toBeInTheDocument();
+  });
+
+  it('fetches board-scoped branches without an archived filter', async () => {
+    const client = makeClient([shownBranch, hiddenBranch]);
+    renderList(client);
+
+    await screen.findByText('feature/visible');
+
+    const service = client.service('branches') as unknown as { findAll: ReturnType<typeof vi.fn> };
+    expect(service.findAll).toHaveBeenCalledWith({
+      query: { board_id: 'board-1', $limit: 1000 },
+    });
+  });
+
+  it('refetches when a board object on this board changes (zone move)', async () => {
+    // Start with the branch pinned to "In Review", then have the daemon patch
+    // the board_object into "Done" and emit a board-objects event. Zone pinning
+    // lives on board_objects, so no branch event fires — the list must still
+    // pick up the new zone label.
+    let current: Branch[] = [{ ...shownBranch, zone_label: 'In Review' } as Branch];
+    const { client, emit, findAll } = makeEmittingClient(() => current);
+
+    renderList(client);
+
+    expect(await screen.findByText('In Review')).toBeInTheDocument();
+    expect(findAll).toHaveBeenCalledTimes(1);
+
+    current = [{ ...shownBranch, zone_label: 'Done' } as Branch];
+    act(() => {
+      emit('board-objects', 'patched', {
+        object_id: 'obj-1',
+        board_id: 'board-1',
+        branch_id: 'branch-shown',
+      } as BoardEntityObject);
+    });
+
+    expect(await screen.findByText('Done')).toBeInTheDocument();
+    expect(findAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores board object events for other boards', async () => {
+    const { client, emit, findAll } = makeEmittingClient(() => [shownBranch]);
+
+    renderList(client);
+    await screen.findByText('feature/visible');
+    expect(findAll).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      emit('board-objects', 'patched', {
+        object_id: 'obj-2',
+        board_id: 'other-board',
+        branch_id: 'branch-elsewhere',
+      } as BoardEntityObject);
+    });
+
+    // No refetch for a different board.
+    await waitFor(() => expect(findAll).toHaveBeenCalledTimes(1));
+  });
+
+  it('pans the board camera to the branch card when a row is clicked', async () => {
+    const recenter = vi.fn().mockReturnValue(true);
+    renderList(makeClient([shownBranch]), recenter);
+
+    fireEvent.click(await screen.findByText('feature/visible'));
+
+    // useRecenterMap forwards a sub-target options object as the second arg
+    // (sessionId/ensureVisible); the branch id is all this row cares about.
+    expect(recenter).toHaveBeenCalledWith('branch-shown', expect.anything());
+  });
+});

--- a/apps/agor-ui/src/components/BranchListDrawer/BoardBranchList.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BoardBranchList.tsx
@@ -1,0 +1,274 @@
+import type { AgorClient, Board, BoardEntityObject, Branch, Repo } from '@agor-live/client';
+import { EnvironmentOutlined } from '@ant-design/icons';
+import { Skeleton, Tag, Tooltip, Typography, theme } from 'antd';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
+import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
+import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
+import { RepoPill } from '../Pill';
+
+/**
+ * Branch enriched with zone-pinning info. The `branches` service `find()`
+ * attaches `zone_id`/`zone_label` server-side (see
+ * `BranchRepository.enrichManyWithZoneInfo`). `BranchWithZone` lives in the
+ * repository layer and isn't exported to the client bundle, so we annotate the
+ * canonical `Branch` with the two enrichment fields locally.
+ */
+type BoardBranch = Branch & { zone_id?: string; zone_label?: string };
+
+export interface BoardBranchListProps {
+  board?: Board;
+  repoById: Map<string, Repo>;
+  client: AgorClient | null;
+  onAfterBranchClick?: () => void;
+}
+
+/**
+ * "All branches" tab body. Mirrors {@link BoardSessionList} but lists the
+ * branches associated with the current board — including archived (hidden)
+ * ones, which the global store intentionally omits. Each row pans the board
+ * camera onto the branch card, reusing the same recenter channel as the
+ * session locator button.
+ */
+export const BoardBranchList: React.FC<BoardBranchListProps> = ({
+  board,
+  repoById,
+  client,
+  onAfterBranchClick,
+}) => {
+  const { token } = theme.useToken();
+  const recenterMap = useRecenterMap();
+  const [branches, setBranches] = useState<BoardBranch[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Keep client stable for the event-listener effect without re-subscribing.
+  const clientRef = useRef(client);
+  clientRef.current = client;
+
+  const boardId = board?.board_id;
+
+  const loadBranches = useCallback(async () => {
+    const currentClient = clientRef.current;
+    if (!currentClient || !boardId) {
+      setBranches([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // Omit the `archived` filter so BOTH shown and hidden branches come
+      // back. The response is enriched with zone_id/zone_label by the daemon.
+      const result = await currentClient.service('branches').findAll({
+        query: {
+          board_id: boardId,
+          $limit: 1000,
+        },
+      });
+      setBranches(result as BoardBranch[]);
+    } catch {
+      // Keep the tab resilient: leave the last-known list in place.
+    } finally {
+      setLoading(false);
+    }
+  }, [boardId]);
+
+  useEffect(() => {
+    void loadBranches();
+  }, [loadBranches]);
+
+  // Refresh on structural changes to branches on this board. Branch counts are
+  // small, so a full board-scoped refetch keeps zone/archived state accurate
+  // without hand-merging partial patch payloads.
+  useEffect(() => {
+    if (!client || !boardId) return;
+    const branchesService = client.service('branches');
+
+    const refreshIfBranchRelevant = (branch: Branch) => {
+      if (branch.board_id === boardId) void loadBranches();
+    };
+
+    branchesService.on('created', refreshIfBranchRelevant);
+    branchesService.on('patched', refreshIfBranchRelevant);
+    branchesService.on('updated', refreshIfBranchRelevant);
+    branchesService.on('removed', refreshIfBranchRelevant);
+
+    // Zone pinning lives on `board_objects.data.zone_id`, not on the branch
+    // row (see BranchRepository.enrichManyWithZoneInfo). Moving a card between
+    // zones patches the `board-objects` service, so a branch event never fires
+    // — without this listener the zone pill only updates on a page refresh.
+    const boardObjectsService = client.service('board-objects');
+
+    const refreshIfBoardObjectRelevant = (boardObject: BoardEntityObject) => {
+      if (boardObject.board_id === boardId) void loadBranches();
+    };
+
+    boardObjectsService.on('created', refreshIfBoardObjectRelevant);
+    boardObjectsService.on('patched', refreshIfBoardObjectRelevant);
+    boardObjectsService.on('updated', refreshIfBoardObjectRelevant);
+    boardObjectsService.on('removed', refreshIfBoardObjectRelevant);
+
+    return () => {
+      branchesService.removeListener('created', refreshIfBranchRelevant);
+      branchesService.removeListener('patched', refreshIfBranchRelevant);
+      branchesService.removeListener('updated', refreshIfBranchRelevant);
+      branchesService.removeListener('removed', refreshIfBranchRelevant);
+
+      boardObjectsService.removeListener('created', refreshIfBoardObjectRelevant);
+      boardObjectsService.removeListener('patched', refreshIfBoardObjectRelevant);
+      boardObjectsService.removeListener('updated', refreshIfBoardObjectRelevant);
+      boardObjectsService.removeListener('removed', refreshIfBoardObjectRelevant);
+    };
+  }, [client, boardId, loadBranches]);
+
+  // Active branches first, then archived; each group most-recently-used first.
+  const sortedBranches = useMemo(() => {
+    return [...branches].sort((a, b) => {
+      if (Boolean(a.archived) !== Boolean(b.archived)) {
+        return a.archived ? 1 : -1;
+      }
+      return (b.last_used ?? '').localeCompare(a.last_used ?? '');
+    });
+  }, [branches]);
+
+  if (!board) {
+    return null;
+  }
+
+  return (
+    <div style={{ height: '100%', position: 'relative', overflow: 'hidden' }}>
+      <div style={{ padding: '8px 0' }}>
+        {loading && branches.length === 0 ? (
+          <div style={{ padding: 16 }}>
+            <Skeleton active paragraph={{ rows: 4 }} title={false} />
+          </div>
+        ) : sortedBranches.length === 0 ? (
+          <Typography.Text
+            type="secondary"
+            style={{ display: 'block', textAlign: 'center', padding: '24px 0', fontSize: 12 }}
+          >
+            No branches on this board
+          </Typography.Text>
+        ) : (
+          sortedBranches.map((branch) => {
+            const repo = repoById.get(branch.repo_id);
+            const branchTitle = repo ? `${repo.slug} / ${branch.name}` : branch.name;
+
+            return (
+              <div
+                key={branch.branch_id}
+                style={{
+                  cursor: 'pointer',
+                  padding: '10px 24px',
+                  transition: 'background 0.2s',
+                  opacity: branch.archived ? 0.6 : 1,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = token.colorBgTextHover;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent';
+                }}
+                onClick={() => {
+                  if (boardId) recenterMap(branch.branch_id, { boardId });
+                  onAfterBranchClick?.();
+                }}
+              >
+                {/* Line 1: branch name · repo · archived state · pan-to button */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    minWidth: 0,
+                  }}
+                >
+                  <Typography.Text
+                    ellipsis={{ tooltip: branchTitle }}
+                    style={{ flex: 1, minWidth: 0, fontWeight: 500 }}
+                  >
+                    {branch.name}
+                  </Typography.Text>
+                  {branch.archived && (
+                    <Tag color="default" style={{ marginInlineEnd: 0, flexShrink: 0 }}>
+                      Archived
+                    </Tag>
+                  )}
+                  <BranchBoardLocatorIcon branch={branch} size={14} />
+                </div>
+
+                {/* Line 2: repo pill · zone label · relative timestamp */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 8,
+                    marginTop: 6,
+                    minWidth: 0,
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      minWidth: 0,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {repo && <RepoPill repoName={repo.slug} color="default" />}
+                    {branch.zone_label ? (
+                      <Tag
+                        icon={<EnvironmentOutlined />}
+                        color="geekblue"
+                        style={{ marginInlineEnd: 0, maxWidth: '100%' }}
+                        title={`Pinned to zone: ${branch.zone_label}`}
+                      >
+                        {branch.zone_label}
+                      </Tag>
+                    ) : (
+                      <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                        No zone
+                      </Typography.Text>
+                    )}
+                  </div>
+                  <Tooltip title={formatTimestampWithRelative(branch.last_used)}>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 11, whiteSpace: 'nowrap', flexShrink: 0 }}
+                    >
+                      {formatRelativeTime(branch.last_used)}
+                    </Typography.Text>
+                  </Tooltip>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Board Info Footer */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          padding: '16px 24px',
+          borderTop: `1px solid ${token.colorBorder}`,
+          background: token.colorBgContainer,
+        }}
+      >
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {`${sortedBranches.length} branch${sortedBranches.length === 1 ? '' : 'es'}${
+            board.description ? ` • ${board.description}` : ''
+          }`}
+        </Typography.Text>
+      </div>
+    </div>
+  );
+};
+
+export default BoardBranchList;

--- a/apps/agor-ui/src/components/BranchListDrawer/index.ts
+++ b/apps/agor-ui/src/components/BranchListDrawer/index.ts
@@ -1,2 +1,4 @@
+export type { BoardBranchListProps } from './BoardBranchList';
+export { BoardBranchList } from './BoardBranchList';
 export type { BoardSessionListProps } from './BranchListDrawer';
 export { BoardSessionList, BranchListDrawer, default } from './BranchListDrawer';


### PR DESCRIPTION
## Summary

Adds an **All branches** tab to the board teammate/assistant panel, sitting alongside the existing **All sessions** tab. It lists every branch on the current board — both active/shown and inactive/hidden (archived) — each with a pan-to-branch locator button (mirroring the All Sessions tab) and the zone(s) the branch is pinned to.

## What's included

- **New `BoardBranchList` component** — fetches board-scoped branches _without_ an `archived` filter, so both shown and hidden branches appear (the global store intentionally omits archived ones). Sorts active-before-archived, most-recently-used first within each group, and surfaces the daemon-enriched `zone_label`.
- **Live updates** — refetches on `branches` and `board-objects` realtime events. Zone pinning lives on `board_objects.data.zone_id` rather than the branch row, so a zone move patches `board-objects` and never fires a branch event; the board-object listener keeps the zone pill accurate without a page refresh.
- **Per-row actions** — repo pill, zone label (or "No zone"), archived tag, relative-time timestamp, and a `BranchBoardLocatorIcon` / row click that pans the canvas camera onto the branch card via the shared recenter channel.
- **Panel wiring** — new `all-branches` tab in `BoardTeammatePanel` and a `BranchesOutlined` entry in the panel rail.

## Testing

- `BoardBranchList.test.tsx` covers: listing both shown and archived branches with zone labels, the archived-filter-free query, realtime refetch on board-object (zone move) events, ignoring events for other boards, and pan-to-branch on row click.
- All 5 tests pass locally (`pnpm vitest run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)