### PR TITLE
chore(daemon): calibrate Socket.io lifecycle logs

### DIFF
--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -72,6 +72,10 @@ interface FakeIO {
   excludedSenders: string[];
   sockets: { sockets: Map<string, FakeSocket> };
   middlewares: Array<(socket: FakeSocket, next: (err?: Error) => void) => void>;
+  engine: {
+    closeHandler?: () => void;
+    once(event: string, fn: () => void): void;
+  };
   on(event: string, fn: any): void;
   use(fn: any): void;
   to(channel: string): { emit: (event: string, data: unknown) => void };
@@ -146,6 +150,11 @@ function makeIO(): FakeIO {
     excludedSenders: [],
     sockets: { sockets: new Map() },
     middlewares: [],
+    engine: {
+      once(event, fn) {
+        if (event === 'close') this.closeHandler = fn;
+      },
+    },
     on(event, fn) {
       if (event === 'connection') {
         this.connectionHandler = fn;
@@ -172,7 +181,7 @@ function makeApp(): Application {
   // app.on('login'), and app.emit for the terminal:ready/error relay.
   const eventHandlers = new Map<string, (...args: any[]) => void>();
   return {
-    service: () => ({ get: async () => ({ user_id: 'u' }) }),
+    service: () => ({ get: async (userId: string) => ({ user_id: userId }) }),
     on: (event: string, handler: (...args: any[]) => void) => eventHandlers.set(event, handler),
     emit: vi.fn(),
     eventHandlers,
@@ -299,6 +308,7 @@ describe('Socket.IO lifecycle logging', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     debugSpy.mockRestore();
     logSpy.mockRestore();
     warnSpy.mockRestore();
@@ -321,6 +331,48 @@ describe('Socket.IO lifecycle logging', () => {
       'socket authenticated: alice-sock user:11111111aaaaaaaaaaaa1111'
     );
     expect(logSpy.mock.calls.flat().join(' ')).not.toContain('alice@example.com');
+  });
+
+  it('uses the same single authentication signal for handshake-authenticated users', async () => {
+    const { io } = buildHarness();
+    const socket = makeSocket('handshake-sock');
+    socket.handshake.auth = {
+      token: issueRuntimeToken({ sub: ALICE, type: 'access' }, 'test-secret', '5m'),
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      io.middlewares[0]?.(socket, (error?: Error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+    connect(io, socket);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      'socket authenticated: handshake-sock user:11111111aaaaaaaaaaaa1111'
+    );
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('joined user room'));
+  });
+
+  it('emits an unconditional five-minute gauge and stops it when Engine.IO closes', () => {
+    vi.useFakeTimers();
+    const { io } = buildHarness();
+
+    vi.advanceTimersByTime(5_000);
+    expect(logSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5 * 60 * 1000 - 5_000);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenLastCalledWith('ws_active_connections=0');
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenLastCalledWith('ws_active_connections=0');
+
+    io.engine.closeHandler?.();
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenCalledTimes(2);
   });
 
   it.each(['transport close', 'client namespace disconnect'])(

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -169,12 +169,13 @@ function makeIO(): FakeIO {
 
 function makeApp(): Application {
   // Minimal Application surface used by createSocketIOConfig: app.service('users').get,
-  // app.on('login'), and app.emit for the terminal:ready/error relay. Tests
-  // don't exercise the login event path.
+  // app.on('login'), and app.emit for the terminal:ready/error relay.
+  const eventHandlers = new Map<string, (...args: any[]) => void>();
   return {
     service: () => ({ get: async () => ({ user_id: 'u' }) }),
-    on: () => {},
+    on: (event: string, handler: (...args: any[]) => void) => eventHandlers.set(event, handler),
     emit: vi.fn(),
+    eventHandlers,
   } as any;
 }
 
@@ -283,6 +284,71 @@ describe('Socket.IO transport ceiling', () => {
     expect(config.serverOptions).toMatchObject({
       maxHttpBufferSize: SOCKET_IO_MAX_BUFFER_SIZE_BYTES,
     });
+  });
+});
+
+describe('Socket.IO lifecycle logging', () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('logs post-connect authentication once at info with only the short user ID', () => {
+    const { app, io } = buildHarness();
+    const socket = makeSocket('alice-sock');
+    connect(io, socket);
+
+    const connection = {};
+    socket.feathers = connection;
+    (app as any).eventHandlers.get('login')?.(
+      { user: { user_id: ALICE, email: 'alice@example.com' } },
+      { connection }
+    );
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      'socket authenticated: alice-sock user:11111111aaaaaaaaaaaa1111'
+    );
+    expect(logSpy.mock.calls.flat().join(' ')).not.toContain('alice@example.com');
+  });
+
+  it.each(['transport close', 'client namespace disconnect'])(
+    'demotes benign disconnect reason %s below info',
+    (reason) => {
+      const { io } = buildHarness();
+      const socket = makeSocket('browser-sock');
+      connect(io, socket);
+
+      socket.handlers.get('disconnect')?.(reason);
+
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining(`reason: ${reason}`));
+    }
+  );
+
+  it('warns on transport errors while retaining ping timeouts at info', () => {
+    const { io } = buildHarness();
+    const transportErrorSocket = makeSocket('transport-error');
+    const pingTimeoutSocket = makeSocket('ping-timeout');
+    connect(io, transportErrorSocket);
+    connect(io, pingTimeoutSocket);
+
+    transportErrorSocket.handlers.get('disconnect')?.('transport error');
+    pingTimeoutSocket.handlers.get('disconnect')?.('ping timeout');
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('reason: transport error'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('reason: ping timeout'));
   });
 });
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -342,9 +342,8 @@ export function createSocketIOConfig(
     // Store Socket.io server instance for shutdown
     socketServer = io;
 
-    // Track active connections for debugging
+    // Track active connections for periodic operational metrics.
     let activeConnections = 0;
-    let lastLoggedCount = 0;
 
     // SECURITY: Add authentication middleware for WebSocket connections
     io.use(async (socket, next) => {
@@ -363,7 +362,6 @@ export function createSocketIOConfig(
           // enforce authentication on every protected endpoint, so an
           // unauthenticated socket can't read or write anything until it
           // authenticates.
-          console.log(`🔓 WebSocket connection without auth (for login flow): ${socket.id}`);
           return next();
         }
 
@@ -465,8 +463,8 @@ export function createSocketIOConfig(
     io.on('connection', (socket) => {
       activeConnections++;
       const user = (socket as FeathersSocket).feathers?.user;
-      console.log(
-        `🔌 Socket.io connection established: ${socket.id} (user: ${user ? shortId(user.user_id) : 'unknown'}, total: ${activeConnections})`
+      console.debug(
+        `🔌 Socket.io connection established: ${socket.id} (auth: ${user ? 'handshake' : 'anonymous'}, user: ${user ? shortId(user.user_id) : 'unknown'}, total: ${activeConnections})`
       );
 
       // Welcome event: ship the daemon's build identity so UI tabs can spot
@@ -493,15 +491,6 @@ export function createSocketIOConfig(
           `🏠 Socket ${socket.id} joined user room at connection: user:${shortId(user.user_id)}`
         );
       }
-
-      // Log connection lifespan after 5 seconds to identify long-lived connections
-      setTimeout(() => {
-        if (socket.connected) {
-          console.log(
-            `⏱️  Socket ${socket.id} still connected after 5s (likely persistent connection)`
-          );
-        }
-      }, 5000);
 
       // Helper to get user ID from socket's Feathers connection
       const getUserId = () => {
@@ -874,9 +863,15 @@ export function createSocketIOConfig(
       // Track disconnections
       socket.on('disconnect', (reason) => {
         activeConnections--;
-        console.log(
-          `🔌 Socket.io disconnected: ${socket.id} (reason: ${reason}, remaining: ${activeConnections})`
-        );
+        const message = `🔌 Socket.io disconnected: ${socket.id} (reason: ${reason}, remaining: ${activeConnections})`;
+        if (reason === 'transport error') {
+          console.warn(message);
+        } else if (reason === 'transport close' || reason === 'client namespace disconnect') {
+          console.debug(message);
+        } else {
+          // Keep ping timeouts (and unexpected/rare reasons) visible at info.
+          console.log(message);
+        }
       });
 
       // Handle socket errors
@@ -895,29 +890,28 @@ export function createSocketIOConfig(
       const result = authResult as { user?: { user_id?: string } };
       const userId = result.user?.user_id;
       if (!userId) return;
-      // Terminal-executor identities get no user room (see connection handler).
-      if (isTerminalExecutorIdentity(result.user)) return;
 
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
-          socket.join(userRoomName(userId));
-          console.debug(
-            `🏠 Socket ${socket.id} joined user room after login: user:${shortId(userId)}`
-          );
+          console.log(`socket authenticated: ${socket.id} user:${shortId(userId)}`);
+          // Terminal-executor identities get no user room (see connection handler).
+          if (!isTerminalExecutorIdentity(result.user)) {
+            socket.join(userRoomName(userId));
+          }
           break;
         }
       }
     });
 
-    // Log connection metrics only when count changes (every 30 seconds)
-    // FIX: Store interval handle to prevent memory leak
-    const metricsInterval = setInterval(() => {
-      if (activeConnections !== lastLoggedCount) {
-        console.log(`📊 Active WebSocket connections: ${activeConnections}`);
-        lastLoggedCount = activeConnections;
-      }
-    }, 30000);
+    // Emit a fixed-key gauge on a steady cadence so log collectors can parse it
+    // and periods with no connection churn remain observable.
+    const metricsInterval = setInterval(
+      () => {
+        console.log(`ws_active_connections=${activeConnections}`);
+      },
+      5 * 60 * 1000
+    );
 
     // Ensure interval is cleared on shutdown
     process.once('beforeExit', () => clearInterval(metricsInterval));
@@ -965,8 +959,6 @@ export function configureChannels(
         authentication?: { payload?: unknown };
         task_id?: string;
       };
-      console.debug('✅ Login event fired:', result.user?.user_id, result.user?.email);
-
       // Authentication can be replaced on an already-open socket. Remove any
       // prior executor capability before considering the new signed claims, so
       // a socket can never accumulate control rooms across Tasks.

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -345,6 +345,14 @@ export function createSocketIOConfig(
     // Track active connections for periodic operational metrics.
     let activeConnections = 0;
 
+    const logAuthenticated = (socketId: string, userId?: string) => {
+      console.log(
+        userId
+          ? `socket authenticated: ${socketId} user:${shortId(userId)}`
+          : `socket authenticated: ${socketId} service`
+      );
+    };
+
     // SECURITY: Add authentication middleware for WebSocket connections
     io.use(async (socket, next) => {
       try {
@@ -428,9 +436,7 @@ export function createSocketIOConfig(
             (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;
             if (fs.data) fs.data.tenant = tenant;
           }
-          console.log(
-            `🔐 WebSocket authenticated (service): ${socket.id} (role: ${decoded.role || 'unknown'})`
-          );
+          logAuthenticated(socket.id);
           return next();
         }
 
@@ -451,7 +457,7 @@ export function createSocketIOConfig(
           if (fs.data) fs.data.tenant = tenant;
         }
 
-        console.log(`🔐 WebSocket authenticated: ${socket.id} (user: ${shortId(user.user_id)})`);
+        logAuthenticated(socket.id, user.user_id);
         next();
       } catch (error) {
         console.error(`❌ WebSocket authentication failed for ${socket.id}:`, error);
@@ -487,7 +493,7 @@ export function createSocketIOConfig(
       // membership would just hand them a firehose subscription they must not have.
       if (user?.user_id && !isTerminalExecutorIdentity(user)) {
         socket.join(userRoomName(user.user_id));
-        console.log(
+        console.debug(
           `🏠 Socket ${socket.id} joined user room at connection: user:${shortId(user.user_id)}`
         );
       }
@@ -894,7 +900,7 @@ export function createSocketIOConfig(
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
-          console.log(`socket authenticated: ${socket.id} user:${shortId(userId)}`);
+          logAuthenticated(socket.id, userId);
           // Terminal-executor identities get no user room (see connection handler).
           if (!isTerminalExecutorIdentity(result.user)) {
             socket.join(userRoomName(userId));
@@ -912,9 +918,10 @@ export function createSocketIOConfig(
       },
       5 * 60 * 1000
     );
+    metricsInterval.unref();
 
-    // Ensure interval is cleared on shutdown
-    process.once('beforeExit', () => clearInterval(metricsInterval));
+    // Socket.io closes its Engine.IO server during application shutdown.
+    io.engine.once('close', () => clearInterval(metricsInterval));
   };
 
   return {


### PR DESCRIPTION
## Summary

- demote expected anonymous Socket.io connections and benign disconnects from info-level logs
- add a single info-level socket authentication success signal with short user IDs
- remove the expected five-second persistent-connection timer log
- split disconnect logging by operational severity
- replace change-triggered connection metrics with an unconditional five-minute `ws_active_connections=N` gauge

## Expected impact

Reduces Socket.io lifecycle noise by an estimated 12,000–16,000 journal lines per three days while restoring production visibility into successful socket authentication and user attribution.

The optional aggregate for sockets that disconnect before authenticating is intentionally deferred to avoid introducing additional per-socket state in this calibration change.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/setup/socketio.test.ts` (66 passed)
