### PR TITLE
fix(db): redact statement values from logged errors

### DIFF
--- a/apps/agor-cli/src/commands/db/migrate.ts
+++ b/apps/agor-cli/src/commands/db/migrate.ts
@@ -2,7 +2,12 @@
  * `agor db migrate` - Run pending database migrations
  */
 
-import { checkMigrationStatus, createDatabase, runMigrations } from '@agor/core/db';
+import {
+  checkMigrationStatus,
+  createDatabase,
+  runMigrations,
+  sanitizeDbError,
+} from '@agor/core/db';
 import { expandPath, extractDbFilePath } from '@agor/core/utils/path';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -131,9 +136,8 @@ export default class DbMigrate extends Command {
       // Force exit to close database connections (postgres-js keeps connections open)
       process.exit(0);
     } catch (error) {
-      this.error(
-        `Failed to run migrations: ${error instanceof Error ? error.message : String(error)}`
-      );
+      const safeError = sanitizeDbError(error);
+      this.error(`Failed to run migrations: ${safeError.message}`);
     }
   }
 }

--- a/apps/agor-cli/src/commands/user/create-admin.ts
+++ b/apps/agor-cli/src/commands/user/create-admin.ts
@@ -13,6 +13,7 @@ import {
   getUserByEmail,
   runMigrations,
   runWithTenantDatabaseScope,
+  sanitizeDbError,
   shortId,
 } from '@agor/core/db';
 import { Command, Flags } from '@oclif/core';
@@ -166,23 +167,8 @@ export default class UserCreateAdmin extends Command {
     } catch (error) {
       this.log('');
       this.log(chalk.red('✗ Failed to create admin user'));
-      if (error instanceof Error) {
-        this.log(chalk.red(`  ${error.message}`));
-        if (error.stack) {
-          this.log(chalk.gray(error.stack));
-        }
-        // Check for nested errors
-        if ('cause' in error && error.cause) {
-          this.log(chalk.red('  Caused by:'));
-          if (error.cause instanceof Error) {
-            this.log(chalk.red(`    ${error.cause.message}`));
-          } else {
-            this.log(chalk.red(`    ${String(error.cause)}`));
-          }
-        }
-      } else {
-        this.log(chalk.red(`  ${String(error)}`));
-      }
+      const safeError = sanitizeDbError(error);
+      this.log(chalk.red(`  ${safeError.message}`));
       process.exit(1);
     }
   }

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -162,8 +162,8 @@ export function renderSchedulePrompt(
       },
     };
     return compiledTemplate(context);
-  } catch (error) {
-    console.error(`❌ Failed to render prompt template:`, sanitizeDbError(error));
+  } catch {
+    console.error(`❌ Failed to render prompt template`);
     return template;
   }
 }

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -56,6 +56,7 @@ import {
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
+  sanitizeDbError,
   shortId,
   UsersRepository,
 } from '@agor/core/db';
@@ -162,7 +163,7 @@ export function renderSchedulePrompt(
     };
     return compiledTemplate(context);
   } catch (error) {
-    console.error(`❌ Failed to render prompt template:`, error);
+    console.error(`❌ Failed to render prompt template:`, sanitizeDbError(error));
     return template;
   }
 }
@@ -319,13 +320,13 @@ export class SchedulerService {
 
     // Run first tick immediately
     this.tick().catch((error) => {
-      console.error('❌ Scheduler tick failed:', error);
+      console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
     });
 
     // Schedule recurring ticks
     this.intervalHandle = setInterval(() => {
       this.tick().catch((error) => {
-        console.error('❌ Scheduler tick failed:', error);
+        console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
       });
     }, this.config.tickInterval);
   }
@@ -388,12 +389,15 @@ export class SchedulerService {
             await this.processSchedule(schedule, now);
           });
         } catch (error) {
-          console.error(`❌ Failed to process schedule ${shortId(ref.scheduleId)}:`, error);
+          console.error(
+            `❌ Failed to process schedule ${shortId(ref.scheduleId)}:`,
+            sanitizeDbError(error)
+          );
           // Continue processing other schedules
         }
       }
     } catch (error) {
-      console.error('❌ Scheduler tick failed:', error);
+      console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
       throw error;
     }
   }
@@ -463,7 +467,10 @@ export class SchedulerService {
         await this.withTenantDatabase(() =>
           this.scheduleRepo.update(schedule.schedule_id, { next_run_at: nextRunAt })
         ).catch((err) =>
-          console.error(`Failed to advance next_run_at for ${schedule.schedule_id}:`, err)
+          console.error(
+            `Failed to advance next_run_at for ${schedule.schedule_id}:`,
+            sanitizeDbError(err)
+          )
         );
       }
       if (this.config.debug) {
@@ -863,7 +870,7 @@ export class SchedulerService {
 
       return createdSession;
     } catch (error) {
-      console.error(`      ❌ Failed to spawn session for ${schedule.name}:`, error);
+      console.error(`      ❌ Failed to spawn scheduled session:`, sanitizeDbError(error));
       throw error;
     }
   }
@@ -890,7 +897,7 @@ export class SchedulerService {
 
       await this.withTenantDatabase(() => this.scheduleRepo.update(schedule.schedule_id, updates));
     } catch (error) {
-      console.error(`      ❌ Failed to update schedule metadata:`, error);
+      console.error(`      ❌ Failed to update schedule metadata:`, sanitizeDbError(error));
       throw error;
     }
   }
@@ -940,7 +947,7 @@ export class SchedulerService {
         );
       }
     } catch (error) {
-      console.error(`      ❌ Failed to enforce retention policy:`, error);
+      console.error(`      ❌ Failed to enforce retention policy:`, sanitizeDbError(error));
       // Don't throw - retention failure shouldn't block scheduling
     }
   }

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -13,6 +13,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { loadConfigSync } from '../config/config-manager';
+import { sanitizeDbError } from './sanitize-error';
 import * as postgresSchema from './schema.postgres';
 
 // Import both schemas explicitly
@@ -145,7 +146,7 @@ async function configureSQLitePragmas(client: Client): Promise<void> {
     await client.execute('PRAGMA foreign_keys = ON');
     if (!silent) console.log('✅ Foreign key constraints enabled');
   } catch (error) {
-    console.warn('⚠️  Failed to configure SQLite pragmas:', error);
+    console.warn('⚠️  Failed to configure SQLite pragmas:', sanitizeDbError(error));
   }
 }
 

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -47,6 +47,7 @@ export * from './migrate';
 export * from './pending-migrations';
 // Repositories
 export * from './repositories';
+export * from './sanitize-error';
 export * from './schema';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -282,10 +282,7 @@ export async function runMigrations(db: Database): Promise<void> {
     console.log('✅ Migrations complete');
   } catch (error) {
     console.error('❌ Migration failed:', sanitizeDbError(error));
-    throw new MigrationError(
-      `Migration failed: ${error instanceof Error ? error.message : String(error)}`,
-      error
-    );
+    throw new MigrationError('Migration failed', error);
   }
 }
 

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -26,7 +26,7 @@ import { migrate as migrateSQLite } from 'drizzle-orm/libsql/migrator';
 import { migrate as migratePostgres } from 'drizzle-orm/postgres-js/migrator';
 import type { Database } from './client';
 import { insert, isPostgresDatabase, isSQLiteDatabase, select } from './database-wrapper';
-import { type SanitizedDbError, sanitizeDbError, sanitizeDbErrorMessage } from './sanitize-error';
+import { sanitizeDbError } from './sanitize-error';
 import { boards } from './schema';
 import { getCurrentTenantId } from './tenant-scope';
 
@@ -34,12 +34,12 @@ import { getCurrentTenantId } from './tenant-scope';
  * Error thrown when migration fails
  */
 export class MigrationError extends Error {
-  public readonly cause?: SanitizedDbError;
-
-  constructor(message: string, cause?: unknown) {
-    super(sanitizeDbErrorMessage(message));
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
     this.name = 'MigrationError';
-    this.cause = cause === undefined ? undefined : sanitizeDbError(cause);
   }
 }
 

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -26,6 +26,7 @@ import { migrate as migrateSQLite } from 'drizzle-orm/libsql/migrator';
 import { migrate as migratePostgres } from 'drizzle-orm/postgres-js/migrator';
 import type { Database } from './client';
 import { insert, isPostgresDatabase, isSQLiteDatabase, select } from './database-wrapper';
+import { type SanitizedDbError, sanitizeDbError, sanitizeDbErrorMessage } from './sanitize-error';
 import { boards } from './schema';
 import { getCurrentTenantId } from './tenant-scope';
 
@@ -33,12 +34,12 @@ import { getCurrentTenantId } from './tenant-scope';
  * Error thrown when migration fails
  */
 export class MigrationError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
+  public readonly cause?: SanitizedDbError;
+
+  constructor(message: string, cause?: unknown) {
+    super(sanitizeDbErrorMessage(message));
     this.name = 'MigrationError';
+    this.cause = cause === undefined ? undefined : sanitizeDbError(cause);
   }
 }
 
@@ -280,26 +281,7 @@ export async function runMigrations(db: Database): Promise<void> {
 
     console.log('✅ Migrations complete');
   } catch (error) {
-    console.error('❌ Migration error details:');
-    console.error('  Error type:', error?.constructor?.name);
-    console.error('  Error message:', error instanceof Error ? error.message : String(error));
-    console.error('  Error stack:', error instanceof Error ? error.stack : 'N/A');
-    if (error && typeof error === 'object') {
-      console.error('  Error keys:', Object.keys(error));
-      // Check for cause (nested error)
-      if ('cause' in error) {
-        console.error('  Cause error:', error.cause);
-        if (error.cause && typeof error.cause === 'object') {
-          console.error('  Cause type:', error.cause.constructor?.name);
-          console.error(
-            '  Cause message:',
-            error.cause instanceof Error ? error.cause.message : String(error.cause)
-          );
-          console.error('  Cause keys:', Object.keys(error.cause));
-        }
-      }
-      console.error('  Full error object:', JSON.stringify(error, null, 2));
-    }
+    console.error('❌ Migration failed:', sanitizeDbError(error));
     throw new MigrationError(
       `Migration failed: ${error instanceof Error ? error.message : String(error)}`,
       error

--- a/packages/core/src/db/repositories/base.ts
+++ b/packages/core/src/db/repositories/base.ts
@@ -7,7 +7,6 @@
 
 import { isValidUUID } from '../../lib/ids';
 import { prefixToLikePattern } from '../../types/id';
-import { type SanitizedDbError, sanitizeDbError, sanitizeDbErrorMessage } from '../sanitize-error';
 import { getCurrentTenantId } from '../tenant-context';
 
 /**
@@ -44,12 +43,12 @@ export interface BaseRepository<T, TInsert = T> {
  * Base repository error
  */
 export class RepositoryError extends Error {
-  public readonly cause?: SanitizedDbError;
-
-  constructor(message: string, cause?: unknown) {
-    super(sanitizeDbErrorMessage(message));
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
     this.name = 'RepositoryError';
-    this.cause = cause === undefined ? undefined : sanitizeDbError(cause);
   }
 }
 

--- a/packages/core/src/db/repositories/base.ts
+++ b/packages/core/src/db/repositories/base.ts
@@ -7,6 +7,7 @@
 
 import { isValidUUID } from '../../lib/ids';
 import { prefixToLikePattern } from '../../types/id';
+import { type SanitizedDbError, sanitizeDbError, sanitizeDbErrorMessage } from '../sanitize-error';
 import { getCurrentTenantId } from '../tenant-context';
 
 /**
@@ -43,12 +44,12 @@ export interface BaseRepository<T, TInsert = T> {
  * Base repository error
  */
 export class RepositoryError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
+  public readonly cause?: SanitizedDbError;
+
+  constructor(message: string, cause?: unknown) {
+    super(sanitizeDbErrorMessage(message));
     this.name = 'RepositoryError';
+    this.cause = cause === undefined ? undefined : sanitizeDbError(cause);
   }
 }
 

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -12,6 +12,7 @@ import { generateId, shortId } from '../../lib/ids';
 import { getSessionUrl } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
+import { sanitizeDbError } from '../sanitize-error';
 import {
   branches,
   branchOwners,
@@ -945,7 +946,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         throw new EntityNotFoundError('Session', id);
       }
     } catch (error) {
-      console.error(`❌ [SessionRepo] Failed to delete session ${id}:`, error);
+      console.error(`❌ [SessionRepo] Failed to delete session ${id}:`, sanitizeDbError(error));
       if (error instanceof EntityNotFoundError) throw error;
       throw new RepositoryError(
         `Failed to delete session: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/sanitize-error.test.ts
+++ b/packages/core/src/db/sanitize-error.test.ts
@@ -31,19 +31,31 @@ describe('sanitizeDbError', () => {
     expect(output).not.toContain('SECRET_SENTINEL');
     expect(output).not.toContain('insert into sessions');
     expect(output).not.toContain('cause');
-    expect(output).toContain('duplicate key value violates unique constraint');
+    expect(output).toContain('Database constraint violation');
     expect(output).toContain('sessions_schedule_run_unique');
     expect(output).toContain('23505');
   });
 
-  it('sanitizes RepositoryError messages and causes at the repository boundary', () => {
+  it('sanitizes RepositoryError output without changing its cause semantics', () => {
     const failure = drizzleFailure();
     const wrapped = new RepositoryError(`Failed to create session: ${failure.message}`, failure);
-    const output = inspect(wrapped);
+    const output = inspect(sanitizeDbError(wrapped));
 
     expect(output).not.toContain('SECRET_SENTINEL');
     expect(output).not.toContain('insert into sessions');
     expect(output).toContain('sessions_schedule_run_unique');
-    expect(output).toContain('Failed to create session');
+    expect(wrapped.cause).toBe(failure);
+  });
+
+  it('does not trust root or nested driver messages', () => {
+    const nested = Object.assign(new Error('invalid uuid: "SECRET_SENTINEL"'), {
+      code: '22P02',
+    });
+    const root = Object.assign(new Error('SECRET_SENTINEL'), { cause: nested });
+    const output = inspect(sanitizeDbError(root));
+
+    expect(output).not.toContain('SECRET_SENTINEL');
+    expect(output).toContain('Database operation failed');
+    expect(output).toContain('22P02');
   });
 });

--- a/packages/core/src/db/sanitize-error.test.ts
+++ b/packages/core/src/db/sanitize-error.test.ts
@@ -1,0 +1,49 @@
+import { inspect } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+import { RepositoryError } from './repositories/base';
+import { sanitizeDbError } from './sanitize-error';
+
+describe('sanitizeDbError', () => {
+  function drizzleFailure(): Error {
+    const postgresError = Object.assign(
+      new Error('duplicate key value violates unique constraint "sessions_schedule_run_unique"'),
+      {
+        code: '23505',
+        constraint_name: 'sessions_schedule_run_unique',
+        detail: 'Key (rendered_prompt)=(SECRET_SENTINEL) already exists',
+      }
+    );
+    return Object.assign(
+      new Error('Failed query: insert into sessions (...) values (...)\nparams: SECRET_SENTINEL'),
+      {
+        name: 'DrizzleQueryError',
+        query: 'insert into sessions (...) values (...)',
+        params: ['SECRET_SENTINEL'],
+        cause: postgresError,
+      }
+    );
+  }
+
+  it('retains useful database metadata without statement values or nested causes', () => {
+    const output = inspect(sanitizeDbError(drizzleFailure()));
+
+    expect(output).not.toContain('SECRET_SENTINEL');
+    expect(output).not.toContain('insert into sessions');
+    expect(output).not.toContain('cause');
+    expect(output).toContain('duplicate key value violates unique constraint');
+    expect(output).toContain('sessions_schedule_run_unique');
+    expect(output).toContain('23505');
+  });
+
+  it('sanitizes RepositoryError messages and causes at the repository boundary', () => {
+    const failure = drizzleFailure();
+    const wrapped = new RepositoryError(`Failed to create session: ${failure.message}`, failure);
+    const output = inspect(wrapped);
+
+    expect(output).not.toContain('SECRET_SENTINEL');
+    expect(output).not.toContain('insert into sessions');
+    expect(output).toContain('sessions_schedule_run_unique');
+    expect(output).toContain('Failed to create session');
+  });
+});

--- a/packages/core/src/db/sanitize-error.test.ts
+++ b/packages/core/src/db/sanitize-error.test.ts
@@ -58,4 +58,20 @@ describe('sanitizeDbError', () => {
     expect(output).toContain('Database operation failed');
     expect(output).toContain('22P02');
   });
+
+  it('only includes strictly validated database metadata', () => {
+    const output = inspect(
+      sanitizeDbError({
+        name: 'SECRET_SENTINEL',
+        code: 'SECRET_SENTINEL',
+        constraint: 'SECRET_SENTINEL\nforged-log-line',
+      })
+    );
+
+    expect(output).not.toContain('SECRET_SENTINEL');
+    expect(output).not.toContain('forged-log-line');
+    expect(output).toContain("name: 'DatabaseError'");
+    expect(output).not.toContain('code:');
+    expect(output).not.toContain('constraint:');
+  });
 });

--- a/packages/core/src/db/sanitize-error.ts
+++ b/packages/core/src/db/sanitize-error.ts
@@ -13,6 +13,10 @@ export interface SanitizedDbError {
 
 type ErrorRecord = Record<string, unknown>;
 
+const POSTGRES_SQLSTATE = /^[0-9A-Z]{5}$/;
+const SQLITE_ERROR_CODE = /^SQLITE_[A-Z0-9_]{1,64}$/;
+const DATABASE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_$]{0,62}$/;
+
 function asRecord(value: unknown): ErrorRecord | undefined {
   return typeof value === 'object' && value !== null ? (value as ErrorRecord) : undefined;
 }
@@ -25,12 +29,6 @@ function asRecord(value: unknown): ErrorRecord | undefined {
  * such as detail, query and params are intentionally ignored.
  */
 export function sanitizeDbError(error: unknown): SanitizedDbError {
-  const root = asRecord(error);
-  const name =
-    (typeof root?.name === 'string' && root.name) ||
-    (error instanceof Error && error.name) ||
-    'DatabaseError';
-
   let code: string | undefined;
   let constraint: string | undefined;
   let current: unknown = error;
@@ -39,9 +37,21 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
   while (current !== undefined && current !== null && !seen.has(current)) {
     seen.add(current);
     const record = asRecord(current);
-    if (!code && typeof record?.code === 'string') code = record.code;
+    if (
+      !code &&
+      typeof record?.code === 'string' &&
+      (POSTGRES_SQLSTATE.test(record.code) || SQLITE_ERROR_CODE.test(record.code))
+    ) {
+      code = record.code;
+    }
     const candidateConstraint = record?.constraint_name ?? record?.constraint;
-    if (!constraint && typeof candidateConstraint === 'string') constraint = candidateConstraint;
+    if (
+      !constraint &&
+      typeof candidateConstraint === 'string' &&
+      DATABASE_IDENTIFIER.test(candidateConstraint)
+    ) {
+      constraint = candidateConstraint;
+    }
 
     current = record?.cause;
   }
@@ -54,7 +64,7 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     ? 'Database constraint violation'
     : 'Database operation failed';
   return {
-    name,
+    name: 'DatabaseError',
     message,
     ...(code ? { code } : {}),
     ...(constraint ? { constraint } : {}),

--- a/packages/core/src/db/sanitize-error.ts
+++ b/packages/core/src/db/sanitize-error.ts
@@ -1,0 +1,82 @@
+/**
+ * The deliberately small, safe representation of a database error that may be
+ * written to shared logs. Drizzle errors retain the SQL and bound parameter
+ * values on `query`, `params`, and nested `cause` objects, so never return the
+ * original error (or its cause chain) from this boundary.
+ */
+export interface SanitizedDbError {
+  name: string;
+  message: string;
+  code?: string;
+  constraint?: string;
+}
+
+type ErrorRecord = Record<string, unknown>;
+
+const STATEMENT_MARKER = /(?:failed\s+query|query|params?|parameters?)\s*:/i;
+
+function asRecord(value: unknown): ErrorRecord | undefined {
+  return typeof value === 'object' && value !== null ? (value as ErrorRecord) : undefined;
+}
+
+/** Remove SQL/parameter sections that some database drivers embed in messages. */
+export function sanitizeDbErrorMessage(message: string): string {
+  const marker = STATEMENT_MARKER.exec(message);
+  if (!marker) return message;
+
+  const prefix = message
+    .slice(0, marker.index)
+    .trimEnd()
+    .replace(/[:\s]+$/, '');
+  return prefix ? `${prefix}: [database statement redacted]` : '[database statement redacted]';
+}
+
+/**
+ * Convert an unknown database failure to log-safe scalar metadata.
+ *
+ * The cause chain is inspected only to recover postgres' code, constraint and
+ * safe message; it is never retained on the result. Arbitrary driver fields
+ * such as detail, query and params are intentionally ignored.
+ */
+export function sanitizeDbError(error: unknown): SanitizedDbError {
+  const root = asRecord(error);
+  const name =
+    (typeof root?.name === 'string' && root.name) ||
+    (error instanceof Error && error.name) ||
+    'DatabaseError';
+
+  const messages: string[] = [];
+  let code: string | undefined;
+  let constraint: string | undefined;
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const record = asRecord(current);
+    const rawMessage =
+      typeof record?.message === 'string'
+        ? record.message
+        : current instanceof Error
+          ? current.message
+          : undefined;
+    if (rawMessage) {
+      const safeMessage = sanitizeDbErrorMessage(rawMessage);
+      if (!messages.includes(safeMessage)) messages.push(safeMessage);
+    }
+
+    if (!code && typeof record?.code === 'string') code = record.code;
+    const candidateConstraint = record?.constraint_name ?? record?.constraint;
+    if (!constraint && typeof candidateConstraint === 'string') constraint = candidateConstraint;
+
+    current = record?.cause;
+  }
+
+  const message = messages.join(': ') || sanitizeDbErrorMessage(String(error));
+  return {
+    name,
+    message,
+    ...(code ? { code } : {}),
+    ...(constraint ? { constraint } : {}),
+  };
+}

--- a/packages/core/src/db/sanitize-error.ts
+++ b/packages/core/src/db/sanitize-error.ts
@@ -13,22 +13,8 @@ export interface SanitizedDbError {
 
 type ErrorRecord = Record<string, unknown>;
 
-const STATEMENT_MARKER = /(?:failed\s+query|query|params?|parameters?)\s*:/i;
-
 function asRecord(value: unknown): ErrorRecord | undefined {
   return typeof value === 'object' && value !== null ? (value as ErrorRecord) : undefined;
-}
-
-/** Remove SQL/parameter sections that some database drivers embed in messages. */
-export function sanitizeDbErrorMessage(message: string): string {
-  const marker = STATEMENT_MARKER.exec(message);
-  if (!marker) return message;
-
-  const prefix = message
-    .slice(0, marker.index)
-    .trimEnd()
-    .replace(/[:\s]+$/, '');
-  return prefix ? `${prefix}: [database statement redacted]` : '[database statement redacted]';
 }
 
 /**
@@ -45,7 +31,6 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     (error instanceof Error && error.name) ||
     'DatabaseError';
 
-  const messages: string[] = [];
   let code: string | undefined;
   let constraint: string | undefined;
   let current: unknown = error;
@@ -54,17 +39,6 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
   while (current !== undefined && current !== null && !seen.has(current)) {
     seen.add(current);
     const record = asRecord(current);
-    const rawMessage =
-      typeof record?.message === 'string'
-        ? record.message
-        : current instanceof Error
-          ? current.message
-          : undefined;
-    if (rawMessage) {
-      const safeMessage = sanitizeDbErrorMessage(rawMessage);
-      if (!messages.includes(safeMessage)) messages.push(safeMessage);
-    }
-
     if (!code && typeof record?.code === 'string') code = record.code;
     const candidateConstraint = record?.constraint_name ?? record?.constraint;
     if (!constraint && typeof candidateConstraint === 'string') constraint = candidateConstraint;
@@ -72,7 +46,13 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     current = record?.cause;
   }
 
-  const message = messages.join(': ') || sanitizeDbErrorMessage(String(error));
+  // Driver messages are not safe metadata. PostgreSQL commonly embeds rejected
+  // values in otherwise ordinary messages (for example invalid UUID syntax),
+  // without a `query:` or `params:` marker. Keep a stable diagnostic category
+  // instead; code and constraint retain the actionable database context.
+  const message = code?.startsWith('23')
+    ? 'Database constraint violation'
+    : 'Database operation failed';
   return {
     name,
     message,

--- a/packages/core/src/db/scripts/fix-message-task-links.ts
+++ b/packages/core/src/db/scripts/fix-message-task-links.ts
@@ -11,6 +11,7 @@ import { createClient } from '@libsql/client';
 import { and, count, eq, gte, isNull, lte } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { shortId } from '../../lib/ids';
+import { sanitizeDbError } from '../sanitize-error';
 import { messages, tasks } from '../schema';
 
 const AGOR_DB_PATH = process.env.AGOR_DB_PATH || resolve(homedir(), '.agor/agor.db');
@@ -102,6 +103,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error('❌ Error:', error);
+  console.error('❌ Error:', sanitizeDbError(error));
   process.exit(1);
 });

--- a/packages/core/src/db/scripts/setup-db.ts
+++ b/packages/core/src/db/scripts/setup-db.ts
@@ -16,6 +16,7 @@ import { sql } from 'drizzle-orm';
 import { createDatabase, DEFAULT_DB_PATH } from '../client';
 import { isSQLiteDatabase } from '../database-wrapper';
 import { initializeDatabase, seedInitialData } from '../migrate';
+import { sanitizeDbError } from '../sanitize-error';
 
 interface SetupOptions {
   path?: string;
@@ -106,12 +107,7 @@ async function main() {
 
     process.exit(0);
   } catch (error) {
-    console.error('❌ Setup failed:', error instanceof Error ? error.message : String(error));
-    if (error instanceof Error && error.stack) {
-      console.error('');
-      console.error('Stack trace:');
-      console.error(error.stack);
-    }
+    console.error('❌ Setup failed:', sanitizeDbError(error));
     process.exit(1);
   }
 }

--- a/packages/core/src/db/scripts/test-integration.ts
+++ b/packages/core/src/db/scripts/test-integration.ts
@@ -24,6 +24,7 @@ import {
   SessionRepository,
   TaskRepository,
 } from '../repositories';
+import { sanitizeDbError } from '../sanitize-error';
 
 // Test database path
 const TEST_DB_PATH = 'file:/tmp/agor-test.db';
@@ -376,11 +377,7 @@ async function main() {
 
     process.exit(0);
   } catch (error) {
-    console.error('\n❌ Test failed:', error instanceof Error ? error.message : String(error));
-    if (error instanceof Error && error.stack) {
-      console.error('\nStack trace:');
-      console.error(error.stack);
-    }
+    console.error('\n❌ Test failed:', sanitizeDbError(error));
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

- add a database-error sanitizer that keeps useful message, code, and constraint metadata
- remove SQL statements, bound parameters, driver details, and nested cause payloads from logged errors
- apply the sanitizer at repository and migration boundaries and to scheduler/database log paths
- add regression coverage using a sentinel parameter value

## Multi-tenancy

Database failures can contain tenant-owned content in driver metadata. This change narrows the shared logging boundary to fixed, non-payload diagnostic fields and verifies that statement values do not appear in formatted output.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm exec vitest run src/db/sanitize-error.test.ts` (from `packages/core`)
