### PR TITLE
Fix branch file downloads and large file command results

### DIFF
--- a/apps/agor-daemon/src/register-routes.file-download-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.file-download-boundary.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Architecture guard for the streamed branch-file download plane.
+ *
+ * The regression this protects against (#2128) had two halves, and a fix can
+ * regress into either one:
+ *
+ *   1. bulk file bytes riding the executor's JSON result over Socket.IO, which
+ *      caps frames and made files over ~1 MB undownloadable; and
+ *   2. "fixing" that by giving the daemon its own read access to branch
+ *      checkouts, which breaks the executor-owns-the-filesystem boundary.
+ *
+ * These assertions are source-level on purpose: the properties are about which
+ * module is allowed to do what, which is exactly what a behavioural test of a
+ * single handler cannot observe.
+ */
+describe('branch file download route boundary', () => {
+  const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
+
+  const browserRoute = () => {
+    const start = source.indexOf("'/branches/:branchId/files/download'");
+    expect(start).toBeGreaterThan(0);
+    return source.slice(start, source.indexOf("'/executor/files/downloads/", start));
+  };
+
+  const dataPlaneRoute = () => {
+    const start = source.indexOf("'/executor/files/downloads/:downloadRef/content'");
+    expect(start).toBeGreaterThan(0);
+    return source.slice(start, source.indexOf('type UploadHttpRequest', start));
+  };
+
+  it('never opens the branch filesystem from the daemon', () => {
+    // The daemon must delegate every byte to the executor. Any fs import here
+    // would also require a new scripts/daemon-filesystem-exceptions.json entry.
+    expect(source).not.toMatch(/from 'node:fs'/);
+    expect(source).not.toMatch(/from 'node:fs\/promises'/);
+    expect(source).not.toMatch(/createReadStream/);
+  });
+
+  it('authenticates and authorizes the browser request before opening a transfer', () => {
+    const route = browserRoute();
+    expect(route.indexOf('uploadAuthMiddleware')).toBeLessThan(route.indexOf('ensureMinimumRole'));
+    expect(route.indexOf('ensureMinimumRole')).toBeLessThan(route.indexOf('.register('));
+    // Branch RBAC 'view' is the same gate the /file service applies.
+    expect(route).toContain('resolveBranchPermission');
+    expect(route).toContain('PERMISSION_RANK.view');
+    expect(route.indexOf('PERMISSION_RANK.view')).toBeLessThan(route.indexOf('.register('));
+  });
+
+  it('scopes the executor capability token to one action, ref, branch and tenant', () => {
+    const route = browserRoute();
+    expect(route).toContain("executor_action: 'files.download'");
+    expect(route).toContain('executor_download_ref: transfer.ref');
+    expect(route).toContain('executor_branch_id: resolved.branchId');
+    // Minted inside a tenant scope so the service token carries tenant_id.
+    expect(route).toMatch(/runWithTenantDatabaseScope\([\s\S]*generateScopedServiceToken/);
+  });
+
+  it('never puts the capability token in the URL it hands the executor', () => {
+    const route = browserRoute();
+    expect(route).toContain('downloadRef: transfer.ref');
+    expect(route).not.toMatch(/downloads\/\$\{[^}]*sessionToken/);
+  });
+
+  it('releases the waiting browser when the executor command fails', () => {
+    // Otherwise a missing or over-limit file hangs the request until the TTL.
+    const route = browserRoute();
+    expect(route).toMatch(/command\.then\(/);
+    expect(route).toContain('transfer.cancel(');
+    expect(route).toContain("res.once('close'");
+  });
+
+  it('verifies the executor claims before accepting a single byte', () => {
+    const route = dataPlaneRoute();
+    const firstClaimCheck = route.indexOf("claims?.type !== 'service'");
+    expect(firstClaimCheck).toBeGreaterThan(0);
+    expect(firstClaimCheck).toBeLessThan(route.indexOf('req.pipe('));
+    expect(route).toContain("claims.executor_action !== 'files.download'");
+    expect(route).toContain('claims.executor_download_ref !== downloadRef');
+    expect(route).toContain("typeof claims.tenant_id !== 'string'");
+  });
+
+  it('claims the transfer with tenant and branch proof, not the ref alone', () => {
+    const route = dataPlaneRoute();
+    expect(route).toMatch(/claim\(downloadRef,\s*\{[\s\S]*tenantId:[\s\S]*branchId:/);
+  });
+
+  it('holds the stream to exactly its declared, authorized length', () => {
+    const route = dataPlaneRoute();
+    expect(route).toContain('transfer.scope.maxBytes');
+    expect(route).toContain('received > size');
+    expect(route).toContain('received === size');
+  });
+
+  it('reads the executor token from the Authorization header only', () => {
+    const route = dataPlaneRoute();
+    expect(route).toContain('req.headers.authorization');
+    expect(route).toContain("authHeader.startsWith('Bearer ')");
+    expect(route).not.toContain('req.query.token');
+  });
+});

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -7,6 +7,7 @@
  */
 
 import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import {
   type AgorConfig,
   type ResolvedDeploymentConfig,
@@ -143,11 +144,15 @@ import {
   checkSessionOwnerOrAdmin,
   ensureBranchPermission,
   loadScheduleAndBranch,
+  PERMISSION_RANK,
+  resolveBranchPermission,
   resolveSessionPromptAccess,
 } from './utils/branch-authorization.js';
+import { getBranchFileDownloadTransfers } from './utils/branch-file-download-transfers.js';
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
 import { buildPrompterPrefixedPrompt } from './utils/build-prompter-prefix.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
+import { resolveDelegatedExecutionHomeKey } from './utils/executor-delegated-home.js';
 import {
   redactMCPServerSecrets,
   shouldExposeMCPServerSecrets,
@@ -169,6 +174,11 @@ import {
 } from './utils/session-task-state.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
+import {
+  generateScopedServiceToken,
+  getDaemonUrl,
+  runExecutorCommand,
+} from './utils/spawn-executor.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';
 import {
@@ -2488,6 +2498,242 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       });
       // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
     }) as any
+  );
+
+  // ============================================================================
+  // Branch file download data plane
+  //
+  // The daemon has no filesystem access to branch checkouts, and executor
+  // results travel as JSON over stdout + Socket.IO, which caps frames at
+  // SOCKET_IO_MAX_BUFFER_SIZE_BYTES. Inlining bytes there is what made files
+  // over ~1 MB undownloadable. These two routes are the streamed alternative:
+  // the browser registers a pending transfer, the executor claims it with a
+  // single-use capability token and POSTs raw bytes, and the daemon pipes those
+  // bytes straight through. No daemon-local workspace access, no base64, no
+  // Socket.IO frame in the path.
+  // ============================================================================
+
+  /** Ceiling on a single streamed branch-file download. */
+  const MAX_BRANCH_FILE_DOWNLOAD_BYTES = 1024 * 1024 * 1024;
+  /** Covers executor spawn, Feathers connect, and the transfer of a large file. */
+  const BRANCH_FILE_DOWNLOAD_TIMEOUT_MS = 300_000;
+
+  /** RFC 5987 attachment header that survives non-ASCII filenames. */
+  function attachmentDisposition(filename: string): string {
+    const fallback = filename.replace(/[^\x20-\x7E]/g, '_').replace(/["\\]/g, '_') || 'download';
+    return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Express route method not on FeathersJS Application type
+  (app as any).get(
+    '/branches/:branchId/files/download',
+    uploadAuthMiddleware,
+    // biome-ignore lint/suspicious/noExplicitAny: Express 5 request augmentation
+    async (req: any, res: any, next: NextFunction) => {
+      try {
+        const params = req.feathers as AuthenticatedParams;
+        ensureMinimumRole(params, ROLES.MEMBER, 'download branch files');
+        const tenantId = params.tenant?.tenant_id;
+        const userId = params.user?.user_id as UUID | undefined;
+        if (!tenantId || !userId) throw new NotAuthenticated('Authentication required');
+        const filePath = typeof req.query.path === 'string' ? req.query.path : '';
+        if (!filePath) throw new BadRequest('path query parameter is required');
+        const branchId = String(req.params.branchId);
+
+        // One short unit of work: branch lookup, branch RBAC, and the delegated
+        // home key the executor read runs under. Mirrors the `/file` service
+        // gate (member role + branch 'view') so both paths share one policy.
+        const resolved = await runWithTenantDatabaseScope(db, tenantId, async () => {
+          const branch = await branchRepo.findById(branchId);
+          if (!branch) return null;
+          if (branchRbacEnabled) {
+            const isOwner = await branchRepo.isOwner(branch.branch_id, userId);
+            const effective = resolveBranchPermission(
+              branch,
+              userId,
+              isOwner,
+              params.user?.role,
+              superadminOpts.allowSuperadmin,
+              await branchRepo.resolveUserPermission(branch, userId)
+            );
+            if (PERMISSION_RANK[effective] < PERMISSION_RANK.view) return null;
+          }
+          const delegatedHomeKey = await resolveDelegatedExecutionHomeKey(
+            db,
+            userId,
+            app.get('config')
+          );
+          return { branchId: branch.branch_id, delegatedHomeKey };
+        });
+        if (!resolved) throw new NotFound(`Branch not found: ${branchId}`);
+
+        const transfer = getBranchFileDownloadTransfers().register(
+          {
+            tenantId,
+            branchId: resolved.branchId,
+            filePath,
+            maxBytes: MAX_BRANCH_FILE_DOWNLOAD_BYTES,
+          },
+          async (metadata, body) => {
+            res.status(200);
+            res.setHeader('Content-Type', metadata.mimeType || 'application/octet-stream');
+            res.setHeader('Content-Length', String(metadata.size));
+            res.setHeader('Content-Disposition', attachmentDisposition(metadata.filename));
+            res.setHeader('Cache-Control', 'private, no-store');
+            res.setHeader('X-Content-Type-Options', 'nosniff');
+            await pipeline(body, res);
+          },
+          BRANCH_FILE_DOWNLOAD_TIMEOUT_MS
+        );
+        // A browser that navigates away must not leave the transfer parked
+        // until its TTL.
+        res.once('close', () =>
+          transfer.cancel('Client disconnected before the download completed')
+        );
+
+        // Capability token: one action, one ref, one branch, one tenant. Minted
+        // inside a tenant scope so the service-token tenant claim is populated.
+        const sessionToken = await runWithTenantDatabaseScope(db, tenantId, async () =>
+          generateScopedServiceToken(
+            app as unknown as { settings: { authentication?: { secret?: string } } },
+            {
+              executor_action: 'files.download',
+              executor_download_ref: transfer.ref,
+              executor_branch_id: resolved.branchId,
+            }
+          )
+        );
+
+        const command = runExecutorCommand(
+          {
+            command: 'branch.files.download',
+            sessionToken,
+            daemonUrl: getDaemonUrl(),
+            params: {
+              branchId: resolved.branchId,
+              filePath,
+              downloadRef: transfer.ref,
+              maxBytes: MAX_BRANCH_FILE_DOWNLOAD_BYTES,
+            },
+          },
+          {
+            logPrefix: `[FileDownload ${shortId(resolved.branchId)}]`,
+            delegatedHomeKey: resolved.delegatedHomeKey,
+            timeoutMs: BRANCH_FILE_DOWNLOAD_TIMEOUT_MS,
+          }
+        );
+        // A missing file or an over-limit file never reaches the data plane, so
+        // the executor's failure — not the TTL — is what releases the browser.
+        command.then(
+          (result) => {
+            if (!result.success) {
+              transfer.cancel(result.error?.message ?? 'Executor download failed');
+            }
+          },
+          (error) => transfer.cancel(error instanceof Error ? error.message : String(error))
+        );
+
+        await transfer.delivered;
+      } catch (error) {
+        if (res.headersSent) {
+          res.destroy();
+          return;
+        }
+        next(error);
+      }
+    }
+  );
+
+  // Executor-only data plane. The scoped service token stays in the
+  // Authorization header and binds exactly one tenant + branch + transfer ref.
+  // biome-ignore lint/suspicious/noExplicitAny: Express route method not on FeathersJS Application type
+  (app as any).post(
+    '/executor/files/downloads/:downloadRef/content',
+    // biome-ignore lint/suspicious/noExplicitAny: Express 5 request augmentation
+    async (req: any, res: any) => {
+      try {
+        const authHeader = req.headers.authorization;
+        if (typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
+          return res.status(401).json({ error: 'Authentication required' });
+        }
+        const result = await app.service('authentication').create({
+          strategy: 'jwt',
+          accessToken: authHeader.slice(7),
+        });
+        const claims = result.authentication?.payload as Record<string, unknown> | undefined;
+        const downloadRef = String(req.params.downloadRef);
+        const size = Number.parseInt(String(req.headers['content-length'] ?? ''), 10);
+        if (
+          claims?.type !== 'service' ||
+          claims.executor_action !== 'files.download' ||
+          claims.executor_download_ref !== downloadRef ||
+          typeof claims.executor_branch_id !== 'string' ||
+          typeof claims.tenant_id !== 'string' ||
+          !Number.isSafeInteger(size) ||
+          size < 0 ||
+          size > MAX_BRANCH_FILE_DOWNLOAD_BYTES
+        ) {
+          return res.status(403).json({ error: 'Download transfer capability denied' });
+        }
+
+        // Single-use, and only for the tenant + branch the transfer was opened
+        // for: a replayed token finds nothing left to claim.
+        const transfer = getBranchFileDownloadTransfers().claim(downloadRef, {
+          tenantId: claims.tenant_id as string,
+          branchId: claims.executor_branch_id as string,
+        });
+        if (!transfer) {
+          return res.status(404).json({ error: 'Download transfer unavailable' });
+        }
+        if (size > transfer.scope.maxBytes) {
+          transfer.settle(new Error('Download stream exceeds its authorized size'));
+          return res.status(413).json({ error: 'Download exceeds its authorized size' });
+        }
+
+        // Hold the stream to exactly the length it declared, so a truncated or
+        // over-long body fails the download instead of reaching the browser as
+        // a silently corrupt file.
+        let received = 0;
+        const limiter = new Transform({
+          transform(chunk: Buffer, _encoding, callback) {
+            received += chunk.byteLength;
+            if (received > size) {
+              callback(new Error('Download stream exceeds its declared size'));
+              return;
+            }
+            callback(null, chunk);
+          },
+          flush(callback) {
+            callback(received === size ? undefined : new Error('Download stream size mismatch'));
+          },
+        });
+        req.pipe(limiter);
+
+        try {
+          await transfer.sink(
+            {
+              filename: decodeURIComponent(String(req.headers['x-agor-filename'] ?? 'download')),
+              mimeType: String(req.headers['x-agor-mime-type'] ?? 'application/octet-stream'),
+              size,
+            },
+            limiter
+          );
+          transfer.settle();
+          res.status(204).end();
+        } catch (error) {
+          transfer.settle(error instanceof Error ? error : new Error(String(error)));
+          if (!res.headersSent) res.status(500).json({ error: 'Download delivery failed' });
+          else res.destroy();
+        }
+      } catch (error) {
+        const status = (error as { code?: number }).code ?? 400;
+        if (!res.headersSent) {
+          res
+            .status(status)
+            .json({ error: error instanceof Error ? error.message : 'Download failed' });
+        } else res.destroy();
+      }
+    }
   );
 
   type UploadHttpRequest = Request & {

--- a/apps/agor-daemon/src/utils/branch-file-download-transfers.test.ts
+++ b/apps/agor-daemon/src/utils/branch-file-download-transfers.test.ts
@@ -1,0 +1,139 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BranchFileDownloadTransfers,
+  type DownloadTransferScope,
+} from './branch-file-download-transfers.js';
+
+const SCOPE: DownloadTransferScope = {
+  tenantId: 'tenant-a',
+  branchId: 'branch-1',
+  filePath: 'big.bin',
+  maxBytes: 1024,
+};
+
+const PROOF = { tenantId: SCOPE.tenantId, branchId: SCOPE.branchId };
+
+function noopSink() {
+  return vi.fn(async () => undefined);
+}
+
+describe('BranchFileDownloadTransfers', () => {
+  it('mints refs the executor payload schema accepts', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+    expect(transfer.ref).toMatch(/^dl_[0-9a-f-]{36}$/);
+    transfer.cancel();
+    await expect(transfer.delivered).rejects.toThrow();
+  });
+
+  it('hands the registered sink to a correctly scoped claim', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const sink = noopSink();
+    const transfer = transfers.register(SCOPE, sink);
+
+    const claimed = transfers.claim(transfer.ref, PROOF);
+    expect(claimed).not.toBeNull();
+    expect(claimed?.scope.maxBytes).toBe(1024);
+
+    const body = new PassThrough();
+    await claimed?.sink(
+      { filename: 'big.bin', mimeType: 'application/octet-stream', size: 3 },
+      body
+    );
+    expect(sink).toHaveBeenCalledOnce();
+
+    claimed?.settle();
+    await expect(transfer.delivered).resolves.toBeUndefined();
+  });
+
+  it('is single-use, so a replayed capability token finds nothing', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    expect(transfers.claim(transfer.ref, PROOF)).not.toBeNull();
+    expect(transfers.claim(transfer.ref, PROOF)).toBeNull();
+    transfer.cancel();
+    await expect(transfer.delivered).rejects.toThrow();
+  });
+
+  it('refuses a claim from another tenant', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    expect(transfers.claim(transfer.ref, { ...PROOF, tenantId: 'tenant-b' })).toBeNull();
+    // The transfer stays parked for its rightful claimant rather than being consumed.
+    expect(transfers.size).toBe(1);
+    expect(transfers.claim(transfer.ref, PROOF)).not.toBeNull();
+    transfer.cancel();
+    await expect(transfer.delivered).rejects.toThrow();
+  });
+
+  it('refuses a claim for another branch in the same tenant', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    expect(transfers.claim(transfer.ref, { ...PROOF, branchId: 'branch-2' })).toBeNull();
+    transfer.cancel();
+    await expect(transfer.delivered).rejects.toThrow();
+  });
+
+  it('rejects the waiting request when the executor never delivers', async () => {
+    vi.useFakeTimers();
+    try {
+      const transfers = new BranchFileDownloadTransfers(50);
+      const transfer = transfers.register(SCOPE, noopSink());
+      const settled = expect(transfer.delivered).rejects.toThrow(/expired/i);
+
+      vi.advanceTimersByTime(51);
+      await settled;
+      // An expired transfer is no longer claimable.
+      expect(transfers.claim(transfer.ref, PROOF)).toBeNull();
+      expect(transfers.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('honours a per-transfer ttl over the registry default', async () => {
+    vi.useFakeTimers();
+    try {
+      const transfers = new BranchFileDownloadTransfers(10_000);
+      const transfer = transfers.register(SCOPE, noopSink(), 25);
+      const settled = expect(transfer.delivered).rejects.toThrow(/expired/i);
+      vi.advanceTimersByTime(26);
+      await settled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancel releases the waiter and drops the entry', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    transfer.cancel('Client disconnected');
+    await expect(transfer.delivered).rejects.toThrow('Client disconnected');
+    expect(transfers.size).toBe(0);
+    expect(transfers.claim(transfer.ref, PROOF)).toBeNull();
+  });
+
+  it('settles exactly once, so a late cancel cannot flip a delivered download', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    const claimed = transfers.claim(transfer.ref, PROOF);
+    claimed?.settle();
+    transfer.cancel('too late');
+
+    await expect(transfer.delivered).resolves.toBeUndefined();
+  });
+
+  it('propagates a delivery failure to the waiting request', async () => {
+    const transfers = new BranchFileDownloadTransfers();
+    const transfer = transfers.register(SCOPE, noopSink());
+
+    transfers.claim(transfer.ref, PROOF)?.settle(new Error('size mismatch'));
+    await expect(transfer.delivered).rejects.toThrow('size mismatch');
+  });
+});

--- a/apps/agor-daemon/src/utils/branch-file-download-transfers.ts
+++ b/apps/agor-daemon/src/utils/branch-file-download-transfers.ts
@@ -1,0 +1,137 @@
+/**
+ * Rendezvous registry for streamed branch-file downloads.
+ *
+ * The daemon has no filesystem access to branch checkouts — only the executor
+ * does. A download therefore has two halves that must meet in the middle:
+ *
+ *   browser  GET /branches/:id/files/download   → registers a pending transfer
+ *   executor POST /executor/files/downloads/:ref/content → claims it and streams
+ *
+ * This registry is the meeting point. It holds no file bytes and does no I/O
+ * itself: the browser-facing route supplies a `sink` closure that pipes the
+ * executor's request body straight into its own response, so bytes never land
+ * in a buffer, a base64 string, or a Socket.IO frame.
+ *
+ * Entries are single-use and TTL-bounded, so a ref that is never claimed (the
+ * executor died, the file was missing) cannot leak or be replayed.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+/** Identity a claiming executor must prove to receive a pending transfer. */
+export interface DownloadTransferScope {
+  tenantId: string;
+  branchId: string;
+  filePath: string;
+  /** Upper bound the executor was authorized to send. */
+  maxBytes: number;
+}
+
+export interface DownloadTransferMetadata {
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
+/**
+ * Consumes the executor's byte stream. Resolves once the bytes have been
+ * handed to the browser, rejects if that delivery fails.
+ */
+export type DownloadTransferSink = (
+  metadata: DownloadTransferMetadata,
+  body: NodeJS.ReadableStream
+) => Promise<void>;
+
+/** A transfer taken off the registry by the executor that is about to stream. */
+export interface ClaimedDownloadTransfer {
+  scope: DownloadTransferScope;
+  sink: DownloadTransferSink;
+  /** Report delivery success (no argument) or failure to the waiting browser route. */
+  settle: (error?: Error) => void;
+}
+
+interface PendingEntry extends ClaimedDownloadTransfer {
+  timer: NodeJS.Timeout;
+}
+
+export interface RegisteredTransfer {
+  /** Single-use handle handed to the executor. Matches `/^dl_[0-9a-f-]{36}$/`. */
+  ref: string;
+  /** Resolves when the executor's bytes have been delivered to the browser. */
+  delivered: Promise<void>;
+  /** Abandon the transfer (executor failed, client disconnected). Idempotent. */
+  cancel: (reason?: string) => void;
+}
+
+/** Generous enough for executor spawn + Feathers connect, short enough to not leak. */
+const DEFAULT_TTL_MS = 120_000;
+
+export class BranchFileDownloadTransfers {
+  private pending = new Map<string, PendingEntry>();
+
+  constructor(private ttlMs: number = DEFAULT_TTL_MS) {}
+
+  register(
+    scope: DownloadTransferScope,
+    sink: DownloadTransferSink,
+    ttlMs: number = this.ttlMs
+  ): RegisteredTransfer {
+    const ref = `dl_${randomUUID()}`;
+    let settled = false;
+    let settleOuter: (error?: Error) => void = () => undefined;
+
+    const delivered = new Promise<void>((resolve, reject) => {
+      settleOuter = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        const entry = this.pending.get(ref);
+        if (entry) clearTimeout(entry.timer);
+        this.pending.delete(ref);
+        if (error) reject(error);
+        else resolve();
+      };
+    });
+
+    const timer = setTimeout(
+      () => settleOuter(new Error('Download transfer expired before the executor delivered bytes')),
+      ttlMs
+    );
+    // A pending download must never hold the process open on shutdown.
+    timer.unref?.();
+
+    this.pending.set(ref, { scope, sink, settle: settleOuter, timer });
+    return {
+      ref,
+      delivered,
+      cancel: (reason?: string) => settleOuter(new Error(reason ?? 'Download transfer cancelled')),
+    };
+  }
+
+  /**
+   * Take the pending transfer for `ref`, but only for a caller that proves the
+   * same tenant and branch the transfer was registered for. Single-use: the
+   * entry is removed here, so a replayed capability token finds nothing.
+   */
+  claim(ref: string, proof: { tenantId: string; branchId: string }): PendingEntry | null {
+    const entry = this.pending.get(ref);
+    if (!entry) return null;
+    if (entry.scope.tenantId !== proof.tenantId || entry.scope.branchId !== proof.branchId) {
+      return null;
+    }
+    clearTimeout(entry.timer);
+    this.pending.delete(ref);
+    return entry;
+  }
+
+  /** Test/observability helper. */
+  get size(): number {
+    return this.pending.size;
+  }
+}
+
+let transfers: BranchFileDownloadTransfers | null = null;
+
+export function getBranchFileDownloadTransfers(): BranchFileDownloadTransfers {
+  if (!transfers) transfers = new BranchFileDownloadTransfers();
+  return transfers;
+}

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
@@ -1,6 +1,8 @@
 import type { AgorClient, Branch, FileDetail, FileListItem } from '@agor-live/client';
 import { Alert, Space } from 'antd';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { getDaemonUrl } from '../../../config/daemon';
+import { getAuthHeaders } from '../../../utils/authHeaders';
 import { useThemedMessage } from '../../../utils/message';
 import { CodePreviewModal } from '../../CodePreviewModal/CodePreviewModal';
 import type { FileItem } from '../../FileCollection/FileCollection';
@@ -8,6 +10,23 @@ import { FileCollection } from '../../FileCollection/FileCollection';
 import { MarkdownModal } from '../../MarkdownModal/MarkdownModal';
 
 const MAX_FILES = 50000;
+
+function branchFileDownloadUrl(branchId: string, path: string): string {
+  const base = getDaemonUrl().replace(/\/$/, '');
+  return `${base}/branches/${encodeURIComponent(branchId)}/files/download?path=${encodeURIComponent(path)}`;
+}
+
+/** Surface the daemon's reason (missing file, too large, denied) instead of a generic failure. */
+async function describeDownloadFailure(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: unknown; error?: unknown };
+    const detail = typeof body.message === 'string' ? body.message : body.error;
+    if (typeof detail === 'string' && detail) return detail;
+  } catch {
+    // Non-JSON error body; fall through to the status text.
+  }
+  return `Download failed (HTTP ${response.status})`;
+}
 
 interface FilesTabProps {
   branch: Branch;
@@ -60,41 +79,22 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
     fetchFiles();
   }, [client, branch.branch_id]);
 
-  // Download file (handles both UTF-8 text and base64 binary)
+  // Download over the streamed HTTP data plane. The `file` service inlines
+  // content in its JSON result, so it is capped at the Socket.IO frame size and
+  // cannot carry large files; this route streams the bytes instead.
   const downloadFile = useCallback(
     async (file: FileItem) => {
-      const currentClient = clientRef.current;
-      if (!currentClient) return;
-
       try {
         showLoading('Downloading file...', { key: 'download' });
 
-        const detail = (await currentClient.service('file').get(file.path, {
-          query: { branch_id: branchIdRef.current },
-        })) as FileDetail;
-
-        // Decode content based on encoding
-        let blob: Blob;
-        const mimeType = 'mimeType' in file ? file.mimeType : undefined;
-
-        if (detail.encoding === 'base64') {
-          // Binary file: decode base64 to binary
-          const binaryString = atob(detail.content);
-          const bytes = new Uint8Array(binaryString.length);
-          for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-          }
-          blob = new Blob([bytes], {
-            type: mimeType || 'application/octet-stream',
-          });
-        } else {
-          // Text file: use UTF-8 string directly
-          blob = new Blob([detail.content], {
-            type: mimeType || 'text/plain',
-          });
+        const response = await fetch(branchFileDownloadUrl(branchIdRef.current, file.path), {
+          headers: getAuthHeaders(),
+        });
+        if (!response.ok) {
+          throw new Error(await describeDownloadFailure(response));
         }
 
-        const url = URL.createObjectURL(blob);
+        const url = URL.createObjectURL(await response.blob());
         const a = document.createElement('a');
         a.href = url;
         a.download = file.path.split('/').pop() || 'download';
@@ -106,7 +106,9 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
         showSuccess('Downloaded!', { key: 'download' });
       } catch (err) {
         console.error('Failed to download file:', err);
-        showError('Failed to download file', { key: 'download' });
+        showError(err instanceof Error ? err.message : 'Failed to download file', {
+          key: 'download',
+        });
       }
     },
     [showLoading, showSuccess, showError]

--- a/packages/executor/src/commands/files-download.test.ts
+++ b/packages/executor/src/commands/files-download.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  lstat: vi.fn(),
+  realpath: vi.fn(),
+  createReadStream: vi.fn(),
+  resolvePathInsideBranch: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({ createReadStream: mocks.createReadStream }));
+vi.mock('node:fs/promises', () => ({
+  lstat: mocks.lstat,
+  realpath: mocks.realpath,
+  // Unused by the download path but imported by the module under test.
+  open: vi.fn(),
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+}));
+vi.mock('../services/feathers-client.js', () => ({
+  createExecutorClient: vi.fn(async () => ({ io: { disconnect: mocks.disconnect } })),
+}));
+vi.mock('./branch-filesystem.js', () => ({
+  resolveExecutorBranch: vi.fn(async () => ({ path: '/branch' })),
+  resolvePathInsideBranch: mocks.resolvePathInsideBranch,
+  filesystemStatus: vi.fn(),
+}));
+
+import { handleBranchFilesDownload } from './files.js';
+
+const DOWNLOAD_REF = 'dl_00000000-0000-4000-8000-000000000009';
+
+const payload = {
+  command: 'branch.files.download' as const,
+  sessionToken: 'scoped-token',
+  daemonUrl: 'http://daemon',
+  params: {
+    branchId: '00000000-0000-4000-8000-000000000001',
+    filePath: 'assets/big.bin',
+    downloadRef: DOWNLOAD_REF,
+    maxBytes: 1024,
+  },
+};
+
+function statsFor(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    size: 512,
+    isSymbolicLink: () => false,
+    isFile: () => true,
+    ...overrides,
+  };
+}
+
+describe('branch.files.download', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.realpath.mockResolvedValue('/branch');
+    mocks.resolvePathInsideBranch.mockResolvedValue({
+      absolute: '/branch/assets/big.bin',
+      relative: 'assets/big.bin',
+    });
+    mocks.lstat.mockResolvedValue(statsFor());
+    mocks.createReadStream.mockReturnValue('READ_STREAM');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 204 }))
+    );
+  });
+
+  it('streams the file body to the daemon rendezvous instead of returning bytes', async () => {
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(true);
+    // The JSON result carries metadata only — never the file contents. This is
+    // the whole point: bytes must not ride the stdout/Socket.IO path.
+    expect(result.data).toEqual({ path: 'assets/big.bin', size: 512 });
+    expect(JSON.stringify(result)).not.toContain('READ_STREAM');
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`http://daemon/executor/files/downloads/${DOWNLOAD_REF}/content`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('READ_STREAM');
+    expect(init.duplex).toBe('half');
+    // Capability token travels in the header, never in the URL.
+    expect(init.headers.Authorization).toBe('Bearer scoped-token');
+    expect(url).not.toContain('scoped-token');
+    expect(init.headers['Content-Length']).toBe('512');
+    expect(init.headers['Content-Type']).toBe('application/octet-stream');
+    expect(init.headers['X-Agor-Filename']).toBe('big.bin');
+  });
+
+  it('confines the path inside the branch root before opening anything', async () => {
+    await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(mocks.resolvePathInsideBranch).toHaveBeenCalledWith('/branch', 'assets/big.bin', {
+      mustExist: true,
+    });
+  });
+
+  it('refuses a symlink rather than following it out of the branch', async () => {
+    mocks.lstat.mockResolvedValue(statsFor({ isSymbolicLink: () => true }));
+
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('BRANCH_FILES_DOWNLOAD_FAILED');
+    expect(result.error?.message).toMatch(/symlink/i);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a directory or device node', async () => {
+    mocks.lstat.mockResolvedValue(statsFor({ isFile: () => false }));
+
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/not a file/i);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a file larger than the daemon authorized, before streaming', async () => {
+    mocks.lstat.mockResolvedValue(statsFor({ size: 4096 }));
+
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/exceeds the 1024-byte download limit/);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected transfer as a failed command', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 403 }))
+    );
+
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/HTTP 403/);
+  });
+
+  it('translates a permission error into an actionable message', async () => {
+    const denied = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    mocks.lstat.mockRejectedValue(denied);
+
+    const result = await handleBranchFilesDownload(payload, { dryRun: false });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/permissions denied/i);
+  });
+
+  it('always disconnects the Feathers client', async () => {
+    await handleBranchFilesDownload(payload, { dryRun: false });
+    expect(mocks.disconnect).toHaveBeenCalled();
+
+    mocks.lstat.mockRejectedValue(new Error('boom'));
+    await handleBranchFilesDownload(payload, { dryRun: false });
+    expect(mocks.disconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does no filesystem work on a dry run', async () => {
+    const result = await handleBranchFilesDownload(payload, { dryRun: true });
+
+    expect(result.success).toBe(true);
+    expect(mocks.lstat).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/executor/src/commands/files.test.ts
+++ b/packages/executor/src/commands/files.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { browseBranchFiles, readBranchFile } from './files.js';
+import { browseBranchFiles, MAX_INLINE_READ_BYTES, readBranchFile } from './files.js';
 
 describe('branch file commands', () => {
   it('browses files while excluding ignored directories and symlinks', async () => {
@@ -47,5 +47,24 @@ describe('branch file commands', () => {
 
     await expect(readBranchFile(root, '../secret.txt')).rejects.toThrow(/path escapes branch/i);
     await expect(readBranchFile(root, 'escape.txt')).rejects.toThrow(/path escapes branch/i);
+  });
+
+  // Regression for #2128: the inline read used to base64 a whole large file
+  // into its JSON result, which then died against the Socket.IO frame cap and
+  // left big files unreadable. Bulk bytes belong on branch.files.download.
+  it('refuses to inline a file above the read cap and names the streaming path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-files-'));
+    await writeFile(join(root, 'huge.bin'), Buffer.alloc(MAX_INLINE_READ_BYTES + 1));
+
+    await expect(readBranchFile(root, 'huge.bin')).rejects.toThrow(/branch\.files\.download/);
+  });
+
+  it('still inlines a file exactly at the read cap', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-files-'));
+    await writeFile(join(root, 'edge.bin'), Buffer.alloc(MAX_INLINE_READ_BYTES));
+
+    await expect(readBranchFile(root, 'edge.bin')).resolves.toMatchObject({
+      size: MAX_INLINE_READ_BYTES,
+    });
   });
 });

--- a/packages/executor/src/commands/files.ts
+++ b/packages/executor/src/commands/files.ts
@@ -1,8 +1,10 @@
+import { createReadStream } from 'node:fs';
 import { lstat, open, readdir, readFile, realpath } from 'node:fs/promises';
-import { extname, join, relative, sep } from 'node:path';
+import { basename, extname, join, relative, sep } from 'node:path';
 import type { FileDetail, FileListItem } from '@agor/core/types';
 import type {
   BranchFilesBrowsePayload,
+  BranchFilesDownloadPayload,
   BranchFilesReadPayload,
   BranchFilesystemStatusPayload,
   ExecutorResult,
@@ -18,6 +20,11 @@ import type { CommandOptions } from './index.js';
 
 const MAX_FILES = 50000;
 const MAX_PREVIEW_SIZE = 1024 * 1024;
+/**
+ * Hard ceiling on what `branch.files.read` may embed in its JSON result.
+ * Anything above this must go through `branch.files.download`, which streams.
+ */
+export const MAX_INLINE_READ_BYTES = MAX_PREVIEW_SIZE;
 const MAX_TITLE_READ_BYTES = 4096;
 const EXCLUDED_DIRECTORIES = new Set([
   'node_modules',
@@ -189,6 +196,15 @@ export async function readBranchFile(
   const stats = await lstat(requestedPath);
   if (stats.isSymbolicLink()) throw new Error('Access denied: symlinks not allowed');
   if (!stats.isFile()) throw new Error('Requested path is not a file');
+  // `branch.files.read` travels back as JSON on the executor's stdout sentinel
+  // and then over Socket.IO, which caps frames at SOCKET_IO_MAX_BUFFER_SIZE_BYTES.
+  // Inlining a whole large file here is what made big files unreadable; bulk
+  // bytes belong on the `branch.files.download` stream instead.
+  if (stats.size > MAX_INLINE_READ_BYTES) {
+    throw new Error(
+      `File is too large to inline (${stats.size} bytes > ${MAX_INLINE_READ_BYTES}); use branch.files.download`
+    );
+  }
   const isText = isTextFile(filePath, stats.size);
   const buffer = await readFile(requestedPath);
   const content = buffer.toString(isText ? 'utf-8' : 'base64');
@@ -293,5 +309,82 @@ export async function handleBranchFilesRead(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return { success: false, error: { code: 'BRANCH_FILES_READ_FAILED', message } };
+  }
+}
+
+/**
+ * Stream a branch file to the daemon's download rendezvous as raw bytes.
+ *
+ * The executor keeps sole filesystem access — the daemon never opens the
+ * branch checkout — while the bytes bypass the JSON result entirely, so file
+ * size is bounded only by the daemon's authorized `maxBytes` rather than by
+ * the Socket.IO frame limit.
+ */
+export async function handleBranchFilesDownload(
+  payload: BranchFilesDownloadPayload,
+  options: CommandOptions
+): Promise<ExecutorResult> {
+  if (options.dryRun) return { success: true, data: { dryRun: true, command: payload.command } };
+  const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
+  let client: AgorClient | null = null;
+  try {
+    client = await createExecutorClient(daemonUrl, payload.sessionToken);
+    const branch = await resolveExecutorBranch(client, payload.params.branchId);
+    const root = await realpath(branch.path);
+    const relativePath = normalizedRelativePath(payload.params.filePath);
+    const { absolute } = await resolvePathInsideBranch(root, relativePath, { mustExist: true });
+
+    // Same confinement contract as the inline read: no symlink escapes, no
+    // directories or devices, and never more bytes than the daemon authorized.
+    const stats = await lstat(absolute);
+    if (stats.isSymbolicLink()) throw new Error('Access denied: symlinks not allowed');
+    if (!stats.isFile()) throw new Error('Requested path is not a file');
+    if (stats.size > payload.params.maxBytes) {
+      throw new Error(
+        `File exceeds the ${payload.params.maxBytes}-byte download limit: ${relativePath} (${stats.size} bytes)`
+      );
+    }
+
+    const response = await fetch(
+      `${daemonUrl}/executor/files/downloads/${payload.params.downloadRef}/content`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${payload.sessionToken}`,
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': String(stats.size),
+          'X-Agor-Filename': encodeURIComponent(basename(relativePath)),
+          'X-Agor-Mime-Type': getMimeType(relativePath),
+        },
+        body: createReadStream(absolute) as never,
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' }
+    );
+    if (!response.ok) {
+      throw new Error(`Download transfer failed with HTTP ${response.status}`);
+    }
+    return { success: true, data: { path: relativePath, size: stats.size } };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const permissionDenied =
+      error instanceof Error &&
+      'code' in error &&
+      ((error as NodeJS.ErrnoException).code === 'EACCES' ||
+        (error as NodeJS.ErrnoException).code === 'EPERM');
+    return {
+      success: false,
+      error: {
+        code: 'BRANCH_FILES_DOWNLOAD_FAILED',
+        message: permissionDenied
+          ? 'Branch filesystem permissions denied this download for the requesting user'
+          : message,
+      },
+    };
+  } finally {
+    try {
+      client?.io.disconnect();
+    } catch {
+      // Ignore disconnect errors.
+    }
   }
 }

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -23,6 +23,7 @@ import { handleCodexAuthFile } from './codex-auth-file.js';
 import { handleEnvironmentLifecycle, handleEnvironmentLogs } from './environment.js';
 import {
   handleBranchFilesBrowse,
+  handleBranchFilesDownload,
   handleBranchFilesRead,
   handleBranchFilesystemStatus,
 } from './files.js';
@@ -246,6 +247,7 @@ registerCommand('git.branch.clean', handleGitBranchClean);
 registerCommand('branch.files.list', handleBranchFilesList);
 registerCommand('branch.files.browse', handleBranchFilesBrowse);
 registerCommand('branch.files.read', handleBranchFilesRead);
+registerCommand('branch.files.download', handleBranchFilesDownload);
 registerCommand('branch.filesystem.status', handleBranchFilesystemStatus);
 registerCommand('branch.artifact.publish', handleBranchArtifactPublish);
 registerCommand('branch.artifact.land', handleBranchArtifactLand);

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   AgenticToolInvokePayloadSchema,
+  BranchFilesDownloadPayloadSchema,
   EnvironmentLifecyclePayloadSchema,
   EnvironmentLogsPayloadSchema,
   ExecutorPayloadSchema,
@@ -581,6 +582,57 @@ describe('Type guards', () => {
   });
 });
 
+describe('BranchFilesDownloadPayloadSchema', () => {
+  const valid = {
+    command: 'branch.files.download' as const,
+    sessionToken: 'token',
+    daemonUrl: 'http://localhost:3030',
+    params: {
+      branchId: '00000000-0000-4000-8000-000000000001',
+      filePath: 'assets/big.bin',
+      downloadRef: 'dl_00000000-0000-4000-8000-000000000002',
+      maxBytes: 1024,
+    },
+  };
+
+  it('accepts a well-formed download payload', () => {
+    expect(BranchFilesDownloadPayloadSchema.parse(valid).params.maxBytes).toBe(1024);
+  });
+
+  it('requires the dl_-prefixed ref the daemon registry mints', () => {
+    // Guards the daemon<->executor contract: BranchFileDownloadTransfers emits
+    // `dl_<uuid>`, so anything else must not reach the data plane.
+    for (const downloadRef of ['upl_00000000-0000-4000-8000-000000000002', 'dl_nope', 'dl_']) {
+      expect(() =>
+        BranchFilesDownloadPayloadSchema.parse({
+          ...valid,
+          params: { ...valid.params, downloadRef },
+        })
+      ).toThrow();
+    }
+  });
+
+  it('requires a positive byte ceiling and a non-empty path', () => {
+    expect(() =>
+      BranchFilesDownloadPayloadSchema.parse({
+        ...valid,
+        params: { ...valid.params, maxBytes: 0 },
+      })
+    ).toThrow();
+    expect(() =>
+      BranchFilesDownloadPayloadSchema.parse({
+        ...valid,
+        params: { ...valid.params, filePath: '' },
+      })
+    ).toThrow();
+  });
+
+  it('resolves through the discriminated union', () => {
+    const parsed = ExecutorPayloadSchema.parse(valid);
+    expect(parsed.command).toBe('branch.files.download');
+  });
+});
+
 describe('getSupportedCommands', () => {
   it('should return all supported commands', () => {
     const commands = getSupportedCommands();
@@ -594,6 +646,7 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('branch.files.list');
     expect(commands).toContain('branch.files.browse');
     expect(commands).toContain('branch.files.read');
+    expect(commands).toContain('branch.files.download');
     expect(commands).toContain('branch.filesystem.status');
     expect(commands).toContain('branch.artifact.publish');
     expect(commands).toContain('branch.artifact.land');
@@ -612,6 +665,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('zellij.tab');
     expect(commands).toContain('agentic-tool.invoke');
     expect(commands).toContain('codex.auth-file');
-    expect(commands.length).toBe(28);
+    expect(commands.length).toBe(29);
   });
 });

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -417,6 +417,30 @@ export const BranchFilesReadPayloadSchema = BasePayloadSchema.extend({
 
 export type BranchFilesReadPayload = z.infer<typeof BranchFilesReadPayloadSchema>;
 
+/**
+ * Stream one branch file to the daemon's download rendezvous.
+ *
+ * Distinct from `branch.files.read` on purpose: `read` returns a bounded
+ * preview inside the JSON result, while `download` keeps file bytes out of
+ * stdout entirely and POSTs them to the daemon as a raw octet-stream. That is
+ * what lets arbitrarily large files through the Socket.IO `maxHttpBufferSize`
+ * ceiling without giving the daemon its own filesystem access.
+ */
+export const BranchFilesDownloadPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('branch.files.download'),
+  sessionToken: z.string(),
+  params: z.object({
+    branchId: z.string().uuid(),
+    filePath: z.string().min(1),
+    /** Single-use handle for the daemon-side transfer awaiting these bytes. */
+    downloadRef: z.string().regex(/^dl_[0-9a-f-]{36}$/),
+    /** Refuse before opening anything larger than the daemon authorized. */
+    maxBytes: z.number().int().positive(),
+  }),
+});
+
+export type BranchFilesDownloadPayload = z.infer<typeof BranchFilesDownloadPayloadSchema>;
+
 export const BranchFilesystemStatusPayloadSchema = BasePayloadSchema.extend({
   command: z.literal('branch.filesystem.status'),
   sessionToken: z.string(),
@@ -819,6 +843,7 @@ export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   BranchFilesListPayloadSchema,
   BranchFilesBrowsePayloadSchema,
   BranchFilesReadPayloadSchema,
+  BranchFilesDownloadPayloadSchema,
   BranchFilesystemStatusPayloadSchema,
   BranchArtifactPublishPayloadSchema,
   BranchArtifactLandPayloadSchema,
@@ -895,6 +920,7 @@ export function getSupportedCommands(): string[] {
     'branch.files.list',
     'branch.files.browse',
     'branch.files.read',
+    'branch.files.download',
     'branch.filesystem.status',
     'branch.artifact.publish',
     'branch.artifact.land',

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -115,7 +115,13 @@ const checks = [
     baseline: {
       // These executor-facing routes authenticate narrow service tokens and
       // consume claims directly; they do not perform an authenticated user lookup.
-      'apps/agor-daemon/src/register-routes.ts': 2,
+      // 1: /executor/uploads/:uploadRef/content
+      // 2: /executor/gateway/slack-file-upload
+      // 3: /executor/files/downloads/:downloadRef/content — takes tenant_id and
+      //    executor_branch_id straight off the verified service-token claims and
+      //    requires them to match the transfer the browser route registered, so
+      //    there is no user identity to resolve and nothing to scope a lookup by.
+      'apps/agor-daemon/src/register-routes.ts': 3,
     },
   },
   {


### PR DESCRIPTION
Fixes #2128.

Reimplemented on top of `main` (`94c3d7573`) to address the architectural-consistency review. The previous approach fixed the symptom by giving the daemon `createReadStream` access to the branch workspace, which trades one boundary violation for a worse one. This version keeps the daemon out of the filesystem entirely.

## Root cause

`branch.files.read` embeds whole file content in its JSON result. That result travels back as a stdout sentinel line and then over Socket.IO, which caps frames at 1 MB (`maxHttpBufferSize`). Base64 inflates the payload further (50 MB becomes ~66 MB). Bytes were being pushed through a control plane.

## Approach

Add a dedicated byte data plane, mirroring the two that already exist (uploads, Slack file upload) but running in the opposite direction.

```
browser  --GET /branches/:id/files/download?path=...-->  daemon
                                                          | auth + RBAC + resolve asUser
                                                          | register transfer -> ref "dl_<uuid>"
                                                          | mint scoped service token
                                                          v
                                                       executor  (branch.files.download)
                                                          | opens the file - only it may
                                                          v
        <---- piped to res ----  daemon  <--POST /executor/files/downloads/:ref/content
```

- **`branch.files.download` executor command** — resolves the path inside the branch root, refuses symlinks, enforces `maxBytes`, streams via `duplex: 'half'`. Its JSON result carries only `{path, size}`, never bytes.
- **Rendezvous registry** (`branch-file-download-transfers.ts`) — the only new stateful piece. Parks a sink callback plus a scope `{tenantId, branchId, filePath, maxBytes}` under a single-use `dl_` ref with a TTL. Holds no bytes, performs no I/O; it exists so the inbound POST can find the outbound response object.
- **Browser route** `GET /branches/:branchId/files/download` — performs all authorization *before* registering the transfer (member role, branch `view` permission, tenant scope, `resolveExecutorReadAsUser`), then awaits delivery.
- **Data-plane route** `POST /executor/files/downloads/:downloadRef/content` — authenticates a scoped service token and requires its `executor_download_ref`, `executor_branch_id` and `tenant_id` claims to match the registered transfer. Enforces exact `Content-Length` through a `Transform` limiter before piping to the browser.
- **Root-cause fix** — `branch.files.read` now hard-refuses anything above `MAX_INLINE_READ_BYTES` (1 MB) and points at the streaming path, instead of silently producing a frame Socket.IO will drop.
- **UI** — `FilesTab` fetches the streaming endpoint and builds a blob URL, replacing the base64 decode. Preview is unchanged; it was already gated at 1 MB, which now matches the executor cap exactly.

## Architecture

| | before | after |
| --- | --- | --- |
| Bytes travel over | control plane (stdout, Socket.IO) | dedicated HTTP data plane |
| Who opens the file | daemon | executor only |
| New daemon filesystem exceptions | 1 required | **0** |
| Oversize inline read | silently dropped | explicit error |

`scripts/check-daemon-filesystem-boundaries.mjs` passes with zero new entries in `daemon-filesystem-exceptions.json`. That is the mechanical proof the review objection is cleared.

The multitenancy baseline for `register-routes.ts` moves 2 to 3, justified inline: the data-plane route consumes tenant identity from verified service-token claims and matches it against the registered transfer, so there is no user identity to resolve and nothing to scope a lookup by.

## Tests

95 new tests:

- `branch-file-download-transfers.test.ts` (11) — ref format, sink handoff, single-use semantics, cross-tenant and cross-branch refusal (entry stays parked), TTL expiry, per-transfer TTL, cancel, settle-once, failure propagation.
- `register-routes.file-download-boundary.test.ts` (8) — source-level architecture assertions: no `node:fs` import, no `createReadStream`, authorization precedes registration, claim scoping, header-only tokens, exact-length limiter.
- `files-download.test.ts` (9) — including an assertion that no stream handle can appear in the serialized result.
- `files.test.ts`, `payload-types.test.ts` — inline-cap regression, at-cap boundary, schema coverage.

Verification: turbo typecheck 8/8 pass, biome clean across 664 files, both boundary scripts pass, full executor and daemon suites show no new failures.
