### PR TITLE
fix(security): enforce daemon home confidentiality

### DIFF
--- a/apps/agor-cli/src/commands/daemon/start.ts
+++ b/apps/agor-cli/src/commands/daemon/start.ts
@@ -11,7 +11,15 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgorConfig } from '@agor/core/config';
-import { loadConfig, loadConfigFromFile } from '@agor/core/config';
+import {
+  getAgorHome,
+  getConfigPath,
+  loadConfig,
+  loadConfigFromFile,
+  restrictDaemonUmask,
+  secureOwnerDirectory,
+  secureOwnerFileIfPresent,
+} from '@agor/core/config';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import {
@@ -44,6 +52,13 @@ export default class DaemonStart extends Command {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(DaemonStart);
+
+    // The CLI performs config and migration preflight before importing the
+    // daemon, so establish the same filesystem boundary first.
+    restrictDaemonUmask();
+    await secureOwnerDirectory(getAgorHome());
+    await secureOwnerFileIfPresent(getConfigPath());
+    if (flags.config) await secureOwnerFileIfPresent(resolve(flags.config));
 
     // 1. Load & validate config
     const config = flags.config ? await this.loadConfigFromPath(flags.config) : await loadConfig();

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -31,13 +31,18 @@ patchConsole();
 
 import type { AgorConfig, ResolvedSecurity } from '@agor/core/config';
 import {
+  getAgorHome,
+  getConfigPath,
   loadConfig,
   loadConfigFromFile,
   renderGitConfigParametersForLog,
   resolveGitConfigParameters,
   resolveMultiTenancyConfig,
   resolveSecurity,
+  restrictDaemonUmask,
   saveConfig,
+  secureOwnerDirectory,
+  secureOwnerFileIfPresent,
 } from '@agor/core/config';
 import { getDatabaseUrl } from '@agor/core/db';
 import {
@@ -139,6 +144,12 @@ export interface DaemonStartOptions {
  * or from main.ts with no args for direct execution.
  */
 export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
+  // System-global daemon state: establish confidentiality before config, JWT,
+  // token, or database material can be created or consumed.
+  restrictDaemonUmask();
+  await secureOwnerDirectory(getAgorHome());
+  await secureOwnerFileIfPresent(getConfigPath());
+  if (options?.configPath) await secureOwnerFileIfPresent(options.configPath);
   // Initialize Handlebars helpers for template rendering
   registerHandlebarsHelpers();
   console.log('✅ Handlebars helpers registered');

--- a/apps/agor-daemon/src/setup/database.security.test.ts
+++ b/apps/agor-daemon/src/setup/database.security.test.ts
@@ -1,0 +1,36 @@
+import { chmod, lstat, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensureDatabaseDirectory } from './database';
+
+describe('SQLite filesystem security', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a fresh database home privately before connecting', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'agor-db-security-'));
+    const databaseDir = path.join(tempDir, 'private');
+    await ensureDatabaseDirectory(`file:${path.join(databaseDir, 'agor.db')}`);
+    expect((await lstat(databaseDir)).mode & 0o777).toBe(0o700);
+  });
+
+  it('repairs existing database and sidecar modes without seizing a custom parent', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'agor-db-security-'));
+    await chmod(tempDir, 0o755);
+    const databasePath = path.join(tempDir, 'agor.db');
+    for (const suffix of ['', '-wal', '-shm', '-journal']) {
+      await writeFile(`${databasePath}${suffix}`, 'data', { mode: 0o644 });
+    }
+
+    await ensureDatabaseDirectory(`file:${databasePath}`);
+
+    expect((await lstat(tempDir)).mode & 0o777).toBe(0o755);
+    for (const suffix of ['', '-wal', '-shm', '-journal']) {
+      expect((await lstat(`${databasePath}${suffix}`)).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -6,7 +6,9 @@
  */
 
 import { constants } from 'node:fs';
-import { access, mkdir } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { getAgorHome, secureOwnerDirectory, secureOwnerFileIfPresent } from '@agor/core/config';
 import {
   checkMigrationStatus,
   createDatabaseAsync,
@@ -33,7 +35,7 @@ export interface DatabaseInitResult {
  *
  * @param dbPath - Database connection string (file:~/.agor/agor.db or postgresql://...)
  */
-async function ensureDatabaseDirectory(dbPath: string): Promise<void> {
+export async function ensureDatabaseDirectory(dbPath: string): Promise<void> {
   // Only handle file system setup for SQLite (file: URLs)
   if (!dbPath.startsWith('file:')) {
     return;
@@ -41,15 +43,24 @@ async function ensureDatabaseDirectory(dbPath: string): Promise<void> {
 
   // Extract file path from DB_PATH (remove 'file:' prefix and expand ~)
   const dbFilePath = extractDbFilePath(dbPath);
-  const dbDir = dbFilePath.substring(0, dbFilePath.lastIndexOf('/'));
+  const dbDir = dirname(dbFilePath);
 
   // Ensure database directory exists
   try {
     await access(dbDir, constants.F_OK);
+    // ~/.agor is the daemon's private data home. A custom database may live in
+    // a shared parent (for example /var/lib), so do not seize that parent;
+    // confidentiality is enforced on the database files themselves.
+    if (dbDir === getAgorHome()) await secureOwnerDirectory(dbDir);
   } catch {
     console.log(`📁 Creating database directory: ${dbDir}`);
-    await mkdir(dbDir, { recursive: true });
+    await secureOwnerDirectory(dbDir);
   }
+
+  await secureOwnerFileIfPresent(dbFilePath);
+  await secureOwnerFileIfPresent(`${dbFilePath}-wal`);
+  await secureOwnerFileIfPresent(`${dbFilePath}-shm`);
+  await secureOwnerFileIfPresent(`${dbFilePath}-journal`);
 
   // Check if database file exists (create message if needed)
   try {
@@ -117,6 +128,13 @@ export async function initializeDatabase(
 
   // Create database with foreign keys enabled
   const db = await createDatabaseAsync({ url: dbPath });
+  if (dbPath.startsWith('file:')) {
+    const dbFilePath = extractDbFilePath(dbPath);
+    await secureOwnerFileIfPresent(dbFilePath);
+    await secureOwnerFileIfPresent(`${dbFilePath}-wal`);
+    await secureOwnerFileIfPresent(`${dbFilePath}-shm`);
+    await secureOwnerFileIfPresent(`${dbFilePath}-journal`);
+  }
   const scopedDb = createTenantScopedDatabaseProxy(db, {
     requireScope: options.requireTenantScope === true,
     label: 'daemon database',

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -832,6 +832,20 @@ describe('saveConfig', () => {
     const agorDir = path.join(tempDir, '.agor');
     const stat = await fs.stat(agorDir);
     expect(stat.isDirectory()).toBe(true);
+    expect(stat.mode & 0o777).toBe(0o700);
+    expect((await fs.stat(path.join(agorDir, 'config.yaml'))).mode & 0o777).toBe(0o600);
+  });
+
+  it('repairs permissive existing config home and file modes', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { mode: 0o755 });
+    await fs.writeFile(configPath, '{}', { mode: 0o644 });
+
+    await saveConfig(createMinimalConfig());
+
+    expect((await fs.stat(agorDir)).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(configPath)).mode & 0o777).toBe(0o600);
   });
 
   it('should overwrite existing config file', async () => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import * as yaml from 'js-yaml';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
+import { secureOwnerDirectory, secureOwnerFileIfPresent } from './daemon-home-security';
 import {
   resolveDispatchConnectTimeoutMs,
   resolveExecutorHeartbeatConfig,
@@ -203,12 +204,7 @@ export function getConfigPath(): string {
  * Ensure ~/.agor directory exists
  */
 async function ensureAgorHome(): Promise<void> {
-  const agorHome = getAgorHome();
-  try {
-    await fs.access(agorHome);
-  } catch {
-    await fs.mkdir(agorHome, { recursive: true });
-  }
+  await secureOwnerDirectory(getAgorHome());
 }
 
 /**
@@ -728,7 +724,20 @@ export async function saveConfig(config: AgorConfig): Promise<void> {
     noRefs: true,
   });
 
-  await fs.writeFile(configPath, content, 'utf-8');
+  await secureOwnerFileIfPresent(configPath);
+  const temporaryPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fs.writeFile(temporaryPath, content, {
+      encoding: 'utf-8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+    await fs.rename(temporaryPath, configPath);
+    await fs.chmod(configPath, 0o600);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
   invalidateConfigCache();
 }
 

--- a/packages/core/src/config/daemon-home-security.test.ts
+++ b/packages/core/src/config/daemon-home-security.test.ts
@@ -1,0 +1,43 @@
+import { chmod, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { secureOwnerDirectory, secureOwnerFileIfPresent } from './daemon-home-security';
+
+describe('daemon home security', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a fresh private home and repairs existing permissive state', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'agor-home-security-'));
+    const home = path.join(tempDir, 'home');
+    await secureOwnerDirectory(home);
+    expect((await lstat(home)).mode & 0o777).toBe(0o700);
+
+    const secret = path.join(home, 'config.yaml');
+    await writeFile(secret, 'secret', { mode: 0o644 });
+    await chmod(home, 0o755);
+    await secureOwnerDirectory(home);
+    await secureOwnerFileIfPresent(secret);
+    expect((await lstat(home)).mode & 0o777).toBe(0o700);
+    expect((await lstat(secret)).mode & 0o777).toBe(0o600);
+  });
+
+  it('refuses symlinked homes and secret files', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'agor-home-security-'));
+    const real = path.join(tempDir, 'real');
+    await mkdir(real);
+    const linkedHome = path.join(tempDir, 'home');
+    await symlink(real, linkedHome);
+    await expect(secureOwnerDirectory(linkedHome)).rejects.toThrow(/expected.*directory/i);
+
+    const realFile = path.join(real, 'real-config');
+    await writeFile(realFile, 'secret');
+    const linkedFile = path.join(real, 'config.yaml');
+    await symlink(realFile, linkedFile);
+    await expect(secureOwnerFileIfPresent(linkedFile)).rejects.toThrow(/regular file/i);
+  });
+});

--- a/packages/core/src/config/daemon-home-security.ts
+++ b/packages/core/src/config/daemon-home-security.ts
@@ -1,0 +1,42 @@
+import { chmod, lstat, mkdir } from 'node:fs/promises';
+
+function assertOwned(stat: Awaited<ReturnType<typeof lstat>>, target: string): void {
+  const uid = process.getuid?.();
+  if (uid !== undefined && stat.uid !== uid) {
+    throw new Error(`Refusing to use ${target}: owned by uid ${stat.uid}, daemon uid is ${uid}`);
+  }
+}
+
+export async function secureOwnerDirectory(target: string): Promise<void> {
+  try {
+    const stat = await lstat(target);
+    if (!stat.isDirectory() || stat.isSymbolicLink())
+      throw new Error(`Refusing to use ${target}: expected a daemon-owned directory`);
+    assertOwned(stat, target);
+    if ((stat.mode & 0o777) !== 0o700) await chmod(target, 0o700);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    await mkdir(target, { recursive: true, mode: 0o700 });
+    const stat = await lstat(target);
+    if (!stat.isDirectory() || stat.isSymbolicLink())
+      throw new Error(`Refusing to use ${target}: expected a daemon-owned directory`);
+    assertOwned(stat, target);
+    await chmod(target, 0o700);
+  }
+}
+
+export async function secureOwnerFileIfPresent(target: string): Promise<void> {
+  try {
+    const stat = await lstat(target);
+    if (!stat.isFile() || stat.isSymbolicLink())
+      throw new Error(`Refusing to use ${target}: expected a daemon-owned regular file`);
+    assertOwned(stat, target);
+    if ((stat.mode & 0o777) !== 0o600) await chmod(target, 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+export function restrictDaemonUmask(): void {
+  process.umask(0o077);
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -7,6 +7,7 @@
 export * from './agentic-tool-preset-resolver';
 export * from './config-manager';
 export * from './constants';
+export * from './daemon-home-security';
 export * from './env-blocklist';
 export * from './env-locking';
 export * from './env-resolver';


### PR DESCRIPTION
## Summary
- establish an owner-only daemon filesystem boundary before startup preflight or secret/data creation
- safely repair existing config, SQLite, and sidecar permissions while refusing unsafe ownership and symlink states
- make config persistence atomic and owner-only
- preserve custom shared database parent directories while protecting database files

## Test plan
- `pnpm --filter @agor/core exec vitest run src/config/daemon-home-security.test.ts src/config/config-manager.test.ts`
- `pnpm --dir apps/agor-daemon exec vitest run src/setup/database.security.test.ts`
- `pnpm check:multitenancy-boundaries`
- `pnpm exec biome check ...` on all changed files
- `git diff --check`

## Notes
This is the August 2026 launch-security M7 package. The protected daemon state is system-global rather than tenant-owned; tests cover fresh/existing installs and refusal of symlinked boundaries. Browser terminals running as the daemon Unix user remain able to access daemon state by design and must remain disabled unless a separate Unix/execution boundary is demonstrated.
