### PR TITLE
fix(executor): supervise Codex post-progress stalls

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -265,6 +265,19 @@ describe('TasksService completion callbacks', () => {
     );
   });
 
+  it('uses the same terminal callback for a failed task', async () => {
+    const { service, createPending } = makeService();
+
+    await service.patch(taskId, {
+      status: TaskStatus.FAILED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'SDK activity stalled (progress_stalled).',
+    });
+
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
+    expect(createPending.mock.calls[0][0].full_prompt).toContain('failed');
+  });
+
   it('includeOriginalPrompt=false queues one templated callback without an original prompt section', async () => {
     const { service, createPending } = makeService({
       childSession: {

--- a/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
@@ -85,6 +85,7 @@ describe('buildResolvedConfigSlice', () => {
           first_progress_timeout_ms: 180_000,
           abort_grace_ms: 15_000,
           claude_idle_timeout_ms: 3_600_000,
+          codex_idle_timeout_ms: null,
         },
       },
     });
@@ -173,6 +174,19 @@ describe('buildResolvedConfigSlice', () => {
       future_section: { anything: true },
     };
     expect(() => ResolvedConfigSliceSchema.parse(fromNewerDaemon)).not.toThrow();
+
+    const fromOlderDaemon = {
+      execution: {
+        sdk_watchdog: {
+          mode: 'enforce',
+          first_progress_timeout_ms: 180_000,
+          abort_grace_ms: 15_000,
+          claude_idle_timeout_ms: 3_600_000,
+        },
+      },
+    };
+    const parsed = ResolvedConfigSliceSchema.parse(fromOlderDaemon);
+    expect(parsed.execution?.sdk_watchdog?.codex_idle_timeout_ms).toBeNull();
   });
 });
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -1043,22 +1043,38 @@ execution:
     first_progress_timeout_ms: 180000
     abort_grace_ms: 15000
     claude_idle_timeout_ms: 3600000 # null disables Claude's post-progress check
+    codex_idle_timeout_ms: null # set a positive value to opt in for Codex
 ```
 
 `enforce` records the diagnosis and begins the existing executor containment
 path. Set `mode: observe` explicitly to record and display the diagnosis while
 leaving the executor running, or use `disabled` to turn off SDK watchdog
 diagnosis. Unknown SDK events continue to fail open, permission/input waits
-pause the applicable deadline, and known active Claude tools pause the
-post-progress deadline.
+pause the applicable deadline, and known active Claude tools, background tasks,
+or lifecycle-bound Codex items pause the post-progress deadline.
 
 An active diagnosis is shown separately from the executor heartbeat: a current
 heartbeat means the wrapper is communicating, not that the agent is making
 progress. For an actionable observe-only diagnosis, a later meaningful progress
 pulse clears only the active UI warning while preserving the recorded diagnosis.
 It does not rearm the first-progress deadline. Provider post-progress detection
-is currently Claude-only through `claude_idle_timeout_ms`; Codex
-post-first-progress detection remains deferred.
+is enabled for Claude by default through `claude_idle_timeout_ms`. Codex
+post-progress detection is opt-in and backward-compatible:
+`codex_idle_timeout_ms` defaults to `null`, and a positive value enables the
+deadline.
+
+The Codex adapter normalizes SDK item lifecycles into progress and generic
+active-operation facts. Commands, MCP calls, web searches, file changes,
+reasoning, and agent messages pause the deadline between their started and
+completed events so legitimate long operations are not contained. New item
+kinds inherit that conservative lifecycle pause until reviewed. Todo-list items
+are turn-long state rather than blocking operations, so their lifecycle events
+reset the deadline without pausing it.
+`event_msg.agent_message`, `event_msg.task_complete`,
+`event_msg.turn_complete`, and `turn.completed` are also progress or terminal
+facts. Thread/turn startup and `event_msg.turn_context` only establish SDK
+startup; `event_msg.token_count` and unrecognized future vocabulary normalize
+to unknown activity that fails open instead of authorizing containment.
 
 SDK activity facts share the existing executor heartbeat transport. Disabling
 `execution.executor_heartbeat.enabled` therefore disables persisted pulse

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -407,6 +407,7 @@ function validateConfig(config: AgorConfig): void {
     'first_progress_timeout_ms',
     'abort_grace_ms',
     'claude_idle_timeout_ms',
+    'codex_idle_timeout_ms',
   ]);
   if (config.execution?.sdk_watchdog) {
     resolveSdkWatchdogConfig(config.execution);

--- a/packages/core/src/config/executor-heartbeat.test.ts
+++ b/packages/core/src/config/executor-heartbeat.test.ts
@@ -56,6 +56,7 @@ describe('resolveSdkWatchdogConfig', () => {
       first_progress_timeout_ms: 180_000,
       abort_grace_ms: 15_000,
       claude_idle_timeout_ms: 3_600_000,
+      codex_idle_timeout_ms: null,
     });
   });
 
@@ -70,10 +71,18 @@ describe('resolveSdkWatchdogConfig', () => {
     ).toBeNull();
   });
 
+  it('supports opt-in Codex post-progress supervision', () => {
+    expect(
+      resolveSdkWatchdogConfig({ sdk_watchdog: { codex_idle_timeout_ms: 7_200_000 } })
+        .codex_idle_timeout_ms
+    ).toBe(7_200_000);
+  });
+
   it.each([
     'first_progress_timeout_ms',
     'abort_grace_ms',
     'claude_idle_timeout_ms',
+    'codex_idle_timeout_ms',
   ] as const)('rejects invalid %s rather than silently changing policy', (key) => {
     expect(() => resolveSdkWatchdogConfig({ sdk_watchdog: { [key]: 0 } })).toThrow(
       'positive safe integer'

--- a/packages/core/src/config/executor-heartbeat.ts
+++ b/packages/core/src/config/executor-heartbeat.ts
@@ -99,5 +99,13 @@ export function resolveSdkWatchdogConfig(
             3_600_000,
             'execution.sdk_watchdog.claude_idle_timeout_ms'
           ),
+    codex_idle_timeout_ms:
+      raw?.codex_idle_timeout_ms == null
+        ? null
+        : positiveSafeInteger(
+            raw.codex_idle_timeout_ms,
+            3_600_000,
+            'execution.sdk_watchdog.codex_idle_timeout_ms'
+          ),
   };
 }

--- a/packages/core/src/config/resolved-config-slice.ts
+++ b/packages/core/src/config/resolved-config-slice.ts
@@ -50,6 +50,7 @@ export const ResolvedConfigSliceSchema = z.object({
           first_progress_timeout_ms: z.number().int().positive(),
           abort_grace_ms: z.number().int().positive(),
           claude_idle_timeout_ms: z.number().int().positive().nullable(),
+          codex_idle_timeout_ms: z.number().int().positive().nullable().default(null),
         })
         .optional(),
     })

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -354,6 +354,7 @@ export interface AgorExecutionSettings {
     first_progress_timeout_ms?: number;
     abort_grace_ms?: number;
     claude_idle_timeout_ms?: number | null;
+    codex_idle_timeout_ms?: number | null;
   };
 
   dispatch_connect_timeout_ms?: number | null;

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -5,6 +5,7 @@ const runtime = vi.hoisted(() => ({
   initialize: vi.fn().mockResolvedValue(undefined),
   recordPulse: vi.fn(),
   stopHeartbeat: vi.fn(),
+  watchdogOptions: [] as Array<Record<string, unknown>>,
 }));
 vi.mock('./executor-heartbeat.js', () => ({
   startExecutorHeartbeat: () => ({
@@ -16,8 +17,21 @@ vi.mock('./handlers/sdk/tool-registry.js', () => ({
   initializeToolRegistry: runtime.initialize,
   ToolRegistry: { execute: runtime.execute },
 }));
+vi.mock('./sdk-watchdog.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./sdk-watchdog.js')>();
+  return {
+    ...actual,
+    SdkWatchdog: class {
+      constructor(options: Record<string, unknown>) {
+        runtime.watchdogOptions.push(options);
+      }
+      record() {}
+      stop() {}
+    },
+  };
+});
 
-import { AgorExecutor } from './index.js';
+import { AgorExecutor, type ExecutorConfig } from './index.js';
 
 const evidence = {
   reason: 'no_first_progress' as const,
@@ -25,13 +39,20 @@ const evidence = {
   watchdog_action: 'enforced' as const,
 };
 
-function harness(reportSdkHealthFailure: () => Promise<unknown>) {
+function harness(
+  reportSdkHealthFailure: () => Promise<unknown>,
+  tool: ExecutorConfig['tool'] = 'codex',
+  idleTimeouts: { claude: number | null; codex: number | null } = {
+    claude: null,
+    codex: null,
+  }
+) {
   const executor = new AgorExecutor({
     sessionToken: 'token',
     sessionId: 'session-1',
     taskId: 'task-1',
     prompt: 'prompt',
-    tool: 'codex',
+    tool,
     daemonUrl: 'http://daemon',
     resolvedConfig: {
       execution: {
@@ -39,7 +60,8 @@ function harness(reportSdkHealthFailure: () => Promise<unknown>) {
           mode: 'enforce',
           first_progress_timeout_ms: 1_000,
           abort_grace_ms: 100,
-          claude_idle_timeout_ms: null,
+          claude_idle_timeout_ms: idleTimeouts.claude,
+          codex_idle_timeout_ms: idleTimeouts.codex,
         },
       },
     },
@@ -47,6 +69,7 @@ function harness(reportSdkHealthFailure: () => Promise<unknown>) {
     client: { service: () => { reportSdkHealthFailure: typeof reportSdkHealthFailure } };
     heartbeat: { stop: ReturnType<typeof vi.fn> } | null;
     abortController: AbortController;
+    executeTask(): Promise<void>;
     handleWatchdogDecision(input: typeof evidence): Promise<void>;
   };
   executor.client = { service: () => ({ reportSdkHealthFailure }) };
@@ -59,6 +82,7 @@ describe('AgorExecutor watchdog handoff', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    runtime.watchdogOptions.length = 0;
   });
 
   it('starts SDK observation before invoking the tool', async () => {
@@ -76,6 +100,7 @@ describe('AgorExecutor watchdog handoff', () => {
             first_progress_timeout_ms: 60_000,
             abort_grace_ms: 100,
             claude_idle_timeout_ms: null,
+            codex_idle_timeout_ms: null,
           },
         },
       },
@@ -91,6 +116,24 @@ describe('AgorExecutor watchdog handoff', () => {
     expect(runtime.recordPulse.mock.invocationCallOrder[0]).toBeLessThan(
       runtime.execute.mock.invocationCallOrder[0]!
     );
+  });
+
+  it.each([
+    ['claude-code', 2_000],
+    ['codex', 3_000],
+    ['gemini', null],
+  ] as const)('selects only the generic idle timeout for %s', async (tool, idleTimeoutMs) => {
+    const executor = harness(() => Promise.resolve(), tool, { claude: 2_000, codex: 3_000 });
+
+    await executor.executeTask();
+
+    expect(runtime.watchdogOptions.at(-1)).toMatchObject({
+      mode: 'enforce',
+      firstProgressTimeoutMs: 1_000,
+      idleTimeoutMs,
+    });
+    expect(runtime.watchdogOptions.at(-1)).not.toHaveProperty('tool');
+    expect(runtime.watchdogOptions.at(-1)).not.toHaveProperty('config');
   });
 
   it('stops liveness and exits for containment when the daemon does not acknowledge', async () => {

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -266,9 +266,16 @@ export class AgorExecutor {
     const watchdogConfig =
       this.config.resolvedConfig?.execution?.sdk_watchdog ?? resolveSdkWatchdogConfig();
     if (this.config.tool !== 'cursor') {
+      const idleTimeoutMs =
+        this.config.tool === 'claude-code'
+          ? watchdogConfig.claude_idle_timeout_ms
+          : this.config.tool === 'codex'
+            ? watchdogConfig.codex_idle_timeout_ms
+            : null;
       this.watchdog = new SdkWatchdog({
-        tool: this.config.tool,
-        config: watchdogConfig,
+        mode: watchdogConfig.mode,
+        firstProgressTimeoutMs: watchdogConfig.first_progress_timeout_ms,
+        idleTimeoutMs,
         sdkVersion: getSdkActivityVersion(this.config.tool),
         onDecision: (evidence) => this.handleWatchdogDecision(evidence),
       });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -38,7 +38,7 @@ const configMocks = vi.hoisted(() => ({
   getDaemonUrl: vi.fn(),
 }));
 
-import { CodexPromptService } from './prompt-service.js';
+import { CodexPromptService, reportCodexActivity } from './prompt-service.js';
 
 // Track how many Codex instances were created (module-level state)
 let mockInstanceCount = 0;
@@ -1762,6 +1762,60 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     }
 
     expect(emitted.some((e) => e.type === 'complete')).toBe(true);
+  });
+
+  it.each([
+    'agent_message',
+    'command_execution',
+    'file_change',
+    'mcp_tool_call',
+    'reasoning',
+    'web_search',
+    'future_operation',
+  ])('normalizes %s item lifecycle as a generic active operation', (itemType) => {
+    const onActivity = vi.fn();
+    reportCodexActivity(onActivity, { type: 'item.started', item: { type: itemType } });
+    reportCodexActivity(onActivity, { type: 'item.updated', item: { type: itemType } });
+    reportCodexActivity(onActivity, { type: 'item.completed', item: { type: itemType } });
+    expect(onActivity.mock.calls).toEqual([
+      ['progress', 'operation.start'],
+      ['progress'],
+      ['progress', 'operation.complete'],
+    ]);
+  });
+
+  it('keeps todo lifecycle as progress without suspending supervision', () => {
+    const onActivity = vi.fn();
+    for (const type of ['item.started', 'item.updated', 'item.completed']) {
+      reportCodexActivity(onActivity, { type, item: { type: 'todo_list' } });
+    }
+    expect(onActivity.mock.calls).toEqual([['progress'], ['progress'], ['progress']]);
+  });
+
+  it.each([
+    [{ type: 'thread.started' }, 'sdk_started'],
+    [{ type: 'turn.started' }, 'sdk_started'],
+    [{ type: 'event_msg', payload: { type: 'turn_context' } }, 'sdk_started'],
+    [{ type: 'turn.completed' }, 'progress'],
+    [{ type: 'turn.failed' }, 'progress'],
+    [{ type: 'error' }, 'progress'],
+    [{ type: 'event_msg', payload: { type: 'agent_message' } }, 'progress'],
+    [{ type: 'event_msg', payload: { type: 'task_complete' } }, 'progress'],
+    [{ type: 'event_msg', payload: { type: 'turn_complete' } }, 'progress'],
+  ])('normalizes known startup and terminal activity %#', (event, expected) => {
+    const onActivity = vi.fn();
+    reportCodexActivity(onActivity, event);
+    expect(onActivity).toHaveBeenCalledWith(expected);
+  });
+
+  it.each([
+    { type: 'future.event' },
+    { type: 'event_msg', payload: { type: 'future_payload' } },
+    { type: 'event_msg', payload: { type: 'token_count' } },
+  ])('fails open for unknown activity %#', (event) => {
+    const onActivity = vi.fn();
+    reportCodexActivity(onActivity, event);
+    expect(onActivity).toHaveBeenCalledWith('unknown_activity');
   });
 });
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -46,7 +46,7 @@ import type {
   SessionRepository,
   UsersRepository,
 } from '../../db/feathers-repositories.js';
-import { reportSdkActivity, type SdkActivityCallback } from '../../sdk-watchdog.js';
+import type { SdkActivityCallback } from '../../sdk-watchdog.js';
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
@@ -54,6 +54,52 @@ import type { TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { forkCodexThreadViaAppServer } from './app-server-client.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
+
+export function reportCodexActivity(
+  callback: SdkActivityCallback | undefined,
+  event: {
+    type: string;
+    item?: { type?: string };
+    payload?: { type?: string };
+  }
+): void {
+  if (event.type === 'item.started' || event.type === 'item.completed') {
+    // Codex todo_list is turn-long progress state. Every other known or
+    // future item type has a bounded lifecycle and suspends supervision.
+    if (event.item?.type === 'todo_list') {
+      callback?.('progress');
+      return;
+    }
+    callback?.(
+      'progress',
+      event.type === 'item.started' ? 'operation.start' : 'operation.complete'
+    );
+    return;
+  }
+  if (event.type === 'item.updated') {
+    callback?.('progress');
+    return;
+  }
+  if (
+    event.type === 'thread.started' ||
+    event.type === 'turn.started' ||
+    (event.type === 'event_msg' && event.payload?.type === 'turn_context')
+  ) {
+    callback?.('sdk_started');
+    return;
+  }
+  if (
+    event.type === 'turn.completed' ||
+    event.type === 'turn.failed' ||
+    event.type === 'error' ||
+    (event.type === 'event_msg' &&
+      ['agent_message', 'task_complete', 'turn_complete'].includes(event.payload?.type ?? ''))
+  ) {
+    callback?.('progress');
+    return;
+  }
+  callback?.('unknown_activity');
+}
 
 /**
  * Map Agor's effort level (`low`/`medium`/`high`/`xhigh`/`max`) to Codex SDK's
@@ -1244,13 +1290,13 @@ export class CodexPromptService {
         eventCount++;
         codexDebug(`📨 [Codex] Event ${eventCount}: ${event.type}`);
 
-        const activityEvent = event as { type: string; payload?: { type?: string } };
-        const activityPayloadType =
-          activityEvent.type === 'event_msg' ? activityEvent.payload?.type : undefined;
-        reportSdkActivity(
+        reportCodexActivity(
           onActivity,
-          'codex',
-          activityPayloadType ? `${activityEvent.type}.${activityPayloadType}` : activityEvent.type
+          event as {
+            type: string;
+            item?: { type?: string };
+            payload?: { type?: string };
+          }
         );
 
         // Check if stop was requested

--- a/packages/executor/src/sdk-handlers/sdk-activity.test.ts
+++ b/packages/executor/src/sdk-handlers/sdk-activity.test.ts
@@ -9,7 +9,6 @@ import {
 describe('SDK activity mapping', () => {
   it.each([
     ['claude-code', 'assistant'],
-    ['codex', 'item.started'],
     ['gemini', 'content'],
     ['copilot', 'assistant.message_delta'],
     ['opencode', 'message.part.updated'],
@@ -17,16 +16,8 @@ describe('SDK activity mapping', () => {
     expect(mapSdkActivity(adapter, event)).toEqual({ kind: 'progress', detail: event });
   });
 
-  it('does not treat the observed Codex initialization signature as progress', () => {
-    expect(mapSdkActivity('codex', 'event_msg.turn_context')).toEqual({
-      kind: 'sdk_started',
-      detail: 'event_msg.turn_context',
-    });
-  });
-
   it.each([
     ['claude-code', 'future.event'],
-    ['codex', 'future.event'],
     ['gemini', 'future.event'],
     ['copilot', 'future.event'],
     ['opencode', 'future.event'],
@@ -39,7 +30,7 @@ describe('SDK activity mapping', () => {
 
   it('ignores OpenCode transport heartbeats and bounds diagnostic detail', () => {
     expect(mapSdkActivity('opencode', 'server.heartbeat')).toBeUndefined();
-    const pulse = mapSdkActivity('codex', `bad secret ${'x'.repeat(200)}`);
+    const pulse = mapSdkActivity('claude-code', `bad secret ${'x'.repeat(200)}`);
     expect(pulse?.detail).toMatch(/^[a-zA-Z0-9._-]+$/);
     expect(pulse?.detail.length).toBe(128);
   });

--- a/packages/executor/src/sdk-watchdog.test.ts
+++ b/packages/executor/src/sdk-watchdog.test.ts
@@ -1,4 +1,3 @@
-import type { ResolvedSdkWatchdogConfig } from '@agor/core/config';
 import type { SdkHealthFailureInput } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -8,20 +7,23 @@ import {
   SdkWatchdog,
 } from './sdk-watchdog.js';
 
-const baseConfig: ResolvedSdkWatchdogConfig = {
+const baseConfig: {
+  mode: 'disabled' | 'observe' | 'enforce';
+  firstProgressTimeoutMs: number;
+  idleTimeoutMs: number | null;
+} = {
   mode: 'observe',
-  first_progress_timeout_ms: 1_000,
-  abort_grace_ms: 100,
-  claude_idle_timeout_ms: 2_000,
+  firstProgressTimeoutMs: 1_000,
+  idleTimeoutMs: 2_000,
 };
 
 type Evidence = Omit<SdkHealthFailureInput, 'task_id'>;
 
-function harness(overrides: Partial<ResolvedSdkWatchdogConfig> = {}, tool = 'codex') {
+function harness(overrides: Partial<typeof baseConfig> = {}) {
   const decisions: Evidence[] = [];
   const watchdog = new SdkWatchdog({
-    tool,
-    config: { ...baseConfig, ...overrides },
+    ...baseConfig,
+    ...overrides,
     sdkVersion: 'sdk@1.0.0',
     now: Date.now,
     onDecision: (evidence) => decisions.push(evidence),
@@ -55,22 +57,106 @@ describe('SdkWatchdog', () => {
   });
 
   it('does not rearm observe mode after late progress', () => {
-    const { watchdog, decisions } = harness({}, 'claude-code');
+    const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     vi.advanceTimersByTime(1_000);
     expect(decisions).toHaveLength(1);
-    watchdog.record('progress', 'item.started');
+    watchdog.record('progress');
     vi.advanceTimersByTime(10_000);
     expect(decisions.map(({ reason }) => reason)).toEqual(['no_first_progress']);
   });
 
-  it('disarms first-progress policy after meaningful progress', () => {
-    const { watchdog, decisions } = harness();
+  it('disarms first-progress policy after meaningful progress when idle supervision is off', () => {
+    const { watchdog, decisions } = harness({ idleTimeoutMs: null });
     watchdog.record('sdk_started');
     vi.advanceTimersByTime(999);
-    watchdog.record('progress', 'item.started');
+    watchdog.record('progress');
     vi.advanceTimersByTime(10_000);
     expect(decisions).toEqual([]);
+  });
+
+  it.each([
+    ['observe', 'would_fire'],
+    ['enforce', 'enforced'],
+  ] as const)('detects post-progress silence exactly once in %s mode', (mode, watchdogAction) => {
+    const { watchdog, decisions } = harness({ mode });
+    watchdog.record('sdk_started');
+    watchdog.record('progress');
+
+    vi.advanceTimersByTime(1_999);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions).toMatchObject([
+      {
+        reason: 'progress_stalled',
+        watchdog_action: watchdogAction,
+      },
+    ]);
+
+    vi.advanceTimersByTime(10_000);
+    expect(decisions).toHaveLength(1);
+  });
+
+  it('resets the post-progress deadline only for later SDK progress', () => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    watchdog.record('progress');
+    vi.advanceTimersByTime(1_500);
+    watchdog.record('progress');
+
+    vi.advanceTimersByTime(1_999);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('progress_stalled');
+  });
+
+  it('preserves the remaining post-progress timeout across an explicit wait', () => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    watchdog.record('progress');
+    vi.advanceTimersByTime(800);
+    watchdog.record('waiting', 'permission.request');
+    vi.advanceTimersByTime(10_000);
+    expect(decisions).toEqual([]);
+
+    watchdog.record('sdk_started', 'permission.resolved');
+    vi.advanceTimersByTime(1_199);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('progress_stalled');
+  });
+
+  it('keeps enforced post-progress supervision fail-open while unknown activity continues', () => {
+    const { watchdog, decisions } = harness({ mode: 'enforce' });
+    watchdog.record('sdk_started');
+    watchdog.record('progress');
+    vi.advanceTimersByTime(1_500);
+    watchdog.record('unknown_activity');
+    vi.advanceTimersByTime(500);
+    expect(decisions).toMatchObject([
+      { reason: 'unknown_activity', watchdog_action: 'would_fire' },
+    ]);
+
+    watchdog.record('unknown_activity');
+    for (let index = 0; index < 3; index++) {
+      vi.advanceTimersByTime(1_999);
+      watchdog.record('unknown_activity');
+    }
+    expect(decisions).toHaveLength(1);
+  });
+
+  it('pauses post-progress supervision while an operation is active', () => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    watchdog.record('progress', 'operation.start');
+    vi.advanceTimersByTime(20_000);
+    expect(decisions).toEqual([]);
+
+    watchdog.record('progress', 'operation.complete');
+    vi.advanceTimersByTime(1_999);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('progress_stalled');
   });
 
   it('fails open while unknown vocabulary remains active, then fires after silence', () => {
@@ -92,7 +178,7 @@ describe('SdkWatchdog', () => {
     });
   });
 
-  it('preserves the remaining timeout across a permission wait', () => {
+  it('preserves the remaining first-progress timeout across a permission wait', () => {
     const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     vi.advanceTimersByTime(400);
@@ -142,8 +228,8 @@ describe('SdkWatchdog', () => {
     expect(decisions[0]?.reason).toBe('no_first_progress');
   });
 
-  it('pauses Claude idle policy while a known tool is active', () => {
-    const { watchdog, decisions } = harness({}, 'claude-code');
+  it('pauses idle policy while a known tool is active', () => {
+    const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     watchdog.record('progress', 'assistant');
     vi.advanceTimersByTime(1_000);
@@ -157,8 +243,8 @@ describe('SdkWatchdog', () => {
     expect(decisions[0]?.reason).toBe('progress_stalled');
   });
 
-  it('pauses Claude idle policy while an SDK background task is active', () => {
-    const { watchdog, decisions } = harness({}, 'claude-code');
+  it('pauses idle policy while an SDK background task is active', () => {
+    const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     watchdog.record('progress', 'assistant');
     watchdog.record('progress', 'background_task.start');
@@ -171,8 +257,8 @@ describe('SdkWatchdog', () => {
     expect(decisions[0]?.reason).toBe('progress_stalled');
   });
 
-  it('keeps Claude idle policy paused until every parallel tool completes', () => {
-    const { watchdog, decisions } = harness({}, 'claude-code');
+  it('keeps idle policy paused until every parallel tool completes', () => {
+    const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     watchdog.record('progress', 'assistant');
     watchdog.record('progress', 'tool.start');
@@ -183,21 +269,6 @@ describe('SdkWatchdog', () => {
     watchdog.record('progress', 'tool.complete');
     vi.advanceTimersByTime(2_000);
     expect(decisions[0]?.reason).toBe('progress_stalled');
-  });
-
-  it('does not enforce Claude idle while unknown SDK activity continues', () => {
-    const { watchdog, decisions } = harness({ mode: 'enforce' }, 'claude-code');
-    watchdog.record('sdk_started');
-    watchdog.record('progress', 'assistant');
-    vi.advanceTimersByTime(1_500);
-    watchdog.record('unknown_activity', 'future.delta');
-    vi.advanceTimersByTime(500);
-    expect(decisions).toMatchObject([
-      { reason: 'unknown_activity', watchdog_action: 'would_fire' },
-    ]);
-    watchdog.record('unknown_activity', 'future.delta');
-    vi.advanceTimersByTime(1_999);
-    expect(decisions).toHaveLength(1);
   });
 
   it('does nothing when disabled or stopped', () => {

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -1,11 +1,11 @@
-import type { ResolvedSdkWatchdogConfig } from '@agor/core/config';
 import type { ExecutorPulseKind, SdkHealthFailureInput } from '@agor/core/types';
 import { hasAgorAbortCause, markAgorAbortCause } from './termination-state.js';
 
-export type SdkActivityAdapter = 'claude-code' | 'codex' | 'gemini' | 'copilot' | 'opencode';
+export type SdkActivityAdapter = 'claude-code' | 'gemini' | 'copilot' | 'opencode';
+type SdkVersionAdapter = SdkActivityAdapter | 'codex';
 export type SdkActivityCallback = (kind: ExecutorPulseKind, detail?: string) => void;
 
-export const SDK_ACTIVITY_VERSION_MANIFEST: Record<SdkActivityAdapter, string> = {
+export const SDK_ACTIVITY_VERSION_MANIFEST: Record<SdkVersionAdapter, string> = {
   'claude-code': '@anthropic-ai/claude-agent-sdk@0.3.197',
   codex: '@openai/codex-sdk@0.144.0',
   gemini: '@google/gemini-cli-core@0.31.0',
@@ -14,14 +14,11 @@ export const SDK_ACTIVITY_VERSION_MANIFEST: Record<SdkActivityAdapter, string> =
 };
 
 export function getSdkActivityVersion(adapter: string): string | undefined {
-  return SDK_ACTIVITY_VERSION_MANIFEST[adapter as SdkActivityAdapter];
+  return SDK_ACTIVITY_VERSION_MANIFEST[adapter as SdkVersionAdapter];
 }
 
 const STARTED = new Set([
   'claude-code:system',
-  'codex:thread.started',
-  'codex:turn.started',
-  'codex:event_msg.turn_context',
   'gemini:model_info',
   'copilot:assistant.turn_start',
 ]);
@@ -39,13 +36,6 @@ const PROGRESS = new Set([
   'claude-code:stream_event',
   'claude-code:user',
   'claude-code:result',
-  'codex:item.started',
-  'codex:item.updated',
-  'codex:item.completed',
-  'codex:turn.completed',
-  'codex:event_msg.agent_message',
-  'codex:event_msg.task_complete',
-  'codex:event_msg.turn_complete',
   'gemini:content',
   'gemini:thought',
   'gemini:tool_call_request',
@@ -106,7 +96,7 @@ interface WatchdogState {
   firstProgressAt?: number;
   idleAnchor?: number;
   pausedAt?: number;
-  activeToolCount: number;
+  activeOperationCount: number;
   unknownCount: number;
   unknownReported: boolean;
 }
@@ -116,20 +106,21 @@ type WatchdogReason = 'no_first_progress' | 'progress_stalled' | 'unknown_activi
 function inspectSdkWatchdog(
   state: Readonly<WatchdogState>,
   now: number,
-  tool: string,
-  config: ResolvedSdkWatchdogConfig
+  mode: 'disabled' | 'observe' | 'enforce',
+  firstProgressTimeoutMs: number,
+  idleTimeoutMs: number | null
 ): { reason?: WatchdogReason; nextCheckAt?: number } {
   if (
-    config.mode === 'disabled' ||
+    mode === 'disabled' ||
     state.startedAt === undefined ||
     state.pausedAt !== undefined ||
-    state.activeToolCount > 0
+    state.activeOperationCount > 0
   ) {
     return {};
   }
   if (state.firstProgressAt === undefined) {
-    const firstDeadline = state.startedAt + config.first_progress_timeout_ms;
-    const silenceDeadline = (state.lastRawAt ?? state.startedAt) + config.first_progress_timeout_ms;
+    const firstDeadline = state.startedAt + firstProgressTimeoutMs;
+    const silenceDeadline = (state.lastRawAt ?? state.startedAt) + firstProgressTimeoutMs;
     if (now >= firstDeadline) {
       if (now >= silenceDeadline) return { reason: 'no_first_progress' };
       if (!state.unknownReported && state.unknownCount > 0) {
@@ -141,11 +132,9 @@ function inspectSdkWatchdog(
     };
   }
 
-  if (tool === 'claude-code' && config.claude_idle_timeout_ms !== null) {
-    const idleDeadline =
-      (state.idleAnchor ?? state.firstProgressAt) + config.claude_idle_timeout_ms;
-    const silenceDeadline =
-      (state.lastRawAt ?? state.firstProgressAt) + config.claude_idle_timeout_ms;
+  if (idleTimeoutMs !== null) {
+    const idleDeadline = (state.idleAnchor ?? state.firstProgressAt) + idleTimeoutMs;
+    const silenceDeadline = (state.lastRawAt ?? state.firstProgressAt) + idleTimeoutMs;
     if (now >= idleDeadline) {
       if (now >= silenceDeadline) return { reason: 'progress_stalled' };
       if (!state.unknownReported && state.unknownCount > 0) {
@@ -161,7 +150,7 @@ function inspectSdkWatchdog(
 
 export class SdkWatchdog {
   private state: WatchdogState = {
-    activeToolCount: 0,
+    activeOperationCount: 0,
     unknownCount: 0,
     unknownReported: false,
   };
@@ -170,8 +159,9 @@ export class SdkWatchdog {
 
   constructor(
     private readonly options: {
-      tool: string;
-      config: ResolvedSdkWatchdogConfig;
+      mode: 'disabled' | 'observe' | 'enforce';
+      firstProgressTimeoutMs: number;
+      idleTimeoutMs: number | null;
       sdkVersion?: string;
       onDecision(evidence: WatchdogEvidence): void | Promise<void>;
       now?: () => number;
@@ -179,7 +169,7 @@ export class SdkWatchdog {
   ) {}
 
   record(kind: ExecutorPulseKind, detail?: string): void {
-    if (this.decided || this.options.config.mode === 'disabled') return;
+    if (this.decided || this.options.mode === 'disabled') return;
     const now = this.now();
     if (kind === 'waiting') {
       if (this.state.startedAt !== undefined && this.state.pausedAt === undefined) {
@@ -207,11 +197,19 @@ export class SdkWatchdog {
     if (kind === 'progress') {
       this.state.firstProgressAt ??= now;
       this.state.idleAnchor = now;
-      if (detail === 'tool.start' || detail === 'background_task.start') {
-        this.state.activeToolCount++;
+      if (
+        detail === 'tool.start' ||
+        detail === 'operation.start' ||
+        detail === 'background_task.start'
+      ) {
+        this.state.activeOperationCount++;
       }
-      if (detail === 'tool.complete' || detail === 'background_task.complete') {
-        this.state.activeToolCount = Math.max(0, this.state.activeToolCount - 1);
+      if (
+        detail === 'tool.complete' ||
+        detail === 'operation.complete' ||
+        detail === 'background_task.complete'
+      ) {
+        this.state.activeOperationCount = Math.max(0, this.state.activeOperationCount - 1);
       }
     }
     this.check();
@@ -229,15 +227,19 @@ export class SdkWatchdog {
   private check(): void {
     if (this.decided) return;
     const now = this.now();
-    const { reason } = inspectSdkWatchdog(this.state, now, this.options.tool, this.options.config);
+    const { reason } = inspectSdkWatchdog(
+      this.state,
+      now,
+      this.options.mode,
+      this.options.firstProgressTimeoutMs,
+      this.options.idleTimeoutMs
+    );
     if (!reason) {
       this.schedule();
       return;
     }
     const action =
-      reason === 'unknown_activity' || this.options.config.mode !== 'enforce'
-        ? 'would_fire'
-        : 'enforced';
+      reason === 'unknown_activity' || this.options.mode !== 'enforce' ? 'would_fire' : 'enforced';
     const evidence: WatchdogEvidence = {
       reason,
       elapsed_ms: Math.max(0, Math.round(now - (this.state.startedAt ?? now))),
@@ -262,8 +264,9 @@ export class SdkWatchdog {
     const { nextCheckAt } = inspectSdkWatchdog(
       this.state,
       now,
-      this.options.tool,
-      this.options.config
+      this.options.mode,
+      this.options.firstProgressTimeoutMs,
+      this.options.idleTimeoutMs
     );
     if (nextCheckAt === undefined) return;
     this.timer = setTimeout(() => this.check(), Math.max(0, nextCheckAt - now));


### PR DESCRIPTION
## Linked issue

Related: #2028

> [!NOTE]
> This is a stacked draft targeting `fix/sdk-stall-supervision`. After #2028 merges, this PR should be rebased and retargeted to `main`.

## Summary

- Add opt-in Codex post-progress stall detection through `sdk_watchdog.codex_idle_timeout_ms`.
- Normalize Codex item lifecycles into provider-neutral operation activity for the shared watchdog.
- Preserve existing Claude supervision, terminal callbacks, and containment behavior.
- Keep the new timeout disabled by default and compatible with older resolved-config payloads.

## Why / context

#2028 adds SDK stall supervision but intentionally limits post-progress `progress_stalled` detection to providers with an idle-timeout signal. A Codex turn can therefore emit progress, become silent, and remain `RUNNING` while the executor wrapper heartbeat is still healthy.

This follow-up adds an opt-in Codex idle deadline. When enabled, genuine post-progress silence can use #2028's existing diagnosis and containment path without changing the default behavior.

## Implementation notes

| Codex activity | Watchdog behavior |
|---|---|
| Lifecycle-bound item starts/completes | Track a generic active operation; suspend the idle deadline while work is active |
| Todo-list update | Count as progress without suspending supervision indefinitely |
| Unknown raw event or item vocabulary | Fail open; do not manufacture a stall diagnosis |
| Missing or `null` `codex_idle_timeout_ms` | Disable Codex post-progress timeout |
| Positive `codex_idle_timeout_ms` | Apply the selected idle deadline to Codex turns |

Raw Codex event interpretation remains in the Codex adapter. The shared watchdog receives only provider-neutral progress, operation, and policy facts. The resolved-config schema defaults a missing field to `null`, so an executor can still accept the preceding daemon payload shape during version skew.

## Validation / test plan

- [x] Executor package suite: 49 files, 636 tests passed.
- [x] Focused executor coverage: 4 files, 107 tests passed.
- [x] Core watchdog configuration coverage: 18 tests passed.
- [x] Daemon resolved-config and callback coverage: 25 tests passed.
- [x] Focused legacy resolved-config compatibility coverage: 11 tests passed after remediation.
- [x] Core, executor, daemon, and docs typechecks passed.
- [x] Targeted Biome checks and MDX Prettier check passed.
- [x] A captured Codex event trace passed two replay checks: the full trace produced no premature diagnosis, and an approximately three-second command lifecycle stayed supervised under a two-second idle deadline.

**Proof limit:** the trace replay exercised the real adapter and watchdog timing, but not a live Codex subprocess or full daemon containment. Malformed or duplicated lifecycle events were not exercised.

## Screenshots / demos

Not applicable; there are no UI changes.

## Risks / rollout / rollback

The new timeout is opt-in and resolves to `null` when omitted. Operators enabling it should choose a value longer than legitimate silent work. Active lifecycle-bound operations suspend the idle deadline to reduce false positives.

Rollback is to remove the setting, set it to `null`, or revert this commit.

## Out of scope / follow-ups

- Recovering a missing completion event or fixing completion propagation at its source.
- Automatic retry, prompt replay, or queue draining.
- A non-null Codex timeout default.
- New task states, services, schemas, APIs, or delivery paths.
- Live subprocess and daemon-containment proof.
