### PR TITLE
fix(schedules): stop write-field validator rejecting server-managed tenant_id

### DIFF
--- a/apps/agor-daemon/src/services/write-data-boundaries.test.ts
+++ b/apps/agor-daemon/src/services/write-data-boundaries.test.ts
@@ -1,5 +1,10 @@
+import type { HookContext } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { markWriteDataPrepared } from '../utils/write-data-boundary.js';
+import {
+  assertServiceWriteFields,
+  enforcePublicWriteFields,
+  markWriteDataPrepared,
+} from '../utils/write-data-boundary.js';
 import { GatewayChannelsService } from './gateway-channels.js';
 import { SchedulesService } from './schedules.js';
 
@@ -24,6 +29,67 @@ describe('runtime write-data boundaries', () => {
         [field]: value,
       } as never)
     ).rejects.toThrow(`Schedule contains unsupported write fields: ${field}`);
+  });
+
+  // Regression: in multi-tenant (Postgres) mode the tenant scoping hook stamps
+  // `tenant_id` onto every tenant-owned create before the schedules service's
+  // public-write allowlist runs. `tenant_id` is server-managed (re-applied by
+  // the DB layer from ambient tenant context), so the write boundary must not
+  // reject it — otherwise creating any schedule from the UI fails with
+  // "Schedule contains unsupported write fields: tenant_id".
+  it('does not reject the server-managed tenant_id on schedule create', async () => {
+    const service = new SchedulesService(null as never);
+
+    // Reaches config normalization (which needs a real db) rather than being
+    // rejected up front as an unsupported write field.
+    await expect(
+      service.create({
+        branch_id: '00000000-0000-7000-8000-000000000001',
+        name: 'Nightly',
+        cron_expression: '0 0 * * *',
+        timezone_mode: 'utc',
+        prompt: 'Run',
+        agentic_tool_config: { agentic_tool: 'codex' },
+        tenant_id: 'tenant-a',
+      } as never)
+    ).rejects.not.toThrow('unsupported write fields');
+  });
+
+  it('does not reject the server-managed tenant_id on gateway create', async () => {
+    const service = new GatewayChannelsService(null as never);
+
+    await expect(
+      service.create({
+        name: 'Engineering',
+        channel_type: 'slack',
+        target_branch_id: '00000000-0000-7000-8000-000000000001',
+        config: {},
+        enabled: false,
+        tenant_id: 'tenant-a',
+      } as never)
+    ).rejects.not.toThrow('unsupported write fields');
+  });
+
+  it('treats tenant_id as server-managed across both write-boundary gates', () => {
+    // Public before-hook gate: a stamped tenant_id passes, an unknown field fails.
+    expect(() =>
+      enforcePublicWriteFields('Schedule', ['name'])({
+        data: { name: 'ok', tenant_id: 'tenant-a' },
+      } as HookContext)
+    ).not.toThrow();
+    expect(() =>
+      enforcePublicWriteFields('Schedule', ['name'])({
+        data: { name: 'ok', bogus: 1 },
+      } as HookContext)
+    ).toThrow('unsupported write fields: bogus');
+
+    // Direct service-consumer gate: same treatment without prepared trust.
+    expect(() =>
+      assertServiceWriteFields('Schedule', { name: 'ok', tenant_id: 'tenant-a' }, ['name'])
+    ).not.toThrow();
+    expect(() => assertServiceWriteFields('Schedule', { name: 'ok', bogus: 1 }, ['name'])).toThrow(
+      'unsupported write fields: bogus'
+    );
   });
 
   it('rejects a runtime-owned schedule cursor on direct patch', async () => {

--- a/apps/agor-daemon/src/utils/write-data-boundary.ts
+++ b/apps/agor-daemon/src/utils/write-data-boundary.ts
@@ -5,12 +5,32 @@ const PREPARED_WRITE_DATA = Symbol('agor.prepared-write-data');
 
 type PreparedParams = Record<PropertyKey, unknown>;
 
+/**
+ * Fields that trusted runtime infrastructure — never the client — owns.
+ *
+ * `tenant_id` is stamped onto tenant-owned create payloads by the tenant
+ * scoping hook (`scopeTenantBefore`) and, authoritatively, applied at the
+ * database layer from ambient tenant context (`withTenantInsertValues`), which
+ * also drops it for dialects that lack the column (SQLite). It is therefore not
+ * a client-supplied field and must not be reported as unsupported: doing so
+ * makes every create on a tenant-owned service that enforces a public-write
+ * allowlist (schedules, gateway channels) fail in multi-tenant mode.
+ *
+ * Ignoring it here cannot weaken tenant isolation — `pickWriteFields` still
+ * omits it (the DB layer stays the single source of truth), so any
+ * client-supplied value is stripped before the insert and overwritten by the
+ * trusted ambient tenant.
+ */
+const SERVER_MANAGED_WRITE_FIELDS: ReadonlySet<string> = new Set(['tenant_id']);
+
 function unsupportedFields(data: unknown, allowedFields: readonly string[]): string[] {
   if (!data || typeof data !== 'object' || Array.isArray(data)) {
     throw new BadRequest('Write data must be an object');
   }
   const allowed = new Set(allowedFields);
-  return Object.keys(data).filter((key) => !allowed.has(key));
+  return Object.keys(data).filter(
+    (key) => !allowed.has(key) && !SERVER_MANAGED_WRITE_FIELDS.has(key)
+  );
 }
 
 /**


### PR DESCRIPTION
## Symptom

Creating a new schedule/cron through the **web UI** failed on multi-tenant (Postgres) deployments with:

> Schedule contains unsupported write fields: tenant_id

…even though the user only touched standard fields (name, cron, prompt, agent, …) and never set `tenant_id`.

## Root cause (diagnosis corrected)

The original diagnosis suspected the UI echoing a server-managed field into the create body. That's **not** what's happening — `ScheduleModal.tsx` already builds a clean, explicitly-whitelisted `ScheduleCreateData` payload and never sends `tenant_id`.

The real cause is **server-side**:

1. `schedules` is a tenant-owned service (`TENANT_OWNED_SERVICE_PATHS`). On Postgres/multi-tenant mode the tenant scoping hook `scopeTenantBefore` (`apps/agor-daemon/src/register-hooks.ts:640`) stamps `tenant_id` onto `context.data` for **every** tenant-owned create.
2. The schedules (and gateway-channels) services additionally enforce a strict public-write allowlist via `enforcePublicWriteFields` / `assertServiceWriteFields` (backed by `unsupportedFields` in `apps/agor-daemon/src/utils/write-data-boundary.ts`). That gate then rejected the very `tenant_id` the tenant hook had just injected.

`tenant_id` is genuinely **server-managed** and doesn't belong in the client write payload at all: it is authoritatively (re)applied at the DB layer from ambient tenant context by `withTenantInsertValues` (`packages/core/src/db/database-wrapper.ts:388`), which also dialect-safely skips tables without the column (SQLite). `pickWriteFields` already strips it before the repository insert, so the DB layer stays the single source of truth.

## The fix (which layer & why)

Fixed at the **shared write-boundary util** (`apps/agor-daemon/src/utils/write-data-boundary.ts`): `tenant_id` is now treated as a reserved server-managed field that `unsupportedFields` ignores. This backs both `enforcePublicWriteFields` (before-hook) and `assertServiceWriteFields` (direct service consumer) in one place.

Why this layer:
- **Prevents the whole class of bug** — covers schedules, gateway channels, and any future service using these helpers, rather than patching one call site.
- **Cannot weaken tenant isolation** — `pickWriteFields` still omits `tenant_id`, so any client-supplied value is stripped before the insert and overwritten by the trusted ambient tenant (`scopeTenantBefore` spreads it last; the DB layer stamps from `getCurrentTenantId()`). It only stops a legitimately server-injected field from being mistaken for a hostile client field.
- Real validation is untouched — genuinely unknown fields (`schedule_id`, `next_run_at`, `created_at`, `bogus`, …) are still rejected.

## Tests

Added to `apps/agor-daemon/src/services/write-data-boundaries.test.ts`:
- Schedule create with `tenant_id` in the payload no longer throws `unsupported write fields`.
- Same for gateway-channel create.
- Direct unit coverage that both write-boundary gates accept `tenant_id` while still rejecting an unknown field.

`pnpm exec vitest run` (write-data-boundaries, schedules, scheduler, tenant-db-scope) → **52 passing**; daemon `typecheck` and biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)