### PR TITLE
fix(executor): restore Claude worktree tool denylist

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/constants.ts
+++ b/packages/executor/src/sdk-handlers/claude/constants.ts
@@ -19,7 +19,7 @@
  * - `ExitPlanMode`: only meaningful inside Claude Code's interactive
  *   plan-mode UX. Agor doesn't expose plan-mode approval; the agent should
  *   produce plans as text in its response.
- * - `EnterBranch` / `ExitBranch`: Agor owns branch lifecycle. Letting
+ * - `EnterWorktree` / `ExitWorktree`: Agor owns branch lifecycle. Letting
  *   the agent create/switch/remove branches from inside its own session
  *   would nest branches on the same branch and could delete the session's
  *   CWD.
@@ -38,7 +38,8 @@
 export const CLAUDE_CODE_DISALLOWED_TOOLS = [
   'AskUserQuestion',
   'ExitPlanMode',
-  'EnterBranch',
-  'ExitBranch',
+  // External Claude Code CLI tool names; do not rename with Agor domain terminology.
+  'EnterWorktree',
+  'ExitWorktree',
   'ScheduleWakeup',
 ] as const satisfies readonly string[];

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -99,7 +99,7 @@ describe('setupQuery - Local Settings Support', () => {
   });
 
   // Pin the literal disallow list so a stray edit to the constant
-  // (e.g. dropping `ExitBranch`) trips this test, not just the plumbing one.
+  // (e.g. dropping `ExitWorktree`) trips this test, not just the plumbing one.
   // See `constants.ts` for why each name is on the list — #1177 covers
   // AskUserQuestion; the rest were operator-approved at the same time.
   // `ScheduleWakeup` added in #1253 (Agor schedules supersede /loop).
@@ -107,8 +107,8 @@ describe('setupQuery - Local Settings Support', () => {
     expect(CLAUDE_CODE_DISALLOWED_TOOLS).toEqual([
       'AskUserQuestion',
       'ExitPlanMode',
-      'EnterBranch',
-      'ExitBranch',
+      'EnterWorktree',
+      'ExitWorktree',
       'ScheduleWakeup',
     ]);
   });


### PR DESCRIPTION
## Summary

- restore the Claude Code CLI tool names `EnterWorktree` and `ExitWorktree` in the executor denylist
- document that these names are external identifiers and should not follow Agor domain terminology renames
- update the query-builder coverage to pin the exact denylist and verify it reaches the SDK

## Audit

Reviewed the executor changes from the Worktree → Branch rename (`2ed5cefd`). No other mechanically renamed external CLI tool names, environment variables, or API fields were found. The other renamed strings are coordinated internal Agor identifiers and protocols.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --dir packages/executor exec vitest run src/sdk-handlers/claude/query-builder.test.ts` (16 tests passed)
