### PR TITLE
fix(config): forward tenant context into executor API-key resolution

### DIFF
--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -5,7 +5,14 @@ const configMocks = vi.hoisted(() => ({
   resolveApiKey: vi.fn(),
 }));
 
+const dbMocks = vi.hoisted(() => ({
+  runWithTenantDatabaseScope: vi.fn(
+    async (db: unknown, _tenantId: unknown, work: (db: unknown) => unknown) => work(db)
+  ),
+}));
+
 vi.mock('@agor/core/config', () => configMocks);
+vi.mock('@agor/core/db', () => dbMocks);
 
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { TaskID, UserID } from '@agor/core/types';
@@ -128,8 +135,9 @@ describe('ConfigService.resolveApiKey', () => {
     });
   });
 
-  it('forwards the resolved tenant into the task and session lookups', async () => {
-    const service = new ConfigService({} as never);
+  it('forwards the resolved tenant into the lookups and scopes key resolution to it', async () => {
+    const db = { marker: 'db' };
+    const service = new ConfigService(db as never);
     const taskGet = vi.fn(async () => ({
       created_by: 'creator-1' as UserID,
       session_id: 'session-1',
@@ -157,6 +165,16 @@ describe('ConfigService.resolveApiKey', () => {
 
     expect(taskGet).toHaveBeenCalledWith('task-1', { provider: undefined, tenant });
     expect(sessionGet).toHaveBeenCalledWith('session-1', { provider: undefined, tenant });
+    expect(dbMocks.runWithTenantDatabaseScope).toHaveBeenCalledWith(
+      db,
+      'tenant-1',
+      expect.any(Function)
+    );
+    expect(configMocks.resolveApiKey).toHaveBeenCalledWith('OPENAI_API_KEY', {
+      userId: 'creator-1',
+      db,
+      tool: 'codex',
+    });
   });
 
   it('allows executor runtime tokens passed as explicit session-token proof', async () => {

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -128,6 +128,37 @@ describe('ConfigService.resolveApiKey', () => {
     });
   });
 
+  it('forwards the resolved tenant into the task and session lookups', async () => {
+    const service = new ConfigService({} as never);
+    const taskGet = vi.fn(async () => ({
+      created_by: 'creator-1' as UserID,
+      session_id: 'session-1',
+    }));
+    const sessionGet = vi.fn(async () => ({ agentic_tool: 'codex' }));
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') return { get: taskGet };
+        if (name === 'sessions') return { get: sessionGet };
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    const tenant = { tenant_id: 'tenant-1', source: 'auth_claim' };
+    await service.resolveApiKey(
+      { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'codex' },
+      {
+        provider: 'socketio',
+        tenant,
+        authentication: {
+          payload: { type: 'executor-session', purpose: 'executor-task', task_id: 'task-1' },
+        },
+      } as never
+    );
+
+    expect(taskGet).toHaveBeenCalledWith('task-1', { provider: undefined, tenant });
+    expect(sessionGet).toHaveBeenCalledWith('session-1', { provider: undefined, tenant });
+  });
+
   it('allows executor runtime tokens passed as explicit session-token proof', async () => {
     const service = new ConfigService({} as never);
     service.app = {

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -176,12 +176,18 @@ export class ConfigService {
 
     // Fetch task to get creator user ID and session. This is required for
     // executor-token calls and best-effort for internal/service-account calls.
+    // Forward the resolved tenant so the tenant-scoped lookups keep context;
+    // in required_from_auth mode a bare internal call has none and is rejected.
+    const internalParams: AuthenticatedParams = {
+      provider: undefined,
+      tenant: (params as AuthenticatedParams | undefined)?.tenant,
+    };
     let userId: UserID | undefined;
     let sessionId: string | undefined;
     try {
       const tasksService = this.app?.service('tasks');
       if (tasksService) {
-        const task = await tasksService.get(taskId, { provider: undefined });
+        const task = await tasksService.get(taskId, internalParams);
         userId = task?.created_by;
         sessionId = task?.session_id;
       }
@@ -215,7 +221,7 @@ export class ConfigService {
       if (!sessionsService) {
         throw new Forbidden('Executor token tool scope could not be verified');
       }
-      const session = await sessionsService.get(verifiedSessionId, { provider: undefined });
+      const session = await sessionsService.get(verifiedSessionId, internalParams);
       if (session?.agentic_tool !== tool) {
         throw new Forbidden('Executor token tool scope does not match this session');
       }

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -176,8 +176,6 @@ export class ConfigService {
 
     // Fetch task to get creator user ID and session. This is required for
     // executor-token calls and best-effort for internal/service-account calls.
-    // Forward the resolved tenant so the tenant-scoped lookups keep context;
-    // in required_from_auth mode a bare internal call has none and is rejected.
     const internalParams: AuthenticatedParams = {
       provider: undefined,
       tenant: (params as AuthenticatedParams | undefined)?.tenant,
@@ -227,9 +225,6 @@ export class ConfigService {
       }
     }
 
-    // Resolve the key inside the request's tenant database scope. This service
-    // carries no ambient scope of its own, and in required_from_auth mode the
-    // resolver's DB read fails closed without one.
     const result = await runWithTenantDatabaseScope(
       this.db,
       internalParams.tenant?.tenant_id,

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -6,7 +6,7 @@
  */
 
 import { type ApiKeyName, loadConfig, resolveApiKey } from '@agor/core/config';
-import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
   type AgenticToolName,
@@ -227,12 +227,14 @@ export class ConfigService {
       }
     }
 
-    // Use core resolveApiKey with database access
-    const result = await resolveApiKey(keyName, {
-      userId,
-      db: this.db,
-      tool,
-    });
+    // Resolve the key inside the request's tenant database scope. This service
+    // carries no ambient scope of its own, and in required_from_auth mode the
+    // resolver's DB read fails closed without one.
+    const result = await runWithTenantDatabaseScope(
+      this.db,
+      internalParams.tenant?.tenant_id,
+      (tenantDb) => resolveApiKey(keyName, { userId, db: tenantDb, tool })
+    );
     if (result.useNativeAuth) {
       const config = await loadConfig();
       if (config.multi_tenancy?.mode === 'required_from_auth') {


### PR DESCRIPTION
## Problem

Every agent session on a `multi_tenancy.mode: required_from_auth` Cell (production) fails immediately with **"Executor token task scope could not be verified"** — for both Codex and Claude. The agent never starts.

## Root cause

When an executor calls `/config/resolve-api-key` to resolve its agent credential:

1. `requireAuth` authenticates the task-scoped executor JWT and resolves `params.tenant` from the token's `tenant_id` claim. ✅
2. But `ConfigService.resolveApiKey` then fetches the task/session with **bare internal params** (`{ provider: undefined }`), dropping `params.tenant`.
3. The tasks service's tenant-scope hook re-resolves the tenant from those bare params, finds none, and throws `TenantResolutionError('Missing tenant context for multi_tenancy.required_from_auth')`.
4. That's caught and rethrown as `Forbidden('Executor token task scope could not be verified')`, which the UI surfaces to the user.

Observed in production (`cell_prod_us1a_cycle12`):
```
[Config.resolveApiKey] Failed to fetch task 019fafb3-…:
NotAuthenticated: Missing tenant context for multi_tenancy.required_from_auth
    at async ConfigService.resolveApiKey
```

## Fix

Forward the request's already-resolved `params.tenant` into both internal lookups (task + session) via a typed `AuthenticatedParams` object, so the tenant-scoped queries keep context. In `static` mode this is a no-op (tenant resolves from static config regardless).

## Test

Adds a unit test asserting the resolved tenant is forwarded into both the `tasks` and `sessions` `.get` calls. Full `config.test.ts` suite green (11/11).

## Scope

Runtime-side only; rides the runtime Release (not the manager-api image). No control-plane change.