### PR TITLE
feat(ui): click-to-pan on the board minimap

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1121,6 +1121,29 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       []
     );
 
+    // Click-to-pan on the minimap: a plain click re-centers the main
+    // viewport on the clicked point. React Flow hands us `position` already
+    // in flow (board) coordinates — the same viewBox transform that drives
+    // the draggable mask — so there's no coordinate math to reinvent here.
+    //
+    // Drag-vs-click is handled for us: with `pannable`, React Flow drives the
+    // mask via d3-zoom, which calls d3's `dragEnable(view, moved)` on mouseup.
+    // A real drag (pointer moved) installs a capture-phase click suppressor,
+    // so this `onClick` fires only for a genuine click and never as the tail
+    // of a drag. Zoom is preserved and we reuse the same animated recenter as
+    // `recenterOnNode`.
+    const handleMiniMapClick = useCallback(
+      (_event: React.MouseEvent, position: { x: number; y: number }) => {
+        const instance = reactFlowInstanceRef.current;
+        if (!instance) return;
+        instance.setCenter(position.x, position.y, {
+          zoom: instance.getZoom(),
+          duration: 400,
+        });
+      },
+      []
+    );
+
     useRegisterRecenter(recenterOnNode);
 
     const consumePendingRecenter = useConsumePendingRecenter();
@@ -2812,6 +2835,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             </Controls>
             <MiniMap
               nodeColor={miniMapNodeColor}
+              onClick={handleMiniMapClick}
               pannable
               zoomable
               style={{


### PR DESCRIPTION
## Summary

The board's bottom-right minimap already supports a **draggable** viewport highlighter. This PR adds **click-to-pan**: clicking anywhere on the minimap re-centers the main board viewport on that point, complementing the existing drag behavior.

## How it works

- Wires a `handleMiniMapClick` callback into React Flow's `<MiniMap onClick={...} />`.
- React Flow hands the callback the clicked `position` already in **flow (board) coordinates** — the same `viewBox` transform that drives the draggable mask — so there's no coordinate math to reinvent.
- Reuses the same animated `setCenter` recenter as `recenterOnNode`, preserving the current zoom level (`duration: 400`).
- Drag-vs-click is disambiguated for free: with `pannable`, React Flow drives the mask via d3-zoom, which installs a capture-phase click suppressor after a real drag. So `onClick` fires only for a genuine click and never as the tail end of a drag.

## Changes

- `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` — add `handleMiniMapClick` callback and pass it to `<MiniMap onClick>`.

## Testing

- Click on an empty area of the minimap → main viewport smoothly re-centers there, zoom preserved.
- Drag the minimap mask → existing pan behavior unchanged, no spurious recenter on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)