### PR TITLE
feat(docs): switch Agor Cloud CTA to new HubSpot form with source attribution

### DIFF
--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -23,11 +23,15 @@ declare global {
 }
 
 // Source form (edit submit button copy, fields, etc. in HubSpot):
-// https://app.hubspot.com/forms/5901754/editor/f76e3259-8c31-4e39-8147-8e23fa53be74/edit
-const HUBSPOT_PORTAL_ID = '5901754';
-const HUBSPOT_FORM_ID = 'f76e3259-8c31-4e39-8147-8e23fa53be74';
-const HUBSPOT_REGION = 'na1';
+// https://app-na2.hubspot.com/forms/246818610/editor/56f5b614-72f0-4412-9247-33b53715fda4/edit
+const HUBSPOT_PORTAL_ID = '246818610';
+const HUBSPOT_FORM_ID = '56f5b614-72f0-4412-9247-33b53715fda4';
+const HUBSPOT_REGION = 'na2';
 const HUBSPOT_SCRIPT_SRC = 'https://js.hsforms.net/forms/embed/v2.js';
+
+// Name of the form's hidden field used to attribute which on-page CTA opened
+// it (nav bar, hero, footer, a specific blog post, etc.) — see `sourceCta`.
+const SOURCE_FIELD_NAME = 'source_page';
 
 // HubSpot v2 renders the form inline into our target div and injects
 // whatever we pass via `css` as a <style> tag in the document head. We
@@ -121,6 +125,10 @@ interface HubSpotFormProps {
   portalId?: string;
   formId?: string;
   region?: string;
+  /** Attribution tag for the hidden `source_page` field — identifies which
+   * specific CTA (nav bar, landing hero, footer, a given blog post, etc.)
+   * opened this form, not just which page it's on. */
+  sourceCta?: string;
   /** When set, "Book a Demo" invokes this (e.g. swap to the in-modal
    * scheduler) instead of linking out to meetings.hubspot.com. */
   onBookDemo?: () => void;
@@ -132,6 +140,7 @@ export function HubSpotForm({
   portalId = HUBSPOT_PORTAL_ID,
   formId = HUBSPOT_FORM_ID,
   region = HUBSPOT_REGION,
+  sourceCta,
   onBookDemo,
 }: HubSpotFormProps) {
   // useId returns ":r0:"-style strings; strip ":" so we can use it
@@ -162,9 +171,25 @@ export function HubSpotForm({
       region,
       target: `#${targetId}`,
       css: HUBSPOT_FORM_CSS,
-      onFormReady: () => setFormReady(true),
+      onFormReady: () => {
+        // Stamp the hidden attribution field directly in the DOM — set
+        // .value and dispatch input/change so HubSpot's own listeners (and
+        // any field-dependent validation) see the update, same as a user
+        // typing it in.
+        if (sourceCta) {
+          const sourceField = target.querySelector<HTMLInputElement>(
+            `input[name="${SOURCE_FIELD_NAME}"]`
+          );
+          if (sourceField) {
+            sourceField.value = sourceCta;
+            sourceField.dispatchEvent(new Event('input', { bubbles: true }));
+            sourceField.dispatchEvent(new Event('change', { bubbles: true }));
+          }
+        }
+        setFormReady(true);
+      },
     });
-  }, [scriptReady, portalId, formId, region, targetId]);
+  }, [scriptReady, portalId, formId, region, targetId, sourceCta]);
 
   return (
     <div id={anchorId} className={styles.wrapper}>

--- a/apps/agor-docs/components/HubSpotFormModal.tsx
+++ b/apps/agor-docs/components/HubSpotFormModal.tsx
@@ -9,12 +9,17 @@ interface HubSpotFormModalProps {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
+  /** Attribution tag for the hidden `source_page` field — which specific CTA
+   * (nav bar, landing hero, footer, a given blog post, etc.) opened this
+   * modal. Forwarded to `HubSpotForm`. */
+  sourceCta?: string;
 }
 
 export function HubSpotFormModal({
   isOpen,
   onClose,
   title = 'Contact us about Agor Cloud',
+  sourceCta,
 }: HubSpotFormModalProps) {
   // "Prefer a chat first?" swaps the modal body to the meeting scheduler
   // instead of bouncing to the (Preset-branded) hubspot.com page.
@@ -60,7 +65,7 @@ export function HubSpotFormModal({
         {view === 'meeting' ? (
           <MeetingEmbed />
         ) : (
-          <HubSpotForm onBookDemo={() => setView('meeting')} />
+          <HubSpotForm sourceCta={sourceCta} onBookDemo={() => setView('meeting')} />
         )}
       </div>
     </div>

--- a/apps/agor-docs/components/JoinBetaCTA.tsx
+++ b/apps/agor-docs/components/JoinBetaCTA.tsx
@@ -6,6 +6,10 @@ import { HubSpotFormModal } from './HubSpotFormModal';
 
 interface JoinBetaCTAProps {
   label?: string;
+  /** Attribution tag for the hidden `source_page` field — identify the
+   * specific spot this instance renders (e.g. `blog-agor-cloud`), since this
+   * component can appear in more than one place. */
+  sourceCta: string;
 }
 
 /**
@@ -14,7 +18,7 @@ interface JoinBetaCTAProps {
  * inline-embedded (blog/agor-cloud) and anywhere a beta CTA should keep the
  * reader on the page. Reuses CloudInviteCTA's primary-pill styling.
  */
-export function JoinBetaCTA({ label = 'Sign up for Agor Cloud' }: JoinBetaCTAProps) {
+export function JoinBetaCTA({ label = 'Sign up for Agor Cloud', sourceCta }: JoinBetaCTAProps) {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div className={styles.wrapper}>
@@ -30,6 +34,7 @@ export function JoinBetaCTA({ label = 'Sign up for Agor Cloud' }: JoinBetaCTAPro
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         title="Join the Agor Cloud private beta"
+        sourceCta={sourceCta}
       />
     </div>
   );

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -546,6 +546,13 @@ const liveCards = [
 export function LandingPage() {
   const landingRef = useRef<HTMLElement>(null);
   const [isBetaFormOpen, setIsBetaFormOpen] = useState(false);
+  // Which on-page CTA opened the (single, shared) beta form modal — stamped
+  // into the form's hidden source_page field for attribution.
+  const [betaCtaSource, setBetaCtaSource] = useState('landing-hero');
+  const openBetaForm = (source: string) => {
+    setBetaCtaSource(source);
+    setIsBetaFormOpen(true);
+  };
   const [isDemoFormOpen, setIsDemoFormOpen] = useState(false);
   const [activeShot, setActiveShot] = useState(0);
   const [activeSurface, setActiveSurface] = useState(0);
@@ -788,7 +795,7 @@ export function LandingPage() {
               <button
                 type="button"
                 className={styles.primaryButton}
-                onClick={() => setIsBetaFormOpen(true)}
+                onClick={() => openBetaForm('landing-hero')}
               >
                 Sign up for Agor Cloud
               </button>
@@ -1295,7 +1302,7 @@ export function LandingPage() {
                     <button
                       type="button"
                       className={styles.busBetaLink}
-                      onClick={() => setIsBetaFormOpen(true)}
+                      onClick={() => openBetaForm('landing-bus-item')}
                     >
                       Register for the Agor Cloud beta
                     </button>
@@ -1494,7 +1501,7 @@ export function LandingPage() {
             <button
               type="button"
               className={styles.primaryButton}
-              onClick={() => setIsBetaFormOpen(true)}
+              onClick={() => openBetaForm('landing-final-cta')}
             >
               Sign up for Agor Cloud
             </button>
@@ -1549,7 +1556,7 @@ export function LandingPage() {
             <button
               type="button"
               className={styles.footerLinkButton}
-              onClick={() => setIsBetaFormOpen(true)}
+              onClick={() => openBetaForm('landing-footer')}
             >
               Sign up for Agor Cloud
             </button>
@@ -1581,6 +1588,7 @@ export function LandingPage() {
         isOpen={isBetaFormOpen}
         onClose={() => setIsBetaFormOpen(false)}
         title="Join the Agor Cloud private beta"
+        sourceCta={betaCtaSource}
       />
       <HubSpotMeetingModal isOpen={isDemoFormOpen} onClose={() => setIsDemoFormOpen(false)} />
     </main>

--- a/apps/agor-docs/components/NavbarCloudCTA.tsx
+++ b/apps/agor-docs/components/NavbarCloudCTA.tsx
@@ -14,7 +14,7 @@ export function NavbarCloudCTA() {
       <button type="button" className="navbar-cloud-cta" onClick={() => setIsOpen(true)}>
         Agor Cloud
       </button>
-      <HubSpotFormModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <HubSpotFormModal isOpen={isOpen} onClose={() => setIsOpen(false)} sourceCta="navbar" />
     </>
   );
 }

--- a/apps/agor-docs/content/blog/agor-cloud.mdx
+++ b/apps/agor-docs/content/blog/agor-cloud.mdx
@@ -213,7 +213,7 @@ Agor Cloud bridges that gap. Fully managed, secure, observable, built by the tea
 
 If that sounds like what your team needs, we'd love to talk.
 
-<JoinBetaCTA />
+<JoinBetaCTA sourceCta="blog-agor-cloud" />
 
 ---
 


### PR DESCRIPTION
## Summary
- Swaps the docs site's HubSpot signup form to the new portal/form (portalId `246818610`, formId `56f5b614-72f0-4412-9247-33b53715fda4`, region `na2`), replacing the old `5901754` / `f76e3259-...` / `na1` form.
- Adds `sourceCta` prop support through `HubSpotForm` → `HubSpotFormModal`, which stamps the form's hidden `source_page` input on `onFormReady` so submissions are attributable to the exact CTA that opened them, not just "the docs site".
- Wires up distinct source tags for every CTA location: `navbar`, `landing-hero`, `landing-bus-item`, `landing-final-cta`, `landing-footer`, and `blog-agor-cloud` (blog post).

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] `biome check` passes clean on all changed files
- [ ] Manually open each CTA (navbar, landing hero, bus-item beta link, final CTA, footer, blog post) and confirm the modal renders the new HubSpot form and the hidden `source_page` field is populated correctly per CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)