### PR TITLE
feat(terminal): settings toggle for bash vs zellij shell

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -214,6 +214,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         groupIds: [],
         eventStreamEnabled: userData.preferences?.eventStream?.enabled ?? true,
         useSlackAvatar: userData.preferences?.use_slack_avatar !== false,
+        terminalUseZellij: userData.preferences?.terminalShell !== 'bash',
         must_change_password: userData.must_change_password ?? false,
       });
     },
@@ -440,6 +441,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         nextPreferences.use_slack_avatar = false;
       } else {
         delete nextPreferences.use_slack_avatar;
+      }
+      if (values.terminalUseZellij === false) {
+        nextPreferences.terminalShell = 'bash';
+      } else {
+        delete nextPreferences.terminalShell;
       }
 
       const updates: UpdateUserInput = {
@@ -827,6 +833,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   maxLength={32}
                   disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
                 />
+              </Form.Item>
+
+              <Form.Item
+                label="Use zellij terminal multiplexer"
+                name="terminalUseZellij"
+                valuePropName="checked"
+                tooltip="On: zellij with tabs and session restore. Off: a plain bash login shell in your home directory."
+              >
+                <Switch />
               </Form.Item>
 
               <Form.Item


### PR DESCRIPTION
UI for the per-user terminal shell choice. **Stacked on #2115** (base = `feat/terminal-shell-choice`); merge #2114 → #2115 → this.

## What

A **Use zellij terminal multiplexer** switch in user settings, right after the Unix Username field:
- **On** (default) → zellij (tabs, session restore).
- **Off** → writes `preferences.terminalShell = 'bash'`; the terminal opens a plain bash login shell in `$HOME`.

## How

- Initial value: `terminalUseZellij = preferences.terminalShell !== 'bash'`.
- On save: off → set `terminalShell: 'bash'`; on → delete the key (default zellij).
- Uses the existing `preferences` JSON write path — **no migration**.

Backend that consumes the pref is #2115.