### PR TITLE
fix(terminal): repaint on browser reconnect (same-size terminal:resize)

### DIFF
--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -439,11 +439,15 @@ export async function handleZellijAttach(
       }
     });
 
-    // Listen for resize events
+    // Same-size resize (browser's reconnect redraw) emits no SIGWINCH — force a repaint.
     socket.on('terminal:resize', (data: { userId: string; cols: number; rows: number }) => {
-      if (data.userId === userId && ptyProcess) {
-        currentPtyCols = data.cols;
-        currentPtyRows = data.rows;
+      if (data.userId !== userId || !ptyProcess) return;
+      const unchanged = data.cols === currentPtyCols && data.rows === currentPtyRows;
+      currentPtyCols = data.cols;
+      currentPtyRows = data.rows;
+      if (unchanged) {
+        forceZellijRepaint(ptyProcess, data.cols, data.rows);
+      } else {
         ptyProcess.resize(data.cols, data.rows);
       }
     });


### PR DESCRIPTION
## Symptom

Reopening the terminal (browser reconnecting to a still-running executor) shows a blank pane — no prompt, no zellij frame — until you hit Enter repeatedly. The frame only builds up as input scrolls the screen.

## Root cause

#2153 fixed repaint on **executor attach**, but the failing case is a **browser reconnecting to a warm executor** — the executor doesn't re-attach, so that path never runs.

The browser *does* try to handle this: on reconnect `TerminalModal.tsx` emits `terminal:resize` with the current size (its own comment: "Send initial resize to trigger Zellij full redraw (important for reconnections)"). But the executor's `terminal:resize` handler did a plain `pty.resize(cols, rows)`, and on reconnect the size is unchanged — a same-size resize emits no `SIGWINCH`, so zellij never repaints. Same no-op-resize bug #2153 fixed for `terminal:redraw`, on a path #2153 didn't cover.

## Fix

In the executor `terminal:resize` handler: if the incoming size equals the current size, call `forceZellijRepaint` (the guaranteed n→n-1→n toggle from #2153) instead of a no-op resize. A genuine resize still takes the normal path (its size change already emits `SIGWINCH`).

Executor-only, reuses the existing tested helper, no browser/daemon change.

## Tests

Typecheck + existing `zellij.test.ts` (11 tests, incl. `forceZellijRepaint`) green. The handler is imperative/module-coupled like the rest of attach, so it relies on the already-tested `forceZellijRepaint`.
