### PR TITLE
feat(docs): link footer AGent ORchestration etymology to origin story

### DIFF
--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -265,12 +265,14 @@
 }
 
 .footerEtymology {
+  display: block;
   margin: 6px 0 0;
   color: var(--landing-muted);
   font-family: var(--font-display-stack);
   font-size: 0.85rem;
   font-weight: 500;
   letter-spacing: 0.02em;
+  text-decoration: none;
 }
 
 .footerEtymology span {

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1522,9 +1522,9 @@ export function LandingPage() {
           <div>
             <strong>agor</strong>
             <p>The command center for AI enablement.</p>
-            <p className={styles.footerEtymology}>
+            <Link href="/blog/making-of-agor" className={styles.footerEtymology}>
               <span>AG</span>ent <span>OR</span>chestration
-            </p>
+            </Link>
           </div>
         </div>
         <div className={styles.footerLinks}>


### PR DESCRIPTION
## Summary
- Microsoft Clarity click-map data flagged users clicking the "AGent ORchestration" etymology text in the landing page footer — it wasn't a link.
- Points it at `/blog/making-of-agor` ("The Making of Agor"), the closest thing we have to an origin story for the name.
- Kept the existing visual treatment as-is (no new hover styling) — the AG/OR teal highlight already reads as "special" text.

## Not included
- The hero header text was also getting stray clicks per Clarity, but there's no clear, non-arbitrary destination for it — left as non-interactive.
- Clarity also flagged a broken resource reference (e.g. `word-mark.svg`) leading to a 404. Searched current code, every `public/` asset reference, full git history, and the live rendered homepage (all image/video URLs return 200) — found no trace of it anywhere, past or present. Likely already fixed by an earlier landing-page redesign, or a stale/cached link. Can revisit if the exact flagged URL turns up.

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] `biome check` passes clean
- [x] Ran the docs dev server locally, confirmed the footer link renders (`href="/blog/making-of-agor"`) and resolves 200
- [x] Verified every image/video asset referenced on the live homepage resolves 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)