### PR TITLE
fix(analytics): include trusted tenant context

### DIFF
--- a/context/concepts/multitenancy.md
+++ b/context/concepts/multitenancy.md
@@ -76,6 +76,7 @@ Reuse these instead of adding local tenant plumbing:
 | Queued session work                                    | `apps/agor-daemon/src/utils/session-queue-tenant-scope.ts`                                                         |
 | MCP database work                                      | `apps/agor-daemon/src/mcp/tenant-scope.ts`                                                                         |
 | Tenant-aware realtime delivery                         | `apps/agor-daemon/src/utils/realtime-publish.ts`                                                                   |
+| Operator-configured analytics event identity           | `packages/core/src/analytics/logger.ts` adds trusted ambient identity as `context.tenant_id`                       |
 | Static guard against new raw boundary bypasses         | `scripts/check-multitenancy-boundaries.mjs`                                                                        |
 
 RLS protects database rows, not files, object storage, caches, tokens, realtime

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -132,7 +132,11 @@ describe('analytics logger', () => {
     const track = vi.fn(() => Promise.resolve());
     const logger = new AnalyticsPackageLogger({ track } as never);
 
-    logger.track('daemon.event', {}, { context: { source: 'system' } });
+    logger.track(
+      'daemon.event',
+      {},
+      { context: { source: 'system', tenant_id: 'spoofed-tenant' } }
+    );
 
     expect(track).toHaveBeenCalledWith('daemon.event', {}, { context: { source: 'system' } });
   });

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
 import { getDefaultConfig } from '../config/config-manager.js';
 import type { AgorAnalyticsSettings } from '../config/types.js';
+import { runWithTenantContext } from '../db/tenant-context.js';
 import { isAnalyticsEventExcluded } from './filters.js';
 import {
   AnalyticsPackageLogger,
@@ -103,6 +104,37 @@ describe('analytics logger', () => {
 
     expect(() => logger.track('task.created', { task_id: 'task-1' })).not.toThrow();
     expect(warn).toHaveBeenCalledWith('[analytics] track failed for "task.created":', 'sync boom');
+  });
+
+  it('adds the trusted ambient tenant id to analytics context', () => {
+    const track = vi.fn(() => Promise.resolve());
+    const logger = new AnalyticsPackageLogger({ track } as never);
+
+    runWithTenantContext('tenant-a', () => {
+      logger.track(
+        'task.created',
+        { task_id: 'task-1' },
+        { userId: 'user-1', context: { source: 'test', tenant_id: 'spoofed-tenant' } }
+      );
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      'task.created',
+      { task_id: 'task-1' },
+      {
+        userId: 'user-1',
+        context: { source: 'test', tenant_id: 'tenant-a' },
+      }
+    );
+  });
+
+  it('does not invent tenant identity outside a tenant context', () => {
+    const track = vi.fn(() => Promise.resolve());
+    const logger = new AnalyticsPackageLogger({ track } as never);
+
+    logger.track('daemon.event', {}, { context: { source: 'system' } });
+
+    expect(track).toHaveBeenCalledWith('daemon.event', {}, { context: { source: 'system' } });
   });
 });
 

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -68,8 +68,10 @@ export class AnalyticsPackageLogger implements AnalyticsLogger {
     const trackOptions: Record<string, unknown> = {};
     const tenantId = getCurrentTenantId();
     if (options.context || tenantId) {
+      const callerContext = { ...options.context };
+      delete callerContext.tenant_id;
       trackOptions.context = {
-        ...options.context,
+        ...callerContext,
         ...(tenantId ? { tenant_id: tenantId } : {}),
       };
     }

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -2,6 +2,7 @@ import type { AnalyticsInstance } from 'analytics';
 import { Analytics } from 'analytics';
 import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
 import type { AgorAnalyticsSettings, AgorConfig } from '../config/types.js';
+import { getCurrentTenantId } from '../db/tenant-context.js';
 import { isAnalyticsEventExcluded } from './filters.js';
 import { resolveAnalyticsPlugins } from './plugins.js';
 import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from './types.js';
@@ -65,7 +66,13 @@ export class AnalyticsPackageLogger implements AnalyticsLogger {
     if (isAnalyticsEventExcluded(event, this.excludeEvents)) return;
 
     const trackOptions: Record<string, unknown> = {};
-    if (options.context) trackOptions.context = options.context;
+    const tenantId = getCurrentTenantId();
+    if (options.context || tenantId) {
+      trackOptions.context = {
+        ...options.context,
+        ...(tenantId ? { tenant_id: tenantId } : {}),
+      };
+    }
     if (options.userId) trackOptions.userId = options.userId;
     if (options.anonymousId) trackOptions.anonymousId = options.anonymousId;
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -853,7 +853,8 @@ export interface AgorTelemetrySettings {
  *
  * Disabled by default. When enabled, daemon/server code sends curated
  * lifecycle events through a central analytics client. Plugin configuration is
- * resolved by type at daemon startup.
+ * resolved by type at daemon startup. Events emitted inside a trusted tenant
+ * scope automatically include that tenant as `context.tenant_id`.
  */
 export interface AgorAnalyticsSettings {
   /** Master kill-switch. Defaults to false. */


### PR DESCRIPTION
## Summary

- add trusted ambient tenant identity to operator-configured analytics events as `context.tenant_id`
- ensure caller-provided analytics context cannot spoof the active tenant
- leave intentional system/global analytics events unlabeled when no tenant scope is active
- document the analytics tenant-identity owner in the multitenancy guide and config types

## Multitenancy and security

The analytics logger reads tenant identity from Agor's trusted `AsyncLocalStorage` tenant context at the point the event is tracked. The trusted value is merged after caller-provided context, so a supplied `context.tenant_id` cannot override it.

This applies only to operator-configured `analytics.*` delivery. It does not add raw tenant IDs to Agor's separate open-source `telemetry.*` pipeline.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core exec vitest run src/analytics/analytics.test.ts`
- `pnpm --filter @agor/daemon exec vitest run src/services/tasks.analytics.test.ts src/utils/analytics-payloads.test.ts`
- `pnpm check:multitenancy-boundaries`
