### PR TITLE
feat(onboarding): wire onboarding teammate as user's primary + private board

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -8,7 +8,7 @@ import {
   runWithTenantDatabaseScope,
   UsersRepository,
 } from '@agor/core/db';
-import type { Application, BoardID, BranchID, UUID } from '@agor/core/types';
+import type { Application, BoardID, BranchID, UserID, UUID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { runExecutorCommand, spawnExecutor } from '../utils/spawn-executor.js';
@@ -1046,6 +1046,93 @@ describe('BranchesService one-shot teammate creation wiring', () => {
 
     expect(boardRepo.setPrimaryTeammateIfUnset).not.toHaveBeenCalled();
     expect(boardsEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('BranchesService onboarding user primary teammate wiring', () => {
+  const onboardingContext = {
+    teammate: { kind: 'teammate', displayName: 'Teammate', createdViaOnboarding: true },
+  };
+
+  function createUserTeammateHarness(existingBranchId: string | null = null) {
+    const app = { service: vi.fn() } as unknown as Application;
+    const primaryTeammateRepo = {
+      getBranchId: vi.fn(async () => existingBranchId),
+      setPrimaryTeammate: vi.fn(async () => undefined),
+    };
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    (
+      service as unknown as { primaryTeammateRepo: typeof primaryTeammateRepo }
+    ).primaryTeammateRepo = primaryTeammateRepo;
+    const invoke = (branch: Record<string, unknown>, params?: unknown) =>
+      (
+        service as unknown as {
+          maybeSetUserPrimaryTeammate: (b: unknown, p?: unknown) => Promise<void>;
+        }
+      ).maybeSetUserPrimaryTeammate(branch, params);
+    return { primaryTeammateRepo, invoke };
+  }
+
+  it("sets the creator's primary teammate for an onboarding teammate branch", async () => {
+    const { primaryTeammateRepo, invoke } = createUserTeammateHarness();
+
+    await invoke({
+      branch_id: 'teammate-new' as BranchID,
+      board_id: 'board-a' as BoardID,
+      created_by: 'user-1' as UserID,
+      custom_context: onboardingContext,
+    });
+
+    expect(primaryTeammateRepo.setPrimaryTeammate).toHaveBeenCalledWith('user-1', 'teammate-new', {
+      source: 'default',
+      updatedBy: 'user-1',
+    });
+  });
+
+  it('prefers the authenticated actor over created_by as the target user', async () => {
+    const { primaryTeammateRepo, invoke } = createUserTeammateHarness();
+
+    await invoke(
+      {
+        branch_id: 'teammate-new' as BranchID,
+        board_id: 'board-a' as BoardID,
+        created_by: 'user-1' as UserID,
+        custom_context: onboardingContext,
+      },
+      { user: { user_id: 'actor-2' as UserID } }
+    );
+
+    expect(primaryTeammateRepo.setPrimaryTeammate).toHaveBeenCalledWith('actor-2', 'teammate-new', {
+      source: 'default',
+      updatedBy: 'actor-2',
+    });
+  });
+
+  it('never clobbers an existing primary teammate assignment', async () => {
+    const { primaryTeammateRepo, invoke } = createUserTeammateHarness('teammate-existing');
+
+    await invoke({
+      branch_id: 'teammate-new' as BranchID,
+      board_id: 'board-a' as BoardID,
+      created_by: 'user-1' as UserID,
+      custom_context: onboardingContext,
+    });
+
+    expect(primaryTeammateRepo.setPrimaryTeammate).not.toHaveBeenCalled();
+  });
+
+  it('ignores teammates not created via onboarding', async () => {
+    const { primaryTeammateRepo, invoke } = createUserTeammateHarness();
+
+    await invoke({
+      branch_id: 'teammate-new' as BranchID,
+      board_id: 'board-a' as BoardID,
+      created_by: 'user-1' as UserID,
+      custom_context: teammateContext,
+    });
+
+    expect(primaryTeammateRepo.getBranchId).not.toHaveBeenCalled();
+    expect(primaryTeammateRepo.setPrimaryTeammate).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -28,6 +28,7 @@ import {
   KnowledgeNamespaceRepository,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
+  UserPrimaryTeammateRepository,
   UsersRepository,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
@@ -143,6 +144,7 @@ interface ManagedProcess {
 export class BranchesService extends DrizzleService<Branch, Partial<Branch>, BranchParams> {
   private branchRepo: BranchRepository;
   private boardRepo: BoardRepository;
+  private primaryTeammateRepo: UserPrimaryTeammateRepository;
   private db: TenantScopeAwareDatabase;
   private app: Application;
   private processes = new Map<BranchID, ManagedProcess>();
@@ -171,6 +173,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     this.branchRepo = branchRepo;
     this.boardRepo = new BoardRepository(db);
+    this.primaryTeammateRepo = new UserPrimaryTeammateRepository(db);
     this.db = db;
     this.app = app;
   }
@@ -766,6 +769,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       await Promise.all(
         readyBranches.map((branch) => this.maybeSetBoardPrimaryTeammate(branch, params))
       );
+      await Promise.all(
+        readyBranches.map((branch) => this.maybeSetUserPrimaryTeammate(branch, params))
+      );
       for (const branch of readyBranches) {
         this.trackBranchCreated(branch);
       }
@@ -776,6 +782,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const created = (await super.create(withDefaults, params)) as Branch;
     const readyBranch = await this.maybeEnsureTeammateKnowledgeNamespace(created, params);
     await this.maybeSetBoardPrimaryTeammate(readyBranch, params);
+    await this.maybeSetUserPrimaryTeammate(readyBranch, params);
     this.trackBranchCreated(readyBranch);
     return readyBranch;
   }
@@ -806,6 +813,30 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     } catch (error) {
       console.warn(
         `⚠️ Failed to set primary teammate for board ${branch.board_id}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  /**
+   * Designate a freshly onboarded teammate as its creator's primary teammate.
+   * Only fires for the onboarding path (`createdViaOnboarding`) and never
+   * clobbers an existing assignment, so a re-run or a later explicit pick wins.
+   */
+  private async maybeSetUserPrimaryTeammate(branch: Branch, params?: BranchParams): Promise<void> {
+    if (!getTeammateConfig(branch)?.createdViaOnboarding) return;
+    const userId = (params?.user?.user_id as UserID | undefined) ?? (branch.created_by as UserID);
+    if (!userId) return;
+
+    try {
+      if (await this.primaryTeammateRepo.getBranchId(userId)) return;
+      await this.primaryTeammateRepo.setPrimaryTeammate(userId, branch.branch_id, {
+        source: 'default',
+        updatedBy: userId,
+      });
+    } catch (error) {
+      console.warn(
+        `⚠️ Failed to set primary teammate for user ${userId}:`,
         error instanceof Error ? error.message : String(error)
       );
     }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -334,13 +334,19 @@ describe('OnboardingWizard', () => {
     const { boardsService } = renderWizard({ initialStep: 'workspace', onUpdateUser });
 
     expect(screen.getByText('Name your AI teammate')).toBeInTheDocument();
+    // Tells the user this teammate becomes their primary assistant on a private board.
+    expect(screen.getByText(/primary assistant, on a private board/i)).toBeInTheDocument();
     // The teammate name is empty by default — the user names their teammate.
     fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Rusty' } });
 
     clickButton(/^continue →/i);
 
     await waitFor(() => {
-      expect(boardsService.create).toHaveBeenCalledWith({ name: 'Rusty', icon: '🤖' });
+      expect(boardsService.create).toHaveBeenCalledWith({
+        name: 'Rusty',
+        icon: '🤖',
+        access_mode: 'private',
+      });
     });
     await waitFor(() => {
       expect(onUpdateUser).toHaveBeenCalledWith(

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -987,6 +987,8 @@ export function OnboardingWizard({
           const board = await client.service('boards').create({
             name: teammateName.trim(),
             icon: teammateEmoji,
+            // Personal onboarding board — private by default, unlike team/topic boards.
+            access_mode: 'private',
           });
           const newBoardId = board?.board_id ?? null;
           if (!newBoardId) {
@@ -1650,6 +1652,9 @@ export function OnboardingWizard({
               />
             </div>
           </div>
+          <Text style={{ fontSize: 12, color: TEXT_MUTED, display: 'block', lineHeight: 1.5 }}>
+            This is your primary assistant, on a private board. Change both anytime in Settings.
+          </Text>
           {(() => {
             const chosenOption = LLM_OPTIONS.find((o) => o.agent === selectedAgent);
             return (

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -80,6 +80,9 @@ describe('seedOnboardingTeammate', () => {
     expect(initialPrompt).toContain('Rusty');
     expect(initialPrompt).toContain('developer');
     expect(initialPrompt).toContain('- Suggested integrations: Slack, GitHub');
+    expect(initialPrompt).toContain(
+      "- Role: you are this user's primary Agor assistant, on a private board only they can see"
+    );
     expect(initialPrompt).toContain('Read ONBOARDING.md');
     expect(initialPrompt).toContain('otherwise, read BOOTSTRAP.md');
 

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -93,6 +93,8 @@ export async function seedOnboardingTeammate(
           userEmail: input.user?.email,
           persona: input.user?.persona,
           suggestedIntegrations: input.suggestedIntegrations,
+          isPrimaryTeammate: true,
+          boardIsPrivate: true,
         }),
       },
       onCreateSession: input.onCreateSession,

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -81,6 +81,24 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(absent).not.toContain('Suggested integrations');
   });
 
+  it('adds a primary-assistant + private-board role line only when the onboarding flags are set', () => {
+    const onboarding = buildTeammateBootstrapPrompt({
+      displayName: 'Rusty',
+      isPrimaryTeammate: true,
+      boardIsPrivate: true,
+    });
+    expect(onboarding).toContain(
+      "- Role: you are this user's primary Agor assistant, on a private board only they can see"
+    );
+
+    // Board "+" button and Settings > Teammates pass no flags — no role line.
+    const otherPaths = buildTeammateBootstrapPrompt({ displayName: 'Board Bot' });
+    expect(otherPaths).not.toContain('- Role:');
+    expect(buildTeammateBootstrapPromptContext({ displayName: 'Board Bot' })).not.toHaveProperty(
+      'isPrimaryTeammate'
+    );
+  });
+
   it('adds a persona line with the id (plus title when known) and dumps unknown ids raw', () => {
     const known = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', persona: 'developer' });
     expect(known).toContain('- User persona: developer (I write code)');

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -10,6 +10,10 @@ export interface TeammateBootstrapPromptInput {
   persona?: string | null;
   /** Persona-tailored MCP integration names surfaced in the onboarding wizard. */
   suggestedIntegrations?: string[] | null;
+  /** Onboarding path only: this teammate is the user's designated primary assistant. */
+  isPrimaryTeammate?: boolean;
+  /** Onboarding path only: the teammate's board is private to the user. */
+  boardIsPrivate?: boolean;
 }
 
 export interface TeammateBootstrapPromptContext {
@@ -24,6 +28,8 @@ export interface TeammateBootstrapPromptContext {
   };
   persona?: { id: string; title?: string };
   suggestedIntegrations?: string[];
+  isPrimaryTeammate?: boolean;
+  boardIsPrivate?: boolean;
   firstSession: true;
 }
 
@@ -63,6 +69,13 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
     lines.push(`- Suggested integrations: ${context.suggestedIntegrations.join(', ')}`);
   }
 
+  if (context.isPrimaryTeammate || context.boardIsPrivate) {
+    const roleFacts: string[] = [];
+    if (context.isPrimaryTeammate) roleFacts.push("this user's primary Agor assistant");
+    if (context.boardIsPrivate) roleFacts.push('on a private board only they can see');
+    lines.push(`- Role: you are ${roleFacts.join(', ')}`);
+  }
+
   lines.push('');
   lines.push(
     "Read ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md. Then respond to the user. Use the supplied context and live Agor state, and ask only the next useful question if the user's goal is not already clear."
@@ -79,6 +92,8 @@ export function buildTeammateBootstrapPromptContext({
   userEmail,
   persona,
   suggestedIntegrations,
+  isPrimaryTeammate,
+  boardIsPrivate,
 }: TeammateBootstrapPromptInput): TeammateBootstrapPromptContext {
   const normalizedUserName = userName?.trim();
   const normalizedUserEmail = userEmail?.trim();
@@ -106,6 +121,8 @@ export function buildTeammateBootstrapPromptContext({
       ? { persona: { id: personaId, ...(personaProfile ? { title: personaProfile.title } : {}) } }
       : {}),
     ...(normalizedIntegrations?.length ? { suggestedIntegrations: normalizedIntegrations } : {}),
+    ...(isPrimaryTeammate ? { isPrimaryTeammate: true } : {}),
+    ...(boardIsPrivate ? { boardIsPrivate: true } : {}),
     firstSession: true,
   };
 }

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -1251,6 +1251,29 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find a single branch by ID only when it is visible to the user.
+   *
+   * Same predicate as findAccessibleBranches, scoped to one id. Mirrors the
+   * accessiblePrimaryTeammateExists check used to resolve boards'
+   * primary_teammate_id across board boundaries. Returns null when the branch
+   * is missing or the user has no access.
+   */
+  async findAccessibleById(branchId: string, userId: UUID): Promise<Branch | null> {
+    const rows = await select(this.db, getTableColumns(branches))
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(this.db, userId)))
+      .all();
+
+    if (rows.length === 0) return null;
+    const baseUrl = await getBaseUrl();
+    return this.rowToBranch(rows[0] as BranchRow, baseUrl);
+  }
+
+  /**
    * Find branch IDs pinned to a specific board zone.
    *
    * Zone membership lives on board_objects.data.zone_id, not on the branches

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -32,4 +32,5 @@ export * from './tenant-agentic-tools';
 export * from './thread-session-map';
 export * from './user-api-keys';
 export * from './user-mcp-oauth-tokens';
+export * from './user-primary-teammate';
 export * from './users';

--- a/packages/core/src/db/repositories/user-primary-teammate.test.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.test.ts
@@ -1,0 +1,163 @@
+import type { Board, BranchID, UUID } from '@agor/core/types';
+import { afterEach, describe, expect } from 'vitest';
+import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from '../../analytics';
+import { resetAnalyticsLoggerForTests, setAnalyticsLoggerForTests } from '../../analytics';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import {
+  USER_PRIMARY_TEAMMATE_SET_EVENT,
+  UserPrimaryTeammateRepository,
+} from './user-primary-teammate';
+import { UsersRepository } from './users';
+
+interface CapturedEvent {
+  event: string;
+  properties?: AnalyticsProperties;
+  options?: AnalyticsTrackOptions;
+}
+
+function createCapturingLogger(sink: CapturedEvent[]): AnalyticsLogger {
+  return {
+    isEnabled: () => true,
+    track: (event, properties, options) => {
+      sink.push({ event, properties, options });
+    },
+  };
+}
+
+let branchUniqueId = 5_000;
+
+async function createUser(db: Database, email: string): Promise<UUID> {
+  const user = await new UsersRepository(db).create({ email, role: 'member' });
+  return user.user_id as UUID;
+}
+
+async function createBoard(db: Database, overrides?: Partial<Board>): Promise<Board> {
+  return new BoardRepository(db).create({
+    board_id: generateId(),
+    name: overrides?.name ?? 'Board',
+    created_by: overrides?.created_by ?? generateId(),
+    access_mode: overrides?.access_mode ?? 'shared',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  boardId: UUID,
+  overrides?: { permission_source?: 'board' | 'override'; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: boardId,
+    created_by: generateId(),
+    permission_source: overrides?.permission_source ?? 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UserPrimaryTeammateRepository', () => {
+  afterEach(() => {
+    resetAnalyticsLoggerForTests();
+  });
+
+  dbTest('resolves a board-level teammate on an accessible board', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'board-level@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    const resolved = await repo.resolvePrimaryTeammate(user);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest(
+    'resolves a teammate embedded on another (private) board via direct ownership',
+    async ({ db }) => {
+      const repo = new UserPrimaryTeammateRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const user = await createUser(db, 'cross-board@example.com');
+
+      // Teammate lives on a private board the user does not own; only direct
+      // branch ownership grants access — the cross-board case boards support.
+      const otherBoard = await createBoard(db, { access_mode: 'private' });
+      const branchId = await createBranch(db, otherBoard.board_id as UUID, {
+        permission_source: 'override',
+        others_can: 'none',
+      });
+      await branchRepo.addOwner(branchId, user);
+
+      await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+      const resolved = await repo.resolvePrimaryTeammate(user);
+      expect(resolved?.branch_id).toBe(branchId);
+    }
+  );
+
+  dbTest('returns null when the user has lost access to the stored branch', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'lost-access@example.com');
+    const privateBoard = await createBoard(db, { access_mode: 'private' });
+    const branchId = await createBranch(db, privateBoard.board_id as UUID, {
+      permission_source: 'override',
+      others_can: 'none',
+    });
+
+    // Stored, but the user is not an owner and the branch is private → no access.
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(await repo.getBranchId(user)).toBe(branchId);
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('returns null when no primary teammate is set', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'unset@example.com');
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('emits an assignment event carrying the source', async ({ db }) => {
+    const events: CapturedEvent[] = [];
+    setAnalyticsLoggerForTests(createCapturingLogger(events));
+
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'event@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: USER_PRIMARY_TEAMMATE_SET_EVENT,
+      properties: { user_id: user, branch_id: branchId, source: 'default' },
+      options: { userId: user },
+    });
+  });
+});

--- a/packages/core/src/db/repositories/user-primary-teammate.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.ts
@@ -1,0 +1,99 @@
+import type { Branch, BranchID, UserID } from '@agor/core/types';
+import { analyticsLogger } from '../../analytics/logger';
+import type { Database } from '../client';
+import { AppVariableRepository } from './app-variables';
+import { BranchRepository } from './branches';
+
+/**
+ * app_variables namespace for a user's primary teammate branch. The row key is
+ * the user id, so there is one value per (tenant, user) — tenant scoping is
+ * ambient via the tenant-scoped database, mirroring KnowledgeSemanticSettings.
+ * Named distinctly from boards' `primary_teammate_id` to avoid any collision.
+ */
+export const USER_PRIMARY_TEAMMATE_NAMESPACE = 'user.primary_teammate_branch';
+
+/** Analytics event emitted whenever a user's primary teammate branch is set. */
+export const USER_PRIMARY_TEAMMATE_SET_EVENT = 'user.primary_teammate.set';
+
+/**
+ * How the primary teammate came to be set: `default` for backfill/onboarding
+ * auto-assignment, `explicit` for a later user-driven pick (a future phase).
+ */
+export type PrimaryTeammateAssignmentSource = 'default' | 'explicit';
+
+export interface SetPrimaryTeammateOptions {
+  source: PrimaryTeammateAssignmentSource;
+  /** Actor for the app_variable audit column; defaults to the target user. */
+  updatedBy?: UserID | null;
+}
+
+export function buildPrimaryTeammateSetAnalyticsProperties(
+  userId: UserID,
+  branchId: BranchID,
+  source: PrimaryTeammateAssignmentSource
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    branch_id: branchId,
+    source,
+  };
+}
+
+/**
+ * Per-user, per-tenant primary teammate branch. Construct with a tenant-scoped
+ * database; reads and writes are scoped to the ambient tenant.
+ */
+export class UserPrimaryTeammateRepository {
+  private variables: AppVariableRepository;
+  private branches: BranchRepository;
+
+  constructor(db: Database) {
+    this.variables = new AppVariableRepository(db);
+    this.branches = new BranchRepository(db);
+  }
+
+  /** Raw stored branch id for the user, or null when unset. */
+  async getBranchId(userId: UserID): Promise<BranchID | null> {
+    const value = await this.variables.getPlain(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+    return (value as BranchID | null) ?? null;
+  }
+
+  /**
+   * Resolve the user's primary teammate branch, or null when unset OR the user
+   * can no longer access the stored branch (deleted, unshared, ownership
+   * removed). Null is the unambiguous "needs picking" signal for callers.
+   *
+   * The access check reuses the same branch-visibility predicate boards use to
+   * resolve `primary_teammate_id`, so a teammate embedded on another board
+   * still resolves as long as the user retains access to it.
+   */
+  async resolvePrimaryTeammate(userId: UserID): Promise<Branch | null> {
+    const branchId = await this.getBranchId(userId);
+    if (!branchId) return null;
+    return this.branches.findAccessibleById(branchId, userId);
+  }
+
+  /** Set the user's primary teammate branch and emit the assignment event. */
+  async setPrimaryTeammate(
+    userId: UserID,
+    branchId: BranchID,
+    options: SetPrimaryTeammateOptions
+  ): Promise<void> {
+    await this.variables.set({
+      namespace: USER_PRIMARY_TEAMMATE_NAMESPACE,
+      key: userId,
+      value: branchId,
+      updated_by: options.updatedBy ?? userId,
+    });
+    analyticsLogger.track(
+      USER_PRIMARY_TEAMMATE_SET_EVENT,
+      buildPrimaryTeammateSetAnalyticsProperties(userId, branchId, options.source),
+      { userId }
+    );
+  }
+
+  /** Clear the user's primary teammate branch. */
+  async clearPrimaryTeammate(userId: UserID): Promise<void> {
+    await this.variables.delete(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+  }
+}

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
@@ -1,0 +1,117 @@
+import type { UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { BranchRepository } from '../repositories/branches';
+import { RepoRepository } from '../repositories/repos';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+import { dbTest } from '../test-helpers';
+import { backfillUserPrimaryTeammates } from './backfill-user-primary-teammate';
+
+let branchUniqueId = 8_000;
+
+async function createBoardWithTeammate(db: Database): Promise<{ boardId: UUID; branchId: UUID }> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: 'Onboarding board',
+    created_by: generateId(),
+    access_mode: 'shared',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: board.board_id,
+    created_by: generateId(),
+    permission_source: 'board',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  await new BoardRepository(db).setPrimaryTeammate(board.board_id, branch.branch_id);
+  return { boardId: board.board_id as UUID, branchId: branch.branch_id as UUID };
+}
+
+describe('backfillUserPrimaryTeammates', () => {
+  dbTest('copies the onboarding board teammate when mainBoardId is present', async ({ db }) => {
+    const { boardId, branchId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'has-board@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(branchId);
+    const resolved = await primaryTeammates.resolvePrimaryTeammate(user.user_id);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest('leaves the field unset when mainBoardId is absent', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      email: 'no-board@example.com',
+      role: 'member',
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.skipped).toBe(1);
+    expect(result.assigned).toBe(0);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('leaves the field unset when the board has no primary teammate', async ({ db }) => {
+    const board = await new BoardRepository(db).create({
+      board_id: generateId(),
+      name: 'Teammate-less board',
+      created_by: generateId(),
+    });
+    const user = await new UsersRepository(db).create({
+      email: 'board-without-teammate@example.com',
+      role: 'member',
+      preferences: { mainBoardId: board.board_id },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(0);
+    expect(result.skipped).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('does not overwrite a primary teammate that is already set', async ({ db }) => {
+    const { boardId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'already-set@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    const existing = generateId() as UUID;
+    await primaryTeammates.setPrimaryTeammate(user.user_id, existing, { source: 'explicit' });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.alreadySet).toBe(1);
+    expect(result.assigned).toBe(0);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(existing);
+  });
+});

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
@@ -1,0 +1,89 @@
+/**
+ * Backfill each user's primary teammate branch from their onboarding board.
+ *
+ * Source of truth is `preferences.mainBoardId` — the board onboarding already
+ * created for the user. We copy that board's designated `primary_teammate_id`
+ * branch (the teammate onboarding set up) into the per-user primary teammate.
+ * Users with no `mainBoardId`, an unknown board, or a board that has no primary
+ * teammate are deliberately left unset — a later UI phase prompts them.
+ *
+ * Runs within the ambient tenant context, so the standalone SQLite runner below
+ * backfills the single local tenant. A multi-tenant caller should invoke
+ * backfillUserPrimaryTeammates once per tenant scope.
+ */
+
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { BranchID } from '@agor/core/types';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+
+export interface BackfillUserPrimaryTeammateResult {
+  /** Users whose primary teammate was set from their onboarding board. */
+  assigned: number;
+  /** Users left unset (no mainBoardId, unknown board, or board has no teammate). */
+  skipped: number;
+  /** Users who already had a primary teammate and were left untouched. */
+  alreadySet: number;
+}
+
+export async function backfillUserPrimaryTeammates(
+  db: Database
+): Promise<BackfillUserPrimaryTeammateResult> {
+  const users = new UsersRepository(db);
+  const boards = new BoardRepository(db);
+  const primaryTeammates = new UserPrimaryTeammateRepository(db);
+
+  const result: BackfillUserPrimaryTeammateResult = { assigned: 0, skipped: 0, alreadySet: 0 };
+
+  for (const user of await users.findAll()) {
+    const mainBoardId = user.preferences?.mainBoardId;
+    if (!mainBoardId) {
+      result.skipped++;
+      continue;
+    }
+
+    if (await primaryTeammates.getBranchId(user.user_id)) {
+      result.alreadySet++;
+      continue;
+    }
+
+    const board = await boards.findById(mainBoardId).catch(() => null);
+    const teammateBranchId = board?.primary_teammate_id;
+    if (!teammateBranchId) {
+      result.skipped++;
+      continue;
+    }
+
+    await primaryTeammates.setPrimaryTeammate(user.user_id, teammateBranchId as BranchID, {
+      source: 'default',
+    });
+    result.assigned++;
+  }
+
+  return result;
+}
+
+async function main() {
+  const dbPath = process.env.AGOR_DB_PATH || resolve(homedir(), '.agor/agor.db');
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client) as unknown as Database;
+
+  const { assigned, skipped, alreadySet } = await backfillUserPrimaryTeammates(db);
+  console.log(
+    `✅ Primary teammate backfill complete: ${assigned} assigned, ${alreadySet} already set, ${skipped} skipped`
+  );
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('❌ Primary teammate backfill failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why

Phase 0 (#2106) added a per-user `primary_teammate_branch` field plus a resolver and backfill — but **nothing in the live product set it**. A brand-new user finished onboarding with their primary teammate unset (only backfilled users got one), and their onboarding board defaulted to `shared` like any team/topic board. This PR wires up the onboarding side so every new user leaves the wizard with a designated primary assistant on a private board.

> **Stacks on #2106 (`primary-teammate-data-model`), which is not yet merged to `main`.** This PR targets `primary-teammate-data-model` and will need a rebase once that lands.

## What

1. **Set `primary_teammate_branch` at onboarding completion (`source: 'default'`).**
   `BranchesService.create` now designates a freshly onboarded teammate branch as its creator's primary teammate, using the Phase-0 `UserPrimaryTeammateRepository`. This is the single authoritative backend hook where the onboarding teammate branch comes into existence — the same place `maybeSetBoardPrimaryTeammate` already runs — so it covers **both** the UI onboarding path and the MCP `agor_branches_create` teammate path without a second way to set the field.
   - Gated on `custom_context.teammate.createdViaOnboarding` so only onboarding teammates trigger it (not CreateDialog/other teammates).
   - Best-effort + non-fatal (mirrors `maybeSetBoardPrimaryTeammate`): never blocks branch creation.
   - **Set-if-unset** — never clobbers an existing assignment, so an onboarding re-run and a future explicit user pick both win (matches the backfill's skip-if-set behavior).

2. **Onboarding board defaults to `access_mode: 'private'`.**
   Set at the wizard's actual board-creation call (`OnboardingWizard` workspace step), **not** in `BoardFormFields.extractBoardFormValues` — a scoped override for the onboarding path only. Team/topic boards created through the form still default to `shared`.

3. **Wizard copy.** One muted line in the workspace step: _"This is your primary assistant, on a private board. Change both anytime in Settings."_

## Multi-tenancy

The new write targets a tenant-owned resource (`user.primary_teammate_branch` app-variable). It goes through the service's tenant-scoped `this.db` — identical to the adjacent `maybeSetBoardPrimaryTeammate` and teammate-knowledge-namespace hooks — and the target user is the authenticated actor (`params.user`) falling back to `branch.created_by`, both within the ambient tenant scope. No cross-tenant path is introduced.

## Testing

- `branches.test.ts`: new `onboarding user primary teammate wiring` block — sets on onboarding teammate with `source: 'default'`; prefers the authenticated actor over `created_by`; never clobbers an existing assignment; ignores non-onboarding teammates. **53 pass.**
- `OnboardingWizard.test.tsx`: updated the board-create assertion to expect `access_mode: 'private'`; added the primary-assistant copy assertion; existing board-reuse / skip / idempotency tests still pass. **29 pass.**
- Biome clean on touched files; UI typecheck **0 errors**. (Daemon typecheck has 4 pre-existing stale-dist `@agor/core/git/pure` errors in files this PR doesn't touch — identical with these changes stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)