### PR TITLE
feat(core): per-user primary teammate branch (data model + resolver)

### DIFF
--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -1306,6 +1306,29 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find a single branch by ID only when it is visible to the user.
+   *
+   * Same predicate as findAccessibleBranches, scoped to one id. Mirrors the
+   * accessiblePrimaryTeammateExists check used to resolve boards'
+   * primary_teammate_id across board boundaries. Returns null when the branch
+   * is missing or the user has no access.
+   */
+  async findAccessibleById(branchId: string, userId: UUID): Promise<Branch | null> {
+    const rows = await select(this.db, getTableColumns(branches))
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(this.db, userId)))
+      .all();
+
+    if (rows.length === 0) return null;
+    const baseUrl = await getBaseUrl();
+    return this.rowToBranch(rows[0] as BranchRow, baseUrl);
+  }
+
+  /**
    * Find branch IDs pinned to a specific board zone.
    *
    * Zone membership lives on board_objects.data.zone_id, not on the branches

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -41,4 +41,5 @@ export * from './thread-session-map';
 export * from './uploads';
 export * from './user-api-keys';
 export * from './user-mcp-oauth-tokens';
+export * from './user-primary-teammate';
 export * from './users';

--- a/packages/core/src/db/repositories/user-primary-teammate.test.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.test.ts
@@ -1,0 +1,163 @@
+import type { Board, BranchID, UUID } from '@agor/core/types';
+import { afterEach, describe, expect } from 'vitest';
+import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from '../../analytics';
+import { resetAnalyticsLoggerForTests, setAnalyticsLoggerForTests } from '../../analytics';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import {
+  USER_PRIMARY_TEAMMATE_SET_EVENT,
+  UserPrimaryTeammateRepository,
+} from './user-primary-teammate';
+import { UsersRepository } from './users';
+
+interface CapturedEvent {
+  event: string;
+  properties?: AnalyticsProperties;
+  options?: AnalyticsTrackOptions;
+}
+
+function createCapturingLogger(sink: CapturedEvent[]): AnalyticsLogger {
+  return {
+    isEnabled: () => true,
+    track: (event, properties, options) => {
+      sink.push({ event, properties, options });
+    },
+  };
+}
+
+let branchUniqueId = 5_000;
+
+async function createUser(db: Database, email: string): Promise<UUID> {
+  const user = await new UsersRepository(db).create({ email, role: 'member' });
+  return user.user_id as UUID;
+}
+
+async function createBoard(db: Database, overrides?: Partial<Board>): Promise<Board> {
+  return new BoardRepository(db).create({
+    board_id: generateId(),
+    name: overrides?.name ?? 'Board',
+    created_by: overrides?.created_by ?? generateId(),
+    access_mode: overrides?.access_mode ?? 'shared',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  boardId: UUID,
+  overrides?: { permission_source?: 'board' | 'override'; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: boardId,
+    created_by: generateId(),
+    permission_source: overrides?.permission_source ?? 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UserPrimaryTeammateRepository', () => {
+  afterEach(() => {
+    resetAnalyticsLoggerForTests();
+  });
+
+  dbTest('resolves a board-level teammate on an accessible board', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'board-level@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    const resolved = await repo.resolvePrimaryTeammate(user);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest(
+    'resolves a teammate embedded on another (private) board via direct ownership',
+    async ({ db }) => {
+      const repo = new UserPrimaryTeammateRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const user = await createUser(db, 'cross-board@example.com');
+
+      // Teammate lives on a private board the user does not own; only direct
+      // branch ownership grants access — the cross-board case boards support.
+      const otherBoard = await createBoard(db, { access_mode: 'private' });
+      const branchId = await createBranch(db, otherBoard.board_id as UUID, {
+        permission_source: 'override',
+        others_can: 'none',
+      });
+      await branchRepo.addOwner(branchId, user);
+
+      await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+      const resolved = await repo.resolvePrimaryTeammate(user);
+      expect(resolved?.branch_id).toBe(branchId);
+    }
+  );
+
+  dbTest('returns null when the user has lost access to the stored branch', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'lost-access@example.com');
+    const privateBoard = await createBoard(db, { access_mode: 'private' });
+    const branchId = await createBranch(db, privateBoard.board_id as UUID, {
+      permission_source: 'override',
+      others_can: 'none',
+    });
+
+    // Stored, but the user is not an owner and the branch is private → no access.
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(await repo.getBranchId(user)).toBe(branchId);
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('returns null when no primary teammate is set', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'unset@example.com');
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('emits an assignment event carrying the source', async ({ db }) => {
+    const events: CapturedEvent[] = [];
+    setAnalyticsLoggerForTests(createCapturingLogger(events));
+
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'event@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: USER_PRIMARY_TEAMMATE_SET_EVENT,
+      properties: { user_id: user, branch_id: branchId, source: 'default' },
+      options: { userId: user },
+    });
+  });
+});

--- a/packages/core/src/db/repositories/user-primary-teammate.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.ts
@@ -1,0 +1,99 @@
+import type { Branch, BranchID, UserID } from '@agor/core/types';
+import { analyticsLogger } from '../../analytics/logger';
+import type { Database } from '../client';
+import { AppVariableRepository } from './app-variables';
+import { BranchRepository } from './branches';
+
+/**
+ * app_variables namespace for a user's primary teammate branch. The row key is
+ * the user id, so there is one value per (tenant, user) — tenant scoping is
+ * ambient via the tenant-scoped database, mirroring KnowledgeSemanticSettings.
+ * Named distinctly from boards' `primary_teammate_id` to avoid any collision.
+ */
+export const USER_PRIMARY_TEAMMATE_NAMESPACE = 'user.primary_teammate_branch';
+
+/** Analytics event emitted whenever a user's primary teammate branch is set. */
+export const USER_PRIMARY_TEAMMATE_SET_EVENT = 'user.primary_teammate.set';
+
+/**
+ * How the primary teammate came to be set: `default` for backfill/onboarding
+ * auto-assignment, `explicit` for a later user-driven pick (a future phase).
+ */
+export type PrimaryTeammateAssignmentSource = 'default' | 'explicit';
+
+export interface SetPrimaryTeammateOptions {
+  source: PrimaryTeammateAssignmentSource;
+  /** Actor for the app_variable audit column; defaults to the target user. */
+  updatedBy?: UserID | null;
+}
+
+export function buildPrimaryTeammateSetAnalyticsProperties(
+  userId: UserID,
+  branchId: BranchID,
+  source: PrimaryTeammateAssignmentSource
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    branch_id: branchId,
+    source,
+  };
+}
+
+/**
+ * Per-user, per-tenant primary teammate branch. Construct with a tenant-scoped
+ * database; reads and writes are scoped to the ambient tenant.
+ */
+export class UserPrimaryTeammateRepository {
+  private variables: AppVariableRepository;
+  private branches: BranchRepository;
+
+  constructor(db: Database) {
+    this.variables = new AppVariableRepository(db);
+    this.branches = new BranchRepository(db);
+  }
+
+  /** Raw stored branch id for the user, or null when unset. */
+  async getBranchId(userId: UserID): Promise<BranchID | null> {
+    const value = await this.variables.getPlain(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+    return (value as BranchID | null) ?? null;
+  }
+
+  /**
+   * Resolve the user's primary teammate branch, or null when unset OR the user
+   * can no longer access the stored branch (deleted, unshared, ownership
+   * removed). Null is the unambiguous "needs picking" signal for callers.
+   *
+   * The access check reuses the same branch-visibility predicate boards use to
+   * resolve `primary_teammate_id`, so a teammate embedded on another board
+   * still resolves as long as the user retains access to it.
+   */
+  async resolvePrimaryTeammate(userId: UserID): Promise<Branch | null> {
+    const branchId = await this.getBranchId(userId);
+    if (!branchId) return null;
+    return this.branches.findAccessibleById(branchId, userId);
+  }
+
+  /** Set the user's primary teammate branch and emit the assignment event. */
+  async setPrimaryTeammate(
+    userId: UserID,
+    branchId: BranchID,
+    options: SetPrimaryTeammateOptions
+  ): Promise<void> {
+    await this.variables.set({
+      namespace: USER_PRIMARY_TEAMMATE_NAMESPACE,
+      key: userId,
+      value: branchId,
+      updated_by: options.updatedBy ?? userId,
+    });
+    analyticsLogger.track(
+      USER_PRIMARY_TEAMMATE_SET_EVENT,
+      buildPrimaryTeammateSetAnalyticsProperties(userId, branchId, options.source),
+      { userId }
+    );
+  }
+
+  /** Clear the user's primary teammate branch. */
+  async clearPrimaryTeammate(userId: UserID): Promise<void> {
+    await this.variables.delete(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+  }
+}

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
@@ -1,0 +1,117 @@
+import type { UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { BranchRepository } from '../repositories/branches';
+import { RepoRepository } from '../repositories/repos';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+import { dbTest } from '../test-helpers';
+import { backfillUserPrimaryTeammates } from './backfill-user-primary-teammate';
+
+let branchUniqueId = 8_000;
+
+async function createBoardWithTeammate(db: Database): Promise<{ boardId: UUID; branchId: UUID }> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: 'Onboarding board',
+    created_by: generateId(),
+    access_mode: 'shared',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: board.board_id,
+    created_by: generateId(),
+    permission_source: 'board',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  await new BoardRepository(db).setPrimaryTeammate(board.board_id, branch.branch_id);
+  return { boardId: board.board_id as UUID, branchId: branch.branch_id as UUID };
+}
+
+describe('backfillUserPrimaryTeammates', () => {
+  dbTest('copies the onboarding board teammate when mainBoardId is present', async ({ db }) => {
+    const { boardId, branchId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'has-board@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(branchId);
+    const resolved = await primaryTeammates.resolvePrimaryTeammate(user.user_id);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest('leaves the field unset when mainBoardId is absent', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      email: 'no-board@example.com',
+      role: 'member',
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.skipped).toBe(1);
+    expect(result.assigned).toBe(0);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('leaves the field unset when the board has no primary teammate', async ({ db }) => {
+    const board = await new BoardRepository(db).create({
+      board_id: generateId(),
+      name: 'Teammate-less board',
+      created_by: generateId(),
+    });
+    const user = await new UsersRepository(db).create({
+      email: 'board-without-teammate@example.com',
+      role: 'member',
+      preferences: { mainBoardId: board.board_id },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(0);
+    expect(result.skipped).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('does not overwrite a primary teammate that is already set', async ({ db }) => {
+    const { boardId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'already-set@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    const existing = generateId() as UUID;
+    await primaryTeammates.setPrimaryTeammate(user.user_id, existing, { source: 'explicit' });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.alreadySet).toBe(1);
+    expect(result.assigned).toBe(0);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(existing);
+  });
+});

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
@@ -1,0 +1,89 @@
+/**
+ * Backfill each user's primary teammate branch from their onboarding board.
+ *
+ * Source of truth is `preferences.mainBoardId` — the board onboarding already
+ * created for the user. We copy that board's designated `primary_teammate_id`
+ * branch (the teammate onboarding set up) into the per-user primary teammate.
+ * Users with no `mainBoardId`, an unknown board, or a board that has no primary
+ * teammate are deliberately left unset — a later UI phase prompts them.
+ *
+ * Runs within the ambient tenant context, so the standalone SQLite runner below
+ * backfills the single local tenant. A multi-tenant caller should invoke
+ * backfillUserPrimaryTeammates once per tenant scope.
+ */
+
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { BranchID } from '@agor/core/types';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+
+export interface BackfillUserPrimaryTeammateResult {
+  /** Users whose primary teammate was set from their onboarding board. */
+  assigned: number;
+  /** Users left unset (no mainBoardId, unknown board, or board has no teammate). */
+  skipped: number;
+  /** Users who already had a primary teammate and were left untouched. */
+  alreadySet: number;
+}
+
+export async function backfillUserPrimaryTeammates(
+  db: Database
+): Promise<BackfillUserPrimaryTeammateResult> {
+  const users = new UsersRepository(db);
+  const boards = new BoardRepository(db);
+  const primaryTeammates = new UserPrimaryTeammateRepository(db);
+
+  const result: BackfillUserPrimaryTeammateResult = { assigned: 0, skipped: 0, alreadySet: 0 };
+
+  for (const user of await users.findAll()) {
+    const mainBoardId = user.preferences?.mainBoardId;
+    if (!mainBoardId) {
+      result.skipped++;
+      continue;
+    }
+
+    if (await primaryTeammates.getBranchId(user.user_id)) {
+      result.alreadySet++;
+      continue;
+    }
+
+    const board = await boards.findById(mainBoardId).catch(() => null);
+    const teammateBranchId = board?.primary_teammate_id;
+    if (!teammateBranchId) {
+      result.skipped++;
+      continue;
+    }
+
+    await primaryTeammates.setPrimaryTeammate(user.user_id, teammateBranchId as BranchID, {
+      source: 'default',
+    });
+    result.assigned++;
+  }
+
+  return result;
+}
+
+async function main() {
+  const dbPath = process.env.AGOR_DB_PATH || resolve(homedir(), '.agor/agor.db');
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client) as unknown as Database;
+
+  const { assigned, skipped, alreadySet } = await backfillUserPrimaryTeammates(db);
+  console.log(
+    `✅ Primary teammate backfill complete: ${assigned} assigned, ${alreadySet} already set, ${skipped} skipped`
+  );
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('❌ Primary teammate backfill failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why

Boards already have a designated primary teammate (`board.primary_teammate_id`) — a default AI teammate branch that the visibility layer resolves even when that branch lives on a *different* board. Users have no equivalent: there's no personal, default teammate for ambient work that isn't tied to a specific project board.

This closes that gap at the data layer. It's **Phase 0 — data model and backend resolver only. No UI** (Settings picker, navbar trigger, onboarding copy, and the inline re-pick prompt are later phases).

## What

- **New field — `primary_teammate_branch` (per user, per tenant), a `BranchID`.** Named deliberately distinct from board-level `primary_teammate_id` to avoid collisions in code and generated docs. It can point at a board-level teammate (common case) *or* a teammate branch embedded on a different board — it is not restricted to boards the user owns, mirroring boards' cross-board `primary_teammate_id`.
- **`resolvePrimaryTeammate(userId)`** on `UserPrimaryTeammateRepository`: returns the stored teammate branch only when the user still has access, reusing the exact branch-visibility predicate (`visibleBranchAccessCondition`) that boards use to resolve `primary_teammate_id`. Returns `null` when unset or when access was lost (branch deleted, unshared, ownership removed) — the unambiguous "needs picking" signal for future UI. This is the clean integration point later phases call.
  - Added `BranchRepository.findAccessibleById(branchId, userId)` — a single-branch version of `findAccessibleBranches`, matching the `accessiblePrimaryTeammateExists` subquery shape.
- **Event:** `setPrimaryTeammate` emits `user.primary_teammate.set` with `source: 'default' | 'explicit'`, so backfill/onboarding auto-assignment is distinguishable from a later explicit user pick (that path lands in a future phase; the shape is ready now). Uses the existing `analyticsLogger.track` mechanism.
- **Backfill:** `backfillUserPrimaryTeammates(db)` copies each user's onboarding board teammate — `preferences.mainBoardId` → that board's `primary_teammate_id` branch — with `source: 'default'`. Users with no `mainBoardId`, an unknown board, or a board without a primary teammate are deliberately left unset (no fallback heuristic). Idempotent: users who already have a value are untouched. Ships as an exported, unit-tested function plus a guarded standalone SQLite runner, matching the existing `db/scripts/` backfill pattern.

## Field name + tenant-scoping approach (for review)

- **Name:** `primary_teammate_branch` (namespace) / concept `primary_teammate_branch_id`. Clearly distinct from board `primary_teammate_id`.
- **Tenant scoping:** stored in the existing `app_variables` table (namespace `user.primary_teammate_branch`, key = user id), which is exactly how the **"Move Knowledge semantic settings to tenant scope" (#2010)** precedent models tenant-scoped settings. Tenant identity is ambient (`currentTenantInsert()` on write; RLS-scoped DB on read) — so a user in two tenants gets one value per tenant (unique `(tenant_id, namespace, key)` on Postgres). The resolver therefore takes only `userId` and relies on the ambient tenant-scoped DB, consistent with `KnowledgeSemanticSettingsRepository` (no explicit `tenantId` param). **No schema migration** is required. Tradeoff vs. a dedicated FK table: no `ON DELETE SET NULL` cascade on the stored branch id — but that's intentionally moot here, since the resolver re-checks access on every read and returns `null` for a dead/inaccessible branch, which is the desired signal.

## Tests

- Resolver returns a board-level teammate on an accessible board.
- Resolver returns a teammate embedded on another (private) board via direct branch ownership — the cross-board case mirroring boards' `primary_teammate_id`.
- Resolver returns `null` when the user has lost access to the stored branch, and when unset.
- Event is emitted carrying `source`.
- Backfill copies from `mainBoardId` when present; leaves unset when absent or when the board has no teammate; does not overwrite an already-set value.

`pnpm typecheck`, `pnpm lint`, `pnpm check:multitenancy-boundaries`, and the new + adjacent repo test suites all pass green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)