### PR TITLE
fix(terminal): force a zellij repaint on attach so existing sessions render

### DIFF
--- a/packages/executor/src/commands/zellij.test.ts
+++ b/packages/executor/src/commands/zellij.test.ts
@@ -14,10 +14,16 @@ describe('forceZellijRepaint', () => {
     expect(resize).toHaveBeenLastCalledWith(100, 40);
   });
 
-  it('never shrinks rows below 1', () => {
+  it('nudges upward at the lower bound (1 → 2 → 1) so the size always changes', () => {
     const resize = vi.fn();
-    forceZellijRepaint({ resize }, 80, 1, (fn) => fn());
-    expect(resize).toHaveBeenCalledWith(80, 1);
+    let restore: (() => void) | undefined;
+    forceZellijRepaint({ resize }, 80, 1, (fn) => {
+      restore = fn;
+    });
+    expect(resize).toHaveBeenCalledWith(80, 2);
+    restore?.();
+    expect(resize).toHaveBeenLastCalledWith(80, 1);
+    expect(resize).toHaveBeenCalledTimes(2);
   });
 
   it('is a no-op when there is no pty', () => {

--- a/packages/executor/src/commands/zellij.test.ts
+++ b/packages/executor/src/commands/zellij.test.ts
@@ -1,5 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createReconnectGrace, waitForZellijReady } from './zellij.js';
+import { createReconnectGrace, forceZellijRepaint, waitForZellijReady } from './zellij.js';
+
+describe('forceZellijRepaint', () => {
+  it('shrinks the row count then restores it to force a SIGWINCH repaint', () => {
+    const resize = vi.fn();
+    let restore: (() => void) | undefined;
+    forceZellijRepaint({ resize }, 100, 40, (fn) => {
+      restore = fn;
+    });
+    expect(resize).toHaveBeenCalledTimes(1);
+    expect(resize).toHaveBeenCalledWith(100, 39);
+    restore?.();
+    expect(resize).toHaveBeenLastCalledWith(100, 40);
+  });
+
+  it('never shrinks rows below 1', () => {
+    const resize = vi.fn();
+    forceZellijRepaint({ resize }, 80, 1, (fn) => fn());
+    expect(resize).toHaveBeenCalledWith(80, 1);
+  });
+
+  it('is a no-op when there is no pty', () => {
+    expect(() => forceZellijRepaint(null, 80, 24, (fn) => fn())).not.toThrow();
+  });
+
+  it('swallows a resize on a pty that died before restore', () => {
+    const resize = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('pty gone');
+      });
+    expect(() => forceZellijRepaint({ resize }, 80, 24, (fn) => fn())).not.toThrow();
+  });
+});
 
 describe('createReconnectGrace', () => {
   beforeEach(() => {

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -124,6 +124,30 @@ function emitTerminalReady(socket: AgorClient['io'], userId: string): void {
   });
 }
 
+// On attach/reconnect zellij leaves the UI (frame, status bar, panes) undrawn
+// until a SIGWINCH or keypress arrives — a same-size resize signals nothing, so
+// briefly shrink the row count and restore it to force a full repaint.
+export function forceZellijRepaint(
+  pty: Pick<IPty, 'resize'> | null,
+  cols: number,
+  rows: number,
+  scheduleRestore: (fn: () => void) => void = (fn) => setTimeout(fn, 50)
+): void {
+  if (!pty) return;
+  try {
+    pty.resize(cols, Math.max(1, rows - 1));
+  } catch {
+    return;
+  }
+  scheduleRestore(() => {
+    try {
+      pty.resize(cols, rows);
+    } catch {
+      // pty already gone — nothing to repaint
+    }
+  });
+}
+
 /** Longest a buffered chunk may wait before it is emitted. */
 const OUTPUT_FLUSH_INTERVAL_MS = 16;
 /** Flush early once the buffer reaches this size, regardless of the timer. */
@@ -437,11 +461,8 @@ export async function handleZellijAttach(
     });
 
     // Listen for redraw requests (when client reconnects)
-    // Trigger resize to force Zellij to redraw via SIGWINCH
     socket.on('terminal:redraw', (data: { userId: string }) => {
-      if (data.userId === userId && ptyProcess) {
-        ptyProcess.resize(currentPtyCols, currentPtyRows);
-      }
+      if (data.userId === userId) forceZellijRepaint(ptyProcess, currentPtyCols, currentPtyRows);
     });
 
     // Confirm zellij's attach is actually operational before announcing
@@ -470,6 +491,10 @@ export async function handleZellijAttach(
       }
       zellijAttached = true;
       emitTerminalReady(socket, userId);
+
+      // Reattaching to an existing session does not repaint on its own; nudge a
+      // resize so the frame and pane content draw without the user hitting Enter.
+      forceZellijRepaint(ptyProcess, currentPtyCols, currentPtyRows);
 
       // Create the initial tab now that the session is confirmed up. Keep a
       // bounded retry as belt-and-suspenders against a residual boot race:

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -126,7 +126,8 @@ function emitTerminalReady(socket: AgorClient['io'], userId: string): void {
 
 // On attach/reconnect zellij leaves the UI (frame, status bar, panes) undrawn
 // until a SIGWINCH or keypress arrives — a same-size resize signals nothing, so
-// briefly shrink the row count and restore it to force a full repaint.
+// briefly change the row count and restore it to force a full repaint. Nudge up
+// when rows is at the lower bound (1 → 2 → 1) so the size always actually changes.
 export function forceZellijRepaint(
   pty: Pick<IPty, 'resize'> | null,
   cols: number,
@@ -134,8 +135,9 @@ export function forceZellijRepaint(
   scheduleRestore: (fn: () => void) => void = (fn) => setTimeout(fn, 50)
 ): void {
   if (!pty) return;
+  const nudged = rows > 1 ? rows - 1 : rows + 1;
   try {
-    pty.resize(cols, Math.max(1, rows - 1));
+    pty.resize(cols, nudged);
   } catch {
     return;
   }


### PR DESCRIPTION
## Symptoms

- Reattaching to an existing terminal session shows a blank/stale pane until you **hit Enter**.
- The zellij **frame / status bar often doesn't render** at all.

## Cause

Zellij (like tmux) does not repaint on attach — it redraws only on `SIGWINCH` or the next keypress. On reattach the executor didn't force anything, so the UI stayed undrawn until the user typed. The frame/status bar are part of that same undrawn UI, so they were missing too.

There was already a `terminal:redraw` reconnect handler meant to fix this, but it resized to the **same** `currentPtyCols/Rows`. A no-op resize emits no `SIGWINCH` (the kernel only signals on an actual size change), so it usually didn't repaint — matching "most of the time the frame doesn't show."

## Fix

`packages/executor/src/commands/zellij.ts` — add `forceZellijRepaint()`: briefly shrink the row count (`rows → rows-1`) then restore it, a **real** size change that guarantees a `SIGWINCH` and a full UI+frame repaint.

Called in two places:
- right after attach readiness (`emitTerminalReady`), so an existing session paints without hitting Enter;
- from the `terminal:redraw` handler (replacing the no-op same-size resize).

It's extracted as a small pure-ish function (pty + dims + an injectable restore scheduler) so it's unit-testable, matching how this file's other helpers (`createReconnectGrace`, `waitForZellijReady`) are tested.

## Tests

Added `forceZellijRepaint` unit tests: shrink-then-restore ordering, rows never drop below 1, no-op with no pty, and swallowing a resize on a pty that died before the restore fires. Executor typecheck + `zellij.test.ts` (11 tests) green.

## Note

Cold/new sessions were unaffected (a new tab is created on cold start, which already forces a redraw) — this only changes the reattach path.
