### PR TITLE
feat(terminal): user-selectable bash or zellij shell

### DIFF
--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -602,6 +602,7 @@ export class TerminalsService {
           params: {
             userId,
             sessionName,
+            shell: user?.preferences?.terminalShell === 'bash' ? 'bash' : 'zellij',
             tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -435,6 +435,7 @@ export class TerminalsService {
         if (branch) {
           const branchTabName = buildBranchShellTabName(branch);
           const channel = `user/${userId}/terminal`;
+          const unixUserMode = (await loadConfig()).execution?.unix_user_mode ?? 'simple';
 
           // Gate ALL executor-directed choreography on readiness. For a normal
           // warm reuse (the executor acked ready this daemon session) this
@@ -457,6 +458,7 @@ export class TerminalsService {
               userId,
               action: 'create',
               tabName: branchTabName,
+              ...(unixUserMode === 'simple' ? { cwd: branch.path } : {}),
             });
             this.dispatchTabFocus(userId, {
               focusTabName: data.focusTabName,
@@ -551,7 +553,7 @@ export class TerminalsService {
         throw err;
       }
 
-      // Branch info for the tab; the shell always opens in the user's home.
+      // Branch info for the tab.
       let branchName: string | undefined;
       let branchTabName: string | undefined;
 
@@ -570,6 +572,9 @@ export class TerminalsService {
         branchName = branch.name;
         branchTabName = buildBranchShellTabName(branch);
       }
+      // Simple mode has no per-user home isolation, so keep the shell in the branch
+      // checkout; impersonation modes (delegated/insulated/strict) open $HOME.
+      const cwd = unixUserMode === 'simple' ? (branch?.path ?? undefined) : undefined;
 
       // Build Zellij session name
       const sessionName = buildZellijSessionName(userId);
@@ -602,6 +607,7 @@ export class TerminalsService {
           params: {
             userId,
             sessionName,
+            ...(cwd ? { cwd } : {}),
             tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -94,15 +94,6 @@ export function buildBranchShellTabName(branch: Pick<Branch, 'branch_id' | 'name
   return `${branch.name} · ${shortId(branch.branch_id)}`;
 }
 
-export function resolveBranchShellCwd(
-  branch: Pick<Branch, 'name' | 'path'>,
-  _finalUnixUser: string | null
-): string {
-  // Path existence/canonicalisation belongs to the executor identity. Passing
-  // the tenant-derived branch path also avoids name-keyed convenience symlinks.
-  return branch.path;
-}
-
 /**
  * Terminals service - manages Zellij sessions via executor
  *
@@ -466,7 +457,6 @@ export class TerminalsService {
               userId,
               action: 'create',
               tabName: branchTabName,
-              cwd: branch.path,
             });
             this.dispatchTabFocus(userId, {
               focusTabName: data.focusTabName,
@@ -561,8 +551,7 @@ export class TerminalsService {
         throw err;
       }
 
-      // Determine cwd and branch info
-      let cwd: string | undefined;
+      // Branch info for the tab; the shell always opens in the user's home.
       let branchName: string | undefined;
       let branchTabName: string | undefined;
 
@@ -580,7 +569,6 @@ export class TerminalsService {
       if (branch) {
         branchName = branch.name;
         branchTabName = buildBranchShellTabName(branch);
-        cwd = resolveBranchShellCwd(branch, finalUnixUser);
       }
 
       // Build Zellij session name
@@ -614,7 +602,6 @@ export class TerminalsService {
           params: {
             userId,
             sessionName,
-            ...(cwd ? { cwd } : {}),
             tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -214,6 +214,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         groupIds: [],
         eventStreamEnabled: userData.preferences?.eventStream?.enabled ?? true,
         useSlackAvatar: userData.preferences?.use_slack_avatar !== false,
+        terminalUseZellij: userData.preferences?.terminalShell !== 'bash',
         must_change_password: userData.must_change_password ?? false,
       });
     },
@@ -440,6 +441,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         nextPreferences.use_slack_avatar = false;
       } else {
         delete nextPreferences.use_slack_avatar;
+      }
+      if (values.terminalUseZellij === false) {
+        nextPreferences.terminalShell = 'bash';
+      } else {
+        delete nextPreferences.terminalShell;
       }
 
       const updates: UpdateUserInput = {
@@ -827,6 +833,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   maxLength={32}
                   disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
                 />
+              </Form.Item>
+
+              <Form.Item
+                label="Use zellij terminal multiplexer"
+                name="terminalUseZellij"
+                valuePropName="checked"
+                tooltip="On: zellij with tabs and session restore. Off: a plain bash login shell in your home directory."
+              >
+                <Switch />
               </Form.Item>
 
               <Form.Item

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -839,7 +839,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                 label="Use zellij terminal multiplexer"
                 name="terminalUseZellij"
                 valuePropName="checked"
-                tooltip="On: zellij with tabs and session restore. Off: a plain bash login shell in your home directory."
+                tooltip="On: zellij with tabs and session restore. Off: a plain bash login shell."
               >
                 <Switch />
               </Form.Item>

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -394,6 +394,8 @@ export interface UserPreferences {
   mainBoardId?: string;
   /** Whether to render Slack-synced avatar_url when available. Undefined defaults to true. */
   use_slack_avatar?: boolean;
+  /** Web terminal shell: 'zellij' multiplexer (default) or 'bash' plain login shell. */
+  terminalShell?: 'zellij' | 'bash';
   // Future preferences can be added here
   [key: string]: unknown;
 }

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -780,7 +780,7 @@ async function handleTabAction(action: string, tabName: string, cwd?: string): P
   }
 
   const actionArgs = ['new-tab', '--name', tabName];
-  if (cwd) actionArgs.push('--cwd', cwd);
+  actionArgs.push('--cwd', cwd || resolveEffectiveUserInfo().homedir);
   const result = await runZellij(sessionName, actionArgs);
   if (result.code !== 0) {
     throw new Error(`zellij new-tab failed with code ${result.code}: ${result.stderr}`);

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -334,7 +334,7 @@ export async function handleZellijAttach(
       }
     }
 
-    const spawnCmd = useZellij ? 'zellij' : userShell;
+    const spawnCmd = useZellij ? 'zellij' : 'bash';
     const spawnArgs = useZellij ? zellijArgs : ['-l'];
     console.log(`[terminal.attach] Spawning PTY: ${spawnCmd} ${spawnArgs.join(' ')}`);
     console.log(`[terminal.attach] CWD: ${cwd}, Size: ${cols}x${rows}`);

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -212,7 +212,8 @@ export async function handleZellijAttach(
   payload: ZellijAttachPayload,
   options: CommandOptions
 ): Promise<ExecutorResult> {
-  const { userId, sessionName, tabName, cols, rows } = payload.params;
+  const { userId, sessionName, tabName, cols, rows, shell } = payload.params;
+  const useZellij = shell !== 'bash';
   const effectiveUser = resolveEffectiveUserInfo();
   const cwd = payload.params.cwd || effectiveUser.homedir;
 
@@ -322,25 +323,23 @@ export async function handleZellijAttach(
     // paths here rather than asking the daemon to inspect another user's home.
     const actualHome = effectiveUser.homedir;
     const userShell = effectiveUser.shell;
-    console.log(`[zellij.attach] User home: ${actualHome}, shell: ${userShell}`);
+    console.log(`[terminal.attach] User home: ${actualHome}, shell: ${userShell}`);
 
-    // Ensure Zellij cache directory exists - useradd -m creates home but not .cache/zellij
-    // Zellij needs this for plugin data, session info, and session serialization
-    const zellijCacheDir = `${actualHome}/.cache/zellij`;
-    if (!fs.existsSync(zellijCacheDir)) {
-      console.log(`[zellij.attach] Creating Zellij cache directory: ${zellijCacheDir}`);
-      fs.mkdirSync(zellijCacheDir, { recursive: true });
+    // useradd -m creates home but not .cache/zellij, which zellij needs for
+    // plugin data, session info, and session serialization.
+    if (useZellij) {
+      const zellijCacheDir = `${actualHome}/.cache/zellij`;
+      if (!fs.existsSync(zellijCacheDir)) {
+        fs.mkdirSync(zellijCacheDir, { recursive: true });
+      }
     }
 
-    // Zellij will use ~/.config/zellij/config.kdl by default
-    // The docker entrypoint copies Agor's default config there on user creation
-    // Users can customize their config as needed
+    const spawnCmd = useZellij ? 'zellij' : userShell;
+    const spawnArgs = useZellij ? zellijArgs : ['-l'];
+    console.log(`[terminal.attach] Spawning PTY: ${spawnCmd} ${spawnArgs.join(' ')}`);
+    console.log(`[terminal.attach] CWD: ${cwd}, Size: ${cols}x${rows}`);
 
-    console.log(`[zellij.attach] Spawning PTY: zellij ${zellijArgs.join(' ')}`);
-    console.log(`[zellij.attach] CWD: ${cwd}, Size: ${cols}x${rows}`);
-
-    // Spawn PTY with zellij
-    const pty = nodePty.spawn('zellij', zellijArgs, {
+    const pty = nodePty.spawn(spawnCmd, spawnArgs, {
       name: 'xterm-256color',
       cols: cols || 80,
       rows: rows || 24,
@@ -413,6 +412,7 @@ export async function handleZellijAttach(
 
     // Listen for tab commands from the daemon when the user switches branches.
     socket.on('terminal:tab', async (data: { action: string; tabName: string; cwd?: string }) => {
+      if (!useZellij) return;
       try {
         await handleTabAction(data.action, data.tabName, data.cwd);
       } catch (err) {
@@ -441,6 +441,13 @@ export async function handleZellijAttach(
     // races an un-booted zellij. If it never comes up, surface terminal:error
     // instead of a false ready that would leave the browser hanging.
     void (async () => {
+      // A plain shell is usable the moment the PTY spawns — no multiplexer to
+      // boot and no tabs to create.
+      if (!useZellij) {
+        zellijAttached = true;
+        emitTerminalReady(socket, userId);
+        return;
+      }
       const attached = await waitForZellijReady(sessionName);
       if (!attached) {
         console.error('[zellij.attach] zellij session did not become ready');

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -877,6 +877,9 @@ export const ZellijAttachPayloadSchema = BasePayloadSchema.extend({
     /** Initial working directory */
     cwd: z.string().optional(),
 
+    /** Shell: 'zellij' multiplexer (default) or 'bash' plain login shell. */
+    shell: z.enum(['zellij', 'bash']).optional(),
+
     /** Initial tab name (branch name) */
     tabName: z.string().optional(),
 


### PR DESCRIPTION
Per-user **bash vs zellij** terminal choice — backend + settings toggle.

> Stacked on #2114 (terminal opens in $HOME, gated to impersonation modes). Base = `feat/terminal-home-cwd`; merge #2114 first.

## What

- New pref `user.preferences.terminalShell: 'zellij' | 'bash'` (default `zellij`), stored in the existing `user.data.preferences` JSON — **no migration**.
- **Settings toggle** ('Use zellij terminal multiplexer') after the Unix Username field. Off writes `terminalShell: 'bash'`.
- **bash** mode: the executor spawns `bash -l` directly in the PTY (cwd $HOME in delegated mode) instead of zellij.

## How

- **Contract** (`payload-types.ts`): `zellij.attach` params gain `shell?: 'zellij' | 'bash'`.
- **Executor** (`zellij.ts`): `useZellij = shell !== 'bash'` branches spawn command/args, skips the zellij cache dir, ignores `terminal:tab`, and announces readiness immediately. bash mode spawns `bash` explicitly (not the account's passwd login shell).
- **Daemon** (`terminals.ts`): reads `terminalShell` off the loaded user record and passes `shell` on the payload.
- **UI** (`UserSettingsModal.tsx`): the switch, wired through the existing preferences read/write path.

## Known limitations (bash mode)

- **No tabs / no cross-restart session restore.** Dropping the multiplexer means no zellij tabs and no pane/scrollback serialization across executor restarts. Basic reconnect during network blips still works (the executor holds the PTY).
- **Applies to the next terminal session.** The shell is chosen at executor spawn; flipping the pref while a terminal executor is alive takes effect after it recycles (all terminals closed / daemon restart), not mid-session.
- **Blank view on browser remount.** On reconnect the daemon sends `terminal:redraw` (a PTY SIGWINCH); zellij repaints, but a plain bash PTY emits nothing, so a freshly-mounted terminal is blank until the next output/keystroke. Server-side scrollback replay would fix this and is a possible follow-up.

Default `zellij` behavior is unchanged.