### PR TITLE
fix(core): emit journald severity prefixes

### DIFF
--- a/packages/core/src/utils/LOGGING.md
+++ b/packages/core/src/utils/LOGGING.md
@@ -17,10 +17,25 @@ DEBUG=agor:* pnpm dev
 
 ## Log Levels
 
-- `console.log()` / `console.debug()` → debug (hidden in production)
+- `console.debug()` → debug (hidden in production)
+- `console.log()` → info
 - `console.info()` → info
 - `console.warn()` → warn
 - `console.error()` → error
+
+The `console.log()` → info mapping is a known deviation from the intended logging
+contract and is tracked separately. It is documented here as the current behavior.
+
+## systemd journal priorities
+
+When `JOURNAL_STREAM` is present, `patchConsole()` adds sd-daemon severity prefixes
+to every emitted line: `<7>` for debug, `<6>` for info/log, `<4>` for warnings, and
+`<3>` for errors. With `StandardOutput=journal` and `SyslogLevelPrefix=yes`, systemd
+uses these prefixes as journal priorities and removes them from the stored message.
+
+Arguments are formatted together before prefixing, so every line of a multi-line
+string, error stack, or object dump receives the same priority. Outside systemd,
+arguments remain unmodified and output stays unprefixed.
 
 ## Implementation
 

--- a/packages/core/src/utils/logger.test.ts
+++ b/packages/core/src/utils/logger.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnvironment = { ...process.env };
+
+describe('patchConsole', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.JOURNAL_STREAM;
+    process.env.LOG_LEVEL = 'debug';
+  });
+
+  afterEach(async () => {
+    const { unpatchConsole } = await import('./logger.js');
+    unpatchConsole();
+    vi.restoreAllMocks();
+    process.env = { ...originalEnvironment };
+  });
+
+  it('preserves unprefixed console arguments outside systemd', async () => {
+    const originalError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { patchConsole } = await import('./logger.js');
+    patchConsole();
+    const error = new Error('failure');
+    console.error('message', error);
+    expect(originalError).toHaveBeenCalledWith('message', error);
+  });
+
+  it('retains the original console methods for unpatching', async () => {
+    const originalError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { patchConsole, unpatchConsole } = await import('./logger.js');
+    patchConsole();
+
+    expect(
+      (console as Console & { __originalMethods?: { error: typeof console.error } })
+        .__originalMethods?.error
+    ).toBe(originalError);
+
+    unpatchConsole();
+    expect(console.error).toBe(originalError);
+  });
+
+  it('adds the corresponding journal priority to each level under systemd', async () => {
+    process.env.JOURNAL_STREAM = '9:12345';
+    const methods = {
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    };
+    const { patchConsole } = await import('./logger.js');
+    patchConsole();
+    console.debug('debug');
+    console.log('log');
+    console.info('info');
+    console.warn('warn');
+    console.error('error');
+    expect(methods.debug).toHaveBeenCalledWith('<7>debug');
+    expect(methods.log).toHaveBeenCalledWith('<6>log');
+    expect(methods.info).toHaveBeenCalledWith('<6>info');
+    expect(methods.warn).toHaveBeenCalledWith('<4>warn');
+    expect(methods.error).toHaveBeenCalledWith('<3>error');
+  });
+
+  it('prefixes every line after formatting multiple arguments', async () => {
+    process.env.JOURNAL_STREAM = '9:12345';
+    const originalError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { patchConsole } = await import('./logger.js');
+    patchConsole();
+    const error = new Error('failure');
+    error.stack = 'Error: failure\n    at worker.ts:10:2';
+    console.error('request failed', error);
+    expect(originalError).toHaveBeenCalledWith(
+      '<3>request failed Error: failure\n<3>    at worker.ts:10:2'
+    );
+  });
+
+  it('still filters messages below LOG_LEVEL', async () => {
+    process.env.JOURNAL_STREAM = '9:12345';
+    process.env.LOG_LEVEL = 'warn';
+    vi.resetModules();
+    const originalLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const originalWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { patchConsole } = await import('./logger.js');
+    patchConsole();
+    console.log('hidden');
+    console.warn('visible');
+    expect(originalLog).not.toHaveBeenCalled();
+    expect(originalWarn).toHaveBeenCalledWith('<4>visible');
+  });
+});

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -3,6 +3,8 @@
  * Respects LOG_LEVEL env var (debug/info/warn/error).
  */
 
+import { format } from 'node:util';
+
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface ConsoleWithOriginals extends Console {
@@ -20,6 +22,13 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   info: 1,
   warn: 2,
   error: 3,
+};
+
+const JOURNAL_PRIORITIES: Record<LogLevel, string> = {
+  debug: '<7>',
+  info: '<6>',
+  warn: '<4>',
+  error: '<3>',
 };
 
 export function getCurrentLogLevel(): LogLevel {
@@ -44,6 +53,19 @@ function shouldLog(level: LogLevel): boolean {
   return LOG_LEVELS[level] >= LOG_LEVELS[currentLevel];
 }
 
+function write(original: (...args: unknown[]) => void, level: LogLevel, args: unknown[]) {
+  if (!shouldLog(level)) return;
+  if (!process.env.JOURNAL_STREAM) {
+    original(...args);
+    return;
+  }
+
+  // Format the complete console call first so embedded newlines in any
+  // argument (notably Error stacks and object dumps) are all classified.
+  const priority = JOURNAL_PRIORITIES[level];
+  original(format(...args).replace(/^/gm, priority));
+}
+
 export function patchConsole() {
   const originalDebug = console.debug;
   const originalLog = console.log;
@@ -52,23 +74,23 @@ export function patchConsole() {
   const originalError = console.error;
 
   console.debug = (...args: unknown[]) => {
-    if (shouldLog('debug')) originalDebug(...args);
+    write(originalDebug, 'debug', args);
   };
 
   console.log = (...args: unknown[]) => {
-    if (shouldLog('info')) originalLog(...args);
+    write(originalLog, 'info', args);
   };
 
   console.info = (...args: unknown[]) => {
-    if (shouldLog('info')) originalInfo(...args);
+    write(originalInfo, 'info', args);
   };
 
   console.warn = (...args: unknown[]) => {
-    if (shouldLog('warn')) originalWarn(...args);
+    write(originalWarn, 'warn', args);
   };
 
   console.error = (...args: unknown[]) => {
-    if (shouldLog('error')) originalError(...args);
+    write(originalError, 'error', args);
   };
 
   (console as ConsoleWithOriginals).__originalMethods = {


### PR DESCRIPTION
## Summary

- emit sd-daemon severity prefixes from patched console methods when `JOURNAL_STREAM` is set
- format multi-argument console calls before applying a priority prefix to every output line
- preserve existing `LOG_LEVEL` filtering and original console method restoration
- document current console level mappings and systemd journal behavior

## Severity mapping

| Console method | Journal priority |
| --- | --- |
| `console.error` | `<3>` (error) |
| `console.warn` | `<4>` (warning) |
| `console.info` / `console.log` | `<6>` (info) |
| `console.debug` | `<7>` (debug) |

## Testing

- `pnpm i`
- `pnpm check`
- `cd packages/core && pnpm exec vitest run src/utils/logger.test.ts` (5 tests passed)
