### PR TITLE
fix(executor): reconcile early Claude background-task completion

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -7,6 +7,8 @@ const started = (taskId: string, taskType = 'agent') =>
   message({ type: 'system', subtype: 'task_started', task_id: taskId, task_type: taskType });
 const settled = (taskId: string, status: 'completed' | 'failed' | 'stopped' = 'completed') =>
   message({ type: 'system', subtype: 'task_notification', task_id: taskId, status });
+const updated = (taskId: string, status: string) =>
+  message({ type: 'system', subtype: 'task_updated', task_id: taskId, patch: { status } });
 const result = (subtype = 'success') => message({ type: 'result', subtype });
 
 describe('ClaudeBackgroundTaskLifecycle', () => {
@@ -37,6 +39,28 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     lifecycle.observe(settled('agent-1', status));
     expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it.each([
+    'completed',
+    'failed',
+    'stopped',
+  ] as const)('settles a task from a terminal task_updated patch when no notification follows (%s)', (status) => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('bash-1'));
+    expect(lifecycle.observe(updated('bash-1', status)).taskTransition).toBe('settled');
+    expect(lifecycle.activeTaskCount).toBe(0);
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it('deduplicates task_updated followed by task_notification and ignores non-terminal patches', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('bash-1'));
+    expect(lifecycle.observe(updated('bash-1', 'running')).taskTransition).toBeUndefined();
+    expect(lifecycle.activeTaskCount).toBe(1);
+    expect(lifecycle.observe(updated('bash-1', 'completed')).taskTransition).toBe('settled');
+    expect(lifecycle.observe(settled('bash-1')).taskTransition).toBeUndefined();
+    expect(lifecycle.activeTaskCount).toBe(0);
   });
 
   it('waits for every background task before accepting a later result', () => {
@@ -70,6 +94,25 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     lifecycle.observe(settled('agent-1'));
     expect(lifecycle.activeTaskCount).toBe(0);
     expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it('ignores a matching notification with a missing or future status', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('agent-1'));
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
+    lifecycle.observe(
+      message({ type: 'system', subtype: 'task_notification', task_id: 'agent-1' })
+    );
+    lifecycle.observe(
+      message({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-1',
+        status: 'paused',
+      })
+    );
+    expect(lifecycle.activeTaskCount).toBe(1);
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
   });
 
   it('reports only real task transitions and can clear orphaned activity', () => {

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { SDKMessage } from '@agor/core/sdk';
 
 type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
+const TERMINAL_TASK_STATUSES = new Set(['completed', 'failed', 'stopped']);
 
 export interface ClaudeQueryLifecycleTransition {
   resultDisposition: ResultDisposition;
@@ -26,10 +27,23 @@ export class ClaudeBackgroundTaskLifecycle {
     }
 
     if (message.type === 'system' && message.subtype === 'task_notification') {
-      return {
-        resultDisposition: 'not-result',
-        taskTransition: this.activeTaskIds.delete(message.task_id) ? 'settled' : undefined,
-      };
+      if (!TERMINAL_TASK_STATUSES.has(message.status)) {
+        return { resultDisposition: 'not-result' };
+      }
+      return this.settleTask(message.task_id);
+    }
+
+    // A task that settles while the model is still handling other tool calls
+    // may be reported only as task_updated. In that ordering the SDK does not
+    // necessarily emit a later task_notification, so both documented terminal
+    // signals must reconcile the same query-scoped task ID.
+    if (
+      message.type === 'system' &&
+      message.subtype === 'task_updated' &&
+      typeof message.patch.status === 'string' &&
+      TERMINAL_TASK_STATUSES.has(message.patch.status)
+    ) {
+      return this.settleTask(message.task_id);
     }
 
     if (message.type !== 'result') return { resultDisposition: 'not-result' };
@@ -51,5 +65,13 @@ export class ClaudeBackgroundTaskLifecycle {
     const count = this.activeTaskIds.size;
     this.activeTaskIds.clear();
     return count;
+  }
+
+  private settleTask(taskId: string): ClaudeQueryLifecycleTransition {
+    const settled = this.activeTaskIds.delete(taskId);
+    return {
+      resultDisposition: 'not-result',
+      taskTransition: settled ? 'settled' : undefined,
+    };
   }
 }

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -133,6 +133,52 @@ describe('ClaudePromptService background task query lifetime', () => {
     expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
   });
 
+  it('settles an early task_updated completion when no task_notification follows', async () => {
+    const query = fakeQuery([
+      {
+        type: 'system',
+        subtype: 'task_started',
+        task_id: 'task-1',
+        description: 'Short background Bash',
+        uuid: 'start',
+        session_id: 'sdk-session',
+      },
+      {
+        type: 'system',
+        subtype: 'task_updated',
+        task_id: 'task-1',
+        patch: { status: 'completed', end_time: 1_000 },
+        uuid: 'updated',
+        session_id: 'sdk-session',
+      },
+      sdkResult('terminal-result'),
+    ]);
+    vi.mocked(setupQuery).mockResolvedValue({
+      query: query as never,
+      resolvedModel: 'claude-sonnet-4-6',
+      getStderr: () => '',
+    });
+    const activity = vi.fn();
+
+    const events = [];
+    for await (const event of service().promptSessionStreaming(
+      sessionId,
+      'prompt',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      activity
+    )) {
+      events.push(event);
+    }
+
+    expect(events.filter((event) => event.type === 'result')).toHaveLength(1);
+    expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.start');
+    expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
+  });
+
   it('releases input and balances watchdog activity when cancellation interrupts a task', async () => {
     const query = fakeQuery(async function* () {
       yield {


### PR DESCRIPTION
## Summary

- reconcile terminal Claude `system/task_updated` events in addition to `task_notification`
- validate terminal task statuses and handle duplicate or late settlement signals idempotently
- preserve the existing #2057 behavior: background work can finish after the parent's first result, and the query settles normally once all tracked tasks are terminal

Closes #2067.

## Root cause

Agor tracked every Claude `system/task_started` event and removed a task only after a terminal `system/task_notification`.

Managed-environment testing exposed another valid SDK ordering: when a short background task finishes while Claude is still processing other tool calls, the SDK can emit only:

```json
{
  "type": "system",
  "subtype": "task_updated",
  "task_id": "...",
  "patch": { "status": "completed" }
}
```

No later `task_notification` is guaranteed for that task. Agor therefore retained the task ID forever, kept the streaming query input open, and never completed the executor task/session or drained queued prompts.

## Lifecycle contract

Both SDK terminal signals now settle the same query-scoped task ID:

- `task_notification.status`
- `task_updated.patch.status`

Recognized terminal statuses are `completed`, `failed`, and `stopped`. Non-terminal, malformed, unknown-ID, late, and duplicate events do not decrement unrelated work. Once every tracked task is terminal, the existing prompt-service flow releases input and completes normally.

This PR intentionally adds no new timeout clock, force-settlement path, daemon reconciliation owner, query wrapper, or SDK process supervision. The empirically observed lost-notification case is deterministic state reconciliation, not a timeout problem.

## Watchdog / #2028 interaction

The existing executor activity contract is unchanged. A real task transition still emits one `background_task.start` and one matching `background_task.complete`; duplicate settlement signals do not double-decrement accounting. No separate supervisor or clock competes with #2028's watchdog ownership.

## Testing

Automated:

- focused lifecycle, prompt-service, and watchdog suites: **3 files, 29 tests passed**
- executor TypeScript typecheck
- targeted Biome check
- `git diff --check`

Managed-environment coverage through the reproduction session included:

- concurrent background Bash tasks
- concurrent background Agent tasks
- mixed Bash success, Bash failure, Agent, and foreground work
- background completion before the first parent result (`task_updated` without a later notification)
- explicit background-task stop
- late/duplicate terminal notification
- queued prompt drain after lifecycle settlement

The deterministic pre-result completion case hung before this change and completed cleanly afterward. The final mixed regression reached zero tracked tasks, released input, completed the SDK iterator/executor, returned the session to idle, and allowed queued work to run.

## Operational considerations

- no schema, migration, persisted-state, configuration, or tenant-boundary changes
- no timeout or watchdog behavior change
- already-running executors need to be restarted to load the updated reconciliation logic
