### PR TITLE
chore: bump pnpm 11.13.0 → 11.17.0 (11.13.0 is a broken release)

### DIFF
--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -41,7 +41,7 @@ on:
   workflow_call:
 
 env:
-  PNPM_VERSION: '11.13.0'
+  PNPM_VERSION: '11.17.0'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,7 +31,7 @@ on:
   workflow_dispatch:
 
 env:
-  PNPM_VERSION: '11.13.0'
+  PNPM_VERSION: '11.17.0'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ on:
       - 'context/**'
 
 env:
-  PNPM_VERSION: '11.13.0'
+  PNPM_VERSION: '11.17.0'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/docs-pr-check.yml
+++ b/.github/workflows/docs-pr-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.17.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/apps/agor-docs/Dockerfile
+++ b/apps/agor-docs/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM node:22-alpine
 
-RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.17.0 --activate
 
 WORKDIR /app
 

--- a/apps/agor-docs/package.json
+++ b/apps/agor-docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.17.0",
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build && next-sitemap --config next-sitemap.config.cjs && pnpm run build:search",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest |
 # Pinned versions for reproducibility across dev and prod
 # NOTE: Update these versions when upgrading Agor SDKs (see packages/core/package.json)
 RUN npm install -g \
-  pnpm@11.13.0 \
+  pnpm@11.17.0 \
   @anthropic-ai/claude-code@2.1.197 \
   @google/gemini-cli@0.31.0 \
   @openai/codex@0.141.0 \

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "turbo": "^2.10.8",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.17.0",
   "engines": {
     "node": ">=22.12.0",
-    "pnpm": ">=11.13.0 <12"
+    "pnpm": ">=11.17.0 <12"
   }
 }


### PR DESCRIPTION
## Why

pnpm **v11.13.0 is a broken release**: its `@pnpm/exe` build shipped **without a binary**. Any CI job that installs the pinned pnpm dies at the install step before a single line of project code runs:

```
[ERR_PNPM_BROKEN_PNPM_RELEASE] pnpm v11.13.0 ... Its @pnpm/exe build shipped without a binary
```

This blocks CI **fully red on `main` and every open PR** — nothing can merge until the pin moves off 11.13.0. This is an independent infra fix that unblocks everyone; it is not stacked on any other PR.

## What

Bump the pinned pnpm `11.13.0 → 11.17.0` everywhere:

- `package.json` — `packageManager` + `engines.pnpm` range (`>=11.17.0 <12`)
- `apps/agor-docs/package.json` — `packageManager`
- `.github/workflows/ci.yml`, `audit.yml`, `agor-live-smoke.yml` — `PNPM_VERSION`
- `.github/workflows/docs-pr-check.yml` — `version`
- `docker/Dockerfile` (`npm install -g`) and `apps/agor-docs/Dockerfile` (`corepack prepare`)

`git grep '11\.13\.0'` returns nothing outside `pnpm-lock.yaml`.

## Verification (local)

- `corepack prepare pnpm@11.17.0 --activate` → `pnpm --version` prints **`11.17.0`** (binary ships, unlike 11.13.0)
- `pnpm install` → completes cleanly, **no `pnpm-lock.yaml` churn**
- `pnpm check` (typecheck + lint + boundary checks + build) → **GREEN**, 7/7 turbo tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)