### PR TITLE
Enforce executor-owned repository filesystem boundary

### DIFF
--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -13,8 +13,10 @@ import {
   ENVIRONMENT,
   getBranchesDir,
   loadConfig,
+  loadConfigSync,
   PAGINATION,
   resolveExecutionSecurityMode,
+  resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
   BoardRepository,
@@ -1286,6 +1288,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     // Get branch details before deletion
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
+    if (
+      (branch.storage_mode ?? 'worktree') === 'worktree' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      throw new BadRequest(
+        'Historical worktree branches cannot be restored in hosted multi-tenant mode.'
+      );
+    }
 
     // Remove from database FIRST for instant UI feedback
     // CASCADE will clean up related comments automatically

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -11,10 +11,12 @@ import { analyticsLogger } from '@agor/core/analytics';
 import {
   createUserProcessEnvironment,
   ENVIRONMENT,
+  ensureBranchStorageModeAllowed,
   getBranchesDir,
   loadConfig,
   loadConfigSync,
   PAGINATION,
+  resolveBranchStorageConfig,
   resolveExecutionSecurityMode,
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
@@ -661,6 +663,29 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    */
   private async applyBranchCreateDefaults(data: Partial<Branch>): Promise<Partial<Branch>> {
     const withDefaults: Partial<Branch> = { ...data };
+    const { defaultMode } = resolveBranchStorageConfig();
+    const storageMode = withDefaults.storage_mode ?? defaultMode;
+    ensureBranchStorageModeAllowed(storageMode);
+    if (
+      storageMode === 'worktree' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      throw new BadRequest(
+        "storage_mode='worktree' is unavailable in hosted multi-tenant mode; use clone storage."
+      );
+    }
+    if (withDefaults.clone_depth !== undefined) {
+      if (storageMode !== 'clone') {
+        throw new BadRequest("clone_depth is only meaningful when storage_mode='clone'.");
+      }
+      if (!Number.isInteger(withDefaults.clone_depth) || withDefaults.clone_depth <= 0) {
+        throw new BadRequest('clone_depth must be a positive integer when set.');
+      }
+    }
+    // Persist the effective mode so the executor never reconstructs a
+    // configuration default at the filesystem boundary.
+    withDefaults.storage_mode = storageMode;
+
     // New branches always start aligned with their board. Branch-specific
     // overrides are an explicit post-create action in the Branch modal.
     withDefaults.permission_source = 'board';
@@ -1644,17 +1669,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // without creating OS groups.
       const executionMode = resolveExecutionSecurityMode();
       const initUnixGroup = executionMode.shouldInitUnixGroups;
-      const { getDaemonUser } = await import('@agor/core/config');
-      const daemonUser = getDaemonUser();
 
-      // No user impersonation for infrastructure operations — the daemon user
-      // owns all branches and impersonation would resolve getBranchesDir()
-      // to the wrong home directory, causing safety check failures.
-
-      // Mirror the create path's storage-mode forwarding. Without this, a
-      // clone-mode branch that was archived with filesystemAction='deleted'
-      // would silently rebuild as native worktree mode, leaving the DB row
-      // (storage_mode='clone') and disk (.git pointer file) inconsistent.
+      // The executor derives the materialization mode from this persisted row.
       const storageMode = branch.storage_mode ?? 'worktree';
       if (storageMode === 'clone' && !repo.remote_url) {
         const errMsg =
@@ -1686,25 +1702,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             params: {
               branchId: branch.branch_id,
               repoId: repo.repo_id,
-              branch: branch.ref,
-              refType: branch.ref_type || 'branch',
               // Use restore mode: checks if branch exists on remote via ls-remote,
               // checks out existing branch if found, otherwise creates new branch from base_ref.
               // This is safe because it only creates a new branch when ls-remote confirms
               // the branch doesn't exist on the remote (no risk of force-deleting existing branches).
-              createBranch: false,
               restoreMode: true,
-              sourceBranch: branch.base_ref || repo.default_branch || 'main',
               // Unix group isolation
               initUnixGroup,
               fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
-              othersAccess: branch.others_fs_access || 'read',
-              daemonUser,
-              repoUnixGroup: repo.unix_group,
-              // Branch storage mode — preserves the branch's original
-              // storage_mode across archive → delete → unarchive.
-              storageMode,
-              ...(branch.clone_depth !== undefined ? { cloneDepth: branch.clone_depth } : {}),
               useReference:
                 storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
             },

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -39,7 +39,6 @@ import {
   validateRenderedManagedEnvUrlFields,
 } from '@agor/core/environment/webhook';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import { stripGitUrlCredentials } from '@agor/core/git/pure';
 import type {
   AuthenticatedParams,
   Board,
@@ -1288,15 +1287,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     // Get branch details before deletion
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
-    if (
-      (branch.storage_mode ?? 'worktree') === 'worktree' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
-    ) {
-      throw new BadRequest(
-        'Historical worktree branches cannot be restored in hosted multi-tenant mode.'
-      );
-    }
-
     // Remove from database FIRST for instant UI feedback
     // CASCADE will clean up related comments automatically
     const result = await super.remove(id, params);
@@ -1566,6 +1556,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     params?: BranchParams
   ): Promise<BranchWithZoneAndSessions> {
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
+    if (
+      (branch.storage_mode ?? 'worktree') === 'worktree' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      throw new BadRequest(
+        'Historical worktree branches cannot be restored in hosted multi-tenant mode.'
+      );
+    }
 
     if (!branch.archived) {
       throw new Error(`Branch ${branch.name} is not archived`);
@@ -1644,7 +1642,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // Unix group initialization is a filesystem concern controlled by
       // unix_user_mode. Logical branch RBAC may be enabled in simple/Cloud mode
       // without creating OS groups.
-      const initUnixGroup = resolveExecutionSecurityMode().shouldInitUnixGroups;
+      const executionMode = resolveExecutionSecurityMode();
+      const initUnixGroup = executionMode.shouldInitUnixGroups;
       const { getDaemonUser } = await import('@agor/core/config');
       const daemonUser = getDaemonUser();
 
@@ -1671,7 +1670,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         );
         return unarchivedBranch;
       }
-      const safeRemoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
 
       try {
         // Use a service JWT so the executor can patch rendered env command
@@ -1688,9 +1686,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
             params: {
               branchId: branch.branch_id,
               repoId: repo.repo_id,
-              repoPath: repo.local_path,
-              branchName: branch.name,
-              branchPath: branch.path,
               branch: branch.ref,
               refType: branch.ref_type || 'branch',
               // Use restore mode: checks if branch exists on remote via ls-remote,
@@ -1702,6 +1697,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               sourceBranch: branch.base_ref || repo.default_branch || 'main',
               // Unix group isolation
               initUnixGroup,
+              fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
               othersAccess: branch.others_fs_access || 'read',
               daemonUser,
               repoUnixGroup: repo.unix_group,
@@ -1709,13 +1705,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               // storage_mode across archive → delete → unarchive.
               storageMode,
               ...(branch.clone_depth !== undefined ? { cloneDepth: branch.clone_depth } : {}),
-              ...(storageMode === 'clone' && safeRemoteUrl ? { remoteUrl: safeRemoteUrl } : {}),
-              // `--reference` hint: see the create-path call site in
-              // ReposService.createBranch for the rationale and strict-mode
-              // exception.
-              ...(storageMode === 'clone' && repo.local_path && shouldUseCloneReferencePath()
-                ? { referencePath: repo.local_path }
-                : {}),
+              useReference:
+                storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
             },
           },
           {

--- a/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
+++ b/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
@@ -1,0 +1,50 @@
+import type { Application, Branch, Repo } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DrizzleService } from '../adapters/drizzle';
+import { BranchesService } from './branches';
+import { ReposService } from './repos';
+
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    resolveMultiTenancyConfig: vi.fn(() => ({ mode: 'required_from_auth' })),
+  };
+});
+
+describe('hosted repository storage policy canonical boundaries', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects worktree rows through the exposed branches.create boundary', async () => {
+    const service = new BranchesService(
+      {} as never,
+      { service: vi.fn() } as unknown as Application
+    );
+
+    await expect(
+      service.create({
+        board_id: '550e8400-e29b-41d4-a716-446655440000',
+        storage_mode: 'worktree',
+      } as Partial<Branch>)
+    ).rejects.toThrow(/worktree.*unavailable in hosted multi-tenant mode/);
+  });
+
+  it('rejects bulk conversion to local repositories', async () => {
+    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+
+    await expect(service.patch(null, { repo_type: 'local' })).rejects.toThrow(
+      /Bulk conversion to local repositories is unavailable/
+    );
+  });
+
+  it('allows unrelated updates to historical local repository rows', async () => {
+    const patched = { repo_id: 'repo-1', repo_type: 'local', slug: 'renamed' } as Repo;
+    const adapterPatch = vi.spyOn(DrizzleService.prototype, 'patch').mockResolvedValue(patched);
+    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+
+    await expect(service.patch('repo-1', { slug: 'renamed' })).resolves.toBe(patched);
+    expect(adapterPatch).toHaveBeenCalledWith('repo-1', { slug: 'renamed' }, undefined);
+  });
+});

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -37,65 +37,6 @@ vi.mock('../utils/spawn-executor.js', () => {
   };
 });
 
-describe('ReposService.createBranch clone preflight', () => {
-  it('rejects clone-mode local-only source refs before persisting branch state', async () => {
-    const branchesCreate = vi.fn();
-    executorMocks.runExecutorCommand.mockResolvedValueOnce({
-      success: false,
-      error: {
-        code: 'GIT_REPO_PREFLIGHT_FAILED',
-        message: "Clone mode cannot clone local-only or missing branch 'local-only'",
-      },
-    });
-
-    const app = {
-      service(path: string) {
-        if (path === 'branches') return { create: branchesCreate };
-        throw new Error(`Unexpected service: ${path}`);
-      },
-    } as unknown as Application;
-
-    const service = new ReposService({} as never, app);
-    vi.spyOn(service, 'get').mockResolvedValue({
-      repo_id: 'repo-1',
-      slug: 'org/repo',
-      remote_url: 'https://github.com/org/repo.git',
-      local_path: undefined,
-      default_branch: 'main',
-    } as never);
-
-    await expect(
-      service.createBranch(
-        'repo-1',
-        {
-          name: 'new-branch',
-          ref: 'new-branch',
-          createBranch: true,
-          sourceBranch: 'local-only',
-          boardId: 'board-1',
-          storage_mode: 'clone',
-        },
-        { user: { user_id: 'user-1' } } as never
-      )
-    ).rejects.toThrow(/Clone mode cannot clone local-only/);
-
-    expect(executorMocks.runExecutorCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command: 'git.repo.preflight',
-        sessionToken: 'scoped-token',
-        params: expect.objectContaining({
-          repoId: 'repo-1',
-          userId: 'user-1',
-          ref: 'local-only',
-          refType: 'branch',
-        }),
-      }),
-      expect.any(Object)
-    );
-    expect(branchesCreate).not.toHaveBeenCalled();
-  });
-});
-
 describe('ReposService.addLocalRepository executor boundary', () => {
   it('persists sanitized executor metadata with an explicit slug and no remote URL', async () => {
     executorMocks.runExecutorCommand.mockResolvedValueOnce({

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -1,4 +1,3 @@
-import { assertRemoteRefVisibleForClone } from '@agor/core/git/exec';
 import type { Application } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { ReposService } from './repos';
@@ -28,27 +27,30 @@ vi.mock('@agor/core/db', async (importOriginal) => {
   };
 });
 
-vi.mock('@agor/core/git/exec', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@agor/core/git/exec')>();
-
+const executorMocks = vi.hoisted(() => ({ runExecutorCommand: vi.fn() }));
+vi.mock('../utils/spawn-executor.js', () => {
   return {
-    ...actual,
-    assertRemoteRefVisibleForClone: vi.fn(),
+    runExecutorCommand: executorMocks.runExecutorCommand,
+    generateScopedServiceToken: vi.fn(() => 'scoped-token'),
+    getDaemonUrl: vi.fn(() => 'http://daemon'),
+    spawnExecutorFireAndForget: vi.fn(),
   };
 });
 
 describe('ReposService.createBranch clone preflight', () => {
   it('rejects clone-mode local-only source refs before persisting branch state', async () => {
     const branchesCreate = vi.fn();
-    const getGitEnvironment = vi.fn(async () => ({ GITHUB_TOKEN: 'gh_test_token_for_preflight' }));
-    vi.mocked(assertRemoteRefVisibleForClone).mockRejectedValueOnce(
-      new Error("Clone mode cannot clone local-only or missing branch 'local-only'")
-    );
+    executorMocks.runExecutorCommand.mockResolvedValueOnce({
+      success: false,
+      error: {
+        code: 'GIT_REPO_PREFLIGHT_FAILED',
+        message: "Clone mode cannot clone local-only or missing branch 'local-only'",
+      },
+    });
 
     const app = {
       service(path: string) {
         if (path === 'branches') return { create: branchesCreate };
-        if (path === 'users') return { getGitEnvironment };
         throw new Error(`Unexpected service: ${path}`);
       },
     } as unknown as Application;
@@ -77,13 +79,73 @@ describe('ReposService.createBranch clone preflight', () => {
       )
     ).rejects.toThrow(/Clone mode cannot clone local-only/);
 
-    expect(getGitEnvironment).toHaveBeenCalledWith({ userId: 'user-1' }, expect.any(Object));
-    expect(assertRemoteRefVisibleForClone).toHaveBeenCalledWith({
-      remoteUrl: 'https://github.com/org/repo.git',
-      ref: 'local-only',
-      refType: 'branch',
-      env: { GITHUB_TOKEN: 'gh_test_token_for_preflight' },
-    });
+    expect(executorMocks.runExecutorCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'git.repo.preflight',
+        sessionToken: 'scoped-token',
+        params: expect.objectContaining({
+          repoId: 'repo-1',
+          userId: 'user-1',
+          ref: 'local-only',
+          refType: 'branch',
+        }),
+      }),
+      expect.any(Object)
+    );
     expect(branchesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReposService.addLocalRepository executor boundary', () => {
+  it('persists sanitized executor metadata with an explicit slug and no remote URL', async () => {
+    executorMocks.runExecutorCommand.mockResolvedValueOnce({
+      success: true,
+      data: {
+        path: '/trusted/repo',
+        defaultBranch: 'main',
+        credentialFindingCount: 0,
+      },
+    });
+    const app = { service: vi.fn() } as unknown as Application;
+    const service = new ReposService({} as never, app);
+    const create = vi.spyOn(service, 'create').mockResolvedValue({
+      repo_id: 'repo-id',
+      slug: 'local/repo',
+    } as never);
+
+    await service.addLocalRepository({ path: '/submitted/repo', slug: 'local/repo' }, {
+      user: { user_id: '550e8400-e29b-41d4-a716-446655440000' },
+    } as never);
+
+    expect(executorMocks.runExecutorCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'git.repo.inspect',
+        params: { path: '/submitted/repo' },
+      }),
+      expect.any(Object)
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        local_path: '/trusted/repo',
+        remote_url: undefined,
+        slug: 'local/repo',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('does not persist when executor inspection fails', async () => {
+    executorMocks.runExecutorCommand.mockResolvedValueOnce({
+      success: false,
+      error: { code: 'GIT_REPO_INSPECT_FAILED', message: 'Not a valid git repository' },
+    });
+    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+    const create = vi.spyOn(service, 'create');
+    await expect(
+      service.addLocalRepository({ path: '/bad', slug: 'local/bad' }, {
+        user: { user_id: '550e8400-e29b-41d4-a716-446655440000' },
+      } as never)
+    ).rejects.toThrow(/Not a valid git repository/);
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -4,12 +4,11 @@
  * Provides REST + WebSocket API for repository management.
  * Uses DrizzleService adapter with RepoRepository.
  *
- * Git clone/worktree mutations for queued branch/repo operations are delegated
- * to the executor process for Unix isolation. The daemon still performs a small
- * set of local preflight/repair checks for registered repo metadata.
+ * Repository Git/filesystem inspection and mutation are delegated to the
+ * executor process. The daemon owns authorization, pure validation, and DB
+ * metadata only.
  */
 
-import { homedir } from 'node:os';
 import path from 'node:path';
 import {
   ensureBranchStorageModeAllowed,
@@ -19,11 +18,12 @@ import {
   getReposDir,
   isValidGitUrl,
   isValidSlug,
+  loadConfigSync,
   normalizeRepoUrl,
   PAGINATION,
-  parseAgorYml,
   resolveBranchStorageConfig,
   resolveExecutionSecurityMode,
+  resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
   BranchRepository,
@@ -33,14 +33,6 @@ import {
 } from '@agor/core/db';
 import { autoAssignBranchUniqueId } from '@agor/core/environment/variable-resolver';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import {
-  assertRemoteRefVisibleForClone,
-  getDefaultBranch,
-  getRemoteUrl,
-  isValidGitRepo,
-  scanGitConfigRemoteCredentials,
-  scrubGitConfigRemoteCredentials,
-} from '@agor/core/git/exec';
 import { redactGitUrlCredentials, stripGitUrlCredentials } from '@agor/core/git/pure';
 import type {
   AuthenticatedParams,
@@ -74,7 +66,7 @@ export type RepoParams = QueryParams<{
   cleanup?: boolean; // For delete operations: true = delete filesystem, false = database only
 }>;
 
-async function deriveLocalRepoSlug(path: string, explicitSlug?: string): Promise<RepoSlug> {
+function deriveLocalRepoSlug(remoteUrl: string | undefined, explicitSlug?: string): RepoSlug {
   if (explicitSlug) {
     if (!isValidSlug(explicitSlug)) {
       throw new Error(`Invalid slug format: ${explicitSlug}`);
@@ -98,7 +90,6 @@ async function deriveLocalRepoSlug(path: string, explicitSlug?: string): Promise
     return `local/${sanitized}` as RepoSlug;
   };
 
-  const remoteUrl = await getRemoteUrl(path);
   if (remoteUrl && isValidGitUrl(remoteUrl)) {
     try {
       const remoteSlug = extractSlugFromUrl(remoteUrl);
@@ -109,7 +100,7 @@ async function deriveLocalRepoSlug(path: string, explicitSlug?: string): Promise
   }
 
   throw new Error(
-    `Could not auto-detect slug for local repository at ${path}.\nUse --slug to provide one explicitly`
+    'Could not auto-detect slug for local repository.\nUse --slug to provide one explicitly'
   );
 }
 
@@ -135,6 +126,42 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     this.repoRepo = repoRepo;
     this.app = app;
     this.db = db;
+  }
+
+  override async create(
+    data: Partial<Repo> | Partial<Repo>[],
+    params?: RepoParams
+  ): Promise<Repo | Repo[]> {
+    const rows = Array.isArray(data) ? data : [data];
+    if (
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth' &&
+      rows.some((row) => row.repo_type === 'local')
+    ) {
+      throw new BadRequest(
+        'Local repository registration is unavailable in hosted multi-tenant mode.'
+      );
+    }
+    return super.create(data, params);
+  }
+
+  override async patch(
+    id: string | null,
+    data: Partial<Repo>,
+    params?: RepoParams
+  ): Promise<Repo | Repo[]> {
+    if (
+      id &&
+      data.repo_type === 'local' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      const current = await this.get(id, params);
+      if (current.repo_type !== 'local') {
+        throw new BadRequest(
+          'Local repository registration is unavailable in hosted multi-tenant mode.'
+        );
+      }
+    }
+    return super.patch(id, data, params);
   }
 
   /**
@@ -472,6 +499,15 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // post-patch shape so we catch both "URL provided in patch" and
     // "URL already on the row".
     const effectiveType = cleanPatch.repo_type ?? current.repo_type;
+    if (
+      effectiveType === 'local' &&
+      current.repo_type !== 'local' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      throw new BadRequest(
+        'Local repository registration is unavailable in hosted multi-tenant mode.'
+      );
+    }
     const effectiveRemoteUrl =
       'remote_url' in cleanPatch ? cleanPatch.remote_url : current.remote_url;
     if (effectiveType === 'remote' && !effectiveRemoteUrl) {
@@ -490,33 +526,42 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     data: { path: string; slug?: string },
     params?: RepoParams
   ): Promise<Repo> {
+    if (resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth') {
+      throw new BadRequest(
+        'Local repository registration is unavailable in hosted multi-tenant mode.'
+      );
+    }
     if (!data.path) {
       throw new Error('Path is required to add a local repository');
     }
 
-    let inputPath = data.path.trim();
+    const inputPath = data.path.trim();
     if (!inputPath) {
       throw new Error('Path is required to add a local repository');
     }
 
-    // Expand leading ~ to user's home directory
-    if (inputPath.startsWith('~')) {
-      const homeDir = homedir();
-      inputPath = path.join(homeDir, inputPath.slice(1).replace(/^[/\\]?/, ''));
-    }
-
-    if (!path.isAbsolute(inputPath)) {
-      throw new Error(`Path must be absolute: ${inputPath}`);
-    }
-
-    const repoPath = path.resolve(inputPath);
-
-    const isValidRepo = await isValidGitRepo(repoPath);
-    if (!isValidRepo) {
-      throw new Error(`Not a valid git repository: ${repoPath}`);
-    }
-
-    const slug = await deriveLocalRepoSlug(repoPath, data.slug);
+    const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
+    const asUser = await resolveExecutorReadAsUser(this.db, userId);
+    const inspection = await runExecutorCommand(
+      {
+        command: 'git.repo.inspect',
+        daemonUrl: getDaemonUrl(),
+        params: { path: inputPath },
+      },
+      { asUser, logPrefix: '[repos.local.inspect]' }
+    );
+    if (!inspection.success)
+      throw new Error(inspection.error?.message ?? 'Repository inspection failed');
+    const metadata = inspection.data as {
+      path: string;
+      defaultBranch?: string;
+      remoteUrl?: string;
+      environment?: RepoEnvironment;
+      credentialFindingCount: number;
+      environmentWarning?: string;
+    };
+    const repoPath = metadata.path;
+    const slug = deriveLocalRepoSlug(metadata.remoteUrl, data.slug);
 
     const existing = await this.repoRepo.findBySlug(slug);
     if (existing) {
@@ -525,30 +570,13 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       );
     }
 
-    const defaultBranch = await getDefaultBranch(repoPath);
-
-    const agorYmlPath = path.join(repoPath, '.agor.yml');
-    let environment: RepoEnvironment | undefined;
-
-    try {
-      const parsed = parseAgorYml(agorYmlPath);
-      if (parsed) {
-        environment = parsed;
-        console.log(`✅ Loaded environment config from .agor.yml for ${slug}`);
-      }
-    } catch (error) {
+    if (metadata.credentialFindingCount > 0) {
       console.warn(
-        `⚠️  Failed to parse .agor.yml for ${slug}:`,
-        error instanceof Error ? error.message : String(error)
+        `[repos.local] Registered local repo has ${metadata.credentialFindingCount} credential-bearing remote URL(s) in git config; persisted remote_url was sanitized. Run the repair utility if this repo is managed/shared.`
       );
     }
-
-    const remoteUrl = stripGitUrlCredentials((await getRemoteUrl(repoPath)) ?? '') || undefined;
-    const scanResult = await scanGitConfigRemoteCredentials(repoPath);
-    if (scanResult.findings.length > 0) {
-      console.warn(
-        `[repos.local] Registered local repo has ${scanResult.findings.length} credential-bearing remote URL(s) in git config; persisted remote_url was sanitized. Run the repair utility if this repo is managed/shared.`
-      );
+    if (metadata.environmentWarning) {
+      console.warn(`[repos.local] ${metadata.environmentWarning}`);
     }
     const name = slug.split('/').pop() ?? slug;
 
@@ -557,10 +585,10 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         repo_type: 'local',
         slug,
         name,
-        remote_url: remoteUrl,
+        remote_url: metadata.remoteUrl,
         local_path: repoPath,
-        default_branch: defaultBranch,
-        environment,
+        default_branch: metadata.defaultBranch,
+        environment: metadata.environment,
       },
       params
     )) as Repo;
@@ -644,6 +672,14 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const { defaultMode } = resolveBranchStorageConfig();
     const storageMode: 'worktree' | 'clone' = data.storage_mode ?? defaultMode;
     ensureBranchStorageModeAllowed(storageMode);
+    if (
+      storageMode === 'worktree' &&
+      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+    ) {
+      throw new BadRequest(
+        "storage_mode='worktree' is unavailable in hosted multi-tenant mode; use clone storage."
+      );
+    }
     const cloneDepth = data.clone_depth;
     if (cloneDepth !== undefined) {
       if (storageMode !== 'clone') {
@@ -672,30 +708,31 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             `Use storage_mode='worktree' or register the repo with a remote first.`
         );
       }
-      const cloneRemoteUrl = repo.remote_url;
-      const cloneRef = data.createBranch ? data.sourceBranch || data.ref : data.ref;
-      const usersService = this.app.service('users') as unknown as {
-        getGitEnvironment(
-          data: { userId: string },
-          params?: RepoParams
-        ): Promise<Record<string, string>>;
-      };
-      const gitEnv = await usersService.getGitEnvironment({ userId }, params);
-      await assertRemoteRefVisibleForClone({
-        remoteUrl: cloneRemoteUrl,
-        ref: cloneRef,
-        refType: data.refType || 'branch',
-        env: gitEnv,
-      });
     }
-
-    if (repo.local_path) {
-      const scrubResult = await scrubGitConfigRemoteCredentials(repo.local_path);
-      if (scrubResult.findings.length > 0) {
-        console.warn(
-          `[ReposService.createBranch] Scrubbed ${scrubResult.findings.length} credential-bearing git remote URL(s) from repo '${repo.slug}' before branch creation.`
-        );
-      }
+    const preflightToken = generateScopedServiceToken(
+      this.app as unknown as { settings: { authentication?: { secret?: string } } }
+    );
+    const preflightAsUser = await resolveExecutorReadAsUser(this.db, userId);
+    const preflight = await runExecutorCommand(
+      {
+        command: 'git.repo.preflight',
+        sessionToken: preflightToken,
+        daemonUrl: getDaemonUrl(),
+        params: {
+          repoId: repo.repo_id,
+          userId,
+          ...(storageMode === 'clone'
+            ? {
+                ref: data.createBranch ? data.sourceBranch || data.ref : data.ref,
+                refType: data.refType || 'branch',
+              }
+            : {}),
+        },
+      },
+      { asUser: preflightAsUser, logPrefix: '[repos.branch.preflight]' }
+    );
+    if (!preflight.success) {
+      throw new Error(preflight.error?.message ?? 'Repository preflight failed');
     }
 
     // NOTE: Filesystem preflights (target-dir-exists,

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -49,7 +49,6 @@ import { DrizzleService } from '../adapters/drizzle';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
-import { resolveGitImpersonationForUser } from '../utils/git-impersonation.js';
 import {
   generateScopedServiceToken,
   getDaemonUrl,
@@ -264,7 +263,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Sudo wrap (asUser) is gated inside the resolver — returns undefined
     // in simple/no-RBAC mode so hosts without passwordless sudoers work
     // (#1140, #1143). Callers no longer duplicate the gate.
-    const asUser = await resolveGitImpersonationForUser(this.db, userId);
+    const asUser = await resolveExecutorReadAsUser(this.db, userId);
 
     // Pre-create the repo row with `clone_status: 'cloning'` so failures stay
     // queryable via `agor_repos_get(repoId)`. Pre-#1126 the row was only
@@ -709,32 +708,6 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         );
       }
     }
-    const preflightToken = generateScopedServiceToken(
-      this.app as unknown as { settings: { authentication?: { secret?: string } } }
-    );
-    const preflightAsUser = await resolveExecutorReadAsUser(this.db, userId);
-    const preflight = await runExecutorCommand(
-      {
-        command: 'git.repo.preflight',
-        sessionToken: preflightToken,
-        daemonUrl: getDaemonUrl(),
-        params: {
-          repoId: repo.repo_id,
-          userId,
-          ...(storageMode === 'clone'
-            ? {
-                ref: data.createBranch ? data.sourceBranch || data.ref : data.ref,
-                refType: data.refType || 'branch',
-              }
-            : {}),
-        },
-      },
-      { asUser: preflightAsUser, logPrefix: '[repos.branch.preflight]' }
-    );
-    if (!preflight.success) {
-      throw new Error(preflight.error?.message ?? 'Repository preflight failed');
-    }
-
     // NOTE: Filesystem preflights (target-dir-exists,
     // branch-already-checked-out) live in the executor / core helpers —
     // they're filesystem facts, not DB facts. Clone-mode remote-ref
@@ -959,13 +932,16 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
 
       // Unix group initialization is a filesystem concern controlled by
       // unix_user_mode, not by app-level branch RBAC.
-      const initUnixGroup = resolveExecutionSecurityMode().shouldInitUnixGroups;
+      const executionMode = resolveExecutionSecurityMode();
+      const initUnixGroup = executionMode.shouldInitUnixGroups;
 
       // Sudo wrap (asUser) is gated inside the resolver — returns undefined
       // in simple/no-RBAC mode so hosts without passwordless sudoers work
       // (#1140, #1143). Callers no longer duplicate the gate.
-      const asUser = await resolveGitImpersonationForUser(this.db, userId);
-      const safeRemoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
+      // Git/materialization runs as the requesting user in strict mode. Any
+      // privileged group/ACL setup is a separate daemon RPC below; in simple
+      // Cloud mode the pod/mount is the filesystem security boundary.
+      const asUser = await resolveExecutorReadAsUser(this.db, userId);
 
       spawnExecutorFireAndForget(
         {
@@ -975,9 +951,6 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           params: {
             branchId: branch.branch_id,
             repoId: repo.repo_id,
-            repoPath: repo.local_path,
-            branchName: data.name,
-            branchPath,
             branch: data.ref,
             sourceBranch: data.sourceBranch,
             createBranch: data.createBranch,
@@ -985,19 +958,13 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             userId: userId as string | undefined,
             // Unix group isolation (only when unix_user_mode is non-simple)
             initUnixGroup,
+            fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
             othersAccess: branch.others_fs_access || 'read',
             // Branch storage mode (forwarded for the clone-mode code path)
             storageMode,
             ...(cloneDepth !== undefined ? { cloneDepth } : {}),
-            ...(storageMode === 'clone' && safeRemoteUrl ? { remoteUrl: safeRemoteUrl } : {}),
-            // Hand the executor the per-repo base clone as a `--reference`
-            // hint only when that object cache is readable by the eventual
-            // session identity. In strict mode, per-user sessions need fully
-            // self-standing clones instead of alternates into daemon-owned
-            // managed repos.
-            ...(storageMode === 'clone' && repo.local_path && shouldUseCloneReferencePath()
-              ? { referencePath: repo.local_path }
-              : {}),
+            useReference:
+              storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
           },
         },
         {

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -149,10 +149,14 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     params?: RepoParams
   ): Promise<Repo | Repo[]> {
     if (
-      id &&
       data.repo_type === 'local' &&
       resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
     ) {
+      if (!id) {
+        throw new BadRequest(
+          'Bulk conversion to local repositories is unavailable in hosted multi-tenant mode.'
+        );
+      }
       const current = await this.get(id, params);
       if (current.repo_type !== 'local') {
         throw new BadRequest(
@@ -695,9 +699,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       }
     }
     // Auth hooks (`requireMinimumRole`) guarantee `params.user` exists by
-    // the time we get here. Resolve it before clone preflight so private
-    // remotes can use the same per-user git credentials the executor will
-    // use for the eventual clone.
+    // the time we get here. The identity is forwarded so executor-local Git
+    // can resolve the requesting user's credentials in strict Unix mode.
     const userId = (params as AuthenticatedParams).user!.user_id as UserID;
 
     if (storageMode === 'clone') {
@@ -708,13 +711,11 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         );
       }
     }
-    // NOTE: Filesystem preflights (target-dir-exists,
-    // branch-already-checked-out) live in the executor / core helpers —
-    // they're filesystem facts, not DB facts. Clone-mode remote-ref
-    // visibility is deliberately checked above before persisting, because
-    // clone-mode cannot materialize local-only base branches and the async
-    // executor failure path otherwise leaves confusing placeholder state.
-    // The executor surfaces other materialization failures via
+    // NOTE: Filesystem and remote-ref checks live in the executor / core
+    // helpers — they're filesystem/network facts, not DB facts. The daemon
+    // persists the authorized intent first; the executor atomically resolves
+    // the tenant-scoped row and performs those checks during materialization.
+    // Materialization failures are surfaced via
     // `filesystem_status='failed'` + `error_message`, which the UI already
     // renders cleanly. Daemon stays focused on DB/auth/config validation.
     // See `core.createBranch` / `createBranchAsClone` for the equivalent
@@ -951,18 +952,10 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           params: {
             branchId: branch.branch_id,
             repoId: repo.repo_id,
-            branch: data.ref,
-            sourceBranch: data.sourceBranch,
-            createBranch: data.createBranch,
-            refType: data.refType,
             userId: userId as string | undefined,
             // Unix group isolation (only when unix_user_mode is non-simple)
             initUnixGroup,
             fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
-            othersAccess: branch.others_fs_access || 'read',
-            // Branch storage mode (forwarded for the clone-mode code path)
-            storageMode,
-            ...(cloneDepth !== undefined ? { cloneDepth } : {}),
             useReference:
               storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
           },

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -34,6 +34,11 @@ import { SchedulerService } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { scrubManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
+import {
+  generateScopedServiceToken,
+  getDaemonUrl,
+  runExecutorCommand,
+} from './utils/spawn-executor.js';
 
 const DEBUG_STARTUP =
   process.env.AGOR_DEBUG_STARTUP === '1' || process.env.DEBUG?.includes('startup');
@@ -613,7 +618,28 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // deliberately skips registered local repos to avoid surprising writes
   // outside Agor-managed storage.
   runPostStartJob('git-remote-credential-scrub', () =>
-    runStartupTenantDatabaseScope(ctx, () => scrubManagedGitRemoteCredentials(db))
+    runStartupTenantDatabaseScope(ctx, async () => {
+      await scrubManagedGitRemoteCredentials(db);
+      if (resolveMultiTenancyConfig(config).mode === 'required_from_auth') {
+        // A later Cell/storage-admin reconciler must scrub physical configs:
+        // one global executor cannot assume every tenant checkout is mounted.
+        return;
+      }
+      const result = await runExecutorCommand(
+        {
+          command: 'git.managed-credentials.reconcile',
+          sessionToken: generateScopedServiceToken(
+            app as unknown as { settings: { authentication?: { secret?: string } } }
+          ),
+          daemonUrl: getDaemonUrl(),
+          params: {},
+        },
+        { logPrefix: '[startup.git-credential-reconcile]' }
+      );
+      if (!result.success) {
+        throw new Error(result.error?.message ?? 'Managed Git credential reconciliation failed');
+      }
+    })
   );
 
   // Log the host IP that will be frozen into env command templates as

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -1,10 +1,4 @@
-import {
-  BranchRepository,
-  RepoRepository,
-  shortId,
-  type TenantScopeAwareDatabase,
-} from '@agor/core/db';
-import { scrubGitConfigRemoteCredentials } from '@agor/core/git/exec';
+import { RepoRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 
 /**
  * Best-effort startup repair for credential-bearing git remote URLs.
@@ -22,19 +16,6 @@ export async function scrubManagedGitRemoteCredentials(
   db: TenantScopeAwareDatabase
 ): Promise<void> {
   const repoRepo = new RepoRepository(db);
-  const branchRepo = new BranchRepository(db);
-
-  const repos = await repoRepo.findAll();
-  const repoById = new Map(repos.map((repo) => [repo.repo_id, repo]));
-  const remoteRepos = repos.filter((repo) => repo.repo_type === 'remote');
-  const remoteRepoIds = new Set(remoteRepos.map((repo) => repo.repo_id));
-  const branches = (await branchRepo.findAll({ includeArchived: true })).filter((branch) =>
-    remoteRepoIds.has(branch.repo_id)
-  );
-
-  const repairedConfigPaths = new Set<string>();
-  let repairedEntries = 0;
-
   try {
     const dbScrub = await repoRepo.scrubRemoteUrls();
     if (dbScrub.changed > 0) {
@@ -49,56 +30,6 @@ export async function scrubManagedGitRemoteCredentials(
       `[git-remote-scrub] Failed to scrub persisted repo remote URLs: ${
         error instanceof Error ? error.message : String(error)
       }`
-    );
-  }
-
-  for (const item of [
-    ...remoteRepos.map((repo) => ({
-      kind: 'repo' as const,
-      label: `${repo.slug} (${shortId(repo.repo_id)})`,
-      path: repo.local_path,
-    })),
-    ...branches.map((branch) => {
-      const repo = repoById.get(branch.repo_id);
-      return {
-        kind: 'branch' as const,
-        label: `${branch.name} (${shortId(branch.branch_id)}, repo=${repo?.slug ?? branch.repo_id})`,
-        path: branch.path,
-      };
-    }),
-  ]) {
-    if (!item.path) continue;
-    try {
-      const result = await scrubGitConfigRemoteCredentials(item.path);
-      if (result.findings.length === 0) continue;
-
-      const newConfigPaths = result.findings
-        .map((finding) => finding.configPath)
-        .filter((configPath) => {
-          if (repairedConfigPaths.has(configPath)) return false;
-          repairedConfigPaths.add(configPath);
-          return true;
-        });
-
-      repairedEntries += result.findings.length;
-      console.warn(
-        `🔒 SECURITY: scrubbed ${result.findings.length} credential-bearing git remote URL(s) from ${item.kind} ${item.label}. ` +
-          `Affected git config file(s): ${newConfigPaths.length}. Rotate any exposed token(s).`
-      );
-    } catch (error) {
-      console.warn(
-        `[git-remote-scrub] Failed to scrub ${item.kind} ${item.label}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
-
-  if (repairedEntries > 0) {
-    console.warn(
-      `🔒 SECURITY: startup scrub removed URL userinfo from ${repairedEntries} git remote config entr${
-        repairedEntries === 1 ? 'y' : 'ies'
-      }. Rotate any token(s) that may have been exposed.`
     );
   }
 }

--- a/apps/agor-daemon/src/utils/session-task-state.test.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.test.ts
@@ -22,6 +22,11 @@ describe('session task state reconciliation', () => {
     expect(sessionCanStartTask(SessionStatus.FAILED, false)).toBe(false);
   });
 
+  it('allows timed-out sessions to retry after the executor marks them ready', () => {
+    expect(sessionCanStartTask(SessionStatus.TIMED_OUT, true)).toBe(true);
+    expect(sessionCanStartTask(SessionStatus.TIMED_OUT, false)).toBe(false);
+  });
+
   it('repairs failed/not-ready sessions when all non-queued tasks are terminal', () => {
     expect(
       shouldReconcileSessionPromptState(baseSession, [

--- a/packages/core/src/types/session.test.ts
+++ b/packages/core/src/types/session.test.ts
@@ -36,10 +36,16 @@ describe('session promptability helpers', () => {
     expect(isSessionPromptable({ status: 'failed', ready_for_prompt: false })).toBe(false);
   });
 
+  it('allows a new prompt after a permission timeout once the executor has exited', () => {
+    expect(sessionCanStartTask('timed_out', true)).toBe(true);
+    expect(sessionCanStartTask('timed_out', false)).toBe(false);
+    expect(isSessionPromptable({ status: 'timed_out', ready_for_prompt: true })).toBe(true);
+    expect(isSessionPromptable({ status: 'timed_out', ready_for_prompt: false })).toBe(false);
+  });
+
   it('does not confuse ready_for_prompt attention state with promptability', () => {
-    expect(sessionCanStartTask('timed_out', true)).toBe(false);
     expect(sessionCanStartTask('running', true)).toBe(false);
-    expect(isSessionPromptable({ status: 'timed_out', ready_for_prompt: true })).toBe(false);
+    expect(isSessionPromptable({ status: 'running', ready_for_prompt: true })).toBe(false);
   });
 
   it('identifies execution states separately from promptability', () => {

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -524,11 +524,16 @@ export type SessionPromptState = Pick<Session, 'status' | 'ready_for_prompt'>;
 
 export type PromptableSessionState =
   | { status: typeof SessionStatus.IDLE; ready_for_prompt: boolean }
-  | { status: typeof SessionStatus.FAILED; ready_for_prompt: true };
+  | {
+      status: typeof SessionStatus.FAILED | typeof SessionStatus.TIMED_OUT;
+      ready_for_prompt: true;
+    };
 
 export function sessionCanStartTask(status: Session['status'], readyForPrompt?: boolean): boolean {
   return (
-    status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
+    status === SessionStatus.IDLE ||
+    ((status === SessionStatus.FAILED || status === SessionStatus.TIMED_OUT) &&
+      readyForPrompt === true)
   );
 }
 

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -13,7 +13,19 @@ const mocks = vi.hoisted(() => ({
   getReposDir: vi.fn(() => '/safe/repos'),
   addConfig: vi.fn(),
   gitRaw: vi.fn(),
+  isValidGitRepo: vi.fn(),
+  getDefaultBranch: vi.fn(),
+  getRemoteUrl: vi.fn(),
+  scanGitConfigRemoteCredentials: vi.fn(),
+  scrubGitConfigRemoteCredentials: vi.fn(),
+  assertRemoteRefVisibleForClone: vi.fn(),
+  userHome: '/passwd/home',
 }));
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return { ...actual, userInfo: vi.fn(() => ({ homedir: mocks.userHome })) };
+});
 
 vi.mock('@agor/core/config', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@agor/core/config');
@@ -33,6 +45,12 @@ vi.mock('../git/index.js', async () => {
     deleteBranchDirectory: mocks.deleteBranchDirectory,
     deleteRepoDirectory: mocks.deleteRepoDirectory,
     getReposDir: mocks.getReposDir,
+    isValidGitRepo: mocks.isValidGitRepo,
+    getDefaultBranch: mocks.getDefaultBranch,
+    getRemoteUrl: mocks.getRemoteUrl,
+    scanGitConfigRemoteCredentials: mocks.scanGitConfigRemoteCredentials,
+    scrubGitConfigRemoteCredentials: mocks.scrubGitConfigRemoteCredentials,
+    assertRemoteRefVisibleForClone: mocks.assertRemoteRefVisibleForClone,
   };
 });
 
@@ -46,7 +64,10 @@ import {
   handleBranchInspect,
   handleGitBranchRemove,
   handleGitClone,
+  handleGitManagedCredentialsReconcile,
   handleGitRepoDelete,
+  handleGitRepoInspect,
+  handleGitRepoPreflight,
 } from './git.js';
 
 const repoId = '550e8400-e29b-41d4-a716-446655440001';
@@ -55,6 +76,7 @@ const deleteRoots = { reposRoot: '/safe/repos', branchesRoot: '/safe/worktrees' 
 
 function createClient(records: {
   repo?: Record<string, unknown>;
+  repoPages?: Array<Array<Record<string, unknown>>>;
   branches?: Array<Record<string, unknown>>;
   branchPages?: Array<Array<Record<string, unknown>>>;
   branch?: Record<string, unknown>;
@@ -64,6 +86,19 @@ function createClient(records: {
     io: { disconnect: vi.fn() },
     service: vi.fn((name: string) => {
       if (name === 'repos') {
+        const find = vi.fn(
+          async ({ query }: { query?: { $skip?: number; $limit?: number } } = {}) => {
+            const allRepos = records.repoPages?.flat() ?? (records.repo ? [records.repo] : []);
+            const skip = query?.$skip ?? 0;
+            const limit = query?.$limit ?? 1000;
+            return {
+              data: allRepos.slice(skip, skip + limit),
+              total: allRepos.length,
+              limit,
+              skip,
+            };
+          }
+        );
         return {
           get: vi.fn(async () => records.repo),
           patch: vi.fn(async (_id: string, data: Record<string, unknown>) => {
@@ -72,6 +107,7 @@ function createClient(records: {
           }),
           create: vi.fn(async (data: Record<string, unknown>) => data),
           initializeUnixGroup: vi.fn(async () => ({ unix_group: 'agor_repo_test' })),
+          find,
         };
       }
       if (name === 'users') {
@@ -126,9 +162,152 @@ beforeEach(() => {
     repoName: 'agor-assistant',
     defaultBranch: 'main',
   });
+  mocks.isValidGitRepo.mockResolvedValue(true);
+  mocks.getDefaultBranch.mockResolvedValue('main');
+  mocks.getRemoteUrl.mockResolvedValue('https://user:secret@example.com/org/repo.git');
+  mocks.scanGitConfigRemoteCredentials.mockResolvedValue({
+    findings: [{ configPath: '/repo/.git/config' }],
+  });
+  mocks.scrubGitConfigRemoteCredentials.mockResolvedValue({ findings: [] });
+  mocks.assertRemoteRefVisibleForClone.mockResolvedValue(undefined);
 });
 
 describe('managed executor git/fs commands', () => {
+  it('inspects local repository contents only inside the executor and returns sanitized metadata', async () => {
+    const result = await handleGitRepoInspect(
+      {
+        command: 'git.repo.inspect',
+        params: { path: '/repo' },
+      },
+      {}
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        path: '/repo',
+        defaultBranch: 'main',
+        remoteUrl: 'https://example.com/org/repo.git',
+        credentialFindingCount: 1,
+      },
+    });
+  });
+
+  it('expands tilde from passwd user info rather than a misleading HOME', async () => {
+    const oldHome = process.env.HOME;
+    process.env.HOME = '/daemon/home';
+    try {
+      await handleGitRepoInspect({ command: 'git.repo.inspect', params: { path: '~/repo' } }, {});
+      expect(mocks.isValidGitRepo).toHaveBeenCalledWith('/passwd/home/repo');
+    } finally {
+      process.env.HOME = oldHome;
+    }
+  });
+
+  it('continues inspection with a safe diagnostic when .agor.yml is malformed', async () => {
+    mocks.parseAgorYml.mockImplementationOnce(() => {
+      throw new Error('secret malformed contents');
+    });
+    const result = await handleGitRepoInspect(
+      { command: 'git.repo.inspect', params: { path: '/repo' } },
+      {}
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { environmentWarning: expect.stringContaining('Failed to parse .agor.yml') },
+    });
+    expect(JSON.stringify(result)).not.toContain('secret malformed contents');
+  });
+
+  it('rejects an invalid local repository', async () => {
+    mocks.isValidGitRepo.mockResolvedValueOnce(false);
+    const result = await handleGitRepoInspect(
+      { command: 'git.repo.inspect', params: { path: '/not-repo' } },
+      {}
+    );
+    expect(result).toMatchObject({ success: false, error: { code: 'GIT_REPO_INSPECT_FAILED' } });
+  });
+
+  it('fails preflight when the tenant-scoped executor token cannot fetch the repo', async () => {
+    mocks.createExecutorClient.mockResolvedValueOnce({
+      io: { disconnect: vi.fn() },
+      service: vi.fn(() => ({
+        get: vi.fn(async () => {
+          throw new Error('Not found');
+        }),
+      })),
+    });
+    const result = await handleGitRepoPreflight(
+      {
+        command: 'git.repo.preflight',
+        sessionToken: 'tenant-b-token',
+        params: { repoId, ref: 'main' },
+      },
+      {}
+    );
+    expect(result).toMatchObject({
+      success: false,
+      error: { code: 'GIT_REPO_PREFLIGHT_FAILED', message: 'Not found' },
+    });
+    expect(mocks.scrubGitConfigRemoteCredentials).not.toHaveBeenCalled();
+  });
+
+  it('uses tenant-fetched repo paths and remote metadata for preflight', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://user:secret@example.com/trusted/repo.git',
+      },
+    });
+    const result = await handleGitRepoPreflight(
+      {
+        command: 'git.repo.preflight',
+        sessionToken: 'tenant-a-token',
+        params: { repoId, ref: 'main', refType: 'branch' },
+      },
+      {}
+    );
+    expect(result.success).toBe(true);
+    expect(mocks.scrubGitConfigRemoteCredentials).toHaveBeenCalledWith('/trusted/repo');
+    expect(mocks.assertRemoteRefVisibleForClone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteUrl: 'https://example.com/trusted/repo.git',
+        ref: 'main',
+      })
+    );
+  });
+
+  it('paginates self-hosted reconciliation and dry-run does not mutate configs', async () => {
+    createClient({
+      repoPages: [
+        Array.from({ length: 1000 }, (_, index) => ({
+          repo_id: `local-${index}`,
+          repo_type: 'local',
+        })),
+        [{ repo_id: repoId, repo_type: 'remote', local_path: '/managed/repo' }],
+      ],
+      branches: [
+        {
+          branch_id: branchId,
+          repo_id: repoId,
+          path: '/managed/archived',
+          archived: true,
+        },
+      ],
+    });
+
+    const result = await handleGitManagedCredentialsReconcile(
+      {
+        command: 'git.managed-credentials.reconcile',
+        sessionToken: 'tenant-token',
+        params: {},
+      },
+      { dryRun: true }
+    );
+
+    expect(result).toMatchObject({ success: true, data: { dryRun: true } });
+    expect(mocks.scrubGitConfigRemoteCredentials).not.toHaveBeenCalled();
+  });
   it('uses the daemon-provided tenant root when removing a branch directory', async () => {
     const branchesRoot = await mkdtemp(join(tmpdir(), 'agor-tenant-worktrees-'));
     const branchPath = join(branchesRoot, 'repo', 'feature');

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -189,6 +189,12 @@ describe('managed executor git/fs commands', () => {
         repo_id: repoId,
         path: '/trusted/branch',
         name: 'feature',
+        ref: 'trusted-ref',
+        base_ref: 'trusted-base',
+        new_branch: true,
+        ref_type: 'branch',
+        storage_mode: 'clone',
+        clone_depth: 42,
       },
     });
 
@@ -199,8 +205,6 @@ describe('managed executor git/fs commands', () => {
         params: {
           branchId,
           repoId,
-          branch: 'main',
-          storageMode: 'clone',
           useReference: true,
         },
       },
@@ -211,6 +215,9 @@ describe('managed executor git/fs commands', () => {
     expect(mocks.createBranchAsClone).toHaveBeenCalledWith(
       expect.objectContaining({
         remoteUrl: 'https://example.com/trusted/repo.git',
+        ref: 'trusted-base',
+        newBranchName: 'trusted-ref',
+        depth: 42,
         referencePath: '/trusted/repo',
       })
     );
@@ -232,7 +239,6 @@ describe('managed executor git/fs commands', () => {
         params: {
           branchId,
           repoId,
-          storageMode: 'clone',
         },
       },
       {}

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   deleteBranchDirectory: vi.fn(),
   deleteRepoDirectory: vi.fn(),
   cloneRepo: vi.fn(),
+  createBranchAsClone: vi.fn(),
   getReposDir: vi.fn(() => '/safe/repos'),
   addConfig: vi.fn(),
   gitRaw: vi.fn(),
@@ -18,7 +19,6 @@ const mocks = vi.hoisted(() => ({
   getRemoteUrl: vi.fn(),
   scanGitConfigRemoteCredentials: vi.fn(),
   scrubGitConfigRemoteCredentials: vi.fn(),
-  assertRemoteRefVisibleForClone: vi.fn(),
   userHome: '/passwd/home',
 }));
 
@@ -42,6 +42,7 @@ vi.mock('../git/index.js', async () => {
     ...actual,
     createGit: vi.fn(() => ({ git: { addConfig: mocks.addConfig, raw: mocks.gitRaw } })),
     cloneRepo: mocks.cloneRepo,
+    createBranchAsClone: mocks.createBranchAsClone,
     deleteBranchDirectory: mocks.deleteBranchDirectory,
     deleteRepoDirectory: mocks.deleteRepoDirectory,
     getReposDir: mocks.getReposDir,
@@ -50,7 +51,6 @@ vi.mock('../git/index.js', async () => {
     getRemoteUrl: mocks.getRemoteUrl,
     scanGitConfigRemoteCredentials: mocks.scanGitConfigRemoteCredentials,
     scrubGitConfigRemoteCredentials: mocks.scrubGitConfigRemoteCredentials,
-    assertRemoteRefVisibleForClone: mocks.assertRemoteRefVisibleForClone,
   };
 });
 
@@ -62,12 +62,12 @@ import {
   handleBranchAgorYmlExport,
   handleBranchAgorYmlImport,
   handleBranchInspect,
+  handleGitBranchAdd,
   handleGitBranchRemove,
   handleGitClone,
   handleGitManagedCredentialsReconcile,
   handleGitRepoDelete,
   handleGitRepoInspect,
-  handleGitRepoPreflight,
 } from './git.js';
 
 const repoId = '550e8400-e29b-41d4-a716-446655440001';
@@ -139,6 +139,10 @@ function createClient(records: {
         return {
           get: vi.fn(async () => records.branch),
           find,
+          patch: vi.fn(async (_id: string, data: Record<string, unknown>) => ({
+            ...(records.branch ?? {}),
+            ...data,
+          })),
         };
       }
       throw new Error(`unexpected service ${name}`);
@@ -162,6 +166,7 @@ beforeEach(() => {
     repoName: 'agor-assistant',
     defaultBranch: 'main',
   });
+  mocks.createBranchAsClone.mockResolvedValue({ path: '/trusted/branch', ref: 'main' });
   mocks.isValidGitRepo.mockResolvedValue(true);
   mocks.getDefaultBranch.mockResolvedValue('main');
   mocks.getRemoteUrl.mockResolvedValue('https://user:secret@example.com/org/repo.git');
@@ -169,10 +174,73 @@ beforeEach(() => {
     findings: [{ configPath: '/repo/.git/config' }],
   });
   mocks.scrubGitConfigRemoteCredentials.mockResolvedValue({ findings: [] });
-  mocks.assertRemoteRefVisibleForClone.mockResolvedValue(undefined);
 });
 
 describe('managed executor git/fs commands', () => {
+  it('resolves trusted repo metadata just-in-time inside git.branch.add', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://user:secret@example.com/trusted/repo.git',
+      },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        path: '/trusted/branch',
+        name: 'feature',
+      },
+    });
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-token',
+        params: {
+          branchId,
+          repoId,
+          branch: 'main',
+          storageMode: 'clone',
+          useReference: true,
+        },
+      },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.createBranchAsClone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteUrl: 'https://example.com/trusted/repo.git',
+        referencePath: '/trusted/repo',
+      })
+    );
+  });
+
+  it('denies missing tenant-scoped repo before filesystem materialization', async () => {
+    mocks.createExecutorClient.mockResolvedValueOnce({
+      io: { disconnect: vi.fn() },
+      service: vi.fn(() => ({
+        get: vi.fn(async () => {
+          throw new Error('Not found');
+        }),
+      })),
+    });
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'other-tenant-token',
+        params: {
+          branchId,
+          repoId,
+          storageMode: 'clone',
+        },
+      },
+      {}
+    );
+    expect(result).toMatchObject({ success: false, error: { message: 'Not found' } });
+    expect(mocks.createBranchAsClone).not.toHaveBeenCalled();
+  });
+
   it('inspects local repository contents only inside the executor and returns sanitized metadata', async () => {
     const result = await handleGitRepoInspect(
       {
@@ -225,56 +293,6 @@ describe('managed executor git/fs commands', () => {
       {}
     );
     expect(result).toMatchObject({ success: false, error: { code: 'GIT_REPO_INSPECT_FAILED' } });
-  });
-
-  it('fails preflight when the tenant-scoped executor token cannot fetch the repo', async () => {
-    mocks.createExecutorClient.mockResolvedValueOnce({
-      io: { disconnect: vi.fn() },
-      service: vi.fn(() => ({
-        get: vi.fn(async () => {
-          throw new Error('Not found');
-        }),
-      })),
-    });
-    const result = await handleGitRepoPreflight(
-      {
-        command: 'git.repo.preflight',
-        sessionToken: 'tenant-b-token',
-        params: { repoId, ref: 'main' },
-      },
-      {}
-    );
-    expect(result).toMatchObject({
-      success: false,
-      error: { code: 'GIT_REPO_PREFLIGHT_FAILED', message: 'Not found' },
-    });
-    expect(mocks.scrubGitConfigRemoteCredentials).not.toHaveBeenCalled();
-  });
-
-  it('uses tenant-fetched repo paths and remote metadata for preflight', async () => {
-    createClient({
-      repo: {
-        repo_id: repoId,
-        local_path: '/trusted/repo',
-        remote_url: 'https://user:secret@example.com/trusted/repo.git',
-      },
-    });
-    const result = await handleGitRepoPreflight(
-      {
-        command: 'git.repo.preflight',
-        sessionToken: 'tenant-a-token',
-        params: { repoId, ref: 'main', refType: 'branch' },
-      },
-      {}
-    );
-    expect(result.success).toBe(true);
-    expect(mocks.scrubGitConfigRemoteCredentials).toHaveBeenCalledWith('/trusted/repo');
-    expect(mocks.assertRemoteRefVisibleForClone).toHaveBeenCalledWith(
-      expect.objectContaining({
-        remoteUrl: 'https://example.com/trusted/repo.git',
-        ref: 'main',
-      })
-    );
   });
 
   it('paginates self-hosted reconciliation and dry-run does not mutate configs', async () => {

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -1131,6 +1131,7 @@ export async function handleGitBranchAdd(
   let resolvedRepoPath: string | undefined;
   let resolvedBranchPath: string | undefined;
   let resolvedBranchName: string | undefined;
+  let resolvedOthersAccess: 'none' | 'read' | 'write' = 'read';
 
   // Dry run mode
   if (options.dryRun) {
@@ -1141,11 +1142,7 @@ export async function handleGitBranchAdd(
         command: 'git.branch.add',
         branchId,
         repoId: payload.params.repoId,
-        branch: payload.params.branch,
-        sourceBranch: payload.params.sourceBranch,
-        createBranch: payload.params.createBranch,
-        storageMode: payload.params.storageMode,
-        cloneDepth: payload.params.cloneDepth,
+        restoreMode: payload.params.restoreMode,
         useReference: payload.params.useReference,
       },
     };
@@ -1179,13 +1176,14 @@ export async function handleGitBranchAdd(
     resolvedRepoPath = repoPath;
     resolvedBranchPath = branchPath;
     resolvedBranchName = branchName;
-    const branch = payload.params.branch || branchName;
-    const shouldCreateBranch = payload.params.createBranch ?? false;
-    const sourceBranch = payload.params.sourceBranch;
-    const refType = payload.params.refType;
+    resolvedOthersAccess = branchRecord.others_fs_access || 'read';
+    const branch = branchRecord.ref || branchName;
+    const shouldCreateBranch = branchRecord.new_branch ?? false;
+    const sourceBranch = branchRecord.base_ref || repo.default_branch || 'main';
+    const refType = branchRecord.ref_type;
     const restoreMode = payload.params.restoreMode ?? false;
-    const storageMode = payload.params.storageMode ?? 'worktree';
-    const cloneDepth = payload.params.cloneDepth;
+    const storageMode = branchRecord.storage_mode ?? 'worktree';
+    const cloneDepth = branchRecord.clone_depth;
     const remoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
     const referencePath = payload.params.useReference ? repo.local_path : undefined;
 
@@ -1266,7 +1264,7 @@ export async function handleGitBranchAdd(
     let unixGroup: string | undefined;
     if (payload.params.initUnixGroup && branchId) {
       try {
-        const othersAccess = payload.params.othersAccess || 'read';
+        const othersAccess = resolvedOthersAccess;
         console.log(`[git.branch.add] Initializing Unix group for branch ${shortId(branchId)}`);
         const result = await client
           .service('branches')
@@ -1393,8 +1391,9 @@ export async function handleGitBranchAdd(
       // Step 2: Apply perms/ACLs via daemon RPC (runs even if dir already existed from a prior attempt)
       if (existsSync(fallbackPath) && payload.params.initUnixGroup && branchId && client) {
         try {
-          const othersAccess = payload.params.othersAccess || 'read';
-          await client.service('branches').initializeUnixGroup({ branchId, othersAccess });
+          await client
+            .service('branches')
+            .initializeUnixGroup({ branchId, othersAccess: resolvedOthersAccess });
           console.log(`[git.branch.add] Fallback: applied Unix group permissions`);
           fallbackPermissionsApplied = true;
         } catch (permError) {
@@ -1410,7 +1409,7 @@ export async function handleGitBranchAdd(
     let userMessage = errorMessage;
     if (errorMessage.includes('already exists')) {
       if (errorMessage.includes('branch')) {
-        userMessage = `A branch named '${payload.params.branch || resolvedBranchName || 'unknown'}' already exists and is in use by another branch. Please choose a different name.`;
+        userMessage = `A branch named '${resolvedBranchName || 'unknown'}' already exists and is in use by another branch. Please choose a different name.`;
       } else {
         userMessage = `Directory '${resolvedBranchPath || resolvedBranchName || 'unknown'}' already exists. An archived or partially-cleaned branch may still occupy this path.`;
       }

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -18,10 +18,12 @@
  */
 
 import { existsSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { userInfo } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
 import { parseAgorYml, writeAgorYml } from '@agor/core/config';
 import { shortId } from '@agor/core/db';
 import {
+  assertRemoteRefVisibleForClone,
   categorizeGitError,
   cleanBranch,
   cloneRepo,
@@ -32,10 +34,15 @@ import {
   deleteBranchDirectory,
   deleteRepoDirectory,
   ensureGitRemoteUrl,
+  getDefaultBranch,
+  getRemoteUrl,
   getReposDir,
+  isValidGitRepo,
   redactGitUrlCredentials,
   removeGitWorktree,
   restoreBranchFilesystem,
+  scanGitConfigRemoteCredentials,
+  scrubGitConfigRemoteCredentials,
   stripGitUrlCredentials,
 } from '../git/index.js';
 import type {
@@ -48,13 +55,156 @@ import type {
   GitBranchCleanPayload,
   GitBranchRemovePayload,
   GitClonePayload,
+  GitManagedCredentialsReconcilePayload,
   GitRepoDeletePayload,
+  GitRepoInspectPayload,
+  GitRepoPreflightPayload,
   GitRepoRealignOriginPayload,
 } from '../payload-types.js';
 import type { AgorClient } from '../services/feathers-client.js';
 import { createExecutorClient } from '../services/feathers-client.js';
 import type { CommandOptions } from './index.js';
 import { fixBranchGitDirPermissionsBasic } from './unix.js';
+
+/**
+ * Self-hosted compatibility operation. The daemon authorizes the request and
+ * launches this narrow inspection under the caller's resolved executor Unix
+ * identity; the command deliberately has no daemon capability token.
+ */
+export async function handleGitRepoInspect(
+  payload: GitRepoInspectPayload,
+  options: CommandOptions
+): Promise<ExecutorResult> {
+  try {
+    let inputPath = payload.params.path.trim();
+    if (inputPath.startsWith('~')) {
+      inputPath = join(userInfo().homedir, inputPath.slice(1).replace(/^[/\\]?/, ''));
+    }
+    if (!isAbsolute(inputPath)) throw new Error(`Path must be absolute: ${inputPath}`);
+    const repoPath = resolve(inputPath);
+    if (!(await isValidGitRepo(repoPath))) {
+      throw new Error(`Not a valid git repository: ${repoPath}`);
+    }
+    const remoteUrl = stripGitUrlCredentials((await getRemoteUrl(repoPath)) ?? '') || undefined;
+    let environment: unknown;
+    let environmentWarning: string | undefined;
+    try {
+      environment = parseAgorYml(join(repoPath, '.agor.yml')) ?? undefined;
+    } catch {
+      environmentWarning = 'Failed to parse .agor.yml; repository registration will continue.';
+    }
+    const scan = await scanGitConfigRemoteCredentials(repoPath);
+    return {
+      success: true,
+      data: {
+        path: repoPath,
+        defaultBranch: await getDefaultBranch(repoPath),
+        remoteUrl,
+        environment,
+        credentialFindingCount: scan.findings.length,
+        ...(environmentWarning ? { environmentWarning } : {}),
+        ...(options.dryRun ? { dryRun: true } : {}),
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 'GIT_REPO_INSPECT_FAILED',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+export async function handleGitRepoPreflight(
+  payload: GitRepoPreflightPayload,
+  _options: CommandOptions
+): Promise<ExecutorResult> {
+  let client: AgorClient | null = null;
+  try {
+    client = await createExecutorClient(
+      payload.daemonUrl || 'http://localhost:3030',
+      payload.sessionToken
+    );
+    const repo = await client.service('repos').get(payload.params.repoId);
+    if (repo.local_path) await scrubGitConfigRemoteCredentials(repo.local_path);
+    if (repo.remote_url && payload.params.ref) {
+      const env = await fetchUserGitEnvironment(client, payload.params.userId);
+      await assertRemoteRefVisibleForClone({
+        remoteUrl: stripGitUrlCredentials(repo.remote_url),
+        ref: payload.params.ref,
+        refType: payload.params.refType ?? 'branch',
+        env,
+      });
+    }
+    return { success: true, data: { repoId: payload.params.repoId } };
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 'GIT_REPO_PREFLIGHT_FAILED',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  } finally {
+    client?.io.disconnect();
+  }
+}
+
+export async function handleGitManagedCredentialsReconcile(
+  payload: GitManagedCredentialsReconcilePayload,
+  options: CommandOptions
+): Promise<ExecutorResult> {
+  let client: AgorClient | null = null;
+  try {
+    client = await createExecutorClient(
+      payload.daemonUrl || 'http://localhost:3030',
+      payload.sessionToken
+    );
+    const fetchAll = async (service: 'repos' | 'branches', query: Record<string, unknown>) => {
+      const rows: Array<{
+        repo_id?: string;
+        repo_type?: string;
+        local_path?: string;
+        path?: string;
+      }> = [];
+      while (true) {
+        const result = await client!.service(service).find({
+          query: { ...query, $limit: 1000, $skip: rows.length },
+        });
+        const page = Array.isArray(result) ? result : result.data;
+        rows.push(...page);
+        if (Array.isArray(result) || page.length === 0 || rows.length >= result.total) return rows;
+      }
+    };
+    const repos = await fetchAll('repos', {});
+    let findings = 0;
+    for (const repo of repos.filter((item) => item.repo_type === 'remote')) {
+      if (!options.dryRun && repo.local_path)
+        findings += (await scrubGitConfigRemoteCredentials(repo.local_path)).findings.length;
+      const branches = await fetchAll('branches', {
+        repo_id: repo.repo_id,
+        archived: { $in: [true, false] },
+      });
+      for (const branch of branches) {
+        if (!options.dryRun && branch.path)
+          findings += (await scrubGitConfigRemoteCredentials(branch.path)).findings.length;
+      }
+    }
+    return { success: true, data: { findings, dryRun: options.dryRun === true } };
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 'GIT_MANAGED_CREDENTIALS_RECONCILE_FAILED',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  } finally {
+    client?.io.disconnect();
+  }
+}
 
 /**
  * Fetch the requesting user's git environment via Feathers RPC.

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -23,7 +23,6 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { parseAgorYml, writeAgorYml } from '@agor/core/config';
 import { shortId } from '@agor/core/db';
 import {
-  assertRemoteRefVisibleForClone,
   categorizeGitError,
   cleanBranch,
   cloneRepo,
@@ -58,7 +57,6 @@ import type {
   GitManagedCredentialsReconcilePayload,
   GitRepoDeletePayload,
   GitRepoInspectPayload,
-  GitRepoPreflightPayload,
   GitRepoRealignOriginPayload,
 } from '../payload-types.js';
 import type { AgorClient } from '../services/feathers-client.js';
@@ -114,41 +112,6 @@ export async function handleGitRepoInspect(
         message: error instanceof Error ? error.message : String(error),
       },
     };
-  }
-}
-
-export async function handleGitRepoPreflight(
-  payload: GitRepoPreflightPayload,
-  _options: CommandOptions
-): Promise<ExecutorResult> {
-  let client: AgorClient | null = null;
-  try {
-    client = await createExecutorClient(
-      payload.daemonUrl || 'http://localhost:3030',
-      payload.sessionToken
-    );
-    const repo = await client.service('repos').get(payload.params.repoId);
-    if (repo.local_path) await scrubGitConfigRemoteCredentials(repo.local_path);
-    if (repo.remote_url && payload.params.ref) {
-      const env = await fetchUserGitEnvironment(client, payload.params.userId);
-      await assertRemoteRefVisibleForClone({
-        remoteUrl: stripGitUrlCredentials(repo.remote_url),
-        ref: payload.params.ref,
-        refType: payload.params.refType ?? 'branch',
-        env,
-      });
-    }
-    return { success: true, data: { repoId: payload.params.repoId } };
-  } catch (error) {
-    return {
-      success: false,
-      error: {
-        code: 'GIT_REPO_PREFLIGHT_FAILED',
-        message: error instanceof Error ? error.message : String(error),
-      },
-    };
-  } finally {
-    client?.io.disconnect();
   }
 }
 
@@ -1165,6 +1128,9 @@ export async function handleGitBranchAdd(
   options: CommandOptions
 ): Promise<ExecutorResult> {
   const branchId = payload.params.branchId;
+  let resolvedRepoPath: string | undefined;
+  let resolvedBranchPath: string | undefined;
+  let resolvedBranchName: string | undefined;
 
   // Dry run mode
   if (options.dryRun) {
@@ -1175,18 +1141,12 @@ export async function handleGitBranchAdd(
         command: 'git.branch.add',
         branchId,
         repoId: payload.params.repoId,
-        repoPath: payload.params.repoPath,
-        branchName: payload.params.branchName,
-        branchPath: payload.params.branchPath,
         branch: payload.params.branch,
         sourceBranch: payload.params.sourceBranch,
         createBranch: payload.params.createBranch,
         storageMode: payload.params.storageMode,
         cloneDepth: payload.params.cloneDepth,
-        remoteUrl: payload.params.remoteUrl
-          ? stripGitUrlCredentials(payload.params.remoteUrl)
-          : payload.params.remoteUrl,
-        referencePath: payload.params.referencePath,
+        useReference: payload.params.useReference,
       },
     };
   }
@@ -1199,14 +1159,26 @@ export async function handleGitBranchAdd(
     client = await createExecutorClient(daemonUrl, payload.sessionToken);
     console.log('[git.branch.add] Connected to daemon');
 
+    // Resolve filesystem-bearing repository metadata through the scoped
+    // service token in this same executor. This makes authorization, trusted
+    // path resolution, credential scrub, and materialization one operation.
+    const repo = await client.service('repos').get(payload.params.repoId);
+    const branchRecord = await client.service('branches').get(branchId);
+    if (branchRecord.repo_id !== payload.params.repoId) {
+      throw new Error(`Branch ${branchId} does not belong to repository ${payload.params.repoId}`);
+    }
+
     // Fetch per-user git credentials via Feathers RPC
     const env = await fetchUserGitEnvironment(client, payload.params.userId);
 
     // Get parameters
     const repoId = payload.params.repoId;
-    const branchPath = payload.params.branchPath;
-    const repoPath = payload.params.repoPath;
-    const branchName = payload.params.branchName;
+    const branchPath = branchRecord.path;
+    const repoPath = repo.local_path;
+    const branchName = branchRecord.name;
+    resolvedRepoPath = repoPath;
+    resolvedBranchPath = branchPath;
+    resolvedBranchName = branchName;
     const branch = payload.params.branch || branchName;
     const shouldCreateBranch = payload.params.createBranch ?? false;
     const sourceBranch = payload.params.sourceBranch;
@@ -1214,8 +1186,12 @@ export async function handleGitBranchAdd(
     const restoreMode = payload.params.restoreMode ?? false;
     const storageMode = payload.params.storageMode ?? 'worktree';
     const cloneDepth = payload.params.cloneDepth;
-    const remoteUrl = payload.params.remoteUrl;
-    const referencePath = payload.params.referencePath;
+    const remoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
+    const referencePath = payload.params.useReference ? repo.local_path : undefined;
+
+    if (!repoPath && storageMode === 'worktree') {
+      throw new Error(`Repository ${repoId} has no local_path for worktree materialization`);
+    }
 
     console.log(`[git.branch.add] Creating branch at ${branchPath}...`);
     console.log(
@@ -1231,8 +1207,7 @@ export async function handleGitBranchAdd(
       // payload schema also enforces this via superRefine.)
       if (!remoteUrl) {
         throw new Error(
-          `storageMode='clone' requires remoteUrl in payload (got none). ` +
-            `The daemon should forward repo.remote_url alongside storageMode.`
+          `Cannot materialize clone-mode branch: tenant-scoped repository ${repoId} has no remote_url.`
         );
       }
 
@@ -1305,7 +1280,7 @@ export async function handleGitBranchAdd(
           error instanceof Error ? error.message : String(error)
         );
       }
-    } else if (!payload.params.initUnixGroup && storageMode === 'worktree') {
+    } else if (payload.params.fixBasicPermissions && storageMode === 'worktree') {
       // RBAC is explicitly disabled — set basic permissions for the base
       // repo's .git/worktrees/<name>/ entry so git operations work even
       // without Unix group isolation.
@@ -1397,7 +1372,7 @@ export async function handleGitBranchAdd(
     // unblocks sync-unix, sessions, and manual recovery — the directory just
     // won't be a proper git branch. Also repairs perms if a prior attempt
     // created the dir but failed on group initialization.
-    const fallbackPath = payload.params.branchPath;
+    const fallbackPath = resolvedBranchPath;
     let fallbackCreated = false;
     let fallbackPermissionsApplied = false;
     if (fallbackPath) {
@@ -1435,9 +1410,9 @@ export async function handleGitBranchAdd(
     let userMessage = errorMessage;
     if (errorMessage.includes('already exists')) {
       if (errorMessage.includes('branch')) {
-        userMessage = `A branch named '${payload.params.branch || payload.params.branchName}' already exists and is in use by another branch. Please choose a different name.`;
+        userMessage = `A branch named '${payload.params.branch || resolvedBranchName || 'unknown'}' already exists and is in use by another branch. Please choose a different name.`;
       } else {
-        userMessage = `Directory '${payload.params.branchPath || payload.params.branchName}' already exists. An archived or partially-cleaned branch may still occupy this path.`;
+        userMessage = `Directory '${resolvedBranchPath || resolvedBranchName || 'unknown'}' already exists. An archived or partially-cleaned branch may still occupy this path.`;
       }
     }
 
@@ -1465,9 +1440,9 @@ export async function handleGitBranchAdd(
         details: {
           branchId,
           repoId: payload.params.repoId,
-          repoPath: payload.params.repoPath,
-          branchName: payload.params.branchName,
-          branchPath: payload.params.branchPath,
+          repoPath: resolvedRepoPath,
+          branchName: resolvedBranchName,
+          branchPath: resolvedBranchPath,
           fallbackDirectoryCreated: fallbackCreated,
           fallbackPermissionsApplied,
         },

--- a/packages/executor/src/commands/index.test.ts
+++ b/packages/executor/src/commands/index.test.ts
@@ -181,7 +181,7 @@ describe('executeCommand - git.clone', () => {
     });
   });
 
-  it('should include optional fields in dry-run response', async () => {
+  it('should include restore intent in dry-run response', async () => {
     const payloadWithOptions: GitClonePayload = {
       ...gitClonePayload,
       params: {
@@ -250,9 +250,7 @@ describe('executeCommand - git.branch.add', () => {
       ...branchAddPayload,
       params: {
         ...branchAddPayload.params,
-        branch: 'feature-x',
-        sourceBranch: 'main',
-        createBranch: true,
+        restoreMode: true,
       },
     };
 
@@ -260,24 +258,15 @@ describe('executeCommand - git.branch.add', () => {
 
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({
-      branch: 'feature-x',
-      sourceBranch: 'main',
-      createBranch: true,
+      restoreMode: true,
     });
   });
 
-  it('should round-trip storageMode / cloneDepth / reference policy in dry-run response', async () => {
-    // PR 1 of the branch→clone storage migration. The daemon forwards
-    // these three knobs; the executor branches on storageMode at run time.
-    // Pin them through the dry-run echo so the daemon-side test fixture
-    // can assert payload-shape correctness without spinning up a real git.
+  it('should round-trip the clone reference policy in dry-run response', async () => {
     const clonePayload: GitBranchAddPayload = {
       ...branchAddPayload,
       params: {
         ...branchAddPayload.params,
-        branch: 'feature-x',
-        storageMode: 'clone',
-        cloneDepth: 100,
         useReference: true,
       },
     };
@@ -286,8 +275,6 @@ describe('executeCommand - git.branch.add', () => {
 
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({
-      storageMode: 'clone',
-      cloneDepth: 100,
       useReference: true,
     });
   });

--- a/packages/executor/src/commands/index.test.ts
+++ b/packages/executor/src/commands/index.test.ts
@@ -230,9 +230,8 @@ describe('executeCommand - git.branch.add', () => {
     command: 'git.branch.add',
     sessionToken: 'jwt-token',
     params: {
-      repoPath: '/data/agor/repos/repo.git',
-      branchName: 'feature-x',
-      branchPath: '/data/agor/worktrees/repo/feature-x',
+      branchId: '550e8400-e29b-41d4-a716-446655440002',
+      repoId: '550e8400-e29b-41d4-a716-446655440003',
     },
   };
 
@@ -243,9 +242,6 @@ describe('executeCommand - git.branch.add', () => {
     expect(result.data).toMatchObject({
       dryRun: true,
       command: 'git.branch.add',
-      repoPath: branchAddPayload.params.repoPath,
-      branchName: branchAddPayload.params.branchName,
-      branchPath: branchAddPayload.params.branchPath,
     });
   });
 
@@ -270,7 +266,7 @@ describe('executeCommand - git.branch.add', () => {
     });
   });
 
-  it('should round-trip storageMode / cloneDepth / remoteUrl in dry-run response', async () => {
+  it('should round-trip storageMode / cloneDepth / reference policy in dry-run response', async () => {
     // PR 1 of the branch→clone storage migration. The daemon forwards
     // these three knobs; the executor branches on storageMode at run time.
     // Pin them through the dry-run echo so the daemon-side test fixture
@@ -282,7 +278,7 @@ describe('executeCommand - git.branch.add', () => {
         branch: 'feature-x',
         storageMode: 'clone',
         cloneDepth: 100,
-        remoteUrl: 'https://github.com/org/repo.git',
+        useReference: true,
       },
     };
 
@@ -292,7 +288,7 @@ describe('executeCommand - git.branch.add', () => {
     expect(result.data).toMatchObject({
       storageMode: 'clone',
       cloneDepth: 100,
-      remoteUrl: 'https://github.com/org/repo.git',
+      useReference: true,
     });
   });
 });

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -33,7 +33,6 @@ import {
   handleGitManagedCredentialsReconcile,
   handleGitRepoDelete,
   handleGitRepoInspect,
-  handleGitRepoPreflight,
   handleGitRepoRealignOrigin,
 } from './git.js';
 import { handleBranchKnowledgeRead, handleBranchKnowledgeWrite } from './knowledge.js';
@@ -195,7 +194,6 @@ registerCommand('environment.logs', handleEnvironmentLogs);
 registerCommand('git.repo.realign-origin', handleGitRepoRealignOrigin);
 registerCommand('git.repo.delete', handleGitRepoDelete);
 registerCommand('git.repo.inspect', handleGitRepoInspect);
-registerCommand('git.repo.preflight', handleGitRepoPreflight);
 registerCommand('git.managed-credentials.reconcile', handleGitManagedCredentialsReconcile);
 registerCommand('unix.sync-repo', handleUnixSyncRepo);
 registerCommand('unix.sync-branch', handleUnixSyncBranch);

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -30,7 +30,10 @@ import {
   handleGitBranchClean,
   handleGitBranchRemove,
   handleGitClone,
+  handleGitManagedCredentialsReconcile,
   handleGitRepoDelete,
+  handleGitRepoInspect,
+  handleGitRepoPreflight,
   handleGitRepoRealignOrigin,
 } from './git.js';
 import { handleBranchKnowledgeRead, handleBranchKnowledgeWrite } from './knowledge.js';
@@ -191,6 +194,9 @@ registerCommand('environment.lifecycle', handleEnvironmentLifecycle);
 registerCommand('environment.logs', handleEnvironmentLogs);
 registerCommand('git.repo.realign-origin', handleGitRepoRealignOrigin);
 registerCommand('git.repo.delete', handleGitRepoDelete);
+registerCommand('git.repo.inspect', handleGitRepoInspect);
+registerCommand('git.repo.preflight', handleGitRepoPreflight);
+registerCommand('git.managed-credentials.reconcile', handleGitManagedCredentialsReconcile);
 registerCommand('unix.sync-repo', handleUnixSyncRepo);
 registerCommand('unix.sync-branch', handleUnixSyncBranch);
 registerCommand('unix.sync-board', handleUnixSyncBoard);

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -294,78 +294,25 @@ describe('GitBranchAddPayloadSchema', () => {
     expect(result.params.branchId).toBe('550e8400-e29b-41d4-a716-446655440002');
   });
 
-  it('should parse with branch creation options', () => {
-    const payload = {
+  it('strips duplicated materialization facts and retains operational intent', () => {
+    const result = GitBranchAddPayloadSchema.parse({
       command: 'git.branch.add',
       sessionToken: 'jwt-token-here',
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
-        branch: 'feature-x',
-        sourceBranch: 'main',
-        createBranch: true,
+        branch: 'untrusted',
+        storageMode: 'worktree',
+        cloneDepth: 100,
+        restoreMode: true,
+        useReference: true,
       },
-    };
-
-    const result = GitBranchAddPayloadSchema.parse(payload);
-    expect(result.params.branch).toBe('feature-x');
-    expect(result.params.sourceBranch).toBe('main');
-    expect(result.params.createBranch).toBe(true);
-  });
-
-  // Clone-mode invariants live on the schema (not just in the executor
-  // handler) so malformed payloads fail at parse time with a clear message.
-  // See enforceClonePayloadInvariants in payload-types.ts.
-  describe('clone-mode invariants (superRefine)', () => {
-    const basePayload = {
-      command: 'git.branch.add' as const,
-      sessionToken: 'jwt-token-here',
-      params: {
-        branchId: '550e8400-e29b-41d4-a716-446655440002',
-        repoId: '550e8400-e29b-41d4-a716-446655440003',
-      },
-    };
-
-    it('accepts a clone-mode intent payload with optional cloneDepth and reference policy', () => {
-      const result = GitBranchAddPayloadSchema.parse({
-        ...basePayload,
-        params: {
-          ...basePayload.params,
-          storageMode: 'clone',
-          cloneDepth: 100,
-          useReference: true,
-        },
-      });
-      expect(result.params.storageMode).toBe('clone');
-      expect(result.params.cloneDepth).toBe(100);
-      expect(result.params.useReference).toBe(true);
     });
-
-    it('rejects cloneDepth paired with branch (or undefined) mode', () => {
-      // Explicit worktree mode.
-      expect(() =>
-        GitBranchAddPayloadSchema.parse({
-          ...basePayload,
-          params: {
-            ...basePayload.params,
-            storageMode: 'worktree',
-            cloneDepth: 100,
-          },
-        })
-      ).toThrow(/cloneDepth is only meaningful when storageMode === 'clone'/);
-
-      // Mode unset (legacy callers) — same rule: cloneDepth without
-      // explicit clone mode is a config bug, not silently dropped.
-      expect(() =>
-        GitBranchAddPayloadSchema.parse({
-          ...basePayload,
-          params: {
-            ...basePayload.params,
-            cloneDepth: 100,
-          },
-        })
-      ).toThrow(/cloneDepth is only meaningful when storageMode === 'clone'/);
-    });
+    expect(result.params).not.toHaveProperty('branch');
+    expect(result.params).not.toHaveProperty('storageMode');
+    expect(result.params).not.toHaveProperty('cloneDepth');
+    expect(result.params.restoreMode).toBe(true);
+    expect(result.params.useReference).toBe(true);
   });
 });
 

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -444,25 +444,6 @@ describe('ZellijAttachPayloadSchema', () => {
     expect(result.params.userId).toBe('550e8400-e29b-41d4-a716-446655440000');
   });
 
-  it('bounds executor Codex credential writes', () => {
-    expect(() =>
-      parseExecutorPayload(
-        JSON.stringify({
-          command: 'codex.auth-file',
-          params: { operation: 'write', content: 'x'.repeat(64 * 1024 + 1) },
-        })
-      )
-    ).toThrow();
-    expect(
-      parseExecutorPayload(
-        JSON.stringify({
-          command: 'codex.auth-file',
-          params: { operation: 'write', content: 'x'.repeat(64 * 1024) },
-        })
-      ).command
-    ).toBe('codex.auth-file');
-  });
-
   it('should parse with optional fields', () => {
     const payload = {
       command: 'zellij.attach',
@@ -644,6 +625,9 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('git.branch.add');
     expect(commands).toContain('git.branch.remove');
     expect(commands).toContain('git.branch.clean');
+    expect(commands).toContain('git.repo.inspect');
+    expect(commands).toContain('git.repo.preflight');
+    expect(commands).toContain('git.managed-credentials.reconcile');
     expect(commands).toContain('branch.files.list');
     expect(commands).toContain('branch.files.browse');
     expect(commands).toContain('branch.files.read');
@@ -667,7 +651,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('unix.sync-user');
     expect(commands).toContain('zellij.attach');
     expect(commands).toContain('zellij.tab');
-    expect(commands).toContain('codex.auth-file');
-    expect(commands.length).toBe(29);
+    expect(commands.length).toBe(31);
   });
 });

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -572,6 +572,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('unix.sync-user');
     expect(commands).toContain('zellij.attach');
     expect(commands).toContain('zellij.tab');
-    expect(commands.length).toBe(30);
+    expect(commands.length).toBe(31);
   });
 });

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -285,15 +285,12 @@ describe('GitBranchAddPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
-        repoPath: '/data/agor/repos/github.com/user/repo.git',
-        branchName: 'feature-x',
-        branchPath: '/data/agor/worktrees/user/repo/feature-x',
       },
     };
 
     const result = GitBranchAddPayloadSchema.parse(payload);
     expect(result.command).toBe('git.branch.add');
-    expect(result.params.branchName).toBe('feature-x');
+    expect(result.params.repoId).toBe('550e8400-e29b-41d4-a716-446655440003');
     expect(result.params.branchId).toBe('550e8400-e29b-41d4-a716-446655440002');
   });
 
@@ -304,9 +301,6 @@ describe('GitBranchAddPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
-        repoPath: '/data/agor/repos/github.com/user/repo.git',
-        branchName: 'feature-x',
-        branchPath: '/data/agor/worktrees/user/repo/feature-x',
         branch: 'feature-x',
         sourceBranch: 'main',
         createBranch: true,
@@ -329,38 +323,22 @@ describe('GitBranchAddPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
-        repoPath: '/data/agor/repos/github.com/user/repo.git',
-        branchName: 'feature-x',
-        branchPath: '/data/agor/worktrees/user/repo/feature-x',
       },
     };
 
-    it('accepts a clone-mode payload with a remoteUrl (and optional cloneDepth)', () => {
+    it('accepts a clone-mode intent payload with optional cloneDepth and reference policy', () => {
       const result = GitBranchAddPayloadSchema.parse({
         ...basePayload,
         params: {
           ...basePayload.params,
           storageMode: 'clone',
-          remoteUrl: 'https://github.com/user/repo.git',
           cloneDepth: 100,
+          useReference: true,
         },
       });
       expect(result.params.storageMode).toBe('clone');
-      expect(result.params.remoteUrl).toBe('https://github.com/user/repo.git');
       expect(result.params.cloneDepth).toBe(100);
-    });
-
-    it('rejects a clone-mode payload missing remoteUrl', () => {
-      expect(() =>
-        GitBranchAddPayloadSchema.parse({
-          ...basePayload,
-          params: {
-            ...basePayload.params,
-            storageMode: 'clone',
-            // no remoteUrl
-          },
-        })
-      ).toThrow(/remoteUrl is required/);
+      expect(result.params.useReference).toBe(true);
     });
 
     it('rejects cloneDepth paired with branch (or undefined) mode', () => {
@@ -579,9 +557,6 @@ describe('Type guards', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
-        repoPath: '/data/repos/repo.git',
-        branchName: 'feature',
-        branchPath: '/data/branches/feature',
       },
     };
     expect(isGitBranchAddPayload(payload)).toBe(true);
@@ -626,7 +601,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('git.branch.remove');
     expect(commands).toContain('git.branch.clean');
     expect(commands).toContain('git.repo.inspect');
-    expect(commands).toContain('git.repo.preflight');
     expect(commands).toContain('git.managed-credentials.reconcile');
     expect(commands).toContain('branch.files.list');
     expect(commands).toContain('branch.files.browse');
@@ -651,6 +625,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('unix.sync-user');
     expect(commands).toContain('zellij.attach');
     expect(commands).toContain('zellij.tab');
-    expect(commands.length).toBe(31);
+    expect(commands.length).toBe(30);
   });
 });

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -754,6 +754,35 @@ export const GitRepoRealignOriginPayloadSchema = BasePayloadSchema.extend({
 
 export type GitRepoRealignOriginPayload = z.infer<typeof GitRepoRealignOriginPayloadSchema>;
 
+export const GitRepoInspectPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('git.repo.inspect'),
+  params: z.object({
+    path: z.string().min(1),
+  }),
+});
+export type GitRepoInspectPayload = z.infer<typeof GitRepoInspectPayloadSchema>;
+
+export const GitRepoPreflightPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('git.repo.preflight'),
+  sessionToken: z.string(),
+  params: z.object({
+    repoId: z.string().uuid(),
+    ref: z.string().optional(),
+    refType: z.enum(['branch', 'tag']).optional(),
+    userId: z.string().uuid().optional(),
+  }),
+});
+export type GitRepoPreflightPayload = z.infer<typeof GitRepoPreflightPayloadSchema>;
+
+export const GitManagedCredentialsReconcilePayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('git.managed-credentials.reconcile'),
+  sessionToken: z.string(),
+  params: z.object({}),
+});
+export type GitManagedCredentialsReconcilePayload = z.infer<
+  typeof GitManagedCredentialsReconcilePayloadSchema
+>;
+
 // ═══════════════════════════════════════════════════════════
 // Git Repo Delete Payload
 // ═══════════════════════════════════════════════════════════
@@ -1014,6 +1043,9 @@ export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   EnvironmentLifecyclePayloadSchema,
   EnvironmentLogsPayloadSchema,
   GitRepoRealignOriginPayloadSchema,
+  GitRepoInspectPayloadSchema,
+  GitRepoPreflightPayloadSchema,
+  GitManagedCredentialsReconcilePayloadSchema,
   GitRepoDeletePayloadSchema,
   UnixSyncBranchPayloadSchema,
   UnixSyncBoardPayloadSchema,
@@ -1073,6 +1105,9 @@ export function getSupportedCommands(): string[] {
     'git.branch.add',
     'git.branch.remove',
     'git.branch.clean',
+    'git.repo.inspect',
+    'git.repo.preflight',
+    'git.managed-credentials.reconcile',
     'branch.files.list',
     'branch.files.browse',
     'branch.files.read',

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -252,16 +252,9 @@ export type GitClonePayload = z.infer<typeof GitClonePayloadSchema>;
  * payloads fail at parse time with a clear message.
  */
 const enforceClonePayloadInvariants = (
-  params: { storageMode?: 'worktree' | 'clone'; remoteUrl?: string; cloneDepth?: number },
+  params: { storageMode?: 'worktree' | 'clone'; cloneDepth?: number },
   ctx: z.RefinementCtx
 ): void => {
-  if (params.storageMode === 'clone' && !params.remoteUrl) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['remoteUrl'],
-      message: "remoteUrl is required when storageMode === 'clone'",
-    });
-  }
   if (params.cloneDepth !== undefined && params.storageMode !== 'clone') {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -286,15 +279,6 @@ export const GitBranchAddPayloadSchema = BasePayloadSchema.extend({
       /** Repo ID (UUID) */
       repoId: z.string().uuid(),
 
-      /** Path to the repository */
-      repoPath: z.string(),
-
-      /** Name for the branch */
-      branchName: z.string(),
-
-      /** Path where branch will be created */
-      branchPath: z.string(),
-
       /** Branch to checkout or create */
       branch: z.string().optional(),
 
@@ -312,6 +296,9 @@ export const GitBranchAddPayloadSchema = BasePayloadSchema.extend({
 
       /** Initialize Unix group for branch isolation (default: false, requires RBAC enabled) */
       initUnixGroup: z.boolean().optional().default(false),
+
+      /** Legacy open-access self-hosted chmod; false for RBAC/simple Cloud mounts. */
+      fixBasicPermissions: z.boolean().optional().default(false),
 
       /** Access level for non-owners ('none' | 'read' | 'write') */
       othersAccess: z.enum(['none', 'read', 'write']).optional().default('read'),
@@ -334,22 +321,8 @@ export const GitBranchAddPayloadSchema = BasePayloadSchema.extend({
        */
       cloneDepth: z.number().int().positive().optional(),
 
-      /**
-       * Remote URL for clone-mode. Daemon resolves from the repo record and
-       * forwards it; the executor uses it as the `git clone` source. Ignored
-       * when storageMode='worktree'.
-       */
-      remoteUrl: z.string().optional(),
-
-      /**
-       * Optional `git clone --reference <path>` hint. Daemon resolves this
-       * to the per-repo base clone (e.g. `~/.agor/repos/<slug>/`) and
-       * forwards it; the executor checks the path on its own filesystem
-       * before adding `--reference` to the clone command. Path missing
-       * (different mount, base not seeded yet) → silent fallback to a
-       * full clone. Ignored when storageMode='worktree'.
-       */
-      referencePath: z.string().optional(),
+      /** Whether clone mode may use the tenant-fetched repo path as an object-cache hint. */
+      useReference: z.boolean().optional().default(false),
     })
     .superRefine(enforceClonePayloadInvariants),
 });
@@ -762,18 +735,6 @@ export const GitRepoInspectPayloadSchema = BasePayloadSchema.extend({
 });
 export type GitRepoInspectPayload = z.infer<typeof GitRepoInspectPayloadSchema>;
 
-export const GitRepoPreflightPayloadSchema = BasePayloadSchema.extend({
-  command: z.literal('git.repo.preflight'),
-  sessionToken: z.string(),
-  params: z.object({
-    repoId: z.string().uuid(),
-    ref: z.string().optional(),
-    refType: z.enum(['branch', 'tag']).optional(),
-    userId: z.string().uuid().optional(),
-  }),
-});
-export type GitRepoPreflightPayload = z.infer<typeof GitRepoPreflightPayloadSchema>;
-
 export const GitManagedCredentialsReconcilePayloadSchema = BasePayloadSchema.extend({
   command: z.literal('git.managed-credentials.reconcile'),
   sessionToken: z.string(),
@@ -1044,7 +1005,6 @@ export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   EnvironmentLogsPayloadSchema,
   GitRepoRealignOriginPayloadSchema,
   GitRepoInspectPayloadSchema,
-  GitRepoPreflightPayloadSchema,
   GitManagedCredentialsReconcilePayloadSchema,
   GitRepoDeletePayloadSchema,
   UnixSyncBranchPayloadSchema,
@@ -1106,7 +1066,6 @@ export function getSupportedCommands(): string[] {
     'git.branch.remove',
     'git.branch.clean',
     'git.repo.inspect',
-    'git.repo.preflight',
     'git.managed-credentials.reconcile',
     'branch.files.list',
     'branch.files.browse',

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -251,80 +251,34 @@ export type GitClonePayload = z.infer<typeof GitClonePayloadSchema>;
  * executor handler, but having them at the schema boundary means malformed
  * payloads fail at parse time with a clear message.
  */
-const enforceClonePayloadInvariants = (
-  params: { storageMode?: 'worktree' | 'clone'; cloneDepth?: number },
-  ctx: z.RefinementCtx
-): void => {
-  if (params.cloneDepth !== undefined && params.storageMode !== 'clone') {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['cloneDepth'],
-      message:
-        "cloneDepth is only meaningful when storageMode === 'clone'; omit it for worktree mode",
-    });
-  }
-};
-
 export const GitBranchAddPayloadSchema = BasePayloadSchema.extend({
   command: z.literal('git.branch.add'),
 
   /** JWT for Feathers authentication */
   sessionToken: z.string(),
 
-  params: z
-    .object({
-      /** Branch ID (UUID) - DB record already exists with filesystem_status: 'creating' */
-      branchId: z.string().uuid(),
+  params: z.object({
+    /** Branch ID (UUID) - DB record already exists with filesystem_status: 'creating' */
+    branchId: z.string().uuid(),
 
-      /** Repo ID (UUID) */
-      repoId: z.string().uuid(),
+    /** Repo ID (UUID) */
+    repoId: z.string().uuid(),
 
-      /** Branch to checkout or create */
-      branch: z.string().optional(),
+    /** Use restore mode: smart branch detection via ls-remote, falls back to creating from sourceBranch */
+    restoreMode: z.boolean().optional(),
 
-      /** Source branch when creating new branch */
-      sourceBranch: z.string().optional(),
+    /** Initialize Unix group for branch isolation (default: false, requires RBAC enabled) */
+    initUnixGroup: z.boolean().optional().default(false),
 
-      /** Create new branch */
-      createBranch: z.boolean().optional(),
+    /** Legacy open-access self-hosted chmod; false for RBAC/simple Cloud mounts. */
+    fixBasicPermissions: z.boolean().optional().default(false),
 
-      /** Use restore mode: smart branch detection via ls-remote, falls back to creating from sourceBranch */
-      restoreMode: z.boolean().optional(),
+    /** User ID of the requesting user (for per-user credential resolution) */
+    userId: z.string().uuid().optional(),
 
-      /** Type of ref (branch or tag) */
-      refType: z.enum(['branch', 'tag']).optional(),
-
-      /** Initialize Unix group for branch isolation (default: false, requires RBAC enabled) */
-      initUnixGroup: z.boolean().optional().default(false),
-
-      /** Legacy open-access self-hosted chmod; false for RBAC/simple Cloud mounts. */
-      fixBasicPermissions: z.boolean().optional().default(false),
-
-      /** Access level for non-owners ('none' | 'read' | 'write') */
-      othersAccess: z.enum(['none', 'read', 'write']).optional().default('read'),
-
-      /** User ID of the requesting user (for per-user credential resolution) */
-      userId: z.string().uuid().optional(),
-
-      /**
-       * Branch storage model. Default 'worktree' (native `git worktree add`,
-       * legacy behaviour). 'clone' routes through `createBranchAsClone` for a
-       * self-standing `git clone` — closes cross-branch leak vectors at the
-       * `.git/config` layer. Forwarded from the branches DB record.
-       */
-      storageMode: z.enum(['worktree', 'clone']).optional(),
-
-      /**
-       * Shallow-clone depth. Only meaningful when storageMode='clone'. Positive
-       * integer → `git clone --depth N`. Omit (or pass null/undefined) for a
-       * full clone with complete history.
-       */
-      cloneDepth: z.number().int().positive().optional(),
-
-      /** Whether clone mode may use the tenant-fetched repo path as an object-cache hint. */
-      useReference: z.boolean().optional().default(false),
-    })
-    .superRefine(enforceClonePayloadInvariants),
+    /** Whether clone mode may use the tenant-fetched repo path as an object-cache hint. */
+    useReference: z.boolean().optional().default(false),
+  }),
 });
 
 export type GitBranchAddPayload = z.infer<typeof GitBranchAddPayloadSchema>;


### PR DESCRIPTION
## Summary
- move local repository inspection and managed Git config reconciliation behind the executor-owned filesystem boundary
- make `git.branch.add` atomically fetch tenant-scoped repository/branch metadata, scrub credentials, perform just-in-time Git checks, and materialize the branch
- remove the standalone branch preflight executor command so branch creation does not require an extra ephemeral executor/pod
- separate requesting-user Git execution identity from daemon-authorized privileged Unix group/ACL management
- avoid Unix permission sync and legacy chmod work in RBAC-enabled `simple` mode, where Cloud pod mounts provide the filesystem isolation boundary
- enforce hosted-mode local-repository/worktree policy while retaining historical-row read/archive/delete/cleanup compatibility

## Verification
- `pnpm i`
- `pnpm check`
- focused executor tests: 71 passed
- focused daemon tests: 57 passed
- executor and daemon package typechecks
- Biome, multitenancy boundary check, and diff-check (included in `pnpm check`)

## Notes
- A broader executor test invocation also encountered three unrelated pre-existing `/tmp` permission failures; the focused suites covering this change pass.
