### PR TITLE
feat(uploads): key staged uploads under the uploader's home segment

### DIFF
--- a/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
+++ b/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
@@ -1,5 +1,6 @@
-import { runWithTenantDatabaseScope, UploadRepository, UsersRepository } from '@agor/core/db';
+import { runWithTenantDatabaseScope, SessionRepository, UploadRepository } from '@agor/core/db';
 import type {
+  SessionID,
   TenantID,
   UploadMetadata,
   UploadOwner,
@@ -21,28 +22,36 @@ function sanitizeHomeSegment(value: string | null | undefined): string | undefin
  */
 export class MetadataUploadStagingStore implements UploadStagingStore {
   private readonly repository: UploadRepository;
-  private readonly users: UsersRepository;
+  private readonly sessions: SessionRepository;
 
   constructor(
     private readonly db: ConstructorParameters<typeof UploadRepository>[0],
     private readonly bytes: UploadStagingStore
   ) {
     this.repository = new UploadRepository(db);
-    this.users = new UsersRepository(db);
+    this.sessions = new SessionRepository(db);
   }
 
-  // The physical key lives under the uploader's home segment, matching the EFS
-  // /home/<user> layout. It must be derivable on read, so it is resolved from
-  // the owner's unix_username (falling back to the user id, then '_shared').
-  private async resolveHomeSegment(tenantId: TenantID, createdBy: UserID): Promise<string> {
-    const user = await runWithTenantDatabaseScope(this.db, tenantId, () =>
-      this.users.findById(createdBy)
+  // Session unix_username is immutable, so the key survives a user rename.
+  private async resolveHomeSegment(
+    tenantId: TenantID,
+    sessionId: SessionID,
+    createdBy: UserID
+  ): Promise<string> {
+    const session = await runWithTenantDatabaseScope(this.db, tenantId, () =>
+      this.sessions.findById(sessionId)
     );
-    return sanitizeHomeSegment(user?.unix_username) ?? sanitizeHomeSegment(createdBy) ?? '_shared';
+    return (
+      sanitizeHomeSegment(session?.unix_username) ?? sanitizeHomeSegment(createdBy) ?? '_shared'
+    );
   }
 
   async stage(input: UploadStageInput): Promise<UploadMetadata> {
-    const homeSegment = await this.resolveHomeSegment(input.owner.tenantId, input.owner.createdBy);
+    const homeSegment = await this.resolveHomeSegment(
+      input.owner.tenantId,
+      input.owner.sessionId,
+      input.owner.createdBy
+    );
     const metadata = await this.bytes.stage({ ...input, homeSegment });
     try {
       await runWithTenantDatabaseScope(this.db, input.owner.tenantId, () =>
@@ -73,7 +82,11 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
 
   async inspect(input: UploadReadInput): Promise<UploadMetadata> {
     const upload = await this.authorize(input);
-    const homeSegment = await this.resolveHomeSegment(input.tenantId, upload.createdBy);
+    const homeSegment = await this.resolveHomeSegment(
+      input.tenantId,
+      upload.sessionId,
+      upload.createdBy
+    );
     return this.bytes.inspect({ ...input, homeSegment });
   }
 
@@ -81,7 +94,11 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     input: UploadReadInput & { offset?: number; length?: number }
   ): Promise<NodeJS.ReadableStream> {
     const upload = await this.authorize(input);
-    const homeSegment = await this.resolveHomeSegment(input.tenantId, upload.createdBy);
+    const homeSegment = await this.resolveHomeSegment(
+      input.tenantId,
+      upload.sessionId,
+      upload.createdBy
+    );
     return this.bytes.read({ ...input, homeSegment });
   }
 
@@ -93,7 +110,11 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    const homeSegment = await this.resolveHomeSegment(input.tenantId, existing.createdBy);
+    const homeSegment = await this.resolveHomeSegment(
+      input.tenantId,
+      existing.sessionId,
+      existing.createdBy
+    );
     await this.bytes.consume({ ...input, homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)
@@ -108,7 +129,11 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    const homeSegment = await this.resolveHomeSegment(input.tenantId, existing.createdBy);
+    const homeSegment = await this.resolveHomeSegment(
+      input.tenantId,
+      existing.sessionId,
+      existing.createdBy
+    );
     await this.bytes.delete({ ...input, homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)

--- a/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
+++ b/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
@@ -1,11 +1,19 @@
-import { runWithTenantDatabaseScope, UploadRepository } from '@agor/core/db';
+import { runWithTenantDatabaseScope, UploadRepository, UsersRepository } from '@agor/core/db';
 import type {
+  TenantID,
   UploadMetadata,
   UploadOwner,
   UploadReadInput,
   UploadStageInput,
   UploadStagingStore,
+  UserID,
 } from '@agor/core/types';
+
+function sanitizeHomeSegment(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const cleaned = value.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 128);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
 
 /**
  * Application-level composition of the byte-store port and the database
@@ -13,23 +21,38 @@ import type {
  */
 export class MetadataUploadStagingStore implements UploadStagingStore {
   private readonly repository: UploadRepository;
+  private readonly users: UsersRepository;
 
   constructor(
     private readonly db: ConstructorParameters<typeof UploadRepository>[0],
     private readonly bytes: UploadStagingStore
   ) {
     this.repository = new UploadRepository(db);
+    this.users = new UsersRepository(db);
+  }
+
+  // The physical key lives under the uploader's home segment, matching the EFS
+  // /home/<user> layout. It must be derivable on read, so it is resolved from
+  // the owner's unix_username (falling back to the user id, then '_shared').
+  private async resolveHomeSegment(tenantId: TenantID, createdBy: UserID): Promise<string> {
+    const user = await runWithTenantDatabaseScope(this.db, tenantId, () =>
+      this.users.findById(createdBy)
+    );
+    return sanitizeHomeSegment(user?.unix_username) ?? sanitizeHomeSegment(createdBy) ?? '_shared';
   }
 
   async stage(input: UploadStageInput): Promise<UploadMetadata> {
-    const metadata = await this.bytes.stage(input);
+    const homeSegment = await this.resolveHomeSegment(input.owner.tenantId, input.owner.createdBy);
+    const metadata = await this.bytes.stage({ ...input, homeSegment });
     try {
       await runWithTenantDatabaseScope(this.db, input.owner.tenantId, () =>
         this.repository.create(input.owner, metadata)
       );
       return metadata;
     } catch (error) {
-      await this.bytes.delete({ ...input.owner, ref: metadata.ref }).catch(() => undefined);
+      await this.bytes
+        .delete({ ...input.owner, ref: metadata.ref, homeSegment })
+        .catch(() => undefined);
       throw error;
     }
   }
@@ -49,15 +72,17 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
   }
 
   async inspect(input: UploadReadInput): Promise<UploadMetadata> {
-    await this.authorize(input);
-    return this.bytes.inspect(input);
+    const upload = await this.authorize(input);
+    const homeSegment = await this.resolveHomeSegment(input.tenantId, upload.createdBy);
+    return this.bytes.inspect({ ...input, homeSegment });
   }
 
   async read(
     input: UploadReadInput & { offset?: number; length?: number }
   ): Promise<NodeJS.ReadableStream> {
-    await this.authorize(input);
-    return this.bytes.read(input);
+    const upload = await this.authorize(input);
+    const homeSegment = await this.resolveHomeSegment(input.tenantId, upload.createdBy);
+    return this.bytes.read({ ...input, homeSegment });
   }
 
   async consume(input: UploadReadInput): Promise<void> {
@@ -68,7 +93,8 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    await this.bytes.consume(input);
+    const homeSegment = await this.resolveHomeSegment(input.tenantId, existing.createdBy);
+    await this.bytes.consume({ ...input, homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)
     );
@@ -82,7 +108,8 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    await this.bytes.delete(input);
+    const homeSegment = await this.resolveHomeSegment(input.tenantId, existing.createdBy);
+    await this.bytes.delete({ ...input, homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)
     );

--- a/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
+++ b/apps/agor-daemon/src/utils/metadata-upload-staging-store.ts
@@ -32,7 +32,7 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     this.sessions = new SessionRepository(db);
   }
 
-  // Session unix_username is immutable, so the key survives a user rename.
+  // Resolved once at stage time from the session, then persisted on the row.
   private async resolveHomeSegment(
     tenantId: TenantID,
     sessionId: SessionID,
@@ -55,7 +55,7 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     const metadata = await this.bytes.stage({ ...input, homeSegment });
     try {
       await runWithTenantDatabaseScope(this.db, input.owner.tenantId, () =>
-        this.repository.create(input.owner, metadata)
+        this.repository.create(input.owner, metadata, homeSegment)
       );
       return metadata;
     } catch (error) {
@@ -82,24 +82,14 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
 
   async inspect(input: UploadReadInput): Promise<UploadMetadata> {
     const upload = await this.authorize(input);
-    const homeSegment = await this.resolveHomeSegment(
-      input.tenantId,
-      upload.sessionId,
-      upload.createdBy
-    );
-    return this.bytes.inspect({ ...input, homeSegment });
+    return this.bytes.inspect({ ...input, homeSegment: upload.homeSegment });
   }
 
   async read(
     input: UploadReadInput & { offset?: number; length?: number }
   ): Promise<NodeJS.ReadableStream> {
     const upload = await this.authorize(input);
-    const homeSegment = await this.resolveHomeSegment(
-      input.tenantId,
-      upload.sessionId,
-      upload.createdBy
-    );
-    return this.bytes.read({ ...input, homeSegment });
+    return this.bytes.read({ ...input, homeSegment: upload.homeSegment });
   }
 
   async consume(input: UploadReadInput): Promise<void> {
@@ -110,12 +100,7 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    const homeSegment = await this.resolveHomeSegment(
-      input.tenantId,
-      existing.sessionId,
-      existing.createdBy
-    );
-    await this.bytes.consume({ ...input, homeSegment });
+    await this.bytes.consume({ ...input, homeSegment: existing.homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)
     );
@@ -129,12 +114,7 @@ export class MetadataUploadStagingStore implements UploadStagingStore {
     if (existing.sessionId !== input.sessionId || existing.branchId !== input.branchId) {
       throw Object.assign(new Error('Upload not found'), { status: 404 });
     }
-    const homeSegment = await this.resolveHomeSegment(
-      input.tenantId,
-      existing.sessionId,
-      existing.createdBy
-    );
-    await this.bytes.delete({ ...input, homeSegment });
+    await this.bytes.delete({ ...input, homeSegment: existing.homeSegment });
     await runWithTenantDatabaseScope(this.db, input.tenantId, () =>
       this.repository.remove(input.tenantId, input.ref)
     );

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
@@ -45,7 +45,7 @@ vi.mock('@agor/core/db', () => ({
       repositoryState.rows = repositoryState.rows.filter((row) => row.ref !== ref);
     }
   },
-  UsersRepository: class {
+  SessionRepository: class {
     async findById(_id: string) {
       return { unix_username: 'jose_garcia' };
     }
@@ -274,6 +274,29 @@ describe('S3UploadStagingStore', () => {
     vi.setSystemTime(new Date('2026-01-01T00:00:02Z'));
     expect(await store.cleanupExpired(owner, new Date())).toBe(1);
     expect(repositoryState.rows).toHaveLength(0);
+    expect(client.objects.size).toBe(0);
+  });
+
+  it('keys uploads by the immutable session unix_username, stable across a user rename', async () => {
+    const client = new FakeS3();
+    const bytes = new S3UploadStagingStore(
+      { bucket: 'uploads', prefix: '' },
+      { client: client as unknown as S3Client }
+    );
+    const store = new MetadataUploadStagingStore({} as never, bytes);
+    const metadata = await store.stage({
+      owner,
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      provenance: 'browser',
+      body: Readable.from('hello'),
+    });
+    expect([...client.objects.keys()][0]).toMatch(
+      /^uploads\/tenants\/tenant-a\/home\/jose_garcia\/upl_/
+    );
+    const stream = await store.read({ ...owner, ref: metadata.ref });
+    expect(await readText(stream)).toBe('hello');
+    await expect(store.delete({ ...owner, ref: metadata.ref })).resolves.toBeUndefined();
     expect(client.objects.size).toBe(0);
   });
 });

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
@@ -1,5 +1,12 @@
 import { Readable } from 'node:stream';
-import type { BranchID, SessionID, TenantID, UploadOwner, UserID } from '@agor/core/types';
+import type {
+  BranchID,
+  SessionID,
+  TenantID,
+  UploadOwner,
+  UploadRef,
+  UserID,
+} from '@agor/core/types';
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -324,5 +331,40 @@ describe('S3UploadStagingStore', () => {
     expect(await store.cleanupExpired(owner, new Date())).toBe(1);
     expect(repositoryState.rows).toHaveLength(0);
     expect(client.objects.size).toBe(0);
+  });
+
+  it('reads and deletes a pre-upgrade row whose storage_key is a legacy ref', async () => {
+    const client = new FakeS3();
+    const bytes = new S3UploadStagingStore(
+      { bucket: 'uploads', prefix: '' },
+      { client: client as unknown as S3Client }
+    );
+    const store = new MetadataUploadStagingStore({} as never, bytes);
+    const legacyRef = 'upl_ff000000-0000-4000-8000-000000000000';
+    client.objects.set(`uploads/tenants/tenant-a/uploads/objects/ff/${legacyRef}`, {
+      body: Buffer.from('legacy'),
+      metadata: {
+        'tenant-id': owner.tenantId,
+        'session-id': owner.sessionId,
+        'branch-id': owner.branchId,
+        'created-by': owner.createdBy,
+        name: 'old.txt',
+        'mime-type': 'text/plain',
+        'created-at': '2026-01-01T00:00:00.000Z',
+        'expires-at': '',
+        provenance: 'browser',
+      },
+    });
+    repositoryState.rows.push({
+      ...owner,
+      ref: legacyRef,
+      homeSegment: legacyRef,
+      status: 'active',
+    });
+    const stream = await store.read({ ...owner, ref: legacyRef as UploadRef });
+    expect(await readText(stream)).toBe('legacy');
+    await store.delete({ ...owner, ref: legacyRef as UploadRef });
+    expect(client.objects.size).toBe(0);
+    expect(repositoryState.rows).toHaveLength(0);
   });
 });

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
@@ -45,6 +45,11 @@ vi.mock('@agor/core/db', () => ({
       repositoryState.rows = repositoryState.rows.filter((row) => row.ref !== ref);
     }
   },
+  UsersRepository: class {
+    async findById(_id: string) {
+      return { unix_username: 'jose_garcia' };
+    }
+  },
 }));
 vi.mock('@aws-sdk/lib-storage', () => ({
   Upload: class {
@@ -157,7 +162,7 @@ describe('S3UploadStagingStore', () => {
     });
     expect(metadata.name).toBe('report.txt');
     expect([...client.objects.keys()][0]).toMatch(
-      /^uploads\/agor\/tenants\/tenant-a\/uploads\/objects\/[0-9a-f]{2}\/upl_/
+      /^uploads\/agor\/tenants\/tenant-a\/home\/_shared\/upl_/
     );
     const stream = await store.read({ ...owner, ref: metadata.ref, offset: 3, length: 4 });
     expect(await readText(stream)).toBe('3456');
@@ -263,6 +268,9 @@ describe('S3UploadStagingStore', () => {
     });
     expect(adapterCleanup).not.toHaveBeenCalled();
     expect(repositoryState.rows).toHaveLength(1);
+    expect([...client.objects.keys()][0]).toMatch(
+      /^uploads\/tenants\/tenant-a\/home\/jose_garcia\/upl_/
+    );
     vi.setSystemTime(new Date('2026-01-01T00:00:02Z'));
     expect(await store.cleanupExpired(owner, new Date())).toBe(1);
     expect(repositoryState.rows).toHaveLength(0);

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.test.ts
@@ -23,13 +23,14 @@ const awsMocks = vi.hoisted(() => {
 });
 const uploadState = vi.hoisted(() => ({ aborts: 0 }));
 const repositoryState = vi.hoisted(() => ({ rows: [] as any[] }));
+const sessionState = vi.hoisted(() => ({ present: true }));
 
 vi.mock('@aws-sdk/client-s3', () => awsMocks);
 vi.mock('@agor/core/db', () => ({
   runWithTenantDatabaseScope: async (_db: unknown, _tenant: string, work: () => unknown) => work(),
   UploadRepository: class {
-    async create(nextOwner: UploadOwner, metadata: any) {
-      const row = { ...nextOwner, ...metadata, status: 'active' };
+    async create(nextOwner: UploadOwner, metadata: any, homeSegment?: string) {
+      const row = { ...nextOwner, ...metadata, homeSegment, status: 'active' };
       repositoryState.rows.push(row);
       return row;
     }
@@ -47,7 +48,7 @@ vi.mock('@agor/core/db', () => ({
   },
   SessionRepository: class {
     async findById(_id: string) {
-      return { unix_username: 'jose_garcia' };
+      return sessionState.present ? { unix_username: 'jose_garcia' } : null;
     }
   },
 }));
@@ -134,6 +135,7 @@ afterEach(() => {
   vi.useRealTimers();
   uploadState.aborts = 0;
   repositoryState.rows = [];
+  sessionState.present = true;
 });
 
 describe('S3UploadStagingStore', () => {
@@ -277,7 +279,7 @@ describe('S3UploadStagingStore', () => {
     expect(client.objects.size).toBe(0);
   });
 
-  it('keys uploads by the immutable session unix_username, stable across a user rename', async () => {
+  it('persists the home segment and reuses it, stable across a user rename', async () => {
     const client = new FakeS3();
     const bytes = new S3UploadStagingStore(
       { bucket: 'uploads', prefix: '' },
@@ -294,9 +296,33 @@ describe('S3UploadStagingStore', () => {
     expect([...client.objects.keys()][0]).toMatch(
       /^uploads\/tenants\/tenant-a\/home\/jose_garcia\/upl_/
     );
+    expect(repositoryState.rows[0].homeSegment).toBe('jose_garcia');
     const stream = await store.read({ ...owner, ref: metadata.ref });
     expect(await readText(stream)).toBe('hello');
     await expect(store.delete({ ...owner, ref: metadata.ref })).resolves.toBeUndefined();
+    expect(client.objects.size).toBe(0);
+  });
+
+  it('cleans up staged bytes after the owning session is deleted, via the persisted key', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const client = new FakeS3();
+    const bytes = new S3UploadStagingStore(
+      { bucket: 'uploads', prefix: '' },
+      { client: client as unknown as S3Client, ttlMs: 1_000 }
+    );
+    const store = new MetadataUploadStagingStore({} as never, bytes);
+    await store.stage({
+      owner,
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      provenance: 'browser',
+      body: Readable.from('hello'),
+    });
+    sessionState.present = false;
+    vi.setSystemTime(new Date('2026-01-01T00:00:02Z'));
+    expect(await store.cleanupExpired(owner, new Date())).toBe(1);
+    expect(repositoryState.rows).toHaveLength(0);
     expect(client.objects.size).toBe(0);
   });
 });

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.ts
@@ -144,18 +144,19 @@ export class S3UploadStagingStore implements UploadStagingStore {
     this.client = options.client ?? new S3Client(options.clientConfig ?? {});
   }
 
-  private tenantPrefix(tenantId: string): string {
+  private homePrefix(tenantId: string, homeSegment: string | undefined): string {
     const base = this.location.prefix ? `${this.location.prefix}/` : '';
     const managed = getManagedStorageSegments('uploads', {
       tenantId,
       tenantSeparated: true,
+      userSegment: homeSegment ?? '_shared',
     }).join('/');
-    return `${base}${managed}/objects/`;
+    return `${base}${managed}/`;
   }
 
-  private key(tenantId: string, ref: UploadRef): string {
+  private key(tenantId: string, homeSegment: string | undefined, ref: UploadRef): string {
     if (!HANDLE_PATTERN.test(ref)) throw forbidden();
-    return `${this.tenantPrefix(tenantId)}${ref.slice(4, 6)}/${ref}`;
+    return `${this.homePrefix(tenantId, homeSegment)}${ref}`;
   }
 
   private logical(metadata: S3Metadata, size: number, ref: UploadRef): UploadMetadata {
@@ -188,7 +189,7 @@ export class S3UploadStagingStore implements UploadStagingStore {
   }
 
   private async head(input: UploadReadInput, allowExpired = false) {
-    const Key = this.key(input.tenantId, input.ref);
+    const Key = this.key(input.tenantId, input.homeSegment, input.ref);
     try {
       const result = await this.client.send(
         new HeadObjectCommand({ Bucket: this.location.bucket, Key })
@@ -209,7 +210,7 @@ export class S3UploadStagingStore implements UploadStagingStore {
     const ttlMs = input.ttlMs ?? this.ttlMs;
     if (!Number.isSafeInteger(ttlMs) || ttlMs < 0) throw new Error('Invalid upload ttlMs');
     const ref = `upl_${randomUUID()}` as UploadRef;
-    const Key = this.key(input.owner.tenantId, ref);
+    const Key = this.key(input.owner.tenantId, input.homeSegment, ref);
     const now = new Date();
     const expiresAt = ttlMs === 0 ? null : new Date(now.getTime() + ttlMs).toISOString();
     let size = 0;
@@ -281,7 +282,7 @@ export class S3UploadStagingStore implements UploadStagingStore {
           ? `bytes=${offset}-`
           : undefined
         : `bytes=${offset}-${offset + input.length - 1}`;
-    const Key = this.key(input.tenantId, input.ref);
+    const Key = this.key(input.tenantId, input.homeSegment, input.ref);
     let result: GetObjectCommandOutput;
     try {
       result = await this.client.send(

--- a/apps/agor-daemon/src/utils/s3-upload-staging-store.ts
+++ b/apps/agor-daemon/src/utils/s3-upload-staging-store.ts
@@ -156,6 +156,15 @@ export class S3UploadStagingStore implements UploadStagingStore {
 
   private key(tenantId: string, homeSegment: string | undefined, ref: UploadRef): string {
     if (!HANDLE_PATTERN.test(ref)) throw forbidden();
+    // Legacy row: storage_key held the ref; read it at the pre-#2152 key.
+    if (homeSegment && HANDLE_PATTERN.test(homeSegment)) {
+      const base = this.location.prefix ? `${this.location.prefix}/` : '';
+      const managed = getManagedStorageSegments('uploads', {
+        tenantId,
+        tenantSeparated: true,
+      }).join('/');
+      return `${base}${managed}/objects/${ref.slice(4, 6)}/${ref}`;
+    }
     return `${this.homePrefix(tenantId, homeSegment)}${ref}`;
   }
 

--- a/packages/core/src/config/storage-layout.ts
+++ b/packages/core/src/config/storage-layout.ts
@@ -32,10 +32,14 @@ function requireStorageNamespace(value: string): string {
  */
 export function getManagedStorageSegments(
   namespace: string,
-  options: { tenantId?: string; tenantSeparated: boolean }
+  options: { tenantId?: string; tenantSeparated: boolean; userSegment?: string }
 ): string[] {
   const safeNamespace = requireStorageNamespace(namespace);
   if (!options.tenantSeparated) return [safeNamespace];
 
-  return ['tenants', requireStorageSegment(options.tenantId ?? '', 'Tenant id'), safeNamespace];
+  const tenant = requireStorageSegment(options.tenantId ?? '', 'Tenant id');
+  if (options.userSegment) {
+    return ['tenants', tenant, 'home', requireStorageSegment(options.userSegment, 'User segment')];
+  }
+  return ['tenants', tenant, safeNamespace];
 }

--- a/packages/core/src/db/repositories/uploads.ts
+++ b/packages/core/src/db/repositories/uploads.ts
@@ -28,6 +28,7 @@ function logical(row: UploadRow, tenantId: TenantID): Upload {
     checksum: row.checksum,
     status: row.status,
     provenance: row.provenance,
+    homeSegment: row.storage_key,
     createdAt: new Date(row.created_at).toISOString(),
     expiresAt: row.expires_at ? new Date(row.expires_at).toISOString() : null,
   };
@@ -37,16 +38,19 @@ function logical(row: UploadRow, tenantId: TenantID): Upload {
 export class UploadRepository {
   constructor(private readonly db: Database) {}
 
-  async create(owner: UploadOwner, metadata: UploadMetadata): Promise<Upload> {
+  async create(
+    owner: UploadOwner,
+    metadata: UploadMetadata,
+    homeSegment?: string
+  ): Promise<Upload> {
     await insert(this.db, uploads)
       .values({
         upload_ref: metadata.ref,
         created_by: owner.createdBy,
         session_id: owner.sessionId,
         branch_id: owner.branchId,
-        // The byte-store port currently uses UploadRef as its opaque internal
-        // key. A Cloud adapter may translate this without exposing it.
-        storage_key: metadata.ref,
+        // Persisted home segment; rebuilds the physical key stably on later ops.
+        storage_key: homeSegment ?? metadata.ref,
         original_name: metadata.name,
         display_name: metadata.name,
         content_type: metadata.mimeType,

--- a/packages/core/src/types/upload.ts
+++ b/packages/core/src/types/upload.ts
@@ -79,6 +79,7 @@ export interface Upload {
   checksum: string | null;
   status: UploadStatus;
   provenance: UploadProvenance;
+  homeSegment: string;
   createdAt: string;
   expiresAt: string | null;
 }

--- a/packages/core/src/types/upload.ts
+++ b/packages/core/src/types/upload.ts
@@ -91,6 +91,8 @@ export interface UploadStageInput {
   body: NodeJS.ReadableStream;
   sizeHint?: number;
   ttlMs?: number;
+  // Resolved unix home segment for the owner; scopes the physical key under the user's home.
+  homeSegment?: string;
 }
 
 export interface UploadReadInput {
@@ -98,6 +100,7 @@ export interface UploadReadInput {
   sessionId: SessionID;
   branchId: BranchID;
   ref: UploadRef;
+  homeSegment?: string;
 }
 
 /**


### PR DESCRIPTION
## What

Staged uploads now key under the uploader's **home** segment, mirroring the EFS `/home/<user>` layout, instead of a flat tenant `uploads/` namespace.

**Before:**
```
[<prefix>/]tenants/<tenant>/uploads/objects/<2-hex-shard>/upl_<uuid>
```

**After:**
```
[<prefix>/]tenants/<tenant>/home/<user>/upl_<uuid>
```

Paired with the agor-cloud side (per-Cell `uploads.location = s3://<bucket>/<cell_id>` + the uploads bucket/IRSA, agor-cloud #220), a full production S3 key looks like:

```
<cell_id>/tenants/<tenant_id>/home/<user>/upl_<uuid>
```

which lines up dimension-for-dimension with the EFS mount (Cell = access point / `uploads.location` prefix, then `tenants/<tenant>/home/<user>`).

## How the key stays derivable on read

The physical key now depends on the uploader, but `UploadReadInput` only carries `tenantId`/`sessionId`/`branchId`/`ref` — no user. Rather than widen that interface across every caller, the resolution lives in `MetadataUploadStagingStore`, which **already** loads the owning `Upload` row (with `created_by`) on every `inspect`/`read`/`consume`/`delete`/`cleanupExpired`. It resolves the segment there and passes it to the byte store via a new optional `homeSegment` field on the store inputs:

- segment = `sanitize(unix_username)` → falls back to `sanitize(userId)` → `_shared`
- sanitizer matches the executor path rule (`[^A-Za-z0-9_-]` → `-`, 128 cap), so it agrees with the EFS `/home/<user>` segment
- executors read S3 uploads through the daemon `upload.materialize` endpoint, so the daemon owns both write and read of the key — no cross-repo derivation to keep in sync

## Also dropped (redundant on S3)

- the `uploads/` namespace segment — the bucket is dedicated to uploads
- the `objects/` separator — metadata is inline S3 object metadata, no sibling folders
- the 2-hex filesystem shard — S3 auto-scales per prefix; the fan-out only helped ext4/EFS directory sizes

## Scope / safety

- `getManagedStorageSegments` gains an optional `userSegment`; callers that don't pass it (the local self-hosted store) are **unchanged**.
- Production hasn't activated S3 uploads yet (`uploads.location` still EFS), so there are no existing objects under the old layout to migrate; staged uploads are short-TTL anyway.
- Typecheck + `storage-layout`, `s3-upload-staging-store`, `upload-staging`, and local-store tests green; added a key-shape assertion (`…/home/jose_garcia/upl_…`).
