### PR TITLE
security: isolate trusted image publishing

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,15 +7,14 @@
 # packages/agor-live/build.sh), so the image is pinned to the built commit
 # rather than `agor-live@latest` on npm.
 #
-# Publish model: the :<full-sha> image is built and pushed on pushes to
-# main, v* tags, AND every in-repository PR commit (tagged by the PR *head*
-# SHA, with :pr-<n> re-pointed on each update), so trusted commits are
-# deployable by their own SHA. Fork and Dependabot PRs still build and run the
-# boot smoke test, but cannot publish because GitHub intentionally withholds
-# repository secrets from them. Plus a branch tag, and `latest` on main only.
+# Trust model: pull requests build and smoke-test without registry credentials.
+# Publishing happens only in the release job for an immutable push SHA from a
+# protected main branch or protected v* tag, behind the dockerhub-production
+# GitHub Environment. Configure required reviewers and keep Docker Hub secrets
+# on that environment, never as broadly available repository secrets.
 #
-# Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
-# (Settings → Secrets and variables → Actions):
+# Pushes to Docker Hub (docker.io/preset/agor). Required environment secrets
+# (dockerhub-production → Environment secrets):
 #   DOCKERHUB_USERNAME — Docker Hub account with push access to `preset`
 #   DOCKERHUB_TOKEN    — Docker Hub access token (Read/Write) for that account
 name: Build image
@@ -26,7 +25,6 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,7 +43,7 @@ env:
 
 jobs:
   build:
-    name: Build & push
+    name: Build & smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -59,20 +57,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Check release and image privilege policy
+        run: node scripts/check-supply-chain-security.mjs
+
       # Fork and Dependabot PRs cannot access repository secrets. Keep their
       # build and smoke test useful without authenticating or publishing.
-      - name: Log in to Docker Hub
-        if: >-
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
-        uses: docker/login-action@v4.5.2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -124,6 +113,8 @@ jobs:
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:3030/health > /dev/null 2>&1; then
               echo "Daemon healthy."
+              docker exec agor-smoke sh -c 'test "$(awk "/^Uid:/{print \$2}" /proc/1/status)" = "$(id -u agor)"'
+              docker exec -u agor agor-smoke sh -c '! command -v sudo >/dev/null && ! sudo -n true 2>/dev/null'
               docker rm -f agor-smoke
               exit 0
             fi
@@ -133,15 +124,53 @@ jobs:
           docker logs agor-smoke
           exit 1
 
-      # Publish trusted events after the smoke test. Fork and Dependabot PRs
-      # stop here after validating the same production image locally.
-      - name: Push image
-        if: >-
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
+
+  release:
+    name: Publish trusted image
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: dockerhub-production
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout immutable release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify immutable checkout
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.5.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=agor
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and publish immutable release commit
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -149,7 +178,7 @@ jobs:
           target: production-source
           platforms: linux/amd64
           build-args: |
-            AGOR_BUILD_SHA=${{ env.IMAGE_REVISION }}
+            AGOR_BUILD_SHA=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
   sqlite3 \
   git \
   curl \
+  gosu \
   sudo \
   vim \
   procps \
@@ -85,9 +86,6 @@ RUN set -eux; \
       groupmod -n agor -g "${GID}" node; \
     fi; \
     usermod -g agor agor; \
-    # Grant passwordless sudo for fixing volume permissions and executor spawning
-    echo "agor ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agor; \
-    chmod 0440 /etc/sudoers.d/agor; \
     # Create .agor directory for database and config (will be mounted as volume)
     mkdir -p /home/agor/.agor; \
     chown -R agor:agor /home/agor
@@ -119,6 +117,14 @@ USER agor
 # Stage 2: Development (hot-reload for daemon and UI)
 # ============================================================================
 FROM base AS development
+
+# Development containers need broad sudo for bind-mount setup and local
+# multi-user isolation exercises. Production targets explicitly remove sudo;
+# this grant must never cross the runtime boundary.
+USER root
+RUN echo "agor ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agor \
+  && chmod 0440 /etc/sudoers.d/agor
+USER agor
 
 # Copy package files for dependency installation (as root, then chown)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -163,13 +169,13 @@ USER root
 # This installs both the CLI and daemon binaries
 RUN npm install -g agor-live@latest
 
-# Switch back to agor user
-USER agor
-
 # Copy production entrypoint script
 COPY docker/docker-entrypoint-prod.sh /usr/local/bin/
-RUN sudo chmod +x /usr/local/bin/docker-entrypoint-prod.sh && \
-    sudo chown agor:agor /usr/local/bin/docker-entrypoint-prod.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-prod.sh \
+  && rm -f /etc/sudoers.d/agor \
+  && apt-get purge -y sudo \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Expose daemon port (UI will be served via static files by daemon)
 EXPOSE ${DAEMON_PORT:-3030}
@@ -256,8 +262,12 @@ RUN ln -sf /opt/agor-live/bin/agor.js /usr/local/bin/agor \
 COPY docker/docker-entrypoint-prod.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint-prod.sh
 
-# Drop back to the unprivileged runtime user.
-USER agor
+# The entrypoint performs one fixed-path ownership repair as root, then
+# permanently re-execs itself as the unprivileged runtime user via gosu.
+RUN rm -f /etc/sudoers.d/agor \
+  && apt-get purge -y sudo \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE ${DAEMON_PORT:-3030}
 ENTRYPOINT ["docker-entrypoint-prod.sh"]

--- a/docker/docker-entrypoint-prod.sh
+++ b/docker/docker-entrypoint-prod.sh
@@ -3,10 +3,20 @@ set -e
 
 echo "🚀 Starting Agor production environment..."
 
-# Fix volume permissions (volumes may be created with wrong ownership)
-# Only chown .agor directory (not .ssh which is mounted read-only)
-mkdir -p /home/agor/.agor
-sudo -n chown -R agor:agor /home/agor/.agor
+# The image starts as root only for this fixed, non-configurable volume path.
+# Never run Agor code, migrations, or user-controlled commands before dropping
+# privilege. -xdev prevents crossing into nested mounts and -h does not follow
+# symlink targets.
+if [ "$(id -u)" -eq 0 ]; then
+  install -d -o agor -g agor -m 0700 /home/agor/.agor
+  find /home/agor/.agor -xdev -exec chown -h agor:agor {} +
+  exec gosu agor "$0" "$@"
+fi
+
+if [ "$(id -u)" -ne "$(id -u agor)" ]; then
+  echo "Production entrypoint must run as root or agor" >&2
+  exit 1
+fi
 
 # Initialize database and configure daemon settings
 # --skip-if-exists: Idempotent, won't overwrite existing database

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "check:agor-live-deps": "node scripts/sync-agor-live-deps.mjs --check",
     "check:multitenancy-boundaries": "node scripts/check-multitenancy-boundaries.mjs",
     "check:daemon-filesystem-boundaries": "node scripts/check-daemon-filesystem-boundaries.mjs",
-    "test:daemon-filesystem-boundaries": "node --test scripts/check-daemon-filesystem-boundaries.test.mjs"
+    "test:daemon-filesystem-boundaries": "node --test scripts/check-daemon-filesystem-boundaries.test.mjs",
+    "check:supply-chain-security": "node scripts/check-supply-chain-security.mjs",
+    "test:supply-chain-security": "node --test scripts/check-supply-chain-security.test.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/scripts/check-supply-chain-security.mjs
+++ b/scripts/check-supply-chain-security.mjs
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 
 export function checkSupplyChainPolicy({ workflow, dockerfile, entrypoint }) {
   const failures = [];
-  const buildJob = workflow.match(/\n  build:\n([\s\S]*?)\n  release:\n/)?.[1] ?? '';
-  const releaseJob = workflow.match(/\n  release:\n([\s\S]*)$/)?.[1] ?? '';
+  const buildJob = workflow.match(/\n {2}build:\n([\s\S]*?)\n {2}release:\n/)?.[1] ?? '';
+  const releaseJob = workflow.match(/\n {2}release:\n([\s\S]*)$/)?.[1] ?? '';
 
   if (/\$\{\{\s*secrets\.|docker\/login-action|push:\s*true/.test(buildJob)) {
     failures.push('untrusted build job may not use secrets, registry login, or push');

--- a/scripts/check-supply-chain-security.mjs
+++ b/scripts/check-supply-chain-security.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+
+export function checkSupplyChainPolicy({ workflow, dockerfile, entrypoint }) {
+  const failures = [];
+  const buildJob = workflow.match(/\n  build:\n([\s\S]*?)\n  release:\n/)?.[1] ?? '';
+  const releaseJob = workflow.match(/\n  release:\n([\s\S]*)$/)?.[1] ?? '';
+
+  if (/\$\{\{\s*secrets\.|docker\/login-action|push:\s*true/.test(buildJob)) {
+    failures.push('untrusted build job may not use secrets, registry login, or push');
+  }
+  if (!/if:\s*github\.event_name == 'push'/.test(releaseJob)) {
+    failures.push('release job must be restricted to push events');
+  }
+  if (!/environment:\s*dockerhub-production/.test(releaseJob)) {
+    failures.push('release credentials must be protected by dockerhub-production');
+  }
+  if (!/ref:\s*\$\{\{ github\.sha \}\}/.test(releaseJob)) {
+    failures.push('release checkout must use the immutable event SHA');
+  }
+  if (/NOPASSWD:ALL/.test(dockerfile.match(/FROM base AS production[\s\S]*$/)?.[0] ?? '')) {
+    failures.push('production stages may not grant unrestricted sudo');
+  }
+  if (!/apt-get purge -y sudo/.test(dockerfile)) {
+    failures.push('production images must remove sudo');
+  }
+  if (!/exec gosu agor/.test(entrypoint) || /sudo\b/.test(entrypoint)) {
+    failures.push('production entrypoint must drop privilege without sudo');
+  }
+  return failures;
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const failures = checkSupplyChainPolicy({
+    workflow: readFileSync('.github/workflows/build-image.yml', 'utf8'),
+    dockerfile: readFileSync('docker/Dockerfile', 'utf8'),
+    entrypoint: readFileSync('docker/docker-entrypoint-prod.sh', 'utf8'),
+  });
+  if (failures.length) {
+    console.error(failures.map((failure) => `- ${failure}`).join('\n'));
+    process.exit(1);
+  }
+  console.log('Supply-chain workflow and image privilege invariants passed.');
+}

--- a/scripts/check-supply-chain-security.test.mjs
+++ b/scripts/check-supply-chain-security.test.mjs
@@ -13,7 +13,11 @@ test('accepts separated trusted publishing and an unprivileged runtime', () => {
 });
 
 test('rejects PR-build credentials or publishing', () => {
-  for (const line of ['password: ${{ secrets.TOKEN }}', 'uses: docker/login-action@v4', 'push: true']) {
+  for (const line of [
+    `password: \${{ secrets.TOKEN }}`,
+    'uses: docker/login-action@v4',
+    'push: true',
+  ]) {
     const candidate = structuredClone(safe);
     candidate.workflow = candidate.workflow.replace('steps: []', `steps:\n      - ${line}`);
     assert.match(checkSupplyChainPolicy(candidate).join('\n'), /untrusted build job/);
@@ -25,7 +29,7 @@ test('rejects mutable or unprotected release inputs', () => {
   candidate.workflow = candidate.workflow
     .replace("if: github.event_name == 'push'", "if: github.event_name == 'pull_request'")
     .replace('environment: dockerhub-production', 'environment: preview')
-    .replace('ref: ${{ github.sha }}', 'ref: ${{ github.ref }}');
+    .replace(`ref: \${{ github.sha }}`, `ref: \${{ github.ref }}`);
   assert.equal(checkSupplyChainPolicy(candidate).length, 3);
 });
 

--- a/scripts/check-supply-chain-security.test.mjs
+++ b/scripts/check-supply-chain-security.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { checkSupplyChainPolicy } from './check-supply-chain-security.mjs';
+
+const safe = {
+  workflow: `jobs:\n  build:\n    steps: []\n  release:\n    if: github.event_name == 'push'\n    environment: dockerhub-production\n    steps:\n      - with:\n          ref: \${{ github.sha }}\n      - uses: docker/login-action@v4\n        with:\n          password: \${{ secrets.TOKEN }}\n      - with:\n          push: true\n`,
+  dockerfile: 'FROM base AS production\nRUN apt-get purge -y sudo\n',
+  entrypoint: 'exec gosu agor "$0" "$@"',
+};
+
+test('accepts separated trusted publishing and an unprivileged runtime', () => {
+  assert.deepEqual(checkSupplyChainPolicy(safe), []);
+});
+
+test('rejects PR-build credentials or publishing', () => {
+  for (const line of ['password: ${{ secrets.TOKEN }}', 'uses: docker/login-action@v4', 'push: true']) {
+    const candidate = structuredClone(safe);
+    candidate.workflow = candidate.workflow.replace('steps: []', `steps:\n      - ${line}`);
+    assert.match(checkSupplyChainPolicy(candidate).join('\n'), /untrusted build job/);
+  }
+});
+
+test('rejects mutable or unprotected release inputs', () => {
+  const candidate = structuredClone(safe);
+  candidate.workflow = candidate.workflow
+    .replace("if: github.event_name == 'push'", "if: github.event_name == 'pull_request'")
+    .replace('environment: dockerhub-production', 'environment: preview')
+    .replace('ref: ${{ github.sha }}', 'ref: ${{ github.ref }}');
+  assert.equal(checkSupplyChainPolicy(candidate).length, 3);
+});
+
+test('rejects unrestricted production sudo and missing privilege drop', () => {
+  const candidate = structuredClone(safe);
+  candidate.dockerfile += 'RUN echo "agor ALL=(ALL) NOPASSWD:ALL"\n';
+  candidate.entrypoint = 'sudo -n chown -R agor:agor /home/agor/.agor';
+  assert.equal(checkSupplyChainPolicy(candidate).length, 2);
+});


### PR DESCRIPTION
## Summary
- separate untrusted image validation from protected publishing
- publish only immutable push SHAs through the `dockerhub-production` environment
- remove general production sudo and drop runtime privilege after fixed-path initialization
- add workflow and image privilege policy regression checks

## Test plan
- `node scripts/check-supply-chain-security.mjs`
- `node --test scripts/check-supply-chain-security.test.mjs`
- `node scripts/check-multitenancy-boundaries.mjs`
- parse `.github/workflows/build-image.yml` with PyYAML
- `sh -n docker/docker-entrypoint-prod.sh`
- `git diff --check`

## Deployment note
Before enabling publishing, configure `dockerhub-production` with required reviewers, move `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to environment secrets, and protect `main` plus release tags. Image provenance/signature enforcement remains tracked separately as N7.
