### PR TITLE
fix(ui): teammate panel badge shows actual branch owners

### DIFF
--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.owners.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.owners.test.tsx
@@ -1,0 +1,224 @@
+import type { AgorClient, Board, Branch, Repo, User } from '@agor-live/client';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { BoardTeammatePanel } from './BoardTeammatePanel';
+
+vi.mock('../BranchCard', () => ({
+  BranchSessionSections: () => null,
+}));
+
+vi.mock('../BranchHeaderPill', () => ({
+  BranchHeaderPill: () => <div data-testid="branch-header-pill" />,
+}));
+
+const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as Board;
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as Repo;
+
+const branchOne = {
+  branch_id: 'branch-1',
+  repo_id: 'repo-1',
+  name: 'teammate',
+  filesystem_status: 'ready',
+  created_by: 'user-creator',
+} as Branch;
+
+const branchTwo = { ...branchOne, branch_id: 'branch-2', created_by: 'user-creator' } as Branch;
+
+const creator = { user_id: 'user-creator', name: 'creator', role: 'member' } as User;
+const alice = { user_id: 'user-alice', name: 'alice', role: 'member' } as User;
+const bob = { user_id: 'user-bob', name: 'bob', role: 'member' } as User;
+
+/**
+ * Feathers-shaped stub: `find` is driven per-test and `on`/`off` record the
+ * listeners so a test can fire the branch-scoped realtime events the daemon
+ * publishes on this route.
+ */
+function makeClient(find: ReturnType<typeof vi.fn>) {
+  const listeners = new Map<string, Set<() => void>>();
+  const service = {
+    find,
+    on: (event: string, handler: () => void) => {
+      const set = listeners.get(event) ?? new Set();
+      set.add(handler);
+      listeners.set(event, set);
+    },
+    off: (event: string, handler: () => void) => {
+      listeners.get(event)?.delete(handler);
+    },
+  };
+  const client = { service: () => service } as unknown as AgorClient;
+  const emit = (event: string) => {
+    for (const handler of listeners.get(event) ?? []) handler();
+  };
+  const listenerCount = (event: string) => listeners.get(event)?.size ?? 0;
+  return { client, emit, listenerCount };
+}
+
+function renderPanel(client: AgorClient, branch: Branch = branchOne) {
+  return render(
+    <AntApp>
+      <BoardTeammatePanel
+        board={board}
+        activeTab="teammate"
+        onTabChange={vi.fn()}
+        primaryTeammateBranch={branch}
+        primaryTeammateRepo={repo}
+        primaryTeammateInaccessible={false}
+        currentUserId="user-viewer"
+        onSessionClick={vi.fn()}
+        client={client}
+      />
+    </AntApp>
+  );
+}
+
+const notFound = Object.assign(new Error('Service not found'), { code: 404 });
+
+describe('BoardTeammatePanel branch owners badge', () => {
+  beforeEach(() => {
+    agorStore.setState({
+      ...EMPTY_MAPS,
+      userById: new Map([
+        [creator.user_id, creator],
+        [alice.user_id, alice],
+        [bob.user_id, bob],
+      ]),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the owners returned by the owners route', async () => {
+    const find = vi.fn().mockResolvedValue([alice]);
+    const { client } = makeClient(find);
+    renderPanel(client);
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(find).toHaveBeenCalledWith({ route: { id: 'branch-1' } });
+  });
+
+  it('falls back to the branch creator when the owners table is empty', async () => {
+    const find = vi.fn().mockResolvedValue([]);
+    const { client } = makeClient(find);
+    renderPanel(client);
+
+    // Matches the Settings modal, which seeds created_by as the owner for
+    // branches that predate RBAC rather than showing no owner at all.
+    expect(await screen.findByText('creator')).toBeInTheDocument();
+  });
+
+  it('falls back to the branch creator when RBAC is disabled', async () => {
+    const find = vi.fn().mockRejectedValue(notFound);
+    const { client } = makeClient(find);
+    renderPanel(client);
+
+    expect(await screen.findByText('creator')).toBeInTheDocument();
+  });
+
+  it('asserts no ownership when the owners request fails for another reason', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const find = vi.fn().mockRejectedValue(Object.assign(new Error('boom'), { code: 500 }));
+    const { client } = makeClient(find);
+    renderPanel(client);
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith('Failed to load branch owners:', expect.any(Error));
+    });
+    expect(screen.queryByText('creator')).not.toBeInTheDocument();
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+  });
+
+  it('does not show the previous branch owners while the next branch resolves', async () => {
+    let resolveSecond: ((owners: User[]) => void) | undefined;
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce([alice])
+      .mockImplementationOnce(
+        () =>
+          new Promise<User[]>((resolve) => {
+            resolveSecond = resolve;
+          })
+      );
+    const { client } = makeClient(find);
+    const { rerender } = renderPanel(client);
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+
+    rerender(
+      <AntApp>
+        <BoardTeammatePanel
+          board={board}
+          activeTab="teammate"
+          onTabChange={vi.fn()}
+          primaryTeammateBranch={branchTwo}
+          primaryTeammateRepo={repo}
+          primaryTeammateInaccessible={false}
+          currentUserId="user-viewer"
+          onSessionClick={vi.fn()}
+          client={client}
+        />
+      </AntApp>
+    );
+
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveSecond?.([bob]);
+    });
+    expect(await screen.findByText('bob')).toBeInTheDocument();
+  });
+
+  it('refetches owners when the branch-scoped owners route emits', async () => {
+    const find = vi.fn().mockResolvedValueOnce([alice]).mockResolvedValueOnce([bob]);
+    const { client, emit } = makeClient(find);
+    renderPanel(client);
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+
+    await act(async () => {
+      emit('created');
+    });
+
+    expect(await screen.findByText('bob')).toBeInTheDocument();
+    expect(find).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes its realtime listeners on unmount', async () => {
+    const find = vi.fn().mockResolvedValue([alice]);
+    const { client, listenerCount } = makeClient(find);
+    const { unmount } = renderPanel(client);
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(listenerCount('created')).toBe(1);
+    expect(listenerCount('removed')).toBe(1);
+
+    unmount();
+
+    expect(listenerCount('created')).toBe(0);
+    expect(listenerCount('removed')).toBe(0);
+  });
+
+  it('resolves a late-hydrating creator without a second owners request', async () => {
+    agorStore.setState({ ...EMPTY_MAPS, userById: new Map() });
+    const find = vi.fn().mockResolvedValue([]);
+    const { client } = makeClient(find);
+    renderPanel(client);
+
+    await waitFor(() => {
+      expect(find).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('creator')).not.toBeInTheDocument();
+
+    act(() => {
+      agorStore.setState({ userById: new Map([[creator.user_id, creator]]) });
+    });
+
+    expect(await screen.findByText('creator')).toBeInTheDocument();
+    expect(find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.rerender.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.rerender.test.tsx
@@ -1,4 +1,4 @@
-import type { Board } from '@agor-live/client';
+import type { AgorClient, Board, Branch, Repo, User } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
@@ -21,6 +21,30 @@ vi.mock('../CommentsPanel', () => ({
 }));
 
 const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
+const branch = {
+  branch_id: 'branch-1',
+  repo_id: 'repo-1',
+  name: 'teammate',
+  filesystem_status: 'ready',
+  created_by: 'user-creator',
+} as unknown as Branch;
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo;
+const owner = { user_id: 'user-owner', name: 'owner', role: 'member' } as unknown as User;
+
+// A real (stable) client so the panel's owners effect actually runs: with
+// `client={null}` it early-returns and the guard proves nothing about it.
+const ownersFind = vi.fn(async () => [owner]);
+const ownersService = { find: ownersFind, on: () => {}, off: () => {} };
+const client = { service: () => ownersService } as unknown as AgorClient;
+
+// Let the owners request settle so its state update is not miscounted as a
+// re-render caused by the parent.
+async function settleOwnersFetch() {
+  await waitFor(() => {
+    expect(ownersFind).toHaveBeenCalled();
+  });
+  await act(async () => {});
+}
 
 // Mirror of App's `useStableCallback`: freeze a handler's identity across renders
 // while delegating to the latest impl via a ref. The inner App stabilizes the
@@ -46,10 +70,12 @@ let triggerParentRerender: () => void = () => {};
 const noop = () => {};
 const asyncNoop = async () => {};
 const STABLE_PANEL_PROPS = {
-  client: null,
+  client,
   board,
   activeTab: 'comments' as const,
   onTabChange: noop,
+  primaryTeammateBranch: branch,
+  primaryTeammateRepo: repo,
   primaryTeammateInaccessible: false,
   currentUserId: 'u1',
   selectedSessionId: null,
@@ -99,6 +125,7 @@ describe('BoardTeammatePanel memo + prop-stabilization re-render bailout', () =>
   beforeEach(() => {
     panelRenders = 0;
     triggerParentRerender = () => {};
+    ownersFind.mockClear();
     agorStore.setState({ ...EMPTY_MAPS });
   });
 
@@ -108,6 +135,7 @@ describe('BoardTeammatePanel memo + prop-stabilization re-render bailout', () =>
     await waitFor(() => {
       expect(panelRenders).toBeGreaterThanOrEqual(1);
     });
+    await settleOwnersFetch();
     const baseline = panelRenders;
 
     // Parent re-renders without changing any prop value or touching the store.
@@ -138,5 +166,23 @@ describe('BoardTeammatePanel memo + prop-stabilization re-render bailout', () =>
     await waitFor(() => {
       expect(panelRenders).toBeGreaterThan(baseline);
     });
+  });
+
+  it('does not refetch branch owners when unrelated store slices churn', async () => {
+    render(<ParentHarness stabilize={true} />);
+    await settleOwnersFetch();
+    expect(ownersFind).toHaveBeenCalledTimes(1);
+
+    // A patched branch row hands out a new Branch identity, and the user map is
+    // replaced wholesale on hydration. Neither changes who owns the branch, so
+    // neither may re-fire the owners request.
+    await act(async () => {
+      agorStore.setState({
+        branchById: new Map([[branch.branch_id, { ...branch }]]),
+        userById: new Map([[owner.user_id, owner]]),
+      });
+    });
+
+    expect(ownersFind).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Board, Branch, Repo, SpawnConfig } from '@agor-live/client';
+import type { AgorClient, Board, Branch, Repo, SpawnConfig, User } from '@agor-live/client';
 import { getTeammateConfig, isTeammate } from '@agor-live/client';
 import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
 import {
@@ -181,6 +181,32 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
     }
   }, [defaultTab, board?.board_id, isControlled, onTabChange]);
 
+  const [branchOwners, setBranchOwners] = useState<User[]>([]);
+  useEffect(() => {
+    if (!client || !primaryTeammateBranch) {
+      setBranchOwners([]);
+      return;
+    }
+    const branchId = primaryTeammateBranch.branch_id;
+    let cancelled = false;
+    client
+      .service('branches/:id/owners')
+      .find({ route: { id: branchId } })
+      .then((response) => {
+        if (!cancelled) setBranchOwners(response as User[]);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // RBAC disabled (404) or network error — fall back to created_by
+        const creator =
+          primaryTeammateBranch.created_by && userById.get(primaryTeammateBranch.created_by);
+        setBranchOwners(creator ? [creator] : []);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, primaryTeammateBranch, userById]);
+
   const teammateOptions = useMemo(() => {
     if (primaryTeammateBranch || primaryTeammateInaccessible) return [];
 
@@ -306,7 +332,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
             <BranchMetadataRow
               branch={primaryTeammateBranch}
               repo={primaryTeammateRepo}
-              userById={userById}
+              owners={branchOwners}
               currentUserId={currentUserId}
               style={{ minWidth: 0 }}
             >

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -37,6 +37,33 @@ import { MarkdownRenderer } from '../MarkdownRenderer';
 
 export type BoardTeammatePanelTab = 'teammate' | 'all-sessions' | 'comments';
 
+/**
+ * Outcome of the branch-owners lookup. A successful empty list is deliberately
+ * distinct from a failed one: the former means "no explicit owners, so the
+ * creator owns it", the latter means ownership is simply unknown.
+ */
+type OwnersState =
+  | { status: 'unresolved' }
+  | { status: 'resolved'; owners: User[] }
+  | { status: 'creator-fallback' }
+  | { status: 'failed' };
+
+// Frozen singletons so setting the same outcome twice is a state no-op and the
+// derived owner list keeps a stable identity for the panel's memo bailout.
+const OWNERS_UNRESOLVED: OwnersState = { status: 'unresolved' };
+const OWNERS_CREATOR_FALLBACK: OwnersState = { status: 'creator-fallback' };
+const OWNERS_FAILED: OwnersState = { status: 'failed' };
+const NO_OWNERS: User[] = [];
+
+/**
+ * The owners route is only registered when branch RBAC is enabled, so a 404 is
+ * a configuration answer rather than a failure. Mirrors the Settings modal.
+ */
+function isOwnersRouteUnavailable(error: unknown): boolean {
+  const { code, message } = (error ?? {}) as { code?: unknown; message?: unknown };
+  return code === 404 || (typeof message === 'string' && message.includes('not found'));
+}
+
 interface BoardTeammatePanelProps {
   board: Board | null;
   activeTab?: BoardTeammatePanelTab;
@@ -181,31 +208,76 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
     }
   }, [defaultTab, board?.board_id, isControlled, onTabChange]);
 
-  const [branchOwners, setBranchOwners] = useState<User[]>([]);
+  // Depend on the branch's identifying primitives rather than the branch object:
+  // the store hands out a fresh Branch on every row patch, which would re-fire
+  // the request on churn unrelated to ownership.
+  const teammateBranchId = primaryTeammateBranch?.branch_id;
+  const teammateCreatedBy = primaryTeammateBranch?.created_by;
+
+  const [ownersState, setOwnersState] = useState<OwnersState>(OWNERS_UNRESOLVED);
   useEffect(() => {
-    if (!client || !primaryTeammateBranch) {
-      setBranchOwners([]);
+    if (!client || !teammateBranchId) {
+      setOwnersState(OWNERS_UNRESOLVED);
       return;
     }
-    const branchId = primaryTeammateBranch.branch_id;
+
+    // Drop the previous branch's owners immediately: keeping them on screen
+    // until the new request lands attributes one branch to another's owner.
+    setOwnersState(OWNERS_UNRESOLVED);
+
     let cancelled = false;
-    client
-      .service('branches/:id/owners')
-      .find({ route: { id: branchId } })
-      .then((response) => {
-        if (!cancelled) setBranchOwners(response as User[]);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        // RBAC disabled (404) or network error — fall back to created_by
-        const creator =
-          primaryTeammateBranch.created_by && userById.get(primaryTeammateBranch.created_by);
-        setBranchOwners(creator ? [creator] : []);
-      });
+    const service = client.service('branches/:id/owners');
+
+    const load = () => {
+      service
+        .find({ route: { id: teammateBranchId } })
+        .then((response) => {
+          if (cancelled) return;
+          const owners = response as User[];
+          // A branch predating RBAC has no branch_owners rows at all. Settings
+          // seeds the creator as the owner in exactly that case, so mirror it
+          // instead of rendering an ownerless branch on one surface only.
+          setOwnersState(
+            owners.length > 0 ? { status: 'resolved', owners } : OWNERS_CREATOR_FALLBACK
+          );
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return;
+          if (isOwnersRouteUnavailable(error)) {
+            // RBAC is off, so the route is unregistered and created_by is the
+            // only ownership signal the deployment has.
+            setOwnersState(OWNERS_CREATOR_FALLBACK);
+            return;
+          }
+          // Ownership is unknown after a real failure. Naming the creator here
+          // would render confidently wrong attribution off a transport error.
+          console.warn('Failed to load branch owners:', error);
+          setOwnersState(OWNERS_FAILED);
+        });
+    };
+
+    load();
+
+    // Owner edits never patch the branch row, so this branch-scoped route is
+    // the only signal the panel gets. The payload is a bare User carrying no
+    // branch id, so any owner change the socket can see triggers a refetch.
+    service.on('created', load);
+    service.on('removed', load);
     return () => {
       cancelled = true;
+      service.off('created', load);
+      service.off('removed', load);
     };
-  }, [client, primaryTeammateBranch, userById]);
+  }, [client, teammateBranchId]);
+
+  // Resolve owners for render rather than inside the effect, so a user map that
+  // hydrates after the response still names the creator without a refetch.
+  const branchOwners = useMemo(() => {
+    if (ownersState.status === 'resolved') return ownersState.owners;
+    if (ownersState.status !== 'creator-fallback' || !teammateCreatedBy) return NO_OWNERS;
+    const creator = userById.get(teammateCreatedBy);
+    return creator ? [creator] : NO_OWNERS;
+  }, [ownersState, teammateCreatedBy, userById]);
 
   const teammateOptions = useMemo(() => {
     if (primaryTeammateBranch || primaryTeammateInaccessible) return [];

--- a/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.test.tsx
+++ b/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.test.tsx
@@ -14,14 +14,18 @@ const branch = {
   pull_request_url: 'https://github.com/preset-io/agor/pull/2',
 } as Branch;
 
-const userById = new Map<string, User>([
-  ['user-2', { user_id: 'user-2', name: 'sam', email: 'sam@example.com' } as User],
-]);
+const sam = { user_id: 'user-2', name: 'sam', email: 'sam@example.com', role: 'member' } as User;
+const alice = {
+  user_id: 'user-3',
+  name: 'alice',
+  email: 'alice@example.com',
+  role: 'member',
+} as User;
 
 describe('BranchMetadataRow', () => {
-  it('renders the pill and metadata links inline in a single wrapping row', () => {
+  it('renders the pill, owner badge, and metadata links inline', () => {
     render(
-      <BranchMetadataRow branch={branch} repo={repo} userById={userById} currentUserId="user-1">
+      <BranchMetadataRow branch={branch} repo={repo} owners={[sam]} currentUserId="user-1">
         <div data-testid="branch-pill" />
       </BranchMetadataRow>
     );
@@ -29,21 +33,40 @@ describe('BranchMetadataRow', () => {
     const pill = screen.getByTestId('branch-pill');
     const issue = screen.getByText(/Issue:/);
     const pr = screen.getByText(/PR:/);
-    const createdBy = screen.getByText('sam');
+    const ownerName = screen.getByText('sam');
 
-    // All items share ONE row container (no stacked second row), pill first.
     const row = pill.parentElement as HTMLElement;
-    for (const item of [issue, pr, createdBy]) {
+    for (const item of [issue, pr, ownerName]) {
       expect(row.contains(item)).toBe(true);
     }
     expect(row.firstElementChild).toBe(pill);
-    // Pill precedes every metadata link in document order.
-    for (const item of [createdBy, issue, pr]) {
+    for (const item of [ownerName, issue, pr]) {
       expect(pill.compareDocumentPosition(item) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     }
   });
 
-  it('omits metadata links the branch does not have and created-by without a user map', () => {
+  it('shows multiple owners', () => {
+    render(
+      <BranchMetadataRow branch={branch} repo={repo} owners={[sam, alice]} currentUserId="user-1">
+        <div data-testid="branch-pill" />
+      </BranchMetadataRow>
+    );
+
+    expect(screen.getByText('sam')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+  });
+
+  it('hides owner tag when the sole owner is the current user', () => {
+    render(
+      <BranchMetadataRow branch={branch} repo={repo} owners={[sam]} currentUserId="user-2">
+        <div data-testid="branch-pill" />
+      </BranchMetadataRow>
+    );
+
+    expect(screen.queryByText('sam')).not.toBeInTheDocument();
+  });
+
+  it('omits metadata links the branch does not have and owner tag without owners', () => {
     render(
       <BranchMetadataRow
         branch={{ ...branch, issue_url: undefined, pull_request_url: undefined } as Branch}

--- a/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.tsx
+++ b/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.tsx
@@ -1,6 +1,6 @@
 import type { Branch, Repo, User } from '@agor-live/client';
 import { Flex, theme } from 'antd';
-import { CreatedByTag } from '../metadata';
+import { OwnersTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 
 interface BranchMetadataRowProps {
@@ -8,23 +8,23 @@ interface BranchMetadataRowProps {
   repo?: Repo | null;
   /** Leading branch pill; renders first so the metadata links flow after it. */
   children: React.ReactNode;
-  /** Users map enabling the "Created by" tag when the branch has a creator. */
-  userById?: Map<string, User>;
-  /** Suppresses the "Created by" tag for the viewer's own branches. */
+  /** Current branch owners (from the owners API). */
+  owners?: User[];
+  /** Suppresses the owner tag when the sole owner is the current viewer. */
   currentUserId?: string;
   style?: React.CSSProperties;
 }
 
 /**
  * Single wrapping row for a branch pill and its metadata links: the pill owns
- * the leading slot, and created-by/issue/PR links sit on the same line when
+ * the leading slot, and owner/issue/PR links sit on the same line when
  * there is room, wrapping to the next line when there is not.
  */
 export function BranchMetadataRow({
   branch,
   repo,
   children,
-  userById,
+  owners,
   currentUserId,
   style,
 }: BranchMetadataRowProps) {
@@ -33,14 +33,7 @@ export function BranchMetadataRow({
   return (
     <Flex wrap gap={token.sizeUnit} align="center" style={style}>
       {children}
-      {branch.created_by && userById && (
-        <CreatedByTag
-          createdBy={branch.created_by}
-          currentUserId={currentUserId}
-          userById={userById}
-          prefix="Created by"
-        />
-      )}
+      {owners && owners.length > 0 && <OwnersTag owners={owners} currentUserId={currentUserId} />}
       {branch.issue_url && (
         <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
       )}

--- a/apps/agor-ui/src/components/metadata/OwnersTag.tsx
+++ b/apps/agor-ui/src/components/metadata/OwnersTag.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@agor-live/client';
-import { Space } from 'antd';
+import { Space, theme } from 'antd';
 import { Tag } from '../Tag';
 import { UserAvatar } from './UserAvatar';
 
@@ -9,22 +9,16 @@ export interface OwnersTagProps {
 }
 
 export const OwnersTag: React.FC<OwnersTagProps> = ({ owners, currentUserId }) => {
+  const { token } = theme.useToken();
+
   if (owners.length === 0) return null;
 
   // Hide when the only owner is the current user
   if (owners.length === 1 && owners[0].user_id === currentUserId) return null;
 
-  if (owners.length === 1) {
-    return (
-      <Tag color="blue" style={{ fontSize: 11 }}>
-        <UserAvatar user={owners[0]} showName size="small" />
-      </Tag>
-    );
-  }
-
   return (
     <Tag color="blue" style={{ fontSize: 11 }}>
-      <Space size={2}>
+      <Space size={token.sizeXXS}>
         {owners.map((owner) => (
           <UserAvatar key={owner.user_id} user={owner} showName size="small" />
         ))}

--- a/apps/agor-ui/src/components/metadata/OwnersTag.tsx
+++ b/apps/agor-ui/src/components/metadata/OwnersTag.tsx
@@ -1,0 +1,34 @@
+import type { User } from '@agor-live/client';
+import { Space } from 'antd';
+import { Tag } from '../Tag';
+import { UserAvatar } from './UserAvatar';
+
+export interface OwnersTagProps {
+  owners: User[];
+  currentUserId?: string;
+}
+
+export const OwnersTag: React.FC<OwnersTagProps> = ({ owners, currentUserId }) => {
+  if (owners.length === 0) return null;
+
+  // Hide when the only owner is the current user
+  if (owners.length === 1 && owners[0].user_id === currentUserId) return null;
+
+  if (owners.length === 1) {
+    return (
+      <Tag color="blue" style={{ fontSize: 11 }}>
+        <UserAvatar user={owners[0]} showName size="small" />
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag color="blue" style={{ fontSize: 11 }}>
+      <Space size={2}>
+        {owners.map((owner) => (
+          <UserAvatar key={owner.user_id} user={owner} showName size="small" />
+        ))}
+      </Space>
+    </Tag>
+  );
+};

--- a/apps/agor-ui/src/components/metadata/index.ts
+++ b/apps/agor-ui/src/components/metadata/index.ts
@@ -1,2 +1,3 @@
 export { CreatedByTag } from './CreatedByTag';
+export { OwnersTag } from './OwnersTag';
 export { UserAvatar } from './UserAvatar';


### PR DESCRIPTION
## Context / Problem

The sidebar "Teammate" panel displays an owner badge next to the branch pill. This badge was bound to `branch.created_by` — an immutable field set once at branch creation — via `CreatedByTag`. When ownership was changed via Settings (which writes to the `branches/:id/owners` API), the badge still showed the original creator, never the actual current owner(s).

Two disconnected data sources: Settings reads/writes the owners table, but the badge read `created_by`.

## Goal

The badge reflects real, current branch ownership — sourced from the same `branches/:id/owners` API the Settings modal uses.

## Changes

- **New `OwnersTag` component** (`metadata/OwnersTag.tsx`): renders one or more owner avatars in a tag. Hides when the sole owner is the current viewer (same UX as the old `CreatedByTag`). Supports multiple owners.
- **`BranchMetadataRow`**: replaced `userById` + `CreatedByTag` with an `owners: User[]` prop and `OwnersTag`. The component no longer reads `branch.created_by`.
- **`BoardTeammatePanel`**: fetches owners from `client.service('branches/:id/owners')` on mount. Falls back to `created_by` user when RBAC is disabled (404).
- **`CreatedByTag`** remains available and unchanged — it's still used in `SessionCard`, `SessionPanel`, `TaskBlock`, etc. where "created by" is the correct semantic.

**Scope**: UI-only. No backend, RBAC, or data-model changes.

## Test plan

- [x] `BranchMetadataRow` tests updated: single owner, multiple owners, hidden-when-self, no-owners cases (4 tests pass)
- [x] All 12 `BoardTeammatePanel` tests pass
- [x] All 77 `SessionPanel` tests pass (no regressions from removing `userById` prop)
- [x] TypeScript type-check clean
- [x] Biome lint/format clean
- [ ] Manual: open teammate panel, verify badge shows the Settings-configured owner(s)
- [ ] Manual: change owner via Settings → badge updates after re-mount
- [ ] Manual: with RBAC disabled, verify fallback to created_by

🤖 Generated with [Claude Code](https://claude.com/claude-code)