### PR TITLE
test(ui): wait for GitHub wizard step transition

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -807,10 +807,12 @@ describe('GatewayChannelsTable GitHub create wizard', () => {
       target: { value: 'pem-body' },
     });
     clickButton(/^Continue$/);
-    await flush();
 
     // Step 3 (Configure): watch repos (tags Select, tokenized via comma) + identity.
-    const watchRepos = document.querySelector('#github_watch_repos') as HTMLInputElement;
+    // Form validation gates this transition asynchronously. Waiting for the
+    // destination control is deterministic under CI load; a single event-loop
+    // tick can run before React has committed the next step.
+    const watchRepos = await screen.findByLabelText('Watch Repos');
     fireEvent.change(watchRepos, { target: { value: 'preset-io/agor,' } });
     fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
 


### PR DESCRIPTION
## Summary

- wait for the GitHub channel wizard's Configure step to render before interacting with its repository field
- replace the single event-loop tick that raced Ant Design form validation under CI load
- keep the existing behavioral assertion and timeout unchanged

## Root cause

The required main CI run failed because the GitHub channel wizard test queried `#github_watch_repos` immediately after one arbitrary event-loop tick. Ant Design form validation gates the step transition asynchronously, so under suite load React had not committed the Configure step and the query returned `null`.

This race originated with the unified gateway wizard coverage in `22809941ec684ae90d99e7d4761277e0b09ac1d8`. The latest main commit only exposed the existing flake.

Failing run: https://github.com/preset-io/agor/actions/runs/30672763508

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui exec vitest run src/components/SettingsModal/GatewayChannelsTable.test.tsx` — 24/24 passed
- focused failing test passed three consecutive runs during investigation
- full UI suite passed during investigation — 1,184/1,184 tests

## Security / multitenancy

Test-only synchronization change. No runtime, persisted-data, tenant-context, authorization, or security boundary changes.
