### PR TITLE
feat(uploads): direct-write staging mode for Mountpoint S3 mounts

### DIFF
--- a/apps/agor-daemon/src/host/local/upload-staging-store.test.ts
+++ b/apps/agor-daemon/src/host/local/upload-staging-store.test.ts
@@ -45,6 +45,22 @@ describe('LocalUploadStagingStore boundary B', () => {
     expect(stored.provenance).toBe('browser');
   });
 
+  it('directWrite (Mountpoint-safe): stages with no temp/rename and round-trips', async () => {
+    const store = await setup({ directWrite: true });
+    const stored = await stage(store, 'mountpoint');
+    const bucket = join(root, tenantA, 'objects', stored.ref.slice(4, 6));
+    const files = await readdir(bucket);
+    expect(files.some((f) => f.endsWith('.partial'))).toBe(false);
+    expect(files).toContain(`${stored.ref}.data`);
+    expect(files).toContain(`${stored.ref}.json`);
+    const key = { tenantId: tenantA, sessionId: sessionA, branchId: branchA, ref: stored.ref };
+    let out = '';
+    for await (const chunk of await store.read(key)) out += chunk;
+    expect(out).toBe('mountpoint');
+    await store.delete(key);
+    expect(await readdir(bucket)).toEqual([]);
+  });
+
   it('denies cross-tenant and cross-session reuse without disclosing ownership', async () => {
     const store = await setup();
     const stored = await stage(store);

--- a/apps/agor-daemon/src/host/local/upload-staging-store.ts
+++ b/apps/agor-daemon/src/host/local/upload-staging-store.ts
@@ -41,7 +41,7 @@ function forbidden(message = 'Upload not found'): Error {
 export class LocalUploadStagingStore implements UploadStagingStore {
   constructor(
     private readonly rootForTenant: (tenantId: string) => string,
-    private readonly options: { maxBytes?: number; ttlMs?: number } = {}
+    private readonly options: { maxBytes?: number; ttlMs?: number; directWrite?: boolean } = {}
   ) {
     const maxBytes = options.maxBytes ?? DEFAULT_UPLOAD_MAX_BYTES;
     const ttlMs = options.ttlMs ?? DEFAULT_UPLOAD_TTL_MS;
@@ -92,7 +92,10 @@ export class LocalUploadStagingStore implements UploadStagingStore {
     const ref = `upl_${randomUUID()}` as UploadRef;
     const paths = this.paths(input.owner, ref);
     await mkdir(paths.dir, { recursive: true, mode: 0o700 });
-    const temporary = `${paths.data}.${randomUUID()}.partial`;
+    // Mountpoint S3 cannot rename or O_EXCL-create; write the object/sidecar directly
+    // (it uploads on close, so atomicity holds). A real filesystem keeps temp+rename.
+    const direct = this.options.directWrite === true;
+    const temporary = direct ? paths.data : `${paths.data}.${randomUUID()}.partial`;
     let size = 0;
     const limiter = new Transform({
       transform(chunk: Buffer, _encoding, callback) {
@@ -110,9 +113,9 @@ export class LocalUploadStagingStore implements UploadStagingStore {
       await pipeline(
         input.body,
         limiter,
-        createWriteStream(temporary, { flags: 'wx', mode: 0o600 })
+        createWriteStream(temporary, { flags: direct ? 'w' : 'wx', mode: 0o600 })
       );
-      await rename(temporary, paths.data);
+      if (!direct) await rename(temporary, paths.data);
       const now = new Date();
       const metadata: StoredMetadata = {
         ref,
@@ -127,7 +130,10 @@ export class LocalUploadStagingStore implements UploadStagingStore {
         branchId: input.owner.branchId,
         createdBy: input.owner.createdBy,
       };
-      await writeFile(paths.meta, JSON.stringify(metadata), { flag: 'wx', mode: 0o600 });
+      await writeFile(paths.meta, JSON.stringify(metadata), {
+        flag: direct ? 'w' : 'wx',
+        mode: 0o600,
+      });
       const {
         tenantId: _tenant,
         sessionId: _session,

--- a/apps/agor-daemon/src/utils/upload-staging.ts
+++ b/apps/agor-daemon/src/utils/upload-staging.ts
@@ -59,7 +59,7 @@ export function configureUploadStagingStoreFromConfig(
   configureUploadStagingStore(() => {
     const adapter = new LocalUploadStagingStore(
       (tenantId) => resolveLocalUploadDirectory(expanded, tenantId, tenantSeparated),
-      { maxBytes, ttlMs }
+      { maxBytes, ttlMs, directWrite: config.uploads?.direct_write === true }
     );
     return db ? new MetadataUploadStagingStore(db, adapter) : adapter;
   });

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -333,7 +333,7 @@ function validateConfig(config: AgorConfig): void {
     ...RETIRED_CONFIG_KEYS.daemon,
   ]);
   only(config.ui, 'ui', ['base_url', 'port', 'host']);
-  only(config.uploads, 'uploads', ['location', 'max_age_days', 'max_file_size_mb']);
+  only(config.uploads, 'uploads', ['location', 'max_age_days', 'max_file_size_mb', 'direct_write']);
   only(config.external_launch, 'external_launch', [
     'enabled',
     'exchange_url',

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -980,6 +980,13 @@ export interface AgorUploadSettings {
 
   /** Maximum bytes accepted for one file, expressed in MiB. */
   max_file_size_mb?: number;
+
+  /**
+   * Write staged objects directly to `location` instead of temp-file + rename.
+   * Required when `location` is a Mountpoint S3 mount (no rename / O_EXCL). Leave
+   * false for a POSIX filesystem, where temp+rename gives crash-atomic staging.
+   */
+  direct_write?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What

Agor Cloud is moving S3 uploads to a **Mountpoint S3 CSI mount** (per-Cell prefix scope, no pod credentials) instead of the S3 API. Mountpoint for S3 is **not full POSIX** — it cannot `rename` or `O_EXCL`-create — so the `LocalUploadStagingStore`'s temp-file + atomic-`rename` staging path fails on such a mount.

## Change

Add a `uploads.direct_write` config flag. When set, the store writes the object and its sidecar **straight to the final path** (no temp file, no rename, no `wx`). Mountpoint uploads the object on file **close**, so a partial object never appears in S3 — atomicity is preserved without rename. On a real POSIX filesystem the flag stays false and the existing temp+rename staging is unchanged.

Wired through `AgorUploadSettings.direct_write` → the store factory → `LocalUploadStagingStore({ directWrite })`.

## Why not the S3 API store

The mount model gives per-Cell isolation at the mount boundary (`--prefix <cellId>/`) with **no S3 credentials on the daemon pod** — which is the isolation property the agor-cloud reviewer required. The daemon therefore uses the filesystem store over the mount, not `S3UploadStagingStore`.

## Tests

Added a direct-write test: stages with no `.partial`/rename, writes `<ref>.data` + `<ref>.json` directly, and read + delete round-trip. Local-store + upload-staging suites green; core + daemon typecheck clean.
