### PR TITLE
docs(migrations): deferrable tenant FKs + lock_timeout guidance

### DIFF
--- a/context/guides/creating-database-migrations.md
+++ b/context/guides/creating-database-migrations.md
@@ -99,6 +99,53 @@ Don't use `CHECK(col IN ('a', 'b', 'c'))` on a SQLite column. When a new value i
 
 Validate enum values at the application layer instead — Drizzle schema `enum` option, Zod, or service hooks. The TypeScript types are the source of truth; the DB just stores text.
 
+### New tenant-table FKs must be made `DEFERRABLE INITIALLY IMMEDIATE` (Postgres)
+
+`agor tenant import` restores a whole tenant inside one transaction with
+`SET CONSTRAINTS ALL DEFERRED`, which only works on constraints *declared*
+deferrable. Migration `0070_tenant_portability_deferrable_fks` marked every
+existing FK between tenant-manifest tables `DEFERRABLE INITIALLY IMMEDIATE`
+(behaviorally identical for normal transactions — checks still run per
+statement unless a transaction explicitly defers them).
+
+Drizzle generates FKs **non-deferrable** by default, so when you add a
+tenant-owned table (or a new FK between existing tenant tables), ship a small
+companion Postgres migration:
+
+```sql
+SET LOCAL lock_timeout = '3s';--> statement-breakpoint
+ALTER TABLE "my_table" ALTER CONSTRAINT "my_table_branch_id_branches_branch_id_fk" DEFERRABLE INITIALLY IMMEDIATE;
+```
+
+If you forget, the integration test
+`packages/core/src/db/tenant-portability.postgres.test.ts`
+("keeps exactly every manifest-to-manifest FK deferrable and initially
+immediate") fails — it pins the exact deferrable set against `pg_constraint`
+in both directions, so stray deferrable FKs outside the manifest also fail.
+
+### Bound lock waits when ALTERing existing tables (Postgres)
+
+`ALTER TABLE … ALTER CONSTRAINT` (and most other ALTERs) need an
+ACCESS EXCLUSIVE lock. Two things make an unbounded wait dangerous on a live
+database:
+
+1. While the ALTER waits for its lock, **every new query on that table queues
+   behind it** — even SELECTs — so a wait is a traffic stall, not a quiet delay.
+2. The migrator runs all pending migrations in **one transaction**, and
+   Postgres holds every acquired lock until commit. A multi-table migration
+   that stalls on table N is still holding exclusive locks on tables 1…N-1.
+
+For any migration touching multiple existing tables, start it with
+`SET LOCAL lock_timeout = '3s';` (see `0070_tenant_portability_deferrable_fks.sql`
+for the pattern and full rationale). On an idle DB the timeout never triggers;
+on a busy one the migration fails fast with `55P03` and rolls back atomically —
+always safe to retry — instead of freezing the app. `SET LOCAL` scopes the
+setting to the migration transaction, so it never leaks onto pooled connections.
+
+The corollary for operators: migrations that ALTER existing tables should run
+with the daemon **stopped** (`systemctl stop` → `agor db migrate` → `start`);
+live daemon connections hold shared locks that will trip the timeout.
+
 ### Schemas drifting
 
 If you only update one schema, generation succeeds for that dialect and silently leaves the other one stale. Catch it before merge:


### PR DESCRIPTION
## Context

While rolling out #2096 on the hosted instance we hit both halves of what this PR documents: the migration (`0070_tenant_portability_deferrable_fks`) failed with `55P03` when run against a live daemon, and the *why do these FKs need to be deferrable at all* question came up while debugging.

## Changes

Adds two gotcha sections to `context/guides/creating-database-migrations.md`:

1. **New tenant-table FKs must be `DEFERRABLE INITIALLY IMMEDIATE`** — `agor tenant import` restores a tenant in one transaction with `SET CONSTRAINTS ALL DEFERRED`, which only applies to constraints declared deferrable. Drizzle emits non-deferrable FKs by default, so new tenant tables need a small companion migration; the `tenant-portability.postgres.test.ts` integration test pins the exact set in both directions.

2. **Bound lock waits on multi-table ALTERs** — copy the `SET LOCAL lock_timeout = '3s'` pattern from 0070. A waiting ACCESS EXCLUSIVE request queues all new traffic behind it, and the single-transaction migrator holds every acquired lock until commit, so an unbounded multi-table ALTER can freeze the app. The timeout converts that into a fast, atomic, retry-safe failure. Also notes the operator-side corollary: stop the daemon before migrating.

Docs only, no code changes.