### PR TITLE
feat(execution): add 'delegated' unix_user_mode — required unix_username without sudo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,25 +74,25 @@ agor/
 
 Terms you'll see across the codebase, UI, and docs:
 
-| Term               | What it is                                                                                                                                                                                      |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Branch**         | A first-class git working directory at `~/.agor/worktrees/<repo>/<name>`, on its own branch, with its own dev environment. **Primary card on a board.** Conventionally 1 branch = 1 feature/PR. |
-| **Board**          | 2D canvas displaying branches as cards. Has zones.                                                                                                                                              |
-| **Zone**           | Rectangular region on a board with an optional Handlebars **prompt template** that fires when a branch is dropped in.                                                                           |
-| **Card**           | Visual representation of a branch (or note/markdown) on a board.                                                                                                                                |
-| **Session**        | An agent conversation. Required FK to a branch. Can **fork** (sibling, copies parent context) or **spawn** (child, fresh context window).                                                       |
-| **Task**           | A single user-prompt-and-its-execution within a session. Tasks (not messages) are the queueable unit when a session is busy.                                                                    |
-| **Message**        | An individual conversation turn (user / assistant / tool / system) within a task.                                                                                                               |
-| **Report**         | Agent-written markdown summary at task completion.                                                                                                                                              |
-| **Environment**    | The runtime instance of a branch's dev server (managed start/stop, ports allocated from `branch.unique_id`).                                                                                    |
-| **Daemon**         | The FeathersJS server (`apps/agor-daemon`) that owns the database, services, WebSocket events, and MCP HTTP endpoint. Default port 3030.                                                        |
-| **Executor**       | Process-isolated agent runtime in `packages/executor/`. Spawns Claude / Codex / Gemini / OpenCode via their SDKs. May run as a separate Unix user.                                              |
-| **MCP**            | Model Context Protocol. Agor exposes itself as an MCP server (`POST /mcp`) so agents can introspect sessions, branches, boards, etc.                                                            |
-| **RBAC**           | Branch-scoped permission tiers (`none`/`view`/`session`/`prompt`/`all`). Feature-flagged via `execution.branch_rbac`. See "Feature Flags" below.                                                |
-| **Unix user mode** | `simple` / `insulated` / `strict` — progressive OS-level isolation tiers. See "Feature Flags" below.                                                                                            |
-| **Genealogy**      | Parent/child + fork ancestry of a session. Surfaced as a tree inside a branch card.                                                                                                             |
-| **Short ID**       | First 8 chars of a UUIDv7, used in UI and CLI. Resolved at API boundary via a `resolveShortId` hook. See [`context/concepts/id-management.md`](context/concepts/id-management.md).              |
-| **Effort**         | Reasoning depth knob (`low`/`medium`/`high`/`xhigh`/`max`) on `model_config`. Maps to Claude API `output_config.effort`.                                                                        |
+| Term               | What it is                                                                                                                                                                                                           |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Branch**         | A first-class git working directory at `~/.agor/worktrees/<repo>/<name>`, on its own branch, with its own dev environment. **Primary card on a board.** Conventionally 1 branch = 1 feature/PR.                      |
+| **Board**          | 2D canvas displaying branches as cards. Has zones.                                                                                                                                                                   |
+| **Zone**           | Rectangular region on a board with an optional Handlebars **prompt template** that fires when a branch is dropped in.                                                                                                |
+| **Card**           | Visual representation of a branch (or note/markdown) on a board.                                                                                                                                                     |
+| **Session**        | An agent conversation. Required FK to a branch. Can **fork** (sibling, copies parent context) or **spawn** (child, fresh context window).                                                                            |
+| **Task**           | A single user-prompt-and-its-execution within a session. Tasks (not messages) are the queueable unit when a session is busy.                                                                                         |
+| **Message**        | An individual conversation turn (user / assistant / tool / system) within a task.                                                                                                                                    |
+| **Report**         | Agent-written markdown summary at task completion.                                                                                                                                                                   |
+| **Environment**    | The runtime instance of a branch's dev server (managed start/stop, ports allocated from `branch.unique_id`).                                                                                                         |
+| **Daemon**         | The FeathersJS server (`apps/agor-daemon`) that owns the database, services, WebSocket events, and MCP HTTP endpoint. Default port 3030.                                                                             |
+| **Executor**       | Process-isolated agent runtime in `packages/executor/`. Spawns Claude / Codex / Gemini / OpenCode via their SDKs. May run as a separate Unix user.                                                                   |
+| **MCP**            | Model Context Protocol. Agor exposes itself as an MCP server (`POST /mcp`) so agents can introspect sessions, branches, boards, etc.                                                                                 |
+| **RBAC**           | Branch-scoped permission tiers (`none`/`view`/`session`/`prompt`/`all`). Feature-flagged via `execution.branch_rbac`. See "Feature Flags" below.                                                                     |
+| **Unix user mode** | `simple` / `delegated` / `insulated` / `strict` — progressive OS-level isolation tiers (`delegated` = simple + required per-user `unix_username`, propagated to the execution substrate). See "Feature Flags" below. |
+| **Genealogy**      | Parent/child + fork ancestry of a session. Surfaced as a tree inside a branch card.                                                                                                                                  |
+| **Short ID**       | First 8 chars of a UUIDv7, used in UI and CLI. Resolved at API boundary via a `resolveShortId` hook. See [`context/concepts/id-management.md`](context/concepts/id-management.md).                                   |
+| **Effort**         | Reasoning depth knob (`low`/`medium`/`high`/`xhigh`/`max`) on `model_config`. Maps to Claude API `output_config.effort`.                                                                                             |
 
 ## Where to look first
 
@@ -259,6 +259,24 @@ execution:
 
 ---
 
+#### Mode 2.5: Delegated Identity (`delegated`)
+
+```yaml
+execution:
+  unix_user_mode: delegated
+```
+
+Like `simple` on the daemon host (no sudo, no Unix groups, no sudoers), but
+every user MUST have a `unix_username`. The identity is passed to the execution
+substrate — the `{unix_user}` executor-command-template variable, which hosted
+deployments use to select per-user home mounts — and sessions/terminals whose
+user has no `unix_username` fail loudly instead of silently sharing an identity.
+
+**Use cases:** Hosted/containerized deployments (e.g. Agor Cloud) where the
+orchestration layer, not the daemon, enforces OS identity.
+
+---
+
 #### Mode 3: RBAC + Branch Groups (Insulated)
 
 ```yaml
@@ -311,7 +329,7 @@ execution:
   # RBAC toggle
   branch_rbac: boolean # default: false
 
-  # Unix mode: simple | insulated | strict
+  # Unix mode: simple | delegated | insulated | strict
   unix_user_mode: string # default: simple
 
   # Executor user (insulated mode)

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2449,7 +2449,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // unix_username load-bearing — otherwise sessions would be stamped
         // null and fail only at prompt time.
         ...(branchRbacEnabled || executionMode.requiresUserUnixUsername
-          ? [setSessionUnixUsername(usersRepository, executionMode)]
+          ? [setSessionUnixUsername(usersRepository, executionMode.unixUserMode)]
           : []),
         ...(branchRbacEnabled
           ? [

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2444,9 +2444,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create sessions'),
+        // Stamp session with creator's unix_username (MUST run first). Also
+        // registered without RBAC when the Unix mode (strict/delegated) makes
+        // unix_username load-bearing — otherwise sessions would be stamped
+        // null and fail only at prompt time.
+        ...(branchRbacEnabled || executionMode.requiresUserUnixUsername
+          ? [setSessionUnixUsername(usersRepository, executionMode)]
+          : []),
         ...(branchRbacEnabled
           ? [
-              setSessionUnixUsername(usersRepository), // Stamp session with creator's unix_username (MUST run first)
               // Check branch permission BEFORE injecting created_by (need branch_id)
               async (context: HookContext) => {
                 // RBAC: Ensure user can create sessions in this branch ('all' permission)

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -979,7 +979,12 @@ function createExecuteHandler(
       templateVariables: {
         session_id: sessionId,
         task_id: taskId,
-        unix_user: sessionUnixUser || executorUnixUser || undefined,
+        // Mode-resolved identity for the execution substrate: the sudo user in
+        // insulated/strict, the session's unix_username in delegated (no sudo),
+        // and unset in simple. Supersedes the interim
+        // `sessionUnixUser || executorUnixUser` ordering from #2082, which
+        // shadowed insulated mode's configured executor identity.
+        unix_user: impersonationResult.reportedUnixUser || undefined,
       },
       onSpawn: (child, spawnContext) => {
         if (spawnContext.mode === 'local' && child.pid) {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -357,7 +357,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     return this.withTenantDatabase(params, async () => {
       let asUser: string | undefined;
 
-      if (unixUserMode !== 'simple') {
+      // Only insulated/strict impersonate; simple and delegated both run
+      // environment commands as the daemon user.
+      if (unixUserMode === 'insulated' || unixUserMode === 'strict') {
         const usersRepo = new UsersRepository(this.db);
         const user = await usersRepo.findById(branch.created_by);
         const impersonationResult = resolveUnixUserForImpersonation({

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -248,13 +248,19 @@ async function probeCodexAuthFile(
   const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
   if (!identity.ok) {
     // A missing unix_username is a real configuration gap (no credential can
-    // exist for this user yet); any other resolution failure is inconclusive.
-    return identity.reason === 'missing-username'
-      ? unauthenticated(
-          'none',
-          'Codex subscription login needs a Unix account — ask an admin to set your unix_username.'
-        )
-      : unknown('Could not resolve the Unix account that holds the Codex login.');
+    // exist for this user yet). An unsupported mode means the daemon cannot
+    // see the credential at all (it lives in the execution substrate) — pass
+    // that explanation through. Any other resolution failure is inconclusive.
+    if (identity.reason === 'missing-username') {
+      return unauthenticated(
+        'none',
+        'Codex subscription login needs a Unix account — ask an admin to set your unix_username.'
+      );
+    }
+    if (identity.reason === 'unsupported-mode') {
+      return unknown(identity.message);
+    }
+    return unknown('Could not resolve the Unix account that holds the Codex login.');
   }
 
   const inspection = await inspectCodexAuthViaExecutor(identity.unixUser);

--- a/apps/agor-daemon/src/services/codex-auth-shared.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for `resolveCodexUnixIdentity()` mode handling.
+ *
+ * Delegated + templated execution must resolve to `unsupported-mode` WITHOUT
+ * looking up the user or touching any credential path: the auth.json Codex
+ * reads lives in the execution substrate's per-user home, so daemon-side
+ * import/verify/logout would silently share one daemon-home file across
+ * users and never reach the executor. Delegated WITHOUT a template keeps the
+ * simple-mode behavior (daemon home) but still requires a unix_username.
+ */
+import { loadConfigSync } from '@agor/core/config';
+import { UsersRepository } from '@agor/core/db';
+import type { TenantScopedDatabase, UserID } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('@agor/core/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/db')>();
+  return {
+    ...actual,
+    UsersRepository: vi.fn(),
+  };
+});
+
+import { resolveCodexUnixIdentity } from './codex-auth-shared.js';
+
+const loadConfigSyncMock = vi.mocked(loadConfigSync);
+const usersRepositoryMock = vi.mocked(UsersRepository);
+
+const USER_ID = 'user-1' as UserID;
+const findById = vi.fn();
+
+const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>): Promise<T> =>
+  work({} as TenantScopedDatabase);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Regular function (not arrow) so `new UsersRepository(...)` works: a
+  // constructor returning an object yields that object.
+  usersRepositoryMock.mockImplementation(function mockRepo() {
+    return { findById } as never;
+  });
+});
+
+describe('resolveCodexUnixIdentity — delegated mode', () => {
+  it('returns unsupported-mode for delegated + templated execution without any user lookup', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      execution: {
+        unix_user_mode: 'delegated',
+        executor_command_template: 'launcher --user {unix_user} -- agor-executor --stdin',
+      },
+    } as never);
+
+    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unsupported-mode',
+      message: expect.stringContaining("execution substrate's per-user home"),
+    });
+    // No credential path is derived and no user row is read — the operation
+    // is rejected before identity resolution starts.
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('resolves to the daemon home (null) for delegated without a template when a unix_username exists', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      execution: { unix_user_mode: 'delegated' },
+    } as never);
+    findById.mockResolvedValue({ user_id: USER_ID, unix_username: 'alice' });
+
+    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+
+    // No impersonation in delegated mode — auth.json lives in the daemon
+    // user's home, exactly like simple mode.
+    expect(result).toEqual({ ok: true, unixUser: null });
+  });
+
+  it('returns missing-username for delegated without a template when the user has no unix_username', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      execution: { unix_user_mode: 'delegated' },
+    } as never);
+    findById.mockResolvedValue({ user_id: USER_ID, unix_username: null });
+
+    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'missing-username',
+      message: expect.stringContaining('Delegated Unix user mode requires a unix_username'),
+    });
+  });
+
+  it('keeps simple mode untouched even with a template configured', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      execution: {
+        unix_user_mode: 'simple',
+        executor_command_template: 'launcher -- agor-executor --stdin',
+      },
+    } as never);
+
+    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+
+    expect(result).toEqual({ ok: true, unixUser: null });
+    expect(findById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/codex-auth-shared.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.test.ts
@@ -9,8 +9,8 @@
  * simple-mode behavior (daemon home) but still requires a unix_username.
  */
 import { loadConfigSync } from '@agor/core/config';
-import { UsersRepository } from '@agor/core/db';
-import type { TenantScopedDatabase, UserID } from '@agor/core/types';
+import { type TenantScopedDatabase, UsersRepository } from '@agor/core/db';
+import type { UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@agor/core/config', async (importOriginal) => {

--- a/apps/agor-daemon/src/services/codex-auth-shared.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.ts
@@ -16,7 +16,7 @@
  *   ownership and 0600 permissions hold in insulated/strict modes.
  */
 
-import { loadConfigSync } from '@agor/core/config';
+import { loadConfigSync, unixUserModeRequiresUsername } from '@agor/core/config';
 import { type TenantScopedDatabase, UsersRepository } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
 import type { AgenticAuthMethods, AuthenticatedParams, User, UserID } from '@agor/core/types';
@@ -44,7 +44,11 @@ interface UsersServiceLike {
 
 export type CodexUnixIdentityResolution =
   | { ok: true; unixUser: string | null }
-  | { ok: false; reason: 'missing-username' | 'resolve-failed'; message: string };
+  | {
+      ok: false;
+      reason: 'missing-username' | 'resolve-failed' | 'unsupported-mode';
+      message: string;
+    };
 
 /**
  * Resolve the Unix account whose `~/.codex/auth.json` Codex will actually read
@@ -63,12 +67,30 @@ export async function resolveCodexUnixIdentity(
   const config = loadConfigSync();
   const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
 
+  // Delegated + templated execution: the executor's home (and therefore the
+  // auth.json Codex actually reads) lives in the execution substrate's
+  // per-user mount, not on the daemon host. Touching the daemon-home file
+  // here would silently share one credential file across users AND never
+  // reach the executor — reject explicitly until substrate-aware credential
+  // routing exists.
+  if (mode === 'delegated' && config.execution?.executor_command_template) {
+    return {
+      ok: false,
+      reason: 'unsupported-mode',
+      message:
+        'In delegated Unix user mode with templated execution, Codex credentials live in the ' +
+        "execution substrate's per-user home — the daemon cannot import, verify, or remove them. " +
+        'Sign in to Codex from within a session instead.',
+    };
+  }
+
   let unixUsername: string | null = null;
   // Both strict and delegated require a per-user unix_username. In strict the
-  // resolver impersonates it; in delegated it resolves to no impersonation
-  // (auth.json lives in the daemon user's home, like simple), but a missing
-  // username must still surface as the actionable `missing-username` result.
-  if (mode === 'strict' || mode === 'delegated') {
+  // resolver impersonates it; in delegated (non-templated) it resolves to no
+  // impersonation (auth.json lives in the daemon user's home, like simple),
+  // but a missing username must still surface as the actionable
+  // `missing-username` result.
+  if (unixUserModeRequiresUsername(mode)) {
     if (!userId) {
       return {
         ok: false,

--- a/apps/agor-daemon/src/services/codex-auth-shared.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.ts
@@ -48,7 +48,7 @@ export type CodexUnixIdentityResolution =
 
 /**
  * Resolve the Unix account whose `~/.codex/auth.json` Codex will actually read
- * for this user: the daemon user (simple), the shared executor user
+ * for this user: the daemon user (simple, delegated), the shared executor user
  * (insulated), or the caller's own Unix account (strict).
  *
  * Returns a discriminated result rather than throwing so callers with
@@ -64,12 +64,16 @@ export async function resolveCodexUnixIdentity(
   const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
 
   let unixUsername: string | null = null;
-  if (mode === 'strict') {
+  // Both strict and delegated require a per-user unix_username. In strict the
+  // resolver impersonates it; in delegated it resolves to no impersonation
+  // (auth.json lives in the daemon user's home, like simple), but a missing
+  // username must still surface as the actionable `missing-username` result.
+  if (mode === 'strict' || mode === 'delegated') {
     if (!userId) {
       return {
         ok: false,
         reason: 'resolve-failed',
-        message: 'Strict Unix user mode requires an authenticated user context.',
+        message: `${mode === 'strict' ? 'Strict' : 'Delegated'} Unix user mode requires an authenticated user context.`,
       };
     }
     const row = await withTenantDatabase((tenantDb) =>
@@ -80,8 +84,7 @@ export async function resolveCodexUnixIdentity(
       return {
         ok: false,
         reason: 'missing-username',
-        message:
-          'Strict Unix user mode requires a unix_username — ask an admin to set one for your account.',
+        message: `${mode === 'strict' ? 'Strict' : 'Delegated'} Unix user mode requires a unix_username — ask an admin to set one for your account.`,
       };
     }
   }

--- a/apps/agor-daemon/src/services/codex-auth-shared.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.ts
@@ -52,8 +52,11 @@ export type CodexUnixIdentityResolution =
 
 /**
  * Resolve the Unix account whose `~/.codex/auth.json` Codex will actually read
- * for this user: the daemon user (simple, delegated), the shared executor user
- * (insulated), or the caller's own Unix account (strict).
+ * for this user: the daemon user (simple, and delegated WITHOUT an executor
+ * command template), the shared executor user (insulated), or the caller's own
+ * Unix account (strict). Delegated WITH a command template resolves to
+ * `unsupported-mode`: the credential lives in the execution substrate's
+ * per-user home, which the daemon cannot reach.
  *
  * Returns a discriminated result rather than throwing so callers with
  * different failure semantics (the import endpoint rejects, the check-auth
@@ -80,7 +83,7 @@ export async function resolveCodexUnixIdentity(
       message:
         'In delegated Unix user mode with templated execution, Codex credentials live in the ' +
         "execution substrate's per-user home — the daemon cannot import, verify, or remove them. " +
-        'Sign in to Codex from within a session instead.',
+        'Sign in to Codex from a branch terminal or from within a session instead.',
     };
   }
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -8,7 +8,6 @@
 
 import {
   assertInlineAgenticConfigurationAllowed,
-  assertUnixUsernameSatisfiesMode,
   getBaseUrl,
   resolveAgenticToolPreset,
   resolveExecutionSecurityMode,
@@ -73,6 +72,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
+import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
 import { getSessionUrl } from '@agor/core/utils/url';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import { hasBranchPermission } from '../utils/branch-authorization.js';

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -10,6 +10,7 @@ import {
   assertInlineAgenticConfigurationAllowed,
   getBaseUrl,
   resolveAgenticToolPreset,
+  resolveExecutionSecurityMode,
 } from '@agor/core/config';
 import {
   BranchRepository,
@@ -73,7 +74,10 @@ import type {
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
-import { hasBranchPermission } from '../utils/branch-authorization.js';
+import {
+  assertUnixUsernameSatisfiesMode,
+  hasBranchPermission,
+} from '../utils/branch-authorization.js';
 import {
   buildPromptWithAttachments,
   ingestInboundAttachments,
@@ -2185,6 +2189,15 @@ export class GatewayService {
         // Flag for downstream consumers: only the last message is posted to Shortcut
         gatewaySource.last_message_only = true;
       }
+
+      // In strict/delegated, refuse to create a gateway session for a user
+      // without a unix_username — it would fail at prompt time (or silently
+      // share an identity in hosted deployments).
+      assertUnixUsernameSatisfiesMode(
+        user.unix_username,
+        resolveExecutionSecurityMode(),
+        `gateway user ${user.user_id}`
+      );
 
       const session = await sessionsService.create({
         title: data.text.substring(0, 100),

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -8,6 +8,7 @@
 
 import {
   assertInlineAgenticConfigurationAllowed,
+  assertUnixUsernameSatisfiesMode,
   getBaseUrl,
   resolveAgenticToolPreset,
   resolveExecutionSecurityMode,
@@ -74,10 +75,7 @@ import type {
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
-import {
-  assertUnixUsernameSatisfiesMode,
-  hasBranchPermission,
-} from '../utils/branch-authorization.js';
+import { hasBranchPermission } from '../utils/branch-authorization.js';
 import {
   buildPromptWithAttachments,
   ingestInboundAttachments,
@@ -2195,7 +2193,7 @@ export class GatewayService {
       // share an identity in hosted deployments).
       assertUnixUsernameSatisfiesMode(
         user.unix_username,
-        resolveExecutionSecurityMode(),
+        resolveExecutionSecurityMode().unixUserMode,
         `gateway user ${user.user_id}`
       );
 

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -44,6 +44,7 @@ import {
   presetConfigurationToScheduleConfig,
   resolveAgenticConfigurationReference,
   resolveAgenticToolPreset,
+  unixUserModeRequiresUsername,
 } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
@@ -570,10 +571,7 @@ export class SchedulerService {
 
     const unixUsername = creator.unix_username || null;
 
-    if (
-      !unixUsername &&
-      (this.config.unixUserMode === 'strict' || this.config.unixUserMode === 'delegated')
-    ) {
+    if (!unixUsername && unixUserModeRequiresUsername(this.config.unixUserMode)) {
       console.error(
         `      ❌ Cannot spawn scheduled session: Creator has no unix_username (${this.config.unixUserMode} mode)`,
         {

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -570,9 +570,12 @@ export class SchedulerService {
 
     const unixUsername = creator.unix_username || null;
 
-    if (!unixUsername && this.config.unixUserMode === 'strict') {
+    if (
+      !unixUsername &&
+      (this.config.unixUserMode === 'strict' || this.config.unixUserMode === 'delegated')
+    ) {
       console.error(
-        `      ❌ Cannot spawn scheduled session: Creator has no unix_username (strict mode)`,
+        `      ❌ Cannot spawn scheduled session: Creator has no unix_username (${this.config.unixUserMode} mode)`,
         {
           schedule_id: schedule.schedule_id,
           schedule_name: schedule.name,
@@ -582,7 +585,7 @@ export class SchedulerService {
         }
       );
       throw new Error(
-        `Schedule creator ${creator.email} has no unix_username set. Cannot spawn scheduled session in strict Unix user mode.`
+        `Schedule creator ${creator.email} has no unix_username set. Cannot spawn scheduled session in ${this.config.unixUserMode} Unix user mode.`
       );
     }
 

--- a/apps/agor-daemon/src/services/sessions.child-identity.test.ts
+++ b/apps/agor-daemon/src/services/sessions.child-identity.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for `SessionsService.resolveChildIdentity()`'s internal
+ * (provider-less) path.
+ *
+ * Internal fork/spawn preserves parent attribution and inherits the parent's
+ * immutable `unix_username` stamp. In strict/delegated modes that stamp is
+ * load-bearing identity, so a null-stamped parent must be rejected at
+ * fork/spawn time — not persisted as a child that only fails at first prompt
+ * (or, in hosted deployments, silently shares an identity).
+ */
+import type { Application } from '@agor/core/feathers';
+import type { Session, UUID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    resolveExecutionSecurityMode: vi.fn(),
+  };
+});
+
+import { resolveExecutionSecurityMode } from '@agor/core/config';
+import { SessionsService } from './sessions';
+
+const resolveExecutionSecurityModeMock = vi.mocked(resolveExecutionSecurityMode);
+
+function mockMode(unixUserMode: 'simple' | 'delegated' | 'insulated' | 'strict'): void {
+  resolveExecutionSecurityModeMock.mockReturnValue({
+    appRbacEnabled: false,
+    unixUserMode,
+    unixImpersonationEnabled: false,
+    unixFsIsolationEnabled: false,
+    unixGroupRefreshNeeded: false,
+    requiresDaemonUnixUser: false,
+    shouldInitUnixGroups: false,
+    requiresUserUnixUsername: unixUserMode === 'strict' || unixUserMode === 'delegated',
+  });
+}
+
+// The internal path never touches repositories or the app — it inherits from
+// the parent object and returns before any lookup. Bare stubs keep the
+// harness minimal (mirrors STUB_APP in sessions.agentic-tool-guard.test.ts).
+function makeService(): SessionsService {
+  return new SessionsService({} as never, {} as unknown as Application);
+}
+
+function makeParent(unixUsername: string | null): Session {
+  return {
+    session_id: 'parent-session' as Session['session_id'],
+    branch_id: 'branch-1' as Session['branch_id'],
+    created_by: 'parent-owner' as UUID,
+    unix_username: unixUsername,
+  } as Session;
+}
+
+async function resolveInternalChildIdentity(
+  service: SessionsService,
+  parent: Session
+): Promise<{ created_by: Session['created_by']; unix_username: Session['unix_username'] }> {
+  // Private method; tested directly because the surrounding fork()/spawn()
+  // flows need a full service harness while the security branch under test
+  // lives entirely in this function's provider-less early return.
+  return (
+    service as unknown as {
+      resolveChildIdentity: (
+        parent: Session,
+        params?: unknown
+      ) => Promise<{ created_by: Session['created_by']; unix_username: Session['unix_username'] }>;
+    }
+  ).resolveChildIdentity(parent, undefined);
+}
+
+describe('resolveChildIdentity — internal (provider-less) calls', () => {
+  it('rejects a null-stamped parent in delegated mode', async () => {
+    mockMode('delegated');
+    await expect(resolveInternalChildIdentity(makeService(), makeParent(null))).rejects.toThrow(
+      /unix_user_mode 'delegated' requires a unix_username/
+    );
+  });
+
+  it('rejects a null-stamped parent in strict mode', async () => {
+    mockMode('strict');
+    await expect(resolveInternalChildIdentity(makeService(), makeParent(null))).rejects.toThrow(
+      /unix_user_mode 'strict' requires a unix_username/
+    );
+  });
+
+  it('inherits the parent stamp in delegated mode when present', async () => {
+    mockMode('delegated');
+    await expect(resolveInternalChildIdentity(makeService(), makeParent('alice'))).resolves.toEqual(
+      { created_by: 'parent-owner', unix_username: 'alice' }
+    );
+  });
+
+  it('allows a null stamp in simple mode', async () => {
+    mockMode('simple');
+    await expect(resolveInternalChildIdentity(makeService(), makeParent(null))).resolves.toEqual({
+      created_by: 'parent-owner',
+      unix_username: null,
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -7,6 +7,7 @@
 
 import {
   assertInlineAgenticConfigurationAllowed,
+  assertUnixUsernameSatisfiesMode,
   isTenantAgenticToolEnabled,
   PAGINATION,
   presetConfigurationToSessionPatch,
@@ -60,7 +61,6 @@ import { ROLES, SessionStatus } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import {
-  assertUnixUsernameSatisfiesMode,
   determineSpawnIdentity,
   isSuperAdmin,
   loadUnixUsernameForUser,
@@ -500,9 +500,17 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     params?: SessionParams
   ): Promise<{ created_by: Session['created_by']; unix_username: Session['unix_username'] }> {
     // Internal call (no transport provider) → service-to-service or scheduler.
-    // Preserve parent attribution; helper-level identity checks don't apply.
+    // Preserve parent attribution. The strict/delegated unix_username
+    // requirement still applies: an internal fork/spawn of a null-stamped
+    // parent must fail here, not later at prompt time.
     if (!params?.provider) {
-      return { created_by: parent.created_by, unix_username: parent.unix_username ?? null };
+      const inheritedUnixUsername = parent.unix_username ?? null;
+      assertUnixUsernameSatisfiesMode(
+        inheritedUnixUsername,
+        resolveExecutionSecurityMode().unixUserMode,
+        `the parent session's owner (${parent.created_by})`
+      );
+      return { created_by: parent.created_by, unix_username: inheritedUnixUsername };
     }
 
     const caller = params.user;
@@ -566,7 +574,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     // inheriting a null stamp from a pre-migration parent.
     assertUnixUsernameSatisfiesMode(
       unixUsername,
-      resolveExecutionSecurityMode(),
+      resolveExecutionSecurityMode().unixUserMode,
       `the attributed user (${createdBy})`
     );
 

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -12,6 +12,7 @@ import {
   presetConfigurationToSessionPatch,
   resolveAgenticConfigurationReference,
   resolveAgenticToolPreset,
+  resolveExecutionSecurityMode,
 } from '@agor/core/config';
 import {
   BranchRepository,
@@ -59,6 +60,7 @@ import { ROLES, SessionStatus } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import {
+  assertUnixUsernameSatisfiesMode,
   determineSpawnIdentity,
   isSuperAdmin,
   loadUnixUsernameForUser,
@@ -557,6 +559,16 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       callerUnixUsername,
       result.usedLegacySharing
     ) as Session['unix_username'];
+
+    // In strict/delegated, a child stamped null would fail at prompt time (or
+    // silently share an identity in hosted deployments) — reject at fork/spawn
+    // time with an actionable error instead. Also covers legacy sharing
+    // inheriting a null stamp from a pre-migration parent.
+    assertUnixUsernameSatisfiesMode(
+      unixUsername,
+      resolveExecutionSecurityMode(),
+      `the attributed user (${createdBy})`
+    );
 
     return { created_by: createdBy, unix_username: unixUsername };
   }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -7,7 +7,6 @@
 
 import {
   assertInlineAgenticConfigurationAllowed,
-  assertUnixUsernameSatisfiesMode,
   isTenantAgenticToolEnabled,
   PAGINATION,
   presetConfigurationToSessionPatch,
@@ -58,6 +57,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { ROLES, SessionStatus } from '@agor/core/types';
+import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import {

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -624,6 +624,12 @@ export class TerminalsService {
           logPrefix: `[TerminalsService.executor ${shortId(userId)}]`,
           asUser: finalUnixUser || undefined,
           env: executorEnv,
+          templateVariables: {
+            // Mode-resolved identity for templated execution: the sudo user in
+            // insulated/strict, the caller's unix_username in delegated (no
+            // sudo), and unset in simple.
+            unix_user: impersonationResult.reportedUnixUser || undefined,
+          },
           // Clean up map when executor exits (handles crashes too)
           onExit: () => this.handleExecutorExit(userId),
         }

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -11,6 +11,7 @@
  * same session-defaults resolution, same MCP-attach behaviour.
  */
 
+import { resolveExecutionSecurityMode } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
@@ -24,6 +25,7 @@ import type {
   User,
 } from '@agor/core/types';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
+import { assertUnixUsernameSatisfiesMode } from '../utils/branch-authorization.js';
 import { inspectBranchViaExecutor } from '../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 
@@ -106,6 +108,15 @@ export async function fireAlwaysNewZoneTrigger(
     asUser,
     logPrefix: `[zone-trigger ${branch.name}]`,
   });
+
+  // In strict/delegated, refuse to create a zone-triggered session for a user
+  // without a unix_username — it would fail at prompt time (or silently share
+  // an identity in hosted deployments).
+  assertUnixUsernameSatisfiesMode(
+    user.unix_username,
+    resolveExecutionSecurityMode(),
+    `user ${userId}`
+  );
 
   const newSession: Session = await app.service('sessions').create(
     {

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -11,7 +11,7 @@
  * same session-defaults resolution, same MCP-attach behaviour.
  */
 
-import { assertUnixUsernameSatisfiesMode, resolveExecutionSecurityMode } from '@agor/core/config';
+import { resolveExecutionSecurityMode } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
@@ -24,6 +24,7 @@ import type {
   Task,
   User,
 } from '@agor/core/types';
+import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import { inspectBranchViaExecutor } from '../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -11,7 +11,7 @@
  * same session-defaults resolution, same MCP-attach behaviour.
  */
 
-import { resolveExecutionSecurityMode } from '@agor/core/config';
+import { assertUnixUsernameSatisfiesMode, resolveExecutionSecurityMode } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
@@ -25,7 +25,6 @@ import type {
   User,
 } from '@agor/core/types';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
-import { assertUnixUsernameSatisfiesMode } from '../utils/branch-authorization.js';
 import { inspectBranchViaExecutor } from '../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 
@@ -114,7 +113,7 @@ export async function fireAlwaysNewZoneTrigger(
   // an identity in hosted deployments).
   assertUnixUsernameSatisfiesMode(
     user.unix_username,
-    resolveExecutionSecurityMode(),
+    resolveExecutionSecurityMode().unixUserMode,
     `user ${userId}`
   );
 

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -655,9 +655,15 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // `allow_web_terminal` defaults to true, so the check treats undefined as enabled.
   if (config.execution?.allow_web_terminal !== false) {
     const unixMode = config.execution?.unix_user_mode ?? 'simple';
-    if (unixMode === 'simple') {
+    // Delegated mode does not impersonate either: without an executor command
+    // template routing terminals elsewhere, a local terminal still runs as the
+    // daemon user, so the same warning applies.
+    const terminalRunsAsDaemon =
+      unixMode === 'simple' ||
+      (unixMode === 'delegated' && !config.execution?.executor_command_template);
+    if (terminalRunsAsDaemon) {
       console.warn(
-        '\x1b[33m⚠️  SECURITY: allow_web_terminal is enabled (default) with unix_user_mode=simple.\x1b[0m\n' +
+        `\x1b[33m⚠️  SECURITY: allow_web_terminal is enabled (default) with unix_user_mode=${unixMode}.\x1b[0m\n` +
           '   Any member-role user can open a shell running as the daemon user, with read\n' +
           '   access to ~/.agor/config.yaml, agor.db, and the JWT secret.\n' +
           "   Recommended: set execution.unix_user_mode to 'insulated' or 'strict' to\n" +

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -10,7 +10,6 @@ import type { Branch, BranchPermissionLevel, HookContext, Session } from '@agor/
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  assertUnixUsernameSatisfiesMode,
   ensureCanPromptInSession,
   hasBranchPermission,
   isSuperAdmin,
@@ -575,35 +574,6 @@ describe('scopeSessionQuery — $sort handling', () => {
   });
 });
 
-describe('assertUnixUsernameSatisfiesMode', () => {
-  const delegated = { unixUserMode: 'delegated', requiresUserUnixUsername: true };
-  const strict = { unixUserMode: 'strict', requiresUserUnixUsername: true };
-  const simple = { unixUserMode: 'simple', requiresUserUnixUsername: false };
-
-  it('passes when the mode does not require a unix_username', () => {
-    expect(() => assertUnixUsernameSatisfiesMode(null, simple)).not.toThrow();
-    expect(() => assertUnixUsernameSatisfiesMode(undefined, simple)).not.toThrow();
-  });
-
-  it('passes when a unix_username is present', () => {
-    expect(() => assertUnixUsernameSatisfiesMode('alice', delegated)).not.toThrow();
-    expect(() => assertUnixUsernameSatisfiesMode('alice', strict)).not.toThrow();
-  });
-
-  it('throws with the mode name and subject when required and missing', () => {
-    expect(() => assertUnixUsernameSatisfiesMode(null, delegated, 'gateway user u-1')).toThrow(
-      /unix_user_mode 'delegated' requires a unix_username, but gateway user u-1 has none/
-    );
-    expect(() => assertUnixUsernameSatisfiesMode(undefined, strict)).toThrow(
-      /unix_user_mode 'strict' requires a unix_username/
-    );
-  });
-
-  it('tolerates an undefined execution mode (callers without resolved config)', () => {
-    expect(() => assertUnixUsernameSatisfiesMode(null, undefined)).not.toThrow();
-  });
-});
-
 describe('setSessionUnixUsername', () => {
   const makeCreateContext = () =>
     ({
@@ -625,21 +595,15 @@ describe('setSessionUnixUsername', () => {
 
   it('stamps null silently when the mode does not require a unix_username', async () => {
     const ctx = makeCreateContext();
-    await setSessionUnixUsername(repoWithUsername(null), {
-      unixUserMode: 'simple',
-      requiresUserUnixUsername: false,
-    })(ctx);
+    await setSessionUnixUsername(repoWithUsername(null), 'simple')(ctx);
     expect((ctx.data as { unix_username?: string | null }).unix_username).toBeNull();
   });
 
   it('rejects a creator without unix_username when the mode requires one', async () => {
     const ctx = makeCreateContext();
-    await expect(
-      setSessionUnixUsername(repoWithUsername(null), {
-        unixUserMode: 'delegated',
-        requiresUserUnixUsername: true,
-      })(ctx)
-    ).rejects.toThrow(/unix_user_mode 'delegated' requires a unix_username/);
+    await expect(setSessionUnixUsername(repoWithUsername(null), 'delegated')(ctx)).rejects.toThrow(
+      /unix_user_mode 'delegated' requires a unix_username/
+    );
   });
 
   it('skips internal calls even when the mode requires a unix_username', async () => {
@@ -649,10 +613,7 @@ describe('setSessionUnixUsername', () => {
       params: {},
       data: {},
     } as unknown as HookContext;
-    await setSessionUnixUsername(repoWithUsername(null), {
-      unixUserMode: 'delegated',
-      requiresUserUnixUsername: true,
-    })(ctx);
+    await setSessionUnixUsername(repoWithUsername(null), 'delegated')(ctx);
     expect((ctx.data as { unix_username?: string | null }).unix_username).toBeUndefined();
   });
 });

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -10,6 +10,7 @@ import type { Branch, BranchPermissionLevel, HookContext, Session } from '@agor/
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  assertUnixUsernameSatisfiesMode,
   ensureCanPromptInSession,
   hasBranchPermission,
   isSuperAdmin,
@@ -20,6 +21,7 @@ import {
   resolveBranchPermission,
   resolveSessionContext,
   scopeSessionQuery,
+  setSessionUnixUsername,
 } from './branch-authorization';
 
 /** Minimal branch fixture for permission tests */
@@ -570,5 +572,87 @@ describe('scopeSessionQuery — $sort handling', () => {
     const ctx = makeCtx({ $sort: { updated_at: -1 }, $limit: 10 });
     await scopeSessionQuery(repoReturning(sessions))(ctx);
     expect(resultIds(ctx)).toEqual(['u-new', 'u-mid', 'u-old']);
+  });
+});
+
+describe('assertUnixUsernameSatisfiesMode', () => {
+  const delegated = { unixUserMode: 'delegated', requiresUserUnixUsername: true };
+  const strict = { unixUserMode: 'strict', requiresUserUnixUsername: true };
+  const simple = { unixUserMode: 'simple', requiresUserUnixUsername: false };
+
+  it('passes when the mode does not require a unix_username', () => {
+    expect(() => assertUnixUsernameSatisfiesMode(null, simple)).not.toThrow();
+    expect(() => assertUnixUsernameSatisfiesMode(undefined, simple)).not.toThrow();
+  });
+
+  it('passes when a unix_username is present', () => {
+    expect(() => assertUnixUsernameSatisfiesMode('alice', delegated)).not.toThrow();
+    expect(() => assertUnixUsernameSatisfiesMode('alice', strict)).not.toThrow();
+  });
+
+  it('throws with the mode name and subject when required and missing', () => {
+    expect(() => assertUnixUsernameSatisfiesMode(null, delegated, 'gateway user u-1')).toThrow(
+      /unix_user_mode 'delegated' requires a unix_username, but gateway user u-1 has none/
+    );
+    expect(() => assertUnixUsernameSatisfiesMode(undefined, strict)).toThrow(
+      /unix_user_mode 'strict' requires a unix_username/
+    );
+  });
+
+  it('tolerates an undefined execution mode (callers without resolved config)', () => {
+    expect(() => assertUnixUsernameSatisfiesMode(null, undefined)).not.toThrow();
+  });
+});
+
+describe('setSessionUnixUsername', () => {
+  const makeCreateContext = () =>
+    ({
+      method: 'create',
+      path: 'sessions',
+      params: { provider: 'rest', user: { user_id: USER_ID } },
+      data: {} as Record<string, unknown>,
+    }) as unknown as HookContext;
+
+  const repoWithUsername = (unix_username: string | null) => ({
+    findById: vi.fn().mockResolvedValue({ user_id: USER_ID, unix_username }),
+  });
+
+  it('stamps the creator current unix_username', async () => {
+    const ctx = makeCreateContext();
+    await setSessionUnixUsername(repoWithUsername('alice'))(ctx);
+    expect((ctx.data as { unix_username?: string | null }).unix_username).toBe('alice');
+  });
+
+  it('stamps null silently when the mode does not require a unix_username', async () => {
+    const ctx = makeCreateContext();
+    await setSessionUnixUsername(repoWithUsername(null), {
+      unixUserMode: 'simple',
+      requiresUserUnixUsername: false,
+    })(ctx);
+    expect((ctx.data as { unix_username?: string | null }).unix_username).toBeNull();
+  });
+
+  it('rejects a creator without unix_username when the mode requires one', async () => {
+    const ctx = makeCreateContext();
+    await expect(
+      setSessionUnixUsername(repoWithUsername(null), {
+        unixUserMode: 'delegated',
+        requiresUserUnixUsername: true,
+      })(ctx)
+    ).rejects.toThrow(/unix_user_mode 'delegated' requires a unix_username/);
+  });
+
+  it('skips internal calls even when the mode requires a unix_username', async () => {
+    const ctx = {
+      method: 'create',
+      path: 'sessions',
+      params: {},
+      data: {},
+    } as unknown as HookContext;
+    await setSessionUnixUsername(repoWithUsername(null), {
+      unixUserMode: 'delegated',
+      requiresUserUnixUsername: true,
+    })(ctx);
+    expect((ctx.data as { unix_username?: string | null }).unix_username).toBeUndefined();
   });
 });

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1131,6 +1131,34 @@ export async function loadUnixUsernameForUser(
 }
 
 /**
+ * Minimal slice of `ResolvedExecutionSecurityMode` needed by the session
+ * identity checks below (kept structural so tests don't have to build the
+ * full resolved config).
+ */
+export interface UnixUsernameRequirement {
+  unixUserMode: string;
+  requiresUserUnixUsername: boolean;
+}
+
+/**
+ * Fail loudly when the configured Unix user mode treats `unix_username` as
+ * load-bearing identity (`strict`, `delegated`) and the resolved value is
+ * missing. Creating a session without one would only defer the failure to
+ * prompt time — or, in hosted deployments, silently share an identity.
+ */
+export function assertUnixUsernameSatisfiesMode(
+  unixUsername: string | null | undefined,
+  executionMode: UnixUsernameRequirement | undefined,
+  subject = 'your account'
+): void {
+  if (!executionMode?.requiresUserUnixUsername || unixUsername) return;
+  throw new Forbidden(
+    `unix_user_mode '${executionMode.unixUserMode}' requires a unix_username, but ${subject} has none. ` +
+      'Ask an admin to set one before creating sessions.'
+  );
+}
+
+/**
  * Set session unix_username from creator's current unix_username
  *
  * When a session is created, stamp it with the creator's current unix_username.
@@ -1146,10 +1174,14 @@ export async function loadUnixUsernameForUser(
  * {@link loadUnixUsernameForUser} to keep the two paths in sync.
  *
  * @param userRepo - UserRepository instance
+ * @param executionMode - When the mode requires per-user unix_username
+ *   (strict/delegated), a creator without one is rejected at create time
+ *   instead of failing later at prompt time.
  */
 export function setSessionUnixUsername(
   // biome-ignore lint/suspicious/noExplicitAny: UserRepository type
-  userRepo: any
+  userRepo: any,
+  executionMode?: UnixUsernameRequirement
 ) {
   return async (context: HookContext) => {
     // Only for session creation
@@ -1173,6 +1205,7 @@ export function setSessionUnixUsername(
     // Stamp session with creator's current unix_username.
     // IMMUTABLE - even if user's unix_username changes later, session keeps this value.
     data.unix_username = await loadUnixUsernameForUser(userRepo, userId);
+    assertUnixUsernameSatisfiesMode(data.unix_username, executionMode);
 
     return context;
   };

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -9,7 +9,7 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { assertUnixUsernameSatisfiesMode, type UnixUserMode } from '@agor/core/config';
+import type { UnixUserMode } from '@agor/core/config';
 import type {
   BoardRepository,
   BranchRepository,
@@ -28,6 +28,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
+import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
 
 /**
  * Check if a user has the superadmin role (or deprecated 'owner' alias).

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -9,6 +9,7 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
+import { assertUnixUsernameSatisfiesMode, type UnixUserMode } from '@agor/core/config';
 import type {
   BoardRepository,
   BranchRepository,
@@ -1131,34 +1132,6 @@ export async function loadUnixUsernameForUser(
 }
 
 /**
- * Minimal slice of `ResolvedExecutionSecurityMode` needed by the session
- * identity checks below (kept structural so tests don't have to build the
- * full resolved config).
- */
-export interface UnixUsernameRequirement {
-  unixUserMode: string;
-  requiresUserUnixUsername: boolean;
-}
-
-/**
- * Fail loudly when the configured Unix user mode treats `unix_username` as
- * load-bearing identity (`strict`, `delegated`) and the resolved value is
- * missing. Creating a session without one would only defer the failure to
- * prompt time — or, in hosted deployments, silently share an identity.
- */
-export function assertUnixUsernameSatisfiesMode(
-  unixUsername: string | null | undefined,
-  executionMode: UnixUsernameRequirement | undefined,
-  subject = 'your account'
-): void {
-  if (!executionMode?.requiresUserUnixUsername || unixUsername) return;
-  throw new Forbidden(
-    `unix_user_mode '${executionMode.unixUserMode}' requires a unix_username, but ${subject} has none. ` +
-      'Ask an admin to set one before creating sessions.'
-  );
-}
-
-/**
  * Set session unix_username from creator's current unix_username
  *
  * When a session is created, stamp it with the creator's current unix_username.
@@ -1174,14 +1147,14 @@ export function assertUnixUsernameSatisfiesMode(
  * {@link loadUnixUsernameForUser} to keep the two paths in sync.
  *
  * @param userRepo - UserRepository instance
- * @param executionMode - When the mode requires per-user unix_username
+ * @param unixUserMode - When the mode requires per-user unix_username
  *   (strict/delegated), a creator without one is rejected at create time
  *   instead of failing later at prompt time.
  */
 export function setSessionUnixUsername(
   // biome-ignore lint/suspicious/noExplicitAny: UserRepository type
   userRepo: any,
-  executionMode?: UnixUsernameRequirement
+  unixUserMode?: UnixUserMode
 ) {
   return async (context: HookContext) => {
     // Only for session creation
@@ -1205,7 +1178,9 @@ export function setSessionUnixUsername(
     // Stamp session with creator's current unix_username.
     // IMMUTABLE - even if user's unix_username changes later, session keeps this value.
     data.unix_username = await loadUnixUsernameForUser(userRepo, userId);
-    assertUnixUsernameSatisfiesMode(data.unix_username, executionMode);
+    if (unixUserMode) {
+      assertUnixUsernameSatisfiesMode(data.unix_username, unixUserMode);
+    }
 
     return context;
   };

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -18,6 +18,9 @@ vi.mock('@agor/core/unix', () => ({
   buildSpawnArgs: vi.fn(),
   escapeShellArg: (value: string) => `'${value.replace(/'/g, "'\\''")}'`,
   isSecretEnvKey: vi.fn(),
+  // Real implementation (mirrors user-manager.ts) — the {unix_user} format
+  // guard under test depends on its actual charset semantics.
+  isValidUnixUsername: (username: string) => /^[a-z_][a-z0-9_-]{0,31}$/.test(username),
   prepareImpersonationEnv: vi.fn(),
 }));
 
@@ -413,5 +416,31 @@ describe('substituteTemplateVariables', () => {
     ).toThrow(
       'executor_command_template requires {tenant_id}, but no active tenant context is available'
     );
+  });
+
+  it('substitutes a valid {unix_user} value', async () => {
+    const { substituteTemplateVariables } = await import('./spawn-executor');
+
+    const result = substituteTemplateVariables('launch --user {unix_user}', {
+      unix_user: 'agor_alice',
+    });
+
+    expect(result).toBe('launch --user agor_alice');
+  });
+
+  it.each([
+    { name: 'shell metacharacters', value: 'alice; rm -rf /' },
+    { name: 'path traversal', value: '../other-tenant' },
+    { name: 'command substitution', value: '$(whoami)' },
+    { name: 'uppercase (outside the Unix username charset)', value: 'Alice' },
+  ])('refuses a malformed {unix_user} value: $name', async ({ value }) => {
+    const { substituteTemplateVariables } = await import('./spawn-executor');
+
+    // The template runs via `sh -c` and launchers use {unix_user} as a path
+    // segment for per-user home mounts, so format validation (not escaping)
+    // is the control — it must reject both shell and path-traversal shapes.
+    expect(() =>
+      substituteTemplateVariables('launch --user {unix_user}', { unix_user: value })
+    ).toThrow('{unix_user} value is not a valid Unix username');
   });
 });

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -32,6 +32,7 @@ import {
   buildSpawnArgs,
   escapeShellArg,
   isSecretEnvKey,
+  isValidUnixUsername,
   prepareImpersonationEnv,
 } from '@agor/core/unix';
 import { getCurrentLogLevel } from '@agor/core/utils/logger';
@@ -168,6 +169,17 @@ export function substituteTemplateVariables(
   if (template.includes('{tenant_id}') && !variables.tenant_id) {
     throw new Error(
       'executor_command_template requires {tenant_id}, but no active tenant context is available'
+    );
+  }
+
+  // `{unix_user}` is rendered into a `sh -c` command AND is typically used by
+  // launchers as a path segment (per-user home mounts), so a malformed value
+  // is both a shell-injection and a path-traversal vector. The Unix username
+  // charset excludes shell metacharacters, `/` and `.`, so format validation
+  // is the control here (stronger than escaping, which would not stop `../`).
+  if (variables.unix_user !== undefined && !isValidUnixUsername(variables.unix_user)) {
+    throw new Error(
+      'executor_command_template {unix_user} value is not a valid Unix username; refusing to execute'
     );
   }
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -372,6 +372,21 @@ template instead of passing a literal or empty tenant value. In
 `required_from_auth` mode, every executor launch requires an active tenant
 context, whether or not its template uses the placeholder.
 
+`{unix_user}` is validated against the Unix-username format and Agor refuses
+to execute the template when the value is malformed — it is rendered into a
+`sh -c` command and commonly used as a path segment for per-user home mounts.
+In `unix_user_mode: delegated` it carries the session user's `unix_username`;
+in `insulated`/`strict` it carries the resolved impersonation identity.
+
+> **Codex subscription credentials caveat:** daemon-side Codex login flows
+> (paste-import, device sign-in, logout) write `~/.codex/auth.json` on the
+> **daemon host**. When executors run through a command template, their home
+> directory is typically provided by the container/orchestration layer, so a
+> daemon-managed credential file may never reach the executor. In
+> `unix_user_mode: delegated` these flows are rejected with a clear message;
+> in `simple` with a template they still write the daemon-host file — sign in
+> to Codex from a branch terminal or inside a session instead.
+
 ### How It Works
 
 1. Daemon receives request (e.g., start agent session)

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -228,6 +228,10 @@ execution:
   # Unix user mode (default: simple)
   # Options:
   #   - simple: No isolation, all runs as daemon user
+  #   - delegated: Like simple (no sudo, no groups), but every user must have
+  #     a unix_username; it is passed to the executor command template as
+  #     {unix_user} and its absence fails loudly. For hosted/containerized
+  #     deployments where the orchestration layer enforces identity.
   #   - insulated: Branch groups + single executor user
   #   - strict: Full per-user isolation, enforced impersonation
   unix_user_mode: insulated # or strict
@@ -238,21 +242,28 @@ execution:
 
 **Mode Comparison:**
 
-| Mode        | Unix Groups | FS Permissions | Process Impersonation | Use Case                 |
-| ----------- | ----------- | -------------- | --------------------- | ------------------------ |
-| `simple`    | ❌          | ❌             | ❌                    | Single user, dev/testing |
-| `insulated` | ✅          | ✅             | Optional              | Shared dev, FS isolation |
-| `strict`    | ✅          | ✅             | ✅ Required           | Production, compliance   |
+| Mode        | Unix Groups | FS Permissions | Process Impersonation | `unix_username` Required | Use Case                    |
+| ----------- | ----------- | -------------- | --------------------- | ------------------------ | --------------------------- |
+| `simple`    | ❌          | ❌             | ❌                    | ❌                       | Single user, dev/testing    |
+| `delegated` | ❌          | ❌             | ❌                    | ✅                       | Hosted/containerized, identity enforced by orchestration |
+| `insulated` | ✅          | ✅             | Optional              | ❌                       | Shared dev, FS isolation    |
+| `strict`    | ✅          | ✅             | ✅ Required           | ✅                       | Production, compliance      |
 
 **When to use each mode:**
 
 - **`simple`** - Default, single user or fully trusted team, no setup required
+- **`delegated`** - Hosted/containerized deployments where the execution
+  substrate (e.g. per-user home mounts selected via the `{unix_user}` template
+  variable) enforces identity. No sudoers or local Unix accounts needed, but a
+  session whose user has no `unix_username` fails loudly instead of silently
+  sharing an identity
 - **`insulated`** - Recommended for shared development, isolates daemon from executors
 - **`strict`** - Production environments, compliance requirements, full audit trail
 
 `branch_rbac` and `unix_user_mode` are intentionally independent: RBAC controls
-Agor app permissions; non-`simple` Unix modes control OS identities, Unix groups,
-and filesystem permissions.
+Agor app permissions; `insulated`/`strict` Unix modes control OS identities,
+Unix groups, and filesystem permissions. `delegated` performs no OS-level work
+on the daemon host — it only requires and propagates per-user identity.
 
 ### 4b. (Optional) Disable the Web Terminal
 

--- a/apps/agor-docs/content/security.mdx
+++ b/apps/agor-docs/content/security.mdx
@@ -22,12 +22,13 @@ This page covers the **four deployment modes** Agor supports, what each enforces
 
 ## Pick a Deployment Mode
 
-Agor has four canonical modes. Choose based on **who shares the daemon** and **how much you trust them**.
+Agor has five canonical modes. Choose based on **who shares the daemon** and **how much you trust them**.
 
 | Mode | `branch_rbac` | `unix_user_mode` | Who's it for? |
 |---|---|---|---|
 | **Dev / Solo** | `false` | `simple` | Personal machine, trusted team of one |
 | **Local Team** | `true` | `simple` | Small team, RBAC for organization, no Unix isolation |
+| **Delegated** | `true` | `delegated` | Hosted/containerized deployments — per-user `unix_username` is required and handed to the orchestration layer (via the `{unix_user}` template variable), which enforces OS identity |
 | **Insulated** | `true` | `insulated` | Shared dev box, filesystem protection, no per-user processes |
 | **Strict** | `true` | `strict` | Production / compliance, full per-user OS isolation |
 
@@ -35,7 +36,7 @@ Agor has four canonical modes. Choose based on **who shares the daemon** and **h
 # ~/.agor/config.yaml
 execution:
   branch_rbac: false        # default: false
-  unix_user_mode: simple       # simple | insulated | strict
+  unix_user_mode: simple       # simple | delegated | insulated | strict
   executor_unix_user: agor_executor   # required for insulated
 ```
 
@@ -194,15 +195,16 @@ If unset, Agor falls back to plaintext storage and logs a warning. Never run a s
 
 ### Web Terminal Trust Boundary
 
-The browser terminal is enabled by default for `member+` users. **In `unix_user_mode: simple`, the terminal runs as the daemon user.** That means a member-tier user can shell out and read `~/.agor/config.yaml`, `agor.db`, the JWT secret, and every API key the daemon knows about.
+The browser terminal is enabled by default for `member+` users. **In `unix_user_mode: simple` — and in `delegated` without an executor command template — the terminal runs as the daemon user.** That means a member-tier user can shell out and read `~/.agor/config.yaml`, `agor.db`, the JWT secret, and every API key the daemon knows about.
 
-Three ways to handle this:
+Ways to handle this:
 
 1. **`unix_user_mode: strict`** runs the terminal as the user's Unix account. Safe.
 2. **`unix_user_mode: insulated`** runs the terminal as the executor user, scoped by branch group. Mostly safe.
-3. **`execution.allow_web_terminal: false`** disables the terminal entirely.
+3. **`unix_user_mode: delegated` with an executor command template** routes the terminal into the execution substrate under the user's identity. Safe when the substrate enforces it.
+4. **`execution.allow_web_terminal: false`** disables the terminal entirely.
 
-The daemon prints a startup warning when the unsafe combination is active.
+The daemon prints a startup warning when an unsafe combination is active.
 
 ### Message Gateway is High-Trust
 

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -255,6 +255,11 @@ export const AboutTab: React.FC<AboutTabProps> = ({
                             (no OS isolation)
                           </Typography.Text>
                         )}
+                        {healthInfo.execution.unixUserMode === 'delegated' && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                            (per-user identity, enforced by substrate)
+                          </Typography.Text>
+                        )}
                         {healthInfo.execution.unixUserMode === 'insulated' && (
                           <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
                             (branch groups)

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -9,7 +9,6 @@ import * as yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetConfigCacheForTests,
-  assertUnixUsernameSatisfiesMode,
   ensureBranchStorageModeAllowed,
   expandHomePath,
   getAgorHome,
@@ -684,27 +683,6 @@ describe('unixUserModeRequiresUsername', () => {
     expect(unixUserModeRequiresUsername('insulated')).toBe(false);
     expect(unixUserModeRequiresUsername('delegated')).toBe(true);
     expect(unixUserModeRequiresUsername('strict')).toBe(true);
-  });
-});
-
-describe('assertUnixUsernameSatisfiesMode', () => {
-  it('passes when the mode does not require a unix_username', () => {
-    expect(() => assertUnixUsernameSatisfiesMode(null, 'simple')).not.toThrow();
-    expect(() => assertUnixUsernameSatisfiesMode(undefined, 'insulated')).not.toThrow();
-  });
-
-  it('passes when a unix_username is present', () => {
-    expect(() => assertUnixUsernameSatisfiesMode('alice', 'delegated')).not.toThrow();
-    expect(() => assertUnixUsernameSatisfiesMode('alice', 'strict')).not.toThrow();
-  });
-
-  it('throws with the mode name and subject when required and missing', () => {
-    expect(() => assertUnixUsernameSatisfiesMode(null, 'delegated', 'gateway user u-1')).toThrow(
-      /unix_user_mode 'delegated' requires a unix_username, but gateway user u-1 has none/
-    );
-    expect(() => assertUnixUsernameSatisfiesMode(undefined, 'strict')).toThrow(
-      /unix_user_mode 'strict' requires a unix_username/
-    );
   });
 });
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -626,6 +626,21 @@ describe('loadConfig cache', () => {
       },
     },
     {
+      // Delegated requires per-user unix_username but performs no OS-level
+      // work on the daemon host: no sudo, no groups, no daemon.unix_user.
+      name: 'delegated (identity enforced by execution substrate)',
+      config: { execution: { branch_rbac: true, unix_user_mode: 'delegated' } } as AgorConfig,
+      expected: {
+        appRbacEnabled: true,
+        unixUserMode: 'delegated',
+        unixImpersonationEnabled: false,
+        unixFsIsolationEnabled: false,
+        unixGroupRefreshNeeded: false,
+        requiresDaemonUnixUser: false,
+        shouldInitUnixGroups: false,
+      },
+    },
+    {
       name: 'Unix insulated without app RBAC',
       config: { execution: { branch_rbac: false, unix_user_mode: 'insulated' } } as AgorConfig,
       expected: {

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -9,6 +9,7 @@ import * as yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __resetConfigCacheForTests,
+  assertUnixUsernameSatisfiesMode,
   ensureBranchStorageModeAllowed,
   expandHomePath,
   getAgorHome,
@@ -37,6 +38,7 @@ import {
   resolveTeammateFrameworkRepoUrl,
   saveConfig,
   setConfigValue,
+  unixUserModeRequiresUsername,
   unsetConfigValue,
 } from './config-manager';
 import type { AgorConfig } from './types';
@@ -673,6 +675,36 @@ describe('loadConfig cache', () => {
     },
   ])('resolves execution security mode: $name', ({ config, expected }) => {
     expect(resolveExecutionSecurityMode(config)).toEqual(expected);
+  });
+});
+
+describe('unixUserModeRequiresUsername', () => {
+  it('requires a username only in strict and delegated', () => {
+    expect(unixUserModeRequiresUsername('simple')).toBe(false);
+    expect(unixUserModeRequiresUsername('insulated')).toBe(false);
+    expect(unixUserModeRequiresUsername('delegated')).toBe(true);
+    expect(unixUserModeRequiresUsername('strict')).toBe(true);
+  });
+});
+
+describe('assertUnixUsernameSatisfiesMode', () => {
+  it('passes when the mode does not require a unix_username', () => {
+    expect(() => assertUnixUsernameSatisfiesMode(null, 'simple')).not.toThrow();
+    expect(() => assertUnixUsernameSatisfiesMode(undefined, 'insulated')).not.toThrow();
+  });
+
+  it('passes when a unix_username is present', () => {
+    expect(() => assertUnixUsernameSatisfiesMode('alice', 'delegated')).not.toThrow();
+    expect(() => assertUnixUsernameSatisfiesMode('alice', 'strict')).not.toThrow();
+  });
+
+  it('throws with the mode name and subject when required and missing', () => {
+    expect(() => assertUnixUsernameSatisfiesMode(null, 'delegated', 'gateway user u-1')).toThrow(
+      /unix_user_mode 'delegated' requires a unix_username, but gateway user u-1 has none/
+    );
+    expect(() => assertUnixUsernameSatisfiesMode(undefined, 'strict')).toThrow(
+      /unix_user_mode 'strict' requires a unix_username/
+    );
   });
 });
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -610,6 +610,7 @@ describe('loadConfig cache', () => {
         unixGroupRefreshNeeded: false,
         requiresDaemonUnixUser: false,
         shouldInitUnixGroups: false,
+        requiresUserUnixUsername: false,
       },
     },
     {
@@ -623,6 +624,7 @@ describe('loadConfig cache', () => {
         unixGroupRefreshNeeded: false,
         requiresDaemonUnixUser: false,
         shouldInitUnixGroups: false,
+        requiresUserUnixUsername: false,
       },
     },
     {
@@ -638,6 +640,7 @@ describe('loadConfig cache', () => {
         unixGroupRefreshNeeded: false,
         requiresDaemonUnixUser: false,
         shouldInitUnixGroups: false,
+        requiresUserUnixUsername: true,
       },
     },
     {
@@ -651,6 +654,7 @@ describe('loadConfig cache', () => {
         unixGroupRefreshNeeded: true,
         requiresDaemonUnixUser: true,
         shouldInitUnixGroups: true,
+        requiresUserUnixUsername: false,
       },
     },
     {
@@ -664,6 +668,7 @@ describe('loadConfig cache', () => {
         unixGroupRefreshNeeded: true,
         requiresDaemonUnixUser: true,
         shouldInitUnixGroups: true,
+        requiresUserUnixUsername: true,
       },
     },
   ])('resolves execution security mode: $name', ({ config, expected }) => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -1188,13 +1188,16 @@ export interface ResolvedExecutionSecurityMode {
  * Keep this as the single semantic boundary between app-layer RBAC and
  * OS/filesystem isolation:
  * - `branch_rbac` controls Agor app permissions only.
- * - non-`simple` `unix_user_mode` controls Unix impersonation/groups/FS ACLs.
+ * - `insulated`/`strict` `unix_user_mode` controls Unix impersonation/groups/FS ACLs.
+ * - `delegated` requires per-user `unix_username` but performs no OS-level
+ *   work on the daemon host (no sudo, no groups, no sudoers) — identity
+ *   enforcement is delegated to the execution substrate.
  */
 export function resolveExecutionSecurityMode(
   config: AgorConfig = loadConfigSync()
 ): ResolvedExecutionSecurityMode {
   const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
-  const unixIsolationEnabled = unixUserMode !== 'simple';
+  const unixIsolationEnabled = unixUserMode === 'insulated' || unixUserMode === 'strict';
 
   return {
     appRbacEnabled: config.execution?.branch_rbac === true,
@@ -1227,8 +1230,8 @@ export function isBranchRbacEnabled(): boolean {
 /**
  * Check if Unix user impersonation is enabled
  *
- * Returns true when unix_user_mode is set to anything other than 'simple'
- * (i.e., 'insulated' or 'strict')
+ * Returns true when unix_user_mode is 'insulated' or 'strict'. 'delegated'
+ * does not impersonate — identity enforcement lives in the execution substrate.
  */
 export function isUnixImpersonationEnabled(): boolean {
   try {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -8,6 +8,7 @@ import { readFileSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Forbidden } from '@feathersjs/errors';
 import * as yaml from 'js-yaml';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
@@ -1212,8 +1213,38 @@ export function resolveExecutionSecurityMode(
     unixGroupRefreshNeeded: unixIsolationEnabled,
     requiresDaemonUnixUser: unixIsolationEnabled,
     shouldInitUnixGroups: unixIsolationEnabled,
-    requiresUserUnixUsername: unixUserMode === 'strict' || unixUserMode === 'delegated',
+    requiresUserUnixUsername: unixUserModeRequiresUsername(unixUserMode),
   };
+}
+
+/**
+ * Whether a Unix user mode treats per-user `unix_username` as load-bearing
+ * identity. Single predicate shared by `resolveExecutionSecurityMode()` and
+ * call sites that only have the raw mode, so the strict/delegated pairing
+ * cannot drift.
+ */
+export function unixUserModeRequiresUsername(mode: import('./types').UnixUserMode): boolean {
+  return mode === 'strict' || mode === 'delegated';
+}
+
+/**
+ * Fail loudly when the configured Unix user mode requires a per-user
+ * `unix_username` (`strict`, `delegated`) and the resolved value is missing.
+ * Creating a session without one would only defer the failure to prompt time —
+ * or, in hosted deployments, silently share an identity. Requiredness is
+ * derived from the mode here so callers cannot fabricate inconsistent
+ * combinations.
+ */
+export function assertUnixUsernameSatisfiesMode(
+  unixUsername: string | null | undefined,
+  mode: import('./types').UnixUserMode,
+  subject = 'your account'
+): void {
+  if (!unixUserModeRequiresUsername(mode) || unixUsername) return;
+  throw new Forbidden(
+    `unix_user_mode '${mode}' requires a unix_username, but ${subject} has none. ` +
+      'Ask an admin to set one before creating sessions.'
+  );
 }
 
 /**

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -1180,6 +1180,11 @@ export interface ResolvedExecutionSecurityMode {
   requiresDaemonUnixUser: boolean;
   /** Whether new repos/branches should initialize Unix groups. */
   shouldInitUnixGroups: boolean;
+  /**
+   * Whether every user must have a `unix_username` (strict and delegated).
+   * Session creation and executor/terminal launches fail loudly without one.
+   */
+  requiresUserUnixUsername: boolean;
 }
 
 /**
@@ -1207,6 +1212,7 @@ export function resolveExecutionSecurityMode(
     unixGroupRefreshNeeded: unixIsolationEnabled,
     requiresDaemonUnixUser: unixIsolationEnabled,
     shouldInitUnixGroups: unixIsolationEnabled,
+    requiresUserUnixUsername: unixUserMode === 'strict' || unixUserMode === 'delegated',
   };
 }
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -8,7 +8,6 @@ import { readFileSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { Forbidden } from '@feathersjs/errors';
 import * as yaml from 'js-yaml';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
@@ -1225,26 +1224,6 @@ export function resolveExecutionSecurityMode(
  */
 export function unixUserModeRequiresUsername(mode: import('./types').UnixUserMode): boolean {
   return mode === 'strict' || mode === 'delegated';
-}
-
-/**
- * Fail loudly when the configured Unix user mode requires a per-user
- * `unix_username` (`strict`, `delegated`) and the resolved value is missing.
- * Creating a session without one would only defer the failure to prompt time —
- * or, in hosted deployments, silently share an identity. Requiredness is
- * derived from the mode here so callers cannot fabricate inconsistent
- * combinations.
- */
-export function assertUnixUsernameSatisfiesMode(
-  unixUsername: string | null | undefined,
-  mode: import('./types').UnixUserMode,
-  subject = 'your account'
-): void {
-  if (!unixUserModeRequiresUsername(mode) || unixUsername) return;
-  throw new Forbidden(
-    `unix_user_mode '${mode}' requires a unix_username, but ${subject} has none. ` +
-      'Ask an admin to set one before creating sessions.'
-  );
 }
 
 /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -311,10 +311,15 @@ export interface AgorDatabaseSettings {
  * OS identities.
  *
  * - `simple` — all processes run as the daemon user (no OS isolation)
+ * - `delegated` — like `simple` (no sudo impersonation, no Unix groups), but
+ *   every user MUST have a `unix_username`: it is passed to the execution
+ *   substrate (e.g. the `{unix_user}` executor-command-template variable, which
+ *   hosted deployments use to select per-user home mounts) and its absence
+ *   fails loudly instead of silently sharing an identity
  * - `insulated` — executors run as a dedicated user with per-branch groups
  * - `strict` — sessions run as the session creator's own Unix user
  */
-export type UnixUserMode = 'simple' | 'insulated' | 'strict';
+export type UnixUserMode = 'simple' | 'delegated' | 'insulated' | 'strict';
 
 export interface AgorExecutorHeartbeatSettings {
   /** Enable executor task heartbeats (default: true). */

--- a/packages/core/src/unix/environment-command-spawn.ts
+++ b/packages/core/src/unix/environment-command-spawn.ts
@@ -145,10 +145,13 @@ export async function spawnEnvironmentCommand(
   const config = await loadConfig();
   const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
 
-  // Resolve impersonation user first to determine if we need impersonation-safe env
+  // Resolve impersonation user first to determine if we need impersonation-safe env.
+  // Only insulated/strict impersonate; simple and delegated both run env
+  // commands as the daemon user (delegated's identity requirement applies to
+  // executor/terminal launches, not local env spawns).
   let asUser: string | undefined;
 
-  if (unixUserMode !== 'simple') {
+  if (unixUserMode === 'insulated' || unixUserMode === 'strict') {
     // Look up user's unix_username
     const usersRepo = new UsersRepository(db);
     const user = await usersRepo.findById(branch.created_by);

--- a/packages/core/src/unix/user-manager.test.ts
+++ b/packages/core/src/unix/user-manager.test.ts
@@ -343,7 +343,75 @@ describe('user-manager', () => {
         });
 
         expect(result.unixUser).toBeNull();
+        expect(result.reportedUnixUser).toBeNull();
         expect(result.reason).toContain('simple mode');
+      });
+    });
+
+    describe('delegated mode', () => {
+      it('reports the user unix_username without impersonating', () => {
+        const result = resolveUnixUserForImpersonation({
+          mode: 'delegated',
+          userUnixUsername: 'alice',
+          executorUnixUser: 'executor',
+        });
+
+        // No sudo identity — the daemon does not impersonate...
+        expect(result.unixUser).toBeNull();
+        // ...but the identity is still reported to the execution substrate.
+        expect(result.reportedUnixUser).toBe('alice');
+        expect(result.reason).toContain('delegated');
+      });
+
+      it('throws when no user unix_username provided', () => {
+        expect(() =>
+          resolveUnixUserForImpersonation({
+            mode: 'delegated',
+            userUnixUsername: undefined,
+            executorUnixUser: 'executor',
+          })
+        ).toThrow('Delegated Unix user mode requires unix_username');
+      });
+
+      it('throws when user unix_username is null', () => {
+        expect(() =>
+          resolveUnixUserForImpersonation({
+            mode: 'delegated',
+            userUnixUsername: null,
+            executorUnixUser: 'executor',
+          })
+        ).toThrow('Delegated Unix user mode requires unix_username');
+      });
+
+      it('ignores the configured executor user', () => {
+        const result = resolveUnixUserForImpersonation({
+          mode: 'delegated',
+          userUnixUsername: 'alice',
+          executorUnixUser: 'agor_executor',
+        });
+
+        expect(result.unixUser).toBeNull();
+        expect(result.reportedUnixUser).toBe('alice');
+      });
+    });
+
+    describe('reportedUnixUser matrix', () => {
+      it('equals the sudo identity in every mode except delegated', () => {
+        const insulated = resolveUnixUserForImpersonation({
+          mode: 'insulated',
+          userUnixUsername: 'alice',
+          executorUnixUser: 'agor_executor',
+        });
+        expect(insulated.reportedUnixUser).toBe(insulated.unixUser);
+        expect(insulated.reportedUnixUser).toBe('agor_executor');
+
+        const strict = resolveUnixUserForImpersonation({
+          mode: 'strict',
+          userUnixUsername: 'alice',
+          executorUnixUser: 'agor_executor',
+        });
+        expect(strict.reportedUnixUser).toBe(strict.unixUser);
+        expect(strict.reportedUnixUser).toBe('alice');
       });
     });
 
@@ -453,6 +521,11 @@ describe('user-manager', () => {
     it('does nothing for simple mode', () => {
       expect(() => validateResolvedUnixUser('simple', 'alice')).not.toThrow();
       expect(() => validateResolvedUnixUser('simple', null)).not.toThrow();
+    });
+
+    it('does nothing for delegated mode (identity need not exist on the daemon host)', () => {
+      expect(() => validateResolvedUnixUser('delegated', 'alice')).not.toThrow();
+      expect(() => validateResolvedUnixUser('delegated', null)).not.toThrow();
     });
 
     it('validates user exists for strict mode', () => {

--- a/packages/core/src/unix/user-manager.test.ts
+++ b/packages/core/src/unix/user-manager.test.ts
@@ -15,6 +15,7 @@ import {
   AGOR_BRANCHES_DIR,
   AGOR_DEFAULT_SHELL,
   AGOR_HOME_BASE,
+  assertUnixUsernameSatisfiesMode,
   generateUnixUsername,
   getUserBranchesDir,
   getUserHomeDir,
@@ -516,6 +517,27 @@ describe('user-manager', () => {
   // =========================================================================
   // Validation of Resolved Unix User
   // =========================================================================
+
+  describe('assertUnixUsernameSatisfiesMode', () => {
+    it('passes when the mode does not require a unix_username', () => {
+      expect(() => assertUnixUsernameSatisfiesMode(null, 'simple')).not.toThrow();
+      expect(() => assertUnixUsernameSatisfiesMode(undefined, 'insulated')).not.toThrow();
+    });
+
+    it('passes when a unix_username is present', () => {
+      expect(() => assertUnixUsernameSatisfiesMode('alice', 'delegated')).not.toThrow();
+      expect(() => assertUnixUsernameSatisfiesMode('alice', 'strict')).not.toThrow();
+    });
+
+    it('throws with the mode name and subject when required and missing', () => {
+      expect(() => assertUnixUsernameSatisfiesMode(null, 'delegated', 'gateway user u-1')).toThrow(
+        /unix_user_mode 'delegated' requires a unix_username, but gateway user u-1 has none/
+      );
+      expect(() => assertUnixUsernameSatisfiesMode(undefined, 'strict')).toThrow(
+        /unix_user_mode 'strict' requires a unix_username/
+      );
+    });
+  });
 
   describe('validateResolvedUnixUser', () => {
     it('does nothing for simple mode', () => {

--- a/packages/core/src/unix/user-manager.ts
+++ b/packages/core/src/unix/user-manager.ts
@@ -363,8 +363,16 @@ export type { UnixUserMode };
  * Result of resolving which Unix user to impersonate
  */
 export interface ImpersonationResult {
-  /** Unix username to impersonate, or null for no impersonation */
+  /** Unix username to impersonate (via sudo), or null for no impersonation */
   unixUser: string | null;
+  /**
+   * Unix identity to report to the execution substrate (e.g. the `{unix_user}`
+   * executor-command-template variable), independent of whether the daemon
+   * itself impersonates. Equals `unixUser` in every mode except `delegated`,
+   * where the daemon does not sudo but the identity is still load-bearing —
+   * hosted deployments use it to select per-user home mounts.
+   */
+  reportedUnixUser: string | null;
   /** Human-readable reason for the decision */
   reason: string;
 }
@@ -411,13 +419,32 @@ export function resolveUnixUserForImpersonation(
       // No impersonation - run as current user
       return {
         unixUser: null,
+        reportedUnixUser: null,
         reason: 'simple mode - no impersonation',
+      };
+
+    case 'delegated':
+      // No impersonation, but the identity is load-bearing: the execution
+      // substrate (command template / orchestration) selects the user's home
+      // from it. A missing unix_username must fail loudly here — falling
+      // through would silently collapse the session into a shared/wrong home.
+      if (!userUnixUsername) {
+        throw new Error(
+          'Delegated Unix user mode requires unix_username to be set. ' +
+            'Ensure the user has a unix_username configured.'
+        );
+      }
+      return {
+        unixUser: null,
+        reportedUnixUser: userUnixUsername,
+        reason: `delegated mode - identity delegated to execution substrate: ${userUnixUsername}`,
       };
 
     case 'insulated':
       // Always use executor user from config
       return {
         unixUser: executorUnixUser ?? null,
+        reportedUnixUser: executorUnixUser ?? null,
         reason: executorUnixUser
           ? `insulated mode - using executor: ${executorUnixUser}`
           : 'insulated mode - no executor configured',
@@ -433,6 +460,7 @@ export function resolveUnixUserForImpersonation(
       }
       return {
         unixUser: userUnixUsername,
+        reportedUnixUser: userUnixUsername,
         reason: `strict mode - using unix_username: ${userUnixUsername}`,
       };
 
@@ -440,6 +468,7 @@ export function resolveUnixUserForImpersonation(
       console.warn(`⚠️ Unknown unix_user_mode: ${mode}, falling back to simple mode`);
       return {
         unixUser: null,
+        reportedUnixUser: null,
         reason: 'unknown mode - defaulting to no impersonation',
       };
   }

--- a/packages/core/src/unix/user-manager.ts
+++ b/packages/core/src/unix/user-manager.ts
@@ -8,6 +8,8 @@
  */
 
 import { execSync } from 'node:child_process';
+import { Forbidden } from '@feathersjs/errors';
+import { unixUserModeRequiresUsername } from '../config/config-manager.js';
 import type { UnixUserMode } from '../config/types.js';
 import { toShortId } from '../lib/ids.js';
 import type { UserID, UUID } from '../types/index.js';
@@ -358,6 +360,28 @@ export function unixUserExists(username: string): boolean {
  * Node-only module.
  */
 export type { UnixUserMode };
+
+/**
+ * Fail loudly when the configured Unix user mode requires a per-user
+ * `unix_username` (`strict`, `delegated`) and the resolved value is missing.
+ * Creating a session without one would only defer the failure to prompt time —
+ * or, in hosted deployments, silently share an identity. Requiredness is
+ * derived from the mode here so callers cannot fabricate inconsistent
+ * combinations. Lives beside {@link resolveUnixUserForImpersonation} because
+ * both express the same identity policy; throws `Forbidden` so Feathers
+ * create/fork/spawn paths surface it as a 403 without per-caller translation.
+ */
+export function assertUnixUsernameSatisfiesMode(
+  unixUsername: string | null | undefined,
+  mode: UnixUserMode,
+  subject = 'your account'
+): void {
+  if (!unixUserModeRequiresUsername(mode) || unixUsername) return;
+  throw new Forbidden(
+    `unix_user_mode '${mode}' requires a unix_username, but ${subject} has none. ` +
+      'Ask an admin to set one before creating sessions.'
+  );
+}
 
 /**
  * Result of resolving which Unix user to impersonate


### PR DESCRIPTION
## What

Introduces a fourth `unix_user_mode`: **`delegated`** — for hosted/containerized deployments (Agor Cloud) that run `simple` mode with an `executor_command_template` and per-user home mounts keyed on `{unix_user}`.

Design doc (short): [KB: unix-user-mode-delegated](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/architecture/unix-user-mode-delegated.md) — from the Slack discussion (Max/Jose/Richard, 2026-07-29) following PR #2082.

| Mode | sudo identity | `{unix_user}` template identity | null `unix_username` |
| --- | --- | --- | --- |
| `simple` | none | none | fine |
| **`delegated`** | **none** | **user's `unix_username`** | **loud error** |
| `insulated` | config `executor_unix_user` | same | fine (ignored) |
| `strict` | user's `unix_username` | same | loud error |

## Why

In Cloud's flavor of `simple`, `unix_username` selects the per-tenant/per-user home mount — but nothing requires it. A null value isn't an error anywhere: the unsubstituted literal `{unix_user}` reaches the launcher via `sh -c`, and all such sessions silently collapse into the same wrong/shared home. `delegated` makes the requirement explicit and the failure loud, without pulling in `insulated`/`strict`'s sudoers/groups machinery (no `daemon.unix_user`, no local Unix accounts needed).

## How

- `resolveUnixUserForImpersonation()` result gains **`reportedUnixUser`** — the identity to report to the execution substrate, decoupled from the sudo identity. `delegated` reports the user's `unix_username` (throws when missing) and never sudos.
- Executor prompt launches (`register-services.ts`) and web terminals (`terminals.ts`) feed `reportedUnixUser` into the `{unix_user}` template variable. This subsumes #2082's `sessionUnixUser || executorUnixUser` line and addresses Richard's review comment #2: `insulated` keeps reporting its configured shared executor identity.
- `substituteTemplateVariables()` now validates `{unix_user}` with `isValidUnixUsername()` and fails closed on malformed values (Richard's review comment #1). Format validation rather than shell-escaping, because launchers use the value as a **path segment** (`…/homes/{unix-username}`) — escaping would not stop `../` traversal into another user's/tenant's home.
- `resolveExecutionSecurityMode()`: `delegated` keeps all OS-isolation booleans false (no sudoers, no groups, no `daemon.unix_user` requirement) and gains **`requiresUserUnixUsername`** (strict ∥ delegated).
- **Create-time enforcement** (`dae07888`): in strict/delegated, sessions for users without a `unix_username` are rejected at create/fork/spawn with an actionable error instead of failing at first prompt. Covers external creates (`setSessionUnixUsername` hook — now also registered when `branch_rbac` is off, fixing a pre-existing gap where the stamping hook was RBAC-gated), fork/spawn (`resolveChildIdentity`, incl. legacy-sharing children inheriting a null pre-migration stamp), gateway sessions, and zone-trigger sessions, via a shared `assertUnixUsernameSatisfiesMode()`.
- `delegated` joins `strict` in requiring `unix_username` at scheduler spawn and Codex identity resolution (`missing-username` UX message); env-command/branch dev-server spawns impersonate only in `insulated`/`strict`; the web-terminal startup warning also fires for `delegated` without a command template (terminal would still run as the daemon user).
- Tests: resolver mode-matrix (4 modes × present/absent), `reportedUnixUser` matrix, `delegated` security-mode resolution, `{unix_user}` malformed-value refusals (shell metachars, `../`, `$()`, bad charset), create-time assert + hook behavior.

## Notes / follow-ups (out of scope here)

- Sessions stamped `unix_username: null` before a deployment flips to `delegated` will fail loudly on their next prompt (and their forks are rejected) — backfill stamps or accept one-time re-creation.
- Internal fire-and-forget spawn sites (repo clone, unix sync, etc.) still default `{unix_user}` to the configured executor user; in `delegated` they carry no per-user identity yet. Same behavior as `simple` today.
- Launch-claim `unix_username` format validation at ingestion (`upsertLaunchUser`, #2082) is complementary defense-in-depth — with the substitution guard in place, a malformed stored value now fails closed at spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)