### PR TITLE
fix(ui): model pill shows bare family name for single-segment versions (opus-5)

### DIFF
--- a/apps/agor-ui/src/components/Pill/modelDisplay.test.ts
+++ b/apps/agor-ui/src/components/Pill/modelDisplay.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getModelDisplayName } from './modelDisplay';
+
+describe('getModelDisplayName', () => {
+  it('renders single-segment versions without a minor', () => {
+    expect(getModelDisplayName('claude-opus-5')).toBe('opus-5');
+    expect(getModelDisplayName('claude-sonnet-5')).toBe('sonnet-5');
+    expect(getModelDisplayName('claude-fable-5')).toBe('fable-5');
+  });
+
+  it('renders two-segment versions as major.minor', () => {
+    expect(getModelDisplayName('claude-opus-4-8')).toBe('opus-4.8');
+    expect(getModelDisplayName('claude-sonnet-4-6')).toBe('sonnet-4.6');
+    expect(getModelDisplayName('claude-haiku-4-5')).toBe('haiku-4.5');
+  });
+
+  it('ignores trailing suffixes like [1m]', () => {
+    expect(getModelDisplayName('claude-sonnet-4-5[1m]')).toBe('sonnet-4.5');
+    expect(getModelDisplayName('claude-opus-5[1m]')).toBe('opus-5');
+  });
+
+  it('falls back to the bare family name when there are no version digits', () => {
+    expect(getModelDisplayName('claude-opus')).toBe('opus');
+    expect(getModelDisplayName('claude-sonnet')).toBe('sonnet');
+  });
+
+  it('passes through unknown families unchanged', () => {
+    expect(getModelDisplayName('some-unknown-model-9')).toBe('some-unknown-model-9');
+  });
+});

--- a/apps/agor-ui/src/components/Pill/modelDisplay.ts
+++ b/apps/agor-ui/src/components/Pill/modelDisplay.ts
@@ -1,15 +1,20 @@
+const MODEL_FAMILIES = ['opus', 'sonnet', 'haiku', 'fable'] as const;
+
+/**
+ * Derive a compact, versioned display name from a model id.
+ *
+ * Handles both single-segment versions (`claude-opus-5` -> `opus-5`) and
+ * two-segment major.minor versions (`claude-opus-4-8` -> `opus-4.8`). Ids may
+ * carry suffixes such as `[1m]` (e.g. `claude-sonnet-4-5[1m]`) which do not
+ * interfere with matching. Falls back to the bare family name only when the id
+ * has no version digits, and returns the raw id for unknown families.
+ */
 export function getModelDisplayName(modelId: string): string {
-  if (modelId.includes('sonnet')) {
-    const match = modelId.match(/sonnet-(\d)-(\d)/);
-    return match ? `sonnet-${match[1]}.${match[2]}` : 'sonnet';
-  }
-  if (modelId.includes('haiku')) {
-    const match = modelId.match(/haiku-(\d)-(\d)/);
-    return match ? `haiku-${match[1]}.${match[2]}` : 'haiku';
-  }
-  if (modelId.includes('opus')) {
-    const match = modelId.match(/opus-(\d)-(\d)/);
-    return match ? `opus-${match[1]}.${match[2]}` : 'opus';
+  for (const family of MODEL_FAMILIES) {
+    if (!modelId.includes(family)) continue;
+    const match = modelId.match(new RegExp(`${family}-(\\d+)(?:-(\\d+))?`));
+    if (!match) return family;
+    return match[2] ? `${family}-${match[1]}.${match[2]}` : `${family}-${match[1]}`;
   }
 
   return modelId;


### PR DESCRIPTION
## Problem

The model pill in the message/session UI showed a bare family name (e.g. `opus`) instead of the versioned name when a **single-segment** model version was selected. The per-family regexes in `getModelDisplayName` required **two** version segments (`opus-(\d)-(\d)`), so ids like `claude-opus-5` / `claude-sonnet-5` fell through to the bare fallback, and `claude-fable-5` (no branch at all) returned the raw id.

## Before / After

| Model id | Before | After |
| --- | --- | --- |
| `claude-opus-5` | `opus` | `opus-5` |
| `claude-sonnet-5` | `sonnet` | `sonnet-5` |
| `claude-fable-5` | `claude-fable-5` | `fable-5` |
| `claude-opus-4-8` | `opus-4.8` | `opus-4.8` (unchanged) |
| unknown id | passthrough | passthrough (unchanged) |

## Fix

- Refactored the three near-duplicate branches into one small family loop (`opus`, `sonnet`, `haiku`, `fable`).
- Regex now matches an optional minor segment `-(\d+)(?:-(\d+))?` → renders `opus-5` with no minor, `opus-4.8` with one. Two-segment behavior is preserved exactly.
- Bare family name is used only when there are no version digits; unknown families pass through unchanged. Trailing suffixes like `[1m]` don't break matching.
- Added `modelDisplay.test.ts` covering all cases.

## Verification

- `vitest run` on `modelDisplay.test.ts` — 5 passed
- `biome check` + typecheck on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)