### PR TITLE
Fix executor OAuth header transport guard

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -243,6 +243,35 @@ describe('executorRuntimeScopeGuard', () => {
     );
   });
 
+  it('allows OAuth auth-header hydration create to reach its session-token validation', async () => {
+    const context = ctx({
+      path: 'mcp-servers/oauth-auth-headers',
+      method: 'create',
+      data: { mcp_server_ids: ['server-1'], executorSessionToken: 'executor-token' },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it.each(['find', 'get', 'patch', 'remove'])(
+    'still blocks OAuth auth-header hydration %s',
+    async (method) => {
+      const context = ctx({ path: 'mcp-servers/oauth-auth-headers', method });
+
+      await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+        /not valid for this endpoint/
+      );
+    }
+  );
+
+  it('still blocks other MCP server endpoints', async () => {
+    const context = ctx({ path: 'mcp-servers', method: 'find' });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+      /not valid for this endpoint/
+    );
+  });
+
   it('bypasses internal (provider-less) service composition', async () => {
     // Route handlers the executor legitimately reaches fan out to non-allowlisted
     // services internally (e.g. sessions/:id/mcp-servers reading `mcp-servers`).

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -335,6 +335,13 @@ export function executorRuntimeScopeGuard() {
         throw new Forbidden('Executor token is not valid for this endpoint');
       }
       requireMatchingSessionRoute(context, scope);
+    } else if (path === 'mcp-servers/oauth-auth-headers') {
+      // This executor-only endpoint validates the submitted session token and
+      // limits returned headers to MCP servers in that session's effective
+      // scope. Let only its read-like create operation reach that validation.
+      if (context.method !== 'create') {
+        throw new Forbidden('Executor token is not valid for this endpoint');
+      }
     } else if (path === 'config/resolve-api-key') {
       if (context.method !== 'create') {
         throw new Forbidden('Executor token is not valid for this endpoint');

--- a/apps/agor-ui/src/utils/authErrors.test.ts
+++ b/apps/agor-ui/src/utils/authErrors.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { isDefiniteAuthFailure, isTransientConnectionError } from './authErrors';
 
 describe('isDefiniteAuthFailure', () => {
-  it('returns true for 401 / 403 via `code`, `status`, `statusCode`', () => {
+  it('returns true for 401 via `code`, `status`, `statusCode`', () => {
     expect(isDefiniteAuthFailure({ code: 401 })).toBe(true);
-    expect(isDefiniteAuthFailure({ status: 403 })).toBe(true);
+    expect(isDefiniteAuthFailure({ status: 401 })).toBe(true);
     expect(isDefiniteAuthFailure({ statusCode: 401 })).toBe(true);
+  });
+
+  it('returns false for 403 authorization failures', () => {
+    expect(isDefiniteAuthFailure({ code: 403 })).toBe(false);
+    expect(isDefiniteAuthFailure({ status: 403 })).toBe(false);
+    expect(isDefiniteAuthFailure({ statusCode: 403 })).toBe(false);
   });
 
   it('returns true for Feathers NotAuthenticated by name or className', () => {

--- a/apps/agor-ui/src/utils/authErrors.ts
+++ b/apps/agor-ui/src/utils/authErrors.ts
@@ -36,13 +36,13 @@ function statusOf(err: unknown): number | undefined {
 
 /**
  * True when the error represents a definite auth failure: the credentials
- * were rejected (401 / 403), or Feathers explicitly raised NotAuthenticated.
+ * were rejected with 401, or Feathers explicitly raised NotAuthenticated.
  * Callers should treat this as "session is dead" — clear tokens, bounce
  * to login, fast-fail pending refreshes.
  */
 export function isDefiniteAuthFailure(err: unknown): boolean {
   const status = statusOf(err);
-  if (status === 401 || status === 403) return true;
+  if (status === 401) return true;
   if (!err || typeof err !== 'object') return false;
   const e = err as FeathersLikeError;
   if (e.name === 'NotAuthenticated') return true;

--- a/packages/executor/src/services/auth-errors.test.ts
+++ b/packages/executor/src/services/auth-errors.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { isDefiniteAuthFailure, isTransientConnectionError } from './auth-errors';
 
 describe('isDefiniteAuthFailure', () => {
-  it('returns true for 401 / 403 via `code`, `status`, `statusCode`', () => {
+  it('returns true for 401 via `code`, `status`, `statusCode`', () => {
     expect(isDefiniteAuthFailure({ code: 401 })).toBe(true);
-    expect(isDefiniteAuthFailure({ status: 403 })).toBe(true);
+    expect(isDefiniteAuthFailure({ status: 401 })).toBe(true);
     expect(isDefiniteAuthFailure({ statusCode: 401 })).toBe(true);
+  });
+
+  it('returns false for 403 authorization failures', () => {
+    expect(isDefiniteAuthFailure({ code: 403 })).toBe(false);
+    expect(isDefiniteAuthFailure({ status: 403 })).toBe(false);
+    expect(isDefiniteAuthFailure({ statusCode: 403 })).toBe(false);
   });
 
   it('returns true for Feathers NotAuthenticated by name or className', () => {

--- a/packages/executor/src/services/auth-errors.ts
+++ b/packages/executor/src/services/auth-errors.ts
@@ -39,13 +39,13 @@ function statusOf(err: unknown): number | undefined {
 
 /**
  * True when the error represents a definite auth failure: the credentials
- * were rejected (401 / 403), or Feathers explicitly raised NotAuthenticated.
+ * were rejected with 401, or Feathers explicitly raised NotAuthenticated.
  * The executor's 401-retry hook treats this as "the socket lost its auth —
  * try re-authenticating once with the still-valid session JWT."
  */
 export function isDefiniteAuthFailure(err: unknown): boolean {
   const status = statusOf(err);
-  if (status === 401 || status === 403) return true;
+  if (status === 401) return true;
   if (!err || typeof err !== 'object') return false;
   const e = err as FeathersLikeError;
   if (e.name === 'NotAuthenticated') return true;


### PR DESCRIPTION
## Summary

- allow executor-token requests to reach the existing OAuth MCP auth-header hydration service for `create` only
- keep all other `mcp-servers` transport operations outside the executor-token allow-list
- stop treating `403 Forbidden` as a retryable credential rejection in the executor and UI auth-error classifiers
- add focused guard and classifier regression coverage

## Security and tenancy

This is a narrow transport-guard exception for an endpoint that already performs its own executor authorization. The service validates the submitted executor session token, derives its session binding, and only returns authorization headers for globally enabled or session-attached MCP servers. Per-user OAuth tokens remain selected from the authenticated user context, while tenant-scoped database access/RLS continues to constrain the underlying session, server, and token records.

An executor cannot use this change to access arbitrary MCP endpoints, invoke another method on this endpoint, request refresh tokens, or retrieve headers for servers outside the validated session scope. `repos.get` remains intentionally blocked and is out of scope for this change.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/auth/executor-runtime-scope.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/services/auth-errors.test.ts`
- `pnpm --filter agor-ui exec vitest run src/utils/authErrors.test.ts`
