### PR TITLE
fix: supervise repository clone lifecycle

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -35,7 +35,7 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         'Get detailed information about a specific repository, including async clone state. ' +
         'For repos created via agor_repos_create_remote, check `clone_status` ' +
         '(`cloning` | `ready` | `failed`). On `failed`, `clone_error.category` ' +
-        '(`auth_failed` | `not_found` | `network` | `unknown`) tells you what went wrong; ' +
+        '(`auth_failed` | `not_found` | `network` | `timeout` | `unknown`) tells you what went wrong; ' +
         '`auth_failed` usually means the calling user has not configured a `GITHUB_TOKEN` ' +
         'in Settings → API Keys (or it has expired/lost access).',
       annotations: { readOnlyHint: true },

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -72,6 +72,14 @@ import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 import {
+  cancelTrackedCloneOperation,
+  REPO_CLONE_CLEANUP_TIMEOUT_MS,
+  REPO_CLONE_TIMEOUT_MS,
+  REPO_CLONE_TOKEN_TTL_SECONDS,
+  superviseRepoClone,
+  trackCloneOperation,
+} from '../utils/repo-clone-supervisor.js';
+import {
   generateScopedServiceToken,
   getDaemonUrl,
   runExecutorCommand,
@@ -1287,6 +1295,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // Get branch details before deletion
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
 
+    // A delete while a self-standing clone is being materialized is explicit
+    // cancellation. Wait for its complete process tree before deleting the DB
+    // row or asking a cleanup executor to touch the same directory.
+    await cancelTrackedCloneOperation('branch', branch.branch_id);
+
     // Remove from database FIRST for instant UI feedback
     // CASCADE will clean up related comments automatically
     const result = await super.remove(id, params);
@@ -1371,6 +1384,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
     // Hook chain enforces auth before we get here.
     const currentUserId = (params as AuthenticatedParams).user!.user_id as UUID;
+
+    await cancelTrackedCloneOperation('branch', branch.branch_id);
 
     // Stop environment if running
     if (branch.environment_instance?.status === 'running') {
@@ -1668,9 +1683,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         // templates without tripping requireAdminForEnvConfig when unarchive
         // is performed by a non-admin user.
         const sessionToken = generateScopedServiceToken(
-          this.app as unknown as { settings: { authentication?: { secret?: string } } }
+          this.app as unknown as { settings: { authentication?: { secret?: string } } },
+          {},
+          storageMode === 'clone' ? REPO_CLONE_TOKEN_TTL_SECONDS : undefined
         );
-        spawnExecutor(
+        const branchProcess = spawnExecutor(
           {
             command: 'git.branch.add',
             sessionToken,
@@ -1712,6 +1729,68 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             logPrefix: `[BranchesService.unarchive ${branch.name}]`,
           }
         );
+
+        if (storageMode === 'clone') {
+          const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
+          const branchCloneSupervisor = superviseRepoClone({
+            process: branchProcess,
+            timeoutMs: REPO_CLONE_TIMEOUT_MS,
+            cleanupPartialClone: async () => {
+              const cleanupToken = generateScopedServiceToken(
+                this.app as unknown as {
+                  settings: { authentication?: { secret?: string } };
+                }
+              );
+              const cleanupResult = await runExecutorCommand(
+                {
+                  command: 'git.branch.remove',
+                  sessionToken: cleanupToken,
+                  daemonUrl: getDaemonUrl(),
+                  params: {
+                    branchId: branch.branch_id,
+                    branchPath: branch.path,
+                    branchesRoot: getBranchesDir(tenantId),
+                    deleteDbRecord: false,
+                    storageMode: 'clone',
+                  },
+                },
+                {
+                  logPrefix: `[BranchesService.unarchive ${branch.name} cleanup]`,
+                  timeoutMs: REPO_CLONE_CLEANUP_TIMEOUT_MS,
+                }
+              );
+              if (!cleanupResult.success) {
+                throw new Error(
+                  cleanupResult.error?.message ?? 'branch clone cleanup executor failed'
+                );
+              }
+            },
+            onExit: async ({ code, signal }) => {
+              if (code === 0) return;
+              const current = await this.get(branch.branch_id);
+              if (current.filesystem_status !== 'creating') return;
+              const exitDescription = signal ? `signal ${signal}` : `exit code ${code ?? 1}`;
+              await this.patch(branch.branch_id, {
+                filesystem_status: 'failed',
+                error_message: `Branch clone exited with ${exitDescription} before reporting an error.`,
+              });
+            },
+            onTimeout: async ({ error }) => {
+              await this.patch(branch.branch_id, {
+                filesystem_status: 'failed',
+                error_message: error.message,
+              });
+            },
+          });
+
+          trackCloneOperation('branch', branch.branch_id, branchCloneSupervisor);
+          void branchCloneSupervisor.completion.catch((error) => {
+            console.error(
+              `[BranchesService.unarchive ${branch.name}] Clone supervisor failed:`,
+              error instanceof Error ? error.message : String(error)
+            );
+          });
+        }
       } catch (error) {
         console.error(
           `⚠️  Failed to spawn executor for branch recreation:`,

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -38,6 +38,58 @@ vi.mock('@agor/core/git/exec', async (importOriginal) => {
 });
 
 describe('ReposService.createBranch clone preflight', () => {
+  it.each([
+    {
+      status: 'cloning',
+      cloneError: undefined,
+      expected: /clone is still in progress.*clone_status='ready'/i,
+    },
+    {
+      status: 'failed',
+      cloneError: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+      expected: /clone failed \(timeout\).*Clone timed out after 30 minutes.*Retry/i,
+    },
+  ])('rejects a $status repository before branch persistence or git preflight', async ({
+    status,
+    cloneError,
+    expected,
+  }) => {
+    const app = {
+      service(path: string) {
+        throw new Error(`Unexpected service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new ReposService({} as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue({
+      repo_id: 'repo-1',
+      slug: 'org/repo',
+      repo_type: 'remote',
+      remote_url: 'https://github.com/org/repo.git',
+      local_path: '/tmp/incomplete-repo',
+      clone_status: status,
+      clone_error: cloneError,
+    } as never);
+
+    await expect(
+      service.createBranch(
+        'repo-1',
+        {
+          name: 'new-branch',
+          ref: 'new-branch',
+          sourceBranch: 'main',
+          boardId: 'board-1',
+        },
+        { user: { user_id: 'user-1' } } as never
+      )
+    ).rejects.toThrow(expected);
+
+    expect(assertRemoteRefVisibleForClone).not.toHaveBeenCalled();
+  });
+
   it('rejects clone-mode local-only source refs before persisting branch state', async () => {
     const branchesCreate = vi.fn();
     const getGitEnvironment = vi.fn(async () => ({ GITHUB_TOKEN: 'gh_test_token_for_preflight' }));

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -59,6 +59,14 @@ import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 import { resolveGitImpersonationForUser } from '../utils/git-impersonation.js';
 import {
+  cancelTrackedCloneOperation,
+  REPO_CLONE_CLEANUP_TIMEOUT_MS,
+  REPO_CLONE_TIMEOUT_MS,
+  REPO_CLONE_TOKEN_TTL_SECONDS,
+  superviseRepoClone,
+  trackCloneOperation,
+} from '../utils/repo-clone-supervisor.js';
+import {
   generateScopedServiceToken,
   getDaemonUrl,
   runExecutorCommand,
@@ -226,8 +234,16 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // token ensures hooks like requireAdminForEnvConfig bypass via
     // _isServiceAccount. Executor fetches per-user credentials via Feathers
     // RPC (users.getGitEnvironment) using the same service JWT.
+    // There was no clone timer on this fire-and-forget path; the only
+    // built-in exact ~300s lifecycle boundary was the generic service-token
+    // default. Clones that legitimately ran longer outlived the credential
+    // needed to persist their final state. Give this clone-specific token
+    // enough life for the bounded 30-minute clone window plus bounded
+    // cleanup and a small scheduling margin.
     const sessionToken = generateScopedServiceToken(
-      this.app as unknown as { settings: { authentication?: { secret?: string } } }
+      this.app as unknown as { settings: { authentication?: { secret?: string } } },
+      {},
+      REPO_CLONE_TOKEN_TTL_SECONDS
     );
 
     // Unix group initialization is a filesystem concern controlled by
@@ -277,7 +293,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // through the same service layer the executor uses — that way clients
     // receive `repos.patched` regardless of which path declares failure.
     const reposService = this.app.service('repos');
-    spawnExecutorFireAndForget(
+    const cloneProcess = spawnExecutorFireAndForget(
       {
         command: 'git.clone',
         sessionToken,
@@ -299,67 +315,113 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       {
         logPrefix: `[clone ${slug}]`,
         asUser, // Run as resolved user (fresh groups via sudo -u)
-        onExit: (code) => {
-          if (code !== 0 && code !== null) {
-            // Broadcast clone failure to all connected clients (the existing
-            // toast UX). Persistent failure state lives on the repo row.
-            console.error(
-              `[clone ${slug}] Clone failed with exit code ${code}, broadcasting error`
-            );
-            const io = (app as unknown as { io?: { emit: (event: string, data: unknown) => void } })
-              .io;
-            if (io) {
-              // Include the pinned branch in the message so an operator who
-              // typo'd the Default Branch can self-diagnose. `git clone
-              // --branch <X>` failure is one of the most common reasons a
-              // clone exits non-zero, but the executor's stderr is consumed
-              // by spawnExecutorFireAndForget — without this hint the user
-              // sees only "Clone failed (exit code 128)" and has no idea
-              // the branch field is the cause.
-              const branchHint = data.default_branch
-                ? ` Default Branch was set to '${data.default_branch}' — verify it exists on the remote.`
-                : '';
-              io.emit('repo:cloneError', {
-                slug,
-                url: remoteUrl,
-                error: `Clone failed (exit code ${code}). Check that the repository URL is correct and accessible.${branchHint}`,
-                repo_id: repoId,
-              });
-            }
-
-            // Safety net: if the executor crashed before it could patch the
-            // row (e.g. lost daemon connection), the repo would be stuck in
-            // `'cloning'` forever. Force it to `'failed'` here, but only if
-            // it's still 'cloning' (don't clobber a 'failed' write the
-            // executor already made with a richer category/message).
-            //
-            // Use the service (no `params` → internal call, bypasses auth
-            // hooks) so the patched event fires for any client that joined
-            // after the initial broadcast above.
-            void (async () => {
-              try {
-                const current = (await reposService.get(repoId)) as Repo;
-                if (current.clone_status === 'cloning') {
-                  await reposService.patch(repoId, {
-                    clone_status: 'failed',
-                    clone_error: {
-                      exit_code: code,
-                      category: 'unknown',
-                      message: `Clone exited with code ${code} before reporting an error.`,
-                    },
-                  });
-                }
-              } catch (err) {
-                console.error(
-                  `[clone ${slug}] Failed to mark repo as failed in onExit safety net:`,
-                  err instanceof Error ? err.message : String(err)
-                );
-              }
-            })();
-          }
-        },
       }
     );
+
+    const io = (app as unknown as { io?: { emit: (event: string, data: unknown) => void } }).io;
+    const cloneSupervisor = superviseRepoClone({
+      process: cloneProcess,
+      timeoutMs: REPO_CLONE_TIMEOUT_MS,
+      cleanupPartialClone: async () => {
+        // Use a fresh token: cleanup must not depend on the clone executor's
+        // credential still being valid. The command re-reads the placeholder
+        // row, validates every path against tenant-scoped roots, and runs as
+        // the same Unix identity that created the partial checkout.
+        const cleanupToken = generateScopedServiceToken(
+          app as unknown as { settings: { authentication?: { secret?: string } } }
+        );
+        const cleanupResult = await runExecutorCommand(
+          {
+            command: 'git.repo.delete',
+            sessionToken: cleanupToken,
+            daemonUrl: getDaemonUrl(),
+            params: {
+              repoId,
+              reposRoot: getReposDir(tenantId),
+              branchesRoot: getBranchesDir(tenantId),
+            },
+          },
+          {
+            logPrefix: `[clone ${slug} cleanup]`,
+            asUser,
+            timeoutMs: REPO_CLONE_CLEANUP_TIMEOUT_MS,
+          }
+        );
+        if (!cleanupResult.success) {
+          throw new Error(cleanupResult.error?.message ?? 'clone cleanup executor failed');
+        }
+      },
+      onExit: async ({ code, signal }) => {
+        if (code === 0) return;
+
+        const effectiveCode = code ?? 1;
+        const exitDescription = signal ? `signal ${signal}` : `exit code ${effectiveCode}`;
+        console.error(`[clone ${slug}] Clone failed with ${exitDescription}, broadcasting error`);
+
+        // Include the pinned branch in the message so an operator who typo'd
+        // it can self-diagnose. The executor normally persists richer stderr
+        // classification before it exits; this is only the crash safety net.
+        const branchHint = data.default_branch
+          ? ` Default Branch was set to '${data.default_branch}' — verify it exists on the remote.`
+          : '';
+        io?.emit('repo:cloneError', {
+          slug,
+          url: remoteUrl,
+          error: `Clone failed (${exitDescription}). Check that the repository URL is correct and accessible.${branchHint}`,
+          repo_id: repoId,
+        });
+
+        try {
+          const current = (await reposService.get(repoId)) as Repo;
+          if (current.clone_status === 'cloning') {
+            await reposService.patch(repoId, {
+              clone_status: 'failed',
+              clone_error: {
+                exit_code: effectiveCode,
+                category: 'unknown',
+                message: `Clone exited with ${exitDescription} before reporting an error.`,
+              },
+            });
+          }
+        } catch (err) {
+          console.error(
+            `[clone ${slug}] Failed to mark repo as failed in exit safety net:`,
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      },
+      onTimeout: async ({ error }) => {
+        // Timeout owns the terminal state once its deadline fires. Patch after
+        // process-tree termination and cleanup so a late executor completion
+        // cannot overwrite this truthful outcome.
+        try {
+          await reposService.patch(repoId, {
+            clone_status: 'failed',
+            clone_error: error,
+          });
+          io?.emit('repo:cloneError', {
+            slug,
+            url: remoteUrl,
+            error: error.message,
+            repo_id: repoId,
+          });
+        } catch (err) {
+          console.error(
+            `[clone ${slug}] Failed to persist timeout state:`,
+            err instanceof Error ? err.message : String(err)
+          );
+          throw err;
+        }
+      },
+    });
+
+    trackCloneOperation('repo', repoId, cloneSupervisor);
+    void cloneSupervisor.completion.catch((error) => {
+      console.error(
+        `[clone ${slug}] Clone supervisor failed:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    });
 
     // Return immediately - callers can poll `agor_repos_get(repoId)` for
     // `clone_status: 'ready' | 'failed'` to discover the final outcome.
@@ -619,6 +681,28 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     }
 
     const repo = await this.get(id, params);
+
+    // Remote clone rows are created before filesystem materialization. Never
+    // let a branch request fall through to simple-git while that base checkout
+    // is absent or partial: callers should receive the durable clone failure,
+    // not an implementation error about a missing directory (#2031).
+    if (repo.clone_status === 'cloning') {
+      throw new BadRequest(
+        `Cannot create a branch from repository '${repo.slug}': the repository clone is still in progress. ` +
+          `Wait for clone_status='ready' before retrying.`
+      );
+    }
+    if (repo.clone_status === 'failed') {
+      const cloneError = repo.clone_error;
+      const category = cloneError?.category ? ` (${cloneError.category})` : '';
+      const detail = cloneError?.message
+        ? ` ${cloneError.message}`
+        : ' The repository checkout is unavailable or incomplete.';
+      throw new BadRequest(
+        `Cannot create a branch from repository '${repo.slug}': clone failed${category}.${detail} ` +
+          'Retry the repository clone before creating a branch.'
+      );
+    }
 
     console.log('🔍 RepoService.createBranch - repo lookup result:', {
       repo_id: repo.repo_id,
@@ -917,7 +1001,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Unix group init: Feathers RPC (branches.initializeUnixGroup) — runs daemon-side
     try {
       const sessionToken = generateScopedServiceToken(
-        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+        this.app as unknown as { settings: { authentication?: { secret?: string } } },
+        {},
+        storageMode === 'clone' ? REPO_CLONE_TOKEN_TTL_SECONDS : undefined
       );
 
       // Unix group initialization is a filesystem concern controlled by
@@ -930,7 +1016,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       const asUser = await resolveGitImpersonationForUser(this.db, userId);
       const safeRemoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
 
-      spawnExecutorFireAndForget(
+      const branchProcess = spawnExecutorFireAndForget(
         {
           command: 'git.branch.add',
           sessionToken,
@@ -968,6 +1054,68 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           asUser, // Run as resolved user (fresh groups via sudo -u)
         }
       );
+
+      if (storageMode === 'clone') {
+        const branchCloneSupervisor = superviseRepoClone({
+          process: branchProcess,
+          timeoutMs: REPO_CLONE_TIMEOUT_MS,
+          cleanupPartialClone: async () => {
+            const cleanupToken = generateScopedServiceToken(
+              this.app as unknown as {
+                settings: { authentication?: { secret?: string } };
+              }
+            );
+            const cleanupResult = await runExecutorCommand(
+              {
+                command: 'git.branch.remove',
+                sessionToken: cleanupToken,
+                daemonUrl: getDaemonUrl(),
+                params: {
+                  branchId: branch.branch_id,
+                  branchPath,
+                  branchesRoot: getBranchesDir(tenantId),
+                  deleteDbRecord: false,
+                  storageMode: 'clone',
+                },
+              },
+              {
+                logPrefix: `[ReposService.createBranch ${data.name} cleanup]`,
+                asUser,
+                timeoutMs: REPO_CLONE_CLEANUP_TIMEOUT_MS,
+              }
+            );
+            if (!cleanupResult.success) {
+              throw new Error(
+                cleanupResult.error?.message ?? 'branch clone cleanup executor failed'
+              );
+            }
+          },
+          onExit: async ({ code, signal }) => {
+            if (code === 0) return;
+            const current = (await branchesService.get(branch.branch_id)) as Branch;
+            if (current.filesystem_status !== 'creating') return;
+            const exitDescription = signal ? `signal ${signal}` : `exit code ${code ?? 1}`;
+            await branchesService.patch(branch.branch_id, {
+              filesystem_status: 'failed',
+              error_message: `Branch clone exited with ${exitDescription} before reporting an error.`,
+            });
+          },
+          onTimeout: async ({ error }) => {
+            await branchesService.patch(branch.branch_id, {
+              filesystem_status: 'failed',
+              error_message: error.message,
+            });
+          },
+        });
+
+        trackCloneOperation('branch', branch.branch_id, branchCloneSupervisor);
+        void branchCloneSupervisor.completion.catch((error) => {
+          console.error(
+            `[ReposService.createBranch ${data.name}] Clone supervisor failed:`,
+            error instanceof Error ? error.message : String(error)
+          );
+        });
+      }
     } catch (error) {
       console.error(
         '[ReposService.createBranch] Failed to spawn executor:',
@@ -1164,6 +1312,12 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   async remove(id: string, params?: RepoParams): Promise<Repo> {
     const repo = await this.get(id, params);
     const cleanup = params?.query?.cleanup === true;
+
+    // Removing an in-flight clone is explicit user cancellation. Stop and
+    // await the complete process tree before either preserving its partial
+    // files (`cleanup=false`) or delegating safe filesystem deletion below.
+    // The clone supervisor deliberately does not classify this as a timeout.
+    await cancelTrackedCloneOperation('repo', repo.repo_id);
 
     // Get ALL branches for this repo (needed for both filesystem and database cleanup).
     // CRITICAL: Use an internal call (no provider) so repo deletion owns the

--- a/apps/agor-daemon/src/utils/process-tree.test.ts
+++ b/apps/agor-daemon/src/utils/process-tree.test.ts
@@ -1,0 +1,89 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { terminateProcessTree } from './process-tree.js';
+
+const spawnedGroups: ChildProcess[] = [];
+const tempPaths: string[] = [];
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && 'code' in error && error.code !== 'ESRCH';
+  }
+}
+
+async function waitForFile(filePath: string, timeoutMs = 2_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(filePath, 'utf8');
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+afterEach(async () => {
+  if (process.platform !== 'win32') {
+    for (const child of spawnedGroups) {
+      if (!child.pid) continue;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        // Already gone.
+      }
+    }
+  }
+  spawnedGroups.length = 0;
+  await Promise.all(
+    tempPaths.splice(0).map((tempPath) => rm(tempPath, { recursive: true, force: true }))
+  );
+});
+
+describe.skipIf(process.platform === 'win32')('terminateProcessTree', () => {
+  it('terminates and awaits a stubborn grandchild in the executor process group', async () => {
+    const tempPath = await mkdtemp(path.join(tmpdir(), 'agor-process-tree-'));
+    tempPaths.push(tempPath);
+    const grandchildPidPath = path.join(tempPath, 'grandchild.pid');
+
+    const grandchildCode = [
+      "process.on('SIGTERM', () => {});",
+      "process.on('SIGINT', () => {});",
+      'setInterval(() => {}, 1_000);',
+    ].join('');
+    const parentCode = [
+      "const { spawn } = require('node:child_process');",
+      "const { writeFileSync } = require('node:fs');",
+      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildCode)}], { stdio: 'ignore' });`,
+      `writeFileSync(${JSON.stringify(grandchildPidPath)}, String(child.pid));`,
+      "process.on('SIGTERM', () => {});",
+      "process.on('SIGINT', () => {});",
+      'setInterval(() => {}, 1_000);',
+    ].join('');
+
+    const parent = spawn(process.execPath, ['-e', parentCode], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    spawnedGroups.push(parent);
+
+    const grandchildPid = Number(await waitForFile(grandchildPidPath));
+    expect(parent.pid).toBeTypeOf('number');
+    expect(processExists(grandchildPid)).toBe(true);
+
+    await terminateProcessTree(parent, {
+      detachedProcessGroup: true,
+      graceMs: 30,
+      forceKillWaitMs: 2_000,
+    });
+
+    expect(parent.pid ? processExists(parent.pid) : false).toBe(false);
+    expect(processExists(grandchildPid)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/process-tree.ts
+++ b/apps/agor-daemon/src/utils/process-tree.ts
@@ -1,0 +1,136 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+
+const DEFAULT_TERMINATION_GRACE_MS = 1_000;
+const DEFAULT_FORCE_KILL_WAIT_MS = 5_000;
+const PROCESS_POLL_MS = 20;
+
+export interface TerminateProcessTreeOptions {
+  /**
+   * Whether `child` was spawned as the leader of a detached POSIX process
+   * group. This must only be true when the matching spawn used
+   * `detached: true`; signalling an inherited group could kill the daemon.
+   */
+  detachedProcessGroup: boolean;
+  graceMs?: number;
+  forceKillWaitMs?: number;
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function childHasExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) return false;
+    await delay(Math.min(PROCESS_POLL_MS, Math.max(1, deadline - Date.now())));
+  }
+  return true;
+}
+
+function isPosixProcessGroupAlive(processGroupId: number): boolean {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if (isErrno(error, 'ESRCH')) return false;
+    // EPERM still proves that the process group exists.
+    if (isErrno(error, 'EPERM')) return true;
+    throw error;
+  }
+}
+
+function signalPosixProcessGroup(processGroupId: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(-processGroupId, signal);
+    return true;
+  } catch (error) {
+    if (isErrno(error, 'ESRCH')) return false;
+    throw error;
+  }
+}
+
+async function terminateWindowsProcessTree(
+  child: ChildProcess,
+  forceKillWaitMs: number
+): Promise<void> {
+  if (!child.pid || childHasExited(child)) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const taskkill = spawn('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    taskkill.once('error', reject);
+    taskkill.once('exit', (code) => {
+      if (code === 0 || childHasExited(child)) {
+        resolve();
+      } else {
+        reject(new Error(`taskkill exited with code ${code}`));
+      }
+    });
+  });
+
+  if (!(await waitUntil(() => childHasExited(child), forceKillWaitMs))) {
+    throw new Error(`Process tree rooted at PID ${child.pid} did not exit after taskkill`);
+  }
+}
+
+/**
+ * Terminate a spawned executor and every process it created.
+ *
+ * On POSIX, executor subprocesses are started as process-group leaders. We
+ * signal the negative PGID, wait for the whole group (not just the direct
+ * child), then escalate to SIGKILL and wait again. On Windows, `taskkill /T`
+ * supplies the equivalent descendant traversal.
+ */
+export async function terminateProcessTree(
+  child: ChildProcess,
+  options: TerminateProcessTreeOptions
+): Promise<void> {
+  const graceMs = options.graceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+  const forceKillWaitMs = options.forceKillWaitMs ?? DEFAULT_FORCE_KILL_WAIT_MS;
+
+  if (process.platform === 'win32') {
+    await terminateWindowsProcessTree(child, forceKillWaitMs);
+    return;
+  }
+
+  const processGroupId = child.pid;
+  if (!processGroupId) {
+    // A spawn error can produce a ChildProcess without ever assigning a PID;
+    // there is no OS process (or descendant tree) to terminate.
+    return;
+  }
+
+  if (!options.detachedProcessGroup) {
+    // This fallback is intentionally direct-child only: signalling `-pid`
+    // would be unsafe unless the matching spawn established a private group.
+    if (!childHasExited(child)) child.kill('SIGTERM');
+    if (!(await waitUntil(() => childHasExited(child), graceMs))) {
+      child.kill('SIGKILL');
+    }
+    if (!(await waitUntil(() => childHasExited(child), forceKillWaitMs))) {
+      throw new Error(`Process ${processGroupId} did not exit after SIGKILL`);
+    }
+    return;
+  }
+
+  if (!isPosixProcessGroupAlive(processGroupId)) return;
+
+  signalPosixProcessGroup(processGroupId, 'SIGTERM');
+  if (await waitUntil(() => !isPosixProcessGroupAlive(processGroupId), graceMs)) return;
+
+  signalPosixProcessGroup(processGroupId, 'SIGKILL');
+  if (!(await waitUntil(() => !isPosixProcessGroupAlive(processGroupId), forceKillWaitMs))) {
+    throw new Error(`Process group ${processGroupId} did not exit after SIGKILL`);
+  }
+}

--- a/apps/agor-daemon/src/utils/repo-clone-supervisor.test.ts
+++ b/apps/agor-daemon/src/utils/repo-clone-supervisor.test.ts
@@ -1,0 +1,262 @@
+import { mkdir, mkdtemp, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildRepoCloneTimeoutError,
+  type RepoCloneTimeoutContext,
+  superviseRepoClone,
+} from './repo-clone-supervisor.js';
+import type { ExecutorExitResult, ExecutorProcessHandle } from './spawn-executor.js';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function exit(code: number | null = 0): ExecutorExitResult {
+  return { mode: 'local', code, signal: null };
+}
+
+function fakeProcess(options: {
+  completion: Promise<ExecutorExitResult>;
+  terminate?: () => Promise<void>;
+}): ExecutorProcessHandle {
+  return {
+    context: { mode: 'local' },
+    completion: options.completion,
+    terminate: options.terminate ?? vi.fn(async () => undefined),
+  };
+}
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  const { rm } = await import('node:fs/promises');
+  await Promise.all(
+    tempPaths.splice(0).map((tempPath) => rm(tempPath, { recursive: true, force: true }))
+  );
+});
+
+describe('superviseRepoClone', () => {
+  it('preserves a successful clone without cleanup or timeout persistence', async () => {
+    const processCompletion = deferred<ExecutorExitResult>();
+    const cleanupPartialClone = vi.fn(async () => undefined);
+    const onExit = vi.fn(async () => undefined);
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({ completion: processCompletion.promise }),
+      timeoutMs: 100,
+      cleanupPartialClone,
+      onExit,
+      onTimeout,
+    });
+
+    processCompletion.resolve(exit(0));
+
+    await expect(supervisor.completion).resolves.toBe('exited');
+    expect(onExit).toHaveBeenCalledWith(exit(0));
+    expect(cleanupPartialClone).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('preserves ordinary clone failure handling without timeout cleanup', async () => {
+    const cleanupPartialClone = vi.fn(async () => undefined);
+    const onExit = vi.fn(async () => undefined);
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    let allowTreeTermination!: () => void;
+    const terminate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          allowTreeTermination = resolve;
+        })
+    );
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({ completion: Promise.resolve(exit(128)), terminate }),
+      timeoutMs: 100,
+      cleanupPartialClone,
+      onExit,
+      onTimeout,
+    });
+
+    await vi.waitFor(() => expect(terminate).toHaveBeenCalledOnce());
+    expect(onExit).not.toHaveBeenCalled();
+    allowTreeTermination();
+
+    await expect(supervisor.completion).resolves.toBe('exited');
+    expect(onExit).toHaveBeenCalledWith(exit(128));
+    expect(cleanupPartialClone).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('awaits process-tree termination before removing a partial checkout', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'agor-clone-timeout-'));
+    tempPaths.push(root);
+    const partialCheckout = path.join(root, 'partial');
+    await mkdir(partialCheckout);
+
+    const processCompletion = deferred<ExecutorExitResult>();
+    const terminationAllowed = deferred<void>();
+    const order: string[] = [];
+    const process = fakeProcess({
+      completion: processCompletion.promise,
+      terminate: vi.fn(async () => {
+        order.push('terminate:start');
+        await terminationAllowed.promise;
+        order.push('terminate:done');
+        processCompletion.resolve({ mode: 'local', code: null, signal: 'SIGKILL' });
+      }),
+    });
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => {
+      order.push('persist');
+    });
+    const supervisor = superviseRepoClone({
+      process,
+      timeoutMs: 10,
+      cleanupPartialClone: async () => {
+        order.push('cleanup');
+        const { rm } = await import('node:fs/promises');
+        await rm(partialCheckout, { recursive: true });
+      },
+      onExit: vi.fn(async () => undefined),
+      onTimeout,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(order).toEqual(['terminate:start']);
+    await expect(stat(partialCheckout)).resolves.toBeDefined();
+
+    terminationAllowed.resolve();
+    await expect(supervisor.completion).resolves.toBe('timed_out');
+    expect(order).toEqual(['terminate:start', 'terminate:done', 'cleanup', 'persist']);
+    await expect(stat(partialCheckout)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(onTimeout.mock.calls[0]?.[0].error).toMatchObject({
+      exit_code: 124,
+      category: 'timeout',
+    });
+  });
+
+  it('persists timeout classification and cleanup failure truthfully', async () => {
+    const processCompletion = deferred<ExecutorExitResult>();
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({
+        completion: processCompletion.promise,
+        terminate: async () => {
+          processCompletion.resolve({ mode: 'local', code: null, signal: 'SIGTERM' });
+        },
+      }),
+      timeoutMs: 5,
+      cleanupPartialClone: async () => {
+        throw new Error('permission denied');
+      },
+      onExit: vi.fn(async () => undefined),
+      onTimeout,
+    });
+
+    await expect(supervisor.completion).resolves.toBe('timed_out');
+    expect(onTimeout.mock.calls[0]?.[0]).toMatchObject({
+      cleanupError: 'permission denied',
+      error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: expect.stringMatching(/cleanup failed.*permission denied/i),
+      },
+    });
+  });
+
+  it('does not let late process completion run normal exit handling after timeout wins', async () => {
+    const processCompletion = deferred<ExecutorExitResult>();
+    const onExit = vi.fn(async () => undefined);
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({
+        completion: processCompletion.promise,
+        terminate: async () => undefined,
+      }),
+      timeoutMs: 5,
+      cleanupPartialClone: async () => undefined,
+      onExit,
+      onTimeout,
+    });
+
+    await expect(supervisor.completion).resolves.toBe('timed_out');
+    processCompletion.resolve(exit(0));
+    await Promise.resolve();
+
+    expect(onTimeout).toHaveBeenCalledOnce();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('preserves explicit cancellation without classifying it as timeout', async () => {
+    const processCompletion = deferred<ExecutorExitResult>();
+    const cleanupPartialClone = vi.fn(async () => undefined);
+    const onExit = vi.fn(async () => undefined);
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({
+        completion: processCompletion.promise,
+        terminate: async () => {
+          processCompletion.resolve({ mode: 'local', code: null, signal: 'SIGTERM' });
+        },
+      }),
+      timeoutMs: 50,
+      cleanupPartialClone,
+      onExit,
+      onTimeout,
+    });
+
+    await expect(supervisor.cancel()).resolves.toBe(true);
+    await expect(supervisor.completion).resolves.toBe('cancelled');
+    expect(cleanupPartialClone).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('skips unsafe cleanup and reports when process-tree termination cannot be confirmed', async () => {
+    const cleanupPartialClone = vi.fn(async () => undefined);
+    const onTimeout = vi.fn(async (_context: RepoCloneTimeoutContext) => undefined);
+    const supervisor = superviseRepoClone({
+      process: fakeProcess({
+        completion: new Promise<ExecutorExitResult>(() => undefined),
+        terminate: async () => {
+          throw new Error('process group still alive');
+        },
+      }),
+      timeoutMs: 5,
+      cleanupPartialClone,
+      onExit: vi.fn(async () => undefined),
+      onTimeout,
+    });
+
+    await expect(supervisor.completion).rejects.toThrow(/failed to confirm termination/i);
+    expect(cleanupPartialClone).not.toHaveBeenCalled();
+    expect(onTimeout.mock.calls[0]?.[0]).toMatchObject({
+      terminationError: 'process group still alive',
+      error: {
+        category: 'timeout',
+        message: expect.stringMatching(/failed to confirm termination.*cleanup was skipped/i),
+      },
+    });
+  });
+});
+
+describe('buildRepoCloneTimeoutError', () => {
+  it('uses a timeout-specific category and conventional timeout exit code', () => {
+    expect(buildRepoCloneTimeoutError(30 * 60_000)).toEqual({
+      exit_code: 124,
+      category: 'timeout',
+      message:
+        'Clone timed out after 30 minutes. The clone process tree was terminated and the partial checkout was removed.',
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/repo-clone-supervisor.ts
+++ b/apps/agor-daemon/src/utils/repo-clone-supervisor.ts
@@ -1,0 +1,251 @@
+import type { RepoCloneError } from '@agor/core/types';
+import type { ExecutorExitResult, ExecutorProcessHandle } from './spawn-executor.js';
+
+/** Conservative bound for full-history repo and self-standing branch clones. */
+export const REPO_CLONE_TIMEOUT_MS = 30 * 60_000;
+export const REPO_CLONE_CLEANUP_TIMEOUT_MS = 2 * 60_000;
+export const REPO_CLONE_TIMEOUT_EXIT_CODE = 124;
+export const REPO_CLONE_TOKEN_TTL_SECONDS = Math.ceil(
+  (REPO_CLONE_TIMEOUT_MS + REPO_CLONE_CLEANUP_TIMEOUT_MS + 60_000) / 1_000
+);
+
+type CloneSupervisorState = 'running' | 'timing_out' | 'cancelling' | 'exited';
+
+export interface RepoCloneTimeoutContext {
+  error: RepoCloneError;
+  cleanupError?: string;
+  terminationError?: string;
+}
+
+export interface SuperviseRepoCloneOptions {
+  process: ExecutorProcessHandle;
+  timeoutMs?: number;
+  cleanupPartialClone(): Promise<void>;
+  onExit(exit: ExecutorExitResult): Promise<void>;
+  onTimeout(context: RepoCloneTimeoutContext): Promise<void>;
+}
+
+export interface RepoCloneSupervisor {
+  readonly completion: Promise<'exited' | 'timed_out' | 'cancelled'>;
+  /** Re-check/terminate the owned tree after a previous containment failure. */
+  ensureTerminated(): Promise<void>;
+  /**
+   * Explicit user cancellation. Returns false if process exit or timeout
+   * already won the lifecycle race.
+   */
+  cancel(): Promise<boolean>;
+}
+
+type CloneOperationKind = 'repo' | 'branch';
+
+const activeCloneOperations = new Map<string, RepoCloneSupervisor>();
+
+function cloneOperationKey(kind: CloneOperationKind, id: string): string {
+  return `${kind}:${id}`;
+}
+
+/**
+ * Track clone ownership across the repos and branches services. Branch
+ * creation lives on ReposService while branch deletion lives on
+ * BranchesService, so a module-level registry is the smallest shared
+ * cancellation boundary.
+ */
+export function trackCloneOperation(
+  kind: CloneOperationKind,
+  id: string,
+  supervisor: RepoCloneSupervisor
+): void {
+  const key = cloneOperationKey(kind, id);
+  activeCloneOperations.set(key, supervisor);
+  const removeIfCurrent = (): void => {
+    if (activeCloneOperations.get(key) === supervisor) {
+      activeCloneOperations.delete(key);
+    }
+  };
+  void supervisor.completion.then(
+    (result) => {
+      // Cancellation removes the entry only after cancel() itself has
+      // confirmed tree termination. A rejected containment attempt
+      // deliberately remains registered so a later delete can retry instead
+      // of touching live files.
+      if (result !== 'cancelled') removeIfCurrent();
+    },
+    () => undefined
+  );
+}
+
+/**
+ * Cancel a tracked clone and await its terminal path. A timeout which already
+ * won is awaited rather than reclassified as an explicit cancellation.
+ */
+export async function cancelTrackedCloneOperation(
+  kind: CloneOperationKind,
+  id: string
+): Promise<boolean> {
+  const supervisor = activeCloneOperations.get(cloneOperationKey(kind, id));
+  if (!supervisor) return false;
+
+  const cancelled = await supervisor.cancel();
+  if (cancelled) {
+    if (activeCloneOperations.get(cloneOperationKey(kind, id)) === supervisor) {
+      activeCloneOperations.delete(cloneOperationKey(kind, id));
+    }
+    return true;
+  }
+
+  try {
+    await supervisor.completion;
+  } catch {
+    // A prior timeout/exit failed to prove containment. Retry before allowing
+    // the caller to preserve or remove the partial directory.
+    await supervisor.ensureTerminated();
+    if (activeCloneOperations.get(cloneOperationKey(kind, id)) === supervisor) {
+      activeCloneOperations.delete(cloneOperationKey(kind, id));
+    }
+  }
+  return true;
+}
+
+function formatTimeout(timeoutMs: number): string {
+  if (timeoutMs % 60_000 === 0) {
+    const minutes = timeoutMs / 60_000;
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  if (timeoutMs % 1_000 === 0) {
+    const seconds = timeoutMs / 1_000;
+    return `${seconds} second${seconds === 1 ? '' : 's'}`;
+  }
+  return `${timeoutMs}ms`;
+}
+
+export function buildRepoCloneTimeoutError(
+  timeoutMs: number,
+  details: { cleanupError?: string; terminationError?: string } = {}
+): RepoCloneError {
+  const prefix = `Clone timed out after ${formatTimeout(timeoutMs)}.`;
+
+  if (details.terminationError) {
+    return {
+      exit_code: REPO_CLONE_TIMEOUT_EXIT_CODE,
+      category: 'timeout',
+      message:
+        `${prefix} Failed to confirm termination of the clone process tree: ` +
+        `${details.terminationError}. Partial checkout cleanup was skipped because files cannot ` +
+        'be removed safely while clone processes may still be running.',
+    };
+  }
+
+  if (details.cleanupError) {
+    return {
+      exit_code: REPO_CLONE_TIMEOUT_EXIT_CODE,
+      category: 'timeout',
+      message:
+        `${prefix} The clone process tree was terminated, but partial checkout cleanup failed: ` +
+        `${details.cleanupError}. Manual cleanup may be required.`,
+    };
+  }
+
+  return {
+    exit_code: REPO_CLONE_TIMEOUT_EXIT_CODE,
+    category: 'timeout',
+    message: `${prefix} The clone process tree was terminated and the partial checkout was removed.`,
+  };
+}
+
+/**
+ * Own the terminal-state race for one remote-repository clone.
+ *
+ * The state transition happens synchronously when timeout/cancellation wins,
+ * before any awaited work. Therefore a late executor-exit callback cannot
+ * reinterpret a timed-out clone as a normal completion. Timeout handling
+ * waits for the complete process tree before touching the partial checkout.
+ */
+export function superviseRepoClone(options: SuperviseRepoCloneOptions): RepoCloneSupervisor {
+  const timeoutMs = options.timeoutMs ?? REPO_CLONE_TIMEOUT_MS;
+  let state: CloneSupervisorState = 'running';
+  let resolveTimeout!: () => void;
+
+  const timeoutPromise = new Promise<void>((resolve) => {
+    resolveTimeout = resolve;
+  });
+
+  const timer = setTimeout(() => {
+    if (state !== 'running') return;
+    state = 'timing_out';
+    resolveTimeout();
+  }, timeoutMs);
+
+  const processExitPromise = options.process.completion.then((exit) => {
+    const stateAtExit = state;
+    if (state === 'running') state = 'exited';
+    return { exit, stateAtExit };
+  });
+
+  const completion = (async (): Promise<'exited' | 'timed_out' | 'cancelled'> => {
+    const winner = await Promise.race([
+      processExitPromise.then((result) => ({ kind: 'process' as const, result })),
+      timeoutPromise.then(() => ({ kind: 'timeout' as const })),
+    ]);
+
+    if (winner.kind === 'process') {
+      clearTimeout(timer);
+      if (winner.result.stateAtExit === 'cancelling') return 'cancelled';
+      if (winner.result.stateAtExit === 'timing_out') {
+        // The timeout branch owns cleanup/error persistence. Its promise was
+        // resolved before termination began and will win the race in practice;
+        // retaining this guard makes that ownership explicit.
+        return 'timed_out';
+      }
+
+      // The direct executor can exit while a git transport/index-pack child
+      // remains alive in its detached process group (the orphan observed in
+      // #2030). A normal exit owns no long-lived descendants, so quiesce and
+      // await the group before running either success or ordinary-failure
+      // handling. This does not reinterpret the exit as a timeout and does
+      // not remove failure artifacts.
+      let descendantTerminationError: unknown;
+      try {
+        await options.process.terminate();
+      } catch (error) {
+        descendantTerminationError = error;
+      }
+      await options.onExit(winner.result.exit);
+      if (descendantTerminationError) throw descendantTerminationError;
+      return 'exited';
+    }
+
+    let terminationError: string | undefined;
+    try {
+      await options.process.terminate();
+    } catch (error) {
+      terminationError = error instanceof Error ? error.message : String(error);
+    }
+
+    let cleanupError: string | undefined;
+    if (!terminationError) {
+      try {
+        await options.cleanupPartialClone();
+      } catch (error) {
+        cleanupError = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    const error = buildRepoCloneTimeoutError(timeoutMs, { cleanupError, terminationError });
+    await options.onTimeout({ error, cleanupError, terminationError });
+    if (terminationError) throw new Error(error.message);
+    return 'timed_out';
+  })();
+
+  return {
+    completion,
+    ensureTerminated: () => options.process.terminate(),
+    async cancel(): Promise<boolean> {
+      if (state !== 'running') return false;
+      state = 'cancelling';
+      clearTimeout(timer);
+      await options.process.terminate();
+      await completion;
+      return true;
+    },
+  };
+}

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -5,8 +5,9 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { spawnMock } = vi.hoisted(() => ({
+const { spawnMock, terminateProcessTreeMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
+  terminateProcessTreeMock: vi.fn((): Promise<void> => Promise.resolve()),
 }));
 
 vi.mock('node:child_process', () => ({
@@ -26,6 +27,10 @@ vi.mock('./build-resolved-config-slice.js', () => ({
     ...payload,
     resolvedConfig: {},
   }),
+}));
+
+vi.mock('./process-tree.js', () => ({
+  terminateProcessTree: terminateProcessTreeMock,
 }));
 
 function createMockProcess() {
@@ -51,6 +56,8 @@ describe('configured executor spawning', () => {
   beforeEach(async () => {
     vi.resetModules();
     spawnMock.mockReset();
+    terminateProcessTreeMock.mockReset();
+    terminateProcessTreeMock.mockResolvedValue(undefined);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -259,6 +266,38 @@ describe('configured executor spawning', () => {
       ['-c', "launch --tenant-id 'tenant-run' -- branch.inspect"],
       expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
     );
+  });
+
+  it('waits for process-tree termination before resolving a command timeout', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    let allowTermination!: () => void;
+    terminateProcessTreeMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        allowTermination = resolve;
+      })
+    );
+    const { runExecutorCommand } = await import('./spawn-executor');
+
+    let resolved = false;
+    const resultPromise = runExecutorCommand(
+      { command: 'branch.inspect' },
+      {
+        timeoutMs: 5,
+      }
+    ).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(terminateProcessTreeMock).toHaveBeenCalledOnce());
+    expect(resolved).toBe(false);
+
+    allowTermination();
+    await expect(resultPromise).resolves.toMatchObject({
+      success: false,
+      error: { code: 'EXECUTOR_TIMEOUT' },
+    });
   });
 
   it('refuses every unscoped executor launch when tenant context is required', async () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -38,6 +38,7 @@ import { getCurrentLogLevel } from '@agor/core/utils/logger';
 import type { SignOptions } from 'jsonwebtoken';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
+import { terminateProcessTree } from './process-tree.js';
 
 let configuredDaemonUrl: string | null = null;
 
@@ -109,6 +110,20 @@ export type ExecutorSpawnMode = 'local' | 'templated';
 
 export interface ExecutorSpawnContext {
   mode: ExecutorSpawnMode;
+}
+
+export interface ExecutorExitResult extends ExecutorSpawnContext {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface ExecutorProcessHandle {
+  /** Direct executor/wrapper PID. Descendants share its POSIX process group. */
+  readonly pid?: number;
+  readonly context: ExecutorSpawnContext;
+  readonly completion: Promise<ExecutorExitResult>;
+  /** Terminate the complete executor process tree and wait until it is gone. */
+  terminate(): Promise<void>;
 }
 
 export interface SpawnExecutorOptions {
@@ -258,6 +273,8 @@ export function findExecutorPath(): string {
  *
  * This is the SINGLE entry point for all executor spawning. It:
  * - Returns immediately after spawning (does NOT wait for completion)
+ * - Returns a process handle for the few lifecycle owners that need to
+ *   terminate/await the executor tree; ordinary callers may ignore it
  * - Supports both local subprocess and templated (k8s/docker) execution
  * - Logs stdout/stderr to daemon logs
  *
@@ -273,7 +290,7 @@ export function findExecutorPath(): string {
 export function spawnExecutor(
   payload: Record<string, unknown>,
   options: SpawnExecutorOptions = {}
-): void {
+): ExecutorProcessHandle {
   const { templateVariables, logPrefix = '[Executor]' } = options;
   const tenantId = resolveExecutorTenantId();
 
@@ -287,7 +304,7 @@ export function spawnExecutor(
   const payloadWithConfig = withResolvedConfig(payload);
 
   if (executorCommandTemplate) {
-    spawnExecutorWithTemplate(payloadWithConfig, {
+    return spawnExecutorWithTemplate(payloadWithConfig, {
       ...options,
       asUser,
       executorCommandTemplate,
@@ -302,7 +319,7 @@ export function spawnExecutor(
       logPrefix,
     });
   } else {
-    spawnExecutorLocal(payloadWithConfig, { ...options, asUser });
+    return spawnExecutorLocal(payloadWithConfig, { ...options, asUser });
   }
 }
 
@@ -310,7 +327,10 @@ export function spawnExecutor(
  * Spawn executor as a local subprocess.
  * stdout/stderr are inherited so logs appear in daemon output.
  */
-function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExecutorOptions): void {
+function spawnExecutorLocal(
+  payload: Record<string, unknown>,
+  options: SpawnExecutorOptions
+): ExecutorProcessHandle {
   const executorPath = findExecutorPath();
 
   // Default cwd to executor package directory for proper module resolution
@@ -408,7 +428,11 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     // conventional "command not found" exit code; close enough semantically
     // for "the cwd is gone" without inventing a new one.
     options.onExit?.(127, { mode: 'local' });
-    return;
+    return {
+      context: { mode: 'local' },
+      completion: Promise.resolve({ mode: 'local', code: 127, signal: null }),
+      async terminate() {},
+    };
   }
 
   let reportedExit = false;
@@ -418,12 +442,25 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     options.onExit?.(code, { mode: 'local' });
   };
 
+  const detachedProcessGroup = process.platform !== 'win32';
   const executorProcess = spawn(cmd, args, {
     cwd,
     env: asUser ? undefined : { ...envWithDaemonUrl }, // When impersonating, env is in the command; otherwise pass to spawn
     stdio: ['pipe', 'inherit', 'inherit'], // stdin: pipe, stdout/stderr: inherit (show in daemon logs)
-    detached: process.platform !== 'win32',
+    detached: detachedProcessGroup,
   });
+
+  let resolveCompletion!: (result: ExecutorExitResult) => void;
+  const completion = new Promise<ExecutorExitResult>((resolve) => {
+    resolveCompletion = resolve;
+  });
+  let completed = false;
+  const complete = (code: number | null, signal: NodeJS.Signals | null): void => {
+    if (completed) return;
+    completed = true;
+    reportExit(code);
+    resolveCompletion({ mode: 'local', code, signal });
+  };
 
   // Best-effort safety-net cleanup: the inner bash script `rm -f`s the env
   // file before exec, but if sudo/bash failed to launch — or `set -eu`
@@ -439,20 +476,30 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     // executable itself cannot be spawned (for example, missing sudo in a dev
     // image). Surface that through the normal onExit safety net so callers do
     // not leave persistent rows stuck in in-progress states.
-    reportExit(127);
+    complete(127, null);
   });
 
-  executorProcess.on('exit', (code) => {
+  executorProcess.on('exit', (code, signal) => {
     if (code === 0) {
       console.log(`${logPrefix} Executor completed successfully`);
     } else {
       console.error(`${logPrefix} Executor exited with code ${code}`);
     }
-    reportExit(code);
+    complete(code, signal);
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));
   executorProcess.stdin?.end();
+
+  return {
+    pid: executorProcess.pid,
+    context: { mode: 'local' },
+    completion,
+    terminate: () =>
+      terminateProcessTree(executorProcess, {
+        detachedProcessGroup,
+      }),
+  };
 }
 
 function spawnExecutorWithTemplate(
@@ -461,7 +508,7 @@ function spawnExecutorWithTemplate(
     executorCommandTemplate: string;
     templateVariables: ExecutorTemplateVariables;
   }
-): void {
+): ExecutorProcessHandle {
   const { executorCommandTemplate, templateVariables, logPrefix = '[Executor]' } = options;
   const logLevel = templateVariables.log_level ?? getCurrentLogLevel();
 
@@ -479,10 +526,24 @@ function spawnExecutorWithTemplate(
     options.onExit?.(code, { mode: 'templated' });
   };
 
+  const detachedProcessGroup = process.platform !== 'win32';
   const executorProcess = spawn('sh', ['-c', command], {
     env: { ...process.env, LOG_LEVEL: logLevel },
     stdio: ['pipe', 'pipe', 'pipe'],
+    detached: detachedProcessGroup,
   });
+
+  let resolveCompletion!: (result: ExecutorExitResult) => void;
+  const completion = new Promise<ExecutorExitResult>((resolve) => {
+    resolveCompletion = resolve;
+  });
+  let completed = false;
+  const complete = (code: number | null, signal: NodeJS.Signals | null): void => {
+    if (completed) return;
+    completed = true;
+    reportExit(code);
+    resolveCompletion({ mode: 'templated', code, signal });
+  };
 
   options.onSpawn?.(executorProcess, { mode: 'templated' });
 
@@ -496,10 +557,10 @@ function spawnExecutorWithTemplate(
 
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
-    reportExit(127);
+    complete(127, null);
   });
 
-  executorProcess.on('exit', (code) => {
+  executorProcess.on('exit', (code, signal) => {
     if (code === 0) {
       console.log(
         `${logPrefix} Executor completed successfully (task: ${templateVariables.task_id})`
@@ -509,11 +570,21 @@ function spawnExecutorWithTemplate(
         `${logPrefix} Executor exited with code ${code} (task: ${templateVariables.task_id})`
       );
     }
-    reportExit(code);
+    complete(code, signal);
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));
   executorProcess.stdin?.end();
+
+  return {
+    pid: executorProcess.pid,
+    context: { mode: 'templated' },
+    completion,
+    terminate: () =>
+      terminateProcessTree(executorProcess, {
+        detachedProcessGroup,
+      }),
+  };
 }
 
 const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';
@@ -681,11 +752,12 @@ function runExecutorCommandLocal(
     let stderr = '';
     let settled = false;
 
+    const detachedProcessGroup = process.platform !== 'win32';
     const child = spawn(cmd, args, {
       cwd,
       env: asUser ? undefined : { ...envWithDaemonUrl },
       stdio: ['pipe', 'pipe', 'pipe'],
-      detached: false,
+      detached: detachedProcessGroup,
     });
 
     attachEnvFileCleanup(child, { envFilePath: prepared.envFilePath, asUser });
@@ -693,15 +765,25 @@ function runExecutorCommandLocal(
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      child.kill('SIGTERM');
-      resolve({
-        success: false,
-        error: {
-          code: 'EXECUTOR_TIMEOUT',
-          message: `Executor command timed out after ${timeoutMs}ms`,
-          details: { command: payload.command },
-        },
-      });
+      void (async () => {
+        let terminationError: string | undefined;
+        try {
+          await terminateProcessTree(child, { detachedProcessGroup });
+        } catch (error) {
+          terminationError = error instanceof Error ? error.message : String(error);
+        }
+        resolve({
+          success: false,
+          error: {
+            code: 'EXECUTOR_TIMEOUT',
+            message: `Executor command timed out after ${timeoutMs}ms`,
+            details: {
+              command: payload.command,
+              ...(terminationError ? { terminationError } : {}),
+            },
+          },
+        });
+      })();
     }, timeoutMs);
 
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -781,23 +863,36 @@ function runExecutorCommandWithTemplate(
     let stderr = '';
     let settled = false;
 
+    const detachedProcessGroup = process.platform !== 'win32';
     const child = spawn('sh', ['-c', command], {
       env: { ...process.env, LOG_LEVEL: logLevel },
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: detachedProcessGroup,
     });
 
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      child.kill('SIGTERM');
-      resolve({
-        success: false,
-        error: {
-          code: 'EXECUTOR_TIMEOUT',
-          message: `Executor command timed out after ${timeoutMs}ms`,
-          details: { command: payload.command, taskId: templateVariables.task_id },
-        },
-      });
+      void (async () => {
+        let terminationError: string | undefined;
+        try {
+          await terminateProcessTree(child, { detachedProcessGroup });
+        } catch (error) {
+          terminationError = error instanceof Error ? error.message : String(error);
+        }
+        resolve({
+          success: false,
+          error: {
+            code: 'EXECUTOR_TIMEOUT',
+            message: `Executor command timed out after ${timeoutMs}ms`,
+            details: {
+              command: payload.command,
+              taskId: templateVariables.task_id,
+              ...(terminationError ? { terminationError } : {}),
+            },
+          },
+        });
+      })();
     }, timeoutMs);
 
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -975,8 +1070,8 @@ export function createConfiguredSpawner(executionConfig?: ExecutorConfig) {
   return function configuredSpawnExecutor(
     payload: Record<string, unknown>,
     options: Omit<SpawnExecutorOptions, 'executorCommandTemplate'> = {}
-  ): void {
-    spawnExecutor(payload, {
+  ): ExecutorProcessHandle {
+    return spawnExecutor(payload, {
       ...options,
       // `null` intentionally suppresses module-level defaults so this
       // factory remains an explicit dependency-injection variant rather than
@@ -990,8 +1085,7 @@ export function createConfiguredSpawner(executionConfig?: ExecutorConfig) {
   };
 }
 
-// `spawnExecutorFireAndForget` is the canonical name used by ~10 call sites
-// across daemon/services and daemon/register-hooks. We keep it as the public
-// name because that's what callers expect; `spawnExecutor` remains the
-// underlying implementation.
+// `spawnExecutorFireAndForget` is the canonical name used by ~10 call sites.
+// Ignoring its returned handle preserves that behavior; clone lifecycle
+// owners retain the handle so timeout/cancellation can contain the process.
 export const spawnExecutorFireAndForget = spawnExecutor;

--- a/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
+++ b/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
@@ -8,6 +8,7 @@
 
 import type { Board, Repo } from '@agor-live/client';
 import {
+  Alert,
   Checkbox,
   Form,
   Input,
@@ -27,6 +28,10 @@ import {
   resolveUiBranchStorageConfig,
 } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
+import {
+  getRepoBranchCreationBlockReason,
+  isRepoReadyForBranchCreation,
+} from '@/utils/repoReadiness';
 
 /**
  * Default depth pre-filled into the "Depth" input when the user selects
@@ -90,6 +95,10 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
     [branchStorageConfig]
   );
   const previousDefaultStorageMode = useRef<BranchStorageMode | undefined>(undefined);
+  const repos = useMemo(() => mapToArray(repoById), [repoById]);
+  const selectedRepo = selectedRepoId ? repoById.get(selectedRepoId) : undefined;
+  const selectedRepoBlockReason = getRepoBranchCreationBlockReason(selectedRepo);
+  const hasReadyRepo = repos.some(isRepoReadyForBranchCreation);
 
   useEffect(() => {
     const current = form.getFieldValue(storageFieldName) as BranchStorageMode | undefined;
@@ -120,7 +129,16 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
       <Form.Item
         name={`${fieldPrefix}repoId`}
         label="Repository"
-        rules={[{ required: true, message: 'Please select a repository' }]}
+        rules={[
+          { required: true, message: 'Please select a repository' },
+          {
+            validator: (_, repoId: string | undefined) => {
+              if (!repoId) return Promise.resolve();
+              const reason = getRepoBranchCreationBlockReason(repoById.get(repoId));
+              return reason ? Promise.reject(new Error(reason)) : Promise.resolve();
+            },
+          },
+        ]}
         validateTrigger={['onBlur', 'onChange']}
       >
         <Select
@@ -131,15 +149,50 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
               .toLowerCase()
               .includes(input.toLowerCase())
           }
-          options={mapToArray(repoById)
+          options={repos
             .sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug))
-            .map((repo: Repo) => ({
-              value: repo.repo_id,
-              label: repo.name || repo.slug,
-            }))}
+            .map((repo: Repo) => {
+              const blockReason = getRepoBranchCreationBlockReason(repo);
+              const statusSuffix =
+                repo.clone_status === 'failed'
+                  ? ' — Clone failed'
+                  : repo.clone_status === 'cloning'
+                    ? ' — Cloning'
+                    : '';
+              return {
+                value: repo.repo_id,
+                label: `${repo.name || repo.slug}${statusSuffix}`,
+                disabled: !isRepoReadyForBranchCreation(repo),
+                title: blockReason,
+              };
+            })}
           onChange={onRepoChange}
         />
       </Form.Item>
+
+      {selectedRepoBlockReason ? (
+        <Alert
+          type={selectedRepo?.clone_status === 'failed' ? 'error' : 'info'}
+          showIcon
+          title={
+            selectedRepo?.clone_status === 'failed'
+              ? 'Repository clone failed'
+              : 'Repository clone in progress'
+          }
+          description={selectedRepoBlockReason}
+          style={{ marginBottom: 24 }}
+        />
+      ) : (
+        !hasReadyRepo && (
+          <Alert
+            type="warning"
+            showIcon
+            title="No repositories are ready"
+            description="Wait for a repository clone to finish or retry a failed clone before creating a branch."
+            style={{ marginBottom: 24 }}
+          />
+        )
+      )}
 
       {showBoardSelector && (
         <Form.Item

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
@@ -148,3 +148,115 @@ describe('BranchTab — branch storage policy', () => {
     expect(result!.storage_mode).toBe('worktree');
   });
 });
+
+describe('BranchTab — repository clone readiness', () => {
+  it('does not select or submit a failed repository', async () => {
+    const formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null> = {
+      current: null,
+    };
+    const repo = makeRepo({
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+    });
+    const board = makeBoard();
+    const onValidityChange = vi.fn();
+
+    render(
+      <BranchTab
+        repoById={new Map([[repo.repo_id, repo]])}
+        boardById={new Map([[board.board_id, board]])}
+        currentBoardId={board.board_id}
+        onValidityChange={onValidityChange}
+        formRef={formRef}
+      />
+    );
+
+    expect(screen.getByText('No repositories are ready')).toBeInTheDocument();
+    expect(await formRef.current?.()).toBeNull();
+    expect(onValidityChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('skips a failed last-used repository and initializes the first ready repository', async () => {
+    const formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null> = {
+      current: null,
+    };
+    const failed = makeRepo({
+      repo_id: 'repo-failed',
+      name: 'failed',
+      clone_status: 'failed',
+    });
+    const ready = makeRepo({
+      repo_id: 'repo-ready',
+      name: 'ready',
+      default_branch: 'develop',
+      clone_status: 'ready',
+    });
+    localStorage.setItem('agor-last-repo-id', failed.repo_id);
+
+    render(
+      <BranchTab
+        repoById={
+          new Map([
+            [failed.repo_id, failed],
+            [ready.repo_id, ready],
+          ])
+        }
+        onValidityChange={vi.fn()}
+        formRef={formRef}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByLabelText(/Source Branch/i)).toHaveValue('develop'));
+  });
+
+  it('invalidates an open form if the selected clone later fails', async () => {
+    const formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null> = {
+      current: null,
+    };
+    const board = makeBoard();
+    const ready = makeRepo({ clone_status: 'ready' });
+    const onValidityChange = vi.fn();
+    const { rerender } = render(
+      <BranchTab
+        repoById={new Map([[ready.repo_id, ready]])}
+        boardById={new Map([[board.board_id, board]])}
+        currentBoardId={board.board_id}
+        onValidityChange={onValidityChange}
+        formRef={formRef}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Branch Name/i), {
+      target: { value: 'new-branch' },
+    });
+    await waitFor(() => expect(onValidityChange).toHaveBeenCalledWith(true));
+
+    const failed = makeRepo({
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+    });
+    rerender(
+      <BranchTab
+        repoById={new Map([[failed.repo_id, failed]])}
+        boardById={new Map([[board.board_id, board]])}
+        currentBoardId={board.board_id}
+        onValidityChange={onValidityChange}
+        formRef={formRef}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    });
+    expect(screen.getByText('Repository clone failed')).toBeInTheDocument();
+    expect(await formRef.current?.()).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
+import { isRepoReadyForBranchCreation } from '@/utils/repoReadiness';
 import { BranchFormFields } from '../../BranchFormFields';
 
 export interface BranchTabConfig {
@@ -52,13 +53,28 @@ export const BranchTab: React.FC<BranchTabProps> = ({
 
   const selectedRepo = selectedRepoId ? repoById.get(selectedRepoId) : undefined;
 
+  // A ready clone can still transition to failed from a daemon event while
+  // this form is open. Disable the parent action immediately; submit-time
+  // validation below remains the final UI guard.
+  useEffect(() => {
+    if (selectedRepoId && !isRepoReadyForBranchCreation(selectedRepo)) {
+      onValidityChange(false);
+    }
+  }, [onValidityChange, selectedRepo, selectedRepoId]);
+
   const handleValuesChange = useCallback(() => {
     setTimeout(() => {
       const values = form.getFieldsValue();
-      const isValid = !!(values.repoId && values.sourceBranch && values.name && values.boardId);
+      const isValid = !!(
+        values.repoId &&
+        isRepoReadyForBranchCreation(repoById.get(values.repoId)) &&
+        values.sourceBranch &&
+        values.name &&
+        values.boardId
+      );
       onValidityChange(isValid);
     }, 0);
-  }, [form, onValidityChange]);
+  }, [form, onValidityChange, repoById]);
 
   // Initialize form once per mount. Without this guard the effect re-fires
   // on every `repos.patched` WebSocket event (which gives `repoById` a new
@@ -71,7 +87,10 @@ export const BranchTab: React.FC<BranchTabProps> = ({
     if (initialized.current || repoById.size === 0) return;
 
     const lastRepoId = localStorage.getItem('agor-last-repo-id');
-    if (lastRepoId && repoById.has(lastRepoId)) {
+    const readyRepos = mapToArray(repoById).filter(isRepoReadyForBranchCreation);
+    if (readyRepos.length === 0) return;
+
+    if (lastRepoId && isRepoReadyForBranchCreation(repoById.get(lastRepoId))) {
       initialized.current = true;
       form.setFieldsValue({
         repoId: lastRepoId,
@@ -80,9 +99,9 @@ export const BranchTab: React.FC<BranchTabProps> = ({
       });
       setSelectedRepoId(lastRepoId);
       handleValuesChange();
-    } else if (repoById.size > 0) {
+    } else {
       initialized.current = true;
-      const firstRepo = mapToArray(repoById)[0];
+      const firstRepo = readyRepos[0];
       form.setFieldsValue({
         repoId: firstRepo.repo_id,
         sourceBranch: firstRepo.default_branch,

--- a/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.test.tsx
+++ b/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.test.tsx
@@ -111,3 +111,28 @@ describe('NewBranchModal — source-branch preservation', { timeout: 10_000 }, (
     expect((screen.getByLabelText(/Source Branch/i) as HTMLInputElement).value).toBe('develop');
   });
 });
+
+describe('NewBranchModal — repository clone readiness', () => {
+  it('keeps branch creation disabled when every repository clone failed', () => {
+    const repo = makeRepo({
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+    });
+
+    render(
+      <NewBranchModal
+        open
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        repoById={new Map([[repo.repo_id, repo]])}
+      />
+    );
+
+    expect(screen.getByText('No repositories are ready')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Create Branch/i })).toBeDisabled();
+  });
+});

--- a/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
+++ b/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
+import { isRepoReadyForBranchCreation } from '@/utils/repoReadiness';
 import { BranchFormFields } from '../BranchFormFields';
 import type { BranchTabConfig } from '../CreateDialog/tabs/BranchTab';
 
@@ -37,6 +38,12 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
 
   const selectedRepo = selectedRepoId ? repoById.get(selectedRepoId) : undefined;
 
+  useEffect(() => {
+    if (selectedRepoId && !isRepoReadyForBranchCreation(selectedRepo)) {
+      setIsFormValid(false);
+    }
+  }, [selectedRepo, selectedRepoId]);
+
   // Form validation handler
   const handleValuesChange = useCallback(() => {
     // Use setTimeout to ensure we're checking after the form state has updated
@@ -44,10 +51,16 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
       const values = form.getFieldsValue();
 
       // Check if required fields are filled
-      const isValid = !!(values.repoId && values.sourceBranch && values.name && values.boardId);
+      const isValid = !!(
+        values.repoId &&
+        isRepoReadyForBranchCreation(repoById.get(values.repoId)) &&
+        values.sourceBranch &&
+        values.name &&
+        values.boardId
+      );
       setIsFormValid(isValid);
     }, 0);
-  }, [form]);
+  }, [form, repoById]);
 
   // Initialize form once per modal-open session. Without this guard the
   // effect re-fires on every `repos.patched` WebSocket event (which gives
@@ -64,9 +77,11 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
     if (initialized.current || repoById.size === 0) return;
 
     const lastRepoId = localStorage.getItem('agor-last-repo-id');
+    const readyRepos = mapToArray(repoById).filter(isRepoReadyForBranchCreation);
+    if (readyRepos.length === 0) return;
 
     // If we have a last used repo and it still exists, use it
-    if (lastRepoId && repoById.has(lastRepoId)) {
+    if (lastRepoId && isRepoReadyForBranchCreation(repoById.get(lastRepoId))) {
       initialized.current = true;
       form.setFieldsValue({
         repoId: lastRepoId,
@@ -76,10 +91,10 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
       setSelectedRepoId(lastRepoId);
       // Trigger validation check
       handleValuesChange();
-    } else if (repoById.size > 0) {
+    } else {
       // No last-repo-id or it doesn't exist anymore - auto-select first repo
       initialized.current = true;
-      const firstRepo = mapToArray(repoById)[0];
+      const firstRepo = readyRepos[0];
       form.setFieldsValue({
         repoId: firstRepo.repo_id,
         sourceBranch: firstRepo.default_branch,

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.test.tsx
@@ -86,3 +86,28 @@ describe('BranchesTable — source-branch preservation', { timeout: 10_000 }, ()
     );
   });
 });
+
+describe('BranchesTable — repository clone readiness', () => {
+  it('disables branch creation when no repository clone is ready', () => {
+    const repo = makeRepo({
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+    });
+
+    renderWithProviders(
+      <BranchesTable
+        client={null}
+        branchById={new Map()}
+        repoById={new Map([[repo.repo_id, repo]])}
+        boardById={new Map()}
+        sessionsByBranch={new Map()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Create Branch/i })).toBeDisabled();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
+import { isRepoReadyForBranchCreation } from '@/utils/repoReadiness';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveToggleButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
@@ -85,8 +86,9 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
   onClose,
   branchStorageConfig,
 }) => {
-  const repos = mapToArray(repoById);
-  const boards = mapToArray(boardById);
+  const repos = useMemo(() => mapToArray(repoById), [repoById]);
+  const readyRepos = useMemo(() => repos.filter(isRepoReadyForBranchCreation), [repos]);
+  const boards = useMemo(() => mapToArray(boardById), [boardById]);
   const { token } = theme.useToken();
   // Reuses the `branchById` prop so we don't read the same data via
   // both props and context. Only goToBranch is used from this table.
@@ -121,6 +123,15 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
   const [archivedLoaded, setArchivedLoaded] = useState(false);
   const [archivedLoading, setArchivedLoading] = useState(false);
   const archivedFetchingRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      selectedRepoId &&
+      !isRepoReadyForBranchCreation(repoById.get(selectedRepoId as Repo['repo_id']))
+    ) {
+      setIsFormValid(false);
+    }
+  }, [repoById, selectedRepoId]);
 
   // No need for reposById anymore, we already have it as a prop
 
@@ -162,14 +173,14 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
   // Validate form fields to enable/disable Create button
   const validateForm = useCallback(() => {
     const values = form.getFieldsValue();
-    const hasRepo = !!values.repoId;
+    const hasRepo = !!values.repoId && isRepoReadyForBranchCreation(repoById.get(values.repoId));
     const hasSourceBranch = !!values.sourceBranch;
     const hasName = !!values.name && /^[a-z0-9-]+$/.test(values.name);
     const hasBranchName = useSameBranchName || !!values.branchName;
     const hasBoard = !!values.boardId;
 
     setIsFormValid(hasRepo && hasSourceBranch && hasName && hasBranchName && hasBoard);
-  }, [form, useSameBranchName]);
+  }, [form, repoById, useSameBranchName]);
 
   // Initialize form once per modal-open session. Without the useRef guard
   // the effect re-fires whenever `repoById` / `boardById` get new Map
@@ -184,7 +195,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
       createInitialized.current = false;
       return;
     }
-    if (createInitialized.current || repos.length === 0) return;
+    if (createInitialized.current || readyRepos.length === 0) return;
     createInitialized.current = true;
 
     // Get last used values from localStorage or use first repo/board
@@ -192,9 +203,9 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
     const lastBoardId = localStorage.getItem('agor:lastUsedBoardId');
 
     const defaultRepoId =
-      lastRepoId && repos.find((r: Repo) => r.repo_id === lastRepoId)
+      lastRepoId && readyRepos.find((r: Repo) => r.repo_id === lastRepoId)
         ? lastRepoId
-        : repos[0].repo_id;
+        : readyRepos[0].repo_id;
 
     const defaultBoardId =
       lastBoardId && boards.find((b: Board) => b.board_id === lastBoardId)
@@ -207,12 +218,13 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
     form.setFieldsValue({
       repoId: defaultRepoId,
       boardId: defaultBoardId,
-      sourceBranch: repos.find((r: Repo) => r.repo_id === defaultRepoId)?.default_branch || 'main',
+      sourceBranch:
+        readyRepos.find((r: Repo) => r.repo_id === defaultRepoId)?.default_branch || 'main',
     });
 
     setSelectedRepoId(defaultRepoId);
     validateForm();
-  }, [createModalOpen, repos, boards, form, validateForm]);
+  }, [createModalOpen, readyRepos, boards, form, validateForm]);
 
   // Helper to get repo name from repo_id
   const getRepoName = (repoId: string): string => {
@@ -567,14 +579,24 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
               ]}
             />
           </Space>
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => setCreateModalOpen(true)}
-            disabled={repos.length === 0}
+          <Tooltip
+            title={
+              repos.length > 0 && readyRepos.length === 0
+                ? 'Wait for a repository clone to finish or retry a failed clone.'
+                : undefined
+            }
           >
-            Create Branch
-          </Button>
+            <span>
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                onClick={() => setCreateModalOpen(true)}
+                disabled={readyRepos.length === 0}
+              >
+                Create Branch
+              </Button>
+            </span>
+          </Tooltip>
         </Space>
       </Space>
 

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
@@ -52,3 +52,22 @@ describe('ReposTable search', () => {
     expect(screen.getByText('preset-docs').tagName.toLowerCase()).toBe('mark');
   });
 });
+
+describe('ReposTable clone state', () => {
+  it('shows the durable clone failure category and message', () => {
+    const repo = makeRepo({
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out after 30 minutes.',
+      },
+    });
+
+    render(<ReposTable repoById={new Map([[repo.repo_id, repo]])} />);
+
+    expect(screen.getByText('Clone failed')).toBeInTheDocument();
+    expect(screen.getByText('Repository clone failed (timeout)')).toBeInTheDocument();
+    expect(screen.getByText('Clone timed out after 30 minutes.')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -1,7 +1,7 @@
 import type { CreateLocalRepoRequest, CreateRepoRequest, Repo } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, FolderOutlined, PlusOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
-import { Button, Card, Empty, Form, Input, Modal, Space, Typography } from 'antd';
+import { Alert, Button, Card, Empty, Form, Input, Modal, Space, Typography } from 'antd';
 import { useMemo, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
@@ -205,6 +205,8 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                     <Tag color={tagColor} style={{ marginLeft: 8 }}>
                       <HighlightMatch text={tagLabel} query={searchTerm} />
                     </Tag>
+                    {repo.clone_status === 'cloning' && <Tag color="gold">Cloning</Tag>}
+                    {repo.clone_status === 'failed' && <Tag color="red">Clone failed</Tag>}
                   </Space>
                 }
                 extra={
@@ -227,6 +229,27 @@ export const ReposTable: React.FC<ReposTableProps> = ({
               >
                 {/* Repo metadata */}
                 <Space orientation="vertical" size={8} style={{ width: '100%' }}>
+                  {repo.clone_status === 'cloning' && (
+                    <Alert
+                      type="info"
+                      showIcon
+                      title="Repository clone in progress"
+                      description="Branch creation will be available after the clone finishes."
+                    />
+                  )}
+                  {repo.clone_status === 'failed' && (
+                    <Alert
+                      type="error"
+                      showIcon
+                      title={`Repository clone failed${
+                        repo.clone_error?.category ? ` (${repo.clone_error.category})` : ''
+                      }`}
+                      description={
+                        repo.clone_error?.message ||
+                        'The repository checkout is unavailable or incomplete.'
+                      }
+                    />
+                  )}
                   <div>
                     <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                       Slug:{' '}

--- a/apps/agor-ui/src/utils/repoReadiness.test.ts
+++ b/apps/agor-ui/src/utils/repoReadiness.test.ts
@@ -1,0 +1,37 @@
+import type { Repo } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { getRepoBranchCreationBlockReason, isRepoReadyForBranchCreation } from './repoReadiness';
+
+function repo(overrides: Partial<Repo>): Repo {
+  return {
+    repo_id: 'repo-1',
+    slug: 'org/repo',
+    name: 'Repo',
+    repo_type: 'remote',
+    ...overrides,
+  } as Repo;
+}
+
+describe('repository branch readiness', () => {
+  it('allows ready and legacy rows but blocks active/failed clones', () => {
+    expect(isRepoReadyForBranchCreation(repo({ clone_status: 'ready' }))).toBe(true);
+    expect(isRepoReadyForBranchCreation(repo({ clone_status: undefined }))).toBe(true);
+    expect(isRepoReadyForBranchCreation(repo({ clone_status: 'cloning' }))).toBe(false);
+    expect(isRepoReadyForBranchCreation(repo({ clone_status: 'failed' }))).toBe(false);
+  });
+
+  it('surfaces the durable timeout category and message', () => {
+    expect(
+      getRepoBranchCreationBlockReason(
+        repo({
+          clone_status: 'failed',
+          clone_error: {
+            exit_code: 124,
+            category: 'timeout',
+            message: 'Clone timed out after 30 minutes.',
+          },
+        })
+      )
+    ).toMatch(/failed \(timeout\).*Clone timed out after 30 minutes.*Retry/i);
+  });
+});

--- a/apps/agor-ui/src/utils/repoReadiness.ts
+++ b/apps/agor-ui/src/utils/repoReadiness.ts
@@ -1,0 +1,27 @@
+import type { Repo } from '@agor-live/client';
+
+/**
+ * Legacy/local repository rows may not have clone_status. Explicit remote
+ * lifecycle states are ready only after materialization completes.
+ */
+export function isRepoReadyForBranchCreation(repo: Repo | undefined): boolean {
+  return !!repo && (repo.clone_status === undefined || repo.clone_status === 'ready');
+}
+
+export function getRepoBranchCreationBlockReason(repo: Repo | undefined): string | undefined {
+  if (!repo) return undefined;
+
+  if (repo.clone_status === 'cloning') {
+    return 'Repository clone is still in progress. Wait for it to finish before creating a branch.';
+  }
+
+  if (repo.clone_status === 'failed') {
+    const category = repo.clone_error?.category ? ` (${repo.clone_error.category})` : '';
+    const detail = repo.clone_error?.message
+      ? ` ${repo.clone_error.message}`
+      : ' The repository checkout is unavailable or incomplete.';
+    return `Repository clone failed${category}.${detail} Retry the clone before creating a branch.`;
+  }
+
+  return undefined;
+}

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -832,6 +832,33 @@ describe('BranchRepository.update', () => {
     expect(updated2.base_ref).toBe('develop');
   });
 
+  dbTest('does not let a late clone completion overwrite a timeout outcome', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const repo = await repoRepo.create(createRepoData());
+    const data = createBranchData({ repo_id: repo.repo_id, storage_mode: 'clone' });
+    await branchRepo.create({
+      ...data,
+      filesystem_status: 'failed',
+      error_message:
+        'Clone timed out after 30 minutes. The clone process tree was terminated and the partial checkout was removed.',
+    });
+
+    const lateCompletion = await branchRepo.update(data.branch_id, {
+      filesystem_status: 'ready',
+      error_message: undefined,
+      unix_group: 'late-executor-group',
+    });
+    const persisted = await branchRepo.findById(data.branch_id);
+
+    expect(lateCompletion).toMatchObject({
+      filesystem_status: 'failed',
+      error_message: expect.stringMatching(/^Clone timed out after 30 minutes/),
+    });
+    expect(lateCompletion.unix_group).toBeUndefined();
+    expect(persisted).toMatchObject(lateCompletion);
+  });
+
   dbTest('should update all field types comprehensively', async ({ db }) => {
     const repoRepo = new RepoRepository(db);
     const wtRepo = new BranchRepository(db);

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -553,6 +553,22 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
 
       const current = this.rowToBranch(currentRow, baseUrl);
 
+      // Clone-mode timeout cleanup makes the branch path unavailable. A
+      // final executor patch may already be queued when that timeout wins;
+      // row locking plus this terminal-state precedence makes both write
+      // orders converge on the timeout rather than allowing a late `ready`
+      // (or generic failure) patch to describe deleted filesystem state.
+      const cloneTimeoutAlreadyWon =
+        current.filesystem_status === 'failed' &&
+        current.error_message?.startsWith('Clone timed out after');
+      const incomingFilesystemOutcome = updates.filesystem_status;
+      const repeatsCloneTimeout =
+        incomingFilesystemOutcome === 'failed' &&
+        updates.error_message?.startsWith('Clone timed out after');
+      if (cloneTimeoutAlreadyWon && incomingFilesystemOutcome && !repeatsCloneTimeout) {
+        return current;
+      }
+
       // STEP 3: Deep merge updates into current branch (in memory)
       // Preserves nested objects like schedule, environment_instance, custom_context
       const merged = deepMerge(current, {

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -576,6 +576,68 @@ describe('RepoRepository.update', () => {
     expect(updated.local_path).toBe('/new/path');
   });
 
+  dbTest('does not let a late clone completion overwrite a timeout outcome', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create({
+      ...data,
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out and the partial checkout was removed.',
+      },
+    });
+
+    const lateCompletion = await repo.update(data.repo_id, {
+      name: 'Late executor name',
+      local_path: '/path/from/late-completion',
+      clone_status: 'ready',
+      clone_error: undefined,
+    });
+    const persisted = await repo.findById(data.repo_id);
+
+    expect(lateCompletion).toMatchObject({
+      name: data.name,
+      local_path: data.local_path,
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+      },
+    });
+    expect(persisted).toMatchObject(lateCompletion);
+  });
+
+  dbTest('does not let a late ordinary failure replace timeout classification', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create({
+      ...data,
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 124,
+        category: 'timeout',
+        message: 'Clone timed out.',
+      },
+    });
+
+    const lateFailure = await repo.update(data.repo_id, {
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 1,
+        category: 'network',
+        message: 'Connection reset.',
+      },
+    });
+
+    expect(lateFailure.clone_error).toMatchObject({
+      exit_code: 124,
+      category: 'timeout',
+      message: 'Clone timed out.',
+    });
+  });
+
   dbTest('should update local repo without requiring remote_url', async ({ db }) => {
     const repo = new RepoRepository(db);
     const data = createRepoData({

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -360,6 +360,25 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
 
         const current = this.rowToRepo(currentRow);
 
+        // A timeout is the authoritative terminal outcome for this clone
+        // attempt. The executor may already have sent its final `ready` or
+        // ordinary `failed` patch when the daemon's timeout wins; row locking
+        // serializes the writes, and this precedence rule makes either order
+        // converge on the timeout instead of allowing a late completion to
+        // resurrect a checkout that the timeout path already removed.
+        //
+        // Failed rows are deleted before retry, so accepting a non-timeout
+        // clone-status transition from a timeout row is never a legitimate
+        // retry path. Metadata-only edits remain allowed.
+        const timeoutAlreadyWon =
+          current.clone_status === 'failed' && current.clone_error?.category === 'timeout';
+        const incomingCloneOutcome = updates.clone_status;
+        const repeatsTimeoutOutcome =
+          incomingCloneOutcome === 'failed' && updates.clone_error?.category === 'timeout';
+        if (timeoutAlreadyWon && incomingCloneOutcome && !repeatsTimeoutOutcome) {
+          return current;
+        }
+
         // STEP 2: Deep merge updates into current repo (in memory)
         // Preserves nested objects like permission_config when doing partial updates
         const merged = deepMerge(current, updates);

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -568,7 +568,7 @@ export const repos = pgTable(
         clone_status?: 'cloning' | 'ready' | 'failed';
         clone_error?: {
           exit_code: number;
-          category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
+          category: 'auth_failed' | 'not_found' | 'network' | 'timeout' | 'unknown';
           message: string;
         };
         // v2 environment config — source of truth. Named variants + optional

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -560,7 +560,7 @@ export const repos = sqliteTable(
         clone_status?: 'cloning' | 'ready' | 'failed';
         clone_error?: {
           exit_code: number;
-          category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
+          category: 'auth_failed' | 'not_found' | 'network' | 'timeout' | 'unknown';
           message: string;
         };
         // v2 environment config — source of truth. Named variants + optional

--- a/packages/core/src/git/index.test.ts
+++ b/packages/core/src/git/index.test.ts
@@ -1594,6 +1594,12 @@ describe('categorizeGitError', () => {
     ).toBe('network');
   });
 
+  it('categorizes clone lifecycle timeouts separately from network failures', () => {
+    expect(categorizeGitError('Clone timed out after 30 minutes.')).toBe('timeout');
+    expect(categorizeGitError('GitPluginError: block timeout reached')).toBe('timeout');
+    expect(categorizeGitError('fatal: operation timed out')).toBe('network');
+  });
+
   it('falls through to unknown for unrecognised stderr', () => {
     expect(categorizeGitError('fatal: corrupted ref refs/heads/main')).toBe('unknown');
     expect(categorizeGitError('')).toBe('unknown');

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -158,7 +158,12 @@ export interface Repo {
 
 export type RepoCloneStatus = 'cloning' | 'ready' | 'failed';
 
-export type RepoCloneErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
+export type RepoCloneErrorCategory =
+  | 'auth_failed'
+  | 'not_found'
+  | 'network'
+  | 'timeout'
+  | 'unknown';
 
 export interface RepoCloneError {
   exit_code: number;

--- a/packages/git/src/clone-error.test.ts
+++ b/packages/git/src/clone-error.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { categorizeGitError } from './index.js';
+
+describe('categorizeGitError', () => {
+  it('distinguishes clone lifecycle timeouts from remote network timeouts', () => {
+    expect(categorizeGitError('Clone timed out after 30 minutes.')).toBe('timeout');
+    expect(categorizeGitError('GitPluginError: block timeout reached')).toBe('timeout');
+    expect(categorizeGitError('fatal: operation timed out')).toBe('network');
+  });
+});

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -24,7 +24,12 @@ import {
   stripGitUrlCredentials,
 } from './pure';
 
-export type RepoCloneErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
+export type RepoCloneErrorCategory =
+  | 'auth_failed'
+  | 'not_found'
+  | 'network'
+  | 'timeout'
+  | 'unknown';
 
 /**
  * Validate a user-supplied git ref (branch name, tag) before it is passed to
@@ -366,6 +371,13 @@ async function resolveAuthHost(repoPath: string): Promise<string> {
  */
 export function categorizeGitError(stderr: string): RepoCloneErrorCategory {
   const s = stderr.toLowerCase();
+  if (
+    s.includes('clone timed out after') ||
+    s.includes('git clone timed out') ||
+    s.includes('block timeout reached')
+  ) {
+    return 'timeout';
+  }
   if (
     s.includes('authentication failed') ||
     s.includes('could not read username') ||

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -44,7 +44,6 @@ const checks = [
       'apps/agor-daemon/src/services/artifacts.test.ts': 1,
       'apps/agor-daemon/src/services/artifacts.ts': 1,
       'apps/agor-daemon/src/services/boards.ts': 2,
-      'apps/agor-daemon/src/services/repos.ts': 1,
       // Claude CLI launch and Stop target only the owning user's terminal room.
       'apps/agor-daemon/src/services/claude-cli-integration.ts': 4,
       // The tenant-aware realtime facade: tenant/session channel join, the


### PR DESCRIPTION
## Summary

- supervise remote repository and self-standing branch clones with an explicit lifecycle owner
- terminate and await the full clone process tree on timeout or cancellation, then safely remove partial clone state
- persist a timeout-specific `clone_error` and prevent late executor events from overwriting the timeout outcome
- block branch creation while a repository is cloning or after its clone has failed, with matching UI readiness/error handling
- cover both initial clone and clone-mode branch creation/unarchive paths without changing full-history clone behavior

## Root cause

The observed ~300-second boundary was not a `simple-git` clone timeout. Remote clone executors inherited the default five-minute scoped service-token lifetime. The daemon launched the executor fire-and-forget and only observed the direct process, while the actual clone could continue in descendant Git transport/index-pack processes. Once the token expired, long clones could no longer report a truthful terminal state, and direct-process handling did not guarantee descendant termination or partial-directory cleanup.

## Design

- Start supervised executor commands in dedicated POSIX process groups (or use `taskkill /T` on Windows).
- On timeout, atomically claim terminal-state ownership, terminate the full group with TERM/KILL escalation, await quiescence, and only then run executor-mediated safe cleanup.
- Use a 30-minute full-clone timeout, a bounded two-minute cleanup window, and a clone-specific token lifetime that covers both plus scheduling margin.
- Preserve explicit user deletion as cancellation rather than classifying it as timeout; cancellation awaits termination before preserving or deleting filesystem state.
- Persist `clone_error.category: timeout` with exit code 124 and messages that truthfully distinguish successful cleanup, cleanup failure, and inability to prove process-tree termination.
- Add repository/branch repository precedence guards so late `ready` or generic failure patches cannot replace a timeout state.
- Keep full clones as the default. The timeout is intentionally internal and fixed for now; progress-aware/configurable policy can be added separately once progress reporting and operator-facing configuration semantics are defined.

## Issue #2031

This also captures failed clone state and prevents branch creation against repositories whose clone is still in progress or failed. API/MCP and all current UI branch-creation entry points now surface the durable clone error instead of proceeding against an absent or partial checkout.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/git exec vitest run src/clone-error.test.ts` — 1 test
- `pnpm --filter @agor/core exec vitest run src/db/repositories/repos.test.ts src/db/repositories/branches.test.ts src/git/index.test.ts` — 198 tests
- `pnpm --filter @agor/daemon exec vitest run src/services/repos.test.ts src/utils/process-tree.test.ts src/utils/repo-clone-supervisor.test.ts src/utils/spawn-executor.configured.test.ts` — 29 tests
- `pnpm --filter agor-ui exec vitest run src/utils/repoReadiness.test.ts src/components/CreateDialog/tabs/BranchTab.test.tsx src/components/NewBranchModal/NewBranchModal.test.tsx src/components/SettingsModal/BranchesTable.test.tsx src/components/SettingsModal/ReposTable.test.tsx` — 16 tests

Closes #2030
Closes #2031
