### PR TITLE
feat(opencode): add provider OAuth authentication

### DIFF
--- a/apps/agor-daemon/src/services/opencode-auth.test.ts
+++ b/apps/agor-daemon/src/services/opencode-auth.test.ts
@@ -1,7 +1,7 @@
 import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
 import { runWithTenantContext, UsersRepository } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { runExecutorCommand } from '../utils/spawn-executor.js';
+import { runExecutorCommand, startOpenCodeOAuthExecutor } from '../utils/spawn-executor.js';
 import { createOpenCodeAuthService } from './opencode-auth';
 
 vi.mock('@agor/core/config', async () => {
@@ -29,9 +29,11 @@ vi.mock('@agor/core/unix', async () => {
 
 vi.mock('../utils/spawn-executor.js', () => ({
   runExecutorCommand: vi.fn(),
+  startOpenCodeOAuthExecutor: vi.fn(),
 }));
 
 const runCommand = vi.mocked(runExecutorCommand);
+const startOAuth = vi.mocked(startOpenCodeOAuthExecutor);
 const enabled = vi.mocked(isTenantAgenticToolEnabled);
 const loadConfig = vi.mocked(loadConfigSync);
 const usersRepository = vi.mocked(UsersRepository);
@@ -193,6 +195,433 @@ describe('OpenCode provider auth service', () => {
     releaseFirst();
     await Promise.all([first, second, independent]);
     expect(runCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps one OAuth attempt on one executor through authorize and callback states', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: {
+      success: boolean;
+      data?: unknown;
+      error?: { code: string; message: string };
+    }) => void;
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel: vi.fn(),
+        submitCode: vi.fn(),
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create(
+        {
+          operation: 'connect-oauth',
+          providerId: 'openai',
+          method: 1,
+          inputs: { region: 'us' },
+        },
+        params
+      )
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Use the synthetic provider.',
+      },
+    });
+    const started = await pending;
+    expect(started).toMatchObject({
+      providerId: 'openai',
+      phase: 'awaiting_callback',
+      authorization: { method: 'auto' },
+    });
+    emit({ type: 'callback-started' });
+    expect(
+      await runWithTenantContext('tenant-a', () =>
+        authService.get((started as { attemptId: string }).attemptId, params)
+      )
+    ).toMatchObject({ phase: 'completing' });
+
+    finish({
+      success: true,
+      data: {
+        ...discovery,
+        providers: [
+          {
+            id: 'openai',
+            name: 'OpenAI',
+            configured: true,
+            status: 'configured',
+            authMethods: [],
+          },
+        ],
+      },
+    });
+    await vi.waitFor(async () =>
+      expect(
+        (
+          await runWithTenantContext('tenant-a', () =>
+            authService.get((started as { attemptId: string }).attemptId, params)
+          )
+        ).phase
+      ).toBe('configured')
+    );
+    expect(startOAuth).toHaveBeenCalledOnce();
+    expect(startOAuth.mock.calls[0]?.[0]).toMatchObject({
+      params: {
+        operation: 'connect-oauth',
+        providerId: 'openai',
+        method: 1,
+        inputs: { region: 'us' },
+      },
+    });
+  });
+
+  it('holds the namespace mutation slot for OAuth across providers while another tenant stays independent', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: { success: boolean; error: { code: string; message: string } }) => void;
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel: vi.fn(),
+        submitCode: vi.fn(),
+      };
+    });
+    const authService = service();
+    const oauth = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Synthetic',
+      },
+    });
+    await oauth;
+
+    const blocked = runWithTenantContext('tenant-a', () =>
+      authService.create({ providerId: 'kimi-for-coding', apiKey: 'key-1' }, params)
+    );
+    const independent = runWithTenantContext('tenant-b', () =>
+      authService.remove('kimi-for-coding', params)
+    );
+    await vi.waitFor(() => expect(runCommand).toHaveBeenCalledOnce());
+    expect(runCommand.mock.calls[0]?.[0]).toMatchObject({
+      params: { operation: 'disconnect' },
+    });
+
+    finish({
+      success: false,
+      error: { code: 'OPENCODE_AUTH_FAILED', message: 'safe' },
+    });
+    await Promise.all([blocked, independent]);
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates attempts by tenant and subject and cancels the full executor handle', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: { success: boolean; error: { code: string; message: string } }) => void;
+    const cancel = vi.fn(async () => {
+      const result = {
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CANCELLED', message: 'safe' },
+      };
+      finish(result);
+      return result;
+    });
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel,
+        submitCode: vi.fn(),
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Synthetic',
+      },
+    });
+    const started = (await pending) as { attemptId: string };
+
+    await runWithTenantContext('tenant-b', async () => {
+      await expect(authService.get(started.attemptId, params)).rejects.toThrow(/not found/i);
+    });
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(
+        authService.get(started.attemptId, {
+          user: { user_id: 'other-user', email: 'other@example.com', role: 'member' },
+        } as never)
+      ).rejects.toThrow(/not found/i);
+    });
+    const cancelled = await runWithTenantContext('tenant-a', () =>
+      authService.patch(started.attemptId, { cancel: true }, params)
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancelled.phase).toBe('cancelled');
+  });
+
+  it('maps a bounded executor timeout to an expired attempt without exposing failure detail', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: {
+      success: boolean;
+      error: { code: string; message: string; details?: unknown };
+    }) => void;
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel: vi.fn(),
+        submitCode: vi.fn(),
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Synthetic',
+      },
+    });
+    const started = (await pending) as { attemptId: string };
+    finish({
+      success: false,
+      error: {
+        code: 'OPENCODE_OAUTH_TIMEOUT',
+        message: 'contains synthetic-secret and /private/path',
+        details: { password: 'synthetic-password' },
+      },
+    });
+    const terminal = await vi.waitFor(() =>
+      runWithTenantContext('tenant-a', () => authService.get(started.attemptId, params))
+    );
+    await vi.waitFor(() =>
+      expect(
+        runWithTenantContext('tenant-a', () => authService.get(started.attemptId, params))
+      ).resolves.toMatchObject({ phase: 'expired' })
+    );
+    expect(JSON.stringify(terminal)).not.toContain('synthetic-secret');
+    expect(JSON.stringify(terminal)).not.toContain('/private/path');
+    expect(JSON.stringify(terminal)).not.toContain('synthetic-password');
+  });
+
+  it('submits one code to the same attempt without storing or returning the secret', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: { success: boolean; error: { code: string; message: string } }) => void;
+    const submitCode = vi.fn(async () => true);
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel: vi.fn(),
+        submitCode,
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'code',
+        instructions: 'Paste the code.',
+      },
+    });
+    const started = (await pending) as { attemptId: string };
+
+    const completing = await runWithTenantContext('tenant-a', () =>
+      authService.patch(started.attemptId, { code: ' synthetic-secret-code ' }, params)
+    );
+    expect(submitCode).toHaveBeenCalledWith('synthetic-secret-code');
+    expect(completing.phase).toBe('completing');
+    expect(JSON.stringify(completing)).not.toContain('synthetic-secret-code');
+
+    await runWithTenantContext('tenant-b', async () => {
+      await expect(
+        authService.patch(started.attemptId, { code: 'wrong-subject-code' }, params)
+      ).rejects.toThrow(/not found/i);
+    });
+    expect(submitCode).toHaveBeenCalledOnce();
+    finish({
+      success: false,
+      error: { code: 'OPENCODE_AUTH_FAILED', message: 'safe' },
+    });
+  });
+
+  it('blocks every later namespace mutation until retained containment verifies absence', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    const cleanupFailure = {
+      success: false,
+      error: {
+        code: 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED',
+        message: 'synthetic-secret password /private/path',
+      },
+    };
+    let finish!: (value: typeof cleanupFailure) => void;
+    const cancel = vi.fn(async () => {
+      finish(cleanupFailure);
+      return cleanupFailure;
+    });
+    const verifyAbsence = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel,
+        submitCode: vi.fn(),
+        verifyAbsence,
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Synthetic',
+      },
+    });
+    const started = (await pending) as { attemptId: string };
+
+    const terminal = await runWithTenantContext('tenant-a', () =>
+      authService.patch(started.attemptId, { cancel: true }, params)
+    );
+    expect(terminal.phase).toBe('failed');
+    expect(terminal.phase).not.toBe('cancelled');
+
+    await runWithTenantContext('tenant-a', async () => {
+      const blockedApi = authService.create(
+        { providerId: 'kimi-for-coding', apiKey: 'later-key' },
+        params
+      );
+      await expect(blockedApi).rejects.toThrow(/cleanup could not be verified/i);
+      const publicError = await blockedApi.catch((error) => error);
+      expect(String(publicError)).not.toContain('synthetic-secret');
+      expect(String(publicError)).not.toContain('/private/path');
+      expect(String(publicError)).not.toContain('password');
+      await expect(authService.remove('zhipuai-coding-plan', params)).rejects.toThrow(
+        /cleanup could not be verified/i
+      );
+    });
+    const blockedOAuth = await runWithTenantContext('tenant-a', () =>
+      authService.create(
+        { operation: 'connect-oauth', providerId: 'another-provider', method: 0 },
+        params
+      )
+    );
+    expect(blockedOAuth).toMatchObject({ providerId: 'another-provider', phase: 'failed' });
+    expect(startOAuth).toHaveBeenCalledOnce();
+    expect(runCommand).not.toHaveBeenCalled();
+
+    await expect(
+      runWithTenantContext('tenant-a', () =>
+        authService.create({ providerId: 'kimi-for-coding', apiKey: 'recovery-key' }, params)
+      )
+    ).resolves.toMatchObject({ runtime: 'available' });
+    expect(verifyAbsence).toHaveBeenCalledTimes(4);
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
+
+  it('does not let an in-flight code submission reverse cancellation', async () => {
+    let emit!: Parameters<typeof startOpenCodeOAuthExecutor>[2];
+    let finish!: (value: { success: boolean; error: { code: string; message: string } }) => void;
+    let releaseCode!: (accepted: boolean) => void;
+    const submitCode = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          releaseCode = resolve;
+        })
+    );
+    const cancelledResult = {
+      success: false,
+      error: { code: 'OPENCODE_OAUTH_CANCELLED', message: 'safe' },
+    };
+    const cancel = vi.fn(async () => {
+      finish(cancelledResult);
+      return cancelledResult;
+    });
+    startOAuth.mockImplementation((_payload, _options, onEvent) => {
+      emit = onEvent;
+      return {
+        result: new Promise((resolve) => {
+          finish = resolve;
+        }),
+        cancel,
+        submitCode,
+      };
+    });
+    const authService = service();
+    const pending = runWithTenantContext('tenant-a', () =>
+      authService.create({ operation: 'connect-oauth', providerId: 'openai', method: 1 }, params)
+    );
+    await vi.waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
+    emit({
+      type: 'authorized',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'code',
+        instructions: 'Paste the code.',
+      },
+    });
+    const started = (await pending) as { attemptId: string };
+    const codePatch = runWithTenantContext('tenant-a', () =>
+      authService.patch(started.attemptId, { code: 'synthetic-code' }, params)
+    );
+    await vi.waitFor(() => expect(submitCode).toHaveBeenCalledOnce());
+    const cancellation = runWithTenantContext('tenant-a', () =>
+      authService.patch(started.attemptId, { cancel: true }, params)
+    );
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    releaseCode(true);
+
+    await expect(cancellation).resolves.toMatchObject({ phase: 'cancelled' });
+    await expect(codePatch).resolves.toMatchObject({ phase: 'cancelled' });
   });
 
   it('reports logical isolation in simple and insulated modes and OS isolation only in strict', async () => {

--- a/apps/agor-daemon/src/services/opencode-auth.ts
+++ b/apps/agor-daemon/src/services/opencode-auth.ts
@@ -6,9 +6,12 @@ import {
   type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
-import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
+import { BadRequest, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
+  OpenCodeOAuthAttempt,
+  OpenCodeOAuthAttemptPatch,
+  OpenCodeOAuthConnectRequest,
   OpenCodeProviderDiscovery,
   OpenCodeProviderSettings,
   UserID,
@@ -23,9 +26,16 @@ import {
   assertOpenCodeNativeAuthSupported,
   resolveOpenCodeCredentialNamespace,
 } from '../utils/opencode-credential-namespace.js';
-import { runExecutorCommand } from '../utils/spawn-executor.js';
+import {
+  type OpenCodeOAuthExecutorHandle,
+  runExecutorCommand,
+  startOpenCodeOAuthExecutor,
+} from '../utils/spawn-executor.js';
 
 const mutationSlots = new Map<string, Promise<void>>();
+// An unverified OAuth process keeps the same namespace coordinator closed.
+// The stored verifier delegates recovery to the existing tracked-process owner.
+const blockedNamespaces = new Map<string, () => Promise<boolean>>();
 const AUTH_EXECUTOR_ENV_KEYS = [
   'PATH',
   'HOME',
@@ -44,7 +54,26 @@ const AUTH_EXECUTOR_ENV_KEYS = [
 
 async function inMutationSlot<T>(key: string, work: () => Promise<T>): Promise<T> {
   const previous = mutationSlots.get(key) ?? Promise.resolve();
-  const current = previous.catch(() => undefined).then(work);
+  const current = previous
+    .catch(() => undefined)
+    .then(async () => {
+      const verifyAbsence = blockedNamespaces.get(key);
+      if (verifyAbsence) {
+        let verified = false;
+        try {
+          verified = await verifyAbsence();
+        } catch {
+          // Existing containment owns details; the public service stays secret-safe.
+        }
+        if (!verified) {
+          throw new BadRequest(
+            'OpenCode provider cleanup could not be verified. Later mutations remain blocked.'
+          );
+        }
+        if (blockedNamespaces.get(key) === verifyAbsence) blockedNamespaces.delete(key);
+      }
+      return work();
+    });
   const settled = current.then(
     () => undefined,
     () => undefined
@@ -63,6 +92,27 @@ type CredentialContext = {
   asUser: string | null;
   mode: UnixUserMode;
 };
+
+type StoredOAuthAttempt = OpenCodeOAuthAttempt & {
+  namespaceKey: string;
+  handle?: OpenCodeOAuthExecutorHandle;
+  cancelRequested: boolean;
+  ready: Promise<void>;
+  resolveReady: () => void;
+};
+
+const oauthAttempts = new Map<string, StoredOAuthAttempt>();
+const OAUTH_TIMEOUT_MS = 10 * 60_000;
+const OAUTH_TERMINAL_RETENTION_MS = 10 * 60_000;
+
+function scheduleAttemptPrune(attempt: StoredOAuthAttempt): void {
+  const timer = setTimeout(() => {
+    if (oauthAttempts.get(attempt.attemptId) === attempt) {
+      oauthAttempts.delete(attempt.attemptId);
+    }
+  }, OAUTH_TERMINAL_RETENTION_MS);
+  timer.unref();
+}
 
 export class OpenCodeAuthService {
   constructor(private readonly db: TenantScopeAwareDatabase) {}
@@ -163,9 +213,14 @@ export class OpenCodeAuthService {
   }
 
   async create(
-    data: { providerId?: string; apiKey?: string; metadata?: Record<string, string> },
+    data:
+      | { providerId?: string; apiKey?: string; metadata?: Record<string, string> }
+      | OpenCodeOAuthConnectRequest,
     params?: AuthenticatedParams
-  ): Promise<OpenCodeProviderSettings> {
+  ): Promise<OpenCodeProviderSettings | OpenCodeOAuthAttempt> {
+    if ('operation' in data) {
+      return this.startOAuth(data, params);
+    }
     const unsupported = Object.keys(data ?? {}).find(
       (field) => field !== 'providerId' && field !== 'apiKey' && field !== 'metadata'
     );
@@ -189,6 +244,212 @@ export class OpenCodeAuthService {
       this.execute(context, { operation: 'connect-api-key', providerId, apiKey, metadata })
     );
     return this.settings(context, result);
+  }
+
+  private publicAttempt(attempt: StoredOAuthAttempt): OpenCodeOAuthAttempt {
+    const { attemptId, providerId, phase, authorization, expiresAt, settings } = attempt;
+    return {
+      attemptId,
+      providerId,
+      phase,
+      expiresAt,
+      ...(authorization ? { authorization } : {}),
+      ...(settings ? { settings } : {}),
+    };
+  }
+
+  private settleAttempt(
+    attempt: StoredOAuthAttempt,
+    result: Awaited<OpenCodeOAuthExecutorHandle['result']>,
+    context: CredentialContext
+  ): void {
+    if (result.success && result.data) {
+      const discovery = result.data as OpenCodeProviderDiscovery;
+      const configured = discovery.providers.some(
+        (provider) => provider.id === attempt.providerId && provider.configured
+      );
+      if (configured) {
+        attempt.settings = this.settings(context, discovery);
+        attempt.phase = 'configured';
+      } else {
+        attempt.phase = 'failed';
+      }
+    } else if (result.error?.code === 'OPENCODE_OAUTH_TIMEOUT') {
+      attempt.phase = 'expired';
+    } else if (result.error?.code === 'OPENCODE_OAUTH_CANCELLED') {
+      attempt.phase = 'cancelled';
+    } else {
+      attempt.phase = 'failed';
+    }
+    attempt.resolveReady();
+  }
+
+  private async ownedAttempt(
+    id: string,
+    params?: AuthenticatedParams
+  ): Promise<StoredOAuthAttempt> {
+    const context = await this.credentialContext(params);
+    const attempt = oauthAttempts.get(id);
+    if (!attempt || attempt.namespaceKey !== context.namespaceKey) {
+      throw new NotFound('OpenCode OAuth attempt was not found.');
+    }
+    return attempt;
+  }
+
+  private async startOAuth(
+    data: OpenCodeOAuthConnectRequest,
+    params?: AuthenticatedParams
+  ): Promise<OpenCodeOAuthAttempt> {
+    const unsupported = Object.keys(data).find(
+      (field) =>
+        field !== 'operation' && field !== 'providerId' && field !== 'method' && field !== 'inputs'
+    );
+    if (unsupported) throw new BadRequest(`Unsupported field: ${unsupported}`);
+    const providerId = data.providerId?.trim();
+    if (!providerId || !Number.isInteger(data.method) || data.method < 0) {
+      throw new BadRequest('Provider and OAuth method are required.');
+    }
+    if (
+      data.inputs !== undefined &&
+      (!data.inputs ||
+        Array.isArray(data.inputs) ||
+        typeof data.inputs !== 'object' ||
+        Object.values(data.inputs).some((value) => typeof value !== 'string'))
+    ) {
+      throw new BadRequest('Provider prompt values must be strings.');
+    }
+
+    const context = await this.credentialContext(params);
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const attempt: StoredOAuthAttempt = {
+      attemptId: crypto.randomUUID(),
+      providerId,
+      phase: 'authorizing',
+      expiresAt: new Date(Date.now() + OAUTH_TIMEOUT_MS).toISOString(),
+      namespaceKey: context.namespaceKey,
+      cancelRequested: false,
+      ready,
+      resolveReady,
+    };
+    oauthAttempts.set(attempt.attemptId, attempt);
+
+    void inMutationSlot(context.namespaceKey, async () => {
+      if (attempt.cancelRequested) {
+        attempt.phase = 'cancelled';
+        attempt.resolveReady();
+        scheduleAttemptPrune(attempt);
+        return;
+      }
+      const handle = startOpenCodeOAuthExecutor(
+        {
+          command: 'opencode.auth',
+          dataHome: context.dataHome,
+          params: {
+            operation: 'connect-oauth',
+            providerId,
+            method: data.method,
+            ...(data.inputs && Object.keys(data.inputs).length > 0 ? { inputs: data.inputs } : {}),
+          },
+        },
+        {
+          asUser: context.asUser,
+          env: Object.fromEntries(
+            AUTH_EXECUTOR_ENV_KEYS.flatMap((key) =>
+              process.env[key] === undefined ? [] : [[key, process.env[key]]]
+            )
+          ) as Record<string, string>,
+          logPrefix: '[OpenCode Auth]',
+          templateVariables: { unix_user: context.asUser ?? undefined },
+          timeoutMs: OAUTH_TIMEOUT_MS,
+        },
+        (event) => {
+          if (attempt.cancelRequested) return;
+          if (event.type === 'authorized') {
+            attempt.authorization = event.authorization;
+            attempt.phase = 'awaiting_callback';
+            attempt.resolveReady();
+          } else {
+            attempt.phase = 'completing';
+          }
+        }
+      );
+      attempt.handle = handle;
+      const result = await handle.result;
+      if (result.error?.code === 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED') {
+        blockedNamespaces.set(context.namespaceKey, () => handle.verifyAbsence());
+      }
+      this.settleAttempt(attempt, result, context);
+      scheduleAttemptPrune(attempt);
+    }).catch(() => {
+      if (!attempt.cancelRequested) attempt.phase = 'failed';
+      attempt.resolveReady();
+      scheduleAttemptPrune(attempt);
+    });
+
+    await attempt.ready;
+    return this.publicAttempt(attempt);
+  }
+
+  async get(id: string, params?: AuthenticatedParams): Promise<OpenCodeOAuthAttempt> {
+    return this.publicAttempt(await this.ownedAttempt(id, params));
+  }
+
+  async patch(
+    id: string,
+    data: OpenCodeOAuthAttemptPatch,
+    params?: AuthenticatedParams
+  ): Promise<OpenCodeOAuthAttempt> {
+    const attempt = await this.ownedAttempt(id, params);
+    if (
+      attempt.phase === 'configured' ||
+      attempt.phase === 'cancelled' ||
+      attempt.phase === 'expired' ||
+      attempt.phase === 'failed'
+    ) {
+      return this.publicAttempt(attempt);
+    }
+    if ('code' in data) {
+      if (Object.keys(data).some((field) => field !== 'code')) {
+        throw new BadRequest('Unsupported OAuth callback field.');
+      }
+      const code = data.code?.trim();
+      if (
+        !code ||
+        attempt.phase !== 'awaiting_callback' ||
+        attempt.authorization?.method !== 'code' ||
+        !attempt.handle
+      ) {
+        throw new BadRequest('This OAuth attempt is not awaiting a code.');
+      }
+      if (!(await attempt.handle.submitCode(code))) {
+        throw new BadRequest('This OAuth attempt no longer accepts a code.');
+      }
+      if (attempt.cancelRequested) {
+        this.settleAttempt(
+          attempt,
+          await attempt.handle.result,
+          await this.credentialContext(params)
+        );
+        return this.publicAttempt(attempt);
+      }
+      attempt.phase = 'completing';
+      return this.publicAttempt(attempt);
+    }
+    if (data.cancel !== true || Object.keys(data).some((field) => field !== 'cancel')) {
+      throw new BadRequest('Only OAuth cancellation or code submission is supported.');
+    }
+    attempt.cancelRequested = true;
+    if (!attempt.handle) {
+      attempt.phase = 'cancelled';
+      attempt.resolveReady();
+      return this.publicAttempt(attempt);
+    }
+    const result = await attempt.handle.cancel();
+    this.settleAttempt(attempt, result, await this.credentialContext(params));
+    return this.publicAttempt(attempt);
   }
 
   async remove(id: string, params?: AuthenticatedParams): Promise<OpenCodeProviderSettings> {

--- a/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
+++ b/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
@@ -16,10 +16,11 @@ import {
   TaskRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Session, Task, UUID } from '@agor/core/types';
+import type { CreateSessionInput, HookContext, Session, Task, UUID } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { applySessionConfigDefaults } from '../utils/apply-session-config-defaults';
 import { SessionsService } from './sessions';
 
 // The guard only touches the session/task repos built from `db`; the stored
@@ -173,5 +174,116 @@ describe('SessionsService.patch — agentic_tool immutability guard', () => {
 
     const result = (await service.patch(sessionId, { title: 'New title' })) as Session;
     expect(result.title).toBe('New title');
+  });
+});
+
+describe('SessionsService OpenCode model_config validation', () => {
+  function createInput(branchId: UUID, modelConfig: CreateSessionInput['model_config']) {
+    return {
+      session_id: generateId(),
+      branch_id: branchId,
+      agentic_tool: 'opencode' as const,
+      status: SessionStatus.IDLE,
+      created_by: 'test-user' as UUID,
+      git_state: { ref: 'main', base_sha: 'abc', current_sha: 'def' },
+      tasks: [],
+      contextFiles: [],
+      genealogy: { children: [] },
+      model_config: modelConfig,
+    } satisfies CreateSessionInput;
+  }
+
+  dbTest(
+    'preserves a deliberate clear through the create hook and persists absence without restoring a stale default',
+    async ({ db }) => {
+      const branchId = await createBranch(db);
+      const data = createInput(branchId, null);
+      const context = {
+        params: { provider: 'rest', user: { user_id: data.created_by } },
+        data,
+        app: {
+          service: () => ({
+            get: async () => ({
+              user_id: data.created_by,
+              default_agentic_config: {
+                opencode: {
+                  modelConfig: {
+                    mode: 'exact',
+                    provider: 'openai',
+                    model: 'stale-user-model',
+                  },
+                },
+              },
+            }),
+          }),
+        },
+      } as unknown as HookContext;
+
+      await applySessionConfigDefaults({ warnOnExternalDefaultFill: false })(context);
+      expect(context.data).toHaveProperty('model_config', null);
+
+      const service = new SessionsService(db, STUB_APP);
+      const created = (await service.create(context.data as CreateSessionInput)) as Session;
+      expect(created.model_config).toBeNull();
+      expect(
+        (await new SessionRepository(db).findById(created.session_id))?.model_config
+      ).toBeNull();
+    }
+  );
+
+  dbTest('rejects incomplete and blank OpenCode pairs on create', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const invalidConfigs = [
+      { mode: 'exact', model: 'gpt-5', updated_at: 'now' },
+      { mode: 'exact', provider: 'openai', updated_at: 'now' },
+      { mode: 'exact', provider: 'openai', model: '   ', updated_at: 'now' },
+      { mode: 'exact', provider: '   ', model: 'gpt-5', updated_at: 'now' },
+    ] as CreateSessionInput['model_config'][];
+
+    for (const modelConfig of invalidConfigs) {
+      await expect(service.create(createInput(branchId, modelConfig))).rejects.toThrow(
+        /provider.*model/i
+      );
+    }
+  });
+
+  dbTest('rejects incomplete and blank OpenCode pairs on patch', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const sessionId = await createSession(db, branchId, {
+      agentic_tool: 'opencode',
+      model_config: null,
+    });
+    const invalidConfigs = [
+      { mode: 'exact', model: 'gpt-5', updated_at: 'now' },
+      { mode: 'exact', provider: 'openai', updated_at: 'now' },
+      { mode: 'exact', provider: 'openai', model: '   ', updated_at: 'now' },
+      { mode: 'exact', provider: '   ', model: 'gpt-5', updated_at: 'now' },
+    ] as NonNullable<Session['model_config']>[];
+
+    for (const model_config of invalidConfigs) {
+      await expect(service.patch(sessionId, { model_config })).rejects.toThrow(/provider.*model/i);
+    }
+  });
+
+  dbTest('preserves a valid exact pair and existing-session null clears', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const exact = {
+      mode: 'exact' as const,
+      provider: 'openai',
+      model: 'gpt-5',
+      updated_at: 'now',
+    };
+
+    const created = (await service.create(createInput(branchId, exact))) as Session;
+    expect(created.model_config).toEqual(exact);
+
+    const cleared = (await service.patch(created.session_id, { model_config: null })) as Session;
+    expect(cleared.model_config).toBeNull();
+
+    const restored = (await service.patch(created.session_id, { model_config: exact })) as Session;
+    expect(restored.model_config).toEqual(exact);
   });
 });

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -33,12 +33,15 @@ import {
   Forbidden,
   NotAuthenticated,
 } from '@agor/core/feathers';
+import type { ModelConfigInput } from '@agor/core/models';
 import {
   formatModelToolMismatchWarning,
   formatUnsupportedAgorCodexModelMessage,
+  hasCompleteOpenCodeModelConfig,
   isResolvedModelConfig,
   isUnsupportedAgorCodexModel,
   lintModelToolMatch,
+  OPENCODE_MODEL_CONFIG_PAIR_ERROR,
 } from '@agor/core/models';
 import { resolveChildSessionConfig } from '@agor/core/sessions';
 import type {
@@ -214,8 +217,18 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
 
   private assertSupportedModelConfig(
     agenticTool: Session['agentic_tool'],
-    modelConfig: Session['model_config'] | undefined
+    modelConfig: ModelConfigInput | null | undefined
   ): void {
+    if (
+      agenticTool === 'opencode' &&
+      modelConfig != null &&
+      !hasCompleteOpenCodeModelConfig(modelConfig)
+    ) {
+      throw new BadRequest(OPENCODE_MODEL_CONFIG_PAIR_ERROR);
+    }
+    if (agenticTool === 'opencode' && modelConfig != null && modelConfig.mode !== 'exact') {
+      throw new BadRequest('OpenCode model_config mode must be exact');
+    }
     if (
       agenticTool === 'codex' &&
       modelConfig?.model &&
@@ -317,7 +330,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       };
     } else {
       await assertInlineAgenticConfigurationAllowed(this.db, agenticTool);
-      if (modelConfig != null && !isResolvedModelConfig(modelConfig)) {
+      this.assertSupportedModelConfig(agenticTool, modelConfig);
+      if (modelConfig != null && !isResolvedModelConfig(modelConfig, agenticTool)) {
         throw new BadRequest('model_config must be resolved before session creation');
       }
       createData = {
@@ -1275,6 +1289,19 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
           this.db,
           data.agentic_tool ?? current.agentic_tool
         );
+      }
+
+      if (data.model_config !== undefined || data.agentic_tool !== undefined) {
+        const effectiveTool = data.agentic_tool ?? current.agentic_tool;
+        const effectiveModelConfig =
+          data.model_config !== undefined ? data.model_config : current.model_config;
+        this.assertSupportedModelConfig(effectiveTool, effectiveModelConfig);
+        if (
+          effectiveModelConfig != null &&
+          !isResolvedModelConfig(effectiveModelConfig, effectiveTool)
+        ) {
+          throw new BadRequest('model_config must be resolved before updating a session');
+        }
       }
     }
     const result = (

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -178,6 +178,80 @@ describe('applySessionConfigDefaults', () => {
     );
   });
 
+  it('preserves an explicit OpenCode model_config null instead of restoring a stale user default', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'opencode',
+        created_by: ALICE,
+        model_config: null,
+      },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: {
+            opencode: {
+              modelConfig: {
+                mode: 'exact',
+                provider: 'openai',
+                model: 'stale-user-model',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await hook(ctx);
+
+    expect(ctx.data).toHaveProperty('model_config', null);
+    expect((ctx.data as { permission_config: unknown }).permission_config).toBeDefined();
+  });
+
+  it.each([
+    ['model-only', { model: 'gpt-5' }],
+    ['provider-only', { provider: 'openai' }],
+    ['blank model', { provider: 'openai', model: '   ' }],
+    ['blank provider', { provider: '   ', model: 'gpt-5' }],
+  ])('rejects an incomplete OpenCode %s create input', async (_label, modelConfig) => {
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'opencode',
+        created_by: ALICE,
+        model_config: modelConfig,
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+
+    await expect(
+      applySessionConfigDefaults({ warnOnExternalDefaultFill: false })(ctx)
+    ).rejects.toThrow(/provider.*model/i);
+  });
+
+  it('rejects an incomplete OpenCode user default through the shared resolver', async () => {
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'opencode', created_by: ALICE },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: {
+            opencode: { modelConfig: { model: 'gpt-5' } },
+          },
+        },
+      },
+    });
+
+    await expect(
+      applySessionConfigDefaults({ warnOnExternalDefaultFill: false })(ctx)
+    ).rejects.toThrow(/provider.*model/i);
+  });
+
   it("rejects an unsupported Codex model from the user's default", async () => {
     const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
     const ctx = makeContext({

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
@@ -41,8 +41,11 @@
 import { BadRequest } from '@agor/core/feathers';
 import {
   formatUnsupportedAgorCodexModelMessage,
+  hasCompleteOpenCodeModelConfig,
+  InvalidModelConfigError,
   isResolvedModelConfig,
   isUnsupportedAgorCodexModel,
+  OPENCODE_MODEL_CONFIG_PAIR_ERROR,
 } from '@agor/core/models';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type { AgenticToolName, CreateSessionInput, HookContext, User } from '@agor/core/types';
@@ -72,11 +75,21 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
     const data = context.data as CreateSessionInput | undefined;
     if (!data) return context;
 
-    const hasPermission = data.permission_config != null;
-    const hasResolvedModel = isResolvedModelConfig(data.model_config);
-
     const agenticTool = data.agentic_tool as AgenticToolName | undefined;
     if (!agenticTool) return context; // can't resolve defaults without a tool
+
+    const hasPermission = data.permission_config != null;
+    const hasExplicitModelClear = Object.hasOwn(data, 'model_config') && data.model_config === null;
+    const hasResolvedModel =
+      hasExplicitModelClear || isResolvedModelConfig(data.model_config, agenticTool);
+
+    if (
+      agenticTool === 'opencode' &&
+      data.model_config != null &&
+      !hasCompleteOpenCodeModelConfig(data.model_config)
+    ) {
+      throw new BadRequest(OPENCODE_MODEL_CONFIG_PAIR_ERROR);
+    }
 
     if (
       agenticTool === 'codex' &&
@@ -118,11 +131,19 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
       user = null;
     }
 
-    const resolved = resolveSessionDefaults({
-      agenticTool,
-      user,
-      overrides: { modelConfig: data.model_config ?? undefined },
-    });
+    let resolved: ReturnType<typeof resolveSessionDefaults>;
+    try {
+      resolved = resolveSessionDefaults({
+        agenticTool,
+        user,
+        overrides: { modelConfig: data.model_config ?? undefined },
+      });
+    } catch (error) {
+      if (error instanceof InvalidModelConfigError) {
+        throw new BadRequest(error.message);
+      }
+      throw error;
+    }
     if (
       resolved.model_config?.model &&
       agenticTool === 'codex' &&

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -5,12 +5,22 @@ import path from 'node:path';
 import { Writable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { spawnMock } = vi.hoisted(() => ({
+const { containMock, spawnMock, trackMock, untrackMock } = vi.hoisted(() => ({
+  containMock: vi.fn(),
   spawnMock: vi.fn(),
+  trackMock: vi.fn(),
+  untrackMock: vi.fn(),
 }));
 
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
+}));
+
+vi.mock('../executor-tracking.js', () => ({
+  containExecutorProcess: containMock,
+  markExecutorProcessExited: vi.fn(),
+  trackExecutorProcess: trackMock,
+  untrackExecutorProcess: untrackMock,
 }));
 
 vi.mock('@agor/core/unix', () => ({
@@ -33,7 +43,9 @@ function createMockProcess() {
     stdout: EventEmitter;
     stderr: EventEmitter;
     written: string;
+    pid: number;
   };
+  proc.pid = 4242;
   proc.written = '';
   proc.stdin = new Writable({
     write(chunk, _encoding, callback) {
@@ -50,12 +62,18 @@ describe('configured executor spawning', () => {
   beforeEach(async () => {
     vi.resetModules();
     spawnMock.mockReset();
+    containMock.mockReset();
+    containMock.mockResolvedValue({ status: 'verified_absent' });
+    trackMock.mockReset();
+    untrackMock.mockReset();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const unix = await import('@agor/core/unix');
     vi.mocked(unix.buildSpawnArgs).mockReturnValue({ cmd: 'node', args: ['executor', '--stdin'] });
     vi.mocked(unix.isSecretEnvKey).mockReturnValue(false);
+    vi.mocked(unix.prepareImpersonationEnv).mockReset();
+    vi.mocked(unix.attachEnvFileCleanup).mockReset();
     vi.mocked(unix.attachEnvFileCleanup).mockImplementation(() => {});
 
     const { configureExecutor } = await import('./spawn-executor');
@@ -263,6 +281,526 @@ describe('configured executor spawning', () => {
       } else {
         process.env.AGOR_EXECUTOR_PATH = previous;
       }
+    }
+  });
+
+  it('rejects a missing generic cwd before creating an impersonation env file', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-executor-cwd-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const missingCwd = path.join(dir, 'missing');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const unix = await import('@agor/core/unix');
+      vi.mocked(unix.prepareImpersonationEnv).mockReturnValue({
+        inlineEnv: { PATH: '/usr/bin' },
+        envFilePath: path.join(dir, 'should-not-exist.env'),
+      });
+      const { runExecutorCommand } = await import('./spawn-executor');
+      const result = await runExecutorCommand(
+        { command: 'opencode.auth', params: { operation: 'discover' } },
+        {
+          cwd: missingCwd,
+          asUser: 'alice',
+          env: { PATH: '/usr/bin', OPENAI_API_KEY: 'must-not-write' },
+        }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: 'EXECUTOR_CWD_MISSING',
+          message: `Refusing to spawn: cwd does not exist on disk: ${missingCwd}`,
+        },
+      });
+      expect(unix.prepareImpersonationEnv).not.toHaveBeenCalled();
+      expect(unix.attachEnvFileCleanup).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps OAuth lifecycle frames private and contains the whole process group on cancel', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-executor-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+    const onEvent = vi.fn();
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        {
+          command: 'opencode.auth',
+          dataHome: '/private/synthetic-home',
+          params: {
+            operation: 'connect-oauth',
+            providerId: 'openai',
+            method: 1,
+            inputs: { account: 'synthetic-secret-input' },
+          },
+        },
+        { env: { PATH: '/usr/bin' } },
+        onEvent
+      );
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'node',
+        ['executor', '--stdin'],
+        expect.objectContaining({ detached: true, stdio: ['pipe', 'pipe', 'pipe'] })
+      );
+      proc.stdout.emit(
+        'data',
+        Buffer.from(
+          'AGOR_OPENCODE_OAUTH_EVENT {"type":"authorized","authorization":{"url":"http://127.0.0.1/authorize","method":"auto","instructions":"Synthetic code 1234"}}\n'
+        )
+      );
+      proc.stderr.emit(
+        'data',
+        Buffer.from('synthetic-secret-input /private/synthetic-home generated-password')
+      );
+      expect(onEvent).toHaveBeenCalledWith({
+        type: 'authorized',
+        authorization: {
+          url: 'http://127.0.0.1/authorize',
+          method: 'auto',
+          instructions: 'Synthetic code 1234',
+        },
+      });
+
+      const cancellation = handle.cancel();
+      proc.emit('exit', null);
+      proc.emit('close', null);
+      await expect(cancellation).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CANCELLED' },
+      });
+      await expect(handle.result).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CANCELLED' },
+      });
+      expect(trackMock).toHaveBeenCalledWith(
+        expect.objectContaining({ pid: 4242, asUser: undefined })
+      );
+      expect(containMock).toHaveBeenCalledOnce();
+      expect(untrackMock).toHaveBeenCalledOnce();
+      expect(JSON.stringify(await handle.result)).not.toContain('synthetic-secret-input');
+      expect(JSON.stringify(await handle.result)).not.toContain('/private/synthetic-home');
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('synthetic-secret-input')
+      );
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('/private/synthetic-home')
+      );
+      expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('Synthetic code 1234'));
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects non-containable templated OAuth without spawning', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { configureExecutor, startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+    configureExecutor({ executor_command_template: 'remote {command}' });
+
+    const handle = startOpenCodeOAuthExecutor({ command: 'opencode.auth' }, {}, vi.fn());
+
+    await expect(handle.result).resolves.toEqual({
+      success: false,
+      error: {
+        code: 'OPENCODE_OAUTH_LOCAL_EXECUTOR_REQUIRED',
+        message: 'OpenCode OAuth requires a locally containable executor process.',
+      },
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('contains the OAuth process group on its bounded timeout', async () => {
+    vi.useFakeTimers();
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-timeout-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' }, timeoutMs: 25 },
+        vi.fn()
+      );
+      await vi.advanceTimersByTimeAsync(25);
+      proc.emit('exit', null);
+      proc.emit('close', null);
+
+      await expect(handle.result).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_TIMEOUT' },
+      });
+      expect(containMock).toHaveBeenCalledOnce();
+      expect(untrackMock).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('waits for close and parses the final OAuth result frame after exit', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-final-frame-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+
+      proc.emit('exit', 0);
+      proc.stdout.emit(
+        'data',
+        Buffer.from('AGOR_EXECUTOR_RESULT {"success":true,"data":{"runtime":"available"}}')
+      );
+      let settled = false;
+      void handle.result.finally(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      proc.emit('close', 0);
+      await expect(handle.result).resolves.toEqual({
+        success: true,
+        data: { runtime: 'available' },
+      });
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['missing', ''],
+    ['truncated', 'AGOR_EXECUTOR_RESULT {"success":true'],
+  ])('fails safely for a %s OAuth result frame after close', async (_label, frame) => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-missing-frame-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      if (frame) proc.stdout.emit('data', Buffer.from(frame));
+      proc.stderr.emit('data', Buffer.from('secret password /private/path'));
+      proc.emit('exit', 1);
+      proc.emit('close', 1);
+
+      await expect(handle.result).resolves.toEqual({
+        success: false,
+        error: {
+          code: 'EXECUTOR_RESULT_MISSING',
+          message: 'OpenCode OAuth executor did not emit a result.',
+          details: { stderr: '[redacted]' },
+        },
+      });
+      expect(JSON.stringify(await handle.result)).not.toContain('secret password');
+      expect(JSON.stringify(await handle.result)).not.toContain('/private/path');
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('shares one finalization across cancel and exit and retains unverified tracking', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-unverified-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    containMock.mockResolvedValue({
+      status: 'unverified',
+      reason: 'synthetic containment failure',
+    });
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      const first = handle.cancel();
+      const second = handle.cancel();
+      expect(second).toBe(first);
+      proc.emit('exit', null);
+      proc.emit('close', null);
+
+      await expect(first).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED' },
+      });
+      await expect(second).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED' },
+      });
+      await expect(handle.result).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED' },
+      });
+      expect(containMock).toHaveBeenCalledOnce();
+      expect(untrackMock).not.toHaveBeenCalled();
+
+      containMock.mockResolvedValue({ status: 'verified_absent' });
+      await expect(handle.verifyAbsence()).resolves.toBe(true);
+      expect(containMock).toHaveBeenCalledTimes(2);
+      expect(untrackMock).toHaveBeenCalledOnce();
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('submits exactly one secret code over the bounded OAuth stdin without echoing it', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-code-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    let finishInput!: () => void;
+    proc.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        proc.written += chunk.toString();
+        callback();
+      },
+      final(callback) {
+        finishInput = callback;
+      },
+    });
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const submission = handle.submitCode('synthetic-secret-code');
+      let deliverySettled = false;
+      void submission.then(() => {
+        deliverySettled = true;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(deliverySettled).toBe(false);
+      finishInput();
+      await expect(submission).resolves.toBe(true);
+      await expect(handle.submitCode('second-code')).resolves.toBe(false);
+      expect(proc.written).toContain('"code":"synthetic-secret-code"');
+      expect(proc.written).not.toContain('second-code');
+      expect(console.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('synthetic-secret-code')
+      );
+
+      const cancellation = handle.cancel();
+      proc.emit('exit', null);
+      proc.emit('close', null);
+      await cancellation;
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects code delivery when stdin finalization fails asynchronously', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-code-final-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    proc.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        proc.written += chunk.toString();
+        callback();
+      },
+      final(callback) {
+        setImmediate(() => callback(new Error('EPIPE synthetic-secret-code /private/final-path')));
+      },
+    });
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const submission = handle.submitCode('synthetic-secret-code');
+
+      await expect(submission).resolves.toBe(false);
+      proc.emit('exit', 1);
+      proc.emit('close', 1);
+
+      await expect(handle.result).resolves.toEqual({
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_STDIN_FAILED',
+          message: 'OpenCode OAuth executor input could not be delivered.',
+        },
+      });
+      expect(JSON.stringify(await handle.result)).not.toContain('synthetic-secret-code');
+      expect(JSON.stringify(await handle.result)).not.toContain('/private/final-path');
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('synthetic-secret-code')
+      );
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('owns an initial OAuth stdin delivery failure without exposing the payload', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-initial-write-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    proc.stdin = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error('EPIPE synthetic-secret /private/path'));
+      },
+    });
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        {
+          command: 'opencode.auth',
+          dataHome: '/private/path',
+          params: { operation: 'connect-oauth', providerId: 'openai', method: 0 },
+        },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      proc.emit('exit', 1);
+      proc.emit('close', 1);
+
+      await expect(handle.result).resolves.toEqual({
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_STDIN_FAILED',
+          message: 'OpenCode OAuth executor input could not be delivered.',
+        },
+      });
+      expect(JSON.stringify(await handle.result)).not.toContain('synthetic-secret');
+      expect(JSON.stringify(await handle.result)).not.toContain('/private/path');
+      expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining('synthetic-secret'));
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('settles a failed code write through concurrent cancellation and exit', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'agor-oauth-code-write-'));
+    const executorPath = path.join(dir, 'agor-executor');
+    const previous = process.env.AGOR_EXECUTOR_PATH;
+    const proc = createMockProcess();
+    let writes = 0;
+    let failCodeWrite!: () => void;
+    proc.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        writes += 1;
+        proc.written += chunk.toString();
+        if (writes === 1) callback();
+        else {
+          failCodeWrite = () =>
+            callback(new Error('EPIPE synthetic-secret-code /private/code-path'));
+        }
+      },
+    });
+    spawnMock.mockReturnValue(proc);
+    writeFileSync(executorPath, '#!/usr/bin/env node\n');
+    process.env.AGOR_EXECUTOR_PATH = executorPath;
+
+    try {
+      const { startOpenCodeOAuthExecutor } = await import('./spawn-executor');
+      const handle = startOpenCodeOAuthExecutor(
+        { command: 'opencode.auth' },
+        { env: { PATH: '/usr/bin' } },
+        vi.fn()
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const submission = handle.submitCode('synthetic-secret-code');
+      expect(writes).toBe(2);
+      const cancellation = handle.cancel();
+      failCodeWrite();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      proc.emit('exit', null);
+      proc.emit('close', null);
+
+      await expect(submission).resolves.toBe(false);
+      await expect(cancellation).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CANCELLED' },
+      });
+      await expect(handle.result).resolves.toMatchObject({
+        success: false,
+        error: { code: 'OPENCODE_OAUTH_CANCELLED' },
+      });
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('synthetic-secret-code')
+      );
+      expect(JSON.stringify(await handle.result)).not.toContain('/private/code-path');
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_EXECUTOR_PATH;
+      else process.env.AGOR_EXECUTOR_PATH = previous;
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -26,7 +26,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgorExecutionSettings } from '@agor/core/config';
-import type { AuthenticatedParams } from '@agor/core/types';
+import type { AuthenticatedParams, OpenCodeOAuthAuthorization } from '@agor/core/types';
 import {
   attachEnvFileCleanup,
   buildSpawnArgs,
@@ -36,6 +36,12 @@ import {
 import { getCurrentLogLevel } from '@agor/core/utils/logger';
 import type { SignOptions } from 'jsonwebtoken';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
+import {
+  containExecutorProcess,
+  markExecutorProcessExited,
+  trackExecutorProcess,
+  untrackExecutorProcess,
+} from '../executor-tracking.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
 
 let configuredDaemonUrl: string | null = null;
@@ -131,6 +137,20 @@ export interface RunExecutorCommandOptions
   extends Omit<SpawnExecutorOptions, 'onExit' | 'onSpawn'> {
   /** Optional timeout for short-lived command execution. */
   timeoutMs?: number;
+}
+
+export type OpenCodeOAuthProcessEvent =
+  | {
+      type: 'authorized';
+      authorization: OpenCodeOAuthAuthorization;
+    }
+  | { type: 'callback-started' };
+
+export interface OpenCodeOAuthExecutorHandle {
+  result: Promise<ExecutorCommandResult>;
+  cancel(): Promise<ExecutorCommandResult>;
+  submitCode(code: string): Promise<boolean>;
+  verifyAbsence(): Promise<boolean>;
 }
 
 /**
@@ -514,6 +534,392 @@ function logChunkedOutput(prefix: string, stream: 'stdout' | 'stderr', chunk: Bu
   }
 }
 
+const OPENCODE_OAUTH_EVENT_PREFIX = 'AGOR_OPENCODE_OAUTH_EVENT ';
+
+function resolveLocalExecutorLocation(options: RunExecutorCommandOptions) {
+  const executorPath = findExecutorPath();
+  return {
+    executorPath,
+    cwd: options.cwd ?? path.dirname(path.dirname(executorPath)),
+  };
+}
+
+function prepareLocalExecutorSpawn(
+  options: RunExecutorCommandOptions,
+  mode: '--stdin' | '--opencode-oauth',
+  location = resolveLocalExecutorLocation(options)
+) {
+  const { executorPath, cwd } = location;
+  const {
+    env = process.env as Record<string, string>,
+    asUser: rawAsUser,
+    preparedEnv,
+    preparedEnvFilePath,
+  } = options;
+  const asUser = rawAsUser || undefined;
+  const envWithDaemonUrl: Record<string, string> = preparedEnv
+    ? withDaemonExecutorEnv(preparedEnv, getDaemonUrl())
+    : asUser
+      ? withDaemonExecutorEnv(
+          Object.fromEntries(
+            Object.entries({
+              PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
+              NODE_ENV: env.NODE_ENV,
+              LOG_LEVEL: env.LOG_LEVEL,
+              ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+              ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
+              ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+              CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
+              OPENAI_API_KEY: env.OPENAI_API_KEY,
+              OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+              GEMINI_API_KEY: env.GEMINI_API_KEY,
+              GOOGLE_API_KEY: env.GOOGLE_API_KEY,
+              GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
+            }).filter(([_, value]) => value !== undefined)
+          ),
+          getDaemonUrl()
+        )
+      : withDaemonExecutorEnv(env, getDaemonUrl());
+  const prepared = asUser
+    ? preparedEnvFilePath
+      ? {
+          inlineEnv: Object.fromEntries(
+            Object.entries(envWithDaemonUrl).filter(([key]) => !isSecretEnvKey(key))
+          ),
+          envFilePath: preparedEnvFilePath,
+        }
+      : prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
+    : { inlineEnv: undefined, envFilePath: undefined };
+  const command = buildSpawnArgs('node', [executorPath, mode], {
+    asUser,
+    env: asUser ? prepared.inlineEnv : undefined,
+    envFilePath: prepared.envFilePath,
+  });
+  return { ...command, cwd, asUser, envWithDaemonUrl, envFilePath: prepared.envFilePath };
+}
+
+function parseOpenCodeOAuthEvent(line: string): OpenCodeOAuthProcessEvent | undefined {
+  if (!line.startsWith(OPENCODE_OAUTH_EVENT_PREFIX)) return undefined;
+  try {
+    const event = JSON.parse(line.slice(OPENCODE_OAUTH_EVENT_PREFIX.length)) as unknown;
+    if (!event || typeof event !== 'object' || !('type' in event)) return undefined;
+    if (event.type === 'callback-started') return { type: 'callback-started' };
+    if (
+      event.type === 'authorized' &&
+      'authorization' in event &&
+      event.authorization &&
+      typeof event.authorization === 'object'
+    ) {
+      const authorization = event.authorization as Record<string, unknown>;
+      if (
+        typeof authorization.url === 'string' &&
+        (authorization.method === 'auto' || authorization.method === 'code') &&
+        typeof authorization.instructions === 'string'
+      ) {
+        return {
+          type: 'authorized',
+          authorization: {
+            url: authorization.url,
+            method: authorization.method,
+            instructions: authorization.instructions,
+          },
+        };
+      }
+    }
+  } catch {
+    // Invalid protocol output is ignored and becomes a missing-result failure.
+  }
+  return undefined;
+}
+
+/**
+ * Starts the one bounded, local executor process used by native OpenCode OAuth.
+ *
+ * This deliberately is not a general interactive executor transport: the only
+ * intermediate frames it understands are the two OpenCode OAuth lifecycle
+ * events above. Cancellation contains the executor's whole process group,
+ * including its task-scoped managed OpenCode server.
+ */
+export function startOpenCodeOAuthExecutor(
+  payload: Record<string, unknown>,
+  options: RunExecutorCommandOptions,
+  onEvent: (event: OpenCodeOAuthProcessEvent) => void
+): OpenCodeOAuthExecutorHandle {
+  const executorCommandTemplate =
+    options.executorCommandTemplate !== undefined
+      ? options.executorCommandTemplate || undefined
+      : configuredExecutorDefaults.executorCommandTemplate;
+  if (executorCommandTemplate) {
+    return {
+      result: Promise.resolve({
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_LOCAL_EXECUTOR_REQUIRED',
+          message: 'OpenCode OAuth requires a locally containable executor process.',
+        },
+      }),
+      cancel: async () => ({
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_LOCAL_EXECUTOR_REQUIRED',
+          message: 'OpenCode OAuth requires a locally containable executor process.',
+        },
+      }),
+      submitCode: async () => false,
+      verifyAbsence: async () => true,
+    };
+  }
+
+  const { timeoutMs = 10 * 60_000 } = options;
+  const rawAsUser = options.asUser;
+  const asUser =
+    rawAsUser !== undefined
+      ? rawAsUser || undefined
+      : configuredExecutorDefaults.asUser || undefined;
+  const attemptId = crypto.randomUUID();
+  const taskId = generateTaskId();
+  const prepared = prepareLocalExecutorSpawn({ ...options, asUser }, '--opencode-oauth');
+  const { cmd, args, cwd, envWithDaemonUrl, envFilePath } = prepared;
+  const child = spawn(cmd, args, {
+    cwd,
+    env: asUser ? undefined : { ...envWithDaemonUrl },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    detached: true,
+  });
+  attachEnvFileCleanup(child, { envFilePath, asUser });
+
+  let resolveResult!: (result: ExecutorCommandResult) => void;
+  const result = new Promise<ExecutorCommandResult>((resolve) => {
+    resolveResult = resolve;
+  });
+  let stdout = '';
+  let lineBuffer = '';
+  let stderrSeen = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let finalization: Promise<ExecutorCommandResult> | undefined;
+  let codeSubmitted = false;
+  let pendingInput:
+    | {
+        fail: (ownTransportFailure: boolean) => void;
+      }
+    | undefined;
+  let resolveClose!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClose = resolve;
+  });
+
+  const finalize = (
+    fallback?: ExecutorCommandResult,
+    leaderExited = false
+  ): Promise<ExecutorCommandResult> => {
+    finalization ??= (async () => {
+      pendingInput?.fail(false);
+      if (timer) clearTimeout(timer);
+      if (leaderExited) markExecutorProcessExited(attemptId, child.pid);
+      const containment = await containExecutorProcess(attemptId, taskId);
+      if (containment.status !== 'verified_absent') {
+        return {
+          success: false,
+          error: {
+            code: 'OPENCODE_OAUTH_CLEANUP_UNVERIFIED',
+            message: 'OpenCode OAuth cleanup could not be verified.',
+          },
+        };
+      }
+      await closed;
+      untrackExecutorProcess(attemptId, taskId);
+      return (
+        fallback ??
+        parseExecutorResultFromStdout(stdout) ?? {
+          success: false,
+          error: {
+            code: 'EXECUTOR_RESULT_MISSING',
+            message: 'OpenCode OAuth executor did not emit a result.',
+            details: { stderr: stderrSeen ? '[redacted]' : '' },
+          },
+        }
+      );
+    })();
+    void finalization.then(resolveResult);
+    return finalization;
+  };
+
+  const stdinFailure: ExecutorCommandResult = {
+    success: false,
+    error: {
+      code: 'OPENCODE_OAUTH_STDIN_FAILED',
+      message: 'OpenCode OAuth executor input could not be delivered.',
+    },
+  };
+  const endInput = (): boolean => {
+    const stream = child.stdin;
+    if (!stream || stream.destroyed) {
+      void finalize(stdinFailure);
+      return false;
+    }
+    if (stream.writableEnded || stream.writableFinished) return true;
+    try {
+      stream.end();
+      return true;
+    } catch {
+      pendingInput?.fail(true);
+      void finalize(stdinFailure);
+      return false;
+    }
+  };
+  const deliverInput = (value: unknown, end = false): Promise<boolean> => {
+    const stream = child.stdin;
+    if (
+      !stream?.writable ||
+      stream.destroyed ||
+      stream.writableEnded ||
+      stream.writableFinished ||
+      finalization
+    ) {
+      void finalize(stdinFailure);
+      return Promise.resolve(false);
+    }
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const succeed = () => {
+        if (settled) return;
+        settled = true;
+        if (pendingInput?.fail === fail) pendingInput = undefined;
+        resolve(true);
+      };
+      const fail = (ownTransportFailure: boolean) => {
+        if (settled) return;
+        settled = true;
+        if (pendingInput?.fail === fail) pendingInput = undefined;
+        if (ownTransportFailure) void finalize(stdinFailure);
+        resolve(false);
+      };
+      pendingInput = { fail };
+      try {
+        stream.write(`${JSON.stringify(value)}\n`, (error?: Error | null) => {
+          if (error) {
+            fail(true);
+            return;
+          }
+          if (settled) return;
+          if (!end) {
+            succeed();
+            return;
+          }
+          try {
+            stream.end((endError?: Error | null) => {
+              if (endError) {
+                fail(true);
+                return;
+              }
+              succeed();
+            });
+          } catch {
+            fail(true);
+          }
+        });
+      } catch {
+        fail(true);
+      }
+    });
+  };
+
+  if (!child.pid) {
+    const spawnFailure = {
+      success: false,
+      error: {
+        code: 'EXECUTOR_SPAWN_ERROR',
+        message: 'OpenCode OAuth executor did not start.',
+      },
+    };
+    resolveResult(spawnFailure);
+    return {
+      result,
+      cancel: async () => spawnFailure,
+      submitCode: async () => false,
+      verifyAbsence: async () => true,
+    };
+  }
+  trackExecutorProcess({ sessionId: attemptId, taskId, pid: child.pid, asUser });
+
+  child.stdout?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString();
+    stdout += text;
+    lineBuffer += text;
+    const lines = lineBuffer.split(/\r?\n/);
+    lineBuffer = lines.pop() ?? '';
+    for (const rawLine of lines) {
+      const event = parseOpenCodeOAuthEvent(rawLine.trim());
+      if (event) {
+        onEvent(event);
+        if (event.type === 'authorized' && event.authorization.method === 'auto') {
+          endInput();
+        }
+      }
+    }
+  });
+  child.stderr?.on('data', () => {
+    stderrSeen = true;
+  });
+  child.stdin?.on('error', () => {
+    pendingInput?.fail(true);
+    void finalize(stdinFailure);
+  });
+  child.on('error', () => {
+    void finalize({
+      success: false,
+      error: {
+        code: 'EXECUTOR_SPAWN_ERROR',
+        message: 'OpenCode OAuth executor failed to start.',
+      },
+    });
+  });
+  child.on('exit', () => {
+    pendingInput?.fail(false);
+    void finalize(undefined, true);
+  });
+  child.on('close', () => {
+    pendingInput?.fail(false);
+    markExecutorProcessExited(attemptId, child.pid);
+    resolveClose();
+    void finalize(undefined, true);
+  });
+
+  timer = setTimeout(() => {
+    void finalize({
+      success: false,
+      error: {
+        code: 'OPENCODE_OAUTH_TIMEOUT',
+        message: 'OpenCode OAuth authorization timed out.',
+      },
+    });
+  }, timeoutMs);
+  void deliverInput(withResolvedConfig(payload));
+
+  return {
+    result,
+    cancel: () =>
+      finalize({
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_CANCELLED',
+          message: 'OpenCode OAuth authorization was cancelled.',
+        },
+      }),
+    submitCode: async (code: string) => {
+      if (finalization || codeSubmitted || !code.trim()) return false;
+      codeSubmitted = true;
+      return deliverInput({ code }, true);
+    },
+    verifyAbsence: async () => {
+      const containment = await containExecutorProcess(attemptId, taskId);
+      if (containment.status !== 'verified_absent') return false;
+      untrackExecutorProcess(attemptId, taskId);
+      return true;
+    },
+  };
+}
+
 /**
  * Run a short-lived executor command and wait for its JSON result.
  *
@@ -560,19 +966,11 @@ function runExecutorCommandLocal(
   payload: Record<string, unknown>,
   options: RunExecutorCommandOptions
 ): Promise<ExecutorCommandResult> {
-  const executorPath = findExecutorPath();
-  const executorDir = path.dirname(path.dirname(executorPath));
-
-  const {
-    cwd = executorDir,
-    env = process.env as Record<string, string>,
-    logPrefix = '[Executor]',
-    asUser: rawAsUser,
-    preparedEnv,
-    preparedEnvFilePath,
-    timeoutMs = 60_000,
-  } = options;
+  const { logPrefix = '[Executor]', timeoutMs = 60_000 } = options;
+  const rawAsUser = options.asUser;
   const asUser = rawAsUser || undefined;
+  const location = resolveLocalExecutorLocation(options);
+  const { cwd } = location;
 
   if (cwd && !existsSync(cwd)) {
     return Promise.resolve({
@@ -584,47 +982,8 @@ function runExecutorCommandLocal(
     });
   }
 
-  const daemonUrl = getDaemonUrl();
-  const envWithDaemonUrl: Record<string, string> = preparedEnv
-    ? withDaemonExecutorEnv(preparedEnv, daemonUrl)
-    : asUser
-      ? withDaemonExecutorEnv(
-          Object.fromEntries(
-            Object.entries({
-              PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
-              NODE_ENV: env.NODE_ENV,
-              LOG_LEVEL: env.LOG_LEVEL,
-              ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-              ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
-              ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
-              CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
-              OPENAI_API_KEY: env.OPENAI_API_KEY,
-              OPENAI_BASE_URL: env.OPENAI_BASE_URL,
-              GEMINI_API_KEY: env.GEMINI_API_KEY,
-              GOOGLE_API_KEY: env.GOOGLE_API_KEY,
-              GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
-            }).filter(([_, v]) => v !== undefined)
-          ),
-          daemonUrl
-        )
-      : withDaemonExecutorEnv(env as Record<string, string>, daemonUrl);
-
-  const prepared = asUser
-    ? preparedEnvFilePath
-      ? {
-          inlineEnv: Object.fromEntries(
-            Object.entries(envWithDaemonUrl).filter(([k]) => !isSecretEnvKey(k))
-          ),
-          envFilePath: preparedEnvFilePath,
-        }
-      : prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
-    : { inlineEnv: undefined, envFilePath: undefined };
-
-  const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
-    asUser,
-    env: asUser ? prepared.inlineEnv : undefined,
-    envFilePath: prepared.envFilePath,
-  });
+  const prepared = prepareLocalExecutorSpawn({ ...options, asUser }, '--stdin', location);
+  const { cmd, args, envWithDaemonUrl, envFilePath } = prepared;
 
   console.log(`${logPrefix} Running executor command: ${payload.command ?? '?'}`);
 
@@ -640,7 +999,7 @@ function runExecutorCommandLocal(
       detached: false,
     });
 
-    attachEnvFileCleanup(child, { envFilePath: prepared.envFilePath, asUser });
+    attachEnvFileCleanup(child, { envFilePath, asUser });
 
     const timer = setTimeout(() => {
       if (settled) return;

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -402,10 +402,13 @@ Agor defines three permission levels per branch:
 
 ### OpenCode provider credentials
 
-OpenCode API keys are configured from the current user's settings and stored by
-the packaged OpenCode runtime in an opaque tenant-and-user namespace. A task
-always routes to the namespace of the immutable session owner
-(`session.created_by`), not the user who submitted the prompt.
+OpenCode API keys and supported native OAuth subscriptions are configured from
+the current user's settings and stored by the packaged OpenCode runtime in an
+opaque tenant-and-user namespace. OAuth authorization runs in one bounded auth
+executor and task-scoped OpenCode server; Agor stops that runtime before a fresh
+server verifies the saved state. A task always routes to the namespace of the
+immutable session owner (`session.created_by`), not the user who submitted the
+prompt.
 
 - In `strict` mode, the session owner's Unix identity, ownership checks, and
   `0700`/`0600` permissions enforce the filesystem boundary.
@@ -413,6 +416,11 @@ always routes to the namespace of the immutable session owner
   users sharing the same Unix identity must trust one another.
 - A “Configured in OpenCode” status means the native runtime reports a saved
   credential. It does not verify a request with the provider.
+- Agor does not silently copy credentials from another CLI. Native OAuth uses
+  the method and instructions reported by the packaged OpenCode runtime,
+  including one bounded authorization-code submission when requested.
+- Native OAuth requires a locally containable executor process. It is not
+  started through a remote executor command template.
 - Native OpenCode credential storage is unavailable when multi-tenancy uses
   `required_from_auth`; configuration and task execution reject before starting
   OpenCode.

--- a/apps/agor-docs/content/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/content/guide/sdk-comparison.mdx
@@ -855,7 +855,13 @@ Agor's per-task Basic credential authenticates only the private SDK-to-server co
 - In `simple` mode, it reads state as the daemon user.
 - Prefer Agor-scoped environment variables when credentials must remain user- or session-specific.
 
-Provider authentication is resolved when the managed task starts. Agor's generic OpenCode auth check confirms that the runtime is enabled; it does not validate a particular provider credential in advance.
+OpenCode provider settings discover native API-key and OAuth methods using a
+disposable managed server. A native OAuth attempt keeps authorize and callback
+on the same auth server, stops the complete auth process path on completion or
+cancellation, and verifies saved state with a fresh server. “Configured” means
+that fresh OpenCode instance reports saved state; it does not make a paid or
+provider-validation request. Failed or cancelled callbacks leave credential
+contents under OpenCode's native ownership rather than using an Agor rollback.
 
 The model override UI does not call a daemon model-discovery endpoint because no persistent OpenCode server exists between tasks. Enter an exact provider/model pair, or leave both fields empty to use OpenCode's configured defaults.
 

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
@@ -23,11 +23,23 @@ vi.mock('../ModelSelector', async () => {
   const actual = await vi.importActual<typeof import('../ModelSelector')>('../ModelSelector');
   return {
     ...actual,
-    ModelSelector: ({ onChange }: { onChange: (v: unknown) => void }) => (
+    ModelSelector: ({
+      onChange,
+      agentic_tool,
+    }: {
+      onChange: (v: unknown) => void;
+      agentic_tool: string;
+    }) => (
       <button
         type="button"
         data-testid="model-change"
-        onClick={() => onChange({ mode: 'alias', model: 'claude-haiku-4-5' })}
+        onClick={() =>
+          onChange(
+            agentic_tool === 'opencode'
+              ? { mode: 'exact', provider: 'openai', model: 'gpt-5' }
+              : { mode: 'alias', model: 'claude-haiku-4-5' }
+          )
+        }
       >
         change model
       </button>
@@ -75,16 +87,18 @@ function Harness({
   user,
   client = makeClient(),
   initialSource,
+  tool = 'claude-code',
 }: {
   user: User;
   client?: AgorClient | null;
   initialSource?: string;
+  tool?: 'claude-code' | 'opencode';
 }) {
   const [form] = Form.useForm();
   return (
     <Form form={form} initialValues={{ agenticToolPresetId: initialSource }}>
       <AgenticConfigChipRow
-        tool="claude-code"
+        tool={tool}
         client={client}
         mcpServerById={new Map()}
         currentUser={user}
@@ -96,6 +110,8 @@ function Harness({
             {JSON.stringify({
               src: form.getFieldValue('agenticToolPresetId'),
               model: (form.getFieldValue('modelConfig') as { model?: string } | undefined)?.model,
+              provider: (form.getFieldValue('modelConfig') as { provider?: string } | undefined)
+                ?.provider,
               perm: form.getFieldValue('permissionMode'),
             })}
           </span>
@@ -212,6 +228,19 @@ describe('AgenticConfigChipRow', () => {
     fireEvent.click(await screen.findByTestId('advisor-select'));
 
     await waitFor(() => expect(chip).toHaveTextContent('Advisor: advisor-model'));
+  });
+
+  it('renders the OpenCode default model chip and keeps its existing exact-pair editor', async () => {
+    render(<Harness tool="opencode" user={{ user_id: 'u4' } as User} initialSource="__inline__" />);
+
+    const chip = await screen.findByRole('button', { name: 'Model: OpenCode default' });
+    fireEvent.click(chip);
+    fireEvent.click(await screen.findByTestId('model-change'));
+
+    await waitFor(() => {
+      const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
+      expect(state).toMatchObject({ provider: 'openai', model: 'gpt-5' });
+    });
   });
 });
 

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -168,7 +168,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
     if (!isInline) seedCustom();
   };
 
-  const onModelChange = (next: ModelConfig) => {
+  const onModelChange = (next: ModelConfig | undefined) => {
     ensureCustom();
     form.setFieldValue('modelConfig', next);
   };
@@ -256,10 +256,10 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
       )}
 
       <Flex gap={token.marginXS} align="center" wrap="wrap">
-        {resolvedModel && (
+        {(resolvedModel || tool === 'opencode') && (
           <EditableChip
             icon={<RobotOutlined />}
-            label={shortModelName(tool, resolvedModel)}
+            label={resolvedModel ? shortModelName(tool, resolvedModel) : 'OpenCode default'}
             title="Model"
             editable={inlineAllowed}
             managedNote={managedNote}

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.test.ts
@@ -1,6 +1,9 @@
 import type { ScheduleAgenticToolConfig } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
-import { buildScheduleConfigFromFormValues } from './agenticConfigHelpers';
+import {
+  buildConfigFromFormValues,
+  buildScheduleConfigFromFormValues,
+} from './agenticConfigHelpers';
 
 describe('buildScheduleConfigFromFormValues', () => {
   it('detaches a previous preset when switching a schedule to inline configuration', () => {
@@ -40,5 +43,42 @@ describe('buildScheduleConfigFromFormValues', () => {
     expect(result.configuration_reference).toBeUndefined();
     expect(result.preset_id).toBeUndefined();
     expect(result.context_files).toEqual(['AGENTS.md']);
+  });
+});
+
+describe('buildConfigFromFormValues', () => {
+  it('omits a cleared OpenCode provider/model override from user defaults', () => {
+    const result = buildConfigFromFormValues('opencode', {
+      modelConfig: undefined,
+      effort: 'high',
+      permissionMode: 'default',
+    });
+
+    expect(result.modelConfig).toBeUndefined();
+  });
+
+  it('omits a partial OpenCode provider/model override even with detached effort', () => {
+    const result = buildConfigFromFormValues('opencode', {
+      modelConfig: { mode: 'exact', provider: 'openai', model: '' },
+      effort: 'high',
+      permissionMode: 'default',
+    });
+
+    expect(result.modelConfig).toBeUndefined();
+  });
+
+  it('preserves a complete exact OpenCode provider/model pair', () => {
+    const result = buildConfigFromFormValues('opencode', {
+      modelConfig: { mode: 'exact', provider: 'openai', model: 'gpt-5' },
+      effort: 'high',
+      permissionMode: 'default',
+    });
+
+    expect(result.modelConfig).toEqual({
+      mode: 'exact',
+      provider: 'openai',
+      model: 'gpt-5',
+      effort: 'high',
+    });
   });
 });

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
@@ -68,12 +68,26 @@ export function buildConfigFromFormValues(
   tool: AgenticToolName,
   values: AgenticFormValues
 ): DefaultAgenticToolConfig {
-  // Merge effort back into modelConfig
-  const modelConfig = values.modelConfig
-    ? { ...values.modelConfig, effort: values.effort }
-    : values.effort
-      ? { effort: values.effort }
+  const openCodeProvider =
+    values.modelConfig && 'provider' in values.modelConfig
+      ? values.modelConfig.provider
       : undefined;
+  const hasCompleteOpenCodeModel =
+    tool !== 'opencode' ||
+    Boolean(
+      typeof openCodeProvider === 'string' &&
+        openCodeProvider.trim() &&
+        values.modelConfig?.model?.trim()
+    );
+
+  // Merge effort back into modelConfig
+  const modelConfig = hasCompleteOpenCodeModel
+    ? values.modelConfig
+      ? { ...values.modelConfig, effort: values.effort }
+      : values.effort
+        ? { effort: values.effort }
+        : undefined
+    : undefined;
 
   return {
     modelConfig,

--- a/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.test.tsx
@@ -1,0 +1,169 @@
+import type { Repo, User } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form, Input } from 'antd';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TeammateTab, type TeammateTabResult } from './TeammateTab';
+
+vi.mock('../../../hooks/useEnsureFrameworkRepo', () => ({
+  useEnsureFrameworkRepo: () => ({
+    frameworkRepo: {
+      repo_id: 'framework-repo',
+      slug: 'preset-io/agor-teammate',
+      name: 'agor-teammate',
+    } as Repo,
+    isCloning: false,
+  }),
+}));
+
+vi.mock('../../forms/TeammateFormFields', () => ({
+  TeammateFormFields: ({
+    onDisplayNameChange,
+    extraBeforeAdvanced,
+  }: {
+    onDisplayNameChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    extraBeforeAdvanced?: React.ReactNode;
+  }) => (
+    <>
+      <Form.Item name="displayName">
+        <Input aria-label="Teammate name" onChange={onDisplayNameChange} />
+      </Form.Item>
+      {extraBeforeAdvanced}
+    </>
+  ),
+}));
+
+vi.mock('../../AgentSelectionGrid', () => ({
+  AgentSelectionGrid: ({ onSelect }: { onSelect: (agent: string) => void }) => (
+    <button type="button" onClick={() => onSelect('opencode')}>
+      OpenCode
+    </button>
+  ),
+}));
+
+vi.mock('../../AgenticToolConfigurationPicker', () => {
+  const ModelConfigControl = ({
+    value,
+    onChange,
+  }: {
+    value?: { mode: 'exact'; provider?: string; model: string };
+    onChange?: (value: { mode: 'exact'; provider?: string; model: string } | undefined) => void;
+  }) => (
+    <div>
+      <output data-testid="teammate-model">
+        {value ? `${value.provider ?? ''}/${value.model}` : ''}
+      </output>
+      <button type="button" onClick={() => onChange?.(undefined)}>
+        Clear model
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange?.({ mode: 'exact', provider: 'anthropic', model: 'claude-4' })}
+      >
+        Complete model
+      </button>
+    </div>
+  );
+
+  return {
+    INLINE_AGENTIC_CONFIGURATION: '__inline__',
+    AgenticToolConfigurationPicker: () => (
+      <>
+        <Form.Item name="agenticToolPresetId">
+          <select aria-label="Configuration source">
+            <option value="">Inherit</option>
+            <option value="__inline__">Inline</option>
+          </select>
+        </Form.Item>
+        <Form.Item name="modelConfig">
+          <ModelConfigControl />
+        </Form.Item>
+      </>
+    ),
+  };
+});
+
+const staleOpenCodeDefault = {
+  user_id: 'user-1',
+  default_agentic_config: {
+    opencode: {
+      modelConfig: {
+        mode: 'exact',
+        provider: 'openai',
+        model: 'gpt-5',
+        effort: 'high',
+      },
+    },
+  },
+} as unknown as User;
+
+function renderTab(currentUser?: User) {
+  const formRef = createRef<() => Promise<TeammateTabResult | null>>();
+  render(
+    <TeammateTab
+      repoById={new Map()}
+      onValidityChange={() => {}}
+      formRef={formRef}
+      availableAgents={[{ id: 'opencode', name: 'OpenCode', icon: 'O', description: 'OpenCode' }]}
+      currentUser={currentUser}
+    />
+  );
+  fireEvent.change(screen.getByRole('textbox', { name: 'Teammate name' }), {
+    target: { value: 'Review bot' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'OpenCode' }));
+  fireEvent.click(screen.getByRole('button', { name: /^down Session Configuration$/ }));
+  return formRef;
+}
+
+async function submit(formRef: React.RefObject<() => Promise<TeammateTabResult | null>>) {
+  let result: TeammateTabResult | null | undefined;
+  await act(async () => {
+    result = await formRef.current?.();
+  });
+  return result;
+}
+
+describe('TeammateTab OpenCode first-session configuration', () => {
+  it('turns an inline clear into null instead of restoring a stale stored default', async () => {
+    const formRef = renderTab(staleOpenCodeDefault);
+    await waitFor(() =>
+      expect(screen.getByTestId('teammate-model')).toHaveTextContent('openai/gpt-5')
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Configuration source' }), {
+      target: { value: '__inline__' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear model' }));
+
+    const result = await submit(formRef);
+    expect(result?.modelConfig).toBeNull();
+    expect(result?.effort).toBeUndefined();
+  });
+
+  it('keeps an omitted override omitted so defaults can be inherited', async () => {
+    const formRef = renderTab();
+
+    const result = await submit(formRef);
+    expect(result?.modelConfig).toBeUndefined();
+  });
+
+  it('keeps a complete inline provider/model pair exact', async () => {
+    const formRef = renderTab(staleOpenCodeDefault);
+    await waitFor(() =>
+      expect(screen.getByTestId('teammate-model')).toHaveTextContent('openai/gpt-5')
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Configuration source' }), {
+      target: { value: '__inline__' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Complete model' }));
+
+    const result = await submit(formRef);
+    expect(result?.modelConfig).toEqual({
+      mode: 'exact',
+      provider: 'anthropic',
+      model: 'claude-4',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/TeammateTab.tsx
@@ -36,7 +36,7 @@ export interface TeammateTabResult {
   sourceBranch?: string;
   agent: AgenticToolName;
   agenticToolPresetId?: string;
-  modelConfig?: ModelConfig;
+  modelConfig?: ModelConfig | null;
   effort?: EffortLevel;
   mcpServerIds?: string[];
   permissionMode?: PermissionMode;
@@ -110,6 +110,13 @@ export const TeammateTab: React.FC<TeammateTabProps> = ({
         (values.permissionMode as PermissionMode | undefined) ??
         agentDefaults?.permissionMode ??
         getDefaultPermissionMode(selectedAgent);
+      const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+      const selectedModelConfig = isInline
+        ? values.modelConfig
+        : (values.modelConfig ?? agentDefaults?.modelConfig);
+      const hasCompleteOpenCodeModel =
+        selectedAgent !== 'opencode' ||
+        Boolean(selectedModelConfig?.provider?.trim() && selectedModelConfig?.model?.trim());
 
       const result: TeammateTabResult = {
         displayName: values.displayName.trim(),
@@ -119,12 +126,19 @@ export const TeammateTab: React.FC<TeammateTabProps> = ({
         branchName: values.name || `private-${slugify(values.displayName)}`,
         sourceBranch: values.sourceBranch || 'main',
         agent: selectedAgent,
-        agenticToolPresetId:
-          values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION
+        agenticToolPresetId: isInline ? undefined : values.agenticToolPresetId,
+        // Match NewSessionModal's three-state contract: an inline OpenCode
+        // clear is explicit null, while omission continues to inherit.
+        modelConfig:
+          selectedAgent === 'opencode' && isInline && !hasCompleteOpenCodeModel
+            ? null
+            : hasCompleteOpenCodeModel
+              ? selectedModelConfig
+              : undefined,
+        effort:
+          selectedAgent === 'opencode' && !hasCompleteOpenCodeModel
             ? undefined
-            : values.agenticToolPresetId,
-        modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
-        effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
+            : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
         mcpServerIds: values.mcpServerIds ?? currentUser?.default_mcp_server_ids,
         permissionMode,
       };

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -34,7 +34,7 @@ export interface ModelConfig {
 
 export interface ModelSelectorProps {
   value?: ModelConfig;
-  onChange?: (config: ModelConfig) => void;
+  onChange?: (config: ModelConfig | undefined) => void;
   agent?:
     | 'claude-code'
     | 'claude-code-cli'
@@ -295,15 +295,17 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
               }
             : undefined
         }
-        onChange={(openCodeConfig: OpenCodeModelConfig) => {
-          if (onChange) {
-            onChange({
-              mode: 'exact',
-              model: openCodeConfig.model,
-              provider: openCodeConfig.provider,
-            });
-          }
-        }}
+        onChange={(openCodeConfig: OpenCodeModelConfig | undefined) =>
+          onChange?.(
+            openCodeConfig
+              ? {
+                  mode: 'exact',
+                  model: openCodeConfig.model,
+                  provider: openCodeConfig.provider,
+                }
+              : undefined
+          )
+        }
       />
     );
   }

--- a/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.test.tsx
@@ -10,7 +10,7 @@ describe('OpenCodeModelSelector', () => {
     fireEvent.change(screen.getByLabelText('OpenCode provider ID'), {
       target: { value: 'openai' },
     });
-    expect(onChange).toHaveBeenLastCalledWith({ provider: '', model: '' });
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
 
     fireEvent.change(screen.getByLabelText('OpenCode model ID'), {
       target: { value: 'gpt-5' },
@@ -28,6 +28,6 @@ describe('OpenCodeModelSelector', () => {
       target: { value: '' },
     });
 
-    expect(onChange).toHaveBeenLastCalledWith({ provider: '', model: '' });
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
   });
 });

--- a/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
@@ -11,7 +11,7 @@ export interface OpenCodeModelConfig {
 
 export interface OpenCodeModelSelectorProps {
   value?: OpenCodeModelConfig;
-  onChange?: (config: OpenCodeModelConfig) => void;
+  onChange?: (config: OpenCodeModelConfig | undefined) => void;
 }
 
 /**
@@ -38,9 +38,9 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
       onChange?.({ provider: nextProvider, model: nextModel });
       return;
     }
-    // A partial pair is not executable. Publish an empty override while the
-    // user finishes editing so stale provider/model values are never retained.
-    onChange?.({ provider: '', model: '' });
+    // A partial pair is not executable. Publish root absence while the user
+    // finishes editing so stale provider/model values are never retained.
+    onChange?.(undefined);
   };
 
   return (

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
@@ -65,6 +65,9 @@ vi.mock('../AgentSelectionGrid/AgentSelectionGrid', () => ({
       <button type="button" data-testid="pick-cli" onClick={() => onSelect('claude-code-cli')}>
         cli
       </button>
+      <button type="button" data-testid="pick-opencode" onClick={() => onSelect('opencode')}>
+        opencode
+      </button>
     </div>
   ),
 }));
@@ -103,6 +106,16 @@ vi.mock('../AgenticConfigChipRow', () => ({
           onClick={() => form.setFieldValue('agenticToolPresetId', 'preset-1')}
         >
           preset
+        </button>
+        <button
+          type="button"
+          data-testid="clear-opencode-model"
+          onClick={() => {
+            form.setFieldValue('agenticToolPresetId', '__inline__');
+            form.setFieldValue('modelConfig', undefined);
+          }}
+        >
+          clear OpenCode model
         </button>
         <output data-testid="configuration-source">{source}</output>
         <button
@@ -271,5 +284,42 @@ describe('NewSessionModal attachment intake', { timeout: 30_000 }, () => {
         permissionMode: 'plan',
       })
     );
+  });
+
+  it('carries a cleared OpenCode provider/model override as atomic absence', async () => {
+    const currentUser = {
+      user_id: 'u1',
+      default_agentic_config: {
+        opencode: {
+          modelConfig: {
+            mode: 'exact',
+            provider: 'openai',
+            model: 'gpt-5',
+            effort: 'high',
+          },
+          permissionMode: 'default',
+        },
+      },
+    } as unknown as User;
+    const onCreate = vi.fn();
+    render(
+      <NewSessionModal
+        open
+        onClose={vi.fn()}
+        onCreate={onCreate}
+        availableAgents={[]}
+        branchId="branch-1"
+        currentUser={currentUser}
+        client={null}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('pick-opencode'));
+    fireEvent.click(screen.getByTestId('clear-opencode-model'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create Session' }));
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1));
+    expect(onCreate.mock.calls[0][0].modelConfig).toBeNull();
+    expect(onCreate.mock.calls[0][0].effort).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -51,7 +51,7 @@ export interface NewSessionConfig {
   initialPrompt?: string;
 
   // Advanced configuration
-  modelConfig?: ModelConfig;
+  modelConfig?: ModelConfig | null;
   effort?: EffortLevel;
   mcpServerIds?: string[];
   permissionMode?: PermissionMode;
@@ -210,6 +210,12 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         getDefaultPermissionMode(selectedAgent as AgenticToolName);
 
       const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+      const selectedModelConfig = isInline
+        ? values.modelConfig
+        : (values.modelConfig ?? agentDefaults?.modelConfig);
+      const hasCompleteOpenCodeModel =
+        selectedAgent !== 'opencode' ||
+        Boolean(selectedModelConfig?.provider?.trim() && selectedModelConfig?.model?.trim());
 
       // Promote the inline config to the user's default when requested. Fire and
       // forget — session creation shouldn't block on the profile patch.
@@ -236,9 +242,19 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         agenticToolPresetId: isInline ? undefined : values.agenticToolPresetId,
         title: values.title,
         initialPrompt: values.initialPrompt,
-        // Daemon's applySessionConfigDefaults hook fills the tool default.
-        modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
-        effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
+        // OpenCode's provider/model selection is atomic. An inline clear must
+        // remain distinct from omission so the daemon does not restore a stale
+        // user default in its create hook.
+        modelConfig:
+          selectedAgent === 'opencode' && isInline && !hasCompleteOpenCodeModel
+            ? null
+            : hasCompleteOpenCodeModel
+              ? selectedModelConfig
+              : undefined,
+        effort:
+          selectedAgent === 'opencode' && !hasCompleteOpenCodeModel
+            ? undefined
+            : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
         mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
         permissionMode,
         envVarNames: envVarNames.length > 0 ? envVarNames : undefined,

--- a/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.test.tsx
+++ b/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.test.tsx
@@ -1,5 +1,5 @@
 import type { AgorClient, OpenCodeProviderSettings as Settings } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { OpenCodeProviderSettings } from './OpenCodeProviderSettings';
@@ -16,6 +16,7 @@ const initial: Settings = {
       status: 'disconnected',
       authMethods: [
         {
+          index: 0,
           type: 'api',
           label: 'Workspace key',
           prompts: [
@@ -47,7 +48,9 @@ const initial: Settings = {
 
 function renderSettings(service: {
   find: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
   create: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
   remove: ReturnType<typeof vi.fn>;
 }) {
   const client = { service: vi.fn(() => service) } as unknown as AgorClient;
@@ -70,7 +73,9 @@ describe('OpenCodeProviderSettings', () => {
     };
     const service = {
       find: vi.fn().mockResolvedValue(initial),
+      get: vi.fn(),
       create: vi.fn().mockResolvedValue(configured),
+      patch: vi.fn(),
       remove: vi.fn(),
     };
     renderSettings(service);
@@ -120,7 +125,9 @@ describe('OpenCodeProviderSettings', () => {
     };
     const service = {
       find: vi.fn().mockResolvedValue(available),
+      get: vi.fn(),
       create: vi.fn().mockResolvedValue(configured),
+      patch: vi.fn(),
       remove: vi.fn(),
     };
     renderSettings(service);
@@ -138,7 +145,7 @@ describe('OpenCodeProviderSettings', () => {
     );
   });
 
-  it('does not offer API-key connection for an OAuth-only provider', async () => {
+  it('starts and cancels a bounded native OAuth attempt with dynamic inputs', async () => {
     const oauthOnly = {
       ...initial,
       providers: [
@@ -147,20 +154,210 @@ describe('OpenCodeProviderSettings', () => {
           name: 'OAuth Provider',
           configured: false,
           status: 'disconnected' as const,
-          authMethods: [{ type: 'oauth' as const, label: 'Sign in with OAuth' }],
+          authMethods: [
+            {
+              index: 0,
+              type: 'oauth' as const,
+              label: 'ChatGPT browser',
+            },
+            {
+              index: 1,
+              type: 'oauth' as const,
+              label: 'ChatGPT headless',
+              prompts: [
+                {
+                  type: 'select' as const,
+                  key: 'region',
+                  message: 'OAuth region',
+                  options: [{ label: 'US', value: 'us' }],
+                },
+                {
+                  type: 'text' as const,
+                  key: 'account',
+                  message: 'OAuth account',
+                  when: { key: 'region', op: 'eq' as const, value: 'us' },
+                },
+              ],
+            },
+          ],
         },
       ],
     };
+    const attempt = {
+      attemptId: 'attempt-1',
+      providerId: 'oauth-provider',
+      phase: 'awaiting_callback' as const,
+      expiresAt: '2026-07-24T00:00:00.000Z',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto' as const,
+        instructions: 'Open the synthetic authorization page.',
+      },
+    };
     const service = {
       find: vi.fn().mockResolvedValue(oauthOnly),
-      create: vi.fn(),
+      get: vi.fn().mockResolvedValue(attempt),
+      create: vi.fn().mockResolvedValue(attempt),
+      patch: vi.fn().mockResolvedValue({ ...attempt, phase: 'cancelled' }),
       remove: vi.fn(),
     };
     renderSettings(service);
 
-    expect(await screen.findByText(/OAuth connection is not available here/i)).toBeInTheDocument();
+    fireEvent.mouseDown(await screen.findByLabelText('OAuth region'));
+    fireEvent.click(await screen.findByText('US'));
+    fireEvent.change(await screen.findByLabelText('OAuth account'), {
+      target: { value: 'synthetic-account' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect with ChatGPT headless' }));
+
+    await waitFor(() =>
+      expect(service.create).toHaveBeenCalledWith({
+        operation: 'connect-oauth',
+        providerId: 'oauth-provider',
+        method: 1,
+        inputs: { region: 'us', account: 'synthetic-account' },
+      })
+    );
+    expect(await screen.findByText('Open the synthetic authorization page.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open authorization page' })).toHaveAttribute(
+      'href',
+      'http://127.0.0.1:9898/authorize'
+    );
     expect(screen.queryByLabelText('OAuth Provider API key')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument();
-    expect(service.create).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel authorization' }));
+    await waitFor(() => expect(service.patch).toHaveBeenCalledWith('attempt-1', { cancel: true }));
+  });
+
+  it('submits a code callback once and clears the secret from UI state', async () => {
+    const oauthOnly = {
+      ...initial,
+      providers: [
+        {
+          id: 'oauth-provider',
+          name: 'OAuth Provider',
+          configured: false,
+          status: 'disconnected' as const,
+          authMethods: [
+            {
+              index: 0,
+              type: 'oauth' as const,
+              label: 'Code flow',
+              prompts: [{ type: 'text' as const, key: 'account', message: 'Code account' }],
+            },
+          ],
+        },
+      ],
+    };
+    const attempt = {
+      attemptId: 'attempt-code',
+      providerId: 'oauth-provider',
+      phase: 'awaiting_callback' as const,
+      expiresAt: '2026-07-24T00:00:00.000Z',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'code' as const,
+        instructions: 'Paste the one-time code.',
+      },
+    };
+    const service = {
+      find: vi.fn().mockResolvedValue(oauthOnly),
+      get: vi.fn().mockResolvedValue({ ...attempt, phase: 'completing' }),
+      create: vi.fn().mockResolvedValue(attempt),
+      patch: vi.fn().mockResolvedValue({ ...attempt, phase: 'completing' }),
+      remove: vi.fn(),
+    };
+    renderSettings(service);
+
+    fireEvent.change(await screen.findByLabelText('Code account'), {
+      target: { value: 'synthetic-account' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect with Code flow' }));
+    await waitFor(() =>
+      expect(service.create).toHaveBeenCalledWith({
+        operation: 'connect-oauth',
+        providerId: 'oauth-provider',
+        method: 0,
+        inputs: { account: 'synthetic-account' },
+      })
+    );
+    const input = await screen.findByLabelText('OAuth Provider authorization code');
+    fireEvent.change(input, { target: { value: 'synthetic-secret-code' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit authorization code' }));
+
+    await waitFor(() =>
+      expect(service.patch).toHaveBeenCalledWith('attempt-code', {
+        code: 'synthetic-secret-code',
+      })
+    );
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(document.body.textContent).not.toContain('synthetic-secret-code');
+  });
+
+  it('does not overlap polls or let a stale configured response reverse cancellation', async () => {
+    const oauthOnly = {
+      ...initial,
+      providers: [
+        {
+          id: 'oauth-provider',
+          name: 'OAuth Provider',
+          configured: false,
+          status: 'disconnected' as const,
+          authMethods: [{ index: 0, type: 'oauth' as const, label: 'Browser flow' }],
+        },
+      ],
+    };
+    const attempt = {
+      attemptId: 'attempt-race',
+      providerId: 'oauth-provider',
+      phase: 'awaiting_callback' as const,
+      expiresAt: '2026-07-24T00:00:00.000Z',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto' as const,
+        instructions: 'Authorize.',
+      },
+    };
+    let resolvePoll!: (value: typeof attempt & { phase: 'configured'; settings: Settings }) => void;
+    const service = {
+      find: vi.fn().mockResolvedValue(oauthOnly),
+      get: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolvePoll = resolve;
+          })
+      ),
+      create: vi.fn().mockResolvedValue(attempt),
+      patch: vi.fn().mockResolvedValue({ ...attempt, phase: 'cancelled' as const }),
+      remove: vi.fn(),
+    };
+    try {
+      renderSettings(service);
+      const connect = await screen.findByRole('button', { name: 'Connect with Browser flow' });
+      vi.useFakeTimers();
+      fireEvent.click(connect);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByText('Authorize.')).toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      expect(service.get).toHaveBeenCalledOnce();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel authorization' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByText('Authorization cancelled.')).toBeInTheDocument();
+
+      resolvePoll({ ...attempt, phase: 'configured', settings: oauthOnly });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByText('Authorization cancelled.')).toBeInTheDocument();
+      expect(screen.queryByText('Configured in OpenCode')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.tsx
+++ b/apps/agor-ui/src/components/OpenCodeAuth/OpenCodeProviderSettings.tsx
@@ -1,13 +1,81 @@
-import type { AgorClient, OpenCodeProviderSettings as Settings } from '@agor-live/client';
+import type {
+  AgorClient,
+  OpenCodeOAuthAttempt,
+  OpenCodeProviderAuthPrompt,
+  OpenCodeProviderSettings as Settings,
+} from '@agor-live/client';
 import { Alert, Button, Input, List, Popconfirm, Select, Space, Tag, Typography } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const ACTIVE_OAUTH_PHASES = new Set(['authorizing', 'awaiting_callback', 'completing']);
+
+function isActiveOAuthAttempt(attempt?: OpenCodeOAuthAttempt): boolean {
+  return Boolean(attempt && ACTIVE_OAUTH_PHASES.has(attempt.phase));
+}
+
+function visibleAuthPrompts(
+  prompts: OpenCodeProviderAuthPrompt[] | undefined,
+  values: Record<string, string>
+): OpenCodeProviderAuthPrompt[] {
+  return (
+    prompts?.filter((prompt) => {
+      if (!prompt.when) return true;
+      const matches = values[prompt.when.key] === prompt.when.value;
+      return prompt.when.op === 'eq' ? matches : !matches;
+    }) ?? []
+  );
+}
+
+function AuthPromptFields({
+  prompts,
+  values,
+  onChange,
+}: {
+  prompts: OpenCodeProviderAuthPrompt[];
+  values: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+}) {
+  return prompts.map((prompt) =>
+    prompt.type === 'select' ? (
+      <Select
+        key={prompt.key}
+        aria-label={prompt.message}
+        placeholder={prompt.message}
+        value={values[prompt.key]}
+        options={prompt.options}
+        onChange={(value) => onChange(prompt.key, value)}
+      />
+    ) : (
+      <Input
+        key={prompt.key}
+        aria-label={prompt.message}
+        placeholder={prompt.placeholder ?? prompt.message}
+        value={values[prompt.key] ?? ''}
+        onChange={(event) => onChange(prompt.key, event.target.value)}
+      />
+    )
+  );
+}
+
+function preferredOAuthMethodIndex(methods: Array<{ label: string }>): number {
+  const headless = methods.findIndex((method) => /headless/i.test(method.label));
+  return headless >= 0 ? headless : 0;
+}
 
 export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [query, setQuery] = useState('');
   const [keys, setKeys] = useState<Record<string, string>>({});
   const [methodIndexes, setMethodIndexes] = useState<Record<string, number>>({});
+  const [oauthMethodIndexes, setOAuthMethodIndexes] = useState<Record<string, number>>({});
   const [promptValues, setPromptValues] = useState<Record<string, Record<string, string>>>({});
+  const [oauthPromptValues, setOAuthPromptValues] = useState<
+    Record<string, Record<string, string>>
+  >({});
+  const [oauthAttempts, setOAuthAttempts] = useState<Record<string, OpenCodeOAuthAttempt>>({});
+  const oauthAttemptsRef = useRef<Record<string, OpenCodeOAuthAttempt>>({});
+  const cancellingAttemptsRef = useRef(new Set<string>());
+  const [oauthCodes, setOAuthCodes] = useState<Record<string, string>>({});
   const [busyProvider, setBusyProvider] = useState<string>();
   const [error, setError] = useState<string>();
 
@@ -23,6 +91,79 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    const active = Object.entries(oauthAttempts).filter(([, attempt]) =>
+      isActiveOAuthAttempt(attempt)
+    );
+    if (active.length === 0) return;
+    let disposed = false;
+    const timers = new Set<number>();
+    const schedule = (providerId: string, attemptId: string) => {
+      const timer = window.setTimeout(async () => {
+        timers.delete(timer);
+        if (disposed) return;
+        const before = oauthAttemptsRef.current[providerId];
+        if (
+          !before ||
+          before.attemptId !== attemptId ||
+          !isActiveOAuthAttempt(before) ||
+          cancellingAttemptsRef.current.has(attemptId)
+        ) {
+          if (before?.attemptId === attemptId && isActiveOAuthAttempt(before)) {
+            schedule(providerId, attemptId);
+          }
+          return;
+        }
+        try {
+          const next = await client.service('opencode-auth').get(attemptId);
+          const current = oauthAttemptsRef.current[providerId];
+          if (
+            disposed ||
+            cancellingAttemptsRef.current.has(attemptId) ||
+            !current ||
+            current.attemptId !== attemptId ||
+            !isActiveOAuthAttempt(current) ||
+            next.attemptId !== attemptId
+          ) {
+            return;
+          }
+          oauthAttemptsRef.current = {
+            ...oauthAttemptsRef.current,
+            [providerId]: next,
+          };
+          setOAuthAttempts(oauthAttemptsRef.current);
+          if (next.phase === 'configured' && next.settings) setSettings(next.settings);
+        } catch {
+          const current = oauthAttemptsRef.current[providerId];
+          if (
+            !disposed &&
+            !cancellingAttemptsRef.current.has(attemptId) &&
+            current?.attemptId === attemptId &&
+            isActiveOAuthAttempt(current)
+          ) {
+            setError('OpenCode authorization status could not be refreshed.');
+          }
+        } finally {
+          const current = oauthAttemptsRef.current[providerId];
+          if (!disposed && current?.attemptId === attemptId && isActiveOAuthAttempt(current)) {
+            schedule(providerId, attemptId);
+          }
+        }
+      }, 1000);
+      timers.add(timer);
+    };
+    for (const [providerId, attempt] of active) schedule(providerId, attempt.attemptId);
+    return () => {
+      disposed = true;
+      for (const timer of timers) window.clearTimeout(timer);
+    };
+  }, [client, oauthAttempts]);
+
+  const storeAttempt = useCallback((providerId: string, attempt: OpenCodeOAuthAttempt) => {
+    oauthAttemptsRef.current = { ...oauthAttemptsRef.current, [providerId]: attempt };
+    setOAuthAttempts(oauthAttemptsRef.current);
+  }, []);
 
   const providers = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -43,12 +184,7 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
     if (!apiKeyAvailable) return;
     const method = apiMethods[methodIndexes[providerId] ?? 0];
     const values = promptValues[providerId] ?? {};
-    const visiblePrompts =
-      method?.prompts?.filter((prompt) => {
-        if (!prompt.when) return true;
-        const matches = values[prompt.when.key] === prompt.when.value;
-        return prompt.when.op === 'eq' ? matches : !matches;
-      }) ?? [];
+    const visiblePrompts = visibleAuthPrompts(method?.prompts, values);
     if (visiblePrompts.some((prompt) => !values[prompt.key]?.trim())) return;
     const metadata = Object.fromEntries(
       visiblePrompts.map((prompt) => [prompt.key, values[prompt.key].trim()])
@@ -57,14 +193,86 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
     setError(undefined);
     try {
       setSettings(
-        await client
-          .service('opencode-auth')
-          .create({ providerId, apiKey, ...(Object.keys(metadata).length ? { metadata } : {}) })
+        (await client.service('opencode-auth').create({
+          providerId,
+          apiKey,
+          ...(Object.keys(metadata).length ? { metadata } : {}),
+        })) as Settings
       );
       setKeys((current) => ({ ...current, [providerId]: '' }));
       setPromptValues((current) => ({ ...current, [providerId]: {} }));
     } catch {
       setError('OpenCode could not configure that provider.');
+    } finally {
+      setBusyProvider(undefined);
+    }
+  };
+
+  const connectOAuth = async (providerId: string) => {
+    const provider = settings?.providers.find((candidate) => candidate.id === providerId);
+    if (!provider) return;
+    const methods = provider.authMethods.filter((method) => method.type === 'oauth');
+    const method = methods[oauthMethodIndexes[providerId] ?? preferredOAuthMethodIndex(methods)];
+    if (!method) return;
+    const values = oauthPromptValues[providerId] ?? {};
+    const visiblePrompts = visibleAuthPrompts(method.prompts, values);
+    if (visiblePrompts.some((prompt) => !values[prompt.key]?.trim())) return;
+    const inputs = Object.fromEntries(
+      visiblePrompts.map((prompt) => [prompt.key, values[prompt.key].trim()])
+    );
+    setBusyProvider(providerId);
+    setError(undefined);
+    try {
+      const attempt = (await client.service('opencode-auth').create({
+        operation: 'connect-oauth',
+        providerId,
+        method: method.index,
+        ...(Object.keys(inputs).length > 0 ? { inputs } : {}),
+      })) as OpenCodeOAuthAttempt;
+      storeAttempt(providerId, attempt);
+      if (attempt.phase === 'configured' && attempt.settings) setSettings(attempt.settings);
+    } catch {
+      setError('OpenCode could not start native authorization.');
+    } finally {
+      setBusyProvider(undefined);
+    }
+  };
+
+  const cancelOAuth = async (providerId: string) => {
+    const attempt = oauthAttempts[providerId];
+    if (!attempt) return;
+    cancellingAttemptsRef.current.add(attempt.attemptId);
+    setBusyProvider(providerId);
+    setError(undefined);
+    try {
+      const cancelled = await client
+        .service('opencode-auth')
+        .patch(attempt.attemptId, { cancel: true });
+      if (oauthAttemptsRef.current[providerId]?.attemptId === attempt.attemptId) {
+        storeAttempt(providerId, cancelled);
+      }
+    } catch {
+      setError('OpenCode authorization could not be cancelled.');
+    } finally {
+      cancellingAttemptsRef.current.delete(attempt.attemptId);
+      setBusyProvider(undefined);
+    }
+  };
+
+  const submitOAuthCode = async (providerId: string) => {
+    const attempt = oauthAttemptsRef.current[providerId];
+    const code = oauthCodes[providerId]?.trim();
+    if (!attempt || !code) return;
+    setOAuthCodes((current) => ({ ...current, [providerId]: '' }));
+    setBusyProvider(providerId);
+    setError(undefined);
+    try {
+      const next = await client.service('opencode-auth').patch(attempt.attemptId, { code });
+      if (oauthAttemptsRef.current[providerId]?.attemptId === attempt.attemptId) {
+        storeAttempt(providerId, next);
+      }
+    } catch {
+      setError('OpenCode authorization code could not be submitted.');
     } finally {
       setBusyProvider(undefined);
     }
@@ -85,8 +293,8 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
   return (
     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-        Connect providers that expose native API-key configuration through the managed OpenCode
-        runtime.
+        Connect providers through native API-key or subscription authorization in the managed
+        OpenCode runtime.
       </Typography.Paragraph>
       {settings && (
         <Alert
@@ -117,17 +325,23 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
         locale={{ emptyText: error ? 'No provider status available' : 'No matching providers' }}
         renderItem={(provider) => {
           const apiMethods = provider.authMethods.filter((method) => method.type === 'api');
+          const oauthMethods = provider.authMethods.filter((method) => method.type === 'oauth');
           const apiKeyAvailable = apiMethods.length > 0 || provider.authMethods.length === 0;
           const methodIndex = methodIndexes[provider.id] ?? 0;
           const method = apiMethods[methodIndex];
           const values = promptValues[provider.id] ?? {};
-          const visiblePrompts =
-            method?.prompts?.filter((prompt) => {
-              if (!prompt.when) return true;
-              const matches = values[prompt.when.key] === prompt.when.value;
-              return prompt.when.op === 'eq' ? matches : !matches;
-            }) ?? [];
+          const visiblePrompts = visibleAuthPrompts(method?.prompts, values);
           const promptsComplete = visiblePrompts.every((prompt) => values[prompt.key]?.trim());
+          const oauthMethodIndex =
+            oauthMethodIndexes[provider.id] ?? preferredOAuthMethodIndex(oauthMethods);
+          const oauthMethod = oauthMethods[oauthMethodIndex];
+          const oauthValues = oauthPromptValues[provider.id] ?? {};
+          const visibleOAuthPrompts = visibleAuthPrompts(oauthMethod?.prompts, oauthValues);
+          const oauthPromptsComplete = visibleOAuthPrompts.every((prompt) =>
+            oauthValues[prompt.key]?.trim()
+          );
+          const oauthAttempt = oauthAttempts[provider.id];
+          const oauthActive = isActiveOAuthAttempt(oauthAttempt);
 
           return (
             <List.Item
@@ -153,6 +367,26 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
                     Connect
                   </Button>
                 ) : null,
+                !provider.configured && oauthMethod && !oauthActive ? (
+                  <Button
+                    key="oauth-connect"
+                    loading={busyProvider === provider.id}
+                    disabled={!oauthPromptsComplete}
+                    onClick={() => connectOAuth(provider.id)}
+                  >
+                    Connect with {oauthMethod.label}
+                  </Button>
+                ) : null,
+                !provider.configured && oauthActive ? (
+                  <Button
+                    key="oauth-cancel"
+                    danger
+                    loading={busyProvider === provider.id}
+                    onClick={() => cancelOAuth(provider.id)}
+                  >
+                    Cancel authorization
+                  </Button>
+                ) : null,
               ]}
             >
               <List.Item.Meta
@@ -167,78 +401,144 @@ export function OpenCodeProviderSettings({ client }: { client: AgorClient }) {
                     <Typography.Text type="secondary">
                       OpenCode reports a saved credential; provider access is not verified here.
                     </Typography.Text>
-                  ) : !apiKeyAvailable ? (
-                    <Typography.Text type="secondary">
-                      OpenCode exposes OAuth-only authentication for this provider. OAuth connection
-                      is not available here yet.
-                    </Typography.Text>
                   ) : (
                     <Space direction="vertical" style={{ width: '100%' }}>
-                      {apiMethods.length > 1 && (
+                      {oauthActive && oauthAttempt.authorization && (
+                        <Alert
+                          type="info"
+                          showIcon
+                          title="Authorization in progress"
+                          description={
+                            <Space direction="vertical">
+                              <Typography.Text>
+                                {oauthAttempt.authorization.instructions}
+                              </Typography.Text>
+                              <Typography.Link
+                                href={oauthAttempt.authorization.url}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                Open authorization page
+                              </Typography.Link>
+                              {oauthAttempt.authorization.method === 'code' &&
+                                oauthAttempt.phase === 'awaiting_callback' && (
+                                  <Space.Compact>
+                                    <Input.Password
+                                      aria-label={`${provider.name} authorization code`}
+                                      autoComplete="one-time-code"
+                                      placeholder="Authorization code"
+                                      value={oauthCodes[provider.id] ?? ''}
+                                      onChange={(event) =>
+                                        setOAuthCodes((current) => ({
+                                          ...current,
+                                          [provider.id]: event.target.value,
+                                        }))
+                                      }
+                                      onPressEnter={() => void submitOAuthCode(provider.id)}
+                                    />
+                                    <Button
+                                      loading={busyProvider === provider.id}
+                                      disabled={!oauthCodes[provider.id]?.trim()}
+                                      onClick={() => submitOAuthCode(provider.id)}
+                                    >
+                                      Submit authorization code
+                                    </Button>
+                                  </Space.Compact>
+                                )}
+                            </Space>
+                          }
+                        />
+                      )}
+                      {oauthAttempt &&
+                        ['failed', 'expired', 'cancelled'].includes(oauthAttempt.phase) && (
+                          <Alert
+                            type={oauthAttempt.phase === 'cancelled' ? 'info' : 'error'}
+                            showIcon
+                            title={
+                              oauthAttempt.phase === 'expired'
+                                ? 'Authorization expired.'
+                                : oauthAttempt.phase === 'cancelled'
+                                  ? 'Authorization cancelled.'
+                                  : 'Authorization failed.'
+                            }
+                          />
+                        )}
+                      {apiKeyAvailable && (
+                        <>
+                          {apiMethods.length > 1 && (
+                            <Select
+                              aria-label={`${provider.name} authentication method`}
+                              value={methodIndex}
+                              options={apiMethods.map((candidate, index) => ({
+                                label: candidate.label ?? `API key method ${index + 1}`,
+                                value: index,
+                              }))}
+                              onChange={(index) => {
+                                setMethodIndexes((current) => ({
+                                  ...current,
+                                  [provider.id]: index,
+                                }));
+                                setPromptValues((current) => ({
+                                  ...current,
+                                  [provider.id]: {},
+                                }));
+                              }}
+                            />
+                          )}
+                          <AuthPromptFields
+                            prompts={visiblePrompts}
+                            values={values}
+                            onChange={(key, value) =>
+                              setPromptValues((current) => ({
+                                ...current,
+                                [provider.id]: { ...current[provider.id], [key]: value },
+                              }))
+                            }
+                          />
+                          <Input.Password
+                            aria-label={`${provider.name} API key`}
+                            autoComplete="new-password"
+                            placeholder="API key"
+                            value={keys[provider.id] ?? ''}
+                            onChange={(event) =>
+                              setKeys((current) => ({
+                                ...current,
+                                [provider.id]: event.target.value,
+                              }))
+                            }
+                            onPressEnter={() => void connect(provider.id)}
+                          />
+                        </>
+                      )}
+                      {oauthMethods.length > 1 && (
                         <Select
-                          aria-label={`${provider.name} authentication method`}
-                          value={methodIndex}
-                          options={apiMethods.map((candidate, index) => ({
-                            label: candidate.label ?? `API key method ${index + 1}`,
+                          aria-label={`${provider.name} OAuth method`}
+                          value={oauthMethodIndex}
+                          options={oauthMethods.map((candidate, index) => ({
+                            label: candidate.label,
                             value: index,
                           }))}
                           onChange={(index) => {
-                            setMethodIndexes((current) => ({
+                            setOAuthMethodIndexes((current) => ({
                               ...current,
                               [provider.id]: index,
                             }));
-                            setPromptValues((current) => ({
+                            setOAuthPromptValues((current) => ({
                               ...current,
                               [provider.id]: {},
                             }));
                           }}
                         />
                       )}
-                      {visiblePrompts.map((prompt) =>
-                        prompt.type === 'select' ? (
-                          <Select
-                            key={prompt.key}
-                            aria-label={prompt.message}
-                            placeholder={prompt.message}
-                            value={values[prompt.key]}
-                            options={prompt.options}
-                            onChange={(value) =>
-                              setPromptValues((current) => ({
-                                ...current,
-                                [provider.id]: {
-                                  ...current[provider.id],
-                                  [prompt.key]: value,
-                                },
-                              }))
-                            }
-                          />
-                        ) : (
-                          <Input
-                            key={prompt.key}
-                            aria-label={prompt.message}
-                            placeholder={prompt.placeholder ?? prompt.message}
-                            value={values[prompt.key] ?? ''}
-                            onChange={(event) =>
-                              setPromptValues((current) => ({
-                                ...current,
-                                [provider.id]: {
-                                  ...current[provider.id],
-                                  [prompt.key]: event.target.value,
-                                },
-                              }))
-                            }
-                          />
-                        )
-                      )}
-                      <Input.Password
-                        aria-label={`${provider.name} API key`}
-                        autoComplete="new-password"
-                        placeholder="API key"
-                        value={keys[provider.id] ?? ''}
-                        onChange={(event) =>
-                          setKeys((current) => ({ ...current, [provider.id]: event.target.value }))
+                      <AuthPromptFields
+                        prompts={visibleOAuthPrompts}
+                        values={oauthValues}
+                        onChange={(key, value) =>
+                          setOAuthPromptValues((current) => ({
+                            ...current,
+                            [provider.id]: { ...current[provider.id], [key]: value },
+                          }))
                         }
-                        onPressEnter={() => void connect(provider.id)}
                       />
                     </Space>
                   )

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -11,6 +11,7 @@ import type {
   BranchID,
   CardWithType,
   MCPServer,
+  PermissionMode,
   Repo,
   Session,
   SpawnConfig,
@@ -85,6 +86,7 @@ import CardModal from '../CardModal';
 import type { CardNodeData } from '../CardNode';
 import CardNode from '../CardNode';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
+import type { ModelConfig } from '../ModelSelector';
 import SessionCard from '../SessionCard';
 import { AppNode } from './canvas/AppNodeLazy';
 import { ArtifactNode } from './canvas/ArtifactNodeLazy';
@@ -371,6 +373,54 @@ const nodeTypes = {
 const EMPTY_BOARD_ENTITY_OBJECTS: BoardEntityObject[] = Object.freeze(
   [] as BoardEntityObject[]
 ) as BoardEntityObject[];
+
+interface CreateZoneTriggerSessionInput {
+  branchId: BranchID;
+  zoneName: string;
+  agent?: string;
+  agenticToolPresetId?: string;
+  modelConfig?: ModelConfig | null;
+  permissionMode?: PermissionMode;
+}
+
+/**
+ * Direct action owner for the interactive zone trigger's new-session path.
+ * The three model_config states are intentional: null clears a stale default,
+ * undefined inherits it, and a complete pair is timestamped for persistence.
+ */
+export function createZoneTriggerSession(
+  client: AgorClient,
+  {
+    branchId,
+    zoneName,
+    agent,
+    agenticToolPresetId,
+    modelConfig,
+    permissionMode,
+  }: CreateZoneTriggerSessionInput
+): Promise<Session> {
+  return client.service('sessions').create({
+    branch_id: branchId,
+    agentic_tool: (agent || 'claude-code') as AgenticToolName,
+    agentic_tool_preset_id: agenticToolPresetId,
+    description: `Session from zone "${zoneName}"`,
+    status: 'idle',
+    model_config:
+      modelConfig === null
+        ? null
+        : modelConfig
+          ? {
+              ...modelConfig,
+              updated_at: new Date().toISOString(),
+            }
+          : undefined,
+    permission_config: permissionMode
+      ? {
+          mode: permissionMode,
+        }
+      : undefined,
+  });
+}
 
 interface BranchZoneTriggerModalProps {
   modal: {
@@ -2923,23 +2973,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
                 // If creating new session, create it first
                 if (sessionId === 'new') {
-                  const newSession = await client.service('sessions').create({
-                    branch_id: branchTriggerModal.branchId,
-                    agentic_tool: (agent || 'claude-code') as AgenticToolName,
-                    agentic_tool_preset_id: agenticToolPresetId,
-                    description: `Session from zone "${branchTriggerModal.zoneName}"`,
-                    status: 'idle',
-                    model_config: modelConfig
-                      ? {
-                          ...modelConfig,
-                          updated_at: new Date().toISOString(),
-                        }
-                      : undefined,
-                    permission_config: permissionMode
-                      ? {
-                          mode: permissionMode,
-                        }
-                      : undefined,
+                  const newSession = await createZoneTriggerSession(client, {
+                    branchId: branchTriggerModal.branchId,
+                    zoneName: branchTriggerModal.zoneName,
+                    agent,
+                    agenticToolPresetId,
+                    modelConfig,
+                    permissionMode,
                   });
                   targetSessionId = newSession.session_id;
 

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zone-trigger-create.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zone-trigger-create.test.ts
@@ -1,0 +1,72 @@
+import type { AgorClient, BranchID } from '@agor-live/client';
+import { describe, expect, it, vi } from 'vitest';
+import { createZoneTriggerSession } from './SessionCanvas';
+
+function makeClient() {
+  const create = vi.fn(async (data) => ({ session_id: 'session-1', ...data }));
+  const client = {
+    service: vi.fn(() => ({ create })),
+  } as unknown as AgorClient;
+  return { client, create };
+}
+
+describe('createZoneTriggerSession OpenCode model config', () => {
+  it('submits a deliberate clear as model_config null', async () => {
+    const { client, create } = makeClient();
+
+    await createZoneTriggerSession(client, {
+      branchId: 'branch-1' as BranchID,
+      zoneName: 'Review',
+      agent: 'opencode',
+      modelConfig: null,
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        model_config: null,
+      })
+    );
+  });
+
+  it('keeps omission distinct so the daemon can inherit defaults', async () => {
+    const { client, create } = makeClient();
+
+    await createZoneTriggerSession(client, {
+      branchId: 'branch-1' as BranchID,
+      zoneName: 'Review',
+      agent: 'opencode',
+      modelConfig: undefined,
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        model_config: undefined,
+      })
+    );
+  });
+
+  it('submits a complete exact pair without changing it', async () => {
+    const { client, create } = makeClient();
+
+    await createZoneTriggerSession(client, {
+      branchId: 'branch-1' as BranchID,
+      zoneName: 'Review',
+      agent: 'opencode',
+      modelConfig: { mode: 'exact', provider: 'openai', model: 'gpt-5' },
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        model_config: {
+          mode: 'exact',
+          provider: 'openai',
+          model: 'gpt-5',
+          updated_at: expect.any(String),
+        },
+      })
+    );
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -1,5 +1,6 @@
-import type { BranchID, Session } from '@agor-live/client';
-import { render } from '@testing-library/react';
+import type { BranchID, Session, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ZoneTriggerModal } from './ZoneTriggerModal';
 
@@ -7,11 +8,56 @@ import { ZoneTriggerModal } from './ZoneTriggerModal';
 // children — the regression lives entirely in ZoneTriggerModal's render-time
 // useMemo, which runs regardless of what these children render.
 vi.mock('../../AgentSelectionGrid', () => ({
-  AgentSelectionGrid: () => null,
+  AgentSelectionGrid: ({ onSelect }: { onSelect: (agent: string) => void }) => (
+    <button type="button" onClick={() => onSelect('opencode')}>
+      OpenCode
+    </button>
+  ),
 }));
 vi.mock('../../AgenticToolConfigForm', () => ({
   AgenticToolConfigForm: () => null,
 }));
+vi.mock('../../AgenticToolConfigurationPicker', () => {
+  const ModelConfigControl = ({
+    value,
+    onChange,
+  }: {
+    value?: { mode: 'exact'; provider?: string; model: string };
+    onChange?: (value: { mode: 'exact'; provider?: string; model: string } | undefined) => void;
+  }) => (
+    <div>
+      <output data-testid="zone-model">
+        {value ? `${value.provider ?? ''}/${value.model}` : ''}
+      </output>
+      <button type="button" onClick={() => onChange?.(undefined)}>
+        Clear zone model
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange?.({ mode: 'exact', provider: 'anthropic', model: 'claude-4' })}
+      >
+        Complete zone model
+      </button>
+    </div>
+  );
+
+  return {
+    INLINE_AGENTIC_CONFIGURATION: '__inline__',
+    AgenticToolConfigurationPicker: () => (
+      <>
+        <Form.Item name="agenticToolPresetId">
+          <select aria-label="Zone configuration source">
+            <option value="">Inherit</option>
+            <option value="__inline__">Inline</option>
+          </select>
+        </Form.Item>
+        <Form.Item name="modelConfig">
+          <ModelConfigControl />
+        </Form.Item>
+      </>
+    ),
+  };
+});
 
 const BRANCH_ID = 'branch-1' as BranchID;
 
@@ -59,5 +105,83 @@ describe('ZoneTriggerModal smart-default session selection', () => {
     // session — surfaced as the closed Select's selected value.
     expect(document.body.textContent).toContain('Newer session');
     expect(document.body.textContent).not.toContain('Older session');
+  });
+});
+
+const staleOpenCodeDefault = {
+  user_id: 'user-1',
+  default_agentic_config: {
+    opencode: {
+      modelConfig: {
+        mode: 'exact',
+        provider: 'openai',
+        model: 'gpt-5',
+      },
+    },
+  },
+} as unknown as User;
+
+function renderNewSessionModal(currentUser?: User) {
+  const onExecute = vi.fn(async () => {});
+  render(
+    <ZoneTriggerModal
+      open
+      onCancel={() => {}}
+      client={null}
+      branchId={BRANCH_ID}
+      branch={undefined}
+      sessionsByBranch={new Map()}
+      zoneName="Zone"
+      trigger={{ template: 'do work' } as never}
+      availableAgents={[{ id: 'opencode', name: 'OpenCode', icon: 'O', description: 'OpenCode' }]}
+      mcpServerById={new Map()}
+      currentUser={currentUser}
+      onExecute={onExecute}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'OpenCode' }));
+  fireEvent.click(screen.getByRole('button', { name: /Agentic Tool Configuration \(optional\)/ }));
+  return onExecute;
+}
+
+describe('ZoneTriggerModal OpenCode new-session configuration', () => {
+  it('turns an inline clear into null instead of restoring a stale stored default', async () => {
+    const onExecute = renderNewSessionModal(staleOpenCodeDefault);
+    await waitFor(() => expect(screen.getByTestId('zone-model')).toHaveTextContent('openai/gpt-5'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Zone configuration source' }), {
+      target: { value: '__inline__' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear zone model' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][0].modelConfig).toBeNull();
+  });
+
+  it('keeps an omitted override omitted so defaults can be inherited', async () => {
+    const onExecute = renderNewSessionModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][0].modelConfig).toBeUndefined();
+  });
+
+  it('keeps a complete inline provider/model pair exact', async () => {
+    const onExecute = renderNewSessionModal(staleOpenCodeDefault);
+    await waitFor(() => expect(screen.getByTestId('zone-model')).toHaveTextContent('openai/gpt-5'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Zone configuration source' }), {
+      target: { value: '__inline__' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Complete zone model' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Execute Trigger' }));
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(onExecute.mock.calls[0][0].modelConfig).toEqual({
+      mode: 'exact',
+      provider: 'anthropic',
+      model: 'claude-4',
+    });
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -59,7 +59,7 @@ interface ZoneTriggerModalProps {
     // New session config (only when sessionId === 'new')
     agent?: string;
     agenticToolPresetId?: string;
-    modelConfig?: ModelConfig;
+    modelConfig?: ModelConfig | null;
     permissionMode?: PermissionMode;
     mcpServerIds?: string[];
   }) => Promise<void>;
@@ -106,7 +106,7 @@ export const ZoneTriggerModal = ({
   // Explicit state for session config (survives form mount/unmount cycles)
   const [sessionConfig, setSessionConfig] = useState<{
     agenticToolPresetId?: string;
-    modelConfig?: ModelConfig;
+    modelConfig?: ModelConfig | null;
     permissionMode?: PermissionMode;
     mcpServerIds?: string[];
   }>({});
@@ -265,6 +265,12 @@ export const ZoneTriggerModal = ({
 
   const handleExecute = async () => {
     if (mode === 'create_new') {
+      const isInline = sessionConfig.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+      const selectedModelConfig = sessionConfig.modelConfig;
+      const hasCompleteOpenCodeModel =
+        selectedAgent !== 'opencode' ||
+        Boolean(selectedModelConfig?.provider?.trim() && selectedModelConfig?.model?.trim());
+
       // Use component state which is guaranteed to have the correct values
       // regardless of whether the form fields are mounted/visible
       await onExecute({
@@ -276,7 +282,14 @@ export const ZoneTriggerModal = ({
           sessionConfig.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION
             ? undefined
             : sessionConfig.agenticToolPresetId,
-        modelConfig: sessionConfig.modelConfig,
+        // Match NewSessionModal's three-state contract: an inline OpenCode
+        // clear is explicit null, while omission continues to inherit.
+        modelConfig:
+          selectedAgent === 'opencode' && isInline && !hasCompleteOpenCodeModel
+            ? null
+            : hasCompleteOpenCodeModel
+              ? selectedModelConfig
+              : undefined,
         permissionMode: sessionConfig.permissionMode,
         mcpServerIds: sessionConfig.mcpServerIds,
       });
@@ -394,7 +407,18 @@ export const ZoneTriggerModal = ({
           onValuesChange={(changedValues) => {
             // Sync form changes to component state (only in create_new mode)
             if (mode === 'create_new') {
-              setSessionConfig((prev) => ({ ...prev, ...changedValues }));
+              setSessionConfig((prev) => {
+                const next = { ...prev, ...changedValues };
+                if (
+                  selectedAgent === 'opencode' &&
+                  next.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION &&
+                  Object.hasOwn(changedValues, 'modelConfig') &&
+                  !(next.modelConfig?.provider?.trim() && next.modelConfig?.model?.trim())
+                ) {
+                  next.modelConfig = null;
+                }
+                return next;
+              });
             }
           }}
         >

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -80,7 +80,7 @@ export interface SessionFooterProps {
   modelLabel?: string;
   modelConfig?: ModelConfig;
   // Handlers
-  onModelConfigChange: (config: ModelConfig) => void;
+  onModelConfigChange: (config: ModelConfig | undefined) => void;
   onOpenSessionSettings?: (sessionId: string) => void;
   onSendPrompt: () => void;
   onStop: () => void;

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -761,7 +761,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // lifetime-stable wrappers that delegate to the latest implementations via
   // a ref (re-pointed each render, right where the impls are defined).
   const footerHandlersRef = React.useRef<{
-    onModelConfigChange: (config: ModelConfig) => void;
+    onModelConfigChange: (config: ModelConfig | undefined) => void;
     onSendPrompt: () => void;
     onStop: () => void;
     onFork: () => void;
@@ -775,7 +775,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   } | null>(null);
   const stableFooterHandlers = React.useMemo(
     () => ({
-      onModelConfigChange: (config: ModelConfig) =>
+      onModelConfigChange: (config: ModelConfig | undefined) =>
         footerHandlersRef.current?.onModelConfigChange(config),
       onSendPrompt: () => footerHandlersRef.current?.onSendPrompt(),
       onStop: () => footerHandlersRef.current?.onStop(),
@@ -1289,8 +1289,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const handleModelConfigChange = (newConfig: ModelConfig) => {
+  const handleModelConfigChange = (newConfig: ModelConfig | undefined) => {
     if (session && onUpdateSession) {
+      if (!newConfig) {
+        onUpdateSession(session.session_id, {
+          model_config: null,
+        } as unknown as Partial<Session>);
+        return;
+      }
       const nextConfig: NonNullable<Session['model_config']> = {
         ...session.model_config,
         mode: newConfig.mode,

--- a/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
@@ -20,7 +20,7 @@ export interface SessionRunSettingsPopoverProps {
   session: Session;
   modelLabel?: string;
   modelConfig?: ModelConfig;
-  onModelConfigChange: (config: ModelConfig) => void;
+  onModelConfigChange: (config: ModelConfig | undefined) => void;
   effortLevel: EffortLevel;
   onEffortChange: (effort: EffortLevel) => void;
   permissionMode: PermissionMode;

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
@@ -57,6 +57,13 @@ vi.mock('../AgenticConfigChipRow', () => ({
         >
           save default
         </button>
+        <button
+          type="button"
+          data-testid="clear-model"
+          onClick={() => form.setFieldValue('modelConfig', undefined)}
+        >
+          clear model
+        </button>
       </div>
     );
   },
@@ -88,6 +95,13 @@ const codexSession = {
   ...claudeSession,
   session_id: 's-codex',
   agentic_tool: 'codex',
+} as unknown as Session;
+
+const openCodeSession = {
+  ...claudeSession,
+  session_id: 's-opencode',
+  agentic_tool: 'opencode',
+  model_config: { mode: 'exact', provider: 'openai', model: 'gpt-5' },
 } as unknown as Session;
 
 describe('SessionSettingsModal configuration', { timeout: 10_000 }, () => {
@@ -151,5 +165,29 @@ describe('SessionSettingsModal configuration', { timeout: 10_000 }, () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(2));
     expect(persistUserDefaultFromForm).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears an existing OpenCode provider/model override with null', async () => {
+    const onUpdate = vi.fn();
+    render(
+      <SessionSettingsModal
+        open
+        onClose={vi.fn()}
+        session={openCodeSession}
+        client={null}
+        currentUser={null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('clear-model'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith(
+        's-opencode',
+        expect.objectContaining({ model_config: null })
+      )
+    );
   });
 });

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -137,6 +137,8 @@ function buildUpdates(values: FormValues, session: Session): Partial<Session> {
       ...(values.effort ? { effort: values.effort } : {}),
       updated_at: new Date().toISOString(),
     };
+  } else if (!presetId && session.model_config) {
+    (updates as { model_config?: Session['model_config'] | null }).model_config = null;
   }
 
   if (!presetId && values.permissionMode) {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1,5 +1,5 @@
 import type { AgenticToolName, AgorClient, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import { type ReactNode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -391,5 +391,167 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 
     expect(screen.getByRole('heading', { name: 'Environment Variables' })).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('resets OpenCode provider state when the authenticated subject changes', async () => {
+    const oldSettings = {
+      runtime: 'available' as const,
+      runtimeVersion: '1.14.33',
+      isolation: { mode: 'simple' as const, boundary: 'logical' as const },
+      providers: [
+        {
+          id: 'old-provider',
+          name: 'Old User Provider',
+          configured: false,
+          status: 'disconnected' as const,
+          authMethods: [
+            { index: 0, type: 'api' as const, label: 'API key' },
+            { index: 1, type: 'oauth' as const, label: 'Browser flow' },
+          ],
+        },
+      ],
+    };
+    const newSettings = {
+      ...oldSettings,
+      providers: [
+        {
+          id: 'new-provider',
+          name: 'New User Provider',
+          configured: true,
+          status: 'configured' as const,
+          authMethods: [],
+        },
+      ],
+    };
+    const attempt = {
+      attemptId: 'old-attempt',
+      providerId: 'old-provider',
+      phase: 'awaiting_callback' as const,
+      expiresAt: '2026-07-24T00:00:00.000Z',
+      authorization: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto' as const,
+        instructions: 'Old user authorization.',
+      },
+    };
+    const service = {
+      find: vi.fn().mockResolvedValueOnce(oldSettings).mockResolvedValueOnce(newSettings),
+      get: vi.fn(),
+      create: vi.fn().mockResolvedValue(attempt),
+      patch: vi.fn(),
+      remove: vi.fn(),
+    };
+    const client = { service: vi.fn(() => service) } as unknown as AgorClient;
+    const oldUser = makeUser();
+    const newUser = makeUser({
+      user_id: 'user-2',
+      email: 'new-user@agor.live',
+      name: 'New User',
+    });
+    const renderModal = (subject: User) => (
+      <AntApp>
+        <UserSettingsModal
+          open
+          onClose={vi.fn()}
+          user={subject}
+          currentUser={subject}
+          client={client}
+          onUpdate={vi.fn()}
+          initialTab="opencode"
+        />
+      </AntApp>
+    );
+    const { rerender } = render(renderModal(oldUser));
+
+    fireEvent.change(await screen.findByLabelText('Old User Provider API key'), {
+      target: { value: 'old-user-secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Connect with Browser flow' }));
+    expect(await screen.findByText('Old user authorization.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Old User Provider API key')).toHaveValue('old-user-secret');
+    expect(screen.getByRole('button', { name: 'Cancel authorization' })).toBeInTheDocument();
+
+    rerender(renderModal(newUser));
+
+    expect(await screen.findByText('New User Provider')).toBeInTheDocument();
+    expect(screen.getByText('Configured in OpenCode')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Old User Provider API key')).not.toBeInTheDocument();
+    expect(screen.queryByText('Old user authorization.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel authorization' })).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain('old-user-secret');
+    expect(service.find).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a delayed OpenCode settings response from the previous subject', async () => {
+    let resolveOld!: (value: unknown) => void;
+    const oldResponse = new Promise((resolve) => {
+      resolveOld = resolve;
+    });
+    const newSettings = {
+      runtime: 'available' as const,
+      runtimeVersion: '1.14.33',
+      isolation: { mode: 'simple' as const, boundary: 'logical' as const },
+      providers: [
+        {
+          id: 'new-provider',
+          name: 'New User Provider',
+          configured: true,
+          status: 'configured' as const,
+          authMethods: [],
+        },
+      ],
+    };
+    const oldSettings = {
+      ...newSettings,
+      providers: [
+        {
+          id: 'old-provider',
+          name: 'Delayed Old Provider',
+          configured: true,
+          status: 'configured' as const,
+          authMethods: [],
+        },
+      ],
+    };
+    const service = {
+      find: vi.fn().mockReturnValueOnce(oldResponse).mockResolvedValueOnce(newSettings),
+      get: vi.fn(),
+      create: vi.fn(),
+      patch: vi.fn(),
+      remove: vi.fn(),
+    };
+    const client = { service: vi.fn(() => service) } as unknown as AgorClient;
+    const oldUser = makeUser();
+    const newUser = makeUser({
+      user_id: 'user-2',
+      email: 'new-user@agor.live',
+      name: 'New User',
+    });
+    const renderModal = (subject: User) => (
+      <AntApp>
+        <UserSettingsModal
+          open
+          onClose={vi.fn()}
+          user={subject}
+          currentUser={subject}
+          client={client}
+          onUpdate={vi.fn()}
+          initialTab="opencode"
+        />
+      </AntApp>
+    );
+    const { rerender } = render(renderModal(oldUser));
+
+    await waitFor(() => expect(service.find).toHaveBeenCalledTimes(1));
+    rerender(renderModal(newUser));
+
+    expect(await screen.findByText('New User Provider')).toBeInTheDocument();
+    await act(async () => {
+      resolveOld(oldSettings);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('New User Provider')).toBeInTheDocument();
+    expect(screen.queryByText('Delayed Old Provider')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1110,7 +1110,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                       title="OpenCode connections can only be managed by that user."
                     />
                   ) : client ? (
-                    <OpenCodeProviderSettings client={client} />
+                    <OpenCodeProviderSettings key={currentUser?.user_id} client={client} />
                   ) : (
                     <Alert type="warning" showIcon title="Not connected to Agor." />
                   ),

--- a/apps/agor-ui/src/hooks/useSessionActions.test.tsx
+++ b/apps/agor-ui/src/hooks/useSessionActions.test.tsx
@@ -54,3 +54,73 @@ describe('useSessionActions archive helpers', () => {
     expect(sessionsPatch).not.toHaveBeenCalled();
   });
 });
+
+describe('useSessionActions OpenCode model config', () => {
+  it('does not create a detached effort-only model config when selection is omitted', async () => {
+    const create = vi.fn(async (data) => ({ session_id: 'session-1', ...data }));
+    const client = makeClient({ sessions: { create } });
+    const { result } = renderHook(() => useSessionActions(client));
+
+    await act(async () => {
+      await result.current.createSession({
+        branch_id: 'branch-1',
+        agent: 'opencode',
+        modelConfig: undefined,
+        effort: 'high',
+      });
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        model_config: undefined,
+      })
+    );
+  });
+
+  it('carries a deliberate clear as model_config null without detached effort', async () => {
+    const create = vi.fn(async (data) => ({ session_id: 'session-1', ...data }));
+    const client = makeClient({ sessions: { create } });
+    const { result } = renderHook(() => useSessionActions(client));
+
+    await act(async () => {
+      await result.current.createSession({
+        branch_id: 'branch-1',
+        agent: 'opencode',
+        modelConfig: null,
+        effort: 'high',
+      });
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        model_config: null,
+      })
+    );
+  });
+
+  it('keeps a complete exact OpenCode provider/model pair', async () => {
+    const create = vi.fn(async (data) => ({ session_id: 'session-1', ...data }));
+    const client = makeClient({ sessions: { create } });
+    const { result } = renderHook(() => useSessionActions(client));
+
+    await act(async () => {
+      await result.current.createSession({
+        branch_id: 'branch-1',
+        agent: 'opencode',
+        modelConfig: { mode: 'exact', provider: 'openai', model: 'gpt-5' },
+      });
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_config: expect.objectContaining({
+          mode: 'exact',
+          provider: 'openai',
+          model: 'gpt-5',
+        }),
+      })
+    );
+  });
+});

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -82,6 +82,20 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
         };
       }
 
+      const hasCompleteOpenCodeModel =
+        agenticTool !== 'opencode' ||
+        Boolean(config.modelConfig?.provider?.trim() && config.modelConfig?.model?.trim());
+      const modelConfig =
+        agenticTool === 'opencode' && config.modelConfig === null
+          ? null
+          : hasCompleteOpenCodeModel
+            ? config.modelConfig
+            : undefined;
+      const effort =
+        agenticTool === 'opencode' && (modelConfig === null || !hasCompleteOpenCodeModel)
+          ? undefined
+          : config.effort;
+
       const newSession = await client.service('sessions').create({
         agentic_tool: agenticTool,
         agentic_tool_preset_id: config.agenticToolPresetId,
@@ -89,15 +103,18 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
         title: config.title || undefined,
         description: config.initialPrompt || undefined,
         branch_id: config.branch_id,
-        model_config: config.modelConfig
-          ? {
-              ...config.modelConfig,
-              ...(config.effort && { effort: config.effort }),
-              updated_at: new Date().toISOString(),
-            }
-          : config.effort
-            ? { effort: config.effort, updated_at: new Date().toISOString() }
-            : undefined,
+        model_config:
+          modelConfig === null
+            ? null
+            : modelConfig
+              ? {
+                  ...modelConfig,
+                  ...(effort && { effort }),
+                  updated_at: new Date().toISOString(),
+                }
+              : effort
+                ? { effort, updated_at: new Date().toISOString() }
+                : undefined,
         permission_config: permissionConfig,
       });
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -34,6 +34,9 @@ import type {
   KnowledgeSemanticSettingsPublic,
   MCPServer,
   Message,
+  OpenCodeOAuthAttempt,
+  OpenCodeOAuthAttemptPatch,
+  OpenCodeOAuthConnectRequest,
   OpenCodeProviderSettings,
   PatchAgenticToolPreset,
   PermissionMode,
@@ -299,10 +302,18 @@ export interface KnowledgeReindexService {
 
 export interface OpenCodeAuthService {
   find(params?: Params): Promise<OpenCodeProviderSettings>;
+  get(attemptId: string, params?: Params): Promise<OpenCodeOAuthAttempt>;
   create(
-    data: { providerId: string; apiKey: string; metadata?: Record<string, string> },
+    data:
+      | { providerId: string; apiKey: string; metadata?: Record<string, string> }
+      | OpenCodeOAuthConnectRequest,
     params?: Params
-  ): Promise<OpenCodeProviderSettings>;
+  ): Promise<OpenCodeProviderSettings | OpenCodeOAuthAttempt>;
+  patch(
+    attemptId: string,
+    data: OpenCodeOAuthAttemptPatch,
+    params?: Params
+  ): Promise<OpenCodeOAuthAttempt>;
   remove(providerId: string, params?: Params): Promise<OpenCodeProviderSettings>;
 }
 

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -178,7 +178,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         contextFiles: session.contextFiles ?? [],
         tasks: session.tasks ?? [],
         permission_config: session.permission_config,
-        model_config: session.model_config ?? undefined,
+        // Keep explicit null as the atomic "no model override" value. Omitting
+        // the property remains distinct and lets create-time defaults apply.
+        model_config: session.model_config,
         callback_config: session.callback_config,
         fork_origin: session.fork_origin,
         custom_context: session.custom_context,

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -255,6 +255,44 @@ describe('resolveModelConfigWithFallback', () => {
     expect(resolveModelConfigWithFallback('opencode', [undefined], { now })).toBeUndefined();
   });
 
+  it('keeps only complete OpenCode provider/model pairs and forces exact mode', () => {
+    expect(
+      resolveModelConfigWithFallback(
+        'opencode',
+        [
+          { mode: 'alias', provider: 'openai', model: 'gpt-5', effort: 'high' },
+          { mode: 'exact', provider: 'anthropic', model: 'claude-sonnet-5' },
+        ],
+        { now }
+      )
+    ).toEqual({
+      mode: 'exact',
+      provider: 'openai',
+      model: 'gpt-5',
+      effort: 'high',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
+  it('rejects incomplete or blank OpenCode pairs', () => {
+    for (const source of [
+      { model: 'gpt-5' },
+      { provider: 'openai' },
+      { provider: '   ', model: 'gpt-5' },
+      { provider: 'openai', model: '   ' },
+    ]) {
+      expect(() => resolveModelConfigWithFallback('opencode', [source], { now })).toThrow(
+        /provider.*model/i
+      );
+    }
+  });
+
+  it('treats model-less OpenCode sources as absent', () => {
+    expect(
+      resolveModelConfigWithFallback('opencode', [undefined, null, {}, { effort: 'high' }], { now })
+    ).toBeUndefined();
+  });
+
   it('still uses an explicit source for tools without a static default', () => {
     const result = resolveModelConfigWithFallback('cursor', [{ model: 'composer-experimental' }], {
       now,

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -45,11 +45,32 @@ export type ModelConfigInput = {
  */
 export type ResolvedModelConfig = NonNullable<Session['model_config']>;
 
+export const OPENCODE_MODEL_CONFIG_PAIR_ERROR =
+  'OpenCode model_config requires nonblank provider and model values';
+
+export class InvalidModelConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidModelConfigError';
+  }
+}
+
+/** OpenCode model selection is atomic: provider and model are either both usable or both absent. */
+export function hasCompleteOpenCodeModelConfig(
+  input: ModelConfigInput | null | undefined
+): boolean {
+  return Boolean(input?.provider?.trim() && input.model?.trim());
+}
+
 /** Whether a model config already has the complete persisted shape. */
 export function isResolvedModelConfig(
-  input: Partial<ResolvedModelConfig> | null | undefined
+  input: Partial<ResolvedModelConfig> | null | undefined,
+  tool?: AgenticToolName
 ): input is ResolvedModelConfig {
-  return Boolean(input?.mode && input.model && input.updated_at);
+  const hasPersistedShape = Boolean(input?.mode && input.model && input.updated_at);
+  if (!hasPersistedShape) return false;
+  if (tool !== 'opencode') return true;
+  return input?.mode === 'exact' && hasCompleteOpenCodeModelConfig(input);
 }
 
 /**
@@ -162,12 +183,30 @@ function mergeModelLessFallbackOverrides(
  * carry model-less `mode` / `provider` because their meaning depends on the
  * missing model value. This prevents partial persisted model_config objects
  * while preserving explicit notes, effort, and advisor choices.
+ *
+ * OpenCode is stricter: provider + model are one atomic exact selection.
+ * Model-less sources remain absent, while a source carrying only one side (or
+ * a blank side) is rejected instead of being persisted or combined with a
+ * lower-priority source.
  */
 export function resolveModelConfigWithFallback(
   tool: AgenticToolName,
   sources: Array<ModelConfigInput | undefined | null>,
   opts?: { now?: Date }
 ): ResolvedModelConfig | undefined {
+  if (tool === 'opencode') {
+    for (const source of sources) {
+      if (source == null) continue;
+      const carriesPairField = source.provider !== undefined || source.model !== undefined;
+      if (!carriesPairField) continue;
+      if (!hasCompleteOpenCodeModelConfig(source)) {
+        throw new InvalidModelConfigError(OPENCODE_MODEL_CONFIG_PAIR_ERROR);
+      }
+      return resolveModelConfig({ ...source, mode: 'exact' }, opts);
+    }
+    return undefined;
+  }
+
   let pendingModelLessOverrides: ModelConfigInput | undefined;
 
   for (const source of sources) {

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -255,6 +255,43 @@ describe('resolveSessionDefaults', () => {
       // first-wins, not merge — must NOT inherit effort from user default
       expect(r.model_config).not.toHaveProperty('effort');
     });
+
+    it('preserves a complete OpenCode provider/model pair as exact', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'opencode',
+        user: makeUser({
+          opencode: {
+            modelConfig: {
+              mode: 'alias',
+              provider: 'openai',
+              model: 'gpt-5',
+              effort: 'high',
+            },
+          },
+        }),
+        now,
+      });
+
+      expect(r.model_config).toEqual({
+        mode: 'exact',
+        provider: 'openai',
+        model: 'gpt-5',
+        effort: 'high',
+        updated_at: now.toISOString(),
+      });
+    });
+
+    it('rejects an incomplete OpenCode user default at the shared resolution boundary', () => {
+      expect(() =>
+        resolveSessionDefaults({
+          agenticTool: 'opencode',
+          user: makeUser({
+            opencode: { modelConfig: { model: 'gpt-5' } },
+          }),
+          now,
+        })
+      ).toThrow(/provider.*model/i);
+    });
   });
 
   describe('mcp_server_ids', () => {

--- a/packages/core/src/types/opencode-auth.ts
+++ b/packages/core/src/types/opencode-auth.ts
@@ -21,10 +21,45 @@ export type OpenCodeProviderAuthPromptCondition = {
 };
 
 export interface OpenCodeProviderAuthMethod {
+  /** Stable index in the native OpenCode auth-method array. */
+  index: number;
   type: 'api' | 'oauth';
   label: string;
   prompts?: OpenCodeProviderAuthPrompt[];
 }
+
+export type OpenCodeOAuthAuthorization = {
+  url: string;
+  method: 'auto' | 'code';
+  instructions: string;
+};
+
+export type OpenCodeOAuthAttemptPhase =
+  | 'authorizing'
+  | 'awaiting_callback'
+  | 'completing'
+  | 'configured'
+  | 'cancelled'
+  | 'expired'
+  | 'failed';
+
+export interface OpenCodeOAuthAttempt {
+  attemptId: string;
+  providerId: string;
+  phase: OpenCodeOAuthAttemptPhase;
+  authorization?: OpenCodeOAuthAuthorization;
+  expiresAt: string;
+  settings?: OpenCodeProviderSettings;
+}
+
+export type OpenCodeOAuthConnectRequest = {
+  operation: 'connect-oauth';
+  providerId: string;
+  method: number;
+  inputs?: Record<string, string>;
+};
+
+export type OpenCodeOAuthAttemptPatch = { cancel: true } | { code: string };
 
 export type OpenCodeProviderConnectionStatus = 'configured' | 'disconnected' | 'unknown';
 

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -95,6 +95,8 @@ export interface DefaultModelConfig {
   mode?: 'alias' | 'exact';
   /** Model identifier (alias or exact ID) */
   model?: string;
+  /** OpenCode provider identifier paired with an exact model */
+  provider?: string;
   /** Effort level for reasoning depth */
   effort?: EffortLevel;
   /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable'); unset means no session override */

--- a/packages/executor/scripts/opencode-provider-auth-harness.mjs
+++ b/packages/executor/scripts/opencode-provider-auth-harness.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const originalEnvironment = { ...process.env };
 const root = await mkdtemp(join(tmpdir(), 'agor-opencode-auth-'));
@@ -18,7 +20,11 @@ const branchDirectory = join(root, 'branch-worktree');
 const synthetic = {
   kimi: 'agor-synthetic-kimi-not-a-real-key',
   glm: 'agor-synthetic-glm-not-a-real-key',
+  oauth: 'agor-synthetic-oauth-not-a-real-key',
+  code: 'agor-synthetic-one-time-code',
+  oauthCode: 'agor-synthetic-code-oauth-not-a-real-key',
 };
+let loopback;
 
 function sanitizeEnvironment() {
   const keep = new Set(['PATH', 'SHELL', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL', 'LC_CTYPE']);
@@ -30,6 +36,8 @@ function sanitizeEnvironment() {
   process.env.XDG_CACHE_HOME = join(root, 'cache');
   process.env.NO_PROXY = '127.0.0.1,localhost';
   process.env.no_proxy = process.env.NO_PROXY;
+  process.env.OPENCODE_DISABLE_AUTOUPDATE = 'true';
+  process.env.OPENCODE_DISABLE_MODELS_FETCH = 'true';
 }
 
 function payload(params) {
@@ -44,7 +52,104 @@ async function expectSuccess(result) {
 try {
   sanitizeEnvironment();
   await mkdir(branchDirectory, { recursive: true });
-  const { handleOpenCodeAuth } = await import('../src/commands/opencode-auth.ts');
+  const loopbackCalls = [];
+  loopback = createServer((request, response) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      loopbackCalls.push({
+        path: request.url,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"ok":true}');
+    });
+  });
+  await new Promise((resolve) => loopback.listen(0, '127.0.0.1', resolve));
+  const address = loopback.address();
+  assert(address && typeof address === 'object');
+  const loopbackOrigin = `http://127.0.0.1:${address.port}`;
+  const pluginPath = join(root, 'synthetic-oauth-plugin.mjs');
+  await writeFile(
+    pluginPath,
+    `
+export async function SyntheticOAuthPlugin() {
+  return {
+    auth: {
+      provider: "openai",
+      loader: async () => ({}),
+      methods: [{
+        type: "oauth",
+        label: "Synthetic headless",
+        prompts: [
+          {
+            type: "select",
+            key: "region",
+            message: "Region",
+            options: [{ label: "Loopback", value: "loopback" }]
+          },
+          {
+            type: "text",
+            key: "account",
+            message: "Account",
+            when: { key: "region", op: "eq", value: "loopback" }
+          }
+        ],
+        authorize: async (inputs) => {
+          await fetch(${JSON.stringify(`${loopbackOrigin}/authorize`)}, {
+            method: "POST",
+            body: JSON.stringify(inputs)
+          })
+          return {
+            url: ${JSON.stringify(`${loopbackOrigin}/consent`)},
+            method: "auto",
+            instructions: "Complete synthetic loopback authorization.",
+            callback: async () => {
+              await fetch(${JSON.stringify(`${loopbackOrigin}/callback`)}, { method: "POST" })
+              return { type: "success", key: ${JSON.stringify(synthetic.oauth)} }
+            }
+          }
+        }
+      }, {
+        type: "oauth",
+        label: "Synthetic denial",
+        authorize: async () => ({
+          url: ${JSON.stringify(`${loopbackOrigin}/denied-consent`)},
+          method: "auto",
+          instructions: "Deny the synthetic authorization.",
+          callback: async () => ({ type: "failed" })
+        })
+      }, {
+        type: "oauth",
+        label: "Synthetic code",
+        authorize: async () => ({
+          url: ${JSON.stringify(`${loopbackOrigin}/code-consent`)},
+          method: "code",
+          instructions: "Paste the synthetic one-time code.",
+          callback: async (code) => {
+            await fetch(${JSON.stringify(`${loopbackOrigin}/code-callback`)}, {
+              method: "POST",
+              body: code
+            })
+            return code === ${JSON.stringify(synthetic.code)}
+              ? { type: "success", key: ${JSON.stringify(synthetic.oauthCode)} }
+              : { type: "failed" }
+          }
+        })
+      }]
+    }
+  }
+}
+`,
+    { mode: 0o600 }
+  );
+  process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+    plugin: [pathToFileURL(pluginPath).href],
+  });
+
+  const { handleOpenCodeAuth, handleOpenCodeOAuth } = await import(
+    '../src/commands/opencode-auth.ts'
+  );
   const { startManagedOpenCodeServer } = await import(
     '../src/sdk-handlers/opencode/managed-server.ts'
   );
@@ -56,8 +161,111 @@ try {
     discovered.providers.find((provider) => pattern.test(`${provider.id} ${provider.name}`));
   const kimi = findProvider(/kimi|moonshot/i);
   const glm = findProvider(/glm|zhipu/i);
+  const oauth = discovered.providers.find((provider) => provider.id === 'openai');
   assert(kimi, 'The packaged OpenCode catalog did not expose a Kimi/Moonshot provider');
   assert(glm, 'The packaged OpenCode catalog did not expose a GLM/Zhipu provider');
+  assert(oauth, 'The OpenAI provider was not loaded by pinned OpenCode');
+  assert.deepEqual(oauth.authMethods, [
+    {
+      index: 0,
+      type: 'oauth',
+      label: 'Synthetic headless',
+      prompts: [
+        {
+          type: 'select',
+          key: 'region',
+          message: 'Region',
+          options: [{ label: 'Loopback', value: 'loopback' }],
+        },
+        {
+          type: 'text',
+          key: 'account',
+          message: 'Account',
+          when: { key: 'region', op: 'eq', value: 'loopback' },
+        },
+      ],
+    },
+    {
+      index: 1,
+      type: 'oauth',
+      label: 'Synthetic denial',
+    },
+    {
+      index: 2,
+      type: 'oauth',
+      label: 'Synthetic code',
+    },
+  ]);
+
+  const oauthEvents = [];
+  const oauthConnected = await expectSuccess(
+    await handleOpenCodeOAuth(
+      payload({
+        operation: 'connect-oauth',
+        providerId: oauth.id,
+        method: oauth.authMethods[0].index,
+        inputs: { region: 'loopback', account: 'synthetic-account' },
+      }),
+      {},
+      (event) => oauthEvents.push(event)
+    )
+  );
+  assert.deepEqual(
+    oauthEvents.map((event) => event.type),
+    ['authorized', 'callback-started']
+  );
+  assert.equal(
+    oauthConnected.providers.find((provider) => provider.id === oauth.id)?.configured,
+    true
+  );
+  assert.deepEqual(
+    loopbackCalls.map((call) => call.path),
+    ['/authorize', '/callback']
+  );
+  assert.match(loopbackCalls[0].body, /synthetic-account/);
+
+  const denied = await handleOpenCodeOAuth(
+    payload({
+      operation: 'connect-oauth',
+      providerId: oauth.id,
+      method: 1,
+    }),
+    {},
+    () => undefined
+  );
+  assert.equal(denied.success, false);
+  const afterDenial = await expectSuccess(
+    await handleOpenCodeAuth(payload({ operation: 'discover' }), {})
+  );
+  assert.equal(
+    afterDenial.providers.find((provider) => provider.id === oauth.id)?.configured,
+    true,
+    'native failed callback must preserve the prior configured connection'
+  );
+
+  const codeEvents = [];
+  const codeConnected = await expectSuccess(
+    await handleOpenCodeOAuth(
+      payload({
+        operation: 'connect-oauth',
+        providerId: oauth.id,
+        method: 2,
+      }),
+      {},
+      (event) => codeEvents.push(event),
+      async () => synthetic.code
+    )
+  );
+  assert.deepEqual(
+    codeEvents.map((event) => event.type),
+    ['authorized', 'callback-started']
+  );
+  assert.equal(
+    codeConnected.providers.find((provider) => provider.id === oauth.id)?.configured,
+    true
+  );
+  assert.equal(loopbackCalls.at(-1)?.path, '/code-callback');
+  assert.equal(loopbackCalls.at(-1)?.body, synthetic.code);
 
   const kimiConnected = await expectSuccess(
     await handleOpenCodeAuth(
@@ -109,7 +317,7 @@ try {
   }
 
   if (!strictQaDataHome) {
-    for (const provider of [kimi, glm]) {
+    for (const provider of [oauth, kimi, glm]) {
       const disconnected = await expectSuccess(
         await handleOpenCodeAuth(payload({ operation: 'disconnect', providerId: provider.id }), {})
       );
@@ -122,7 +330,13 @@ try {
 
   const evidence = JSON.stringify({
     runtimeVersion: discovered.runtimeVersion,
-    providers: [kimi.id, glm.id],
+    providers: ['openai', 'kimi-or-moonshot', 'glm-or-zhipu'],
+    oauthAuthorizeCallbackSameRuntime: true,
+    oauthLoopbackTransitions: oauthEvents.map((event) => event.type),
+    oauthCodeTransitions: codeEvents.map((event) => event.type),
+    nativeFailurePreservesPriorConnection: true,
+    boundedCodeCallback: true,
+    oauthFreshDisconnect: !strictQaDataHome,
     freshStatusAfterMutation: true,
     freshTaskShapedRead: true,
     authMode: '0600',
@@ -132,8 +346,10 @@ try {
   assert(!evidence.includes(root));
   assert(!evidence.includes(synthetic.kimi));
   assert(!evidence.includes(synthetic.glm));
+  assert(!evidence.includes(synthetic.oauth));
   console.log(evidence);
 } finally {
+  if (loopback?.listening) await new Promise((resolve) => loopback.close(resolve));
   process.env = originalEnvironment;
   await rm(root, { recursive: true, force: true });
 }

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -15,9 +15,11 @@
  * impersonation - it's already running as the correct user.
  */
 
+import { createInterface } from 'node:readline';
 import { parseArgs } from 'node:util';
 
 import { executeCommand, getRegisteredCommands } from './commands/index.js';
+import { handleOpenCodeOAuth, type OpenCodeOAuthPayload } from './commands/opencode-auth.js';
 import { AgorExecutor } from './index.js';
 import {
   type ExecutorPayload,
@@ -48,6 +50,10 @@ async function readStdin(): Promise<string> {
 
 function emitExecutorResult(result: unknown): void {
   console.log(`AGOR_EXECUTOR_RESULT ${JSON.stringify(result)}`);
+}
+
+function emitOpenCodeOAuthEvent(event: unknown): void {
+  console.log(`AGOR_OPENCODE_OAUTH_EVENT ${JSON.stringify(event)}`);
 }
 
 /**
@@ -115,6 +121,61 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
   emitExecutorResult(result);
 
   process.exit(result.success ? 0 : 1);
+}
+
+/**
+ * Dedicated two-message stdin mode for the bounded OpenCode OAuth protocol.
+ * The first line is the normal command payload. A `method: "code"` flow may
+ * consume exactly one additional `{ "code": "..." }` line.
+ */
+async function handleOpenCodeOAuthMode(options: { dryRun: boolean }): Promise<void> {
+  const lines = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
+  const iterator = lines[Symbol.asyncIterator]();
+  try {
+    const first = await iterator.next();
+    if (first.done || !first.value.trim()) throw new Error('missing payload');
+    const payload = ExecutorPayloadSchema.parse(JSON.parse(first.value));
+    if (payload.command !== 'opencode.auth' || payload.params.operation !== 'connect-oauth') {
+      throw new Error('invalid OAuth payload');
+    }
+    let codeRead = false;
+    const readCode = async () => {
+      if (codeRead) throw new Error('OAuth code was already consumed');
+      codeRead = true;
+      const next = await iterator.next();
+      if (next.done) throw new Error('OAuth code input closed');
+      const control = JSON.parse(next.value) as unknown;
+      if (
+        !control ||
+        typeof control !== 'object' ||
+        !('code' in control) ||
+        typeof control.code !== 'string' ||
+        !control.code.trim()
+      ) {
+        throw new Error('invalid OAuth code input');
+      }
+      return control.code;
+    };
+    const result = await handleOpenCodeOAuth(
+      payload as OpenCodeOAuthPayload,
+      { dryRun: options.dryRun },
+      emitOpenCodeOAuthEvent,
+      readCode
+    );
+    emitExecutorResult(result);
+    process.exitCode = result.success ? 0 : 1;
+  } catch {
+    emitExecutorResult({
+      success: false,
+      error: {
+        code: 'OPENCODE_OAUTH_PROTOCOL_INVALID',
+        message: 'OpenCode OAuth executor input was invalid.',
+      },
+    });
+    process.exitCode = 1;
+  } finally {
+    lines.close();
+  }
 }
 
 /**
@@ -303,6 +364,10 @@ async function main() {
         type: 'boolean',
         default: false,
       },
+      'opencode-oauth': {
+        type: 'boolean',
+        default: false,
+      },
       'dry-run': {
         type: 'boolean',
         default: false,
@@ -334,7 +399,9 @@ async function main() {
   });
 
   // Route to appropriate mode
-  if (values.stdin) {
+  if (values['opencode-oauth']) {
+    await handleOpenCodeOAuthMode({ dryRun: values['dry-run'] || false });
+  } else if (values.stdin) {
     await handleStdinMode({ dryRun: values['dry-run'] || false });
   } else if (values['session-token']) {
     // Legacy mode - use CLI arguments

--- a/packages/executor/src/commands/opencode-auth.test.ts
+++ b/packages/executor/src/commands/opencode-auth.test.ts
@@ -53,6 +53,10 @@ function client(
     provider: {
       list: vi.fn(async () => providerList(connected)),
       auth: vi.fn(async () => ({ data: authMethods })),
+      oauth: {
+        authorize: vi.fn(),
+        callback: vi.fn(),
+      },
     },
     instance: { dispose: vi.fn(async () => ({ data: true })) },
   };
@@ -155,6 +159,7 @@ describe('opencode.auth executor command', () => {
             id: 'kimi-for-coding',
             authMethods: [
               {
+                index: 0,
                 type: 'api',
                 label: 'Workspace key',
                 prompts: [
@@ -178,6 +183,223 @@ describe('opencode.auth executor command', () => {
         ]),
       }),
     });
+  });
+
+  it('keeps the native method index and completes auto OAuth on one server before fresh verification', async () => {
+    const authClient = client([], {
+      openai: [
+        { type: 'oauth', label: 'ChatGPT browser' },
+        {
+          type: 'oauth',
+          label: 'ChatGPT headless',
+          prompts: [
+            {
+              type: 'select',
+              key: 'region',
+              message: 'Region',
+              options: [{ label: 'US', value: 'us' }],
+            },
+          ],
+        },
+      ],
+    });
+    authClient.provider.oauth.authorize.mockResolvedValue({
+      data: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'auto',
+        instructions: 'Open the synthetic authorization page.',
+      },
+    });
+    authClient.provider.oauth.callback.mockResolvedValue({ data: true });
+    const verificationClient = client(['openai'], {
+      openai: [
+        { type: 'oauth', label: 'ChatGPT browser' },
+        { type: 'oauth', label: 'ChatGPT headless' },
+      ],
+    });
+    verificationClient.provider.list.mockResolvedValue({
+      data: {
+        all: [{ id: 'openai', name: 'OpenAI' }],
+        connected: ['openai'],
+        default: {},
+      },
+    });
+    runtime.clients.push(authClient, verificationClient);
+    const events: unknown[] = [];
+
+    const { handleOpenCodeOAuth } = await import('./opencode-auth');
+    const result = await handleOpenCodeOAuth(
+      {
+        command: 'opencode.auth',
+        dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+        params: {
+          operation: 'connect-oauth',
+          providerId: 'openai',
+          method: 1,
+          inputs: { region: 'us' },
+        },
+      } as never,
+      {},
+      (event) => events.push(event)
+    );
+
+    expect(authClient.provider.oauth.authorize).toHaveBeenCalledWith({
+      providerID: 'openai',
+      method: 1,
+      inputs: { region: 'us' },
+      directory: '/home/alice/.local/share/agor/opencode/opaque',
+    });
+    expect(authClient.provider.oauth.callback).toHaveBeenCalledWith({
+      providerID: 'openai',
+      method: 1,
+      directory: '/home/alice/.local/share/agor/opencode/opaque',
+    });
+    expect(events).toEqual([
+      {
+        type: 'authorized',
+        authorization: {
+          url: 'http://127.0.0.1:9898/authorize',
+          method: 'auto',
+          instructions: 'Open the synthetic authorization page.',
+        },
+      },
+      { type: 'callback-started' },
+    ]);
+    expect(runtime.start).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        providers: expect.arrayContaining([
+          expect.objectContaining({ id: 'openai', configured: true }),
+        ]),
+      }),
+    });
+  });
+
+  it('closes a denied OAuth runtime without changing a previously configured connection', async () => {
+    const authClient = client(['openai']);
+    authClient.provider.oauth.authorize.mockResolvedValue({
+      data: {
+        url: 'http://127.0.0.1:9898/authorize?secret=synthetic',
+        method: 'auto',
+        instructions: 'Synthetic instruction code 1234',
+      },
+    });
+    authClient.provider.oauth.callback.mockResolvedValue({ error: { name: 'denied' } });
+    runtime.clients.push(authClient);
+
+    const { handleOpenCodeOAuth } = await import('./opencode-auth');
+    const result = await handleOpenCodeOAuth(
+      {
+        command: 'opencode.auth',
+        dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+        params: {
+          operation: 'connect-oauth',
+          providerId: 'openai',
+          method: 1,
+        },
+      } as never,
+      {},
+      () => undefined
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'OPENCODE_AUTH_FAILED',
+        message: 'OpenCode provider operation failed without exposing credential details.',
+      },
+    });
+    expect(authClient.auth.set).not.toHaveBeenCalled();
+    expect(authClient.auth.remove).not.toHaveBeenCalled();
+    expect(runtime.close).toHaveBeenCalledOnce();
+    expect(JSON.stringify(result)).not.toContain('synthetic');
+    expect(JSON.stringify(result)).not.toContain('/home/alice');
+
+    const preservedClient = client(['openai']);
+    preservedClient.provider.list.mockResolvedValue({
+      data: {
+        all: [{ id: 'openai', name: 'OpenAI' }],
+        connected: ['openai'],
+        default: {},
+      },
+    });
+    runtime.clients.push(preservedClient);
+    const preservedConnection = await executeCommand({
+      command: 'opencode.auth',
+      dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+      params: { operation: 'discover' },
+    } as never);
+    expect(preservedConnection).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        providers: expect.arrayContaining([
+          expect.objectContaining({ id: 'openai', configured: true }),
+        ]),
+      }),
+    });
+  });
+
+  it('delivers one bounded code callback to the same native auth client without exposing it', async () => {
+    const authClient = client();
+    authClient.provider.oauth.authorize.mockResolvedValue({
+      data: {
+        url: 'http://127.0.0.1:9898/authorize',
+        method: 'code',
+        instructions: 'Paste the one-time code.',
+      },
+    });
+    authClient.provider.oauth.callback.mockImplementation(async ({ code }) => {
+      expect(code).toBe('synthetic-one-time-code');
+      return { data: true };
+    });
+    const verificationClient = client(['openai']);
+    verificationClient.provider.list.mockResolvedValue({
+      data: {
+        all: [{ id: 'openai', name: 'OpenAI' }],
+        connected: ['openai'],
+        default: {},
+      },
+    });
+    runtime.clients.push(authClient, verificationClient);
+    const events: unknown[] = [];
+
+    const { handleOpenCodeOAuth } = await import('./opencode-auth');
+    const result = await handleOpenCodeOAuth(
+      {
+        command: 'opencode.auth',
+        dataHome: '/home/alice/.local/share/agor/opencode/opaque',
+        params: {
+          operation: 'connect-oauth',
+          providerId: 'openai',
+          method: 1,
+        },
+      } as never,
+      {},
+      (event) => events.push(event),
+      async () => 'synthetic-one-time-code'
+    );
+
+    expect(authClient.provider.oauth.callback).toHaveBeenCalledWith({
+      providerID: 'openai',
+      method: 1,
+      code: 'synthetic-one-time-code',
+      directory: '/home/alice/.local/share/agor/opencode/opaque',
+    });
+    expect(events).toEqual([
+      {
+        type: 'authorized',
+        authorization: {
+          url: 'http://127.0.0.1:9898/authorize',
+          method: 'code',
+          instructions: 'Paste the one-time code.',
+        },
+      },
+      { type: 'callback-started' },
+    ]);
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result)).not.toContain('synthetic-one-time-code');
+    expect(JSON.stringify(result)).not.toContain('/home/alice');
   });
 
   it('disconnects GLM generically and verifies it is absent on a fresh server', async () => {

--- a/packages/executor/src/commands/opencode-auth.ts
+++ b/packages/executor/src/commands/opencode-auth.ts
@@ -1,4 +1,5 @@
 import type {
+  OpenCodeOAuthAuthorization,
   OpenCodeProviderAuthMethod,
   OpenCodeProviderConnection,
   OpenCodeProviderDiscovery,
@@ -18,7 +19,8 @@ function safeMethods(
   methods: Awaited<ReturnType<V2Client['provider']['auth']>>['data'] | undefined,
   providerId: string
 ): OpenCodeProviderAuthMethod[] {
-  return (methods?.[providerId] ?? []).map((method) => ({
+  return (methods?.[providerId] ?? []).map((method, index) => ({
+    index,
     type: method.type,
     label: method.label,
     ...(method.prompts
@@ -127,6 +129,16 @@ export async function handleOpenCodeAuth(payload: OpenCodeAuthPayload, options: 
       return { success: true, data: await discover(payload.dataHome) };
     }
 
+    if (payload.params.operation === 'connect-oauth') {
+      return {
+        success: false,
+        error: {
+          code: 'OPENCODE_OAUTH_PROTOCOL_REQUIRED',
+          message: 'OpenCode OAuth requires the bounded authorization protocol.',
+        },
+      };
+    }
+
     const { providerId } = payload.params;
     const apiKey =
       payload.params.operation === 'connect-api-key' ? payload.params.apiKey : undefined;
@@ -152,6 +164,79 @@ export async function handleOpenCodeAuth(payload: OpenCodeAuthPayload, options: 
       });
     });
 
+    return { success: true, data: await discover(payload.dataHome) };
+  } catch {
+    return {
+      success: false,
+      error: {
+        code: 'OPENCODE_AUTH_FAILED',
+        message: 'OpenCode provider operation failed without exposing credential details.',
+      },
+    };
+  }
+}
+
+export type OpenCodeOAuthExecutorEvent =
+  | { type: 'authorized'; authorization: OpenCodeOAuthAuthorization }
+  | { type: 'callback-started' };
+
+export type OpenCodeOAuthPayload = Omit<OpenCodeAuthPayload, 'params'> & {
+  params: Extract<OpenCodeAuthPayload['params'], { operation: 'connect-oauth' }>;
+};
+
+export async function handleOpenCodeOAuth(
+  payload: OpenCodeOAuthPayload,
+  options: CommandOptions,
+  emit: (event: OpenCodeOAuthExecutorEvent) => void,
+  readCode?: () => Promise<string>
+) {
+  if (options.dryRun) {
+    return {
+      success: true,
+      data: { dryRun: true, command: payload.command, operation: payload.params.operation },
+    };
+  }
+
+  const { providerId, method, inputs } = payload.params;
+  try {
+    const mutation = await withFreshClient(
+      payload.dataHome,
+      Object.values(inputs ?? {}),
+      async (client) => {
+        const response = await client.provider.oauth.authorize({
+          providerID: providerId,
+          method,
+          ...(inputs && Object.keys(inputs).length > 0 ? { inputs } : {}),
+          directory: payload.dataHome,
+        });
+        if (response.error || !response.data) {
+          throw new Error('OpenCode rejected OAuth authorization');
+        }
+        const authorization: OpenCodeOAuthAuthorization = {
+          url: response.data.url,
+          method: response.data.method,
+          instructions: response.data.instructions,
+        };
+        emit({ type: 'authorized', authorization });
+        const code = authorization.method === 'code' ? (await readCode?.())?.trim() : undefined;
+        if (authorization.method === 'code' && !code) {
+          throw new Error('OpenCode OAuth code was not supplied');
+        }
+        emit({ type: 'callback-started' });
+        const callback = await client.provider.oauth.callback({
+          providerID: providerId,
+          method,
+          ...(code ? { code } : {}),
+          directory: payload.dataHome,
+        });
+        if (callback.error || callback.data !== true) {
+          throw new Error('OpenCode rejected OAuth callback');
+        }
+        await verifyOpenCodeAuthFileBoundary(payload.dataHome);
+        return true;
+      }
+    );
+    if (!mutation) throw new Error('OpenCode OAuth mutation did not complete');
     return { success: true, data: await discover(payload.dataHome) };
   } catch {
     return {

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -27,6 +27,45 @@ describe('FeathersMessagesRepository', () => {
         session_id: 'session-1',
         $sort: { index: 1 },
         $limit: 10000,
+        $skip: 0,
+      },
+    });
+  });
+
+  it('consumes every paginated history page in message order', async () => {
+    const firstPage = Array.from({ length: 10000 }, (_, index) => ({
+      message_id: `message-${index}`,
+      index,
+    }));
+    const lastMessage = { message_id: 'message-10000', index: 10000 };
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce({
+        total: 10001,
+        limit: 10000,
+        skip: 0,
+        data: firstPage,
+      })
+      .mockResolvedValueOnce({
+        total: 10001,
+        limit: 10000,
+        skip: 10000,
+        data: [lastMessage],
+      });
+    const repo = new FeathersMessagesRepository({
+      service: () => ({ find }),
+    } as unknown as AgorClient);
+
+    const result = await repo.findBySessionId('session-1' as SessionID);
+
+    expect(result).toHaveLength(10001);
+    expect(result.at(-1)).toBe(lastMessage);
+    expect(find).toHaveBeenNthCalledWith(2, {
+      query: {
+        session_id: 'session-1',
+        $sort: { index: 1 },
+        $limit: 10000,
+        $skip: 10000,
       },
     });
   });

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -30,14 +30,24 @@ export class FeathersMessagesRepository {
 
   async findBySessionId(sessionId: SessionID): Promise<Message[]> {
     const service = this.client.service('messages');
-    const result = await service.find({
-      query: {
-        session_id: sessionId,
-        $sort: { index: 1 },
-        $limit: 10000,
-      },
-    });
-    return Array.isArray(result) ? result : result.data;
+    const messages: Message[] = [];
+    const pageSize = 10000;
+
+    while (true) {
+      const result = await service.find({
+        query: {
+          session_id: sessionId,
+          $sort: { index: 1 },
+          $limit: pageSize,
+          $skip: messages.length,
+        },
+      });
+
+      if (Array.isArray(result)) return result;
+
+      messages.push(...result.data);
+      if (result.data.length === 0 || messages.length >= result.total) return messages;
+    }
   }
 
   async findById(messageId: MessageID): Promise<Message | null> {

--- a/packages/executor/src/handlers/sdk/opencode.test.ts
+++ b/packages/executor/src/handlers/sdk/opencode.test.ts
@@ -128,6 +128,7 @@ describe('executeOpenCodeTask', () => {
       prompt: 'Do the work',
       permissionMode: 'default',
       abortController,
+      messageSource: 'gateway',
       dataHome: '/opaque/opencode-home',
       resolvedConfig: { execution: { permission_timeout_ms: 1234 } },
     });
@@ -165,6 +166,15 @@ describe('executeOpenCodeTask', () => {
     });
     const assistantMessageId = mocks.runTurn.mock.calls[0][0].agorAssistantMessageId;
     expect(mocks.messagesCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        role: 'user',
+        task_id: '00000000-0000-7000-8000-000000000002',
+        content: 'Do the work',
+        metadata: { source: 'gateway' },
+      })
+    );
+    expect(mocks.messagesCreate).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         message_id: assistantMessageId,
@@ -183,6 +193,62 @@ describe('executeOpenCodeTask', () => {
     expect(services.tasks.patch).toHaveBeenCalledWith(
       '00000000-0000-7000-8000-000000000002',
       expect.objectContaining({ status: 'completed', model: 'openai/gpt-test' })
+    );
+  });
+
+  it('reuses a daemon-written user message beyond the default Feathers page', async () => {
+    const order: string[] = [];
+    const { client } = createClient(order);
+    const firstPage = Array.from({ length: 10000 }, (_, index) => ({
+      message_id: `00000000-0000-7000-8000-${String(index).padStart(12, '0')}`,
+      session_id: '00000000-0000-7000-8000-000000000001',
+      task_id: `00000000-0000-7000-8001-${String(index).padStart(12, '0')}`,
+      type: 'system',
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      index,
+      timestamp: '2026-07-24T00:00:00.000Z',
+      content_preview: `Previous message ${index}`,
+      content: `Previous message ${index}`,
+    }));
+    const existingUserMessage = {
+      message_id: '00000000-0000-7000-8000-000000000004',
+      session_id: '00000000-0000-7000-8000-000000000001',
+      task_id: '00000000-0000-7000-8000-000000000002',
+      type: 'system',
+      role: 'user',
+      index: 10000,
+      timestamp: '2026-07-24T00:00:00.000Z',
+      content_preview: 'Daemon wrote this prompt',
+      content: 'Daemon wrote this prompt',
+      metadata: { is_agor_callback: true, source: 'agor' },
+    };
+    mocks.messagesFindBySession.mockResolvedValue([...firstPage, existingUserMessage]);
+    mocks.runTurn.mockResolvedValue({
+      openCodeSessionId: 'oc-existing',
+      sessionWasCreated: false,
+      finalMessage: {
+        content: 'done',
+        contentBlocks: [{ type: 'text', text: 'done' }],
+        toolUses: [],
+        metadata: {},
+      },
+    });
+
+    await executeOpenCodeTask({
+      client: client as never,
+      sessionId: '00000000-0000-7000-8000-000000000001' as never,
+      taskId: '00000000-0000-7000-8000-000000000002' as never,
+      prompt: 'Daemon wrote this prompt',
+      abortController: new AbortController(),
+      messageSource: 'agor',
+    });
+
+    expect(mocks.messagesCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.messagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'assistant',
+        index: 10001,
+      })
     );
   });
 

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -8,6 +8,7 @@ import { generateId, shortId } from '@agor/core';
 import type {
   ExecutorPulseKind,
   MessageID,
+  MessageSource,
   PermissionMode,
   SessionID,
   TaskID,
@@ -17,6 +18,7 @@ import { createFeathersBackedRepositories } from '../../db/feathers-repositories
 import type { ResolvedConfigSlice } from '../../payload-types.js';
 import { globalPermissionManager } from '../../permissions/permission-manager.js';
 import { PermissionService } from '../../permissions/permission-service.js';
+import { createUserMessage } from '../../sdk-handlers/claude/message-builder.js';
 import { OpenCodeTool } from '../../sdk-handlers/opencode/index.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 import { createStreamingCallbacks } from './base-executor.js';
@@ -28,6 +30,7 @@ export async function executeOpenCodeTask(params: {
   prompt: string;
   permissionMode?: PermissionMode;
   abortController: AbortController;
+  messageSource?: MessageSource;
   dataHome?: string;
   resolvedConfig?: ResolvedConfigSlice;
   onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
@@ -57,25 +60,10 @@ export async function executeOpenCodeTask(params: {
       throw new Error('OpenCode requires an Agor branch working directory');
     }
 
-    const existingMessages = await client.service('messages').find({
-      query: {
-        session_id: sessionId,
-        $sort: { index: 1 },
-      },
-    });
-    const messages = Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
-    const nextIndex = messages?.length || 0;
-
-    await repos.messagesService.create({
-      message_id: generateId() as MessageID,
-      session_id: sessionId,
-      task_id: taskId,
-      type: 'user' as const,
-      role: MessageRole.USER,
-      index: nextIndex,
-      timestamp: new Date().toISOString(),
-      content_preview: prompt.substring(0, 200),
-      content: prompt,
+    const messages = await repos.messages.findBySessionId(sessionId);
+    await createUserMessage(sessionId, prompt, taskId, messages.length, repos.messagesService, {
+      messageSource: params.messageSource,
+      existingMessages: messages,
     });
 
     const assistantMessageId = generateId() as MessageID;

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -186,6 +186,12 @@ export const OpenCodeAuthPayloadSchema = BasePayloadSchema.extend({
       operation: z.literal('disconnect'),
       providerId: z.string().trim().min(1).max(200),
     }),
+    z.object({
+      operation: z.literal('connect-oauth'),
+      providerId: z.string().trim().min(1).max(200),
+      method: z.number().int().nonnegative(),
+      inputs: z.record(z.string(), z.string()).optional(),
+    }),
   ]),
 });
 


### PR DESCRIPTION
## Linked issue

Architecture-review companion to #2078. Stacked on #2094, which is stacked on #2092.

## Summary

- Extend provider authentication with OAuth authorization flows.
- Carry OpenCode configuration through session creation, defaults, spawning, and executor launch boundaries.
- Add OAuth controls and state handling across the relevant settings and session surfaces.

## Why / context

This is the third historical layer of the OpenCode work now combined in #2078. It separates interactive OAuth orchestration from API-key storage in #2094 and the managed-runtime foundation in #2092.

```text
#2092 managed runtime
  └─ #2094 API-key authentication
       └─ OAuth authentication (this draft)
            └─ provider/model configuration in #2078
```

## Implementation notes

The OAuth flow keeps responsibilities separated:

| Owner | Responsibility |
|---|---|
| Agor service and UI | Authorize the caller, start the bounded flow, and expose actionable state |
| Executor boundary | Run the authentication command in the correct execution-owner namespace |
| OpenCode | Own provider-specific OAuth behavior and persist resulting credentials |

The same layer also carries the selected OpenCode configuration through existing session/default and executor-launch seams instead of adding a parallel configuration lifecycle.

This draft is a historical comparison branch. #2078 remains the cumulative integration PR and is unchanged.

## Validation / test plan

- [x] The historical OAuth commit is preserved exactly.
- [x] The comparison contains one feature commit on top of #2094's API-key layer.
- [ ] This review-only branch has not been independently rebased or revalidated against current `main`; use #2078 for current integration and CI evidence.

## Screenshots / demos

The OAuth settings and session surfaces are included, but no separate screenshots are attached to this architecture-review draft.

## Risks / rollout / rollback

Do not merge this draft independently in its current form. It exists to make OAuth and configuration propagation reviewable; #2078 owns the current integrated state, conflict resolutions, and rollout evidence.

## Out of scope / follow-ups

- Provider/model catalog and selection
- Automatic provider or model fallback
- Independent deployment of this historical layer
