### PR TITLE
feat(models): make Opus 5 the latest Opus (keep Sonnet default)

### DIFF
--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
@@ -66,6 +66,20 @@ describe('curateModelOptions (Claude)', () => {
     expect(ids).toHaveLength(normalized.length);
   });
 
+  it('renders Opus 5 ahead of every older Opus', () => {
+    const ids = curateModelOptions('claude-code', normalized, DEFAULT_CLAUDE_MODEL).map(
+      (m) => m.id
+    );
+    const opus5 = ids.indexOf('claude-opus-5');
+    const olderOpus = ids.filter((id) => id.startsWith('claude-opus-4'));
+
+    expect(opus5).toBeGreaterThanOrEqual(0);
+    expect(olderOpus.length).toBeGreaterThan(0);
+    for (const id of olderOpus) {
+      expect(ids.indexOf(id)).toBeGreaterThan(opus5);
+    }
+  });
+
   it('surfaces the default/recommended model first', () => {
     const ids = curateModelOptions('claude-code', normalized, DEFAULT_CLAUDE_MODEL).map(
       (m) => m.id

--- a/packages/core/src/models/claude.test.ts
+++ b/packages/core/src/models/claude.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { AVAILABLE_CLAUDE_MODEL_ALIASES, hasNativeMillionContext } from './claude.js';
+import {
+  AVAILABLE_CLAUDE_MODEL_ALIASES,
+  DEFAULT_CLAUDE_MODEL,
+  hasNativeMillionContext,
+} from './claude.js';
 
 describe('AVAILABLE_CLAUDE_MODEL_ALIASES', () => {
   it('includes current Claude model aliases', () => {
@@ -17,10 +21,32 @@ describe('AVAILABLE_CLAUDE_MODEL_ALIASES', () => {
   it('does not offer synthetic [1m] variants for native-1M models', () => {
     const ids = AVAILABLE_CLAUDE_MODEL_ALIASES.map((model) => model.id);
 
+    expect(ids).not.toContain('claude-opus-5[1m]');
     expect(ids).not.toContain('claude-opus-4-7[1m]');
     expect(ids).not.toContain('claude-opus-4-6[1m]');
     expect(ids).not.toContain('claude-sonnet-4-6[1m]');
     expect(ids).toContain('claude-sonnet-4-5[1m]');
+  });
+
+  it('lists Opus 5 ahead of every older Opus', () => {
+    const ids = AVAILABLE_CLAUDE_MODEL_ALIASES.map((model) => model.id);
+    const opus5 = ids.indexOf('claude-opus-5');
+    const olderOpus = ids.filter((id) => id.startsWith('claude-opus-4'));
+
+    expect(opus5).toBeGreaterThanOrEqual(0);
+    expect(olderOpus.length).toBeGreaterThan(0);
+    // curateModelOptions() preserves this order (only hoisting the default),
+    // so registry position is what the picker renders.
+    for (const id of olderOpus) {
+      expect(ids.indexOf(id)).toBeGreaterThan(opus5);
+    }
+  });
+
+  it('keeps Sonnet 5 as the default model', () => {
+    // Opus 5 is the newest Opus, not the new default. Changing this is a
+    // deliberate product decision, not a side effect of adding a model.
+    expect(DEFAULT_CLAUDE_MODEL).toBe('claude-sonnet-5');
+    expect(AVAILABLE_CLAUDE_MODEL_ALIASES.map((m) => m.id)).toContain(DEFAULT_CLAUDE_MODEL);
   });
 });
 
@@ -30,6 +56,7 @@ describe('hasNativeMillionContext', () => {
     'claude-opus-4-7',
     'claude-opus-4-8-20260528',
     'claude-opus-5',
+    'claude-opus-5-20260101',
     'claude-sonnet-4-6',
     'claude-sonnet-5',
     'claude-fable-5',

--- a/packages/core/src/models/copilot.ts
+++ b/packages/core/src/models/copilot.ts
@@ -28,6 +28,13 @@ export const DEFAULT_COPILOT_MODEL = 'claude-sonnet-4.6';
  *
  * Order matters — the picker renders in this order, and the first entry
  * is what alias-mode falls back to.
+ *
+ * Claude Opus 5 is deliberately absent. Anthropic documents it on the Claude
+ * API, Bedrock, Vertex, and Microsoft Foundry, but does not list GitHub Copilot
+ * as a surface that serves it. Add it here — metadata entry *and* a matching
+ * `COPILOT_CONTEXT_LIMITS` entry — only once Copilot is confirmed to offer it.
+ * Accounts that already have it still get it from the live `/copilot-models`
+ * endpoint, which overrides this fallback list.
  */
 const _COPILOT_MODEL_METADATA = {
   // Feb 2026 GA cohort — Copilot CLI default lineup


### PR DESCRIPTION
Follow-up audit to #2034, which added `claude-opus-5` to the model registry. Goal: verify Opus 5 is fully and correctly wired as the **newest Opus** everywhere it matters on the native Claude path, **without** changing the default model.

**Outcome: the registry already satisfies "latest opus = 5". No production code change was required.** This PR ships the tests that lock that in, plus one explanatory comment.

Specs cited: [What's new in Claude Opus 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5) — model ID `claude-opus-5`; 1M context as both default and max (so no smaller variant exists); 128K max output; thinking on by default; $5/M in, $25/M out; available on Claude API, Bedrock (`anthropic.claude-opus-5`), Vertex, and Microsoft Foundry. **Not** listed for GitHub Copilot.

## What changed

**`packages/core/src/models/claude.test.ts`**
- Opus 5 is listed ahead of every `claude-opus-4*` entry in `AVAILABLE_CLAUDE_MODEL_ALIASES`.
- `hasNativeMillionContext('claude-opus-5-20260101')` is true (prefix match, so dated snapshots are covered).
- Opus 5 gets no synthetic `[1m]` variant.
- `DEFAULT_CLAUDE_MODEL` is still `claude-sonnet-5`.

**`apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts`**
- Same ordering assertion against the *rendered* picker list. `curateModelOptions()` preserves registry order and only hoists the configured default, so this pins the user-visible outcome rather than just the array literal.

**`packages/core/src/models/copilot.ts`**
- Comment only. Documents why Opus 5 is intentionally absent and what to add if that changes.

## Why nothing else changed

**`hasNativeMillionContext` / `[1m]` variants — already correct.** `claude-opus-5` is in `NATIVE_MILLION_CONTEXT_PREFIXES`, so `apps/agor-daemon/src/services/claude-models.ts` skips the synthetic `[1m]` variant for it. That matters: Opus 5's 1M window is both default and max, so a `[1m]` entry would be a duplicate advertising a beta flag it doesn't need.

**Ordering — already correct.** Registry index 1 (`claude-opus-5`) precedes index 2 (`claude-opus-4-8`). Verified against `curateModelOptions()`, not just the literal.

**Pricing — nothing to update, as expected.** Confirmed there is no static Claude token-price table anywhere in the repo. `packages/core/src/claude-cli/pricing.ts` is gone. Claude cost is SDK-reported via `msg.total_cost_usd` (`packages/executor/src/sdk-handlers/claude/normalizer.ts:19`, `message-processor.ts:571`). The only price table left is `packages/core/src/models/gemini-shared.ts`, which is Gemini-only.

**Advisor path — no aliasing to fix.** `advisorModel` is a free-form string passed straight through to the Claude Code CLI's `--advisor` flag (`packages/executor/src/sdk-handlers/claude/query-builder.ts:340-345`). Agor never resolves `'opus'` to a concrete model — the CLI/server does — so there is no pinned 4.x to update. The picker (`AdvisorModelSelect.tsx`) sources its options from the same registry / live models endpoint, so Opus 5 already appears there. I did not add alias-resolution logic; that would be new behavior, not a fix.

## Grep decision list

Swept `packages/`, `apps/`, config, templates, prompts, and docs for `claude-opus-4-8|4-7|4-6|4.6` and bare `opus`. Every hit, with the call:

| Location | Hit | Decision |
|---|---|---|
| `packages/core/src/models/claude.ts` | opus-4-8/4-7/4-6 registry entries + 1M prefixes | **Keep** — legitimate older models, correctly ordered after opus-5 |
| `packages/core/src/models/copilot.ts` | `claude-opus-4.6` model + context-limit entry | **Keep** — different provider; see open question below |
| `apps/agor-ui/.../ModelSelector.tsx:459` | placeholder `e.g., claude-opus-4-8-20251115` | **Keep** — illustrative placeholder for exact-pin mode, not a default |
| `apps/agor-ui/.../DemoSessionStage.tsx:53` | `STAGE_MODEL = 'claude-opus-4-6'` | **Keep** — marketing demo fixture rendering a fake session; a dated snapshot, not a "latest opus" default |
| `apps/agor-daemon/src/services/sessions.ts:682` | `claude-opus-4-7` in comment | **Keep** — comment illustrating cross-tool inheritance |
| `apps/agor-daemon/src/mcp/tools/sessions.ts` (×5) | `claude-opus-4-6` in MCP tool descriptions | **Keep** — format examples for agents, not defaults |
| `apps/agor-daemon/src/mcp/tools/schedules.ts:57`, `types/session.ts`, `types/user.ts` | advisor examples `'opus'`, `'sonnet'`, `'fable'` | **Keep** — pass-through CLI aliases; Agor does not resolve them |
| `packages/executor/.../model-utils.ts:16-17` | `claude-opus-4-6[1m]` in JSDoc | **Keep** — doc example for a model that genuinely has a `[1m]` variant |
| `CLAUDE.md` / `AGENTS.md:461` | `claude-opus-4-6[1m]` `[1m]` explanation | **Keep** — same; still an accurate example |
| Test fixtures (leaderboard, sessions, resolve-config, resolve-session-defaults, task-extractor, UI component tests) | various opus-4.x | **Keep** — arbitrary fixture values; none assert "the newest Opus" |

No case (b) — a real "newest opus" default/alias pinned to an older Opus — was found.

## Open questions / findings not fixed

1. **Copilot + Opus 5 (default: not added).** `packages/core/src/models/copilot.ts` tops out at `claude-opus-4.6`. Anthropic's docs do not list GitHub Copilot as a surface serving Opus 5, and I found no in-repo evidence either way, so I did **not** add it — I added a comment explaining the omission and what to add (metadata entry *and* `COPILOT_CONTEXT_LIMITS` entry) if confirmed. Worth noting this list is only the offline fallback; the authoritative source is the live `/copilot-models` endpoint, so any account that already has Opus 5 sees it regardless. **Please confirm whether Copilot serves Opus 5.**

2. **Pre-existing, out of scope: model pills render 5-series models without a version.** `apps/agor-ui/src/components/Pill/modelDisplay.ts` matches `/opus-(\d)-(\d)/`, so `claude-opus-5` falls through to the bare label `"opus"` instead of `"opus-5"`. This is not Opus-5-specific — it predates this work and equally affects `claude-sonnet-5` (**the current default model**, rendering as bare `"sonnet"`) and `claude-fable-5`. I left it alone because fixing it changes the label for the default model and the whole 5-series, which is a separate, visible UI change rather than part of an Opus-5 wiring audit. Happy to send it as its own PR if you want it.

## Test results

Run in this worktree (deps installed via `pnpm install --frozen-lockfile`):

| Suite | Result |
|---|---|
| `packages/core/src/models/` (claude, codex, lint-model-tool-match, resolve-config) | **69 passed** / 4 files |
| `apps/agor-ui/src/components/ModelSelector/` (modelDefaults + ModelSelector) | **20 passed** / 2 files |

New tests confirmed executing by name: `lists Opus 5 ahead of every older Opus`, `keeps Sonnet 5 as the default model`, `recognizes claude-opus-5-20260101 as native 1M`, `renders Opus 5 ahead of every older Opus`.

**Typecheck:** `tsc --noEmit` on `packages/core` reports **50 errors, all pre-existing and unrelated** — verified identical count (50) on a stashed clean tree. They all stem from the unbuilt `@agor/git` workspace dependency in this worktree (`Cannot find module '@agor/git'` and downstream `has no exported member` errors in `src/git/**`). **Zero errors in `src/models/`.** Biome passes on all three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
