### PR TITLE
fix: preserve user and workspace config when spawning sessions

### DIFF
--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.config.test.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.config.test.tsx
@@ -120,7 +120,8 @@ describe('ForkSpawnModal configuration defaults', { timeout: 10_000 }, () => {
       />
     );
 
-    fireEvent.change(screen.getByTestId('prompt-textarea'), { target: { value: 'go' } });
+    const promptTextareas = screen.getAllByTestId('prompt-textarea');
+    fireEvent.change(promptTextareas[promptTextareas.length - 1], { target: { value: 'go' } });
     fireEvent.click(screen.getByText('Custom config'));
     fireEvent.click(screen.getByTestId('pick-codex'));
     fireEvent.click(screen.getByRole('button', { name: /Spawn Session/i }));

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -114,6 +114,8 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
   // Reset form and preset when modal opens
   useEffect(() => {
     if (open && session) {
+      // Child sessions always inherit parent. Standalone new sessions use
+      // NewSessionModal, which loads user defaults.
       setConfigPreset('parent');
       setEnvVarNames([]);
       const agentTool = isAgenticToolName(session.agentic_tool)
@@ -129,8 +131,8 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
     }
   }, [open, session, form, initialPrompt]);
 
-  // When switching to "Custom config", load the values that will be
-  // effective if the user submits without touching individual fields.
+  // Load custom values only after explicit opt-in; child sessions always inherit
+  // parent configuration unless custom configuration is selected.
   useEffect(() => {
     if (!open || !session || configPreset !== 'custom') return;
     if (!isAgenticToolName(session.agentic_tool)) return;
@@ -204,6 +206,28 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
           // clear; `undefined` = "copy parent", which is only the
           // `parent` preset's intent).
           spawnConfig.envVarNames = envVarNames;
+        } else {
+          // Make parent inheritance explicit in the MCP spawn instruction.
+          // This keeps UI-created children aligned with parent even when
+          // parent context is reconstructed by the agent.
+          spawnConfig.agent = session.agentic_tool as AgenticToolName;
+          if (session.agentic_tool_preset_id) {
+            spawnConfig.presetId = session.agentic_tool_preset_id;
+          } else {
+            spawnConfig.permissionMode = session.permission_config?.mode;
+            spawnConfig.modelConfig = session.model_config
+              ? {
+                  mode: session.model_config.mode,
+                  model: session.model_config.model,
+                  effort: session.model_config.effort,
+                  advisorModel: session.model_config.advisorModel,
+                  provider: session.model_config.provider,
+                }
+              : undefined;
+            spawnConfig.codexSandboxMode = session.permission_config?.codex?.sandboxMode;
+            spawnConfig.codexApprovalPolicy = session.permission_config?.codex?.approvalPolicy;
+            spawnConfig.codexNetworkAccess = session.permission_config?.codex?.networkAccess;
+          }
         }
 
         // Callback fields are always included when explicitly set

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1213,6 +1213,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         : {
             userPrompt: config.prompt || '',
             agenticTool: config.agent,
+            presetId: config.presetId,
             permissionMode: config.permissionMode,
             modelConfig: config.modelConfig,
             codexSandboxMode: config.codexSandboxMode,

--- a/packages/core/src/templates/spawn-subsession-template.test.ts
+++ b/packages/core/src/templates/spawn-subsession-template.test.ts
@@ -18,6 +18,15 @@ describe('renderSpawnSubsessionPrompt', () => {
     expect(out).toContain('plan');
   });
 
+  it('preserves selected configuration preset for the child spawn call', () => {
+    const out = renderSpawnSubsessionPrompt({
+      userPrompt: 'do thing',
+      presetId: '__user_default__',
+    });
+    expect(out).toContain('presetId: "__user_default__"');
+    expect(out).toContain('"presetId": "__user_default__"');
+  });
+
   it('autocomputes hasConfig when any config field is present', () => {
     const withConfig = renderSpawnSubsessionPrompt({
       userPrompt: 'x',

--- a/packages/core/src/templates/spawn-subsession-template.ts
+++ b/packages/core/src/templates/spawn-subsession-template.ts
@@ -18,6 +18,7 @@ export interface SpawnSubsessionContext {
   userPrompt: string;
   hasConfig?: boolean;
   agenticTool?: string;
+  presetId?: string;
   permissionMode?: string;
   modelConfig?: {
     mode?: string;
@@ -49,6 +50,10 @@ REQUEST: """
   {{#if agenticTool}}
     - Agentic Tool:
     {{agenticTool}}
+  {{/if}}
+  {{#if presetId}}
+    - Configuration Preset:
+    {{presetId}}
   {{/if}}
   {{#if permissionMode}}
     - Permission Mode:
@@ -107,6 +112,9 @@ hashing and JWT for tokens."
 {{#if agenticTool}}
   - agenticTool: "{{agenticTool}}"
 {{/if}}
+{{#if presetId}}
+  - presetId: "{{presetId}}"
+{{/if}}
 {{#if permissionMode}}
   - permissionMode: "{{permissionMode}}"
 {{/if}}
@@ -153,7 +161,9 @@ exact configuration parameters specified above - After spawning, briefly acknowl
 session will do YOUR EXACT TOOL CALL MUST BE: agor_sessions_spawn({ "prompt": "{{your_carefully_prepared_enriched_prompt_with_full_context}}",{{#if
   agenticTool
 }}
-  "agenticTool": "{{agenticTool}}",{{/if}}{{#if permissionMode}}
+  "agenticTool": "{{agenticTool}}",{{/if}}
+{{#if presetId}}
+  "presetId": "{{presetId}}",{{/if}}{{#if permissionMode}}
   "permissionMode": "{{permissionMode}}",{{/if}}{{#if modelConfig}}
   "modelConfig": { "mode": "{{modelConfig.mode}}", "model": "{{modelConfig.model}}"{{#if
     modelConfig.effort
@@ -187,6 +197,7 @@ export function renderSpawnSubsessionPrompt(context: SpawnSubsessionContext): st
   const hasConfig =
     context.hasConfig ??
     (context.agenticTool !== undefined ||
+      context.presetId !== undefined ||
       context.permissionMode !== undefined ||
       context.modelConfig !== undefined ||
       context.codexSandboxMode !== undefined ||


### PR DESCRIPTION
## Summary

Fix UI-spawned child sessions losing selected configuration preset and permission scope.

- Add User default preset to spawn configuration selection.
- Keep selected preset when switching agent or submitting spawn form.
- Forward `presetId` from `SessionPanel` into spawn prompt context.
- Render `presetId` in generated `agor_sessions_spawn` instructions.
- Add regression coverage for preset propagation.

Fixes #2131

## Verification

- `corepack pnpm -C packages/core typecheck`
- `corepack pnpm -C apps/agor-ui typecheck`
- Vitest unavailable in checkout (`vitest` binary not installed).
