### PR TITLE
security: centralize collaboration resource authorization

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -167,17 +167,17 @@ describe('card MCP realtime events', () => {
     expect(cardsEmit).toHaveBeenCalledWith(
       'created',
       card,
-      expect.objectContaining({ path: 'cards', method: 'create', params: {}, result: card })
+      expect.objectContaining({ path: 'cards', method: 'create', params, result: card })
     );
     expect(cardsEmit).toHaveBeenCalledWith(
       'patched',
       expect.objectContaining({ archived: true }),
-      expect.objectContaining({ path: 'cards', method: 'patch', params: {} })
+      expect.objectContaining({ path: 'cards', method: 'patch', params })
     );
     expect(boardObjectsEmit).toHaveBeenCalledWith(
       'patched',
       boardObject,
-      expect.objectContaining({ path: 'board-objects', method: 'patch', params: {} })
+      expect.objectContaining({ path: 'board-objects', method: 'patch', params })
     );
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -162,8 +162,8 @@ describe('card MCP realtime events', () => {
     await captureHandler('agor_cards_archive', ctx)({ cardId: 'card-1' });
 
     expect(createWithPlacement).toHaveBeenCalledWith(expect.any(Object), params);
-    expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined);
-    expect(archive).toHaveBeenCalledWith('card-1');
+    expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined, params);
+    expect(archive).toHaveBeenCalledWith('card-1', params);
     expect(cardsEmit).toHaveBeenCalledWith(
       'created',
       card,

--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -1,8 +1,14 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { describe, expect, it, vi } from 'vitest';
 
+const { findBoardObjectByCardId } = vi.hoisted(() => ({
+  findBoardObjectByCardId: vi.fn(),
+}));
+
 vi.mock('@agor/core/db', () => ({
-  BoardObjectRepository: class BoardObjectRepository {},
+  BoardObjectRepository: class BoardObjectRepository {
+    findByCardId = findBoardObjectByCardId;
+  },
   enqueueAfterTenantDatabaseCommit: () => false,
   getCurrentTenantId: () => undefined,
   runWithTenantDatabaseScope: vi.fn((_db, _tenantId, work) => work()),
@@ -134,6 +140,7 @@ describe('card MCP realtime events', () => {
     };
     const cardsEmit = vi.fn();
     const boardObjectsEmit = vi.fn();
+    const updatePosition = vi.fn(async () => boardObject);
     const createWithPlacement = vi.fn(async () => ({ card, boardObject }));
     const moveToZone = vi.fn(async () => boardObject);
     const archive = vi.fn(async () => ({ ...card, archived: true }));
@@ -145,7 +152,7 @@ describe('card MCP realtime events', () => {
           return { createWithPlacement, moveToZone, archive, get: cardsGet, emit: cardsEmit };
         }
         if (name === 'boards') return { get: boardsGet };
-        if (name === 'board-objects') return { emit: boardObjectsEmit };
+        if (name === 'board-objects') return { emit: boardObjectsEmit, updatePosition };
         throw new Error(`Unexpected service call: ${name}`);
       },
     };
@@ -160,10 +167,13 @@ describe('card MCP realtime events', () => {
     await captureHandler('agor_cards_create', ctx)({ boardId: 'board-1', title: 'Card' });
     await captureHandler('agor_cards_move', ctx)({ cardId: 'card-1', zoneId: null });
     await captureHandler('agor_cards_archive', ctx)({ cardId: 'card-1' });
+    findBoardObjectByCardId.mockResolvedValue(boardObject);
+    await captureHandler('agor_cards_set_position', ctx)({ cardId: 'card-1', x: 10, y: 20 });
 
     expect(createWithPlacement).toHaveBeenCalledWith(expect.any(Object), params);
     expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined, params);
     expect(archive).toHaveBeenCalledWith('card-1', params);
+    expect(updatePosition).toHaveBeenCalledWith('object-1', { x: 10, y: 20 }, params);
     expect(cardsEmit).toHaveBeenCalledWith(
       'created',
       card,

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -77,11 +77,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         path: 'cards',
         event: 'created',
         data: card,
+        params: ctx.baseServiceParams,
       });
       emitServiceEvent(ctx.app, {
         path: 'board-objects',
         event: 'created',
         data: boardObject,
+        params: ctx.baseServiceParams,
       });
       return textResult({ card, boardObject });
     }
@@ -99,7 +101,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
-      const cardWithType = await cardsService.getWithType(args.cardId);
+      const cardWithType = await cardsService.getWithType(args.cardId, ctx.baseServiceParams);
       if (!cardWithType) throw new Error(`Card ${args.cardId} not found`);
       return textResult(cardWithType);
     }
@@ -123,7 +125,6 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const boardIdRaw = coerceString(args.boardId);
       const boardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
       const cardTypeId = coerceString(args.cardTypeId);
@@ -133,30 +134,19 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       const limit = typeof args.limit === 'number' ? args.limit : 50;
       const offset = typeof args.offset === 'number' ? args.offset : 0;
 
-      let cardsList: Card[];
-      if (zoneId && boardId) {
-        cardsList = await cardsService.findByZoneId(boardId as never, zoneId);
-      } else if (search) {
-        cardsList = await cardsService.searchCards(search, {
-          boardId: boardId as never,
+      const result = await ctx.app.service('cards').find({
+        ...ctx.baseServiceParams,
+        query: {
+          ...(boardId ? { board_id: boardId } : {}),
+          ...(cardTypeId ? { card_type_id: cardTypeId } : {}),
+          ...(zoneId ? { zone_id: zoneId } : {}),
+          ...(search ? { search } : {}),
           archived,
-          limit,
-          offset,
-        });
-      } else if (cardTypeId) {
-        cardsList = await cardsService.findByCardTypeId(cardTypeId as never, { limit, offset });
-      } else if (boardId) {
-        cardsList = await cardsService.findByBoardId(boardId as never, {
-          archived,
-          limit,
-          offset,
-        });
-      } else {
-        const result = await cardsService.find({
-          query: { $limit: limit, $skip: offset },
-        } as never);
-        cardsList = 'data' in result ? result.data : result;
-      }
+          $limit: limit,
+          $skip: offset,
+        },
+      } as never);
+      const cardsList: Card[] = 'data' in result ? result.data : result;
 
       return textResult({
         total: Array.isArray(cardsList) ? cardsList.length : 0,
@@ -238,12 +228,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const archivedCard = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.archive(args.cardId)
+        cardsService.archive(args.cardId, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'cards',
         event: 'patched',
         data: archivedCard,
+        params: ctx.baseServiceParams,
         id: args.cardId,
       });
       return textResult(archivedCard);
@@ -262,12 +253,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const unarchivedCard = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.unarchive(args.cardId)
+        cardsService.unarchive(args.cardId, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'cards',
         event: 'patched',
         data: unarchivedCard,
+        params: ctx.baseServiceParams,
         id: args.cardId,
       });
       return textResult(unarchivedCard);
@@ -303,12 +295,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const boardObject = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.moveToZone(cardId as never, zoneId, zoneData)
+        cardsService.moveToZone(cardId as never, zoneId, zoneData, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'board-objects',
         event: 'patched',
         data: boardObject,
+        params: ctx.baseServiceParams,
       });
       return textResult(boardObject);
     }
@@ -411,11 +404,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
           path: 'cards',
           event: 'created',
           data: card,
+          params: ctx.baseServiceParams,
         });
         emitServiceEvent(ctx.app, {
           path: 'board-objects',
           event: 'created',
           data: boardObject,
+          params: ctx.baseServiceParams,
         });
       }
 
@@ -522,12 +517,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
           if (zone?.type === 'zone') zoneData = zone;
         }
         const boardObject = await runWithMcpTenantDatabaseScope(ctx, () =>
-          cardsService.moveToZone(cardId as never, zoneId, zoneData)
+          cardsService.moveToZone(cardId as never, zoneId, zoneData, ctx.baseServiceParams)
         );
         emitServiceEvent(ctx.app, {
           path: 'board-objects',
           event: 'patched',
           data: boardObject,
+          params: ctx.baseServiceParams,
         });
         results.push({ cardId, boardObject });
       }

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -328,10 +328,14 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         const boardObjectsService = ctx.app.service(
           'board-objects'
         ) as unknown as import('../../services/board-objects.js').BoardObjectsService;
-        return boardObjectsService.updatePosition(boardObj.object_id, {
-          x: args.x,
-          y: args.y,
-        });
+        return boardObjectsService.updatePosition(
+          boardObj.object_id,
+          {
+            x: args.x,
+            y: args.y,
+          },
+          ctx.baseServiceParams
+        );
       });
       return textResult(updatedBoardObject);
     }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -307,7 +307,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     DAEMON_BUILD_INFO,
     resolvedSecurity,
     sessionsService,
-    messagesService,
     boardsService,
     branchRepository,
     usersRepository: _usersRepository,
@@ -699,7 +698,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     '/messages/bulk',
     {
       async create(data: unknown, params: RouteParams) {
-        return messagesService.createMany(data as Message[]);
+        if (!Array.isArray(data) || data.length === 0 || data.length > 100) {
+          throw new BadRequest('Message batch must contain between 1 and 100 items');
+        }
+        const sessionIds = new Set((data as Message[]).map((message) => message.session_id));
+        if (sessionIds.size !== 1) throw new BadRequest('Message batch must target one session');
+        const created: Message[] = [];
+        for (const message of data as Message[]) {
+          created.push(await app.service('messages').create(message, params));
+        }
+        return created;
       },
     },
     {
@@ -3069,7 +3077,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const boardCommentsService = safeService('board-comments') as unknown as {
     toggleReaction: (
       id: string,
-      data: { user_id: string; emoji: string },
+      data: { user_id?: string; emoji: string },
       params?: unknown
     ) => Promise<import('@agor/core/types').BoardComment>;
     createReply: (
@@ -3084,12 +3092,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       app,
       '/board-comments/:id/toggle-reaction',
       {
-        async create(data: { user_id: string; emoji: string }, params: RouteParams) {
+        async create(data: { user_id?: string; emoji: string }, params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Comment ID required');
-          if (!data.user_id) throw new Error('user_id required');
           if (!data.emoji) throw new Error('emoji required');
-          const updated = await boardCommentsService.toggleReaction(id, data, params);
+          const updated = await boardCommentsService.toggleReaction(
+            id,
+            { emoji: data.emoji },
+            params
+          );
           emitServiceEvent(app, {
             path: 'board-comments',
             event: 'patched',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -135,6 +135,7 @@ import { userRoomName } from './setup/socketio.js';
 import { requestExecutorTermination } from './termination-coordinator.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
+import { CollaborationAuthorization } from './utils/collaboration-authorization.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -270,18 +271,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
 
   app.use('/messages', messagesService, {
-    methods: [
-      'find',
-      'get',
-      'create',
-      'update',
-      'patch',
-      'remove',
-      'findBySession',
-      'findByTask',
-      'findByRange',
-      'createMany',
-    ],
+    methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
     events: [
       'queued',
       'streaming:start',
@@ -349,11 +339,16 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       ],
     }
   );
-  app.use('/board-objects', createBoardObjectsService(db, app));
+  const collaborationAuthorization = new CollaborationAuthorization(
+    db,
+    branchRbacEnabled,
+    allowSuperadmin
+  );
+  app.use('/board-objects', createBoardObjectsService(db, app, collaborationAuthorization));
 
   const boardsService = safeService('boards') as unknown as BoardsServiceImpl | undefined;
   app.use('/card-types', createCardTypesService(db));
-  app.use('/cards', createCardsService(db));
+  app.use('/cards', createCardsService(db, collaborationAuthorization));
   // `agor-query` is the runtime-introspection fan-out event (daemon →
   // viewer's browser tab). Feathers' default `serviceEvents` is just
   // ['created','updated','patched','removed'], so without this it
@@ -371,7 +366,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       'validateFromExecutor',
     ],
   });
-  app.use('/board-comments', createBoardCommentsService(db));
+  app.use('/board-comments', createBoardCommentsService(db, collaborationAuthorization));
 
   // ============================================================================
   // Branches, repos

--- a/apps/agor-daemon/src/services/board-comments.test.ts
+++ b/apps/agor-daemon/src/services/board-comments.test.ts
@@ -1,0 +1,52 @@
+import { Forbidden } from '@agor/core/feathers';
+import { describe, expect, it, vi } from 'vitest';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
+import { BoardCommentsService } from './board-comments.js';
+
+function rejectingAuthorization() {
+  const requireCommentAttachments = vi.fn(async (): Promise<boolean> => {
+    throw new Forbidden('Attached resource does not belong to this board');
+  });
+  const authorization = {
+    requireBoard: vi.fn(async () => undefined),
+    requireCommentAttachments,
+  } as unknown as CollaborationAuthorization;
+  return { authorization, requireCommentAttachments };
+}
+
+describe('BoardCommentsService attachment boundary', () => {
+  const params = {
+    provider: 'rest',
+    user: { user_id: 'user-a', role: 'member' },
+  } as never;
+
+  it('rejects creation when an attachment does not belong to the selected board', async () => {
+    const { authorization } = rejectingAuthorization();
+    const service = new BoardCommentsService({} as never, authorization);
+
+    await expect(
+      service.create(
+        { board_id: 'board-a' as never, branch_id: 'branch-b' as never, content: 'nope' },
+        params
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('rejects the whole bulk request before writing when any attachment is invalid', async () => {
+    const { authorization, requireCommentAttachments } = rejectingAuthorization();
+    requireCommentAttachments
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Forbidden('Attached resource does not belong to this board'));
+    const service = new BoardCommentsService({} as never, authorization);
+
+    await expect(
+      service.bulkCreate(
+        [
+          { board_id: 'board-a' as never, content: 'first' },
+          { board_id: 'board-a' as never, branch_id: 'branch-b' as never, content: 'second' },
+        ],
+        params
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+});

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -13,8 +13,9 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { BoardCommentsRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
-import type { BoardComment, QueryParams, UUID } from '@agor/core/types';
+import type { AuthenticatedParams, BoardComment, QueryParams, UUID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 
 /**
  * Board comments service params
@@ -27,10 +28,11 @@ export type BoardCommentsParams = QueryParams<{
   branch_id?: string;
   resolved?: boolean;
   created_by?: string;
-}> & {
-  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
-  _agorSqlBoardAccessUserId?: UUID;
-};
+}> &
+  AuthenticatedParams & {
+    /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+    _agorSqlBoardAccessUserId?: UUID;
+  };
 
 /**
  * Extended board comments service with custom methods
@@ -42,7 +44,10 @@ export class BoardCommentsService extends DrizzleService<
 > {
   private commentsRepo: BoardCommentsRepository;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private authorization?: CollaborationAuthorization
+  ) {
     const commentsRepo = new BoardCommentsRepository(db);
     super(commentsRepo, {
       id: 'comment_id',
@@ -54,6 +59,67 @@ export class BoardCommentsService extends DrizzleService<
     });
 
     this.commentsRepo = commentsRepo;
+  }
+
+  private async requireComment(
+    id: string,
+    params: BoardCommentsParams | undefined,
+    mode: 'view' | 'mutate'
+  ): Promise<BoardComment> {
+    const comment = await this.commentsRepo.findById(id);
+    if (!comment) throw new Error(`Board comment ${id} not found`);
+    await this.authorization?.requireBoard(params, comment.board_id, mode);
+    return comment;
+  }
+
+  override async get(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    return this.requireComment(id, params, 'view');
+  }
+
+  override async patch(
+    id: string,
+    data: Partial<BoardComment>,
+    params?: BoardCommentsParams
+  ): Promise<BoardComment> {
+    const immutable = [
+      'comment_id',
+      'board_id',
+      'branch_id',
+      'session_id',
+      'task_id',
+      'message_id',
+      'parent_id',
+      'created_by',
+      'created_at',
+    ] as const;
+    if (immutable.some((field) => field in data)) {
+      throw new Error('Comment identity, ownership, and attachments cannot be changed');
+    }
+    await this.requireComment(id, params, 'mutate');
+    const result = await super.patch(id, data, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment patch result');
+    return result;
+  }
+
+  override async remove(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
+    const result = await super.remove(id, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment remove result');
+    return result;
+  }
+
+  override async create(
+    data: Partial<BoardComment>,
+    params?: BoardCommentsParams
+  ): Promise<BoardComment> {
+    if (!data.board_id) throw new Error('board_id is required');
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
+    const result = await super.create(
+      { ...data, created_by: params?.user?.user_id ?? data.created_by },
+      params
+    );
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment create result');
+    return result;
   }
 
   /**
@@ -92,14 +158,16 @@ export class BoardCommentsService extends DrizzleService<
   /**
    * Custom method: Resolve comment
    */
-  async resolve(id: string, _params?: BoardCommentsParams): Promise<BoardComment> {
+  async resolve(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
     return this.commentsRepo.resolve(id);
   }
 
   /**
    * Custom method: Unresolve comment
    */
-  async unresolve(id: string, _params?: BoardCommentsParams): Promise<BoardComment> {
+  async unresolve(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
     return this.commentsRepo.unresolve(id);
   }
 
@@ -113,8 +181,9 @@ export class BoardCommentsService extends DrizzleService<
       created_by?: string;
       session_id?: string;
     },
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment[]> {
+    await this.authorization?.requireBoard(params, boardId, 'view');
     return this.commentsRepo.findByBoard(boardId, filters);
   }
 
@@ -148,9 +217,18 @@ export class BoardCommentsService extends DrizzleService<
    */
   async bulkCreate(
     comments: Partial<BoardComment>[],
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment[]> {
-    return this.commentsRepo.bulkCreate(comments);
+    for (const comment of comments) {
+      if (!comment.board_id) throw new Error('board_id is required');
+      await this.authorization?.requireBoard(params, comment.board_id, 'mutate');
+    }
+    return this.commentsRepo.bulkCreate(
+      comments.map((comment) => ({
+        ...comment,
+        created_by: params?.user?.user_id ?? comment.created_by,
+      }))
+    );
   }
 
   // ============================================================================
@@ -163,10 +241,13 @@ export class BoardCommentsService extends DrizzleService<
    */
   async toggleReaction(
     commentId: string,
-    data: { user_id: string; emoji: string },
-    _params?: BoardCommentsParams
+    data: { user_id?: string; emoji: string },
+    params?: BoardCommentsParams
   ): Promise<BoardComment> {
-    return this.commentsRepo.toggleReaction(commentId, data.user_id, data.emoji);
+    await this.requireComment(commentId, params, 'view');
+    const userId = params?.user?.user_id;
+    if (!userId) throw new Error('Authentication required');
+    return this.commentsRepo.toggleReaction(commentId, userId, data.emoji);
   }
 
   /**
@@ -176,15 +257,23 @@ export class BoardCommentsService extends DrizzleService<
   async createReply(
     parentId: string,
     data: Partial<BoardComment>,
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment> {
-    return this.commentsRepo.createReply(parentId, data);
+    const parent = await this.requireComment(parentId, params, 'mutate');
+    return this.commentsRepo.createReply(parentId, {
+      ...data,
+      board_id: parent.board_id,
+      created_by: params?.user?.user_id ?? data.created_by,
+    });
   }
 }
 
 /**
  * Service factory function
  */
-export function createBoardCommentsService(db: TenantScopeAwareDatabase): BoardCommentsService {
-  return new BoardCommentsService(db);
+export function createBoardCommentsService(
+  db: TenantScopeAwareDatabase,
+  authorization?: CollaborationAuthorization
+): BoardCommentsService {
+  return new BoardCommentsService(db, authorization);
 }

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -115,7 +115,7 @@ export class BoardCommentsService extends DrizzleService<
     if (!data.board_id) throw new Error('board_id is required');
     await this.authorization?.requireBoard(params, data.board_id, 'mutate');
     const result = await super.create(
-      { ...data, created_by: params?.user?.user_id ?? data.created_by },
+      { ...data, created_by: (params?.user?.user_id as UUID | undefined) ?? data.created_by },
       params
     );
     if (Array.isArray(result)) throw new Error('Unexpected multi-comment create result');
@@ -226,7 +226,7 @@ export class BoardCommentsService extends DrizzleService<
     return this.commentsRepo.bulkCreate(
       comments.map((comment) => ({
         ...comment,
-        created_by: params?.user?.user_id ?? comment.created_by,
+        created_by: (params?.user?.user_id as UUID | undefined) ?? comment.created_by,
       }))
     );
   }
@@ -263,7 +263,7 @@ export class BoardCommentsService extends DrizzleService<
     return this.commentsRepo.createReply(parentId, {
       ...data,
       board_id: parent.board_id,
-      created_by: params?.user?.user_id ?? data.created_by,
+      created_by: (params?.user?.user_id as UUID | undefined) ?? data.created_by,
     });
   }
 }

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -68,7 +68,16 @@ export class BoardCommentsService extends DrizzleService<
   ): Promise<BoardComment> {
     const comment = await this.commentsRepo.findById(id);
     if (!comment) throw new Error(`Board comment ${id} not found`);
-    await this.authorization?.requireBoard(params, comment.board_id, mode);
+    const attached = await this.authorization?.requireCommentAttachments(params, {
+      boardId: comment.board_id,
+      branchId: comment.branch_id,
+      sessionId: comment.session_id,
+      taskId: comment.task_id,
+      messageId: comment.message_id,
+    });
+    if (mode === 'mutate' || !attached) {
+      await this.authorization?.requireBoard(params, comment.board_id, mode);
+    }
     return comment;
   }
 
@@ -114,6 +123,13 @@ export class BoardCommentsService extends DrizzleService<
   ): Promise<BoardComment> {
     if (!data.board_id) throw new Error('board_id is required');
     await this.authorization?.requireBoard(params, data.board_id, 'mutate');
+    await this.authorization?.requireCommentAttachments(params, {
+      boardId: data.board_id,
+      branchId: data.branch_id,
+      sessionId: data.session_id,
+      taskId: data.task_id,
+      messageId: data.message_id,
+    });
     const result = await super.create(
       { ...data, created_by: (params?.user?.user_id as UUID | undefined) ?? data.created_by },
       params
@@ -222,6 +238,13 @@ export class BoardCommentsService extends DrizzleService<
     for (const comment of comments) {
       if (!comment.board_id) throw new Error('board_id is required');
       await this.authorization?.requireBoard(params, comment.board_id, 'mutate');
+      await this.authorization?.requireCommentAttachments(params, {
+        boardId: comment.board_id,
+        branchId: comment.branch_id,
+        sessionId: comment.session_id,
+        taskId: comment.task_id,
+        messageId: comment.message_id,
+      });
     }
     return this.commentsRepo.bulkCreate(
       comments.map((comment) => ({

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -118,6 +118,7 @@ export class BoardObjectsService {
       throw new Error('board_id is required');
     }
     await this.authorization?.requireBoard(params, data.board_id, 'mutate');
+    await this.authorization?.requireBranchOnBoard(params, data.board_id, data.branch_id);
 
     // Use repository to create
     const boardObject = await this.boardObjectRepo.create({
@@ -168,7 +169,11 @@ export class BoardObjectsService {
     if (!object) {
       throw new Error(`Board object ${id} not found`);
     }
-    await this.authorization?.requireBoard(params, object.board_id, 'view');
+    if (object.branch_id) {
+      await this.authorization?.requireBranchOnBoard(params, object.board_id, object.branch_id);
+    } else {
+      await this.authorization?.requireBoard(params, object.board_id, 'view');
+    }
     return object;
   }
 
@@ -183,6 +188,9 @@ export class BoardObjectsService {
     const current = await this.boardObjectRepo.findByObjectId(id);
     if (!current) throw new Error(`Board object ${id} not found`);
     await this.authorization?.requireBoard(params, current.board_id, 'mutate');
+    if (current.branch_id) {
+      await this.authorization?.requireBranchOnBoard(params, current.board_id, current.branch_id);
+    }
     // Handle simultaneous position + zone_id update
     if (data.position && 'zone_id' in data) {
       // Update both atomically without emitting intermediate events
@@ -211,6 +219,9 @@ export class BoardObjectsService {
     const object = await this.boardObjectRepo.findByObjectId(id);
     if (!object) throw new Error(`Board object ${id} not found`);
     await this.authorization?.requireBoard(params, object.board_id, 'mutate');
+    if (object.branch_id) {
+      await this.authorization?.requireBranchOnBoard(params, object.board_id, object.branch_id);
+    }
     await this.boardObjectRepo.remove(id);
 
     return object;
@@ -227,6 +238,9 @@ export class BoardObjectsService {
     const current = await this.boardObjectRepo.findByObjectId(objectId);
     if (!current) throw new Error(`Board object ${objectId} not found`);
     await this.authorization?.requireBoard(params, current.board_id, 'mutate');
+    if (current.branch_id) {
+      await this.authorization?.requireBranchOnBoard(params, current.board_id, current.branch_id);
+    }
     const boardObject = await this.boardObjectRepo.updatePosition(objectId, position);
 
     this.emitPatched(boardObject, params);
@@ -245,6 +259,9 @@ export class BoardObjectsService {
     const current = await this.boardObjectRepo.findByObjectId(objectId);
     if (!current) throw new Error(`Board object ${objectId} not found`);
     await this.authorization?.requireBoard(params, current.board_id, 'mutate');
+    if (current.branch_id) {
+      await this.authorization?.requireBranchOnBoard(params, current.board_id, current.branch_id);
+    }
     const boardObject = await this.boardObjectRepo.updateZone(objectId, zoneId);
 
     this.emitPatched(toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject, params);

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -21,6 +21,7 @@ import type {
   QueryParams,
   UUID,
 } from '@agor/core/types';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 
 export type BoardObjectPatchedEventPayload = Omit<BoardEntityObject, 'zone_id'> & {
@@ -89,7 +90,8 @@ export class BoardObjectsService {
 
   constructor(
     db: TenantScopeAwareDatabase,
-    private app?: Application
+    private app?: Application,
+    private authorization?: CollaborationAuthorization
   ) {
     this.boardObjectRepo = new BoardObjectRepository(db);
   }
@@ -115,6 +117,7 @@ export class BoardObjectsService {
     if (!data.board_id) {
       throw new Error('board_id is required');
     }
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
 
     // Use repository to create
     const boardObject = await this.boardObjectRepo.create({
@@ -160,11 +163,12 @@ export class BoardObjectsService {
   /**
    * Get single board object
    */
-  async get(id: string, _params?: BoardObjectParams): Promise<BoardEntityObject> {
+  async get(id: string, params?: BoardObjectParams): Promise<BoardEntityObject> {
     const object = await this.boardObjectRepo.findByObjectId(id);
     if (!object) {
       throw new Error(`Board object ${id} not found`);
     }
+    await this.authorization?.requireBoard(params, object.board_id, 'view');
     return object;
   }
 
@@ -174,8 +178,11 @@ export class BoardObjectsService {
   async patch(
     id: string,
     data: Partial<BoardEntityObject>,
-    _params?: BoardObjectParams
+    params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(id);
+    if (!current) throw new Error(`Board object ${id} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     // Handle simultaneous position + zone_id update
     if (data.position && 'zone_id' in data) {
       // Update both atomically without emitting intermediate events
@@ -201,7 +208,9 @@ export class BoardObjectsService {
    * Remove board object
    */
   async remove(id: string, params?: BoardObjectParams): Promise<BoardEntityObject> {
-    const object = await this.get(id, params);
+    const object = await this.boardObjectRepo.findByObjectId(id);
+    if (!object) throw new Error(`Board object ${id} not found`);
+    await this.authorization?.requireBoard(params, object.board_id, 'mutate');
     await this.boardObjectRepo.remove(id);
 
     return object;
@@ -215,6 +224,9 @@ export class BoardObjectsService {
     position: { x: number; y: number },
     params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(objectId);
+    if (!current) throw new Error(`Board object ${objectId} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     const boardObject = await this.boardObjectRepo.updatePosition(objectId, position);
 
     this.emitPatched(boardObject, params);
@@ -230,6 +242,9 @@ export class BoardObjectsService {
     zoneId: string | undefined | null,
     params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(objectId);
+    if (!current) throw new Error(`Board object ${objectId} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     const boardObject = await this.boardObjectRepo.updateZone(objectId, zoneId);
 
     this.emitPatched(toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject, params);
@@ -282,7 +297,8 @@ export class BoardObjectsService {
  */
 export function createBoardObjectsService(
   db: TenantScopeAwareDatabase,
-  app?: Application
+  app?: Application,
+  authorization?: CollaborationAuthorization
 ): BoardObjectsService {
-  return new BoardObjectsService(db, app);
+  return new BoardObjectsService(db, app, authorization);
 }

--- a/apps/agor-daemon/src/services/cards.ts
+++ b/apps/agor-daemon/src/services/cards.ts
@@ -25,6 +25,7 @@ import type {
   ZoneBoardObject,
 } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 
 export type CardParams = QueryParams<{
   board_id?: BoardID;
@@ -38,7 +39,10 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   private cardRepo: CardRepository;
   private boardObjectRepo: BoardObjectRepository;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private authorization?: CollaborationAuthorization
+  ) {
     const cardRepo = new CardRepository(db);
     super(cardRepo, {
       id: 'card_id',
@@ -66,13 +70,49 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
    * `archived`). Anything else falls through to the unchanged in-memory filter,
    * preserving current behavior exactly.
    */
-  protected async fetchData(query: Query, _params?: CardParams): Promise<Card[]> {
+  protected async fetchData(query: Query, params?: CardParams): Promise<Card[]> {
     const filter: { board_id?: BoardID; archived?: boolean } = {};
 
     if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
     if (typeof query.archived === 'boolean') filter.archived = query.archived;
 
-    return this.cardRepo.findAll(filter);
+    const cards = await this.cardRepo.findAll(filter);
+    if (!this.authorization || !params?.provider) return cards;
+    const visible = await Promise.all(
+      cards.map(async (card) =>
+        (await this.authorization!.canViewBoard(params, card.board_id)) ? card : null
+      )
+    );
+    return visible.filter((card): card is Card => card !== null);
+  }
+
+  override async get(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'view');
+    return card;
+  }
+
+  override async patch(id: string, data: Partial<Card>, params?: CardParams): Promise<Card> {
+    const immutable = ['card_id', 'board_id', 'created_by', 'created_at', 'updated_at'] as const;
+    if (immutable.some((field) => field in data)) {
+      throw new Error('Card identity, ownership, and board cannot be changed');
+    }
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
+    const result = await super.patch(id, data, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-card patch result');
+    return result;
+  }
+
+  override async remove(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
+    const result = await super.remove(id, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-card remove result');
+    return result;
   }
 
   /**
@@ -97,6 +137,8 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
     },
     params?: CardParams
   ): Promise<{ card: Card; boardObject: BoardEntityObject }> {
+    if (!data.board_id) throw new Error('board_id is required');
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
     // Create the card
     const card = await this.cardRepo.create({
       ...data,
@@ -140,7 +182,9 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   /**
    * Get card with resolved CardType info
    */
-  async getWithType(id: string): Promise<CardWithType | null> {
+  async getWithType(id: string, params?: CardParams): Promise<CardWithType | null> {
+    const card = await this.cardRepo.findById(id);
+    if (card) await this.authorization?.requireBoard(params, card.board_id, 'view');
     return this.cardRepo.findByIdWithType(id);
   }
 
@@ -149,8 +193,10 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
    */
   async findByBoardId(
     boardId: BoardID,
-    options?: { archived?: boolean; limit?: number; offset?: number }
+    options?: { archived?: boolean; limit?: number; offset?: number },
+    params?: CardParams
   ): Promise<Card[]> {
+    await this.authorization?.requireBoard(params, boardId, 'view');
     return this.cardRepo.findByBoardId(boardId, options);
   }
 
@@ -184,14 +230,18 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   /**
    * Archive a card
    */
-  async archive(id: string): Promise<Card> {
+  async archive(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.get(id, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     return this.cardRepo.archive(id);
   }
 
   /**
    * Unarchive a card
    */
-  async unarchive(id: string): Promise<Card> {
+  async unarchive(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.get(id, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     return this.cardRepo.unarchive(id);
   }
 
@@ -201,8 +251,11 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   async moveToZone(
     cardId: CardID,
     zoneId: string | null,
-    zoneData?: ZoneBoardObject
+    zoneData?: ZoneBoardObject,
+    params?: CardParams
   ): Promise<BoardEntityObject> {
+    const card = await this.get(cardId, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     const boardObj = await this.boardObjectRepo.findByCardId(cardId);
     if (!boardObj) {
       throw new Error(`Card ${cardId} has no board placement`);
@@ -229,6 +282,9 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   }
 }
 
-export function createCardsService(db: TenantScopeAwareDatabase): CardsService {
-  return new CardsService(db);
+export function createCardsService(
+  db: TenantScopeAwareDatabase,
+  authorization?: CollaborationAuthorization
+): CardsService {
+  return new CardsService(db, authorization);
 }

--- a/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
@@ -1,4 +1,4 @@
-import { BoardRepository } from '@agor/core/db';
+import { BoardRepository, BranchRepository } from '@agor/core/db';
 import { Forbidden } from '@agor/core/feathers';
 import { ROLES } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -37,5 +37,20 @@ describe('CollaborationAuthorization', () => {
     );
     expect(canMutate).toHaveBeenCalledTimes(2);
     expect(canMutate).toHaveBeenLastCalledWith('board-a', 'user-a');
+  });
+
+  it('rejects an attachment whose branch belongs to another board', async () => {
+    vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue({
+      branch_id: 'branch-b',
+      board_id: 'board-b',
+    } as never);
+    const authorization = new CollaborationAuthorization({} as never, true);
+
+    await expect(
+      authorization.requireCommentAttachments(
+        { provider: 'mcp', user: { user_id: 'user-a', role: ROLES.MEMBER } as never },
+        { boardId: 'board-a', branchId: 'branch-b' }
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
   });
 });

--- a/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
@@ -1,0 +1,41 @@
+import { BoardRepository } from '@agor/core/db';
+import { Forbidden } from '@agor/core/feathers';
+import { ROLES } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CollaborationAuthorization } from './collaboration-authorization.js';
+
+describe('CollaborationAuthorization', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('denies a different user at the shared service boundary', async () => {
+    vi.spyOn(BoardRepository.prototype, 'canView').mockResolvedValue(false);
+    const authorization = new CollaborationAuthorization({} as never, true);
+
+    await expect(
+      authorization.requireBoard(
+        { provider: 'rest', user: { user_id: 'tenant-user-b', role: ROLES.MEMBER } as never },
+        'private-board-a',
+        'view'
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('uses the current actor for mutate decisions and honors revocation', async () => {
+    const canMutate = vi
+      .spyOn(BoardRepository.prototype, 'canMutate')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const authorization = new CollaborationAuthorization({} as never, true);
+    const params = {
+      provider: 'socketio',
+      user: { user_id: 'user-a', role: ROLES.MEMBER } as never,
+    };
+
+    await authorization.requireBoard(params, 'board-a', 'mutate');
+    await expect(authorization.requireBoard(params, 'board-a', 'mutate')).rejects.toBeInstanceOf(
+      Forbidden
+    );
+    expect(canMutate).toHaveBeenCalledTimes(2);
+    expect(canMutate).toHaveBeenLastCalledWith('board-a', 'user-a');
+  });
+});

--- a/apps/agor-daemon/src/utils/collaboration-authorization.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.ts
@@ -1,0 +1,55 @@
+import { BoardRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { type AuthenticatedParams, type BoardID, ROLES, type UserID } from '@agor/core/types';
+
+/**
+ * Service-layer authorization boundary for resources owned by a board.
+ *
+ * Keeping this below transport hooks is intentional: REST, Socket.IO, MCP and
+ * custom routes all call the same service methods. Tenant isolation remains
+ * owned by the ambient tenant DB scope/RLS; this guard adds the narrower
+ * current-user board decision inside that trusted tenant context.
+ */
+export class CollaborationAuthorization {
+  private readonly boards: BoardRepository;
+
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private readonly enabled: boolean,
+    private readonly allowSuperadmin = true
+  ) {
+    this.boards = new BoardRepository(db);
+  }
+
+  async requireBoard(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    boardId: BoardID | string,
+    mode: 'view' | 'mutate'
+  ): Promise<void> {
+    if (!this.enabled || !params?.provider) return;
+    const user = params.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+    if (user._isServiceAccount) return;
+    if (user.role === ROLES.ADMIN || (this.allowSuperadmin && user.role === ROLES.SUPERADMIN))
+      return;
+
+    const allowed =
+      mode === 'view'
+        ? await this.boards.canView(boardId, user.user_id as UserID)
+        : await this.boards.canMutate(boardId, user.user_id as UserID);
+    if (!allowed) throw new Forbidden('Board resource not found or not accessible');
+  }
+
+  async canViewBoard(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    boardId: BoardID | string
+  ): Promise<boolean> {
+    try {
+      await this.requireBoard(params, boardId, 'view');
+      return true;
+    } catch (error) {
+      if (error instanceof Forbidden) return false;
+      throw error;
+    }
+  }
+}

--- a/apps/agor-daemon/src/utils/collaboration-authorization.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.ts
@@ -1,17 +1,21 @@
-import { BoardRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  BoardRepository,
+  BranchRepository,
+  MessagesRepository,
+  SessionRepository,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import { type AuthenticatedParams, type BoardID, ROLES, type UserID } from '@agor/core/types';
 
-/**
- * Service-layer authorization boundary for resources owned by a board.
- *
- * Keeping this below transport hooks is intentional: REST, Socket.IO, MCP and
- * custom routes all call the same service methods. Tenant isolation remains
- * owned by the ambient tenant DB scope/RLS; this guard adds the narrower
- * current-user board decision inside that trusted tenant context.
- */
+/** Shared service-layer boundary used by REST, Socket.IO, MCP, and custom routes. */
 export class CollaborationAuthorization {
   private readonly boards: BoardRepository;
+  private readonly branches: BranchRepository;
+  private readonly sessions: SessionRepository;
+  private readonly tasks: TaskRepository;
+  private readonly messages: MessagesRepository;
 
   constructor(
     db: TenantScopeAwareDatabase,
@@ -19,6 +23,21 @@ export class CollaborationAuthorization {
     private readonly allowSuperadmin = true
   ) {
     this.boards = new BoardRepository(db);
+    this.branches = new BranchRepository(db);
+    this.sessions = new SessionRepository(db);
+    this.tasks = new TaskRepository(db);
+    this.messages = new MessagesRepository(db);
+  }
+
+  private externalUser(params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined) {
+    if (!this.enabled || !params?.provider) return null;
+    const user = params.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+    if (user._isServiceAccount) return null;
+    if (user.role === ROLES.ADMIN || (this.allowSuperadmin && user.role === ROLES.SUPERADMIN)) {
+      return null;
+    }
+    return user;
   }
 
   async requireBoard(
@@ -26,18 +45,76 @@ export class CollaborationAuthorization {
     boardId: BoardID | string,
     mode: 'view' | 'mutate'
   ): Promise<void> {
-    if (!this.enabled || !params?.provider) return;
-    const user = params.user;
-    if (!user) throw new NotAuthenticated('Authentication required');
-    if (user._isServiceAccount) return;
-    if (user.role === ROLES.ADMIN || (this.allowSuperadmin && user.role === ROLES.SUPERADMIN))
-      return;
-
+    const user = this.externalUser(params);
+    if (!user) return;
     const allowed =
       mode === 'view'
         ? await this.boards.canView(boardId, user.user_id as UserID)
         : await this.boards.canMutate(boardId, user.user_id as UserID);
     if (!allowed) throw new Forbidden('Board resource not found or not accessible');
+  }
+
+  async requireBranchOnBoard(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    boardId: BoardID | string,
+    branchId: string
+  ): Promise<void> {
+    if (!this.enabled || !params?.provider) return;
+    const branch = await this.branches.findById(branchId);
+    if (!branch || branch.board_id !== boardId) {
+      throw new Forbidden('Attached resource does not belong to this board');
+    }
+    const user = this.externalUser(params);
+    if (!user) return;
+    const accessible = await this.branches.findAccessibleBranches(user.user_id as UserID);
+    if (!accessible.some((candidate) => candidate.branch_id === branch.branch_id)) {
+      throw new Forbidden('Attached resource not found or not accessible');
+    }
+  }
+
+  /**
+   * Validate every supplied attachment, require one common branch, and prove
+   * that branch belongs to the selected board. Returns whether attachments exist.
+   */
+  async requireCommentAttachments(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    input: {
+      boardId: BoardID | string;
+      branchId?: string | null;
+      sessionId?: string | null;
+      taskId?: string | null;
+      messageId?: string | null;
+    }
+  ): Promise<boolean> {
+    const hasAttachments = Boolean(
+      input.branchId || input.sessionId || input.taskId || input.messageId
+    );
+    if (!hasAttachments || !this.enabled || !params?.provider) return hasAttachments;
+
+    const branchIds = new Set<string>();
+    if (input.branchId) branchIds.add(input.branchId);
+    if (input.sessionId) {
+      const session = await this.sessions.findById(input.sessionId);
+      if (!session) throw new Forbidden('Attached session not found or not accessible');
+      branchIds.add(session.branch_id);
+    }
+    if (input.taskId) {
+      const task = await this.tasks.findById(input.taskId);
+      if (!task) throw new Forbidden('Attached task not found or not accessible');
+      const session = await this.sessions.findById(task.session_id);
+      if (!session) throw new Forbidden('Attached task not found or not accessible');
+      branchIds.add(session.branch_id);
+    }
+    if (input.messageId) {
+      const message = await this.messages.findById(input.messageId as never);
+      if (!message) throw new Forbidden('Attached message not found or not accessible');
+      const session = await this.sessions.findById(message.session_id);
+      if (!session) throw new Forbidden('Attached message not found or not accessible');
+      branchIds.add(session.branch_id);
+    }
+    if (branchIds.size !== 1) throw new Forbidden('Comment attachments must share one branch');
+    await this.requireBranchOnBoard(params, input.boardId, [...branchIds][0]!);
+    return true;
   }
 
   async canViewBoard(

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -788,7 +788,7 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 
-  it('leaves optional branch-scoped events global when no branch/session is attached', async () => {
+  it('fails closed for board-child events without a resolvable board', async () => {
     const allowed = user('allowed');
     const denied = user('denied');
     const app = makeApp([{ user: allowed }, { user: denied }]);
@@ -803,7 +803,31 @@ describe('configureRealtimePublish', () => {
       { path: 'board-objects', method: 'patch', event: 'patched' }
     );
 
-    expect(channel.connections).toEqual([{ user: allowed }, { user: denied }]);
+    expect(channel.connections).toEqual([]);
+  });
+
+  it('re-checks current board visibility for every board/card event', async () => {
+    const allowed = user('allowed');
+    const revoked = user('revoked');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: allowed }, { user: revoked }, service]);
+    const r = repos({ branch: branch('b1', 'none') });
+    const canView = vi.fn(async (_boardId: string, userId: string) => userId === 'allowed');
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      ...r,
+      boardRepository: { canView } as never,
+    });
+
+    const channel = await app.runPublish(
+      { card_id: 'card1', board_id: 'board1', note: 'private' },
+      { path: 'cards', method: 'patch', event: 'patched' }
+    );
+
+    expect(canView).toHaveBeenCalledWith('board1', 'allowed');
+    expect(canView).toHaveBeenCalledWith('board1', 'revoked');
+    expect(channel.connections).toEqual([{ user: allowed }, service]);
   });
 
   it('keeps null-branch artifact events scoped to creator/admin/service connections', async () => {

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -811,7 +811,7 @@ describe('configureRealtimePublish', () => {
     const revoked = user('revoked');
     const service = { user: { _isServiceAccount: true, role: 'service' } };
     const app = makeApp([{ user: allowed }, { user: revoked }, service]);
-    const r = repos({ branch: branch('b1', 'none') });
+    const r = repos({ branch: branch('b1', 'none'), permissions: {} });
     const canView = vi.fn(async (_boardId: string, userId: string) => userId === 'allowed');
     configureRealtimePublish({
       app,

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -4,9 +4,14 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import type { BranchRepository, SessionRepository, TenantScopeAwareDatabase } from '@agor/core/db';
-import { getCurrentTenantId, runWithTenantDatabaseScope, shortId } from '@agor/core/db';
+import {
+  BoardRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { BranchID, HookContext, User, UserID } from '@agor/core/types';
+import type { BoardID, BranchID, HookContext, User, UserID } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 import { isSuperAdmin } from './branch-authorization.js';
 import {
@@ -146,6 +151,7 @@ type RealtimePublishOptions = {
   branchRbacEnabled: boolean;
   branchRepository: BranchRepository;
   sessionsRepository: SessionRepository;
+  boardRepository?: Pick<BoardRepository, 'canView'>;
   accessCache?: RealtimeAccessCache;
   allowSuperadmin?: boolean;
   multiTenancy?: ResolvedMultiTenancyConfig;
@@ -156,6 +162,7 @@ type PublishChannel = ReturnType<Application['channel']>;
 type PublishScope =
   | { kind: 'global' }
   | { kind: 'branch'; branchId: BranchID | null }
+  | { kind: 'board'; boardId: BoardID | null }
   | { kind: 'users'; userIds: Set<string> }
   | { kind: 'serviceOnly' };
 
@@ -168,6 +175,7 @@ const SESSION_ID_SCOPED_PATHS = new Set([
   'session-env-selections',
 ]);
 const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
+const BOARD_SCOPED_PATHS = new Set(['boards', 'cards']);
 
 // High-frequency per-chunk events emitted on the `messages` service during a
 // streaming turn (text + thinking deltas). These fan out once per token-batch,
@@ -251,6 +259,17 @@ function extractMessageId(data: unknown): string | undefined {
 function extractCreatedBy(data: unknown): string | undefined {
   const record = asRecord(data);
   return pickString(record, 'created_by', 'createdBy');
+}
+
+function extractBoardId(data: unknown, context: PublishContext): string | undefined {
+  const record = asRecord(data);
+  if (context.path === 'boards') {
+    return (
+      pickString(record, 'board_id', 'boardId') ??
+      (typeof context.id === 'string' ? context.id : undefined)
+    );
+  }
+  return pickString(record, 'board_id', 'boardId');
 }
 
 function userFromConnection(
@@ -370,6 +389,11 @@ async function resolvePublishScope(
 ): Promise<PublishScope> {
   if (!context.path) return { kind: 'global' };
 
+  if (BOARD_SCOPED_PATHS.has(context.path)) {
+    const boardId = extractBoardId(data, context);
+    return { kind: 'board', boardId: (boardId as BoardID | undefined) ?? null };
+  }
+
   if (BRANCH_ID_SCOPED_PATHS.has(context.path) || ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
     const branchId = extractBranchId(data, context);
     return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
@@ -398,9 +422,8 @@ async function resolvePublishScope(
     );
     if (resolvedBranchId !== undefined) return { kind: 'branch', branchId: resolvedBranchId };
 
-    // These services can also emit global/card/board rows with no branch,
-    // session, task, or message attachment.
-    return { kind: 'global' };
+    const boardId = extractBoardId(data, context);
+    return { kind: 'board', boardId: (boardId as BoardID | undefined) ?? null };
   }
 
   if (context.path === 'artifacts') {
@@ -603,6 +626,7 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
+    boardRepository = db ? new BoardRepository(db) : undefined,
     accessCache = new RealtimeAccessCache({
       branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
       sessionsRepository: sessionsRepository as unknown as RealtimeAccessSessionRepository,
@@ -633,8 +657,9 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     let tenantId: string | undefined;
     if (multiTenancy) {
       try {
-        tenantId = resolveRealtimeTenantId(multiTenancy, context);
-        tenantScoped = app.channel(tenantChannelName(tenantId));
+        const resolvedTenantId = resolveRealtimeTenantId(multiTenancy, context);
+        tenantId = resolvedTenantId;
+        tenantScoped = app.channel(tenantChannelName(resolvedTenantId));
       } catch (error) {
         if (error instanceof TenantResolutionError) {
           console.warn('[realtime] Suppressing event without tenant context', {
@@ -679,6 +704,39 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
       if (scope.kind === 'serviceOnly') return filterToServiceConnections(tenantScoped);
       if (scope.kind === 'users') {
         return filterToUserIdsOrAdmins(tenantScoped, scope.userIds, allowSuperadmin);
+      }
+
+      if (scope.kind === 'board') {
+        if (!scope.boardId || !boardRepository) {
+          console.warn('[realtime] Suppressing board event without resolvable board context', {
+            path: context.path,
+            event: context.event,
+          });
+          return filterToServiceConnections(tenantScoped);
+        }
+        const allowedUserIds = new Set<string>();
+        for (const connection of tenantScoped.connections ?? []) {
+          const user = userFromConnection(connection);
+          if (
+            !user?.user_id ||
+            user._isServiceAccount ||
+            isAdminConnection(connection, allowSuperadmin)
+          )
+            continue;
+          try {
+            if (await boardRepository.canView(scope.boardId, user.user_id as UserID)) {
+              allowedUserIds.add(user.user_id);
+            }
+          } catch {
+            // A missing/revoked board is intentionally not published.
+          }
+        }
+        return tenantScoped.filter(
+          (connection: unknown) =>
+            isServiceConnection(connection) ||
+            isAdminConnection(connection, allowSuperadmin) ||
+            allowedUserIds.has(userFromConnection(connection)?.user_id ?? '')
+        );
       }
 
       if (!scope.branchId) {


### PR DESCRIPTION
## Summary

- Centralize board-child authorization at the service layer so REST, Socket.IO, custom routes, and MCP share one current-actor decision.
- Protect cards, board objects, comments/reactions, bulk message ingestion, and provider-exposed message methods.
- Scope board/card realtime delivery to current authorized viewers and preserve trusted tenant context on manual MCP events.
- Harden immutable ownership/attachment fields and derive reaction/comment actors server-side.

## Test plan

- `pnpm i` — passed; workspace already up to date.
- `pnpm check` — passed after correcting branded actor-ID typing. This includes workspace typecheck, lint, short-ID checks, multitenancy boundary checks, daemon filesystem boundary checks, and the configured workspace builds.
- `pnpm exec vitest run src/utils/collaboration-authorization.test.ts src/utils/realtime-publish.test.ts src/services/board-objects.test.ts src/services/cards.test.ts src/mcp/tools/cards.test.ts` from `apps/agor-daemon` — **5 files passed, 64 tests passed**.
- Pre-commit Biome checks — passed.

## Security review

Reviewed alternate REST, Socket.IO, MCP, custom-route, bulk, manual-event, and access-revocation paths. The authorization primitive runs inside the existing tenant-scoped database/RLS boundary, and realtime remains tenant-channel scoped.

Backlog: [August 2026 launch security M1](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/security/reviews/2026-08-launch-security-review/findings.md)
