### PR TITLE
fix(terminals): enable the web terminal in the ephemeral-pod topology (daemon-host zellij gate)

### DIFF
--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => {
     resolveUserEnvironment: vi.fn(async () => ({})),
     createUserProcessEnvironment: vi.fn(async () => ({})),
     loadConfig: vi.fn(async () => ({ daemon: { port: 3030 }, execution: { branch_rbac: false } })),
+    loadConfigSync: vi.fn(() => ({ daemon: { port: 3030 }, execution: { branch_rbac: false } })),
   };
 });
 
@@ -38,6 +39,7 @@ vi.mock('node:child_process', () => ({
 vi.mock('@agor/core/config', () => ({
   createUserProcessEnvironment: mocks.createUserProcessEnvironment,
   loadConfig: mocks.loadConfig,
+  loadConfigSync: mocks.loadConfigSync,
   resolveUserEnvironment: mocks.resolveUserEnvironment,
 }));
 
@@ -173,6 +175,42 @@ describe('TerminalsService tenant database units of work', () => {
       'Missing active tenant context for terminal creation'
     );
     expect(mocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerminalsService Zellij availability by topology', () => {
+  beforeEach(() => {
+    mocks.branchesById.clear();
+    mocks.branchesById.set(mocks.branch.branch_id, mocks.branch);
+    mocks.resolveUserEnvironment.mockResolvedValue({});
+    mocks.createUserProcessEnvironment.mockResolvedValue({});
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: null });
+    // No Zellij on the daemon host.
+    mocks.execSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
+      throw new Error('not found');
+    });
+  });
+
+  it('rejects creation when Zellij is absent on the host and execution is not offloaded', async () => {
+    mocks.loadConfigSync.mockReturnValue({ daemon: { port: 3030 }, execution: {} });
+    const service = new TerminalsService(makeApp() as never, {} as never);
+
+    await expect(
+      service.create({ branchId: mocks.branch.branch_id }, params as never)
+    ).rejects.toThrow('Zellij is not installed');
+    expect(mocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
+  });
+
+  it('treats Zellij as available when execution is offloaded, without host Zellij', async () => {
+    mocks.loadConfigSync.mockReturnValue({
+      daemon: { port: 3030 },
+      execution: { executor_command_template: 'run {tenant_id}' },
+    });
+    const service = new TerminalsService(makeApp() as never, {} as never);
+
+    await service.create({ branchId: mocks.branch.branch_id }, params as never);
+    expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -26,6 +26,7 @@ import path from 'node:path';
 import {
   createUserProcessEnvironment,
   loadConfig,
+  loadConfigSync,
   resolveUserEnvironment,
 } from '@agor/core/config';
 import {
@@ -249,8 +250,9 @@ export class TerminalsService {
       }
     );
 
-    // Check if Zellij is available - warn but don't fail
-    this.zellijAvailable = isZellijAvailable();
+    // Templated execution runs the PTY in the executor image, not the daemon host.
+    const executionOffloaded = Boolean(loadConfigSync().execution?.executor_command_template);
+    this.zellijAvailable = executionOffloaded || isZellijAvailable();
 
     if (!this.zellijAvailable) {
       if (!zellijWarningShown) {


### PR DESCRIPTION
## Problem

The web terminal shows "Zellij isn't installed on the daemon host" and is disabled on Cloud Cells, even though the daemon isn't where the shell runs.

`TerminalsService` probes `which zellij` **on the daemon host** and sets `zellijAvailable` from it. But the terminal spawns an executor with `command: 'zellij.attach'` — so under `executor_command_template` (ephemeral/templated execution) the PTY runs in the **executor image**, in a separate pod. The daemon-host probe is a leftover from the `local_process` model where the executor ran as a subprocess on the daemon host. The `agor-daemon` image has no zellij, so the gate always fails in the pod topology.

## Change

`terminals.ts` — when execution is offloaded (`execution.executor_command_template` set), treat zellij as available (it's in the executor image); otherwise keep the daemon-host probe for `local_process`:

    const executionOffloaded = Boolean(loadConfigSync().execution?.executor_command_template);
    this.zellijAvailable = executionOffloaded || isZellijAvailable();

## Pairs with

**preset-io/agor-cloud** — adds `zellij` to `Dockerfile.executor` (the image where the PTY actually runs). Both are needed together.

## Not covered (follow-up)

The session-adoption logic (`pgrep -f 'zellij attach …'`) also `pgrep`s the daemon host, so reconnecting to a **surviving** session after a daemon restart still assumes daemon/executor co-location and won't find pod-based executors. Basic spawn -> PTY streaming works (the executor connects back to the daemon service); adoption/reconnect-after-restart needs a separate rework.
