### PR TITLE
fix(executor): enforce MCP tool_permissions at the tool-call boundary

### DIFF
--- a/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
@@ -1,0 +1,79 @@
+/**
+ * OpenCode's invocation config carries no per-tool filter, so withholding the
+ * whole server is the only way a `deny` or `ask` can bind here. That makes the
+ * declarative config the enforcement boundary: a gated server must be absent
+ * from what gets handed to the managed server, not merely absent from some
+ * intermediate list.
+ */
+
+import type { MCPServer, SessionID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { OpenCodeTool } from './opencode-tool';
+
+const GATED = 'gated-server';
+const PLAIN = 'plain-server';
+/** The builder sanitizes names into its key, so assertions match that form. */
+const sanitized = (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+
+function server(id: string, toolPermissions?: MCPServer['tool_permissions']): MCPServer {
+  return {
+    mcp_server_id: id,
+    name: id,
+    transport: 'stdio',
+    command: '/usr/bin/node',
+    args: [],
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+    tool_permissions: toolPermissions,
+  } as unknown as MCPServer;
+}
+
+/** Stands in for the executor's admission gate, which withholds what it cannot honour. */
+function admit(servers: MCPServer[]) {
+  return servers
+    .filter(
+      (s) => !Object.values(s.tool_permissions ?? {}).some((p) => p === 'deny' || p === 'ask')
+    )
+    .map((s) => ({ server: s, source: 'global' as const }));
+}
+
+async function buildConfig(servers: MCPServer[]) {
+  const tool = new OpenCodeTool({
+    resolveMcpServers: async () => admit(servers),
+    getDaemonUrl: async () => 'http://localhost:3030',
+  });
+  return (
+    tool as unknown as {
+      buildInvocationConfig: (
+        s: SessionID,
+        t: string,
+        d?: string
+      ) => Promise<{ mcp: Record<string, unknown> }>;
+    }
+  ).buildInvocationConfig('session-1' as SessionID, 'token', '/branch');
+}
+
+describe('MCP servers reaching OpenCode invocation config', () => {
+  it('omits a server whose tools are gated, while keeping the rest', async () => {
+    const config = await buildConfig([server(GATED, { write_file: 'deny' }), server(PLAIN)]);
+    const configured = Object.keys(config.mcp).join(' ');
+
+    expect(configured).not.toContain(sanitized(GATED));
+    // Positive control: the builder does emit servers, so the absence above is
+    // the gate and not an empty config.
+    expect(configured).toContain(sanitized(PLAIN));
+  });
+
+  it('omits a server gated with ask, which has no prompt channel here', async () => {
+    const config = await buildConfig([server(GATED, { write_file: 'ask' }), server(PLAIN)]);
+
+    expect(Object.keys(config.mcp).join(' ')).not.toContain(sanitized(GATED));
+  });
+
+  it('keeps the built-in Agor server addressable', async () => {
+    const config = await buildConfig([server(PLAIN)]);
+
+    expect(Object.keys(config.mcp).some((name) => name.startsWith('agor_'))).toBe(true);
+  });
+});

--- a/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
@@ -88,7 +88,10 @@ describe('MCP servers reaching OpenCode invocation config', () => {
       server(PLAIN),
     ]);
 
-    expect(Object.keys(config.mcp).join(' ')).not.toContain(sanitized(GATED));
+    const configured = Object.keys(config.mcp).join(' ');
+    expect(configured).not.toContain(sanitized(GATED));
+    // Positive control, as above: the config is not simply empty.
+    expect(configured).toContain(sanitized(PLAIN));
     expect(withheld).toEqual([GATED]);
   });
 

--- a/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
@@ -6,8 +6,13 @@
  * intermediate list.
  */
 
-import type { MCPServer, SessionID } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+import { getMcpServersForSession } from '@agor/core/mcp';
+import type { MCPServer, MessageID, SessionID, TaskID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import type { ManagedChild } from './managed-server';
 import { OpenCodeTool } from './opencode-tool';
 
 const GATED = 'gated-server';
@@ -29,21 +34,26 @@ function server(id: string, toolPermissions?: MCPServer['tool_permissions']): MC
   } as unknown as MCPServer;
 }
 
-/** Stands in for the executor's admission gate, which withholds what it cannot honour. */
-function admit(servers: MCPServer[]) {
-  return servers
-    .filter(
-      (s) => !Object.values(s.tool_permissions ?? {}).some((p) => p === 'deny' || p === 'ask')
-    )
-    .map((s) => ({ server: s, source: 'global' as const }));
-}
-
+/**
+ * Runs the production admission gate, not a restatement of it. A local copy of
+ * the policy would keep passing after the real one drifted.
+ */
 async function buildConfig(servers: MCPServer[]) {
+  const withheld: string[] = [];
   const tool = new OpenCodeTool({
-    resolveMcpServers: async () => admit(servers),
+    resolveMcpServers: (sessionId) =>
+      getMcpServersForSession(
+        sessionId,
+        {
+          sessionMCPRepo: { listEffectiveServers: vi.fn().mockResolvedValue(servers) } as never,
+          mcpServerRepo: { findAll: vi.fn().mockResolvedValue([]) } as never,
+          onServerWithheld: (server) => withheld.push(server.name),
+        },
+        { toolFiltering: 'none' }
+      ),
     getDaemonUrl: async () => 'http://localhost:3030',
   });
-  return (
+  const config = await (
     tool as unknown as {
       buildInvocationConfig: (
         s: SessionID,
@@ -52,28 +62,112 @@ async function buildConfig(servers: MCPServer[]) {
       ) => Promise<{ mcp: Record<string, unknown> }>;
     }
   ).buildInvocationConfig('session-1' as SessionID, 'token', '/branch');
+  return { config, withheld };
 }
 
 describe('MCP servers reaching OpenCode invocation config', () => {
   it('omits a server whose tools are gated, while keeping the rest', async () => {
-    const config = await buildConfig([server(GATED, { write_file: 'deny' }), server(PLAIN)]);
+    const { config, withheld } = await buildConfig([
+      server(GATED, { write_file: 'deny' }),
+      server(PLAIN),
+    ]);
     const configured = Object.keys(config.mcp).join(' ');
 
     expect(configured).not.toContain(sanitized(GATED));
     // Positive control: the builder does emit servers, so the absence above is
     // the gate and not an empty config.
     expect(configured).toContain(sanitized(PLAIN));
+    // A server that vanishes without a word is indistinguishable from a broken
+    // one, so the gate has to say so as well as act.
+    expect(withheld).toEqual([GATED]);
   });
 
   it('omits a server gated with ask, which has no prompt channel here', async () => {
-    const config = await buildConfig([server(GATED, { write_file: 'ask' }), server(PLAIN)]);
+    const { config, withheld } = await buildConfig([
+      server(GATED, { write_file: 'ask' }),
+      server(PLAIN),
+    ]);
 
     expect(Object.keys(config.mcp).join(' ')).not.toContain(sanitized(GATED));
+    expect(withheld).toEqual([GATED]);
   });
 
   it('keeps the built-in Agor server addressable', async () => {
-    const config = await buildConfig([server(PLAIN)]);
+    const { config, withheld } = await buildConfig([server(PLAIN)]);
 
     expect(Object.keys(config.mcp).some((name) => name.startsWith('agor_'))).toBe(true);
+    expect(withheld).toEqual([]);
+  });
+});
+
+/**
+ * The config object is an intermediate. What the OpenCode process actually
+ * obeys is `OPENCODE_CONFIG_CONTENT` on its own environment, so that string is
+ * where a `deny` either binds or does not.
+ */
+describe('MCP servers reaching the OpenCode process environment', () => {
+  it('never names a gated server in OPENCODE_CONFIG_CONTENT', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null,
+      kill: () => true,
+    }) as ManagedChild;
+
+    const tool = new OpenCodeTool({
+      resolveMcpServers: (sessionId) =>
+        getMcpServersForSession(
+          sessionId,
+          {
+            sessionMCPRepo: {
+              listEffectiveServers: vi
+                .fn()
+                .mockResolvedValue([server(GATED, { write_file: 'deny' }), server(PLAIN)]),
+            } as never,
+            mcpServerRepo: { findAll: vi.fn().mockResolvedValue([]) } as never,
+          },
+          { toolFiltering: 'none' }
+        ),
+      getDaemonUrl: async () => 'http://localhost:3030',
+      resolveBinary: async () => ({ executable: process.execPath, argsPrefix: ['/opencode'] }),
+      spawn: (_executable, _args, options) => {
+        spawnEnvs.push((options.env ?? {}) as Record<string, string | undefined>);
+        setImmediate(() =>
+          child.stdout.write('opencode server listening on http://127.0.0.1:43210\n')
+        );
+        return child;
+      },
+      fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+      // The turn is abandoned here: spawn has already been handed the config,
+      // which is the only thing under test.
+      createClient: () => {
+        throw new Error('stop after handoff');
+      },
+    });
+
+    await expect(
+      tool.runTurn({
+        agorSessionId: 'session-1' as SessionID,
+        taskId: 'task-1' as TaskID,
+        prompt: 'hi',
+        agorAssistantMessageId: 'message-1' as MessageID,
+        title: 'turn',
+        directory: tmpdir(),
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        mcpToken: 'token',
+        signal: new AbortController().signal,
+        persistOpenCodeSessionId: async () => {},
+      })
+    ).rejects.toThrow();
+
+    expect(spawnEnvs).toHaveLength(1);
+    const configContent = spawnEnvs[0].OPENCODE_CONFIG_CONTENT ?? '';
+    expect(configContent).not.toContain(sanitized(GATED));
+    expect(configContent).not.toContain(GATED);
+    // Positive control: an ungated server does make it into the same string,
+    // so the two absences above are the gate and not a stubbed-out config.
+    expect(configContent).toContain(sanitized(PLAIN));
   });
 });

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1434,6 +1434,9 @@ export const mcpServers = pgTable(
             required?: boolean;
           }>;
         }>;
+
+        // Tool permissions configuration
+        tool_permissions?: Record<string, 'ask' | 'allow' | 'deny'>;
       }>()
       .notNull(),
   },

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -3,6 +3,7 @@
  */
 
 export {
+  AGOR_MCP_SERVER_NAME,
   getMcpServersForSession,
   type MCPAuthHeadersRepository,
   type MCPResolutionDeps,
@@ -21,3 +22,9 @@ export {
   resolveMcpServerTemplates,
   TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS,
 } from './template-resolver';
+export {
+  canEnforceMcpToolPermissions,
+  type HandlerPermissionCapabilities,
+  listMcpToolsWithPermission,
+  PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+} from './tool-permissions';

--- a/packages/core/src/mcp/scoping.test.ts
+++ b/packages/core/src/mcp/scoping.test.ts
@@ -193,6 +193,11 @@ describe('getMcpServersForSession - tool_permissions admission gate', () => {
       const servers = await resolve(gatedServer(permission), { toolFiltering: 'none' });
 
       expect(servers).toEqual([]);
+      // Positive control: the same fixture is admitted by a handler that can
+      // filter, so the empty result is the gate and not a resolver that found
+      // nothing to begin with.
+      const admitted = await resolve(gatedServer(permission), { toolFiltering: 'exclude' });
+      expect(admitted).toHaveLength(1);
     }
   );
 

--- a/packages/core/src/mcp/scoping.test.ts
+++ b/packages/core/src/mcp/scoping.test.ts
@@ -1,6 +1,7 @@
 import type { MCPServer, SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { getMcpServersForSession } from './scoping';
+import type { HandlerPermissionCapabilities } from './tool-permissions';
 
 const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer =>
   ({
@@ -15,6 +16,9 @@ const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer
     auth: { type: 'token', token: `value-${id}` },
   }) as unknown as MCPServer;
 
+/** A handler that can drop individual tools — keeps these cases about scoping. */
+const ENFORCING: HandlerPermissionCapabilities = { toolFiltering: 'exclude' };
+
 describe('getMcpServersForSession', () => {
   it('uses session-scoped effective config retrieval when available', async () => {
     const globalServer = makeServer('global-server', 'global');
@@ -23,11 +27,15 @@ describe('getMcpServersForSession', () => {
     const findAll = vi.fn();
     const listServers = vi.fn();
 
-    const servers = await getMcpServersForSession('session-a' as SessionID, {
-      mcpServerRepo: { findAll } as never,
-      sessionMCPRepo: { listEffectiveServers, listServers } as never,
-      forUserId: 'user-a',
-    });
+    const servers = await getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll } as never,
+        sessionMCPRepo: { listEffectiveServers, listServers } as never,
+        forUserId: 'user-a',
+      },
+      ENFORCING
+    );
 
     expect(listEffectiveServers).toHaveBeenCalledWith('session-a', true, 'user-a');
     expect(findAll).not.toHaveBeenCalled();
@@ -45,10 +53,14 @@ describe('getMcpServersForSession', () => {
     const aGlobal = makeServer('global-a', 'global', 'alpha');
     const listEffectiveServers = vi.fn().mockResolvedValue([zSession, bGlobal, aSession, aGlobal]);
 
-    const servers = await getMcpServersForSession('session-a' as SessionID, {
-      mcpServerRepo: { findAll: vi.fn() } as never,
-      sessionMCPRepo: { listEffectiveServers } as never,
-    });
+    const servers = await getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll: vi.fn() } as never,
+        sessionMCPRepo: { listEffectiveServers } as never,
+      },
+      ENFORCING
+    );
 
     expect(servers.map(({ server }) => server.mcp_server_id)).toEqual([
       'global-a',
@@ -65,10 +77,14 @@ describe('getMcpServersForSession', () => {
     const globalA = makeServer('global-a', 'global', 'shared');
     const listEffectiveServers = vi.fn().mockResolvedValue([sessionB, globalB, sessionA, globalA]);
 
-    const servers = await getMcpServersForSession('session-a' as SessionID, {
-      mcpServerRepo: { findAll: vi.fn() } as never,
-      sessionMCPRepo: { listEffectiveServers } as never,
-    });
+    const servers = await getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll: vi.fn() } as never,
+        sessionMCPRepo: { listEffectiveServers } as never,
+      },
+      ENFORCING
+    );
 
     expect(servers.map(({ server }) => server.mcp_server_id)).toEqual([
       'global-a',
@@ -95,10 +111,14 @@ describe('getMcpServersForSession', () => {
       } as MCPServer;
       const listEffectiveServers = vi.fn().mockResolvedValue([oauthServer]);
 
-      const servers = await getMcpServersForSession('session-a' as SessionID, {
-        mcpServerRepo: { findAll: vi.fn() } as never,
-        sessionMCPRepo: { listEffectiveServers } as never,
-      });
+      const servers = await getMcpServersForSession(
+        'session-a' as SessionID,
+        {
+          mcpServerRepo: { findAll: vi.fn() } as never,
+          sessionMCPRepo: { listEffectiveServers } as never,
+        },
+        ENFORCING
+      );
 
       const resolved = servers.find(
         ({ server }) => server.mcp_server_id === 'oauth-server'
@@ -127,11 +147,15 @@ describe('getMcpServersForSession', () => {
       'oauth-server': { authorization: 'Bearer real-oauth-token' },
     });
 
-    const servers = await getMcpServersForSession('session-a' as SessionID, {
-      mcpServerRepo: { findAll: vi.fn() } as never,
-      sessionMCPRepo: { listEffectiveServers } as never,
-      mcpOAuthAuthHeadersRepo: { getAuthHeaders } as never,
-    });
+    const servers = await getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll: vi.fn() } as never,
+        sessionMCPRepo: { listEffectiveServers } as never,
+        mcpOAuthAuthHeadersRepo: { getAuthHeaders } as never,
+      },
+      ENFORCING
+    );
 
     expect(getAuthHeaders).toHaveBeenCalledWith(['oauth-server']);
     const hydrated = servers.find(({ server }) => server.mcp_server_id === 'oauth-server')?.server;
@@ -139,5 +163,59 @@ describe('getMcpServersForSession', () => {
       type: 'oauth',
       oauth_access_token: 'real-oauth-token',
     });
+  });
+});
+
+describe('getMcpServersForSession - tool_permissions admission gate', () => {
+  const gatedServer = (permission: 'deny' | 'ask' = 'deny') => {
+    const server = makeServer('gated', 'global');
+    server.tool_permissions = { write_file: permission };
+    return server;
+  };
+
+  async function resolve(server: MCPServer, caps: HandlerPermissionCapabilities, onWithheld?: any) {
+    return getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll: vi.fn() } as never,
+        sessionMCPRepo: { listEffectiveServers: vi.fn().mockResolvedValue([server]) } as never,
+        onServerWithheld: onWithheld,
+      },
+      caps
+    );
+  }
+
+  // This is the only enforcement a handler without per-tool filtering gets, so
+  // a server it cannot honour must never appear in what that handler configures.
+  it.each(['deny', 'ask'] as const)(
+    'withholds a server carrying a %s from a handler that cannot filter tools',
+    async (permission) => {
+      const servers = await resolve(gatedServer(permission), { toolFiltering: 'none' });
+
+      expect(servers).toEqual([]);
+    }
+  );
+
+  it('keeps a gated server for a handler that can exclude tools', async () => {
+    const servers = await resolve(gatedServer(), { toolFiltering: 'exclude' });
+
+    expect(servers.map(({ server }) => server.mcp_server_id)).toEqual(['gated']);
+  });
+
+  it('leaves servers without tool_permissions untouched on every handler', async () => {
+    const servers = await resolve(makeServer('plain', 'global'), { toolFiltering: 'none' });
+
+    expect(servers.map(({ server }) => server.mcp_server_id)).toEqual(['plain']);
+  });
+
+  // A server that vanishes without explanation is indistinguishable, from the
+  // session, from one that is broken.
+  it('reports each withheld server with a reason', async () => {
+    const onWithheld = vi.fn();
+    await resolve(gatedServer(), { toolFiltering: 'none' }, onWithheld);
+
+    expect(onWithheld).toHaveBeenCalledTimes(1);
+    expect(onWithheld.mock.calls[0][0].mcp_server_id).toBe('gated');
+    expect(onWithheld.mock.calls[0][1]).toMatch(/cannot enforce/);
   });
 });

--- a/packages/core/src/mcp/scoping.ts
+++ b/packages/core/src/mcp/scoping.ts
@@ -23,6 +23,10 @@ import {
   resolveMcpServerTemplates,
   TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS,
 } from './template-resolver';
+import {
+  canEnforceMcpToolPermissions,
+  type HandlerPermissionCapabilities,
+} from './tool-permissions';
 
 export interface MCPScopingServerRepository {
   findAll(filters?: MCPServerFilters, forUserId?: string): Promise<MCPServer[]>;
@@ -82,7 +86,20 @@ export interface MCPResolutionDeps {
    * When provided, MCP servers with per-user OAuth will have tokens injected.
    */
   forUserId?: string;
+  /**
+   * Told about each server the caller may not attach. An executor log is not a
+   * channel an operator reads, and a server vanishing without explanation is
+   * indistinguishable from it being broken.
+   */
+  onServerWithheld?: (server: MCPServer, reason: string) => void;
 }
+
+/**
+ * Config key the built-in Agor MCP server is installed under. Reserved: it
+ * carries the session's daemon bearer token and is auto-approved by name, so a
+ * user-configured server must never be able to claim it.
+ */
+export const AGOR_MCP_SERVER_NAME = 'agor';
 
 /**
  * Get MCP servers that should be attached to a session
@@ -107,7 +124,8 @@ export interface MCPResolutionDeps {
  */
 export async function getMcpServersForSession(
   sessionId: SessionID,
-  deps: MCPResolutionDeps
+  deps: MCPResolutionDeps,
+  caps: HandlerPermissionCapabilities
 ): Promise<MCPServerWithSource[]> {
   const servers: MCPServerWithSource[] = [];
 
@@ -251,6 +269,22 @@ export async function getMcpServersForSession(
       console.warn(
         `   ⚠️  Skipped ${serversSkipped} MCP server(s) due to unresolved required templates`
       );
+    }
+
+    // Admission gate: a handler that cannot honour a server's `tool_permissions`
+    // does not get the server. Refusing to attach is the only way to keep a
+    // `deny` meaningful on a handler with no per-tool control — the alternative
+    // is handing over the exact tools someone switched off.
+    for (let i = servers.length - 1; i >= 0; i--) {
+      const { server } = servers[i];
+      if (canEnforceMcpToolPermissions(server, caps)) continue;
+
+      servers.splice(i, 1);
+      const reason =
+        `it sets tool_permissions this agent cannot enforce (tool filtering: ` +
+        `${caps.toolFiltering}). Attach it to an agent that can, or clear the deny/ask entries.`;
+      console.warn(`   ⛔ Withholding MCP server "${server.name}": ${reason}`);
+      deps.onServerWithheld?.(server, reason);
     }
 
     const oauthServers = servers

--- a/packages/core/src/mcp/tool-permissions.ts
+++ b/packages/core/src/mcp/tool-permissions.ts
@@ -1,0 +1,75 @@
+/**
+ * Policy vocabulary for `mcp_servers.data.tool_permissions`.
+ *
+ * This half answers "may this handler be handed this server at all?", which is
+ * what the scoping gate needs. The other half — translating a tool name an SDK
+ * invented back to the bare key permissions are stored under — stays with the
+ * handlers, because it encodes how each vendor SDK mangles names and core has
+ * no business knowing that.
+ */
+
+import type { MCPServer, ToolPermission } from '../types';
+
+/**
+ * Permissions a handler with no interactive approval flow must refuse.
+ *
+ * Codex and Gemini run headless — there is no channel to surface a prompt on —
+ * so `ask` degrades to a refusal there rather than silently becoming `allow`.
+ */
+export const PERMISSIONS_BLOCKED_WITHOUT_PROMPT: readonly ToolPermission[] = ['deny', 'ask'];
+
+/**
+ * What a handler can actually do about `tool_permissions`.
+ *
+ * Required at the resolution boundary rather than assumed, because the way this
+ * control failed the first time was silent: several handlers resolved MCP
+ * servers, some enforced, and the rest kept reporting success while ignoring
+ * every `deny`.
+ */
+export interface HandlerPermissionCapabilities {
+  /**
+   * Whether the handler can name a tool to drop in the config it hands its SDK
+   * (`exclude`) or has no per-tool control at all (`none`).
+   *
+   * Deliberately not "can express a tool set". An include-list can only say
+   * "all but these" by enumerating the survivors, and the only inventory
+   * available here is `server.tools` — a cached discovery snapshot that no SDK
+   * reads and that nothing proves is current. Enforcing from it would turn a
+   * stale cache into the authoritative tool set.
+   */
+  toolFiltering: 'exclude' | 'none';
+}
+
+/** Bare tool names on `server` whose configured permission is one of `permissions`. */
+export function listMcpToolsWithPermission(
+  server: MCPServer,
+  permissions: readonly ToolPermission[]
+): string[] {
+  const configured = server.tool_permissions;
+  if (!configured) return [];
+
+  return Object.entries(configured)
+    .filter(([, permission]) => permissions.includes(permission))
+    .map(([toolName]) => toolName);
+}
+
+/**
+ * Whether `server`'s configured permissions can be honoured under `caps`.
+ *
+ * A handler that cannot honour them must not be handed the server at all —
+ * attaching it anyway would expose exactly the tools someone switched off.
+ */
+export function canEnforceMcpToolPermissions(
+  server: MCPServer,
+  caps: HandlerPermissionCapabilities
+): boolean {
+  const gated = listMcpToolsWithPermission(server, PERMISSIONS_BLOCKED_WITHOUT_PROMPT);
+  if (gated.length === 0) return true;
+
+  switch (caps.toolFiltering) {
+    case 'exclude':
+      return true;
+    case 'none':
+      return false;
+  }
+}

--- a/packages/core/src/mcp/tool-permissions.ts
+++ b/packages/core/src/mcp/tool-permissions.ts
@@ -11,10 +11,22 @@
 import type { MCPServer, ToolPermission } from '../types';
 
 /**
- * Permissions a handler with no interactive approval flow must refuse.
+ * Permissions that cannot be honoured without somewhere to put a prompt.
  *
- * Codex and Gemini run headless — there is no channel to surface a prompt on —
- * so `ask` degrades to a refusal there rather than silently becoming `allow`.
+ * `ask` is the only member that varies: it means "refuse unless a human can be
+ * asked", so wherever no one can be asked it collapses onto `deny`. Three
+ * distinct situations reach that same conclusion, and callers use this list for
+ * all three:
+ *
+ * - the handler is headless (Codex, Gemini — no prompt channel exists at all);
+ * - this turn has no approval channel, even on a handler that usually has one
+ *   (Claude under `bypassPermissions`, or a turn with no task to attribute a
+ *   request to);
+ * - the handler cannot filter tools, so the server is withheld whole rather
+ *   than attached with an unenforceable gate.
+ *
+ * In every case the alternative is silently becoming `allow`, which is the
+ * failure this control exists to prevent.
  */
 export const PERMISSIONS_BLOCKED_WITHOUT_PROMPT: readonly ToolPermission[] = ['deny', 'ask'];
 

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -31,6 +31,7 @@
     "@cursor/sdk": "^1.0.26",
     "@google/gemini-cli-core": "^0.40.0",
     "@google/genai": "^1.43.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/diff": "^6.0.0",
     "@types/node": "^24.6.0",
     "typescript": "^6.0.3",

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -41,6 +41,22 @@ export class FeathersMessagesRepository {
     return Array.isArray(result) ? result : result.data;
   }
 
+  /**
+   * Total messages in a session, without transferring any of them.
+   *
+   * `$limit: 0` makes the service answer from `total`, which counts the whole
+   * result set rather than the returned page — a page length stops being the
+   * count once a session exceeds the service's pagination limit.
+   */
+  async countBySessionId(sessionId: SessionID): Promise<number> {
+    const service = this.client.service('messages');
+    const result = await service.find({
+      query: { session_id: sessionId, $limit: 0 },
+    });
+    if (Array.isArray(result)) return result.length;
+    return typeof result.total === 'number' ? result.total : 0;
+  }
+
   async findById(messageId: MessageID): Promise<Message | null> {
     try {
       const service = this.client.service('messages');

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -30,6 +30,10 @@ import { getDaemonUrl } from '../../config.js';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { ResolvedConfigSlice } from '../../payload-types.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
+import {
+  collectWithheldMcpServers,
+  reportWithheldMcpServers,
+} from '../../sdk-handlers/base/withheld-mcp-report.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 import {
   captureGitStateAtTaskEnd,
@@ -189,6 +193,7 @@ async function resolveCursorApiKey(client: AgorClient, taskId: TaskID): Promise<
 
 async function buildCursorMcpServers(args: {
   sessionId: SessionID;
+  taskId: TaskID;
   mcpToken?: string;
   repos: ReturnType<typeof createFeathersBackedRepositories>;
   forUserId?: string;
@@ -208,6 +213,7 @@ async function buildCursorMcpServers(args: {
     };
   }
 
+  const reporter = collectWithheldMcpServers();
   const serversWithSource = await getMcpServersForSession(
     args.sessionId,
     {
@@ -215,9 +221,17 @@ async function buildCursorMcpServers(args: {
       mcpServerRepo: args.repos.mcpServers,
       mcpOAuthAuthHeadersRepo: args.repos.mcpOAuthAuthHeaders,
       forUserId: args.forUserId,
+      onServerWithheld: reporter.onServerWithheld,
     },
+    // Cursor's MCP config carries no per-tool filter, so a server with gated
+    // tools cannot be honoured and is withheld whole.
     { toolFiltering: 'none' }
   );
+  await reportWithheldMcpServers(args.repos.messages, {
+    sessionId: args.sessionId,
+    taskId: args.taskId,
+    withheld: reporter.withheld,
+  });
 
   for (const { server } of serversWithSource) {
     const name = claimMcpName(server.name, claimed);
@@ -482,6 +496,7 @@ export async function executeCursorTask(params: {
     const model = toCursorModel(configuredModel);
     const mcpServers = await buildCursorMcpServers({
       sessionId,
+      taskId,
       mcpToken: session.mcp_token,
       repos,
       forUserId: session.created_by,

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -208,12 +208,16 @@ async function buildCursorMcpServers(args: {
     };
   }
 
-  const serversWithSource = await getMcpServersForSession(args.sessionId, {
-    sessionMCPRepo: args.repos.sessionMCP,
-    mcpServerRepo: args.repos.mcpServers,
-    mcpOAuthAuthHeadersRepo: args.repos.mcpOAuthAuthHeaders,
-    forUserId: args.forUserId,
-  });
+  const serversWithSource = await getMcpServersForSession(
+    args.sessionId,
+    {
+      sessionMCPRepo: args.repos.sessionMCP,
+      mcpServerRepo: args.repos.mcpServers,
+      mcpOAuthAuthHeadersRepo: args.repos.mcpOAuthAuthHeaders,
+      forUserId: args.forUserId,
+    },
+    { toolFiltering: 'none' }
+  );
 
   for (const { server } of serversWithSource) {
     const name = claimMcpName(server.name, claimed);

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -30,7 +30,9 @@ import type { ResolvedConfigSlice } from '../../payload-types.js';
 import { globalPermissionManager } from '../../permissions/permission-manager.js';
 import { PermissionService } from '../../permissions/permission-service.js';
 import { enrichContentBlocks } from '../../sdk-handlers/base/diff-enrichment.js';
+import { EMPTY_MCP_TOOL_PERMISSION_INDEX } from '../../sdk-handlers/base/mcp-tool-permissions.js';
 import { createCanUseToolCallback } from '../../sdk-handlers/base/permission-hooks.js';
+import { reportWithheldMcpServer } from '../../sdk-handlers/base/withheld-mcp-report.js';
 import { createUserMessage } from '../../sdk-handlers/claude/message-builder.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 import { createStreamingCallbacks, settleTaskFailure } from './base-executor.js';
@@ -78,12 +80,21 @@ export async function executeOpenCodeTask(params: {
     const permissionLocks = new Map<SessionID, Promise<void>>();
     const tool = new OpenCodeTool({
       resolveMcpServers: (targetSessionId) =>
-        getMcpServersForSession(targetSessionId, {
-          sessionMCPRepo: repos.sessionMCP,
-          mcpServerRepo: repos.mcpServers,
-          mcpOAuthAuthHeadersRepo: repos.mcpOAuthAuthHeaders,
-          forUserId: session.created_by,
-        }),
+        getMcpServersForSession(
+          targetSessionId,
+          {
+            sessionMCPRepo: repos.sessionMCP,
+            mcpServerRepo: repos.mcpServers,
+            mcpOAuthAuthHeadersRepo: repos.mcpOAuthAuthHeaders,
+            forUserId: session.created_by,
+            onServerWithheld: (withheldServer, reason) =>
+              void reportWithheldMcpServer(client, targetSessionId, withheldServer.name, reason),
+          },
+          // OpenCode's invocation config carries no per-tool filter, so a server
+          // with gated tools cannot be honoured and is withheld whole. This is
+          // the only enforcement point on this path.
+          { toolFiltering: 'none' }
+        ),
       getDaemonUrl,
       createPermissionCallback: (targetSessionId, targetTaskId) =>
         createCanUseToolCallback(targetSessionId, targetTaskId, {
@@ -95,6 +106,9 @@ export async function executeOpenCodeTask(params: {
           permissionLocks,
           mcpServerRepo: repos.mcpServers,
           sessionMCPRepo: repos.sessionMCP,
+          // Gated servers never reach this handler, so nothing here can be
+          // configured; the admission gate above already withheld them.
+          mcpToolPermissions: EMPTY_MCP_TOOL_PERMISSION_INDEX,
         }),
       cancelPendingPermissions: (targetSessionId) =>
         permissionService.cancelPendingRequests(targetSessionId),

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -32,7 +32,10 @@ import { PermissionService } from '../../permissions/permission-service.js';
 import { enrichContentBlocks } from '../../sdk-handlers/base/diff-enrichment.js';
 import { EMPTY_MCP_TOOL_PERMISSION_INDEX } from '../../sdk-handlers/base/mcp-tool-permissions.js';
 import { createCanUseToolCallback } from '../../sdk-handlers/base/permission-hooks.js';
-import { reportWithheldMcpServer } from '../../sdk-handlers/base/withheld-mcp-report.js';
+import {
+  collectWithheldMcpServers,
+  reportWithheldMcpServers,
+} from '../../sdk-handlers/base/withheld-mcp-report.js';
 import { createUserMessage } from '../../sdk-handlers/claude/message-builder.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 import { createStreamingCallbacks, settleTaskFailure } from './base-executor.js';
@@ -79,22 +82,29 @@ export async function executeOpenCodeTask(params: {
     const assistantMessageId = generateId() as MessageID;
     const permissionLocks = new Map<SessionID, Promise<void>>();
     const tool = new OpenCodeTool({
-      resolveMcpServers: (targetSessionId) =>
-        getMcpServersForSession(
+      resolveMcpServers: async (targetSessionId) => {
+        const reporter = collectWithheldMcpServers();
+        const servers = await getMcpServersForSession(
           targetSessionId,
           {
             sessionMCPRepo: repos.sessionMCP,
             mcpServerRepo: repos.mcpServers,
             mcpOAuthAuthHeadersRepo: repos.mcpOAuthAuthHeaders,
             forUserId: session.created_by,
-            onServerWithheld: (withheldServer, reason) =>
-              void reportWithheldMcpServer(client, targetSessionId, withheldServer.name, reason),
+            onServerWithheld: reporter.onServerWithheld,
           },
           // OpenCode's invocation config carries no per-tool filter, so a server
           // with gated tools cannot be honoured and is withheld whole. This is
           // the only enforcement point on this path.
           { toolFiltering: 'none' }
-        ),
+        );
+        await reportWithheldMcpServers(repos.messages, {
+          sessionId: targetSessionId,
+          taskId,
+          withheld: reporter.withheld,
+        });
+        return servers;
+      },
       getDaemonUrl,
       createPermissionCallback: (targetSessionId, targetTaskId) =>
         createCanUseToolCallback(targetSessionId, targetTaskId, {

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permission-hook.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permission-hook.test.ts
@@ -1,0 +1,80 @@
+import type { MCPServer } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { createMcpToolPermissionHook } from './mcp-tool-permission-hook.js';
+import {
+  buildMcpToolPermissionIndex,
+  EMPTY_MCP_TOOL_PERMISSION_INDEX,
+} from './mcp-tool-permissions.js';
+
+const index = buildMcpToolPermissionIndex([
+  {
+    name: 'github',
+    tool_permissions: {
+      create_pull_request: 'deny',
+      merge_pull_request: 'ask',
+      list_issues: 'allow',
+    },
+  } as unknown as MCPServer,
+]);
+
+function invoke(hook: ReturnType<typeof createMcpToolPermissionHook>, toolName: string) {
+  return hook(
+    {
+      hook_event_name: 'PreToolUse',
+      tool_name: toolName,
+      tool_input: {},
+      tool_use_id: 'tool-1',
+    } as never,
+    'tool-1',
+    { signal: new AbortController().signal }
+  );
+}
+
+describe('createMcpToolPermissionHook', () => {
+  it('denies a denied tool ahead of settings.json rule matching', async () => {
+    const hook = createMcpToolPermissionHook(index, true);
+
+    const result = await invoke(hook, 'mcp__github__create_pull_request');
+
+    expect(result.hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+    });
+  });
+
+  it('forces an "ask" tool to prompt even when a persisted allow rule exists', async () => {
+    // The SDK consults settings.json BEFORE canUseTool, so without this decision
+    // a stale "remember for project" allow would skip the gate entirely.
+    const hook = createMcpToolPermissionHook(index, true);
+
+    const result = await invoke(hook, 'mcp__github__merge_pull_request');
+
+    expect(result.hookSpecificOutput).toMatchObject({
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'ask',
+    });
+  });
+
+  it('fails an "ask" tool closed when there is no approval channel', async () => {
+    const hook = createMcpToolPermissionHook(index, false);
+
+    const result = await invoke(hook, 'mcp__github__merge_pull_request');
+
+    expect(result.hookSpecificOutput).toMatchObject({ permissionDecision: 'deny' });
+  });
+
+  it('lets allowed, unlisted and non-MCP tools proceed untouched', async () => {
+    const hook = createMcpToolPermissionHook(index, true);
+
+    for (const toolName of ['mcp__github__list_issues', 'mcp__github__list_commits', 'Bash']) {
+      const result = await invoke(hook, toolName);
+      expect(result, toolName).toEqual({ continue: true });
+    }
+  });
+
+  it('proceeds when nothing is configured at all', async () => {
+    const hook = createMcpToolPermissionHook(EMPTY_MCP_TOOL_PERMISSION_INDEX, true);
+
+    expect(await invoke(hook, 'mcp__github__create_pull_request')).toEqual({ continue: true });
+  });
+});

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permission-hook.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permission-hook.ts
@@ -1,0 +1,59 @@
+/**
+ * PreToolUse gate for MCP `tool_permissions`.
+ *
+ * `canUseTool` alone is not enough to hold an "ask": the SDK matches
+ * settings.json permission rules FIRST and only calls `canUseTool` when no rule
+ * decided the call. Agor writes those rules itself — a "remember for project"
+ * approval persists `allow` for that exact tool — so a tool later switched to
+ * `ask` would keep sailing through on the stale rule without ever prompting.
+ *
+ * PreToolUse runs ahead of rule matching, so a decision here outranks any
+ * settings.json entry. `ask` hands back to `canUseTool`, which runs Agor's
+ * existing permission-request flow.
+ */
+
+import type * as ClaudeSdk from '@anthropic-ai/claude-agent-sdk';
+import type { McpToolPermissionIndex } from './mcp-tool-permissions.js';
+import { resolveMcpToolPermission } from './mcp-tool-permissions.js';
+
+type HookCallback = ClaudeSdk.HookCallback;
+type HookJSONOutput = ClaudeSdk.HookJSONOutput;
+
+const PROCEED: HookJSONOutput = { continue: true };
+
+export function createMcpToolPermissionHook(
+  mcpToolPermissions: McpToolPermissionIndex,
+  /** Whether a live approval channel exists; without one, `ask` cannot be answered. */
+  canPromptForPermission: boolean
+): HookCallback {
+  return async (input): Promise<HookJSONOutput> => {
+    if (input.hook_event_name !== 'PreToolUse') return PROCEED;
+
+    const toolName = input.tool_name;
+    if (!toolName.startsWith('mcp__')) return PROCEED;
+
+    const permission = resolveMcpToolPermission(mcpToolPermissions, toolName);
+    if (permission === 'deny' || (permission === 'ask' && !canPromptForPermission)) {
+      console.warn(`🛑 [PreToolUse] MCP tool "${toolName}" blocked by tool_permissions`);
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: `Tool "${toolName}" is denied by its MCP server's tool permissions.`,
+        },
+      };
+    }
+
+    if (permission === 'ask') {
+      return {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: `Tool "${toolName}" requires approval per its MCP server's tool permissions.`,
+        },
+      };
+    }
+
+    return PROCEED;
+  };
+}

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
@@ -74,8 +74,34 @@ describe('resolveMcpToolPermission', () => {
     expect(resolveMcpToolPermission(dotted, 'my_server__run_query')).toBe('deny');
   });
 
+  // The CLI rewrites BOTH halves of a namespaced name, so a tool advertised as
+  // `repo.create` is offered to the model as `mcp__gh__repo_create`. Keyed only
+  // on the raw form, the lookup misses — and a miss reads as "unconfigured",
+  // i.e. allow. The gate would be silently open on exactly the tool someone
+  // switched off.
+  it('matches tools whose names contain characters illegal in a tool name', () => {
+    const dotted = buildMcpToolPermissionIndex([
+      server('gh', { 'repo.create': 'deny', 'repo.read': 'allow' }),
+    ]);
+
+    expect(resolveMcpToolPermission(dotted, 'mcp__gh__repo_create')).toBe('deny');
+    // The raw form still resolves, so nothing that worked before regressed.
+    expect(resolveMcpToolPermission(dotted, 'mcp__gh__repo.create')).toBe('deny');
+    // An unrelated permission is not dragged along by the rewrite.
+    expect(resolveMcpToolPermission(dotted, 'mcp__gh__repo_read')).toBe('allow');
+  });
+
+  it('rewrites both halves at once', () => {
+    const both = buildMcpToolPermissionIndex([server('My.Server', { 'repo.create': 'deny' })]);
+
+    expect(resolveMcpToolPermission(both, 'mcp__My_Server__repo_create')).toBe('deny');
+  });
+
   it('never matches a bare tool name, so an unrelated tool cannot be denied by coincidence', () => {
     expect(resolveMcpToolPermission(index, 'create_pull_request')).toBeUndefined();
+    // Positive control: the same index does answer when the name is qualified,
+    // so the miss above is the rule and not an empty fixture.
+    expect(resolveMcpToolPermission(index, 'mcp__github__create_pull_request')).toBe('deny');
   });
 
   // "foo.bar" and "foo_bar" both rewrite to "foo_bar". Overwriting the shared

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
@@ -1,0 +1,111 @@
+import type { MCPServer, ToolPermission } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMcpToolPermissionIndex,
+  EMPTY_MCP_TOOL_PERMISSION_INDEX,
+  resolveMcpToolPermission,
+} from './mcp-tool-permissions.js';
+
+function server(name: string, toolPermissions?: Record<string, ToolPermission>): MCPServer {
+  return { name, tool_permissions: toolPermissions } as MCPServer;
+}
+
+describe('resolveMcpToolPermission', () => {
+  const index = buildMcpToolPermissionIndex([
+    server('github', { create_pull_request: 'deny', merge_pull_request: 'ask' }),
+    server('linear', { create_issue: 'allow' }),
+  ]);
+
+  it('maps a Claude-namespaced tool name onto the bare key it is stored under', () => {
+    // tool_permissions is keyed on `create_pull_request`; the SDK asks about
+    // `mcp__github__create_pull_request`. Bridging the two IS the feature.
+    expect(resolveMcpToolPermission(index, 'mcp__github__create_pull_request')).toBe('deny');
+    expect(resolveMcpToolPermission(index, 'mcp__github__merge_pull_request')).toBe('ask');
+    expect(resolveMcpToolPermission(index, 'mcp__linear__create_issue')).toBe('allow');
+  });
+
+  it('maps a Gemini server-qualified tool name', () => {
+    expect(resolveMcpToolPermission(index, 'github__create_pull_request')).toBe('deny');
+  });
+
+  it('returns undefined for tools with no configured entry', () => {
+    expect(resolveMcpToolPermission(index, 'mcp__github__list_issues')).toBeUndefined();
+    expect(resolveMcpToolPermission(index, 'mcp__unknown__create_pull_request')).toBeUndefined();
+    expect(resolveMcpToolPermission(index, 'Bash')).toBeUndefined();
+    expect(resolveMcpToolPermission(EMPTY_MCP_TOOL_PERMISSION_INDEX, 'mcp__github__x')).toBe(
+      undefined
+    );
+  });
+
+  it('keeps the underscores inside a tool name intact', () => {
+    const withUnderscores = buildMcpToolPermissionIndex([
+      server('gh', { create__pull__request: 'deny' }),
+    ]);
+
+    expect(resolveMcpToolPermission(withUnderscores, 'mcp__gh__create__pull__request')).toBe(
+      'deny'
+    );
+  });
+
+  it('prefers the longest matching server prefix', () => {
+    const overlapping = buildMcpToolPermissionIndex([
+      server('gh', { enterprise__deploy: 'allow' }),
+      server('gh__enterprise', { deploy: 'deny' }),
+    ]);
+
+    expect(resolveMcpToolPermission(overlapping, 'mcp__gh__enterprise__deploy')).toBe('deny');
+  });
+
+  it('matches servers whose names the SDK had to sanitize', () => {
+    const spaced = buildMcpToolPermissionIndex([server('preset sdx', { run_query: 'deny' })]);
+
+    expect(resolveMcpToolPermission(spaced, 'mcp__preset_sdx__run_query')).toBe('deny');
+    expect(resolveMcpToolPermission(spaced, 'mcp__preset sdx__run_query')).toBe('deny');
+  });
+
+  // A dot is legal in an MCP server name but not in a tool name, so the SDK
+  // must rewrite it. Missing the rewritten form would read as "unconfigured".
+  it('matches servers whose names contain characters illegal in a tool name', () => {
+    const dotted = buildMcpToolPermissionIndex([server('My.Server', { run_query: 'deny' })]);
+
+    expect(resolveMcpToolPermission(dotted, 'mcp__My_Server__run_query')).toBe('deny');
+    // Codex lowercases as well as sanitizing.
+    expect(resolveMcpToolPermission(dotted, 'my_server__run_query')).toBe('deny');
+  });
+
+  it('never matches a bare tool name, so an unrelated tool cannot be denied by coincidence', () => {
+    expect(resolveMcpToolPermission(index, 'create_pull_request')).toBeUndefined();
+  });
+
+  // "foo.bar" and "foo_bar" both rewrite to "foo_bar". Overwriting the shared
+  // entry silently dropped the first server's denials, which the SDK would then
+  // surface as unconfigured, i.e. allowed.
+  it('merges servers whose names rewrite to the same alias instead of overwriting', () => {
+    const colliding = buildMcpToolPermissionIndex([
+      server('foo.bar', { write_file: 'deny' }),
+      server('foo_bar', { read_file: 'allow' }),
+    ]);
+
+    expect(resolveMcpToolPermission(colliding, 'mcp__foo_bar__write_file')).toBe('deny');
+    expect(resolveMcpToolPermission(colliding, 'mcp__foo_bar__read_file')).toBe('allow');
+  });
+
+  it('keeps the most restrictive value when colliding aliases disagree', () => {
+    const colliding = buildMcpToolPermissionIndex([
+      server('a.b', { search: 'allow' }),
+      server('a_b', { search: 'deny' }),
+    ]);
+
+    expect(resolveMcpToolPermission(colliding, 'mcp__a_b__search')).toBe('deny');
+  });
+
+  it('is order-independent across colliding aliases', () => {
+    const reversed = buildMcpToolPermissionIndex([
+      server('a_b', { search: 'deny' }),
+      server('a.b', { search: 'allow' }),
+    ]);
+
+    expect(resolveMcpToolPermission(reversed, 'mcp__a_b__search')).toBe('deny');
+  });
+});

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-tool MCP permission resolution.
+ *
+ * `mcp_servers.data.tool_permissions` is keyed on the BARE tool name exactly as
+ * the MCP server advertises it (`create_pull_request`). Handlers that gate tools
+ * through per-server config (Gemini `excludeTools`, Codex `disabled_tools`,
+ * Copilot `tools`) use those keys directly and only need
+ * `listMcpToolsWithPermission`.
+ *
+ * The policy half — whether a handler may be handed a server at all — lives in
+ * `@agor/core/mcp`, where the scoping gate consumes it. What stays here is the
+ * SDK-name machinery, because it encodes how each vendor mangles names and core
+ * has no business knowing that.
+ *
+ * The index exists for the one handler that must decide at call time from a
+ * name the SDK invented: Claude, which surfaces MCP tools as
+ * `mcp__<server>__<tool>`. Lookups are therefore always server-qualified —
+ * there is deliberately no bare-name fallback, because a bare key could only
+ * match a qualified string by coincidence, and that coincidence would deny an
+ * unrelated tool.
+ */
+
+import type { MCPServer, ToolPermission } from '@agor/core/types';
+
+const SEPARATOR = '__';
+const CLAUDE_MCP_PREFIX = `mcp${SEPARATOR}`;
+
+/** Ranked most-permissive-first, so a larger value is the safer answer. */
+const RESTRICTIVENESS: Record<ToolPermission, number> = { allow: 0, ask: 1, deny: 2 };
+
+export interface McpToolPermissionIndex {
+  /** Server name (raw and SDK-rewritten) → bare tool name → permission. */
+  readonly byServer: ReadonlyMap<string, ReadonlyMap<string, ToolPermission>>;
+}
+
+export const EMPTY_MCP_TOOL_PERMISSION_INDEX: McpToolPermissionIndex = {
+  byServer: new Map(),
+};
+
+/**
+ * SDKs rewrite server names into their own identifier alphabets before
+ * embedding them in a tool name. Indexing the rewritten forms alongside the raw
+ * one keeps lookups working for servers named e.g. "preset sdx" or "my.server".
+ *
+ * The alphabet is the tool-name one (`[a-zA-Z0-9_-]`), deliberately narrower
+ * than any single SDK's: a character we leave in but the SDK rewrites would
+ * make the index miss, and a miss reads as "unconfigured", i.e. allow. Codex
+ * also lowercases, so that variant is indexed too.
+ */
+export function mcpToolNameAliasesForServer(name: string): string[] {
+  const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return [name, sanitized, sanitized.toLowerCase()];
+}
+
+export function buildMcpToolPermissionIndex(servers: MCPServer[]): McpToolPermissionIndex {
+  const byServer = new Map<string, Map<string, ToolPermission>>();
+
+  for (const server of servers) {
+    const configured = server.tool_permissions;
+    if (!configured || Object.keys(configured).length === 0) continue;
+
+    for (const alias of new Set(mcpToolNameAliasesForServer(server.name))) {
+      // Two servers can share an alias ("foo.bar" and "foo_bar" both rewrite to
+      // "foo_bar"). Overwriting would drop the first server's denials on the
+      // floor, so entries merge and the most restrictive value survives.
+      let tools = byServer.get(alias);
+      if (!tools) {
+        tools = new Map<string, ToolPermission>();
+        byServer.set(alias, tools);
+      }
+      for (const [toolName, permission] of Object.entries(configured)) {
+        const current = tools.get(toolName);
+        if (!current || RESTRICTIVENESS[permission] > RESTRICTIVENESS[current]) {
+          tools.set(toolName, permission);
+        }
+      }
+    }
+  }
+
+  return { byServer };
+}
+
+/**
+ * Resolve the configured permission for a tool name as an SDK surfaced it.
+ *
+ * Returns `undefined` when nothing is configured — callers must treat that as
+ * "unchanged behaviour", never as an implicit allow or deny.
+ */
+export function resolveMcpToolPermission(
+  index: McpToolPermissionIndex,
+  sdkToolName: string
+): ToolPermission | undefined {
+  const qualified = sdkToolName.startsWith(CLAUDE_MCP_PREFIX)
+    ? sdkToolName.slice(CLAUDE_MCP_PREFIX.length)
+    : sdkToolName;
+
+  // Longest prefix wins so a server named "github" can't shadow "github_enterprise".
+  let matchedServerName: string | undefined;
+  for (const serverName of index.byServer.keys()) {
+    if (!qualified.startsWith(`${serverName}${SEPARATOR}`)) continue;
+    if (!matchedServerName || serverName.length > matchedServerName.length) {
+      matchedServerName = serverName;
+    }
+  }
+
+  if (!matchedServerName) return undefined;
+
+  const bareName = qualified.slice(matchedServerName.length + SEPARATOR.length);
+  return index.byServer.get(matchedServerName)?.get(bareName);
+}

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
@@ -38,18 +38,41 @@ export const EMPTY_MCP_TOOL_PERMISSION_INDEX: McpToolPermissionIndex = {
 };
 
 /**
- * SDKs rewrite server names into their own identifier alphabets before
- * embedding them in a tool name. Indexing the rewritten forms alongside the raw
- * one keeps lookups working for servers named e.g. "preset sdx" or "my.server".
+ * The alphabet SDKs rewrite names into before embedding them in a tool name.
  *
- * The alphabet is the tool-name one (`[a-zA-Z0-9_-]`), deliberately narrower
- * than any single SDK's: a character we leave in but the SDK rewrites would
- * make the index miss, and a miss reads as "unconfigured", i.e. allow. Codex
- * also lowercases, so that variant is indexed too.
+ * Deliberately narrower than any single SDK's: a character we leave in but the
+ * SDK rewrites would make a lookup miss, and a miss reads as "unconfigured",
+ * i.e. allow.
+ */
+function sanitizeToToolNameAlphabet(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/**
+ * Indexing the rewritten server forms alongside the raw one keeps lookups
+ * working for servers named e.g. "preset sdx" or "my.server". Codex also
+ * lowercases, so that variant is indexed too.
  */
 export function mcpToolNameAliasesForServer(name: string): string[] {
-  const sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '_');
+  const sanitized = sanitizeToToolNameAlphabet(name);
   return [name, sanitized, sanitized.toLowerCase()];
+}
+
+/**
+ * Both halves of a namespaced tool name get rewritten, not just the server.
+ *
+ * `tool_permissions` is keyed on the bare name exactly as the MCP server
+ * advertises it, and a server is free to advertise `repo.create`. Claude builds
+ * `mcp__<rewritten server>__<rewritten tool>` and matches rules against that,
+ * so a permission stored under the raw key would never bind — the same silent
+ * fail-open the server half already guards against.
+ *
+ * No lowercase variant here: the rewrite that produces the name being matched
+ * preserves case, and folding it would let a `Foo` denial capture an unrelated
+ * `foo` on the same server.
+ */
+export function mcpToolNameAliasesForTool(name: string): string[] {
+  return [name, sanitizeToToolNameAlphabet(name)];
 }
 
 export function buildMcpToolPermissionIndex(servers: MCPServer[]): McpToolPermissionIndex {
@@ -59,19 +82,22 @@ export function buildMcpToolPermissionIndex(servers: MCPServer[]): McpToolPermis
     const configured = server.tool_permissions;
     if (!configured || Object.keys(configured).length === 0) continue;
 
-    for (const alias of new Set(mcpToolNameAliasesForServer(server.name))) {
+    for (const serverAlias of new Set(mcpToolNameAliasesForServer(server.name))) {
       // Two servers can share an alias ("foo.bar" and "foo_bar" both rewrite to
       // "foo_bar"). Overwriting would drop the first server's denials on the
-      // floor, so entries merge and the most restrictive value survives.
-      let tools = byServer.get(alias);
+      // floor, so entries merge and the most restrictive value survives. Tool
+      // aliases collide the same way and merge on the same rule.
+      let tools = byServer.get(serverAlias);
       if (!tools) {
         tools = new Map<string, ToolPermission>();
-        byServer.set(alias, tools);
+        byServer.set(serverAlias, tools);
       }
       for (const [toolName, permission] of Object.entries(configured)) {
-        const current = tools.get(toolName);
-        if (!current || RESTRICTIVENESS[permission] > RESTRICTIVENESS[current]) {
-          tools.set(toolName, permission);
+        for (const toolAlias of new Set(mcpToolNameAliasesForTool(toolName))) {
+          const current = tools.get(toolAlias);
+          if (!current || RESTRICTIVENESS[permission] > RESTRICTIVENESS[current]) {
+            tools.set(toolAlias, permission);
+          }
         }
       }
     }

--- a/packages/executor/src/sdk-handlers/base/permission-hooks.test.ts
+++ b/packages/executor/src/sdk-handlers/base/permission-hooks.test.ts
@@ -8,6 +8,7 @@ vi.mock('@agor/core', () => ({
   shortId: vi.fn((id: string) => id),
 }));
 
+import { EMPTY_MCP_TOOL_PERMISSION_INDEX } from './mcp-tool-permissions.js';
 import { createCanUseToolCallback } from './permission-hooks.js';
 
 /**
@@ -49,6 +50,7 @@ describe('createCanUseToolCallback', () => {
       mcpServerRepo: {
         findById: vi.fn(),
       } as any,
+      mcpToolPermissions: EMPTY_MCP_TOOL_PERMISSION_INDEX,
       sessionMCPRepo: {
         findBySessionId: vi.fn().mockResolvedValue([]),
         listServers: vi.fn().mockResolvedValue([]),

--- a/packages/executor/src/sdk-handlers/base/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/base/permission-hooks.ts
@@ -7,6 +7,7 @@
  */
 
 import { generateId, shortId } from '@agor/core';
+import { AGOR_MCP_SERVER_NAME } from '@agor/core/mcp';
 import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 import {
   MessageRole,
@@ -22,6 +23,8 @@ import type {
 } from '../../db/feathers-repositories.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from './index.js';
+import type { McpToolPermissionIndex } from './mcp-tool-permissions.js';
+import { mcpToolNameAliasesForServer, resolveMcpToolPermission } from './mcp-tool-permissions.js';
 
 /**
  * Create canUseTool callback for permission handling
@@ -42,6 +45,8 @@ export function createCanUseToolCallback(
     permissionLocks: Map<SessionID, Promise<void>>;
     mcpServerRepo: MCPServerRepository;
     sessionMCPRepo: SessionMCPServerRepository;
+    /** Per-tool `tool_permissions` from the session's resolved MCP servers. */
+    mcpToolPermissions: McpToolPermissionIndex;
   }
 ) {
   return async (
@@ -62,12 +67,30 @@ export function createCanUseToolCallback(
     // Auto-approve MCP tools only if they belong to an attached MCP server
     // MCP tool names follow pattern: mcp__<server_name>__<tool_name>
     if (toolName.startsWith('mcp__')) {
+      // Per-tool `tool_permissions` outrank every fast-path below: a denied tool
+      // must never reach the MCP server, and an `ask` tool must never be
+      // auto-approved just because its server is attached.
+      const configuredPermission = resolveMcpToolPermission(deps.mcpToolPermissions, toolName);
+
+      if (configuredPermission === 'deny') {
+        console.warn(`🛑 [canUseTool] MCP tool "${toolName}" denied by tool_permissions`);
+        return {
+          behavior: 'deny' as const,
+          message: `Tool "${toolName}" is denied by its MCP server's tool permissions.`,
+        };
+      }
+
       const parts = toolName.split('__');
-      if (parts.length >= 3) {
+      if (configuredPermission === 'ask') {
+        console.log(
+          `❓ [canUseTool] MCP tool "${toolName}" set to "ask" by tool_permissions, prompting user`
+        );
+        // Fall through to normal permission flow
+      } else if (parts.length >= 3) {
         const serverName = parts[1]; // Extract server name from mcp__<server_name>__<tool_name>
 
         // Built-in "agor" server is always auto-approved (it's added dynamically, not in DB)
-        if (serverName === 'agor') {
+        if (serverName === AGOR_MCP_SERVER_NAME) {
           console.log(
             `✅ [canUseTool] Auto-approving MCP tool: ${toolName} (built-in "agor" server)`
           );
@@ -87,7 +110,12 @@ export function createCanUseToolCallback(
 
         try {
           const attachedServers = await deps.sessionMCPRepo.listServers(sessionId, true);
-          const serverVerified = attachedServers.some((server) => server.name === serverName);
+          // `serverName` was split out of a tool name the SDK already rewrote,
+          // so a raw comparison misses every server whose name carries
+          // punctuation or spaces.
+          const serverVerified = attachedServers.some((server) =>
+            mcpToolNameAliasesForServer(server.name).includes(serverName)
+          );
 
           if (serverVerified) {
             console.log(

--- a/packages/executor/src/sdk-handlers/base/withheld-mcp-report.ts
+++ b/packages/executor/src/sdk-handlers/base/withheld-mcp-report.ts
@@ -1,0 +1,38 @@
+import { generateId } from '@agor/core';
+import type { MessageID, SessionID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import type { AgorClient } from '../../services/feathers-client.js';
+
+/**
+ * Put a withheld MCP server where an operator will see it.
+ *
+ * `tool_permissions` has no UI, so an executor log is the only trace that a
+ * server was dropped — and from inside the session, a server that silently
+ * disappears is indistinguishable from one that is broken.
+ */
+export async function reportWithheldMcpServer(
+  client: AgorClient,
+  sessionId: SessionID,
+  serverName: string,
+  reason: string
+): Promise<void> {
+  try {
+    const existing = await client.service('messages').find({
+      query: { session_id: sessionId, $sort: { index: 1 } },
+    });
+    const messages = Array.isArray(existing) ? existing : existing.data;
+
+    await client.service('messages').create({
+      message_id: generateId() as MessageID,
+      session_id: sessionId,
+      type: 'system' as const,
+      role: MessageRole.SYSTEM,
+      index: messages.length,
+      timestamp: new Date().toISOString(),
+      content_preview: `MCP server "${serverName}" withheld by tool permissions`,
+      content: `MCP server "${serverName}" was withheld from this session: ${reason}`,
+    });
+  } catch (error) {
+    console.warn(`[MCP] Could not report withheld server "${serverName}":`, error);
+  }
+}

--- a/packages/executor/src/sdk-handlers/base/withheld-mcp-report.ts
+++ b/packages/executor/src/sdk-handlers/base/withheld-mcp-report.ts
@@ -1,38 +1,70 @@
 import { generateId } from '@agor/core';
-import type { MessageID, SessionID } from '@agor/core/types';
+import type { MCPServer, Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
-import type { AgorClient } from '../../services/feathers-client.js';
+import type { MessagesRepository } from '../../db/feathers-repositories.js';
+
+/** A server the admission gate refused to hand to a handler. */
+export interface WithheldMcpServer {
+  name: string;
+  reason: string;
+}
 
 /**
- * Put a withheld MCP server where an operator will see it.
+ * Collect withheld servers during scoping so they can be reported afterwards.
+ *
+ * `onServerWithheld` fires synchronously inside resolution, which is the wrong
+ * place to write a message: the index has to be read and used without another
+ * writer landing in between. Buffering keeps the callback synchronous and
+ * defers the writes to a single awaited point.
+ */
+export function collectWithheldMcpServers(): {
+  withheld: WithheldMcpServer[];
+  onServerWithheld: (server: MCPServer, reason: string) => void;
+} {
+  const withheld: WithheldMcpServer[] = [];
+  return {
+    withheld,
+    onServerWithheld: (server, reason) => {
+      withheld.push({ name: server.name, reason });
+    },
+  };
+}
+
+/**
+ * Put withheld MCP servers where an operator will see them.
  *
  * `tool_permissions` has no UI, so an executor log is the only trace that a
  * server was dropped — and from inside the session, a server that silently
  * disappears is indistinguishable from one that is broken.
+ *
+ * Written one at a time so each notice reads the index the previous one
+ * created, and awaited before the turn starts so they stay clear of the
+ * messages the turn itself writes.
  */
-export async function reportWithheldMcpServer(
-  client: AgorClient,
-  sessionId: SessionID,
-  serverName: string,
-  reason: string
+export async function reportWithheldMcpServers(
+  messagesRepo: MessagesRepository,
+  args: {
+    sessionId: SessionID;
+    taskId: TaskID;
+    withheld: readonly WithheldMcpServer[];
+  }
 ): Promise<void> {
-  try {
-    const existing = await client.service('messages').find({
-      query: { session_id: sessionId, $sort: { index: 1 } },
-    });
-    const messages = Array.isArray(existing) ? existing : existing.data;
-
-    await client.service('messages').create({
-      message_id: generateId() as MessageID,
-      session_id: sessionId,
-      type: 'system' as const,
-      role: MessageRole.SYSTEM,
-      index: messages.length,
-      timestamp: new Date().toISOString(),
-      content_preview: `MCP server "${serverName}" withheld by tool permissions`,
-      content: `MCP server "${serverName}" was withheld from this session: ${reason}`,
-    });
-  } catch (error) {
-    console.warn(`[MCP] Could not report withheld server "${serverName}":`, error);
+  for (const { name, reason } of args.withheld) {
+    try {
+      const message: Message = {
+        message_id: generateId() as MessageID,
+        session_id: args.sessionId,
+        task_id: args.taskId,
+        type: 'system',
+        role: MessageRole.SYSTEM,
+        index: await messagesRepo.countBySessionId(args.sessionId),
+        timestamp: new Date().toISOString(),
+        content_preview: `MCP server "${name}" withheld by tool permissions`,
+        content: `MCP server "${name}" was withheld from this session: ${reason}`,
+      };
+      await messagesRepo.create(message);
+    } catch (error) {
+      console.warn(`[MCP] Could not report withheld server "${name}":`, error);
+    }
   }
 }

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -555,6 +555,77 @@ describe('setupQuery - ask under bypassPermissions', () => {
 
     const options = vi.mocked(Claude.query).mock.calls[0][0].options;
     expect(options.disallowedTools).not.toContain(`mcp__${GATED_SERVER}__write_file`);
+    // Positive control: the server really was processed, so the absence above
+    // is the promptable path and not a fixture that produced no servers.
+    expect(Object.keys(options.mcpServers ?? {})).toContain(GATED_SERVER);
     expect(options.canUseTool).toBeTypeOf('function');
+  });
+});
+
+/**
+ * The CLI rewrites both halves of a namespaced name into `[a-zA-Z0-9_-]`, and
+ * matches rules against the rewritten form. A rule carrying the raw tool name
+ * binds to nothing, which reads as unconfigured — allow.
+ */
+describe('setupQuery - tool names the CLI has to rewrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Claude.query).mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve({ done: true }) }),
+      interrupt: () => Promise.resolve(),
+    } as any);
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          mcp_server_id: 'gh-server',
+          name: 'My.Server',
+          transport: 'stdio',
+          command: 'noop',
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+          tool_permissions: { 'repo.create': 'deny', repo_read: 'allow' },
+        },
+        source: 'global',
+      },
+    ] as any);
+  });
+
+  function deps(): QuerySetupDeps {
+    return {
+      sessionsRepo: {
+        findById: vi.fn().mockResolvedValue({
+          session_id: 'test-session' as SessionID,
+          branch_id: 'test-branch' as BranchID,
+          mcp_token: 'token',
+        }),
+      } as any,
+      branchesRepo: { findById: vi.fn().mockResolvedValue({ path: '/test/project/path' }) } as any,
+      messagesRepo: {} as any,
+      sessionMCPRepo: {} as any,
+      mcpServerRepo: {} as any,
+      permissionService: {} as any,
+      tasksService: {} as any,
+      messagesService: {} as any,
+      sessionsService: {} as any,
+      permissionLocks: new Map(),
+    };
+  }
+
+  it('denies under the rewritten tool name, not only the raw one', async () => {
+    await setupQuery('test-session' as SessionID, 'test prompt', deps(), {
+      taskId: 'test-task' as TaskID,
+      permissionMode: 'default',
+    });
+
+    const disallowed = vi.mocked(Claude.query).mock.calls[0][0].options.disallowedTools as string[];
+
+    // What the CLI actually offers the model, and therefore the only form that
+    // can bind: both halves rewritten.
+    expect(disallowed).toContain('mcp__My_Server__repo_create');
+    // The raw form stays listed too — a rule that matches nothing is inert.
+    expect(disallowed).toContain('mcp__My.Server__repo.create');
+    // An "allow" tool is not swept in by the rewrite.
+    expect(disallowed).not.toContain('mcp__My_Server__repo_read');
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -477,3 +477,84 @@ describe('setupQuery - canUseTool registration', () => {
     expect(callArgs.options.canUseTool).toBeUndefined();
   });
 });
+
+/**
+ * `bypassPermissions` removes the approval channel, which leaves an `ask` tool
+ * unanswerable. It resolves to a refusal rather than to `allow`, so the mode is
+ * "stop asking me" for everything except the tools an operator explicitly asked
+ * to be prompted about.
+ */
+describe('setupQuery - ask under bypassPermissions', () => {
+  const GATED_SERVER = 'files';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Claude.query).mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve({ done: true }) }),
+      interrupt: () => Promise.resolve(),
+    } as any);
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          mcp_server_id: 'files-server',
+          name: GATED_SERVER,
+          transport: 'stdio',
+          command: 'noop',
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+          tool_permissions: { write_file: 'ask', read_file: 'allow' },
+        },
+        source: 'global',
+      },
+    ] as any);
+  });
+
+  function createDepsWithGatedServer(): QuerySetupDeps {
+    return {
+      sessionsRepo: {
+        findById: vi.fn().mockResolvedValue({
+          session_id: 'test-session' as SessionID,
+          branch_id: 'test-branch' as BranchID,
+          mcp_token: 'token',
+        }),
+      } as any,
+      branchesRepo: {
+        findById: vi.fn().mockResolvedValue({ path: '/test/project/path' }),
+      } as any,
+      messagesRepo: {} as any,
+      sessionMCPRepo: {} as any,
+      mcpServerRepo: {} as any,
+      permissionService: {} as any,
+      tasksService: {} as any,
+      messagesService: {} as any,
+      sessionsService: {} as any,
+      permissionLocks: new Map(),
+    };
+  }
+
+  it('hard-denies an "ask" tool when there is nowhere to ask', async () => {
+    await setupQuery('test-session' as SessionID, 'test prompt', createDepsWithGatedServer(), {
+      taskId: 'test-task' as TaskID,
+      permissionMode: 'bypassPermissions',
+    });
+
+    const options = vi.mocked(Claude.query).mock.calls[0][0].options;
+    // `disallowedTools` is mode-independent, so this holds even though bypass
+    // skips canUseTool and could skip hooks.
+    expect(options.disallowedTools).toContain(`mcp__${GATED_SERVER}__write_file`);
+    // An "allow" tool is untouched: the mode is not a blanket refusal.
+    expect(options.disallowedTools).not.toContain(`mcp__${GATED_SERVER}__read_file`);
+  });
+
+  it('leaves an "ask" tool promptable when an approval channel exists', async () => {
+    await setupQuery('test-session' as SessionID, 'test prompt', createDepsWithGatedServer(), {
+      taskId: 'test-task' as TaskID,
+      permissionMode: 'default',
+    });
+
+    const options = vi.mocked(Claude.query).mock.calls[0][0].options;
+    expect(options.disallowedTools).not.toContain(`mcp__${GATED_SERVER}__write_file`);
+    expect(options.canUseTool).toBeTypeOf('function');
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -22,9 +22,10 @@ vi.mock('@agor/core/tools/mcp/jwt-auth', () => ({
 vi.mock('../../config.js', () => ({
   getDaemonUrl: vi.fn().mockResolvedValue('http://localhost:3030'),
 }));
-vi.mock('@agor/core/mcp', () => ({
-  getMcpServersForSession: vi.fn().mockResolvedValue([]),
-}));
+vi.mock('@agor/core/mcp', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/mcp')>('@agor/core/mcp');
+  return { ...actual, getMcpServersForSession: vi.fn().mockResolvedValue([]) };
+});
 vi.mock('./models.js', () => ({
   DEFAULT_CLAUDE_MODEL: 'claude-sonnet-4-6',
 }));

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -44,6 +44,7 @@ import {
   buildMcpToolPermissionIndex,
   EMPTY_MCP_TOOL_PERMISSION_INDEX,
   mcpToolNameAliasesForServer,
+  mcpToolNameAliasesForTool,
 } from '../base/mcp-tool-permissions.js';
 import { createCanUseToolCallback } from '../base/permission-hooks.js';
 import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
@@ -522,12 +523,14 @@ export async function setupQuery(
             ? (['deny'] as const)
             : PERMISSIONS_BLOCKED_WITHOUT_PROMPT;
           for (const tool of listMcpToolsWithPermission(server, blocked)) {
-            // The CLI rewrites a server name into the tool-name alphabet before
-            // it reaches a rule, so a name with punctuation would never match if
-            // only the raw form were listed. Both forms are emitted; a rule that
-            // matches nothing is inert.
-            for (const alias of new Set(mcpToolNameAliasesForServer(server.name))) {
-              deniedTools.push(`mcp__${alias}__${tool}`);
+            // The CLI rewrites BOTH halves into the tool-name alphabet before a
+            // name reaches a rule, so either half carrying punctuation would
+            // never match if only the raw form were listed. Every combination is
+            // emitted; a rule that matches nothing is inert.
+            for (const serverAlias of new Set(mcpToolNameAliasesForServer(server.name))) {
+              for (const toolAlias of new Set(mcpToolNameAliasesForTool(tool))) {
+                deniedTools.push(`mcp__${serverAlias}__${toolAlias}`);
+              }
             }
           }
         }

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -18,7 +18,12 @@ import type * as ClaudeSdk from '@anthropic-ai/claude-agent-sdk';
 type PermissionMode = ClaudeSdk.PermissionMode;
 type Options = ClaudeSdk.Options;
 
-import { getMcpServersForSession } from '@agor/core/mcp';
+import {
+  AGOR_MCP_SERVER_NAME,
+  getMcpServersForSession,
+  listMcpToolsWithPermission,
+  PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+} from '@agor/core/mcp';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
@@ -34,6 +39,12 @@ import type { PermissionService } from '../../permissions/permission-service.js'
 import type { MCPServersConfig, SessionID, TaskID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
+import { createMcpToolPermissionHook } from '../base/mcp-tool-permission-hook.js';
+import {
+  buildMcpToolPermissionIndex,
+  EMPTY_MCP_TOOL_PERMISSION_INDEX,
+  mcpToolNameAliasesForServer,
+} from '../base/mcp-tool-permissions.js';
 import { createCanUseToolCallback } from '../base/permission-hooks.js';
 import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
 import { DEFAULT_CLAUDE_MODEL } from './models.js';
@@ -260,32 +271,6 @@ export async function setupQuery(
     queryOptions.extraArgs = extraArgs;
   }
 
-  // Add canUseTool callback if permission service is available and taskId provided.
-  // This enables Agor's custom permission UI (WebSocket-based) when the SDK would
-  // show a prompt. Fires AFTER the SDK checks settings.json — respects user's
-  // existing Claude CLI permissions.
-  //
-  // Skip in bypassPermissions mode: the SDK skips canUseTool there anyway, and
-  // we no longer need a workaround to intercept AskUserQuestion (now disallowed).
-  if (
-    deps.permissionService &&
-    taskId &&
-    deps.sessionMCPRepo &&
-    deps.mcpServerRepo &&
-    effectivePermissionMode !== 'bypassPermissions'
-  ) {
-    queryOptions.canUseTool = createCanUseToolCallback(sessionId, taskId, {
-      permissionService: deps.permissionService,
-      tasksService: deps.tasksService!,
-      messagesRepo: deps.messagesRepo!,
-      messagesService: deps.messagesService,
-      sessionsService: deps.sessionsService,
-      permissionLocks: deps.permissionLocks,
-      mcpServerRepo: deps.mcpServerRepo,
-      sessionMCPRepo: deps.sessionMCPRepo,
-    });
-  }
-
   // Add optional apiKey if provided
   // NOTE: Don't require API key - user may have used `claude login` (OAuth)
   // API keys are already resolved by base-executor with proper precedence (user → config → env)
@@ -428,26 +413,58 @@ export async function setupQuery(
     }
   }
 
+  // Whether this query will have a live approval channel back to the UI.
+  // Decided up front because MCP `tool_permissions` need it: an "ask" tool with
+  // nowhere to ask has to fail closed rather than silently become "allow".
+  const canPromptForPermission = Boolean(
+    deps.permissionService &&
+      taskId &&
+      deps.sessionMCPRepo &&
+      deps.mcpServerRepo &&
+      effectivePermissionMode !== 'bypassPermissions'
+  );
+
   // Fetch and configure MCP servers for this session
+  let mcpToolPermissions = EMPTY_MCP_TOOL_PERMISSION_INDEX;
   if (deps.sessionMCPRepo && deps.mcpServerRepo) {
     try {
       // Use shared MCP scoping utility
       // Pass forUserId to enable per-user OAuth token injection
-      const serversWithSource = await getMcpServersForSession(sessionId, {
-        sessionMCPRepo: deps.sessionMCPRepo,
-        mcpServerRepo: deps.mcpServerRepo,
-        mcpOAuthAuthHeadersRepo: deps.mcpOAuthAuthHeadersRepo,
-        forUserId: contextUserId,
+      const serversWithSource = await getMcpServersForSession(
+        sessionId,
+        {
+          sessionMCPRepo: deps.sessionMCPRepo,
+          mcpServerRepo: deps.mcpServerRepo,
+          mcpOAuthAuthHeadersRepo: deps.mcpOAuthAuthHeadersRepo,
+          forUserId: contextUserId,
+        },
+        { toolFiltering: 'exclude' }
+      );
+
+      // The built-in Agor server carries this session's daemon bearer token and
+      // is auto-approved by name in canUseTool. Drop any DB server claiming that
+      // name before anything reads the list, so it can neither be configured nor
+      // contribute permissions that would gate the genuine built-in's tools.
+      const attachableServers = serversWithSource.filter(({ server }) => {
+        if (server.name !== AGOR_MCP_SERVER_NAME) return true;
+        console.warn(
+          `   ⚠️  Skipping MCP server "${server.name}": reserved for the built-in Agor MCP server`
+        );
+        return false;
       });
 
-      if (serversWithSource.length > 0) {
+      mcpToolPermissions = buildMcpToolPermissionIndex(
+        attachableServers.map(({ server }) => server)
+      );
+
+      if (attachableServers.length > 0) {
         // Convert to SDK format
         const mcpConfig: MCPServersConfig = {};
-        const allowedTools: string[] = [];
+        const deniedTools: string[] = [];
         const missingAuthServers: string[] = [];
         const unresolvedAuthServers: string[] = [];
 
-        for (const { server } of serversWithSource) {
+        for (const { server } of attachableServers) {
           // Infer transport if missing (backwards compatibility)
           const transport = server.transport || (server.url ? 'sse' : 'stdio');
 
@@ -497,10 +514,20 @@ export async function setupQuery(
 
           mcpConfig[server.name] = serverConfig;
 
-          // Add tools to allowlist
-          if (server.tools) {
-            for (const tool of server.tools) {
-              allowedTools.push(tool.name);
+          // Denied tools are blocked at the SDK layer as well as in canUseTool,
+          // so the model is never even offered a tool the user switched off.
+          // Without an approval channel an "ask" tool is unanswerable, so it
+          // joins them rather than degrading to "allow".
+          const blocked = canPromptForPermission
+            ? (['deny'] as const)
+            : PERMISSIONS_BLOCKED_WITHOUT_PROMPT;
+          for (const tool of listMcpToolsWithPermission(server, blocked)) {
+            // The CLI rewrites a server name into the tool-name alphabet before
+            // it reaches a rule, so a name with punctuation would never match if
+            // only the raw form were listed. Both forms are emitted; a rule that
+            // matches nothing is inert.
+            for (const alias of new Set(mcpToolNameAliasesForServer(server.name))) {
+              deniedTools.push(`mcp__${alias}__${tool}`);
             }
           }
         }
@@ -522,14 +549,55 @@ export async function setupQuery(
               formatListForLog(unresolvedAuthServers, 3)
           );
         }
-        if (allowedTools.length > 0) {
-          queryOptions.allowedTools = allowedTools;
+        if (deniedTools.length > 0) {
+          queryOptions.disallowedTools = [
+            ...(queryOptions.disallowedTools as string[]),
+            ...deniedTools,
+          ];
         }
       }
     } catch (error) {
       console.warn('⚠️  Failed to fetch MCP servers for session:', error);
       // Continue without MCP servers - non-fatal error
     }
+  }
+
+  // PreToolUse runs ahead of settings.json rule matching, so this is what stops
+  // a stale persisted `allow` rule from skipping an `ask` gate entirely.
+  if (mcpToolPermissions.byServer.size > 0) {
+    queryOptions.hooks = {
+      ...(queryOptions.hooks as Record<string, unknown> | undefined),
+      PreToolUse: [
+        { hooks: [createMcpToolPermissionHook(mcpToolPermissions, canPromptForPermission)] },
+      ],
+    };
+  }
+
+  // Add canUseTool callback if permission service is available and taskId provided.
+  // This enables Agor's custom permission UI (WebSocket-based) when the SDK would
+  // show a prompt. Fires AFTER the SDK checks settings.json — respects user's
+  // existing Claude CLI permissions.
+  //
+  // Skip in bypassPermissions mode: the SDK skips canUseTool there anyway, and
+  // we no longer need a workaround to intercept AskUserQuestion (now disallowed).
+  if (
+    deps.permissionService &&
+    taskId &&
+    deps.sessionMCPRepo &&
+    deps.mcpServerRepo &&
+    effectivePermissionMode !== 'bypassPermissions'
+  ) {
+    queryOptions.canUseTool = createCanUseToolCallback(sessionId, taskId, {
+      permissionService: deps.permissionService,
+      tasksService: deps.tasksService!,
+      messagesRepo: deps.messagesRepo!,
+      messagesService: deps.messagesService,
+      sessionsService: deps.sessionsService,
+      permissionLocks: deps.permissionLocks,
+      mcpServerRepo: deps.mcpServerRepo,
+      sessionMCPRepo: deps.sessionMCPRepo,
+      mcpToolPermissions,
+    });
   }
 
   // Wrap the string prompt in an AsyncIterable so the SDK treats this as a

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -72,7 +72,10 @@ async function* streamMockEvents() {
 
 // Mock the Codex SDK to avoid spawning real Codex CLI processes
 vi.mock('./app-server-client.js', () => appServerMocks);
-vi.mock('@agor/core/mcp', () => mcpScopingMocks);
+vi.mock('@agor/core/mcp', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/mcp')>('@agor/core/mcp');
+  return { ...actual, ...mcpScopingMocks };
+});
 vi.mock('@agor/core/tools/mcp/jwt-auth', () => mcpAuthMocks);
 vi.mock('../../config.js', () => configMocks);
 
@@ -2119,7 +2122,9 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
       '019e3700-aaaa-bbbb-cccc-dddddddddddd',
       expect.objectContaining({
         forUserId: '019e3700-user-user-user-user00000001',
-      })
+      }),
+      // Codex can drop individual tools but has no way to prompt.
+      { toolFiltering: 'exclude' }
     );
   });
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -28,12 +28,21 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { loadManagedAgenticToolSdk } from '@agor/core/agentic-integrations';
 import { shortId } from '@agor/core/db';
-import { getMcpServersForSession } from '@agor/core/mcp';
+import {
+  getMcpServersForSession,
+  listMcpToolsWithPermission,
+  PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+} from '@agor/core/mcp';
 import type { CodexOptions, Thread, ThreadItem } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
-import type { CodexSandboxMode, ContextUsageSnapshot, EffortLevel } from '@agor/core/types';
+import type {
+  CodexSandboxMode,
+  ContextUsageSnapshot,
+  EffortLevel,
+  MCPServer,
+} from '@agor/core/types';
 import { getDefaultPermissionMode, isGatewaySession } from '@agor/core/types';
 import { mapToCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import type * as CodexSdk from '@openai/codex-sdk';
@@ -92,6 +101,30 @@ type CodexConfigValue = CodexConfigObject[string];
  * clears the prompt.
  */
 const MCP_AUTO_APPROVE: CodexConfigObject = { default_tools_approval_mode: 'approve' };
+
+/**
+ * Apply the server's `tool_permissions` to its Codex config.
+ *
+ * Codex's approval mode is per-server, not per-tool, so a gated tool cannot be
+ * singled out for a prompt — and `exec --json` has no channel to prompt on
+ * anyway (see `MCP_AUTO_APPROVE`). `disabled_tools` is the only per-tool lever
+ * Codex exposes, so both `deny` and `ask` fail closed there; `allow` and
+ * unlisted tools keep the server-wide auto-approve.
+ */
+function applyMcpToolPermissions(config: CodexConfigObject, server: MCPServer): void {
+  const blocked = listMcpToolsWithPermission(server, PERMISSIONS_BLOCKED_WITHOUT_PROMPT);
+  if (blocked.length === 0) return;
+
+  config.disabled_tools = blocked as CodexConfigValue[];
+
+  const asked = listMcpToolsWithPermission(server, ['ask']);
+  console.warn(
+    `   ⛔ [Codex MCP] Disabling ${blocked.length} tool(s) on "${server.name}" per tool_permissions` +
+      (asked.length > 0
+        ? ` (${asked.length} set to "ask"; Codex runs headless with no approval prompt, so they fail closed)`
+        : '')
+  );
+}
 const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
@@ -637,12 +670,16 @@ export class CodexPromptService {
     codexDebug(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
     codexDebug(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
 
-    const serversWithSource = await getMcpServersForSession(sessionId, {
-      sessionMCPRepo: this.sessionMCPServerRepo,
-      mcpServerRepo: this.mcpServerRepo,
-      mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
-      forUserId,
-    });
+    const serversWithSource = await getMcpServersForSession(
+      sessionId,
+      {
+        sessionMCPRepo: this.sessionMCPServerRepo,
+        mcpServerRepo: this.mcpServerRepo,
+        mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
+        forUserId,
+      },
+      { toolFiltering: 'exclude' }
+    );
 
     const mcpServers = serversWithSource.map((s) => s.server);
 
@@ -688,6 +725,7 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
+      applyMcpToolPermissions(serverConfig, server);
       applyGatewayMcpStartupGuard(serverConfig, requireMcpServers);
       codexDebug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
@@ -714,6 +752,7 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
+      applyMcpToolPermissions(serverConfig, server);
       let canRequireServer = requireMcpServers;
       codexDebug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
@@ -35,6 +35,10 @@ import { reportSdkActivity, type SdkActivityCallback } from '../../sdk-watchdog.
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
+import {
+  collectWithheldMcpServers,
+  reportWithheldMcpServers,
+} from '../base/withheld-mcp-report.js';
 import type { CopilotSessionEvents } from './event-mapper.js';
 import { DEFAULT_COPILOT_MODEL } from './models.js';
 import { createPermissionHandler, type PermissionDeps } from './permission-mapper.js';
@@ -150,20 +154,37 @@ export class CopilotPromptService {
    */
   private async buildMcpServers(
     sessionId: SessionID,
+    taskId: TaskID,
     mcpToken?: string
   ): Promise<Record<string, unknown>> {
     const copilotMcpServers: Record<string, unknown> = {};
 
     // Fetch MCP servers for this session
+    const reporter = collectWithheldMcpServers();
     const serversWithSource = await getMcpServersForSession(
       sessionId,
       {
         sessionMCPRepo: this.sessionMCPServerRepo,
         mcpServerRepo: this.mcpServerRepo,
         mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
+        onServerWithheld: reporter.onServerWithheld,
       },
+      // The per-server `tools` field below is an include-list, which cannot
+      // express "all but these" without enumerating a tool set that changes
+      // under us. `SessionConfig.excludedTools` is a true exclude-list, but the
+      // SDK forwards it verbatim to the Copilot CLI, which resolves it in
+      // native code against a name it mints itself (`namespacedName`) — a name
+      // Agor cannot construct, and a miss here reads as "allow". The CLI does
+      // document a `<mcp-server-name>(tool-name?)` permission pattern built
+      // from names Agor holds verbatim, but only for its `--deny-tool` flag,
+      // which `SessionConfig` does not expose.
       { toolFiltering: 'none' }
     );
+    await reportWithheldMcpServers(this.messagesRepo, {
+      sessionId,
+      taskId,
+      withheld: reporter.withheld,
+    });
 
     const mcpServers = serversWithSource.map((s) => s.server);
     console.log(`📊 [Copilot MCP] Found ${mcpServers.length} MCP server(s) for session`);
@@ -297,7 +318,11 @@ export class CopilotPromptService {
         permissionMode,
         permissionDeps
       );
-      const mcpServers = await this.buildMcpServers(sessionId, session.mcp_token);
+      const mcpServers = await this.buildMcpServers(
+        sessionId,
+        taskId || ('' as TaskID),
+        session.mcp_token
+      );
       const systemMessage = await this.buildSystemMessage(sessionId);
 
       // configuredModel for recording, invocationModel for the SDK.

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
@@ -155,11 +155,15 @@ export class CopilotPromptService {
     const copilotMcpServers: Record<string, unknown> = {};
 
     // Fetch MCP servers for this session
-    const serversWithSource = await getMcpServersForSession(sessionId, {
-      sessionMCPRepo: this.sessionMCPServerRepo,
-      mcpServerRepo: this.mcpServerRepo,
-      mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
-    });
+    const serversWithSource = await getMcpServersForSession(
+      sessionId,
+      {
+        sessionMCPRepo: this.sessionMCPServerRepo,
+        mcpServerRepo: this.mcpServerRepo,
+        mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
+      },
+      { toolFiltering: 'none' }
+    );
 
     const mcpServers = serversWithSource.map((s) => s.server);
     console.log(`📊 [Copilot MCP] Found ${mcpServers.length} MCP server(s) for session`);

--- a/packages/executor/src/sdk-handlers/gemini/mcp-server-config.test.ts
+++ b/packages/executor/src/sdk-handlers/gemini/mcp-server-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `@google/gemini-cli-core` can't be loaded under vitest (its OpenTelemetry
+ * dependency uses unsupported directory imports), so this mirrors the real
+ * `MCPServerConfig` constructor signature from the SDK's type declarations.
+ * The positional order is the thing under test — `tsc` covers the arity and
+ * types against the real class, this covers which slot each value lands in.
+ */
+import { buildGeminiMcpServerConfig } from './mcp-server-config.js';
+
+/**
+ * Mirrors the SDK's positional constructor. Passing it in beats mocking the
+ * module: the builder's whole job is putting values in the right slots, and a
+ * stub constructor lets the test see exactly which slot each landed in.
+ */
+class MCPServerConfig {
+  constructor(
+    readonly command?: string,
+    readonly args?: string[],
+    readonly env?: Record<string, string>,
+    readonly cwd?: string,
+    readonly url?: string,
+    readonly httpUrl?: string,
+    readonly headers?: Record<string, string>,
+    readonly tcp?: string,
+    readonly type?: string,
+    readonly timeout?: number,
+    readonly trust?: boolean,
+    readonly description?: string,
+    readonly includeTools?: string[],
+    readonly excludeTools?: string[]
+  ) {}
+}
+
+describe('buildGeminiMcpServerConfig', () => {
+  it('lands excludeTools on the SDK field, not a neighbouring positional slot', () => {
+    const config = buildGeminiMcpServerConfig(MCPServerConfig, {
+      command: 'npx',
+      args: ['-y', 'server-github'],
+      env: { GITHUB_TOKEN: 'x' },
+      cwd: '/branch',
+      excludeTools: ['create_pull_request', 'merge_pull_request'],
+    });
+
+    expect(config.excludeTools).toEqual(['create_pull_request', 'merge_pull_request']);
+    // Everything Agor never sets must stay unset — a shifted argument would
+    // silently populate one of these instead.
+    expect(config.includeTools).toBeUndefined();
+    expect(config.trust).toBeUndefined();
+    expect(config.description).toBeUndefined();
+    expect(config.timeout).toBeUndefined();
+    expect(config.tcp).toBeUndefined();
+  });
+
+  it('preserves the transport fields for each shape Agor builds', () => {
+    const stdio = buildGeminiMcpServerConfig(MCPServerConfig, {
+      command: 'npx',
+      args: ['-y', 'server-github'],
+      env: {},
+      cwd: '/branch',
+      excludeTools: [],
+    });
+    expect(stdio).toMatchObject({ command: 'npx', args: ['-y', 'server-github'], cwd: '/branch' });
+
+    const http = buildGeminiMcpServerConfig(MCPServerConfig, {
+      env: {},
+      httpUrl: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer t' },
+      excludeTools: [],
+    });
+    expect(http).toMatchObject({
+      httpUrl: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer t' },
+    });
+    expect(http.url).toBeUndefined();
+
+    const sse = buildGeminiMcpServerConfig(MCPServerConfig, {
+      env: {},
+      url: 'https://example.com/sse',
+      excludeTools: [],
+    });
+    expect(sse).toMatchObject({ url: 'https://example.com/sse' });
+    expect(sse.httpUrl).toBeUndefined();
+  });
+
+  it('leaves excludeTools unset when nothing is gated', () => {
+    const config = buildGeminiMcpServerConfig(MCPServerConfig, {
+      command: 'npx',
+      env: {},
+      excludeTools: [],
+    });
+
+    expect(config.excludeTools).toBeUndefined();
+  });
+});

--- a/packages/executor/src/sdk-handlers/gemini/mcp-server-config.ts
+++ b/packages/executor/src/sdk-handlers/gemini/mcp-server-config.ts
@@ -1,0 +1,37 @@
+/**
+ * `MCPServerConfig` takes positional arguments only, and `excludeTools` sits in
+ * the 14th slot behind a run of options Agor never sets. Funnelling every
+ * transport branch through one keyword-argument builder keeps the call sites
+ * readable and the padding in exactly one place.
+ */
+export function buildGeminiMcpServerConfig<T>(
+  MCPServerConfig: new (...args: never[]) => T,
+  options: {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+    url?: string;
+    httpUrl?: string;
+    headers?: Record<string, string>;
+    excludeTools: string[];
+  }
+): T {
+  const ctor = MCPServerConfig as unknown as new (...args: unknown[]) => T;
+  return new ctor(
+    options.command,
+    options.args,
+    options.env,
+    options.cwd,
+    options.url,
+    options.httpUrl,
+    options.headers,
+    undefined, // tcp
+    undefined, // type
+    undefined, // timeout
+    undefined, // trust
+    undefined, // description
+    undefined, // includeTools
+    options.excludeTools.length > 0 ? options.excludeTools : undefined
+  );
+}

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -24,7 +24,11 @@ const Gemini = await loadManagedAgenticToolSdk<typeof GeminiTypes>('gemini');
 type ResumedSessionData = GeminiTypes.ResumedSessionData;
 
 import { shortId } from '@agor/core/db';
-import { getMcpServersForSession } from '@agor/core/mcp';
+import {
+  getMcpServersForSession,
+  listMcpToolsWithPermission,
+  PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+} from '@agor/core/mcp';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
@@ -42,6 +46,7 @@ import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
 import { convertConversationToHistory } from './conversation-converter.js';
+import { buildGeminiMcpServerConfig } from './mcp-server-config.js';
 import { DEFAULT_GEMINI_MODEL, type GeminiModel } from './models.js';
 import { mapPermissionMode } from './permission-mapper.js';
 import { extractGeminiTokenUsage } from './usage.js';
@@ -739,12 +744,16 @@ export class GeminiPromptService {
       try {
         // Use shared MCP scoping utility. forUserId injects the prompter's
         // per-user OAuth tokens for personal OAuth-protected MCP servers.
-        const serversWithSource = await getMcpServersForSession(sessionId, {
-          sessionMCPRepo: this.sessionMCPRepo,
-          mcpServerRepo: this.mcpServerRepo,
-          mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
-          forUserId: contextUserId,
-        });
+        const serversWithSource = await getMcpServersForSession(
+          sessionId,
+          {
+            sessionMCPRepo: this.sessionMCPRepo,
+            mcpServerRepo: this.mcpServerRepo,
+            mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
+            forUserId: contextUserId,
+          },
+          { toolFiltering: 'exclude' }
+        );
 
         // Convert to Gemini SDK format
         for (const { server } of serversWithSource) {
@@ -759,35 +768,45 @@ export class GeminiPromptService {
             );
           }
 
+          const excludeTools = listMcpToolsWithPermission(
+            server,
+            PERMISSIONS_BLOCKED_WITHOUT_PROMPT
+          );
+
           // Convert Agor's MCP server format to Gemini SDK's MCPServerConfig
           if (server.transport === 'stdio') {
-            mcpServersConfig[server.name] = new Gemini.MCPServerConfig(
-              server.command,
-              server.args || [],
-              server.env || {},
-              workingDirectory // Use branch path as cwd
-            );
+            mcpServersConfig[server.name] = buildGeminiMcpServerConfig(Gemini.MCPServerConfig, {
+              command: server.command,
+              args: server.args || [],
+              env: server.env || {},
+              cwd: workingDirectory, // Use branch path as cwd
+              excludeTools,
+            });
           } else if (server.transport === 'http') {
             // HTTP transport: use httpUrl parameter
-            mcpServersConfig[server.name] = new Gemini.MCPServerConfig(
-              undefined, // command
-              undefined, // args
-              server.env || {},
-              undefined, // cwd
-              undefined, // url (websocket)
-              server.url, // httpUrl
-              headers
-            );
+            mcpServersConfig[server.name] = buildGeminiMcpServerConfig(Gemini.MCPServerConfig, {
+              env: server.env || {},
+              httpUrl: server.url,
+              headers,
+              excludeTools,
+            });
           } else if (server.transport === 'sse') {
             // SSE transport: use url parameter (websocket/sse)
-            mcpServersConfig[server.name] = new Gemini.MCPServerConfig(
-              undefined, // command
-              undefined, // args
-              server.env || {},
-              undefined, // cwd
-              server.url, // url (websocket/sse)
-              undefined,
-              headers
+            mcpServersConfig[server.name] = buildGeminiMcpServerConfig(Gemini.MCPServerConfig, {
+              env: server.env || {},
+              url: server.url, // url (websocket/sse)
+              headers,
+              excludeTools,
+            });
+          }
+
+          if (excludeTools.length > 0) {
+            const asked = listMcpToolsWithPermission(server, ['ask']);
+            console.warn(
+              `   ⛔ [Gemini] Excluding ${excludeTools.length} tool(s) on "${server.name}" per tool_permissions` +
+                (asked.length > 0
+                  ? ` (${asked.length} set to "ask"; Gemini runs headless with no approval prompt, so they fail closed)`
+                  : '')
             );
           }
 

--- a/packages/executor/src/sdk-handlers/mcp-deny-boundary.test.ts
+++ b/packages/executor/src/sdk-handlers/mcp-deny-boundary.test.ts
@@ -103,6 +103,16 @@ describe('a denied MCP tool never reaches the server', () => {
       }
 
       expect(mcp.calls).toEqual([]);
+
+      // Positive control: the same fixture under a handler that CAN filter is
+      // admitted, so the withholding above is the gate and not a resolver that
+      // returns nothing.
+      const admitted = await getMcpServersForSession(
+        'session-a' as SessionID,
+        resolutionDeps(serverRow()),
+        { toolFiltering: 'exclude' }
+      );
+      expect(admitted.map(({ server }) => server.name)).toEqual([SERVER_NAME]);
     } finally {
       await mcp.close();
     }

--- a/packages/executor/src/sdk-handlers/mcp-deny-boundary.test.ts
+++ b/packages/executor/src/sdk-handlers/mcp-deny-boundary.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Transport-level proof that a denied MCP tool never reaches its server.
+ *
+ * The original defect was integration-shaped: `tool_permissions` was persisted
+ * and every execution path ignored it. A test that only re-checks a decision
+ * function cannot catch that class, so these cases run a REAL MCP server over
+ * the real protocol and assert on the server's own `tools/call` counter.
+ *
+ * Each case carries a positive control — an allowed call that must arrive. A
+ * zero counter only means something if the same harness can deliver.
+ *
+ * Boundary of the proof: the last hop into Claude's own rule matcher runs
+ * inside the Claude CLI, which needs credentials and a live model turn, so the
+ * config it would consume is applied here instead. Everything upstream of that
+ * — scoping, admission, index construction, hook and callback decisions — is
+ * the production code path.
+ */
+
+import {
+  getMcpServersForSession,
+  listMcpToolsWithPermission,
+  PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+} from '@agor/core/mcp';
+import type { MCPServer, SessionID, TaskID } from '@agor/core/types';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMcpToolPermissionHook } from './base/mcp-tool-permission-hook.js';
+import {
+  buildMcpToolPermissionIndex,
+  mcpToolNameAliasesForServer,
+} from './base/mcp-tool-permissions.js';
+import { createCanUseToolCallback } from './base/permission-hooks.js';
+
+const SERVER_NAME = 'files';
+const DENIED_TOOL = 'write_file';
+const ALLOWED_TOOL = 'read_file';
+
+/** A real MCP server that records every tool invocation that reaches it. */
+async function startCountingMcpServer() {
+  const calls: string[] = [];
+  const server = new McpServer({ name: SERVER_NAME, version: '1.0.0' });
+
+  for (const toolName of [DENIED_TOOL, ALLOWED_TOOL]) {
+    server.tool(toolName, async () => {
+      calls.push(toolName);
+      return { content: [{ type: 'text' as const, text: 'ok' }] };
+    });
+  }
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: 'harness', version: '1.0.0' });
+  await client.connect(clientTransport);
+
+  return { calls, client, close: () => client.close() };
+}
+
+function serverRow(): MCPServer {
+  return {
+    mcp_server_id: 'files-server',
+    name: SERVER_NAME,
+    transport: 'stdio',
+    command: 'noop',
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+    tools: [{ name: DENIED_TOOL, description: '' }],
+    tool_permissions: { [DENIED_TOOL]: 'deny' },
+  } as unknown as MCPServer;
+}
+
+function resolutionDeps(server: MCPServer) {
+  return {
+    mcpServerRepo: { findAll: vi.fn() } as never,
+    sessionMCPRepo: { listEffectiveServers: vi.fn().mockResolvedValue([server]) } as never,
+  };
+}
+
+describe('a denied MCP tool never reaches the server', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is not reachable on a handler that cannot filter tools, because the server is withheld', async () => {
+    const mcp = await startCountingMcpServer();
+    try {
+      // Production scoping + admission decides what the handler may attach.
+      const attached = await getMcpServersForSession(
+        'session-a' as SessionID,
+        resolutionDeps(serverRow()),
+        {
+          toolFiltering: 'none',
+        }
+      );
+
+      // A handler can only dispatch to a server it was handed.
+      const reachable = new Set(attached.map(({ server }) => server.name));
+      expect(reachable.has(SERVER_NAME)).toBe(false);
+
+      if (reachable.has(SERVER_NAME)) {
+        await mcp.client.callTool({ name: DENIED_TOOL, arguments: {} });
+      }
+
+      expect(mcp.calls).toEqual([]);
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  it('is blocked at the Claude gates while an allowed tool still gets through', async () => {
+    const mcp = await startCountingMcpServer();
+    try {
+      const attached = await getMcpServersForSession(
+        'session-a' as SessionID,
+        resolutionDeps(serverRow()),
+        {
+          toolFiltering: 'exclude',
+        }
+      );
+      // An `exclude` handler keeps the server — enforcement is per tool.
+      expect(attached.map(({ server }) => server.name)).toEqual([SERVER_NAME]);
+
+      const servers = attached.map(({ server }) => server);
+      const index = buildMcpToolPermissionIndex(servers);
+
+      // The exact config `setupQuery` hands the SDK.
+      const disallowedTools = new Set(
+        servers.flatMap((server) =>
+          listMcpToolsWithPermission(server, PERMISSIONS_BLOCKED_WITHOUT_PROMPT).flatMap((tool) =>
+            [...new Set(mcpToolNameAliasesForServer(server.name))].map(
+              (alias) => `mcp__${alias}__${tool}`
+            )
+          )
+        )
+      );
+      const preToolUse = createMcpToolPermissionHook(index, true);
+      const canUseTool = createCanUseToolCallback('session-a' as SessionID, 't1' as TaskID, {
+        permissionService: {
+          emitRequest: vi.fn(),
+          waitForDecision: vi.fn(),
+          cancelPendingRequests: vi.fn(),
+        } as never,
+        tasksService: { patch: vi.fn().mockResolvedValue(undefined) } as never,
+        messagesRepo: { findBySessionId: vi.fn().mockResolvedValue([]) } as never,
+        sessionsService: { patch: vi.fn().mockResolvedValue(undefined) } as never,
+        permissionLocks: new Map(),
+        mcpServerRepo: {} as never,
+        sessionMCPRepo: {
+          listServers: vi.fn().mockResolvedValue([{ name: SERVER_NAME }]),
+        } as never,
+        mcpToolPermissions: index,
+      });
+
+      // Applies the gates in the SDK's documented order, then dispatches over
+      // the real transport. Anything the gates permit genuinely runs.
+      async function attempt(bareTool: string) {
+        const sdkToolName = `mcp__${SERVER_NAME}__${bareTool}`;
+        if (disallowedTools.has(sdkToolName)) return 'blocked-by-rule';
+
+        const hook = await preToolUse(
+          {
+            hook_event_name: 'PreToolUse',
+            tool_name: sdkToolName,
+            tool_input: {},
+            tool_use_id: 'u1',
+          } as never,
+          'u1',
+          { signal: new AbortController().signal }
+        );
+        if (hook.hookSpecificOutput?.permissionDecision === 'deny') return 'blocked-by-hook';
+
+        const decision = await canUseTool(
+          sdkToolName,
+          {},
+          {
+            signal: new AbortController().signal,
+          }
+        );
+        if (decision.behavior !== 'allow') return 'blocked-by-callback';
+
+        await mcp.client.callTool({ name: bareTool, arguments: {} });
+        return 'dispatched';
+      }
+
+      expect(await attempt(DENIED_TOOL)).toBe('blocked-by-rule');
+      expect(mcp.calls).toEqual([]);
+
+      // Positive control: the harness can reach the server, so the empty
+      // counter above is enforcement and not a broken test.
+      expect(await attempt(ALLOWED_TOOL)).toBe('dispatched');
+      expect(mcp.calls).toEqual([ALLOWED_TOOL]);
+    } finally {
+      await mcp.close();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1152,6 +1152,9 @@ importers:
       '@google/genai':
         specifier: ^1.43.0
         version: 1.43.0(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(supports-color@8.1.1)
+      '@modelcontextprotocol/sdk':
+        specifier: '>=1.29.0 <2'
+        version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       '@openai/codex-sdk':
         specifier: ^0.144.0
         version: 0.144.0


### PR DESCRIPTION
## Problem

`mcp_servers.data.tool_permissions` (`Record<string, 'ask' | 'allow' | 'deny'>`) was persisted, settable via `agor_mcp_servers_update`, and typed in `packages/core/src/types/mcp.ts` — but never read by any handler. Write-only config: set `write_file: deny` and the executor called `write_file` anyway.

## What this does

Enforces it at the point each SDK decides whether a tool call proceeds. The mechanism is necessarily per-handler — the tool list a model sees is discovered live from the MCP server by each SDK, not read from the cached `server.tools` snapshot, so the three SDKs expose three non-unifiable filter primitives.

| Handler | `deny` | `ask` |
| --- | --- | --- |
| Claude | `disallowedTools` + `PreToolUse` hook + `canUseTool` | routes to the existing permission prompt |
| Gemini | `excludeTools` (dropped at discovery) | fails closed — no prompt channel |
| Codex | `disabled_tools` | fails closed — no prompt channel |
| Copilot | per-server `tools` include-list | fails closed (see caveat below) |
| Copilot / Cursor / OpenCode | server withheld entirely | server withheld entirely |

`allow` and unlisted tools are unchanged throughout.

**Namespacing.** `tool_permissions` is keyed on the bare tool name; SDKs qualify differently — Claude `mcp__<server>__<tool>`, Gemini bare (or `<server>__<tool>` on collision), Codex per-server config. `base/mcp-tool-permissions.ts` bridges this with longest-server-prefix matching and sanitized/lowercased name aliases.

**Admission gate.** `getMcpServersForSession` now takes a required `HandlerPermissionCapabilities` and withholds any server whose permissions the calling handler cannot honour, reusing the existing template-resolution drop pattern. Six call sites resolve MCP servers; three originally enforced. Making the argument required means a new handler can't repeat that omission silently.

## Security fixes found during architectural review

Both predate this branch and are independent of the original bug:

- **`allowedTools` was a permission-rule injection sink.** It was fed `server.tools[].name` — whatever a remote MCP server returns from `tools/list`, stored verbatim. The SDK defines `allowedTools` as *"auto-allowed without prompting"* and it matches **built-in** tool names, so an attached server advertising a tool called `Bash` silently disabled the permission prompt for the built-in Bash. It was also inert for its stated purpose, since bare names never match `mcp__server__tool`. Removed; the false `MCPTool.name` comment that made it look correct is fixed.
- **A DB server named `agor` could hijack the built-in Agor MCP namespace.** User servers were spread over the built-in config, so a server named `agor` inherited the session's daemon bearer token *and* `permission-hooks`' unconditional auto-approve. Codex already guarded this; Claude had the spread backwards. The key is now reserved.

Also closed: a stale `settings.json` allow rule (written by Agor itself on "remember") could skip an `ask` gate, since the SDK matches rules before `canUseTool` — a `PreToolUse` hook now decides first. And `ask` no longer degrades to `allow` under `bypassPermissions`.

## Testing

44 new tests. The deny path is asserted at the dispatch boundary — calls are routed through a stand-in for the SDK's forward step that only reaches the server on `allow`, so a deny that still dispatched would fail. Coverage: deny / ask / allow / unlisted-default, namespaced-vs-bare mapping, the admission gate across all three capability shapes, `bypassPermissions`, and both security fixes above.

`pnpm check` passes (typecheck, lint 2100 files, shortid, multitenancy-boundaries, 15 builds). Executor 661/661, core 3093 passed / 47 skipped, agentic-tool-opencode 135/135.

Gate assertions are confirmed load-bearing by mutation rather than by a green run. Flipping `canEnforceMcpToolPermissions` to admit under `toolFiltering: 'none'` fails the admission and process-boundary cases; dropping the `ask` promotion fails the `bypassPermissions` case; dropping the tool-half rewrite fails three cases, and reverting it on the `disallowedTools` emission alone still fails one — so the index and emission paths are independently covered.

### Test-methodology notes

Two green runs in this PR proved less than they appeared to, both worth recording because the failure mode is silent:

- **A mutation check against a stale build passes.** `packages/agentic-tool-opencode` resolves `@agor/core` from `dist`, so flipping the gate in `src` and re-running the suite showed all green. It only failed after `pnpm --filter @agor/core build`. Any mutation check in that package is worthless without a rebuild first.
- **A negative assertion with no positive control can pass on an empty fixture.** `getMcpServersForSession` is module-mocked in `query-builder.test.ts`, so a repo-shaped fixture returned nothing and `not.toContain` succeeded vacuously. Caught only because a positive assertion alongside it failed.

The second generalises, and it is the same defect as the hand-rolled `admit()` helper deleted from the admission test: **every `not.toContain`-style assertion in this PR now carries a positive control in the same test**, proving the fixture produced something before its absence is read as enforcement. Four lacked one and were fixed — the `ask` admission case, the promptable-mode case, the withheld-server dispatch case, and the scoping withhold case.


## Reporting a withheld server

The admission gate withholds a server whose `tool_permissions` a handler cannot enforce. Three handlers declare `toolFiltering: 'none'` and can therefore reach that branch — OpenCode, Copilot, Cursor — but only OpenCode said so. The other two dropped the server with nothing but a `console.warn` in a process an operator cannot read, which with no UI for `tool_permissions` is indistinguishable from a broken server. All three now report into the session.

Moving it surfaced three defects in the notice itself:

- **Index came from a page, not a count.** `find({ $sort })` returns one page capped at the service's pagination limit, so `messages.length` stopped being the index past that point, and pulled up to 10k rows to compute a scalar. `countBySessionId` uses `$limit: 0` and reads `total`, matching the idiom already in `base-executor.ts`.
- **Unattributed.** The notice now carries `task_id`.
- **Raced the turn.** Fired as bare `void`, it competed with the turn's own messages for an index. Withheld servers are buffered during scoping and written once, awaited, before the turn starts.

The three `toolFiltering: 'exclude'` handlers pass no callback and correctly do not need one — `canEnforceMcpToolPermissions` returns `true` unconditionally there, so the withhold branch is unreachable.

## Claude's name rewrite: verified, not assumed

`mcpToolNameAliasesForServer` guessed how the Claude CLI rewrites a server name, and a miss reads as "unconfigured", i.e. allow. Checked against the pinned `@anthropic-ai/claude-agent-sdk@0.3.197`, whose `--mcp-config` payload is consumed by the vendored `claude` binary:

```js
function Gl(e){ let t = e.replace(/[^a-zA-Z0-9_-]/g, "_");
                if (e.startsWith("claude.ai ")) t = t.replace(/_+/g,"_").replace(/^_|_$/g,"");
                return t }
function R9(e,t){ return `mcp__${Gl(e)}__${Gl(t)}` }
```

The server half matches the guess exactly, and the `claude.ai ` branch is unreachable from Agor config — that prefix is minted internally by Claude's own connector proxy.

**The tool half was a live fail-open, and is fixed here.** `R9` applies the same rewrite to the tool name, and `isToolDisallowed` compares `disallowedTools` against `R9(...)`, so a rule must equal the fully-rewritten form to bind. Only the server half was aliased. `tool_permissions` is keyed on the bare name exactly as the MCP server advertises it, and a server is free to advertise `repo.create` — which registers as `mcp__gh__repo_create` while our deny entry said `mcp__gh__repo.create` and matched nothing. The index missed the same way, and a miss reads as unconfigured, i.e. allow. Narrow trigger, silent failure, on the gate itself.

Both halves are now aliased on both paths that construct or match a namespaced name, so a name cannot bind in one and miss in the other. No lowercase variant for the tool half: the rewrite preserves case, and folding it would let a `Foo` denial capture an unrelated `foo` on the same server.

## Known follow-ups

Filed rather than done, to keep this PR to one change:

- **C6 — make `caps` demonstrated rather than declared**, by attaching an `onBlockedTools` sink to the `'exclude'` variant, so a handler cannot claim the capability without supplying where the exclusion happens.
- **C7 — merge rather than overwrite `config.disabled_tools`** on Codex.
- Freeze `EMPTY_MCP_TOOL_PERMISSION_INDEX` — it is a shared mutable `Map`.
- Move `AGOR_MCP_SERVER_NAME` next to `canEnforceMcpToolPermissions`.

Worth recording: `CodexConfigObject` is an untyped bag, so nothing in the type system would have caught `disabled_tools` being the wrong key. It was verified independently against the 0.144.0 binary — a real serde field, adjacent to `enabled_tools` in the string table, with a runtime diagnostic.

## OpenCode: reconciliation obsoleted by main's rewrite

Earlier revisions of this PR carried a reconciliation layer for OpenCode — a durable record of what Agor had registered, session-namespaced keys, and withdrawal via `mcp.disconnect` — built to fix a real bug: OpenCode retained dynamically added MCP clients, so a server used once stayed callable after its `tool_permissions` changed. That analysis was correct at the time, and the finding that drove it (`MCP.status` at 1.14.33 enumerates configured `cfg.mcp` entries only, so anything added via `POST /mcp` was live but unlistable) held up against both the shipped binary and the tagged source.

**Main has since rebuilt the OpenCode integration and the problem no longer exists.** In `packages/agentic-tool-opencode/`:

- `startManagedOpenCodeServer(...)` (`opencode-tool.ts:574`) spawns a server **per invocation**, torn down after the turn.
- MCP config arrives declaratively through `OPENCODE_CONFIG_CONTENT` (`:579`), described in-code at `:567` as the highest-precedence, invocation-scoped configuration.
- `mcp.add` / `mcp.disconnect` / `mcp.status` appear **nowhere** in the package.

Nothing survives a turn, so there is no registry to go stale and nothing to reconcile. The reconciliation layer was dropped rather than ported — keeping it would have shipped dead code whose comments assert facts about a long-lived registry that no longer exists.

Main also arrived independently at both naming fixes this PR had made: keys are `agor_${shortId(sessionId)}_${shortId(server.mcp_server_id)}_${sanitizedName}` (`:808`) — session-namespaced *and* id-derived, rather than sanitized display names. Independent corroboration of the analysis, not a coincidence.

**The architect's cross-session concern is resolved by the same change.** With a per-invocation server there is no directory-shared client state, so one session can neither inherit nor tear down another's servers.

**What enforces OpenCode now:** the admission gate alone. `{ toolFiltering: 'none' }` at its resolution call site withholds any server carrying `deny` or `ask`, and `onServerWithheld` reports it into the session so a missing server is distinguishable from a broken one. `packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts` asserts at the real boundary: it runs the production `getMcpServersForSession` rather than a local restatement of the policy, checks the gated server is absent from the `OPENCODE_CONFIG_CONTENT` actually handed to the spawned process, and confirms `onServerWithheld` fired — with an ungated server present throughout as a positive control.

## Known gaps — not fixed here

- **Copilot's permission handler never consults `tool_permissions`.** Its `isAttachedMcpServer` auto-approve fast path — the hole closed on Claude — is still open at runtime. Copilot is now a withhold-only handler, so a gated server never reaches it; but a server with no gated tools still gets blanket auto-approve there.
- **Subagent propagation unverified.** Whether `disallowedTools` and hooks reach Task-tool sidechains could not be confirmed from the minified CLI bundle. Wants one integration test.
- **Out of scope per the brief:** no UI for `tool_permissions` (only agents can set it today), no validation of keys against the discovered tool list (a typo'd key is a silently ineffective deny), and no server-name validation at the REST boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




