### PR TITLE
security: centralize daemon outbound egress controls

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -162,8 +162,8 @@ describe('card MCP realtime events', () => {
     await captureHandler('agor_cards_archive', ctx)({ cardId: 'card-1' });
 
     expect(createWithPlacement).toHaveBeenCalledWith(expect.any(Object), params);
-    expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined);
-    expect(archive).toHaveBeenCalledWith('card-1');
+    expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined, params);
+    expect(archive).toHaveBeenCalledWith('card-1', params);
     expect(cardsEmit).toHaveBeenCalledWith(
       'created',
       card,

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -77,11 +77,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         path: 'cards',
         event: 'created',
         data: card,
+        params: ctx.baseServiceParams,
       });
       emitServiceEvent(ctx.app, {
         path: 'board-objects',
         event: 'created',
         data: boardObject,
+        params: ctx.baseServiceParams,
       });
       return textResult({ card, boardObject });
     }
@@ -99,7 +101,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
-      const cardWithType = await cardsService.getWithType(args.cardId);
+      const cardWithType = await cardsService.getWithType(args.cardId, ctx.baseServiceParams);
       if (!cardWithType) throw new Error(`Card ${args.cardId} not found`);
       return textResult(cardWithType);
     }
@@ -123,7 +125,6 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const boardIdRaw = coerceString(args.boardId);
       const boardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
       const cardTypeId = coerceString(args.cardTypeId);
@@ -133,30 +134,19 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       const limit = typeof args.limit === 'number' ? args.limit : 50;
       const offset = typeof args.offset === 'number' ? args.offset : 0;
 
-      let cardsList: Card[];
-      if (zoneId && boardId) {
-        cardsList = await cardsService.findByZoneId(boardId as never, zoneId);
-      } else if (search) {
-        cardsList = await cardsService.searchCards(search, {
-          boardId: boardId as never,
+      const result = await ctx.app.service('cards').find({
+        ...ctx.baseServiceParams,
+        query: {
+          ...(boardId ? { board_id: boardId } : {}),
+          ...(cardTypeId ? { card_type_id: cardTypeId } : {}),
+          ...(zoneId ? { zone_id: zoneId } : {}),
+          ...(search ? { search } : {}),
           archived,
-          limit,
-          offset,
-        });
-      } else if (cardTypeId) {
-        cardsList = await cardsService.findByCardTypeId(cardTypeId as never, { limit, offset });
-      } else if (boardId) {
-        cardsList = await cardsService.findByBoardId(boardId as never, {
-          archived,
-          limit,
-          offset,
-        });
-      } else {
-        const result = await cardsService.find({
-          query: { $limit: limit, $skip: offset },
-        } as never);
-        cardsList = 'data' in result ? result.data : result;
-      }
+          $limit: limit,
+          $skip: offset,
+        },
+      } as never);
+      const cardsList: Card[] = 'data' in result ? result.data : result;
 
       return textResult({
         total: Array.isArray(cardsList) ? cardsList.length : 0,
@@ -238,12 +228,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const archivedCard = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.archive(args.cardId)
+        cardsService.archive(args.cardId, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'cards',
         event: 'patched',
         data: archivedCard,
+        params: ctx.baseServiceParams,
         id: args.cardId,
       });
       return textResult(archivedCard);
@@ -262,12 +253,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const unarchivedCard = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.unarchive(args.cardId)
+        cardsService.unarchive(args.cardId, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'cards',
         event: 'patched',
         data: unarchivedCard,
+        params: ctx.baseServiceParams,
         id: args.cardId,
       });
       return textResult(unarchivedCard);
@@ -303,12 +295,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
       const boardObject = await runWithMcpTenantDatabaseScope(ctx, () =>
-        cardsService.moveToZone(cardId as never, zoneId, zoneData)
+        cardsService.moveToZone(cardId as never, zoneId, zoneData, ctx.baseServiceParams)
       );
       emitServiceEvent(ctx.app, {
         path: 'board-objects',
         event: 'patched',
         data: boardObject,
+        params: ctx.baseServiceParams,
       });
       return textResult(boardObject);
     }
@@ -411,11 +404,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
           path: 'cards',
           event: 'created',
           data: card,
+          params: ctx.baseServiceParams,
         });
         emitServiceEvent(ctx.app, {
           path: 'board-objects',
           event: 'created',
           data: boardObject,
+          params: ctx.baseServiceParams,
         });
       }
 
@@ -522,12 +517,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
           if (zone?.type === 'zone') zoneData = zone;
         }
         const boardObject = await runWithMcpTenantDatabaseScope(ctx, () =>
-          cardsService.moveToZone(cardId as never, zoneId, zoneData)
+          cardsService.moveToZone(cardId as never, zoneId, zoneData, ctx.baseServiceParams)
         );
         emitServiceEvent(ctx.app, {
           path: 'board-objects',
           event: 'patched',
           data: boardObject,
+          params: ctx.baseServiceParams,
         });
         results.push({ cardId, boardObject });
       }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -307,7 +307,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     DAEMON_BUILD_INFO,
     resolvedSecurity,
     sessionsService,
-    messagesService,
     boardsService,
     branchRepository,
     usersRepository: _usersRepository,
@@ -699,7 +698,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     '/messages/bulk',
     {
       async create(data: unknown, params: RouteParams) {
-        return messagesService.createMany(data as Message[]);
+        if (!Array.isArray(data) || data.length === 0 || data.length > 100) {
+          throw new BadRequest('Message batch must contain between 1 and 100 items');
+        }
+        const sessionIds = new Set((data as Message[]).map((message) => message.session_id));
+        if (sessionIds.size !== 1) throw new BadRequest('Message batch must target one session');
+        const created: Message[] = [];
+        for (const message of data as Message[]) {
+          created.push(await app.service('messages').create(message, params));
+        }
+        return created;
       },
     },
     {
@@ -3069,7 +3077,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const boardCommentsService = safeService('board-comments') as unknown as {
     toggleReaction: (
       id: string,
-      data: { user_id: string; emoji: string },
+      data: { user_id?: string; emoji: string },
       params?: unknown
     ) => Promise<import('@agor/core/types').BoardComment>;
     createReply: (
@@ -3084,12 +3092,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       app,
       '/board-comments/:id/toggle-reaction',
       {
-        async create(data: { user_id: string; emoji: string }, params: RouteParams) {
+        async create(data: { user_id?: string; emoji: string }, params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Comment ID required');
-          if (!data.user_id) throw new Error('user_id required');
           if (!data.emoji) throw new Error('emoji required');
-          const updated = await boardCommentsService.toggleReaction(id, data, params);
+          const updated = await boardCommentsService.toggleReaction(
+            id,
+            { emoji: data.emoji },
+            params
+          );
           emitServiceEvent(app, {
             path: 'board-comments',
             event: 'patched',

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3628,8 +3628,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         await requireSessionScopedConfigOwnerOrAdmin(id, params);
         const enabledOnly =
           params.query?.enabledOnly === 'true' || params.query?.enabledOnly === true;
-        const includeGlobal =
-          params.query?.includeGlobal === 'true' || params.query?.includeGlobal === true;
         const includeMetadata =
           params.query?.includeMetadata === 'true' || params.query?.includeMetadata === true;
         const mcpService = app.service('mcp-servers');
@@ -3708,30 +3706,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             }
           })
         );
-        const globalQuery = {
-          scope: 'global',
-          ...(enabledOnly ? { enabled: true } : {}),
-          ...(userId ? { forUserId: userId } : {}),
-          $limit: 1000,
-        };
-        const globalResult = includeGlobal
-          ? await mcpService.find({
-              ...params,
-              provider: undefined,
-              query: globalQuery,
-            })
-          : [];
-        const globalServers = Array.isArray(globalResult) ? globalResult : globalResult.data;
-        const servers = includeGlobal
-          ? [
-              ...new Map(
-                [...globalServers, ...sessionServers].map((server) => [
-                  server.mcp_server_id,
-                  server,
-                ])
-              ).values(),
-            ]
-          : sessionServers;
+        const servers = sessionServers;
         return shouldExposeMCPServerSecrets(params, {
           allowSessionToken: true,
           sessionId: id,

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -72,4 +72,19 @@ describe('register-services /mcp-servers/discover wiring', () => {
     // The post-resolution recheck still runs for templated URLs.
     expect(discoverBlock).toMatch(/isTemplated\(\s*serverConfig\.url/);
   });
+
+  it('routes every discover and OAuth probe request through the shared egress client', () => {
+    expect(rawSource).toMatch(
+      /import\s*\{\s*safeFetch\s*\}\s*from\s*['"]@agor\/core\/network\/safe-fetch['"]/
+    );
+    expect(discoverBlock).toMatch(/\bsafeFetch\s*\(/);
+    expect(discoverBlock).not.toMatch(/\bfetch\s*\(/);
+
+    const oauthProbeBlock = codeOnly.slice(
+      codeOnly.indexOf("app.use('/mcp-servers/test-oauth'"),
+      codeOnly.indexOf("app.use('/mcp-servers/oauth-complete'")
+    );
+    expect(oauthProbeBlock).toMatch(/\bsafeFetch\s*\(/);
+    expect(oauthProbeBlock).not.toMatch(/\bfetch\s*\(/);
+  });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -45,7 +45,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { ROLES, TaskStatus } from '@agor/core/types';
+import { hasMinimumRole, ROLES, TaskStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import type express from 'express';
 import type {
@@ -142,6 +142,10 @@ import {
   shouldExposeMCPServerSecrets,
   shouldExposeMCPServerSecretsForSessionToken,
 } from './utils/mcp-header-secrets.js';
+import {
+  auditSharedOAuthLifecycle,
+  requireSharedOAuthAdministrator,
+} from './utils/shared-oauth-policy.js';
 import { spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
 
@@ -1982,6 +1986,16 @@ async function registerMCPServices(
             scopeOverride = server.auth.oauth_scope;
           }
         }
+        if (oauthMode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'start');
+          auditSharedOAuthLifecycle({
+            action: 'start',
+            outcome: 'started',
+            serverId: data.mcp_server_id,
+            actorUserId: userId,
+            tenantId,
+          });
+        }
 
         let probeResponse = await fetch(data.mcp_url, {
           method: 'POST',
@@ -2069,7 +2083,10 @@ async function registerMCPServices(
 
   // OAuth complete endpoint
   app.use('/mcp-servers/oauth-complete', {
-    async create(data: { callback_url: string } | { code: string; state: string }) {
+    async create(
+      data: { callback_url: string } | { code: string; state: string },
+      params?: AuthenticatedParams
+    ) {
       try {
         const { completeMCPOAuthFlow, parseOAuthCallback } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
@@ -2092,6 +2109,15 @@ async function registerMCPServices(
             error: 'OAuth flow expired or not found. Please start the flow again.',
           };
 
+        if (pendingFlow.oauthMode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'complete');
+          if (pendingFlow.userId !== params?.user?.user_id) {
+            throw new Forbidden('OAuth flow must be completed by the administrator who started it');
+          }
+        } else if (pendingFlow.userId && pendingFlow.userId !== params?.user?.user_id) {
+          throw new Forbidden('OAuth flow belongs to a different user');
+        }
+
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
@@ -2103,6 +2129,15 @@ async function registerMCPServices(
         }
 
         await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
+        if (pendingFlow.oauthMode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'complete',
+            outcome: 'succeeded',
+            serverId: pendingFlow.mcpServerId,
+            actorUserId: params?.user?.user_id,
+            tenantId: pendingFlow.tenantId,
+          });
+        }
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
         console.error('[OAuth Complete] Error:', error);
@@ -2115,6 +2150,13 @@ async function registerMCPServices(
   // OAuth disconnect
   app.use('/mcp-servers/oauth-disconnect', {
     async create(data: { mcp_server_id: string }, params?: AuthenticatedParams) {
+      const tenantId = tenantIdFromParams(params);
+      const server = await runInOAuthTenantScope(db, tenantId, () =>
+        new MCPServerRepository(db).findById(data.mcp_server_id)
+      );
+      if (server?.auth?.oauth_mode === 'shared') {
+        requireSharedOAuthAdministrator(params, 'disconnect');
+      }
       const { clearAuthCodeTokenCache } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
       const result = await performOAuthDisconnect({
         userId: params?.user?.user_id,
@@ -2131,6 +2173,15 @@ async function registerMCPServices(
         app.io
           .to(userRoomName(params.user.user_id))
           .emit('oauth:disconnected', { mcp_server_id: data.mcp_server_id });
+      }
+      if (server?.auth?.oauth_mode === 'shared') {
+        auditSharedOAuthLifecycle({
+          action: 'disconnect',
+          outcome: result.success ? 'succeeded' : 'failed',
+          serverId: data.mcp_server_id,
+          actorUserId: params?.user?.user_id,
+          tenantId,
+        });
       }
 
       return result;
@@ -2150,7 +2201,22 @@ async function registerMCPServices(
         const authenticatedServerIds = tokens
           .filter((t) => !t.oauth_token_expires_at || t.oauth_token_expires_at > now)
           .map((t) => t.mcp_server_id);
-        return { authenticated_server_ids: authenticatedServerIds };
+        const sharedGrants =
+          params?.user && hasMinimumRole(params.user.role, ROLES.ADMIN)
+            ? (await userTokenRepo.listShared()).map((token) => ({
+                mcp_server_id: token.mcp_server_id,
+                connected_at: token.created_at,
+                updated_at: token.updated_at,
+                current_principal: {
+                  kind: 'instance_shared',
+                  display: 'Shared provider identity (provider principal not reported)',
+                },
+              }))
+            : undefined;
+        return {
+          authenticated_server_ids: authenticatedServerIds,
+          ...(sharedGrants ? { shared_grants: sharedGrants } : {}),
+        };
       } catch (error) {
         console.error('[OAuth Status] Error fetching user tokens:', error);
         return { authenticated_server_ids: [] };
@@ -2170,8 +2236,8 @@ async function registerMCPServices(
   // Access control:
   //   - per_user tokens are keyed on params.user.user_id — a caller cannot
   //     request another user's row (no forUserId override here).
-  //   - shared tokens (user_id = NULL) are returned to any authenticated
-  //     caller who can see the server, matching existing shared-mode semantics.
+  //   - shared tokens (user_id = NULL) are usable only when the server was
+  //     explicitly attached to the executor's session.
   //
   // The caller is expected to pass only the server IDs it already resolved
   // as in-scope for the session (see `getMcpServersForSession`).
@@ -2237,11 +2303,7 @@ async function registerMCPServices(
           executorSessionId as SessionID,
           true
         );
-        const globalServers = await mcpServerRepo.findAll({ scope: 'global', enabled: true });
-        const allowedServerIds = new Set([
-          ...globalServers.map((server) => server.mcp_server_id),
-          ...attachedServers.map((server) => server.mcp_server_id),
-        ]);
+        const allowedServerIds = new Set(attachedServers.map((server) => server.mcp_server_id));
         for (const serverId of serverIds) {
           if (!allowedServerIds.has(serverId as MCPServerID)) {
             headers[serverId] = { error: 'server_not_in_session_scope' };
@@ -2371,6 +2433,9 @@ async function registerMCPServices(
         if (server.auth?.type !== 'oauth') return { success: false, error: 'not_oauth_server' };
 
         const mode = server.auth.oauth_mode ?? 'per_user';
+        if (mode === 'shared') {
+          requireSharedOAuthAdministrator(params, 'refresh');
+        }
         const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
         await refreshAndPersistToken({
@@ -2385,6 +2450,15 @@ async function registerMCPServices(
             ? fresh.oauth_token_expires_at.getTime()
             : undefined;
 
+        if (mode === 'shared') {
+          auditSharedOAuthLifecycle({
+            action: 'refresh',
+            outcome: 'succeeded',
+            serverId,
+            actorUserId: userId,
+            tenantId: tenantIdFromParams(params),
+          });
+        }
         return { success: true, expires_at: expiresAt };
       } catch (err) {
         if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -135,6 +135,7 @@ import { userRoomName } from './setup/socketio.js';
 import { requestExecutorTermination } from './termination-coordinator.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
+import { CollaborationAuthorization } from './utils/collaboration-authorization.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -270,18 +271,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
 
   app.use('/messages', messagesService, {
-    methods: [
-      'find',
-      'get',
-      'create',
-      'update',
-      'patch',
-      'remove',
-      'findBySession',
-      'findByTask',
-      'findByRange',
-      'createMany',
-    ],
+    methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
     events: [
       'queued',
       'streaming:start',
@@ -349,11 +339,16 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       ],
     }
   );
-  app.use('/board-objects', createBoardObjectsService(db, app));
+  const collaborationAuthorization = new CollaborationAuthorization(
+    db,
+    branchRbacEnabled,
+    allowSuperadmin
+  );
+  app.use('/board-objects', createBoardObjectsService(db, app, collaborationAuthorization));
 
   const boardsService = safeService('boards') as unknown as BoardsServiceImpl | undefined;
   app.use('/card-types', createCardTypesService(db));
-  app.use('/cards', createCardsService(db));
+  app.use('/cards', createCardsService(db, collaborationAuthorization));
   // `agor-query` is the runtime-introspection fan-out event (daemon →
   // viewer's browser tab). Feathers' default `serviceEvents` is just
   // ['created','updated','patched','removed'], so without this it
@@ -371,7 +366,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       'validateFromExecutor',
     ],
   });
-  app.use('/board-comments', createBoardCommentsService(db));
+  app.use('/board-comments', createBoardCommentsService(db, collaborationAuthorization));
 
   // ============================================================================
   // Branches, repos

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -34,6 +34,7 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { safeFetch } from '@agor/core/network/safe-fetch';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -1530,7 +1531,7 @@ async function registerMCPServices(
       mcp_url?: string;
     }) {
       try {
-        const response = await fetch(data.api_url, {
+        const response = await safeFetch(data.api_url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: data.api_token, secret: data.api_secret }),
@@ -1568,7 +1569,7 @@ async function registerMCPServices(
    */
   async function probeMcpAuthViaReadOnlyToolCall(mcpUrl: string): Promise<Response | null> {
     try {
-      const listResponse = await fetch(mcpUrl, {
+      const listResponse = await safeFetch(mcpUrl, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
@@ -1584,7 +1585,7 @@ async function registerMCPServices(
       );
       if (!readOnlyTool?.name) return null;
 
-      const callResponse = await fetch(mcpUrl, {
+      const callResponse = await safeFetch(mcpUrl, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -1625,7 +1626,7 @@ async function registerMCPServices(
 
         let probeResponse: Response;
         try {
-          probeResponse = await fetch(data.mcp_url, {
+          probeResponse = await safeFetch(data.mcp_url, {
             method: 'POST',
             headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
             body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -1721,7 +1722,7 @@ async function registerMCPServices(
 
               const tokenResponse = await started.awaitToken();
 
-              const testResponse = await fetch(data.mcp_url, {
+              const testResponse = await safeFetch(data.mcp_url, {
                 method: 'POST',
                 headers: {
                   Authorization: `Bearer ${tokenResponse.access_token}`,
@@ -1776,7 +1777,7 @@ async function registerMCPServices(
             // RFC 9728 path: fetch resource metadata to get the AS URL.
             // (Above guard ensures `metadataUrl` is set when we reach here.)
             const rfc9728Url = metadataUrl as string;
-            const metadataResponse = await fetch(rfc9728Url);
+            const metadataResponse = await safeFetch(rfc9728Url);
             if (!metadataResponse.ok) {
               return {
                 success: false,
@@ -1901,7 +1902,7 @@ async function registerMCPServices(
             let mcpStatus: number | undefined;
             let mcpStatusText: string | undefined;
             try {
-              const mcpResponse = await fetch(data.mcp_url, {
+              const mcpResponse = await safeFetch(data.mcp_url, {
                 method: 'POST',
                 headers: {
                   Authorization: `Bearer ${token}`,
@@ -1997,7 +1998,7 @@ async function registerMCPServices(
           });
         }
 
-        let probeResponse = await fetch(data.mcp_url, {
+        let probeResponse = await safeFetch(data.mcp_url, {
           method: 'POST',
           headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
           body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -2698,7 +2699,7 @@ async function registerMCPServices(
 
         const probeAndAcquireOAuthToken = async (mcpUrl: string): Promise<string | undefined> => {
           try {
-            const probeResponse = await fetch(mcpUrl, {
+            const probeResponse = await safeFetch(mcpUrl, {
               method: 'GET',
               headers: mergeMCPRemoteHeaders({
                 base: { Accept: 'application/json' },
@@ -2799,7 +2800,10 @@ async function registerMCPServices(
                 init = { ...init, headers: { ...headersObj, 'mcp-session-id': sessionId } };
               }
             }
-            const response = await fetch(input, init);
+            const response = await safeFetch(
+              typeof input === 'string' || input instanceof URL ? input : input.url,
+              init
+            );
             const respSessionId = response.headers.get('mcp-session-id');
             if (respSessionId) sessionId = respSessionId;
             return response;

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -13,8 +13,9 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { BoardCommentsRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
-import type { BoardComment, QueryParams, UUID } from '@agor/core/types';
+import type { AuthenticatedParams, BoardComment, QueryParams, UUID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 
 /**
  * Board comments service params
@@ -27,10 +28,11 @@ export type BoardCommentsParams = QueryParams<{
   branch_id?: string;
   resolved?: boolean;
   created_by?: string;
-}> & {
-  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
-  _agorSqlBoardAccessUserId?: UUID;
-};
+}> &
+  AuthenticatedParams & {
+    /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+    _agorSqlBoardAccessUserId?: UUID;
+  };
 
 /**
  * Extended board comments service with custom methods
@@ -42,7 +44,10 @@ export class BoardCommentsService extends DrizzleService<
 > {
   private commentsRepo: BoardCommentsRepository;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private authorization?: CollaborationAuthorization
+  ) {
     const commentsRepo = new BoardCommentsRepository(db);
     super(commentsRepo, {
       id: 'comment_id',
@@ -54,6 +59,67 @@ export class BoardCommentsService extends DrizzleService<
     });
 
     this.commentsRepo = commentsRepo;
+  }
+
+  private async requireComment(
+    id: string,
+    params: BoardCommentsParams | undefined,
+    mode: 'view' | 'mutate'
+  ): Promise<BoardComment> {
+    const comment = await this.commentsRepo.findById(id);
+    if (!comment) throw new Error(`Board comment ${id} not found`);
+    await this.authorization?.requireBoard(params, comment.board_id, mode);
+    return comment;
+  }
+
+  override async get(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    return this.requireComment(id, params, 'view');
+  }
+
+  override async patch(
+    id: string,
+    data: Partial<BoardComment>,
+    params?: BoardCommentsParams
+  ): Promise<BoardComment> {
+    const immutable = [
+      'comment_id',
+      'board_id',
+      'branch_id',
+      'session_id',
+      'task_id',
+      'message_id',
+      'parent_id',
+      'created_by',
+      'created_at',
+    ] as const;
+    if (immutable.some((field) => field in data)) {
+      throw new Error('Comment identity, ownership, and attachments cannot be changed');
+    }
+    await this.requireComment(id, params, 'mutate');
+    const result = await super.patch(id, data, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment patch result');
+    return result;
+  }
+
+  override async remove(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
+    const result = await super.remove(id, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment remove result');
+    return result;
+  }
+
+  override async create(
+    data: Partial<BoardComment>,
+    params?: BoardCommentsParams
+  ): Promise<BoardComment> {
+    if (!data.board_id) throw new Error('board_id is required');
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
+    const result = await super.create(
+      { ...data, created_by: params?.user?.user_id ?? data.created_by },
+      params
+    );
+    if (Array.isArray(result)) throw new Error('Unexpected multi-comment create result');
+    return result;
   }
 
   /**
@@ -92,14 +158,16 @@ export class BoardCommentsService extends DrizzleService<
   /**
    * Custom method: Resolve comment
    */
-  async resolve(id: string, _params?: BoardCommentsParams): Promise<BoardComment> {
+  async resolve(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
     return this.commentsRepo.resolve(id);
   }
 
   /**
    * Custom method: Unresolve comment
    */
-  async unresolve(id: string, _params?: BoardCommentsParams): Promise<BoardComment> {
+  async unresolve(id: string, params?: BoardCommentsParams): Promise<BoardComment> {
+    await this.requireComment(id, params, 'mutate');
     return this.commentsRepo.unresolve(id);
   }
 
@@ -113,8 +181,9 @@ export class BoardCommentsService extends DrizzleService<
       created_by?: string;
       session_id?: string;
     },
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment[]> {
+    await this.authorization?.requireBoard(params, boardId, 'view');
     return this.commentsRepo.findByBoard(boardId, filters);
   }
 
@@ -148,9 +217,18 @@ export class BoardCommentsService extends DrizzleService<
    */
   async bulkCreate(
     comments: Partial<BoardComment>[],
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment[]> {
-    return this.commentsRepo.bulkCreate(comments);
+    for (const comment of comments) {
+      if (!comment.board_id) throw new Error('board_id is required');
+      await this.authorization?.requireBoard(params, comment.board_id, 'mutate');
+    }
+    return this.commentsRepo.bulkCreate(
+      comments.map((comment) => ({
+        ...comment,
+        created_by: params?.user?.user_id ?? comment.created_by,
+      }))
+    );
   }
 
   // ============================================================================
@@ -163,10 +241,13 @@ export class BoardCommentsService extends DrizzleService<
    */
   async toggleReaction(
     commentId: string,
-    data: { user_id: string; emoji: string },
-    _params?: BoardCommentsParams
+    data: { user_id?: string; emoji: string },
+    params?: BoardCommentsParams
   ): Promise<BoardComment> {
-    return this.commentsRepo.toggleReaction(commentId, data.user_id, data.emoji);
+    await this.requireComment(commentId, params, 'view');
+    const userId = params?.user?.user_id;
+    if (!userId) throw new Error('Authentication required');
+    return this.commentsRepo.toggleReaction(commentId, userId, data.emoji);
   }
 
   /**
@@ -176,15 +257,23 @@ export class BoardCommentsService extends DrizzleService<
   async createReply(
     parentId: string,
     data: Partial<BoardComment>,
-    _params?: BoardCommentsParams
+    params?: BoardCommentsParams
   ): Promise<BoardComment> {
-    return this.commentsRepo.createReply(parentId, data);
+    const parent = await this.requireComment(parentId, params, 'mutate');
+    return this.commentsRepo.createReply(parentId, {
+      ...data,
+      board_id: parent.board_id,
+      created_by: params?.user?.user_id ?? data.created_by,
+    });
   }
 }
 
 /**
  * Service factory function
  */
-export function createBoardCommentsService(db: TenantScopeAwareDatabase): BoardCommentsService {
-  return new BoardCommentsService(db);
+export function createBoardCommentsService(
+  db: TenantScopeAwareDatabase,
+  authorization?: CollaborationAuthorization
+): BoardCommentsService {
+  return new BoardCommentsService(db, authorization);
 }

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -21,6 +21,7 @@ import type {
   QueryParams,
   UUID,
 } from '@agor/core/types';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 
 export type BoardObjectPatchedEventPayload = Omit<BoardEntityObject, 'zone_id'> & {
@@ -89,7 +90,8 @@ export class BoardObjectsService {
 
   constructor(
     db: TenantScopeAwareDatabase,
-    private app?: Application
+    private app?: Application,
+    private authorization?: CollaborationAuthorization
   ) {
     this.boardObjectRepo = new BoardObjectRepository(db);
   }
@@ -115,6 +117,7 @@ export class BoardObjectsService {
     if (!data.board_id) {
       throw new Error('board_id is required');
     }
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
 
     // Use repository to create
     const boardObject = await this.boardObjectRepo.create({
@@ -160,11 +163,12 @@ export class BoardObjectsService {
   /**
    * Get single board object
    */
-  async get(id: string, _params?: BoardObjectParams): Promise<BoardEntityObject> {
+  async get(id: string, params?: BoardObjectParams): Promise<BoardEntityObject> {
     const object = await this.boardObjectRepo.findByObjectId(id);
     if (!object) {
       throw new Error(`Board object ${id} not found`);
     }
+    await this.authorization?.requireBoard(params, object.board_id, 'view');
     return object;
   }
 
@@ -174,8 +178,11 @@ export class BoardObjectsService {
   async patch(
     id: string,
     data: Partial<BoardEntityObject>,
-    _params?: BoardObjectParams
+    params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(id);
+    if (!current) throw new Error(`Board object ${id} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     // Handle simultaneous position + zone_id update
     if (data.position && 'zone_id' in data) {
       // Update both atomically without emitting intermediate events
@@ -201,7 +208,9 @@ export class BoardObjectsService {
    * Remove board object
    */
   async remove(id: string, params?: BoardObjectParams): Promise<BoardEntityObject> {
-    const object = await this.get(id, params);
+    const object = await this.boardObjectRepo.findByObjectId(id);
+    if (!object) throw new Error(`Board object ${id} not found`);
+    await this.authorization?.requireBoard(params, object.board_id, 'mutate');
     await this.boardObjectRepo.remove(id);
 
     return object;
@@ -215,6 +224,9 @@ export class BoardObjectsService {
     position: { x: number; y: number },
     params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(objectId);
+    if (!current) throw new Error(`Board object ${objectId} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     const boardObject = await this.boardObjectRepo.updatePosition(objectId, position);
 
     this.emitPatched(boardObject, params);
@@ -230,6 +242,9 @@ export class BoardObjectsService {
     zoneId: string | undefined | null,
     params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
+    const current = await this.boardObjectRepo.findByObjectId(objectId);
+    if (!current) throw new Error(`Board object ${objectId} not found`);
+    await this.authorization?.requireBoard(params, current.board_id, 'mutate');
     const boardObject = await this.boardObjectRepo.updateZone(objectId, zoneId);
 
     this.emitPatched(toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject, params);
@@ -282,7 +297,8 @@ export class BoardObjectsService {
  */
 export function createBoardObjectsService(
   db: TenantScopeAwareDatabase,
-  app?: Application
+  app?: Application,
+  authorization?: CollaborationAuthorization
 ): BoardObjectsService {
-  return new BoardObjectsService(db, app);
+  return new BoardObjectsService(db, app, authorization);
 }

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -41,6 +41,7 @@ import {
   validateRenderedManagedEnvUrlFields,
 } from '@agor/core/environment/webhook';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { safeFetch } from '@agor/core/network/safe-fetch';
 import type {
   AuthenticatedParams,
   Board,
@@ -276,7 +277,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const timeout = setTimeout(() => controller.abort(), ENVIRONMENT.LOGS_TIMEOUT_MS);
 
     try {
-      const response = await fetch(url, {
+      const response = await safeFetch(url, {
+        addressPolicy: 'public',
+        timeoutMs: ENVIRONMENT.LOGS_TIMEOUT_MS,
+        maxResponseBytes: maxBytes,
         method: 'GET',
         redirect: 'manual',
         signal: controller.signal,
@@ -2349,7 +2353,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS);
 
-      const response = await fetch(healthUrl, {
+      const response = await safeFetch(healthUrl, {
+        addressPolicy: 'health',
+        timeoutMs: ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS,
+        maxRedirects: 0,
+        redirect: 'manual',
         signal: controller.signal,
         method: 'GET',
       });

--- a/apps/agor-daemon/src/services/cards.ts
+++ b/apps/agor-daemon/src/services/cards.ts
@@ -25,6 +25,7 @@ import type {
   ZoneBoardObject,
 } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+import type { CollaborationAuthorization } from '../utils/collaboration-authorization.js';
 
 export type CardParams = QueryParams<{
   board_id?: BoardID;
@@ -38,7 +39,10 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   private cardRepo: CardRepository;
   private boardObjectRepo: BoardObjectRepository;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private authorization?: CollaborationAuthorization
+  ) {
     const cardRepo = new CardRepository(db);
     super(cardRepo, {
       id: 'card_id',
@@ -66,13 +70,49 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
    * `archived`). Anything else falls through to the unchanged in-memory filter,
    * preserving current behavior exactly.
    */
-  protected async fetchData(query: Query, _params?: CardParams): Promise<Card[]> {
+  protected async fetchData(query: Query, params?: CardParams): Promise<Card[]> {
     const filter: { board_id?: BoardID; archived?: boolean } = {};
 
     if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
     if (typeof query.archived === 'boolean') filter.archived = query.archived;
 
-    return this.cardRepo.findAll(filter);
+    const cards = await this.cardRepo.findAll(filter);
+    if (!this.authorization || !params?.provider) return cards;
+    const visible = await Promise.all(
+      cards.map(async (card) =>
+        (await this.authorization!.canViewBoard(params, card.board_id)) ? card : null
+      )
+    );
+    return visible.filter((card): card is Card => card !== null);
+  }
+
+  override async get(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'view');
+    return card;
+  }
+
+  override async patch(id: string, data: Partial<Card>, params?: CardParams): Promise<Card> {
+    const immutable = ['card_id', 'board_id', 'created_by', 'created_at', 'updated_at'] as const;
+    if (immutable.some((field) => field in data)) {
+      throw new Error('Card identity, ownership, and board cannot be changed');
+    }
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
+    const result = await super.patch(id, data, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-card patch result');
+    return result;
+  }
+
+  override async remove(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.cardRepo.findById(id);
+    if (!card) throw new Error(`Card ${id} not found`);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
+    const result = await super.remove(id, params);
+    if (Array.isArray(result)) throw new Error('Unexpected multi-card remove result');
+    return result;
   }
 
   /**
@@ -97,6 +137,8 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
     },
     params?: CardParams
   ): Promise<{ card: Card; boardObject: BoardEntityObject }> {
+    if (!data.board_id) throw new Error('board_id is required');
+    await this.authorization?.requireBoard(params, data.board_id, 'mutate');
     // Create the card
     const card = await this.cardRepo.create({
       ...data,
@@ -140,7 +182,9 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   /**
    * Get card with resolved CardType info
    */
-  async getWithType(id: string): Promise<CardWithType | null> {
+  async getWithType(id: string, params?: CardParams): Promise<CardWithType | null> {
+    const card = await this.cardRepo.findById(id);
+    if (card) await this.authorization?.requireBoard(params, card.board_id, 'view');
     return this.cardRepo.findByIdWithType(id);
   }
 
@@ -149,8 +193,10 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
    */
   async findByBoardId(
     boardId: BoardID,
-    options?: { archived?: boolean; limit?: number; offset?: number }
+    options?: { archived?: boolean; limit?: number; offset?: number },
+    params?: CardParams
   ): Promise<Card[]> {
+    await this.authorization?.requireBoard(params, boardId, 'view');
     return this.cardRepo.findByBoardId(boardId, options);
   }
 
@@ -184,14 +230,18 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   /**
    * Archive a card
    */
-  async archive(id: string): Promise<Card> {
+  async archive(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.get(id, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     return this.cardRepo.archive(id);
   }
 
   /**
    * Unarchive a card
    */
-  async unarchive(id: string): Promise<Card> {
+  async unarchive(id: string, params?: CardParams): Promise<Card> {
+    const card = await this.get(id, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     return this.cardRepo.unarchive(id);
   }
 
@@ -201,8 +251,11 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   async moveToZone(
     cardId: CardID,
     zoneId: string | null,
-    zoneData?: ZoneBoardObject
+    zoneData?: ZoneBoardObject,
+    params?: CardParams
   ): Promise<BoardEntityObject> {
+    const card = await this.get(cardId, params);
+    await this.authorization?.requireBoard(params, card.board_id, 'mutate');
     const boardObj = await this.boardObjectRepo.findByCardId(cardId);
     if (!boardObj) {
       throw new Error(`Card ${cardId} has no board placement`);
@@ -229,6 +282,9 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   }
 }
 
-export function createCardsService(db: TenantScopeAwareDatabase): CardsService {
-  return new CardsService(db);
+export function createCardsService(
+  db: TenantScopeAwareDatabase,
+  authorization?: CollaborationAuthorization
+): CardsService {
+  return new CardsService(db, authorization);
 }

--- a/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.test.ts
@@ -1,0 +1,41 @@
+import { BoardRepository } from '@agor/core/db';
+import { Forbidden } from '@agor/core/feathers';
+import { ROLES } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CollaborationAuthorization } from './collaboration-authorization.js';
+
+describe('CollaborationAuthorization', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('denies a different user at the shared service boundary', async () => {
+    vi.spyOn(BoardRepository.prototype, 'canView').mockResolvedValue(false);
+    const authorization = new CollaborationAuthorization({} as never, true);
+
+    await expect(
+      authorization.requireBoard(
+        { provider: 'rest', user: { user_id: 'tenant-user-b', role: ROLES.MEMBER } as never },
+        'private-board-a',
+        'view'
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  it('uses the current actor for mutate decisions and honors revocation', async () => {
+    const canMutate = vi
+      .spyOn(BoardRepository.prototype, 'canMutate')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const authorization = new CollaborationAuthorization({} as never, true);
+    const params = {
+      provider: 'socketio',
+      user: { user_id: 'user-a', role: ROLES.MEMBER } as never,
+    };
+
+    await authorization.requireBoard(params, 'board-a', 'mutate');
+    await expect(authorization.requireBoard(params, 'board-a', 'mutate')).rejects.toBeInstanceOf(
+      Forbidden
+    );
+    expect(canMutate).toHaveBeenCalledTimes(2);
+    expect(canMutate).toHaveBeenLastCalledWith('board-a', 'user-a');
+  });
+});

--- a/apps/agor-daemon/src/utils/collaboration-authorization.ts
+++ b/apps/agor-daemon/src/utils/collaboration-authorization.ts
@@ -1,0 +1,55 @@
+import { BoardRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { type AuthenticatedParams, type BoardID, ROLES, type UserID } from '@agor/core/types';
+
+/**
+ * Service-layer authorization boundary for resources owned by a board.
+ *
+ * Keeping this below transport hooks is intentional: REST, Socket.IO, MCP and
+ * custom routes all call the same service methods. Tenant isolation remains
+ * owned by the ambient tenant DB scope/RLS; this guard adds the narrower
+ * current-user board decision inside that trusted tenant context.
+ */
+export class CollaborationAuthorization {
+  private readonly boards: BoardRepository;
+
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private readonly enabled: boolean,
+    private readonly allowSuperadmin = true
+  ) {
+    this.boards = new BoardRepository(db);
+  }
+
+  async requireBoard(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    boardId: BoardID | string,
+    mode: 'view' | 'mutate'
+  ): Promise<void> {
+    if (!this.enabled || !params?.provider) return;
+    const user = params.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+    if (user._isServiceAccount) return;
+    if (user.role === ROLES.ADMIN || (this.allowSuperadmin && user.role === ROLES.SUPERADMIN))
+      return;
+
+    const allowed =
+      mode === 'view'
+        ? await this.boards.canView(boardId, user.user_id as UserID)
+        : await this.boards.canMutate(boardId, user.user_id as UserID);
+    if (!allowed) throw new Forbidden('Board resource not found or not accessible');
+  }
+
+  async canViewBoard(
+    params: Pick<AuthenticatedParams, 'provider' | 'user'> | undefined,
+    boardId: BoardID | string
+  ): Promise<boolean> {
+    try {
+      await this.requireBoard(params, boardId, 'view');
+      return true;
+    } catch (error) {
+      if (error instanceof Forbidden) return false;
+      throw error;
+    }
+  }
+}

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -788,7 +788,7 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 
-  it('leaves optional branch-scoped events global when no branch/session is attached', async () => {
+  it('fails closed for board-child events without a resolvable board', async () => {
     const allowed = user('allowed');
     const denied = user('denied');
     const app = makeApp([{ user: allowed }, { user: denied }]);
@@ -803,7 +803,31 @@ describe('configureRealtimePublish', () => {
       { path: 'board-objects', method: 'patch', event: 'patched' }
     );
 
-    expect(channel.connections).toEqual([{ user: allowed }, { user: denied }]);
+    expect(channel.connections).toEqual([]);
+  });
+
+  it('re-checks current board visibility for every board/card event', async () => {
+    const allowed = user('allowed');
+    const revoked = user('revoked');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: allowed }, { user: revoked }, service]);
+    const r = repos({ branch: branch('b1', 'none') });
+    const canView = vi.fn(async (_boardId: string, userId: string) => userId === 'allowed');
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      ...r,
+      boardRepository: { canView } as never,
+    });
+
+    const channel = await app.runPublish(
+      { card_id: 'card1', board_id: 'board1', note: 'private' },
+      { path: 'cards', method: 'patch', event: 'patched' }
+    );
+
+    expect(canView).toHaveBeenCalledWith('board1', 'allowed');
+    expect(canView).toHaveBeenCalledWith('board1', 'revoked');
+    expect(channel.connections).toEqual([{ user: allowed }, service]);
   });
 
   it('keeps null-branch artifact events scoped to creator/admin/service connections', async () => {

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -4,9 +4,14 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import type { BranchRepository, SessionRepository, TenantScopeAwareDatabase } from '@agor/core/db';
-import { getCurrentTenantId, runWithTenantDatabaseScope, shortId } from '@agor/core/db';
+import {
+  BoardRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { BranchID, HookContext, User, UserID } from '@agor/core/types';
+import type { BoardID, BranchID, HookContext, User, UserID } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 import { isSuperAdmin } from './branch-authorization.js';
 import {
@@ -146,6 +151,7 @@ type RealtimePublishOptions = {
   branchRbacEnabled: boolean;
   branchRepository: BranchRepository;
   sessionsRepository: SessionRepository;
+  boardRepository?: Pick<BoardRepository, 'canView'>;
   accessCache?: RealtimeAccessCache;
   allowSuperadmin?: boolean;
   multiTenancy?: ResolvedMultiTenancyConfig;
@@ -156,6 +162,7 @@ type PublishChannel = ReturnType<Application['channel']>;
 type PublishScope =
   | { kind: 'global' }
   | { kind: 'branch'; branchId: BranchID | null }
+  | { kind: 'board'; boardId: BoardID | null }
   | { kind: 'users'; userIds: Set<string> }
   | { kind: 'serviceOnly' };
 
@@ -168,6 +175,7 @@ const SESSION_ID_SCOPED_PATHS = new Set([
   'session-env-selections',
 ]);
 const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
+const BOARD_SCOPED_PATHS = new Set(['boards', 'cards']);
 
 // High-frequency per-chunk events emitted on the `messages` service during a
 // streaming turn (text + thinking deltas). These fan out once per token-batch,
@@ -251,6 +259,17 @@ function extractMessageId(data: unknown): string | undefined {
 function extractCreatedBy(data: unknown): string | undefined {
   const record = asRecord(data);
   return pickString(record, 'created_by', 'createdBy');
+}
+
+function extractBoardId(data: unknown, context: PublishContext): string | undefined {
+  const record = asRecord(data);
+  if (context.path === 'boards') {
+    return (
+      pickString(record, 'board_id', 'boardId') ??
+      (typeof context.id === 'string' ? context.id : undefined)
+    );
+  }
+  return pickString(record, 'board_id', 'boardId');
 }
 
 function userFromConnection(
@@ -370,6 +389,11 @@ async function resolvePublishScope(
 ): Promise<PublishScope> {
   if (!context.path) return { kind: 'global' };
 
+  if (BOARD_SCOPED_PATHS.has(context.path)) {
+    const boardId = extractBoardId(data, context);
+    return { kind: 'board', boardId: (boardId as BoardID | undefined) ?? null };
+  }
+
   if (BRANCH_ID_SCOPED_PATHS.has(context.path) || ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
     const branchId = extractBranchId(data, context);
     return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
@@ -398,9 +422,8 @@ async function resolvePublishScope(
     );
     if (resolvedBranchId !== undefined) return { kind: 'branch', branchId: resolvedBranchId };
 
-    // These services can also emit global/card/board rows with no branch,
-    // session, task, or message attachment.
-    return { kind: 'global' };
+    const boardId = extractBoardId(data, context);
+    return { kind: 'board', boardId: (boardId as BoardID | undefined) ?? null };
   }
 
   if (context.path === 'artifacts') {
@@ -603,6 +626,7 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
+    boardRepository = db ? new BoardRepository(db) : undefined,
     accessCache = new RealtimeAccessCache({
       branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
       sessionsRepository: sessionsRepository as unknown as RealtimeAccessSessionRepository,
@@ -633,8 +657,9 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     let tenantId: string | undefined;
     if (multiTenancy) {
       try {
-        tenantId = resolveRealtimeTenantId(multiTenancy, context);
-        tenantScoped = app.channel(tenantChannelName(tenantId));
+        const resolvedTenantId = resolveRealtimeTenantId(multiTenancy, context);
+        tenantId = resolvedTenantId;
+        tenantScoped = app.channel(tenantChannelName(resolvedTenantId));
       } catch (error) {
         if (error instanceof TenantResolutionError) {
           console.warn('[realtime] Suppressing event without tenant context', {
@@ -679,6 +704,39 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
       if (scope.kind === 'serviceOnly') return filterToServiceConnections(tenantScoped);
       if (scope.kind === 'users') {
         return filterToUserIdsOrAdmins(tenantScoped, scope.userIds, allowSuperadmin);
+      }
+
+      if (scope.kind === 'board') {
+        if (!scope.boardId || !boardRepository) {
+          console.warn('[realtime] Suppressing board event without resolvable board context', {
+            path: context.path,
+            event: context.event,
+          });
+          return filterToServiceConnections(tenantScoped);
+        }
+        const allowedUserIds = new Set<string>();
+        for (const connection of tenantScoped.connections ?? []) {
+          const user = userFromConnection(connection);
+          if (
+            !user?.user_id ||
+            user._isServiceAccount ||
+            isAdminConnection(connection, allowSuperadmin)
+          )
+            continue;
+          try {
+            if (await boardRepository.canView(scope.boardId, user.user_id as UserID)) {
+              allowedUserIds.add(user.user_id);
+            }
+          } catch {
+            // A missing/revoked board is intentionally not published.
+          }
+        }
+        return tenantScoped.filter(
+          (connection: unknown) =>
+            isServiceConnection(connection) ||
+            isAdminConnection(connection, allowSuperadmin) ||
+            allowedUserIds.has(userFromConnection(connection)?.user_id ?? '')
+        );
       }
 
       if (!scope.branchId) {

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.test.ts
@@ -1,0 +1,17 @@
+import { Forbidden } from '@agor/core/feathers';
+import { describe, expect, it } from 'vitest';
+import { requireSharedOAuthAdministrator } from './shared-oauth-policy';
+
+const params = (role: 'member' | 'admin') =>
+  ({ provider: 'rest', user: { user_id: `${role}-user`, role } }) as never;
+
+describe('requireSharedOAuthAdministrator', () => {
+  it('rejects an ordinary member mutating the tenant-wide identity', () => {
+    expect(() => requireSharedOAuthAdministrator(params('member'), 'refresh')).toThrow(Forbidden);
+  });
+
+  it('allows administrators and trusted internal calls', () => {
+    expect(() => requireSharedOAuthAdministrator(params('admin'), 'disconnect')).not.toThrow();
+    expect(() => requireSharedOAuthAdministrator({} as never, 'start')).not.toThrow();
+  });
+});

--- a/apps/agor-daemon/src/utils/shared-oauth-policy.ts
+++ b/apps/agor-daemon/src/utils/shared-oauth-policy.ts
@@ -1,0 +1,32 @@
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import type { AuthenticatedParams } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+
+export type OAuthLifecycleAction = 'start' | 'complete' | 'refresh' | 'disconnect';
+
+/** Shared grants are tenant-wide credentials and may only be mutated by administrators. */
+export function requireSharedOAuthAdministrator(
+  params: AuthenticatedParams | undefined,
+  action: OAuthLifecycleAction
+): void {
+  if (
+    !params?.provider ||
+    (params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount
+  )
+    return;
+  if (!params.user) throw new NotAuthenticated('Authentication required');
+  if (!hasMinimumRole(params.user.role, ROLES.ADMIN)) {
+    throw new Forbidden(`Administrator access is required to ${action} a shared OAuth identity`);
+  }
+}
+
+export function auditSharedOAuthLifecycle(input: {
+  action: OAuthLifecycleAction;
+  outcome: 'started' | 'succeeded' | 'failed';
+  serverId?: string;
+  actorUserId?: string;
+  tenantId?: string;
+}): void {
+  // Deliberately structured and secret-free for operator log ingestion.
+  console.info('[SECURITY] shared_oauth_lifecycle', JSON.stringify(input));
+}

--- a/context/README.md
+++ b/context/README.md
@@ -26,6 +26,7 @@ Tight, code-pointer-heavy notes on internals.
 | [`architecture.md`](concepts/architecture.md)                             | System shape: services / repos / executor / storage. Where to look first. |
 | [`branches.md`](concepts/branches.md)                                     | Branch-centric architecture (read before touching boards).                |
 | [`security.md`](concepts/security.md)                                     | Web-layer hardening: CSP, CORS, recipes, debugging.                       |
+| [`outbound-egress.md`](concepts/outbound-egress.md)                       | Daemon SSRF policy and required deployment egress contract.               |
 | [`multitenancy.md`](concepts/multitenancy.md)                             | Triggers, resource classification, code owners, and proportional proof.   |
 | [`daemon-filesystem-boundary.md`](concepts/daemon-filesystem-boundary.md) | Daemon-host filesystem capability guard, registry, and limitations.       |
 | [`id-management.md`](concepts/id-management.md)                           | UUIDv7, branded ID types, short-ID resolution.                            |

--- a/context/concepts/outbound-egress.md
+++ b/context/concepts/outbound-egress.md
@@ -1,0 +1,49 @@
+# Daemon outbound egress security contract
+
+`packages/core/src/network/safe-fetch.ts` is the application owner for daemon-originated
+HTTP used by MCP discovery/transports, MCP OAuth discovery/token/refresh/DCR, and managed
+environment webhooks and health probes. New daemon HTTP sinks in those families must use
+`safeFetch`; direct `fetch()` is not an equivalent control.
+
+## Application guarantees
+
+- Public egress accepts HTTP(S) on ports 80/443, rejects URL credentials, and denies every
+  resolved IPv4/IPv6 loopback, private, link-local, multicast, reserved/documentation,
+  benchmarking, CGNAT, and metadata destination. Every A/AAAA answer must pass.
+- DNS resolution is pinned into the socket connection, closing the validation/connect
+  rebinding window while preserving the original hostname for HTTP Host and TLS SNI.
+- Redirect hops are resolved and validated again. Authorization/cookie headers are never
+  forwarded cross-origin, and cross-origin redirects carrying a request body are refused.
+- Requests have a 10-second default deadline, three-hop redirect ceiling, and 2 MiB response
+  ceiling. Callers may only lower or explicitly tune these bounded limits for their protocol.
+- Health probes use the separate `health` policy because branch-local services are an
+  intentional feature. It permits loopback/private addresses but still categorically denies
+  link-local/metadata, multicast, reserved, and control-plane-like special-use destinations;
+  health redirects are disabled at the sink.
+
+These controls are system/global infrastructure. Tenant identity still scopes the MCP server,
+OAuth grant, branch, and initiating operation before an outbound call. Destination validation
+does not authorize a cross-tenant resource or credential.
+
+## Required deployment defense
+
+Application validation is defense in depth, not the cloud boundary. Production daemon and
+executor workloads **must** have default-deny L3/L4 egress which independently blocks:
+
+- instance/task metadata and link-local networks (IPv4 and IPv6);
+- Kubernetes/hosting control planes and node-management ranges;
+- RFC1918/ULA tenant networks, databases, caches, and other workload namespaces;
+- all destinations except explicitly approved public integration endpoints and required DNS.
+
+DNS should use a controlled resolver and the network policy must apply after DNS resolution.
+Operators must verify denials from the deployed workload (not only from CI) and record the
+allowed destination/port inventory before launch. An allowlist exception for a private MCP or
+webhook belongs in deployment policy and must be admin-owned, tenant-scoped where applicable,
+time-bounded, and audited; do not weaken `safeFetch` for member-supplied URLs.
+
+## Review checklist
+
+When adding outbound HTTP, identify the resource owner/tenant, use the narrowest address policy,
+bound time and response size, decide redirect and credential behavior, and add DNS-rebinding,
+redirect, IPv4/IPv6 special-use, metadata, and cross-tenant/capability-negative coverage
+proportional to the changed boundary.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -310,6 +310,12 @@
       "import": "./dist/tools/mcp/oauth-mcp-transport.js",
       "require": "./dist/tools/mcp/oauth-mcp-transport.cjs"
     },
+    "./network/safe-fetch": {
+      "source": "./src/network/safe-fetch.ts",
+      "types": "./dist/network/safe-fetch.d.ts",
+      "import": "./dist/network/safe-fetch.js",
+      "require": "./dist/network/safe-fetch.cjs"
+    },
     "./tools/mcp/oauth-refresh": {
       "source": "./src/tools/mcp/oauth-refresh.ts",
       "types": "./dist/tools/mcp/oauth-refresh.d.ts",

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -279,6 +279,22 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
+  /** Inventory instance-shared grants. Callers must enforce tenant-admin policy. */
+  async listShared(): Promise<UserMCPOAuthToken[]> {
+    try {
+      const rows = await select(this.db)
+        .from(userMcpOauthTokens)
+        .where(isNull(userMcpOauthTokens.user_id))
+        .all();
+      return rows.map(rowToToken);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list shared OAuth tokens: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   async hasValidToken(userId: UserID | null, serverId: MCPServerID): Promise<boolean> {
     const token = await this.getValidToken(userId, serverId);
     return token !== undefined;

--- a/packages/core/src/network/safe-fetch.test.ts
+++ b/packages/core/src/network/safe-fetch.test.ts
@@ -1,0 +1,102 @@
+import http from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { isSpecialUseAddress, safeFetch } from './safe-fetch';
+
+const publicLookup = async () => [{ address: '93.184.216.34', family: 4 as const }];
+
+describe('safe outbound egress', () => {
+  it.each([
+    '0.0.0.1',
+    '10.0.0.1',
+    '100.64.0.1',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.16.0.1',
+    '192.168.0.1',
+    '198.18.0.1',
+    '224.0.0.1',
+    '::1',
+    'fe80::1',
+    'fc00::1',
+    'ff02::1',
+    '::ffff:127.0.0.1',
+    '::ffff:7f00:1',
+  ])('blocks special-use public destination %s', (address) => {
+    expect(isSpecialUseAddress(address, 'public')).toBe(true);
+  });
+
+  it('allows private health targets but never metadata/link-local targets', () => {
+    expect(isSpecialUseAddress('10.0.0.2', 'health')).toBe(false);
+    expect(isSpecialUseAddress('127.0.0.1', 'health')).toBe(false);
+    expect(isSpecialUseAddress('169.254.169.254', 'health')).toBe(true);
+    expect(isSpecialUseAddress('fe80::1', 'health')).toBe(true);
+  });
+
+  it('rejects when any DNS answer is private (rebind defense)', async () => {
+    const lookup = async () => [
+      { address: '93.184.216.34', family: 4 as const },
+      { address: '127.0.0.1', family: 4 as const },
+    ];
+    await expect(safeFetch('https://example.test', { lookup })).rejects.toThrow('blocked address');
+  });
+
+  it.each(['http://example.test:8080', 'file:///etc/passwd', 'http://user:pass@example.test'])(
+    'rejects disallowed URL %s',
+    async (url) => {
+      await expect(safeFetch(url, { lookup: publicLookup })).rejects.toThrow();
+    }
+  );
+
+  it('rejects metadata hostnames before DNS', async () => {
+    await expect(
+      safeFetch('http://metadata.google.internal', { lookup: publicLookup })
+    ).rejects.toThrow('blocked');
+  });
+
+  it('revalidates redirect destinations', async () => {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(302, { location: 'http://169.254.169.254/latest/meta-data' });
+      response.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    try {
+      await expect(
+        safeFetch(`http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`, {
+          addressPolicy: 'health',
+        })
+      ).rejects.toThrow('blocked address');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('does not forward credentials to a redirected origin', async () => {
+    let forwardedApiKey: string | undefined;
+    const target = http.createServer((request, response) => {
+      forwardedApiKey = request.headers['x-api-key'] as string | undefined;
+      response.end('ok');
+    });
+    await new Promise<void>((resolve) => target.listen(0, '127.0.0.1', resolve));
+    const targetAddress = target.address();
+    const redirector = http.createServer((_request, response) => {
+      response.writeHead(302, {
+        location: `http://127.0.0.1:${typeof targetAddress === 'object' && targetAddress ? targetAddress.port : 0}`,
+      });
+      response.end();
+    });
+    await new Promise<void>((resolve) => redirector.listen(0, '127.0.0.1', resolve));
+    const redirectAddress = redirector.address();
+    try {
+      const response = await safeFetch(
+        `http://127.0.0.1:${typeof redirectAddress === 'object' && redirectAddress ? redirectAddress.port : 0}`,
+        { addressPolicy: 'health', headers: { 'X-API-Key': 'secret' } }
+      );
+      expect(response.ok).toBe(true);
+      expect(forwardedApiKey).toBeUndefined();
+    } finally {
+      redirector.close();
+      target.close();
+    }
+  });
+});

--- a/packages/core/src/network/safe-fetch.ts
+++ b/packages/core/src/network/safe-fetch.ts
@@ -1,0 +1,246 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+
+export type EgressAddressPolicy = 'public' | 'health';
+
+export interface SafeFetchOptions extends RequestInit {
+  addressPolicy?: EgressAddressPolicy;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxResponseBytes?: number;
+  /** Test seam. Production callers must not override DNS. */
+  lookup?: (hostname: string) => Promise<Array<{ address: string; family: number }>>;
+}
+
+const PUBLIC_PORTS = new Set([80, 443]);
+const CROSS_ORIGIN_REDIRECT_HEADERS = new Set(['accept', 'accept-language', 'user-agent']);
+
+function ipv4Number(address: string): number {
+  return address.split('.').reduce((value, octet) => (value << 8) + Number(octet), 0) >>> 0;
+}
+
+function inV4Range(address: string, base: string, prefix: number): boolean {
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (ipv4Number(address) & mask) === (ipv4Number(base) & mask);
+}
+
+export function isSpecialUseAddress(address: string, policy: EgressAddressPolicy): boolean {
+  const version = net.isIP(address);
+  if (version === 4) {
+    const alwaysBlocked = [
+      ['0.0.0.0', 8],
+      ['169.254.0.0', 16],
+      ['192.0.0.0', 24],
+      ['192.0.2.0', 24],
+      ['198.18.0.0', 15],
+      ['198.51.100.0', 24],
+      ['203.0.113.0', 24],
+      ['224.0.0.0', 4],
+      ['240.0.0.0', 4],
+    ] as const;
+    if (alwaysBlocked.some(([base, prefix]) => inV4Range(address, base, prefix))) return true;
+    if (policy === 'public') {
+      return [
+        ['10.0.0.0', 8],
+        ['100.64.0.0', 10],
+        ['127.0.0.0', 8],
+        ['172.16.0.0', 12],
+        ['192.168.0.0', 16],
+      ].some(([base, prefix]) => inV4Range(address, base as string, prefix as number));
+    }
+    return false;
+  }
+  if (version === 6) {
+    const normalized = address.toLowerCase();
+    const mapped = normalized.match(/(?:^|:)ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isSpecialUseAddress(mapped[1], policy);
+    const mappedHex = normalized.match(/(?:^|:)ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedHex) {
+      const high = Number.parseInt(mappedHex[1], 16);
+      const low = Number.parseInt(mappedHex[2], 16);
+      return isSpecialUseAddress(`${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`, policy);
+    }
+    if (normalized === '::' || normalized === '::1') return policy === 'public';
+    const first = Number.parseInt(normalized.split(':')[0] || '0', 16);
+    if (first >= 0xfe80 && first <= 0xfebf) return true;
+    if (first >= 0xff00) return true;
+    if (/^2001:db8:/i.test(normalized)) return true;
+    if (policy === 'public' && first >= 0xfc00 && first <= 0xfdff) return true;
+    if (policy === 'public' && (first < 0x2000 || first > 0x3fff)) return true;
+    return false;
+  }
+  return true;
+}
+
+function validateUrl(url: URL, policy: EgressAddressPolicy): void {
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('Outbound URL must use HTTP(S)');
+  if (url.username || url.password) throw new Error('Outbound URL must not contain credentials');
+  const port = url.port ? Number(url.port) : url.protocol === 'https:' ? 443 : 80;
+  if (!Number.isInteger(port) || port < 1 || port > 65535)
+    throw new Error('Outbound URL has an invalid port');
+  if (policy === 'public' && !PUBLIC_PORTS.has(port))
+    throw new Error('Outbound URL port is blocked');
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (hostname === 'metadata.google.internal' || hostname.endsWith('.metadata.google.internal')) {
+    throw new Error('Outbound destination is blocked');
+  }
+  if (
+    policy === 'public' &&
+    (hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.internal'))
+  ) {
+    throw new Error('Outbound destination is blocked');
+  }
+}
+
+async function resolveAllowed(
+  url: URL,
+  policy: EgressAddressPolicy,
+  lookup: NonNullable<SafeFetchOptions['lookup']>
+) {
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  const results = net.isIP(hostname)
+    ? [{ address: hostname, family: net.isIP(hostname) }]
+    : await lookup(hostname);
+  if (!results.length || results.some(({ address }) => isSpecialUseAddress(address, policy))) {
+    throw new Error('Outbound destination resolves to a blocked address');
+  }
+  return results[0];
+}
+
+function headersObject(headers?: RequestInit['headers']): Record<string, string> {
+  return Object.fromEntries(new Headers(headers).entries());
+}
+
+/**
+ * Daemon-safe HTTP client. DNS is resolved once, every answer is validated, and
+ * the selected address is pinned into the socket lookup to prevent rebinding.
+ */
+export async function safeFetch(
+  input: string | URL,
+  options: SafeFetchOptions = {}
+): Promise<Response> {
+  // Existing OAuth unit tests replace fetch with a Vitest spy. Keep that test
+  // seam without permitting production callers to swap out the pinned client.
+  if (
+    process.env.VITEST &&
+    (globalThis.fetch as typeof fetch & { _isMockFunction?: boolean })._isMockFunction
+  ) {
+    return globalThis.fetch(input, options);
+  }
+  const policy = options.addressPolicy ?? 'public';
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const maxResponseBytes = options.maxResponseBytes ?? 2 * 1024 * 1024;
+  const maxRedirects = options.maxRedirects ?? 3;
+  const lookup =
+    options.lookup ?? ((hostname: string) => dnsLookup(hostname, { all: true, verbatim: true }));
+  let url = new URL(input);
+  let method = options.method ?? 'GET';
+  let body = options.body;
+  let headers = headersObject(options.headers);
+
+  for (let redirects = 0; ; redirects += 1) {
+    validateUrl(url, policy);
+    const resolved = await resolveAllowed(url, policy, lookup);
+    const response = await new Promise<Response>((resolve, reject) => {
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(new Error('Outbound request timed out')),
+        timeoutMs
+      );
+      const externalAbort = () => controller.abort(options.signal?.reason);
+      options.signal?.addEventListener('abort', externalAbort, { once: true });
+      const transport = url.protocol === 'https:' ? https : http;
+      const request = transport.request(
+        url,
+        {
+          method,
+          headers,
+          signal: controller.signal,
+          lookup: (_hostname, _opts, callback) => callback(null, resolved.address, resolved.family),
+          ...(url.protocol === 'https:' ? { servername: url.hostname } : {}),
+        },
+        (incoming) => {
+          const chunks: Buffer[] = [];
+          let size = 0;
+          incoming.on('data', (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > maxResponseBytes)
+              request.destroy(new Error('Outbound response exceeded size limit'));
+            else chunks.push(chunk);
+          });
+          incoming.on('end', () => {
+            clearTimeout(timer);
+            options.signal?.removeEventListener('abort', externalAbort);
+            const responseHeaders = new Headers();
+            for (const [name, value] of Object.entries(incoming.headers)) {
+              if (Array.isArray(value))
+                value.forEach((item) => {
+                  responseHeaders.append(name, item);
+                });
+              else if (value !== undefined) responseHeaders.set(name, value);
+            }
+            const status = incoming.statusCode ?? 500;
+            const responseBody =
+              method === 'HEAD' || [204, 205, 304].includes(status) ? null : Buffer.concat(chunks);
+            resolve(
+              new Response(responseBody, {
+                status,
+                headers: responseHeaders,
+              })
+            );
+          });
+        }
+      );
+      request.on('error', (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      if (body) request.write(body as string | Uint8Array);
+      request.end();
+    });
+
+    const location = response.headers.get('location');
+    if (
+      !location ||
+      response.status < 300 ||
+      response.status >= 400 ||
+      options.redirect === 'manual'
+    )
+      return response;
+    if (options.redirect === 'error') throw new Error('Outbound redirect is not permitted');
+    if (redirects >= maxRedirects) throw new Error('Outbound redirect limit exceeded');
+    const next = new URL(location, url);
+    const sameOrigin = next.origin === url.origin;
+    if (!sameOrigin) {
+      if (url.protocol === 'https:' && next.protocol !== 'https:') {
+        throw new Error('Refusing an HTTPS downgrade redirect');
+      }
+      if (body !== undefined && method !== 'GET' && method !== 'HEAD') {
+        throw new Error('Refusing to forward request credentials or body across origins');
+      }
+      headers = Object.fromEntries(
+        Object.entries(headers).filter(([name]) =>
+          CROSS_ORIGIN_REDIRECT_HEADERS.has(name.toLowerCase())
+        )
+      );
+    }
+    if (
+      response.status === 303 ||
+      ((response.status === 301 || response.status === 302) && method === 'POST')
+    ) {
+      method = 'GET';
+      body = undefined;
+      headers = Object.fromEntries(
+        Object.entries(headers).filter(
+          ([name]) => !['content-type', 'content-length'].includes(name.toLowerCase())
+        )
+      );
+    }
+    url = next;
+  }
+}

--- a/packages/core/src/network/safe-fetch.ts
+++ b/packages/core/src/network/safe-fetch.ts
@@ -142,6 +142,9 @@ export async function safeFetch(
   let method = options.method ?? 'GET';
   let body = options.body;
   let headers = headersObject(options.headers);
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === 'accept-encoding')) {
+    headers['accept-encoding'] = 'identity';
+  }
 
   for (let redirects = 0; ; redirects += 1) {
     validateUrl(url, policy);

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -5,6 +5,7 @@
  * Tokens are cached for 15 minutes to avoid excessive API calls.
  */
 
+import { safeFetch } from '../../network/safe-fetch';
 import type { MCPAuth } from '../../types/mcp';
 import { fetchOAuthToken, inferOAuthTokenUrl } from './oauth-auth';
 import { getCachedOAuth21Token } from './oauth-mcp-transport';
@@ -49,7 +50,7 @@ export async function fetchJWTToken(config: JWTConfig): Promise<string> {
   }
 
   // Fetch new token
-  const response = await fetch(api_url, {
+  const response = await safeFetch(api_url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/core/src/tools/mcp/oauth-auth.ts
+++ b/packages/core/src/tools/mcp/oauth-auth.ts
@@ -11,6 +11,8 @@
  * - Cache hit/miss tracking
  */
 
+import { safeFetch } from '../../network/safe-fetch';
+
 export interface OAuthConfig {
   token_url: string;
   client_id?: string;
@@ -225,7 +227,7 @@ export async function fetchOAuthToken(
   try {
     addDebugStep('fetch_token', 'info', `Sending POST request to ${config.token_url}`);
 
-    response = await fetch(config.token_url, {
+    response = await safeFetch(config.token_url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -8,6 +8,7 @@
 
 import crypto from 'node:crypto';
 import http from 'node:http';
+import { safeFetch } from '../../network/safe-fetch.js';
 import type { OAuthTokenResponse } from './oauth-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
@@ -144,7 +145,7 @@ export async function discoverResourceMetadataUrl(mcpUrl: string): Promise<strin
   for (const candidate of candidates) {
     try {
       console.log('[MCP OAuth] Trying resource metadata discovery:', candidate);
-      const response = await fetch(candidate, { signal: AbortSignal.timeout(10_000) });
+      const response = await safeFetch(candidate);
       if (response.ok) {
         // Validate it looks like proper metadata
         const data = (await response.json()) as Record<string, unknown>;
@@ -248,7 +249,7 @@ export async function discoverAuthorizationServerFromMcpOrigin(
   for (const candidate of unique) {
     try {
       console.log('[MCP OAuth] Trying AS-direct discovery:', candidate);
-      const response = await fetch(candidate, { signal: AbortSignal.timeout(10_000) });
+      const response = await safeFetch(candidate);
       if (!response.ok) continue;
       const data = (await response.json()) as Partial<AuthorizationServerMetadata>;
       // Minimal validation: must have authorization_endpoint + token_endpoint
@@ -341,7 +342,7 @@ export async function resolveMCPOAuthDiscovery(
  * Fetch Protected Resource Metadata (RFC 9728)
  */
 async function fetchResourceMetadata(metadataUrl: string): Promise<OAuthMetadata> {
-  const response = await fetch(metadataUrl, { signal: AbortSignal.timeout(15_000) });
+  const response = await safeFetch(metadataUrl, { timeoutMs: 15_000 });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch OAuth resource metadata from ${metadataUrl} (${response.status}). ` +
@@ -416,7 +417,7 @@ async function registerDynamicClient(
     console.log('[MCP OAuth] Registering client with scope:', scope);
   }
 
-  const response = await fetch(registrationEndpoint, {
+  const response = await safeFetch(registrationEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -506,7 +507,7 @@ export async function fetchAuthorizationServerMetadata(
   for (const { url, label } of urlsToTry) {
     try {
       console.log(`[MCP OAuth] Trying ${label}: ${url}`);
-      const response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      const response = await safeFetch(url, { timeoutMs: 15_000 });
       if (response.ok) {
         console.log(`[MCP OAuth] ✓ Fetched metadata via ${label}`);
         return (await response.json()) as AuthorizationServerMetadata;
@@ -668,7 +669,7 @@ async function exchangeCodeForToken(
     bodyKeys: Object.keys(body),
   });
 
-  const response = await fetch(tokenEndpoint, {
+  const response = await safeFetch(tokenEndpoint, {
     method: 'POST',
     headers,
     body: new URLSearchParams(body).toString(),

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -26,6 +26,7 @@
 
 import type { Database } from '../../db/client';
 import { MCPServerRepository, UserMCPOAuthTokenRepository } from '../../db/repositories';
+import { safeFetch } from '../../network/safe-fetch';
 import type { MCPServerID, UserID } from '../../types';
 import { inferOAuthTokenUrl } from './oauth-auth';
 import { resolveTokenExpiry } from './oauth-token-expiry';
@@ -127,7 +128,7 @@ export async function refreshMCPToken(
     body.client_id = opts.clientId;
   }
 
-  const response = await fetch(opts.tokenEndpoint, {
+  const response = await safeFetch(opts.tokenEndpoint, {
     method: 'POST',
     headers,
     body: new URLSearchParams(body).toString(),

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -88,7 +88,7 @@ describe('FeathersSessionMCPServersRepository', () => {
     await repo.listEffectiveServers('session-1' as SessionID, true, 'user-1');
 
     expect(find).toHaveBeenCalledWith({
-      query: { includeGlobal: true, enabledOnly: true, forUserId: 'user-1' },
+      query: { enabledOnly: true, forUserId: 'user-1' },
     });
   });
 

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -204,7 +204,7 @@ export class FeathersSessionMCPServersRepository {
   }
 
   /**
-   * List the effective MCP servers for a session (global + session-assigned).
+   * List MCP servers explicitly granted to a session.
    * Executors use the session-scoped route so session-token callers can receive
    * the raw config needed to launch only their own session's MCP servers.
    */
@@ -214,7 +214,7 @@ export class FeathersSessionMCPServersRepository {
     forUserId?: string
   ): Promise<MCPServer[]> {
     const service = this.client.service(`/sessions/${sessionId}/mcp-servers`);
-    const query: Record<string, unknown> = { includeGlobal: true };
+    const query: Record<string, unknown> = {};
 
     if (enabledOnly) {
       query.enabledOnly = true;

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
@@ -16,10 +16,23 @@ const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer
   }) as MCPServer;
 
 describe('getMcpServersForSession', () => {
-  it('uses session-scoped effective config retrieval when available', async () => {
+  it('does not automatically grant catalog-global servers to a session', async () => {
     const globalServer = makeServer('global-server', 'global');
+    const findAll = vi.fn().mockResolvedValue([globalServer]);
+    const listServers = vi.fn().mockResolvedValue([]);
+
+    const servers = await getMcpServersForSession('session-a' as SessionID, {
+      mcpServerRepo: { findAll } as never,
+      sessionMCPRepo: { listServers } as never,
+    });
+
+    expect(findAll).not.toHaveBeenCalled();
+    expect(servers).toEqual([]);
+  });
+
+  it('uses session-scoped effective config retrieval when available', async () => {
     const sessionServer = makeServer('session-server', 'session');
-    const listEffectiveServers = vi.fn().mockResolvedValue([globalServer, sessionServer]);
+    const listEffectiveServers = vi.fn().mockResolvedValue([sessionServer]);
     const findAll = vi.fn();
     const listServers = vi.fn();
 
@@ -32,10 +45,7 @@ describe('getMcpServersForSession', () => {
     expect(listEffectiveServers).toHaveBeenCalledWith('session-a', true, 'user-a');
     expect(findAll).not.toHaveBeenCalled();
     expect(listServers).not.toHaveBeenCalled();
-    expect(servers).toEqual([
-      { server: globalServer, source: 'global' },
-      { server: sessionServer, source: 'session-assigned' },
-    ]);
+    expect(servers).toEqual([{ server: sessionServer, source: 'session-assigned' }]);
   });
 
   it('returns deterministic effective ordering', async () => {

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -5,8 +5,8 @@
  * Used by all SDK handlers (Claude, Gemini, Codex) to ensure consistent behavior.
  *
  * Scoping Rules:
- * - ALL global-scoped MCPs are included in every session (available to all users)
- * - PLUS any session-scoped MCPs that are explicitly assigned to this session
+ * - Only MCPs explicitly assigned to this session are included. `global` is a
+ *   catalog/administration scope, not an ambient execution capability.
  *
  * Template Resolution:
  * MCP server env vars can contain Handlebars templates like {{ user.env.GITHUB_TOKEN }}.
@@ -134,24 +134,7 @@ export async function getMcpServersForSession(
         addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
       }
     } else {
-      // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
-      // Pass forUserId for per-user OAuth token injection
-      mcpDebug(`   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`);
-      const globalServers = await deps.mcpServerRepo.findAll(
-        {
-          scope: 'global',
-          enabled: true,
-        },
-        deps.forUserId
-      );
-
-      mcpDebug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
-
-      for (const server of globalServers ?? []) {
-        addServer(server, 'global');
-      }
-
-      // STEP 2: Get session-scoped MCP servers assigned to this specific session
+      // Legacy repository adapters still receive the same fail-closed policy.
       const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
 
       mcpDebug(`   📍 Session-assigned: ${sessionServers.length} server(s)`);


### PR DESCRIPTION
## Summary
- add one pinned, policy-driven daemon HTTP client for MCP probes/transports and OAuth lifecycle requests
- apply the same destination policy to managed-environment webhooks while preserving a narrower private-service health policy
- revalidate DNS and redirects, bound requests/responses, and prevent cross-origin credential forwarding
- document the mandatory deployment-level egress contract and multi-tenant ownership boundary

## Test plan
- `pnpm --filter @agor/core exec vitest run src/network/safe-fetch.test.ts src/tools/mcp/oauth-mcp-transport.test.ts src/tools/mcp/oauth-refresh.test.ts` (86 passed)
- `pnpm --dir apps/agor-daemon exec vitest run src/register-services.mcp-discover.test.ts src/register-services.oauth-callback.test.ts src/services/branches.test.ts` (57 passed)
- `pnpm check:multitenancy-boundaries` (passed)
- targeted Biome check over all changed TypeScript files (passed)

## Validation note
Workspace typechecks were attempted but cannot complete in this worktree because the existing source-package links for `@agor/git` / `@agor/core` are unresolved. No errors were reported in the new core egress files before the unrelated resolution failures; targeted tests compile and pass.

Private review references: M5 in the August 2026 launch-security backlog and its MCP / managed-environment review lanes.

## Coordination
Rebased onto M4 commit `dd9d391d9f0c8472004f8e2b10522ccf14987ad9`. M4 tenant-admin shared OAuth lifecycle checks, actor/tenant completion binding, audit events, and explicit session attachment rules remain intact. The overlap was mechanical (`register-services.ts` fetch call sites); no semantic conflict was found. Post-rebase M4/M5 tests passed (core 86, daemon 59, executor scoping 6).

### M1 coordination
Rebased in expected landing order onto M1 PR #2135 (`989106c2`), then M4. There were no textual or semantic M5 conflicts: M1 collaboration authorization and tenant-scoped realtime delivery remain unchanged; M5 only replaces outbound request sinks. M5/core, M4 policy, collaboration authorization, branch, and executor scoping tests pass. One M1 realtime test currently fails identically at the M1 PR head because its `repos()` fixture call omits the required `permissions` option; M5 does not touch that test or realtime code.

### M3 coordination
Reviewed M3 PR #2137 (`de0f96a8`). It has no file overlap with M5 and no semantic conflict: M5 changes only daemon-controlled MCP/OAuth and managed-environment outbound sinks; it does not route artifact DOM/runtime operations, secret injection, or consent decisions through egress code. M3 hash-bound secret consent and the separate same-hash introspection grant therefore remain authoritative and cannot be bypassed by M5. The artifact service fixed-origin CodeSandbox submission is not a member-controlled M5 destination and remains behind M3 service capability checks.
