### PR TITLE
security: lock shared OAuth lifecycle and explicit MCP grants

### DIFF
--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -22,8 +22,8 @@ describe('register-hooks MCP server secret redaction', () => {
     expect(routesSource).toContain('redactMCPServerSecrets');
     expect(routesSource).toContain('servers.map(redactMCPServerSecrets)');
     expect(routesSource).toContain('await requireSessionScopedConfigOwnerOrAdmin(id, params)');
-    expect(routesSource).toContain('includeGlobal');
-    expect(routesSource).toContain("scope: 'global'");
+    expect(routesSource).not.toContain('includeGlobal');
+    expect(routesSource).toContain('const servers = sessionServers');
     expect(routesSource).toContain('forUserId');
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3617,8 +3617,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         await requireSessionScopedConfigOwnerOrAdmin(id, params);
         const enabledOnly =
           params.query?.enabledOnly === 'true' || params.query?.enabledOnly === true;
-        const includeGlobal =
-          params.query?.includeGlobal === 'true' || params.query?.includeGlobal === true;
         const includeMetadata =
           params.query?.includeMetadata === 'true' || params.query?.includeMetadata === true;
         const mcpService = app.service('mcp-servers');
@@ -3697,30 +3695,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             }
           })
         );
-        const globalQuery = {
-          scope: 'global',
-          ...(enabledOnly ? { enabled: true } : {}),
-          ...(userId ? { forUserId: userId } : {}),
-          $limit: 1000,
-        };
-        const globalResult = includeGlobal
-          ? await mcpService.find({
-              ...params,
-              provider: undefined,
-              query: globalQuery,
-            })
-          : [];
-        const globalServers = Array.isArray(globalResult) ? globalResult : globalResult.data;
-        const servers = includeGlobal
-          ? [
-              ...new Map(
-                [...globalServers, ...sessionServers].map((server) => [
-                  server.mcp_server_id,
-                  server,
-                ])
-              ).values(),
-            ]
-          : sessionServers;
+        const servers = sessionServers;
         return shouldExposeMCPServerSecrets(params, {
           allowSessionToken: true,
           sessionId: id,

--- a/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
@@ -54,7 +54,8 @@ describe('register-services /mcp-servers/oauth-auth-headers authorization', () =
     expect(authHeadersBlock).toContain('trusted executor paths');
     expect(authHeadersBlock).toContain('shouldExposeMCPServerSecretsForSessionToken');
     expect(authHeadersBlock).toContain('SessionMCPServerRepository');
-    expect(authHeadersBlock).toContain("scope: 'global'");
+    expect(authHeadersBlock).not.toContain("scope: 'global'");
+    expect(authHeadersBlock).toContain('attachedServers.map');
     expect(authHeadersBlock).toContain('allowedServerIds');
     expect(authHeadersBlock).toContain('server_not_in_session_scope');
   });

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -71,6 +71,6 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/tenantId:\s*opts\.tenantId\s*\?\?\s*getCurrentTenantId\s*\(\s*\)/);
     expect(codeOnly).toMatch(/runInOAuthTenantScope\s*\(\s*db,\s*pendingFlow\.tenantId/);
     expect(codeOnly).toMatch(/Missing tenant context for MCP OAuth callback/);
-    expect(codeOnly).toMatch(/OAuth flow belongs to a different tenant/);
+    expect(codeOnly).toMatch(/OAuth flow tenant context is missing or does not match/);
   });
 });

--- a/apps/agor-daemon/src/register-services.shared-oauth-policy.test.ts
+++ b/apps/agor-daemon/src/register-services.shared-oauth-policy.test.ts
@@ -15,11 +15,13 @@ describe('shared OAuth lifecycle registration', () => {
 
   it('admin-gates every shared pending flow at the central start boundary', () => {
     expect(flowStart).toContain("if (opts.oauthMode === 'shared')");
-    expect(flowStart).toContain("requireSharedOAuthAdministrator(opts.actorParams, 'start')");
+    expect(flowStart).toContain(
+      "requireSharedOAuthAdministrator(opts.sharedOAuthAuthorization, 'start')"
+    );
     expect(flowStart.indexOf('requireSharedOAuthAdministrator')).toBeLessThan(
       flowStart.indexOf('startMCPOAuthFlow(')
     );
-    expect(source.match(/actorParams: params/g)).toHaveLength(3);
+    expect(source.match(/sharedOAuthAuthorization:/g)).toHaveLength(4);
   });
 
   it('rejects cross-tenant manual completion before token exchange or state consumption', () => {

--- a/apps/agor-daemon/src/register-services.shared-oauth-policy.test.ts
+++ b/apps/agor-daemon/src/register-services.shared-oauth-policy.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('shared OAuth lifecycle registration', () => {
+  const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
+  const flowStart = source.slice(
+    source.indexOf('async function startTwoPhaseMCPOAuthFlowInternal'),
+    source.indexOf('const tenantIdFromParams')
+  );
+  const completeStart = source.indexOf("app.use('/mcp-servers/oauth-complete'");
+  const completeBlock = source.slice(
+    completeStart,
+    source.indexOf("app.service('mcp-servers/oauth-complete')", completeStart)
+  );
+
+  it('admin-gates every shared pending flow at the central start boundary', () => {
+    expect(flowStart).toContain("if (opts.oauthMode === 'shared')");
+    expect(flowStart).toContain("requireSharedOAuthAdministrator(opts.actorParams, 'start')");
+    expect(flowStart.indexOf('requireSharedOAuthAdministrator')).toBeLessThan(
+      flowStart.indexOf('startMCPOAuthFlow(')
+    );
+    expect(source.match(/actorParams: params/g)).toHaveLength(3);
+  });
+
+  it('rejects cross-tenant manual completion before token exchange or state consumption', () => {
+    const tenantCheck = completeBlock.indexOf('isPostgresDatabase(db)');
+    expect(tenantCheck).toBeGreaterThan(0);
+    expect(tenantCheck).toBeLessThan(completeBlock.indexOf('completeMCPOAuthFlow('));
+    expect(tenantCheck).toBeLessThan(completeBlock.indexOf('pendingOAuthFlows.delete(state)'));
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -45,7 +45,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { ROLES, TaskStatus } from '@agor/core/types';
+import { hasMinimumRole, ROLES, TaskStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import type express from 'express';
 import type {
@@ -141,6 +141,10 @@ import {
   shouldExposeMCPServerSecrets,
   shouldExposeMCPServerSecretsForSessionToken,
 } from './utils/mcp-header-secrets.js';
+import {
+  auditSharedOAuthLifecycle,
+  requireSharedOAuthAdministrator,
+} from './utils/shared-oauth-policy.js';
 import { spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
 
@@ -1987,6 +1991,16 @@ async function registerMCPServices(
             scopeOverride = server.auth.oauth_scope;
           }
         }
+        if (oauthMode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'start');
+          auditSharedOAuthLifecycle({
+            action: 'start',
+            outcome: 'started',
+            serverId: data.mcp_server_id,
+            actorUserId: userId,
+            tenantId,
+          });
+        }
 
         let probeResponse = await fetch(data.mcp_url, {
           method: 'POST',
@@ -2074,7 +2088,10 @@ async function registerMCPServices(
 
   // OAuth complete endpoint
   app.use('/mcp-servers/oauth-complete', {
-    async create(data: { callback_url: string } | { code: string; state: string }) {
+    async create(
+      data: { callback_url: string } | { code: string; state: string },
+      params?: AuthenticatedParams
+    ) {
       try {
         const { completeMCPOAuthFlow, parseOAuthCallback } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
@@ -2097,6 +2114,15 @@ async function registerMCPServices(
             error: 'OAuth flow expired or not found. Please start the flow again.',
           };
 
+        if (pendingFlow.oauthMode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'complete');
+          if (pendingFlow.userId !== params?.user?.user_id) {
+            throw new Forbidden('OAuth flow must be completed by the administrator who started it');
+          }
+        } else if (pendingFlow.userId && pendingFlow.userId !== params?.user?.user_id) {
+          throw new Forbidden('OAuth flow belongs to a different user');
+        }
+
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
@@ -2108,6 +2134,15 @@ async function registerMCPServices(
         }
 
         await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
+        if (pendingFlow.oauthMode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'complete',
+            outcome: 'succeeded',
+            serverId: pendingFlow.mcpServerId,
+            actorUserId: params?.user?.user_id,
+            tenantId: pendingFlow.tenantId,
+          });
+        }
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
         console.error('[OAuth Complete] Error:', error);
@@ -2120,6 +2155,13 @@ async function registerMCPServices(
   // OAuth disconnect
   app.use('/mcp-servers/oauth-disconnect', {
     async create(data: { mcp_server_id: string }, params?: AuthenticatedParams) {
+      const tenantId = tenantIdFromParams(params);
+      const server = await runInOAuthTenantScope(db, tenantId, () =>
+        new MCPServerRepository(db).findById(data.mcp_server_id)
+      );
+      if (server?.auth?.oauth_mode === 'shared') {
+        requireSharedOAuthAdministrator(params, 'disconnect');
+      }
       const { clearAuthCodeTokenCache } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
       const result = await performOAuthDisconnect({
         userId: params?.user?.user_id,
@@ -2136,6 +2178,15 @@ async function registerMCPServices(
         app.io
           .to(userRoomName(params.user.user_id))
           .emit('oauth:disconnected', { mcp_server_id: data.mcp_server_id });
+      }
+      if (server?.auth?.oauth_mode === 'shared') {
+        auditSharedOAuthLifecycle({
+          action: 'disconnect',
+          outcome: result.success ? 'succeeded' : 'failed',
+          serverId: data.mcp_server_id,
+          actorUserId: params?.user?.user_id,
+          tenantId,
+        });
       }
 
       return result;
@@ -2155,7 +2206,22 @@ async function registerMCPServices(
         const authenticatedServerIds = tokens
           .filter((t) => !t.oauth_token_expires_at || t.oauth_token_expires_at > now)
           .map((t) => t.mcp_server_id);
-        return { authenticated_server_ids: authenticatedServerIds };
+        const sharedGrants =
+          params?.user && hasMinimumRole(params.user.role, ROLES.ADMIN)
+            ? (await userTokenRepo.listShared()).map((token) => ({
+                mcp_server_id: token.mcp_server_id,
+                connected_at: token.created_at,
+                updated_at: token.updated_at,
+                current_principal: {
+                  kind: 'instance_shared',
+                  display: 'Shared provider identity (provider principal not reported)',
+                },
+              }))
+            : undefined;
+        return {
+          authenticated_server_ids: authenticatedServerIds,
+          ...(sharedGrants ? { shared_grants: sharedGrants } : {}),
+        };
       } catch (error) {
         console.error('[OAuth Status] Error fetching user tokens:', error);
         return { authenticated_server_ids: [] };
@@ -2175,8 +2241,8 @@ async function registerMCPServices(
   // Access control:
   //   - per_user tokens are keyed on params.user.user_id — a caller cannot
   //     request another user's row (no forUserId override here).
-  //   - shared tokens (user_id = NULL) are returned to any authenticated
-  //     caller who can see the server, matching existing shared-mode semantics.
+  //   - shared tokens (user_id = NULL) are usable only when the server was
+  //     explicitly attached to the executor's session.
   //
   // The caller is expected to pass only the server IDs it already resolved
   // as in-scope for the session (see `getMcpServersForSession`).
@@ -2242,11 +2308,7 @@ async function registerMCPServices(
           executorSessionId as SessionID,
           true
         );
-        const globalServers = await mcpServerRepo.findAll({ scope: 'global', enabled: true });
-        const allowedServerIds = new Set([
-          ...globalServers.map((server) => server.mcp_server_id),
-          ...attachedServers.map((server) => server.mcp_server_id),
-        ]);
+        const allowedServerIds = new Set(attachedServers.map((server) => server.mcp_server_id));
         for (const serverId of serverIds) {
           if (!allowedServerIds.has(serverId as MCPServerID)) {
             headers[serverId] = { error: 'server_not_in_session_scope' };
@@ -2376,6 +2438,9 @@ async function registerMCPServices(
         if (server.auth?.type !== 'oauth') return { success: false, error: 'not_oauth_server' };
 
         const mode = server.auth.oauth_mode ?? 'per_user';
+        if (mode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'refresh');
+        }
         const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
         await refreshAndPersistToken({
@@ -2390,6 +2455,15 @@ async function registerMCPServices(
             ? fresh.oauth_token_expires_at.getTime()
             : undefined;
 
+        if (mode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'refresh',
+            outcome: 'succeeded',
+            serverId,
+            actorUserId: userId,
+            tenantId: tenantIdFromParams(params),
+          });
+        }
         return { success: true, expires_at: expiresAt };
       } catch (err) {
         if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1239,6 +1239,8 @@ async function registerMCPServices(
     tokenUrlOverride?: string;
     scope?: string;
     socketId?: string;
+    /** Authenticated initiator. Required for every externally initiated shared grant. */
+    actorParams?: AuthenticatedParams;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -1270,6 +1272,9 @@ async function registerMCPServices(
     opts: StartTwoPhaseOAuthOptions,
     awaitToken: boolean
   ): Promise<StartTwoPhaseOAuthResult | StartTwoPhaseOAuthAndAwaitResult> {
+    if (opts.oauthMode === 'shared') {
+      requireSharedOAuthAdministrator(opts.actorParams, 'start');
+    }
     const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
 
     // Strict public base URL — see oauth-start endpoint for the rationale.
@@ -1344,6 +1349,15 @@ async function registerMCPServices(
       tokenResolve,
       tokenReject,
     });
+    if (opts.oauthMode === 'shared') {
+      auditSharedOAuthLifecycle({
+        action: 'start',
+        outcome: 'started',
+        serverId: opts.mcpServerId,
+        actorUserId: opts.userId,
+        tenantId: opts.tenantId,
+      });
+    }
 
     if (app.io) {
       const payload = { authUrl: context.authorizationUrl };
@@ -1425,6 +1439,15 @@ async function registerMCPServices(
         // caller (discover / test-oauth) can surface the failure.
         if (state) {
           const pending = pendingOAuthFlows.get(state);
+          if (pending?.oauthMode === 'shared') {
+            auditSharedOAuthLifecycle({
+              action: 'complete',
+              outcome: 'failed',
+              serverId: pending.mcpServerId,
+              actorUserId: pending.userId,
+              tenantId: pending.tenantId,
+            });
+          }
           pending?.tokenReject?.(new Error(`Authorization failed: ${errorDescription}`));
           pendingOAuthFlows.delete(state);
         }
@@ -1461,6 +1484,15 @@ async function registerMCPServices(
         pendingOAuthFlows.delete(state);
 
         await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Callback');
+        if (pendingFlow.oauthMode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'complete',
+            outcome: 'succeeded',
+            serverId: pendingFlow.mcpServerId,
+            actorUserId: pendingFlow.userId,
+            tenantId: pendingFlow.tenantId,
+          });
+        }
 
         if (app.io) {
           const oauthEvent = {
@@ -1509,6 +1541,15 @@ async function registerMCPServices(
         pendingFlow.tokenReject?.(
           innerErr instanceof Error ? innerErr : new Error(String(innerErr))
         );
+        if (pendingFlow.oauthMode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'complete',
+            outcome: 'failed',
+            serverId: pendingFlow.mcpServerId,
+            actorUserId: pendingFlow.userId,
+            tenantId: pendingFlow.tenantId,
+          });
+        }
         throw innerErr;
       }
     } catch (err) {
@@ -1716,6 +1757,7 @@ async function registerMCPServices(
                   clientId: data.client_id,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
                   socketId: connection?.id,
+                  actorParams: params as AuthenticatedParams | undefined,
                 });
               } catch (err) {
                 if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -1991,17 +2033,6 @@ async function registerMCPServices(
             scopeOverride = server.auth.oauth_scope;
           }
         }
-        if (oauthMode === 'shared') {
-          requireSharedOAuthAdministrator(params, 'start');
-          auditSharedOAuthLifecycle({
-            action: 'start',
-            outcome: 'started',
-            serverId: data.mcp_server_id,
-            actorUserId: userId,
-            tenantId,
-          });
-        }
-
         let probeResponse = await fetch(data.mcp_url, {
           method: 'POST',
           headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
@@ -2061,6 +2092,7 @@ async function registerMCPServices(
             scope: scopeOverride,
             tenantId,
             socketId,
+            actorParams: params,
           });
         } catch (err) {
           if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -2092,6 +2124,7 @@ async function registerMCPServices(
       data: { callback_url: string } | { code: string; state: string },
       params?: AuthenticatedParams
     ) {
+      let sharedFlowForAudit: PendingOAuthFlow | undefined;
       try {
         const { completeMCPOAuthFlow, parseOAuthCallback } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
@@ -2113,6 +2146,7 @@ async function registerMCPServices(
             success: false,
             error: 'OAuth flow expired or not found. Please start the flow again.',
           };
+        if (pendingFlow.oauthMode === 'shared') sharedFlowForAudit = pendingFlow;
 
         if (pendingFlow.oauthMode === 'shared') {
           requireSharedOAuthAdministrator(params, 'complete');
@@ -2123,15 +2157,18 @@ async function registerMCPServices(
           throw new Forbidden('OAuth flow belongs to a different user');
         }
 
-        const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
-        pendingOAuthFlows.delete(state);
-
         const activeTenantId = getCurrentTenantId();
-        if (pendingFlow.tenantId && activeTenantId && pendingFlow.tenantId !== activeTenantId) {
+        if (
+          (isPostgresDatabase(db) && (!pendingFlow.tenantId || !activeTenantId)) ||
+          (pendingFlow.tenantId !== activeTenantId && !!(pendingFlow.tenantId || activeTenantId))
+        ) {
           throw new Error(
-            'OAuth flow belongs to a different tenant. Please restart the OAuth flow.'
+            'OAuth flow tenant context is missing or does not match. Please restart the OAuth flow.'
           );
         }
+
+        const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+        pendingOAuthFlows.delete(state);
 
         await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
         if (pendingFlow.oauthMode === 'shared') {
@@ -2145,6 +2182,15 @@ async function registerMCPServices(
         }
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
+        if (sharedFlowForAudit) {
+          auditSharedOAuthLifecycle({
+            action: 'complete',
+            outcome: 'failed',
+            serverId: sharedFlowForAudit.mcpServerId,
+            actorUserId: params?.user?.user_id,
+            tenantId: sharedFlowForAudit.tenantId,
+          });
+        }
         console.error('[OAuth Complete] Error:', error);
         return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
@@ -2432,6 +2478,7 @@ async function registerMCPServices(
         MissingClientIdError,
       } = await import('@agor/core/tools/mcp/oauth-refresh');
 
+      let sharedRefresh = false;
       try {
         const server = await mcpServerRepo.findById(serverId);
         if (!server) return { success: false, error: 'server_not_found' };
@@ -2439,6 +2486,7 @@ async function registerMCPServices(
 
         const mode = server.auth.oauth_mode ?? 'per_user';
         if (mode === 'shared') {
+          sharedRefresh = true;
           requireSharedOAuthAdministrator(params, 'refresh');
         }
         const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
@@ -2466,6 +2514,15 @@ async function registerMCPServices(
         }
         return { success: true, expires_at: expiresAt };
       } catch (err) {
+        if (sharedRefresh) {
+          auditSharedOAuthLifecycle({
+            action: 'refresh',
+            outcome: 'failed',
+            serverId,
+            actorUserId: userId,
+            tenantId: tenantIdFromParams(params),
+          });
+        }
         if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {
           return { success: false, error: 'needs_reauth' };
         }
@@ -2740,6 +2797,7 @@ async function registerMCPServices(
               oauthMode: 'shared',
               tenantId: tenantIdFromParams(params),
               socketId: connection?.id,
+              actorParams: params,
             });
 
             const tokenResponse = await started.awaitToken();

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -144,6 +144,7 @@ import {
 import {
   auditSharedOAuthLifecycle,
   requireSharedOAuthAdministrator,
+  type SharedOAuthAuthorization,
 } from './utils/shared-oauth-policy.js';
 import { spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
@@ -1239,8 +1240,8 @@ async function registerMCPServices(
     tokenUrlOverride?: string;
     scope?: string;
     socketId?: string;
-    /** Authenticated initiator. Required for every externally initiated shared grant. */
-    actorParams?: AuthenticatedParams;
+    /** Explicit authority for creating a shared pending grant. Never inferred from omission. */
+    sharedOAuthAuthorization: SharedOAuthAuthorization;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -1273,7 +1274,7 @@ async function registerMCPServices(
     awaitToken: boolean
   ): Promise<StartTwoPhaseOAuthResult | StartTwoPhaseOAuthAndAwaitResult> {
     if (opts.oauthMode === 'shared') {
-      requireSharedOAuthAdministrator(opts.actorParams, 'start');
+      requireSharedOAuthAdministrator(opts.sharedOAuthAuthorization, 'start');
     }
     const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
 
@@ -1757,7 +1758,10 @@ async function registerMCPServices(
                   clientId: data.client_id,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
                   socketId: connection?.id,
-                  actorParams: params as AuthenticatedParams | undefined,
+                  sharedOAuthAuthorization: {
+                    kind: 'actor',
+                    params: params as AuthenticatedParams | undefined,
+                  },
                 });
               } catch (err) {
                 if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -2092,7 +2096,7 @@ async function registerMCPServices(
             scope: scopeOverride,
             tenantId,
             socketId,
-            actorParams: params,
+            sharedOAuthAuthorization: { kind: 'actor', params },
           });
         } catch (err) {
           if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -2149,7 +2153,7 @@ async function registerMCPServices(
         if (pendingFlow.oauthMode === 'shared') sharedFlowForAudit = pendingFlow;
 
         if (pendingFlow.oauthMode === 'shared') {
-          requireSharedOAuthAdministrator(params, 'complete');
+          requireSharedOAuthAdministrator({ kind: 'actor', params }, 'complete');
           if (pendingFlow.userId !== params?.user?.user_id) {
             throw new Forbidden('OAuth flow must be completed by the administrator who started it');
           }
@@ -2206,7 +2210,7 @@ async function registerMCPServices(
         new MCPServerRepository(db).findById(data.mcp_server_id)
       );
       if (server?.auth?.oauth_mode === 'shared') {
-        requireSharedOAuthAdministrator(params, 'disconnect');
+        requireSharedOAuthAdministrator({ kind: 'actor', params }, 'disconnect');
       }
       const { clearAuthCodeTokenCache } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
       const result = await performOAuthDisconnect({
@@ -2487,7 +2491,7 @@ async function registerMCPServices(
         const mode = server.auth.oauth_mode ?? 'per_user';
         if (mode === 'shared') {
           sharedRefresh = true;
-          requireSharedOAuthAdministrator(params, 'refresh');
+          requireSharedOAuthAdministrator({ kind: 'actor', params }, 'refresh');
         }
         const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
@@ -2797,7 +2801,7 @@ async function registerMCPServices(
               oauthMode: 'shared',
               tenantId: tenantIdFromParams(params),
               socketId: connection?.id,
-              actorParams: params,
+              sharedOAuthAuthorization: { kind: 'actor', params },
             });
 
             const tokenResponse = await started.awaitToken();

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
@@ -1,0 +1,17 @@
+import { Forbidden } from '@agor/core/feathers';
+import { describe, expect, it } from 'vitest';
+import { requireSharedOAuthAdministrator } from './shared-oauth-policy';
+
+const params = (role: 'member' | 'admin') =>
+  ({ provider: 'rest', user: { user_id: `${role}-user`, role } }) as never;
+
+describe('requireSharedOAuthAdministrator', () => {
+  it('rejects an ordinary member mutating the tenant-wide identity', () => {
+    expect(() => requireSharedOAuthAdministrator(params('member'), 'refresh')).toThrow(Forbidden);
+  });
+
+  it('allows administrators and trusted internal calls', () => {
+    expect(() => requireSharedOAuthAdministrator(params('admin'), 'disconnect')).not.toThrow();
+    expect(() => requireSharedOAuthAdministrator({} as never, 'start')).not.toThrow();
+  });
+});

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
@@ -7,11 +7,23 @@ const params = (role: 'member' | 'admin') =>
 
 describe('requireSharedOAuthAdministrator', () => {
   it('rejects an ordinary member mutating the tenant-wide identity', () => {
-    expect(() => requireSharedOAuthAdministrator(params('member'), 'refresh')).toThrow(Forbidden);
+    expect(() =>
+      requireSharedOAuthAdministrator({ kind: 'actor', params: params('member') }, 'refresh')
+    ).toThrow(Forbidden);
   });
 
-  it('allows administrators and trusted internal calls', () => {
-    expect(() => requireSharedOAuthAdministrator(params('admin'), 'disconnect')).not.toThrow();
-    expect(() => requireSharedOAuthAdministrator({} as never, 'start')).not.toThrow();
+  it('fails closed when actor context is missing', () => {
+    expect(() =>
+      requireSharedOAuthAdministrator({ kind: 'actor', params: undefined }, 'start')
+    ).toThrow('Authentication required');
+  });
+
+  it('allows administrators and explicitly trusted internal calls', () => {
+    expect(() =>
+      requireSharedOAuthAdministrator({ kind: 'actor', params: params('admin') }, 'disconnect')
+    ).not.toThrow();
+    expect(() =>
+      requireSharedOAuthAdministrator({ kind: 'trusted-internal' }, 'start')
+    ).not.toThrow();
   });
 });

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.ts
@@ -3,18 +3,19 @@ import type { AuthenticatedParams } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 
 export type OAuthLifecycleAction = 'start' | 'complete' | 'refresh' | 'disconnect';
+export type SharedOAuthAuthorization =
+  | { kind: 'actor'; params: AuthenticatedParams | undefined }
+  | { kind: 'trusted-internal' };
 
 /** Shared grants are tenant-wide credentials and may only be mutated by administrators. */
 export function requireSharedOAuthAdministrator(
-  params: AuthenticatedParams | undefined,
+  authorization: SharedOAuthAuthorization,
   action: OAuthLifecycleAction
 ): void {
-  if (
-    !params?.provider ||
-    (params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount
-  )
-    return;
-  if (!params.user) throw new NotAuthenticated('Authentication required');
+  if (authorization.kind === 'trusted-internal') return;
+  const { params } = authorization;
+  if (!params?.user) throw new NotAuthenticated('Authentication required');
+  if ((params.user as { _isServiceAccount?: boolean })._isServiceAccount) return;
   if (!hasMinimumRole(params.user.role, ROLES.ADMIN)) {
     throw new Forbidden(`Administrator access is required to ${action} a shared OAuth identity`);
   }

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.ts
@@ -1,0 +1,32 @@
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import type { AuthenticatedParams } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+
+export type OAuthLifecycleAction = 'start' | 'complete' | 'refresh' | 'disconnect';
+
+/** Shared grants are tenant-wide credentials and may only be mutated by administrators. */
+export function requireSharedOAuthAdministrator(
+  params: AuthenticatedParams | undefined,
+  action: OAuthLifecycleAction
+): void {
+  if (
+    !params?.provider ||
+    (params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount
+  )
+    return;
+  if (!params.user) throw new NotAuthenticated('Authentication required');
+  if (!hasMinimumRole(params.user.role, ROLES.ADMIN)) {
+    throw new Forbidden(`Administrator access is required to ${action} a shared OAuth identity`);
+  }
+}
+
+export function auditSharedOAuthLifecycle(input: {
+  action: OAuthLifecycleAction;
+  outcome: 'started' | 'succeeded' | 'failed';
+  serverId?: string;
+  actorUserId?: string;
+  tenantId?: string;
+}): void {
+  // Deliberately structured and secret-free for operator log ingestion.
+  console.info('[SECURITY] shared_oauth_lifecycle', JSON.stringify(input));
+}

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.ts
@@ -28,5 +28,5 @@ export function auditSharedOAuthLifecycle(input: {
   tenantId?: string;
 }): void {
   // Deliberately structured and secret-free for operator log ingestion.
-  console.info('[SECURITY] shared_oauth_lifecycle', JSON.stringify(input));
+  console.info('[SECURITY] shared_oauth_lifecycle', input);
 }

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -279,6 +279,22 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
+  /** Inventory instance-shared grants. Callers must enforce tenant-admin policy. */
+  async listShared(): Promise<UserMCPOAuthToken[]> {
+    try {
+      const rows = await select(this.db)
+        .from(userMcpOauthTokens)
+        .where(isNull(userMcpOauthTokens.user_id))
+        .all();
+      return rows.map(rowToToken);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list shared OAuth tokens: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   async hasValidToken(userId: UserID | null, serverId: MCPServerID): Promise<boolean> {
     const token = await this.getValidToken(userId, serverId);
     return token !== undefined;

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -88,7 +88,7 @@ describe('FeathersSessionMCPServersRepository', () => {
     await repo.listEffectiveServers('session-1' as SessionID, true, 'user-1');
 
     expect(find).toHaveBeenCalledWith({
-      query: { includeGlobal: true, enabledOnly: true, forUserId: 'user-1' },
+      query: { enabledOnly: true, forUserId: 'user-1' },
     });
   });
 

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -204,7 +204,7 @@ export class FeathersSessionMCPServersRepository {
   }
 
   /**
-   * List the effective MCP servers for a session (global + session-assigned).
+   * List MCP servers explicitly granted to a session.
    * Executors use the session-scoped route so session-token callers can receive
    * the raw config needed to launch only their own session's MCP servers.
    */
@@ -214,7 +214,7 @@ export class FeathersSessionMCPServersRepository {
     forUserId?: string
   ): Promise<MCPServer[]> {
     const service = this.client.service(`/sessions/${sessionId}/mcp-servers`);
-    const query: Record<string, unknown> = { includeGlobal: true };
+    const query: Record<string, unknown> = {};
 
     if (enabledOnly) {
       query.enabledOnly = true;

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
@@ -16,10 +16,23 @@ const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer
   }) as MCPServer;
 
 describe('getMcpServersForSession', () => {
-  it('uses session-scoped effective config retrieval when available', async () => {
+  it('does not automatically grant catalog-global servers to a session', async () => {
     const globalServer = makeServer('global-server', 'global');
+    const findAll = vi.fn().mockResolvedValue([globalServer]);
+    const listServers = vi.fn().mockResolvedValue([]);
+
+    const servers = await getMcpServersForSession('session-a' as SessionID, {
+      mcpServerRepo: { findAll } as never,
+      sessionMCPRepo: { listServers } as never,
+    });
+
+    expect(findAll).not.toHaveBeenCalled();
+    expect(servers).toEqual([]);
+  });
+
+  it('uses session-scoped effective config retrieval when available', async () => {
     const sessionServer = makeServer('session-server', 'session');
-    const listEffectiveServers = vi.fn().mockResolvedValue([globalServer, sessionServer]);
+    const listEffectiveServers = vi.fn().mockResolvedValue([sessionServer]);
     const findAll = vi.fn();
     const listServers = vi.fn();
 
@@ -32,10 +45,7 @@ describe('getMcpServersForSession', () => {
     expect(listEffectiveServers).toHaveBeenCalledWith('session-a', true, 'user-a');
     expect(findAll).not.toHaveBeenCalled();
     expect(listServers).not.toHaveBeenCalled();
-    expect(servers).toEqual([
-      { server: globalServer, source: 'global' },
-      { server: sessionServer, source: 'session-assigned' },
-    ]);
+    expect(servers).toEqual([{ server: sessionServer, source: 'session-assigned' }]);
   });
 
   it('returns deterministic effective ordering', async () => {

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -5,8 +5,8 @@
  * Used by all SDK handlers (Claude, Gemini, Codex) to ensure consistent behavior.
  *
  * Scoping Rules:
- * - ALL global-scoped MCPs are included in every session (available to all users)
- * - PLUS any session-scoped MCPs that are explicitly assigned to this session
+ * - Only MCPs explicitly assigned to this session are included. `global` is a
+ *   catalog/administration scope, not an ambient execution capability.
  *
  * Template Resolution:
  * MCP server env vars can contain Handlebars templates like {{ user.env.GITHUB_TOKEN }}.
@@ -134,24 +134,7 @@ export async function getMcpServersForSession(
         addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
       }
     } else {
-      // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
-      // Pass forUserId for per-user OAuth token injection
-      mcpDebug(`   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`);
-      const globalServers = await deps.mcpServerRepo.findAll(
-        {
-          scope: 'global',
-          enabled: true,
-        },
-        deps.forUserId
-      );
-
-      mcpDebug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
-
-      for (const server of globalServers ?? []) {
-        addServer(server, 'global');
-      }
-
-      // STEP 2: Get session-scoped MCP servers assigned to this specific session
+      // Legacy repository adapters still receive the same fail-closed policy.
       const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
 
       mcpDebug(`   📍 Session-assigned: ${sessionServers.length} server(s)`);


### PR DESCRIPTION
## Summary

- Require tenant administrators for instance-shared OAuth lifecycle changes and bind manual completion to the initiating user.
- Emit secret-safe shared OAuth lifecycle audit records and expose an admin-only shared-grant inventory with principal visibility.
- Stop treating catalog-global MCP servers as ambient execution grants; executors now receive only session-attached servers.
- Preserve tenant database scoping and enforce the attachment boundary when hydrating OAuth headers.

## Test plan

- `pnpm i` — passed; workspace already up to date.
- `pnpm check` — passed, including workspace typecheck, lint, boundary checks, and production builds.
- `apps/agor-daemon/node_modules/.bin/vitest run src/utils/shared-oauth-policy.test.ts src/services/oauth-disconnect.test.ts --maxWorkers=1` — 11 passed.
- `packages/executor/node_modules/.bin/vitest run src/sdk-handlers/base/mcp-scoping.test.ts src/db/feathers-repositories.test.ts --maxWorkers=1` — 11 passed.

Security package: M4, August 2026 launch review.
