### PR TITLE
fix(terminal): open the shell in $HOME instead of the branch path

### DIFF
--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -435,6 +435,7 @@ export class TerminalsService {
         if (branch) {
           const branchTabName = buildBranchShellTabName(branch);
           const channel = `user/${userId}/terminal`;
+          const unixUserMode = (await loadConfig()).execution?.unix_user_mode ?? 'simple';
 
           // Gate ALL executor-directed choreography on readiness. For a normal
           // warm reuse (the executor acked ready this daemon session) this
@@ -457,6 +458,7 @@ export class TerminalsService {
               userId,
               action: 'create',
               tabName: branchTabName,
+              ...(unixUserMode === 'simple' ? { cwd: branch.path } : {}),
             });
             this.dispatchTabFocus(userId, {
               focusTabName: data.focusTabName,
@@ -551,7 +553,7 @@ export class TerminalsService {
         throw err;
       }
 
-      // Branch info for the tab; the shell always opens in the user's home.
+      // Branch info for the tab.
       let branchName: string | undefined;
       let branchTabName: string | undefined;
 
@@ -570,6 +572,9 @@ export class TerminalsService {
         branchName = branch.name;
         branchTabName = buildBranchShellTabName(branch);
       }
+      // Simple mode has no per-user home isolation, so keep the shell in the branch
+      // checkout; impersonation modes (delegated/insulated/strict) open $HOME.
+      const cwd = unixUserMode === 'simple' ? (branch?.path ?? undefined) : undefined;
 
       // Build Zellij session name
       const sessionName = buildZellijSessionName(userId);
@@ -602,6 +607,7 @@ export class TerminalsService {
           params: {
             userId,
             sessionName,
+            ...(cwd ? { cwd } : {}),
             tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -94,15 +94,6 @@ export function buildBranchShellTabName(branch: Pick<Branch, 'branch_id' | 'name
   return `${branch.name} · ${shortId(branch.branch_id)}`;
 }
 
-export function resolveBranchShellCwd(
-  branch: Pick<Branch, 'name' | 'path'>,
-  _finalUnixUser: string | null
-): string {
-  // Path existence/canonicalisation belongs to the executor identity. Passing
-  // the tenant-derived branch path also avoids name-keyed convenience symlinks.
-  return branch.path;
-}
-
 /**
  * Terminals service - manages Zellij sessions via executor
  *
@@ -466,7 +457,6 @@ export class TerminalsService {
               userId,
               action: 'create',
               tabName: branchTabName,
-              cwd: branch.path,
             });
             this.dispatchTabFocus(userId, {
               focusTabName: data.focusTabName,
@@ -561,8 +551,7 @@ export class TerminalsService {
         throw err;
       }
 
-      // Determine cwd and branch info
-      let cwd: string | undefined;
+      // Branch info for the tab; the shell always opens in the user's home.
       let branchName: string | undefined;
       let branchTabName: string | undefined;
 
@@ -580,7 +569,6 @@ export class TerminalsService {
       if (branch) {
         branchName = branch.name;
         branchTabName = buildBranchShellTabName(branch);
-        cwd = resolveBranchShellCwd(branch, finalUnixUser);
       }
 
       // Build Zellij session name
@@ -614,7 +602,6 @@ export class TerminalsService {
           params: {
             userId,
             sessionName,
-            ...(cwd ? { cwd } : {}),
             tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -780,7 +780,7 @@ async function handleTabAction(action: string, tabName: string, cwd?: string): P
   }
 
   const actionArgs = ['new-tab', '--name', tabName];
-  if (cwd) actionArgs.push('--cwd', cwd);
+  actionArgs.push('--cwd', cwd || resolveEffectiveUserInfo().homedir);
   const result = await runZellij(sessionName, actionArgs);
   if (result.code !== 0) {
     throw new Error(`zellij new-tab failed with code ${result.code}: ${result.stderr}`);


### PR DESCRIPTION
Open the web terminal in $HOME instead of the deep tenant `branch.path` — **only where there is real per-user home isolation**.

## What

The terminal opened in `branch.path` (e.g. `/home/agor/.agor/tenants/<id>/repos/<slug>` or `.../worktrees/<slug>/<branch>`), a long deep path. This opens it in the user's home instead — **gated on `unix_user_mode`**: only impersonation modes (delegated/insulated/strict, i.e. k8s prod) open $HOME; `simple` mode (shared uid, local/dev) keeps the previous `branch.path` behavior.

## How

- `terminals.ts`: `cwd = unix_user_mode === 'simple' ? branch.path : undefined`, applied to both the initial `zellij.attach` payload and the warm-reuse `terminal:tab create` broadcast. When undefined the executor falls back to `effectiveUser.homedir` ($HOME). Removed the now-unused `resolveBranchShellCwd`.
- `zellij.ts`: `handleTabAction` defaults `--cwd` to `resolveEffectiveUserInfo().homedir` when none is given.

## Design note (cwd model — intentional)

An automated reviewer flagged that this changes zellij's cwd from the branch checkout to $HOME in delegated mode. **That is intended** — the deep tenant path is undesirable in the hosted product, and cwd is decided by isolation **mode**, not by the terminal shell (a separate, deliberate product decision). Simple/local keeps `branch.path`.

## Result

Delegated/k8s: terminal opens in `$HOME`. Simple/local: unchanged (`branch.path`).