### PR TITLE
feat(ui): Settings picker for a user's primary assistant

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -736,6 +736,8 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       'getAvatarSettings',
       'updateAvatarSettings',
       'syncAvatars',
+      'getPrimaryTeammate',
+      'setPrimaryTeammate',
     ],
   });
 

--- a/apps/agor-daemon/src/services/users.primary-teammate.test.ts
+++ b/apps/agor-daemon/src/services/users.primary-teammate.test.ts
@@ -1,0 +1,102 @@
+import {
+  BranchRepository,
+  type Database,
+  generateId,
+  RepoRepository,
+  UserPrimaryTeammateRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { BranchID, UUID } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { createUsersService } from './users';
+
+const CALLER = 'caller-user' as UUID;
+const CALLER_PARAMS = { user: { user_id: CALLER } } as never;
+
+let uniqueId = 9_000;
+
+async function ensureCaller(db: Database) {
+  await new UsersRepository(db).create({
+    user_id: CALLER,
+    email: 'caller@example.com',
+    role: 'member',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  overrides?: { created_by?: UUID; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const slug = `repo-${uniqueId}`;
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug,
+    name: slug,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/tmp/${slug}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${uniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: uniqueId++,
+    path: `/tmp/${name}`,
+    created_by: overrides?.created_by ?? CALLER,
+    permission_source: 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UsersService primary teammate', () => {
+  dbTest('getPrimaryTeammate returns null when unset', async ({ db }) => {
+    await ensureCaller(db);
+    const service = createUsersService(db);
+    expect(await service.getPrimaryTeammate(undefined, CALLER_PARAMS)).toBeNull();
+  });
+
+  dbTest('setPrimaryTeammate records an explicit pick and reads back', async ({ db }) => {
+    await ensureCaller(db);
+    const branchId = await createBranch(db);
+    const service = createUsersService(db);
+    const setSpy = vi.spyOn(UserPrimaryTeammateRepository.prototype, 'setPrimaryTeammate');
+
+    const written = await service.setPrimaryTeammate({ branchId }, CALLER_PARAMS);
+
+    expect(written?.branch_id).toBe(branchId);
+    expect(setSpy).toHaveBeenCalledWith(CALLER, branchId, {
+      source: 'explicit',
+      updatedBy: CALLER,
+    });
+    const resolved = await service.getPrimaryTeammate(undefined, CALLER_PARAMS);
+    expect(resolved?.branch_id).toBe(branchId);
+    setSpy.mockRestore();
+  });
+
+  dbTest('setPrimaryTeammate rejects a branch the caller cannot access', async ({ db }) => {
+    await ensureCaller(db);
+    const inaccessible = await createBranch(db, {
+      created_by: generateId() as UUID,
+      others_can: 'none',
+    });
+    const service = createUsersService(db);
+
+    await expect(
+      service.setPrimaryTeammate({ branchId: inaccessible }, CALLER_PARAMS)
+    ).rejects.toThrow();
+  });
+
+  dbTest('primary teammate methods require an authenticated caller', async ({ db }) => {
+    const service = createUsersService(db);
+    await expect(service.getPrimaryTeammate(undefined, {} as never)).rejects.toThrow();
+    await expect(
+      service.setPrimaryTeammate({ branchId: generateId() }, {} as never)
+    ).rejects.toThrow();
+  });
+});

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -18,6 +18,7 @@ import {
 } from '@agor/core/config';
 import {
   and,
+  BranchRepository,
   compare,
   decryptApiKey,
   deleteFrom,
@@ -28,6 +29,7 @@ import {
   insert,
   select,
   type TenantScopeAwareDatabase,
+  UserPrimaryTeammateRepository,
   update,
   users,
 } from '@agor/core/db';
@@ -38,6 +40,8 @@ import type {
   AgenticToolsConfig,
   AgenticToolsUpdate,
   AuthenticatedParams,
+  Branch,
+  BranchID,
   EnvVarMetadata,
   EnvVarScope,
   InternalUser,
@@ -137,6 +141,14 @@ function isAdmin(params: Params | undefined): boolean {
 function isSelfEmailLookup(params: Params | undefined, email: string): boolean {
   const requesterEmail = (params as AuthenticatedParams | undefined)?.user?.email;
   return !!requesterEmail && requesterEmail.toLowerCase() === email.toLowerCase();
+}
+
+function requireCallerId(params: Params | undefined): UserID {
+  const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
+  if (!userId) {
+    throw new NotAuthenticated('Authentication required');
+  }
+  return userId;
 }
 
 function ensureCanExactEmailLookup(params: Params | undefined, email: string): void {
@@ -822,6 +834,40 @@ export class UsersService {
 
   async refreshAvatarFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
     return this.requireAvatarSync().refreshUserFromSettings(userId);
+  }
+
+  /**
+   * Resolve the calling user's primary teammate branch, or null when unset or
+   * no longer accessible (the "needs picking" signal for the settings picker).
+   */
+  async getPrimaryTeammate(_data: unknown, params?: Params): Promise<Branch | null> {
+    const userId = requireCallerId(params);
+    return new UserPrimaryTeammateRepository(this.db).resolvePrimaryTeammate(userId);
+  }
+
+  /**
+   * Set the calling user's primary teammate to a branch they can access. The
+   * pick is a manual user action, so it is recorded with `source: 'explicit'`.
+   * Rejects branches the caller cannot access to avoid persisting a pointer
+   * that would immediately resolve back to null.
+   */
+  async setPrimaryTeammate(data: { branchId: string }, params?: Params): Promise<Branch | null> {
+    const userId = requireCallerId(params);
+    const branchId = data?.branchId as BranchID | undefined;
+    if (!branchId) {
+      throw new Forbidden('A branchId is required to set a primary teammate');
+    }
+
+    const branch = await new BranchRepository(this.db).findAccessibleById(branchId, userId);
+    if (!branch) {
+      throw new Forbidden('Cannot set a primary teammate you do not have access to');
+    }
+
+    await new UserPrimaryTeammateRepository(this.db).setPrimaryTeammate(userId, branchId, {
+      source: 'explicit',
+      updatedBy: userId,
+    });
+    return branch;
   }
 
   /**

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
@@ -1,0 +1,101 @@
+import type { AgorClient, Board, Branch, Repo } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { PrimaryTeammatePicker } from './PrimaryTeammatePicker';
+
+function teammate(id: string, displayName: string, overrides?: Partial<Branch>): Branch {
+  return {
+    branch_id: id,
+    repo_id: 'repo-1',
+    name: `${id}-branch`,
+    board_id: 'board-1',
+    archived: false,
+    custom_context: { teammate: { kind: 'teammate', displayName } },
+    ...overrides,
+  } as unknown as Branch;
+}
+
+const board = { board_id: 'board-1', name: 'Ambient', icon: '📋' } as Board;
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as Repo;
+
+function seedStore(branches: Branch[]) {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    branchById: new Map(branches.map((b) => [b.branch_id, b])),
+    boardById: new Map([[board.board_id, board]]),
+    repoById: new Map([[repo.repo_id, repo]]),
+  });
+}
+
+function createClient(current: Branch | null) {
+  const getPrimaryTeammate = vi.fn().mockResolvedValue(current);
+  const setPrimaryTeammate = vi.fn((data: { branchId: string }) =>
+    Promise.resolve(teammate(data.branchId, data.branchId))
+  );
+  const client = {
+    service: (name: string) => {
+      if (name === 'users') return { getPrimaryTeammate, setPrimaryTeammate };
+      throw new Error(`unexpected service ${name}`);
+    },
+  } as unknown as AgorClient;
+  return { client, getPrimaryTeammate, setPrimaryTeammate };
+}
+
+function renderPicker(client: AgorClient) {
+  return render(
+    <AntApp>
+      <PrimaryTeammatePicker client={client} />
+    </AntApp>
+  );
+}
+
+describe('PrimaryTeammatePicker', () => {
+  beforeEach(() => {
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('shows the current board-level primary with its board context', async () => {
+    const current = teammate('branch-1', 'Ada');
+    seedStore([current, teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(current).client);
+
+    const currently = await screen.findByText(/Currently/);
+    expect(currently).toHaveTextContent('Ada');
+    expect(currently).toHaveTextContent('Ambient');
+  });
+
+  it('renders a primary that lives outside the listed teammates', async () => {
+    // Resolved primary is accessible but not among the store's teammate list
+    // (embedded on a board the picker isn't otherwise surfacing).
+    const elsewhere = teammate('branch-remote', 'Remote Pilot', { board_id: undefined });
+    seedStore([teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(elsewhere).client);
+
+    const currently = await screen.findByText(/Currently/);
+    expect(currently).toHaveTextContent('Remote Pilot');
+    // Board unknown → falls back to the repo slug.
+    expect(currently).toHaveTextContent('preset-io/agor');
+  });
+
+  it('shows the no-primary prompt instead of a blank field when unset', async () => {
+    seedStore([teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(null).client);
+
+    expect(await screen.findByText('No primary assistant set')).toBeInTheDocument();
+  });
+
+  it('writes the picked teammate as an explicit change', async () => {
+    seedStore([teammate('branch-1', 'Ada'), teammate('branch-2', 'Grace')]);
+    const { client, setPrimaryTeammate } = createClient(null);
+    renderPicker(client);
+
+    await screen.findByText('No primary assistant set');
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByText('Grace'));
+
+    await waitFor(() => expect(setPrimaryTeammate).toHaveBeenCalledWith({ branchId: 'branch-2' }));
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -1,0 +1,157 @@
+import type { AgorClient, Board, Branch, Repo } from '@agor-live/client';
+import { getTeammateConfig, isTeammate } from '@agor-live/client';
+import { RobotOutlined } from '@ant-design/icons';
+import { Alert, App as AntApp, Select, Space, Spin, Typography } from 'antd';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectBranchById, selectRepoById } from '../../store/selectors';
+
+interface PrimaryTeammatePickerProps {
+  client: AgorClient | null;
+}
+
+interface TeammateOption {
+  value: string;
+  label: string;
+  context: string;
+  searchText: string;
+}
+
+function teammateLabel(branch: Branch): string {
+  return getTeammateConfig(branch)?.displayName ?? branch.name;
+}
+
+/** Where the teammate lives — its board, falling back to the repo slug. */
+function teammateContext(
+  branch: Branch,
+  boardById: Map<string, Board>,
+  repoById: Map<string, Repo>
+): string {
+  const board = branch.board_id ? boardById.get(branch.board_id) : undefined;
+  if (board) return `${board.icon ?? '📋'} ${board.name}`;
+  return repoById.get(branch.repo_id)?.slug ?? 'Unknown board';
+}
+
+/**
+ * Self-contained picker for the calling user's primary assistant — the default
+ * teammate for personal/ambient work. Reads and writes via the caller-scoped
+ * `users.getPrimaryTeammate` / `users.setPrimaryTeammate` RPCs; no assumptions
+ * about the surrounding modal so it can be relocated by moving its mount point.
+ */
+export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({ client }) => {
+  const { message } = AntApp.useApp();
+  const branchById = useAgorStore(selectBranchById);
+  const boardById = useAgorStore(selectBoardById);
+  const repoById = useAgorStore(selectRepoById);
+
+  const [current, setCurrent] = useState<Branch | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setLoading(true);
+    client
+      .service('users')
+      .getPrimaryTeammate()
+      .then((branch) => {
+        if (!cancelled) setCurrent(branch);
+      })
+      .catch(() => {
+        if (!cancelled) setCurrent(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const options = useMemo<TeammateOption[]>(() => {
+    const teammates = Array.from(branchById.values()).filter(
+      (branch) => isTeammate(branch) && !branch.archived
+    );
+    // The resolved primary may live on a board this list doesn't otherwise
+    // surface; keep it selectable so its label renders instead of a raw id.
+    if (current && !teammates.some((branch) => branch.branch_id === current.branch_id)) {
+      teammates.push(current);
+    }
+    return teammates
+      .sort((a, b) => teammateLabel(a).localeCompare(teammateLabel(b)))
+      .map((branch) => {
+        const label = teammateLabel(branch);
+        const context = teammateContext(branch, boardById, repoById);
+        return {
+          value: branch.branch_id,
+          label,
+          context,
+          searchText: `${label} ${branch.name} ${context}`,
+        };
+      });
+  }, [branchById, boardById, repoById, current]);
+
+  const handleChange = async (branchId: string) => {
+    if (!client) return;
+    setSaving(true);
+    try {
+      const branch = await client.service('users').setPrimaryTeammate({ branchId });
+      setCurrent(branch);
+      message.success('Primary assistant updated');
+    } catch (error) {
+      message.error(
+        `Failed to update primary assistant: ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Typography.Text type="secondary">
+        Your default teammate for personal, ambient work. Change it anytime.
+      </Typography.Text>
+
+      {loading ? (
+        <Spin />
+      ) : current ? (
+        <Typography.Text>
+          Currently <Typography.Text strong>{teammateLabel(current)}</Typography.Text> on{' '}
+          {teammateContext(current, boardById, repoById)}.
+        </Typography.Text>
+      ) : (
+        <Alert
+          type="info"
+          showIcon
+          message="No primary assistant set"
+          description="Pick a teammate below to use as your default for personal work."
+        />
+      )}
+
+      <Select
+        showSearch
+        loading={saving}
+        disabled={saving || !client}
+        placeholder="Select a primary assistant"
+        value={current?.branch_id}
+        onChange={handleChange}
+        options={options}
+        optionFilterProp="searchText"
+        notFoundContent={options.length === 0 ? 'No teammates available' : undefined}
+        suffixIcon={<RobotOutlined />}
+        style={{ maxWidth: 420 }}
+        optionRender={(option) => (
+          <div style={{ lineHeight: 1.3 }}>
+            <div>{option.data.label}</div>
+            <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+              {option.data.context}
+            </Typography.Text>
+          </div>
+        )}
+      />
+    </Space>
+  );
+};

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1030,6 +1030,57 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     await screen.findByText(/No settings match/i);
     expect(screen.queryByRole('menuitem', { name: /OpenAI API Key/i })).not.toBeInTheDocument();
   });
+
+  it('renders the Primary Assistant entry in the Account group and mounts its picker for self', async () => {
+    // Caller-scoped: the picker reads the signed-in user's primary teammate via
+    // the users service. A null result renders the "no primary" prompt — enough
+    // to prove the relocated Account-group entry mounts PrimaryTeammatePicker.
+    const getPrimaryTeammate = vi.fn(async () => null);
+    const client = {
+      service: (name: string) => {
+        if (name === 'users') return { getPrimaryTeammate };
+        return { findAll: vi.fn(async () => []), find: vi.fn(async () => ({ data: [] })) };
+      },
+    } as unknown as AgorClient;
+
+    const user = makeUser();
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={user}
+        currentUser={user}
+        client={client}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    const entry = screen.getByRole('menuitem', { name: /primary assistant/i });
+    fireEvent.click(entry);
+
+    await screen.findByRole('heading', { name: 'Primary Assistant' });
+    expect(await screen.findByText('No primary assistant set')).toBeInTheDocument();
+    expect(getPrimaryTeammate).toHaveBeenCalled();
+  });
+
+  it('hides the caller-scoped Primary Assistant entry when an admin edits another user', async () => {
+    const admin = makeUser({ user_id: 'admin-1', name: 'Ada', role: 'admin' });
+    const target = makeUser({ user_id: 'user-2', name: 'Bob', role: 'member' });
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={target}
+        currentUser={admin}
+        client={null as AgorClient | null}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await screen.findByRole('heading', { name: 'Profile' });
+    expect(screen.queryByRole('menuitem', { name: /primary assistant/i })).not.toBeInTheDocument();
+  });
 });
 
 // The tenant tool-settings store is module-global. Seed it as HYDRATED (empty =

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -26,6 +26,7 @@ import {
   KeyOutlined,
   LockOutlined,
   MinusCircleOutlined,
+  RobotOutlined,
   SafetyCertificateOutlined,
   SearchOutlined,
   ThunderboltOutlined,
@@ -78,6 +79,7 @@ import { UserIdentityAvatar } from '../UserIdentityAvatar';
 import { AudioSettingsTab } from './AudioSettingsTab';
 import { syncGroupsForUser } from './groupMembershipSync';
 import { PersonalApiKeysTab } from './PersonalApiKeysTab';
+import { PrimaryTeammatePicker } from './PrimaryTeammatePicker';
 import { FieldRow, PanelHeader, SectionDivider } from './panelPrimitives';
 import { UploadsTab } from './UploadsTab';
 import { UserAgenticDefaultEditor } from './UserAgenticDefaultEditor';
@@ -176,6 +178,11 @@ const PANEL_META: Record<string, { title: string; icon: React.ReactNode; keyword
     keywords: 'audio sound interface chime',
   },
   security: { title: 'Security', icon: <LockOutlined />, keywords: 'account password credentials' },
+  'primary-teammate': {
+    title: 'Primary Assistant',
+    icon: <RobotOutlined />,
+    keywords: 'primary assistant teammate default agent',
+  },
   tokens: { title: 'API tokens', icon: <KeyOutlined />, keywords: 'api token key ci pipeline' },
   uploads: {
     title: 'Uploads',
@@ -281,7 +288,12 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         ? rawActiveKey
         : 'profile';
     }
-    if ((rawActiveKey === 'tokens' || rawActiveKey === 'uploads') && isEditingOther)
+    if (
+      (rawActiveKey === 'tokens' ||
+        rawActiveKey === 'uploads' ||
+        rawActiveKey === 'primary-teammate') &&
+      isEditingOther
+    )
       return 'profile';
     if (rawActiveKey === 'access' && !isAdmin) return 'profile';
     return rawActiveKey;
@@ -976,12 +988,13 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           { key: 'profile', ...PANEL_META.profile },
           { key: 'preferences', ...PANEL_META.preferences },
           { key: 'security', ...PANEL_META.security },
-          // Personal API tokens and uploads are scoped to the signed-in caller,
-          // so they are meaningless (and misleading) when an admin edits another
-          // user.
+          // Primary Assistant, personal API tokens, and uploads are scoped to
+          // the signed-in caller, so they are meaningless (and misleading) when
+          // an admin edits another user.
           ...(isEditingOther
             ? []
             : [
+                { key: 'primary-teammate', ...PANEL_META['primary-teammate'] },
                 { key: 'tokens', ...PANEL_META.tokens },
                 { key: 'uploads', ...PANEL_META.uploads },
               ]),
@@ -1829,6 +1842,13 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         return renderSecurityPanel();
       case 'preferences':
         return renderPreferencesPanel();
+      case 'primary-teammate':
+        return (
+          <>
+            <PanelHeader title={PANEL_META['primary-teammate'].title} />
+            <PrimaryTeammatePicker client={client} />
+          </>
+        );
       case 'env-vars':
         return renderEnvVarsPanel();
       case 'tokens':

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -530,6 +530,16 @@ export interface UsersService extends AgorService<User> {
     params?: Params
   ): Promise<UserAvatarSettings>;
   syncAvatars(data?: UserAvatarSyncRequest, params?: Params): Promise<UserAvatarSyncResult>;
+  /**
+   * Resolve the calling user's primary teammate branch, or null when unset or
+   * no longer accessible.
+   */
+  getPrimaryTeammate(data?: unknown, params?: Params): Promise<Branch | null>;
+  /**
+   * Set the calling user's primary teammate to an accessible branch,
+   * recorded as an explicit user pick.
+   */
+  setPrimaryTeammate(data: { branchId: string }, params?: Params): Promise<Branch | null>;
 }
 
 /**
@@ -893,7 +903,9 @@ function extendUsersService(client: AgorClient): void {
       'getGitEnvironment',
       'getAvatarSettings',
       'updateAvatarSettings',
-      'syncAvatars'
+      'syncAvatars',
+      'getPrimaryTeammate',
+      'setPrimaryTeammate'
     );
   }
   usersService[USERS_SERVICE_EXTENDED] = true;

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -1251,6 +1251,29 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find a single branch by ID only when it is visible to the user.
+   *
+   * Same predicate as findAccessibleBranches, scoped to one id. Mirrors the
+   * accessiblePrimaryTeammateExists check used to resolve boards'
+   * primary_teammate_id across board boundaries. Returns null when the branch
+   * is missing or the user has no access.
+   */
+  async findAccessibleById(branchId: string, userId: UUID): Promise<Branch | null> {
+    const rows = await select(this.db, getTableColumns(branches))
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(this.db, userId)))
+      .all();
+
+    if (rows.length === 0) return null;
+    const baseUrl = await getBaseUrl();
+    return this.rowToBranch(rows[0] as BranchRow, baseUrl);
+  }
+
+  /**
    * Find branch IDs pinned to a specific board zone.
    *
    * Zone membership lives on board_objects.data.zone_id, not on the branches

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -33,4 +33,5 @@ export * from './thread-session-map';
 export * from './uploads';
 export * from './user-api-keys';
 export * from './user-mcp-oauth-tokens';
+export * from './user-primary-teammate';
 export * from './users';

--- a/packages/core/src/db/repositories/user-primary-teammate.test.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.test.ts
@@ -1,0 +1,163 @@
+import type { Board, BranchID, UUID } from '@agor/core/types';
+import { afterEach, describe, expect } from 'vitest';
+import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from '../../analytics';
+import { resetAnalyticsLoggerForTests, setAnalyticsLoggerForTests } from '../../analytics';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import {
+  USER_PRIMARY_TEAMMATE_SET_EVENT,
+  UserPrimaryTeammateRepository,
+} from './user-primary-teammate';
+import { UsersRepository } from './users';
+
+interface CapturedEvent {
+  event: string;
+  properties?: AnalyticsProperties;
+  options?: AnalyticsTrackOptions;
+}
+
+function createCapturingLogger(sink: CapturedEvent[]): AnalyticsLogger {
+  return {
+    isEnabled: () => true,
+    track: (event, properties, options) => {
+      sink.push({ event, properties, options });
+    },
+  };
+}
+
+let branchUniqueId = 5_000;
+
+async function createUser(db: Database, email: string): Promise<UUID> {
+  const user = await new UsersRepository(db).create({ email, role: 'member' });
+  return user.user_id as UUID;
+}
+
+async function createBoard(db: Database, overrides?: Partial<Board>): Promise<Board> {
+  return new BoardRepository(db).create({
+    board_id: generateId(),
+    name: overrides?.name ?? 'Board',
+    created_by: overrides?.created_by ?? generateId(),
+    access_mode: overrides?.access_mode ?? 'shared',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  boardId: UUID,
+  overrides?: { permission_source?: 'board' | 'override'; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: boardId,
+    created_by: generateId(),
+    permission_source: overrides?.permission_source ?? 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UserPrimaryTeammateRepository', () => {
+  afterEach(() => {
+    resetAnalyticsLoggerForTests();
+  });
+
+  dbTest('resolves a board-level teammate on an accessible board', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'board-level@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    const resolved = await repo.resolvePrimaryTeammate(user);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest(
+    'resolves a teammate embedded on another (private) board via direct ownership',
+    async ({ db }) => {
+      const repo = new UserPrimaryTeammateRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const user = await createUser(db, 'cross-board@example.com');
+
+      // Teammate lives on a private board the user does not own; only direct
+      // branch ownership grants access — the cross-board case boards support.
+      const otherBoard = await createBoard(db, { access_mode: 'private' });
+      const branchId = await createBranch(db, otherBoard.board_id as UUID, {
+        permission_source: 'override',
+        others_can: 'none',
+      });
+      await branchRepo.addOwner(branchId, user);
+
+      await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+      const resolved = await repo.resolvePrimaryTeammate(user);
+      expect(resolved?.branch_id).toBe(branchId);
+    }
+  );
+
+  dbTest('returns null when the user has lost access to the stored branch', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'lost-access@example.com');
+    const privateBoard = await createBoard(db, { access_mode: 'private' });
+    const branchId = await createBranch(db, privateBoard.board_id as UUID, {
+      permission_source: 'override',
+      others_can: 'none',
+    });
+
+    // Stored, but the user is not an owner and the branch is private → no access.
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(await repo.getBranchId(user)).toBe(branchId);
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('returns null when no primary teammate is set', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'unset@example.com');
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('emits an assignment event carrying the source', async ({ db }) => {
+    const events: CapturedEvent[] = [];
+    setAnalyticsLoggerForTests(createCapturingLogger(events));
+
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'event@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: USER_PRIMARY_TEAMMATE_SET_EVENT,
+      properties: { user_id: user, branch_id: branchId, source: 'default' },
+      options: { userId: user },
+    });
+  });
+});

--- a/packages/core/src/db/repositories/user-primary-teammate.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.ts
@@ -1,0 +1,99 @@
+import type { Branch, BranchID, UserID } from '@agor/core/types';
+import { analyticsLogger } from '../../analytics/logger';
+import type { Database } from '../client';
+import { AppVariableRepository } from './app-variables';
+import { BranchRepository } from './branches';
+
+/**
+ * app_variables namespace for a user's primary teammate branch. The row key is
+ * the user id, so there is one value per (tenant, user) — tenant scoping is
+ * ambient via the tenant-scoped database, mirroring KnowledgeSemanticSettings.
+ * Named distinctly from boards' `primary_teammate_id` to avoid any collision.
+ */
+export const USER_PRIMARY_TEAMMATE_NAMESPACE = 'user.primary_teammate_branch';
+
+/** Analytics event emitted whenever a user's primary teammate branch is set. */
+export const USER_PRIMARY_TEAMMATE_SET_EVENT = 'user.primary_teammate.set';
+
+/**
+ * How the primary teammate came to be set: `default` for backfill/onboarding
+ * auto-assignment, `explicit` for a later user-driven pick (a future phase).
+ */
+export type PrimaryTeammateAssignmentSource = 'default' | 'explicit';
+
+export interface SetPrimaryTeammateOptions {
+  source: PrimaryTeammateAssignmentSource;
+  /** Actor for the app_variable audit column; defaults to the target user. */
+  updatedBy?: UserID | null;
+}
+
+export function buildPrimaryTeammateSetAnalyticsProperties(
+  userId: UserID,
+  branchId: BranchID,
+  source: PrimaryTeammateAssignmentSource
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    branch_id: branchId,
+    source,
+  };
+}
+
+/**
+ * Per-user, per-tenant primary teammate branch. Construct with a tenant-scoped
+ * database; reads and writes are scoped to the ambient tenant.
+ */
+export class UserPrimaryTeammateRepository {
+  private variables: AppVariableRepository;
+  private branches: BranchRepository;
+
+  constructor(db: Database) {
+    this.variables = new AppVariableRepository(db);
+    this.branches = new BranchRepository(db);
+  }
+
+  /** Raw stored branch id for the user, or null when unset. */
+  async getBranchId(userId: UserID): Promise<BranchID | null> {
+    const value = await this.variables.getPlain(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+    return (value as BranchID | null) ?? null;
+  }
+
+  /**
+   * Resolve the user's primary teammate branch, or null when unset OR the user
+   * can no longer access the stored branch (deleted, unshared, ownership
+   * removed). Null is the unambiguous "needs picking" signal for callers.
+   *
+   * The access check reuses the same branch-visibility predicate boards use to
+   * resolve `primary_teammate_id`, so a teammate embedded on another board
+   * still resolves as long as the user retains access to it.
+   */
+  async resolvePrimaryTeammate(userId: UserID): Promise<Branch | null> {
+    const branchId = await this.getBranchId(userId);
+    if (!branchId) return null;
+    return this.branches.findAccessibleById(branchId, userId);
+  }
+
+  /** Set the user's primary teammate branch and emit the assignment event. */
+  async setPrimaryTeammate(
+    userId: UserID,
+    branchId: BranchID,
+    options: SetPrimaryTeammateOptions
+  ): Promise<void> {
+    await this.variables.set({
+      namespace: USER_PRIMARY_TEAMMATE_NAMESPACE,
+      key: userId,
+      value: branchId,
+      updated_by: options.updatedBy ?? userId,
+    });
+    analyticsLogger.track(
+      USER_PRIMARY_TEAMMATE_SET_EVENT,
+      buildPrimaryTeammateSetAnalyticsProperties(userId, branchId, options.source),
+      { userId }
+    );
+  }
+
+  /** Clear the user's primary teammate branch. */
+  async clearPrimaryTeammate(userId: UserID): Promise<void> {
+    await this.variables.delete(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+  }
+}

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
@@ -1,0 +1,117 @@
+import type { UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { BranchRepository } from '../repositories/branches';
+import { RepoRepository } from '../repositories/repos';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+import { dbTest } from '../test-helpers';
+import { backfillUserPrimaryTeammates } from './backfill-user-primary-teammate';
+
+let branchUniqueId = 8_000;
+
+async function createBoardWithTeammate(db: Database): Promise<{ boardId: UUID; branchId: UUID }> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: 'Onboarding board',
+    created_by: generateId(),
+    access_mode: 'shared',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: board.board_id,
+    created_by: generateId(),
+    permission_source: 'board',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  await new BoardRepository(db).setPrimaryTeammate(board.board_id, branch.branch_id);
+  return { boardId: board.board_id as UUID, branchId: branch.branch_id as UUID };
+}
+
+describe('backfillUserPrimaryTeammates', () => {
+  dbTest('copies the onboarding board teammate when mainBoardId is present', async ({ db }) => {
+    const { boardId, branchId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'has-board@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(branchId);
+    const resolved = await primaryTeammates.resolvePrimaryTeammate(user.user_id);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest('leaves the field unset when mainBoardId is absent', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      email: 'no-board@example.com',
+      role: 'member',
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.skipped).toBe(1);
+    expect(result.assigned).toBe(0);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('leaves the field unset when the board has no primary teammate', async ({ db }) => {
+    const board = await new BoardRepository(db).create({
+      board_id: generateId(),
+      name: 'Teammate-less board',
+      created_by: generateId(),
+    });
+    const user = await new UsersRepository(db).create({
+      email: 'board-without-teammate@example.com',
+      role: 'member',
+      preferences: { mainBoardId: board.board_id },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(0);
+    expect(result.skipped).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('does not overwrite a primary teammate that is already set', async ({ db }) => {
+    const { boardId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'already-set@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    const existing = generateId() as UUID;
+    await primaryTeammates.setPrimaryTeammate(user.user_id, existing, { source: 'explicit' });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.alreadySet).toBe(1);
+    expect(result.assigned).toBe(0);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(existing);
+  });
+});

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
@@ -1,0 +1,89 @@
+/**
+ * Backfill each user's primary teammate branch from their onboarding board.
+ *
+ * Source of truth is `preferences.mainBoardId` — the board onboarding already
+ * created for the user. We copy that board's designated `primary_teammate_id`
+ * branch (the teammate onboarding set up) into the per-user primary teammate.
+ * Users with no `mainBoardId`, an unknown board, or a board that has no primary
+ * teammate are deliberately left unset — a later UI phase prompts them.
+ *
+ * Runs within the ambient tenant context, so the standalone SQLite runner below
+ * backfills the single local tenant. A multi-tenant caller should invoke
+ * backfillUserPrimaryTeammates once per tenant scope.
+ */
+
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { BranchID } from '@agor/core/types';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+
+export interface BackfillUserPrimaryTeammateResult {
+  /** Users whose primary teammate was set from their onboarding board. */
+  assigned: number;
+  /** Users left unset (no mainBoardId, unknown board, or board has no teammate). */
+  skipped: number;
+  /** Users who already had a primary teammate and were left untouched. */
+  alreadySet: number;
+}
+
+export async function backfillUserPrimaryTeammates(
+  db: Database
+): Promise<BackfillUserPrimaryTeammateResult> {
+  const users = new UsersRepository(db);
+  const boards = new BoardRepository(db);
+  const primaryTeammates = new UserPrimaryTeammateRepository(db);
+
+  const result: BackfillUserPrimaryTeammateResult = { assigned: 0, skipped: 0, alreadySet: 0 };
+
+  for (const user of await users.findAll()) {
+    const mainBoardId = user.preferences?.mainBoardId;
+    if (!mainBoardId) {
+      result.skipped++;
+      continue;
+    }
+
+    if (await primaryTeammates.getBranchId(user.user_id)) {
+      result.alreadySet++;
+      continue;
+    }
+
+    const board = await boards.findById(mainBoardId).catch(() => null);
+    const teammateBranchId = board?.primary_teammate_id;
+    if (!teammateBranchId) {
+      result.skipped++;
+      continue;
+    }
+
+    await primaryTeammates.setPrimaryTeammate(user.user_id, teammateBranchId as BranchID, {
+      source: 'default',
+    });
+    result.assigned++;
+  }
+
+  return result;
+}
+
+async function main() {
+  const dbPath = process.env.AGOR_DB_PATH || resolve(homedir(), '.agor/agor.db');
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client) as unknown as Database;
+
+  const { assigned, skipped, alreadySet } = await backfillUserPrimaryTeammates(db);
+  console.log(
+    `✅ Primary teammate backfill complete: ${assigned} assigned, ${alreadySet} already set, ${skipped} skipped`
+  );
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('❌ Primary teammate backfill failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why

Every user should have a designated **primary assistant** — their default teammate for personal/ambient work, changeable anytime. Phase 0/1a (#2106) landed the data model and backend resolver with *no UI*. This PR is the **Settings-side picker**: view your current primary and change it.

## Rebased onto merged #2022 (2026-08-11)

This branch was rebased onto the latest `main`, which now includes the merged **#2022** (the `UserSettingsModal` redesign into the new **Account-group IA**). The `PrimaryTeammatePicker` has been **relocated accordingly**: it is no longer mounted under Profile — it is now a first-class **"Primary Assistant"** entry in the **Account** group (alongside Profile / Preferences / Security / API Tokens), following #2022's menu-item + panel pattern (the panel owns its header via `PanelHeader`, mirroring `tokens`/`uploads`). `PrimaryTeammatePicker.tsx` itself is unchanged apart from dropping its now-redundant inline title (the panel header supplies it). #2106's backend commit applied cleanly on the new base; only `UserSettingsModal.tsx` conflicted, and it was resolved by relocating into the new IA rather than line-merging the old integration.

## What

- **Caller-scoped RPCs** on the `users` service: `getPrimaryTeammate` / `setPrimaryTeammate`.
  - Read reuses `UserPrimaryTeammateRepository.resolvePrimaryTeammate` — returns `null` when unset or access was lost (the unambiguous "needs picking" signal).
  - Write reuses the **same underlying repository write method** (`setPrimaryTeammate`) with `source: 'explicit'` (this is a manual pick, vs. `'default'` used by backfill/onboarding). It validates the branch is accessible to the caller via `BranchRepository.findAccessibleById` and rejects otherwise, so we never persist a pointer that would immediately resolve back to `null`.
- **`PrimaryTeammatePicker`** — a self-contained component:
  - Shows the current primary (**name + resolved board/context**).
  - Renders a clear **"No primary assistant set"** prompt when unset — not a blank field.
  - A searchable teammate `Select` that writes on change.
  - **Options** reuse the existing store-backed teammate list (`isTeammate` over the user's accessible branches — the same mechanism `BoardTeammatePanel` uses). **No ownership restriction**: you can set your primary to a board-level teammate you collaborate on but don't own (intentional).
- Mounted as the **"Primary Assistant"** entry in the redesigned `UserSettingsModal`'s **Account** group, shown only when editing your own profile (the RPCs are caller-scoped). Like `tokens`/`uploads`, a stale deep link to it resolves to Profile when an admin is editing another user.

## Intentional decisions / known follow-ups

- **Stacks on #2106** (`primary-teammate-data-model`), which is still a separate open PR and remains the base branch of this PR. This branch now carries #2106's backend commit rebased onto the latest `main`; #2106's own branch has **not** been re-pointed here, so its PR base may need its own rebase before this PR shows a clean single-commit diff.
- **Now targets the merged #2022 IA directly.** The earlier "deliberately standalone, relocate later" plan is resolved: #2022 has merged and the picker has been moved into the Account group. Because the component made no assumptions about the modal/tab structure, the relocation was purely a matter of moving its mount point + adding its `PANEL_META`/nav entry/panel case.
- **New RPCs vs. existing selector.** The options list reuses the existing accessible-teammate mechanism (store + `isTeammate`), so no new options-fetching was built. There was, however, **no existing HTTP endpoint** exposing the user-level `resolvePrimaryTeammate`/`setPrimaryTeammate` (only board-level `boards.setPrimaryTeammate` exists), so this PR adds the two thin caller-scoped `users` RPCs to reach the Phase-0 repository.

## Multi-tenancy

Both RPCs run against the tenant-scoped `this.db` and key on `params.user.user_id`. The accessibility check uses the same tenant-scoped predicate, so a caller cannot point their primary at a branch outside their tenant. Negative coverage added for the cross-user access-denied and unauthenticated paths.

## Testing

- `PrimaryTeammatePicker.test.tsx` — renders current (board-level + a primary embedded outside the listed teammates), the no-primary prompt, and that a pick writes `{ branchId }`.
- `UserSettingsModal.test.tsx` — new coverage for the relocated entry: the **"Primary Assistant"** item renders in the Account group and mounts its picker panel for self, and is hidden when an admin edits another user.
- `users.primary-teammate.test.ts` — set records `source: 'explicit'` and reads back; rejects an inaccessible branch; requires an authenticated caller.
- Full workspace typecheck (11 packages) and Biome on touched files are green. All UI SettingsModal tests pass (7 files); the daemon service test passes once the pre-existing local `analytics.plugins[type: module]` config (rejected by newer core, unrelated to this change) is bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
