### PR TITLE
fix(ui): allow clearing the inherited advisor model when starting a new session

### DIFF
--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
@@ -6,6 +6,7 @@ import {
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildModelConfigFromFormValues } from '../AgenticToolConfigForm/agenticConfigHelpers';
 import { AgenticConfigChipRow } from './AgenticConfigChipRow';
 
 const storeSettings = vi.hoisted(() => ({ inlineAllowed: true }));
@@ -33,10 +34,19 @@ vi.mock('../ModelSelector', async () => {
         change model
       </button>
     ),
-    AdvisorModelSelect: ({ onChange }: { onChange: (value: string) => void }) => (
-      <button type="button" data-testid="advisor-select" onClick={() => onChange('advisor-model')}>
-        choose advisor
-      </button>
+    AdvisorModelSelect: ({ onChange }: { onChange: (value: string | undefined) => void }) => (
+      <>
+        <button
+          type="button"
+          data-testid="advisor-select"
+          onClick={() => onChange('advisor-model')}
+        >
+          choose advisor
+        </button>
+        <button type="button" data-testid="advisor-clear" onClick={() => onChange(undefined)}>
+          clear advisor
+        </button>
+      </>
     ),
   };
 });
@@ -110,16 +120,24 @@ function Harness({
         enableSaveAsDefault
       />
       <Form.Item shouldUpdate noStyle>
-        {() => (
-          <span data-testid="state">
-            {JSON.stringify({
-              src: form.getFieldValue('agenticToolPresetId'),
-              model: (form.getFieldValue('modelConfig') as { model?: string } | undefined)?.model,
-              perm: form.getFieldValue('permissionMode'),
-              effort: form.getFieldValue('effort'),
-            })}
-          </span>
-        )}
+        {() => {
+          const modelConfig = form.getFieldValue('modelConfig') as
+            | { model?: string; advisorModel?: string }
+            | undefined;
+          return (
+            <span data-testid="state">
+              {JSON.stringify({
+                src: form.getFieldValue('agenticToolPresetId'),
+                model: modelConfig?.model,
+                perm: form.getFieldValue('permissionMode'),
+                effort: form.getFieldValue('effort'),
+                // Round-trip through the submit path so the assertion proves what
+                // the created session receives, not just the form field.
+                submittedModelConfig: buildModelConfigFromFormValues({ modelConfig }),
+              })}
+            </span>
+          );
+        }}
       </Form.Item>
     </Form>
   );
@@ -232,6 +250,39 @@ describe('AgenticConfigChipRow', () => {
     fireEvent.click(await screen.findByTestId('advisor-select'));
 
     await waitFor(() => expect(chip).toHaveTextContent('Advisor: advisor-model'));
+  });
+
+  it('surfaces an advisor inherited from "My default" and clears it as a custom override', async () => {
+    const userWithAdvisor = {
+      user_id: 'u4',
+      default_agentic_config: {
+        'claude-code': {
+          modelConfig: { model: 'claude-opus-4-8', advisorModel: 'claude-haiku-4-5' },
+          permissionMode: 'acceptEdits',
+        },
+      },
+    } as unknown as User;
+
+    render(<Harness user={userWithAdvisor} initialSource={USER_DEFAULT_AGENTIC_CONFIGURATION} />);
+
+    // The inherited advisor is visible without first switching to Custom.
+    const chip = await screen.findByTestId('advisor-chip');
+    expect(chip).toHaveTextContent('Advisor: Haiku 4.5');
+
+    fireEvent.click(chip);
+    fireEvent.click(await screen.findByTestId('advisor-clear'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('advisor-chip')).toHaveTextContent('Advisor: Off')
+    );
+
+    const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
+    // Clearing overrides only this session: the source flips to Custom…
+    expect(state.src).toBe('__inline__');
+    // …seeded from the resolved default, minus the advisor.
+    expect(state.model).toBe('claude-opus-4-8');
+    expect(state.perm).toBe('acceptEdits');
+    expect(state.submittedModelConfig).not.toHaveProperty('advisorModel');
   });
 
   it('shows inherited Codex effort and turns an explicit selection into a custom override', async () => {

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -152,7 +152,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const resolvedPermission = resolved.permissionMode || getDefaultPermissionMode(tool);
   const explicitEffort = isInline ? formEffort : resolved.modelConfig?.effort;
   const resolvedEffort = explicitEffort ?? toolCapabilities.defaultReasoningEffort;
-  const advisorModel = isInline ? formModelConfig?.advisorModel : undefined;
+  const advisorModel = resolved.modelConfig?.advisorModel;
   const mcpCount = formMcp?.length ?? 0;
 
   // Seed inline fields from the currently-resolved config, then flip to Custom.
@@ -188,6 +188,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
     form.setFieldValue('effort', effort);
   };
   const onAdvisorChange = (advisor: string | undefined) => {
+    ensureCustom();
     const current = (form.getFieldValue('modelConfig') as ModelConfig | undefined) ?? {
       mode: 'alias',
       model: resolvedModel,
@@ -352,13 +353,14 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
           )}
         />
 
-        {/* Advisor — only meaningful (and applied) while inline config is active */}
-        {isClaude && isInline && (
+        {/* Advisor — applied from any source, so it must stay clearable from any source */}
+        {isClaude && (
           <EditableChip
             icon={<InfoCircleOutlined />}
             label={advisorModel ? `Advisor: ${shortModelName(tool, advisorModel)}` : 'Advisor: Off'}
             title="Advisor model"
-            editable
+            editable={inlineAllowed}
+            managedNote={managedNote}
             width={340}
             testid="advisor-chip"
             renderContent={() => (


### PR DESCRIPTION
## Problem

A user with a Claude Code **advisor model** saved in their personal default agentic config inherited that advisor on **every** new session, with no way to see or turn it off for a single session from the New Session modal. Reported by Joe (admin).

## Root cause

`AgenticConfigChipRow` rendered the advisor chip only when the configuration source was inline (`Custom`):

```tsx
const advisorModel = isInline ? formModelConfig?.advisorModel : undefined;
...
{isClaude && isInline && ( <EditableChip ... /> )}
```

But the advisor is applied from **any** source: for `My default`, `resolveConfiguration` returns the user's `default_agentic_config['claude-code']` blob — advisor included — and `NewSessionModal.handleCreate` submits that `modelConfig`. The advisor was therefore active while invisible, and only became visible/clearable after manually switching the source to `Customize for this session…`. The old inline comment ("only meaningful (and applied) while inline config is active") was factually wrong.

Every other resolved chip (model, permission, effort) already followed the intended pattern — show the resolved value from any source, and call `ensureCustom()` on edit to override just this session. The advisor chip was simply left out of it.

## Fix

- Derive the chip value from `resolved.modelConfig?.advisorModel` so it reflects `My default` / preset / inline alike (inline still shows live edits, since `configForSource(INLINE)` returns the live form `modelConfig`).
- Render the chip for Claude regardless of source, with `editable={inlineAllowed}` and `managedNote` so admin-managed setups show the managed note instead of an editable control — consistent with the sibling chips.
- `onAdvisorChange` now calls `ensureCustom()` first, then merges onto the (possibly just-seeded) `modelConfig`, so editing or clearing from the `My default` view works and overrides only this session.

Clearing sets `advisorModel: undefined`, which is dropped downstream by `buildModelConfigFromFormValues` → `resolveModelConfig` (it only writes `advisorModel` when `!== undefined`), so the created session ends up with **no** advisor.

This brings the new-session path to parity with the running-session path in `SessionPanel.handleModelConfigChange`, which already deletes `advisorModel` when the advisor is cleared.

## Tests

Added coverage in `AgenticConfigChipRow.test.tsx`: with a user whose `default_agentic_config['claude-code']` carries an `advisorModel` and source = `My default` (not inline), the advisor chip is visible and shows the advisor; clearing it flips the source to `__inline__`, keeps the seeded model/permission, and produces a `modelConfig` with no `advisorModel` — asserted through `buildModelConfigFromFormValues`, i.e. the actual submit path. Verified the new test fails without the component change.

Existing assertions were not weakened: the codex "no advisor chip" test and the inline advisor test remain green.

## Verification

- `pnpm vitest run src/components/AgenticConfigChipRow` — 11 passed
- Consumers of the shared chip row: `NewSessionModal`, `ForkSpawnModal`, `SessionSettingsModal`, `AgenticToolConfigForm` suites — 32 passed
- `pnpm typecheck --filter=agor-ui` — clean
- `biome check` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)