### PR TITLE
fix(auth): propagate launch-claim unix_username to the runtime user + executor

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -83,6 +83,7 @@ function makeUsersService(db: Database) {
         name: row.name ?? undefined,
         emoji: row.emoji ?? undefined,
         role: row.role as User['role'],
+        unix_username: row.unix_username ?? undefined,
         onboarding_completed: row.onboarding_completed,
         must_change_password: row.must_change_password,
         tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
@@ -268,6 +269,19 @@ describe('one-time launch auth service', () => {
       external_launch: { ...baseConfig().external_launch, allow_admin_roles: true },
     }).create({ launchCode: 'admin-role' });
     expect(allowedResult.user.role).toBe('admin');
+  });
+
+  it('applies the launch claim unix_username to the runtime user', async () => {
+    mockExchange(
+      signClaims({ sub: 'unix-user', email: 'unix@example.test', unix_username: 'jose_garcia' })
+    );
+    const created = await service().create({ launchCode: 'unix-code' });
+    expect(created.user.unix_username).toBe('jose_garcia');
+
+    // A repeat launch keeps it in sync, and never nulls it when the claim omits it.
+    mockExchange(signClaims({ sub: 'unix-user', email: 'unix@example.test' }));
+    const relaunched = await service().create({ launchCode: 'unix-code-2' });
+    expect(relaunched.user.unix_username).toBe('jose_garcia');
   });
 
   it('repeat login maps the same external identity to the same local user', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -86,6 +86,7 @@ interface LaunchClaims extends JwtPayload {
   picture?: string;
   avatar?: string;
   role?: string;
+  unix_username?: string | null;
   provider?: string;
   instance_id?: string;
   runtime_instance_id?: string;
@@ -336,6 +337,7 @@ async function upsertLaunchUser(
   const nowIso = now.toISOString();
   const email = normalizeLaunchEmail(claims.email);
   const name = claims.name?.trim() || undefined;
+  const unixUsername = claims.unix_username?.trim() || null;
   const avatar = claims.avatar || claims.picture;
   const identity: StoredExternalIdentity = {
     key,
@@ -370,6 +372,7 @@ async function upsertLaunchUser(
       .set({
         name: name ?? existing.name,
         role,
+        unix_username: unixUsername ?? existing.unix_username,
         updated_at: now,
         data: {
           ...data,
@@ -398,6 +401,7 @@ async function upsertLaunchUser(
       name,
       emoji: '👤',
       role,
+      unix_username: unixUsername,
       created_at: now,
       updated_at: now,
       onboarding_completed: false,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -979,7 +979,7 @@ function createExecuteHandler(
       templateVariables: {
         session_id: sessionId,
         task_id: taskId,
-        unix_user: executorUnixUser || undefined,
+        unix_user: sessionUnixUser || executorUnixUser || undefined,
       },
       onSpawn: (child, spawnContext) => {
         if (spawnContext.mode === 'local' && child.pid) {


### PR DESCRIPTION
Makes a Cloud/externally-launched user's `unix_username` actually reach the runtime, so per-user SDK/home isolation works instead of collapsing every session into one shared home. Two independent gaps, both in the launch → session → executor identity chain.

## Problem

The trusted launch claim already carries `unix_username` (the control-plane membership value), but it was being dropped in two places:

1. **The runtime never applied it.** `upsertLaunchUser` never read `claims.unix_username` — it wasn't in the `LaunchClaims` type and was set on neither the create nor update path. So every externally-launched user had a **null `unix_username`**, which cascades to a null `session.unix_username` (stamped from the user) and a shared executor home.

2. **`simple` mode dropped it again at the executor launch.** The executor-launch template var `unix_user` was bound to `executorUnixUser` (the `sudo -u` impersonation target), which is **null under `unix_user_mode: simple`**. So even a populated `session.unix_username` never reached the executor — remote/ephemeral executors received no identity and fell back to a shared home.

## Changes

- **`auth/launch-auth.ts`** — add `unix_username` to `LaunchClaims` and apply it in `upsertLaunchUser` on both create and update. On update it syncs from the claim but never nulls an existing value when the claim omits it (so a manually-set value survives).
- **`register-services.ts`** — bind the executor-launch `unix_user` template var to the **session user's** `unix_username` (already stamped at creation), independent of the `sudo -u` impersonation target. `asUser` stays `executorUnixUser`, so `simple` mode still does no impersonation.

## Effect

`unix_username` now flows end-to-end: membership → launch claim → runtime user → `session.unix_username` → executor `--unix-user`. Combined with the agor-cloud side (preset-io/agor-cloud#202, which names the per-user home from `run.unixUser`), a user's SDK state and home land under their own identity instead of a shared `_shared` directory.

## Notes / follow-ups

- Test harness: `launch-auth.test.ts`'s mock users-service mapping omits `unix_username`, so a `result.user.unix_username` assertion needs that mapping extended first — adding as a follow-up.
- Admin role is a **separate** concern (the claim's `owner` role is correctly mapped to superadmin but capped to MEMBER unless the Cell sets `external_launch.allow_admin_roles: true`) — handled on the agor-cloud side, not here.
