### PR TITLE
feat(ui): add current board edit shortcut

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1284,6 +1284,7 @@ function AppContent() {
     if (updated) {
       showSuccess('Board updated successfully!');
     }
+    return Boolean(updated);
   };
 
   const handleDeleteBoard = async (boardId: string) => {

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1440,6 +1440,7 @@ export const App: React.FC<AppProps> = ({
           currentBoardId={headerBoardId}
           onBoardChange={navigation.goToBoard}
           onHomeClick={handleHomeClick}
+          onUpdateBoard={onUpdateBoard}
           onUserClick={handleHeaderUserClick}
           instanceLabel={instanceLabel}
           instanceDescription={instanceDescription}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -44,6 +44,7 @@ export interface AppHeaderProps {
   currentBoardId?: string;
   onBoardChange?: (boardId: string) => void;
   onHomeClick?: () => void;
+  onUpdateBoard?: (boardId: string, updates: Partial<Board>) => void | Promise<void>;
   onUserClick?: (
     userId: string,
     boardId?: BoardID,
@@ -111,6 +112,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   currentBoardId,
   onBoardChange,
   onHomeClick,
+  onUpdateBoard,
   onUserClick,
   instanceLabel,
   instanceDescription,
@@ -241,6 +243,9 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             onBoardChange={onBoardChange || (() => {})}
             onHomeClick={onHomeClick}
             branchById={branchById}
+            client={presenceClient}
+            currentUser={user}
+            onUpdateBoard={onUpdateBoard}
           />
         </div>
         {boards.length > 0 && (

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
@@ -1,0 +1,142 @@
+import type { AgorClient, Board } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form, Input } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardEditModal } from './BoardEditModal';
+
+const showError = vi.hoisted(() => vi.fn());
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({ showError }),
+}));
+vi.mock('../JSONEditor', () => ({
+  JSONEditor: () => <textarea aria-label="Custom Context (JSON)" />,
+  validateJSON: () => Promise.resolve(),
+}));
+vi.mock('../forms/BoardFormFields', () => ({
+  BoardFormFields: () => (
+    <Form.Item name="name" label="Name" rules={[{ required: true }]}>
+      <Input />
+    </Form.Item>
+  ),
+  extractBoardFormValues: (form: { getFieldValue: (name: string) => unknown }) => ({
+    name: form.getFieldValue('name'),
+  }),
+  isCustomCSS: () => false,
+}));
+
+const listedBoard = {
+  board_id: 'board-1',
+  name: 'Stale name',
+  created_by: 'owner-1',
+  created_at: '',
+  last_updated: '',
+} as Board;
+const freshBoard = { ...listedBoard, name: 'Fresh name', icon: '✨' } as Board;
+
+function makeClient(metadataError: { code?: number; message?: string } = { code: 404 }) {
+  const get = vi.fn().mockResolvedValue(freshBoard);
+  return {
+    get,
+    client: {
+      service: (name: string) => {
+        if (name === 'boards') return { get };
+        if (name === 'boards/:id/owners' || name === 'boards/:id/group-grants') {
+          return { find: vi.fn().mockRejectedValue(metadataError) };
+        }
+        return { findAll: vi.fn().mockResolvedValue([]) };
+      },
+    } as unknown as AgorClient,
+  };
+}
+
+describe('BoardEditModal', () => {
+  beforeEach(() => showError.mockReset());
+
+  it('loads the latest full board and permits save when RBAC routes are disabled', async () => {
+    const { client, get } = makeClient({ code: 404 });
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={onClose}
+        onUpdate={onUpdate}
+      />
+    );
+
+    expect(await screen.findByDisplayValue('Fresh name')).toBeInTheDocument();
+    expect(get).toHaveBeenCalledWith(listedBoard.board_id);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed' } });
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith(listedBoard.board_id, { name: 'Renamed' })
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces non-404 metadata failures and prevents saving stale settings', async () => {
+    const { client } = makeClient({ code: 500, message: 'metadata unavailable' });
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Board settings unavailable')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.queryByDisplayValue('Stale name')).not.toBeInTheDocument();
+  });
+
+  it('awaits the board mutation before closing', async () => {
+    const { client } = makeClient({ code: 404 });
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+    const onClose = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={onClose}
+        onUpdate={onUpdate}
+      />
+    );
+    await screen.findByDisplayValue('Fresh name');
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledOnce());
+    expect(onClose).not.toHaveBeenCalled();
+
+    resolveUpdate?.();
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+  });
+
+  it('stays open when the board mutation reports failure', async () => {
+    const { client } = makeClient({ code: 404 });
+    const onClose = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={onClose}
+        onUpdate={vi.fn().mockResolvedValue(false)}
+      />
+    );
+    await screen.findByDisplayValue('Fresh name');
+    fireEvent.click(await screen.findByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -8,7 +8,7 @@ import type {
   User,
   UUID,
 } from '@agor-live/client';
-import { Form, Modal } from 'antd';
+import { Alert, Form, Modal } from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
@@ -19,7 +19,7 @@ export interface BoardEditModalProps {
   client: AgorClient | null;
   open: boolean;
   onClose: () => void;
-  onUpdate?: (boardId: string, updates: Partial<Board>) => void | Promise<void>;
+  onUpdate?: (boardId: string, updates: Partial<Board>) => unknown;
 }
 
 /** The single board-settings editor used by Settings and the navbar shortcut. */
@@ -30,65 +30,78 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
   const [rbacEnabled, setRbacEnabled] = useState(false);
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [allGroups, setAllGroups] = useState<Group[]>([]);
+  const [loadedBoard, setLoadedBoard] = useState<Board | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!open || !board) return;
     let cancelled = false;
     setLoading(true);
+    setLoadError(null);
+    setLoadedBoard(null);
 
     // Re-read the board as the modal opens. The selector uses a lean board list,
     // while this form must always start from the full, latest representation.
     const load = async () => {
-      let fresh = board;
-      let ownerIds: string[] = [];
-      let grants: Array<{ group_id: string; can: string; fs_access?: string }> = [];
       try {
-        if (client) fresh = await client.service('boards').get(board.board_id);
+        const fresh = client ? await client.service('boards').get(board.board_id) : board;
+        let ownerIds: string[] = [];
+        let grants: Array<{ group_id: string; can: string; fs_access?: string }> = [];
         if (client) {
-          const [users, groups, owners, groupGrants] = await Promise.all([
-            client.service('users').findAll({}),
-            client.service('groups').findAll({ query: { archived: false } }),
-            client.service('boards/:id/owners').find({ route: { id: board.board_id } }),
-            client.service('boards/:id/group-grants').find({ route: { id: board.board_id } }),
-          ]);
-          if (cancelled) return;
-          setRbacEnabled(true);
-          setAllUsers(users as User[]);
-          setAllGroups(groups as Group[]);
-          ownerIds = (owners as User[]).map((user) => user.user_id);
-          grants = (groupGrants as BoardGroupGrantWithGroup[]).map((grant) => ({
-            group_id: grant.group_id,
-            can: grant.can,
-            fs_access: grant.fs_access,
-          }));
+          try {
+            const [users, groups, owners, groupGrants] = await Promise.all([
+              client.service('users').findAll({}),
+              client.service('groups').findAll({ query: { archived: false } }),
+              client.service('boards/:id/owners').find({ route: { id: board.board_id } }),
+              client.service('boards/:id/group-grants').find({ route: { id: board.board_id } }),
+            ]);
+            if (cancelled) return;
+            setRbacEnabled(true);
+            setAllUsers(users as User[]);
+            setAllGroups(groups as Group[]);
+            ownerIds = (owners as User[]).map((user) => user.user_id);
+            grants = (groupGrants as BoardGroupGrantWithGroup[]).map((grant) => ({
+              group_id: grant.group_id,
+              can: grant.can,
+              fs_access: grant.fs_access,
+            }));
+          } catch (error) {
+            if ((error as { code?: number })?.code !== 404) throw error;
+            // Owner/group routes intentionally do not exist when RBAC is disabled.
+            setRbacEnabled(false);
+            setAllUsers([]);
+            setAllGroups([]);
+          }
         }
+        if (cancelled) return;
+        if (ownerIds.length === 0 && fresh.created_by) ownerIds = [fresh.created_by];
+        setLoadedBoard(fresh);
+        form.resetFields();
+        form.setFieldsValue({
+          name: fresh.name,
+          icon: fresh.icon,
+          description: fresh.description,
+          background_color: fresh.background_color,
+          custom_css: fresh.custom_css,
+          access_mode: fresh.access_mode || 'shared',
+          default_others_can: fresh.default_others_can || 'session',
+          default_others_fs_access: fresh.default_others_fs_access || 'read',
+          default_dangerously_allow_session_sharing: Boolean(
+            fresh.default_dangerously_allow_session_sharing
+          ),
+          owner_ids: ownerIds,
+          board_group_grants: grants,
+          custom_context: fresh.custom_context ? JSON.stringify(fresh.custom_context, null, 2) : '',
+        });
       } catch (error) {
-        // Owner/group routes intentionally do not exist when RBAC is disabled.
-        setRbacEnabled(false);
-        setAllUsers([]);
-        setAllGroups([]);
-        console.warn('Board RBAC metadata unavailable:', error);
+        if (!cancelled) {
+          const detail = error instanceof Error ? error.message : String(error);
+          setLoadError(`Could not load current board settings: ${detail}`);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-      if (cancelled) return;
-      if (ownerIds.length === 0 && fresh.created_by) ownerIds = [fresh.created_by];
-      form.resetFields();
-      form.setFieldsValue({
-        name: fresh.name,
-        icon: fresh.icon,
-        description: fresh.description,
-        background_color: fresh.background_color,
-        custom_css: fresh.custom_css,
-        access_mode: fresh.access_mode || 'shared',
-        default_others_can: fresh.default_others_can || 'session',
-        default_others_fs_access: fresh.default_others_fs_access || 'read',
-        default_dangerously_allow_session_sharing: Boolean(
-          fresh.default_dangerously_allow_session_sharing
-        ),
-        owner_ids: ownerIds,
-        board_group_grants: grants,
-        custom_context: fresh.custom_context ? JSON.stringify(fresh.custom_context, null, 2) : '',
-      });
-      setLoading(false);
     };
     void load();
     return () => {
@@ -138,17 +151,21 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
   const save = async () => {
     if (!board) return;
     try {
+      setSaving(true);
       await form.validateFields();
       const values = form.getFieldsValue(true);
       if (values.access_mode === 'private' && (values.owner_ids || []).length !== 1) {
         showError('Private boards must have exactly one private user');
         return;
       }
-      await onUpdate?.(board.board_id, extractBoardFormValues(form));
+      const updated = await onUpdate?.(board.board_id, extractBoardFormValues(form));
+      if (updated === false) return;
       await syncPermissions();
       close();
     } catch (error) {
-      if (error instanceof Error) showError(`Failed to update board permissions: ${error.message}`);
+      if (error instanceof Error) showError(`Failed to update board: ${error.message}`);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -157,33 +174,39 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
       title="Edit Board"
       open={open}
       width={760}
-      confirmLoading={loading}
-      okButtonProps={{ disabled: loading }}
+      confirmLoading={loading || saving}
+      okButtonProps={{ disabled: loading || saving || Boolean(loadError) }}
       onOk={() => void save()}
       onCancel={close}
       okText="Save"
       destroyOnHidden
     >
-      <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
-        <BoardFormFields
-          key={board?.board_id}
-          form={form}
-          initialCustomCSS={isCustomCSS(board?.background_color) || Boolean(board?.custom_css)}
-          rbacEnabled={rbacEnabled}
-          allUsers={allUsers}
-          allGroups={allGroups}
-          extra={
-            <Form.Item
-              label="Custom Context (JSON)"
-              name="custom_context"
-              help="Add custom fields for use in zone trigger templates (e.g., {{ board.context.yourField }})"
-              rules={[{ validator: validateJSON }]}
-            >
-              <JSONEditor placeholder='{"team": "Backend", "sprint": 42}' rows={4} />
-            </Form.Item>
-          }
-        />
-      </Form>
+      {loadError ? (
+        <Alert type="error" showIcon title="Board settings unavailable" description={loadError} />
+      ) : (
+        <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
+          <BoardFormFields
+            key={board?.board_id}
+            form={form}
+            initialCustomCSS={
+              isCustomCSS(loadedBoard?.background_color) || Boolean(loadedBoard?.custom_css)
+            }
+            rbacEnabled={rbacEnabled}
+            allUsers={allUsers}
+            allGroups={allGroups}
+            extra={
+              <Form.Item
+                label="Custom Context (JSON)"
+                name="custom_context"
+                help="Add custom fields for use in zone trigger templates (e.g., {{ board.context.yourField }})"
+                rules={[{ validator: validateJSON }]}
+              >
+                <JSONEditor placeholder='{"team": "Backend", "sprint": 42}' rows={4} />
+              </Form.Item>
+            }
+          />
+        </Form>
+      )}
     </Modal>
   );
 }

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -1,0 +1,189 @@
+import type {
+  AgorClient,
+  Board,
+  BoardGroupGrantWithGroup,
+  BranchFsAccessLevel,
+  BranchPermissionLevel,
+  Group,
+  User,
+  UUID,
+} from '@agor-live/client';
+import { Form, Modal } from 'antd';
+import { useEffect, useState } from 'react';
+import { useThemedMessage } from '@/utils/message';
+import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
+import { JSONEditor, validateJSON } from '../JSONEditor';
+
+export interface BoardEditModalProps {
+  board: Board | null;
+  client: AgorClient | null;
+  open: boolean;
+  onClose: () => void;
+  onUpdate?: (boardId: string, updates: Partial<Board>) => void | Promise<void>;
+}
+
+/** The single board-settings editor used by Settings and the navbar shortcut. */
+export function BoardEditModal({ board, client, open, onClose, onUpdate }: BoardEditModalProps) {
+  const [form] = Form.useForm();
+  const { showError } = useThemedMessage();
+  const [loading, setLoading] = useState(false);
+  const [rbacEnabled, setRbacEnabled] = useState(false);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [allGroups, setAllGroups] = useState<Group[]>([]);
+
+  useEffect(() => {
+    if (!open || !board) return;
+    let cancelled = false;
+    setLoading(true);
+
+    // Re-read the board as the modal opens. The selector uses a lean board list,
+    // while this form must always start from the full, latest representation.
+    const load = async () => {
+      let fresh = board;
+      let ownerIds: string[] = [];
+      let grants: Array<{ group_id: string; can: string; fs_access?: string }> = [];
+      try {
+        if (client) fresh = await client.service('boards').get(board.board_id);
+        if (client) {
+          const [users, groups, owners, groupGrants] = await Promise.all([
+            client.service('users').findAll({}),
+            client.service('groups').findAll({ query: { archived: false } }),
+            client.service('boards/:id/owners').find({ route: { id: board.board_id } }),
+            client.service('boards/:id/group-grants').find({ route: { id: board.board_id } }),
+          ]);
+          if (cancelled) return;
+          setRbacEnabled(true);
+          setAllUsers(users as User[]);
+          setAllGroups(groups as Group[]);
+          ownerIds = (owners as User[]).map((user) => user.user_id);
+          grants = (groupGrants as BoardGroupGrantWithGroup[]).map((grant) => ({
+            group_id: grant.group_id,
+            can: grant.can,
+            fs_access: grant.fs_access,
+          }));
+        }
+      } catch (error) {
+        // Owner/group routes intentionally do not exist when RBAC is disabled.
+        setRbacEnabled(false);
+        setAllUsers([]);
+        setAllGroups([]);
+        console.warn('Board RBAC metadata unavailable:', error);
+      }
+      if (cancelled) return;
+      if (ownerIds.length === 0 && fresh.created_by) ownerIds = [fresh.created_by];
+      form.resetFields();
+      form.setFieldsValue({
+        name: fresh.name,
+        icon: fresh.icon,
+        description: fresh.description,
+        background_color: fresh.background_color,
+        custom_css: fresh.custom_css,
+        access_mode: fresh.access_mode || 'shared',
+        default_others_can: fresh.default_others_can || 'session',
+        default_others_fs_access: fresh.default_others_fs_access || 'read',
+        default_dangerously_allow_session_sharing: Boolean(
+          fresh.default_dangerously_allow_session_sharing
+        ),
+        owner_ids: ownerIds,
+        board_group_grants: grants,
+        custom_context: fresh.custom_context ? JSON.stringify(fresh.custom_context, null, 2) : '',
+      });
+      setLoading(false);
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [board, client, form, open]);
+
+  const syncPermissions = async () => {
+    if (!client || !board || !rbacEnabled) return;
+    const id = board.board_id as UUID;
+    const values = form.getFieldsValue(true);
+    const desiredOwners = (values.owner_ids || []) as UUID[];
+    const desiredGrants = (
+      values.access_mode === 'private' ? [] : values.board_group_grants || []
+    ) as Array<{ group_id: string; can: BranchPermissionLevel; fs_access?: BranchFsAccessLevel }>;
+    const owners = (await client.service('boards/:id/owners').find({ route: { id } })) as User[];
+    const currentOwnerIds = owners.map((user) => user.user_id as UUID);
+    const currentGrants = (await client
+      .service('boards/:id/group-grants')
+      .find({ route: { id } })) as BoardGroupGrantWithGroup[];
+    const desiredGroups = new Set(desiredGrants.map((grant) => grant.group_id));
+    await Promise.all([
+      ...desiredOwners
+        .filter((userId) => !currentOwnerIds.includes(userId))
+        .map((user_id) =>
+          client.service('boards/:id/owners').create({ user_id }, { route: { id } })
+        ),
+      ...currentOwnerIds
+        .filter((userId) => !desiredOwners.includes(userId))
+        .map((userId) => client.service('boards/:id/owners').remove(userId, { route: { id } })),
+      ...desiredGrants.map((grant) =>
+        client.service('boards/:id/group-grants').create(grant, { route: { id } })
+      ),
+      ...currentGrants
+        .filter((grant) => !desiredGroups.has(grant.group_id))
+        .map((grant) =>
+          client.service('boards/:id/group-grants').remove(grant.group_id, { route: { id } })
+        ),
+    ]);
+  };
+
+  const close = () => {
+    form.resetFields();
+    onClose();
+  };
+
+  const save = async () => {
+    if (!board) return;
+    try {
+      await form.validateFields();
+      const values = form.getFieldsValue(true);
+      if (values.access_mode === 'private' && (values.owner_ids || []).length !== 1) {
+        showError('Private boards must have exactly one private user');
+        return;
+      }
+      await onUpdate?.(board.board_id, extractBoardFormValues(form));
+      await syncPermissions();
+      close();
+    } catch (error) {
+      if (error instanceof Error) showError(`Failed to update board permissions: ${error.message}`);
+    }
+  };
+
+  return (
+    <Modal
+      title="Edit Board"
+      open={open}
+      width={760}
+      confirmLoading={loading}
+      okButtonProps={{ disabled: loading }}
+      onOk={() => void save()}
+      onCancel={close}
+      okText="Save"
+      destroyOnHidden
+    >
+      <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
+        <BoardFormFields
+          key={board?.board_id}
+          form={form}
+          initialCustomCSS={isCustomCSS(board?.background_color) || Boolean(board?.custom_css)}
+          rbacEnabled={rbacEnabled}
+          allUsers={allUsers}
+          allGroups={allGroups}
+          extra={
+            <Form.Item
+              label="Custom Context (JSON)"
+              name="custom_context"
+              help="Add custom fields for use in zone trigger templates (e.g., {{ board.context.yourField }})"
+              rules={[{ validator: validateJSON }]}
+            >
+              <JSONEditor placeholder='{"team": "Backend", "sprint": 42}' rows={4} />
+            </Form.Item>
+          }
+        />
+      </Form>
+    </Modal>
+  );
+}

--- a/apps/agor-ui/src/components/BoardEditModal/index.ts
+++ b/apps/agor-ui/src/components/BoardEditModal/index.ts
@@ -1,0 +1,2 @@
+export type { BoardEditModalProps } from './BoardEditModal';
+export { BoardEditModal } from './BoardEditModal';

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -1,0 +1,89 @@
+import type { AgorClient, Board, User } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BoardSwitcher } from './BoardSwitcher';
+
+const modalProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+vi.mock('../BoardEditModal', () => ({
+  BoardEditModal: (props: Record<string, unknown>) => {
+    modalProps.current = props;
+    return props.open ? <div role="dialog">board editor</div> : null;
+  },
+}));
+
+const board = {
+  board_id: 'board-1',
+  name: 'A board with a very long name that should not move its action',
+  created_by: 'owner-1',
+  created_at: '',
+  last_updated: '',
+} as Board;
+const owner = { user_id: 'owner-1', role: 'member' } as User;
+
+function clientFor({ owners = [owner], reject }: { owners?: User[]; reject?: unknown } = {}) {
+  return {
+    service: (name: string) => ({
+      find: vi
+        .fn()
+        .mockImplementation(() =>
+          reject ? Promise.reject(reject) : Promise.resolve(name.includes('owners') ? owners : [])
+        ),
+      findAll: vi.fn().mockResolvedValue([]),
+    }),
+  } as unknown as AgorClient;
+}
+
+function renderSwitcher(client = clientFor(), user: User = owner) {
+  const onBoardChange = vi.fn();
+  render(
+    <BoardSwitcher
+      boards={[board]}
+      currentBoardId={board.board_id}
+      onBoardChange={onBoardChange}
+      branchById={new Map()}
+      client={client}
+      currentUser={user}
+      onUpdateBoard={vi.fn()}
+    />
+  );
+  return { onBoardChange };
+}
+
+describe('BoardSwitcher current-board edit shortcut', () => {
+  it('passes only the current board to the canonical editor and does not navigate', async () => {
+    const { onBoardChange } = renderSwitcher();
+    const edit = await screen.findByRole('button', { name: /Edit current board:/ });
+
+    fireEvent.click(edit);
+
+    expect(onBoardChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toHaveTextContent('board editor');
+    expect(modalProps.current?.board).toBe(board);
+  });
+
+  it('keeps the action keyboard reachable and reveals it on focus-within', async () => {
+    renderSwitcher();
+    const edit = await screen.findByRole('button', { name: /Edit current board:/ });
+    act(() => edit.focus());
+    expect(edit).toHaveFocus();
+    await waitFor(() =>
+      expect(edit.closest('span[style*="opacity"]')).toHaveStyle({
+        opacity: '1',
+        pointerEvents: 'auto',
+      })
+    );
+  });
+
+  it('hides the action when the canonical owner/group inputs deny management', async () => {
+    renderSwitcher(clientFor({ owners: [] }), { user_id: 'member-2', role: 'member' } as User);
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Edit current board:/ })).not.toBeInTheDocument()
+    );
+  });
+
+  it('keeps the action visible without hover on small/touch layouts', async () => {
+    renderSwitcher();
+    const edit = await screen.findByRole('button', { name: /Edit current board:/ });
+    expect(edit).toBeVisible();
+  });
+});

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -50,6 +50,11 @@ function renderSwitcher(client = clientFor(), user: User = owner) {
 }
 
 describe('BoardSwitcher current-board edit shortcut', () => {
+  it('allows the board creator even when legacy owner rows are missing', async () => {
+    renderSwitcher(clientFor({ reject: { code: 500 } }));
+    expect(await screen.findByRole('button', { name: /Edit current board:/ })).toBeVisible();
+  });
+
   it('passes only the current board to the canonical editor and does not navigate', async () => {
     const { onBoardChange } = renderSwitcher();
     const edit = await screen.findByRole('button', { name: /Edit current board:/ });
@@ -59,6 +64,15 @@ describe('BoardSwitcher current-board edit shortcut', () => {
     expect(onBoardChange).not.toHaveBeenCalled();
     expect(screen.getByRole('dialog')).toHaveTextContent('board editor');
     expect(modalProps.current?.board).toBe(board);
+  });
+
+  it('overlays the edit action without reserving trigger width', async () => {
+    renderSwitcher();
+    const edit = await screen.findByRole('button', { name: /Edit current board:/ });
+    const trigger = edit.closest('div')?.querySelector('button.ant-dropdown-trigger');
+
+    expect(trigger).toHaveStyle({ padding: '8px 12px' });
+    expect(edit.closest('span[style*="position: absolute"]')).toHaveStyle({ right: '28px' });
   });
 
   it('keeps the action keyboard reachable and reveals it on focus-within', async () => {

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -1,12 +1,4 @@
-import type {
-  AgorClient,
-  Board,
-  BoardGroupGrantWithGroup,
-  Branch,
-  GroupMembership,
-  User,
-} from '@agor-live/client';
-import { hasMinimumRole, ROLES } from '@agor-live/client';
+import type { AgorClient, Board, Branch, User } from '@agor-live/client';
 import { DownOutlined, EditOutlined, HomeOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import {
@@ -23,6 +15,7 @@ import {
 } from 'antd';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCanManageBoard } from '../../hooks/useCanManageBoard';
 import { BoardEditModal } from '../BoardEditModal';
 
 const { Text } = Typography;
@@ -73,50 +66,11 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [triggerActive, setTriggerActive] = useState(false);
-  const [canManage, setCanManage] = useState(false);
   const screens = Grid.useBreakpoint();
   const coarsePointer = useCoarsePointer();
 
   const currentBoard = boards.find((b) => b.board_id === currentBoardId);
-
-  useEffect(() => {
-    let cancelled = false;
-    setCanManage(false);
-    if (!currentBoard || !currentUser || !client || currentBoard.archived) return;
-    if (hasMinimumRole(currentUser.role, ROLES.ADMIN)) {
-      setCanManage(true);
-      return;
-    }
-    if (!hasMinimumRole(currentUser.role, ROLES.MEMBER)) return;
-
-    // Resolve the same owner/group-'all' inputs used by the daemon's
-    // BoardRepository.canMutate contract. If the RBAC routes are absent, the
-    // instance is in open-access mode and every member may update boards.
-    void Promise.all([
-      client.service('boards/:id/owners').find({ route: { id: currentBoard.board_id } }),
-      client.service('boards/:id/group-grants').find({ route: { id: currentBoard.board_id } }),
-      client.service('group-memberships').findAll({ query: { user_id: currentUser.user_id } }),
-    ])
-      .then(([owners, grants, memberships]) => {
-        if (cancelled) return;
-        const groupIds = new Set((memberships as GroupMembership[]).map((item) => item.group_id));
-        setCanManage(
-          (owners as User[]).some((owner) => owner.user_id === currentUser.user_id) ||
-            (grants as BoardGroupGrantWithGroup[]).some(
-              (grant) => grant.can === 'all' && groupIds.has(grant.group_id)
-            )
-        );
-      })
-      .catch((error: unknown) => {
-        // A 404 is the daemon's documented signal that board RBAC services are
-        // disabled. Fail closed for disconnects and other authorization errors.
-        const code = (error as { code?: number })?.code;
-        if (!cancelled) setCanManage(code === 404);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [client, currentBoard, currentUser]);
+  const canManage = useCanManageBoard(client, currentBoard, currentUser);
 
   const branchCountByBoard = useMemo(() => {
     const counts = new Map<string, number>();
@@ -316,7 +270,6 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'space-between',
-              paddingRight: canManage ? 58 : 12,
             }}
           >
             <Space size={8} style={{ minWidth: 0, overflow: 'hidden' }}>
@@ -334,7 +287,9 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
           <span
             style={{
               position: 'absolute',
-              right: 24,
+              // Keep one base spacing unit between the overlay action and the
+              // dropdown caret without reserving any navbar layout width.
+              right: token.paddingLG + token.sizeUnit,
               top: '50%',
               transform: 'translateY(-50%)',
               opacity: !screens.md || coarsePointer || triggerActive ? 1 : 0,

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -1,14 +1,51 @@
-import type { Board, Branch } from '@agor-live/client';
-import { DownOutlined, HomeOutlined, SearchOutlined } from '@ant-design/icons';
+import type {
+  AgorClient,
+  Board,
+  BoardGroupGrantWithGroup,
+  Branch,
+  GroupMembership,
+  User,
+} from '@agor-live/client';
+import { hasMinimumRole, ROLES } from '@agor-live/client';
+import { DownOutlined, EditOutlined, HomeOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Badge, Button, Divider, Dropdown, Input, Space, Typography, theme } from 'antd';
+import {
+  Badge,
+  Button,
+  Divider,
+  Dropdown,
+  Grid,
+  Input,
+  Space,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BoardEditModal } from '../BoardEditModal';
 
 const { Text } = Typography;
 const { useToken } = theme;
 
 const FILTER_THRESHOLD = 8;
+
+function useCoarsePointer() {
+  const [coarse, setCoarse] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(hover: none), (pointer: coarse)').matches
+  );
+  useEffect(() => {
+    const query = window.matchMedia?.('(hover: none), (pointer: coarse)');
+    if (!query) return;
+    const update = () => setCoarse(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+  return coarse;
+}
 
 interface BoardSwitcherProps {
   boards: Board[];
@@ -16,6 +53,9 @@ interface BoardSwitcherProps {
   onBoardChange: (boardId: string) => void;
   onHomeClick?: () => void;
   branchById: Map<string, Branch>;
+  client?: AgorClient | null;
+  currentUser?: User | null;
+  onUpdateBoard?: (boardId: string, updates: Partial<Board>) => void | Promise<void>;
 }
 
 export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
@@ -24,12 +64,59 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
   onBoardChange,
   onHomeClick,
   branchById,
+  client = null,
+  currentUser,
+  onUpdateBoard,
 }) => {
   const { token } = useToken();
   const [filterText, setFilterText] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [triggerActive, setTriggerActive] = useState(false);
+  const [canManage, setCanManage] = useState(false);
+  const screens = Grid.useBreakpoint();
+  const coarsePointer = useCoarsePointer();
 
   const currentBoard = boards.find((b) => b.board_id === currentBoardId);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCanManage(false);
+    if (!currentBoard || !currentUser || !client || currentBoard.archived) return;
+    if (hasMinimumRole(currentUser.role, ROLES.ADMIN)) {
+      setCanManage(true);
+      return;
+    }
+    if (!hasMinimumRole(currentUser.role, ROLES.MEMBER)) return;
+
+    // Resolve the same owner/group-'all' inputs used by the daemon's
+    // BoardRepository.canMutate contract. If the RBAC routes are absent, the
+    // instance is in open-access mode and every member may update boards.
+    void Promise.all([
+      client.service('boards/:id/owners').find({ route: { id: currentBoard.board_id } }),
+      client.service('boards/:id/group-grants').find({ route: { id: currentBoard.board_id } }),
+      client.service('group-memberships').findAll({ query: { user_id: currentUser.user_id } }),
+    ])
+      .then(([owners, grants, memberships]) => {
+        if (cancelled) return;
+        const groupIds = new Set((memberships as GroupMembership[]).map((item) => item.group_id));
+        setCanManage(
+          (owners as User[]).some((owner) => owner.user_id === currentUser.user_id) ||
+            (grants as BoardGroupGrantWithGroup[]).some(
+              (grant) => grant.can === 'all' && groupIds.has(grant.group_id)
+            )
+        );
+      })
+      .catch((error: unknown) => {
+        // A 404 is the daemon's documented signal that board RBAC services are
+        // disabled. Fail closed for disconnects and other authorization errors.
+        const code = (error as { code?: number })?.code;
+        if (!cancelled) setCanManage(code === 404);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, currentBoard, currentUser]);
 
   const branchCountByBoard = useMemo(() => {
     const counts = new Map<string, number>();
@@ -138,79 +225,135 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
     </Button>
   );
 
-  return (
-    <Dropdown
-      menu={{ items: boardMenuItems }}
-      trigger={['click']}
-      placement="bottomLeft"
-      open={dropdownOpen}
-      onOpenChange={(open) => {
-        setDropdownOpen(open);
-        if (!open) setFilterText('');
-      }}
-      popupRender={(menu) => (
-        <div
-          style={{
-            backgroundColor: token.colorBgElevated,
-            borderRadius: token.borderRadiusLG,
-            boxShadow: token.boxShadowSecondary,
-            minWidth: 290,
-          }}
-        >
-          <div
-            style={{
-              position: 'sticky',
-              top: 0,
-              zIndex: 1,
-              padding: '8px 8px 0',
-              background: token.colorBgElevated,
-              borderTopLeftRadius: token.borderRadiusLG,
-              borderTopRightRadius: token.borderRadiusLG,
-            }}
-          >
-            {homeRow}
-            <Divider style={{ margin: '8px 0 0' }} />
-          </div>
-          {showFilter && (
-            <>
-              <div style={{ padding: '8px 12px' }}>
-                <Input
-                  placeholder="Filter boards..."
-                  prefix={<SearchOutlined style={{ color: token.colorTextQuaternary }} />}
-                  value={filterText}
-                  onChange={(e) => setFilterText(e.target.value)}
-                  size="small"
-                  allowClear
-                  autoFocus
-                  aria-label="Filter boards"
-                />
-              </div>
-              <Divider style={{ margin: 0 }} />
-            </>
-          )}
-          <div style={{ maxHeight: 'calc(100vh - 240px)', overflowY: 'auto' }}>{menu}</div>
-        </div>
-      )}
-    >
+  const editButton = canManage && currentBoard && (
+    <Tooltip title="Edit current board">
       <Button
         type="text"
-        style={{
-          width: '100%',
-          height: 'auto',
-          padding: '8px 12px',
-          textAlign: 'left',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
+        size="small"
+        icon={<EditOutlined />}
+        aria-label={`Edit current board: ${currentBoard.name}`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setDropdownOpen(false);
+          setEditing(true);
+        }}
+      />
+    </Tooltip>
+  );
+
+  return (
+    <>
+      <div
+        style={{ position: 'relative', width: '100%' }}
+        onPointerEnter={() => setTriggerActive(true)}
+        onPointerLeave={() => setTriggerActive(false)}
+        onFocus={() => setTriggerActive(true)}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) setTriggerActive(false);
         }}
       >
-        <Space size={8}>
-          <span style={{ fontSize: 18 }}>{currentBoard ? currentBoard.icon || '📋' : '🏠'}</span>
-          <Text strong>{currentBoard?.name || 'Home'}</Text>
-        </Space>
-        <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-      </Button>
-    </Dropdown>
+        <Dropdown
+          menu={{ items: boardMenuItems }}
+          trigger={['click']}
+          placement="bottomLeft"
+          open={dropdownOpen}
+          onOpenChange={(open) => {
+            setDropdownOpen(open);
+            if (!open) setFilterText('');
+          }}
+          popupRender={(menu) => (
+            <div
+              style={{
+                backgroundColor: token.colorBgElevated,
+                borderRadius: token.borderRadiusLG,
+                boxShadow: token.boxShadowSecondary,
+                minWidth: 290,
+              }}
+            >
+              <div
+                style={{
+                  position: 'sticky',
+                  top: 0,
+                  zIndex: 1,
+                  padding: '8px 8px 0',
+                  background: token.colorBgElevated,
+                  borderTopLeftRadius: token.borderRadiusLG,
+                  borderTopRightRadius: token.borderRadiusLG,
+                }}
+              >
+                {homeRow}
+                <Divider style={{ margin: '8px 0 0' }} />
+              </div>
+              {showFilter && (
+                <>
+                  <div style={{ padding: '8px 12px' }}>
+                    <Input
+                      placeholder="Filter boards..."
+                      prefix={<SearchOutlined style={{ color: token.colorTextQuaternary }} />}
+                      value={filterText}
+                      onChange={(e) => setFilterText(e.target.value)}
+                      size="small"
+                      allowClear
+                      autoFocus
+                      aria-label="Filter boards"
+                    />
+                  </div>
+                  <Divider style={{ margin: 0 }} />
+                </>
+              )}
+              <div style={{ maxHeight: 'calc(100vh - 240px)', overflowY: 'auto' }}>{menu}</div>
+            </div>
+          )}
+        >
+          <Button
+            type="text"
+            style={{
+              width: '100%',
+              height: 'auto',
+              padding: '8px 12px',
+              textAlign: 'left',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingRight: canManage ? 58 : 12,
+            }}
+          >
+            <Space size={8} style={{ minWidth: 0, overflow: 'hidden' }}>
+              <span style={{ fontSize: 18 }}>
+                {currentBoard ? currentBoard.icon || '📋' : '🏠'}
+              </span>
+              <Text strong ellipsis style={{ minWidth: 0 }}>
+                {currentBoard?.name || 'Home'}
+              </Text>
+            </Space>
+            <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+          </Button>
+        </Dropdown>
+        {editButton && (
+          <span
+            style={{
+              position: 'absolute',
+              right: 24,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              opacity: !screens.md || coarsePointer || triggerActive ? 1 : 0,
+              pointerEvents: !screens.md || coarsePointer || triggerActive ? 'auto' : 'none',
+              transition: `opacity ${token.motionDurationFast}`,
+            }}
+          >
+            {editButton}
+          </span>
+        )}
+      </div>
+      <BoardEditModal
+        board={currentBoard ?? null}
+        client={client}
+        open={editing && Boolean(currentBoard)}
+        onClose={() => setEditing(false)}
+        onUpdate={onUpdateBoard}
+      />
+    </>
   );
 };
 

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -1,16 +1,5 @@
 import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
-import type {
-  AgorClient,
-  Board,
-  BoardGroupGrantWithGroup,
-  Branch,
-  BranchFsAccessLevel,
-  BranchPermissionLevel,
-  Group,
-  Session,
-  User,
-  UUID,
-} from '@agor-live/client';
+import type { AgorClient, Board, Branch, Session } from '@agor-live/client';
 import {
   CopyOutlined,
   DeleteOutlined,
@@ -37,7 +26,8 @@ import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ArchiveToggleButton } from '../ArchiveButton';
-import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
+import { BoardEditModal } from '../BoardEditModal';
+import { BoardFormFields, extractBoardFormValues } from '../forms/BoardFormFields';
 import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { SettingsActionGroup } from './SettingsActionGroup';
@@ -68,11 +58,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const { modal } = App.useApp();
   const { showSuccess, showError } = useThemedMessage();
   const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingBoard, setEditingBoard] = useState<Board | null>(null);
-  const [rbacEnabled, setRbacEnabled] = useState(false);
-  const [allUsers, setAllUsers] = useState<User[]>([]);
-  const [allGroups, setAllGroups] = useState<Group[]>([]);
   const [archiveFilter, setArchiveFilter] = useState<'active' | 'archived' | 'all'>('active');
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
@@ -98,51 +84,6 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
     return counts;
   }, [boardById, sessionsByBranch, branchById]);
 
-  const syncBoardPermissions = async (boardId: string) => {
-    if (!client || !rbacEnabled) return;
-    const boardUuid = boardId as UUID;
-    const values = form.getFieldsValue(true);
-    const isPrivate = values.access_mode === 'private';
-    const desiredOwnerIds = (values.owner_ids || []) as UUID[];
-    const desiredGrants = (isPrivate ? [] : values.board_group_grants || []) as Array<{
-      group_id: string;
-      can: BranchPermissionLevel;
-      fs_access?: BranchFsAccessLevel;
-    }>;
-
-    const currentOwners = (await client
-      .service('boards/:id/owners')
-      .find({ route: { id: boardUuid } })) as User[];
-    const currentOwnerIds = currentOwners.map((u) => u.user_id as UUID);
-    await Promise.all([
-      ...desiredOwnerIds
-        .filter((id) => !currentOwnerIds.includes(id))
-        .map((user_id) =>
-          client.service('boards/:id/owners').create({ user_id }, { route: { id: boardUuid } })
-        ),
-      ...currentOwnerIds
-        .filter((id) => !desiredOwnerIds.includes(id))
-        .map((id) => client.service('boards/:id/owners').remove(id, { route: { id: boardUuid } })),
-    ]);
-
-    const currentGrants = (await client
-      .service('boards/:id/group-grants')
-      .find({ route: { id: boardUuid } })) as BoardGroupGrantWithGroup[];
-    const desiredByGroup = new Map(desiredGrants.map((grant) => [grant.group_id, grant]));
-    await Promise.all([
-      ...desiredGrants.map((grant) =>
-        client.service('boards/:id/group-grants').create(grant, { route: { id: boardUuid } })
-      ),
-      ...currentGrants
-        .filter((grant) => !desiredByGroup.has(grant.group_id))
-        .map((grant) =>
-          client.service('boards/:id/group-grants').remove(grant.group_id, {
-            route: { id: boardUuid },
-          })
-        ),
-    ]);
-  };
-
   const handleCreate = () => {
     // Validate all fields (not just 'name') so custom_context JSON rules run.
     // Otherwise the extractor's JSON.parse can throw and get swallowed.
@@ -158,81 +99,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
       });
   };
 
-  const handleEdit = async (board: Board) => {
-    setEditingBoard(board);
-    let ownerIds: string[] = [];
-    let boardGroupGrants: Array<{ group_id: string; can: string; fs_access?: string }> = [];
-    if (client) {
-      try {
-        const [users, groups, owners, grants] = await Promise.all([
-          client.service('users').findAll({}),
-          client.service('groups').findAll({ query: { archived: false } }),
-          client.service('boards/:id/owners').find({ route: { id: board.board_id } }),
-          client.service('boards/:id/group-grants').find({ route: { id: board.board_id } }),
-        ]);
-        setRbacEnabled(true);
-        setAllUsers(users as User[]);
-        setAllGroups(groups as Group[]);
-        ownerIds = (owners as User[]).map((user) => user.user_id);
-        if (ownerIds.length === 0 && board.created_by) {
-          ownerIds = [board.created_by];
-        }
-        boardGroupGrants = (
-          grants as Array<{ group_id: string; can: string; fs_access?: string }>
-        ).map((grant) => ({
-          group_id: grant.group_id,
-          can: grant.can,
-          fs_access: grant.fs_access,
-        }));
-      } catch (error) {
-        setRbacEnabled(false);
-        setAllUsers([]);
-        setAllGroups([]);
-        console.warn('Board RBAC metadata unavailable:', error);
-      }
-    }
-    form.setFieldsValue({
-      name: board.name,
-      icon: board.icon,
-      description: board.description,
-      background_color: board.background_color,
-      custom_css: board.custom_css,
-      access_mode: board.access_mode || 'shared',
-      default_others_can: board.default_others_can || 'session',
-      default_others_fs_access: board.default_others_fs_access || 'read',
-      default_dangerously_allow_session_sharing: Boolean(
-        board.default_dangerously_allow_session_sharing
-      ),
-      owner_ids: ownerIds,
-      board_group_grants: boardGroupGrants,
-      custom_context: board.custom_context ? JSON.stringify(board.custom_context, null, 2) : '',
-    });
-    setEditModalOpen(true);
-  };
-
-  const handleUpdate = () => {
-    if (!editingBoard) return;
-
-    form
-      .validateFields()
-      .then(() => {
-        const values = form.getFieldsValue(true);
-        if (values.access_mode === 'private' && (values.owner_ids || []).length !== 1) {
-          showError('Private boards must have exactly one private user');
-          return;
-        }
-        onUpdate?.(editingBoard.board_id, extractBoardFormValues(form));
-        syncBoardPermissions(editingBoard.board_id).catch((error) => {
-          showError(`Failed to update board permissions: ${error.message}`);
-        });
-        form.resetFields();
-        setEditModalOpen(false);
-        setEditingBoard(null);
-      })
-      .catch(() => {
-        // Antd displays inline field errors; nothing to do here.
-      });
-  };
+  const handleEdit = (board: Board) => setEditingBoard(board);
 
   const handleDelete = (boardId: string) => {
     onDelete?.(boardId);
@@ -527,35 +394,13 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         </Form>
       </Modal>
 
-      {/* Edit Board Modal */}
-      <Modal
-        title="Edit Board"
-        open={editModalOpen}
-        width={760}
-        onOk={handleUpdate}
-        onCancel={() => {
-          form.resetFields();
-          setEditModalOpen(false);
-          setEditingBoard(null);
-        }}
-        okText="Save"
-      >
-        <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
-          {/* Keyed on board_id so useCustomCSS state and Collapse defaultActiveKey
-              re-initialize when switching between boards (Modal stays mounted). */}
-          <BoardFormFields
-            key={editingBoard?.board_id}
-            form={form}
-            extra={customContextField}
-            initialCustomCSS={
-              isCustomCSS(editingBoard?.background_color) || Boolean(editingBoard?.custom_css)
-            }
-            rbacEnabled={rbacEnabled}
-            allUsers={allUsers}
-            allGroups={allGroups}
-          />
-        </Form>
-      </Modal>
+      <BoardEditModal
+        board={editingBoard}
+        client={client}
+        open={Boolean(editingBoard)}
+        onClose={() => setEditingBoard(null)}
+        onUpdate={onUpdate}
+      />
     </div>
   );
 };

--- a/apps/agor-ui/src/hooks/useCanManageBoard.ts
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.ts
@@ -1,0 +1,60 @@
+import type {
+  AgorClient,
+  Board,
+  BoardGroupGrantWithGroup,
+  GroupMembership,
+  User,
+} from '@agor-live/client';
+import { hasMinimumRole, ROLES } from '@agor-live/client';
+import { useEffect, useState } from 'react';
+
+/**
+ * Resolve the UI equivalent of BoardRepository.canMutate from canonical
+ * owner, group-grant, membership, creator, and role inputs.
+ */
+export function useCanManageBoard(
+  client: AgorClient | null,
+  board: Board | undefined,
+  user: User | null | undefined
+) {
+  const [canManage, setCanManage] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCanManage(false);
+    if (!board || !user || !client || board.archived) return;
+    if (hasMinimumRole(user.role, ROLES.ADMIN) || board.created_by === user.user_id) {
+      setCanManage(true);
+      return;
+    }
+    if (!hasMinimumRole(user.role, ROLES.MEMBER)) return;
+
+    void Promise.all([
+      client.service('boards/:id/owners').find({ route: { id: board.board_id } }),
+      client.service('boards/:id/group-grants').find({ route: { id: board.board_id } }),
+      client.service('group-memberships').findAll({ query: { user_id: user.user_id } }),
+    ])
+      .then(([owners, grants, memberships]) => {
+        if (cancelled) return;
+        const groupIds = new Set((memberships as GroupMembership[]).map((item) => item.group_id));
+        setCanManage(
+          (owners as User[]).some((owner) => owner.user_id === user.user_id) ||
+            (board.access_mode !== 'private' &&
+              (grants as BoardGroupGrantWithGroup[]).some(
+                (grant) => grant.can === 'all' && groupIds.has(grant.group_id)
+              ))
+        );
+      })
+      .catch((error: unknown) => {
+        // A 404 is the daemon's documented signal that board RBAC services are
+        // disabled. Fail closed for disconnects and authorization/server errors.
+        if (!cancelled) setCanManage((error as { code?: number })?.code === 404);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [board, client, user]);
+
+  return canManage;
+}


### PR DESCRIPTION
## Summary

- add a lean edit affordance for the current board to the navbar board selector
- reveal the action on desktop hover/focus and keep it visible on small-screen or coarse-pointer layouts
- reuse a shared canonical board edit modal from both Settings and the navbar
- gate the shortcut using board owner, group `all`, role, and RBAC-mode inputs
- refresh the full board when opening the editor and preserve existing realtime update behavior

## UX details

- the edit action is right-aligned without shifting long board names
- the action has an accessible name and tooltip and remains keyboard reachable
- edit clicks stop propagation and do not switch boards or navigate
- Home, archived/missing boards, and users without management access do not receive the shortcut

## Testing

- `pnpm i`
- `pnpm exec vitest run src/components/BoardSwitcher/BoardSwitcher.test.tsx src/components/forms/BoardFormFields.test.tsx src/components/AppHeader/AppHeader.test.tsx src/components/AppHeader/AppHeader.rerender.test.tsx --reporter=dot` (18 tests passed)
- `pnpm check` passes typecheck, lint, frontend design-system checks, and short-ID checks, then stops at the existing multitenancy-boundary baseline mismatch: `apps/agor-daemon/src/setup/socketio.ts` has 18 raw realtime/socket occurrences while the baseline allows 17. This PR does not modify that file or boundary.

Same as before with hover:

<img width="725" height="116" alt="Screenshot 2026-08-05 at 1 51 13 PM" src="https://github.com/user-attachments/assets/c339c70e-a11c-4965-930f-ed9dfe562e77" />

What it looks like without hover:

<img width="719" height="138" alt="Screenshot 2026-08-05 at 1 51 07 PM" src="https://github.com/user-attachments/assets/0a0b9ffa-e1d8-424d-afc4-3c98ea46c875" />


