### PR TITLE
feat(sessions): deterministic priority-context injection for fresh root sessions

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1132,6 +1132,55 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       params
     );
 
+    // Priority-context injection (see @agor/core/sessions/priority-context): a
+    // brand-new root session's very first spawn gets the repo's designated
+    // `.agor/priority-context.json` files (if any) prepended as established
+    // context. Root-only and first-spawn-only (messageStartIndex === 0, i.e.
+    // no messages exist yet for this session) so this never re-fires on later
+    // turns, spawned/forked children, or repos that haven't opted in (the
+    // common case — resolves to undefined).
+    //
+    // Deliberately applied here — to the bytes shipped to the executor —
+    // rather than folded into `task.full_prompt` at task-creation time: the
+    // transcript row and `task.full_prompt` (title generation, previews) must
+    // keep showing exactly what the user typed. Same reasoning as the
+    // `[Prompted by: ...]` prefix below, and centralizing here means it's
+    // resolved once per session at the single choke point both the idle path
+    // and the queue drainer route through, instead of being baked in at
+    // enqueue time and only correct for whichever task happened to be first.
+    //
+    // The daemon reads these files with its own (broader) privileges, so for
+    // non-owner sessions we gate injection on the session creator's
+    // *effective* filesystem access to the branch — the same resolved grant
+    // (owner / group / board-aligned defaults) that decides whether that
+    // user's own executor is allowed to read the worktree at all in
+    // insulated/strict Unix modes. This must go through `resolveUserAccess`
+    // rather than the raw `others_fs_access` column: group and board grants
+    // can raise or lower a specific user's effective access relative to that
+    // column's fallback.
+    let rawPromptForExecutor = task.full_prompt;
+    if (isRootSessionGenealogy(session.genealogy) && messageStartIndex === 0) {
+      try {
+        const branch = await branchRepository.findById(session.branch_id);
+        const canReadWorktreeFiles =
+          !!branch &&
+          canInjectPriorityContextForBranch(
+            await branchRepository.resolveUserAccess(branch, session.created_by as UUID)
+          );
+        const priorityContext =
+          branch && canReadWorktreeFiles
+            ? await resolvePriorityContextForWorktree(branch.path)
+            : undefined;
+        if (priorityContext) {
+          rawPromptForExecutor = `${priorityContext}\n\n${task.full_prompt}`;
+        }
+      } catch (error) {
+        console.warn(
+          `[priority-context] Skipping injection for session ${shortId(task.session_id)}: ${(error as Error).message}`
+        );
+      }
+    }
+
     // Tag the bytes shipped to the executor with `[Prompted by: ...]` when a
     // non-owner is prompting. The prompter identity comes from `task.created_by`
     // (NOT `params.user`): every persisted Task row requires `created_by`
@@ -1141,7 +1190,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // that don't carry `queued_by_user_id` and is therefore not authoritative.
     // See `./utils/build-prompter-prefix.ts` for the helper + tests.
     const { prompt: promptForExecutor } = await buildPrompterPrefixedPrompt({
-      rawPrompt: task.full_prompt,
+      rawPrompt: rawPromptForExecutor,
       sessionCreatedBy: session.created_by,
       prompterUserId: task.created_by,
       usersRepo: bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db)),
@@ -1348,49 +1397,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               params
             );
 
-            // Priority-context injection (see @agor/core/sessions/priority-context):
-            // a brand-new root session's very first prompt gets the repo's
-            // designated `.agor/priority-context.json` files (if any) prepended
-            // as established context. Root-only and first-task-only so this
-            // never re-fires on later turns, spawned/forked children, or repos
-            // that haven't opted in (the common case — resolves to undefined).
-            //
-            // The daemon reads these files with its own (broader) privileges, so
-            // for non-owner sessions we gate injection on the session creator's
-            // *effective* filesystem access to the branch — the same resolved
-            // grant (owner / group / board-aligned defaults) that decides
-            // whether that user's own executor is allowed to read the worktree
-            // at all in insulated/strict Unix modes. This must go through
-            // `resolveUserAccess` rather than the raw `others_fs_access`
-            // column: group and board grants can raise or lower a specific
-            // user's effective access relative to that column's fallback.
-            let effectivePrompt = data.prompt;
-            const isRootSession = isRootSessionGenealogy(lockedSession.genealogy);
-            if (isRootSession && (await taskRepo.countBySession(id as SessionID)) === 0) {
-              try {
-                const branch = await branchRepository.findById(lockedSession.branch_id);
-                const canReadWorktreeFiles =
-                  !!branch &&
-                  canInjectPriorityContextForBranch(
-                    await branchRepository.resolveUserAccess(
-                      branch,
-                      lockedSession.created_by as UUID
-                    )
-                  );
-                const priorityContext =
-                  branch && canReadWorktreeFiles
-                    ? await resolvePriorityContextForWorktree(branch.path)
-                    : undefined;
-                if (priorityContext) {
-                  effectivePrompt = `${priorityContext}\n\n${data.prompt}`;
-                }
-              } catch (error) {
-                console.warn(
-                  `[priority-context] Skipping injection for session ${shortId(id)}: ${(error as Error).message}`
-                );
-              }
-            }
-
             const queuedTasks = await taskRepo.findQueued(id as SessionID);
             const shouldQueue =
               !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||
@@ -1399,7 +1405,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             if (shouldQueue) {
               const queuedTask = await taskRepo.createPending({
                 session_id: id as SessionID,
-                full_prompt: effectivePrompt,
+                full_prompt: data.prompt,
                 created_by: createdBy,
                 status: TaskStatus.QUEUED,
                 metadata: buildPromptTaskMetadata(data.metadata, messageSource, createdBy),
@@ -1444,7 +1450,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             const idleTaskMetadata = buildPromptTaskMetadata(data.metadata, messageSource);
             const task = await taskRepo.createPending({
               session_id: id as SessionID,
-              full_prompt: effectivePrompt,
+              full_prompt: data.prompt,
               created_by: createdBy,
               status: TaskStatus.CREATED,
               metadata: Object.keys(idleTaskMetadata).length > 0 ? idleTaskMetadata : undefined,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -45,7 +45,11 @@ import {
   NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
-import { isRootSessionGenealogy, resolvePriorityContextForWorktree } from '@agor/core/sessions';
+import {
+  canInjectPriorityContextForBranch,
+  isRootSessionGenealogy,
+  resolvePriorityContextForWorktree,
+} from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -1350,14 +1354,32 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             // as established context. Root-only and first-task-only so this
             // never re-fires on later turns, spawned/forked children, or repos
             // that haven't opted in (the common case — resolves to undefined).
+            //
+            // The daemon reads these files with its own (broader) privileges, so
+            // for non-owner sessions we gate injection on the branch's
+            // `others_fs_access` — the same signal that decides whether that
+            // user's own executor is allowed to read the worktree at all in
+            // insulated/strict Unix modes. Without this, a non-owner denied
+            // filesystem access via `others_fs_access: 'none'` could still
+            // receive file contents through the injected prompt.
             let effectivePrompt = data.prompt;
             const isRootSession = isRootSessionGenealogy(lockedSession.genealogy);
             if (isRootSession && (await taskRepo.countBySession(id as SessionID)) === 0) {
               try {
                 const branch = await branchRepository.findById(lockedSession.branch_id);
-                const priorityContext = branch
-                  ? await resolvePriorityContextForWorktree(branch.path)
-                  : undefined;
+                const canReadWorktreeFiles =
+                  !!branch &&
+                  canInjectPriorityContextForBranch({
+                    isOwner: await branchRepository.isOwner(
+                      branch.branch_id,
+                      lockedSession.created_by as UUID
+                    ),
+                    othersFsAccess: branch.others_fs_access,
+                  });
+                const priorityContext =
+                  branch && canReadWorktreeFiles
+                    ? await resolvePriorityContextForWorktree(branch.path)
+                    : undefined;
                 if (priorityContext) {
                   effectivePrompt = `${priorityContext}\n\n${data.prompt}`;
                 }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -45,6 +45,7 @@ import {
   NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
+import { resolvePriorityContextForWorktree } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -1342,6 +1343,33 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               taskRepo,
               params
             );
+
+            // Priority-context injection (see @agor/core/sessions/priority-context):
+            // a brand-new root session's very first prompt gets the repo's
+            // designated `.agor/priority-context.json` files (if any) prepended
+            // as established context. Root-only and first-task-only so this
+            // never re-fires on later turns, spawned/forked children, or repos
+            // that haven't opted in (the common case — resolves to undefined).
+            let effectivePrompt = data.prompt;
+            const isRootSession =
+              !lockedSession.genealogy?.parent_session_id &&
+              !lockedSession.genealogy?.forked_from_session_id;
+            if (isRootSession && (await taskRepo.countBySession(id as SessionID)) === 0) {
+              try {
+                const branch = await branchRepository.findById(lockedSession.branch_id);
+                const priorityContext = branch
+                  ? await resolvePriorityContextForWorktree(branch.path)
+                  : undefined;
+                if (priorityContext) {
+                  effectivePrompt = `${priorityContext}\n\n${data.prompt}`;
+                }
+              } catch (error) {
+                console.warn(
+                  `[priority-context] Skipping injection for session ${shortId(id)}: ${(error as Error).message}`
+                );
+              }
+            }
+
             const queuedTasks = await taskRepo.findQueued(id as SessionID);
             const shouldQueue =
               !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||
@@ -1350,7 +1378,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             if (shouldQueue) {
               const queuedTask = await taskRepo.createPending({
                 session_id: id as SessionID,
-                full_prompt: data.prompt,
+                full_prompt: effectivePrompt,
                 created_by: createdBy,
                 status: TaskStatus.QUEUED,
                 metadata: buildPromptTaskMetadata(data.metadata, messageSource, createdBy),
@@ -1395,7 +1423,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             const idleTaskMetadata = buildPromptTaskMetadata(data.metadata, messageSource);
             const task = await taskRepo.createPending({
               session_id: id as SessionID,
-              full_prompt: data.prompt,
+              full_prompt: effectivePrompt,
               created_by: createdBy,
               status: TaskStatus.CREATED,
               metadata: Object.keys(idleTaskMetadata).length > 0 ? idleTaskMetadata : undefined,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -45,7 +45,7 @@ import {
   NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
-import { resolvePriorityContextForWorktree } from '@agor/core/sessions';
+import { isRootSessionGenealogy, resolvePriorityContextForWorktree } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -1351,9 +1351,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             // never re-fires on later turns, spawned/forked children, or repos
             // that haven't opted in (the common case — resolves to undefined).
             let effectivePrompt = data.prompt;
-            const isRootSession =
-              !lockedSession.genealogy?.parent_session_id &&
-              !lockedSession.genealogy?.forked_from_session_id;
+            const isRootSession = isRootSessionGenealogy(lockedSession.genealogy);
             if (isRootSession && (await taskRepo.countBySession(id as SessionID)) === 0) {
               try {
                 const branch = await branchRepository.findById(lockedSession.branch_id);

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1356,12 +1356,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             // that haven't opted in (the common case — resolves to undefined).
             //
             // The daemon reads these files with its own (broader) privileges, so
-            // for non-owner sessions we gate injection on the branch's
-            // `others_fs_access` — the same signal that decides whether that
-            // user's own executor is allowed to read the worktree at all in
-            // insulated/strict Unix modes. Without this, a non-owner denied
-            // filesystem access via `others_fs_access: 'none'` could still
-            // receive file contents through the injected prompt.
+            // for non-owner sessions we gate injection on the session creator's
+            // *effective* filesystem access to the branch — the same resolved
+            // grant (owner / group / board-aligned defaults) that decides
+            // whether that user's own executor is allowed to read the worktree
+            // at all in insulated/strict Unix modes. This must go through
+            // `resolveUserAccess` rather than the raw `others_fs_access`
+            // column: group and board grants can raise or lower a specific
+            // user's effective access relative to that column's fallback.
             let effectivePrompt = data.prompt;
             const isRootSession = isRootSessionGenealogy(lockedSession.genealogy);
             if (isRootSession && (await taskRepo.countBySession(id as SessionID)) === 0) {
@@ -1369,13 +1371,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 const branch = await branchRepository.findById(lockedSession.branch_id);
                 const canReadWorktreeFiles =
                   !!branch &&
-                  canInjectPriorityContextForBranch({
-                    isOwner: await branchRepository.isOwner(
-                      branch.branch_id,
+                  canInjectPriorityContextForBranch(
+                    await branchRepository.resolveUserAccess(
+                      branch,
                       lockedSession.created_by as UUID
-                    ),
-                    othersFsAccess: branch.others_fs_access,
-                  });
+                    )
+                  );
                 const priorityContext =
                   branch && canReadWorktreeFiles
                     ? await resolvePriorityContextForWorktree(branch.path)

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -80,8 +80,8 @@ describe('seedOnboardingTeammate', () => {
     expect(initialPrompt).toContain('Rusty');
     expect(initialPrompt).toContain('developer');
     expect(initialPrompt).toContain('- Suggested integrations: Slack, GitHub');
-    expect(initialPrompt).toContain('Read ONBOARDING.md');
-    expect(initialPrompt).toContain('otherwise, read BOOTSTRAP.md');
+    expect(initialPrompt).toContain('ONBOARDING.md) already provided above');
+    expect(initialPrompt).toContain("or BOOTSTRAP.md if it doesn't");
 
     expect(result).toEqual({ sessionId: 'session-1' });
     expect(onWarn).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -27,8 +27,9 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(prompt).toContain('- AI teammate description: Reviews pull requests');
     expect(prompt).toContain('- User: Max <max@example.com>');
     expect(prompt).toContain(
-      '- User: Max <max@example.com>\n\nRead ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md'
+      '- User: Max <max@example.com>\n\nUse any onboarding guidance (e.g. ONBOARDING.md) already provided above'
     );
+    expect(prompt).toContain("or BOOTSTRAP.md if it doesn't");
     expect(prompt).toContain('ask only the next useful question');
     expect(prompt).not.toContain("don't re-ask");
     expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -65,7 +65,10 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
 
   lines.push('');
   lines.push(
-    "Read ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md. Then respond to the user. Use the supplied context and live Agor state, and ask only the next useful question if the user's goal is not already clear."
+    'Use any onboarding guidance (e.g. ONBOARDING.md) already provided above as established ' +
+      'context. If none was provided, read ONBOARDING.md yourself if it exists, or BOOTSTRAP.md ' +
+      "if it doesn't. Then respond to the user. Use the supplied context and live Agor state, " +
+      "and ask only the next useful question if the user's goal is not already clear."
   );
 
   return lines.join('\n');

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,4 +1,5 @@
 export * from './derive-title-from-prompt.js';
+export * from './priority-context.js';
 export * from './resolve-child-session-config.js';
 export * from './resolve-permission-config.js';
 export * from './resolve-session-defaults.js';

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -4,6 +4,9 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   formatPriorityContextMessage,
+  MAX_FILE_BYTES,
+  MAX_MANIFEST_FILES,
+  MAX_TOTAL_BYTES,
   readPriorityContextFiles,
   readPriorityContextManifest,
   resolvePriorityContextForWorktree,
@@ -49,6 +52,21 @@ describe('readPriorityContextManifest', () => {
   it('returns undefined and does not throw when `files` is missing or the wrong shape', async () => {
     await writeManifest({ onMissing: 'skip' });
     expect(await readPriorityContextManifest(worktree)).toBeUndefined();
+  });
+
+  it('rejects an unsupported `onMissing` value instead of silently ignoring it', async () => {
+    await writeManifest({ files: ['SOUL.md'], onMissing: 'fail' });
+    expect(await readPriorityContextManifest(worktree)).toBeUndefined();
+  });
+
+  it('caps the file list at MAX_MANIFEST_FILES and warns', async () => {
+    const files = Array.from({ length: MAX_MANIFEST_FILES + 5 }, (_, i) => `file-${i}.md`);
+    await writeManifest({ files });
+
+    const manifest = await readPriorityContextManifest(worktree);
+
+    expect(manifest?.files).toHaveLength(MAX_MANIFEST_FILES);
+    expect(manifest?.files).toEqual(files.slice(0, MAX_MANIFEST_FILES));
   });
 });
 
@@ -105,6 +123,41 @@ describe('readPriorityContextFiles', () => {
     }
   });
 
+  it('refuses to follow a final-component symlink pointing outside the worktree', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-priority-context-symlink-'));
+    try {
+      await fs.writeFile(path.join(outside, 'secret.md'), 'top secret', 'utf-8');
+      await fs.symlink(path.join(outside, 'secret.md'), path.join(worktree, 'LINK.md'));
+
+      const files = await readPriorityContextFiles(worktree, { files: ['LINK.md'] });
+
+      expect(files).toEqual([]);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to follow a symlinked ancestor directory pointing outside the worktree, even for a not-yet-existing file', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-priority-context-ancestor-'));
+    try {
+      // The target file doesn't exist yet -- this is the "dangling target"
+      // case: fs.realpath fails on the full path, so containment must be
+      // checked by walking up to the symlinked ancestor, not by falling
+      // back to the lexical (pre-symlink) path.
+      await fs.symlink(outside, path.join(worktree, 'notes'));
+
+      const files = await readPriorityContextFiles(worktree, { files: ['notes/today.md'] });
+      expect(files).toEqual([]);
+
+      // Now create the target after the fact and confirm it's still refused.
+      await fs.writeFile(path.join(outside, 'today.md'), 'leaked', 'utf-8');
+      const filesAfter = await readPriorityContextFiles(worktree, { files: ['notes/today.md'] });
+      expect(filesAfter).toEqual([]);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it('resolves a {today} path to the current date file when it exists', async () => {
     await writeFile('memory/2026-07-28.md', "today's log");
 
@@ -137,6 +190,28 @@ describe('readPriorityContextFiles', () => {
     );
 
     expect(files).toEqual([]);
+  });
+
+  it('skips a single file that exceeds the per-file byte limit', async () => {
+    await writeFile('SOUL.md', 'ok');
+    await writeFile('HUGE.md', 'x'.repeat(MAX_FILE_BYTES + 1));
+
+    const files = await readPriorityContextFiles(worktree, { files: ['SOUL.md', 'HUGE.md'] });
+
+    expect(files).toEqual([{ path: 'SOUL.md', content: 'ok' }]);
+  });
+
+  it('stops once the total byte budget is reached, keeping earlier files', async () => {
+    const chunk = 'x'.repeat(MAX_FILE_BYTES);
+    await writeFile('A.md', chunk);
+    await writeFile('B.md', chunk);
+    await writeFile('C.md', chunk);
+
+    const files = await readPriorityContextFiles(worktree, { files: ['A.md', 'B.md', 'C.md'] });
+    const totalBytes = files.reduce((sum, f) => sum + Buffer.byteLength(f.content), 0);
+
+    expect(files.map((f) => f.path)).toEqual(['A.md', 'B.md']);
+    expect(totalBytes).toBeLessThanOrEqual(MAX_TOTAL_BYTES);
   });
 });
 

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -55,10 +55,15 @@ describe('canInjectPriorityContextForBranch', () => {
   // pair — it can't distinguish "the raw branch column" from "a group grant
   // that overrode it", so it correctly denies/allows based on whatever
   // resolveUserAccess decided, whether that raises or lowers access relative
-  // to the branch's raw others_fs_access fallback. The combinatorics of how
-  // resolveUserAccess itself picks a winning candidate across direct
-  // ownership, branch/board group grants, and board-aligned defaults are
-  // covered in `db/repositories/branches.test.ts` ("resolveUserAccess").
+  // to the branch's raw others_fs_access fallback. `resolveUserAccess`
+  // itself (how it picks a winning candidate across ownership, group
+  // grants, and board-aligned defaults) is exercised separately in
+  // `db/repositories/branches.test.ts` ("resolveUserAccess"), though that
+  // suite doesn't yet cover every combination (e.g. a group grant that
+  // lowers filesystem access below a stronger app permission, or a
+  // board-aligned `none` default) — this predicate's contract doesn't
+  // depend on those cases being covered there, but the resolver's own test
+  // suite would benefit from them.
 });
 
 let worktree: string;

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  canInjectPriorityContextForBranch,
   formatPriorityContextMessage,
   isRootSessionGenealogy,
   MAX_FILE_BYTES,
@@ -28,6 +29,36 @@ describe('isRootSessionGenealogy', () => {
 
   it('is false for a forked sibling session', () => {
     expect(isRootSessionGenealogy({ forked_from_session_id: 'session-1' })).toBe(false);
+  });
+});
+
+describe('canInjectPriorityContextForBranch', () => {
+  it('always allows injection for the branch owner, regardless of others_fs_access', () => {
+    expect(canInjectPriorityContextForBranch({ isOwner: true, othersFsAccess: 'none' })).toBe(true);
+    expect(canInjectPriorityContextForBranch({ isOwner: true, othersFsAccess: undefined })).toBe(
+      true
+    );
+  });
+
+  it('denies injection for a non-owner when others_fs_access is none', () => {
+    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'none' })).toBe(
+      false
+    );
+  });
+
+  it('allows injection for a non-owner when others_fs_access grants read or write', () => {
+    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'read' })).toBe(
+      true
+    );
+    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'write' })).toBe(
+      true
+    );
+  });
+
+  it('defaults to allowed for a non-owner when others_fs_access is unset (open-access mode)', () => {
+    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: undefined })).toBe(
+      true
+    );
   });
 });
 

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -77,6 +77,34 @@ describe('readPriorityContextFiles', () => {
     expect(files).toEqual([{ path: 'SOUL.md', content: 'Be warm and concise.' }]);
   });
 
+  it('refuses to read a path that escapes the worktree via ../', async () => {
+    const secretDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-priority-context-secret-'));
+    try {
+      await fs.writeFile(path.join(secretDir, 'secret.md'), 'top secret', 'utf-8');
+      const traversal = `${path.relative(worktree, secretDir)}/secret.md`;
+
+      const files = await readPriorityContextFiles(worktree, { files: [traversal] });
+
+      expect(files).toEqual([]);
+    } finally {
+      await fs.rm(secretDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to read an absolute path', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-priority-context-abs-'));
+    try {
+      const absoluteFile = path.join(outside, 'secret.md');
+      await fs.writeFile(absoluteFile, 'top secret', 'utf-8');
+
+      const files = await readPriorityContextFiles(worktree, { files: [absoluteFile] });
+
+      expect(files).toEqual([]);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it('resolves a {today} path to the current date file when it exists', async () => {
     await writeFile('memory/2026-07-28.md', "today's log");
 

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -192,6 +193,23 @@ describe('readPriorityContextFiles', () => {
 
     const files = await readPriorityContextFiles(worktree, {
       files: ['NOT_A_FILE.md', 'SOUL.md'],
+    });
+
+    expect(files).toEqual([{ path: 'SOUL.md', content: 'ok' }]);
+  });
+
+  it('skips a FIFO with no writer instead of hanging (open() must not block)', {
+    timeout: 5_000,
+  }, async () => {
+    const fifoPath = path.join(worktree, 'PIPE.md');
+    execFileSync('mkfifo', [fifoPath]);
+    await writeFile('SOUL.md', 'ok');
+
+    // No writer ever connects to the FIFO. A plain blocking open() would
+    // hang here indefinitely (while holding the daemon's per-session
+    // prompt lock in production); this must return promptly instead.
+    const files = await readPriorityContextFiles(worktree, {
+      files: ['PIPE.md', 'SOUL.md'],
     });
 
     expect(files).toEqual([{ path: 'SOUL.md', content: 'ok' }]);

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   formatPriorityContextMessage,
+  isRootSessionGenealogy,
   MAX_FILE_BYTES,
   MAX_MANIFEST_FILES,
   MAX_TOTAL_BYTES,
@@ -11,6 +12,22 @@ import {
   readPriorityContextManifest,
   resolvePriorityContextForWorktree,
 } from './priority-context.js';
+
+describe('isRootSessionGenealogy', () => {
+  it('is true for a session with no parent and no fork source', () => {
+    expect(isRootSessionGenealogy({ children: [] } as never)).toBe(true);
+    expect(isRootSessionGenealogy(undefined)).toBe(true);
+    expect(isRootSessionGenealogy(null)).toBe(true);
+  });
+
+  it('is false for a spawned child session', () => {
+    expect(isRootSessionGenealogy({ parent_session_id: 'session-1' })).toBe(false);
+  });
+
+  it('is false for a forked sibling session', () => {
+    expect(isRootSessionGenealogy({ forked_from_session_id: 'session-1' })).toBe(false);
+  });
+});
 
 let worktree: string;
 

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -6,6 +6,7 @@ import {
   formatPriorityContextMessage,
   isRootSessionGenealogy,
   MAX_FILE_BYTES,
+  MAX_MANIFEST_BYTES,
   MAX_MANIFEST_FILES,
   MAX_TOTAL_BYTES,
   readPriorityContextFiles,
@@ -84,6 +85,16 @@ describe('readPriorityContextManifest', () => {
 
     expect(manifest?.files).toHaveLength(MAX_MANIFEST_FILES);
     expect(manifest?.files).toEqual(files.slice(0, MAX_MANIFEST_FILES));
+  });
+
+  it('rejects a manifest file that exceeds MAX_MANIFEST_BYTES, without fully parsing it', async () => {
+    // Padded with a JSON string value so the file is valid-looking JSON
+    // shape-wise, were it ever parsed -- the size cap must reject it before
+    // JSON.parse runs at all, not because parsing itself fails.
+    const padding = 'x'.repeat(MAX_MANIFEST_BYTES + 1);
+    await writeFile('.agor/priority-context.json', JSON.stringify({ files: [], padding }));
+
+    expect(await readPriorityContextManifest(worktree)).toBeUndefined();
   });
 });
 
@@ -173,6 +184,17 @@ describe('readPriorityContextFiles', () => {
     } finally {
       await fs.rm(outside, { recursive: true, force: true });
     }
+  });
+
+  it('skips a listed path that is not a regular file (e.g. a directory)', async () => {
+    await fs.mkdir(path.join(worktree, 'NOT_A_FILE.md'), { recursive: true });
+    await writeFile('SOUL.md', 'ok');
+
+    const files = await readPriorityContextFiles(worktree, {
+      files: ['NOT_A_FILE.md', 'SOUL.md'],
+    });
+
+    expect(files).toEqual([{ path: 'SOUL.md', content: 'ok' }]);
   });
 
   it('resolves a {today} path to the current date file when it exists', async () => {

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -1,0 +1,154 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  formatPriorityContextMessage,
+  readPriorityContextFiles,
+  readPriorityContextManifest,
+  resolvePriorityContextForWorktree,
+} from './priority-context.js';
+
+let worktree: string;
+
+beforeEach(async () => {
+  worktree = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-priority-context-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(worktree, { recursive: true, force: true });
+});
+
+async function writeFile(relativePath: string, content: string): Promise<void> {
+  const absolutePath = path.join(worktree, relativePath);
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content, 'utf-8');
+}
+
+async function writeManifest(manifest: unknown): Promise<void> {
+  await writeFile('.agor/priority-context.json', JSON.stringify(manifest));
+}
+
+describe('readPriorityContextManifest', () => {
+  it('returns undefined when no manifest exists (the common, opted-out case)', async () => {
+    expect(await readPriorityContextManifest(worktree)).toBeUndefined();
+  });
+
+  it('reads a valid manifest', async () => {
+    await writeManifest({ files: ['SOUL.md', 'IDENTITY.md'] });
+    expect(await readPriorityContextManifest(worktree)).toEqual({
+      files: ['SOUL.md', 'IDENTITY.md'],
+    });
+  });
+
+  it('returns undefined and does not throw on malformed JSON', async () => {
+    await writeFile('.agor/priority-context.json', '{ not valid json');
+    expect(await readPriorityContextManifest(worktree)).toBeUndefined();
+  });
+
+  it('returns undefined and does not throw when `files` is missing or the wrong shape', async () => {
+    await writeManifest({ onMissing: 'skip' });
+    expect(await readPriorityContextManifest(worktree)).toBeUndefined();
+  });
+});
+
+describe('readPriorityContextFiles', () => {
+  it('reads listed files that exist', async () => {
+    await writeFile('SOUL.md', 'Be warm and concise.');
+    await writeFile('IDENTITY.md', 'You are Hodor.');
+
+    const files = await readPriorityContextFiles(worktree, {
+      files: ['SOUL.md', 'IDENTITY.md'],
+    });
+
+    expect(files).toEqual([
+      { path: 'SOUL.md', content: 'Be warm and concise.' },
+      { path: 'IDENTITY.md', content: 'You are Hodor.' },
+    ]);
+  });
+
+  it('silently skips files that do not exist (onMissing: skip)', async () => {
+    await writeFile('SOUL.md', 'Be warm and concise.');
+
+    const files = await readPriorityContextFiles(worktree, {
+      files: ['SOUL.md', 'MISSING.md'],
+    });
+
+    expect(files).toEqual([{ path: 'SOUL.md', content: 'Be warm and concise.' }]);
+  });
+
+  it('resolves a {today} path to the current date file when it exists', async () => {
+    await writeFile('memory/2026-07-28.md', "today's log");
+
+    const files = await readPriorityContextFiles(
+      worktree,
+      { files: ['memory/{today}.md'] },
+      new Date('2026-07-28T12:00:00.000Z')
+    );
+
+    expect(files).toEqual([{ path: 'memory/2026-07-28.md', content: "today's log" }]);
+  });
+
+  it("falls back to the prior day when {today}'s file is missing", async () => {
+    await writeFile('memory/2026-07-27.md', "yesterday's log");
+
+    const files = await readPriorityContextFiles(
+      worktree,
+      { files: ['memory/{today}.md'] },
+      new Date('2026-07-28T12:00:00.000Z')
+    );
+
+    expect(files).toEqual([{ path: 'memory/2026-07-27.md', content: "yesterday's log" }]);
+  });
+
+  it('skips a {today} entry when neither today nor yesterday exists', async () => {
+    const files = await readPriorityContextFiles(
+      worktree,
+      { files: ['memory/{today}.md'] },
+      new Date('2026-07-28T12:00:00.000Z')
+    );
+
+    expect(files).toEqual([]);
+  });
+});
+
+describe('formatPriorityContextMessage', () => {
+  it('returns undefined for an empty file list', () => {
+    expect(formatPriorityContextMessage([])).toBeUndefined();
+  });
+
+  it('formats a header plus one section per file', () => {
+    const message = formatPriorityContextMessage([
+      { path: 'SOUL.md', content: 'Be warm.' },
+      { path: 'IDENTITY.md', content: 'You are Hodor.' },
+    ]);
+
+    expect(message).toContain('SOUL.md');
+    expect(message).toContain('Be warm.');
+    expect(message).toContain('IDENTITY.md');
+    expect(message).toContain('You are Hodor.');
+    expect(message?.indexOf('SOUL.md')).toBeLessThan(message?.indexOf('IDENTITY.md') ?? 0);
+  });
+});
+
+describe('resolvePriorityContextForWorktree (end-to-end)', () => {
+  it('returns undefined when the repo has no manifest', async () => {
+    expect(await resolvePriorityContextForWorktree(worktree)).toBeUndefined();
+  });
+
+  it('returns undefined when the manifest lists only missing files', async () => {
+    await writeManifest({ files: ['NOPE.md'] });
+    expect(await resolvePriorityContextForWorktree(worktree)).toBeUndefined();
+  });
+
+  it('resolves manifest + files into a single synthetic message', async () => {
+    await writeManifest({ files: ['SOUL.md', 'BOARD.md'] });
+    await writeFile('SOUL.md', 'Values and communication style.');
+    await writeFile('BOARD.md', 'Board zones and workflow.');
+
+    const message = await resolvePriorityContextForWorktree(worktree);
+
+    expect(message).toContain('Values and communication style.');
+    expect(message).toContain('Board zones and workflow.');
+  });
+});

--- a/packages/core/src/sessions/priority-context.test.ts
+++ b/packages/core/src/sessions/priority-context.test.ts
@@ -33,33 +33,32 @@ describe('isRootSessionGenealogy', () => {
 });
 
 describe('canInjectPriorityContextForBranch', () => {
-  it('always allows injection for the branch owner, regardless of others_fs_access', () => {
-    expect(canInjectPriorityContextForBranch({ isOwner: true, othersFsAccess: 'none' })).toBe(true);
-    expect(canInjectPriorityContextForBranch({ isOwner: true, othersFsAccess: undefined })).toBe(
-      true
-    );
+  it('always allows injection for the branch owner, regardless of fs_access', () => {
+    expect(canInjectPriorityContextForBranch({ is_owner: true, fs_access: 'none' })).toBe(true);
+    expect(canInjectPriorityContextForBranch({ is_owner: true, fs_access: undefined })).toBe(true);
   });
 
-  it('denies injection for a non-owner when others_fs_access is none', () => {
-    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'none' })).toBe(
-      false
-    );
+  it('denies injection for a non-owner when effective fs_access is none', () => {
+    expect(canInjectPriorityContextForBranch({ is_owner: false, fs_access: 'none' })).toBe(false);
   });
 
-  it('allows injection for a non-owner when others_fs_access grants read or write', () => {
-    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'read' })).toBe(
-      true
-    );
-    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: 'write' })).toBe(
-      true
-    );
+  it('allows injection for a non-owner when effective fs_access grants read or write', () => {
+    expect(canInjectPriorityContextForBranch({ is_owner: false, fs_access: 'read' })).toBe(true);
+    expect(canInjectPriorityContextForBranch({ is_owner: false, fs_access: 'write' })).toBe(true);
   });
 
-  it('defaults to allowed for a non-owner when others_fs_access is unset (open-access mode)', () => {
-    expect(canInjectPriorityContextForBranch({ isOwner: false, othersFsAccess: undefined })).toBe(
-      true
-    );
+  it('defaults to allowed for a non-owner when fs_access is unset (open-access mode)', () => {
+    expect(canInjectPriorityContextForBranch({ is_owner: false, fs_access: undefined })).toBe(true);
   });
+
+  // The predicate only sees the already-resolved `{ is_owner, fs_access }`
+  // pair — it can't distinguish "the raw branch column" from "a group grant
+  // that overrode it", so it correctly denies/allows based on whatever
+  // resolveUserAccess decided, whether that raises or lowers access relative
+  // to the branch's raw others_fs_access fallback. The combinatorics of how
+  // resolveUserAccess itself picks a winning candidate across direct
+  // ownership, branch/board group grants, and board-aligned defaults are
+  // covered in `db/repositories/branches.test.ts` ("resolveUserAccess").
 });
 
 let worktree: string;

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -20,6 +20,7 @@
  * files instead, not this manifest.
  */
 
+import { Buffer } from 'node:buffer';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -74,6 +75,7 @@ const TODAY_TOKEN = '{today}';
  * agent's discretion.
  */
 export const MAX_MANIFEST_FILES = 20;
+export const MAX_MANIFEST_BYTES = 64 * 1024; // 64 KB for the manifest JSON itself
 export const MAX_FILE_BYTES = 200 * 1024; // 200 KB per file
 export const MAX_TOTAL_BYTES = 512 * 1024; // 512 KB across all injected files
 
@@ -87,24 +89,71 @@ function isValidManifest(value: unknown): value is PriorityContextManifest {
 }
 
 /**
+ * Open `absolutePath` once and read at most `maxBytes` from that single
+ * file descriptor — closes two gaps a separate `stat()` + `readFile()`
+ * pair would leave open:
+ *
+ * - A regular file can grow between an initial size check and a later
+ *   unbounded read; reading a fixed number of bytes from one already-open
+ *   descriptor can't be affected by writes that happen after the open.
+ * - A FIFO/named pipe (or other non-regular file) placed in the worktree
+ *   can report a harmless size via `stat()` yet block indefinitely on
+ *   `readFile()` — fatal here, since this runs inside the daemon's
+ *   per-session prompt lock (`withSessionTurnLock`). `handle.stat()` on
+ *   the open descriptor rejects anything that isn't a regular file before
+ *   any read is attempted.
+ *
+ * Reads `maxBytes + 1` bytes so an over-budget file can be distinguished
+ * from one that exactly fits, without ever holding more than
+ * `maxBytes + 1` bytes in memory. Returns `undefined` for anything that
+ * can't be opened or isn't a regular file (treated the same as a missing
+ * file by callers); `truncated: true` when the real content exceeds
+ * `maxBytes`.
+ */
+async function readBoundedFile(
+  absolutePath: string,
+  maxBytes: number
+): Promise<{ content: string; truncated: boolean } | undefined> {
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(absolutePath, 'r');
+    const stats = await handle.stat();
+    if (!stats.isFile()) return undefined;
+
+    const buffer = Buffer.alloc(maxBytes + 1);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes + 1, 0);
+    const truncated = bytesRead > maxBytes;
+    return { content: buffer.toString('utf-8', 0, Math.min(bytesRead, maxBytes)), truncated };
+  } catch {
+    return undefined;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+/**
  * Read and validate `.agor/priority-context.json` from a branch's worktree.
- * Returns `undefined` if the repo hasn't opted in, or the manifest is
- * missing/malformed — this feature is inert by default.
+ * Returns `undefined` if the repo hasn't opted in, the manifest is
+ * missing/malformed, or it exceeds `MAX_MANIFEST_BYTES` — this feature is
+ * inert by default. The size cap is enforced by `readBoundedFile` before
+ * any JSON parsing, so an oversized manifest never gets fully parsed.
  */
 export async function readPriorityContextManifest(
   worktreePath: string
 ): Promise<PriorityContextManifest | undefined> {
   const manifestPath = path.join(worktreePath, MANIFEST_RELATIVE_PATH);
-  let raw: string;
-  try {
-    raw = await fs.readFile(manifestPath, 'utf-8');
-  } catch {
+  const bounded = await readBoundedFile(manifestPath, MAX_MANIFEST_BYTES);
+  if (!bounded) return undefined;
+  if (bounded.truncated) {
+    console.warn(
+      `[priority-context] Ignoring ${manifestPath}: exceeds the ${MAX_MANIFEST_BYTES}-byte manifest size limit`
+    );
     return undefined;
   }
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(bounded.content);
   } catch (error) {
     console.warn(`[priority-context] Failed to parse ${manifestPath}: ${(error as Error).message}`);
     return undefined;
@@ -235,12 +284,15 @@ async function resolveTemplatedPath(
 }
 
 /**
- * Read a manifest's listed files from the worktree. Missing files, and any
- * path that resolves outside the worktree, are silently skipped —
- * `onMissing: 'skip'` is the only supported mode. Stops accepting further
- * files once `MAX_TOTAL_BYTES` is reached; each file is also capped at
- * `MAX_FILE_BYTES` individually. Both limits log a warning when they cause
- * a file to be skipped, so a repo can tell its manifest is being trimmed.
+ * Read a manifest's listed files from the worktree. Missing files, files
+ * that aren't regular files (directories, FIFOs, devices, ...), and any
+ * path that resolves outside the worktree, are all silently skipped —
+ * `onMissing: 'skip'` is the only supported mode. Each file is read through
+ * `readBoundedFile` at `min(MAX_FILE_BYTES, <remaining total budget>)`, so
+ * one file can never consume more than its per-file cap, and the batch as a
+ * whole can never exceed `MAX_TOTAL_BYTES`. Both a truncated (over-budget)
+ * file and reaching the total budget log a warning, so a repo can tell its
+ * manifest is being trimmed.
  */
 export async function readPriorityContextFiles(
   worktreePath: string,
@@ -267,27 +319,18 @@ export async function readPriorityContextFiles(
       continue;
     }
 
-    try {
-      const stats = await fs.stat(safePath);
-      if (stats.size > MAX_FILE_BYTES) {
-        console.warn(
-          `[priority-context] Skipping "${relativePath}": ${stats.size} bytes exceeds the ${MAX_FILE_BYTES}-byte per-file limit`
-        );
-        continue;
-      }
-      if (totalBytes + stats.size > MAX_TOTAL_BYTES) {
-        console.warn(
-          `[priority-context] Skipping "${relativePath}": would exceed the ${MAX_TOTAL_BYTES}-byte total budget`
-        );
-        continue;
-      }
-
-      const content = await fs.readFile(safePath, 'utf-8');
-      results.push({ path: relativePath, content });
-      totalBytes += stats.size;
-    } catch {
-      // onMissing: 'skip' — the only supported mode today.
+    const budget = Math.min(MAX_FILE_BYTES, MAX_TOTAL_BYTES - totalBytes);
+    const bounded = await readBoundedFile(safePath, budget);
+    if (!bounded) continue; // missing, unreadable, or not a regular file — onMissing: 'skip'
+    if (bounded.truncated) {
+      console.warn(
+        `[priority-context] Skipping "${relativePath}": exceeds the ${budget}-byte read budget`
+      );
+      continue;
     }
+
+    results.push({ path: relativePath, content: bounded.content });
+    totalBytes += Buffer.byteLength(bounded.content, 'utf-8');
   }
 
   return results;

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -56,10 +56,10 @@ export type PriorityContextGenealogy =
  * A session is eligible for priority-context injection only if it's a root
  * session — no parent (spawn) and no fork source. Spawned/forked/continued
  * sessions already inherit context from their parent and are out of scope
- * (see the spec's Decision 4). Combine with a first-task check (e.g.
- * `taskRepo.countBySession(id) === 0`) at the call site to also exclude a
+ * (see the spec's Decision 4). Combine with a first-turn check (e.g. "no
+ * messages exist yet for this session") at the call site to also exclude a
  * root session's later turns — this predicate alone doesn't know about
- * tasks.
+ * tasks or messages.
  */
 export function isRootSessionGenealogy(genealogy: PriorityContextGenealogy): boolean {
   return !genealogy?.parent_session_id && !genealogy?.forked_from_session_id;
@@ -389,7 +389,12 @@ const PRIORITY_CONTEXT_HEADER =
   "The following are this repo's designated priority-context files " +
   '(`.agor/priority-context.json`), provided automatically because this is ' +
   'a brand-new session. Treat them as established context, not as part of ' +
-  "the message below — there's no need to re-read them yourself.";
+  "the message below — there's no need to re-read them yourself, and no " +
+  'need to acknowledge, summarize, or describe them in your reply. Let ' +
+  'them inform who you are, not what you open with: reply to the message ' +
+  'below the way you would if this context had already been part of you ' +
+  'from the start, leading with the user and their goal rather than with ' +
+  'the repo, its files, or its state.';
 
 /** Build the synthetic context message to prepend to a root session's first prompt. */
 export function formatPriorityContextMessage(files: PriorityContextFile[]): string | undefined {

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -1,0 +1,173 @@
+/**
+ * Priority context injection for brand-new root sessions.
+ *
+ * A repo can opt in to a `.agor/priority-context.json` manifest at its
+ * worktree root, listing files that should be read and prepended as a
+ * synthetic context message before a root session's first turn. This
+ * replaces asking the agent to self-enforce a "read these files on a fresh
+ * session" instruction (e.g. via a `BOOT.md` convention) — that convention
+ * depends on the agent correctly recognizing session freshness and choosing
+ * to act on it before answering, which can silently fail. Resolving and
+ * injecting the manifest here, at session-bootstrap time, removes that
+ * discretion: the content is either present before the first turn, or the
+ * repo has no manifest.
+ *
+ * This is a one-time read at session creation, not a per-turn mechanism —
+ * mirrors the read-once-at-start semantics of the `BOOT.md` convention it
+ * replaces. It intentionally does not persist across context compaction the
+ * way a harness's native `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` loading does;
+ * content meant to hold for the whole conversation belongs in one of those
+ * files instead, not this manifest.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface PriorityContextManifest {
+  /** Paths relative to the worktree root. May contain a `{today}` segment. */
+  files: string[];
+  /**
+   * Behavior when a listed file doesn't exist. Only `'skip'` is supported
+   * today — session creation never fails because a designated file is
+   * missing.
+   */
+  onMissing?: 'skip';
+}
+
+export interface PriorityContextFile {
+  /** Path actually read, relative to the worktree root (post `{today}` resolution). */
+  path: string;
+  content: string;
+}
+
+const MANIFEST_RELATIVE_PATH = path.join('.agor', 'priority-context.json');
+const TODAY_TOKEN = '{today}';
+
+function isValidManifest(value: unknown): value is PriorityContextManifest {
+  if (!value || typeof value !== 'object') return false;
+  const files = (value as Record<string, unknown>).files;
+  return Array.isArray(files) && files.every((entry) => typeof entry === 'string');
+}
+
+/**
+ * Read and validate `.agor/priority-context.json` from a branch's worktree.
+ * Returns `undefined` if the repo hasn't opted in, or the manifest is
+ * missing/malformed — this feature is inert by default.
+ */
+export async function readPriorityContextManifest(
+  worktreePath: string
+): Promise<PriorityContextManifest | undefined> {
+  const manifestPath = path.join(worktreePath, MANIFEST_RELATIVE_PATH);
+  let raw: string;
+  try {
+    raw = await fs.readFile(manifestPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.warn(`[priority-context] Failed to parse ${manifestPath}: ${(error as Error).message}`);
+    return undefined;
+  }
+
+  if (!isValidManifest(parsed)) {
+    console.warn(`[priority-context] Ignoring ${manifestPath}: expected { files: string[] }`);
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function formatDateToken(date: Date): string {
+  return date.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+async function fileExists(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.access(absolutePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a `{today}` segment in a manifest path to today's date, falling
+ * back to yesterday's if today's file doesn't exist yet (mirrors the
+ * existing `BOOT.md` convention: "if missing, read yesterday's daily log").
+ * Paths without `{today}` pass through unchanged.
+ */
+async function resolveTemplatedPath(
+  worktreePath: string,
+  relativePath: string,
+  now: Date
+): Promise<string> {
+  if (!relativePath.includes(TODAY_TOKEN)) return relativePath;
+
+  const todayPath = relativePath.replace(TODAY_TOKEN, formatDateToken(now));
+  if (await fileExists(path.join(worktreePath, todayPath))) return todayPath;
+
+  const yesterday = new Date(now);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const yesterdayPath = relativePath.replace(TODAY_TOKEN, formatDateToken(yesterday));
+  if (await fileExists(path.join(worktreePath, yesterdayPath))) return yesterdayPath;
+
+  // Neither exists — return today's path so the normal onMissing skip applies.
+  return todayPath;
+}
+
+/**
+ * Read a manifest's listed files from the worktree. Missing files are
+ * silently skipped — `onMissing: 'skip'` is the only supported mode.
+ */
+export async function readPriorityContextFiles(
+  worktreePath: string,
+  manifest: PriorityContextManifest,
+  now: Date = new Date()
+): Promise<PriorityContextFile[]> {
+  const results: PriorityContextFile[] = [];
+
+  for (const rawPath of manifest.files) {
+    const relativePath = await resolveTemplatedPath(worktreePath, rawPath, now);
+    try {
+      const content = await fs.readFile(path.join(worktreePath, relativePath), 'utf-8');
+      results.push({ path: relativePath, content });
+    } catch {
+      // onMissing: 'skip' — the only supported mode today.
+    }
+  }
+
+  return results;
+}
+
+const PRIORITY_CONTEXT_HEADER =
+  "The following are this repo's designated priority-context files " +
+  '(`.agor/priority-context.json`), provided automatically because this is ' +
+  'a brand-new session. Treat them as established context, not as part of ' +
+  "the message below — there's no need to re-read them yourself.";
+
+/** Build the synthetic context message to prepend to a root session's first prompt. */
+export function formatPriorityContextMessage(files: PriorityContextFile[]): string | undefined {
+  if (files.length === 0) return undefined;
+  const sections = files.map((file) => `### ${file.path}\n\n${file.content.trim()}`).join('\n\n');
+  return `${PRIORITY_CONTEXT_HEADER}\n\n${sections}`;
+}
+
+/**
+ * End-to-end resolution: manifest + files + formatting. Returns `undefined`
+ * when the repo has no manifest, or none of its listed files resolve to
+ * content — callers should leave the prompt untouched in that case.
+ */
+export async function resolvePriorityContextForWorktree(
+  worktreePath: string,
+  now: Date = new Date()
+): Promise<string | undefined> {
+  const manifest = await readPriorityContextManifest(worktreePath);
+  if (!manifest) return undefined;
+
+  const files = await readPriorityContextFiles(worktreePath, manifest, now);
+  return formatPriorityContextMessage(files);
+}

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -40,6 +40,28 @@ export interface PriorityContextFile {
   content: string;
 }
 
+/** Minimal genealogy shape this predicate reads — keeps tests free of full Session fixtures. */
+export type PriorityContextGenealogy =
+  | {
+      parent_session_id?: unknown;
+      forked_from_session_id?: unknown;
+    }
+  | null
+  | undefined;
+
+/**
+ * A session is eligible for priority-context injection only if it's a root
+ * session — no parent (spawn) and no fork source. Spawned/forked/continued
+ * sessions already inherit context from their parent and are out of scope
+ * (see the spec's Decision 4). Combine with a first-task check (e.g.
+ * `taskRepo.countBySession(id) === 0`) at the call site to also exclude a
+ * root session's later turns — this predicate alone doesn't know about
+ * tasks.
+ */
+export function isRootSessionGenealogy(genealogy: PriorityContextGenealogy): boolean {
+  return !genealogy?.parent_session_id && !genealogy?.forked_from_session_id;
+}
+
 const MANIFEST_RELATIVE_PATH = path.join('.agor', 'priority-context.json');
 const TODAY_TOKEN = '{today}';
 

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -85,9 +85,40 @@ function formatDateToken(date: Date): string {
   return date.toISOString().slice(0, 10); // YYYY-MM-DD
 }
 
-async function fileExists(absolutePath: string): Promise<boolean> {
+/**
+ * Resolve `relativePath` against `worktreePath` and confirm the result
+ * doesn't escape the worktree (`../`, an absolute path, a symlink pointing
+ * outside, etc.). The manifest is repo-authored, but it's still read as
+ * plain untrusted-ish data — a typo'd or malicious `../../.ssh/id_rsa`
+ * entry must never turn into an arbitrary host-file read. Returns
+ * `undefined` for anything outside the worktree, which callers treat the
+ * same as a missing file (`onMissing: 'skip'`).
+ */
+async function resolveWithinWorktree(
+  worktreePath: string,
+  relativePath: string
+): Promise<string | undefined> {
+  if (path.isAbsolute(relativePath)) return undefined;
+
+  const root = await fs.realpath(worktreePath).catch(() => path.resolve(worktreePath));
+  const candidate = path.resolve(root, relativePath);
+  const real = await fs.realpath(candidate).catch(() => candidate);
+
+  const relativeToRoot = path.relative(root, real);
+  const escapesRoot = relativeToRoot === '' ? false : relativeToRoot.startsWith('..');
+  if (escapesRoot || path.isAbsolute(relativeToRoot)) return undefined;
+
+  return candidate;
+}
+
+async function fileExistsWithinWorktree(
+  worktreePath: string,
+  relativePath: string
+): Promise<boolean> {
+  const safePath = await resolveWithinWorktree(worktreePath, relativePath);
+  if (!safePath) return false;
   try {
-    await fs.access(absolutePath);
+    await fs.access(safePath);
     return true;
   } catch {
     return false;
@@ -108,20 +139,21 @@ async function resolveTemplatedPath(
   if (!relativePath.includes(TODAY_TOKEN)) return relativePath;
 
   const todayPath = relativePath.replace(TODAY_TOKEN, formatDateToken(now));
-  if (await fileExists(path.join(worktreePath, todayPath))) return todayPath;
+  if (await fileExistsWithinWorktree(worktreePath, todayPath)) return todayPath;
 
   const yesterday = new Date(now);
   yesterday.setUTCDate(yesterday.getUTCDate() - 1);
   const yesterdayPath = relativePath.replace(TODAY_TOKEN, formatDateToken(yesterday));
-  if (await fileExists(path.join(worktreePath, yesterdayPath))) return yesterdayPath;
+  if (await fileExistsWithinWorktree(worktreePath, yesterdayPath)) return yesterdayPath;
 
   // Neither exists — return today's path so the normal onMissing skip applies.
   return todayPath;
 }
 
 /**
- * Read a manifest's listed files from the worktree. Missing files are
- * silently skipped — `onMissing: 'skip'` is the only supported mode.
+ * Read a manifest's listed files from the worktree. Missing files, and any
+ * path that resolves outside the worktree, are silently skipped —
+ * `onMissing: 'skip'` is the only supported mode.
  */
 export async function readPriorityContextFiles(
   worktreePath: string,
@@ -132,8 +164,15 @@ export async function readPriorityContextFiles(
 
   for (const rawPath of manifest.files) {
     const relativePath = await resolveTemplatedPath(worktreePath, rawPath, now);
+    const safePath = await resolveWithinWorktree(worktreePath, relativePath);
+    if (!safePath) {
+      // resolveWithinWorktree only returns undefined for an absolute path or
+      // one that escapes the worktree root — never for a merely-missing file.
+      console.warn(`[priority-context] Skipping "${rawPath}": resolves outside the worktree`);
+      continue;
+    }
     try {
-      const content = await fs.readFile(path.join(worktreePath, relativePath), 'utf-8');
+      const content = await fs.readFile(safePath, 'utf-8');
       results.push({ path: relativePath, content });
     } catch {
       // onMissing: 'skip' — the only supported mode today.

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -95,8 +95,11 @@ function isValidManifest(value: unknown): value is PriorityContextManifest {
  * pair would leave open:
  *
  * - A regular file can grow between an initial size check and a later
- *   unbounded read; reading a fixed number of bytes from one already-open
- *   descriptor can't be affected by writes that happen after the open.
+ *   unbounded read. An already-open descriptor can still observe writes
+ *   made after the open — the safety property isn't that the descriptor is
+ *   a snapshot, it's that reading a fixed `maxBytes + 1` from it can never
+ *   itself become an unbounded read, regardless of how large the file
+ *   grows underneath it.
  * - A FIFO/named pipe (or other non-regular file) placed in the worktree
  *   can report a harmless size via `stat()` yet block indefinitely on
  *   `readFile()` — fatal here, since this runs inside the daemon's

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -64,6 +64,22 @@ export function isRootSessionGenealogy(genealogy: PriorityContextGenealogy): boo
   return !genealogy?.parent_session_id && !genealogy?.forked_from_session_id;
 }
 
+/**
+ * The daemon reads manifest-listed files with its own (broader) filesystem
+ * privileges, not the session creator's. That's fine for branch owners, but
+ * for non-owners it would otherwise bypass `others_fs_access` — the same
+ * setting that decides whether that user's own executor can read the
+ * worktree at all under `insulated`/`strict` Unix isolation. Gate injection
+ * on it so a non-owner denied filesystem access can't receive file contents
+ * through the injected prompt instead.
+ */
+export function canInjectPriorityContextForBranch(args: {
+  isOwner: boolean;
+  othersFsAccess: 'none' | 'read' | 'write' | undefined;
+}): boolean {
+  return args.isOwner || args.othersFsAccess !== 'none';
+}
+
 const MANIFEST_RELATIVE_PATH = path.join('.agor', 'priority-context.json');
 const TODAY_TOKEN = '{today}';
 

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -24,6 +24,7 @@ import { Buffer } from 'node:buffer';
 import { constants as fsConstants } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import type { EffectiveBranchAccess } from '../types/index.js';
 
 export interface PriorityContextManifest {
   /** Paths relative to the worktree root. May contain a `{today}` segment. */
@@ -73,19 +74,16 @@ export function isRootSessionGenealogy(genealogy: PriorityContextGenealogy): boo
  * injection on it so a non-owner denied filesystem access can't receive
  * file contents through the injected prompt instead.
  *
- * Takes the shape of `BranchRepository.resolveUserAccess(...)`'s return
- * value (deliberately duck-typed rather than importing that type, to keep
- * this module dependency-free) so callers pass its result directly — not
- * the branch's raw `others_fs_access` column. A user's effective access can
- * differ from that raw fallback via branch/board group grants or
+ * Takes `BranchRepository.resolveUserAccess(...)`'s return value directly —
+ * not the branch's raw `others_fs_access` column. A user's effective access
+ * can differ from that raw fallback via branch/board group grants or
  * board-aligned defaults, so passing the raw column here would both leak
  * (when a grant lowers access below the raw fallback) and over-deny (when a
  * grant raises it above).
  */
-export function canInjectPriorityContextForBranch(access: {
-  is_owner: boolean;
-  fs_access?: 'none' | 'read' | 'write';
-}): boolean {
+export function canInjectPriorityContextForBranch(
+  access: Pick<EffectiveBranchAccess, 'is_owner' | 'fs_access'>
+): boolean {
   return access.is_owner || access.fs_access !== 'none';
 }
 

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -21,6 +21,7 @@
  */
 
 import { Buffer } from 'node:buffer';
+import { constants as fsConstants } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
@@ -90,7 +91,7 @@ function isValidManifest(value: unknown): value is PriorityContextManifest {
 
 /**
  * Open `absolutePath` once and read at most `maxBytes` from that single
- * file descriptor — closes two gaps a separate `stat()` + `readFile()`
+ * file descriptor — closes three gaps a separate `stat()` + `readFile()`
  * pair would leave open:
  *
  * - A regular file can grow between an initial size check and a later
@@ -102,28 +103,50 @@ function isValidManifest(value: unknown): value is PriorityContextManifest {
  *   per-session prompt lock (`withSessionTurnLock`). `handle.stat()` on
  *   the open descriptor rejects anything that isn't a regular file before
  *   any read is attempted.
+ * - Opening a FIFO with a plain read-only flag can itself block until a
+ *   writer connects, before `stat()` ever runs. `O_NONBLOCK` makes the
+ *   `open()` call itself return immediately instead of waiting for a
+ *   writer; it has no effect on reading a regular file.
  *
- * Reads `maxBytes + 1` bytes so an over-budget file can be distinguished
- * from one that exactly fits, without ever holding more than
- * `maxBytes + 1` bytes in memory. Returns `undefined` for anything that
- * can't be opened or isn't a regular file (treated the same as a missing
- * file by callers); `truncated: true` when the real content exceeds
- * `maxBytes`.
+ * Reads up to `maxBytes + 1` bytes, looping until EOF or the cap is hit —
+ * `FileHandle.read()` is allowed to return fewer bytes than requested
+ * before EOF, so a single call isn't enough to guarantee the full content
+ * was read. Memory never exceeds `maxBytes + 1` bytes. Returns `undefined`
+ * for anything that can't be opened or isn't a regular file (treated the
+ * same as a missing file by callers); `truncated: true` when the real
+ * content exceeds `maxBytes`,
+ * alongside the exact number of content bytes actually accepted
+ * (`bytesRead`, always `<= maxBytes`) so callers doing their own budget
+ * accounting don't need to re-derive it from the decoded string (which can
+ * disagree with the source byte count across a split/invalid UTF-8
+ * sequence at the truncation boundary).
  */
 async function readBoundedFile(
   absolutePath: string,
   maxBytes: number
-): Promise<{ content: string; truncated: boolean } | undefined> {
+): Promise<{ content: string; bytesRead: number; truncated: boolean } | undefined> {
   let handle: fs.FileHandle | undefined;
   try {
-    handle = await fs.open(absolutePath, 'r');
+    handle = await fs.open(absolutePath, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
     const stats = await handle.stat();
     if (!stats.isFile()) return undefined;
 
     const buffer = Buffer.alloc(maxBytes + 1);
-    const { bytesRead } = await handle.read(buffer, 0, maxBytes + 1, 0);
-    const truncated = bytesRead > maxBytes;
-    return { content: buffer.toString('utf-8', 0, Math.min(bytesRead, maxBytes)), truncated };
+    let total = 0;
+    for (;;) {
+      const { bytesRead } = await handle.read(buffer, total, buffer.length - total, total);
+      if (bytesRead === 0) break; // EOF
+      total += bytesRead;
+      if (total >= buffer.length) break;
+    }
+
+    const truncated = total > maxBytes;
+    const acceptedBytes = Math.min(total, maxBytes);
+    return {
+      content: buffer.toString('utf-8', 0, acceptedBytes),
+      bytesRead: acceptedBytes,
+      truncated,
+    };
   } catch {
     return undefined;
   } finally {
@@ -330,7 +353,7 @@ export async function readPriorityContextFiles(
     }
 
     results.push({ path: relativePath, content: bounded.content });
-    totalBytes += Buffer.byteLength(bounded.content, 'utf-8');
+    totalBytes += bounded.bytesRead;
   }
 
   return results;

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -43,10 +43,25 @@ export interface PriorityContextFile {
 const MANIFEST_RELATIVE_PATH = path.join('.agor', 'priority-context.json');
 const TODAY_TOKEN = '{today}';
 
+/**
+ * Bounds on what a manifest can pull into the first prompt of every fresh
+ * root session. Without these, a manifest (accidentally oversized, or in a
+ * cloned/untrusted repo) could balloon request latency, token cost, or
+ * model context on the very first turn — before the agent has any chance to
+ * push back, since this is injected unconditionally, not read at the
+ * agent's discretion.
+ */
+export const MAX_MANIFEST_FILES = 20;
+export const MAX_FILE_BYTES = 200 * 1024; // 200 KB per file
+export const MAX_TOTAL_BYTES = 512 * 1024; // 512 KB across all injected files
+
 function isValidManifest(value: unknown): value is PriorityContextManifest {
   if (!value || typeof value !== 'object') return false;
-  const files = (value as Record<string, unknown>).files;
-  return Array.isArray(files) && files.every((entry) => typeof entry === 'string');
+  const record = value as Record<string, unknown>;
+  const { files, onMissing } = record;
+  if (!Array.isArray(files) || !files.every((entry) => typeof entry === 'string')) return false;
+  if (onMissing !== undefined && onMissing !== 'skip') return false;
+  return true;
 }
 
 /**
@@ -74,8 +89,18 @@ export async function readPriorityContextManifest(
   }
 
   if (!isValidManifest(parsed)) {
-    console.warn(`[priority-context] Ignoring ${manifestPath}: expected { files: string[] }`);
+    console.warn(
+      `[priority-context] Ignoring ${manifestPath}: expected { files: string[], onMissing?: 'skip' }`
+    );
     return undefined;
+  }
+
+  if (parsed.files.length > MAX_MANIFEST_FILES) {
+    console.warn(
+      `[priority-context] ${manifestPath} lists ${parsed.files.length} files, ` +
+        `only reading the first ${MAX_MANIFEST_FILES}`
+    );
+    return { ...parsed, files: parsed.files.slice(0, MAX_MANIFEST_FILES) };
   }
 
   return parsed;
@@ -85,14 +110,39 @@ function formatDateToken(date: Date): string {
   return date.toISOString().slice(0, 10); // YYYY-MM-DD
 }
 
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return !(relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative));
+}
+
 /**
  * Resolve `relativePath` against `worktreePath` and confirm the result
- * doesn't escape the worktree (`../`, an absolute path, a symlink pointing
- * outside, etc.). The manifest is repo-authored, but it's still read as
- * plain untrusted-ish data — a typo'd or malicious `../../.ssh/id_rsa`
- * entry must never turn into an arbitrary host-file read. Returns
- * `undefined` for anything outside the worktree, which callers treat the
- * same as a missing file (`onMissing: 'skip'`).
+ * doesn't escape the worktree (`../`, an absolute path, a symlinked
+ * ancestor directory, etc.), returning the *canonicalized* path that was
+ * actually validated — never the unresolved lexical join — so a caller
+ * that reads exactly this path isn't relying on a second, unvalidated
+ * resolution.
+ *
+ * The manifest is repo-authored, but it's still read as plain
+ * untrusted-ish data — a typo'd or malicious `../../.ssh/id_rsa` entry (or
+ * a symlink swapped in under the worktree) must never turn into an
+ * arbitrary host-file read.
+ *
+ * This walks up to the nearest ancestor that actually exists and
+ * canonicalizes *that*, then re-appends the missing remainder — otherwise
+ * a not-yet-existing file beneath a symlinked ancestor directory would
+ * skip containment checking entirely (`fs.realpath` simply fails for a
+ * path that doesn't exist, which is the common case for most manifest
+ * entries). This closes the straightforward cases (final component is a
+ * symlink; an ancestor directory is a symlink to outside the worktree).
+ * It cannot fully close a filesystem that's concurrently and adversarially
+ * modified between this check and the subsequent read (no descriptor-
+ * relative/openat-style API is available via plain `node:fs/promises`) —
+ * that residual TOCTOU window is accepted here, matching the trust model
+ * of a manifest that already lives inside the branch's own worktree.
+ *
+ * Returns `undefined` for anything outside the worktree, which callers
+ * treat the same as a missing file (`onMissing: 'skip'`).
  */
 async function resolveWithinWorktree(
   worktreePath: string,
@@ -101,14 +151,26 @@ async function resolveWithinWorktree(
   if (path.isAbsolute(relativePath)) return undefined;
 
   const root = await fs.realpath(worktreePath).catch(() => path.resolve(worktreePath));
-  const candidate = path.resolve(root, relativePath);
-  const real = await fs.realpath(candidate).catch(() => candidate);
+  const lexicalCandidate = path.resolve(root, relativePath);
+  if (!isContained(root, lexicalCandidate)) return undefined;
 
-  const relativeToRoot = path.relative(root, real);
-  const escapesRoot = relativeToRoot === '' ? false : relativeToRoot.startsWith('..');
-  if (escapesRoot || path.isAbsolute(relativeToRoot)) return undefined;
+  let existingAncestor = lexicalCandidate;
+  const remainder: string[] = [];
+  for (;;) {
+    try {
+      existingAncestor = await fs.realpath(existingAncestor);
+      break;
+    } catch {
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) return undefined; // reached filesystem root
+      remainder.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
+  }
 
-  return candidate;
+  const resolved =
+    remainder.length > 0 ? path.join(existingAncestor, ...remainder) : existingAncestor;
+  return isContained(root, resolved) ? resolved : undefined;
 }
 
 async function fileExistsWithinWorktree(
@@ -153,7 +215,10 @@ async function resolveTemplatedPath(
 /**
  * Read a manifest's listed files from the worktree. Missing files, and any
  * path that resolves outside the worktree, are silently skipped —
- * `onMissing: 'skip'` is the only supported mode.
+ * `onMissing: 'skip'` is the only supported mode. Stops accepting further
+ * files once `MAX_TOTAL_BYTES` is reached; each file is also capped at
+ * `MAX_FILE_BYTES` individually. Both limits log a warning when they cause
+ * a file to be skipped, so a repo can tell its manifest is being trimmed.
  */
 export async function readPriorityContextFiles(
   worktreePath: string,
@@ -161,8 +226,16 @@ export async function readPriorityContextFiles(
   now: Date = new Date()
 ): Promise<PriorityContextFile[]> {
   const results: PriorityContextFile[] = [];
+  let totalBytes = 0;
 
   for (const rawPath of manifest.files) {
+    if (totalBytes >= MAX_TOTAL_BYTES) {
+      console.warn(
+        `[priority-context] Reached ${MAX_TOTAL_BYTES}-byte total budget, skipping remaining files`
+      );
+      break;
+    }
+
     const relativePath = await resolveTemplatedPath(worktreePath, rawPath, now);
     const safePath = await resolveWithinWorktree(worktreePath, relativePath);
     if (!safePath) {
@@ -171,9 +244,25 @@ export async function readPriorityContextFiles(
       console.warn(`[priority-context] Skipping "${rawPath}": resolves outside the worktree`);
       continue;
     }
+
     try {
+      const stats = await fs.stat(safePath);
+      if (stats.size > MAX_FILE_BYTES) {
+        console.warn(
+          `[priority-context] Skipping "${relativePath}": ${stats.size} bytes exceeds the ${MAX_FILE_BYTES}-byte per-file limit`
+        );
+        continue;
+      }
+      if (totalBytes + stats.size > MAX_TOTAL_BYTES) {
+        console.warn(
+          `[priority-context] Skipping "${relativePath}": would exceed the ${MAX_TOTAL_BYTES}-byte total budget`
+        );
+        continue;
+      }
+
       const content = await fs.readFile(safePath, 'utf-8');
       results.push({ path: relativePath, content });
+      totalBytes += stats.size;
     } catch {
       // onMissing: 'skip' — the only supported mode today.
     }

--- a/packages/core/src/sessions/priority-context.ts
+++ b/packages/core/src/sessions/priority-context.ts
@@ -67,17 +67,26 @@ export function isRootSessionGenealogy(genealogy: PriorityContextGenealogy): boo
 /**
  * The daemon reads manifest-listed files with its own (broader) filesystem
  * privileges, not the session creator's. That's fine for branch owners, but
- * for non-owners it would otherwise bypass `others_fs_access` — the same
- * setting that decides whether that user's own executor can read the
- * worktree at all under `insulated`/`strict` Unix isolation. Gate injection
- * on it so a non-owner denied filesystem access can't receive file contents
- * through the injected prompt instead.
+ * for non-owners it would otherwise bypass filesystem access control — the
+ * same effective grant that decides whether that user's own executor can
+ * read the worktree at all under `insulated`/`strict` Unix isolation. Gate
+ * injection on it so a non-owner denied filesystem access can't receive
+ * file contents through the injected prompt instead.
+ *
+ * Takes the shape of `BranchRepository.resolveUserAccess(...)`'s return
+ * value (deliberately duck-typed rather than importing that type, to keep
+ * this module dependency-free) so callers pass its result directly — not
+ * the branch's raw `others_fs_access` column. A user's effective access can
+ * differ from that raw fallback via branch/board group grants or
+ * board-aligned defaults, so passing the raw column here would both leak
+ * (when a grant lowers access below the raw fallback) and over-deny (when a
+ * grant raises it above).
  */
-export function canInjectPriorityContextForBranch(args: {
-  isOwner: boolean;
-  othersFsAccess: 'none' | 'read' | 'write' | undefined;
+export function canInjectPriorityContextForBranch(access: {
+  is_owner: boolean;
+  fs_access?: 'none' | 'read' | 'write';
 }): boolean {
-  return args.isOwner || args.othersFsAccess !== 'none';
+  return access.is_owner || access.fs_access !== 'none';
 }
 
 const MANIFEST_RELATIVE_PATH = path.join('.agor', 'priority-context.json');


### PR DESCRIPTION
## Summary

Replaces the approach in #1983 with a platform-level mechanism, per further investigation into why #1982's underlying failure mode happens at all.

- A repo can opt in via `.agor/priority-context.json` at its worktree root, listing files (identity, memory, user profile, board state, etc.) that should be read once and prepended as established context before a brand-new **root** session's first prompt.
- Resolved and injected server-side at `agor_sessions_prompt` time (`apps/agor-daemon/src/register-routes.ts`), scoped to sessions with no parent/fork source (`isRootSessionGenealogy`) on their first-ever task (`taskRepo.countBySession(id) === 0`) — never re-fires on later turns, spawned/forked children, or repos without a manifest.
- Supports a `{today}`-templated path segment with automatic fallback to the prior day's file, mirroring the existing `BOOT.md` convention's "if missing, read yesterday's" behavior.
- Bounded by design: manifest file count, manifest byte size, per-file byte size, and total injected bytes are all capped, since this content lands in every fresh root session's first prompt unconditionally.
- Hardened against path traversal (`../`, absolute paths, symlinked ancestors with dangling targets) and against non-regular files (FIFOs opened non-blocking, `isFile()` checked on the open descriptor before any read) — this runs inside the daemon's per-session prompt lock, so a hang here would be a real availability problem.

### Why this replaces #1983 instead of extending it

#1983's `gateway.ts` hint nudged the model to *maybe* read a bootstrap file, prepended into the same untrusted, recency-weighted prompt-text channel as everything else — racing later instructions (e.g. "answer the current summon now") for attention, a race it could and did lose in production. Investigating why led to a platform-level spec (independently drafted after the same root-cause analysis) proposing deterministic server-side injection instead of a discretionary nudge. This PR implements that spec. The `gateway.ts` hint is fully reverted (see the first two commits) — there is no remaining overlap between the two approaches.

## Test plan

- [x] 28 unit tests in `packages/core/src/sessions/priority-context.test.ts` — manifest parsing (valid/missing/malformed/wrong-shape/oversized), file resolution (present/missing/traversal/symlink escapes/non-regular files/FIFO-without-writer), `{today}` + prior-day fallback, byte-budget enforcement, and the root-session predicate.
- [x] Reviewed across 4 rounds by an independent Codex session, with full context on why the approach changed from #1983 — all identified merge blockers (path traversal, unbounded manifest/file reads, check-then-read TOCTOU, FIFO open-blocking) addressed and re-verified.
- [x] `git diff --check` clean; branch rebased onto current `main`.
- [ ] Manual smoke test: create a fresh root session in a branch with a `.agor/priority-context.json` manifest and confirm the listed files' content appears prepended to the first task's prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)