### PR TITLE
security: make artifact secret and introspection consent explicit

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -121,12 +121,12 @@ DECLARATIVE CONFIG:
     \`agor_board_id: true\`   → \`AGOR_BOARD_ID\` (informational, no consent).
 - \`sandpackConfig\`: author-controlled SandpackProvider config (template, customSetup, theme, options). Sanitized on write — UI-affecting / private-account props are stripped.
 
-CONSENT MODEL (TOFU): when the viewer is NOT the artifact author, the daemon does NOT inject env vars or grants without an explicit trust grant. Untrusted artifacts render with empty env values and a "Trust to render with secrets" badge.
+CONSENT MODEL: authorship never grants secret access. The daemon injects env vars or sensitive grants only after the viewer explicitly consents to the exact render-affecting artifact hash. Untrusted or changed artifacts render with empty env values and a "Trust to render with secrets" badge.
 
 SYNCHRONOUS-ISH VALIDATION: pass \`waitForStatus: true\` to wait briefly for YOUR browser render to report Sandpack boot status, errors, and console output. This is not a headless/server build: Sandpack runs in the browser, and logs are per-viewer to avoid leaking secret-derived output. If no browser tab for you is viewing the artifact, the validation returns \`observed:false\` with a note instead of pretending success.
 
 IMPORTANT:
-- Secret VALUES are never sent to the LLM as-is — they're only injected into the served \`.env\` at view time. CAVEAT: if your artifact renders a secret-derived value into the DOM (e.g. \`<div>API: {key}</div>\`), an agent calling \`agor_artifacts_query_dom\` against your own running render WILL see the rendered text. Treat any \`agor_artifacts_query_*\` reply as potentially carrying secret-derived output if the artifact renders one.
+- Secret VALUES are injected only after explicit hash-bound consent. DOM/document and console output remain unavailable to agents unless the viewer separately consents to introspection for that same hash.
 - Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
 - For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1200,7 +1200,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       '/artifacts/:id/trust',
       {
         async create(
-          data: { scopeType: import('@agor/core/types').ArtifactTrustScopeType },
+          data: {
+            scopeType: import('@agor/core/types').ArtifactTrustScopeType;
+            allowIntrospection?: boolean;
+          },
           _params: RouteParams
         ) {
           const artifactId = _params.route?.id;
@@ -1217,6 +1220,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             userId,
             artifactId,
             scopeType: data.scopeType,
+            allowIntrospection: data.allowIntrospection === true,
           });
         },
       },

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -504,35 +504,66 @@ describe('ArtifactsService.getPayload trust + .env synthesis', () => {
     }
   );
 
-  // Seed an artifact whose `created_by` is the author. The payload's trust
-  // resolution should treat the author as 'self' and skip consent.
-  dbTest('viewer-is-author → trust_state=self, .env injected', async ({ db }) => {
+  dbTest('content changes invalidate an artifact-scoped secret grant', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
+    await seedUser(db, 'viewer-1');
     const artifactRepo = new ArtifactRepository(db);
     const created = await artifactRepo.create({
       artifact_id: generateId(),
       board_id: board.board_id,
-      name: 'self-render',
+      name: 'version-bound',
       template: 'react',
-      files: { '/index.js': 'console.log("self")', '/package.json': '{}' },
-      required_env_vars: ['OPENAI_KEY'],
+      files: { '/index.js': 'export default 1' },
+      required_env_vars: ['FAKE_LAUNCH_SECRET'],
       public: true,
-      created_by: 'user-owner',
+      created_by: 'viewer-1',
+    });
+    await service.grantTrust({
+      userId: 'viewer-1',
+      artifactId: created.artifact_id,
+      scopeType: 'artifact',
+    });
+    await artifactRepo.update(created.artifact_id, {
+      files: { '/index.js': 'document.body.textContent = import.meta.env.VITE_FAKE_LAUNCH_SECRET' },
     });
 
-    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
-    expect(payload.trust_state).toBe('self');
-    expect(payload.trust_scope).toBe('self');
-    // .env is synthesized even though the user has no env var stored — value is empty.
-    // `react` template is CRA-backed, so the prefix is `REACT_APP_`.
-    expect(payload.files['/.env']).toMatch(/REACT_APP_OPENAI_KEY=/);
+    const payload = await service.getPayload(created.artifact_id, 'viewer-1' as never);
+    expect(payload.trust_state).toBe('untrusted');
+    expect(payload.files['/.env']).not.toContain('FAKE_LAUNCH_SECRET=fake-secret-value');
   });
+
+  dbTest(
+    'viewer-is-author still renders without secrets until explicitly consented',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'self-render',
+        template: 'react',
+        files: { '/index.js': 'console.log("self")', '/package.json': '{}' },
+        required_env_vars: ['OPENAI_KEY'],
+        public: true,
+        created_by: 'user-owner',
+      });
+
+      const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+      expect(payload.trust_state).toBe('untrusted');
+      expect(payload.trust_scope).toBeUndefined();
+      // The safe render contains only an empty placeholder, never a resolved value.
+      // `react` template is CRA-backed, so the prefix is `REACT_APP_`.
+      expect(payload.files['/.env']).toMatch(/REACT_APP_OPENAI_KEY=/);
+    }
+  );
 
   dbTest('injects the daemon origin for the artifact API grant', async ({ db }) => {
     vi.mocked(getDaemonBaseUrl).mockResolvedValueOnce('http://[::1]:3030');
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
+    await seedUser(db, 'user-owner');
     const artifactRepo = new ArtifactRepository(db);
     const created = await artifactRepo.create({
       artifact_id: generateId(),
@@ -545,6 +576,11 @@ describe('ArtifactsService.getPayload trust + .env synthesis', () => {
       created_by: 'user-owner',
     });
 
+    await service.grantTrust({
+      userId: 'user-owner',
+      artifactId: created.artifact_id,
+      scopeType: 'artifact',
+    });
     const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
 
     expect(payload.files['/.env']).toContain('REACT_APP_AGOR_API_URL="http://[::1]:3030"');
@@ -697,44 +733,47 @@ describe('ArtifactsService.grantTrust', () => {
     }
   );
 
-  dbTest('author-scope grant covers a different artifact by the same author', async ({ db }) => {
-    const service = new ArtifactsService(db, makeFakeApp());
-    const board = await seedBoard(db);
-    await seedUser(db, 'viewer-1');
-    const artifactRepo = new ArtifactRepository(db);
-    const a = await artifactRepo.create({
-      artifact_id: generateId(),
-      board_id: board.board_id,
-      name: 'a',
-      template: 'react',
-      files: { '/index.js': 'a' },
-      required_env_vars: ['OPENAI_KEY'],
-      public: true,
-      created_by: 'author-1',
-    });
-    const b = await artifactRepo.create({
-      artifact_id: generateId(),
-      board_id: board.board_id,
-      name: 'b',
-      template: 'react',
-      files: { '/index.js': 'b' },
-      required_env_vars: ['OPENAI_KEY'],
-      public: true,
-      created_by: 'author-1',
-    });
+  dbTest(
+    'rejects legacy broad trust scopes instead of trusting another artifact',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      await seedUser(db, 'viewer-1');
+      const artifactRepo = new ArtifactRepository(db);
+      const a = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'a',
+        template: 'react',
+        files: { '/index.js': 'a' },
+        required_env_vars: ['OPENAI_KEY'],
+        public: true,
+        created_by: 'author-1',
+      });
+      const b = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'b',
+        template: 'react',
+        files: { '/index.js': 'b' },
+        required_env_vars: ['OPENAI_KEY'],
+        public: true,
+        created_by: 'author-1',
+      });
 
-    // Grant on artifact A at author scope.
-    await service.grantTrust({
-      userId: 'viewer-1',
-      artifactId: a.artifact_id,
-      scopeType: 'author',
-    });
+      await expect(
+        service.grantTrust({
+          userId: 'viewer-1',
+          artifactId: a.artifact_id,
+          scopeType: 'author' as never,
+        })
+      ).rejects.toThrow(/scoped to this artifact/i);
 
-    // Artifact B (same author) should be trusted via the author grant.
-    const payload = await service.getPayload(b.artifact_id, 'viewer-1' as never);
-    expect(payload.trust_state).toBe('trusted');
-    expect(payload.trust_scope).toBe('author');
-  });
+      // Artifact B (same author) should be trusted via the author grant.
+      const payload = await service.getPayload(b.artifact_id, 'viewer-1' as never);
+      expect(payload.trust_state).toBe('untrusted');
+    }
+  );
 
   dbTest('grantTrust rejects when artifact is not visible to caller', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
@@ -762,6 +801,32 @@ describe('ArtifactsService.grantTrust', () => {
 });
 
 describe('ArtifactsService.getStatus + console isolation', () => {
+  dbTest(
+    'does not disclose fake secret console output without introspection consent',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'fake-secret-console',
+        template: 'react',
+        files: { '/index.js': 'console.log(import.meta.env.VITE_FAKE_SECRET)' },
+        required_env_vars: ['FAKE_SECRET'],
+        public: true,
+        created_by: 'user-owner',
+      });
+      await service.appendConsoleLogs(created.artifact_id, 'user-owner', [
+        { timestamp: 1, level: 'log', message: 'fake-launch-secret-do-not-disclose' },
+      ]);
+
+      const status = await service.getStatus(created.artifact_id, 'user-owner' as never);
+      expect(JSON.stringify(status)).not.toContain('fake-launch-secret-do-not-disclose');
+      expect(status.console_logs).toEqual([]);
+    }
+  );
+
   dbTest('console logs and sandpack errors are scoped per viewer', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
@@ -1253,6 +1318,37 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
 });
 
 describe('ArtifactsService.queryArtifactRuntime', () => {
+  dbTest('blocks secret-bearing DOM introspection without separate consent', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    await seedUser(db, 'user-owner');
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'secret-dom',
+      template: 'react',
+      files: { '/index.js': 'document.body.textContent = import.meta.env.VITE_FAKE_SECRET' },
+      required_env_vars: ['FAKE_SECRET'],
+      public: true,
+      created_by: 'user-owner',
+    });
+    await service.grantTrust({
+      userId: 'user-owner',
+      artifactId: created.artifact_id,
+      scopeType: 'artifact',
+      allowIntrospection: false,
+    });
+
+    await expect(
+      service.queryArtifactRuntime({
+        artifactId: created.artifact_id,
+        userId: 'user-owner',
+        kind: 'document_html',
+        args: {},
+      })
+    ).rejects.toThrow(/separate DOM-to-agent consent/i);
+  });
   dbTest('rejects when agor_runtime.enabled is false', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -14,12 +14,7 @@
 
 import { createHash } from 'node:crypto';
 import * as path from 'node:path';
-import {
-  getDaemonBaseUrl,
-  loadConfig,
-  PAGINATION,
-  resolveUserEnvironment,
-} from '@agor/core/config';
+import { getDaemonBaseUrl, PAGINATION, resolveUserEnvironment } from '@agor/core/config';
 import {
   ArtifactRepository,
   ArtifactTrustGrantRepository,
@@ -204,7 +199,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * Just-once / session-scope grants live here only — never persisted.
    * Keyed by `${userId}:${artifactId}`. Cleared when the daemon restarts.
    */
-  private sessionGrants: Map<string, { envVars: Set<string>; grants: AgorGrants }> = new Map();
+  private sessionGrants: Map<
+    string,
+    { envVars: Set<string>; grants: AgorGrants; artifactHash: string; allowIntrospection: boolean }
+  > = new Map();
 
   /**
    * In-flight runtime queries keyed by request_id.
@@ -982,7 +980,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       });
       trustState = decision.state;
       trustScope = decision.scope;
-      if (decision.state === 'self' || decision.state === 'trusted') {
+      if (decision.state === 'trusted') {
         envValues = await this.resolveEnvVarValues(userId, requiredEnvVars);
       }
     }
@@ -1009,7 +1007,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         grants,
         artifact,
         userId,
-        injectConsentGated: trustState === 'self' || trustState === 'trusted',
+        injectConsentGated: trustState === 'trusted',
       });
       // Only emit a .env if we have something meaningful to put in it AND
       // the artifact's bundler can read it. For vanilla/static templates the
@@ -1061,9 +1059,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * Resolve consent for an artifact's requested env vars + grants.
    * Returns the trust state and (when applicable) the scope of the matching grant.
    *
-   * Resolution order matches the roadmap:
-   *   1. Author is the viewer → 'self'.
-   *   2. instance > author > artifact > session — first matching wins.
+   * Authorship is attribution, not consent. Every grant is bound to the
+   * artifact's exact render-affecting hash and is invalidated by any change.
    */
   private async resolveTrust(input: {
     artifact: Artifact;
@@ -1072,31 +1069,24 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     grants: AgorGrants;
   }): Promise<{ state: ArtifactPayload['trust_state']; scope?: ArtifactTrustScopeType }> {
     const { artifact, userId, requiredEnvVars, grants } = input;
-    if (userId && artifact.created_by && artifact.created_by === userId) {
-      return { state: 'self', scope: 'self' };
-    }
     if (!userId) return { state: 'untrusted' };
+    const artifactHash = this.computeRuntimeReportHash(artifact);
 
     const consentRelevantGrants = pickConsentRelevantGrants(grants);
 
-    const tryScopes: {
-      type: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
-      value: string | null;
-    }[] = [
-      { type: 'instance', value: null },
-      { type: 'author', value: artifact.created_by ?? null },
-      { type: 'artifact', value: artifact.artifact_id },
-    ];
-    for (const sc of tryScopes) {
-      if (sc.type === 'author' && !sc.value) continue;
-      const matches = await this.trustRepo.findActiveForScope({
-        userId,
-        scopeType: sc.type,
-        scopeValue: sc.value,
-      });
-      if (matches.some((g) => coversRequest(g, requiredEnvVars, consentRelevantGrants))) {
-        return { state: 'trusted', scope: sc.type };
-      }
+    const matches = await this.trustRepo.findActiveForScope({
+      userId,
+      scopeType: 'artifact',
+      scopeValue: artifact.artifact_id,
+    });
+    if (
+      matches.some(
+        (g) =>
+          g.artifact_hash === artifactHash &&
+          coversRequest(g, requiredEnvVars, consentRelevantGrants)
+      )
+    ) {
+      return { state: 'trusted', scope: 'artifact' };
     }
 
     const sessionKey = `${userId}:${artifact.artifact_id}`;
@@ -1104,7 +1094,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (sessionGrant) {
       const envCovered = requiredEnvVars.every((v) => sessionGrant.envVars.has(v));
       const grantsCovered = grantsAreSubset(consentRelevantGrants, sessionGrant.grants);
-      if (envCovered && grantsCovered) {
+      if (envCovered && grantsCovered && sessionGrant.artifactHash === artifactHash) {
         return { state: 'trusted', scope: 'session' };
       }
     }
@@ -1261,9 +1251,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     userId: string;
     artifactId: string;
     scopeType: ArtifactTrustScopeType;
+    allowIntrospection?: boolean;
   }): Promise<{ scope: ArtifactTrustScopeType; persisted: boolean }> {
-    if (input.scopeType === 'self') {
-      throw new Error("'self' grants are implicit and cannot be persisted");
+    if (input.scopeType !== 'artifact' && input.scopeType !== 'session') {
+      throw new Error('Artifact trust must be scoped to this artifact or this render session');
     }
 
     // Server-derive the consent surface from the artifact's current request.
@@ -1276,43 +1267,25 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
     const sanitizedEnv = sanitizeEnvVarNames(artifact.required_env_vars ?? []);
     const sanitizedGrants = canonicalizeAgorGrants(artifact.agor_grants ?? {});
+    const artifactHash = this.computeRuntimeReportHash(artifact);
 
     if (input.scopeType === 'session') {
       const key = `${input.userId}:${input.artifactId}`;
       this.sessionGrants.set(key, {
         envVars: new Set(sanitizedEnv),
         grants: sanitizedGrants,
+        artifactHash,
+        allowIntrospection: input.allowIntrospection === true,
       });
       return { scope: 'session', persisted: false };
     }
 
-    // Resolve scope_value from artifact when needed.
-    let scopeValue: string | null = null;
-    if (input.scopeType === 'artifact') {
-      scopeValue = input.artifactId;
-    } else if (input.scopeType === 'author') {
-      if (!artifact.created_by) {
-        throw new Error('Cannot grant author-scope trust: artifact has no recorded author');
-      }
-      scopeValue = artifact.created_by;
-    } else if (input.scopeType === 'instance') {
-      scopeValue = null;
-      // Instance-wide trust is meaningful only on single-user instances. On
-      // multi-user setups it would mean "trust any artifact published by any
-      // user on this server with my secrets" — too broad. Reject.
-      const config = await loadConfig();
-      const unixMode = config.execution?.unix_user_mode ?? 'simple';
-      if (unixMode !== 'simple') {
-        throw new Error(
-          "'instance'-scope trust grants are disabled when execution.unix_user_mode is not 'simple' (multi-user instance)"
-        );
-      }
-    }
-
     await this.trustRepo.create({
       user_id: input.userId,
-      scope_type: input.scopeType,
-      scope_value: scopeValue,
+      scope_type: 'artifact',
+      scope_value: input.artifactId,
+      artifact_hash: artifactHash,
+      allow_introspection: input.allowIntrospection === true,
       env_vars_set: sanitizedEnv,
       agor_grants_set: sanitizedGrants,
     });
@@ -1518,6 +1491,19 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       );
     }
 
+    const requiredEnvVars = artifact.required_env_vars ?? [];
+    const grants = canonicalizeAgorGrants(artifact.agor_grants);
+    const needsSecretConsent =
+      requiredEnvVars.length > 0 || Object.keys(pickConsentRelevantGrants(grants)).length > 0;
+    if (needsSecretConsent) {
+      const allowed = await this.hasIntrospectionConsent(artifact, input.userId);
+      if (!allowed) {
+        throw new Error(
+          'Runtime introspection is locked because this artifact can receive secrets. Grant separate DOM-to-agent consent for this exact artifact version.'
+        );
+      }
+    }
+
     const requestId = generateId();
     const timeoutMs = Math.min(Math.max(input.timeoutMs ?? 5000, 500), 30000);
 
@@ -1550,6 +1536,22 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     });
 
     return promise;
+  }
+
+  private async hasIntrospectionConsent(artifact: Artifact, userId: string): Promise<boolean> {
+    const artifactHash = this.computeRuntimeReportHash(artifact);
+    const persisted = await this.trustRepo.findActiveForScope({
+      userId,
+      scopeType: 'artifact',
+      scopeValue: artifact.artifact_id,
+    });
+    const sessionGrant = this.sessionGrants.get(`${userId}:${artifact.artifact_id}`);
+    return (
+      persisted.some(
+        (grant) => grant.artifact_hash === artifactHash && grant.allow_introspection
+      ) ||
+      (sessionGrant?.artifactHash === artifactHash && sessionGrant.allowIntrospection === true)
+    );
   }
 
   /**
@@ -1801,10 +1803,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
 
     const key = userId ? this.viewerKey(artifactId, userId) : null;
-    const sandpackError = key ? (this.sandpackErrors.get(key) ?? null) : null;
+    const needsSecretConsent =
+      (artifact.required_env_vars?.length ?? 0) > 0 ||
+      Object.keys(pickConsentRelevantGrants(canonicalizeAgorGrants(artifact.agor_grants))).length >
+        0;
+    const outputAllowed =
+      !needsSecretConsent || (!!userId && (await this.hasIntrospectionConsent(artifact, userId)));
+    const sandpackError = key && outputAllowed ? (this.sandpackErrors.get(key) ?? null) : null;
     const sandpackStatus = key ? this.sandpackStatuses.get(key) : undefined;
     const runtimeObservedAt = key ? this.runtimeObservedAt.get(key) : undefined;
-    const consoleLogs = key ? (this.consoleLogs.get(key) ?? []) : [];
+    const consoleLogs = key && outputAllowed ? (this.consoleLogs.get(key) ?? []) : [];
 
     let buildStatus = artifact.build_status;
     let buildErrors = artifact.build_errors;

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -9,23 +9,18 @@
  * Scopes:
  *  - just-once     → in-memory session grant (cleared on daemon restart)
  *  - this-artifact → DB-backed; only this artifact ID
- *  - this-author   → DB-backed; every artifact this author publishes
- *  - instance-wide → DB-backed; every artifact on this Agor instance
- *
- * `instance-wide` is hidden when the daemon is in multi-user mode
- * (`unix_user_mode !== 'simple'`). The roadmap's reasoning: a "trust everyone"
- * button on a shared instance is too sharp.
+ * Both choices are bound to the exact render-affecting artifact hash. Secret
+ * consent and agent/LLM introspection consent are independent decisions.
  *
  */
 
 import type { AgorGrants, ArtifactTrustScopeType } from '@agor-live/client';
 import { LockOutlined, SafetyCertificateOutlined, WarningOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Modal, Radio, Space, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Checkbox, Modal, Radio, Space, Tag, Typography } from 'antd';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { getDaemonUrl } from '@/config/daemon';
-import { useAuthConfig } from '@/hooks/useAuthConfig';
 import { getAuthHeaders } from '@/utils/authHeaders';
 import { getLanguageFromPath } from '@/utils/language';
 import { useThemedMessage } from '@/utils/message';
@@ -43,7 +38,6 @@ interface ArtifactConsentModalProps {
    * left unset, the modal hides instance scope automatically on multi-user
    * Unix isolation modes (read from `/health` features.multiUser).
    */
-  hideInstanceScope?: boolean;
   onClose: () => void;
   onGranted: () => void;
 }
@@ -55,18 +49,14 @@ export function ArtifactConsentModal({
   files,
   requiredEnvVars,
   grants,
-  hideInstanceScope,
   onClose,
   onGranted,
 }: ArtifactConsentModalProps) {
-  const { featuresConfig } = useAuthConfig();
   const { showSuccess, showError } = useThemedMessage();
-  const [scope, setScope] = useState<Exclude<ArtifactTrustScopeType, 'self'>>('artifact');
+  const [scope, setScope] = useState<ArtifactTrustScopeType>('artifact');
+  const [allowIntrospection, setAllowIntrospection] = useState(false);
   const [activeFile, setActiveFile] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  // Auto-hide the instance scope when the daemon is in multi-user Unix
-  // isolation mode, unless the caller explicitly forces a value via prop.
-  const effectivelyHideInstanceScope = hideInstanceScope ?? featuresConfig?.multiUser === true;
 
   const fileItems: FileItem[] = useMemo(
     () =>
@@ -90,7 +80,7 @@ export function ArtifactConsentModal({
         headers: getAuthHeaders(),
         // The server derives the consent surface (env vars + grants) from
         // the artifact itself; the client only nominates the scope.
-        body: JSON.stringify({ scopeType: scope }),
+        body: JSON.stringify({ scopeType: scope, allowIntrospection }),
       });
       if (!res.ok) {
         const detail = await res.text().catch(() => '');
@@ -126,7 +116,7 @@ export function ArtifactConsentModal({
         icon={<WarningOutlined />}
         style={{ marginBottom: 16 }}
         title="Read the source before granting trust"
-        description="Granting trust injects your env-var values and any requested daemon capabilities into this artifact's runtime. The artifact's JS can read those values. Secrets never enter LLM context — but the artifact iframe can still exfiltrate them via fetch()."
+        description="Granting trust injects your env-var values and requested daemon capabilities into this exact reviewed artifact version. The artifact can read and exfiltrate them. Any change invalidates this consent."
       />
 
       <div
@@ -214,13 +204,23 @@ export function ArtifactConsentModal({
           <Space orientation="vertical">
             <Radio value="session">Just once (in-memory; cleared when daemon restarts)</Radio>
             <Radio value="artifact">This artifact only</Radio>
-            <Radio value="author">Anything published by this author</Radio>
-            {!effectivelyHideInstanceScope && (
-              <Radio value="instance">Anything on this Agor instance</Radio>
-            )}
           </Space>
         </Radio.Group>
       </div>
+
+      <Alert
+        type="info"
+        style={{ marginTop: 16 }}
+        title="Agent introspection is a separate permission"
+        description={
+          <Checkbox
+            checked={allowIntrospection}
+            onChange={(event) => setAllowIntrospection(event.target.checked)}
+          >
+            Allow DOM and page output from this secret-bearing render to enter agent/LLM context
+          </Checkbox>
+        }
+      />
 
       <div style={{ marginTop: 24, display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
         <Button onClick={onClose}>Render without secrets</Button>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
@@ -1,7 +1,7 @@
 import type { AppBoardObject, BoardObject, SandpackTemplate } from '@agor-live/client';
 import { CodeOutlined, DeleteOutlined, EyeOutlined } from '@ant-design/icons';
 import { SandpackPreview, SandpackProvider, type SandpackSetup } from '@codesandbox/sandpack-react';
-import { Button, Card, Tooltip, Typography, theme } from 'antd';
+import { Alert, Button, Card, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import { useStableSandpackProviderInputs } from './utils/sandpackDefaults';
@@ -28,6 +28,7 @@ const MIN_HEIGHT = 200;
 export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: boolean }) => {
   const { token } = theme.useToken();
   const [interactMode, setInteractMode] = useState(false);
+  const [legacyExecutionAllowed, setLegacyExecutionAllowed] = useState(false);
   const iframeContainerRef = useRef<HTMLDivElement>(null);
   const sandpackInputs = useStableSandpackProviderInputs({
     template: data.template,
@@ -150,22 +151,37 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
             pointerEvents: interactMode ? 'auto' : 'none',
           }}
         >
-          <SandpackProvider
-            template={sandpackInputs.template as 'react'}
-            files={sandpackInputs.files}
-            customSetup={sandpackInputs.customSetup as SandpackSetup | undefined}
-            options={sandpackInputs.options}
-          >
-            <SandpackPreview
-              style={{
-                height: previewHeight > 0 ? previewHeight : 200,
-                border: 'none',
-              }}
-              showNavigator={false}
-              showOpenInCodeSandbox={false}
-              showRefreshButton={interactMode}
+          {!legacyExecutionAllowed ? (
+            <Alert
+              type="warning"
+              showIcon
+              title="Legacy active app disabled"
+              description="This board app predates artifact consent. Migrate it to an artifact, or explicitly run this untrusted code without secrets or agent introspection."
+              action={
+                <Button size="small" danger onClick={() => setLegacyExecutionAllowed(true)}>
+                  Run without secrets
+                </Button>
+              }
+              style={{ margin: 12 }}
             />
-          </SandpackProvider>
+          ) : (
+            <SandpackProvider
+              template={sandpackInputs.template as 'react'}
+              files={sandpackInputs.files}
+              customSetup={sandpackInputs.customSetup as SandpackSetup | undefined}
+              options={sandpackInputs.options}
+            >
+              <SandpackPreview
+                style={{
+                  height: previewHeight > 0 ? previewHeight : 200,
+                  border: 'none',
+                }}
+                showNavigator={false}
+                showOpenInCodeSandbox={false}
+                showRefreshButton={interactMode}
+              />
+            </SandpackProvider>
+          )}
         </div>
       </Card>
     </>

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -264,24 +264,14 @@ export function ArtifactTrustStatusIcon({
 
   const isUntrusted = state === 'untrusted';
   const isTrusted = state === 'trusted';
-  const isSelf = state === 'self';
-  const scopeLabel =
-    payload.trust_scope === 'instance'
-      ? 'instance-wide'
-      : payload.trust_scope === 'author'
-        ? 'this author'
-        : payload.trust_scope === 'session'
-          ? 'just-once'
-          : 'this artifact';
+  const scopeLabel = payload.trust_scope === 'session' ? 'just-once' : 'this artifact version';
   const title = isUntrusted
     ? onTrustClick
       ? 'Click to review and grant trust so secrets are injected'
       : 'Secrets are locked until trust is granted'
     : isTrusted
       ? `Secrets injected — trust granted for ${scopeLabel}`
-      : isSelf
-        ? 'You created this artifact; secrets are injected'
-        : 'Artifact trust status';
+      : 'Artifact trust status';
   const color = isUntrusted ? token.colorWarning : isTrusted ? token.colorSuccess : token.colorInfo;
   const backgroundColor = isUntrusted
     ? token.colorWarningBg

--- a/packages/core/drizzle/postgres/0070_artifact_consent_hash.sql
+++ b/packages/core/drizzle/postgres/0070_artifact_consent_hash.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "artifact_trust_grants" ADD COLUMN "artifact_hash" text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "artifact_trust_grants" ADD COLUMN "allow_introspection" boolean DEFAULT false NOT NULL;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1785700000000,
       "tag": "0069_upload_maintenance",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1785782700000,
+      "tag": "0070_artifact_consent_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0074_artifact_consent_hash.sql
+++ b/packages/core/drizzle/sqlite/0074_artifact_consent_hash.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `artifact_trust_grants` ADD `artifact_hash` text DEFAULT '' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `artifact_trust_grants` ADD `allow_introspection` integer DEFAULT false NOT NULL;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1785452400000,
       "tag": "0073_uploads",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "6",
+      "when": 1785782700000,
+      "tag": "0074_artifact_consent_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/artifact-trust.ts
+++ b/packages/core/src/db/repositories/artifact-trust.ts
@@ -2,12 +2,10 @@
  * Artifact Trust Grants Repository
  *
  * Stores per-viewer TOFU consent for injecting env vars and daemon grants
- * into artifacts they didn't author. The viewer is `user_id`. The grant
+ * into artifacts regardless of authorship. The viewer is `user_id`. The grant
  * matches an artifact via `(scope_type, scope_value)`:
  *
  * - 'artifact'  → scope_value = artifact_id
- * - 'author'    → scope_value = author user_id
- * - 'instance'  → scope_value = null (covers every artifact on this Agor instance)
  * - 'session'   → in-memory only; the service layer keeps these out of the DB.
  *
  * Soft-deletion: `revoked_at` is set instead of DELETE so the audit log
@@ -35,6 +33,8 @@ export class ArtifactTrustGrantRepository {
       user_id: row.user_id as never,
       scope_type: row.scope_type as ArtifactTrustScopeType,
       scope_value: row.scope_value ?? null,
+      artifact_hash: row.artifact_hash,
+      allow_introspection: row.allow_introspection,
       env_vars_set: row.env_vars_set,
       agor_grants_set: canonicalizeAgorGrants(row.agor_grants_set),
       granted_at: new Date(row.granted_at).toISOString(),
@@ -50,8 +50,10 @@ export class ArtifactTrustGrantRepository {
    */
   async create(input: {
     user_id: string;
-    scope_type: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
+    scope_type: Exclude<ArtifactTrustScopeType, 'session'>;
     scope_value: string | null;
+    artifact_hash: string;
+    allow_introspection: boolean;
     env_vars_set: string[];
     agor_grants_set: AgorGrants;
   }): Promise<ArtifactTrustGrant> {
@@ -63,6 +65,8 @@ export class ArtifactTrustGrantRepository {
       user_id: input.user_id,
       scope_type: input.scope_type,
       scope_value: input.scope_value,
+      artifact_hash: input.artifact_hash,
+      allow_introspection: input.allow_introspection,
       env_vars_set: input.env_vars_set,
       agor_grants_set: canonicalizeAgorGrants(input.agor_grants_set),
       granted_at: now,
@@ -96,7 +100,7 @@ export class ArtifactTrustGrantRepository {
    */
   async findActiveForScope(input: {
     userId: string;
-    scopeType: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
+    scopeType: Exclude<ArtifactTrustScopeType, 'session'>;
     scopeValue: string | null;
   }): Promise<ArtifactTrustGrant[]> {
     const conditions = [

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1499,6 +1499,9 @@ export const artifactTrustGrants = pgTable(
     user_id: varchar('user_id', { length: 36 }).notNull(),
     scope_type: text('scope_type').notNull(),
     scope_value: text('scope_value'),
+    // Empty default deliberately invalidates legacy broad grants.
+    artifact_hash: text('artifact_hash').notNull().default(''),
+    allow_introspection: t.bool('allow_introspection').notNull().default(false),
     env_vars_set: t.json<string[]>('env_vars_set').notNull(),
     agor_grants_set: t.json<AgorGrants>('agor_grants_set').notNull(),
     granted_at: t.timestamp('granted_at').notNull(),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1450,6 +1450,9 @@ export const artifactTrustGrants = sqliteTable(
     // scope_types in the future doesn't require a SQLite table-recreate.
     scope_type: text('scope_type').notNull(),
     scope_value: text('scope_value'),
+    // Empty default deliberately invalidates legacy broad grants.
+    artifact_hash: text('artifact_hash').notNull().default(''),
+    allow_introspection: t.bool('allow_introspection').notNull().default(false),
     env_vars_set: t.json<string[]>('env_vars_set').notNull(),
     agor_grants_set: t.json<AgorGrants>('agor_grants_set').notNull(),
     granted_at: t.timestamp('granted_at').notNull(),

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -264,7 +264,6 @@ export interface ArtifactPayload {
   /**
    * Whether the daemon injected secrets into this payload.
    *
-   * - 'self' — viewer is the author; secrets always injected.
    * - 'trusted' — an active trust grant matched the requested set.
    * - 'untrusted' — empty values injected; UI should offer the consent flow.
    * - 'no_secrets_needed' — artifact requested no env vars or grants.
@@ -288,12 +287,12 @@ export interface ArtifactPayload {
 /**
  * Where the daemon found the trust grant that authorized injection.
  */
-export type ArtifactTrustScopeType = 'self' | 'instance' | 'author' | 'artifact' | 'session';
+export type ArtifactTrustScopeType = 'artifact' | 'session';
 
 /**
  * Trust state attached to a payload.
  */
-export type ArtifactTrustState = 'self' | 'trusted' | 'untrusted' | 'no_secrets_needed';
+export type ArtifactTrustState = 'trusted' | 'untrusted' | 'no_secrets_needed';
 
 /**
  * Console log entry from Sandpack runtime (captured in browser, sent to daemon)
@@ -340,8 +339,8 @@ export interface ArtifactStatus {
 
 /**
  * A persisted trust grant. The viewer (`user_id`) consented to inject the
- * listed `env_vars_set` and `agor_grants_set` into one or more artifacts
- * matching `scope_type` + `scope_value`.
+ * listed `env_vars_set` and `agor_grants_set` into the exact artifact render
+ * identified by `artifact_hash`.
  *
  * Soft-deleted via `revoked_at` for audit history.
  */
@@ -352,12 +351,13 @@ export interface ArtifactTrustGrant {
   /**
    * Resolves per scope_type:
    * - 'artifact'  → ArtifactID
-   * - 'author'    → UserID (artifact author)
-   * - 'instance'  → null
    * - 'session'   → in-memory only; never persisted with this row shape
-   * - 'self'      → never persisted (viewer-is-author bypass)
    */
   scope_value: string | null;
+  /** Exact render-affecting artifact hash reviewed when consent was granted. */
+  artifact_hash: string;
+  /** Separate consent for moving secret-derived runtime output into agent context. */
+  allow_introspection: boolean;
   env_vars_set: string[];
   agor_grants_set: AgorGrants;
   granted_at: string;


### PR DESCRIPTION
## Summary
- require explicit, artifact-version-bound consent before injecting secrets, including for artifact authors
- gate DOM/document and console output behind separate introspection consent
- keep legacy inline board apps disabled until a viewer explicitly runs them without ambient capabilities
- invalidate legacy broad grants and preserve tenant-scoped grant storage

## Test plan
- `pnpm --filter @agor/daemon exec vitest run src/services/artifacts.test.ts` (52 passed)
- `pnpm --filter @agor/core exec vitest run src/db/multitenancy-schema.test.ts` (4 passed)
- `pnpm check:multitenancy-boundaries`
- Biome check on all touched TypeScript/TSX files

Full workspace typechecks were attempted but are currently blocked in this worktree by unresolved workspace packages (`@agor/git`, `@agor/core`, and `@agor-live/client`); no build was run.
