### PR TITLE
refactor: type branch authorization utilities

### DIFF
--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -15,15 +15,19 @@ import type {
   BranchRepository,
   ScheduleRepository,
   SessionRepository,
+  UsersRepository,
 } from '@agor/core/db';
-import { shortId } from '@agor/core/db';
+import { isValidUUID, shortId } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
 import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
+  BaseService,
   Branch,
   BranchID,
   BranchPermissionLevel,
   HookContext,
+  RBACParams,
   Session,
   UUID,
 } from '@agor/core/types';
@@ -68,16 +72,28 @@ interface RequestScopedRbacCache {
   >;
 }
 
-type PrefetchParams = AuthenticatedParams & {
-  branch?: Branch;
-  session?: Session;
+interface PrefetchParams extends RBACParams {
   _agorRbacCache?: RequestScopedRbacCache;
   _agorPrefetchedRecord?: {
     id: string;
     idField: string;
     record: unknown;
   };
-};
+}
+
+function readField(value: unknown, field: string): unknown {
+  return typeof value === 'object' && value !== null ? Reflect.get(value, field) : undefined;
+}
+
+function readStringField(value: unknown, field: string): string | undefined {
+  const fieldValue = readField(value, field);
+  return typeof fieldValue === 'string' ? fieldValue : undefined;
+}
+
+function readUuidField(value: unknown, field: string): UUID | undefined {
+  const fieldValue = readStringField(value, field);
+  return fieldValue && isValidUUID(fieldValue) ? fieldValue : undefined;
+}
 
 function getRequestRbacCache(params: AuthenticatedParams): RequestScopedRbacCache {
   const prefetchParams = params as PrefetchParams;
@@ -130,11 +146,10 @@ function rememberPrefetchedRecord(
 
 async function loadCachedSession(
   params: AuthenticatedParams,
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
-  sessionService: any,
+  sessionService: Pick<BaseService<Session>, 'get'>,
   sessionId: string
 ): Promise<Session> {
-  const cachedParamSession = (params as PrefetchParams).session as Session | undefined;
+  const cachedParamSession = (params as PrefetchParams).session;
   if (cachedParamSession?.session_id === sessionId) {
     return cachedParamSession;
   }
@@ -143,7 +158,7 @@ async function loadCachedSession(
   const cached = cache.sessions.get(sessionId);
   if (cached) return cached;
 
-  const session = (await sessionService.get(sessionId, { provider: undefined })) as Session | null;
+  const session = await sessionService.get(sessionId, { provider: undefined });
   if (!session) {
     throw new Forbidden(`Session not found: ${sessionId}`);
   }
@@ -378,13 +393,11 @@ export function loadBranch(branchRepo: BranchRepository, branchIdField = 'branch
     // Extract branch_id from data or query
     let branchId: string | undefined;
 
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const data = context.data as any;
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const query = context.params.query as any;
+    const data = context.data;
+    const query = context.params.query;
 
-    if (context.method === 'create' && data?.[branchIdField]) {
-      branchId = data[branchIdField];
+    if (context.method === 'create' && readStringField(data, branchIdField)) {
+      branchId = readStringField(data, branchIdField);
     } else if (context.id) {
       // For get/patch/remove, branch_id might be the ID itself (for branches service)
       // or we need to load the parent resource (for sessions/tasks/messages)
@@ -392,10 +405,10 @@ export function loadBranch(branchRepo: BranchRepository, branchIdField = 'branch
         branchId = context.id as string;
       } else {
         // For nested resources, branch_id should be in data/query
-        branchId = data?.[branchIdField] || query?.[branchIdField];
+        branchId = readStringField(data, branchIdField) ?? readStringField(query, branchIdField);
       }
-    } else if (query?.[branchIdField]) {
-      branchId = query[branchIdField];
+    } else if (readStringField(query, branchIdField)) {
+      branchId = readStringField(query, branchIdField);
     }
 
     if (!branchId) {
@@ -591,10 +604,7 @@ export function paginateClientSide<T>(
   let filtered = rows;
   for (const [key, value] of Object.entries(q)) {
     if (key.startsWith('$') || skipFilterKeys.has(key)) continue;
-    filtered = filtered.filter(
-      // biome-ignore lint/suspicious/noExplicitAny: dynamic property access for generic query filtering
-      (item: any) => item[key] === value
-    );
+    filtered = filtered.filter((item) => readField(item, key) === value);
   }
 
   // 2. $sort with null-safe comparison.
@@ -807,8 +817,7 @@ export function filterBranchesByPermission(branchRepo: BranchRepository) {
  * @returns Feathers hook
  */
 export function loadSessionBranch(
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
-  sessionService: any, // Type as FeathersService if available
+  sessionService: Pick<BaseService<Session>, 'get'>,
   branchRepo: BranchRepository
 ) {
   return async (context: HookContext) => {
@@ -820,13 +829,11 @@ export function loadSessionBranch(
     // Extract session_id from data, query, or id
     let sessionId: string | undefined;
 
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const data = context.data as any;
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const query = context.params.query as any;
+    const data = context.data;
+    const query = context.params.query;
 
-    if (context.method === 'create' && data?.session_id) {
-      sessionId = data.session_id;
+    if (context.method === 'create' && readStringField(data, 'session_id')) {
+      sessionId = readStringField(data, 'session_id');
     } else if (context.id) {
       // For get/patch/remove on sessions
       if (context.path === 'sessions') {
@@ -838,11 +845,10 @@ export function loadSessionBranch(
         // task/message that actually belongs to a different session.
         if (context.method === 'get' || context.method === 'patch' || context.method === 'remove') {
           try {
-            // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
-            const existingRecord = await (context.service as any).get(context.id, {
+            const existingRecord: unknown = await context.service.get(context.id, {
               provider: undefined, // Bypass provider to avoid recursion
             });
-            sessionId = existingRecord?.session_id;
+            sessionId = readStringField(existingRecord, 'session_id');
             const idField = inferIdFieldForPath(context.path);
             if (existingRecord && idField) {
               rememberPrefetchedRecord(context, existingRecord, idField, String(context.id));
@@ -855,11 +861,11 @@ export function loadSessionBranch(
           }
         } else {
           // For create/find on nested resources, session_id should be in data/query.
-          sessionId = data?.session_id || query?.session_id;
+          sessionId = readStringField(data, 'session_id') ?? readStringField(query, 'session_id');
         }
       }
-    } else if (query?.session_id) {
-      sessionId = query.session_id;
+    } else if (readStringField(query, 'session_id')) {
+      sessionId = readStringField(query, 'session_id');
     }
 
     if (!sessionId) {
@@ -901,15 +907,13 @@ export function resolveSessionContext() {
 
     let sessionId: string | undefined;
 
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const data = context.data as any;
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const query = context.params.query as any;
+    const data = context.data;
+    const query = context.params.query;
 
     // Sessions service - session_id IS the record ID
     if (context.path === 'sessions') {
       if (context.method === 'create') {
-        sessionId = data?.session_id;
+        sessionId = readStringField(data, 'session_id');
       } else if (context.id) {
         sessionId = context.id as string;
       }
@@ -917,7 +921,7 @@ export function resolveSessionContext() {
     // Tasks/Messages services - session_id is a foreign key
     else if (context.path === 'tasks' || context.path === 'messages') {
       if (context.method === 'create') {
-        sessionId = data?.session_id;
+        sessionId = readStringField(data, 'session_id');
       } else if (
         context.method === 'get' ||
         context.method === 'patch' ||
@@ -929,11 +933,10 @@ export function resolveSessionContext() {
         // this safety read does not add a second primary-key read later.
         if (context.id) {
           try {
-            // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type
-            const existing = await (context.service as any).get(context.id, {
+            const existing: unknown = await context.service.get(context.id, {
               provider: undefined,
             });
-            sessionId = existing?.session_id;
+            sessionId = readStringField(existing, 'session_id');
             const idField = inferIdFieldForPath(context.path);
             if (existing && idField) {
               rememberPrefetchedRecord(context, existing, idField, String(context.id));
@@ -943,7 +946,7 @@ export function resolveSessionContext() {
           }
         }
       } else if (context.method === 'find') {
-        sessionId = query?.session_id;
+        sessionId = readStringField(query, 'session_id');
       }
     }
 
@@ -970,10 +973,7 @@ export function resolveSessionContext() {
  *
  * @param sessionService - FeathersJS sessions service
  */
-export function loadSession(
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type
-  sessionService: any
-) {
+export function loadSession(sessionService: Pick<BaseService<Session>, 'get'>) {
   return async (context: HookContext) => {
     // Skip for internal calls
     if (!context.params.provider) {
@@ -1051,18 +1051,17 @@ export function ensureSessionImmutability() {
       return context;
     }
 
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context extension
-    const data = context.data as any;
+    const data = context.data;
 
     // Check if created_by is being changed
-    if (data?.created_by !== undefined) {
+    if (readField(data, 'created_by') !== undefined) {
       throw new Forbidden(
         'session.created_by is immutable - it determines execution context (Unix user, credentials, SDK state)'
       );
     }
 
     // Check if unix_username is being changed
-    if (data?.unix_username !== undefined) {
+    if (readField(data, 'unix_username') !== undefined) {
       throw new Forbidden(
         'session.unix_username is immutable - it determines SDK session storage location and execution user'
       );
@@ -1121,8 +1120,7 @@ export function resolveChildUnixUsername(
  * @returns The user's current `unix_username`, or `null` if they don't have one set
  */
 export async function loadUnixUsernameForUser(
-  // biome-ignore lint/suspicious/noExplicitAny: UsersRepository type lives in @agor/core/db but both callers pass compatible instances
-  userRepo: any,
+  userRepo: Pick<UsersRepository, 'findById'>,
   userId: string
 ): Promise<string | null> {
   const user = await userRepo.findById(userId);
@@ -1153,8 +1151,7 @@ export async function loadUnixUsernameForUser(
  *   instead of failing later at prompt time.
  */
 export function setSessionUnixUsername(
-  // biome-ignore lint/suspicious/noExplicitAny: UserRepository type
-  userRepo: any,
+  userRepo: Pick<UsersRepository, 'findById'>,
   unixUserMode?: UnixUserMode
 ) {
   return async (context: HookContext) => {
@@ -1168,8 +1165,6 @@ export function setSessionUnixUsername(
       return context;
     }
 
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers context data is dynamic
-    const data = context.data as any;
     const userId = context.params.user?.user_id;
 
     if (!userId) {
@@ -1178,9 +1173,13 @@ export function setSessionUnixUsername(
 
     // Stamp session with creator's current unix_username.
     // IMMUTABLE - even if user's unix_username changes later, session keeps this value.
-    data.unix_username = await loadUnixUsernameForUser(userRepo, userId);
+    const unixUsername = await loadUnixUsernameForUser(userRepo, userId);
+    if (typeof context.data !== 'object' || context.data === null) {
+      throw new Error('Session create data is required');
+    }
+    Reflect.set(context.data, 'unix_username', unixUsername);
     if (unixUserMode) {
-      assertUnixUsernameSatisfiesMode(data.unix_username, unixUserMode);
+      assertUnixUsernameSatisfiesMode(unixUsername, unixUserMode);
     }
 
     return context;
@@ -1202,10 +1201,7 @@ export function setSessionUnixUsername(
  *
  * @param userRepo - UserRepository instance
  */
-export function validateSessionUnixUsername(
-  // biome-ignore lint/suspicious/noExplicitAny: UserRepository type
-  userRepo: any
-) {
+export function validateSessionUnixUsername(userRepo: Pick<UsersRepository, 'findById'>) {
   return async (context: HookContext) => {
     // Only validate for operations that will execute code (create tasks/messages)
     if (context.method !== 'create') return context;
@@ -1271,8 +1267,7 @@ export function validateSessionUnixUsername(
 export async function ensureCanPromptTargetSession(
   sessionId: string,
   userId: string,
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS app type
-  app: { service(name: string): any },
+  app: Application,
   branchRepo: BranchRepository
 ): Promise<Session> {
   // Load target session
@@ -1520,8 +1515,7 @@ function intersectFindQuery(
   field: string,
   accessibleIds: Set<string>
 ): HookContext {
-  // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
-  const query = (context.params.query ?? {}) as any;
+  const query: Record<string, unknown> = context.params.query ?? {};
   const existing = query[field];
 
   if (typeof existing === 'string') {
@@ -1529,8 +1523,11 @@ function intersectFindQuery(
     return context;
   }
 
-  if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
-    const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
+  const existingIn = readField(existing, '$in');
+  if (Array.isArray(existingIn)) {
+    const intersect = existingIn.filter(
+      (id): id is string => typeof id === 'string' && accessibleIds.has(id)
+    );
     if (intersect.length === 0) return emptyFindResult(context);
     query[field] = { $in: intersect };
     context.params.query = query;
@@ -1909,17 +1906,21 @@ export function scopeScheduleQuery(
     // Lift query filters that the repository understands (pushed into
     // the SQL JOIN for efficiency); the rest go through the generic
     // client-side filter pass below.
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers query is loosely-typed
-    const q = (context.params.query ?? {}) as any;
+    const q: Record<string, unknown> = context.params.query ?? {};
+    const branchId = readUuidField(q, 'branch_id');
+    const createdBy = readUuidField(q, 'created_by');
+    if ((q.branch_id !== undefined && !branchId) || (q.created_by !== undefined && !createdBy)) {
+      return emptyFindResult(context);
+    }
     const filter = {
-      branch_id: q.branch_id,
+      branch_id: branchId,
       enabled:
         q.enabled === true || q.enabled === 'true'
           ? true
           : q.enabled === false || q.enabled === 'false'
             ? false
             : undefined,
-      created_by: q.created_by,
+      created_by: createdBy,
     };
 
     const allSchedules = isSuperAdmin(userRole, allowSuperadmin)
@@ -1930,7 +1931,7 @@ export function scopeScheduleQuery(
     // pass the rest of the query through the shared paginate+sort helper.
     context.result = paginateClientSide(
       allSchedules,
-      q as Record<string, unknown>,
+      q,
       new Set(['branch_id', 'enabled', 'created_by'])
     );
     return context;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "load:fixtures": "tsx scripts/load-fixtures.ts",
     "sync:agor-live-deps": "node scripts/sync-agor-live-deps.mjs",
     "check:agor-live-deps": "node scripts/sync-agor-live-deps.mjs --check",
-    "check:multitenancy-boundaries": "node scripts/check-multitenancy-boundaries.mjs"
+    "check:multitenancy-boundaries": "node scripts/check-multitenancy-boundaries.mjs",
+    "typing:budget": "node scripts/typing-budget.mjs",
+    "typing:budget:update": "node scripts/typing-budget.mjs --update"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -26,7 +26,7 @@ export const compare = bcryptjs.compare;
 export const hash = bcryptjs.hash;
 
 // ID utilities (re-exported from lib for convenience)
-export { generateId, IdResolutionError, resolveShortId, shortId } from '../lib/ids';
+export { generateId, IdResolutionError, isValidUUID, resolveShortId, shortId } from '../lib/ids';
 
 // Slug utilities
 export { generateSlug, generateUniqueSlug, identifyUrlParam, isShortId } from '../lib/slugs';

--- a/scripts/typing-budget-baseline.json
+++ b/scripts/typing-budget-baseline.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "./typing-budget-baseline.schema.json",
+  "methodology": "TypeScript compiler API over production TS/TSX source roots; tests, specs, fixtures, mocks, stories, and generated/build directories excluded.",
+  "workspaces": {
+    "apps/agor-cli": {
+      "explicitAny": 3,
+      "asAny": 3,
+      "doubleAssertion": 1,
+      "nonNullAssertion": 2,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 3
+    },
+    "apps/agor-daemon": {
+      "explicitAny": 142,
+      "asAny": 52,
+      "doubleAssertion": 155,
+      "nonNullAssertion": 79,
+      "tsExpectError": 3,
+      "typingBiomeIgnore": 113
+    },
+    "apps/agor-docs": {
+      "explicitAny": 0,
+      "asAny": 0,
+      "doubleAssertion": 1,
+      "nonNullAssertion": 0,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 0
+    },
+    "apps/agor-ui": {
+      "explicitAny": 14,
+      "asAny": 4,
+      "doubleAssertion": 72,
+      "nonNullAssertion": 25,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 14
+    },
+    "packages/client": {
+      "explicitAny": 0,
+      "asAny": 0,
+      "doubleAssertion": 0,
+      "nonNullAssertion": 2,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 0
+    },
+    "packages/core": {
+      "explicitAny": 44,
+      "asAny": 25,
+      "doubleAssertion": 51,
+      "nonNullAssertion": 37,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 43
+    },
+    "packages/executor": {
+      "explicitAny": 4,
+      "asAny": 0,
+      "doubleAssertion": 13,
+      "nonNullAssertion": 46,
+      "tsExpectError": 4,
+      "typingBiomeIgnore": 3
+    },
+    "packages/git": {
+      "explicitAny": 0,
+      "asAny": 0,
+      "doubleAssertion": 0,
+      "nonNullAssertion": 2,
+      "tsExpectError": 0,
+      "typingBiomeIgnore": 0
+    }
+  }
+}

--- a/scripts/typing-budget-baseline.json
+++ b/scripts/typing-budget-baseline.json
@@ -11,12 +11,12 @@
       "typingBiomeIgnore": 3
     },
     "apps/agor-daemon": {
-      "explicitAny": 142,
-      "asAny": 52,
+      "explicitAny": 122,
+      "asAny": 40,
       "doubleAssertion": 155,
       "nonNullAssertion": 79,
       "tsExpectError": 3,
-      "typingBiomeIgnore": 113
+      "typingBiomeIgnore": 93
     },
     "apps/agor-docs": {
       "explicitAny": 0,

--- a/scripts/typing-budget-baseline.schema.json
+++ b/scripts/typing-budget-baseline.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["workspaces"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "methodology": { "type": "string" },
+    "workspaces": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "explicitAny",
+          "asAny",
+          "doubleAssertion",
+          "nonNullAssertion",
+          "tsExpectError",
+          "typingBiomeIgnore"
+        ],
+        "additionalProperties": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/typing-budget.mjs
+++ b/scripts/typing-budget.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Count TypeScript escape hatches in production source and compare them with
+ * the checked-in baseline.
+ *
+ * Usage:
+ *   pnpm typing:budget
+ *   pnpm typing:budget:update
+ *
+ * Syntax nodes are counted with the TypeScript compiler API. Directives are
+ * counted from comments because they are trivia rather than AST nodes.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = path.resolve(new URL('..', import.meta.url).pathname);
+const BASELINE_PATH = path.join(ROOT, 'scripts/typing-budget-baseline.json');
+const UPDATE = process.argv.includes('--update');
+
+const WORKSPACES = {
+  'apps/agor-cli': ['src', 'bin'],
+  'apps/agor-daemon': ['src'],
+  'apps/agor-docs': ['app', 'components', 'lib'],
+  'apps/agor-ui': ['src'],
+  'packages/client': ['src'],
+  'packages/core': ['src'],
+  'packages/executor': ['src', 'bin'],
+  'packages/git': ['src'],
+};
+
+const CATEGORIES = [
+  'explicitAny',
+  'asAny',
+  'doubleAssertion',
+  'nonNullAssertion',
+  'tsExpectError',
+  'typingBiomeIgnore',
+];
+
+const SOURCE_EXTENSION = /\.(?:[cm]?ts|tsx)$/;
+const EXCLUDED_DIRECTORY = /^(?:node_modules|dist|build|coverage|test|tests|__tests__|fixtures)$/;
+const EXCLUDED_FILE =
+  /(?:^|\.)(?:test|spec|stories|fixture|fixtures|mock|mocks)(?:\.[^.]+)?\.(?:[cm]?ts|tsx)$/;
+
+// Biome rules whose suppression directly relaxes TypeScript typing.
+const TYPING_BIOME_RULE =
+  /\b(?:noExplicitAny|noNonNullAssertion|noUnsafeDeclarationMerging|useUnknownInCatchVariables|noBannedTypes)\b/;
+
+function emptyCounts() {
+  return Object.fromEntries(CATEGORIES.map((category) => [category, 0]));
+}
+
+function walk(directory) {
+  if (!statSync(directory, { throwIfNoEntry: false })?.isDirectory()) return [];
+
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && EXCLUDED_DIRECTORY.test(entry.name)) continue;
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...walk(fullPath));
+    else if (
+      entry.isFile() &&
+      SOURCE_EXTENSION.test(entry.name) &&
+      !EXCLUDED_FILE.test(entry.name)
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function unwrapParentheses(node) {
+  while (ts.isParenthesizedExpression(node)) node = node.expression;
+  return node;
+}
+
+function countFile(filePath, counts) {
+  const text = readFileSync(filePath, 'utf8');
+  const scriptKind = filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, scriptKind);
+
+  function visit(node) {
+    if (node.kind === ts.SyntaxKind.AnyKeyword) counts.explicitAny++;
+    if (ts.isAsExpression(node)) {
+      if (node.type.kind === ts.SyntaxKind.AnyKeyword) counts.asAny++;
+
+      const inner = unwrapParentheses(node.expression);
+      if (ts.isAsExpression(inner) && inner.type.kind === ts.SyntaxKind.UnknownKeyword) {
+        counts.doubleAssertion++;
+      }
+    }
+    if (ts.isNonNullExpression(node)) counts.nonNullAssertion++;
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+
+  // These directive spellings are meaningful only in comments in TypeScript
+  // source; line matching also handles comments not attached to an AST node.
+  counts.tsExpectError += [...text.matchAll(/@ts-expect-error\b/g)].length;
+  for (const match of text.matchAll(/biome-ignore[^\r\n]*/g)) {
+    if (TYPING_BIOME_RULE.test(match[0])) counts.typingBiomeIgnore++;
+  }
+}
+
+function collect() {
+  return Object.fromEntries(
+    Object.entries(WORKSPACES).map(([workspace, sourceRoots]) => {
+      const counts = emptyCounts();
+      for (const sourceRoot of sourceRoots) {
+        for (const file of walk(path.join(ROOT, workspace, sourceRoot))) countFile(file, counts);
+      }
+      return [workspace, counts];
+    })
+  );
+}
+
+function printTable(workspaces) {
+  console.table(
+    Object.fromEntries(
+      Object.entries(workspaces).map(([workspace, counts]) => [
+        workspace,
+        {
+          any: counts.explicitAny,
+          'as any': counts.asAny,
+          'as unknown as': counts.doubleAssertion,
+          '!': counts.nonNullAssertion,
+          '@ts-expect-error': counts.tsExpectError,
+          'biome-ignore': counts.typingBiomeIgnore,
+        },
+      ])
+    )
+  );
+}
+
+const observed = collect();
+printTable(observed);
+
+if (UPDATE) {
+  const baseline = {
+    $schema: './typing-budget-baseline.schema.json',
+    methodology:
+      'TypeScript compiler API over production TS/TSX source roots; tests, specs, fixtures, mocks, stories, and generated/build directories excluded.',
+    workspaces: observed,
+  };
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`);
+  console.log(`Updated ${path.relative(ROOT, BASELINE_PATH)}`);
+  process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+let failed = false;
+for (const [workspace, counts] of Object.entries(observed)) {
+  const allowed = baseline.workspaces?.[workspace];
+  if (!allowed) {
+    console.error(`[typing-budget] ${workspace}: missing from baseline`);
+    failed = true;
+    continue;
+  }
+  for (const category of CATEGORIES) {
+    if (counts[category] > allowed[category]) {
+      console.error(
+        `[typing-budget] ${workspace}.${category} increased: ${counts[category]} (baseline ${allowed[category]})`
+      );
+      failed = true;
+    } else if (counts[category] < allowed[category]) {
+      console.log(
+        `[typing-budget] ${workspace}.${category} improved: ${counts[category]} (baseline ${allowed[category]}); run pnpm typing:budget:update`
+      );
+    }
+  }
+}
+
+if (failed) {
+  console.error(
+    '\nTyping budget exceeded. Remove the regression or deliberately update the baseline.'
+  );
+  process.exit(1);
+}
+console.log('[typing-budget] ok');


### PR DESCRIPTION
## Summary

- remove all 20 explicit `any` occurrences (including all 12 `as any` assertions) from `branch-authorization.ts`
- replace dynamic Feathers data/query access with `unknown`-based runtime narrowing
- type session/user/application dependencies with existing canonical service and repository types
- update the checked-in typing budget to lock in the reduction

## Canonical type audit

| Resolved shape | Canonical type and location | Resolution |
| --- | --- | --- |
| Request params carrying cached branch/session RBAC state | `RBACParams` in `packages/core/src/types/feathers.ts` | Existed as-is. `PrefetchParams` now extends it instead of redeclaring `branch` and `session`; only this utility's private prefetch/cache fields remain local. |
| Loaded branch/session rows | `Branch` / `Session` in `packages/core/src/types/branch.ts` and `packages/core/src/types/session.ts` | Existed as-is and are used directly in caches and service results. |
| Sessions service read surface | `BaseService<Session>` in `packages/core/src/types/feathers.ts` | Existed as-is. The helpers accept `Pick<BaseService<Session>, 'get'>`, matching the single method they require. |
| Users repository read surface | `UsersRepository` in `packages/core/src/db/repositories/users.ts` | Existed as-is. The helpers accept `Pick<UsersRepository, 'findById'>`, matching the single method they require. |
| Feathers application used for session lookup | `Application` re-exported by `packages/core/src/feathers/index.ts` | Existed as-is and replaces the local `{ service(name: string): any }` shape. |
| IDs read from dynamic schedule queries | `UUID` in `packages/core/src/types/id.ts`, narrowed by `isValidUUID` in `packages/core/src/lib/ids.ts` | Both existed as-is. `isValidUUID` was already canonical but was not exposed from the existing `@agor/core/db` ID-utility barrel, so this PR adds that small export rather than duplicating validation or asserting. |
| Dynamic Feathers data, query, and generic row fields | `unknown` plus runtime narrowing | No entity type applies before the hook path/method determines the record kind. These are narrowed with generic field readers rather than inventing a local branch/session/task/message union or asserting a record shape. |

No conflicting canonical definitions were found.

## Call-site scope

No direct call-site edits were required: existing callers already pass the canonical implementations.

- `register-hooks.ts`: `loadSession`, `loadSessionBranch`, `setSessionUnixUsername`, `validateSessionUnixUsername`, and `ensureCanPromptTargetSession`
- `mcp/tools/sessions.ts`: `ensureCanPromptTargetSession`
- session identity paths in `services/sessions.ts` continue to call `loadUnixUsernameForUser` with `UsersRepository`

No known call sites were left for follow-up. There was no broad repository sweep.

## Typing budget

Before:

| workspace | explicit any | as any | typing biome-ignore |
| --- | ---: | ---: | ---: |
| `apps/agor-daemon` | 142 | 52 | 113 |

After:

| workspace | explicit any | as any | typing biome-ignore |
| --- | ---: | ---: | ---: |
| `apps/agor-daemon` | 122 | 40 | 93 |

All other workspace/category counts are unchanged. `scripts/typing-budget-baseline.json` was updated to lock in the lower values.

## Behavioral review

No behavioral bug was discovered and no intended runtime behavior was changed. Invalid UUID schedule filters now short-circuit to the same empty result they previously produced through the repository query, while allowing the values to be narrowed without an assertion.

The request-scoped caches remain request-local and tenant-owned branch/session reads continue through the existing tenant-scoped repositories/services; no tenant boundary or identity propagation changed.

## Validation

- `pnpm typing:budget`
- `pnpm typecheck`
- `pnpm lint`
- daemon Vitest suite: 164 files passed, 1 skipped; 2043 tests passed, 31 skipped
- `pnpm check:multitenancy-boundaries`
