### PR TITLE
Remove runtime analytics module plugins

### DIFF
--- a/context/explorations/daemon-fs-decoupling.md
+++ b/context/explorations/daemon-fs-decoupling.md
@@ -16,6 +16,14 @@
 
 **Phase 1A — Config hygiene — shipped in this PR (H1–H4).** Daemon stays the only authority on `~/.agor/config.yaml`; executor stops reading it directly (resolved-slice payload); shutdown sentinel + secret bootstrap degrade gracefully on read-only mounts (capability-driven, no deployment-mode flag). H5 (CLI config separation) is split to a follow-up branch. See §1.5.
 
+**2026-08-03 boundary follow-up:** `DAEMON-FS-CAP-004` is resolved by removing the
+runtime-selected analytics module plugin. The daemon no longer dynamically imports an
+operator-provided package or filesystem path. Analytics delivery is now limited to the
+type-safe built-in registry: `stdout` and HTTP batch. Existing configuration containing
+`analytics.plugins[*].type: module` fails during config loading with migration guidance;
+it is never loaded or silently ignored. The capability was removed from
+`scripts/daemon-filesystem-exceptions.json`.
+
 ---
 
 ## 1. Today's reality

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -219,14 +219,12 @@ describe('analytics plugins', () => {
     ]);
   });
 
-  it('rejects removed module plugins passed by an untyped caller', async () => {
+  it('rejects unsupported plugins passed by an untyped caller', async () => {
     await expect(
       resolveAnalyticsPlugins({
         ...enabledBase,
         plugins: [{ type: 'module', enabled: true, options: { module_path: '/plugin.js' } }],
       } as unknown as AgorAnalyticsSettings)
-    ).rejects.toThrow(
-      "Analytics plugin type 'module' has been removed because loading operator-selected code in the daemon is unsafe. Use the built-in 'stdout' or 'http_batch' analytics plugin instead."
-    );
+    ).rejects.toThrow('Unsupported analytics plugin type: module');
   });
 });

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -25,6 +25,10 @@ describe('analytics config defaults', () => {
   it('is disabled by default', () => {
     expect(getDefaultAnalyticsConfig().enabled).toBe(false);
     expect(getDefaultConfig().analytics?.enabled).toBe(false);
+    expect(getDefaultAnalyticsConfig().plugins?.map((plugin) => plugin.type)).toEqual([
+      'stdout',
+      'http_batch',
+    ]);
   });
 });
 
@@ -215,23 +219,14 @@ describe('analytics plugins', () => {
     ]);
   });
 
-  it('skips relative module plugin paths to avoid cwd-dependent imports', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    const plugins = await resolveAnalyticsPlugins({
-      ...enabledBase,
-      plugins: [
-        {
-          type: 'module',
-          enabled: true,
-          options: { module_path: './analytics-plugin.js' },
-        },
-      ],
-    });
-
-    expect(plugins).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(
-      '[analytics] module plugin options.module_path must be a package specifier or absolute path; skipping relative path'
+  it('rejects removed module plugins passed by an untyped caller', async () => {
+    await expect(
+      resolveAnalyticsPlugins({
+        ...enabledBase,
+        plugins: [{ type: 'module', enabled: true, options: { module_path: '/plugin.js' } }],
+      } as unknown as AgorAnalyticsSettings)
+    ).rejects.toThrow(
+      "Analytics plugin type 'module' has been removed because loading operator-selected code in the daemon is unsafe. Use the built-in 'stdout' or 'http_batch' analytics plugin instead."
     );
   });
 });

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -5,9 +5,6 @@ import type {
 } from '../config/types.js';
 import type { ResolvedAnalyticsPlugin } from './types.js';
 
-export const REMOVED_ANALYTICS_MODULE_PLUGIN_MESSAGE =
-  "Analytics plugin type 'module' has been removed because loading operator-selected code in the daemon is unsafe. Use the built-in 'stdout' or 'http_batch' analytics plugin instead.";
-
 interface AnalyticsTrackPayload {
   type?: string;
   event?: string;
@@ -217,7 +214,6 @@ export async function resolveAnalyticsPlugins(
       default: {
         const unsupported: never = pluginConfig;
         const type = (unsupported as { type?: unknown }).type;
-        if (type === 'module') throw new Error(REMOVED_ANALYTICS_MODULE_PLUGIN_MESSAGE);
         throw new Error(`Unsupported analytics plugin type: ${String(type)}`);
       }
     }

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -1,13 +1,12 @@
-import { pathToFileURL } from 'node:url';
-import type { AnalyticsPlugin } from 'analytics';
 import type {
   AgorAnalyticsHttpBatchPluginSettings,
-  AgorAnalyticsModulePluginSettings,
-  AgorAnalyticsPluginSettings,
   AgorAnalyticsSettings,
   AgorAnalyticsStdoutPluginSettings,
 } from '../config/types.js';
-import type { AnalyticsPluginContext, ResolvedAnalyticsPlugin } from './types.js';
+import type { ResolvedAnalyticsPlugin } from './types.js';
+
+export const REMOVED_ANALYTICS_MODULE_PLUGIN_MESSAGE =
+  "Analytics plugin type 'module' has been removed because loading operator-selected code in the daemon is unsafe. Use the built-in 'stdout' or 'http_batch' analytics plugin instead.";
 
 interface AnalyticsTrackPayload {
   type?: string;
@@ -172,55 +171,6 @@ export function createHttpBatchAnalyticsPlugin(
   };
 }
 
-function importTargetForModulePath(modulePath: string): string | null {
-  if (modulePath.startsWith('.')) {
-    warnAnalytics(
-      'module plugin options.module_path must be a package specifier or absolute path; skipping relative path'
-    );
-    return null;
-  }
-  if (modulePath.startsWith('/')) {
-    return pathToFileURL(modulePath).href;
-  }
-  return modulePath;
-}
-
-export async function createModuleAnalyticsPlugins(
-  settings: AgorAnalyticsModulePluginSettings,
-  context: AnalyticsPluginContext
-): Promise<ResolvedAnalyticsPlugin[]> {
-  const options = settings.options ?? {};
-  if (!options.module_path) {
-    warnAnalytics('module plugin enabled without options.module_path; skipping plugin');
-    return [];
-  }
-
-  try {
-    const importTarget = importTargetForModulePath(options.module_path);
-    if (!importTarget) return [];
-
-    const imported = await import(importTarget);
-    const exportName = options.export_name ?? 'createAnalyticsPlugin';
-    const factory = imported[exportName];
-    if (typeof factory !== 'function') {
-      warnAnalytics(`module plugin export "${exportName}" is not a function; skipping plugin`);
-      return [];
-    }
-    const result = await factory(options.plugin_options ?? {}, context);
-    const plugins = Array.isArray(result) ? result : [result];
-    return plugins.filter((plugin): plugin is ResolvedAnalyticsPlugin => {
-      return (
-        !!plugin &&
-        typeof plugin === 'object' &&
-        typeof (plugin as AnalyticsPlugin).name === 'string'
-      );
-    });
-  } catch (error) {
-    warnAnalytics('module plugin failed to load', error);
-    return [];
-  }
-}
-
 function wrapPluginMethod(pluginName: string, methodName: string, method: unknown): unknown {
   if (typeof method !== 'function') return method;
   return (...args: unknown[]) => {
@@ -255,19 +205,21 @@ export async function resolveAnalyticsPlugins(
   for (const pluginConfig of config.plugins ?? []) {
     if (pluginConfig.enabled !== true) continue;
 
-    const context: AnalyticsPluginContext = { config, pluginConfig };
-    if (pluginConfig.type === 'stdout') {
-      resolved.push(createStdoutAnalyticsPlugin(pluginConfig));
-    } else if (pluginConfig.type === 'http_batch') {
-      const plugin = createHttpBatchAnalyticsPlugin(pluginConfig);
-      if (plugin) resolved.push(plugin);
-    } else if (pluginConfig.type === 'module') {
-      resolved.push(...(await createModuleAnalyticsPlugins(pluginConfig, context)));
-    } else {
-      const unknown = pluginConfig as AgorAnalyticsPluginSettings;
-      warnAnalytics(
-        `unknown plugin type "${(unknown as { type?: string }).type}"; skipping plugin`
-      );
+    switch (pluginConfig.type) {
+      case 'stdout':
+        resolved.push(createStdoutAnalyticsPlugin(pluginConfig));
+        break;
+      case 'http_batch': {
+        const plugin = createHttpBatchAnalyticsPlugin(pluginConfig);
+        if (plugin) resolved.push(plugin);
+        break;
+      }
+      default: {
+        const unsupported: never = pluginConfig;
+        const type = (unsupported as { type?: unknown }).type;
+        if (type === 'module') throw new Error(REMOVED_ANALYTICS_MODULE_PLUGIN_MESSAGE);
+        throw new Error(`Unsupported analytics plugin type: ${String(type)}`);
+      }
     }
   }
 

--- a/packages/core/src/analytics/types.ts
+++ b/packages/core/src/analytics/types.ts
@@ -1,5 +1,4 @@
 import type { AnalyticsPlugin } from 'analytics';
-import type { AgorAnalyticsSettings } from '../config/types.js';
 
 export type AnalyticsProperties = Record<string, unknown>;
 export type AnalyticsContext = Record<string, unknown>;
@@ -13,11 +12,6 @@ export interface AnalyticsTrackOptions {
 export interface AnalyticsLogger {
   isEnabled(): boolean;
   track(event: string, properties?: AnalyticsProperties, options?: AnalyticsTrackOptions): void;
-}
-
-export interface AnalyticsPluginContext {
-  config: AgorAnalyticsSettings;
-  pluginConfig: NonNullable<AgorAnalyticsSettings['plugins']>[number];
 }
 
 export type ResolvedAnalyticsPlugin = AnalyticsPlugin & {

--- a/packages/core/src/config/analytics-defaults.ts
+++ b/packages/core/src/config/analytics-defaults.ts
@@ -30,15 +30,6 @@ export function getDefaultAnalyticsConfig(): AgorAnalyticsSettings {
           headers: {},
         },
       },
-      {
-        type: 'module',
-        enabled: false,
-        options: {
-          module_path: null,
-          export_name: 'createAnalyticsPlugin',
-          plugin_options: {},
-        },
-      },
     ],
   };
 }

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -575,6 +575,19 @@ describe('loadConfig cache', () => {
     await expect(loadConfig()).rejects.toThrow(/opportunistic.*deprecated/s);
   });
 
+  it('rejects removed analytics module plugins on every load path', async () => {
+    await writeConfigFile(
+      'analytics:\n  enabled: false\n  plugins:\n    - type: module\n      enabled: false\n      options:\n        module_path: /opt/agor/plugin.js\n'
+    );
+
+    expect(() => loadConfigSync()).toThrow(
+      /analytics\.plugins\[0\].*module.*removed.*stdout.*http_batch/s
+    );
+    await expect(loadConfig()).rejects.toThrow(
+      /analytics\.plugins\[0\].*module.*removed.*stdout.*http_batch/s
+    );
+  });
+
   it('treats branch_rbac as app-level only in simple Unix mode', async () => {
     await writeConfigFile({
       execution: { branch_rbac: true, unix_user_mode: 'simple' },

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -215,6 +215,17 @@ async function ensureAgorHome(): Promise<void> {
  * Validate config and throw helpful errors for deprecated/invalid settings
  */
 function validateConfig(config: AgorConfig): void {
+  const configuredAnalyticsPlugins = (config.analytics as { plugins?: unknown[] } | undefined)
+    ?.plugins;
+  const removedModulePluginIndex = configuredAnalyticsPlugins?.findIndex(
+    (plugin) =>
+      !!plugin && typeof plugin === 'object' && (plugin as { type?: unknown }).type === 'module'
+  );
+  if (removedModulePluginIndex !== undefined && removedModulePluginIndex >= 0) {
+    throw new Error(
+      `Config error: analytics.plugins[${removedModulePluginIndex}].type 'module' has been removed because loading operator-selected code in the daemon is unsafe. Use the built-in 'stdout' or 'http_batch' analytics plugin instead.`
+    );
+  }
   const removedConfig = config as AgorConfig & {
     resources?: unknown;
     services?: unknown;
@@ -445,13 +456,26 @@ function validateConfig(config: AgorConfig): void {
   only(config.analytics?.filters, 'analytics.filters', ['exclude_events']);
   for (const [index, plugin] of (config.analytics?.plugins ?? []).entries()) {
     only(plugin, `analytics.plugins[${index}]`, ['type', 'enabled', 'options']);
-    const optionKeys =
-      plugin.type === 'stdout'
-        ? ['pretty']
-        : plugin.type === 'http_batch'
-          ? ['url', 'flush_interval_ms', 'max_batch_size', 'timeout_ms', 'headers']
-          : ['module_path', 'export_name', 'plugin_options'];
-    only(plugin.options, `analytics.plugins[${index}].options`, optionKeys);
+    switch (plugin.type) {
+      case 'stdout':
+        only(plugin.options, `analytics.plugins[${index}].options`, ['pretty']);
+        break;
+      case 'http_batch':
+        only(plugin.options, `analytics.plugins[${index}].options`, [
+          'url',
+          'flush_interval_ms',
+          'max_batch_size',
+          'timeout_ms',
+          'headers',
+        ]);
+        break;
+      default: {
+        const unsupported: never = plugin;
+        throw new Error(
+          `Config error: analytics.plugins[${index}].type '${String((unsupported as { type?: unknown }).type)}' is not supported. Use 'stdout' or 'http_batch'.`
+        );
+      }
+    }
   }
   only(config.telemetry, 'telemetry', [
     'enabled',

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -878,8 +878,7 @@ export interface AgorAnalyticsSettings {
 
 export type AgorAnalyticsPluginSettings =
   | AgorAnalyticsStdoutPluginSettings
-  | AgorAnalyticsHttpBatchPluginSettings
-  | AgorAnalyticsModulePluginSettings;
+  | AgorAnalyticsHttpBatchPluginSettings;
 
 export interface AgorAnalyticsStdoutPluginSettings {
   type: 'stdout';
@@ -901,19 +900,6 @@ export interface AgorAnalyticsHttpBatchPluginSettings {
     timeout_ms?: number;
     /** Static headers only. */
     headers?: Record<string, string>;
-  };
-}
-
-export interface AgorAnalyticsModulePluginSettings {
-  type: 'module';
-  enabled?: boolean;
-  options?: {
-    /** Package name or absolute local module path to dynamically import. */
-    module_path?: string | null;
-    /** Factory export to call. Defaults to createAnalyticsPlugin. */
-    export_name?: string;
-    /** Passed as the first argument to the module factory. */
-    plugin_options?: Record<string, unknown>;
   };
 }
 

--- a/scripts/daemon-filesystem-exceptions.json
+++ b/scripts/daemon-filesystem-exceptions.json
@@ -42,20 +42,6 @@
     "reviewDate": null
   },
   {
-    "id": "DAEMON-FS-CAP-004",
-    "class": "D",
-    "file": "packages/core/src/analytics/plugins.ts",
-    "import": "<non-literal-dynamic-import>",
-    "symbol": "<expression>",
-    "local": "<dynamic>",
-    "operation": "review:dynamic-import@createModuleAnalyticsPlugins#1",
-    "owner": "@agor/core analytics maintainers",
-    "boundary": "ambiguous product decision",
-    "rationale": "Product decision is required before runtime-selected code loading can be classified.",
-    "reviewTarget": "Decide whether plugin loading is a daemon-host capability or must use a constrained registry.",
-    "reviewDate": "2026-09-01"
-  },
-  {
     "id": "DAEMON-FS-CAP-005",
     "class": "A",
     "file": "packages/core/src/telemetry/version.ts",


### PR DESCRIPTION
## Summary

- remove runtime-selected analytics module plugins and their non-literal dynamic import path
- retain the type-safe built-in `stdout` and `http_batch` analytics delivery plugins
- reject legacy `type: module` configuration with actionable migration guidance
- remove `DAEMON-FS-CAP-004` from the daemon filesystem exception registry
- update focused coverage and the daemon filesystem decoupling documentation

## Compatibility impact

Existing configurations containing `analytics.plugins[*].type: module` now fail during config loading, even when the plugin or analytics is disabled. Operators must remove those entries and use either `stdout` or `http_batch`. Arbitrary in-process analytics module loading is no longer supported.

## Residual analytics capabilities

- analytics master enable/disable switch
- static client metadata/options
- event exclusion filters
- stdout JSON/pretty-JSON delivery
- HTTP batch delivery with static headers, batching, flush interval, timeout, and maximum batch size

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm test:daemon-filesystem-boundaries`
- `pnpm --filter @agor/core exec vitest run src/analytics/analytics.test.ts src/config/config-manager.test.ts`
- `git diff --check`
