### PR TITLE
feat(opencode): add provider API key authentication

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -464,6 +464,7 @@ export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'codex-auth/device',
   'codex-auth/import',
   'codex-auth/logout',
+  'opencode-auth',
   'claude-models',
   'copilot-models',
   'cursor-models',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5,6 +5,7 @@
  * Extracted from index.ts for maintainability.
  */
 
+import { homedir } from 'node:os';
 import {
   type AgorConfig,
   PublicBaseUrlNotConfiguredError,
@@ -116,6 +117,7 @@ import { createLocalActionsService } from './services/local-actions.js';
 import { createMCPServersService } from './services/mcp-servers.js';
 import { createMessagesService } from './services/messages.js';
 import { performOAuthDisconnect } from './services/oauth-disconnect.js';
+import { createOpenCodeAuthService } from './services/opencode-auth.js';
 import { createReposService } from './services/repos.js';
 import { createSchedulesService } from './services/schedules.js';
 import { createSessionEnvSelectionsService } from './services/session-env-selections.js';
@@ -138,6 +140,8 @@ import {
   shouldExposeMCPServerSecrets,
   shouldExposeMCPServerSecretsForSessionToken,
 } from './utils/mcp-header-secrets.js';
+import { resolveOpenCodeTaskCredentialNamespace } from './utils/opencode-credential-namespace.js';
+import { admitOpenCodeExecutor } from './utils/opencode-executor-admission.js';
 import {
   computeFileHash,
   findCodexSessionFile,
@@ -564,6 +568,10 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.use('/check-auth', createCheckAuthService(db));
   app.service('/check-auth').hooks({ before: { create: [ctx.requireAuth] } });
 
+  app.use('/opencode-auth', createOpenCodeAuthService(db));
+  app.service('/opencode-auth').hooks({ before: { all: [ctx.requireAuth] } });
+  app.service('/opencode-auth').publish(() => []);
+
   // Imports a pasted Codex CLI auth.json for the authenticated user — writes
   // it 0600 into the Unix identity that runs Codex and flips their auth
   // method to subscription. Token material never leaves the daemon.
@@ -786,27 +794,28 @@ function createExecuteHandler(
       session.agentic_tool as import('@agor/core/types').AgenticToolName,
       config.execution?.stateless_fs_mode
     );
-
-    // Generate session token for executor authentication
-    const appWithExecutor = app as unknown as {
-      sessionTokenService?: import('./services/session-token-service.js').SessionTokenService;
-    };
-    if (!appWithExecutor.sessionTokenService) {
-      throw new Error('Session token service not initialized');
-    }
-    // Hook chain enforces auth before we get here.
-    const sessionToken = await appWithExecutor.sessionTokenService.generateToken(
-      sessionId,
-      (params as AuthenticatedParams).user!.user_id,
+    const sessionToken = await admitOpenCodeExecutor(
       {
-        taskId: data.taskId,
-        branchId: session.branch_id,
-        // Executor JWTs authenticate on every daemon API call over the runtime
-        // connection, so low per-call max-use limits make normal execution
-        // fail after startup. Keep expiry + in-memory revocation for these
-        // scoped runtime credentials; revisit max-use semantics once they can
-        // be counted per connection/task instead of per service method.
-        maxUses: -1,
+        tool: session.agentic_tool as import('@agor/core/types').AgenticToolName,
+        tenantId,
+        config,
+      },
+      async () => {
+        // Hook chain enforces auth before we get here.
+        return sessionTokenService.generateToken(
+          sessionId,
+          (params as AuthenticatedParams).user!.user_id,
+          {
+            taskId: data.taskId,
+            branchId: session.branch_id,
+            // Executor JWTs authenticate on every daemon API call over the runtime
+            // connection, so low per-call max-use limits make normal execution
+            // fail after startup. Keep expiry + in-memory revocation for these
+            // scoped runtime credentials; revisit max-use semantics once they can
+            // be counted per connection/task instead of per service method.
+            maxUses: -1,
+          }
+        );
       }
     );
 
@@ -843,6 +852,7 @@ function createExecuteHandler(
     });
 
     const executorUnixUser = impersonationResult.unixUser;
+    const executorHomeDir = executorUnixUser ? getHomedirFromUsername(executorUnixUser) : undefined;
     const effectivePermissionMode =
       data.permissionMode || session.permission_config?.mode || undefined;
     const permissionModeForPayload =
@@ -951,6 +961,15 @@ function createExecuteHandler(
       command: 'prompt' as const,
       sessionToken,
       daemonUrl,
+      ...(session.agentic_tool === 'opencode'
+        ? {
+            dataHome: resolveOpenCodeTaskCredentialNamespace({
+              tenantId: tenantId!,
+              session,
+              homeDir: executorHomeDir ?? homedir(),
+            }).dataHome,
+          }
+        : {}),
       env: executorEnv,
       params: {
         sessionId,
@@ -968,9 +987,6 @@ function createExecuteHandler(
         messageSource: data.messageSource,
       },
     };
-
-    // Stateless FS mode: resolve executor home dir for session file path
-    const executorHomeDir = executorUnixUser ? getHomedirFromUsername(executorUnixUser) : undefined;
 
     // Stateless FS mode: restore session file from DB before executor starts
     if (config.execution?.stateless_fs_mode && session.sdk_session_id) {
@@ -1136,7 +1152,7 @@ function createExecuteHandler(
           }
         }
 
-        appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+        sessionTokenService.revokeToken(sessionToken);
       },
     });
 

--- a/apps/agor-daemon/src/services/opencode-auth.test.ts
+++ b/apps/agor-daemon/src/services/opencode-auth.test.ts
@@ -1,0 +1,213 @@
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import { runWithTenantContext, UsersRepository } from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runExecutorCommand } from '../utils/spawn-executor.js';
+import { createOpenCodeAuthService } from './opencode-auth';
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
+  return {
+    ...actual,
+    isTenantAgenticToolEnabled: vi.fn(),
+    loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('@agor/core/db', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/db')>('@agor/core/db');
+  return { ...actual, UsersRepository: vi.fn() };
+});
+
+vi.mock('@agor/core/unix', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/unix')>('@agor/core/unix');
+  return {
+    ...actual,
+    getHomedirFromUsername: (username: string) => `/home/${username}`,
+    validateResolvedUnixUser: vi.fn(),
+  };
+});
+
+vi.mock('../utils/spawn-executor.js', () => ({
+  runExecutorCommand: vi.fn(),
+}));
+
+const runCommand = vi.mocked(runExecutorCommand);
+const enabled = vi.mocked(isTenantAgenticToolEnabled);
+const loadConfig = vi.mocked(loadConfigSync);
+const usersRepository = vi.mocked(UsersRepository);
+const db = { run: vi.fn() } as never;
+const params = {
+  user: { user_id: 'same-user', email: 'user@example.com', role: 'member' },
+} as never;
+
+const discovery = {
+  runtime: 'available',
+  runtimeVersion: '1.14.33',
+  providers: [
+    {
+      id: 'kimi-for-coding',
+      name: 'Kimi for Coding',
+      configured: false,
+      status: 'disconnected',
+      authMethods: [],
+    },
+  ],
+};
+
+function service() {
+  return createOpenCodeAuthService(db);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enabled.mockResolvedValue(true);
+  loadConfig.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
+  usersRepository.mockImplementation(function repository() {
+    return { findById: vi.fn(async () => ({ unix_username: 'alice' })) };
+  } as never);
+  runCommand.mockResolvedValue({ success: true, data: discovery });
+});
+
+describe('OpenCode provider auth service', () => {
+  it('requires an authenticated caller before resolving a credential namespace', async () => {
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(service().find()).rejects.toThrow(/sign in/i);
+    });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not copy daemon provider credentials into the native auth executor', async () => {
+    const originalOpenAiKey = process.env.OPENAI_API_KEY;
+    const originalClaudeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.OPENAI_API_KEY = 'must-not-cross';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'must-not-cross';
+    try {
+      await runWithTenantContext('tenant-a', () => service().find(params));
+      const options = runCommand.mock.calls[0]?.[1];
+      expect(options?.env).not.toHaveProperty('OPENAI_API_KEY');
+      expect(options?.env).not.toHaveProperty('CLAUDE_CODE_OAUTH_TOKEN');
+    } finally {
+      if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = originalOpenAiKey;
+      if (originalClaudeToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalClaudeToken;
+    }
+  });
+
+  it('derives the subject from the authenticated caller and rejects target identity fields', async () => {
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(
+        service().create(
+          {
+            providerId: 'kimi-for-coding',
+            apiKey: 'synthetic-key',
+            userId: 'another-user',
+          } as never,
+          params
+        )
+      ).rejects.toThrow(/unsupported field/i);
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('forwards native API prompt values as auth metadata', async () => {
+    await runWithTenantContext('tenant-a', () =>
+      service().create(
+        {
+          providerId: 'kimi-for-coding',
+          apiKey: 'synthetic-key',
+          metadata: { region: 'us', accountId: 'synthetic-account' },
+        },
+        params
+      )
+    );
+
+    expect(runCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'opencode.auth',
+        params: {
+          operation: 'connect-api-key',
+          providerId: 'kimi-for-coding',
+          apiKey: 'synthetic-key',
+          metadata: { region: 'us', accountId: 'synthetic-account' },
+        },
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('routes identical user IDs in different tenants to different opaque namespaces', async () => {
+    const seen: string[] = [];
+    runCommand.mockImplementation(async (payload) => {
+      seen.push(String(payload.dataHome));
+      return { success: true, data: discovery };
+    });
+
+    await runWithTenantContext('tenant-a', () => service().find(params));
+    await runWithTenantContext('tenant-b', () => service().find(params));
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(seen[1]);
+    expect(seen.join(' ')).not.toContain('tenant-a');
+    expect(seen.join(' ')).not.toContain('tenant-b');
+    expect(seen.join(' ')).not.toContain('same-user');
+  });
+
+  it('rejects hosted auth-resolved tenancy before executor or provider activity', async () => {
+    loadConfig.mockReturnValue({
+      multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+    } as never);
+
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(service().find(params)).rejects.toThrow(/hosted multi-tenant/i);
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('serializes all mutations for one namespace while another tenant remains independent', async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    runCommand
+      .mockImplementationOnce(async () => {
+        await firstGate;
+        return { success: true, data: discovery };
+      })
+      .mockResolvedValue({ success: true, data: discovery });
+
+    const first = runWithTenantContext('tenant-a', () =>
+      service().create({ providerId: 'kimi-for-coding', apiKey: 'key-1' }, params)
+    );
+    await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(1));
+    const second = runWithTenantContext('tenant-a', () =>
+      service().remove('kimi-for-coding', params)
+    );
+    const independent = runWithTenantContext('tenant-b', () =>
+      service().remove('kimi-for-coding', params)
+    );
+
+    await vi.waitFor(() => expect(runCommand).toHaveBeenCalledTimes(2));
+    releaseFirst();
+    await Promise.all([first, second, independent]);
+    expect(runCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports logical isolation in simple and insulated modes and OS isolation only in strict', async () => {
+    const modes = [
+      { mode: 'simple', boundary: 'logical' },
+      { mode: 'insulated', boundary: 'logical', executor_unix_user: 'agor_executor' },
+      { mode: 'strict', boundary: 'os' },
+    ] as const;
+
+    for (const { mode, boundary, executor_unix_user } of modes) {
+      loadConfig.mockReturnValue({
+        execution: { unix_user_mode: mode, executor_unix_user },
+      } as never);
+      const result = await runWithTenantContext('tenant-a', () => service().find(params));
+      expect(result.isolation).toEqual({ mode, boundary });
+    }
+  });
+});

--- a/apps/agor-daemon/src/services/opencode-auth.ts
+++ b/apps/agor-daemon/src/services/opencode-auth.ts
@@ -1,0 +1,207 @@
+import { homedir } from 'node:os';
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
+import type {
+  AuthenticatedParams,
+  OpenCodeProviderDiscovery,
+  OpenCodeProviderSettings,
+  UserID,
+} from '@agor/core/types';
+import {
+  getHomedirFromUsername,
+  resolveUnixUserForImpersonation,
+  type UnixUserMode,
+  validateResolvedUnixUser,
+} from '@agor/core/unix';
+import {
+  assertOpenCodeNativeAuthSupported,
+  resolveOpenCodeCredentialNamespace,
+} from '../utils/opencode-credential-namespace.js';
+import { runExecutorCommand } from '../utils/spawn-executor.js';
+
+const mutationSlots = new Map<string, Promise<void>>();
+const AUTH_EXECUTOR_ENV_KEYS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'NODE_ENV',
+  'LOG_LEVEL',
+] as const;
+
+async function inMutationSlot<T>(key: string, work: () => Promise<T>): Promise<T> {
+  const previous = mutationSlots.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(work);
+  const settled = current.then(
+    () => undefined,
+    () => undefined
+  );
+  mutationSlots.set(key, settled);
+  try {
+    return await current;
+  } finally {
+    if (mutationSlots.get(key) === settled) mutationSlots.delete(key);
+  }
+}
+
+type CredentialContext = {
+  namespaceKey: string;
+  dataHome: string;
+  asUser: string | null;
+  mode: UnixUserMode;
+};
+
+export class OpenCodeAuthService {
+  constructor(private readonly db: TenantScopeAwareDatabase) {}
+
+  private async credentialContext(params?: AuthenticatedParams): Promise<CredentialContext> {
+    const callerId = params?.user?.user_id as UserID | undefined;
+    if (!callerId) throw new NotAuthenticated('Sign in before managing OpenCode providers.');
+
+    const config = loadConfigSync();
+    assertOpenCodeNativeAuthSupported(config);
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new NotAuthenticated('Missing tenant context for OpenCode providers.');
+
+    const user = await runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+      if (!(await isTenantAgenticToolEnabled('opencode', tenantDb))) {
+        throw new BadRequest('OpenCode is disabled for this workspace.');
+      }
+      return new UsersRepository(tenantDb).findById(callerId);
+    });
+    if (!user) throw new NotAuthenticated('Authenticated OpenCode user no longer exists.');
+
+    const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
+    const { unixUser } = resolveUnixUserForImpersonation({
+      mode,
+      userUnixUsername: user.unix_username,
+      executorUnixUser: config.execution?.executor_unix_user,
+    });
+    validateResolvedUnixUser(mode, unixUser);
+    const homeDir = unixUser ? getHomedirFromUsername(unixUser) : homedir();
+    if (!homeDir) {
+      throw new BadRequest('Could not resolve the Unix home used by OpenCode execution.');
+    }
+    return {
+      ...resolveOpenCodeCredentialNamespace({
+        tenantId,
+        subjectUserId: callerId,
+        homeDir,
+      }),
+      asUser: unixUser,
+      mode,
+    };
+  }
+
+  private async execute(
+    context: CredentialContext,
+    params:
+      | { operation: 'discover' }
+      | {
+          operation: 'connect-api-key';
+          providerId: string;
+          apiKey: string;
+          metadata?: Record<string, string>;
+        }
+      | { operation: 'disconnect'; providerId: string }
+  ): Promise<OpenCodeProviderDiscovery> {
+    const result = await runExecutorCommand(
+      {
+        command: 'opencode.auth',
+        dataHome: context.dataHome,
+        params,
+      },
+      {
+        asUser: context.asUser,
+        env: Object.fromEntries(
+          AUTH_EXECUTOR_ENV_KEYS.flatMap((key) =>
+            process.env[key] === undefined ? [] : [[key, process.env[key]]]
+          )
+        ) as Record<string, string>,
+        logPrefix: '[OpenCode Auth]',
+        templateVariables: { unix_user: context.asUser ?? undefined },
+      }
+    );
+    if (!result.success || !result.data) {
+      throw new BadRequest('OpenCode provider operation failed. Try again.');
+    }
+    return result.data as OpenCodeProviderDiscovery;
+  }
+
+  private settings(
+    context: CredentialContext,
+    discovery: OpenCodeProviderDiscovery
+  ): OpenCodeProviderSettings {
+    return {
+      runtime: discovery.runtime,
+      runtimeVersion: discovery.runtimeVersion,
+      providers: discovery.providers,
+      isolation: {
+        mode: context.mode,
+        boundary: context.mode === 'strict' ? 'os' : 'logical',
+      },
+    };
+  }
+
+  async find(params?: AuthenticatedParams): Promise<OpenCodeProviderSettings> {
+    const context = await this.credentialContext(params);
+    const result = await this.execute(context, { operation: 'discover' });
+    return this.settings(context, result);
+  }
+
+  async create(
+    data: { providerId?: string; apiKey?: string; metadata?: Record<string, string> },
+    params?: AuthenticatedParams
+  ): Promise<OpenCodeProviderSettings> {
+    const unsupported = Object.keys(data ?? {}).find(
+      (field) => field !== 'providerId' && field !== 'apiKey' && field !== 'metadata'
+    );
+    if (unsupported) throw new BadRequest(`Unsupported field: ${unsupported}`);
+    const providerId = data?.providerId?.trim();
+    const apiKey = data?.apiKey?.trim();
+    if (!providerId || !apiKey) throw new BadRequest('Provider and API key are required.');
+    const metadata = data.metadata;
+    if (
+      metadata !== undefined &&
+      (!metadata ||
+        Array.isArray(metadata) ||
+        typeof metadata !== 'object' ||
+        Object.values(metadata).some((value) => typeof value !== 'string'))
+    ) {
+      throw new BadRequest('Provider prompt values must be strings.');
+    }
+
+    const context = await this.credentialContext(params);
+    const result = await inMutationSlot(context.namespaceKey, () =>
+      this.execute(context, { operation: 'connect-api-key', providerId, apiKey, metadata })
+    );
+    return this.settings(context, result);
+  }
+
+  async remove(id: string, params?: AuthenticatedParams): Promise<OpenCodeProviderSettings> {
+    const providerId = id?.trim();
+    if (!providerId) throw new BadRequest('Provider is required.');
+    const context = await this.credentialContext(params);
+    const result = await inMutationSlot(context.namespaceKey, () =>
+      this.execute(context, { operation: 'disconnect', providerId })
+    );
+    return this.settings(context, result);
+  }
+}
+
+export function createOpenCodeAuthService(db: TenantScopeAwareDatabase) {
+  return new OpenCodeAuthService(db);
+}

--- a/apps/agor-daemon/src/utils/opencode-credential-namespace.test.ts
+++ b/apps/agor-daemon/src/utils/opencode-credential-namespace.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertOpenCodeNativeAuthSupported,
+  resolveOpenCodeCredentialNamespace,
+  resolveOpenCodeTaskCredentialNamespace,
+} from './opencode-credential-namespace';
+
+describe('OpenCode credential namespace routing', () => {
+  it('is stable for one tenant and subject without exposing either identifier in the path', () => {
+    const first = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-a',
+      subjectUserId: 'user-1',
+      homeDir: '/home/alice',
+    });
+    const second = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-a',
+      subjectUserId: 'user-1',
+      homeDir: '/home/alice',
+    });
+
+    expect(first).toEqual(second);
+    expect(first.namespaceKey).toBe(
+      'e8d27b8337cc8452e28a74a7afdae72daa6bf9b3a66c68037b24cc545c094e1c'
+    );
+    expect(first.dataHome).toBe(
+      '/home/alice/.local/share/agor/opencode/e8d27b8337cc8452e28a74a7afdae72daa6bf9b3a66c68037b24cc545c094e1c'
+    );
+    expect(first.dataHome).not.toContain('tenant-a');
+    expect(first.dataHome).not.toContain('user-1');
+  });
+
+  it('separates identical user IDs across tenants', () => {
+    const tenantA = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-a',
+      subjectUserId: 'same-user',
+      homeDir: '/home/shared',
+    });
+    const tenantB = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-b',
+      subjectUserId: 'same-user',
+      homeDir: '/home/shared',
+    });
+
+    expect(tenantA.namespaceKey).not.toBe(tenantB.namespaceKey);
+    expect(tenantA.dataHome).not.toBe(tenantB.dataHome);
+  });
+
+  it('routes tasks by immutable session owner rather than a prompt actor', () => {
+    const owner = resolveOpenCodeTaskCredentialNamespace({
+      tenantId: 'tenant-a',
+      session: {
+        created_by: 'session-owner',
+        unix_username: 'alice',
+      },
+      homeDir: '/home/alice',
+    });
+    const expected = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-a',
+      subjectUserId: 'session-owner',
+      homeDir: '/home/alice',
+    });
+    const promptActor = resolveOpenCodeCredentialNamespace({
+      tenantId: 'tenant-a',
+      subjectUserId: 'latest-prompt-actor',
+      homeDir: '/home/alice',
+    });
+
+    expect(owner).toEqual(expected);
+    expect(owner).not.toEqual(promptActor);
+  });
+
+  it('rejects hosted auth-resolved tenancy before native OpenCode work', () => {
+    expect(() =>
+      assertOpenCodeNativeAuthSupported({
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      })
+    ).toThrow(/unavailable in hosted multi-tenant mode/i);
+  });
+});

--- a/apps/agor-daemon/src/utils/opencode-credential-namespace.ts
+++ b/apps/agor-daemon/src/utils/opencode-credential-namespace.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import type { AgorConfig } from '@agor/core/config';
+import { resolveMultiTenancyConfig } from '@agor/core/config';
+import { BadRequest } from '@agor/core/feathers';
+import type { Session } from '@agor/core/types';
+
+const SUBJECT_KEY_VERSION = 'agor-opencode-v1';
+
+export type OpenCodeCredentialNamespace = {
+  namespaceKey: string;
+  dataHome: string;
+};
+
+/**
+ * Resolve one opaque native OpenCode data namespace.
+ *
+ * Tenant and user identifiers are hashed together and never become path
+ * segments. The home directory is already selected from the executor identity
+ * by the caller, so auth and task executors can share this single resolver.
+ */
+export function resolveOpenCodeCredentialNamespace(input: {
+  tenantId: string;
+  subjectUserId: string;
+  homeDir: string;
+}): OpenCodeCredentialNamespace {
+  const tenantId = input.tenantId.trim();
+  const subjectUserId = input.subjectUserId.trim();
+  if (!tenantId || !subjectUserId) {
+    throw new Error('OpenCode credential routing requires tenant and user identity');
+  }
+  if (!isAbsolute(input.homeDir)) {
+    throw new Error('OpenCode credential routing requires an absolute executor home');
+  }
+
+  const homeDir = resolve(input.homeDir);
+  const namespaceKey = createHash('sha256')
+    .update(JSON.stringify([SUBJECT_KEY_VERSION, tenantId, subjectUserId]))
+    .digest('hex');
+  const root = join(homeDir, '.local', 'share', 'agor', 'opencode');
+  const dataHome = join(root, namespaceKey);
+  const child = relative(root, dataHome);
+  if (!child || child.startsWith('..') || isAbsolute(child)) {
+    throw new Error('OpenCode credential namespace escaped its executor home');
+  }
+  return { namespaceKey, dataHome };
+}
+
+export function resolveOpenCodeTaskCredentialNamespace(input: {
+  tenantId: string;
+  session: Pick<Session, 'created_by' | 'unix_username'>;
+  homeDir: string;
+}): OpenCodeCredentialNamespace {
+  return resolveOpenCodeCredentialNamespace({
+    tenantId: input.tenantId,
+    subjectUserId: input.session.created_by,
+    homeDir: input.homeDir,
+  });
+}
+
+/** Hosted auth-resolved tenancy has no durable native per-user home boundary yet. */
+export function assertOpenCodeNativeAuthSupported(config: Pick<AgorConfig, 'multi_tenancy'>): void {
+  if (resolveMultiTenancyConfig(config).mode === 'required_from_auth') {
+    throw new BadRequest(
+      'OpenCode provider connection and execution are unavailable in hosted multi-tenant mode.'
+    );
+  }
+}

--- a/apps/agor-daemon/src/utils/opencode-executor-admission.test.ts
+++ b/apps/agor-daemon/src/utils/opencode-executor-admission.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { admitOpenCodeExecutor } from './opencode-executor-admission';
+
+describe('OpenCode executor admission', () => {
+  it('rejects hosted native auth before token creation or executor spawn', async () => {
+    const generateToken = vi.fn();
+    const spawnExecutor = vi.fn();
+
+    await expect(
+      admitOpenCodeExecutor(
+        {
+          tool: 'opencode',
+          tenantId: 'tenant-a',
+          config: {
+            multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+          } as never,
+        },
+        async () => {
+          await generateToken();
+          spawnExecutor();
+        }
+      )
+    ).rejects.toThrow(/unavailable in hosted multi-tenant mode/i);
+
+    expect(generateToken).not.toHaveBeenCalled();
+    expect(spawnExecutor).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/utils/opencode-executor-admission.ts
+++ b/apps/agor-daemon/src/utils/opencode-executor-admission.ts
@@ -1,0 +1,21 @@
+import type { AgorConfig } from '@agor/core/config';
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { AgenticToolName } from '@agor/core/types';
+import { assertOpenCodeNativeAuthSupported } from './opencode-credential-namespace.js';
+
+export async function admitOpenCodeExecutor<T>(
+  input: {
+    tool: AgenticToolName;
+    tenantId: string | undefined;
+    config: Pick<AgorConfig, 'multi_tenancy'>;
+  },
+  admitted: () => Promise<T>
+): Promise<T> {
+  if (input.tool === 'opencode') {
+    if (!input.tenantId) {
+      throw new NotAuthenticated('Missing tenant context for OpenCode execution');
+    }
+    assertOpenCodeNativeAuthSupported(input.config);
+  }
+  return admitted();
+}

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -400,6 +400,23 @@ Agor defines three permission levels per branch:
 - Session continuity requires consistent user context
 - Credentials belong to session creator
 
+### OpenCode provider credentials
+
+OpenCode API keys are configured from the current user's settings and stored by
+the packaged OpenCode runtime in an opaque tenant-and-user namespace. A task
+always routes to the namespace of the immutable session owner
+(`session.created_by`), not the user who submitted the prompt.
+
+- In `strict` mode, the session owner's Unix identity, ownership checks, and
+  `0700`/`0600` permissions enforce the filesystem boundary.
+- In `simple` and `insulated` modes, namespaces remain logically separate, but
+  users sharing the same Unix identity must trust one another.
+- A “Configured in OpenCode” status means the native runtime reports a saved
+  credential. It does not verify a request with the provider.
+- Native OpenCode credential storage is unavailable when multi-tenancy uses
+  `required_from_auth`; configuration and task execution reject before starting
+  OpenCode.
+
 ---
 
 ## Troubleshooting

--- a/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.test.tsx
+++ b/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.test.tsx
@@ -1,0 +1,166 @@
+import type { AgorClient, OpenCodeProviderSettings as Settings } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenCodeProviderSettings } from './OpenCodeProviderSettings';
+
+const initial: Settings = {
+  runtime: 'available',
+  runtimeVersion: '1.14.33',
+  isolation: { mode: 'simple', boundary: 'logical' },
+  providers: [
+    {
+      id: 'moonshotai',
+      name: 'Kimi',
+      configured: false,
+      status: 'disconnected',
+      authMethods: [
+        {
+          type: 'api',
+          label: 'Workspace key',
+          prompts: [
+            {
+              type: 'select',
+              key: 'region',
+              message: 'Region',
+              options: [{ label: 'US', value: 'us' }],
+            },
+            {
+              type: 'text',
+              key: 'accountId',
+              message: 'Account ID',
+              when: { key: 'region', op: 'eq', value: 'us' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'zhipuai',
+      name: 'GLM',
+      configured: true,
+      status: 'configured',
+      authMethods: [],
+    },
+  ],
+};
+
+function renderSettings(service: {
+  find: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}) {
+  const client = { service: vi.fn(() => service) } as unknown as AgorClient;
+  render(
+    <AntApp>
+      <OpenCodeProviderSettings client={client} />
+    </AntApp>
+  );
+}
+
+describe('OpenCodeProviderSettings', () => {
+  it('renders a native API method with conditional prompts and connects it', async () => {
+    const configured = {
+      ...initial,
+      providers: initial.providers.map((provider) =>
+        provider.id === 'moonshotai'
+          ? { ...provider, configured: true, status: 'configured' as const }
+          : provider
+      ),
+    };
+    const service = {
+      find: vi.fn().mockResolvedValue(initial),
+      create: vi.fn().mockResolvedValue(configured),
+      remove: vi.fn(),
+    };
+    renderSettings(service);
+
+    expect(await screen.findByText(/separate logical namespaces/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search OpenCode providers'), {
+      target: { value: 'Kimi' },
+    });
+    expect(screen.queryByLabelText('Account ID')).not.toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByLabelText('Region'));
+    fireEvent.click(await screen.findByText('US'));
+    fireEvent.change(await screen.findByLabelText('Account ID'), {
+      target: { value: 'synthetic-account' },
+    });
+    fireEvent.change(screen.getByLabelText('Kimi API key'), {
+      target: { value: 'synthetic-kimi-key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() =>
+      expect(service.create).toHaveBeenCalledWith({
+        providerId: 'moonshotai',
+        apiKey: 'synthetic-kimi-key',
+        metadata: { region: 'us', accountId: 'synthetic-account' },
+      })
+    );
+    expect(await screen.findByText('Configured in OpenCode')).toBeInTheDocument();
+    expect(screen.getByText(/provider access is not verified/i)).toBeInTheDocument();
+  });
+
+  it('keeps the generic API-key fallback for a provider with no declared methods', async () => {
+    const available = {
+      ...initial,
+      providers: [
+        {
+          id: 'zhipuai',
+          name: 'GLM',
+          configured: false,
+          status: 'disconnected' as const,
+          authMethods: [],
+        },
+      ],
+    };
+    const configured = {
+      ...available,
+      providers: [{ ...available.providers[0], configured: true, status: 'configured' as const }],
+    };
+    const service = {
+      find: vi.fn().mockResolvedValue(available),
+      create: vi.fn().mockResolvedValue(configured),
+      remove: vi.fn(),
+    };
+    renderSettings(service);
+
+    fireEvent.change(await screen.findByLabelText('GLM API key'), {
+      target: { value: 'synthetic-glm-key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() =>
+      expect(service.create).toHaveBeenCalledWith({
+        providerId: 'zhipuai',
+        apiKey: 'synthetic-glm-key',
+      })
+    );
+  });
+
+  it('does not offer API-key connection for an OAuth-only provider', async () => {
+    const oauthOnly = {
+      ...initial,
+      providers: [
+        {
+          id: 'oauth-provider',
+          name: 'OAuth Provider',
+          configured: false,
+          status: 'disconnected' as const,
+          authMethods: [{ type: 'oauth' as const, label: 'Sign in with OAuth' }],
+        },
+      ],
+    };
+    const service = {
+      find: vi.fn().mockResolvedValue(oauthOnly),
+      create: vi.fn(),
+      remove: vi.fn(),
+    };
+    renderSettings(service);
+
+    expect(await screen.findByText(/OAuth connection is not available here/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText('OAuth Provider API key')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument();
+    expect(service.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.tsx
+++ b/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.tsx
@@ -1,0 +1,258 @@
+import type { AgorClient, OpenCodeProviderSettings as Settings } from '@agor-live/client';
+import { Alert, Button, Input, List, Popconfirm, Select, Space, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
+  const [settings, setSettings] = useState<Settings | null>(null);
+  const [query, setQuery] = useState('');
+  const [keys, setKeys] = useState<Record<string, string>>({});
+  const [methodIndexes, setMethodIndexes] = useState<Record<string, number>>({});
+  const [promptValues, setPromptValues] = useState<Record<string, Record<string, string>>>({});
+  const [busyProvider, setBusyProvider] = useState<string>();
+  const [error, setError] = useState<string>();
+
+  const load = useCallback(async () => {
+    setError(undefined);
+    try {
+      setSettings(await client.service('opencode-auth').find());
+    } catch {
+      setError('OpenCode provider settings could not be loaded.');
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const providers = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return settings?.providers ?? [];
+    return (settings?.providers ?? []).filter(
+      (provider) =>
+        provider.name.toLowerCase().includes(needle) || provider.id.toLowerCase().includes(needle)
+    );
+  }, [query, settings]);
+
+  const connect = async (providerId: string) => {
+    const apiKey = keys[providerId]?.trim();
+    if (!apiKey) return;
+    const provider = settings?.providers.find((candidate) => candidate.id === providerId);
+    if (!provider) return;
+    const apiMethods = provider?.authMethods.filter((method) => method.type === 'api') ?? [];
+    const apiKeyAvailable = apiMethods.length > 0 || provider.authMethods.length === 0;
+    if (!apiKeyAvailable) return;
+    const method = apiMethods[methodIndexes[providerId] ?? 0];
+    const values = promptValues[providerId] ?? {};
+    const visiblePrompts =
+      method?.prompts?.filter((prompt) => {
+        if (!prompt.when) return true;
+        const matches = values[prompt.when.key] === prompt.when.value;
+        return prompt.when.op === 'eq' ? matches : !matches;
+      }) ?? [];
+    if (visiblePrompts.some((prompt) => !values[prompt.key]?.trim())) return;
+    const metadata = Object.fromEntries(
+      visiblePrompts.map((prompt) => [prompt.key, values[prompt.key].trim()])
+    );
+    setBusyProvider(providerId);
+    setError(undefined);
+    try {
+      setSettings(
+        await client
+          .service('opencode-auth')
+          .create({ providerId, apiKey, ...(Object.keys(metadata).length ? { metadata } : {}) })
+      );
+      setKeys((current) => ({ ...current, [providerId]: '' }));
+      setPromptValues((current) => ({ ...current, [providerId]: {} }));
+    } catch {
+      setError('OpenCode could not configure that provider.');
+    } finally {
+      setBusyProvider(undefined);
+    }
+  };
+
+  const disconnect = async (providerId: string) => {
+    setBusyProvider(providerId);
+    setError(undefined);
+    try {
+      setSettings(await client.service('opencode-auth').remove(providerId));
+    } catch {
+      setError('OpenCode could not disconnect that provider.');
+    } finally {
+      setBusyProvider(undefined);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+        Connect providers that expose native API-key configuration through the managed OpenCode
+        runtime.
+      </Typography.Paragraph>
+      {settings && (
+        <Alert
+          type={settings.isolation.boundary === 'os' ? 'success' : 'warning'}
+          showIcon
+          title={
+            settings.isolation.boundary === 'os'
+              ? 'Credentials are isolated by the session owner’s Unix identity.'
+              : 'Credentials use separate logical namespaces under a shared Unix identity.'
+          }
+          description={
+            settings.isolation.boundary === 'os'
+              ? 'Strict mode enforces the credential boundary with filesystem ownership and permissions.'
+              : 'Simple and insulated modes require users who share the Unix identity to trust one another.'
+          }
+        />
+      )}
+      {error && <Alert type="error" showIcon title={error} />}
+      <Input.Search
+        allowClear
+        placeholder="Search OpenCode providers"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+      />
+      <List
+        loading={!settings && !error}
+        dataSource={providers}
+        locale={{ emptyText: error ? 'No provider status available' : 'No matching providers' }}
+        renderItem={(provider) => {
+          const apiMethods = provider.authMethods.filter((method) => method.type === 'api');
+          const apiKeyAvailable = apiMethods.length > 0 || provider.authMethods.length === 0;
+          const methodIndex = methodIndexes[provider.id] ?? 0;
+          const method = apiMethods[methodIndex];
+          const values = promptValues[provider.id] ?? {};
+          const visiblePrompts =
+            method?.prompts?.filter((prompt) => {
+              if (!prompt.when) return true;
+              const matches = values[prompt.when.key] === prompt.when.value;
+              return prompt.when.op === 'eq' ? matches : !matches;
+            }) ?? [];
+          const promptsComplete = visiblePrompts.every((prompt) => values[prompt.key]?.trim());
+
+          return (
+            <List.Item
+              actions={[
+                provider.configured ? (
+                  <Popconfirm
+                    key="disconnect"
+                    title={`Disconnect ${provider.name}?`}
+                    onConfirm={() => disconnect(provider.id)}
+                  >
+                    <Button danger loading={busyProvider === provider.id}>
+                      Disconnect
+                    </Button>
+                  </Popconfirm>
+                ) : apiKeyAvailable ? (
+                  <Button
+                    key="connect"
+                    type="primary"
+                    loading={busyProvider === provider.id}
+                    disabled={!keys[provider.id]?.trim() || !promptsComplete}
+                    onClick={() => connect(provider.id)}
+                  >
+                    Connect
+                  </Button>
+                ) : null,
+              ]}
+            >
+              <List.Item.Meta
+                title={
+                  <Space>
+                    <Typography.Text strong>{provider.name}</Typography.Text>
+                    {provider.configured && <Tag color="green">Configured in OpenCode</Tag>}
+                  </Space>
+                }
+                description={
+                  provider.configured ? (
+                    <Typography.Text type="secondary">
+                      OpenCode reports a saved credential; provider access is not verified here.
+                    </Typography.Text>
+                  ) : !apiKeyAvailable ? (
+                    <Typography.Text type="secondary">
+                      OpenCode exposes OAuth-only authentication for this provider. OAuth connection
+                      is not available here yet.
+                    </Typography.Text>
+                  ) : (
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      {apiMethods.length > 1 && (
+                        <Select
+                          aria-label={`${provider.name} authentication method`}
+                          value={methodIndex}
+                          options={apiMethods.map((candidate, index) => ({
+                            label: candidate.label ?? `API key method ${index + 1}`,
+                            value: index,
+                          }))}
+                          onChange={(index) => {
+                            setMethodIndexes((current) => ({
+                              ...current,
+                              [provider.id]: index,
+                            }));
+                            setPromptValues((current) => ({
+                              ...current,
+                              [provider.id]: {},
+                            }));
+                          }}
+                        />
+                      )}
+                      {visiblePrompts.map((prompt) =>
+                        prompt.type === 'select' ? (
+                          <Select
+                            key={prompt.key}
+                            aria-label={prompt.message}
+                            placeholder={prompt.message}
+                            value={values[prompt.key]}
+                            options={prompt.options}
+                            onChange={(value) =>
+                              setPromptValues((current) => ({
+                                ...current,
+                                [provider.id]: {
+                                  ...current[provider.id],
+                                  [prompt.key]: value,
+                                },
+                              }))
+                            }
+                          />
+                        ) : (
+                          <Input
+                            key={prompt.key}
+                            aria-label={prompt.message}
+                            placeholder={prompt.placeholder ?? prompt.message}
+                            value={values[prompt.key] ?? ''}
+                            onChange={(event) =>
+                              setPromptValues((current) => ({
+                                ...current,
+                                [provider.id]: {
+                                  ...current[provider.id],
+                                  [prompt.key]: event.target.value,
+                                },
+                              }))
+                            }
+                          />
+                        )
+                      )}
+                      <Input.Password
+                        aria-label={`${provider.name} API key`}
+                        autoComplete="new-password"
+                        placeholder="API key"
+                        value={keys[provider.id] ?? ''}
+                        onChange={(event) =>
+                          setKeys((current) => ({ ...current, [provider.id]: event.target.value }))
+                        }
+                        onPressEnter={() => void connect(provider.id)}
+                      />
+                    </Space>
+                  )
+                }
+              />
+            </List.Item>
+          );
+        }}
+      />
+      {settings && (
+        <Typography.Text type="secondary">
+          Managed OpenCode runtime {settings.runtimeVersion}
+        </Typography.Text>
+      )}
+    </Space>
+  );
+}

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -57,6 +57,7 @@ import { CodexAuthSettings } from '../CodexAuth';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
 import { SessionMcpServersField } from '../MCPServerSelect';
+import { OpenCodeProviderSettings } from '../OpenCodeAuth/OpenCodeProviderSettings';
 import { ToolIcon } from '../ToolIcon';
 import { AudioSettingsTab } from './AudioSettingsTab';
 import { syncGroupsForUser } from './groupMembershipSync';
@@ -1094,7 +1095,33 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           </>
         );
 
-        // Tools with no auth/config fields (e.g. OpenCode) skip the tab strip entirely.
+        if (canonicalTool === 'opencode') {
+          const managesOwnSettings = user?.user_id === currentUser?.user_id;
+          return (
+            <Tabs
+              items={[
+                {
+                  key: 'auth',
+                  label: 'Providers',
+                  children: !managesOwnSettings ? (
+                    <Alert
+                      type="info"
+                      showIcon
+                      title="OpenCode connections can only be managed by that user."
+                    />
+                  ) : client ? (
+                    <OpenCodeProviderSettings client={client} />
+                  ) : (
+                    <Alert type="warning" showIcon title="Not connected to Agor." />
+                  ),
+                },
+                { key: 'defaults', label: 'Defaults', children: defaultsPane },
+              ]}
+            />
+          );
+        }
+
+        // Tools with no auth/config fields skip the tab strip entirely.
         if (allToolFields.length === 0) {
           return defaultsPane;
         }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -34,6 +34,7 @@ import type {
   KnowledgeSemanticSettingsPublic,
   MCPServer,
   Message,
+  OpenCodeProviderSettings,
   PatchAgenticToolPreset,
   PermissionMode,
   Repo,
@@ -214,6 +215,7 @@ export interface ServiceTypes {
   templates: TemplateRenderResponse;
   'agentic-tool-settings': TenantAgenticToolSettings;
   'agentic-tool-presets': AgenticToolPreset;
+  'opencode-auth': OpenCodeProviderSettings;
 }
 
 /**
@@ -293,6 +295,15 @@ export interface KnowledgeReindexService {
     data?: Record<string, never>,
     params?: Params
   ): Promise<{ queued: number; status: KnowledgeEmbeddingStatus }>;
+}
+
+export interface OpenCodeAuthService {
+  find(params?: Params): Promise<OpenCodeProviderSettings>;
+  create(
+    data: { providerId: string; apiKey: string; metadata?: Record<string, string> },
+    params?: Params
+  ): Promise<OpenCodeProviderSettings>;
+  remove(providerId: string, params?: Params): Promise<OpenCodeProviderSettings>;
 }
 
 /**
@@ -630,6 +641,7 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'kb/indexing/reindex'): KnowledgeReindexService;
   service(path: 'agentic-tool-settings'): AgenticToolSettingsService;
   service(path: 'agentic-tool-presets'): AgenticToolPresetsService;
+  service(path: 'opencode-auth'): OpenCodeAuthService;
 
   // Bulk operation endpoints
   service(path: 'messages/bulk'): MessagesService;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,6 +18,7 @@ export * from './id';
 export * from './knowledge';
 export * from './mcp';
 export * from './message';
+export * from './opencode-auth';
 export * from './presence';
 export * from './repo';
 export * from './report';

--- a/packages/core/src/types/opencode-auth.ts
+++ b/packages/core/src/types/opencode-auth.ts
@@ -1,0 +1,52 @@
+export type OpenCodeProviderAuthPrompt =
+  | {
+      type: 'text';
+      key: string;
+      message: string;
+      placeholder?: string;
+      when?: OpenCodeProviderAuthPromptCondition;
+    }
+  | {
+      type: 'select';
+      key: string;
+      message: string;
+      options: Array<{ label: string; value: string; hint?: string }>;
+      when?: OpenCodeProviderAuthPromptCondition;
+    };
+
+export type OpenCodeProviderAuthPromptCondition = {
+  key: string;
+  op: 'eq' | 'neq';
+  value: string;
+};
+
+export interface OpenCodeProviderAuthMethod {
+  type: 'api' | 'oauth';
+  label: string;
+  prompts?: OpenCodeProviderAuthPrompt[];
+}
+
+export type OpenCodeProviderConnectionStatus = 'configured' | 'disconnected' | 'unknown';
+
+export interface OpenCodeProviderConnection {
+  id: string;
+  name: string;
+  configured: boolean;
+  status: OpenCodeProviderConnectionStatus;
+  authMethods: OpenCodeProviderAuthMethod[];
+}
+
+export interface OpenCodeProviderDiscovery {
+  runtime: 'available';
+  runtimeVersion: string;
+  providers: OpenCodeProviderConnection[];
+}
+
+export type OpenCodeCredentialIsolation = {
+  mode: 'simple' | 'insulated' | 'strict';
+  boundary: 'logical' | 'os';
+};
+
+export type OpenCodeProviderSettings = OpenCodeProviderDiscovery & {
+  isolation: OpenCodeCredentialIsolation;
+};

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:opencode-runtime": "tsx scripts/opencode-managed-runtime-harness.mjs --module src/sdk-handlers/opencode/opencode-tool.ts --permission-module src/permissions/permission-service.ts --streaming-module src/handlers/sdk/base-executor.ts --containment-module ../../apps/agor-daemon/src/executor-tracking.ts",
+    "test:opencode-auth": "tsx scripts/opencode-provider-auth-harness.mjs",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/packages/executor/scripts/opencode-provider-auth-harness.mjs
+++ b/packages/executor/scripts/opencode-provider-auth-harness.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+
+const originalEnvironment = { ...process.env };
+const root = await mkdtemp(join(tmpdir(), 'agor-opencode-auth-'));
+const strictQaArgument = process.argv.indexOf('--strict-qa-data-home');
+const strictQaDataHome = strictQaArgument === -1 ? undefined : process.argv[strictQaArgument + 1];
+assert(
+  strictQaArgument === -1 || (strictQaDataHome && isAbsolute(strictQaDataHome)),
+  '--strict-qa-data-home requires an absolute path'
+);
+const dataHome = strictQaDataHome ?? join(root, 'opaque-namespace');
+const branchDirectory = join(root, 'branch-worktree');
+const synthetic = {
+  kimi: 'agor-synthetic-kimi-not-a-real-key',
+  glm: 'agor-synthetic-glm-not-a-real-key',
+};
+
+function sanitizeEnvironment() {
+  const keep = new Set(['PATH', 'SHELL', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL', 'LC_CTYPE']);
+  for (const key of Object.keys(process.env)) {
+    if (!keep.has(key)) delete process.env[key];
+  }
+  process.env.HOME = join(root, 'home');
+  process.env.XDG_CONFIG_HOME = join(root, 'config');
+  process.env.XDG_CACHE_HOME = join(root, 'cache');
+  process.env.NO_PROXY = '127.0.0.1,localhost';
+  process.env.no_proxy = process.env.NO_PROXY;
+}
+
+function payload(params) {
+  return { command: 'opencode.auth', dataHome, params };
+}
+
+async function expectSuccess(result) {
+  assert.equal(result.success, true, JSON.stringify(result.error));
+  return result.data;
+}
+
+try {
+  sanitizeEnvironment();
+  await mkdir(branchDirectory, { recursive: true });
+  const { handleOpenCodeAuth } = await import('../src/commands/opencode-auth.ts');
+  const { startManagedOpenCodeServer } = await import(
+    '../src/sdk-handlers/opencode/managed-server.ts'
+  );
+  const { createOpencodeClient } = await import('@opencode-ai/sdk/v2');
+  const discovered = await expectSuccess(
+    await handleOpenCodeAuth(payload({ operation: 'discover' }), {})
+  );
+  const findProvider = (pattern) =>
+    discovered.providers.find((provider) => pattern.test(`${provider.id} ${provider.name}`));
+  const kimi = findProvider(/kimi|moonshot/i);
+  const glm = findProvider(/glm|zhipu/i);
+  assert(kimi, 'The packaged OpenCode catalog did not expose a Kimi/Moonshot provider');
+  assert(glm, 'The packaged OpenCode catalog did not expose a GLM/Zhipu provider');
+
+  const kimiConnected = await expectSuccess(
+    await handleOpenCodeAuth(
+      payload({
+        operation: 'connect-api-key',
+        providerId: kimi.id,
+        apiKey: synthetic.kimi,
+      }),
+      {}
+    )
+  );
+  assert.equal(
+    kimiConnected.providers.find((provider) => provider.id === kimi.id)?.configured,
+    true
+  );
+
+  const glmConnected = await expectSuccess(
+    await handleOpenCodeAuth(
+      payload({
+        operation: 'connect-api-key',
+        providerId: glm.id,
+        apiKey: synthetic.glm,
+      }),
+      {}
+    )
+  );
+  assert.equal(glmConnected.providers.find((provider) => provider.id === glm.id)?.configured, true);
+  assert.equal((await stat(join(dataHome, 'opencode', 'auth.json'))).mode & 0o777, 0o600);
+
+  const taskServer = await startManagedOpenCodeServer({
+    directory: branchDirectory,
+    dataHome,
+    secrets: Object.values(synthetic),
+  });
+  const taskClient = createOpencodeClient({
+    baseUrl: taskServer.baseUrl,
+    directory: branchDirectory,
+    headers: { Authorization: taskServer.authorization },
+  });
+  let taskProviderResponse;
+  try {
+    taskProviderResponse = await taskClient.provider.list({ directory: branchDirectory });
+    assert.equal(taskProviderResponse.error, undefined);
+    assert(taskProviderResponse.data?.connected.includes(kimi.id));
+    assert(taskProviderResponse.data?.connected.includes(glm.id));
+    await taskClient.instance.dispose({ directory: branchDirectory });
+  } finally {
+    await taskServer.close();
+  }
+
+  if (!strictQaDataHome) {
+    for (const provider of [kimi, glm]) {
+      const disconnected = await expectSuccess(
+        await handleOpenCodeAuth(payload({ operation: 'disconnect', providerId: provider.id }), {})
+      );
+      assert.equal(
+        disconnected.providers.find((candidate) => candidate.id === provider.id)?.configured,
+        false
+      );
+    }
+  }
+
+  const evidence = JSON.stringify({
+    runtimeVersion: discovered.runtimeVersion,
+    providers: [kimi.id, glm.id],
+    freshStatusAfterMutation: true,
+    freshTaskShapedRead: true,
+    authMode: '0600',
+    syntheticOnly: true,
+    strictQaFixtureRetained: Boolean(strictQaDataHome),
+  });
+  assert(!evidence.includes(root));
+  assert(!evidence.includes(synthetic.kimi));
+  assert(!evidence.includes(synthetic.glm));
+  console.log(evidence);
+} finally {
+  process.env = originalEnvironment;
+  await rm(root, { recursive: true, force: true });
+}

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -195,6 +195,7 @@ async function handlePromptPayload(
     permissionMode: payload.params.permissionMode,
     daemonUrl: resolvedDaemonUrl,
     messageSource: payload.params.messageSource,
+    dataHome: payload.dataHome,
     resolvedConfig: payload.resolvedConfig,
   });
 

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -21,6 +21,7 @@ import {
   handleGitRepoDelete,
   handleGitRepoRealignOrigin,
 } from './git.js';
+import { handleOpenCodeAuth } from './opencode-auth.js';
 import {
   handleUnixSyncBoard,
   handleUnixSyncBranch,
@@ -157,6 +158,7 @@ async function handlePromptCommand(
 // ═══════════════════════════════════════════════════════════
 
 registerCommand('prompt', handlePromptCommand);
+registerCommand('opencode.auth', handleOpenCodeAuth);
 registerCommand('git.clone', handleGitClone);
 registerCommand('git.branch.add', handleGitBranchAdd);
 registerCommand('git.branch.remove', handleGitBranchRemove);

--- a/packages/executor/src/commands/opencode-auth.test.ts
+++ b/packages/executor/src/commands/opencode-auth.test.ts
@@ -1,0 +1,268 @@
+import { inspect } from 'node:util';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  clients: [] as Array<Record<string, unknown>>,
+  close: vi.fn(async () => undefined),
+  start: vi.fn(),
+  sanitizeError: vi.fn((value: unknown) =>
+    value instanceof Error ? value : new Error(String(value))
+  ),
+}));
+
+vi.mock('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: vi.fn(() => runtime.clients.shift()),
+}));
+
+vi.mock('../sdk-handlers/opencode/managed-server.js', async () => {
+  const actual = await vi.importActual<typeof import('../sdk-handlers/opencode/managed-server.js')>(
+    '../sdk-handlers/opencode/managed-server.js'
+  );
+  return {
+    ...actual,
+    startManagedOpenCodeServer: runtime.start,
+    verifyOpenCodeAuthFileBoundary: vi.fn(async () => undefined),
+  };
+});
+
+import { executeCommand } from './index';
+
+const providerList = (connected: string[]) => ({
+  data: {
+    all: [
+      { id: 'kimi-for-coding', name: 'Kimi for Coding' },
+      { id: 'zhipuai-coding-plan', name: 'GLM Coding Plan' },
+    ],
+    connected,
+    default: {},
+  },
+});
+
+function client(
+  connected: string[] = [],
+  authMethods: Record<string, unknown[]> = {
+    'kimi-for-coding': [],
+    'zhipuai-coding-plan': [],
+  }
+) {
+  return {
+    auth: {
+      set: vi.fn(async () => ({ data: true })),
+      remove: vi.fn(async () => ({ data: true })),
+    },
+    provider: {
+      list: vi.fn(async () => providerList(connected)),
+      auth: vi.fn(async () => ({ data: authMethods })),
+    },
+    instance: { dispose: vi.fn(async () => ({ data: true })) },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runtime.clients = [];
+  runtime.start.mockImplementation(async () => ({
+    baseUrl: 'http://127.0.0.1:1234',
+    authorization: 'Basic synthetic',
+    sanitizer: {
+      text: (value: string) => value,
+      error: runtime.sanitizeError,
+    },
+    close: runtime.close,
+  }));
+});
+
+describe('opencode.auth executor command', () => {
+  it('connects Kimi through generic native API auth and verifies status on a fresh server', async () => {
+    const mutationClient = client();
+    const verificationClient = client(['kimi-for-coding']);
+    runtime.clients.push(mutationClient, verificationClient);
+
+    const result = await executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: {
+        operation: 'connect-api-key',
+        providerId: 'kimi-for-coding',
+        apiKey: 'synthetic-kimi-key',
+        metadata: { accountId: 'synthetic-account' },
+      },
+    } as never);
+
+    expect(result).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        providers: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'kimi-for-coding',
+            configured: true,
+            status: 'configured',
+          }),
+        ]),
+      }),
+    });
+    expect(mutationClient.auth.set).toHaveBeenCalledWith({
+      providerID: 'kimi-for-coding',
+      auth: {
+        type: 'api',
+        key: 'synthetic-kimi-key',
+        metadata: { accountId: 'synthetic-account' },
+      },
+    });
+    expect(runtime.start).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(result)).not.toContain('synthetic-kimi-key');
+    expect(JSON.stringify(result)).not.toContain('/home/alice');
+  });
+
+  it('preserves pinned native API prompts and conditional metadata during discovery', async () => {
+    runtime.clients.push(
+      client([], {
+        'kimi-for-coding': [
+          {
+            type: 'api',
+            label: 'Workspace key',
+            prompts: [
+              {
+                type: 'select',
+                key: 'region',
+                message: 'Region',
+                options: [{ label: 'US', value: 'us', hint: 'United States' }],
+              },
+              {
+                type: 'text',
+                key: 'account',
+                message: 'Account',
+                placeholder: 'acct-123',
+                when: { key: 'region', op: 'eq', value: 'us' },
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const result = await executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: { operation: 'discover' },
+    } as never);
+
+    expect(result).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        providers: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'kimi-for-coding',
+            authMethods: [
+              {
+                type: 'api',
+                label: 'Workspace key',
+                prompts: [
+                  {
+                    type: 'select',
+                    key: 'region',
+                    message: 'Region',
+                    options: [{ label: 'US', value: 'us', hint: 'United States' }],
+                  },
+                  {
+                    type: 'text',
+                    key: 'account',
+                    message: 'Account',
+                    placeholder: 'acct-123',
+                    when: { key: 'region', op: 'eq', value: 'us' },
+                  },
+                ],
+              },
+            ],
+          }),
+        ]),
+      }),
+    });
+  });
+
+  it('disconnects GLM generically and verifies it is absent on a fresh server', async () => {
+    const mutationClient = client(['zhipuai-coding-plan']);
+    const verificationClient = client([]);
+    runtime.clients.push(mutationClient, verificationClient);
+
+    const result = await executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: {
+        operation: 'disconnect',
+        providerId: 'zhipuai-coding-plan',
+      },
+    } as never);
+
+    expect(mutationClient.auth.remove).toHaveBeenCalledWith({
+      providerID: 'zhipuai-coding-plan',
+    });
+    expect(result).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        providers: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'zhipuai-coding-plan',
+            configured: false,
+            status: 'disconnected',
+          }),
+        ]),
+      }),
+    });
+    expect(runtime.start).toHaveBeenCalledTimes(2);
+  });
+
+  it('awaits instance disposal before closing the managed child', async () => {
+    const order: string[] = [];
+    let releaseDispose!: () => void;
+    const disposeGate = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    const discoveryClient = client();
+    discoveryClient.instance.dispose.mockImplementation(async () => {
+      order.push('dispose-start');
+      await disposeGate;
+      order.push('dispose-end');
+      return { data: true };
+    });
+    runtime.close.mockImplementation(async () => {
+      order.push('close');
+    });
+    runtime.clients.push(discoveryClient);
+
+    const pending = executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: { operation: 'discover' },
+    } as never);
+
+    await vi.waitFor(() => expect(order).toContain('dispose-start'));
+    expect(runtime.close).not.toHaveBeenCalled();
+    releaseDispose();
+    const result = await pending;
+    expect(result.success).toBe(true);
+    expect(order).toEqual(['dispose-start', 'dispose-end', 'close']);
+  });
+
+  it('always closes and preserves disposal and close failures for sanitization', async () => {
+    const discoveryClient = client();
+    discoveryClient.instance.dispose.mockRejectedValue(new Error('dispose failed'));
+    runtime.close.mockRejectedValue(new Error('close failed'));
+    runtime.clients.push(discoveryClient);
+
+    const result = await executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: { operation: 'discover' },
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(runtime.close).toHaveBeenCalledOnce();
+    const preserved = runtime.sanitizeError.mock.calls.at(-1)?.[0];
+    expect(preserved).toBeInstanceOf(Error);
+    expect(inspect((preserved as Error).cause, { depth: null })).toContain('dispose failed');
+    expect(inspect((preserved as Error).cause, { depth: null })).toContain('close failed');
+    expect(JSON.stringify(result)).not.toContain('dispose failed');
+    expect(JSON.stringify(result)).not.toContain('close failed');
+  });
+});

--- a/packages/executor/src/commands/opencode-auth.ts
+++ b/packages/executor/src/commands/opencode-auth.ts
@@ -1,0 +1,165 @@
+import type {
+  OpenCodeProviderAuthMethod,
+  OpenCodeProviderConnection,
+  OpenCodeProviderDiscovery,
+} from '@agor/core/types';
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+import type { OpenCodeAuthPayload } from '../payload-types.js';
+import {
+  OPENCODE_VERSION,
+  startManagedOpenCodeServer,
+  verifyOpenCodeAuthFileBoundary,
+} from '../sdk-handlers/opencode/managed-server.js';
+import type { CommandOptions } from './index.js';
+
+type V2Client = ReturnType<typeof createOpencodeClient>;
+
+function safeMethods(
+  methods: Awaited<ReturnType<V2Client['provider']['auth']>>['data'] | undefined,
+  providerId: string
+): OpenCodeProviderAuthMethod[] {
+  return (methods?.[providerId] ?? []).map((method) => ({
+    type: method.type,
+    label: method.label,
+    ...(method.prompts
+      ? {
+          prompts: method.prompts.map((prompt) =>
+            prompt.type === 'select'
+              ? {
+                  type: prompt.type,
+                  key: prompt.key,
+                  message: prompt.message,
+                  options: prompt.options.map(({ label, value, hint }) => ({
+                    label,
+                    value,
+                    ...(hint ? { hint } : {}),
+                  })),
+                  ...(prompt.when ? { when: prompt.when } : {}),
+                }
+              : {
+                  type: prompt.type,
+                  key: prompt.key,
+                  message: prompt.message,
+                  ...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
+                  ...(prompt.when ? { when: prompt.when } : {}),
+                }
+          ),
+        }
+      : {}),
+  }));
+}
+
+async function withFreshClient<T>(
+  dataHome: string,
+  secrets: readonly unknown[],
+  work: (client: V2Client) => Promise<T>
+): Promise<T> {
+  const server = await startManagedOpenCodeServer({ directory: dataHome, dataHome, secrets });
+  const client = createOpencodeClient({
+    baseUrl: server.baseUrl,
+    directory: dataHome,
+    headers: { Authorization: server.authorization },
+  });
+  let result: T | undefined;
+  const failures: Array<{ phase: string; error: unknown }> = [];
+  try {
+    result = await work(client);
+  } catch (error) {
+    failures.push({ phase: 'operation', error });
+  }
+  try {
+    await client.instance.dispose({ directory: dataHome });
+  } catch (error) {
+    failures.push({ phase: 'instance disposal', error });
+  } finally {
+    try {
+      await server.close();
+    } catch (error) {
+      failures.push({ phase: 'managed child close', error });
+    }
+  }
+  if (failures.length > 0) {
+    const cause = failures.reduceRight<Error | undefined>((next, failure) => {
+      const message =
+        failure.error instanceof Error ? failure.error.message : String(failure.error);
+      return new Error(`${failure.phase} failed: ${message}`, next ? { cause: next } : undefined);
+    }, undefined);
+    throw server.sanitizer.error(
+      new Error('OpenCode provider runtime operation failed', { cause })
+    );
+  }
+  return result as T;
+}
+
+async function discover(dataHome: string): Promise<OpenCodeProviderDiscovery> {
+  return withFreshClient(dataHome, [], async (client) => {
+    const [providerResponse, authResponse] = await Promise.all([
+      client.provider.list({ directory: dataHome }),
+      client.provider.auth({ directory: dataHome }),
+    ]);
+    if (providerResponse.error || !providerResponse.data || authResponse.error) {
+      throw new Error('OpenCode provider discovery failed');
+    }
+    const connected = new Set(providerResponse.data.connected);
+    const providers = providerResponse.data.all.map(
+      (provider): OpenCodeProviderConnection => ({
+        id: provider.id,
+        name: provider.name,
+        configured: connected.has(provider.id),
+        status: connected.has(provider.id) ? 'configured' : 'disconnected',
+        authMethods: safeMethods(authResponse.data, provider.id),
+      })
+    );
+    return { runtime: 'available', runtimeVersion: OPENCODE_VERSION, providers };
+  });
+}
+
+export async function handleOpenCodeAuth(payload: OpenCodeAuthPayload, options: CommandOptions) {
+  if (options.dryRun) {
+    return {
+      success: true,
+      data: { dryRun: true, command: payload.command, operation: payload.params.operation },
+    };
+  }
+
+  try {
+    if (payload.params.operation === 'discover') {
+      return { success: true, data: await discover(payload.dataHome) };
+    }
+
+    const { providerId } = payload.params;
+    const apiKey =
+      payload.params.operation === 'connect-api-key' ? payload.params.apiKey : undefined;
+    const metadata =
+      payload.params.operation === 'connect-api-key' ? payload.params.metadata : undefined;
+    await withFreshClient(payload.dataHome, [apiKey ?? '', metadata], async (client) => {
+      const response =
+        payload.params.operation === 'connect-api-key'
+          ? await client.auth.set({
+              providerID: providerId,
+              auth: {
+                type: 'api',
+                key: payload.params.apiKey,
+                ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+              },
+            })
+          : await client.auth.remove({ providerID: providerId });
+      if (response.error || response.data !== true) {
+        throw new Error('OpenCode rejected the provider credential mutation');
+      }
+      await verifyOpenCodeAuthFileBoundary(payload.dataHome, {
+        allowMissing: payload.params.operation === 'disconnect',
+      });
+    });
+
+    return { success: true, data: await discover(payload.dataHome) };
+  } catch {
+    return {
+      success: false,
+      error: {
+        code: 'OPENCODE_AUTH_FAILED',
+        message: 'OpenCode provider operation failed without exposing credential details.',
+      },
+    };
+  }
+}

--- a/packages/executor/src/handlers/sdk/opencode.test.ts
+++ b/packages/executor/src/handlers/sdk/opencode.test.ts
@@ -128,6 +128,7 @@ describe('executeOpenCodeTask', () => {
       prompt: 'Do the work',
       permissionMode: 'default',
       abortController,
+      dataHome: '/opaque/opencode-home',
       resolvedConfig: { execution: { permission_timeout_ms: 1234 } },
     });
 
@@ -143,6 +144,7 @@ describe('executeOpenCodeTask', () => {
       mcpToken: 'mcp-token',
       permissionMode: 'default',
       signal: abortController.signal,
+      dataHome: '/opaque/opencode-home',
     });
     expect(mocks.permissionServiceCtor).toHaveBeenCalledWith(expect.any(Function), 1234);
     expect(mocks.permissionRegister).toHaveBeenCalledWith(

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -28,6 +28,7 @@ export async function executeOpenCodeTask(params: {
   prompt: string;
   permissionMode?: PermissionMode;
   abortController: AbortController;
+  dataHome?: string;
   resolvedConfig?: ResolvedConfigSlice;
   onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
 }): Promise<void> {
@@ -102,6 +103,7 @@ export async function executeOpenCodeTask(params: {
         mcpToken: session.mcp_token,
         permissionMode: params.permissionMode,
         signal: params.abortController.signal,
+        dataHome: params.dataHome,
         persistOpenCodeSessionId: async (openCodeSessionId) => {
           await client.service('sessions').patch(sessionId, {
             sdk_session_id: openCodeSessionId,

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -32,6 +32,7 @@ export type ToolRunner = (params: {
   permissionMode?: PermissionMode;
   abortController: AbortController;
   messageSource?: MessageSource;
+  dataHome?: string;
   /** Daemon-resolved config slice. Undefined in legacy CLI mode. */
   resolvedConfig?: ResolvedConfigSlice;
   onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
@@ -110,6 +111,7 @@ export class ToolRegistry {
       permissionMode?: PermissionMode;
       abortController: AbortController;
       messageSource?: MessageSource;
+      dataHome?: string;
       resolvedConfig?: ResolvedConfigSlice;
       onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
     }

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -68,6 +68,7 @@ describe('AgorExecutor watchdog handoff', () => {
       taskId: 'task-1',
       prompt: 'prompt',
       tool: 'opencode',
+      dataHome: '/opaque/opencode-home',
       daemonUrl: 'http://daemon',
       resolvedConfig: {
         execution: {
@@ -88,6 +89,10 @@ describe('AgorExecutor watchdog handoff', () => {
     await executor.executeTask();
 
     expect(runtime.recordPulse).toHaveBeenCalledWith('sdk_started', 'opencode');
+    expect(runtime.execute).toHaveBeenCalledWith(
+      'opencode',
+      expect.objectContaining({ dataHome: '/opaque/opencode-home' })
+    );
     expect(runtime.recordPulse.mock.invocationCallOrder[0]).toBeLessThan(
       runtime.execute.mock.invocationCallOrder[0]!
     );

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -51,6 +51,8 @@ export interface ExecutorConfig {
   permissionMode?: PermissionMode;
   daemonUrl: string;
   messageSource?: MessageSource;
+  /** Daemon-derived OpenCode credential namespace. Never derived by the executor. */
+  dataHome?: string;
   /** Daemon-resolved config slice. See payload-types.ResolvedConfigSliceSchema. */
   resolvedConfig?: ResolvedConfigSlice;
 }
@@ -212,6 +214,7 @@ export class AgorExecutor {
         permissionMode: this.config.permissionMode,
         abortController: this.abortController,
         messageSource: this.config.messageSource,
+        dataHome: this.config.dataHome,
         resolvedConfig: this.config.resolvedConfig,
         onPulse: (kind, detail) => this.recordPulse(kind, detail),
       });

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -636,6 +636,7 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('unix.sync-user');
     expect(commands).toContain('zellij.attach');
     expect(commands).toContain('zellij.tab');
-    expect(commands.length).toBe(19);
+    expect(commands).toContain('opencode.auth');
+    expect(commands.length).toBe(20);
   });
 });

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -168,6 +168,30 @@ export const PromptPayloadSchema = BasePayloadSchema.extend({
 export type PromptPayload = z.infer<typeof PromptPayloadSchema>;
 
 // ═══════════════════════════════════════════════════════════
+// OpenCode Provider Authentication Payload
+// ═══════════════════════════════════════════════════════════
+
+export const OpenCodeAuthPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('opencode.auth'),
+  dataHome: z.string().min(1),
+  params: z.discriminatedUnion('operation', [
+    z.object({ operation: z.literal('discover') }),
+    z.object({
+      operation: z.literal('connect-api-key'),
+      providerId: z.string().trim().min(1).max(200),
+      apiKey: z.string().trim().min(1),
+      metadata: z.record(z.string(), z.string()).optional(),
+    }),
+    z.object({
+      operation: z.literal('disconnect'),
+      providerId: z.string().trim().min(1).max(200),
+    }),
+  ]),
+});
+
+export type OpenCodeAuthPayload = z.infer<typeof OpenCodeAuthPayloadSchema>;
+
+// ═══════════════════════════════════════════════════════════
 // Git Clone Payload
 // ═══════════════════════════════════════════════════════════
 
@@ -905,6 +929,7 @@ export type ZellijTabPayload = z.infer<typeof ZellijTabPayloadSchema>;
  */
 export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   PromptPayloadSchema,
+  OpenCodeAuthPayloadSchema,
   GitClonePayloadSchema,
   GitBranchAddPayloadSchema,
   GitBranchRemovePayloadSchema,
@@ -970,6 +995,7 @@ export function parseExecutorPayload(json: string): ExecutorPayload {
 export function getSupportedCommands(): string[] {
   return [
     'prompt',
+    'opencode.auth',
     'git.clone',
     'git.branch.add',
     'git.branch.remove',

--- a/packages/executor/src/sdk-handlers/opencode/managed-server.test.ts
+++ b/packages/executor/src/sdk-handlers/opencode/managed-server.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensureOpenCodeDataHome, verifyOpenCodeAuthFileBoundary } from './managed-server';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  const { rm } = await import('node:fs/promises');
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('OpenCode native data boundary', () => {
+  it('provisions a private namespace and verifies OpenCode-owned auth permissions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-opencode-boundary-'));
+    roots.push(root);
+    const dataHome = join(root, 'namespace');
+
+    await ensureOpenCodeDataHome(dataHome);
+    const directory = await stat(dataHome);
+    expect(directory.mode & 0o777).toBe(0o700);
+    if (typeof process.getuid === 'function') expect(directory.uid).toBe(process.getuid());
+
+    const authDir = join(dataHome, 'opencode');
+    await ensureOpenCodeDataHome(authDir);
+    const authPath = join(authDir, 'auth.json');
+    await writeFile(authPath, '{"synthetic":true}', { mode: 0o600 });
+
+    await expect(verifyOpenCodeAuthFileBoundary(dataHome)).resolves.toBeUndefined();
+    expect((await stat(authPath)).mode & 0o777).toBe(0o600);
+    expect(await readFile(authPath, 'utf8')).toBe('{"synthetic":true}');
+  });
+
+  it('rejects a symlink instead of provisioning through it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-opencode-symlink-'));
+    roots.push(root);
+    const target = join(root, 'target');
+    const dataHome = join(root, 'namespace');
+    await ensureOpenCodeDataHome(target);
+    await symlink(target, dataHome);
+
+    await expect(ensureOpenCodeDataHome(dataHome)).rejects.toThrow(/symbolic link/i);
+  });
+});

--- a/packages/executor/src/sdk-handlers/opencode/managed-server.ts
+++ b/packages/executor/src/sdk-handlers/opencode/managed-server.ts
@@ -1,0 +1,403 @@
+import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
+import { randomBytes as nodeRandomBytes } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import { access, chmod, lstat, mkdir, readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const OPENCODE_VERSION = '1.14.33';
+const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
+const MAX_STARTUP_OUTPUT = 4_096;
+
+export type ManagedChild = {
+  stdout: NodeJS.ReadableStream | null;
+  stderr: NodeJS.ReadableStream | null;
+  exitCode: number | null;
+  kill(signal: NodeJS.Signals): boolean;
+  once(
+    event: 'exit',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void
+  ): unknown;
+  once(
+    event: 'close',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void
+  ): unknown;
+  once(event: 'error', listener: (error: Error) => void): unknown;
+  removeListener(
+    event: 'exit',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void
+  ): unknown;
+  removeListener(event: 'error', listener: (error: Error) => void): unknown;
+};
+
+export type OpenCodeSanitizer = {
+  text(value: string): string;
+  error(value: unknown): Error;
+};
+
+type PackageLocation = { packageJsonPath: string; version: string };
+
+function collectConfigSecrets(value: unknown): string[] {
+  if (typeof value === 'string') {
+    const credential = /^(?:Bearer|Basic)\s+(.+)$/i.exec(value)?.[1];
+    return credential ? [value, credential] : [value];
+  }
+  if (!value || typeof value !== 'object') return [];
+  if (Array.isArray(value)) return value.flatMap((item) => collectConfigSecrets(item));
+  return Object.values(value).flatMap((item) => collectConfigSecrets(item));
+}
+
+function collectEnvironmentSecrets(environment: NodeJS.ProcessEnv): string[] {
+  const declared = new Set(
+    (environment.AGOR_USER_ENV_KEYS ?? '')
+      .split(',')
+      .map((key) => key.trim())
+      .filter(Boolean)
+  );
+  return Object.entries(environment).flatMap(([key, value]) =>
+    value && (declared.has(key) || /(?:KEY|TOKEN|SECRET|PASSWORD|AUTH|CREDENTIAL)$/i.test(key))
+      ? [value]
+      : []
+  );
+}
+
+export function createOpenCodeSanitizer(
+  secrets: readonly unknown[],
+  environment: NodeJS.ProcessEnv = process.env
+): OpenCodeSanitizer {
+  const uniqueSecrets = [
+    ...new Set([
+      ...secrets.flatMap((value) => collectConfigSecrets(value)),
+      ...collectEnvironmentSecrets(environment),
+    ]),
+  ]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  const text = (value: string) =>
+    uniqueSecrets.reduce((safe, secret) => safe.replaceAll(secret, '[REDACTED]'), value);
+  const error = (value: unknown): Error => {
+    const failure = value instanceof Error ? value : new Error(String(value));
+    const seen = new WeakSet<Error>();
+    const normalize = (unsafe: Error): Error => {
+      if (seen.has(unsafe)) return new Error('[Circular error cause]');
+      seen.add(unsafe);
+
+      const safe = new Error(text(unsafe.message));
+      Object.defineProperty(safe, 'name', {
+        value: text(unsafe.name || 'Error'),
+        configurable: true,
+        writable: true,
+      });
+      if (unsafe.stack) safe.stack = text(unsafe.stack);
+      if (unsafe.cause !== undefined) {
+        const safeCause =
+          unsafe.cause instanceof Error
+            ? normalize(unsafe.cause)
+            : new Error(text(String(unsafe.cause)));
+        Object.defineProperty(safe, 'cause', {
+          value: safeCause,
+          configurable: true,
+          writable: true,
+        });
+      }
+      return safe;
+    };
+    return normalize(failure);
+  };
+  return { text, error };
+}
+
+async function findPackageLocation(
+  entryPath: string,
+  packageName: string
+): Promise<PackageLocation> {
+  let current = dirname(entryPath);
+  for (;;) {
+    const packageJsonPath = join(current, 'package.json');
+    try {
+      const parsed = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+        name?: string;
+        version?: string;
+      };
+      if (parsed.name === packageName && parsed.version) {
+        return { packageJsonPath, version: parsed.version };
+      }
+    } catch {
+      // Keep walking toward the package root.
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`OpenCode package ${packageName} is not installed correctly`);
+}
+
+export async function resolvePackagedOpenCodeBinary(): Promise<string> {
+  const require = createRequire(import.meta.url);
+  let cli: PackageLocation;
+  let sdk: PackageLocation;
+  try {
+    cli = await findPackageLocation(require.resolve('opencode-ai/package.json'), 'opencode-ai');
+    sdk = await findPackageLocation(
+      fileURLToPath(import.meta.resolve('@opencode-ai/sdk')),
+      '@opencode-ai/sdk'
+    );
+  } catch (error) {
+    throw new Error(
+      `OpenCode ${OPENCODE_VERSION} is not fully installed; reinstall Agor with optional dependencies enabled`,
+      { cause: error }
+    );
+  }
+
+  if (cli.version !== OPENCODE_VERSION || sdk.version !== OPENCODE_VERSION) {
+    throw new Error(
+      `OpenCode SDK/CLI mismatch: expected ${OPENCODE_VERSION}, found SDK ${sdk.version} and CLI ${cli.version}`
+    );
+  }
+
+  const packageRoot = dirname(cli.packageJsonPath);
+  const binary =
+    process.platform === 'win32'
+      ? join(packageRoot, 'bin', 'opencode.exe')
+      : join(packageRoot, 'bin', '.opencode');
+  try {
+    await access(binary, process.platform === 'win32' ? fsConstants.F_OK : fsConstants.X_OK);
+  } catch (error) {
+    throw new Error(
+      `Packaged OpenCode ${OPENCODE_VERSION} native binary is missing or not executable; reinstall Agor with optional dependencies enabled`,
+      { cause: error }
+    );
+  }
+  return binary;
+}
+
+function assertOwnedPrivatePath(
+  entry: Awaited<ReturnType<typeof lstat>>,
+  expectedMode: number
+): void {
+  if (entry.isSymbolicLink())
+    throw new Error('OpenCode native data path cannot be a symbolic link');
+  if (typeof process.getuid === 'function' && entry.uid !== process.getuid()) {
+    throw new Error('OpenCode native data path is not owned by the executor identity');
+  }
+  if ((Number(entry.mode) & 0o777) !== expectedMode) {
+    throw new Error('OpenCode native data path has unsafe permissions');
+  }
+}
+
+export async function ensureOpenCodeDataHome(dataHome: string): Promise<void> {
+  if (!isAbsolute(dataHome)) throw new Error('OpenCode native data path must be absolute');
+  try {
+    const existing = await lstat(dataHome);
+    if (existing.isSymbolicLink()) {
+      throw new Error('OpenCode native data path cannot be a symbolic link');
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  await mkdir(dataHome, { recursive: true, mode: 0o700 });
+  await chmod(dataHome, 0o700);
+  const entry = await lstat(dataHome);
+  if (!entry.isDirectory()) throw new Error('OpenCode native data path must be a directory');
+  assertOwnedPrivatePath(entry, 0o700);
+}
+
+export async function verifyOpenCodeAuthFileBoundary(
+  dataHome: string,
+  options: { allowMissing?: boolean } = {}
+): Promise<void> {
+  const authPath = join(dataHome, 'opencode', 'auth.json');
+  let entry: Awaited<ReturnType<typeof lstat>>;
+  try {
+    entry = await lstat(authPath);
+  } catch (error) {
+    if (options.allowMissing && (error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  if (!entry.isFile()) throw new Error('OpenCode native auth path must be a regular file');
+  assertOwnedPrivatePath(entry, 0o600);
+}
+
+function settlesWithin(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+  return Promise.race([
+    promise.then(() => true),
+    new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function createBoundedClose(child: ManagedChild, shutdownTimeoutMs: number): () => Promise<void> {
+  let exitObserved = child.exitCode !== null;
+  const exited = exitObserved
+    ? Promise.resolve()
+    : new Promise<void>((resolve) => {
+        const observe = () => {
+          exitObserved = true;
+          resolve();
+        };
+        child.once('exit', observe);
+        child.once('close', observe);
+      });
+  let closePromise: Promise<void> | undefined;
+  return () => {
+    closePromise ??= (async () => {
+      if (exitObserved || child.exitCode !== null) return;
+      child.kill('SIGTERM');
+      if (await settlesWithin(exited, shutdownTimeoutMs)) return;
+      child.kill('SIGKILL');
+      if (!(await settlesWithin(exited, shutdownTimeoutMs))) {
+        throw new Error('OpenCode server did not exit after bounded SIGTERM/SIGKILL cleanup');
+      }
+    })();
+    return closePromise;
+  };
+}
+
+function waitForReadiness(
+  child: ManagedChild,
+  sanitizer: OpenCodeSanitizer,
+  readinessTimeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    let settled = false;
+    const diagnostic = () => {
+      const tail = sanitizer.text(output.slice(-MAX_STARTUP_OUTPUT)).trim();
+      return tail ? `: ${tail}` : '';
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout?.off('data', onData);
+      child.stderr?.off('data', onData);
+      child.removeListener('exit', onExit);
+      child.removeListener('error', onError);
+    };
+    const fail = (message: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`${message}${diagnostic()}`));
+    };
+    const onData = (chunk: Buffer | string) => {
+      output = `${output}${chunk.toString()}`.slice(-MAX_STARTUP_OUTPUT);
+      const matches = [
+        ...output.matchAll(/(?:^|\n)opencode server listening on (https?:\/\/[^\s]+)/g),
+      ];
+      const raw = matches.at(-1)?.[1]?.replace(/[),.;]+$/, '');
+      if (!raw) return;
+      try {
+        const url = new URL(raw);
+        if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !url.port) {
+          fail('OpenCode reported a non-loopback readiness URL');
+          return;
+        }
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(url.origin);
+      } catch {
+        fail('OpenCode reported malformed readiness output');
+      }
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+      fail(
+        `OpenCode server exited before readiness (code ${code ?? 'null'}, signal ${signal ?? 'none'})`
+      );
+    const onError = (error: Error) => fail(`OpenCode server failed to start: ${error.message}`);
+    const timer = setTimeout(
+      () => fail(`OpenCode server readiness timed out after ${readinessTimeoutMs}ms`),
+      readinessTimeoutMs
+    );
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}
+
+export type ManagedOpenCodeServer = {
+  baseUrl: string;
+  authorization: string;
+  sanitizer: OpenCodeSanitizer;
+  close(): Promise<void>;
+};
+
+export type ManagedOpenCodeServerDependencies = {
+  resolveBinary?: () => Promise<string>;
+  spawn?: (executable: string, args: readonly string[], options: SpawnOptions) => ManagedChild;
+  randomBytes?: typeof nodeRandomBytes;
+  readinessTimeoutMs?: number;
+  shutdownTimeoutMs?: number;
+};
+
+export async function startManagedOpenCodeServer(
+  input: {
+    directory: string;
+    dataHome?: string;
+    environment?: NodeJS.ProcessEnv;
+    secrets?: readonly unknown[];
+  },
+  dependencies: ManagedOpenCodeServerDependencies = {}
+): Promise<ManagedOpenCodeServer> {
+  if (input.dataHome) await ensureOpenCodeDataHome(input.dataHome);
+
+  const randomBytes = dependencies.randomBytes ?? nodeRandomBytes;
+  const password = randomBytes(32).toString('base64url');
+  const username = 'agor';
+  const authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+  const environment = {
+    ...process.env,
+    ...input.environment,
+    ...(input.dataHome ? { XDG_DATA_HOME: input.dataHome } : {}),
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+  };
+  const sanitizer = createOpenCodeSanitizer(
+    [password, authorization, input.dataHome ?? '', input.secrets ?? [], input.environment],
+    environment
+  );
+  const resolveBinary = dependencies.resolveBinary ?? resolvePackagedOpenCodeBinary;
+  const spawn =
+    dependencies.spawn ??
+    ((executable: string, args: readonly string[], options: SpawnOptions) =>
+      nodeSpawn(executable, [...args], options));
+
+  let child: ManagedChild;
+  try {
+    child = spawn(await resolveBinary(), ['serve', '--hostname=127.0.0.1', '--port=0'], {
+      cwd: input.directory,
+      detached: false,
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    throw sanitizer.error(error);
+  }
+  const close = createBoundedClose(
+    child,
+    dependencies.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
+  );
+  try {
+    const baseUrl = await waitForReadiness(
+      child,
+      sanitizer,
+      dependencies.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS
+    );
+    return { baseUrl, authorization, sanitizer, close };
+  } catch (error) {
+    try {
+      await close();
+    } catch (closeError) {
+      throw sanitizer.error(
+        new AggregateError([error, closeError], 'OpenCode startup and cleanup both failed')
+      );
+    }
+    throw sanitizer.error(error);
+  }
+}

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.test.ts
@@ -1221,7 +1221,15 @@ describe('OpenCodeTool managed turn', () => {
   });
 
   it('normalizes invocation-resolution failures before fatal rethrow', async () => {
-    const rawError = new Error('attached MCP unavailable: mcp-secret');
+    const previousDeclared = process.env.AGOR_USER_ENV_KEYS;
+    const previousDeclaredValue = process.env.OPENCODE_DECLARED_VALUE;
+    const previousNamedValue = process.env.OPENCODE_RESOLVER_TOKEN;
+    process.env.AGOR_USER_ENV_KEYS = 'OPENCODE_DECLARED_VALUE';
+    process.env.OPENCODE_DECLARED_VALUE = 'declared-process-secret';
+    process.env.OPENCODE_RESOLVER_TOKEN = 'secret-named-process-value';
+    const rawError = new Error(
+      'attached MCP unavailable: mcp-secret declared-process-secret secret-named-process-value'
+    );
     Object.assign(rawError, {
       response: {
         headers: { authorization: 'Bearer mcp-secret' },
@@ -1234,19 +1242,31 @@ describe('OpenCodeTool managed turn', () => {
       resolveInvocationConfig: vi.fn().mockRejectedValue(rawError),
     });
 
-    let rejection: unknown;
     try {
-      await tool.runTurn(input());
-    } catch (error) {
-      rejection = error;
-    }
+      let rejection: unknown;
+      try {
+        await tool.runTurn(input());
+      } catch (error) {
+        rejection = error;
+      }
 
-    expect(rejection).toBeInstanceOf(Error);
-    expect(rejection).not.toBe(rawError);
-    expect(Object.keys(rejection as Error)).toEqual([]);
-    expect(inspect(rejection, { depth: null })).not.toContain('mcp-secret');
-    expect(spawnCalls).toHaveLength(0);
-    expect(client.session.prompt).not.toHaveBeenCalled();
+      expect(rejection).toBeInstanceOf(Error);
+      expect(rejection).not.toBe(rawError);
+      expect(Object.keys(rejection as Error)).toEqual([]);
+      const inspected = inspect(rejection, { depth: null });
+      expect(inspected).not.toContain('mcp-secret');
+      expect(inspected).not.toContain('declared-process-secret');
+      expect(inspected).not.toContain('secret-named-process-value');
+      expect(spawnCalls).toHaveLength(0);
+      expect(client.session.prompt).not.toHaveBeenCalled();
+    } finally {
+      if (previousDeclared === undefined) delete process.env.AGOR_USER_ENV_KEYS;
+      else process.env.AGOR_USER_ENV_KEYS = previousDeclared;
+      if (previousDeclaredValue === undefined) delete process.env.OPENCODE_DECLARED_VALUE;
+      else process.env.OPENCODE_DECLARED_VALUE = previousDeclaredValue;
+      if (previousNamedValue === undefined) delete process.env.OPENCODE_RESOLVER_TOKEN;
+      else process.env.OPENCODE_RESOLVER_TOKEN = previousNamedValue;
+    }
   });
 
   it('normalizes managed spawn failures before fatal rethrow', async () => {

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
@@ -6,13 +6,8 @@
  * behind this single runtime owner.
  */
 
-import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
-import { randomBytes as nodeRandomBytes } from 'node:crypto';
-import { constants as fsConstants } from 'node:fs';
-import { access, readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import type { SpawnOptions } from 'node:child_process';
+import type { randomBytes as nodeRandomBytes } from 'node:crypto';
 import { shortId } from '@agor/core';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
@@ -49,12 +44,20 @@ import {
   type OpenCodeEventEffect,
   reconcileOpenCodeMessages,
 } from './event-translator.js';
+import {
+  createOpenCodeSanitizer,
+  type ManagedChild,
+  type ManagedOpenCodeServer,
+  type OpenCodeSanitizer,
+  resolvePackagedOpenCodeBinary,
+  startManagedOpenCodeServer,
+} from './managed-server.js';
 
-const OPENCODE_VERSION = '1.14.33';
+export { resolvePackagedOpenCodeBinary };
+
 const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2_000;
 const DEFAULT_EVENT_DRAIN_MS = 10;
-const MAX_STARTUP_OUTPUT = 4_096;
 const AGOR_PERMISSION_INTERCEPTION = {
   '*': 'ask',
   read: 'ask',
@@ -79,27 +82,6 @@ type OpenCodeClient = ReturnType<typeof createOpencodeClient>;
 
 export class OpenCodePermissionRejectedError extends Error {}
 
-type ManagedChild = {
-  stdout: NodeJS.ReadableStream | null;
-  stderr: NodeJS.ReadableStream | null;
-  exitCode: number | null;
-  kill(signal: NodeJS.Signals): boolean;
-  once(
-    event: 'exit',
-    listener: (code: number | null, signal: NodeJS.Signals | null) => void
-  ): unknown;
-  once(
-    event: 'close',
-    listener: (code: number | null, signal: NodeJS.Signals | null) => void
-  ): unknown;
-  once(event: 'error', listener: (error: Error) => void): unknown;
-  removeListener(
-    event: 'exit',
-    listener: (code: number | null, signal: NodeJS.Signals | null) => void
-  ): unknown;
-  removeListener(event: 'error', listener: (error: Error) => void): unknown;
-};
-
 export type RunOpenCodeTurnInput = {
   agorSessionId: SessionID;
   taskId: TaskID;
@@ -112,6 +94,7 @@ export type RunOpenCodeTurnInput = {
   model?: string;
   mcpToken?: string;
   permissionMode?: PermissionMode;
+  dataHome?: string;
   signal: AbortSignal;
   persistOpenCodeSessionId: (sessionId: string) => Promise<void>;
 };
@@ -152,73 +135,6 @@ export type OpenCodeToolDependencies = {
   eventDrainMs?: number;
 };
 
-type PackageLocation = { packageJsonPath: string; version: string };
-
-function collectConfigSecrets(value: unknown): string[] {
-  if (typeof value === 'string') {
-    const credential = /^(?:Bearer|Basic)\s+(.+)$/i.exec(value)?.[1];
-    return credential ? [value, credential] : [value];
-  }
-  if (!value || typeof value !== 'object') return [];
-  if (Array.isArray(value)) return value.flatMap((item) => collectConfigSecrets(item));
-  return Object.values(value).flatMap((item) => collectConfigSecrets(item));
-}
-
-function collectEnvironmentSecrets(environment: NodeJS.ProcessEnv): string[] {
-  const declared = new Set(
-    (environment.AGOR_USER_ENV_KEYS ?? '')
-      .split(',')
-      .map((key) => key.trim())
-      .filter(Boolean)
-  );
-  return Object.entries(environment).flatMap(([key, value]) =>
-    value && (declared.has(key) || /(?:KEY|TOKEN|SECRET|PASSWORD|AUTH|CREDENTIAL)$/i.test(key))
-      ? [value]
-      : []
-  );
-}
-
-type TurnSanitizer = {
-  text(value: string): string;
-  error(value: unknown): Error;
-};
-
-function createTurnSanitizer(secrets: readonly string[]): TurnSanitizer {
-  const uniqueSecrets = [...new Set(secrets.filter(Boolean))].sort((a, b) => b.length - a.length);
-  const text = (value: string) =>
-    uniqueSecrets.reduce((safe, secret) => safe.replaceAll(secret, '[REDACTED]'), value);
-  const error = (value: unknown): Error => {
-    const failure = value instanceof Error ? value : new Error(String(value));
-    const seen = new WeakSet<Error>();
-    const normalize = (unsafe: Error): Error => {
-      if (seen.has(unsafe)) return new Error('[Circular error cause]');
-      seen.add(unsafe);
-
-      const safe = new Error(text(unsafe.message));
-      Object.defineProperty(safe, 'name', {
-        value: text(unsafe.name || 'Error'),
-        configurable: true,
-        writable: true,
-      });
-      if (unsafe.stack) safe.stack = text(unsafe.stack);
-      if (unsafe.cause !== undefined) {
-        const safeCause =
-          unsafe.cause instanceof Error
-            ? normalize(unsafe.cause)
-            : new Error(text(String(unsafe.cause)));
-        Object.defineProperty(safe, 'cause', {
-          value: safeCause,
-          configurable: true,
-          writable: true,
-        });
-      }
-      return safe;
-    };
-    return normalize(failure);
-  };
-  return { text, error };
-}
-
 function automaticallyAllowsOpenCodePermission(
   permissionMode: PermissionMode | undefined,
   permission: string
@@ -255,70 +171,6 @@ function asUnknownAsyncIterable(value: unknown): AsyncIterable<unknown> {
   throw new Error('OpenCode event subscription returned no iterable stream');
 }
 
-async function findPackageLocation(
-  entryPath: string,
-  packageName: string
-): Promise<PackageLocation> {
-  let current = dirname(entryPath);
-  for (;;) {
-    const packageJsonPath = join(current, 'package.json');
-    try {
-      const parsed = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
-        name?: string;
-        version?: string;
-      };
-      if (parsed.name === packageName && parsed.version) {
-        return { packageJsonPath, version: parsed.version };
-      }
-    } catch {
-      // Keep walking toward the package root.
-    }
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-  throw new Error(`OpenCode package ${packageName} is not installed correctly`);
-}
-
-export async function resolvePackagedOpenCodeBinary(): Promise<string> {
-  const require = createRequire(import.meta.url);
-  let cli: PackageLocation;
-  let sdk: PackageLocation;
-  try {
-    cli = await findPackageLocation(require.resolve('opencode-ai/package.json'), 'opencode-ai');
-    sdk = await findPackageLocation(
-      fileURLToPath(import.meta.resolve('@opencode-ai/sdk')),
-      '@opencode-ai/sdk'
-    );
-  } catch (error) {
-    throw new Error(
-      `OpenCode ${OPENCODE_VERSION} is not fully installed; reinstall Agor with optional dependencies enabled`,
-      { cause: error }
-    );
-  }
-
-  if (cli.version !== OPENCODE_VERSION || sdk.version !== OPENCODE_VERSION) {
-    throw new Error(
-      `OpenCode SDK/CLI mismatch: expected ${OPENCODE_VERSION}, found SDK ${sdk.version} and CLI ${cli.version}`
-    );
-  }
-
-  const packageRoot = dirname(cli.packageJsonPath);
-  const binary =
-    process.platform === 'win32'
-      ? join(packageRoot, 'bin', 'opencode.exe')
-      : join(packageRoot, 'bin', '.opencode');
-  try {
-    await access(binary, process.platform === 'win32' ? fsConstants.F_OK : fsConstants.X_OK);
-  } catch (error) {
-    throw new Error(
-      `Packaged OpenCode ${OPENCODE_VERSION} native binary is missing or not executable; reinstall Agor with optional dependencies enabled`,
-      { cause: error }
-    );
-  }
-  return binary;
-}
-
 /**
  * Session context for an Agor session mapped to OpenCode
  */
@@ -332,19 +184,16 @@ interface SessionContext {
 
 export class OpenCodeTool {
   private client: OpenCodeClient | null = null;
-  private readonly dependencies: Required<
-    Pick<
-      OpenCodeToolDependencies,
-      | 'resolveBinary'
-      | 'spawn'
-      | 'createClient'
-      | 'resolveInvocationConfig'
-      | 'randomBytes'
-      | 'readinessTimeoutMs'
-      | 'shutdownTimeoutMs'
-      | 'eventDrainMs'
-    >
-  >;
+  private readonly dependencies: Pick<
+    OpenCodeToolDependencies,
+    'resolveBinary' | 'spawn' | 'randomBytes'
+  > & {
+    createClient: typeof createOpencodeClient;
+    resolveInvocationConfig: (input: RunOpenCodeTurnInput) => Promise<InvocationConfig>;
+    readinessTimeoutMs: number;
+    shutdownTimeoutMs: number;
+    eventDrainMs: number;
+  };
   private sessionContexts: Map<string, SessionContext> = new Map(); // Agor session ID → session context
   /** MCP repository dependencies for resolving user-defined MCP servers */
   private sessionMCPRepo?: SessionMCPServerRepository;
@@ -367,16 +216,14 @@ export class OpenCodeTool {
     this.tasksService = dependencies.tasksService;
     this.sessionsService = dependencies.sessionsService;
     this.dependencies = {
-      resolveBinary: dependencies.resolveBinary ?? resolvePackagedOpenCodeBinary,
-      spawn:
-        dependencies.spawn ??
-        ((executable, args, options) => nodeSpawn(executable, [...args], options)),
+      resolveBinary: dependencies.resolveBinary,
+      spawn: dependencies.spawn,
       createClient: dependencies.createClient ?? createOpencodeClient,
       resolveInvocationConfig:
         dependencies.resolveInvocationConfig ??
         ((input) =>
           this.buildInvocationConfig(input.agorSessionId, input.mcpToken, input.directory)),
-      randomBytes: dependencies.randomBytes ?? nodeRandomBytes,
+      randomBytes: dependencies.randomBytes,
       readinessTimeoutMs: dependencies.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS,
       shutdownTimeoutMs: dependencies.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS,
       eventDrainMs: dependencies.eventDrainMs ?? DEFAULT_EVENT_DRAIN_MS,
@@ -387,8 +234,10 @@ export class OpenCodeTool {
     input: RunOpenCodeTurnInput,
     streamingCallbacks?: StreamingCallbacks
   ): Promise<OpenCodeTurnResult> {
-    const environmentSecrets = collectEnvironmentSecrets(process.env);
-    const preliminarySanitizer = createTurnSanitizer([input.mcpToken ?? '', ...environmentSecrets]);
+    const preliminarySanitizer = createOpenCodeSanitizer([
+      input.mcpToken ?? '',
+      input.dataHome ?? '',
+    ]);
     let resolvedInvocationConfig: InvocationConfig;
     try {
       resolvedInvocationConfig = await this.dependencies.resolveInvocationConfig(input);
@@ -413,40 +262,34 @@ export class OpenCodeTool {
       },
     };
     const configContent = JSON.stringify(invocationConfig);
-    const password = this.dependencies.randomBytes(32).toString('base64url');
-    const username = 'agor';
-    const authorization = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-    const turnSecrets = [
-      password,
-      authorization,
-      input.mcpToken ?? '',
-      configContent,
-      ...collectConfigSecrets(invocationConfig),
-      ...environmentSecrets,
-    ];
-    const sanitizer = createTurnSanitizer(turnSecrets);
-    let child: ManagedChild;
+    let managedServer: ManagedOpenCodeServer;
     try {
-      const executable = await this.dependencies.resolveBinary();
-      child = this.dependencies.spawn(executable, ['serve', '--hostname=127.0.0.1', '--port=0'], {
-        cwd: input.directory,
-        detached: false,
-        env: {
-          ...process.env,
-          OPENCODE_CONFIG_CONTENT: configContent,
-          // OpenCode resolves this dedicated runtime override when creating
-          // session permission rules. Keep it alongside the config content so
-          // permissive project/agent rules cannot bypass Agor interception.
-          OPENCODE_PERMISSION: JSON.stringify(AGOR_PERMISSION_INTERCEPTION),
-          OPENCODE_SERVER_USERNAME: username,
-          OPENCODE_SERVER_PASSWORD: password,
+      managedServer = await startManagedOpenCodeServer(
+        {
+          directory: input.directory,
+          dataHome: input.dataHome,
+          environment: {
+            OPENCODE_CONFIG_CONTENT: configContent,
+            // OpenCode resolves this dedicated runtime override when creating
+            // session permission rules. Keep it alongside the config content so
+            // permissive project/agent rules cannot bypass Agor interception.
+            OPENCODE_PERMISSION: JSON.stringify(AGOR_PERMISSION_INTERCEPTION),
+          },
+          secrets: [input.mcpToken ?? '', configContent, invocationConfig],
         },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+        {
+          resolveBinary: this.dependencies.resolveBinary,
+          spawn: this.dependencies.spawn,
+          randomBytes: this.dependencies.randomBytes,
+          readinessTimeoutMs: this.dependencies.readinessTimeoutMs,
+          shutdownTimeoutMs: this.dependencies.shutdownTimeoutMs,
+        }
+      );
     } catch (error) {
-      throw sanitizer.error(error);
+      this.permissionService?.cancelPendingRequests(input.agorSessionId);
+      throw preliminarySanitizer.error(error);
     }
-    const close = this.createBoundedClose(child);
+    const { authorization, baseUrl, close, sanitizer } = managedServer;
     let stopEventCollector = async () => {};
     let turnCompleted = false;
     let cleanupPromise: Promise<void> | undefined;
@@ -488,7 +331,6 @@ export class OpenCodeTool {
     let outcome: OpenCodeTurnResult | undefined;
     let turnFailure: Error | undefined;
     try {
-      const baseUrl = await this.waitForReadiness(child, turnSecrets);
       this.client = this.dependencies.createClient({
         baseUrl,
         directory: input.directory,
@@ -574,99 +416,6 @@ export class OpenCodeTool {
     } catch {
       // Local child cleanup remains authoritative.
     }
-  }
-
-  private waitForReadiness(child: ManagedChild, secrets: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let output = '';
-      let settled = false;
-      const redact = (value: string) =>
-        secrets.reduce(
-          (safe, secret) => (secret ? safe.replaceAll(secret, '[REDACTED]') : safe),
-          value
-        );
-      const diagnostic = () => {
-        const tail = redact(output.slice(-MAX_STARTUP_OUTPUT)).trim();
-        return tail ? `: ${tail}` : '';
-      };
-      const cleanup = () => {
-        clearTimeout(timer);
-        child.stdout?.off('data', onData);
-        child.stderr?.off('data', onData);
-        child.removeListener('exit', onExit);
-        child.removeListener('error', onError);
-      };
-      const fail = (message: string) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        reject(new Error(`${message}${diagnostic()}`));
-      };
-      const onData = (chunk: Buffer | string) => {
-        output = `${output}${chunk.toString()}`.slice(-MAX_STARTUP_OUTPUT);
-        const matches = [
-          ...output.matchAll(/(?:^|\n)opencode server listening on (https?:\/\/[^\s]+)/g),
-        ];
-        const raw = matches.at(-1)?.[1]?.replace(/[),.;]+$/, '');
-        if (!raw) return;
-        try {
-          const url = new URL(raw);
-          if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !url.port) {
-            fail('OpenCode reported a non-loopback readiness URL');
-            return;
-          }
-          if (settled) return;
-          settled = true;
-          cleanup();
-          resolve(url.origin);
-        } catch {
-          fail('OpenCode reported malformed readiness output');
-        }
-      };
-      const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
-        fail(
-          `OpenCode server exited before readiness (code ${code ?? 'null'}, signal ${signal ?? 'none'})`
-        );
-      const onError = (error: Error) => fail(`OpenCode server failed to start: ${error.message}`);
-      const timer = setTimeout(
-        () =>
-          fail(
-            `OpenCode server readiness timed out after ${this.dependencies.readinessTimeoutMs}ms`
-          ),
-        this.dependencies.readinessTimeoutMs
-      );
-      child.stdout?.on('data', onData);
-      child.stderr?.on('data', onData);
-      child.once('exit', onExit);
-      child.once('error', onError);
-    });
-  }
-
-  private createBoundedClose(child: ManagedChild): () => Promise<void> {
-    let exitObserved = child.exitCode !== null;
-    const exited = exitObserved
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          const observe = () => {
-            exitObserved = true;
-            resolve();
-          };
-          child.once('exit', observe);
-          child.once('close', observe);
-        });
-    let closePromise: Promise<void> | undefined;
-    return () => {
-      closePromise ??= (async () => {
-        if (exitObserved || child.exitCode !== null) return;
-        child.kill('SIGTERM');
-        if (await this.settlesWithin(exited, this.dependencies.shutdownTimeoutMs)) return;
-        child.kill('SIGKILL');
-        if (!(await this.settlesWithin(exited, this.dependencies.shutdownTimeoutMs))) {
-          throw new Error('OpenCode server did not exit after bounded SIGTERM/SIGKILL cleanup');
-        }
-      })();
-      return closePromise;
-    };
   }
 
   private async settlesWithin(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
@@ -833,7 +582,7 @@ export class OpenCodeTool {
     context: SessionContext,
     streamingCallbacks: StreamingCallbacks | undefined,
     registerStopEventCollector: (stop: () => Promise<void>) => void,
-    sanitizer: TurnSanitizer
+    sanitizer: OpenCodeSanitizer
   ): Promise<OpenCodeTurnResult['finalMessage']> {
     const client = this.getClientForDirectory(context.branchPath);
     const request = {


### PR DESCRIPTION
## Linked issue

Architecture-review companion to #2078. Stacked on #2092; stack continues in #2095.

## Summary

- Add provider API-key authentication through OpenCode's native credential storage.
- Add caller-scoped credential namespacing and executor admission checks.
- Add the daemon service, executor command, settings UI, and focused coverage for the authentication boundary.

## Why / context

This is the second historical layer of the OpenCode work now combined in #2078. It isolates provider credential ownership from the managed-runtime foundation in #2092.

```text
#2092 managed runtime
  └─ API-key authentication (this draft)
       └─ #2095 OAuth authentication
            └─ provider/model configuration in #2078
```

## Implementation notes

The central boundary is:

```text
Agor caller scope
  → bounded authentication service
  → execution-owner credential namespace
  → OpenCode-native credential persistence
```

Agor controls authorization, execution-owner scoping, and admission. OpenCode remains the credential store; this layer does not introduce a competing provider-secret registry.

This draft is a historical comparison branch. #2078 remains the cumulative integration PR and is unchanged.

## Validation / test plan

- [x] The historical API-key authentication commit is preserved exactly.
- [x] The comparison contains one feature commit on top of #2092's historical runtime layer.
- [ ] This review-only branch has not been independently rebased or revalidated against current `main`; use #2078 for current integration and CI evidence.

## Screenshots / demos

The settings surface is included, but no separate screenshots are attached to this architecture-review draft.

## Risks / rollout / rollback

Do not merge this draft independently in its current form. It exists to expose credential ownership and authorization boundaries; #2078 owns the current integrated state and rollout evidence.

## Out of scope / follow-ups

- Provider OAuth authentication
- Provider/model discovery and selection
- Automatic credential or model fallback
