### PR TITLE
fix: restore branch materialization lifecycle identity

### DIFF
--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -2,6 +2,23 @@ import type { Application } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { ReposService } from './repos';
 
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    ensureBranchStorageModeAllowed: vi.fn(),
+    resolveBranchStorageConfig: vi.fn(() => ({
+      defaultMode: 'worktree',
+      allowedModes: ['worktree', 'clone'],
+    })),
+    resolveExecutionSecurityMode: vi.fn(() => ({
+      appRbacEnabled: true,
+      shouldInitUnixGroups: true,
+    })),
+    resolveMultiTenancyConfig: vi.fn(() => ({ mode: 'disabled' })),
+  };
+});
+
 vi.mock('@agor/core/db', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor/core/db')>();
 
@@ -27,15 +44,29 @@ vi.mock('@agor/core/db', async (importOriginal) => {
   };
 });
 
-const executorMocks = vi.hoisted(() => ({ runExecutorCommand: vi.fn() }));
+const executorMocks = vi.hoisted(() => ({
+  runExecutorCommand: vi.fn(),
+  spawnExecutorFireAndForget: vi.fn(),
+}));
 vi.mock('../utils/spawn-executor.js', () => {
   return {
     runExecutorCommand: executorMocks.runExecutorCommand,
     generateScopedServiceToken: vi.fn(() => 'scoped-token'),
     getDaemonUrl: vi.fn(() => 'http://daemon'),
-    spawnExecutorFireAndForget: vi.fn(),
+    spawnExecutorFireAndForget: executorMocks.spawnExecutorFireAndForget,
   };
 });
+
+const impersonationMocks = vi.hoisted(() => ({
+  resolveExecutorReadAsUser: vi.fn(async () => 'requesting-user'),
+  resolveGitImpersonationForUser: vi.fn(async () => 'daemon-user'),
+}));
+vi.mock('../utils/executor-read-impersonation.js', () => ({
+  resolveExecutorReadAsUser: impersonationMocks.resolveExecutorReadAsUser,
+}));
+vi.mock('../utils/git-impersonation.js', () => ({
+  resolveGitImpersonationForUser: impersonationMocks.resolveGitImpersonationForUser,
+}));
 
 describe('ReposService.addLocalRepository executor boundary', () => {
   it('persists sanitized executor metadata with an explicit slug and no remote URL', async () => {
@@ -88,5 +119,69 @@ describe('ReposService.addLocalRepository executor boundary', () => {
       } as never)
     ).rejects.toThrow(/Not a valid git repository/);
     expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReposService.createBranch Git lifecycle identity', () => {
+  it('uses the Git lifecycle resolver rather than the requesting-user read resolver', async () => {
+    executorMocks.spawnExecutorFireAndForget.mockClear();
+    impersonationMocks.resolveExecutorReadAsUser.mockClear();
+    impersonationMocks.resolveGitImpersonationForUser.mockClear();
+
+    const repo = {
+      repo_id: '550e8400-e29b-41d4-a716-446655440001',
+      slug: 'preset-io/agor',
+      local_path: '/managed/repos/agor',
+      default_branch: 'main',
+    };
+    const branch = {
+      branch_id: '550e8400-e29b-41d4-a716-446655440002',
+      repo_id: repo.repo_id,
+      name: 'fix-lifecycle-identity',
+      path: '/managed/worktrees/preset-io/agor/fix-lifecycle-identity',
+      others_fs_access: 'read',
+    };
+    const branches = {
+      create: vi.fn(async () => branch),
+      find: vi.fn(async () => []),
+    };
+    const boardObjects = {
+      create: vi.fn(async () => undefined),
+      find: vi.fn(async () => ({ data: [] })),
+    };
+    const app = {
+      settings: { authentication: { secret: 'test-secret' } },
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return { get: vi.fn(async () => ({ objects: {} })) };
+        if (name === 'branches') return branches;
+        if (name === 'board-objects') return boardObjects;
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    } as unknown as Application;
+    const service = new ReposService({} as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue(repo as never);
+
+    await service.createBranch(
+      repo.repo_id,
+      {
+        name: branch.name,
+        ref: branch.name,
+        createBranch: true,
+        sourceBranch: 'main',
+        boardId: '550e8400-e29b-41d4-a716-446655440003',
+        position: { x: 10, y: 20 },
+        storage_mode: 'worktree',
+      },
+      {
+        user: { user_id: '550e8400-e29b-41d4-a716-446655440004' },
+      } as never
+    );
+
+    expect(impersonationMocks.resolveGitImpersonationForUser).toHaveBeenCalledOnce();
+    expect(impersonationMocks.resolveExecutorReadAsUser).not.toHaveBeenCalled();
+    expect(executorMocks.spawnExecutorFireAndForget).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'git.branch.add' }),
+      expect.objectContaining({ asUser: 'daemon-user' })
+    );
   });
 });

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -49,6 +49,7 @@ import { DrizzleService } from '../adapters/drizzle';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
+import { resolveGitImpersonationForUser } from '../utils/git-impersonation.js';
 import {
   generateScopedServiceToken,
   getDaemonUrl,
@@ -936,13 +937,12 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       const executionMode = resolveExecutionSecurityMode();
       const initUnixGroup = executionMode.shouldInitUnixGroups;
 
-      // Sudo wrap (asUser) is gated inside the resolver — returns undefined
-      // in simple/no-RBAC mode so hosts without passwordless sudoers work
-      // (#1140, #1143). Callers no longer duplicate the gate.
-      // Git/materialization runs as the requesting user in strict mode. Any
-      // privileged group/ACL setup is a separate daemon RPC below; in simple
-      // Cloud mode the pod/mount is the filesystem security boundary.
-      const asUser = await resolveExecutorReadAsUser(this.db, userId);
+      // Managed Git lifecycle operations must run as the daemon lifecycle
+      // identity. In strict mode the requesting user can read an initialized
+      // branch through its group/ACL, but cannot create a child beneath the
+      // daemon-owned worktree root or mutate the base repo's .git/worktrees.
+      // Keep resolveExecutorReadAsUser for read/probe commands only.
+      const asUser = await resolveGitImpersonationForUser(this.db, userId);
 
       spawnExecutorFireAndForget(
         {
@@ -962,7 +962,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         },
         {
           logPrefix: `[ReposService.createBranch ${data.name}]`,
-          asUser, // Run as resolved user (fresh groups via sudo -u)
+          asUser, // Run as lifecycle identity with fresh supplemental groups
         }
       );
     } catch (error) {


### PR DESCRIPTION
## Summary

- restore the managed Git lifecycle identity for branch materialization
- keep requesting-user impersonation limited to repository read/probe operations
- add regression coverage proving `git.branch.add` selects the lifecycle resolver

## Root cause

PR #2069 routed `git.branch.add` through `resolveExecutorReadAsUser`. In strict Unix-user mode, that executes branch materialization as the requesting user. That user cannot create a worktree beneath a daemon-managed `0755` worktree root or update the shared repository's `.git/worktrees` metadata.

This change routes the already-authorized lifecycle operation through `resolveGitImpersonationForUser` again. Existing scoped service-token authorization and trusted path construction are unchanged.

## Multi-tenancy

This does not change tenant lookup, authorization, token scope, or filesystem path routing. It corrects only the host Unix identity used for an already-authorized managed Git lifecycle operation. The tenant-scoped database lookup and daemon-controlled repository/worktree paths remain intact.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-daemon exec vitest run src/services/repos.test.ts` (3 passed)
- full daemon suite during fix validation (164 files passed, 1 skipped; 2,042 tests passed, 31 skipped)
