### PR TITLE
fix(terminal): route input to one active executor per user (stop bouncing)

### DIFF
--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -461,6 +461,9 @@ export function createSocketIOConfig(
       }
     });
 
+    // One input-target executor socket per user; keeps keystrokes off orphans.
+    const activeTerminalExecutorByUser = new Map<string, string>();
+
     // Configure Socket.io for cursor presence events
     io.on('connection', (socket) => {
       activeConnections++;
@@ -748,6 +751,11 @@ export function createSocketIOConfig(
         }
         console.log(`🖥️  Socket ${socket.id} joining terminal channel: ${channel}`);
         socket.join(channel);
+        if (auth.isService && auth.terminalUserId === target) {
+          const prev = activeTerminalExecutorByUser.get(target);
+          if (prev && prev !== socket.id) io.to(prev).emit('terminal:shutdown', { userId: target });
+          activeTerminalExecutorByUser.set(target, socket.id);
+        }
       });
 
       // Handle explicit channel leaves. Same scoping as join: a terminal
@@ -781,6 +789,12 @@ export function createSocketIOConfig(
         socket.leave(channel);
       });
 
+      socket.on('disconnect', () => {
+        for (const [uid, sid] of activeTerminalExecutorByUser) {
+          if (sid === socket.id) activeTerminalExecutorByUser.delete(uid);
+        }
+      });
+
       // Route terminal output from executor to browser.
       // Executor emits: terminal:output { userId, data } → broadcast to channel
       // ONLY service sockets may emit this — otherwise a member could spoof
@@ -812,7 +826,8 @@ export function createSocketIOConfig(
         // never see attacker-controlled strings even if the check above is
         // ever weakened.
         const channel = `user/${userId}/terminal`;
-        io.to(channel).emit('terminal:input', { userId, input: data.input });
+        const executor = activeTerminalExecutorByUser.get(userId);
+        io.to(executor ?? channel).emit('terminal:input', { userId, input: data.input });
       });
 
       // Route terminal resize events. Same auth model as terminal:input —
@@ -823,7 +838,12 @@ export function createSocketIOConfig(
         const userId = requireUserForOwnUserId('terminal:resize', data?.userId);
         if (!userId) return;
         const channel = `user/${userId}/terminal`;
-        io.to(channel).emit('terminal:resize', { userId, cols: data.cols, rows: data.rows });
+        const executor = activeTerminalExecutorByUser.get(userId);
+        io.to(executor ?? channel).emit('terminal:resize', {
+          userId,
+          cols: data.cols,
+          rows: data.rows,
+        });
       });
 
       // Route terminal tab commands. The daemon emits this server-side via

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -395,6 +395,17 @@ export async function handleZellijAttach(
       process.exit(exitCode || 0);
     });
 
+    // Daemon retires a duplicate executor: disconnect first so pty.onExit can't
+    // relay a spurious terminal:exit to the browser, then exit (no reconnect).
+    socket.on('terminal:shutdown', (data: { userId: string }) => {
+      if (data.userId !== userId) return;
+      graceController?.cancel();
+      feathersClient?.io.disconnect();
+      feathersClient = null;
+      ptyProcess?.kill();
+      process.exit(0);
+    });
+
     // Listen for input from browser via channel
     socket.on('terminal:input', (data: { userId: string; input: string }) => {
       if (data.userId === userId && ptyProcess) {


### PR DESCRIPTION
## Bug
When the daemon restarts (deploys/reconciles), terminal executors survive via reconnect-grace and re-join the shared `user/<id>/terminal` room. `terminal:input` was **broadcast to the room** (`io.to(channel)`), so a browser keystroke fanned out to *every* surviving executor — each wrote to its PTY and echoed back. Result: the prompt visibly **bounces between pods** (multiple `agor-executor-<hash>` hostnames per line). The `executorTerminals` map tracked 'one per user' but never limited how many executor **sockets** sat on the room, and orphans never exited (their sockets stayed connected + auto-reconnected).

## Fix (daemon + executor)
- **Daemon** (`socketio.ts`): track the active executor **socket** per user. `terminal:input`/`terminal:resize` target that one socket instead of the room. When a new executor joins the channel, the previous one is retired via a `terminal:shutdown` emit; a disconnect drops it from the map.
- **Executor** (`zellij.ts`): handle `terminal:shutdown` → disconnect first (so `pty.onExit` can't relay a spurious `terminal:exit` to the browser), kill the PTY, and exit — so it doesn't reconnect.

Net: exactly one live executor per user is the input target, orphans are reaped, and the normal single-executor path is unchanged (`io.to(socketId)` == `io.to(channel)` when there's one).

## Tests
typecheck clean (daemon + executor). Rollout: agor build → executor+daemon images → Release → Cell pin.