### PR TITLE
security: confine managed branch workspace paths

### DIFF
--- a/apps/agor-cli/src/commands/session/load-claude.ts
+++ b/apps/agor-cli/src/commands/session/load-claude.ts
@@ -12,17 +12,8 @@ import {
   loadClaudeSession,
   transcriptsToMessages,
 } from '@agor/core/claude';
-import { generateId, shortId } from '@agor/core/db';
-import type {
-  Branch,
-  BranchID,
-  MessageID,
-  Repo,
-  Session,
-  SessionID,
-  TaskID,
-  UUID,
-} from '@agor-live/client';
+import { generateId } from '@agor/core/db';
+import type { Branch, MessageID, Session, SessionID, TaskID } from '@agor-live/client';
 import { TaskStatus } from '@agor-live/client';
 import { Args, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -79,50 +70,20 @@ export default class SessionLoadClaude extends BaseCommand {
           : JSON.stringify(firstUserMessage.message.content).substring(0, 200)
         : 'Imported Claude Code session';
 
-      // Create or find repo for the project directory
-      this.log(`${chalk.blue('●')} Setting up branch for imported session...`);
-      const reposService = client.service('repos');
+      // Imports attach only to a workspace already created and managed by Agor.
+      this.log(`${chalk.blue('●')} Finding managed branch for imported session...`);
       const absoluteProjectDir = path.resolve(projectDir);
-      const projectName = path.basename(absoluteProjectDir);
-
-      // Try to find existing repo by path
-      let repo: { repo_id: UUID; slug: string } | null = null;
-      try {
-        const reposList = await reposService.findAll({ query: { $limit: 1000 } });
-        repo = reposList.find((r: Repo) => r.local_path === absoluteProjectDir) || null;
-      } catch {
-        // Ignore errors
-      }
-
-      // Create repo if it doesn't exist
-      if (!repo) {
-        const newRepo = (await client.service('repos/local').create({
-          path: absoluteProjectDir,
-          slug: `imported-${projectName}`,
-        })) as Repo;
-        repo = { repo_id: newRepo.repo_id, slug: newRepo.slug };
-        this.log(`${chalk.green('✓')} Created repo: ${chalk.cyan(repo.slug)}`);
-      } else {
-        this.log(`${chalk.green('✓')} Found existing repo: ${chalk.cyan(repo.slug)}`);
-      }
-
-      // Create branch for this imported session
       const branchesService = client.service('branches');
-      const branchName = `imported-${shortId(sessionId)}`;
-      const branch = (await branchesService.create({
-        branch_id: generateId() as BranchID,
-        repo_id: repo.repo_id,
-        name: branchName,
-        ref: 'unknown', // Claude sessions don't track git state
-        branch_unique_id: 0, // Will be auto-assigned by service hook
-        path: absoluteProjectDir,
-        new_branch: false,
-        last_used: new Date().toISOString(),
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        created_by: 'cli-import' as UUID,
-      })) as Branch;
-      this.log(`${chalk.green('✓')} Created branch: ${chalk.cyan(branchName)}`);
+      const branches = await branchesService.findAll({ query: { $limit: 1000 } });
+      const branch = branches.find(
+        (candidate: Branch) => path.resolve(candidate.path) === absoluteProjectDir
+      );
+      if (!branch) {
+        throw new Error(
+          'Claude sessions can only be imported into an existing Agor-managed branch; pass that workspace with --project-dir'
+        );
+      }
+      this.log(`${chalk.green('✓')} Found branch: ${chalk.cyan(branch.name)}`);
 
       // Create Agor session
       const agorSession = {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -651,6 +651,19 @@ describe('branch MCP input schemas', () => {
     }
   });
 
+  it.each(['/tmp/branch', '../tenant-b', 'feature/../../tenant-b'])(
+    'rejects path-shaped branchName %s at the MCP schema boundary',
+    (branchName) => {
+      const config = registerAndCaptureConfig('agor_branches_create', {
+        app: {},
+        userId: 'user-1',
+      });
+      expect(
+        config.inputSchema?.safeParse({ repoId: 'repo-1', branchName, boardId: 'board-1' }).success
+      ).toBe(false);
+    }
+  );
+
   it('accepts a valid teammate object and rejects an empty teammate displayName', () => {
     const config = registerAndCaptureConfig('agor_branches_create', {
       app: {},

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -496,7 +496,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           'Slug name for the branch directory (lowercase letters, numbers, hyphens). ' +
             'If the name conflicts with an existing branch, a numeric suffix is auto-appended (e.g., "my-feature-2"). ' +
             'Set autoSuffix=false to get an error on conflict instead.'
-        ),
+        ).refine((value) => BRANCH_NAME_PATTERN.test(value), {
+          message: 'branchName must use lowercase letters, numbers, or hyphens',
+        }),
         boardId: mcpOptionalId(
           'boardId',
           'Board',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -135,6 +135,7 @@ import { userRoomName } from './setup/socketio.js';
 import { requestExecutorTermination } from './termination-coordinator.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
+import { resolveTrustedBranchWorkspace } from './utils/branch-workspace.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -827,7 +828,7 @@ function createExecuteHandler(
     if (session.branch_id) {
       const branchPath = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
         const branch = await new BranchRepository(tenantDb).findById(session.branch_id);
-        return branch?.path;
+        return branch ? resolveTrustedBranchWorkspace(tenantDb, branch, tenantId) : undefined;
       });
       if (!branchPath)
         throw new Error(`Branch ${session.branch_id} not found for executor startup`);

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -69,6 +69,7 @@ import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
+import { resolveTrustedBranchWorkspace } from '../utils/branch-workspace.js';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
@@ -104,8 +105,6 @@ export type BranchParams = QueryParams<{
     _include_sessions?: boolean | 'true' | 'false';
     /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
     _agorSqlBranchAccessUserId?: UUID;
-    /** Server-only capability set by ReposService after deriving the workspace path. */
-    _agorTrustedBranchCreate?: boolean;
   };
 
 type EnvironmentLifecycleAction = 'start' | 'stop' | 'restart' | 'nuke';
@@ -118,6 +117,7 @@ interface EnvironmentLifecycleExecutorPayload extends Record<string, unknown> {
   params: {
     branchId: BranchID;
     branchPath: string;
+    branchesRoot: string;
     action: EnvironmentLifecycleAction;
     startCommand?: string;
     stopCommand?: string;
@@ -415,6 +415,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     const { asUser, env } = await this.resolveEnvironmentExecutorContext(branch, options.params);
+    const branchPath = await this.resolveWorkspace(branch, params);
 
     return {
       asUser,
@@ -426,7 +427,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         env,
         params: {
           branchId: branch.branch_id,
-          branchPath: branch.path,
+          branchPath,
+          branchesRoot: getBranchesDir(params?.tenant?.tenant_id ?? getCurrentTenantId()),
           action,
           startCommand: branch.start_command,
           stopCommand: branch.stop_command,
@@ -538,6 +540,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     const { asUser, env } = await this.resolveEnvironmentExecutorContext(branch, params);
+    const branchPath = await this.resolveWorkspace(branch, params);
     const result = await runExecutorCommand(
       {
         command: 'environment.logs',
@@ -546,7 +549,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         env,
         params: {
           branchId: branch.branch_id,
-          branchPath: branch.path,
+          branchPath,
+          branchesRoot: getBranchesDir(params?.tenant?.tenant_id ?? getCurrentTenantId()),
           logsCommand,
         },
       },
@@ -750,11 +754,19 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: Partial<Branch> | Partial<Branch>[],
     params?: BranchParams
   ): Promise<Branch | Branch[]> {
-    if (params?.provider && !params._agorTrustedBranchCreate) {
+    if (params?.provider) {
       throw new BadRequest(
         'Direct branch creation is unavailable; use the repository branch creation endpoint'
       );
     }
+    return this.createManaged(data, params);
+  }
+
+  /** Internal creation boundary used after ReposService derives the managed path. */
+  async createManaged(
+    data: Partial<Branch> | Partial<Branch>[],
+    params?: BranchParams
+  ): Promise<Branch | Branch[]> {
     const assertHasBoard = (item: Partial<Branch>) => {
       if (!item.board_id) {
         throw new BadRequest('board_id is required when creating a branch');
@@ -785,6 +797,13 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     await this.maybeSetBoardPrimaryTeammate(readyBranch, params);
     this.trackBranchCreated(readyBranch);
     return readyBranch;
+  }
+
+  private resolveWorkspace(branch: Branch, params?: BranchParams): Promise<string> {
+    const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
+    return this.withTenantDatabase(params, () =>
+      resolveTrustedBranchWorkspace(this.db, branch, tenantId)
+    );
   }
 
   private trackBranchCreated(branch: Branch): void {
@@ -1327,6 +1346,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     // Get branch details before deletion
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
+    const branchPath = deleteFromFilesystem
+      ? await this.resolveWorkspace(branch, params)
+      : branch.path;
     // Remove from database FIRST for instant UI feedback
     // CASCADE will clean up related comments automatically
     const result = await super.remove(id, params);
@@ -1334,7 +1356,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // Then remove from filesystem via executor (fire-and-forget)
     // Executor handles its own logging and error reporting via Feathers
     if (deleteFromFilesystem) {
-      console.log(`🗑️  Spawning executor to remove branch from filesystem: ${branch.path}`);
+      console.log(`🗑️  Spawning executor to remove branch from filesystem: ${branchPath}`);
 
       // Resolve Unix user for sudo wrap. Returns undefined in simple/no-RBAC
       // mode so we don't try to sudo on hosts without passwordless sudoers
@@ -1360,7 +1382,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               daemonUrl: getDaemonUrl(),
               params: {
                 branchId: branch.branch_id,
-                branchPath: branch.path,
+                branchPath,
                 branchesRoot: getBranchesDir(tenantId),
                 deleteDbRecord: false, // Already deleted above
                 // Clean up the branch if it was created by Agor
@@ -1409,6 +1431,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   ): Promise<BranchWithZoneAndSessions | { deleted: true; branch_id: BranchID }> {
     const { metadataAction, filesystemAction } = options;
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
+    const branchPath =
+      filesystemAction === 'preserved' ? branch.path : await this.resolveWorkspace(branch, params);
+    const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
     // Hook chain enforces auth before we get here.
     const currentUserId = (params as AuthenticatedParams).user!.user_id as UUID;
 
@@ -1434,7 +1459,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     };
 
     if (filesystemAction === 'cleaned') {
-      console.log(`🧹 Spawning executor to clean branch filesystem: ${branch.path}`);
+      console.log(`🧹 Spawning executor to clean branch filesystem: ${branchPath}`);
 
       // No user impersonation for infrastructure operations — the daemon user
       // owns all branches and impersonation would resolve getBranchesDir()
@@ -1455,7 +1480,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               sessionToken,
               daemonUrl: getDaemonUrl(),
               params: {
-                branchPath: branch.path,
+                branchId: branch.branch_id,
+                branchPath,
+                branchesRoot: getBranchesDir(tenantId),
               },
             },
             {
@@ -1470,8 +1497,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           );
         });
     } else if (filesystemAction === 'deleted') {
-      console.log(`🗑️  Spawning executor to delete branch from filesystem: ${branch.path}`);
-      const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
+      console.log(`🗑️  Spawning executor to delete branch from filesystem: ${branchPath}`);
 
       // No user impersonation for infrastructure operations — the daemon user
       // owns all branches and impersonation would resolve getBranchesDir()
@@ -1497,7 +1523,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               daemonUrl: getDaemonUrl(),
               params: {
                 branchId: branch.branch_id,
-                branchPath: branch.path,
+                branchPath,
                 branchesRoot: getBranchesDir(tenantId),
                 deleteDbRecord: false, // Daemon handles DB deletion separately
                 // Clean up the branch if it was created by Agor

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -104,6 +104,8 @@ export type BranchParams = QueryParams<{
     _include_sessions?: boolean | 'true' | 'false';
     /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
     _agorSqlBranchAccessUserId?: UUID;
+    /** Server-only capability set by ReposService after deriving the workspace path. */
+    _agorTrustedBranchCreate?: boolean;
   };
 
 type EnvironmentLifecycleAction = 'start' | 'stop' | 'restart' | 'nuke';
@@ -748,6 +750,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: Partial<Branch> | Partial<Branch>[],
     params?: BranchParams
   ): Promise<Branch | Branch[]> {
+    if (params?.provider && !params._agorTrustedBranchCreate) {
+      throw new BadRequest(
+        'Direct branch creation is unavailable; use the repository branch creation endpoint'
+      );
+    }
     const assertHasBoard = (item: Partial<Branch>) => {
       if (!item.board_id) {
         throw new BadRequest('board_id is required when creating a branch');
@@ -1069,6 +1076,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   ): Promise<BranchWithZoneAndSessions> {
     // Get current branch to check type/board changes
     const currentBranch = await super.get(id, params);
+    if (Object.hasOwn(data, 'path') && data.path !== currentBranch.path) {
+      throw new BadRequest('Branch workspace paths are immutable and server-derived');
+    }
     await this.assertCanMutateTeammateKnowledgeConfig(currentBranch, data, params);
     this.assertTeammateKindIsStable(currentBranch, data);
 
@@ -1153,6 +1163,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
   async update(id: BranchID, data: Partial<Branch>, params?: BranchParams): Promise<Branch> {
     const currentBranch = await super.get(id, params);
+    if (data.path !== currentBranch.path) {
+      throw new BadRequest('Branch workspace paths are immutable and server-derived');
+    }
     await this.assertCanMutateTeammateKnowledgeConfig(currentBranch, data, params);
     this.assertTeammateKindIsStable(currentBranch, data);
     if (

--- a/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
+++ b/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
@@ -31,6 +31,25 @@ describe('hosted repository storage policy canonical boundaries', () => {
     ).rejects.toThrow(/worktree.*unavailable in hosted multi-tenant mode/);
   });
 
+  it.each([
+    ['rest', '/tmp/caller-selected'],
+    ['socketio', '../../other-tenant/workspace'],
+  ])('rejects caller-controlled paths through the %s branches service', async (provider, path) => {
+    const create = vi.spyOn(DrizzleService.prototype, 'create');
+    const service = new BranchesService(
+      {} as never,
+      { service: vi.fn() } as unknown as Application
+    );
+
+    await expect(
+      service.create(
+        { board_id: '550e8400-e29b-41d4-a716-446655440000', path } as Partial<Branch>,
+        { provider } as never
+      )
+    ).rejects.toThrow(/Direct branch creation is unavailable/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it('rejects bulk conversion to local repositories', async () => {
     const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
 

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -769,7 +769,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const allUsedIds = await branchRepo.getAllUsedUniqueIds();
     const branchUniqueId = autoAssignBranchUniqueId(allUsedIds);
 
-    const branchesService = this.app.service('branches');
+    const branchesService = this.app.service(
+      'branches'
+    ) as unknown as import('./branches').BranchesService;
 
     // NOTE: Environment command templates (start_command, stop_command, etc.) are NOT
     // rendered here. They will be rendered by the executor after Unix groups are created
@@ -785,7 +787,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // 2. Initialize Unix groups (if unix_user_mode needs filesystem isolation)
     // 3. Render environment templates with full context including GID
     // 4. Patch branch to 'ready' with rendered templates
-    const branch = (await branchesService.create(
+    const branch = (await branchesService.createManaged(
       {
         repo_id: repo.repo_id,
         name: data.name,
@@ -803,16 +805,15 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         ...(data.environment_variant ? { environment_variant: data.environment_variant } : {}),
         storage_mode: storageMode,
         ...(cloneDepth !== undefined ? { clone_depth: cloneDepth } : {}),
-        sessions: [],
         last_used: new Date().toISOString(),
-        issue_url: data.issue_url,
-        pull_request_url: data.pull_request_url,
-        notes: data.notes,
+        issue_url: data.issue_url ?? undefined,
+        pull_request_url: data.pull_request_url ?? undefined,
+        notes: data.notes ?? undefined,
         custom_context: data.custom_context,
-        board_id: data.boardId,
+        board_id: data.boardId as import('@agor/core/types').BoardID,
         created_by: userId,
       },
-      { ...params, _agorTrustedBranchCreate: true } as never
+      params
     )) as Branch;
 
     // Add creating user as owner of the branch

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -812,7 +812,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         board_id: data.boardId,
         created_by: userId,
       },
-      params
+      { ...params, _agorTrustedBranchCreate: true } as never
     )) as Branch;
 
     // Add creating user as owner of the branch
@@ -954,6 +954,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           params: {
             branchId: branch.branch_id,
             repoId: repo.repo_id,
+            branchesRoot: getBranchesDir(tenantId),
             userId: userId as string | undefined,
             // Unix group isolation (only when unix_user_mode is non-simple)
             initUnixGroup,

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -78,6 +78,12 @@ vi.mock('@agor/core/unix', () => ({
   validateResolvedUnixUser: () => undefined,
 }));
 
+vi.mock('../utils/branch-workspace.js', () => ({
+  resolveTrustedBranchWorkspace: vi.fn(
+    async (_db: unknown, branch: { path: string }) => branch.path
+  ),
+}));
+
 vi.mock('../utils/branch-authorization.js', () => ({
   hasBranchPermission: () => true,
 }));

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -40,6 +40,7 @@ import {
 } from '@agor/core/unix';
 import { REMOVED_AGENTIC_TOOL_RUNTIME_MESSAGE } from '../utils/agentic-tool-runtime.js';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
+import { resolveTrustedBranchWorkspace } from '../utils/branch-workspace.js';
 import { generateScopedServiceToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
 
 /**
@@ -458,7 +459,15 @@ export class TerminalsService {
               userId,
               action: 'create',
               tabName: branchTabName,
-              ...(unixUserMode === 'simple' ? { cwd: branch.path } : {}),
+              ...(unixUserMode === 'simple'
+                ? {
+                    cwd: await resolveTrustedBranchWorkspace(
+                      this.db,
+                      branch,
+                      params?.tenant?.tenant_id
+                    ),
+                  }
+                : {}),
             });
             this.dispatchTabFocus(userId, {
               focusTabName: data.focusTabName,

--- a/apps/agor-daemon/src/utils/branch-workspace.ts
+++ b/apps/agor-daemon/src/utils/branch-workspace.ts
@@ -1,10 +1,11 @@
-import { assertManagedBranchPath, getBranchesDir } from '@agor/core/config';
+import { getBranchesDir } from '@agor/core/config';
 import {
   RepoRepository,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
 } from '@agor/core/db';
 import type { Branch } from '@agor/core/types';
+import { assertManagedBranchPath } from '@agor/core/workspace-paths';
 
 /** Fail closed when a historical branch row reaches an execution boundary. */
 export async function resolveTrustedBranchWorkspace(

--- a/apps/agor-daemon/src/utils/branch-workspace.ts
+++ b/apps/agor-daemon/src/utils/branch-workspace.ts
@@ -1,0 +1,23 @@
+import { assertManagedBranchPath, getBranchesDir } from '@agor/core/config';
+import {
+  RepoRepository,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+import type { Branch } from '@agor/core/types';
+
+/** Fail closed when a historical branch row reaches an execution boundary. */
+export async function resolveTrustedBranchWorkspace(
+  db: TenantScopedDatabase | TenantScopeAwareDatabase,
+  branch: Branch,
+  tenantId?: string
+): Promise<string> {
+  const repo = await new RepoRepository(db).findById(branch.repo_id);
+  if (!repo) throw new Error(`Repository ${branch.repo_id} not found for branch workspace`);
+  return assertManagedBranchPath({
+    root: getBranchesDir(tenantId),
+    repoSlug: repo.slug,
+    branchName: branch.name,
+    storedPath: branch.path,
+  });
+}

--- a/apps/agor-daemon/src/utils/unix-group-init.ts
+++ b/apps/agor-daemon/src/utils/unix-group-init.ts
@@ -15,7 +15,7 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getDaemonUser } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { shortId, UsersRepository } from '@agor/core/db';
+import { getCurrentTenantId, shortId, UsersRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { BranchID, RepoID } from '@agor/core/types';
 import {
@@ -25,6 +25,7 @@ import {
   REPO_GIT_PERMISSION_MODE,
   UnixGroupCommands,
 } from '@agor/core/unix';
+import { resolveTrustedBranchWorkspace } from './branch-workspace.js';
 
 const execAsync = promisify(exec);
 
@@ -146,7 +147,7 @@ export async function initializeBranchUnixGroup(
 
   // Look up branch from DB
   const branch = await app.service('branches').get(branchId);
-  const branchPath = branch.path;
+  const branchPath = await resolveTrustedBranchWorkspace(db, branch, getCurrentTenantId());
 
   // Create group if it doesn't exist
   const exists = await checkCommand(UnixGroupCommands.groupExists(groupName));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,12 @@
       "import": "./dist/types/index.js",
       "require": "./dist/types/index.cjs"
     },
+    "./workspace-paths": {
+      "source": "./src/workspace-paths.ts",
+      "types": "./dist/workspace-paths.d.ts",
+      "import": "./dist/workspace-paths.js",
+      "require": "./dist/workspace-paths.cjs"
+    },
     "./design/board-backgrounds": {
       "source": "./src/design/board-backgrounds.ts",
       "types": "./dist/design/board-backgrounds.d.ts",

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as yaml from 'js-yaml';
+import { deriveManagedBranchPath } from '../workspace-paths.js';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
 import {
@@ -1527,7 +1528,7 @@ export function getBranchesDir(tenantId?: string): string {
  * @returns Absolute path to the branch
  */
 export function getBranchPath(repoSlug: string, branchName: string, tenantId?: string): string {
-  return path.join(getBranchesDir(tenantId), repoSlug, branchName);
+  return deriveManagedBranchPath(getBranchesDir(tenantId), repoSlug, branchName);
 }
 
 /**

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,7 +4,6 @@
  * Exports configuration management, repo reference parsing utilities.
  */
 
-export * from '../workspace-paths';
 export * from './agentic-tool-preset-resolver';
 export * from './config-manager';
 export * from './constants';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,6 +4,7 @@
  * Exports configuration management, repo reference parsing utilities.
  */
 
+export * from '../workspace-paths';
 export * from './agentic-tool-preset-resolver';
 export * from './config-manager';
 export * from './constants';

--- a/packages/core/src/workspace-paths.test.ts
+++ b/packages/core/src/workspace-paths.test.ts
@@ -1,13 +1,5 @@
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { assertManagedBranchPath, deriveManagedBranchPath } from './workspace-paths';
-
-const cleanup: string[] = [];
-afterEach(async () =>
-  Promise.all(cleanup.splice(0).map((entry) => rm(entry, { recursive: true, force: true })))
-);
 
 describe('managed branch workspace paths', () => {
   it.each(['/absolute', '../other', 'feature/../../other', 'feature\\..\\other'])(
@@ -15,33 +7,14 @@ describe('managed branch workspace paths', () => {
     (name) => expect(() => deriveManagedBranchPath('/managed/tenant-a', 'org/repo', name)).toThrow()
   );
 
-  it('rejects a stored path from another tenant root', async () => {
-    await expect(
+  it('rejects a stored path from another tenant root', () => {
+    expect(() =>
       assertManagedBranchPath({
         root: '/managed/tenant-b/worktrees',
         repoSlug: 'org/repo',
         branchName: 'feature',
         storedPath: '/managed/tenant-a/worktrees/org/repo/feature',
       })
-    ).rejects.toThrow(/trusted storage layout/);
-  });
-
-  it('rejects a symlinked ancestor that escapes the managed root', async () => {
-    const base = await mkdtemp(join(tmpdir(), 'agor-workspace-path-'));
-    cleanup.push(base);
-    const root = join(base, 'tenant-a', 'worktrees');
-    const outside = join(base, 'tenant-b');
-    await mkdir(root, { recursive: true });
-    await mkdir(outside, { recursive: true });
-    await symlink(outside, join(root, 'org'));
-
-    await expect(
-      assertManagedBranchPath({
-        root,
-        repoSlug: 'org/repo',
-        branchName: 'feature',
-        storedPath: join(root, 'org', 'repo', 'feature'),
-      })
-    ).rejects.toThrow(/outside the managed root/);
+    ).toThrow(/trusted storage layout/);
   });
 });

--- a/packages/core/src/workspace-paths.test.ts
+++ b/packages/core/src/workspace-paths.test.ts
@@ -1,0 +1,47 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertManagedBranchPath, deriveManagedBranchPath } from './workspace-paths';
+
+const cleanup: string[] = [];
+afterEach(async () =>
+  Promise.all(cleanup.splice(0).map((entry) => rm(entry, { recursive: true, force: true })))
+);
+
+describe('managed branch workspace paths', () => {
+  it.each(['/absolute', '../other', 'feature/../../other', 'feature\\..\\other'])(
+    'rejects unsafe branch identity %s',
+    (name) => expect(() => deriveManagedBranchPath('/managed/tenant-a', 'org/repo', name)).toThrow()
+  );
+
+  it('rejects a stored path from another tenant root', async () => {
+    await expect(
+      assertManagedBranchPath({
+        root: '/managed/tenant-b/worktrees',
+        repoSlug: 'org/repo',
+        branchName: 'feature',
+        storedPath: '/managed/tenant-a/worktrees/org/repo/feature',
+      })
+    ).rejects.toThrow(/trusted storage layout/);
+  });
+
+  it('rejects a symlinked ancestor that escapes the managed root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'agor-workspace-path-'));
+    cleanup.push(base);
+    const root = join(base, 'tenant-a', 'worktrees');
+    const outside = join(base, 'tenant-b');
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await symlink(outside, join(root, 'org'));
+
+    await expect(
+      assertManagedBranchPath({
+        root,
+        repoSlug: 'org/repo',
+        branchName: 'feature',
+        storedPath: join(root, 'org', 'repo', 'feature'),
+      })
+    ).rejects.toThrow(/outside the managed root/);
+  });
+});

--- a/packages/core/src/workspace-paths.ts
+++ b/packages/core/src/workspace-paths.ts
@@ -1,4 +1,3 @@
-import { lstat, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 function assertRelativeIdentity(value: string, label: string): void {
@@ -29,54 +28,19 @@ export function deriveManagedBranchPath(
   return candidate;
 }
 
-async function nearestExistingPath(candidate: string, floor: string): Promise<string> {
-  let current = candidate;
-  while (true) {
-    try {
-      await lstat(current);
-      return current;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    }
-    if (current === floor) return floor;
-    const parent = path.dirname(current);
-    if (parent === current) return current;
-    current = parent;
-  }
-}
-
 /**
- * Revalidate a stored workspace at a filesystem sink. Exact derivation catches
- * stale/caller-controlled rows; canonical ancestor comparison catches symlink
- * escapes before a missing workspace is created.
+ * Revalidate a stored workspace against trusted identity. Filesystem-owning
+ * execution substrates must additionally canonicalize existing ancestors.
  */
-export async function assertManagedBranchPath(options: {
+export function assertManagedBranchPath(options: {
   root: string;
   repoSlug: string;
   branchName: string;
   storedPath: string;
-}): Promise<string> {
+}): string {
   const expected = deriveManagedBranchPath(options.root, options.repoSlug, options.branchName);
   if (path.resolve(options.storedPath) !== expected || options.storedPath !== expected) {
     throw new Error('Stored branch workspace does not match the trusted storage layout');
-  }
-
-  const root = path.resolve(options.root);
-  const existingRoot = await nearestExistingPath(root, path.parse(root).root);
-  // If the tenant root itself has not been created yet, there cannot be a
-  // symlink below it. The lifecycle identity will create the derived path.
-  if (existingRoot !== root) return expected;
-  const existingCandidate = await nearestExistingPath(expected, root);
-  const [canonicalRootBase, canonicalCandidate] = await Promise.all([
-    realpath(existingRoot),
-    realpath(existingCandidate),
-  ]);
-  const canonicalRoot = path.join(canonicalRootBase, path.relative(existingRoot, root));
-  if (
-    canonicalCandidate !== canonicalRoot &&
-    !canonicalCandidate.startsWith(`${canonicalRoot}${path.sep}`)
-  ) {
-    throw new Error('Branch workspace resolves outside the managed root');
   }
   return expected;
 }

--- a/packages/core/src/workspace-paths.ts
+++ b/packages/core/src/workspace-paths.ts
@@ -1,0 +1,82 @@
+import { lstat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+function assertRelativeIdentity(value: string, label: string): void {
+  if (
+    !value ||
+    path.isAbsolute(value) ||
+    value.includes('\\') ||
+    value.includes('\0') ||
+    value.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`${label} is not a safe workspace identity`);
+  }
+}
+
+/** Derive the only valid persisted path for a managed branch workspace. */
+export function deriveManagedBranchPath(
+  root: string,
+  repoSlug: string,
+  branchName: string
+): string {
+  assertRelativeIdentity(repoSlug, 'Repository slug');
+  assertRelativeIdentity(branchName, 'Branch name');
+  const resolvedRoot = path.resolve(root);
+  const candidate = path.resolve(resolvedRoot, repoSlug, branchName);
+  if (candidate === resolvedRoot || !candidate.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error('Derived branch workspace escapes the managed root');
+  }
+  return candidate;
+}
+
+async function nearestExistingPath(candidate: string, floor: string): Promise<string> {
+  let current = candidate;
+  while (true) {
+    try {
+      await lstat(current);
+      return current;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (current === floor) return floor;
+    const parent = path.dirname(current);
+    if (parent === current) return current;
+    current = parent;
+  }
+}
+
+/**
+ * Revalidate a stored workspace at a filesystem sink. Exact derivation catches
+ * stale/caller-controlled rows; canonical ancestor comparison catches symlink
+ * escapes before a missing workspace is created.
+ */
+export async function assertManagedBranchPath(options: {
+  root: string;
+  repoSlug: string;
+  branchName: string;
+  storedPath: string;
+}): Promise<string> {
+  const expected = deriveManagedBranchPath(options.root, options.repoSlug, options.branchName);
+  if (path.resolve(options.storedPath) !== expected || options.storedPath !== expected) {
+    throw new Error('Stored branch workspace does not match the trusted storage layout');
+  }
+
+  const root = path.resolve(options.root);
+  const existingRoot = await nearestExistingPath(root, path.parse(root).root);
+  // If the tenant root itself has not been created yet, there cannot be a
+  // symlink below it. The lifecycle identity will create the derived path.
+  if (existingRoot !== root) return expected;
+  const existingCandidate = await nearestExistingPath(expected, root);
+  const [canonicalRootBase, canonicalCandidate] = await Promise.all([
+    realpath(existingRoot),
+    realpath(existingCandidate),
+  ]);
+  const canonicalRoot = path.join(canonicalRootBase, path.relative(existingRoot, root));
+  if (
+    canonicalCandidate !== canonicalRoot &&
+    !canonicalCandidate.startsWith(`${canonicalRoot}${path.sep}`)
+  ) {
+    throw new Error('Branch workspace resolves outside the managed root');
+  }
+  return expected;
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     'claude/index': 'src/claude/index.ts',
     'codex/auth-file': 'src/codex/auth-file.ts', // Pure Codex auth.json schema inspection
     'config/index': 'src/config/index.ts',
+    'workspace-paths': 'src/workspace-paths.ts',
     'config/agor-yml': 'src/config/agor-yml.ts', // Node-only .agor.yml file I/O
     'config/browser': 'src/config/browser.ts', // Browser-safe config utilities
     'permissions/index': 'src/permissions/index.ts',

--- a/packages/executor/src/commands/environment.ts
+++ b/packages/executor/src/commands/environment.ts
@@ -10,12 +10,14 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import { ENVIRONMENT } from '@agor/core/config';
 import { assertEnvCommandAllowed } from '@agor/core/unix';
+import { assertManagedBranchPath } from '@agor/core/workspace-paths';
 import type {
   EnvironmentLifecyclePayload,
   EnvironmentLogsPayload,
   ExecutorResult,
 } from '../payload-types.js';
 import { createExecutorClient } from '../services/feathers-client.js';
+import { assertCanonicalWorkspaceContainment } from '../workspace-paths.js';
 import type { CommandOptions } from './index.js';
 
 const MAX_OUTPUT_LINES = ENVIRONMENT.LOGS_MAX_LINES;
@@ -83,6 +85,25 @@ async function updateBranchEnvironment(
   });
 }
 
+async function resolveEnvironmentWorkspace(
+  client: Awaited<ReturnType<typeof createExecutorClient>>,
+  branch: { repo_id: string; name: string; path: string },
+  params: { branchPath?: string; branchesRoot: string }
+): Promise<string> {
+  const repo = await client.service('repos').get(branch.repo_id);
+  const trustedPath = assertManagedBranchPath({
+    root: params.branchesRoot,
+    repoSlug: repo.slug,
+    branchName: branch.name,
+    storedPath: branch.path,
+  });
+  if (params.branchPath && params.branchPath !== trustedPath) {
+    throw new Error('Executor branch path does not match the trusted workspace layout');
+  }
+  await assertCanonicalWorkspaceContainment(params.branchesRoot, trustedPath);
+  return trustedPath;
+}
+
 async function runShellCommand(options: {
   command: string;
   cwd: string;
@@ -146,9 +167,9 @@ export async function handleEnvironmentLogs(
   const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
   const client = await createExecutorClient(daemonUrl, payload.sessionToken);
   const branch = await client.service('branches').get(payload.params.branchId);
-  const cwd = payload.params.branchPath || branch.path;
 
   try {
+    const cwd = await resolveEnvironmentWorkspace(client, branch, payload.params);
     const result = await runShellCommand({
       command: payload.params.logsCommand,
       cwd,
@@ -200,7 +221,7 @@ export async function handleEnvironmentLifecycle(
 
   try {
     const branch = await client.service('branches').get(branchId);
-    const cwd = payload.params.branchPath || branch.path;
+    const cwd = await resolveEnvironmentWorkspace(client, branch, payload.params);
 
     if (payload.params.action === 'restart' && payload.params.stopCommand) {
       await updateBranchEnvironment(client, branchId, {

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -84,6 +84,7 @@ function createClient(records: {
   branchPages?: Array<Array<Record<string, unknown>>>;
   branch?: Record<string, unknown>;
   patchedRepos?: Array<Record<string, unknown>>;
+  patchedBranches?: Array<Record<string, unknown>>;
 }) {
   const client = {
     io: { disconnect: vi.fn() },
@@ -142,10 +143,10 @@ function createClient(records: {
         return {
           get: vi.fn(async () => records.branch),
           find,
-          patch: vi.fn(async (_id: string, data: Record<string, unknown>) => ({
-            ...(records.branch ?? {}),
-            ...data,
-          })),
+          patch: vi.fn(async (_id: string, data: Record<string, unknown>) => {
+            records.patchedBranches?.push(data);
+            return { ...(records.branch ?? {}), ...data };
+          }),
         };
       }
       throw new Error(`unexpected service ${name}`);
@@ -184,13 +185,14 @@ describe('managed executor git/fs commands', () => {
     createClient({
       repo: {
         repo_id: repoId,
+        slug: 'org/repo',
         local_path: '/trusted/repo',
         remote_url: 'https://user:secret@example.com/trusted/repo.git',
       },
       branch: {
         branch_id: branchId,
         repo_id: repoId,
-        path: '/trusted/branch',
+        path: '/trusted/worktrees/org/repo/feature',
         name: 'feature',
         ref: 'trusted-ref',
         base_ref: 'trusted-base',
@@ -208,6 +210,7 @@ describe('managed executor git/fs commands', () => {
         params: {
           branchId,
           repoId,
+          branchesRoot: '/trusted/worktrees',
           useReference: true,
         },
       },
@@ -242,12 +245,42 @@ describe('managed executor git/fs commands', () => {
         params: {
           branchId,
           repoId,
+          branchesRoot: '/other-tenant/worktrees',
         },
       },
       {}
     );
     expect(result).toMatchObject({ success: false, error: { message: 'Not found' } });
     expect(mocks.createBranchAsClone).not.toHaveBeenCalled();
+  });
+
+  it('quarantines a cross-tenant stored workspace before materialization or fallback creation', async () => {
+    const patchedBranches: Array<Record<string, unknown>> = [];
+    createClient({
+      repo: { repo_id: repoId, slug: 'org/repo', local_path: '/safe/repo' },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        name: 'feature',
+        path: '/tenant-a/worktrees/org/repo/feature',
+      },
+      patchedBranches,
+    });
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-b-token',
+        params: { branchId, repoId, branchesRoot: '/tenant-b/worktrees' },
+      },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    expect(mocks.createBranchAsClone).not.toHaveBeenCalled();
+    expect(patchedBranches).toContainEqual(
+      expect.objectContaining({ filesystem_status: 'failed' })
+    );
   });
 
   it('inspects local repository contents only inside the executor and returns sanitized metadata', async () => {

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -62,6 +62,7 @@ import type {
 } from '../payload-types.js';
 import type { AgorClient } from '../services/feathers-client.js';
 import { createExecutorClient } from '../services/feathers-client.js';
+import { assertCanonicalWorkspaceContainment } from '../workspace-paths.js';
 import type { CommandOptions } from './index.js';
 import { fixBranchGitDirPermissionsBasic } from './unix.js';
 
@@ -1185,6 +1186,7 @@ export async function handleGitBranchAdd(
       branchName: branchRecord.name,
       storedPath: branchRecord.path,
     });
+    await assertCanonicalWorkspaceContainment(payload.params.branchesRoot, branchPath);
     const repoPath = repo.local_path;
     const branchName = branchRecord.name;
     resolvedRepoPath = repoPath;

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -1178,7 +1178,13 @@ export async function handleGitBranchAdd(
 
     // Get parameters
     const repoId = payload.params.repoId;
-    const branchPath = branchRecord.path;
+    const { assertManagedBranchPath } = await import('@agor/core/config');
+    const branchPath = await assertManagedBranchPath({
+      root: payload.params.branchesRoot,
+      repoSlug: repo.slug,
+      branchName: branchRecord.name,
+      storedPath: branchRecord.path,
+    });
     const repoPath = repo.local_path;
     const branchName = branchRecord.name;
     resolvedRepoPath = repoPath;

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -23,6 +23,7 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { getReposDir } from '@agor/core/config';
 import { parseAgorYml, writeAgorYml } from '@agor/core/config/node';
 import { shortId } from '@agor/core/db';
+import { assertManagedBranchPath } from '@agor/core/workspace-paths';
 import { appendGitConfigParameterPairs } from '../git/config-parameters.js';
 import {
   categorizeGitError,
@@ -1179,8 +1180,7 @@ export async function handleGitBranchAdd(
 
     // Get parameters
     const repoId = payload.params.repoId;
-    const { assertManagedBranchPath } = await import('@agor/core/config');
-    const branchPath = await assertManagedBranchPath({
+    const branchPath = assertManagedBranchPath({
       root: payload.params.branchesRoot,
       repoSlug: repo.slug,
       branchName: branchRecord.name,
@@ -1703,8 +1703,24 @@ export async function handleGitBranchClean(
     };
   }
 
+  let client: AgorClient | null = null;
   try {
-    const branchPath = payload.params.branchPath;
+    client = await createExecutorClient(
+      payload.daemonUrl || 'http://localhost:3030',
+      payload.sessionToken
+    );
+    const branch = await client.service('branches').get(payload.params.branchId);
+    const repo = await client.service('repos').get(branch.repo_id);
+    const branchPath = assertManagedBranchPath({
+      root: payload.params.branchesRoot,
+      repoSlug: repo.slug,
+      branchName: branch.name,
+      storedPath: branch.path,
+    });
+    if (payload.params.branchPath !== branchPath) {
+      throw new Error('Executor branch path does not match the trusted workspace layout');
+    }
+    await assertCanonicalWorkspaceContainment(payload.params.branchesRoot, branchPath);
 
     console.log(`[git.branch.clean] Cleaning branch at ${branchPath}...`);
 

--- a/packages/executor/src/commands/index.test.ts
+++ b/packages/executor/src/commands/index.test.ts
@@ -234,6 +234,7 @@ describe('executeCommand - git.branch.add', () => {
     params: {
       branchId: '550e8400-e29b-41d4-a716-446655440002',
       repoId: '550e8400-e29b-41d4-a716-446655440003',
+      branchesRoot: '/data/agor/worktrees',
     },
   };
 

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -285,6 +285,7 @@ describe('GitBranchAddPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
+        branchesRoot: '/data/agor/worktrees',
       },
     };
 
@@ -301,6 +302,7 @@ describe('GitBranchAddPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
+        branchesRoot: '/data/agor/worktrees',
         branch: 'untrusted',
         storageMode: 'worktree',
         cloneDepth: 100,
@@ -504,6 +506,7 @@ describe('Type guards', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440002',
         repoId: '550e8400-e29b-41d4-a716-446655440003',
+        branchesRoot: '/data/agor/worktrees',
       },
     };
     expect(isGitBranchAddPayload(payload)).toBe(true);

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -233,6 +233,7 @@ describe('EnvironmentLifecyclePayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440000',
         branchPath: '/data/agor/worktrees/repo/feature',
+        branchesRoot: '/data/agor/worktrees',
         action: 'start',
         startCommand: 'docker compose up -d --build',
         appUrl: 'http://localhost:3000',
@@ -267,6 +268,7 @@ describe('EnvironmentLogsPayloadSchema', () => {
       params: {
         branchId: '550e8400-e29b-41d4-a716-446655440000',
         branchPath: '/data/agor/worktrees/repo/feature',
+        branchesRoot: '/data/agor/worktrees',
         logsCommand: 'docker compose logs --tail=100',
       },
     };

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -364,6 +364,8 @@ export const GitBranchCleanPayloadSchema = BasePayloadSchema.extend({
   params: z.object({
     /** Path to the branch to clean */
     branchPath: z.string(),
+    branchId: z.string().uuid(),
+    branchesRoot: z.string().min(1),
   }),
 });
 
@@ -608,6 +610,7 @@ export const EnvironmentLifecyclePayloadSchema = BasePayloadSchema.extend({
 
       /** Branch checkout path. Executor refetches the branch but this avoids ambiguity. */
       branchPath: z.string().optional(),
+      branchesRoot: z.string().min(1),
 
       /** Lifecycle action */
       action: z.enum(['start', 'stop', 'restart', 'nuke']),
@@ -667,6 +670,7 @@ export const EnvironmentLogsPayloadSchema = BasePayloadSchema.extend({
 
     /** Branch checkout path. Executor refetches the branch but this avoids ambiguity. */
     branchPath: z.string().optional(),
+    branchesRoot: z.string().min(1),
 
     /** Shell logs command */
     logsCommand: z.string(),

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -264,6 +264,9 @@ export const GitBranchAddPayloadSchema = BasePayloadSchema.extend({
     /** Repo ID (UUID) */
     repoId: z.string().uuid(),
 
+    /** Tenant-scoped root that must contain the derived workspace. */
+    branchesRoot: z.string().min(1),
+
     /** Use restore mode: smart branch detection via ls-remote, falls back to creating from sourceBranch */
     restoreMode: z.boolean().optional(),
 

--- a/packages/executor/src/workspace-paths.test.ts
+++ b/packages/executor/src/workspace-paths.test.ts
@@ -1,0 +1,24 @@
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, it } from 'vitest';
+import { assertCanonicalWorkspaceContainment } from './workspace-paths';
+
+const cleanup: string[] = [];
+afterEach(async () =>
+  Promise.all(cleanup.splice(0).map((entry) => rm(entry, { recursive: true, force: true })))
+);
+
+it('rejects a symlinked workspace ancestor that escapes the tenant root', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'agor-workspace-path-'));
+  cleanup.push(base);
+  const root = join(base, 'tenant-a', 'worktrees');
+  const outside = join(base, 'tenant-b');
+  await mkdir(root, { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await symlink(outside, join(root, 'org'));
+
+  await expect(
+    assertCanonicalWorkspaceContainment(root, join(root, 'org', 'repo', 'feature'))
+  ).rejects.toThrow(/outside the managed root/);
+});

--- a/packages/executor/src/workspace-paths.ts
+++ b/packages/executor/src/workspace-paths.ts
@@ -1,0 +1,37 @@
+import { lstat, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+async function nearestExistingPath(candidate: string, floor: string): Promise<string> {
+  let current = candidate;
+  while (true) {
+    try {
+      await lstat(current);
+      return current;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (current === floor) return floor;
+    current = path.dirname(current);
+  }
+}
+
+/** Canonical containment check owned by the filesystem execution substrate. */
+export async function assertCanonicalWorkspaceContainment(
+  rootPath: string,
+  workspacePath: string
+): Promise<void> {
+  const root = path.resolve(rootPath);
+  const existingRoot = await nearestExistingPath(root, path.parse(root).root);
+  if (existingRoot !== root) return;
+  const existingWorkspace = await nearestExistingPath(workspacePath, root);
+  const [canonicalRoot, canonicalWorkspace] = await Promise.all([
+    realpath(root),
+    realpath(existingWorkspace),
+  ]);
+  if (
+    canonicalWorkspace !== canonicalRoot &&
+    !canonicalWorkspace.startsWith(`${canonicalRoot}${path.sep}`)
+  ) {
+    throw new Error('Branch workspace resolves outside the managed root');
+  }
+}


### PR DESCRIPTION
## Summary

- derive managed branch workspace locations from trusted tenant, repository, and branch identity
- close direct external persistence of workspace locations and make stored paths immutable
- revalidate identity/layout at daemon boundaries and canonical symlink containment in the filesystem-owning executor
- fail closed and mark invalid materialization rows failed for safe operator recovery

## Test plan

- `pnpm i`
- `pnpm check`
- `pnpm exec vitest run src/workspace-paths.test.ts src/config/config-manager.test.ts` in `packages/core` — 136 passed
- `pnpm exec vitest run src/services/terminals.test.ts src/services/hosted-repo-policy.test.ts src/mcp/tools/branches.test.ts` in `apps/agor-daemon` — 64 passed
- `pnpm exec vitest run src/workspace-paths.test.ts src/payload-types.test.ts src/commands/git.executor-managed.test.ts src/commands/index.test.ts` in `packages/executor` — 71 passed

Branch: https://github.com/preset-io/agor/tree/security-m2-workspace-paths

Security package: M2 (August 2026 launch security review).
