### PR TITLE
fix(user-settings): add left breathing room to settings sidebar

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1952,7 +1952,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
               background: token.colorBgElevated,
               borderRight: `1px solid ${token.colorBorderSecondary}`,
               overflow: 'auto',
-              padding: '20px 0',
+              padding: `20px ${token.marginSM}px`,
             }}
           >
             <div style={{ padding: `0 ${token.marginXXS}px ${token.marginMD}px` }}>


### PR DESCRIPTION
Adds uniform horizontal padding (`token.marginSM`, 12px) to the settings modal's `<Sider>` so the title, search box, and nav rows sit ~12px off the modal's left edge instead of hugging it — keeping them left-aligned with each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)