### PR TITLE
feat(ui): navbar compose trigger for a user's primary assistant

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -730,6 +730,8 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       'getAvatarSettings',
       'updateAvatarSettings',
       'syncAvatars',
+      'getPrimaryTeammate',
+      'setPrimaryTeammate',
     ],
   });
 

--- a/apps/agor-daemon/src/services/users.primary-teammate.test.ts
+++ b/apps/agor-daemon/src/services/users.primary-teammate.test.ts
@@ -1,0 +1,102 @@
+import {
+  BranchRepository,
+  type Database,
+  generateId,
+  RepoRepository,
+  UserPrimaryTeammateRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { BranchID, UUID } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { createUsersService } from './users';
+
+const CALLER = 'caller-user' as UUID;
+const CALLER_PARAMS = { user: { user_id: CALLER } } as never;
+
+let uniqueId = 9_000;
+
+async function ensureCaller(db: Database) {
+  await new UsersRepository(db).create({
+    user_id: CALLER,
+    email: 'caller@example.com',
+    role: 'member',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  overrides?: { created_by?: UUID; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const slug = `repo-${uniqueId}`;
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug,
+    name: slug,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/tmp/${slug}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${uniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: uniqueId++,
+    path: `/tmp/${name}`,
+    created_by: overrides?.created_by ?? CALLER,
+    permission_source: 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UsersService primary teammate', () => {
+  dbTest('getPrimaryTeammate returns null when unset', async ({ db }) => {
+    await ensureCaller(db);
+    const service = createUsersService(db);
+    expect(await service.getPrimaryTeammate(undefined, CALLER_PARAMS)).toBeNull();
+  });
+
+  dbTest('setPrimaryTeammate records an explicit pick and reads back', async ({ db }) => {
+    await ensureCaller(db);
+    const branchId = await createBranch(db);
+    const service = createUsersService(db);
+    const setSpy = vi.spyOn(UserPrimaryTeammateRepository.prototype, 'setPrimaryTeammate');
+
+    const written = await service.setPrimaryTeammate({ branchId }, CALLER_PARAMS);
+
+    expect(written?.branch_id).toBe(branchId);
+    expect(setSpy).toHaveBeenCalledWith(CALLER, branchId, {
+      source: 'explicit',
+      updatedBy: CALLER,
+    });
+    const resolved = await service.getPrimaryTeammate(undefined, CALLER_PARAMS);
+    expect(resolved?.branch_id).toBe(branchId);
+    setSpy.mockRestore();
+  });
+
+  dbTest('setPrimaryTeammate rejects a branch the caller cannot access', async ({ db }) => {
+    await ensureCaller(db);
+    const inaccessible = await createBranch(db, {
+      created_by: generateId() as UUID,
+      others_can: 'none',
+    });
+    const service = createUsersService(db);
+
+    await expect(
+      service.setPrimaryTeammate({ branchId: inaccessible }, CALLER_PARAMS)
+    ).rejects.toThrow();
+  });
+
+  dbTest('primary teammate methods require an authenticated caller', async ({ db }) => {
+    const service = createUsersService(db);
+    await expect(service.getPrimaryTeammate(undefined, {} as never)).rejects.toThrow();
+    await expect(
+      service.setPrimaryTeammate({ branchId: generateId() }, {} as never)
+    ).rejects.toThrow();
+  });
+});

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -19,6 +19,7 @@ import {
 } from '@agor/core/config';
 import {
   and,
+  BranchRepository,
   compare,
   decryptApiKey,
   deleteFrom,
@@ -28,6 +29,7 @@ import {
   insert,
   select,
   type TenantScopeAwareDatabase,
+  UserPrimaryTeammateRepository,
   update,
   users,
 } from '@agor/core/db';
@@ -38,6 +40,8 @@ import type {
   AgenticToolsConfig,
   AgenticToolsUpdate,
   AuthenticatedParams,
+  Branch,
+  BranchID,
   EnvVarMetadata,
   EnvVarScope,
   InternalUser,
@@ -137,6 +141,14 @@ function isAdmin(params: Params | undefined): boolean {
 function isSelfEmailLookup(params: Params | undefined, email: string): boolean {
   const requesterEmail = (params as AuthenticatedParams | undefined)?.user?.email;
   return !!requesterEmail && requesterEmail.toLowerCase() === email.toLowerCase();
+}
+
+function requireCallerId(params: Params | undefined): UserID {
+  const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
+  if (!userId) {
+    throw new NotAuthenticated('Authentication required');
+  }
+  return userId;
 }
 
 function ensureCanExactEmailLookup(params: Params | undefined, email: string): void {
@@ -822,6 +834,40 @@ export class UsersService {
 
   async refreshAvatarFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
     return this.requireAvatarSync().refreshUserFromSettings(userId);
+  }
+
+  /**
+   * Resolve the calling user's primary teammate branch, or null when unset or
+   * no longer accessible (the "needs picking" signal for the settings picker).
+   */
+  async getPrimaryTeammate(_data: unknown, params?: Params): Promise<Branch | null> {
+    const userId = requireCallerId(params);
+    return new UserPrimaryTeammateRepository(this.db).resolvePrimaryTeammate(userId);
+  }
+
+  /**
+   * Set the calling user's primary teammate to a branch they can access. The
+   * pick is a manual user action, so it is recorded with `source: 'explicit'`.
+   * Rejects branches the caller cannot access to avoid persisting a pointer
+   * that would immediately resolve back to null.
+   */
+  async setPrimaryTeammate(data: { branchId: string }, params?: Params): Promise<Branch | null> {
+    const userId = requireCallerId(params);
+    const branchId = data?.branchId as BranchID | undefined;
+    if (!branchId) {
+      throw new Forbidden('A branchId is required to set a primary teammate');
+    }
+
+    const branch = await new BranchRepository(this.db).findAccessibleById(branchId, userId);
+    if (!branch) {
+      throw new Forbidden('Cannot set a primary teammate you do not have access to');
+    }
+
+    await new UserPrimaryTeammateRepository(this.db).setPrimaryTeammate(userId, branchId, {
+      source: 'explicit',
+      updatedBy: userId,
+    });
+    return branch;
   }
 
   /**

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -96,9 +96,17 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
           options={visibleAgents.map((agent) => ({
             value: agent.id,
             label: (
-              <Space size={8}>
-                {/* height:0 keeps the icon from inflating the single-line control past controlHeight */}
-                <span style={{ display: 'inline-flex', height: 0, alignItems: 'center' }}>
+              <Space size={8} align="center">
+                {/* height:0 stops the badge inflating the single-line control; the small
+                    translate re-centers it (the badge is baseline-, not center-aligned). */}
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    height: 0,
+                    alignItems: 'center',
+                    transform: 'translateY(3px)',
+                  }}
+                >
                   <ToolIcon tool={agent.id} size={16} />
                 </span>
                 <span>{agent.name}</span>

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -97,7 +97,10 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
             value: agent.id,
             label: (
               <Space size={8}>
-                <ToolIcon tool={agent.id} size={16} />
+                {/* height:0 keeps the icon from inflating the single-line control past controlHeight */}
+                <span style={{ display: 'inline-flex', height: 0, alignItems: 'center' }}>
+                  <ToolIcon tool={agent.id} size={16} />
+                </span>
                 <span>{agent.name}</span>
                 {agent.beta && <Tag color="warning">BETA</Tag>}
               </Space>

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -57,6 +57,11 @@ export interface AgenticConfigChipRowProps {
    * callers can disable submission proactively. `reason` explains why.
    */
   onConfigValidityChange?: (valid: boolean, reason?: string) => void;
+  /**
+   * Optional field rendered left of the "Configuration" select, sharing a 50/50
+   * row. Chips still render full-width below. Omit for the default stacked layout.
+   */
+  leadingField?: React.ReactNode;
 }
 
 const EFFORT_LABELS: Record<EffortLevel, string> = {
@@ -98,6 +103,7 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   enableSaveAsDefault = false,
   showEffort = true,
   onConfigValidityChange,
+  leadingField,
 }) => {
   const { token } = theme.useToken();
   const form = Form.useFormInstance();
@@ -211,6 +217,37 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
     </Typography.Text>
   );
 
+  const configField = (
+    <Form.Item
+      name={fieldName}
+      label="Configuration"
+      tooltip="Presets are admin-managed configs; “My default” is your personal setup. Edit any chip below to override just this session."
+      style={{ marginBottom: token.marginSM }}
+      rules={[
+        {
+          validator: () =>
+            configError ? Promise.reject(new Error(configError)) : Promise.resolve(),
+        },
+      ]}
+    >
+      <Select
+        onChange={onSelectSource}
+        loading={loading}
+        options={sourceOptions.map((option) => ({
+          value: option.value,
+          disabled: option.disabled,
+          label:
+            option.value === INLINE_AGENTIC_CONFIGURATION
+              ? 'Custom'
+              : option.summary
+                ? `${option.title} · ${option.summary}`
+                : option.title,
+        }))}
+        style={{ width: '100%' }}
+      />
+    </Form.Item>
+  );
+
   return (
     <div style={{ marginBottom: token.marginLG }}>
       {/* Register the fields the chips edit imperatively so useWatch stays reactive. */}
@@ -220,34 +257,14 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
         </Form.Item>
       ))}
 
-      <Form.Item
-        name={fieldName}
-        label="Configuration"
-        tooltip="Presets are admin-managed configs; “My default” is your personal setup. Edit any chip below to override just this session."
-        style={{ marginBottom: token.marginSM }}
-        rules={[
-          {
-            validator: () =>
-              configError ? Promise.reject(new Error(configError)) : Promise.resolve(),
-          },
-        ]}
-      >
-        <Select
-          onChange={onSelectSource}
-          loading={loading}
-          options={sourceOptions.map((option) => ({
-            value: option.value,
-            disabled: option.disabled,
-            label:
-              option.value === INLINE_AGENTIC_CONFIGURATION
-                ? 'Custom'
-                : option.summary
-                  ? `${option.title} · ${option.summary}`
-                  : option.title,
-          }))}
-          style={{ width: '100%' }}
-        />
-      </Form.Item>
+      {leadingField ? (
+        <Flex gap={token.marginSM} align="flex-start">
+          <div style={{ flex: '1 1 0', minWidth: 0 }}>{leadingField}</div>
+          <div style={{ flex: '1 1 0', minWidth: 0 }}>{configField}</div>
+        </Flex>
+      ) : (
+        configField
+      )}
 
       {loadError && (
         <Alert

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1409,6 +1409,7 @@ export const App: React.FC<AppProps> = ({
   );
   const stableOnLogout = useStableCallback(onLogout);
   const stableOnRetryConnection = useStableCallback(onRetryConnection);
+  const stableOnCreateSession = useStableCallback(onCreateSession);
 
   return (
     <AppActionsProvider value={appActionsValue}>
@@ -1441,6 +1442,7 @@ export const App: React.FC<AppProps> = ({
           onUserClick={handleHeaderUserClick}
           instanceLabel={instanceLabel}
           instanceDescription={instanceDescription}
+          onCreateSession={stableOnCreateSession}
         />
         {topBanner}
         <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -273,6 +273,14 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           staticActiveUsers={staticActiveUsers}
           maxVisible={presenceMaxVisible}
         />
+        {onCreateSession && (
+          <NavbarComposeButton
+            client={presenceClient}
+            currentUser={user}
+            currentBoardId={currentBoardId}
+            onCreateSession={onCreateSession}
+          />
+        )}
         <AppHeaderGlobalSearch
           currentUserId={currentUserId}
           branchById={branchById}
@@ -302,17 +310,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           />
         </Tooltip>
-        {onCreateSession && (
-          <>
-            <Divider orientation="vertical" style={{ height: 32, margin: '0 4px' }} />
-            <NavbarComposeButton
-              client={presenceClient}
-              currentUser={user}
-              currentBoardId={currentBoardId}
-              onCreateSession={onCreateSession}
-            />
-          </>
-        )}
         <SettingsDropdown items={settingsItems} />
         <GlobalUserMenu
           user={user}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -16,9 +16,11 @@ import { BrandMark } from '../BrandMark';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { GlobalUserMenu } from '../GlobalUserMenu';
 import { MarkdownRenderer } from '../MarkdownRenderer';
+import type { NewSessionConfig } from '../NewSessionModal';
 import { buildThemeMenuItems } from '../ThemeSwitcher';
 import { AppHeaderGlobalSearch } from './AppHeaderGlobalSearch';
 import { GlobalPresenceFacepile } from './GlobalPresenceFacepile';
+import { NavbarComposeButton } from './NavbarComposeButton';
 import { SettingsDropdown } from './SettingsDropdown';
 
 const { Header } = Layout;
@@ -53,6 +55,8 @@ export interface AppHeaderProps {
   instanceLabel?: string;
   /** Instance description (markdown) shown in popover around the instance label */
   instanceDescription?: string;
+  /** Session-creation seam behind the navbar compose affordance. */
+  onCreateSession?: (config: NewSessionConfig, boardId: string) => Promise<string | null>;
 }
 
 const RecentBoardPills: React.FC<{
@@ -114,6 +118,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   onUserClick,
   instanceLabel,
   instanceDescription,
+  onCreateSession,
 }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
@@ -253,6 +258,17 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
       </Space>
 
       <Space>
+        {onCreateSession && (
+          <>
+            <NavbarComposeButton
+              client={presenceClient}
+              currentUser={user}
+              currentBoardId={currentBoardId}
+              onCreateSession={onCreateSession}
+            />
+            <Divider orientation="vertical" style={{ height: 32, margin: '0 4px' }} />
+          </>
+        )}
         <ConnectionStatus
           connected={connected}
           connecting={connecting}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -258,17 +258,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
       </Space>
 
       <Space>
-        {onCreateSession && (
-          <>
-            <NavbarComposeButton
-              client={presenceClient}
-              currentUser={user}
-              currentBoardId={currentBoardId}
-              onCreateSession={onCreateSession}
-            />
-            <Divider orientation="vertical" style={{ height: 32, margin: '0 4px' }} />
-          </>
-        )}
         <ConnectionStatus
           connected={connected}
           connecting={connecting}
@@ -313,6 +302,17 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           />
         </Tooltip>
+        {onCreateSession && (
+          <>
+            <Divider orientation="vertical" style={{ height: 32, margin: '0 4px' }} />
+            <NavbarComposeButton
+              client={presenceClient}
+              currentUser={user}
+              currentBoardId={currentBoardId}
+              onCreateSession={onCreateSession}
+            />
+          </>
+        )}
         <SettingsDropdown items={settingsItems} />
         <GlobalUserMenu
           user={user}

--- a/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
+++ b/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
@@ -1,5 +1,4 @@
 import type { ActiveUser, AgorClient, Board, BoardID, User } from '@agor-live/client';
-import { Divider } from 'antd';
 import { useMemo } from 'react';
 import { PRESENCE_CONFIG } from '../../config/presence';
 import { usePresence } from '../../hooks/usePresence';
@@ -59,19 +58,16 @@ export const GlobalPresenceFacepile: React.FC<GlobalPresenceFacepileProps> = ({
   if (allActiveUsers.length === 0) return null;
 
   return (
-    <>
-      <Facepile
-        activeUsers={allActiveUsers}
-        currentUserId={currentUser?.user_id}
-        maxVisible={maxVisible}
-        avatarSize={32}
-        boardById={boardById}
-        onUserClick={onUserClick}
-        style={{
-          marginRight: 8,
-        }}
-      />
-      <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
-    </>
+    <Facepile
+      activeUsers={allActiveUsers}
+      currentUserId={currentUser?.user_id}
+      maxVisible={maxVisible}
+      avatarSize={32}
+      boardById={boardById}
+      onUserClick={onUserClick}
+      style={{
+        marginRight: 8,
+      }}
+    />
   );
 };

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -341,11 +341,12 @@ describe('NavbarComposeButton', () => {
     expect(onCreateSession.mock.calls[0][0].attachmentFiles).toHaveLength(1);
   });
 
-  it('gives the trigger and Send & Open primary weight, Send in Background secondary', async () => {
+  it('keeps the navbar trigger neutral (not primary) while Send & Open stays primary', async () => {
     renderCompose({ primary: primaryBranch });
+    // The collapsed trigger is a calm default button, not a loud primary CTA.
     expect(
       screen.getByRole('button', { name: 'Compose — ask your primary assistant' })
-    ).toHaveClass('ant-btn-primary');
+    ).not.toHaveClass('ant-btn-primary');
 
     openPopover();
     await screen.findByTestId('compose-prompt');

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -204,15 +204,26 @@ describe('NavbarComposeButton', () => {
     renderCompose({ primary: primaryBranch });
     openPopover();
     expect(await screen.findByTestId('compose-prompt')).toBeInTheDocument();
-    expect(screen.getByText('Ask your primary assistant')).toBeInTheDocument();
+    expect(screen.getByText(/your primary assistant/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send & Open' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send in Background' })).toBeInTheDocument();
   });
 
-  it('explains the null-primary state above the inline picker', async () => {
+  it('merges the resolved primary name into the header line', async () => {
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.getByText(/your primary assistant/i)).toHaveTextContent(
+      'Ask Ada, your primary assistant'
+    );
+  });
+
+  it('explains the null-primary state above the inline picker (no name in header)', async () => {
     renderCompose({ primary: null });
     openPopover();
     expect(await screen.findByTestId('pick-teammate')).toBeInTheDocument();
+    // No resolved name yet, so the header stays generic (no broken/empty identity).
+    expect(screen.getByText('Ask your primary assistant')).toBeInTheDocument();
     expect(screen.getByText(/don't have a primary assistant yet/i)).toBeInTheDocument();
     expect(screen.getByText(/default teammate for personal, ambient work/i)).toBeInTheDocument();
     expect(screen.getByText(/change it anytime in Settings/i)).toBeInTheDocument();
@@ -261,12 +272,40 @@ describe('NavbarComposeButton', () => {
     expect(screen.getByTestId('config-chip-row')).toContainElement(agentGrid);
   });
 
-  it('shows the resolved primary as a tag once resolved', async () => {
-    renderCompose({ primary: primaryBranch });
+  it('shows a board-switch wayfinding line when the primary lives on another board', async () => {
+    renderCompose({ primary: primaryBranch, currentBoardId: 'board-current' });
     openPopover();
     await screen.findByTestId('compose-prompt');
-    // The tag renders the bare teammate name; the wayfinding sentence embeds it in prose.
-    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText(/Opens on Ada/)).toBeInTheDocument();
+  });
+
+  it('shows the off-board wayfinding line on a non-board surface', async () => {
+    renderCompose({ primary: primaryBranch, currentBoardId: '', pathname: '/knowledge' });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.getByText(/Opens a panel here/)).toBeInTheDocument();
+  });
+
+  it('omits the wayfinding line when already on the primary’s own board', async () => {
+    renderCompose({ primary: primaryBranch, currentBoardId: 'board-primary' });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.queryByText(/Opens on/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Opens a panel here/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Creates a session/)).not.toBeInTheDocument();
+  });
+
+  it('gives both send buttons an explanatory tooltip', async () => {
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    // Enable the buttons first; AntD tooltips don't fire on disabled controls.
+    fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'hi' } });
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Send & Open' }));
+    expect(await screen.findByText('Send and go to the session')).toBeInTheDocument();
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Send in Background' }));
+    expect(await screen.findByText(/Send and stay here/)).toBeInTheDocument();
   });
 
   it('lets a dropped file be sent even with an empty prompt', async () => {

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -200,6 +200,20 @@ describe('NavbarComposeButton', () => {
     localStorage.clear();
   });
 
+  it('shows the resolved primary teammate emoji on the collapsed trigger before opening', async () => {
+    const withEmoji = makeBranch({
+      custom_context: { teammate: { kind: 'teammate', displayName: 'Ada', emoji: '🎨' } },
+    });
+    renderCompose({ primary: withEmoji });
+    // Resolved eagerly on mount — no popover open needed.
+    expect(await screen.findByText('🎨')).toBeInTheDocument();
+  });
+
+  it('shows the 🤖 placeholder emoji on the trigger when no primary is set', async () => {
+    renderCompose({ primary: null });
+    expect(await screen.findByText('🤖')).toBeInTheDocument();
+  });
+
   it('opens the compose popover with a heading and prompt', async () => {
     renderCompose({ primary: primaryBranch });
     openPopover();

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -131,6 +131,20 @@ describe('NavbarComposeButton', () => {
     expect(screen.getByRole('button', { name: 'Send in Background' })).toBeInTheDocument();
   });
 
+  it('gives the trigger and Send & Open primary weight, Send in Background secondary', async () => {
+    renderCompose({ primary: primaryBranch });
+    expect(
+      screen.getByRole('button', { name: 'Compose — ask your primary assistant' })
+    ).toHaveClass('ant-btn-primary');
+
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.getByRole('button', { name: 'Send & Open' })).toHaveClass('ant-btn-primary');
+    expect(screen.getByRole('button', { name: 'Send in Background' })).not.toHaveClass(
+      'ant-btn-primary'
+    );
+  });
+
   it('Send & Open navigates to the new session when on a non-primary board', async () => {
     const { onCreateSession } = renderCompose({
       primary: primaryBranch,

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -214,6 +214,14 @@ describe('NavbarComposeButton', () => {
     expect(await screen.findByText('🤖')).toBeInTheDocument();
   });
 
+  it('shows a "Start quick session" tooltip on the trigger', async () => {
+    renderCompose({ primary: primaryBranch });
+    fireEvent.mouseEnter(
+      screen.getByRole('button', { name: 'Compose — ask your primary assistant' })
+    );
+    expect(await screen.findByText('Start quick session')).toBeInTheDocument();
+  });
+
   it('opens the compose popover with a heading and prompt', async () => {
     renderCompose({ primary: primaryBranch });
     openPopover();
@@ -293,11 +301,12 @@ describe('NavbarComposeButton', () => {
     expect(screen.getByText(/Opens on Ada/)).toBeInTheDocument();
   });
 
-  it('shows the off-board wayfinding line on a non-board surface', async () => {
+  it('shows no wayfinding line on a non-board surface', async () => {
     renderCompose({ primary: primaryBranch, currentBoardId: '', pathname: '/knowledge' });
     openPopover();
     await screen.findByTestId('compose-prompt');
-    expect(screen.getByText(/Opens a panel here/)).toBeInTheDocument();
+    expect(screen.queryByText(/Opens a panel here/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Opens on/)).not.toBeInTheDocument();
   });
 
   it('omits the wayfinding line when already on the primary’s own board', async () => {

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -1,0 +1,214 @@
+import type { AgorClient, Branch } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NavbarComposeButton } from './NavbarComposeButton';
+
+const goToSession = vi.hoisted(() => vi.fn());
+
+vi.mock('../../hooks/useAppNavigation', () => ({
+  useAppNavigation: () => ({
+    goToSession,
+    goToBranch: vi.fn(),
+    goToBoard: vi.fn(),
+    goToArtifact: vi.fn(),
+    goHome: vi.fn(),
+  }),
+}));
+
+vi.mock('../../store/agorStore', () => ({
+  useAgorStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      boardById: new Map([['board-primary', { board_id: 'board-primary', name: 'Ada Board' }]]),
+      mcpServerById: new Map(),
+      userById: new Map(),
+    }),
+}));
+
+vi.mock('../AgenticConfigChipRow', () => ({
+  AgenticConfigChipRow: () => <div data-testid="config-chip-row" />,
+}));
+
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="compose-prompt"
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+vi.mock('../AgenticToolConfigForm', () => ({
+  buildConfigFromFormValues: () => ({ modelConfig: undefined }),
+  getFormValuesFromConfig: () => ({}),
+}));
+
+vi.mock('../AgenticToolConfigurationPicker', () => ({
+  INLINE_AGENTIC_CONFIGURATION: '__inline__',
+}));
+
+vi.mock('../AgenticToolConfigurationPicker/useAgenticConfigurationSources', () => ({
+  getUserAgenticToolDefault: () => ({ configuration: {} }),
+  getUserDefaultConfigurationSource: () => 'default',
+}));
+
+// The Settings picker is reused verbatim in the null-primary case; here it just
+// needs to surface an `onPicked` trigger so we can assert the send resumes.
+vi.mock('../SettingsModal/PrimaryTeammatePicker', () => ({
+  PrimaryTeammatePicker: ({ onPicked }: { onPicked?: (branch: Branch) => void }) => (
+    <button type="button" data-testid="pick-teammate" onClick={() => onPicked?.(pickedBranch)}>
+      pick
+    </button>
+  ),
+}));
+
+function makeBranch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    branch_id: 'branch-primary',
+    name: 'ada',
+    board_id: 'board-primary',
+    custom_context: { teammate: { kind: 'teammate', displayName: 'Ada' } },
+    ...overrides,
+  } as unknown as Branch;
+}
+
+const primaryBranch = makeBranch();
+const pickedBranch = makeBranch({ branch_id: 'branch-picked', board_id: 'board-primary' });
+
+function makeClient(primary: Branch | null): AgorClient {
+  return {
+    service: () => ({ getPrimaryTeammate: () => Promise.resolve(primary) }),
+  } as unknown as AgorClient;
+}
+
+function renderCompose(opts: {
+  primary: Branch | null;
+  currentBoardId?: string;
+  pathname?: string;
+  onCreateSession?: (config: unknown, boardId: string) => Promise<string | null>;
+}) {
+  const onCreateSession = opts.onCreateSession ?? vi.fn().mockResolvedValue('session-new');
+  render(
+    <MemoryRouter initialEntries={[opts.pathname ?? '/b/x/']}>
+      <AntApp>
+        <NavbarComposeButton
+          client={makeClient(opts.primary)}
+          currentUser={null}
+          currentBoardId={opts.currentBoardId ?? 'board-current'}
+          onCreateSession={onCreateSession as never}
+        />
+      </AntApp>
+    </MemoryRouter>
+  );
+  return { onCreateSession };
+}
+
+function openPopover() {
+  fireEvent.click(screen.getByRole('button', { name: 'Compose — ask your primary assistant' }));
+}
+
+describe('NavbarComposeButton', () => {
+  beforeEach(() => {
+    goToSession.mockClear();
+  });
+
+  it('opens the compose popover from the navbar trigger', async () => {
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    expect(await screen.findByTestId('compose-prompt')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send & Open' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send in Background' })).toBeInTheDocument();
+  });
+
+  it('Send & Open navigates to the new session when on a non-primary board', async () => {
+    const { onCreateSession } = renderCompose({
+      primary: primaryBranch,
+      currentBoardId: 'board-current',
+    });
+    openPopover();
+    fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'hi Ada' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send & Open' }));
+
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(onCreateSession.mock.calls[0][0]).toMatchObject({
+      branch_id: 'branch-primary',
+      initialPrompt: 'hi Ada',
+    });
+    await waitFor(() => expect(goToSession).toHaveBeenCalledWith('session-new'));
+  });
+
+  it('Send & Open on a non-board surface shows an in-place panel instead of navigating', async () => {
+    renderCompose({ primary: primaryBranch, currentBoardId: '', pathname: '/knowledge' });
+    openPopover();
+    fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'ping' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send & Open' }));
+
+    // The in-place panel appears; no navigation happens until "Open on board".
+    expect(await screen.findByText('Session started')).toBeInTheDocument();
+    expect(goToSession).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open on board' }));
+    expect(goToSession).toHaveBeenCalledWith('session-new');
+  });
+
+  it('Send in Background never navigates (board surface)', async () => {
+    const { onCreateSession } = renderCompose({
+      primary: primaryBranch,
+      currentBoardId: 'board-current',
+    });
+    openPopover();
+    fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'bg' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send in Background' }));
+
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(goToSession).not.toHaveBeenCalled();
+    expect(screen.queryByText('Session started')).not.toBeInTheDocument();
+  });
+
+  it('Send in Background never navigates (non-board surface)', async () => {
+    const { onCreateSession } = renderCompose({
+      primary: primaryBranch,
+      currentBoardId: '',
+      pathname: '/knowledge',
+    });
+    openPopover();
+    fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'bg' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send in Background' }));
+
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(goToSession).not.toHaveBeenCalled();
+    expect(screen.queryByText('Session started')).not.toBeInTheDocument();
+  });
+
+  it('shows the inline picker for a null primary and resumes the send with the typed prompt', async () => {
+    const { onCreateSession } = renderCompose({ primary: null, currentBoardId: 'board-current' });
+    openPopover();
+
+    // Type first, then discover no primary is set — the prompt must survive.
+    fireEvent.change(await screen.findByTestId('compose-prompt'), {
+      target: { value: 'keep me' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send & Open' }));
+    // Nothing created yet — we're waiting on a teammate pick.
+    expect(onCreateSession).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('pick-teammate'));
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(onCreateSession.mock.calls[0][0]).toMatchObject({
+      branch_id: 'branch-picked',
+      initialPrompt: 'keep me',
+    });
+    await waitFor(() => expect(goToSession).toHaveBeenCalledWith('session-new'));
+  });
+});

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -27,8 +27,16 @@ vi.mock('../../store/agorStore', () => ({
 }));
 
 vi.mock('../AgenticConfigChipRow', () => ({
-  AgenticConfigChipRow: ({ tool }: { tool: string }) => (
-    <div data-testid="config-chip-row" data-tool={tool} />
+  AgenticConfigChipRow: ({
+    tool,
+    leadingField,
+  }: {
+    tool: string;
+    leadingField?: React.ReactNode;
+  }) => (
+    <div data-testid="config-chip-row" data-tool={tool}>
+      {leadingField}
+    </div>
   ),
 }));
 
@@ -206,6 +214,8 @@ describe('NavbarComposeButton', () => {
     openPopover();
     expect(await screen.findByTestId('pick-teammate')).toBeInTheDocument();
     expect(screen.getByText(/don't have a primary assistant yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/default teammate for personal, ambient work/i)).toBeInTheDocument();
+    expect(screen.getByText(/change it anytime in Settings/i)).toBeInTheDocument();
   });
 
   it('shows the first-time hint once, then never again after dismissal', async () => {
@@ -242,10 +252,13 @@ describe('NavbarComposeButton', () => {
     expect(onCreateSession.mock.calls[0][0]).toMatchObject({ agent: 'codex' });
   });
 
-  it('renders the agent picker as the compact select variant', async () => {
+  it('renders the agent picker as the compact select variant, co-located with the config row', async () => {
     renderCompose({ primary: primaryBranch });
     openPopover();
-    expect(await screen.findByTestId('agent-grid')).toHaveAttribute('data-variant', 'select');
+    const agentGrid = await screen.findByTestId('agent-grid');
+    expect(agentGrid).toHaveAttribute('data-variant', 'select');
+    // Agent field lives in the config row's leadingField slot (side-by-side layout).
+    expect(screen.getByTestId('config-chip-row')).toContainElement(agentGrid);
   });
 
   it('shows the resolved primary as a tag once resolved', async () => {

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -27,8 +27,76 @@ vi.mock('../../store/agorStore', () => ({
 }));
 
 vi.mock('../AgenticConfigChipRow', () => ({
-  AgenticConfigChipRow: () => <div data-testid="config-chip-row" />,
+  AgenticConfigChipRow: ({ tool }: { tool: string }) => (
+    <div data-testid="config-chip-row" data-tool={tool} />
+  ),
 }));
+
+vi.mock('../AgentSelectionGrid', () => ({
+  AVAILABLE_AGENTS: [
+    { id: 'claude-code', name: 'Claude Code', icon: '🤖' },
+    { id: 'codex', name: 'Codex', icon: '💻' },
+  ],
+  AgentSelectionGrid: ({
+    selectedAgentId,
+    onSelect,
+    variant,
+  }: {
+    selectedAgentId: string | null;
+    onSelect: (id: string) => void;
+    variant?: string;
+  }) => (
+    <div data-testid="agent-grid" data-selected={selectedAgentId ?? ''} data-variant={variant}>
+      <button type="button" data-testid="pick-codex" onClick={() => onSelect('codex')}>
+        codex
+      </button>
+    </div>
+  ),
+}));
+
+// Passthrough drop zone that exposes a file-drop trigger.
+vi.mock('../SessionPanel/SessionComposerDropZone', () => ({
+  SessionComposerDropZone: ({
+    children,
+    onFilesDrop,
+  }: {
+    children: React.ReactNode;
+    onFilesDrop: (files: File[]) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="drop-file"
+        onClick={() => onFilesDrop([new File(['x'], 'shot.png', { type: 'image/png' })])}
+      >
+        drop
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../SessionPanel/SessionAttachmentTray', () => ({
+  SessionAttachmentTray: ({ attachments }: { attachments: unknown[] }) => (
+    <div data-testid="attach-tray" data-count={attachments.length} />
+  ),
+}));
+
+vi.mock('../SessionPanel/useComposerAttachments', async () => {
+  const { useState } = await vi.importActual<typeof import('react')>('react');
+  return {
+    useComposerAttachments: () => {
+      const [attachments, setAttachments] = useState<{ id: string; file: File }[]>([]);
+      return {
+        attachments,
+        addAttachments: (files: File[]) =>
+          setAttachments((prev) => [...prev, ...files.map((file) => ({ id: file.name, file }))]),
+        removeAttachment: (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id)),
+        clearAttachments: () => setAttachments([]),
+      };
+    },
+  };
+});
 
 vi.mock('../AutocompleteTextarea', () => ({
   AutocompleteTextarea: ({
@@ -99,7 +167,7 @@ function renderCompose(opts: {
   onCreateSession?: (config: unknown, boardId: string) => Promise<string | null>;
 }) {
   const onCreateSession = opts.onCreateSession ?? vi.fn().mockResolvedValue('session-new');
-  render(
+  const result = render(
     <MemoryRouter initialEntries={[opts.pathname ?? '/b/x/']}>
       <AntApp>
         <NavbarComposeButton
@@ -111,7 +179,7 @@ function renderCompose(opts: {
       </AntApp>
     </MemoryRouter>
   );
-  return { onCreateSession };
+  return { onCreateSession, ...result };
 }
 
 function openPopover() {
@@ -121,14 +189,90 @@ function openPopover() {
 describe('NavbarComposeButton', () => {
   beforeEach(() => {
     goToSession.mockClear();
+    localStorage.clear();
   });
 
-  it('opens the compose popover from the navbar trigger', async () => {
+  it('opens the compose popover with a heading and prompt', async () => {
     renderCompose({ primary: primaryBranch });
     openPopover();
     expect(await screen.findByTestId('compose-prompt')).toBeInTheDocument();
+    expect(screen.getByText('Ask your primary assistant')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send & Open' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send in Background' })).toBeInTheDocument();
+  });
+
+  it('explains the null-primary state above the inline picker', async () => {
+    renderCompose({ primary: null });
+    openPopover();
+    expect(await screen.findByTestId('pick-teammate')).toBeInTheDocument();
+    expect(screen.getByText(/don't have a primary assistant yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the first-time hint once, then never again after dismissal', async () => {
+    const { unmount } = renderCompose({ primary: primaryBranch });
+    openPopover();
+    expect(await screen.findByText(/Ask for anything/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss tip' }));
+    expect(screen.queryByText(/Ask for anything/i)).not.toBeInTheDocument();
+
+    // Remount fresh: the dismissal persisted, so the hint stays gone.
+    unmount();
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.queryByText(/Ask for anything/i)).not.toBeInTheDocument();
+  });
+
+  it('routes the picked tool into the chip row and the created session', async () => {
+    const { onCreateSession } = renderCompose({
+      primary: primaryBranch,
+      currentBoardId: 'board-current',
+    });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.getByTestId('config-chip-row')).toHaveAttribute('data-tool', 'claude-code');
+
+    fireEvent.click(screen.getByTestId('pick-codex'));
+    expect(screen.getByTestId('config-chip-row')).toHaveAttribute('data-tool', 'codex');
+
+    fireEvent.change(screen.getByTestId('compose-prompt'), { target: { value: 'go' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send & Open' }));
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(onCreateSession.mock.calls[0][0]).toMatchObject({ agent: 'codex' });
+  });
+
+  it('renders the agent picker as the compact select variant', async () => {
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    expect(await screen.findByTestId('agent-grid')).toHaveAttribute('data-variant', 'select');
+  });
+
+  it('shows the resolved primary as a tag once resolved', async () => {
+    renderCompose({ primary: primaryBranch });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    // The tag renders the bare teammate name; the wayfinding sentence embeds it in prose.
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+  });
+
+  it('lets a dropped file be sent even with an empty prompt', async () => {
+    const { onCreateSession } = renderCompose({
+      primary: primaryBranch,
+      currentBoardId: 'board-current',
+    });
+    openPopover();
+    await screen.findByTestId('compose-prompt');
+    expect(screen.getByTestId('attach-tray')).toHaveAttribute('data-count', '0');
+    // Empty prompt + no attachment → send is blocked.
+    expect(screen.getByRole('button', { name: 'Send & Open' })).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('drop-file'));
+    expect(screen.getByTestId('attach-tray')).toHaveAttribute('data-count', '1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send & Open' }));
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(onCreateSession.mock.calls[0][0].attachmentFiles).toHaveLength(1);
   });
 
   it('gives the trigger and Send & Open primary weight, Send in Background secondary', async () => {

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -302,10 +302,10 @@ describe('NavbarComposeButton', () => {
     fireEvent.change(await screen.findByTestId('compose-prompt'), { target: { value: 'hi' } });
 
     fireEvent.mouseEnter(screen.getByRole('button', { name: 'Send & Open' }));
-    expect(await screen.findByText('Send and go to the session')).toBeInTheDocument();
+    expect(await screen.findByText(/takes you there now, on Ada's board/)).toBeInTheDocument();
 
     fireEvent.mouseEnter(screen.getByRole('button', { name: 'Send in Background' }));
-    expect(await screen.findByText(/Send and stay here/)).toBeInTheDocument();
+    expect(await screen.findByText(/in the background, on Ada's board/)).toBeInTheDocument();
   });
 
   it('lets a dropped file be sent even with an empty prompt', async () => {

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -240,7 +240,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
   })();
 
   const content = (
-    <div style={{ width: 380 }}>
+    <div style={{ width: 600, maxWidth: '90vw' }}>
       {resolving ? (
         <Flex justify="center" style={{ padding: token.paddingLG }}>
           <Spin />
@@ -325,7 +325,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         content={content}
       >
         <Button
-          type="text"
+          type="primary"
           icon={<EditOutlined style={{ fontSize: token.fontSizeLG }} />}
           aria-label="Compose — ask your primary assistant"
           title="Ask your primary assistant"

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -2,12 +2,18 @@ import type {
   AgenticToolName,
   AgorClient,
   Branch,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
   EffortLevel,
   PermissionMode,
   User,
 } from '@agor-live/client';
-import { getDefaultPermissionMode, getTeammateConfig } from '@agor-live/client';
-import { EditOutlined } from '@ant-design/icons';
+import {
+  getDefaultPermissionMode,
+  getTeammateConfig,
+  mapToCodexPermissionConfig,
+} from '@agor-live/client';
+import { BulbOutlined, CloseOutlined, EditOutlined, RobotOutlined } from '@ant-design/icons';
 import {
   App as AntApp,
   Button,
@@ -24,6 +30,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectMcpServerById, selectUserById } from '../../store/selectors';
 import { AgenticConfigChipRow } from '../AgenticConfigChipRow';
@@ -33,12 +40,16 @@ import {
   getUserAgenticToolDefault,
   getUserDefaultConfigurationSource,
 } from '../AgenticToolConfigurationPicker/useAgenticConfigurationSources';
+import { AgentSelectionGrid, AVAILABLE_AGENTS } from '../AgentSelectionGrid';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import type { NewSessionConfig } from '../NewSessionModal';
+import { SessionAttachmentTray } from '../SessionPanel/SessionAttachmentTray';
+import { SessionComposerDropZone } from '../SessionPanel/SessionComposerDropZone';
+import { useComposerAttachments } from '../SessionPanel/useComposerAttachments';
 import { PrimaryTeammatePicker } from '../SettingsModal/PrimaryTeammatePicker';
 
-// Compact composer defaults to Claude Code; the chip row still lets the model be tuned.
-const COMPOSE_TOOL: AgenticToolName = 'claude-code';
+const DEFAULT_TOOL: AgenticToolName = 'claude-code';
+const HINT_DISMISSED_KEY = 'agor:compose-hint-dismissed';
 
 type SendMode = 'open' | 'background';
 
@@ -59,12 +70,16 @@ function teammateName(branch: Branch): string {
   return getTeammateConfig(branch)?.displayName ?? branch.name;
 }
 
+function teammateEmoji(branch: Branch): string | undefined {
+  return getTeammateConfig(branch)?.emoji;
+}
+
 /**
  * Global compose affordance: ask your primary assistant from anywhere. Resolves
- * the caller's primary teammate branch, mounts a compact model picker + prompt,
- * and either navigates to the new session ("Send & Open") or leaves the user in
- * place ("Send in Background"). A null primary shows the Settings picker inline
- * and resumes the send once one is chosen, preserving the typed prompt.
+ * the caller's primary teammate branch, mounts an agent picker + config chips +
+ * prompt, and either navigates to the new session ("Send & Open") or leaves the
+ * user in place ("Send in Background"). A null primary shows the Settings picker
+ * inline and resumes the send once one is chosen, preserving the typed prompt.
  */
 export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
   client,
@@ -85,14 +100,26 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
   const [open, setOpen] = useState(false);
   const [resolving, setResolving] = useState(false);
   const [primaryBranch, setPrimaryBranch] = useState<Branch | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<string>(DEFAULT_TOOL);
   const [prompt, setPrompt] = useState('');
   const [pendingSend, setPendingSend] = useState<SendMode | null>(null);
   const [submitting, setSubmitting] = useState<SendMode | null>(null);
   const [inPlaceResult, setInPlaceResult] = useState<{ sessionId: string; branch: Branch } | null>(
     null
   );
+  const [hintDismissed, setHintDismissed] = useLocalStorage<boolean>(HINT_DISMISSED_KEY, false);
+  const { attachments, addAttachments, removeAttachment, clearAttachments } =
+    useComposerAttachments({ sessionId: null, showError: (msg) => message.error(msg) });
 
   const onBoardSurface = !!currentBoardId && !isKnowledgePath(location.pathname);
+
+  // One lightweight tinted-box treatment, shared by the tip and the no-primary banner.
+  const bannerBox: React.CSSProperties = {
+    padding: `${token.paddingXS}px ${token.paddingSM}px`,
+    background: token.colorFillQuaternary,
+    border: `1px solid ${token.colorBorderSecondary}`,
+    borderRadius: token.borderRadius,
+  };
 
   // Resolve the primary teammate each time the popover opens — access can change
   // between opens (branch archived, unshared), and null is the "needs picking" signal.
@@ -117,37 +144,55 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     };
   }, [open, client]);
 
-  // Seed the chip-row form from the user's Claude Code default on open. Only keyed
-  // on `open` so a live user refresh can't wipe edits made while the popover is up.
+  // Seed the chip-row form from the user's default on open. Only keyed on `open`
+  // so a live user refresh can't wipe edits made while the popover is up.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset only on open
   useEffect(() => {
     if (!open) return;
-    const agentDefaults = getUserAgenticToolDefault(currentUser, COMPOSE_TOOL).configuration;
+    setSelectedAgent(DEFAULT_TOOL);
+    const agentDefaults = getUserAgenticToolDefault(currentUser, DEFAULT_TOOL).configuration;
     form.resetFields();
     form.setFieldsValue({
-      agenticToolPresetId: getUserDefaultConfigurationSource(currentUser, COMPOSE_TOOL),
-      ...getFormValuesFromConfig(COMPOSE_TOOL, agentDefaults),
+      agenticToolPresetId: getUserDefaultConfigurationSource(currentUser, DEFAULT_TOOL),
+      ...getFormValuesFromConfig(DEFAULT_TOOL, agentDefaults),
       mcpServerIds: currentUser?.default_mcp_server_ids,
     });
   }, [open, form]);
+
+  // Re-seed config defaults when the picked tool changes (mirrors NewSessionModal).
+  useEffect(() => {
+    const tool = selectedAgent as AgenticToolName;
+    const agentDefaults = getUserAgenticToolDefault(currentUser, tool).configuration;
+    form.setFieldsValue({
+      ...getFormValuesFromConfig(tool, agentDefaults),
+      agenticToolPresetId: getUserDefaultConfigurationSource(currentUser, tool),
+      ...(tool !== 'codex' && {
+        codexSandboxMode: undefined,
+        codexApprovalPolicy: undefined,
+        codexNetworkAccess: undefined,
+      }),
+    });
+  }, [selectedAgent, form, currentUser]);
 
   const closeAndReset = () => {
     setOpen(false);
     setPrompt('');
     setPendingSend(null);
     setPrimaryBranch(null);
+    clearAttachments();
   };
 
   const buildConfig = (branch: Branch): NewSessionConfig => {
+    const tool = selectedAgent as AgenticToolName;
     const values = form.getFieldsValue(true);
-    const agentDefaults = getUserAgenticToolDefault(currentUser, COMPOSE_TOOL).configuration;
+    const agentDefaults = getUserAgenticToolDefault(currentUser, tool).configuration;
     const permissionMode: PermissionMode =
       (values.permissionMode as PermissionMode | undefined) ??
       agentDefaults?.permissionMode ??
-      getDefaultPermissionMode(COMPOSE_TOOL);
+      getDefaultPermissionMode(tool);
     const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
     const inlineConfig = isInline
-      ? buildConfigFromFormValues(COMPOSE_TOOL, {
+      ? buildConfigFromFormValues(tool, {
           modelConfig: values.modelConfig,
           effort: values.effort,
           permissionMode: values.permissionMode,
@@ -158,9 +203,9 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         ? branch.mcp_server_ids
         : currentUser?.default_mcp_server_ids;
 
-    return {
+    const config: NewSessionConfig = {
       branch_id: branch.branch_id,
-      agent: COMPOSE_TOOL,
+      agent: tool,
       agenticToolPresetId: isInline ? undefined : values.agenticToolPresetId,
       initialPrompt: prompt,
       modelConfig: isInline
@@ -171,7 +216,27 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
       mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
       permissionMode,
+      attachmentFiles:
+        attachments.length > 0 ? attachments.map((attachment) => attachment.file) : undefined,
     };
+
+    if (tool === 'codex') {
+      const codexDefaults = mapToCodexPermissionConfig(permissionMode);
+      config.codexSandboxMode =
+        (values.codexSandboxMode as CodexSandboxMode | undefined) ??
+        agentDefaults?.codexSandboxMode ??
+        codexDefaults.sandboxMode;
+      config.codexApprovalPolicy =
+        (values.codexApprovalPolicy as CodexApprovalPolicy | undefined) ??
+        agentDefaults?.codexApprovalPolicy ??
+        codexDefaults.approvalPolicy;
+      config.codexNetworkAccess =
+        values.codexNetworkAccess ??
+        agentDefaults?.codexNetworkAccess ??
+        codexDefaults.networkAccess;
+    }
+
+    return config;
   };
 
   const doSend = async (mode: SendMode, branch: Branch) => {
@@ -199,6 +264,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         setOpen(false);
         setPrompt('');
         setPendingSend(null);
+        clearAttachments();
         setInPlaceResult({ sessionId, branch });
       }
     } finally {
@@ -224,7 +290,8 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     }
   };
 
-  const sendDisabled = resolving || submitting !== null || !prompt.trim();
+  const sendDisabled =
+    resolving || submitting !== null || (!prompt.trim() && attachments.length === 0);
 
   const wayfinding = (() => {
     if (!primaryBranch) return null;
@@ -240,7 +307,46 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
   })();
 
   const content = (
-    <div style={{ width: 600, maxWidth: '90vw' }}>
+    <div style={{ width: 680, maxWidth: '90vw' }}>
+      <Flex
+        align="center"
+        justify="space-between"
+        gap={token.marginSM}
+        style={{ marginBottom: token.marginSM }}
+      >
+        <Typography.Text strong>Ask your primary assistant</Typography.Text>
+        {primaryBranch && (
+          <Tag
+            icon={teammateEmoji(primaryBranch) ? undefined : <RobotOutlined />}
+            style={{ marginInlineEnd: 0 }}
+          >
+            {teammateEmoji(primaryBranch) ? `${teammateEmoji(primaryBranch)} ` : ''}
+            {teammateName(primaryBranch)}
+          </Tag>
+        )}
+      </Flex>
+
+      {!hintDismissed && (
+        <Flex
+          align="flex-start"
+          gap={token.marginXS}
+          style={{ ...bannerBox, marginBottom: token.marginSM }}
+        >
+          <BulbOutlined style={{ color: token.colorTextTertiary, marginTop: 3 }} />
+          <Typography.Text type="secondary" style={{ flex: 1, fontSize: token.fontSizeSM }}>
+            Ask for anything — setup help, finding a feature, fixing something. Your assistant
+            handles it for you.
+          </Typography.Text>
+          <Button
+            type="text"
+            size="small"
+            aria-label="Dismiss tip"
+            icon={<CloseOutlined style={{ fontSize: token.fontSizeSM }} />}
+            onClick={() => setHintDismissed(true)}
+          />
+        </Flex>
+      )}
+
       {resolving ? (
         <Flex justify="center" style={{ padding: token.paddingLG }}>
           <Spin />
@@ -249,12 +355,28 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         <Form form={form} layout="vertical" requiredMark={false}>
           {!primaryBranch && (
             <div style={{ marginBottom: token.marginSM }}>
+              <div style={{ ...bannerBox, marginBottom: token.marginSM }}>
+                <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+                  You don't have a primary assistant yet — pick one to continue.
+                </Typography.Text>
+              </div>
               <PrimaryTeammatePicker client={client} compact onPicked={handlePicked} />
             </div>
           )}
 
+          <Form.Item label="Coding agent" style={{ marginBottom: token.marginSM }}>
+            <AgentSelectionGrid
+              agents={AVAILABLE_AGENTS}
+              selectedAgentId={selectedAgent}
+              onSelect={setSelectedAgent}
+              variant="select"
+              showComparisonLink={false}
+              fallbackToFirstVisibleAgent
+            />
+          </Form.Item>
+
           <AgenticConfigChipRow
-            tool={COMPOSE_TOOL}
+            tool={selectedAgent as AgenticToolName}
             mcpServerById={mcpServerById}
             currentUser={currentUser}
             client={client}
@@ -262,17 +384,27 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
           />
 
           <Form.Item style={{ marginBottom: token.marginXS }}>
-            <AutocompleteTextarea
-              value={prompt}
-              onChange={setPrompt}
-              placeholder="Ask your primary assistant…"
-              autoSize={{ minRows: 2, maxRows: 6 }}
-              client={client}
-              sessionId={null}
-              userById={userById}
-              enableKnowledgeMentions
-              kbLinkTarget="absolute-route"
-            />
+            <SessionComposerDropZone disabled={submitting !== null} onFilesDrop={addAttachments}>
+              <SessionAttachmentTray
+                attachments={attachments}
+                disabled={submitting !== null}
+                onRemove={removeAttachment}
+              />
+              <AutocompleteTextarea
+                value={prompt}
+                onChange={setPrompt}
+                placeholder="Ask your primary assistant…"
+                autoSize={{ minRows: 2, maxRows: 6 }}
+                client={client}
+                sessionId={null}
+                userById={userById}
+                enableKnowledgeMentions
+                kbLinkTarget="absolute-route"
+                onFilesDrop={addAttachments}
+                filesDropDisabled={submitting !== null}
+                showFilesDropOverlay={false}
+              />
+            </SessionComposerDropZone>
           </Form.Item>
 
           {wayfinding && (

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -308,6 +308,12 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     return null;
   })();
 
+  const boardPhrase = primaryBranch
+    ? `${teammateName(primaryBranch)}'s board`
+    : "your primary assistant's board";
+  const openTooltip = `Creates the session and takes you there now, on ${boardPhrase}.`;
+  const backgroundTooltip = `Creates the session in the background, on ${boardPhrase} — check on it anytime.`;
+
   const content = (
     <div style={{ width: 680, maxWidth: '90vw' }}>
       <Typography.Text strong style={{ display: 'block', marginBottom: token.marginSM }}>
@@ -430,7 +436,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
           )}
 
           <Flex justify="flex-end" gap={token.marginXS}>
-            <Tooltip title="Send and stay here — come back to it later">
+            <Tooltip title={backgroundTooltip}>
               <Button
                 onClick={() => runSend('background')}
                 loading={submitting === 'background'}
@@ -439,7 +445,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
                 Send in Background
               </Button>
             </Tooltip>
-            <Tooltip title="Send and go to the session">
+            <Tooltip title={openTooltip}>
               <Button
                 type="primary"
                 onClick={() => runSend('open')}

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -24,6 +24,7 @@ import {
   Space,
   Spin,
   Tag,
+  Tooltip,
   Typography,
   theme,
 } from 'antd';
@@ -303,28 +304,27 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     if (primaryBranch.board_id && primaryBranch.board_id !== currentBoardId) {
       return `→ Opens on ${name}${board ? ` · ${board.name}` : ''}`;
     }
-    return `Creates a session with ${name} here.`;
+    // On the primary's own board: identity is already in the header, no nav to preview.
+    return null;
   })();
 
   const content = (
     <div style={{ width: 680, maxWidth: '90vw' }}>
-      <Flex
-        align="center"
-        justify="space-between"
-        gap={token.marginSM}
-        style={{ marginBottom: token.marginSM }}
-      >
-        <Typography.Text strong>Ask your primary assistant</Typography.Text>
-        {primaryBranch && (
-          <Tag
-            icon={teammateEmoji(primaryBranch) ? undefined : <RobotOutlined />}
-            style={{ marginInlineEnd: 0 }}
-          >
-            {teammateEmoji(primaryBranch) ? `${teammateEmoji(primaryBranch)} ` : ''}
-            {teammateName(primaryBranch)}
-          </Tag>
+      <Typography.Text strong style={{ display: 'block', marginBottom: token.marginSM }}>
+        {primaryBranch ? (
+          <>
+            Ask{' '}
+            {teammateEmoji(primaryBranch) ? (
+              `${teammateEmoji(primaryBranch)} `
+            ) : (
+              <RobotOutlined style={{ marginInlineEnd: token.marginXXS }} />
+            )}
+            {teammateName(primaryBranch)}, your primary assistant
+          </>
+        ) : (
+          'Ask your primary assistant'
         )}
-      </Flex>
+      </Typography.Text>
 
       {!hintDismissed && (
         <Flex
@@ -396,7 +396,9 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
               <AutocompleteTextarea
                 value={prompt}
                 onChange={setPrompt}
-                placeholder="Ask your primary assistant…"
+                placeholder={
+                  'Ask your primary assistant… e.g. “connect Slack”, “find the API docs”, “fix this bug”'
+                }
                 autoSize={{ minRows: 2, maxRows: 6 }}
                 client={client}
                 sessionId={null}
@@ -428,21 +430,25 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
           )}
 
           <Flex justify="flex-end" gap={token.marginXS}>
-            <Button
-              onClick={() => runSend('background')}
-              loading={submitting === 'background'}
-              disabled={sendDisabled}
-            >
-              Send in Background
-            </Button>
-            <Button
-              type="primary"
-              onClick={() => runSend('open')}
-              loading={submitting === 'open'}
-              disabled={sendDisabled}
-            >
-              Send &amp; Open
-            </Button>
+            <Tooltip title="Send and stay here — come back to it later">
+              <Button
+                onClick={() => runSend('background')}
+                loading={submitting === 'background'}
+                disabled={sendDisabled}
+              >
+                Send in Background
+              </Button>
+            </Tooltip>
+            <Tooltip title="Send and go to the session">
+              <Button
+                type="primary"
+                onClick={() => runSend('open')}
+                loading={submitting === 'open'}
+                disabled={sendDisabled}
+              >
+                Send &amp; Open
+              </Button>
+            </Tooltip>
           </Flex>
         </Form>
       )}

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -475,7 +475,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         content={content}
       >
         <Button
-          type="primary"
+          type="default"
           aria-label="Compose — ask your primary assistant"
           title="Ask your primary assistant"
           style={{

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -300,13 +300,9 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     if (!primaryBranch) return null;
     const name = teammateName(primaryBranch);
     const board = primaryBranch.board_id ? boardById.get(primaryBranch.board_id) : undefined;
-    if (!onBoardSurface) {
-      return `Opens a panel here — session starts with ${name}${board ? ` on ${board.name}` : ''}.`;
-    }
-    if (primaryBranch.board_id && primaryBranch.board_id !== currentBoardId) {
+    if (onBoardSurface && primaryBranch.board_id && primaryBranch.board_id !== currentBoardId) {
       return `→ Opens on ${name}${board ? ` · ${board.name}` : ''}`;
     }
-    // On the primary's own board: identity is already in the header, no nav to preview.
     return null;
   })();
 
@@ -474,20 +470,21 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
         destroyTooltipOnHide
         content={content}
       >
-        <Button
-          type="default"
-          aria-label="Compose — ask your primary assistant"
-          title="Ask your primary assistant"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: token.marginXXS,
-          }}
-        >
-          <span style={{ fontSize: token.fontSize, lineHeight: 1 }}>{triggerEmoji}</span>
-          <EditOutlined style={{ fontSize: token.fontSizeLG }} />
-        </Button>
+        <Tooltip title="Start quick session">
+          <Button
+            type="default"
+            aria-label="Compose — ask your primary assistant"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: token.marginXXS,
+            }}
+          >
+            <span style={{ fontSize: token.fontSize, lineHeight: 1 }}>{triggerEmoji}</span>
+            <EditOutlined style={{ fontSize: token.fontSizeLG }} />
+          </Button>
+        </Tooltip>
       </Popover>
 
       <Drawer

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -122,10 +122,12 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     borderRadius: token.borderRadius,
   };
 
-  // Resolve the primary teammate each time the popover opens — access can change
-  // between opens (branch archived, unshared), and null is the "needs picking" signal.
+  // Resolve eagerly once the client exists (so the collapsed trigger shows the
+  // teammate's emoji before first open) and re-resolve on open to catch changes
+  // made elsewhere. Null is the "needs picking" signal.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `open` re-resolves on reopen
   useEffect(() => {
-    if (!open || !client) return;
+    if (!client) return;
     let cancelled = false;
     setResolving(true);
     client
@@ -308,6 +310,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     return null;
   })();
 
+  const triggerEmoji = (primaryBranch && teammateEmoji(primaryBranch)) || '🤖';
   const boardPhrase = primaryBranch
     ? `${teammateName(primaryBranch)}'s board`
     : "your primary assistant's board";
@@ -473,11 +476,18 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
       >
         <Button
           type="primary"
-          icon={<EditOutlined style={{ fontSize: token.fontSizeLG }} />}
           aria-label="Compose — ask your primary assistant"
           title="Ask your primary assistant"
-          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        />
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: token.marginXXS,
+          }}
+        >
+          <span style={{ fontSize: token.fontSize, lineHeight: 1 }}>{triggerEmoji}</span>
+          <EditOutlined style={{ fontSize: token.fontSizeLG }} />
+        </Button>
       </Popover>
 
       <Drawer

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -1,0 +1,370 @@
+import type {
+  AgenticToolName,
+  AgorClient,
+  Branch,
+  EffortLevel,
+  PermissionMode,
+  User,
+} from '@agor-live/client';
+import { getDefaultPermissionMode, getTeammateConfig } from '@agor-live/client';
+import { EditOutlined } from '@ant-design/icons';
+import {
+  App as AntApp,
+  Button,
+  Drawer,
+  Flex,
+  Form,
+  Popover,
+  Space,
+  Spin,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAppNavigation } from '../../hooks/useAppNavigation';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectMcpServerById, selectUserById } from '../../store/selectors';
+import { AgenticConfigChipRow } from '../AgenticConfigChipRow';
+import { buildConfigFromFormValues, getFormValuesFromConfig } from '../AgenticToolConfigForm';
+import { INLINE_AGENTIC_CONFIGURATION } from '../AgenticToolConfigurationPicker';
+import {
+  getUserAgenticToolDefault,
+  getUserDefaultConfigurationSource,
+} from '../AgenticToolConfigurationPicker/useAgenticConfigurationSources';
+import { AutocompleteTextarea } from '../AutocompleteTextarea';
+import type { NewSessionConfig } from '../NewSessionModal';
+import { PrimaryTeammatePicker } from '../SettingsModal/PrimaryTeammatePicker';
+
+// Compact composer defaults to Claude Code; the chip row still lets the model be tuned.
+const COMPOSE_TOOL: AgenticToolName = 'claude-code';
+
+type SendMode = 'open' | 'background';
+
+export interface NavbarComposeButtonProps {
+  client: AgorClient | null;
+  currentUser?: User | null;
+  /** The board currently in view, or '' on a non-board surface (home/knowledge). */
+  currentBoardId?: string;
+  onCreateSession?: (config: NewSessionConfig, boardId: string) => Promise<string | null>;
+}
+
+/** Knowledge Base renders no board even when a board id lingers in app state. */
+function isKnowledgePath(pathname: string): boolean {
+  return ['/knowledge', '/kb'].some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+function teammateName(branch: Branch): string {
+  return getTeammateConfig(branch)?.displayName ?? branch.name;
+}
+
+/**
+ * Global compose affordance: ask your primary assistant from anywhere. Resolves
+ * the caller's primary teammate branch, mounts a compact model picker + prompt,
+ * and either navigates to the new session ("Send & Open") or leaves the user in
+ * place ("Send in Background"). A null primary shows the Settings picker inline
+ * and resumes the send once one is chosen, preserving the typed prompt.
+ */
+export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
+  client,
+  currentUser,
+  currentBoardId,
+  onCreateSession,
+}) => {
+  const { token } = theme.useToken();
+  const { message } = AntApp.useApp();
+  const [form] = Form.useForm();
+  const navigation = useAppNavigation();
+  const location = useLocation();
+
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const userById = useAgorStore(selectUserById);
+  const boardById = useAgorStore(selectBoardById);
+
+  const [open, setOpen] = useState(false);
+  const [resolving, setResolving] = useState(false);
+  const [primaryBranch, setPrimaryBranch] = useState<Branch | null>(null);
+  const [prompt, setPrompt] = useState('');
+  const [pendingSend, setPendingSend] = useState<SendMode | null>(null);
+  const [submitting, setSubmitting] = useState<SendMode | null>(null);
+  const [inPlaceResult, setInPlaceResult] = useState<{ sessionId: string; branch: Branch } | null>(
+    null
+  );
+
+  const onBoardSurface = !!currentBoardId && !isKnowledgePath(location.pathname);
+
+  // Resolve the primary teammate each time the popover opens — access can change
+  // between opens (branch archived, unshared), and null is the "needs picking" signal.
+  useEffect(() => {
+    if (!open || !client) return;
+    let cancelled = false;
+    setResolving(true);
+    client
+      .service('users')
+      .getPrimaryTeammate()
+      .then((branch) => {
+        if (!cancelled) setPrimaryBranch(branch);
+      })
+      .catch(() => {
+        if (!cancelled) setPrimaryBranch(null);
+      })
+      .finally(() => {
+        if (!cancelled) setResolving(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, client]);
+
+  // Seed the chip-row form from the user's Claude Code default on open. Only keyed
+  // on `open` so a live user refresh can't wipe edits made while the popover is up.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset only on open
+  useEffect(() => {
+    if (!open) return;
+    const agentDefaults = getUserAgenticToolDefault(currentUser, COMPOSE_TOOL).configuration;
+    form.resetFields();
+    form.setFieldsValue({
+      agenticToolPresetId: getUserDefaultConfigurationSource(currentUser, COMPOSE_TOOL),
+      ...getFormValuesFromConfig(COMPOSE_TOOL, agentDefaults),
+      mcpServerIds: currentUser?.default_mcp_server_ids,
+    });
+  }, [open, form]);
+
+  const closeAndReset = () => {
+    setOpen(false);
+    setPrompt('');
+    setPendingSend(null);
+    setPrimaryBranch(null);
+  };
+
+  const buildConfig = (branch: Branch): NewSessionConfig => {
+    const values = form.getFieldsValue(true);
+    const agentDefaults = getUserAgenticToolDefault(currentUser, COMPOSE_TOOL).configuration;
+    const permissionMode: PermissionMode =
+      (values.permissionMode as PermissionMode | undefined) ??
+      agentDefaults?.permissionMode ??
+      getDefaultPermissionMode(COMPOSE_TOOL);
+    const isInline = values.agenticToolPresetId === INLINE_AGENTIC_CONFIGURATION;
+    const inlineConfig = isInline
+      ? buildConfigFromFormValues(COMPOSE_TOOL, {
+          modelConfig: values.modelConfig,
+          effort: values.effort,
+          permissionMode: values.permissionMode,
+        })
+      : undefined;
+    const fallbackMcpServerIds =
+      branch.mcp_server_ids && branch.mcp_server_ids.length > 0
+        ? branch.mcp_server_ids
+        : currentUser?.default_mcp_server_ids;
+
+    return {
+      branch_id: branch.branch_id,
+      agent: COMPOSE_TOOL,
+      agenticToolPresetId: isInline ? undefined : values.agenticToolPresetId,
+      initialPrompt: prompt,
+      modelConfig: isInline
+        ? inlineConfig?.modelConfig
+        : (values.modelConfig ?? agentDefaults?.modelConfig),
+      effort: isInline
+        ? undefined
+        : ((values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort),
+      mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
+      permissionMode,
+    };
+  };
+
+  const doSend = async (mode: SendMode, branch: Branch) => {
+    if (!onCreateSession) return;
+    setSubmitting(mode);
+    try {
+      const sessionId = await onCreateSession(
+        buildConfig(branch),
+        branch.board_id ?? currentBoardId ?? ''
+      );
+      if (!sessionId) return; // onCreateSession already surfaced the failure
+
+      if (mode === 'background') {
+        message.success(`Sent to ${teammateName(branch)} in the background`);
+        closeAndReset();
+        return;
+      }
+
+      if (onBoardSurface) {
+        // Case 1 / same-board: full navigation to the new session.
+        closeAndReset();
+        navigation.goToSession(sessionId);
+      } else {
+        // Case 2: non-board surface — stay put, surface an in-place panel.
+        setOpen(false);
+        setPrompt('');
+        setPendingSend(null);
+        setInPlaceResult({ sessionId, branch });
+      }
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  const runSend = (mode: SendMode) => {
+    if (!primaryBranch) {
+      // Null primary: arm the send; the inline picker resumes it once chosen.
+      setPendingSend(mode);
+      return;
+    }
+    void doSend(mode, primaryBranch);
+  };
+
+  const handlePicked = (branch: Branch) => {
+    setPrimaryBranch(branch);
+    if (pendingSend) {
+      const mode = pendingSend;
+      setPendingSend(null);
+      void doSend(mode, branch);
+    }
+  };
+
+  const sendDisabled = resolving || submitting !== null || !prompt.trim();
+
+  const wayfinding = (() => {
+    if (!primaryBranch) return null;
+    const name = teammateName(primaryBranch);
+    const board = primaryBranch.board_id ? boardById.get(primaryBranch.board_id) : undefined;
+    if (!onBoardSurface) {
+      return `Opens a panel here — session starts with ${name}${board ? ` on ${board.name}` : ''}.`;
+    }
+    if (primaryBranch.board_id && primaryBranch.board_id !== currentBoardId) {
+      return `→ Opens on ${name}${board ? ` · ${board.name}` : ''}`;
+    }
+    return `Creates a session with ${name} here.`;
+  })();
+
+  const content = (
+    <div style={{ width: 380 }}>
+      {resolving ? (
+        <Flex justify="center" style={{ padding: token.paddingLG }}>
+          <Spin />
+        </Flex>
+      ) : (
+        <Form form={form} layout="vertical" requiredMark={false}>
+          {!primaryBranch && (
+            <div style={{ marginBottom: token.marginSM }}>
+              <PrimaryTeammatePicker client={client} compact onPicked={handlePicked} />
+            </div>
+          )}
+
+          <AgenticConfigChipRow
+            tool={COMPOSE_TOOL}
+            mcpServerById={mcpServerById}
+            currentUser={currentUser}
+            client={client}
+            showEffort
+          />
+
+          <Form.Item style={{ marginBottom: token.marginXS }}>
+            <AutocompleteTextarea
+              value={prompt}
+              onChange={setPrompt}
+              placeholder="Ask your primary assistant…"
+              autoSize={{ minRows: 2, maxRows: 6 }}
+              client={client}
+              sessionId={null}
+              userById={userById}
+              enableKnowledgeMentions
+              kbLinkTarget="absolute-route"
+            />
+          </Form.Item>
+
+          {wayfinding && (
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: token.fontSizeSM, display: 'block', marginBottom: token.marginXS }}
+            >
+              {wayfinding}
+            </Typography.Text>
+          )}
+          {!primaryBranch && pendingSend && (
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: token.fontSizeSM, display: 'block', marginBottom: token.marginXS }}
+            >
+              Pick a primary assistant above to send.
+            </Typography.Text>
+          )}
+
+          <Flex justify="flex-end" gap={token.marginXS}>
+            <Button
+              onClick={() => runSend('background')}
+              loading={submitting === 'background'}
+              disabled={sendDisabled}
+            >
+              Send in Background
+            </Button>
+            <Button
+              type="primary"
+              onClick={() => runSend('open')}
+              loading={submitting === 'open'}
+              disabled={sendDisabled}
+            >
+              Send &amp; Open
+            </Button>
+          </Flex>
+        </Form>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        trigger="click"
+        placement="bottomRight"
+        destroyTooltipOnHide
+        content={content}
+      >
+        <Button
+          type="text"
+          icon={<EditOutlined style={{ fontSize: token.fontSizeLG }} />}
+          aria-label="Compose — ask your primary assistant"
+          title="Ask your primary assistant"
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        />
+      </Popover>
+
+      <Drawer
+        open={!!inPlaceResult}
+        onClose={() => setInPlaceResult(null)}
+        title="Session started"
+        placement="right"
+        width={340}
+      >
+        {inPlaceResult && (
+          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <Typography.Text>
+              Your session with{' '}
+              <Typography.Text strong>{teammateName(inPlaceResult.branch)}</Typography.Text> is
+              running.
+            </Typography.Text>
+            <Tag>
+              {(inPlaceResult.branch.board_id &&
+                boardById.get(inPlaceResult.branch.board_id)?.name) ||
+                'its board'}
+            </Tag>
+            <Button
+              type="primary"
+              onClick={() => {
+                const sessionId = inPlaceResult.sessionId;
+                setInPlaceResult(null);
+                navigation.goToSession(sessionId);
+              }}
+            >
+              Open on board
+            </Button>
+          </Space>
+        )}
+      </Drawer>
+    </>
+  );
+};

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -357,23 +357,14 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
             <div style={{ marginBottom: token.marginSM }}>
               <div style={{ ...bannerBox, marginBottom: token.marginSM }}>
                 <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-                  You don't have a primary assistant yet — pick one to continue.
+                  You don't have a primary assistant yet. Your primary assistant is your default
+                  teammate for personal, ambient work — pick one below to continue. You can change
+                  it anytime in Settings.
                 </Typography.Text>
               </div>
               <PrimaryTeammatePicker client={client} compact onPicked={handlePicked} />
             </div>
           )}
-
-          <Form.Item label="Coding agent" style={{ marginBottom: token.marginSM }}>
-            <AgentSelectionGrid
-              agents={AVAILABLE_AGENTS}
-              selectedAgentId={selectedAgent}
-              onSelect={setSelectedAgent}
-              variant="select"
-              showComparisonLink={false}
-              fallbackToFirstVisibleAgent
-            />
-          </Form.Item>
 
           <AgenticConfigChipRow
             tool={selectedAgent as AgenticToolName}
@@ -381,6 +372,18 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
             currentUser={currentUser}
             client={client}
             showEffort
+            leadingField={
+              <Form.Item label="Coding agent" style={{ marginBottom: token.marginSM }}>
+                <AgentSelectionGrid
+                  agents={AVAILABLE_AGENTS}
+                  selectedAgentId={selectedAgent}
+                  onSelect={setSelectedAgent}
+                  variant="select"
+                  showComparisonLink={false}
+                  fallbackToFirstVisibleAgent
+                />
+              </Form.Item>
+            }
           />
 
           <Form.Item style={{ marginBottom: token.marginXS }}>

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -318,7 +318,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
   const backgroundTooltip = `Creates the session in the background, on ${boardPhrase} — check on it anytime.`;
 
   const content = (
-    <div style={{ width: 680, maxWidth: '90vw' }}>
+    <div style={{ width: 450, maxWidth: '90vw' }}>
       <Typography.Text strong style={{ display: 'block', marginBottom: token.marginSM }}>
         {primaryBranch ? (
           <>

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
@@ -84,7 +84,7 @@ describe('PrimaryTeammatePicker', () => {
     seedStore([teammate('branch-2', 'Grace')]);
     renderPicker(createClient(null).client);
 
-    expect(await screen.findByText('No primary assistant set')).toBeInTheDocument();
+    expect(await screen.findByText(/No primary assistant set/)).toBeInTheDocument();
   });
 
   it('writes the picked teammate as an explicit change', async () => {
@@ -92,7 +92,7 @@ describe('PrimaryTeammatePicker', () => {
     const { client, setPrimaryTeammate } = createClient(null);
     renderPicker(client);
 
-    await screen.findByText('No primary assistant set');
+    await screen.findByText(/No primary assistant set/);
     fireEvent.mouseDown(screen.getByRole('combobox'));
     fireEvent.click(await screen.findByText('Grace'));
 

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
@@ -1,0 +1,101 @@
+import type { AgorClient, Board, Branch, Repo } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { PrimaryTeammatePicker } from './PrimaryTeammatePicker';
+
+function teammate(id: string, displayName: string, overrides?: Partial<Branch>): Branch {
+  return {
+    branch_id: id,
+    repo_id: 'repo-1',
+    name: `${id}-branch`,
+    board_id: 'board-1',
+    archived: false,
+    custom_context: { teammate: { kind: 'teammate', displayName } },
+    ...overrides,
+  } as unknown as Branch;
+}
+
+const board = { board_id: 'board-1', name: 'Ambient', icon: '📋' } as Board;
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as Repo;
+
+function seedStore(branches: Branch[]) {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    branchById: new Map(branches.map((b) => [b.branch_id, b])),
+    boardById: new Map([[board.board_id, board]]),
+    repoById: new Map([[repo.repo_id, repo]]),
+  });
+}
+
+function createClient(current: Branch | null) {
+  const getPrimaryTeammate = vi.fn().mockResolvedValue(current);
+  const setPrimaryTeammate = vi.fn((data: { branchId: string }) =>
+    Promise.resolve(teammate(data.branchId, data.branchId))
+  );
+  const client = {
+    service: (name: string) => {
+      if (name === 'users') return { getPrimaryTeammate, setPrimaryTeammate };
+      throw new Error(`unexpected service ${name}`);
+    },
+  } as unknown as AgorClient;
+  return { client, getPrimaryTeammate, setPrimaryTeammate };
+}
+
+function renderPicker(client: AgorClient) {
+  return render(
+    <AntApp>
+      <PrimaryTeammatePicker client={client} />
+    </AntApp>
+  );
+}
+
+describe('PrimaryTeammatePicker', () => {
+  beforeEach(() => {
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('shows the current board-level primary with its board context', async () => {
+    const current = teammate('branch-1', 'Ada');
+    seedStore([current, teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(current).client);
+
+    const currently = await screen.findByText(/Currently/);
+    expect(currently).toHaveTextContent('Ada');
+    expect(currently).toHaveTextContent('Ambient');
+  });
+
+  it('renders a primary that lives outside the listed teammates', async () => {
+    // Resolved primary is accessible but not among the store's teammate list
+    // (embedded on a board the picker isn't otherwise surfacing).
+    const elsewhere = teammate('branch-remote', 'Remote Pilot', { board_id: undefined });
+    seedStore([teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(elsewhere).client);
+
+    const currently = await screen.findByText(/Currently/);
+    expect(currently).toHaveTextContent('Remote Pilot');
+    // Board unknown → falls back to the repo slug.
+    expect(currently).toHaveTextContent('preset-io/agor');
+  });
+
+  it('shows the no-primary prompt instead of a blank field when unset', async () => {
+    seedStore([teammate('branch-2', 'Grace')]);
+    renderPicker(createClient(null).client);
+
+    expect(await screen.findByText('No primary assistant set')).toBeInTheDocument();
+  });
+
+  it('writes the picked teammate as an explicit change', async () => {
+    seedStore([teammate('branch-1', 'Ada'), teammate('branch-2', 'Grace')]);
+    const { client, setPrimaryTeammate } = createClient(null);
+    renderPicker(client);
+
+    await screen.findByText('No primary assistant set');
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByText('Grace'));
+
+    await waitFor(() => expect(setPrimaryTeammate).toHaveBeenCalledWith({ branchId: 'branch-2' }));
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.test.tsx
@@ -97,5 +97,7 @@ describe('PrimaryTeammatePicker', () => {
     fireEvent.click(await screen.findByText('Grace'));
 
     await waitFor(() => expect(setPrimaryTeammate).toHaveBeenCalledWith({ branchId: 'branch-2' }));
+    // Named confirmation toast on a successful pick.
+    expect(await screen.findByText(/Primary assistant set to/)).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -9,6 +9,10 @@ import { selectBoardById, selectBranchById, selectRepoById } from '../../store/s
 
 interface PrimaryTeammatePickerProps {
   client: AgorClient | null;
+  /** Drop the heading/description chrome for embedding in a tight surface (e.g. a popover). */
+  compact?: boolean;
+  /** Fired after a successful pick so an embedder can continue an in-flight action. */
+  onPicked?: (branch: Branch) => void;
 }
 
 interface TeammateOption {
@@ -39,7 +43,11 @@ function teammateContext(
  * `users.getPrimaryTeammate` / `users.setPrimaryTeammate` RPCs; no assumptions
  * about the surrounding modal so it can be relocated by moving its mount point.
  */
-export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({ client }) => {
+export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({
+  client,
+  compact = false,
+  onPicked,
+}) => {
   const { message } = AntApp.useApp();
   const branchById = useAgorStore(selectBranchById);
   const boardById = useAgorStore(selectBoardById);
@@ -100,6 +108,7 @@ export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({ cl
       const branch = await client.service('users').setPrimaryTeammate({ branchId });
       setCurrent(branch);
       message.success('Primary assistant updated');
+      if (branch) onPicked?.(branch);
     } catch (error) {
       message.error(
         `Failed to update primary assistant: ${error instanceof Error ? error.message : String(error)}`
@@ -111,14 +120,16 @@ export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({ cl
 
   return (
     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-      <div>
-        <Typography.Title level={5} style={{ marginBottom: 4 }}>
-          Primary assistant
-        </Typography.Title>
-        <Typography.Text type="secondary">
-          Your default teammate for personal, ambient work. Change it anytime.
-        </Typography.Text>
-      </div>
+      {!compact && (
+        <div>
+          <Typography.Title level={5} style={{ marginBottom: 4 }}>
+            Primary assistant
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            Your default teammate for personal, ambient work. Change it anytime.
+          </Typography.Text>
+        </div>
+      )}
 
       {loading ? (
         <Spin />

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -107,8 +107,10 @@ export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({
     try {
       const branch = await client.service('users').setPrimaryTeammate({ branchId });
       setCurrent(branch);
-      message.success('Primary assistant updated');
-      if (branch) onPicked?.(branch);
+      if (branch) {
+        message.success(`Primary assistant set to ${teammateLabel(branch)}`);
+        onPicked?.(branch);
+      }
     } catch (error) {
       message.error(
         `Failed to update primary assistant: ${error instanceof Error ? error.message : String(error)}`

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -1,7 +1,7 @@
 import type { AgorClient, Board, Branch, Repo } from '@agor-live/client';
 import { getTeammateConfig, isTeammate } from '@agor-live/client';
 import { RobotOutlined } from '@ant-design/icons';
-import { Alert, App as AntApp, Select, Space, Spin, Typography } from 'antd';
+import { App as AntApp, Select, Space, Spin, Typography } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
@@ -139,12 +139,9 @@ export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({
           {teammateContext(current, boardById, repoById)}.
         </Typography.Text>
       ) : (
-        <Alert
-          type="info"
-          showIcon
-          message="No primary assistant set"
-          description="Pick a teammate below to use as your default for personal work."
-        />
+        <Typography.Text type="secondary">
+          No primary assistant set — pick one below to use as your default for personal work.
+        </Typography.Text>
       )}
 
       <Select

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -1,0 +1,162 @@
+import type { AgorClient, Board, Branch, Repo } from '@agor-live/client';
+import { getTeammateConfig, isTeammate } from '@agor-live/client';
+import { RobotOutlined } from '@ant-design/icons';
+import { Alert, App as AntApp, Select, Space, Spin, Typography } from 'antd';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectBranchById, selectRepoById } from '../../store/selectors';
+
+interface PrimaryTeammatePickerProps {
+  client: AgorClient | null;
+}
+
+interface TeammateOption {
+  value: string;
+  label: string;
+  context: string;
+  searchText: string;
+}
+
+function teammateLabel(branch: Branch): string {
+  return getTeammateConfig(branch)?.displayName ?? branch.name;
+}
+
+/** Where the teammate lives — its board, falling back to the repo slug. */
+function teammateContext(
+  branch: Branch,
+  boardById: Map<string, Board>,
+  repoById: Map<string, Repo>
+): string {
+  const board = branch.board_id ? boardById.get(branch.board_id) : undefined;
+  if (board) return `${board.icon ?? '📋'} ${board.name}`;
+  return repoById.get(branch.repo_id)?.slug ?? 'Unknown board';
+}
+
+/**
+ * Self-contained picker for the calling user's primary assistant — the default
+ * teammate for personal/ambient work. Reads and writes via the caller-scoped
+ * `users.getPrimaryTeammate` / `users.setPrimaryTeammate` RPCs; no assumptions
+ * about the surrounding modal so it can be relocated by moving its mount point.
+ */
+export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({ client }) => {
+  const { message } = AntApp.useApp();
+  const branchById = useAgorStore(selectBranchById);
+  const boardById = useAgorStore(selectBoardById);
+  const repoById = useAgorStore(selectRepoById);
+
+  const [current, setCurrent] = useState<Branch | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setLoading(true);
+    client
+      .service('users')
+      .getPrimaryTeammate()
+      .then((branch) => {
+        if (!cancelled) setCurrent(branch);
+      })
+      .catch(() => {
+        if (!cancelled) setCurrent(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const options = useMemo<TeammateOption[]>(() => {
+    const teammates = Array.from(branchById.values()).filter(
+      (branch) => isTeammate(branch) && !branch.archived
+    );
+    // The resolved primary may live on a board this list doesn't otherwise
+    // surface; keep it selectable so its label renders instead of a raw id.
+    if (current && !teammates.some((branch) => branch.branch_id === current.branch_id)) {
+      teammates.push(current);
+    }
+    return teammates
+      .sort((a, b) => teammateLabel(a).localeCompare(teammateLabel(b)))
+      .map((branch) => {
+        const label = teammateLabel(branch);
+        const context = teammateContext(branch, boardById, repoById);
+        return {
+          value: branch.branch_id,
+          label,
+          context,
+          searchText: `${label} ${branch.name} ${context}`,
+        };
+      });
+  }, [branchById, boardById, repoById, current]);
+
+  const handleChange = async (branchId: string) => {
+    if (!client) return;
+    setSaving(true);
+    try {
+      const branch = await client.service('users').setPrimaryTeammate({ branchId });
+      setCurrent(branch);
+      message.success('Primary assistant updated');
+    } catch (error) {
+      message.error(
+        `Failed to update primary assistant: ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <div>
+        <Typography.Title level={5} style={{ marginBottom: 4 }}>
+          Primary assistant
+        </Typography.Title>
+        <Typography.Text type="secondary">
+          Your default teammate for personal, ambient work. Change it anytime.
+        </Typography.Text>
+      </div>
+
+      {loading ? (
+        <Spin />
+      ) : current ? (
+        <Typography.Text>
+          Currently <Typography.Text strong>{teammateLabel(current)}</Typography.Text> on{' '}
+          {teammateContext(current, boardById, repoById)}.
+        </Typography.Text>
+      ) : (
+        <Alert
+          type="info"
+          showIcon
+          message="No primary assistant set"
+          description="Pick a teammate below to use as your default for personal work."
+        />
+      )}
+
+      <Select
+        showSearch
+        loading={saving}
+        disabled={saving || !client}
+        placeholder="Select a primary assistant"
+        value={current?.branch_id}
+        onChange={handleChange}
+        options={options}
+        optionFilterProp="searchText"
+        notFoundContent={options.length === 0 ? 'No teammates available' : undefined}
+        suffixIcon={<RobotOutlined />}
+        style={{ maxWidth: 420 }}
+        optionRender={(option) => (
+          <div style={{ lineHeight: 1.3 }}>
+            <div>{option.data.label}</div>
+            <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+              {option.data.context}
+            </Typography.Text>
+          </div>
+        )}
+      />
+    </Space>
+  );
+};

--- a/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PrimaryTeammatePicker.tsx
@@ -138,7 +138,7 @@ export const PrimaryTeammatePicker: React.FC<PrimaryTeammatePickerProps> = ({
           Currently <Typography.Text strong>{teammateLabel(current)}</Typography.Text> on{' '}
           {teammateContext(current, boardById, repoById)}.
         </Typography.Text>
-      ) : (
+      ) : compact ? null : (
         <Typography.Text type="secondary">
           No primary assistant set — pick one below to use as your default for personal work.
         </Typography.Text>

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -15,6 +15,7 @@ import { AGENTIC_TOOL_DISPLAY_NAMES, hasMinimumRole, ROLE_OPTIONS, ROLES } from 
 import {
   ApiOutlined,
   CloseOutlined,
+  RobotOutlined,
   SettingOutlined,
   SoundOutlined,
   TeamOutlined,
@@ -61,6 +62,7 @@ import { ToolIcon } from '../ToolIcon';
 import { AudioSettingsTab } from './AudioSettingsTab';
 import { syncGroupsForUser } from './groupMembershipSync';
 import { PersonalApiKeysTab } from './PersonalApiKeysTab';
+import { PrimaryTeammatePicker } from './PrimaryTeammatePicker';
 import { UserAgenticDefaultEditor } from './UserAgenticDefaultEditor';
 
 const { Sider, Content } = Layout;
@@ -115,6 +117,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [activeTab, setActiveTab] = useState<string>(initialTab ?? 'general');
   const initializedUserIdRef = useRef<string | null>(null);
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  // The primary-assistant RPCs are caller-scoped, so the picker is only
+  // meaningful when editing your own profile — not when an admin edits another.
+  const isSelf = !!user?.user_id && user.user_id === currentUser?.user_id;
 
   // Separate forms for each agentic tool tab
   const [claudeForm] = Form.useForm();
@@ -712,6 +717,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           label: 'General',
           icon: <SettingOutlined />,
         },
+        ...(isSelf
+          ? [
+              {
+                key: 'primary-teammate',
+                label: 'Primary Assistant',
+                icon: <RobotOutlined />,
+              },
+            ]
+          : []),
         {
           key: 'env-vars',
           label: 'Env Vars',
@@ -993,6 +1007,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
             </Form>
           </>
         );
+      case 'primary-teammate':
+        return <PrimaryTeammatePicker client={client} />;
       case 'personal-api-keys':
         return <PersonalApiKeysTab client={client} />;
       case 'claude-code':

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -539,6 +539,16 @@ export interface UsersService extends AgorService<User> {
     params?: Params
   ): Promise<UserAvatarSettings>;
   syncAvatars(data?: UserAvatarSyncRequest, params?: Params): Promise<UserAvatarSyncResult>;
+  /**
+   * Resolve the calling user's primary teammate branch, or null when unset or
+   * no longer accessible.
+   */
+  getPrimaryTeammate(data?: unknown, params?: Params): Promise<Branch | null>;
+  /**
+   * Set the calling user's primary teammate to an accessible branch,
+   * recorded as an explicit user pick.
+   */
+  setPrimaryTeammate(data: { branchId: string }, params?: Params): Promise<Branch | null>;
 }
 
 /**
@@ -911,7 +921,9 @@ function extendUsersService(client: AgorClient): void {
       'getGitEnvironment',
       'getAvatarSettings',
       'updateAvatarSettings',
-      'syncAvatars'
+      'syncAvatars',
+      'getPrimaryTeammate',
+      'setPrimaryTeammate'
     );
   }
   usersService[USERS_SERVICE_EXTENDED] = true;

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -1251,6 +1251,29 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find a single branch by ID only when it is visible to the user.
+   *
+   * Same predicate as findAccessibleBranches, scoped to one id. Mirrors the
+   * accessiblePrimaryTeammateExists check used to resolve boards'
+   * primary_teammate_id across board boundaries. Returns null when the branch
+   * is missing or the user has no access.
+   */
+  async findAccessibleById(branchId: string, userId: UUID): Promise<Branch | null> {
+    const rows = await select(this.db, getTableColumns(branches))
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(this.db, userId)))
+      .all();
+
+    if (rows.length === 0) return null;
+    const baseUrl = await getBaseUrl();
+    return this.rowToBranch(rows[0] as BranchRow, baseUrl);
+  }
+
+  /**
    * Find branch IDs pinned to a specific board zone.
    *
    * Zone membership lives on board_objects.data.zone_id, not on the branches

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -32,4 +32,5 @@ export * from './tenant-agentic-tools';
 export * from './thread-session-map';
 export * from './user-api-keys';
 export * from './user-mcp-oauth-tokens';
+export * from './user-primary-teammate';
 export * from './users';

--- a/packages/core/src/db/repositories/user-primary-teammate.test.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.test.ts
@@ -1,0 +1,163 @@
+import type { Board, BranchID, UUID } from '@agor/core/types';
+import { afterEach, describe, expect } from 'vitest';
+import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from '../../analytics';
+import { resetAnalyticsLoggerForTests, setAnalyticsLoggerForTests } from '../../analytics';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import {
+  USER_PRIMARY_TEAMMATE_SET_EVENT,
+  UserPrimaryTeammateRepository,
+} from './user-primary-teammate';
+import { UsersRepository } from './users';
+
+interface CapturedEvent {
+  event: string;
+  properties?: AnalyticsProperties;
+  options?: AnalyticsTrackOptions;
+}
+
+function createCapturingLogger(sink: CapturedEvent[]): AnalyticsLogger {
+  return {
+    isEnabled: () => true,
+    track: (event, properties, options) => {
+      sink.push({ event, properties, options });
+    },
+  };
+}
+
+let branchUniqueId = 5_000;
+
+async function createUser(db: Database, email: string): Promise<UUID> {
+  const user = await new UsersRepository(db).create({ email, role: 'member' });
+  return user.user_id as UUID;
+}
+
+async function createBoard(db: Database, overrides?: Partial<Board>): Promise<Board> {
+  return new BoardRepository(db).create({
+    board_id: generateId(),
+    name: overrides?.name ?? 'Board',
+    created_by: overrides?.created_by ?? generateId(),
+    access_mode: overrides?.access_mode ?? 'shared',
+  });
+}
+
+async function createBranch(
+  db: Database,
+  boardId: UUID,
+  overrides?: { permission_source?: 'board' | 'override'; others_can?: 'none' | 'session' }
+): Promise<BranchID> {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: boardId,
+    created_by: generateId(),
+    permission_source: overrides?.permission_source ?? 'override',
+    others_can: overrides?.others_can ?? 'session',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('UserPrimaryTeammateRepository', () => {
+  afterEach(() => {
+    resetAnalyticsLoggerForTests();
+  });
+
+  dbTest('resolves a board-level teammate on an accessible board', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'board-level@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    const resolved = await repo.resolvePrimaryTeammate(user);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest(
+    'resolves a teammate embedded on another (private) board via direct ownership',
+    async ({ db }) => {
+      const repo = new UserPrimaryTeammateRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const user = await createUser(db, 'cross-board@example.com');
+
+      // Teammate lives on a private board the user does not own; only direct
+      // branch ownership grants access — the cross-board case boards support.
+      const otherBoard = await createBoard(db, { access_mode: 'private' });
+      const branchId = await createBranch(db, otherBoard.board_id as UUID, {
+        permission_source: 'override',
+        others_can: 'none',
+      });
+      await branchRepo.addOwner(branchId, user);
+
+      await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+      const resolved = await repo.resolvePrimaryTeammate(user);
+      expect(resolved?.branch_id).toBe(branchId);
+    }
+  );
+
+  dbTest('returns null when the user has lost access to the stored branch', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'lost-access@example.com');
+    const privateBoard = await createBoard(db, { access_mode: 'private' });
+    const branchId = await createBranch(db, privateBoard.board_id as UUID, {
+      permission_source: 'override',
+      others_can: 'none',
+    });
+
+    // Stored, but the user is not an owner and the branch is private → no access.
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(await repo.getBranchId(user)).toBe(branchId);
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('returns null when no primary teammate is set', async ({ db }) => {
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'unset@example.com');
+    expect(await repo.resolvePrimaryTeammate(user)).toBeNull();
+  });
+
+  dbTest('emits an assignment event carrying the source', async ({ db }) => {
+    const events: CapturedEvent[] = [];
+    setAnalyticsLoggerForTests(createCapturingLogger(events));
+
+    const repo = new UserPrimaryTeammateRepository(db);
+    const user = await createUser(db, 'event@example.com');
+    const board = await createBoard(db, { access_mode: 'shared' });
+    const branchId = await createBranch(db, board.board_id as UUID, {
+      permission_source: 'board',
+    });
+
+    await repo.setPrimaryTeammate(user, branchId, { source: 'default' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: USER_PRIMARY_TEAMMATE_SET_EVENT,
+      properties: { user_id: user, branch_id: branchId, source: 'default' },
+      options: { userId: user },
+    });
+  });
+});

--- a/packages/core/src/db/repositories/user-primary-teammate.ts
+++ b/packages/core/src/db/repositories/user-primary-teammate.ts
@@ -1,0 +1,99 @@
+import type { Branch, BranchID, UserID } from '@agor/core/types';
+import { analyticsLogger } from '../../analytics/logger';
+import type { Database } from '../client';
+import { AppVariableRepository } from './app-variables';
+import { BranchRepository } from './branches';
+
+/**
+ * app_variables namespace for a user's primary teammate branch. The row key is
+ * the user id, so there is one value per (tenant, user) — tenant scoping is
+ * ambient via the tenant-scoped database, mirroring KnowledgeSemanticSettings.
+ * Named distinctly from boards' `primary_teammate_id` to avoid any collision.
+ */
+export const USER_PRIMARY_TEAMMATE_NAMESPACE = 'user.primary_teammate_branch';
+
+/** Analytics event emitted whenever a user's primary teammate branch is set. */
+export const USER_PRIMARY_TEAMMATE_SET_EVENT = 'user.primary_teammate.set';
+
+/**
+ * How the primary teammate came to be set: `default` for backfill/onboarding
+ * auto-assignment, `explicit` for a later user-driven pick (a future phase).
+ */
+export type PrimaryTeammateAssignmentSource = 'default' | 'explicit';
+
+export interface SetPrimaryTeammateOptions {
+  source: PrimaryTeammateAssignmentSource;
+  /** Actor for the app_variable audit column; defaults to the target user. */
+  updatedBy?: UserID | null;
+}
+
+export function buildPrimaryTeammateSetAnalyticsProperties(
+  userId: UserID,
+  branchId: BranchID,
+  source: PrimaryTeammateAssignmentSource
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    branch_id: branchId,
+    source,
+  };
+}
+
+/**
+ * Per-user, per-tenant primary teammate branch. Construct with a tenant-scoped
+ * database; reads and writes are scoped to the ambient tenant.
+ */
+export class UserPrimaryTeammateRepository {
+  private variables: AppVariableRepository;
+  private branches: BranchRepository;
+
+  constructor(db: Database) {
+    this.variables = new AppVariableRepository(db);
+    this.branches = new BranchRepository(db);
+  }
+
+  /** Raw stored branch id for the user, or null when unset. */
+  async getBranchId(userId: UserID): Promise<BranchID | null> {
+    const value = await this.variables.getPlain(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+    return (value as BranchID | null) ?? null;
+  }
+
+  /**
+   * Resolve the user's primary teammate branch, or null when unset OR the user
+   * can no longer access the stored branch (deleted, unshared, ownership
+   * removed). Null is the unambiguous "needs picking" signal for callers.
+   *
+   * The access check reuses the same branch-visibility predicate boards use to
+   * resolve `primary_teammate_id`, so a teammate embedded on another board
+   * still resolves as long as the user retains access to it.
+   */
+  async resolvePrimaryTeammate(userId: UserID): Promise<Branch | null> {
+    const branchId = await this.getBranchId(userId);
+    if (!branchId) return null;
+    return this.branches.findAccessibleById(branchId, userId);
+  }
+
+  /** Set the user's primary teammate branch and emit the assignment event. */
+  async setPrimaryTeammate(
+    userId: UserID,
+    branchId: BranchID,
+    options: SetPrimaryTeammateOptions
+  ): Promise<void> {
+    await this.variables.set({
+      namespace: USER_PRIMARY_TEAMMATE_NAMESPACE,
+      key: userId,
+      value: branchId,
+      updated_by: options.updatedBy ?? userId,
+    });
+    analyticsLogger.track(
+      USER_PRIMARY_TEAMMATE_SET_EVENT,
+      buildPrimaryTeammateSetAnalyticsProperties(userId, branchId, options.source),
+      { userId }
+    );
+  }
+
+  /** Clear the user's primary teammate branch. */
+  async clearPrimaryTeammate(userId: UserID): Promise<void> {
+    await this.variables.delete(USER_PRIMARY_TEAMMATE_NAMESPACE, userId);
+  }
+}

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.test.ts
@@ -1,0 +1,117 @@
+import type { UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { BranchRepository } from '../repositories/branches';
+import { RepoRepository } from '../repositories/repos';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+import { dbTest } from '../test-helpers';
+import { backfillUserPrimaryTeammates } from './backfill-user-primary-teammate';
+
+let branchUniqueId = 8_000;
+
+async function createBoardWithTeammate(db: Database): Promise<{ boardId: UUID; branchId: UUID }> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: 'Onboarding board',
+    created_by: generateId(),
+    access_mode: 'shared',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${branchUniqueId}`,
+    name: `repo-${branchUniqueId}`,
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/repo-${branchUniqueId}`,
+    default_branch: 'main',
+  });
+  const name = `teammate-${branchUniqueId}`;
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: board.board_id,
+    created_by: generateId(),
+    permission_source: 'board',
+    custom_context: { teammate: { kind: 'teammate', displayName: name } },
+  });
+  await new BoardRepository(db).setPrimaryTeammate(board.board_id, branch.branch_id);
+  return { boardId: board.board_id as UUID, branchId: branch.branch_id as UUID };
+}
+
+describe('backfillUserPrimaryTeammates', () => {
+  dbTest('copies the onboarding board teammate when mainBoardId is present', async ({ db }) => {
+    const { boardId, branchId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'has-board@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(branchId);
+    const resolved = await primaryTeammates.resolvePrimaryTeammate(user.user_id);
+    expect(resolved?.branch_id).toBe(branchId);
+  });
+
+  dbTest('leaves the field unset when mainBoardId is absent', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      email: 'no-board@example.com',
+      role: 'member',
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.skipped).toBe(1);
+    expect(result.assigned).toBe(0);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('leaves the field unset when the board has no primary teammate', async ({ db }) => {
+    const board = await new BoardRepository(db).create({
+      board_id: generateId(),
+      name: 'Teammate-less board',
+      created_by: generateId(),
+    });
+    const user = await new UsersRepository(db).create({
+      email: 'board-without-teammate@example.com',
+      role: 'member',
+      preferences: { mainBoardId: board.board_id },
+    });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.assigned).toBe(0);
+    expect(result.skipped).toBe(1);
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBeNull();
+  });
+
+  dbTest('does not overwrite a primary teammate that is already set', async ({ db }) => {
+    const { boardId } = await createBoardWithTeammate(db);
+    const user = await new UsersRepository(db).create({
+      email: 'already-set@example.com',
+      role: 'member',
+      preferences: { mainBoardId: boardId },
+    });
+    const primaryTeammates = new UserPrimaryTeammateRepository(db);
+    const existing = generateId() as UUID;
+    await primaryTeammates.setPrimaryTeammate(user.user_id, existing, { source: 'explicit' });
+
+    const result = await backfillUserPrimaryTeammates(db);
+
+    expect(result.alreadySet).toBe(1);
+    expect(result.assigned).toBe(0);
+    expect(await primaryTeammates.getBranchId(user.user_id)).toBe(existing);
+  });
+});

--- a/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
+++ b/packages/core/src/db/scripts/backfill-user-primary-teammate.ts
@@ -1,0 +1,89 @@
+/**
+ * Backfill each user's primary teammate branch from their onboarding board.
+ *
+ * Source of truth is `preferences.mainBoardId` — the board onboarding already
+ * created for the user. We copy that board's designated `primary_teammate_id`
+ * branch (the teammate onboarding set up) into the per-user primary teammate.
+ * Users with no `mainBoardId`, an unknown board, or a board that has no primary
+ * teammate are deliberately left unset — a later UI phase prompts them.
+ *
+ * Runs within the ambient tenant context, so the standalone SQLite runner below
+ * backfills the single local tenant. A multi-tenant caller should invoke
+ * backfillUserPrimaryTeammates once per tenant scope.
+ */
+
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { BranchID } from '@agor/core/types';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { Database } from '../client';
+import { BoardRepository } from '../repositories/boards';
+import { UserPrimaryTeammateRepository } from '../repositories/user-primary-teammate';
+import { UsersRepository } from '../repositories/users';
+
+export interface BackfillUserPrimaryTeammateResult {
+  /** Users whose primary teammate was set from their onboarding board. */
+  assigned: number;
+  /** Users left unset (no mainBoardId, unknown board, or board has no teammate). */
+  skipped: number;
+  /** Users who already had a primary teammate and were left untouched. */
+  alreadySet: number;
+}
+
+export async function backfillUserPrimaryTeammates(
+  db: Database
+): Promise<BackfillUserPrimaryTeammateResult> {
+  const users = new UsersRepository(db);
+  const boards = new BoardRepository(db);
+  const primaryTeammates = new UserPrimaryTeammateRepository(db);
+
+  const result: BackfillUserPrimaryTeammateResult = { assigned: 0, skipped: 0, alreadySet: 0 };
+
+  for (const user of await users.findAll()) {
+    const mainBoardId = user.preferences?.mainBoardId;
+    if (!mainBoardId) {
+      result.skipped++;
+      continue;
+    }
+
+    if (await primaryTeammates.getBranchId(user.user_id)) {
+      result.alreadySet++;
+      continue;
+    }
+
+    const board = await boards.findById(mainBoardId).catch(() => null);
+    const teammateBranchId = board?.primary_teammate_id;
+    if (!teammateBranchId) {
+      result.skipped++;
+      continue;
+    }
+
+    await primaryTeammates.setPrimaryTeammate(user.user_id, teammateBranchId as BranchID, {
+      source: 'default',
+    });
+    result.assigned++;
+  }
+
+  return result;
+}
+
+async function main() {
+  const dbPath = process.env.AGOR_DB_PATH || resolve(homedir(), '.agor/agor.db');
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client) as unknown as Database;
+
+  const { assigned, skipped, alreadySet } = await backfillUserPrimaryTeammates(db);
+  console.log(
+    `✅ Primary teammate backfill complete: ${assigned} assigned, ${alreadySet} already set, ${skipped} skipped`
+  );
+  process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('❌ Primary teammate backfill failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why

Every user has a **primary assistant** — a default teammate for personal/ambient work (Phase 0/1.5 of the primary-assistant work). Until now you could only *set* it in Settings; there was no way to actually *use* it. This adds a global, always-reachable entry point to ask your primary assistant from anywhere in the app — not just from a board.

> **Stacked PR.** Targets `primary-teammate-settings-picker` (#2111, unmerged), which itself stacks on #2106 (also unmerged). Review/merge in order. The diff here is only the navbar trigger; the resolver + Settings picker come from the base branch.

## What

A pencil-icon **compose** button in the navbar (a dedicated, standalone affordance) opens a compact **popover**, not a full drawer:

- **Agent + model/config** — reuses PR #1923's `AgenticConfigChipRow` (source select + resolved chips) and `AgentSelectionGrid` for the tool.
- **Prompt input** — reuses the quick-start `AutocompleteTextarea` (same component the existing "Add session" flow uses), with paste/drop attachments via the same `SessionComposerDropZone` the main chat composer uses.
- **Two buttons, fixed copy:**
  - **Send & Open** (primary) — creates the session on the primary's branch and navigates to it.
  - **Send in Background** (subtle) — creates the session and **never** navigates; you stay exactly where you were.

### Targeting rule for "Send & Open"
Resolved via `users.getPrimaryTeammate`:

1. **On a non-primary board** → full navigation to the new session (`goToSession`). A persistent caption in the popover signals `→ Opens on <teammate>` before you commit.
2. **On a non-board surface** (Knowledge Base / Home) → does **not** navigate. Shows a lightweight in-place "Session started" panel tagged with the teammate/board, plus an explicit "Open on board" button.
3. **`getPrimaryTeammate` returns null** → shows the Settings picker (#2111) **inline** in the popover, reused verbatim. Once a teammate is chosen the send **resumes automatically with the already-typed prompt**.
4. **Already on the primary's own board** → creates + opens the session there, same as today's "Add session".

**Send in Background** skips all navigation branching in every case.

## Deliberately out of scope
- **No "background session finished" notification** — deferred to the separate Notification Center project (`session_returned`). Background sessions go through the normal creation path so that producer picks them up when it ships.
- **No Cmd+K shortcut** (feasible later; the popover is `open`-controlled).
- The existing generic **"Add session"** flow (branch card, board canvas, event stream) is **untouched**.
- **Frontend instrumentation events** (navbar_trigger_impression/submit, quick_session_created) were investigated and intentionally **not** built: no frontend→backend analytics path exists in `agor-ui` today (the only `analyticsLogger` is daemon-side, and there's no client-callable analytics service), so wiring them now would mean inventing that pipe. Flagged as a larger, separate gap.

## Round 2 — design review (2026-08-04)

- **Placement.** Moved the compose trigger to the trailing utility region, just before the gear/account cluster (Material app-bar convention), instead of ahead of the neutral connection/presence/search icons.
- **Button treatment.** Gave the trigger the app's primary-button treatment (`type="primary"`, same as `NewSessionButton`) so it reads as a CTA, not a neutral icon.
- **Banner flattened to a plain caption.** The "No primary assistant set" state was an `Alert` with icon/title/description; replaced with a single muted caption line (same "big banners are overwhelming" feedback from the Settings redesign).
- **Popover widened** so the configuration chips fit on one row instead of wrapping.
- **Button hierarchy fixed.** "Send & Open" is solid/primary; "Send in Background" secondary.

## Round 3 — design review (2026-08-05)

- **No-primary state kept its message.** Round 2's flattening over-corrected: `PrimaryTeammatePicker`'s `compact` mode stripped the explanatory line. Restored a short muted caption above the picker in the popover.
- **Popover heading.** Added a `Typography.Text strong` heading at the top of the content, matching the house popover-title convention.
- **First-time capability hint.** A one-time dismissible tip using the established `useLocalStorage<boolean>` mechanism (key `agor:compose-hint-dismissed`), rendered as a light bulb+text+close row — not another `Alert`.
- **Real tool picker.** Replaced the hardcoded `COMPOSE_TOOL` with `AgentSelectionGrid` + real `selectedAgent` state, wired exactly like `NewSessionModal` (reset-on-agent-change effect, tool threaded into `AgenticConfigChipRow` + `buildConfig` incl. Codex).

## Round 4 — design review (2026-08-05)

- **No-primary caption → lightweight banner.** Wrapped the caption in the same tinted-box style as the first-time tip (shared `bannerBox`); suppressed `PrimaryTeammatePicker`'s own compact caption so the message isn't duplicated.
- **Resolved primary as a Tag.** A compact `Tag` (emoji + name) by the header (identity), distinct from the wayfinding sentence (action).
- **Compact agent picker.** Kept agent above the config chips but swapped the 4-column tile grid for `AgentSelectionGrid`'s `variant="select"` compact dropdown; the reset effect still fires.
- **Paste/drop attachments.** Wrapped the textarea in the same `SessionComposerDropZone` + `useComposerAttachments` + tray the main chat composer uses; carried files through `NewSessionConfig.attachmentFiles`.

## Round 5 — design review (2026-08-17)

- **Agent + Configuration on one row.** `AgenticConfigChipRow` gained an optional `leadingField` slot that renders beside its "Configuration" select in a 50/50 flex row; the chips still render full-width below. Optional and defaults to the prior stacked layout, so other consumers (`NewSessionModal`, `ForkSpawnModal`, `SessionSettingsModal`) are unchanged.
- **Fuller no-primary copy** explaining what a primary assistant is and that it's changeable in Settings, inside the existing banner box.

## Round 6 — design review (2026-08-17)

- **Matched field heights.** The compact agent select rendered ~35px vs the Configuration select's 32px because its inline `ToolIcon` inflated the single-line control. Wrapped the icon in a `height: 0` centered box so it no longer contributes to line height; both are now the standard 32px (also consistent for the select variant's other consumers).
- **Merged header + identity** into one header-weight line: "Ask {icon} {name}, your primary assistant"; falls back to plain "Ask your primary assistant" when no primary.
- **Named the pick confirmation toast** in `PrimaryTeammatePicker` ("Primary assistant set to {name}") — where the set actually succeeds — instead of adding a second toast that would double it.
- **Removed the redundant "Creates a session with X here"** wayfinding (on-primary-board case); kept the board-switch and off-board variants.
- **Send-button tooltips** and a **richer prompt placeholder** with concrete example asks.

## Round 7 — design review (2026-08-17)

- **Agent icon vertical centering.** Round 6's `height: 0` wrapper left the badge baseline-aligned (~3px above the control center, confirmed by DOM measurement). Added a small `translateY` to re-center it (icon center now == control center, control still 32px); verified with a zoomed screenshot. Fix is in the shared select variant.
- **Concrete send-button tooltips**, referencing the live-resolved teammate name:
  - Send & Open → "Creates the session and takes you there now, on {name}'s board."
  - Send in Background → "Creates the session in the background, on {name}'s board — check on it anytime."
  Falls back to "your primary assistant's board" before one is resolved.

## Round 8 — primary teammate emoji on the trigger (2026-08-17)

- The collapsed navbar trigger now shows the resolved primary teammate's emoji to the left of the pencil icon, so you can see who you're about to ask before opening the popover. Falls back to the existing 🤖 placeholder (the same convention `teammateBootstrapPrompt.ts` uses) when no primary is set.
- Primary-teammate resolution now runs eagerly once the `client` exists instead of being gated on the popover being opened, so the emoji is correct on first render. It still re-resolves on open to catch changes made elsewhere.
- The emoji is sized at `token.fontSize` with `lineHeight: 1` so it doesn't distort the button height — verified 32px in both states.

Verified both states via headless-Chrome screenshots — real emoji when a primary is set, 🤖 placeholder when not.

## Round 9 — tone down the trigger button (2026-08-17)

- After Round 8 added the teammate emoji, the trigger read as overwhelming: emoji + pencil icon on a solid primary-blue fill is a lot for a small navbar control. Dropped the trigger's `type="primary"` for AntD's default outlined/neutral button — it stays a distinct, bordered affordance (still set apart by the existing divider before it) but no longer shouts. "Send & Open" remains the primary CTA inside the popover.
- Everything else from Round 8 is unchanged: the resolved teammate emoji (or 🤖 placeholder) to the left of the pencil, resolved eagerly on mount.

Verified both states (emoji set / placeholder) via headless-Chrome screenshots — the neutral button reads noticeably calmer.

## Round 10 — navbar placement + divider (2026-08-17)

- **Compose left of search.** Reordered the navbar's right cluster so the compose trigger sits immediately before `AppHeaderGlobalSearch` (it was previously after search + Knowledge Base). New order: presence · compose · search · Knowledge Base · settings · account.
- **No divider by the button.** After relocating, I inspected the rendered DOM to confirm which divider was showing next to the trigger: it was `GlobalPresenceFacepile`'s trailing vertical `Divider` (the presence/actions separator), now adjacent to the compose button. Removed it so the whole right cluster has no separators.

Verified via DOM (0 dividers in the right cluster; compose x < search x) and a navbar screenshot.

## Round 11 — narrow the popover (2026-08-17)

- Reduced the popover content width from **680 → 450px** (~⅓ thinner), per Kasia.
- Checked each internal element at the new width via DOM measurement so nothing overflows or wraps awkwardly: the side-by-side **Coding agent / Configuration** selects stay on one row at ~219px each (labels fully legible), the prompt textarea spans full width, and `scrollWidth == clientWidth` (no horizontal overflow). The resolved-config chip row simply wraps to two rows, which it's already built to do. No stacking or padding deviation was needed to keep things legible.

Verified both states (primary set / no primary) via headless-Chrome screenshots.

## Round 12 — trigger tooltip + drop off-board wayfinding (2026-08-17)

- **Tooltip on the trigger.** Wrapped the collapsed navbar button in an AntD `Tooltip` reading **"Start quick session"** (same pattern as the send buttons), replacing the plain `title` attribute.
- **Removed the off-board wayfinding line.** Deleted the template `Opens a panel here — session starts with {name} on {board}.` outright. The board-switch line (`→ Opens on {name} · {board}`) is now guarded on `onBoardSurface`, so it doesn't leak into the non-board case; non-board and same-board states show no wayfinding line at all.

Verified in a real browser: hovering the trigger shows "Start quick session", and the off-board popover contains neither the removed line nor the board-switch one.

## Notes for reviewers
- Session creation reuses the existing `onCreateSession` seam (MCP association, env vars, initial-prompt sending) — threaded to the memoized `AppHeader` via `useStableCallback` so the header's `React.memo` bailout still holds.
- Surface detection (`board` vs `non-board`) uses the header's `currentBoardId` plus a Knowledge-Base pathname check.
- `AgenticConfigChipRow` gained an optional `leadingField` slot (round 5) and `AgentSelectionGrid`'s select variant got small icon-centering/height fixes (rounds 6–7) — both backward-compatible for existing consumers, confirmed by their tests.

## Testing
`NavbarComposeButton.test.tsx` covers: trigger opens the popover; Send & Open navigates on a non-primary board and shows the in-place panel on a non-board surface; Send in Background never navigates; null-primary shows the inline picker and preserves the typed prompt; button hierarchy; merged-header name; wayfinding present/absent per case; both send-button tooltips; tool selection routes into the chip row + created session; attachment-only send; compact select variant; and the trigger emoji (real + 🤖 placeholder, resolved eagerly). `PrimaryTeammatePicker.test.tsx` covers the named pick toast. Existing `AppHeader` (incl. memoization rerender) and the `AgenticConfigChipRow`/`AgentSelectionGrid` consumer suites still pass. UI typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)