### PR TITLE
fix(rbac): restore None permission option

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -467,9 +467,39 @@ describe('agor_boards_create schema', () => {
       expect(result.error.issues[0]?.message).toMatch(/name cannot be empty/i);
     }
   });
+
+  it('accepts None as a board branch-permission default', () => {
+    const config = registerAndCaptureConfig('agor_boards_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(
+      config.inputSchema?.safeParse({ name: 'Private fallback', defaultOthersCan: 'none' }).success
+    ).toBe(true);
+  });
 });
 
 describe('agor_boards_update realtime events', () => {
+  it('persists None as the default for aligned branches', async () => {
+    const patch = vi.fn(async (_id, data) => ({ board_id: 'board-1', ...data }));
+    const get = vi.fn(async () => ({ board_id: 'board-1', default_others_can: 'none' }));
+    const app = {
+      service(name: string) {
+        if (name === 'boards') return { patch, get, emit: vi.fn() };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const updateBoard = registerAndCaptureHandler('agor_boards_update', {
+      app,
+      userId: 'user-1',
+      baseServiceParams: {},
+    });
+
+    await updateBoard({ boardId: 'board-1', defaultOthersCan: 'none' });
+    expect(patch).toHaveBeenCalledWith('board-1', { default_others_can: 'none' }, {});
+  });
+
   it('emits custom object mutations with a correctly-shaped HookContext', async () => {
     const params = {
       authenticated: true,

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -5,6 +5,7 @@ import type {
   BoardObjectType,
   BranchID,
 } from '@agor/core/types';
+import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BoardsServiceImpl } from '../../declarations.js';
@@ -240,6 +241,14 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           'Custom CSS for board canvas animations (@keyframes, animation, background-size, etc.). Rendered in a scoped <style> tag. Dangerous patterns like url(), expression(), @import are blocked.'
         ),
         slug: mcpOptionalString('slug', 'URL-friendly slug (optional)'),
+        accessMode: z.enum(['private', 'shared']).optional(),
+        defaultOthersCan: z
+          .enum(BRANCH_PERMISSION_LEVELS)
+          .optional()
+          .describe(
+            'Default app-layer permission for non-owners of aligned branches. "none" denies the public fallback; owners and explicit group grants still apply on shared boards.'
+          ),
+        defaultOthersFsAccess: z.enum(['none', 'read', 'write']).optional(),
         customContext: z
           .object({})
           .passthrough()
@@ -272,6 +281,11 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         metadataUpdates.background_color = args.backgroundColor;
       if (args.customCss !== undefined) metadataUpdates.custom_css = args.customCss;
       if (args.slug !== undefined) metadataUpdates.slug = args.slug;
+      if (args.accessMode !== undefined) metadataUpdates.access_mode = args.accessMode;
+      if (args.defaultOthersCan !== undefined)
+        metadataUpdates.default_others_can = args.defaultOthersCan;
+      if (args.defaultOthersFsAccess !== undefined)
+        metadataUpdates.default_others_fs_access = args.defaultOthersFsAccess;
       if (args.customContext !== undefined) metadataUpdates.custom_context = args.customContext;
 
       if (Object.keys(metadataUpdates).length > 0) {
@@ -344,6 +358,9 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           'customCss',
           'Custom CSS for board canvas animations (@keyframes, animation, etc.). Optional.'
         ),
+        accessMode: z.enum(['private', 'shared']).optional(),
+        defaultOthersCan: z.enum(BRANCH_PERMISSION_LEVELS).optional(),
+        defaultOthersFsAccess: z.enum(['none', 'read', 'write']).optional(),
       }),
     },
     async (args) => {
@@ -361,6 +378,10 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       if (args.backgroundColor !== undefined)
         boardData.background_color = coerceString(args.backgroundColor);
       if (args.customCss !== undefined) boardData.custom_css = coerceString(args.customCss);
+      if (args.accessMode !== undefined) boardData.access_mode = args.accessMode;
+      if (args.defaultOthersCan !== undefined) boardData.default_others_can = args.defaultOthersCan;
+      if (args.defaultOthersFsAccess !== undefined)
+        boardData.default_others_fs_access = args.defaultOthersFsAccess;
 
       const board = await ctx.app.service('boards').create(boardData, ctx.baseServiceParams);
       return textResult(board);

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -241,7 +241,6 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           'Custom CSS for board canvas animations (@keyframes, animation, background-size, etc.). Rendered in a scoped <style> tag. Dangerous patterns like url(), expression(), @import are blocked.'
         ),
         slug: mcpOptionalString('slug', 'URL-friendly slug (optional)'),
-        accessMode: z.enum(['private', 'shared']).optional(),
         defaultOthersCan: z
           .enum(BRANCH_PERMISSION_LEVELS)
           .optional()
@@ -281,7 +280,6 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         metadataUpdates.background_color = args.backgroundColor;
       if (args.customCss !== undefined) metadataUpdates.custom_css = args.customCss;
       if (args.slug !== undefined) metadataUpdates.slug = args.slug;
-      if (args.accessMode !== undefined) metadataUpdates.access_mode = args.accessMode;
       if (args.defaultOthersCan !== undefined)
         metadataUpdates.default_others_can = args.defaultOthersCan;
       if (args.defaultOthersFsAccess !== undefined)
@@ -358,7 +356,6 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           'customCss',
           'Custom CSS for board canvas animations (@keyframes, animation, etc.). Optional.'
         ),
-        accessMode: z.enum(['private', 'shared']).optional(),
         defaultOthersCan: z.enum(BRANCH_PERMISSION_LEVELS).optional(),
         defaultOthersFsAccess: z.enum(['none', 'read', 'write']).optional(),
       }),
@@ -378,7 +375,6 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       if (args.backgroundColor !== undefined)
         boardData.background_color = coerceString(args.backgroundColor);
       if (args.customCss !== undefined) boardData.custom_css = coerceString(args.customCss);
-      if (args.accessMode !== undefined) boardData.access_mode = args.accessMode;
       if (args.defaultOthersCan !== undefined) boardData.default_others_can = args.defaultOthersCan;
       if (args.defaultOthersFsAccess !== undefined)
         boardData.default_others_fs_access = args.defaultOthersFsAccess;

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -137,6 +137,30 @@ afterEach(() => {
 });
 
 describe('agor_branches_update', () => {
+  it('can persist an explicit None override instead of an inherited board default', async () => {
+    const branchesPatch = vi.fn(async (_id, data) => ({ branch_id: 'branch-1', ...data }));
+    const branchesGet = vi.fn(async () => ({ branch_id: 'branch-1' }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const update = registerAndCaptureUpdate({ app, userId: 'user-1' });
+
+    await update({
+      branchId: 'branch-1',
+      permissionSource: 'override',
+      othersCan: 'none',
+    });
+
+    expect(branchesPatch).toHaveBeenCalledWith(
+      'branch-1',
+      { permission_source: 'override', others_can: 'none' },
+      {}
+    );
+  });
+
   it('uses authenticated service params when falling back to the current session branch', async () => {
     const baseServiceParams = {
       authenticated: true,

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -948,6 +948,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               '"prompt" = can prompt ANY session (including other users\'), "all" = full access. ' +
               'Always effective regardless of Unix isolation mode. Single-user setups can ignore this.'
           ),
+        permissionSource: z
+          .enum(['board', 'override'])
+          .optional()
+          .describe(
+            'Choose whether effective non-owner access is inherited from the board or read from this branch override. Set "override" with othersCan="none" for an explicit private fallback.'
+          ),
         othersFsAccess: z
           .enum(['none', 'read', 'write'])
           .optional()
@@ -1043,6 +1049,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       if (args.othersCan !== undefined) {
         fieldsProvided++;
         updates.others_can = args.othersCan;
+      }
+      if (args.permissionSource !== undefined) {
+        fieldsProvided++;
+        updates.permission_source = args.permissionSource;
       }
       if (args.othersFsAccess !== undefined) {
         fieldsProvided++;

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.test.tsx
@@ -132,4 +132,72 @@ describe('PermissionsTab', () => {
     expect(screen.getByText('Others Can')).toBeInTheDocument();
     expect(screen.getByText('Filesystem Access')).toBeInTheDocument();
   });
+
+  it('renders explicit None and allows transitioning away from it', () => {
+    const setField = vi.fn();
+    renderWithApp(
+      <PermissionsTab
+        loadingOwners={false}
+        canEdit
+        allUsers={[makeUser()]}
+        currentUser={makeUser()}
+        state={{ ...defaultState, permissionSource: 'override', othersCan: 'none' }}
+        setField={setField}
+      />
+    );
+
+    const selector = screen.getByRole('combobox', { name: 'Others Can' });
+    expect(selector).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('None')).toBeInTheDocument();
+    fireEvent.mouseDown(selector);
+    fireEvent.click(screen.getByText('View', { selector: '.ant-select-item-option-content' }));
+    expect(setField).toHaveBeenCalledWith('othersCan', 'view');
+  });
+
+  it('shows None as an available branch fallback', () => {
+    renderWithApp(
+      <PermissionsTab
+        loadingOwners={false}
+        canEdit
+        allUsers={[makeUser()]}
+        currentUser={makeUser()}
+        state={defaultState}
+        setField={vi.fn()}
+      />
+    );
+
+    const selector = screen.getByRole('combobox', { name: 'Others Can' });
+    fireEvent.mouseDown(selector);
+    expect(
+      screen.getByText('None', { selector: '.ant-select-item-option-content' })
+    ).toBeInTheDocument();
+  });
+
+  it('distinguishes an inherited board None default from a branch override', () => {
+    const client = {
+      service: () => ({ find: vi.fn(async () => []) }),
+    };
+    renderWithApp(
+      <PermissionsTab
+        loadingOwners={false}
+        canEdit
+        allUsers={[makeUser()]}
+        currentUser={makeUser()}
+        client={client as never}
+        board={
+          {
+            board_id: 'board-1',
+            access_mode: 'shared',
+            default_others_can: 'none',
+          } as never
+        }
+        state={{ ...defaultState, permissionSource: 'board' }}
+        setField={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Aligned with board permissions')).toBeInTheDocument();
+    expect(screen.getByText('none')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Others Can' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.test.tsx
@@ -141,7 +141,14 @@ describe('PermissionsTab', () => {
         canEdit
         allUsers={[makeUser()]}
         currentUser={makeUser()}
-        state={{ ...defaultState, permissionSource: 'override', othersCan: 'none' }}
+        allGroups={[{ group_id: 'group-1', name: 'Reviewers' } as never]}
+        state={{
+          ...defaultState,
+          permissionSource: 'override',
+          othersCan: 'none',
+          othersFsAccess: 'write',
+          groupGrants: [{ group_id: 'group-1', can: 'view' }],
+        }}
         setField={setField}
       />
     );
@@ -149,6 +156,9 @@ describe('PermissionsTab', () => {
     const selector = screen.getByRole('combobox', { name: 'Others Can' });
     expect(selector).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.getAllByText('Reviewers').length).toBeGreaterThan(0);
+    expect(screen.getByText('Filesystem Access')).toBeInTheDocument();
+    expect(screen.queryByText(/Owner-only access/)).not.toBeInTheDocument();
     fireEvent.mouseDown(selector);
     fireEvent.click(screen.getByText('View', { selector: '.ant-select-item-option-content' }));
     expect(setField).toHaveBeenCalledWith('othersCan', 'view');

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
@@ -14,7 +14,6 @@ import { useEffect, useState } from 'react';
 import {
   RbacPermissionFields,
   type RbacPermissionValue,
-  rbacVisibilityFromOthersCan,
 } from '../../permissions/RbacPermissionFields';
 import type { GroupGrantsStatus, PermissionsFormState } from '../useBranchModalForm';
 
@@ -54,7 +53,9 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
   const permissionSource = state.permissionSource ?? 'override';
   const canEditBranchFallbacks = canEdit && permissionSource === 'override';
   const fieldValue: RbacPermissionValue = {
-    visibility: rbacVisibilityFromOthersCan(state.othersCan),
+    // Branches have no persisted visibility mode: `none` is the public
+    // fallback and does not disable explicit owners/groups/filesystem grants.
+    visibility: 'shared',
     ownerIds: state.selectedOwnerIds,
     groupGrants: state.groupGrants ?? [],
     othersCan: state.othersCan,
@@ -218,7 +219,7 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
             groupGrantsError={groupGrantsError}
             ownersLoadError={ownersLoadError}
             groupsHelp="Grant explicit branch access to user groups"
-            canEditOthersCanWhenPrivate
+            showVisibility={false}
           />
         )}
       </Form>

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
@@ -218,6 +218,7 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
             groupGrantsError={groupGrantsError}
             ownersLoadError={ownersLoadError}
             groupsHelp="Grant explicit branch access to user groups"
+            canEditOthersCanWhenPrivate
           />
         )}
       </Form>

--- a/apps/agor-ui/src/components/forms/BoardFormFields.test.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithApp } from '../BranchModal/testUtils';
+import { BoardFormFields, extractBoardFormValues } from './BoardFormFields';
+
+function BoardFormHarness({
+  onRead,
+}: {
+  onRead: (values: ReturnType<typeof extractBoardFormValues>) => void;
+}) {
+  const [form] = Form.useForm();
+  return (
+    <Form
+      form={form}
+      initialValues={{
+        access_mode: 'shared',
+        default_others_can: 'session',
+        default_others_fs_access: 'read',
+        owner_ids: ['user-1'],
+      }}
+    >
+      <BoardFormFields form={form} rbacEnabled />
+      <button type="button" onClick={() => onRead(extractBoardFormValues(form))}>
+        Read values
+      </button>
+    </Form>
+  );
+}
+
+describe('BoardFormFields permissions', () => {
+  it('offers and persists an explicit None default, then allows changing away', () => {
+    const onRead = vi.fn();
+    renderWithApp(<BoardFormHarness onRead={onRead} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Permissions' }));
+    const selector = screen.getByRole('combobox', { name: 'Default others can' });
+
+    fireEvent.mouseDown(selector);
+    fireEvent.click(screen.getByText('None', { selector: '.ant-select-item-option-content' }));
+    expect(screen.getByText('None')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Read values' }));
+    expect(onRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({ default_others_can: 'none' })
+    );
+
+    fireEvent.mouseDown(selector);
+    fireEvent.click(screen.getByText('View', { selector: '.ant-select-item-option-content' }));
+    expect(screen.getByText('View')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Read values' }));
+    expect(onRead).toHaveBeenLastCalledWith(
+      expect.objectContaining({ default_others_can: 'view' })
+    );
+  });
+});

--- a/apps/agor-ui/src/components/permissions/RbacPermissionFields.tsx
+++ b/apps/agor-ui/src/components/permissions/RbacPermissionFields.tsx
@@ -49,6 +49,8 @@ interface RbacPermissionFieldsProps {
   othersCanLabel?: string;
   othersFsAccessLabel?: string;
   showLegacySessionSharing?: boolean;
+  /** Branches can leave owner/group grants intact while denying the public fallback. */
+  canEditOthersCanWhenPrivate?: boolean;
 }
 
 const permissionLevelDescriptions: Record<BranchPermissionLevel, string> = {
@@ -95,6 +97,7 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
   othersCanLabel = 'Others Can',
   othersFsAccessLabel = 'Filesystem Access',
   showLegacySessionSharing = true,
+  canEditOthersCanWhenPrivate = false,
 }) => {
   const { showError } = useThemedMessage();
   const [selectKey, setSelectKey] = useState(0);
@@ -304,25 +307,6 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
             </Space>
           </Form.Item>
 
-          <Form.Item
-            label={othersCanLabel}
-            labelCol={{ span: 8 }}
-            wrapperCol={{ span: 16 }}
-            help={permissionLevelDescriptions[value.othersCan]}
-          >
-            <Select
-              value={value.othersCan}
-              onChange={(othersCan) => onChange('othersCan', othersCan)}
-              disabled={!canEdit}
-              options={[
-                { value: 'view', label: 'View' },
-                { value: 'session', label: 'Own Sessions' },
-                { value: 'prompt', label: 'Prompt' },
-                { value: 'all', label: 'All' },
-              ]}
-            />
-          </Form.Item>
-
           {value.othersCan === 'prompt' && (
             <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
               <Alert
@@ -383,6 +367,28 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
           )}
         </>
       )}
+
+      <Form.Item
+        label={othersCanLabel}
+        labelCol={{ span: 8 }}
+        wrapperCol={{ span: 16 }}
+        help={permissionLevelDescriptions[value.othersCan]}
+      >
+        <Select
+          aria-label={othersCanLabel}
+          virtual={false}
+          value={value.othersCan}
+          onChange={(othersCan) => onChange('othersCan', othersCan)}
+          disabled={!canEdit || (!isShared && !canEditOthersCanWhenPrivate)}
+          options={[
+            { value: 'none', label: 'None' },
+            { value: 'view', label: 'View' },
+            { value: 'session', label: 'Own Sessions' },
+            { value: 'prompt', label: 'Prompt' },
+            { value: 'all', label: 'All' },
+          ]}
+        />
+      </Form.Item>
     </>
   );
 };

--- a/apps/agor-ui/src/components/permissions/RbacPermissionFields.tsx
+++ b/apps/agor-ui/src/components/permissions/RbacPermissionFields.tsx
@@ -49,8 +49,8 @@ interface RbacPermissionFieldsProps {
   othersCanLabel?: string;
   othersFsAccessLabel?: string;
   showLegacySessionSharing?: boolean;
-  /** Branches can leave owner/group grants intact while denying the public fallback. */
-  canEditOthersCanWhenPrivate?: boolean;
+  /** Boards expose private/shared visibility; branch overrides expose grants and fallback directly. */
+  showVisibility?: boolean;
 }
 
 const permissionLevelDescriptions: Record<BranchPermissionLevel, string> = {
@@ -97,7 +97,7 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
   othersCanLabel = 'Others Can',
   othersFsAccessLabel = 'Filesystem Access',
   showLegacySessionSharing = true,
-  canEditOthersCanWhenPrivate = false,
+  showVisibility = true,
 }) => {
   const { showError } = useThemedMessage();
   const [selectKey, setSelectKey] = useState(0);
@@ -149,22 +149,24 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
         />
       )}
 
-      <Form.Item
-        label={visibilityLabel}
-        labelCol={{ span: 8 }}
-        wrapperCol={{ span: 16 }}
-        help={isShared ? 'Group and fallback access.' : 'Owner-only access.'}
-      >
-        <Radio.Group
-          value={value.visibility}
-          disabled={!canEdit}
-          onChange={(e) => handleVisibilityChange(e.target.value)}
-          options={[
-            { value: 'private', label: privateOwnerLabel },
-            { value: 'shared', label: 'Shared' },
-          ]}
-        />
-      </Form.Item>
+      {showVisibility && (
+        <Form.Item
+          label={visibilityLabel}
+          labelCol={{ span: 8 }}
+          wrapperCol={{ span: 16 }}
+          help={isShared ? 'Group and fallback access.' : 'Owner-only access.'}
+        >
+          <Radio.Group
+            value={value.visibility}
+            disabled={!canEdit}
+            onChange={(e) => handleVisibilityChange(e.target.value)}
+            options={[
+              { value: 'private', label: privateOwnerLabel },
+              { value: 'shared', label: 'Shared' },
+            ]}
+          />
+        </Form.Item>
+      )}
 
       {isShared && (
         <Form.Item label="Owners" labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} help={ownerHelp}>
@@ -379,7 +381,7 @@ export const RbacPermissionFields: React.FC<RbacPermissionFieldsProps> = ({
           virtual={false}
           value={value.othersCan}
           onChange={(othersCan) => onChange('othersCan', othersCan)}
-          disabled={!canEdit || (!isShared && !canEditOthersCanWhenPrivate)}
+          disabled={!canEdit || !isShared}
           options={[
             { value: 'none', label: 'None' },
             { value: 'view', label: 'View' },

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -1055,6 +1055,64 @@ describe('BranchRepository permission_source', () => {
 
 describe('BranchRepository resolveUserAccess', () => {
   dbTest(
+    'enforces None for board defaults and branch overrides without granting access from board membership',
+    async ({ db }) => {
+      const users = new UsersRepository(db);
+      const repos = new RepoRepository(db);
+      const boards = new BoardRepository(db);
+      const branches = new BranchRepository(db);
+      const owner = await users.create({ email: 'none-owner@example.com' });
+      const boardOwner = await users.create({ email: 'none-board-owner@example.com' });
+      const outsider = await users.create({ email: 'none-outsider@example.com' });
+      const repo = await repos.create(createRepoData({ slug: 'none-contract-repo' }));
+      const board = await boards.create({
+        board_id: generateId(),
+        name: 'Shared board with no public fallback',
+        created_by: owner.user_id,
+        access_mode: 'shared',
+        default_others_can: 'none',
+      });
+      await boards.addOwner(board.board_id, boardOwner.user_id as UUID);
+
+      const aligned = await branches.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          created_by: owner.user_id as UUID,
+          name: 'aligned-none',
+          branch_unique_id: 9198,
+          permission_source: 'board',
+        })
+      );
+      const overridden = await branches.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          created_by: owner.user_id as UUID,
+          name: 'override-none',
+          branch_unique_id: 9199,
+          permission_source: 'override',
+          others_can: 'none',
+        })
+      );
+      await branches.addOwner(aligned.branch_id, owner.user_id as UUID);
+      await branches.addOwner(overridden.branch_id, owner.user_id as UUID);
+
+      expect(await branches.resolveUserAccess(aligned, outsider.user_id as UUID)).toMatchObject({
+        can: 'none',
+        source: 'board',
+      });
+      expect(await branches.resolveUserAccess(aligned, owner.user_id as UUID)).toMatchObject({
+        can: 'all',
+        source: 'owner',
+      });
+      expect(
+        await branches.resolveUserAccess(overridden, boardOwner.user_id as UUID)
+      ).toMatchObject({ can: 'none', source: 'others' });
+    }
+  );
+
+  dbTest(
     'uses board session-sharing defaults for direct owners of board-aligned branches',
     async ({ db }) => {
       const repoRepo = new RepoRepository(db);


### PR DESCRIPTION
## Summary

- restore the canonical `None` choice in Board and Branch **Others can** selectors
- keep explicit branch overrides distinct from board inheritance and allow transitions away from `None`
- expose board RBAC defaults and branch `permissionSource` through MCP automation
- add UI, MCP, repository, and authorization contract coverage for `others_can: "none"`

## Root cause

PR #1415 (`bf3b517c`, “Implement board-level RBAC defaults”) extracted the shared `RbacPermissionFields` component. The previous Branch selector included `None`, but the extracted selector started at `View`. Board defaults were introduced through the same component, so shared Boards also could not choose an explicit `None` fallback.

The backend contract remained intact: canonical types, database schemas, repositories, and authorization evaluation all continued accepting and enforcing `none`. This change restores the missing UI and automation surfaces without a migration.

## Security semantics

- non-owner/non-admin users resolve to no fallback access when effective `others_can` is `none`
- direct owners retain full recovery access
- board ownership applies only to board-aligned branches; it does not override an explicit per-branch `permission_source: "override"` with `others_can: "none"`
- explicit group grants remain independent from the public fallback
- filesystem access and dangerous session sharing remain separate settings

## Verification

- `pnpm i`
- `pnpm check`
- UI permissions tests: 11 passed
- MCP and daemon RBAC tests: 150 passed
- Core branch repository tests: 41 passed
