### PR TITLE
fix: forward delegated identity to executor reads

### DIFF
--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -2,8 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
 import { FileService } from './file.js';
 
+const impersonationMocks = vi.hoisted(() => ({
+  resolveExecutorReadAsUser: vi.fn(),
+}));
+
 vi.mock('../utils/executor-read-impersonation.js', () => ({
-  resolveExecutorReadAsUser: vi.fn().mockResolvedValue(undefined),
+  resolveExecutorReadAsUser: impersonationMocks.resolveExecutorReadAsUser,
 }));
 
 vi.mock('../utils/spawn-executor.js', () => ({
@@ -13,7 +17,10 @@ vi.mock('../utils/spawn-executor.js', () => ({
 }));
 
 describe('FileService executor failures', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    impersonationMocks.resolveExecutorReadAsUser.mockResolvedValue(undefined);
+  });
 
   it('does not report executor failure as an empty repository', async () => {
     vi.mocked(runExecutorCommand).mockResolvedValue({
@@ -36,5 +43,60 @@ describe('FileService executor failures', () => {
         },
       })
     ).rejects.toThrow('Failed to browse files: executor unavailable');
+  });
+
+  it.each([
+    {
+      operation: 'listing',
+      invoke: (service: FileService, params: Parameters<FileService['find']>[0]) =>
+        service.find(params),
+      command: 'branch.files.browse',
+      data: { files: [] },
+    },
+    {
+      operation: 'reading/preview',
+      invoke: (service: FileService, params: Parameters<FileService['get']>[1]) =>
+        service.get('README.md', params),
+      command: 'branch.files.read',
+      data: {
+        file: {
+          path: 'README.md',
+          title: 'README',
+          size: 0,
+          lastModified: '2026-07-30T00:00:00.000Z',
+          isText: true,
+          mimeType: 'text/markdown',
+          content: '',
+          encoding: 'utf-8',
+        },
+      },
+    },
+  ])('passes the resolved execution-substrate identity through file $operation', async ({
+    invoke,
+    command,
+    data,
+  }) => {
+    impersonationMocks.resolveExecutorReadAsUser.mockResolvedValue('alice');
+    vi.mocked(runExecutorCommand).mockResolvedValue({ success: true, data });
+    const service = new FileService(
+      { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
+      null as never,
+      { settings: { authentication: { secret: 'test' } } } as never
+    );
+    const params = {
+      query: { branch_id: 'branch-1' },
+      user: {
+        user_id: 'user-1',
+        email: 'member@example.com',
+        role: 'member' as const,
+      },
+    };
+
+    await invoke(service, params);
+
+    expect(runExecutorCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ command }),
+      expect.objectContaining({ asUser: 'alice' })
+    );
   });
 });

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.test.ts
@@ -52,9 +52,39 @@ describe('resolveExecutorReadAsUser', () => {
     await expect(resolveExecutorReadAsUser(db, user)).resolves.toBe('alice');
   });
 
+  it('reports the requesting unix_username to a delegated executor command template', async () => {
+    mocks.loadConfigSync.mockReturnValue({
+      execution: {
+        unix_user_mode: 'delegated',
+        executor_command_template: 'launcher --user {unix_user} -- agor-executor --stdin',
+      },
+    });
+    mocks.findById.mockResolvedValue(user);
+
+    await expect(resolveExecutorReadAsUser(db, user.user_id)).resolves.toBe('alice');
+    expect(mocks.findById).toHaveBeenCalledWith(user.user_id);
+  });
+
+  it('does not turn delegated local execution into sudo impersonation', async () => {
+    mocks.loadConfigSync.mockReturnValue({ execution: { unix_user_mode: 'delegated' } });
+    await expect(resolveExecutorReadAsUser(db, user)).resolves.toBeUndefined();
+  });
+
   it('loads a user id and fails clearly when strict mode lacks unix_username', async () => {
     mocks.loadConfigSync.mockReturnValue({ execution: { unix_user_mode: 'strict' } });
     mocks.findById.mockResolvedValue({ user_id: user.user_id });
+    await expect(resolveExecutorReadAsUser(db, user.user_id)).rejects.toThrow(/unix_username/);
+  });
+
+  it('fails before launch when a delegated command template lacks unix_username', async () => {
+    mocks.loadConfigSync.mockReturnValue({
+      execution: {
+        unix_user_mode: 'delegated',
+        executor_command_template: 'launcher --user {unix_user} -- agor-executor --stdin',
+      },
+    });
+    mocks.findById.mockResolvedValue({ user_id: user.user_id });
+
     await expect(resolveExecutorReadAsUser(db, user.user_id)).rejects.toThrow(/unix_username/);
   });
 });

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.ts
@@ -1,6 +1,7 @@
 import { loadConfigSync } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import type { User, UserID } from '@agor/core/types';
+import { resolveUnixUserForImpersonation } from '@agor/core/unix';
 
 /**
  * Resolve the optional `asUser` for short-lived executor read/probe commands.
@@ -35,11 +36,17 @@ export async function resolveExecutorReadAsUser(
     user = userOrId;
   }
 
-  if (!user?.unix_username) {
-    throw new Error(
-      'execution.unix_user_mode=strict requires the requesting user to have unix_username configured'
-    );
-  }
+  const resolved = resolveUnixUserForImpersonation({
+    mode: unixMode,
+    userUnixUsername: user?.unix_username,
+    executorUnixUser: config.execution?.executor_unix_user,
+  });
 
-  return user.unix_username;
+  // `asUser` serves two transport-specific roles in runExecutorCommand:
+  // local execution uses it for sudo impersonation, while templated execution
+  // reports it as `{unix_user}` to the external substrate. The canonical
+  // resolver deliberately separates those identities in delegated mode.
+  return unixMode === 'delegated'
+    ? (resolved.reportedUnixUser ?? undefined)
+    : (resolved.unixUser ?? undefined);
 }

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.ts
@@ -7,9 +7,11 @@ import type { User, UserID } from '@agor/core/types';
  *
  * These commands are not long-running agent sessions and should not force sudo
  * on default installs. In `insulated` mode, leaving this undefined allows the
- * globally configured executor_unix_user to apply. Only `strict` requires the
+ * globally configured executor_unix_user to apply. `strict` requires the
  * caller's Unix identity so reads happen with the same OS-level access as the
- * requesting user.
+ * requesting user. `delegated` needs that identity only when a command template
+ * hands execution to the external substrate; local delegated execution must
+ * continue to run as the daemon user rather than attempting sudo.
  */
 export async function resolveExecutorReadAsUser(
   db: TenantScopeAwareDatabase,
@@ -17,8 +19,11 @@ export async function resolveExecutorReadAsUser(
 ): Promise<string | undefined> {
   const config = loadConfigSync();
   const unixMode = config.execution?.unix_user_mode ?? 'simple';
+  const needsRequestingUser =
+    unixMode === 'strict' ||
+    (unixMode === 'delegated' && Boolean(config.execution?.executor_command_template));
 
-  if (unixMode !== 'strict') {
+  if (!needsRequestingUser) {
     return undefined;
   }
 

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -118,6 +118,35 @@ describe('configured executor spawning', () => {
     );
   });
 
+  it('forwards a delegated read identity through a configured command template', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { runExecutorCommand } = await import('./spawn-executor');
+    const promise = runExecutorCommand(
+      { command: 'branch.files.browse' },
+      {
+        executorCommandTemplate: 'launch --user {unix_user} -- {command}',
+        asUser: 'alice',
+      }
+    );
+
+    proc.stdout.emit(
+      'data',
+      Buffer.from('AGOR_EXECUTOR_RESULT {"success":true,"data":{"files":[]}}\n')
+    );
+    proc.emit('exit', 0);
+
+    await expect(promise).resolves.toEqual({
+      success: true,
+      data: { files: [] },
+    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'launch --user alice -- branch.files.browse'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+  });
+
   it('calls onExit for templated spawns', async () => {
     const proc = createMockProcess();
     spawnMock.mockReturnValue(proc);

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -290,6 +290,31 @@ describe('configured executor spawning', () => {
     expect(vi.mocked(console.error).mock.calls.flat().join(' ')).not.toContain(secret);
   });
 
+  it('preserves the exit-0/no-result protocol failure diagnostic', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { runExecutorCommand } = await import('./spawn-executor');
+    const promise = runExecutorCommand(
+      { command: 'branch.files.browse' },
+      { executorCommandTemplate: 'launch --user {unix_user} -- {command}' }
+    );
+
+    proc.emit('exit', 0);
+
+    await expect(promise).resolves.toEqual({
+      success: false,
+      error: {
+        code: 'EXECUTOR_RESULT_MISSING',
+        message: 'Executor exited with code 0 but did not emit a JSON result',
+        details: {
+          command: 'branch.files.browse',
+          exitCode: 0,
+          stderr: '',
+        },
+      },
+    });
+  });
+
   it('refuses every unscoped executor launch when tenant context is required', async () => {
     const { configureExecutor, spawnExecutor } = await import('./spawn-executor');
     configureExecutor(null, { requireTenantContext: true });


### PR DESCRIPTION
## Summary

- forward the requesting user's Unix identity to short-lived executor commands in delegated mode when an executor command template is configured
- keep local delegated execution on the daemon user so the change does not introduce sudo impersonation
- cover BranchModal file listing and file preview reads, plus the exact exit-0/no-JSON-result diagnostic

## Root cause

Delegated Unix-user mode taught long-running executor sessions to report the requesting user's `unix_username` to the external execution substrate through `{unix_user}`. Short-lived executor reads and probes still only resolved an identity in strict mode.

In hosted delegated deployments, `{unix_user}` was therefore left unresolved for `branch.files.browse` and `branch.files.read`. The launcher could exit successfully without starting `agor-executor`, leaving the daemon with exit code 0 and no `AGOR_EXECUTOR_RESULT` line.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-daemon exec vitest run src/utils/executor-read-impersonation.test.ts src/services/file.test.ts src/services/files.test.ts src/utils/spawn-executor.configured.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/commands/files.test.ts src/commands/index.test.ts src/payload-types.test.ts`

Focused results: 34 daemon tests and 57 executor tests passed.
