### PR TITLE
feat(scheduler): add HA-safe occurrence recovery

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -35,6 +35,7 @@ import type {
   Session,
   SessionUpdate,
   Task,
+  TaskPendingDispatchStatus,
 } from '@agor/core/types';
 import type {
   ExecuteTaskData,
@@ -147,9 +148,7 @@ export interface SessionsServiceImpl
 export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersParams> {
   claimDispatchAndProjectSession(
     taskId: string,
-    expectedStatus:
-      | typeof import('@agor/core/types').TaskStatus.CREATED
-      | typeof import('@agor/core/types').TaskStatus.QUEUED,
+    expectedStatus: TaskPendingDispatchStatus,
     updates: Partial<Task>,
     params?: FeathersParams
   ): Promise<TaskDispatchClaimResult>;

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -7,6 +7,7 @@
  * - Application instance
  */
 
+import type { DistributedWorkIdentity } from '@agor/core/coordination';
 import type {
   TaskDispatchClaimResult,
   TerminationClaimInput,
@@ -50,7 +51,10 @@ export type HookContext<T = unknown> = CoreHookContext<T>;
 /**
  * Application type for the daemon
  */
-export type Application = ExpressApplication;
+export type Application = ExpressApplication & {
+  get(name: 'distributedWorkIdentity'): DistributedWorkIdentity | undefined;
+  set(name: 'distributedWorkIdentity', value: DistributedWorkIdentity): ExpressApplication;
+};
 
 /**
  * Sessions service with custom methods (server-side implementation)

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  TaskDispatchClaimResult,
   TerminationClaimInput,
   TerminationClaimResult,
   TerminationSettlementInput,
@@ -140,6 +141,14 @@ export interface SessionsServiceImpl
  * Tasks service with custom methods (server-side implementation)
  */
 export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersParams> {
+  claimDispatch(
+    taskId: string,
+    expectedStatus:
+      | typeof import('@agor/core/types').TaskStatus.CREATED
+      | typeof import('@agor/core/types').TaskStatus.QUEUED,
+    updates: Partial<Task>,
+    params?: FeathersParams
+  ): Promise<TaskDispatchClaimResult>;
   connectExecutor(data: { task_id: string }, params?: FeathersParams): Promise<Task>;
   reportTerminationComplete(
     data: import('@agor/core/types').ExecutorTerminationCompleteInput,

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -141,7 +141,7 @@ export interface SessionsServiceImpl
  * Tasks service with custom methods (server-side implementation)
  */
 export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersParams> {
-  claimDispatch(
+  claimDispatchAndProjectSession(
     taskId: string,
     expectedStatus:
       | typeof import('@agor/core/types').TaskStatus.CREATED

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -278,11 +278,9 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // --------------------------------------------------------------------------
   const app = feathersExpress(feathers());
   // One application-owned identity spans every background worker in this
-  // daemon process. external_launch.instance_id is the only settled explicit
-  // runtime-instance config field; its authorization semantics remain local
-  // to launch auth, while this shared identity is diagnostic only.
+  // daemon process. A dedicated YAML deployment.instance_id may be added with
+  // the HA config contract later; unrelated auth configuration is not reused.
   const distributedWorkIdentity = initializeDistributedWorkIdentity(app, {
-    configuredInstanceId: config.external_launch?.instance_id,
     environment: {
       AGOR_DAEMON_INSTANCE_ID: process.env.AGOR_DAEMON_INSTANCE_ID,
       HOSTNAME: process.env.HOSTNAME,

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -39,7 +39,7 @@ import {
   resolveSecurity,
   saveConfig,
 } from '@agor/core/config';
-import { getDatabaseUrl } from '@agor/core/db';
+import { generateId, getDatabaseUrl } from '@agor/core/db';
 import {
   authenticate,
   Forbidden,
@@ -63,6 +63,7 @@ import { loadBuildInfo } from './setup/build-info.js';
 import { createDynamicCompressionMiddleware } from './setup/compression.js';
 import { buildCorsConfig, isSandpackOrigin } from './setup/cors.js';
 import { initializeDatabase } from './setup/database.js';
+import { initializeDistributedWorkIdentity } from './setup/distributed-work-identity.js';
 import { warnDeprecatedConfig } from './setup/first-run-admin.js';
 import { securityHeaders } from './setup/security-headers.js';
 import { configureChannels, createSocketIOConfig } from './setup/socketio.js';
@@ -276,6 +277,18 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // Create Feathers app + Express middleware
   // --------------------------------------------------------------------------
   const app = feathersExpress(feathers());
+  // One application-owned identity spans every background worker in this
+  // daemon process. external_launch.instance_id is the only settled explicit
+  // runtime-instance config field; its authorization semantics remain local
+  // to launch auth, while this shared identity is diagnostic only.
+  const distributedWorkIdentity = initializeDistributedWorkIdentity(app, {
+    configuredInstanceId: config.external_launch?.instance_id,
+    environment: {
+      AGOR_DAEMON_INSTANCE_ID: process.env.AGOR_DAEMON_INSTANCE_ID,
+      HOSTNAME: process.env.HOSTNAME,
+    },
+    generateBootId: generateId,
+  });
 
   // Configure how many reverse proxies we trust in front of the daemon.
   // Default 0 = ignore X-Forwarded-* entirely (so a client cannot spoof their
@@ -732,5 +745,6 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     getSocketServer: socketIOConfig.getSocketServer,
     sessionsService: services.sessionsService,
     terminalsService: services.terminalsService,
+    distributedWorkIdentity,
   });
 }

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -169,6 +169,7 @@ import {
 import {
   createTenantDatabaseScopeAroundHook,
   deferWithTenantContext,
+  resolveTenantIdForDeferredScope,
 } from './utils/tenant-db-scope.js';
 import { enforcePublicWriteFields, markWriteDataPrepared } from './utils/write-data-boundary.js';
 
@@ -796,26 +797,31 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     app.service('sessions').on('created', (session: Session, hook?: Partial<HookContext>) => {
       if (!session.branch_id || !session.unix_username) return;
       if ((hook?.params as { isBranchOwner?: boolean } | undefined)?.isBranchOwner) return;
+      const tenantId = resolveTenantIdForDeferredScope(hook?.params);
       deferWithTenantContext(
         hook?.params,
         async () => {
-          const tenantId = getCurrentTenantId();
-          const branch = await runWithTenantDatabaseScope(db, tenantId, () =>
+          const activeTenantId = getCurrentTenantId();
+          const branch = await runWithTenantDatabaseScope(db, activeTenantId, () =>
             branchRepository.findById(session.branch_id)
           );
           if (!branch?.others_fs_access || branch.others_fs_access === 'none') return;
-          console.log(
-            `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
-              `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
+          console.info(
+            `[unix-access.sync] event=scheduled source=session_created` +
+              `${tenantId ? ` tenant_id=${JSON.stringify(tenantId)}` : ''}` +
+              ` branch_id=${JSON.stringify(session.branch_id)}` +
+              ` session_id=${JSON.stringify(session.session_id)}`
           );
           syncBranchUnixAccess(branch.branch_id, '[Executor/session.created.unix-group]', {
             scope: { session_id: session.session_id },
           });
         },
-        (error) =>
+        () =>
           console.error(
-            `[Unix Integration] Failed to trigger group sync for session ${shortId(session.session_id)}:`,
-            error
+            `[unix-access.sync] event=schedule_failed source=session_created` +
+              `${tenantId ? ` tenant_id=${JSON.stringify(tenantId)}` : ''}` +
+              ` branch_id=${JSON.stringify(session.branch_id)}` +
+              ` session_id=${JSON.stringify(session.session_id)}`
           )
       );
     });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -27,6 +27,8 @@ import {
   BoardRepository,
   type BranchRepository,
   getCurrentTenantDatabaseScope,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
   ScheduleRepository,
   type SessionRepository,
   shortId,
@@ -785,6 +787,39 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       { logPrefix }
     );
   };
+
+  // Session creation can be an internal scheduler admission that deliberately
+  // bypasses the public Feathers create hook pipeline while a schedule row is
+  // locked. Own the Unix side effect as a service event consumer so both paths
+  // share it, and always defer database/process work until after commit.
+  if (executionMode.unixFsIsolationEnabled) {
+    app.service('sessions').on('created', (session: Session, hook?: Partial<HookContext>) => {
+      if (!session.branch_id || !session.unix_username) return;
+      if ((hook?.params as { isBranchOwner?: boolean } | undefined)?.isBranchOwner) return;
+      deferWithTenantContext(
+        hook?.params,
+        async () => {
+          const tenantId = getCurrentTenantId();
+          const branch = await runWithTenantDatabaseScope(db, tenantId, () =>
+            branchRepository.findById(session.branch_id)
+          );
+          if (!branch?.others_fs_access || branch.others_fs_access === 'none') return;
+          console.log(
+            `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
+              `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
+          );
+          syncBranchUnixAccess(branch.branch_id, '[Executor/session.created.unix-group]', {
+            scope: { session_id: session.session_id },
+          });
+        },
+        (error) =>
+          console.error(
+            `[Unix Integration] Failed to trigger group sync for session ${shortId(session.session_id)}:`,
+            error
+          )
+      );
+    });
+  }
 
   const syncUnixAccessForBoardAlignedBranches = async (
     boardId: unknown,
@@ -2624,55 +2659,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
         sessionMcpTokenAfterHooks.create,
         // TODO: OpenCode session creation moved to executor - implement via IPC if needed
-
-        // Unix Integration: When a non-owner creates a session in a branch with
-        // others_fs_access != 'none', ensure they're added to the branch and repo
-        // unix groups. Without this, non-owners can't access the .git/ directory
-        // (which uses 2770 = no others access) even if the branch directory itself
-        // allows "others" access via ACLs.
-        ...(executionMode.unixFsIsolationEnabled
-          ? [
-              async (context: HookContext) => {
-                const session = context.result as Session;
-
-                // Only for sessions with a branch and unix_username
-                if (!session.branch_id || !session.unix_username) {
-                  return context;
-                }
-
-                // Check if user is NOT an owner (owners are already handled by sync)
-                const isOwner = context.params?.isBranchOwner;
-                if (isOwner) {
-                  return context;
-                }
-
-                // Load branch to check others_fs_access
-                try {
-                  const branch = await branchRepository.findById(session.branch_id);
-                  if (!branch?.others_fs_access || branch.others_fs_access === 'none') {
-                    return context;
-                  }
-
-                  // Fire-and-forget: trigger unix.sync-branch to add session user to groups
-                  console.log(
-                    `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
-                      `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
-                  );
-                  syncBranchUnixAccess(branch.branch_id, '[Executor/session.create.unix-group]', {
-                    scope: { session_id: session.session_id },
-                  });
-                } catch (error) {
-                  // Don't fail session creation if unix sync fails
-                  console.error(
-                    `[Unix Integration] Failed to trigger group sync for session ${shortId(session.session_id)}:`,
-                    error
-                  );
-                }
-
-                return context;
-              },
-            ]
-          : []),
       ],
       patch: [
         async (context) => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -166,6 +166,7 @@ import {
   serviceTokenScopeForCurrentTenant,
   spawnExecutorFireAndForget,
 } from './utils/spawn-executor.js';
+import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';
 import {
   createTenantDatabaseScopeAroundHook,
   deferWithTenantContext,
@@ -807,21 +808,28 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           );
           if (!branch?.others_fs_access || branch.others_fs_access === 'none') return;
           console.info(
-            `[unix-access.sync] event=scheduled source=session_created` +
-              `${tenantId ? ` tenant_id=${JSON.stringify(tenantId)}` : ''}` +
-              ` branch_id=${JSON.stringify(session.branch_id)}` +
-              ` session_id=${JSON.stringify(session.session_id)}`
+            formatStructuredLog('[unix-access.sync]', {
+              event: 'scheduled',
+              source: 'session_created',
+              tenant_id: tenantId,
+              branch_id: session.branch_id,
+              session_id: session.session_id,
+            })
           );
           syncBranchUnixAccess(branch.branch_id, '[Executor/session.created.unix-group]', {
             scope: { session_id: session.session_id },
           });
         },
-        () =>
+        (error) =>
           console.error(
-            `[unix-access.sync] event=schedule_failed source=session_created` +
-              `${tenantId ? ` tenant_id=${JSON.stringify(tenantId)}` : ''}` +
-              ` branch_id=${JSON.stringify(session.branch_id)}` +
-              ` session_id=${JSON.stringify(session.session_id)}`
+            formatStructuredLog('[unix-access.sync]', {
+              event: 'schedule_failed',
+              source: 'session_created',
+              tenant_id: tenantId,
+              branch_id: session.branch_id,
+              session_id: session.session_id,
+              error_code: structuredLogErrorCode(error),
+            })
           )
       );
     });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1048,10 +1048,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       config.execution?.executor_command_template ? 'templated' : 'local'
     );
 
-    // Patch task: queued/created → launch status, with real ranges. queue_position
-    // is cleared here so a draining task is no longer considered queued.
-    const updatedTask = (await app.service('tasks').patch(
+    if (task.status !== TaskStatus.CREATED && task.status !== TaskStatus.QUEUED) {
+      // A concurrent daemon may have won between the caller's read and this
+      // handoff. Returning the durable task is the idempotent success path.
+      return task;
+    }
+
+    // Atomically claim queued/created → launch status. Process-local session
+    // locks reduce contention, but this expected-state transition is the
+    // cross-daemon fence that prevents duplicate executor launches.
+    const dispatchClaim = await tasksService.claimDispatch(
       task.task_id,
+      task.status,
       {
         ...launchState,
         ...(launchState.executor_mode
@@ -1070,7 +1078,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         },
       },
       { ...params, provider: undefined }
-    )) as Task;
+    );
+    if (dispatchClaim.outcome !== 'claimed') {
+      console.info('[DistributedWork]', {
+        component: 'task-dispatch',
+        event: 'claim_lost',
+        task_id: task.task_id,
+        session_id: task.session_id,
+        observed_status: dispatchClaim.task.status,
+      });
+      return dispatchClaim.task;
+    }
+    const updatedTask = dispatchClaim.task;
 
     // Alt D — write the user-message row before spawning. Gated by kill switch.
     // The executor's createUserMessage has a skip-if-exists guard so a duplicate
@@ -1259,6 +1278,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
            * excluded/sanitized even for stale or untyped clients.
            */
           metadata?: PromptTaskMetadataInput;
+          /**
+           * Internal-only stable task identity for idempotent producers such
+           * as the scheduler. External callers may not set this field.
+           */
+          idempotencyTaskId?: UUID;
         },
         params: RouteParams
       ) {
@@ -1272,6 +1296,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         let id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         if (!data.prompt) throw new Error('Prompt required');
+        if (data.idempotencyTaskId && params.provider) {
+          throw new Forbidden('idempotencyTaskId is internal-only');
+        }
 
         // Validate and normalize messageSource
         const messageSource = normalizeMessageSource(data.messageSource, params);
@@ -1346,6 +1373,44 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               taskRepo,
               params
             );
+
+            // A scheduled occurrence owns a stable initial task ID persisted
+            // with its session. Reconciliation always targets that row rather
+            // than inferring idempotence from process-local locks or creating a
+            // second queued prompt after another daemon starts it.
+            if (data.idempotencyTaskId) {
+              const prior = await taskRepo.findById(data.idempotencyTaskId);
+              if (prior && prior.session_id !== id) {
+                throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
+              }
+              const task = await taskRepo.createPending({
+                task_id: data.idempotencyTaskId,
+                session_id: id as SessionID,
+                full_prompt: data.prompt,
+                created_by: createdBy,
+                status: TaskStatus.CREATED,
+              });
+              if (!prior) {
+                emitServiceEvent(app, {
+                  path: 'tasks',
+                  event: 'created',
+                  data: task,
+                  params,
+                  id: task.task_id,
+                });
+              }
+              if (task.status !== TaskStatus.CREATED) return task;
+              return await spawnTaskExecutor(
+                task,
+                {
+                  permissionMode: data.permissionMode,
+                  stream: data.stream !== false,
+                  messageSource,
+                },
+                params
+              );
+            }
+
             const queuedTasks = await taskRepo.findQueued(id as SessionID);
             const shouldQueue =
               !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -51,6 +51,7 @@ import type {
   AuthenticatedParams,
   HookContext,
   Message,
+  MessageID,
   MessageSource,
   Paginated,
   Params,
@@ -975,6 +976,71 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   }
 
   /**
+   * Persist the first transcript row for a Task. Scheduled/idempotent prompts
+   * pass a stable message ID, so a replacement daemon can repair a kill after
+   * the dispatch claim without duplicating the prompt. Ordinary prompts retain
+   * the historical best-effort/random-ID behavior and executor fallback.
+   */
+  async function ensureInitialUserMessage(
+    task: Task,
+    params: RouteParams,
+    input: {
+      messageStartIndex: number;
+      startTimestamp: string;
+      messageSource?: MessageSource;
+      stableMessageId?: MessageID;
+    }
+  ): Promise<void> {
+    if (config.execution?.daemon_writes_user_message === false) return;
+
+    const messageRepo = new MessagesRepository(db);
+    if (input.stableMessageId) {
+      const existing = await messageRepo.findById(input.stableMessageId);
+      if (existing) {
+        if (existing.session_id !== task.session_id || existing.task_id !== task.task_id) {
+          throw new Conflict(
+            `Stable initial message identity ${input.stableMessageId} is already in use`
+          );
+        }
+        return;
+      }
+    }
+
+    const isCallback = task.metadata?.is_agor_callback === true;
+    const messageMetadata: Message['metadata'] = {};
+    if (isCallback) messageMetadata.is_agor_callback = true;
+    if (input.messageSource === 'gateway' || input.messageSource === 'agor') {
+      messageMetadata.source = input.messageSource;
+    }
+    const userMessage = buildInitialUserMessage({
+      messageId: input.stableMessageId,
+      sessionId: task.session_id,
+      taskId: task.task_id,
+      index: input.messageStartIndex,
+      timestamp: input.startTimestamp,
+      content: task.full_prompt,
+      type: isCallback ? 'system' : 'user',
+      metadata: Object.keys(messageMetadata).length > 0 ? messageMetadata : undefined,
+    });
+
+    try {
+      await app.service('messages').create(userMessage, params);
+    } catch (error) {
+      if (input.stableMessageId) {
+        const winner = await messageRepo.findById(input.stableMessageId);
+        if (winner?.session_id === task.session_id && winner.task_id === task.task_id) return;
+        throw error;
+      }
+      // Don't fail the spawn — the executor's createUserMessage fallback
+      // (with skip-if-exists) will write the row when it connects.
+      console.warn(
+        `⚠️  [Daemon] Failed to write initial user-message row for task ${shortId(task.task_id)} (executor will retry):`,
+        error
+      );
+    }
+  }
+
+  /**
    * spawnTaskExecutor — sole transition point for `tasks.status` going from
    * `created` / `queued` → `dispatching`.
    *
@@ -1007,6 +1073,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       permissionMode?: import('@agor/core/types').PermissionMode;
       stream?: boolean;
       messageSource?: MessageSource;
+      stableInitialMessageId?: MessageID;
     },
     params: RouteParams
   ): Promise<Task> {
@@ -1050,14 +1117,23 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
     if (task.status !== TaskStatus.CREATED && task.status !== TaskStatus.QUEUED) {
       // A concurrent daemon may have won between the caller's read and this
-      // handoff. Returning the durable task is the idempotent success path.
+      // handoff. Repair the deterministic transcript projection before
+      // returning the durable task as the idempotent success path.
+      if (options.stableInitialMessageId) {
+        await ensureInitialUserMessage(task, params, {
+          messageStartIndex: task.message_range?.start_index ?? messageStartIndex,
+          startTimestamp: task.message_range?.start_timestamp ?? task.started_at ?? startTimestamp,
+          messageSource: runtimeMessageSource,
+          stableMessageId: options.stableInitialMessageId,
+        });
+      }
       return task;
     }
 
     // Atomically claim queued/created → launch status. Process-local session
     // locks reduce contention, but this expected-state transition is the
     // cross-daemon fence that prevents duplicate executor launches.
-    const dispatchClaim = await tasksService.claimDispatch(
+    const dispatchClaim = await tasksService.claimDispatchAndProjectSession(
       task.task_id,
       task.status,
       {
@@ -1087,6 +1163,17 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         session_id: task.session_id,
         observed_status: dispatchClaim.task.status,
       });
+      if (options.stableInitialMessageId) {
+        await ensureInitialUserMessage(dispatchClaim.task, params, {
+          messageStartIndex: dispatchClaim.task.message_range?.start_index ?? messageStartIndex,
+          startTimestamp:
+            dispatchClaim.task.message_range?.start_timestamp ??
+            dispatchClaim.task.started_at ??
+            startTimestamp,
+          messageSource: runtimeMessageSource,
+          stableMessageId: options.stableInitialMessageId,
+        });
+      }
       return dispatchClaim.task;
     }
     const updatedTask = dispatchClaim.task;
@@ -1094,44 +1181,20 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // Alt D — write the user-message row before spawning. Gated by kill switch.
     // The executor's createUserMessage has a skip-if-exists guard so a duplicate
     // write is harmless if the daemon path is enabled.
-    if (config.execution?.daemon_writes_user_message !== false) {
-      try {
-        const isCallback = task.metadata?.is_agor_callback === true;
-        const messageMetadata: Message['metadata'] = {};
-        if (isCallback) {
-          messageMetadata.is_agor_callback = true;
-        }
-        // Prefer task.metadata.source (set when the task was queued) over
-        // the request's messageSource — the latter applies only to the
-        // current draining tick, the former to where the prompt originated.
-        if (runtimeMessageSource) {
-          messageMetadata.source = runtimeMessageSource;
-        }
+    // Prefer task.metadata.source (set when the task was queued) over the
+    // request's messageSource — the latter applies only to this drain tick.
+    await ensureInitialUserMessage(task, params, {
+      messageStartIndex,
+      startTimestamp,
+      messageSource: runtimeMessageSource,
+      stableMessageId: options.stableInitialMessageId,
+    });
 
-        const userMessage = buildInitialUserMessage({
-          sessionId: task.session_id,
-          taskId: task.task_id,
-          index: messageStartIndex,
-          timestamp: startTimestamp,
-          content: task.full_prompt,
-          // Callback messages are typed `system` so the UI shows the special
-          // Agor-callback styling. Normal prompts stay `user`.
-          type: isCallback ? 'system' : 'user',
-          metadata: Object.keys(messageMetadata).length > 0 ? messageMetadata : undefined,
-        });
-        await app.service('messages').create(userMessage, params);
-      } catch (msgErr) {
-        // Don't fail the spawn — the executor's createUserMessage fallback
-        // (with skip-if-exists) will write the row when it connects.
-        console.warn(
-          `⚠️  [Daemon] Failed to write initial user-message row for task ${shortId(task.task_id)} (executor will retry):`,
-          msgErr
-        );
-      }
-    }
-
-    // Flip session to RUNNING and append to session.tasks. Done here so both
-    // callers (idle prompt and queue drain) get this for free.
+    // Re-apply the Session projection through Feathers so hooks/realtime see
+    // the transition. TaskRepository.claimDispatchAndProjectSession already
+    // committed the same projection atomically with the Task fence; this
+    // service patch is no longer correctness-critical on SQLite and is
+    // intentionally idempotent.
     //
     // The session-status flip used to fall out of `TasksService.create` when
     // the IDLE path created a task with `status: RUNNING` directly. Now the
@@ -1399,13 +1462,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                   id: task.task_id,
                 });
               }
-              if (task.status !== TaskStatus.CREATED) return task;
               return await spawnTaskExecutor(
                 task,
                 {
                   permissionMode: data.permissionMode,
                   stream: data.stream !== false,
                   messageSource,
+                  stableInitialMessageId: data.idempotencyTaskId as MessageID,
                 },
                 params
               );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1041,10 +1041,52 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       // Don't fail the spawn — the executor's createUserMessage fallback
       // (with skip-if-exists) will write the row when it connects.
       console.warn(
-        `⚠️  [Daemon] Failed to write initial user-message row for task ${shortId(task.task_id)} (executor will retry):`,
-        error
+        `[messages.initial] event=write_failed task_id=${JSON.stringify(task.task_id)} outcome=executor_retry`
       );
     }
+  }
+
+  /** Repair one stable initial transcript row from durable Task state. */
+  async function reconcileStableInitialUserMessage(
+    task: Task,
+    params: RouteParams,
+    stableMessageId: MessageID,
+    fallback: {
+      messageStartIndex?: number;
+      startTimestamp?: string;
+      messageSource?: MessageSource;
+    } = {}
+  ): Promise<void> {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for message reconciliation');
+    const persistedStartIndex = task.message_range?.start_index;
+    const hasPersistedStartIndex =
+      typeof persistedStartIndex === 'number' && persistedStartIndex >= 0;
+    const fallbackStartIndex =
+      typeof fallback.messageStartIndex === 'number' && fallback.messageStartIndex >= 0
+        ? fallback.messageStartIndex
+        : undefined;
+    const messageStartIndex = hasPersistedStartIndex
+      ? persistedStartIndex
+      : (fallbackStartIndex ??
+        (await runWithTenantDatabaseScope(db, tenantId, () =>
+          sessionsRepository.countMessages(task.session_id)
+        )));
+    const startTimestamp =
+      (hasPersistedStartIndex ? task.message_range?.start_timestamp : undefined) ??
+      task.started_at ??
+      fallback.startTimestamp ??
+      new Date().toISOString();
+    const persistedSource = task.metadata?.source ?? fallback.messageSource;
+    const messageSource =
+      persistedSource === 'gateway' || persistedSource === 'agor' ? persistedSource : undefined;
+
+    await ensureInitialUserMessage(task, params, {
+      messageStartIndex,
+      startTimestamp,
+      messageSource,
+      stableMessageId,
+    });
   }
 
   /**
@@ -1097,18 +1139,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // on mutable launch-time state (tool enablement, preset validity, or user
     // defaults): no new executor launch will occur on this path.
     if (options.stableInitialMessageId && !isTaskPendingDispatch(task)) {
-      const messageStartIndex =
-        task.message_range?.start_index ??
-        (await runWithTenantDatabaseScope(db, tenantId, () =>
-          sessionsRepository.countMessages(task.session_id)
-        ));
-      const startTimestamp =
-        task.message_range?.start_timestamp ?? task.started_at ?? new Date().toISOString();
-      await ensureInitialUserMessage(task, params, {
-        messageStartIndex,
-        startTimestamp,
+      await reconcileStableInitialUserMessage(task, params, options.stableInitialMessageId, {
         messageSource: runtimeMessageSource,
-        stableMessageId: options.stableInitialMessageId,
       });
       return task;
     }
@@ -1172,23 +1204,26 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       { ...params, provider: undefined }
     );
     if (dispatchClaim.outcome !== 'claimed') {
-      console.info('[DistributedWork]', {
-        component: 'task-dispatch',
-        event: 'claim_lost',
-        task_id: task.task_id,
-        session_id: task.session_id,
-        observed_status: dispatchClaim.task.status,
-      });
+      const workIdentity = app.get('distributedWorkIdentity');
+      console.info(
+        `[distributed-work.task-dispatch] event=claim_lost` +
+          `${workIdentity ? ` instance_id=${JSON.stringify(workIdentity.instanceId)} boot_id=${JSON.stringify(workIdentity.bootId)}` : ''}` +
+          ` tenant_id=${JSON.stringify(tenantId)}` +
+          ` task_id=${JSON.stringify(task.task_id)}` +
+          ` session_id=${JSON.stringify(task.session_id)}` +
+          ` observed_status=${dispatchClaim.task.status}`
+      );
       if (options.stableInitialMessageId) {
-        await ensureInitialUserMessage(dispatchClaim.task, params, {
-          messageStartIndex: dispatchClaim.task.message_range?.start_index ?? messageStartIndex,
-          startTimestamp:
-            dispatchClaim.task.message_range?.start_timestamp ??
-            dispatchClaim.task.started_at ??
+        await reconcileStableInitialUserMessage(
+          dispatchClaim.task,
+          params,
+          options.stableInitialMessageId,
+          {
+            messageStartIndex,
             startTimestamp,
-          messageSource: runtimeMessageSource,
-          stableMessageId: options.stableInitialMessageId,
-        });
+            messageSource: runtimeMessageSource,
+          }
+        );
       }
       return dispatchClaim.task;
     }
@@ -1199,12 +1234,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // write is harmless if the daemon path is enabled.
     // Prefer task.metadata.source (set when the task was queued) over the
     // request's messageSource — the latter applies only to this drain tick.
-    await ensureInitialUserMessage(task, params, {
-      messageStartIndex,
-      startTimestamp,
-      messageSource: runtimeMessageSource,
-      stableMessageId: options.stableInitialMessageId,
-    });
+    if (options.stableInitialMessageId) {
+      await reconcileStableInitialUserMessage(updatedTask, params, options.stableInitialMessageId, {
+        messageStartIndex,
+        startTimestamp,
+        messageSource: runtimeMessageSource,
+      });
+    } else {
+      await ensureInitialUserMessage(task, params, {
+        messageStartIndex,
+        startTimestamp,
+        messageSource: runtimeMessageSource,
+      });
+    }
 
     // Re-apply the Session projection through Feathers so hooks/realtime see
     // the transition. TaskRepository.claimDispatchAndProjectSession already
@@ -1404,18 +1446,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           }
           if (isTaskPendingDispatch(prior)) return null;
 
-          await ensureInitialUserMessage(prior, params, {
-            messageStartIndex:
-              prior.message_range?.start_index ??
-              (await sessionsRepository.countMessages(prior.session_id)),
-            startTimestamp:
-              prior.message_range?.start_timestamp ?? prior.started_at ?? new Date().toISOString(),
-            messageSource:
-              prior.metadata?.source === 'gateway' || prior.metadata?.source === 'agor'
-                ? prior.metadata.source
-                : undefined,
-            stableMessageId: data.idempotencyTaskId as MessageID,
-          });
+          await reconcileStableInitialUserMessage(
+            prior,
+            params,
+            data.idempotencyTaskId as MessageID
+          );
           return prior;
         };
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -65,7 +65,14 @@ import type {
   User,
   UUID,
 } from '@agor/core/types';
-import { hasMinimumRole, MessageRole, ROLES, SessionStatus, TaskStatus } from '@agor/core/types';
+import {
+  hasMinimumRole,
+  isTaskPendingDispatch,
+  MessageRole,
+  ROLES,
+  SessionStatus,
+  TaskStatus,
+} from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { NextFunction, Request, Response } from 'express';
 import { rateLimit } from 'express-rate-limit';
@@ -1079,6 +1086,33 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   ): Promise<Task> {
     const tenantId = getCurrentTenantId();
     if (!tenantId) throw new Error('Missing active tenant context for task executor startup');
+    const persistedMessageSource = task.metadata?.source ?? options.messageSource;
+    const runtimeMessageSource =
+      persistedMessageSource === 'gateway' || persistedMessageSource === 'agor'
+        ? persistedMessageSource
+        : undefined;
+
+    // A stable scheduled Task that has crossed the dispatch fence needs only
+    // deterministic projection repair. Do not make that reconciliation depend
+    // on mutable launch-time state (tool enablement, preset validity, or user
+    // defaults): no new executor launch will occur on this path.
+    if (options.stableInitialMessageId && !isTaskPendingDispatch(task)) {
+      const messageStartIndex =
+        task.message_range?.start_index ??
+        (await runWithTenantDatabaseScope(db, tenantId, () =>
+          sessionsRepository.countMessages(task.session_id)
+        ));
+      const startTimestamp =
+        task.message_range?.start_timestamp ?? task.started_at ?? new Date().toISOString();
+      await ensureInitialUserMessage(task, params, {
+        messageStartIndex,
+        startTimestamp,
+        messageSource: runtimeMessageSource,
+        stableMessageId: options.stableInitialMessageId,
+      });
+      return task;
+    }
+
     const {
       agenticToolEnabled,
       messageStartIndex,
@@ -1097,11 +1131,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       throw new Forbidden(`${loadedSession.agentic_tool} is disabled for this workspace`);
     }
     const session = await sessionsService.materializeAgenticToolPreset(loadedSession, params);
-    const persistedMessageSource = task.metadata?.source ?? options.messageSource;
-    const runtimeMessageSource =
-      persistedMessageSource === 'gateway' || persistedMessageSource === 'agor'
-        ? persistedMessageSource
-        : undefined;
     const startTimestamp = new Date().toISOString();
 
     // The daemon persists launch intent and writes required sentinel git fields
@@ -1115,20 +1144,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       config.execution?.executor_command_template ? 'templated' : 'local'
     );
 
-    if (task.status !== TaskStatus.CREATED && task.status !== TaskStatus.QUEUED) {
-      // A concurrent daemon may have won between the caller's read and this
-      // handoff. Repair the deterministic transcript projection before
-      // returning the durable task as the idempotent success path.
-      if (options.stableInitialMessageId) {
-        await ensureInitialUserMessage(task, params, {
-          messageStartIndex: task.message_range?.start_index ?? messageStartIndex,
-          startTimestamp: task.message_range?.start_timestamp ?? task.started_at ?? startTimestamp,
-          messageSource: runtimeMessageSource,
-          stableMessageId: options.stableInitialMessageId,
-        });
-      }
-      return task;
-    }
+    if (!isTaskPendingDispatch(task)) return task;
 
     // Atomically claim queued/created → launch status. Process-local session
     // locks reduce contention, but this expected-state transition is the
@@ -1373,18 +1389,62 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         let session = await sessionsService.get(id, params);
         id = session.session_id;
-        const activeAgenticTool = requireActiveAgenticTool(session.agentic_tool);
+        const taskRepo = new TaskRepository(db);
 
-        if (!(await isTenantAgenticToolEnabled(activeAgenticTool, db))) {
-          throw new Forbidden(`${activeAgenticTool} is disabled for this workspace`);
-        }
-        session = await sessionsService.materializeAgenticToolPreset(session, params);
-        if (
-          session.agentic_tool_preset_id &&
-          data.permissionMode !== undefined &&
-          data.permissionMode !== session.permission_config?.mode
-        ) {
-          throw new Forbidden('Preset-backed sessions cannot override permission mode per task');
+        const reconcileDurablyDispatchedTask = async (): Promise<Task | null> => {
+          if (!data.idempotencyTaskId) return null;
+          const prior = await taskRepo.findById(data.idempotencyTaskId);
+          if (!prior) return null;
+          if (prior.session_id !== id) {
+            throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
+          }
+          const expectedCreator = params.user?.user_id ?? session.created_by;
+          if (prior.created_by !== expectedCreator || prior.full_prompt !== data.prompt) {
+            throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
+          }
+          if (isTaskPendingDispatch(prior)) return null;
+
+          await ensureInitialUserMessage(prior, params, {
+            messageStartIndex:
+              prior.message_range?.start_index ??
+              (await sessionsRepository.countMessages(prior.session_id)),
+            startTimestamp:
+              prior.message_range?.start_timestamp ?? prior.started_at ?? new Date().toISOString(),
+            messageSource:
+              prior.metadata?.source === 'gateway' || prior.metadata?.source === 'agor'
+                ? prior.metadata.source
+                : undefined,
+            stableMessageId: data.idempotencyTaskId as MessageID,
+          });
+          return prior;
+        };
+
+        // Scheduled recovery is reconciliation, not a fresh launch admission,
+        // once its stable Task has crossed the durable dispatch fence. Return
+        // that Task before consulting mutable tool/preset/user configuration.
+        const durableTask = await reconcileDurablyDispatchedTask();
+        if (durableTask) return durableTask;
+
+        try {
+          const activeAgenticTool = requireActiveAgenticTool(session.agentic_tool);
+          if (!(await isTenantAgenticToolEnabled(activeAgenticTool, db))) {
+            throw new Forbidden(`${activeAgenticTool} is disabled for this workspace`);
+          }
+          session = await sessionsService.materializeAgenticToolPreset(session, params);
+          if (
+            session.agentic_tool_preset_id &&
+            data.permissionMode !== undefined &&
+            data.permissionMode !== session.permission_config?.mode
+          ) {
+            throw new Forbidden('Preset-backed sessions cannot override permission mode per task');
+          }
+        } catch (error) {
+          // Another daemon can cross the dispatch fence between the first
+          // stable-Task read and launch admission. Re-check before surfacing a
+          // mutable configuration failure; the winner no longer needs launch.
+          const concurrentlyDurableTask = await reconcileDurablyDispatchedTask();
+          if (concurrentlyDurableTask) return concurrentlyDurableTask;
+          throw error;
         }
 
         // Auto-unarchive on prompt
@@ -1414,7 +1474,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // prompts on an idle session could both observe `status === 'idle'`
         // and both spawn executors. Inside the lock the session is re-read,
         // so the decision is made against the freshest possible state.
-        const taskRepo = new TaskRepository(db);
         if (!params.user?.user_id) {
           throw new NotAuthenticated('Authentication required to prompt a session');
         }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -154,6 +154,7 @@ import {
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
+import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';
 import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
@@ -1041,7 +1042,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       // Don't fail the spawn — the executor's createUserMessage fallback
       // (with skip-if-exists) will write the row when it connects.
       console.warn(
-        `[messages.initial] event=write_failed task_id=${JSON.stringify(task.task_id)} outcome=executor_retry`
+        formatStructuredLog('[messages.initial]', {
+          event: 'write_failed',
+          task_id: task.task_id,
+          outcome: 'executor_retry',
+          error_code: structuredLogErrorCode(error),
+        })
       );
     }
   }
@@ -1206,12 +1212,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     if (dispatchClaim.outcome !== 'claimed') {
       const workIdentity = app.get('distributedWorkIdentity');
       console.info(
-        `[distributed-work.task-dispatch] event=claim_lost` +
-          `${workIdentity ? ` instance_id=${JSON.stringify(workIdentity.instanceId)} boot_id=${JSON.stringify(workIdentity.bootId)}` : ''}` +
-          ` tenant_id=${JSON.stringify(tenantId)}` +
-          ` task_id=${JSON.stringify(task.task_id)}` +
-          ` session_id=${JSON.stringify(task.session_id)}` +
-          ` observed_status=${dispatchClaim.task.status}`
+        formatStructuredLog('[distributed-work.task-dispatch]', {
+          event: 'claim_lost',
+          instance_id: workIdentity?.instanceId,
+          boot_id: workIdentity?.bootId,
+          tenant_id: tenantId,
+          task_id: task.task_id,
+          session_id: task.session_id,
+          observed_status: dispatchClaim.task.status,
+        })
       );
       if (options.stableInitialMessageId) {
         await reconcileStableInitialUserMessage(
@@ -1548,6 +1557,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 status: TaskStatus.CREATED,
               });
               if (!prior) {
+                // createPending is conflict-tolerant: another daemon can win
+                // between the pre-read and insert. In that case this is only a
+                // harmless same-ID realtime catch-up event, not a correctness
+                // dependency.
                 emitServiceEvent(app, {
                   path: 'tasks',
                   event: 'created',

--- a/apps/agor-daemon/src/services/scheduler.test.ts
+++ b/apps/agor-daemon/src/services/scheduler.test.ts
@@ -10,6 +10,7 @@ import {
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
+  TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
@@ -20,7 +21,7 @@ import {
   USER_DEFAULT_AGENTIC_CONFIGURATION,
   WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
 } from '@agor/core/types';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, type MockInstance, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import {
   materializeScheduleAgenticToolConfig,
@@ -265,6 +266,88 @@ describe('scheduler HA occurrence recovery', () => {
       nowSpy.mockRestore();
     }
   });
+
+  dbTest(
+    'already-dispatched recovery does not reload mutable creator launch state',
+    async ({ db }) => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+      let creatorLookup: MockInstance<UsersRepository['findById']> | undefined;
+      try {
+        const { creator, schedule } = await seedRunnableSchedule(
+          db,
+          {
+            email: `scheduler-durable-recovery-${Math.random()}@example.com`,
+            name: 'Schedule creator',
+          },
+          { agentic_tool: 'claude-code' }
+        );
+        await new ScheduleRepository(db).update(schedule.schedule_id, { enabled: false });
+        const initialTaskId = generateId();
+        const session = await new SessionRepository(db).create({
+          session_id: generateId(),
+          branch_id: schedule.branch_id,
+          created_by: creator.user_id,
+          agentic_tool: 'claude-code',
+          status: SessionStatus.IDLE,
+          scheduled_from_branch: true,
+          scheduled_run_at: NOW,
+          schedule_id: schedule.schedule_id,
+          custom_context: {
+            scheduled_run: {
+              rendered_prompt: 'already durably dispatching',
+              run_index: 1,
+              initial_task_id: initialTaskId,
+              schedule_config_snapshot: {
+                schedule_id: schedule.schedule_id,
+                cron: schedule.cron_expression,
+                timezone: 'UTC',
+                retention: schedule.retention,
+                allow_concurrent_runs: schedule.allow_concurrent_runs,
+                mcp_server_ids: [],
+              },
+            },
+          },
+        });
+        const tasks = new TaskRepository(db);
+        const pending = await tasks.createPending({
+          task_id: initialTaskId,
+          session_id: session.session_id,
+          full_prompt: 'already durably dispatching',
+          created_by: creator.user_id,
+          status: TaskStatus.CREATED,
+        });
+        await tasks.claimDispatchAndProjectSession(pending.task_id, TaskStatus.CREATED, {
+          status: TaskStatus.DISPATCHING,
+          started_at: new Date(NOW).toISOString(),
+          message_range: {
+            start_index: 0,
+            end_index: 1,
+            start_timestamp: new Date(NOW).toISOString(),
+          },
+        });
+
+        creatorLookup = vi
+          .spyOn(UsersRepository.prototype, 'findById')
+          .mockRejectedValue(new Error('durable recovery must not reload the creator'));
+        const { app, prompt } = createSchedulerApp(db);
+        await (
+          new SchedulerService(db, app, { tenantId: 'default' }) as unknown as {
+            tick(): Promise<unknown>;
+          }
+        ).tick();
+
+        expect(creatorLookup).not.toHaveBeenCalled();
+        expect(prompt).toHaveBeenCalledOnce();
+        expect(prompt.mock.calls[0][1].user).toBeUndefined();
+        expect(
+          await new SessionRepository(db).isScheduledInitializationComplete(session.session_id)
+        ).toBe(true);
+      } finally {
+        creatorLookup?.mockRestore();
+        nowSpy.mockRestore();
+      }
+    }
+  );
 
   dbTest('recovers an admitted occurrence after its schedule is deleted', async ({ db }) => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);

--- a/apps/agor-daemon/src/services/scheduler.test.ts
+++ b/apps/agor-daemon/src/services/scheduler.test.ts
@@ -3,16 +3,19 @@ import {
   BranchRepository,
   createTenantScopedDatabaseProxy,
   generateId,
+  MCPServerRepository,
   RepoRepository,
   runWithTenantContext,
   runWithTenantDatabaseScope,
   ScheduleRepository,
+  SessionMCPServerRepository,
   SessionRepository,
   UsersRepository,
 } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
-import type { Branch, Schedule, Session, UserID } from '@agor/core/types';
+import type { Branch, Schedule, Session, Task, UserID } from '@agor/core/types';
 import {
+  TaskStatus,
   USER_DEFAULT_AGENTIC_CONFIGURATION,
   WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
 } from '@agor/core/types';
@@ -115,16 +118,299 @@ async function seedRunnableSchedule(
 function createSchedulerApp(db: SchedulerDb) {
   const sessions = new SessionRepository(db);
   const createSession = vi.fn((data: Partial<Session>, _params?: unknown) => sessions.create(data));
-  const prompt = vi.fn(async () => ({}));
+  const prompt = vi.fn(
+    async (data: { prompt: string; idempotencyTaskId: string }, params: any) =>
+      ({
+        task_id: data.idempotencyTaskId,
+        session_id: params.route.id,
+        status: TaskStatus.DISPATCHING,
+        full_prompt: data.prompt,
+      }) as Task
+  );
   const app = {
     service: (path: string) => {
-      if (path === 'sessions') return { create: createSession, remove: vi.fn() };
+      if (path === 'sessions') {
+        return {
+          create: createSession,
+          patch: (id: string, data: Partial<Session>) => sessions.update(id, data),
+          remove: vi.fn(),
+        };
+      }
       if (path === '/sessions/:id/prompt') return { create: prompt };
+      if (path === 'session-mcp-servers') return { emit: vi.fn() };
       throw new Error(`Unexpected service: ${path}`);
     },
   } as unknown as ConstructorParameters<typeof SchedulerService>[1];
   return { app, createSession, prompt };
 }
+
+describe('scheduler HA occurrence recovery', () => {
+  const killStages = [
+    'afterSessionAdmission',
+    'afterMcpAttachments',
+    'afterPromptDispatch',
+    'afterRetention',
+    'afterMetadata',
+  ] as const;
+
+  for (const stage of killStages) {
+    dbTest(`recovers a replacement scheduler killed at ${stage}`, async ({ db }) => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+      try {
+        const { creator, schedule } = await seedRunnableSchedule(
+          db,
+          {
+            email: `scheduler-recovery-${stage}-${Math.random()}@example.com`,
+            name: 'Schedule creator',
+          },
+          { agentic_tool: 'claude-code' }
+        );
+        const mcpServer = await new MCPServerRepository(db).create({
+          name: `scheduler-recovery-${stage}-${generateId()}`,
+          transport: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+        });
+        await new ScheduleRepository(db).update(schedule.schedule_id, {
+          mcp_server_ids: [mcpServer.mcp_server_id],
+        });
+        const { app, prompt } = createSchedulerApp(db);
+        let killed = false;
+        const crash = async () => {
+          if (killed) return;
+          killed = true;
+          throw new Error(`simulated kill at ${stage}`);
+        };
+        const first = new SchedulerService(db, app, {
+          testHooks: { [stage]: crash },
+          workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+        });
+        await expect(
+          first.executeScheduleNow({
+            scheduleId: schedule.schedule_id,
+            triggeredBy: creator.user_id,
+          })
+        ).rejects.toThrow(`simulated kill at ${stage}`);
+
+        const replacement = new SchedulerService(db, app, {
+          workIdentity: { instanceId: 'daemon-b', bootId: 'boot-b' },
+        });
+        const recovered = await replacement.executeScheduleNow({
+          scheduleId: schedule.schedule_id,
+          triggeredBy: creator.user_id,
+        });
+
+        const sessions = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
+        expect(sessions).toHaveLength(1);
+        expect(recovered.session_id).toBe(sessions[0].session_id);
+        expect(await new SessionMCPServerRepository(db).count(recovered.session_id)).toBe(1);
+        const taskIds = prompt.mock.calls.map((call) => call[0].idempotencyTaskId);
+        expect(new Set(taskIds).size).toBeLessThanOrEqual(1);
+        const updated = await new ScheduleRepository(db).findById(schedule.schedule_id);
+        expect(updated?.last_run_session_id).toBe(recovered.session_id);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+  }
+
+  dbTest('background recovery is independent of cron grace and manual retry', async ({ db }) => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      const { creator, schedule } = await seedRunnableSchedule(
+        db,
+        {
+          email: `scheduler-late-recovery-${Math.random()}@example.com`,
+          name: 'Schedule creator',
+        },
+        { agentic_tool: 'claude-code' }
+      );
+      const { app, prompt } = createSchedulerApp(db);
+      const killed = new SchedulerService(db, app, {
+        tenantId: 'default',
+        testHooks: {
+          afterSessionAdmission: () => {
+            throw new Error('simulated process death');
+          },
+        },
+      });
+      await expect(
+        killed.executeScheduleNow({
+          scheduleId: schedule.schedule_id,
+          triggeredBy: creator.user_id,
+        })
+      ).rejects.toThrow('simulated process death');
+
+      nowSpy.mockReturnValue(NOW + 10 * 60_000);
+      const replacement = new SchedulerService(db, app, { tenantId: 'default' });
+      await (
+        replacement as unknown as {
+          tick(): Promise<unknown>;
+        }
+      ).tick();
+
+      expect(prompt).toHaveBeenCalledOnce();
+      const [session] = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
+      expect(
+        await new SessionRepository(db).isScheduledInitializationComplete(session.session_id)
+      ).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  dbTest('five concurrent scheduler instances create one occurrence', async ({ db }) => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      const { creator, schedule } = await seedRunnableSchedule(
+        db,
+        {
+          email: `scheduler-five-${Math.random()}@example.com`,
+          name: 'Schedule creator',
+        },
+        { agentic_tool: 'claude-code' }
+      );
+      const { app, prompt } = createSchedulerApp(db);
+      const schedulers = Array.from(
+        { length: 5 },
+        (_, index) =>
+          new SchedulerService(db, app, {
+            workIdentity: { instanceId: `daemon-${index}`, bootId: `boot-${index}` },
+          })
+      );
+
+      const sessions = await Promise.all(
+        schedulers.map((scheduler) =>
+          scheduler.executeScheduleNow({
+            scheduleId: schedule.schedule_id,
+            triggeredBy: creator.user_id,
+          })
+        )
+      );
+
+      expect(new Set(sessions.map((session) => session.session_id)).size).toBe(1);
+      expect(await new SessionRepository(db).findByScheduleId(schedule.schedule_id)).toHaveLength(
+        1
+      );
+      expect(new Set(prompt.mock.calls.map((call) => call[0].idempotencyTaskId)).size).toBe(1);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  dbTest('cron and manual triggers in the same minute share one occurrence', async ({ db }) => {
+    const collisionNow = NOW + 30_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(collisionNow);
+    try {
+      const { creator, schedule } = await seedRunnableSchedule(
+        db,
+        {
+          email: `scheduler-collision-${Math.random()}@example.com`,
+          name: 'Schedule creator',
+        },
+        { agentic_tool: 'claude-code' }
+      );
+      const { app } = createSchedulerApp(db);
+      const cron = new SchedulerService(db, app);
+      const manual = new SchedulerService(db, app);
+
+      await Promise.all([
+        (
+          cron as unknown as {
+            processSchedule(schedule: Schedule, now: number): Promise<void>;
+          }
+        ).processSchedule(schedule, collisionNow),
+        manual.executeScheduleNow({
+          scheduleId: schedule.schedule_id,
+          triggeredBy: creator.user_id,
+        }),
+      ]);
+
+      expect(await new SessionRepository(db).findByScheduleId(schedule.schedule_id)).toHaveLength(
+        1
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  dbTest('allow_concurrent_runs=false treats incomplete initialization as busy', async ({ db }) => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      const { creator, schedule } = await seedRunnableSchedule(
+        db,
+        {
+          email: `scheduler-busy-init-${Math.random()}@example.com`,
+          name: 'Schedule creator',
+        },
+        { agentic_tool: 'claude-code' }
+      );
+      await new SessionRepository(db).create({
+        session_id: generateId(),
+        branch_id: schedule.branch_id,
+        created_by: creator.user_id,
+        agentic_tool: 'claude-code',
+        status: 'idle',
+        scheduled_from_branch: true,
+        scheduled_run_at: NOW - 60_000,
+        schedule_id: schedule.schedule_id,
+      });
+      const { app } = createSchedulerApp(db);
+
+      await expect(
+        new SchedulerService(db, app).executeScheduleNow({
+          scheduleId: schedule.schedule_id,
+          triggeredBy: creator.user_id,
+        })
+      ).rejects.toMatchObject({ code: 'schedule_busy' });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  dbTest(
+    'allow_concurrent_runs=false does not treat a completed no-task history row as busy',
+    async ({ db }) => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+      try {
+        const { creator, schedule } = await seedRunnableSchedule(
+          db,
+          {
+            email: `scheduler-complete-history-${Math.random()}@example.com`,
+            name: 'Schedule creator',
+          },
+          { agentic_tool: 'claude-code' }
+        );
+        const sessions = new SessionRepository(db);
+        const historical = await sessions.create({
+          session_id: generateId(),
+          branch_id: schedule.branch_id,
+          created_by: creator.user_id,
+          agentic_tool: 'claude-code',
+          status: 'idle',
+          scheduled_from_branch: true,
+          scheduled_run_at: NOW - 60_000,
+          schedule_id: schedule.schedule_id,
+        });
+        await sessions.markScheduledInitializationComplete(historical.session_id);
+        const { app } = createSchedulerApp(db);
+
+        await expect(
+          new SchedulerService(db, app).executeScheduleNow({
+            scheduleId: schedule.schedule_id,
+            triggeredBy: creator.user_id,
+          })
+        ).resolves.toBeDefined();
+        expect(await sessions.findByScheduleId(schedule.schedule_id)).toHaveLength(2);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    }
+  );
+});
 
 describe('renderSchedulePrompt', () => {
   it('renders {{branch.*}} fields (canonical names)', () => {

--- a/apps/agor-daemon/src/services/scheduler.test.ts
+++ b/apps/agor-daemon/src/services/scheduler.test.ts
@@ -119,6 +119,7 @@ async function seedRunnableSchedule(
 
 function createSchedulerApp(db: SchedulerDb) {
   const sessions = new SessionRepository(db);
+  const workIdentity = { instanceId: 'test-daemon', bootId: 'test-boot' } as const;
   const sessionEvent = vi.fn();
   const removeSession = vi.fn(async (id: string) => {
     await sessions.delete(id);
@@ -133,6 +134,7 @@ function createSchedulerApp(db: SchedulerDb) {
       }) as Task
   );
   const app = {
+    get: (name: string) => (name === 'distributedWorkIdentity' ? workIdentity : undefined),
     service: (path: string) => {
       if (path === 'sessions') {
         return {
@@ -146,7 +148,7 @@ function createSchedulerApp(db: SchedulerDb) {
       throw new Error(`Unexpected service: ${path}`);
     },
   } as unknown as ConstructorParameters<typeof SchedulerService>[1];
-  return { app, prompt, removeSession, sessionEvent };
+  return { app, prompt, removeSession, sessionEvent, workIdentity };
 }
 
 describe('scheduler HA occurrence recovery', () => {
@@ -157,6 +159,21 @@ describe('scheduler HA occurrence recovery', () => {
     'afterRetention',
     'afterMetadata',
   ] as const;
+
+  dbTest('uses the application-owned diagnostic identity across consumers', async ({ db }) => {
+    const { app, workIdentity } = createSchedulerApp(db);
+    const first = new SchedulerService(db, app);
+    const second = new SchedulerService(db, app);
+    const readIdentity = (scheduler: SchedulerService) =>
+      (
+        scheduler as unknown as {
+          config: { workIdentity: typeof workIdentity };
+        }
+      ).config.workIdentity;
+
+    expect(readIdentity(first)).toBe(workIdentity);
+    expect(readIdentity(second)).toBe(workIdentity);
+  });
 
   for (const stage of killStages) {
     dbTest(`recovers a replacement scheduler killed at ${stage}`, async ({ db }) => {

--- a/apps/agor-daemon/src/services/scheduler.test.ts
+++ b/apps/agor-daemon/src/services/scheduler.test.ts
@@ -15,6 +15,7 @@ import {
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type { Branch, Schedule, Session, Task, UserID } from '@agor/core/types';
 import {
+  SessionStatus,
   TaskStatus,
   USER_DEFAULT_AGENTIC_CONFIGURATION,
   WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
@@ -117,7 +118,10 @@ async function seedRunnableSchedule(
 
 function createSchedulerApp(db: SchedulerDb) {
   const sessions = new SessionRepository(db);
-  const createSession = vi.fn((data: Partial<Session>, _params?: unknown) => sessions.create(data));
+  const sessionEvent = vi.fn();
+  const removeSession = vi.fn(async (id: string) => {
+    await sessions.delete(id);
+  });
   const prompt = vi.fn(
     async (data: { prompt: string; idempotencyTaskId: string }, params: any) =>
       ({
@@ -131,9 +135,9 @@ function createSchedulerApp(db: SchedulerDb) {
     service: (path: string) => {
       if (path === 'sessions') {
         return {
-          create: createSession,
+          emit: sessionEvent,
           patch: (id: string, data: Partial<Session>) => sessions.update(id, data),
-          remove: vi.fn(),
+          remove: removeSession,
         };
       }
       if (path === '/sessions/:id/prompt') return { create: prompt };
@@ -141,7 +145,7 @@ function createSchedulerApp(db: SchedulerDb) {
       throw new Error(`Unexpected service: ${path}`);
     },
   } as unknown as ConstructorParameters<typeof SchedulerService>[1];
-  return { app, createSession, prompt };
+  return { app, prompt, removeSession, sessionEvent };
 }
 
 describe('scheduler HA occurrence recovery', () => {
@@ -262,6 +266,68 @@ describe('scheduler HA occurrence recovery', () => {
     }
   });
 
+  dbTest('recovers an admitted occurrence after its schedule is deleted', async ({ db }) => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    try {
+      const { creator, schedule } = await seedRunnableSchedule(
+        db,
+        {
+          email: `scheduler-deleted-recovery-${Math.random()}@example.com`,
+          name: 'Schedule creator',
+        },
+        { agentic_tool: 'claude-code' }
+      );
+      const initialTaskId = generateId();
+      const session = await new SessionRepository(db).create({
+        session_id: generateId(),
+        branch_id: schedule.branch_id,
+        created_by: creator.user_id,
+        agentic_tool: 'claude-code',
+        status: 'idle',
+        scheduled_from_branch: true,
+        scheduled_run_at: NOW,
+        schedule_id: schedule.schedule_id,
+        custom_context: {
+          scheduled_run: {
+            rendered_prompt: 'prompt preserved before schedule deletion',
+            run_index: 1,
+            initial_task_id: initialTaskId,
+            schedule_config_snapshot: {
+              schedule_id: schedule.schedule_id,
+              cron: schedule.cron_expression,
+              timezone: 'UTC',
+              retention: schedule.retention,
+              allow_concurrent_runs: schedule.allow_concurrent_runs,
+              mcp_server_ids: [],
+            },
+          },
+        },
+      });
+      await new ScheduleRepository(db).delete(schedule.schedule_id);
+
+      expect((await new SessionRepository(db).findById(session.session_id))?.schedule_id).toBe(
+        undefined
+      );
+      const { app, prompt } = createSchedulerApp(db);
+      await (
+        new SchedulerService(db, app, { tenantId: 'default' }) as unknown as {
+          tick(): Promise<unknown>;
+        }
+      ).tick();
+
+      expect(prompt).toHaveBeenCalledOnce();
+      expect(prompt.mock.calls[0][0]).toMatchObject({
+        prompt: 'prompt preserved before schedule deletion',
+        idempotencyTaskId: initialTaskId,
+      });
+      expect(
+        await new SessionRepository(db).isScheduledInitializationComplete(session.session_id)
+      ).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   dbTest('five concurrent scheduler instances create one occurrence', async ({ db }) => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
     try {
@@ -273,7 +339,7 @@ describe('scheduler HA occurrence recovery', () => {
         },
         { agentic_tool: 'claude-code' }
       );
-      const { app, prompt } = createSchedulerApp(db);
+      const { app, prompt, sessionEvent } = createSchedulerApp(db);
       const schedulers = Array.from(
         { length: 5 },
         (_, index) =>
@@ -296,6 +362,7 @@ describe('scheduler HA occurrence recovery', () => {
         1
       );
       expect(new Set(prompt.mock.calls.map((call) => call[0].idempotencyTaskId)).size).toBe(1);
+      expect(sessionEvent.mock.calls.filter(([event]) => event === 'created')).toHaveLength(1);
     } finally {
       nowSpy.mockRestore();
     }
@@ -410,6 +477,58 @@ describe('scheduler HA occurrence recovery', () => {
       }
     }
   );
+
+  dbTest('retention defers active overflow occurrences until they are terminal', async ({ db }) => {
+    const { creator, schedule: createdSchedule } = await seedRunnableSchedule(
+      db,
+      {
+        email: `scheduler-retention-active-${Math.random()}@example.com`,
+        name: 'Schedule creator',
+      },
+      { agentic_tool: 'claude-code' }
+    );
+    const schedule = await new ScheduleRepository(db).update(createdSchedule.schedule_id, {
+      retention: 1,
+    });
+    const sessions = new SessionRepository(db);
+    const olderActive = await sessions.create({
+      session_id: generateId(),
+      branch_id: schedule.branch_id,
+      created_by: creator.user_id,
+      agentic_tool: 'claude-code',
+      status: SessionStatus.RUNNING,
+      scheduled_from_branch: true,
+      scheduled_run_at: NOW - 60_000,
+      schedule_id: schedule.schedule_id,
+    });
+    const newest = await sessions.create({
+      session_id: generateId(),
+      branch_id: schedule.branch_id,
+      created_by: creator.user_id,
+      agentic_tool: 'claude-code',
+      status: SessionStatus.COMPLETED,
+      scheduled_from_branch: true,
+      scheduled_run_at: NOW,
+      schedule_id: schedule.schedule_id,
+    });
+    await sessions.markScheduledInitializationComplete(olderActive.session_id);
+    await sessions.markScheduledInitializationComplete(newest.session_id);
+    const { app, removeSession } = createSchedulerApp(db);
+    const scheduler = new SchedulerService(db, app);
+
+    await (
+      scheduler as unknown as { enforceRetentionPolicy(schedule: Schedule): Promise<void> }
+    ).enforceRetentionPolicy(schedule);
+    expect(removeSession).not.toHaveBeenCalled();
+    expect(await sessions.findById(olderActive.session_id)).not.toBeNull();
+
+    await sessions.update(olderActive.session_id, { status: SessionStatus.COMPLETED });
+    await (
+      scheduler as unknown as { enforceRetentionPolicy(schedule: Schedule): Promise<void> }
+    ).enforceRetentionPolicy(schedule);
+    expect(removeSession).toHaveBeenCalledWith(olderActive.session_id, { provider: undefined });
+    expect(await sessions.findById(olderActive.session_id)).toBeNull();
+  });
 });
 
 describe('renderSchedulePrompt', () => {
@@ -631,7 +750,7 @@ describe('materializeScheduleAgenticToolConfig', () => {
         configuration_reference: USER_DEFAULT_AGENTIC_CONFIGURATION,
       }
     );
-    const { app, createSession, prompt } = createSchedulerApp(db);
+    const { app, prompt } = createSchedulerApp(db);
     const scheduler = new SchedulerService(db, app);
 
     await scheduler.executeScheduleNow({
@@ -639,14 +758,13 @@ describe('materializeScheduleAgenticToolConfig', () => {
       triggeredBy: creator.user_id,
     });
 
-    expect(createSession).toHaveBeenCalledOnce();
-    expect(createSession.mock.calls[0][0]).toMatchObject({
+    const [created] = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
+    expect(created).toMatchObject({
       created_by: creator.user_id,
       agentic_tool: 'codex',
       agentic_tool_preset_id: undefined,
       model_config: { mode: 'exact', model: 'gpt-5.4' },
     });
-    expect(createSession.mock.calls[0][1]).toEqual({ _agenticConfigResolved: true });
     expect(prompt).toHaveBeenCalledOnce();
   });
 
@@ -683,15 +801,14 @@ describe('materializeScheduleAgenticToolConfig', () => {
           codex: { source: 'preset', preset_id: preset.preset_id },
         },
       });
-      const { app, createSession, prompt } = createSchedulerApp(db);
+      const { app, prompt } = createSchedulerApp(db);
 
       await new SchedulerService(db, app).executeScheduleNow({
         scheduleId: schedule.schedule_id,
         triggeredBy: creator.user_id,
       });
 
-      expect(createSession).toHaveBeenCalledOnce();
-      const created = createSession.mock.calls[0][0];
+      const [created] = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
       expect({
         agentic_tool_preset_id: created.agentic_tool_preset_id,
         permission_config: created.permission_config,
@@ -712,7 +829,6 @@ describe('materializeScheduleAgenticToolConfig', () => {
           updated_at: expect.any(String),
         },
       });
-      expect(createSession.mock.calls[0][1]).toEqual({ _agenticConfigResolved: true });
       expect(prompt).toHaveBeenCalledOnce();
     }
   );
@@ -738,7 +854,7 @@ describe('materializeScheduleAgenticToolConfig', () => {
         configuration_reference: USER_DEFAULT_AGENTIC_CONFIGURATION,
       }
     );
-    const { app, createSession } = createSchedulerApp(db);
+    const { app } = createSchedulerApp(db);
     const expected = resolveSessionDefaults({ agenticTool: 'codex', user: null });
 
     await new SchedulerService(db, app).executeScheduleNow({
@@ -746,14 +862,15 @@ describe('materializeScheduleAgenticToolConfig', () => {
       triggeredBy: creator.user_id,
     });
 
-    expect(createSession.mock.calls[0][0]).toMatchObject({
+    const [created] = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
+    expect(created).toMatchObject({
       permission_config: expected.permission_config,
       model_config: {
         ...expected.model_config,
         updated_at: expect.any(String),
       },
     });
-    expect(createSession.mock.calls[0][0].model_config?.model).not.toBe('stale-user-model');
+    expect(created.model_config?.model).not.toBe('stale-user-model');
   });
 
   dbTest(
@@ -771,14 +888,14 @@ describe('materializeScheduleAgenticToolConfig', () => {
           model_config: { mode: 'exact', model: 'gpt-5.4' },
         }
       );
-      const { app, createSession, prompt } = createSchedulerApp(db);
+      const { app, prompt } = createSchedulerApp(db);
 
       await new SchedulerService(db, app).executeScheduleNow({
         scheduleId: schedule.schedule_id,
         triggeredBy: creator.user_id,
       });
-      expect(createSession).toHaveBeenCalledOnce();
-      expect(createSession.mock.calls[0][0].model_config?.model).not.toBe('gpt-5.4');
+      const [created] = await new SessionRepository(db).findByScheduleId(schedule.schedule_id);
+      expect(created.model_config?.model).not.toBe('gpt-5.4');
       expect(prompt).toHaveBeenCalledOnce();
     }
   );
@@ -794,7 +911,7 @@ describe('materializeScheduleAgenticToolConfig', () => {
         },
         { agentic_tool: 'claude-code-cli' }
       );
-      const { app, createSession, prompt } = createSchedulerApp(db);
+      const { app, prompt } = createSchedulerApp(db);
 
       const run = new SchedulerService(db, app).executeScheduleNow({
         scheduleId: schedule.schedule_id,
@@ -805,7 +922,9 @@ describe('materializeScheduleAgenticToolConfig', () => {
         name: 'ScheduleNotReadyError',
         code: 'schedule_agentic_tool_removed',
       } satisfies Partial<ScheduleNotReadyError>);
-      expect(createSession).not.toHaveBeenCalled();
+      expect(await new SessionRepository(db).findByScheduleId(schedule.schedule_id)).toHaveLength(
+        0
+      );
       expect(prompt).not.toHaveBeenCalled();
     }
   );
@@ -821,7 +940,7 @@ describe('materializeScheduleAgenticToolConfig', () => {
         },
         { agentic_tool: 'claude-code-cli' }
       );
-      const { app, createSession, prompt } = createSchedulerApp(db);
+      const { app, prompt } = createSchedulerApp(db);
       const scheduler = new SchedulerService(db, app);
       const cronNow = NOW + 30_000;
 
@@ -840,7 +959,9 @@ describe('materializeScheduleAgenticToolConfig', () => {
       expect(updated?.next_run_at).toBeGreaterThan(cronNow);
       expect(updated?.last_run_at).toBeUndefined();
       expect(updated?.last_run_session_id).toBeUndefined();
-      expect(createSession).not.toHaveBeenCalled();
+      expect(await new SessionRepository(db).findByScheduleId(schedule.schedule_id)).toHaveLength(
+        0
+      );
       expect(prompt).not.toHaveBeenCalled();
     }
   );

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -63,8 +63,6 @@ import {
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
-  sanitizeDbError,
-  shortId,
   TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
@@ -78,15 +76,19 @@ import type {
   Session,
   SessionID,
   Task,
+  TaskID,
   TenantID,
   User,
   UUID,
 } from '@agor/core/types';
 import {
+  EXECUTING_SESSION_STATUSES,
   isAgenticToolName,
+  isSessionExecuting,
   isTaskPendingDispatch,
+  isTerminalTaskStatus,
+  NONTERMINAL_TASK_STATUSES,
   SessionStatus,
-  TaskStatus,
 } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import {
@@ -104,28 +106,28 @@ import {
 import { buildSessionCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 
-/**
- * Session statuses that count as "actively consuming the branch" for
- * the scheduler's concurrency guard. Owned by the scheduler (not the
- * SessionRepository) because the definition of "busy" is a scheduler-
- * policy decision, not a generic session-store fact.
- */
-const ACTIVE_SESSION_STATUSES: ReadonlyArray<SessionStatus> = [
-  SessionStatus.RUNNING,
-  SessionStatus.STOPPING,
-  SessionStatus.AWAITING_PERMISSION,
-  SessionStatus.AWAITING_INPUT,
-];
+type SchedulerWorkLogLevel = 'info' | 'warn' | 'error';
+type SchedulerWorkLogValue = string | number | boolean | null | undefined;
 
-const ACTIVE_TASK_STATUSES: ReadonlyArray<Task['status']> = [
-  TaskStatus.CREATED,
-  TaskStatus.QUEUED,
-  TaskStatus.DISPATCHING,
-  TaskStatus.RUNNING,
-  TaskStatus.STOPPING,
-  TaskStatus.AWAITING_PERMISSION,
-  TaskStatus.AWAITING_INPUT,
-];
+function formatWorkLogValue(value: Exclude<SchedulerWorkLogValue, undefined>): string {
+  return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
+/** Extract only a bounded, non-payload error category for shared logs. */
+function schedulerErrorCode(error: unknown): string {
+  let current = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current && !seen.has(current); depth += 1) {
+    seen.add(current);
+    if (typeof current !== 'object') break;
+    const record = current as { code?: unknown; cause?: unknown };
+    if (typeof record.code === 'string' && /^[A-Za-z0-9_]{1,64}$/.test(record.code)) {
+      return record.code;
+    }
+    current = record.cause;
+  }
+  return 'operation_failed';
+}
 
 /**
  * Best-effort detection of the partial-unique-index conflict raised by
@@ -197,7 +199,7 @@ export function renderSchedulePrompt(
     };
     return compiledTemplate(context);
   } catch {
-    console.error(`❌ Failed to render prompt template`);
+    console.warn('[scheduler.render] event=template_failed outcome=raw_template_fallback');
     return template;
   }
 }
@@ -271,15 +273,13 @@ export interface SchedulerConfig {
   tickInterval?: number;
   /** Grace period for missed runs in milliseconds (default: 120000 = 2min) */
   gracePeriod?: number;
-  /** Enable debug logging (default: false) */
-  debug?: boolean;
   /** Unix user mode for validation (default: 'simple') */
   unixUserMode?: UnixUserMode;
   /** Static/single-tenant id used for request-less cron ticks. Undefined means discover due schedule tenants from schedule rows. */
   tenantId?: TenantID | string;
   /** Maximum due schedules read per scan (default: 25). */
   scanBatchSize?: number;
-  /** Maximum idle delay before another scan (default: 60000). */
+  /** Pre-jitter cap for idle scan backoff (default: 60000; default worst case: 72000). */
   maxIdleInterval?: number;
   /** Symmetric scan-delay jitter ratio (default: 0.2). */
   jitterRatio?: number;
@@ -302,7 +302,6 @@ export interface SchedulerTestHooks {
 interface ResolvedSchedulerConfig {
   tickInterval: number;
   gracePeriod: number;
-  debug: boolean;
   unixUserMode: UnixUserMode;
   tenantId?: TenantID | string;
   scanBatchSize: number;
@@ -348,7 +347,6 @@ export class SchedulerService {
     this.config = {
       tickInterval: config.tickInterval ?? 30000, // 30 seconds
       gracePeriod: config.gracePeriod ?? 120000, // 2 minutes
-      debug: config.debug ?? false,
       unixUserMode: config.unixUserMode ?? 'simple',
       tenantId:
         typeof config.tenantId === 'string' && config.tenantId.trim()
@@ -390,40 +388,61 @@ export class SchedulerService {
     return runWithTenantDatabaseScope(this.db, getCurrentTenantId(), work);
   }
 
+  private logWorkEvent(
+    level: SchedulerWorkLogLevel,
+    event: string,
+    fields: Record<string, SchedulerWorkLogValue> = {}
+  ): void {
+    const allFields: Record<string, SchedulerWorkLogValue> = {
+      event,
+      instance_id: this.config.workIdentity.instanceId,
+      boot_id: this.config.workIdentity.bootId,
+      tenant_id: getCurrentTenantId(),
+      ...fields,
+    };
+    const details = Object.entries(allFields)
+      .filter(
+        (entry): entry is [string, Exclude<SchedulerWorkLogValue, undefined>] =>
+          entry[1] !== undefined
+      )
+      .map(([key, value]) => `${key}=${formatWorkLogValue(value)}`)
+      .join(' ');
+    const message = `[distributed-work.scheduler] ${details}`;
+    if (level === 'error') console.error(message);
+    else if (level === 'warn') console.warn(message);
+    else console.info(message);
+  }
+
   /**
    * Start the scheduler tick loop
    */
   start(): void {
-    if (this.isRunning) {
-      console.warn('⚠️  Scheduler already running');
-      return;
-    }
-
-    if (this.config.debug) {
-      console.log(`🔄 Starting scheduler (tick interval: ${this.config.tickInterval}ms)`);
-    }
+    if (this.isRunning) return;
     this.isRunning = true;
 
     const initialDelay = initialWorkOffset(this.config.tickInterval, this.config.random());
     this.scheduleNextTick(initialDelay);
+    this.logWorkEvent('info', 'loop_started', {
+      tick_interval_ms: this.config.tickInterval,
+      scan_batch_size: this.config.scanBatchSize,
+      idle_backoff_cap_ms: this.config.maxIdleInterval,
+      jitter_ratio: this.config.jitterRatio,
+      initial_delay_ms: initialDelay,
+    });
   }
 
   /**
    * Stop the scheduler tick loop
    */
   stop(): void {
-    if (!this.isRunning) {
-      console.warn('⚠️  Scheduler not running');
-      return;
-    }
-
-    console.log('🛑 Scheduler stopped');
+    if (!this.isRunning) return;
     this.isRunning = false;
 
     if (this.timerHandle) {
       clearTimeout(this.timerHandle);
       this.timerHandle = undefined;
     }
+    this.logWorkEvent('info', 'loop_stopped');
   }
 
   private scheduleNextTick(delayMs: number): void {
@@ -439,7 +458,9 @@ export class SchedulerService {
       try {
         stats = await this.tick();
       } catch (error) {
-        console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
+        this.logWorkEvent('error', 'scan_failed', {
+          error_code: schedulerErrorCode(error),
+        });
       }
       if (!this.isRunning) return;
       this.idleRounds = stats.candidates === 0 ? this.idleRounds + 1 : 0;
@@ -478,80 +499,76 @@ export class SchedulerService {
       failures: 0,
     };
 
-    try {
-      const recoveryRefs = await this.findIncompleteSessionRefs();
-      const dueScheduleRefs = await this.findDueScheduleRefs(now);
-      stats.recoveryCandidates = recoveryRefs.length;
-      stats.dueCandidates = dueScheduleRefs.length;
-      stats.candidates = recoveryRefs.length + dueScheduleRefs.length;
+    const recoveryRefs = await this.findIncompleteSessionRefs();
+    const dueScheduleRefs = await this.findDueScheduleRefs(now);
+    stats.recoveryCandidates = recoveryRefs.length;
+    stats.dueCandidates = dueScheduleRefs.length;
+    stats.candidates = recoveryRefs.length + dueScheduleRefs.length;
 
-      if (this.config.debug) {
-        console.log(
-          `🔄 Scheduler tick: Found ${recoveryRefs.length} recoveries and ${dueScheduleRefs.length} due schedules`
+    for (const ref of recoveryRefs) {
+      if (!ref.tenantId) {
+        stats.failures += 1;
+        this.logWorkEvent('error', 'recovery_missing_tenant', {
+          session_id: ref.sessionId,
+        });
+        continue;
+      }
+      try {
+        await runWithTenantContext(ref.tenantId, () =>
+          this.recoverIncompleteSession(ref.sessionId, ref.scheduledRunAt, now)
         );
+        stats.processed += 1;
+      } catch (error) {
+        stats.failures += 1;
+        this.logWorkEvent('error', 'recovery_failed', {
+          tenant_id: ref.tenantId,
+          session_id: ref.sessionId,
+          error_code: schedulerErrorCode(error),
+        });
       }
-
-      for (const ref of recoveryRefs) {
-        if (!ref.tenantId) {
-          stats.failures += 1;
-          console.error(`❌ Skipping scheduler recovery ${shortId(ref.sessionId)}: missing tenant`);
-          continue;
-        }
-        try {
-          await runWithTenantContext(ref.tenantId, () =>
-            this.recoverIncompleteSession(ref.sessionId, ref.scheduledRunAt, now)
-          );
-          stats.processed += 1;
-        } catch (error) {
-          stats.failures += 1;
-          console.error(
-            `❌ Failed to recover scheduled session ${shortId(ref.sessionId)}:`,
-            sanitizeDbError(error)
-          );
-        }
-      }
-
-      for (const ref of dueScheduleRefs) {
-        if (!ref.tenantId) {
-          console.error(
-            `❌ Skipping due schedule ${shortId(ref.scheduleId)}: missing tenant metadata`
-          );
-          continue;
-        }
-
-        try {
-          await runWithTenantContext(ref.tenantId, async () => {
-            // Re-load inside the tenant scope before reading schedule content or
-            // spawning work. The system discovery phase only supplies routing
-            // metadata.
-            const schedule = await this.withTenantDatabase(() =>
-              this.scheduleRepo.findById(ref.scheduleId)
-            );
-            if (!schedule) return;
-            await this.processSchedule(schedule, now);
-            stats.processed += 1;
-          });
-        } catch (error) {
-          stats.failures += 1;
-          console.error(
-            `❌ Failed to process schedule ${shortId(ref.scheduleId)}:`,
-            sanitizeDbError(error)
-          );
-          // Continue processing other schedules
-        }
-      }
-      console.info('[DistributedWork]', {
-        component: 'scheduler',
-        event: 'scan_complete',
-        instance_id: this.config.workIdentity.instanceId,
-        boot_id: this.config.workIdentity.bootId,
-        ...stats,
-      });
-      return stats;
-    } catch (error) {
-      console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
-      throw error;
     }
+
+    for (const ref of dueScheduleRefs) {
+      if (!ref.tenantId) {
+        stats.failures += 1;
+        this.logWorkEvent('error', 'schedule_missing_tenant', {
+          schedule_id: ref.scheduleId,
+        });
+        continue;
+      }
+
+      try {
+        await runWithTenantContext(ref.tenantId, async () => {
+          // Re-load inside the tenant scope before reading schedule content or
+          // spawning work. The system discovery phase only supplies routing
+          // metadata.
+          const schedule = await this.withTenantDatabase(() =>
+            this.scheduleRepo.findById(ref.scheduleId)
+          );
+          if (!schedule) return;
+          await this.processSchedule(schedule, now);
+          stats.processed += 1;
+        });
+      } catch (error) {
+        stats.failures += 1;
+        this.logWorkEvent('error', 'schedule_processing_failed', {
+          tenant_id: ref.tenantId,
+          schedule_id: ref.scheduleId,
+          error_code: schedulerErrorCode(error),
+        });
+        // Continue processing other schedules
+      }
+    }
+    if (stats.candidates > 0 || stats.failures > 0) {
+      this.logWorkEvent(stats.failures > 0 ? 'warn' : 'info', 'scan_complete', {
+        candidates: stats.candidates,
+        recovery_candidates: stats.recoveryCandidates,
+        due_candidates: stats.dueCandidates,
+        processed: stats.processed,
+        failures: stats.failures,
+      });
+    }
+    return stats;
   }
 
   private async findIncompleteSessionRefs(): Promise<
@@ -666,25 +683,16 @@ export class SchedulerService {
       if (schedule.next_run_at == null || schedule.next_run_at <= now) {
         await this.withTenantDatabase(() =>
           this.scheduleRepo.update(schedule.schedule_id, { next_run_at: nextRunAt })
-        ).catch((err) =>
-          console.error(
-            `Failed to advance next_run_at for ${schedule.schedule_id}:`,
-            sanitizeDbError(err)
-          )
-        );
-      }
-      if (this.config.debug) {
-        const timeUntilNext = nextRunAt - now;
-        console.log(
-          `   ⏱️  ${schedule.name}: Not due yet (next run in ${Math.round(timeUntilNext / 1000)}s)`
-        );
+        ).catch((error) => {
+          this.logWorkEvent('error', 'cursor_advance_failed', {
+            schedule_id: schedule.schedule_id,
+            error_code: schedulerErrorCode(error),
+          });
+        });
       }
       return;
     }
 
-    console.log(
-      `   🕒 Scheduler due: "${schedule.name}" scheduled_at=${new Date(scheduledRunAt).toISOString()} — spawning session`
-    );
     await this.spawnScheduledSession(schedule, scheduledRunAt, now, { source: 'cron' });
   }
 
@@ -725,10 +733,6 @@ export class SchedulerService {
     // collisions within the same minute) dedupe via scheduled_run_at.
     const scheduledRunAt = roundToMinute(new Date(now)).getTime();
 
-    console.log(
-      `   🖐️  ${schedule.name}: manual execute-now triggered by ${triggeredBy.substring(0, 8)}`
-    );
-
     const session = await this.spawnScheduledSession(schedule, scheduledRunAt, now, {
       source: 'manual',
       triggeredBy,
@@ -765,12 +769,6 @@ export class SchedulerService {
     );
 
     if (!creator) {
-      console.error(`      ❌ Cannot spawn scheduled session: Schedule creator not found`, {
-        schedule_id: schedule.schedule_id,
-        schedule_name: schedule.name,
-        created_by: schedule.created_by,
-        unix_user_mode: this.config.unixUserMode,
-      });
       throw new Error(
         `Schedule creator ${schedule.created_by} not found. Cannot spawn scheduled session.`
       );
@@ -779,16 +777,6 @@ export class SchedulerService {
     const unixUsername = creator.unix_username || null;
 
     if (!unixUsername && unixUserModeRequiresUsername(this.config.unixUserMode)) {
-      console.error(
-        `      ❌ Cannot spawn scheduled session: Creator has no unix_username (${this.config.unixUserMode} mode)`,
-        {
-          schedule_id: schedule.schedule_id,
-          schedule_name: schedule.name,
-          created_by: schedule.created_by,
-          creator_email: creator.email,
-          unix_user_mode: this.config.unixUserMode,
-        }
-      );
       throw new Error(
         `Schedule creator ${creator.email} has no unix_username set. Cannot spawn scheduled session in ${this.config.unixUserMode} Unix user mode.`
       );
@@ -878,7 +866,7 @@ export class SchedulerService {
           ? branch.mcp_server_ids
           : [];
     const candidateSessionId = generateId() as SessionID;
-    const candidateTaskId = generateId() as import('@agor/core/types').TaskID;
+    const candidateTaskId = generateId() as TaskID;
 
     type Admission =
       | { outcome: 'created' | 'existing'; session: Session }
@@ -901,8 +889,8 @@ export class SchedulerService {
           !schedule.allow_concurrent_runs &&
           (await this.sessionRepo.existsActiveOrInitializingInSchedule(
             schedule.schedule_id,
-            ACTIVE_SESSION_STATUSES,
-            ACTIVE_TASK_STATUSES
+            EXECUTING_SESSION_STATUSES,
+            NONTERMINAL_TASK_STATUSES
           ))
         ) {
           return { outcome: 'busy', session: null } as const;
@@ -978,12 +966,7 @@ export class SchedulerService {
     }
 
     if (admission.outcome === 'busy') {
-      console.info('[DistributedWork]', {
-        component: 'scheduler',
-        event: 'occurrence_skipped_busy',
-        instance_id: this.config.workIdentity.instanceId,
-        boot_id: this.config.workIdentity.bootId,
-        tenant_id: getCurrentTenantId(),
+      this.logWorkEvent('info', 'occurrence_skipped_busy', {
         schedule_id: schedule.schedule_id,
         scheduled_run_at: scheduledRunAt,
         source,
@@ -994,17 +977,16 @@ export class SchedulerService {
     }
 
     const recovering = admission.outcome === 'existing';
-    console.info('[DistributedWork]', {
-      component: 'scheduler',
-      event: recovering ? 'occurrence_claim_lost_reconciling' : 'occurrence_claim_won',
-      instance_id: this.config.workIdentity.instanceId,
-      boot_id: this.config.workIdentity.bootId,
-      tenant_id: getCurrentTenantId(),
-      schedule_id: schedule.schedule_id,
-      session_id: admission.session.session_id,
-      scheduled_run_at: scheduledRunAt,
-      source,
-    });
+    this.logWorkEvent(
+      'info',
+      recovering ? 'occurrence_claim_lost_reconciling' : 'occurrence_claim_won',
+      {
+        schedule_id: schedule.schedule_id,
+        session_id: admission.session.session_id,
+        scheduled_run_at: scheduledRunAt,
+        source,
+      }
+    );
     if (
       recovering &&
       (await this.withTenantDatabase(() =>
@@ -1141,12 +1123,7 @@ export class SchedulerService {
   }
 
   private logDeletedScheduleRecovery(scheduleId: ScheduleID, sessionId: SessionID): void {
-    console.info('[DistributedWork]', {
-      component: 'scheduler',
-      event: 'occurrence_recovered_after_schedule_delete',
-      instance_id: this.config.workIdentity.instanceId,
-      boot_id: this.config.workIdentity.bootId,
-      tenant_id: getCurrentTenantId(),
+    this.logWorkEvent('info', 'occurrence_recovered_after_schedule_delete', {
       schedule_id: scheduleId,
       session_id: sessionId,
     });
@@ -1224,12 +1201,7 @@ export class SchedulerService {
         // schedule configuration and initialization. Transient database
         // failures must escape so this occurrence remains recoverable.
         if (!(error instanceof EntityNotFoundError)) throw error;
-        console.warn('[DistributedWork]', {
-          component: 'scheduler',
-          event: 'mcp_attachment_missing',
-          instance_id: this.config.workIdentity.instanceId,
-          boot_id: this.config.workIdentity.bootId,
-          tenant_id: getCurrentTenantId(),
+        this.logWorkEvent('warn', 'mcp_attachment_missing', {
           schedule_id: scheduleId,
           session_id: session.session_id,
           mcp_server_id: serverId,
@@ -1255,17 +1227,16 @@ export class SchedulerService {
     )) as Task;
     await this.config.testHooks?.afterPromptDispatch?.(task);
 
-    console.info('[DistributedWork]', {
-      component: 'scheduler',
-      event: input.recovering ? 'occurrence_recovered' : 'occurrence_initialized',
-      instance_id: this.config.workIdentity.instanceId,
-      boot_id: this.config.workIdentity.bootId,
-      tenant_id: tenantId,
-      schedule_id: scheduleId,
-      session_id: session.session_id,
-      task_id: task.task_id,
-      task_status: task.status,
-    });
+    this.logWorkEvent(
+      'info',
+      input.recovering ? 'occurrence_recovered' : 'occurrence_initialized',
+      {
+        schedule_id: scheduleId,
+        session_id: session.session_id,
+        task_id: task.task_id,
+        task_status: task.status,
+      }
+    );
     return task;
   }
 
@@ -1302,7 +1273,6 @@ export class SchedulerService {
           attempt + 1
         );
       }
-      console.error(`      ❌ Failed to update schedule metadata:`, sanitizeDbError(error));
       throw error;
     }
   }
@@ -1340,6 +1310,7 @@ export class SchedulerService {
     );
     const overflow = mine.slice(schedule.retention);
     const sessionsToDelete: Session[] = [];
+    let activeSkipped = 0;
     for (const session of overflow) {
       const initializationComplete = await this.withTenantDatabase(() =>
         this.sessionRepo.isScheduledInitializationComplete(session.session_id)
@@ -1348,23 +1319,22 @@ export class SchedulerService {
         this.taskRepo.findBySession(session.session_id)
       );
       const active =
-        ACTIVE_SESSION_STATUSES.includes(session.status) ||
+        isSessionExecuting(session) ||
         !initializationComplete ||
-        sessionTasks.some((task) => ACTIVE_TASK_STATUSES.includes(task.status));
+        sessionTasks.some((task) => !isTerminalTaskStatus(task.status));
       if (active) {
-        console.info('[DistributedWork]', {
-          component: 'scheduler',
-          event: 'retention_skipped_active_occurrence',
-          instance_id: this.config.workIdentity.instanceId,
-          boot_id: this.config.workIdentity.bootId,
-          tenant_id: getCurrentTenantId(),
-          schedule_id: schedule.schedule_id,
-          session_id: session.session_id,
-          session_status: session.status,
-        });
+        activeSkipped += 1;
         continue;
       }
       sessionsToDelete.push(session);
+    }
+
+    if (activeSkipped > 0) {
+      this.logWorkEvent('info', 'retention_deferred', {
+        schedule_id: schedule.schedule_id,
+        skipped_active_count: activeSkipped,
+        retention: schedule.retention,
+      });
     }
 
     if (sessionsToDelete.length > 0) {
@@ -1383,9 +1353,11 @@ export class SchedulerService {
         }
       }
 
-      console.log(
-        `      🗑️  Deleted ${sessionsToDelete.length} old sessions on schedule ${schedule.name} (retention: ${schedule.retention})`
-      );
+      this.logWorkEvent('info', 'retention_deleted', {
+        schedule_id: schedule.schedule_id,
+        deleted_count: sessionsToDelete.length,
+        retention: schedule.retention,
+      });
     }
   }
 }

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -15,10 +15,11 @@
  * - Enforces retention policy per-schedule (deletes oldest scheduled
  *   sessions linked via `sessions.schedule_id`)
  *
- * Multi-daemon dedup is enforced by the partial unique index
- * `sessions_schedule_run_unique`. We deliberately do not hold an advisory
- * transaction while spawning an agent: external work must never extend a
- * tenant DB transaction or monopolize a pooled connection.
+ * Multi-daemon occurrence ownership is enforced by the tenant-aware partial
+ * unique index `sessions_schedule_run_unique`. A short schedule-row lock
+ * serializes admission/concurrency checks. MCP attachment and initial Task
+ * dispatch are reconciled after commit using stable identities and atomic
+ * expected-state transitions; no transaction spans rendering or launching.
  *
  * **Smart Recovery:**
  * - If scheduler is down for an extended period, only schedules LATEST
@@ -43,9 +44,16 @@ import {
   normalizePersistedScheduleAgenticToolConfig,
   unixUserModeRequiresUsername,
 } from '@agor/core/config';
+import {
+  boundedBackoffDelay,
+  type DistributedWorkIdentity,
+  initialWorkOffset,
+} from '@agor/core/coordination';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
   BranchRepository,
+  EntityNotFoundError,
+  generateId,
   getCurrentTenantId,
   runWithSystemDatabaseScope,
   runWithTenantContext,
@@ -55,6 +63,7 @@ import {
   SessionRepository,
   sanitizeDbError,
   shortId,
+  TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
 import { Forbidden } from '@agor/core/feathers';
@@ -66,11 +75,12 @@ import type {
   ScheduleID,
   Session,
   SessionID,
+  Task,
   TenantID,
   User,
   UUID,
 } from '@agor/core/types';
-import { isAgenticToolName, SessionStatus } from '@agor/core/types';
+import { isAgenticToolName, SessionStatus, TaskStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import {
   getNextRunTime,
@@ -100,6 +110,16 @@ const ACTIVE_SESSION_STATUSES: ReadonlyArray<SessionStatus> = [
   SessionStatus.AWAITING_INPUT,
 ];
 
+const ACTIVE_TASK_STATUSES: ReadonlyArray<Task['status']> = [
+  TaskStatus.CREATED,
+  TaskStatus.QUEUED,
+  TaskStatus.DISPATCHING,
+  TaskStatus.RUNNING,
+  TaskStatus.STOPPING,
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.AWAITING_INPUT,
+];
+
 /**
  * Best-effort detection of the partial-unique-index conflict raised by
  * `sessions_schedule_run_unique` when a concurrent spawn races past
@@ -110,12 +130,20 @@ const ACTIVE_SESSION_STATUSES: ReadonlyArray<SessionStatus> = [
  */
 function isUniqueConstraintError(err: unknown): boolean {
   if (!err) return false;
-  const e = err as { code?: string; cause?: { code?: string }; message?: string };
-  const code = e.code ?? e.cause?.code ?? '';
+  const e = err as { code?: string; cause?: unknown; message?: string };
+  const code = e.code ?? '';
   if (code === '23505') return true; // postgres
   if (code.startsWith('SQLITE_CONSTRAINT')) return true; // libsql / sqlite
   const msg = (e.message ?? '').toLowerCase();
-  return msg.includes('unique constraint') || msg.includes('sqlite_constraint_unique');
+  if (msg.includes('unique constraint') || msg.includes('sqlite_constraint_unique')) return true;
+  return e.cause !== err && isUniqueConstraintError(e.cause);
+}
+
+function isSQLiteBusyError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as { code?: string; cause?: unknown; message?: string };
+  if (e.code === 'SQLITE_BUSY' || (e.message ?? '').includes('database is locked')) return true;
+  return e.cause !== err && isSQLiteBusyError(e.cause);
 }
 
 /**
@@ -242,19 +270,64 @@ export interface SchedulerConfig {
   unixUserMode?: UnixUserMode;
   /** Static/single-tenant id used for request-less cron ticks. Undefined means discover due schedule tenants from schedule rows. */
   tenantId?: TenantID | string;
+  /** Maximum due schedules read per scan (default: 25). */
+  scanBatchSize?: number;
+  /** Maximum idle delay before another scan (default: 60000). */
+  maxIdleInterval?: number;
+  /** Symmetric scan-delay jitter ratio (default: 0.2). */
+  jitterRatio?: number;
+  /** Injected for deterministic tests. */
+  random?: () => number;
+  /** Diagnostic daemon instance/process identity. */
+  workIdentity?: DistributedWorkIdentity;
+  /** Deterministic crash injection used only by kill-point tests. */
+  testHooks?: SchedulerTestHooks;
+}
+
+export interface SchedulerTestHooks {
+  afterSessionAdmission?(session: Session): Promise<void> | void;
+  afterMcpAttachments?(session: Session): Promise<void> | void;
+  afterPromptDispatch?(task: Task): Promise<void> | void;
+  afterRetention?(session: Session): Promise<void> | void;
+  afterMetadata?(session: Session): Promise<void> | void;
+}
+
+interface ResolvedSchedulerConfig {
+  tickInterval: number;
+  gracePeriod: number;
+  debug: boolean;
+  unixUserMode: UnixUserMode;
+  tenantId?: TenantID | string;
+  scanBatchSize: number;
+  maxIdleInterval: number;
+  jitterRatio: number;
+  random: () => number;
+  workIdentity: DistributedWorkIdentity;
+  testHooks?: SchedulerTestHooks;
+}
+
+interface SchedulerTickStats {
+  candidates: number;
+  recoveryCandidates: number;
+  dueCandidates: number;
+  processed: number;
+  failures: number;
 }
 
 export class SchedulerService {
   private app: Application;
   private db: TenantScopeAwareDatabase;
-  private config: Required<Omit<SchedulerConfig, 'tenantId'>> & Pick<SchedulerConfig, 'tenantId'>;
-  private intervalHandle?: NodeJS.Timeout;
+  private config: ResolvedSchedulerConfig;
+  private timerHandle?: NodeJS.Timeout;
   private isRunning = false;
+  private idleRounds = 0;
+  private recoveryCursor?: { created_at: number; session_id: SessionID };
   private branchRepo: BranchRepository;
   private scheduleRepo: ScheduleRepository;
   private sessionRepo: SessionRepository;
   private userRepo: UsersRepository;
   private sessionMCPRepo: SessionMCPServerRepository;
+  private taskRepo: TaskRepository;
 
   constructor(db: TenantScopeAwareDatabase, app: Application, config: SchedulerConfig = {}) {
     this.app = app;
@@ -268,12 +341,41 @@ export class SchedulerService {
         typeof config.tenantId === 'string' && config.tenantId.trim()
           ? config.tenantId.trim()
           : undefined,
+      scanBatchSize: config.scanBatchSize ?? 25,
+      maxIdleInterval: config.maxIdleInterval ?? 60_000,
+      jitterRatio: config.jitterRatio ?? 0.2,
+      random: config.random ?? Math.random,
+      workIdentity:
+        config.workIdentity ??
+        ({
+          instanceId: process.env.AGOR_DAEMON_INSTANCE_ID ?? process.env.HOSTNAME ?? 'daemon',
+          bootId: generateId(),
+        } satisfies DistributedWorkIdentity),
+      testHooks: config.testHooks,
     };
     this.branchRepo = new BranchRepository(db);
     this.scheduleRepo = new ScheduleRepository(db);
     this.sessionRepo = new SessionRepository(db);
     this.userRepo = new UsersRepository(db);
     this.sessionMCPRepo = new SessionMCPServerRepository(db);
+    this.taskRepo = new TaskRepository(db);
+
+    if (
+      !Number.isInteger(this.config.scanBatchSize) ||
+      this.config.scanBatchSize <= 0 ||
+      this.config.scanBatchSize > 1_000
+    ) {
+      throw new Error('Scheduler scanBatchSize must be between 1 and 1000');
+    }
+    if (this.config.tickInterval <= 0 || this.config.gracePeriod <= 0) {
+      throw new Error('Scheduler intervals must be positive');
+    }
+    if (this.config.maxIdleInterval < this.config.tickInterval) {
+      throw new Error('Scheduler maxIdleInterval must be >= tickInterval');
+    }
+    if (this.config.jitterRatio < 0 || this.config.jitterRatio > 1) {
+      throw new Error('Scheduler jitterRatio must be between 0 and 1');
+    }
   }
 
   private withTenantDatabase<T>(work: () => Promise<T>): Promise<T> {
@@ -294,17 +396,8 @@ export class SchedulerService {
     }
     this.isRunning = true;
 
-    // Run first tick immediately
-    this.tick().catch((error) => {
-      console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
-    });
-
-    // Schedule recurring ticks
-    this.intervalHandle = setInterval(() => {
-      this.tick().catch((error) => {
-        console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
-      });
-    }, this.config.tickInterval);
+    const initialDelay = initialWorkOffset(this.config.tickInterval, this.config.random());
+    this.scheduleNextTick(initialDelay);
   }
 
   /**
@@ -319,30 +412,95 @@ export class SchedulerService {
     console.log('🛑 Scheduler stopped');
     this.isRunning = false;
 
-    if (this.intervalHandle) {
-      clearInterval(this.intervalHandle);
-      this.intervalHandle = undefined;
+    if (this.timerHandle) {
+      clearTimeout(this.timerHandle);
+      this.timerHandle = undefined;
     }
+  }
+
+  private scheduleNextTick(delayMs: number): void {
+    if (!this.isRunning) return;
+    this.timerHandle = setTimeout(async () => {
+      let stats: SchedulerTickStats = {
+        candidates: 0,
+        recoveryCandidates: 0,
+        dueCandidates: 0,
+        processed: 0,
+        failures: 1,
+      };
+      try {
+        stats = await this.tick();
+      } catch (error) {
+        console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
+      }
+      if (!this.isRunning) return;
+      this.idleRounds = stats.candidates === 0 ? this.idleRounds + 1 : 0;
+      const saturated = stats.candidates >= this.config.scanBatchSize;
+      const nextDelay = saturated
+        ? Math.round(50 + this.config.random() * 200)
+        : boundedBackoffDelay(
+            this.idleRounds,
+            {
+              baseDelayMs: this.config.tickInterval,
+              maxDelayMs: this.config.maxIdleInterval,
+              jitterRatio: this.config.jitterRatio,
+            },
+            this.config.random()
+          );
+      this.scheduleNextTick(nextDelay);
+    }, delayMs);
   }
 
   /**
    * Execute one scheduler tick.
    *
-   * 1. Fetch all due schedules via the indexed
+   * 1. Fetch a bounded batch of due schedules via the indexed
    *    `WHERE enabled = true AND next_run_at <= now` query.
-   * 2. For each due schedule, try to acquire its per-schedule advisory
-   *    lock (Postgres only; no-op on SQLite). On miss, skip — another
-   *    daemon is handling that one.
-   * 3. Process the schedule (dedup, concurrency check, spawn).
+   * 2. Re-enter the trusted tenant scope and process each occurrence.
+   * 3. Database uniqueness/row locking owns correctness; jitter only reduces
+   *    synchronized contention.
    */
-  private async tick(): Promise<void> {
+  private async tick(): Promise<SchedulerTickStats> {
     const now = Date.now();
+    const stats: SchedulerTickStats = {
+      candidates: 0,
+      recoveryCandidates: 0,
+      dueCandidates: 0,
+      processed: 0,
+      failures: 0,
+    };
 
     try {
+      const recoveryRefs = await this.findIncompleteSessionRefs();
       const dueScheduleRefs = await this.findDueScheduleRefs(now);
+      stats.recoveryCandidates = recoveryRefs.length;
+      stats.dueCandidates = dueScheduleRefs.length;
+      stats.candidates = recoveryRefs.length + dueScheduleRefs.length;
 
       if (this.config.debug) {
-        console.log(`🔄 Scheduler tick: Found ${dueScheduleRefs.length} due schedules`);
+        console.log(
+          `🔄 Scheduler tick: Found ${recoveryRefs.length} recoveries and ${dueScheduleRefs.length} due schedules`
+        );
+      }
+
+      for (const ref of recoveryRefs) {
+        if (!ref.tenantId) {
+          stats.failures += 1;
+          console.error(`❌ Skipping scheduler recovery ${shortId(ref.sessionId)}: missing tenant`);
+          continue;
+        }
+        try {
+          await runWithTenantContext(ref.tenantId, () =>
+            this.recoverIncompleteSession(ref.sessionId, ref.scheduleId, ref.scheduledRunAt, now)
+          );
+          stats.processed += 1;
+        } catch (error) {
+          stats.failures += 1;
+          console.error(
+            `❌ Failed to recover scheduled session ${shortId(ref.sessionId)}:`,
+            sanitizeDbError(error)
+          );
+        }
       }
 
       for (const ref of dueScheduleRefs) {
@@ -363,8 +521,10 @@ export class SchedulerService {
             );
             if (!schedule) return;
             await this.processSchedule(schedule, now);
+            stats.processed += 1;
           });
         } catch (error) {
+          stats.failures += 1;
           console.error(
             `❌ Failed to process schedule ${shortId(ref.scheduleId)}:`,
             sanitizeDbError(error)
@@ -372,17 +532,70 @@ export class SchedulerService {
           // Continue processing other schedules
         }
       }
+      console.info('[DistributedWork]', {
+        component: 'scheduler',
+        event: 'scan_complete',
+        instance_id: this.config.workIdentity.instanceId,
+        boot_id: this.config.workIdentity.bootId,
+        ...stats,
+      });
+      return stats;
     } catch (error) {
       console.error('❌ Scheduler tick failed:', sanitizeDbError(error));
       throw error;
     }
   }
 
+  private async findIncompleteSessionRefs(): Promise<
+    Array<{
+      sessionId: SessionID;
+      scheduleId: ScheduleID;
+      scheduledRunAt: number;
+      tenantId?: TenantID | string;
+    }>
+  > {
+    const find = async (tenantId?: TenantID | string) => {
+      const refs = await this.sessionRepo.findIncompleteScheduledRefs(
+        this.config.scanBatchSize,
+        this.recoveryCursor
+      );
+      if (refs.length === 0 && this.recoveryCursor) {
+        // Wrap on the next tick. Advancing even past poison rows prevents one
+        // bounded batch of bad configuration from starving newer recoveries;
+        // the database marker remains the authority for what is unfinished.
+        this.recoveryCursor = undefined;
+      } else if (refs.length > 0) {
+        const last = refs.at(-1)!;
+        this.recoveryCursor = { created_at: last.created_at, session_id: last.session_id };
+      }
+      return refs.map((ref) => ({
+        sessionId: ref.session_id,
+        scheduleId: ref.schedule_id,
+        scheduledRunAt: ref.scheduled_run_at,
+        tenantId: tenantId ?? ref.tenant_id,
+      }));
+    };
+    if (this.config.tenantId) {
+      return runWithTenantDatabaseScope(this.db, this.config.tenantId, () =>
+        find(this.config.tenantId)
+      );
+    }
+    return runWithSystemDatabaseScope(
+      this.db,
+      'scheduler incomplete Session discovery',
+      () => find(),
+      { capability: 'scheduler_discovery' }
+    );
+  }
+
   private async findDueScheduleRefs(
     now: number
   ): Promise<Array<{ scheduleId: ScheduleID; tenantId?: TenantID | string }>> {
     const findDue = async (tenantId?: TenantID | string) => {
-      const dueSchedules = await this.scheduleRepo.findDueRefs(now + this.config.gracePeriod);
+      const dueSchedules = await this.scheduleRepo.findDueRefs(
+        now + this.config.gracePeriod,
+        this.config.scanBatchSize
+      );
       return dueSchedules.map((schedule) => ({
         scheduleId: schedule.schedule_id,
         tenantId: tenantId ?? schedule.tenant_id,
@@ -395,7 +608,14 @@ export class SchedulerService {
       );
     }
 
-    return runWithSystemDatabaseScope(this.db, 'scheduler due schedule discovery', () => findDue());
+    return runWithSystemDatabaseScope(
+      this.db,
+      'scheduler due schedule discovery',
+      () => findDue(),
+      {
+        capability: 'scheduler_discovery',
+      }
+    );
   }
 
   /**
@@ -407,10 +627,8 @@ export class SchedulerService {
    * 2. If prev is within grace period and no session exists, spawn it.
    * 3. Otherwise, check if we're close to the next scheduled time.
    *
-   * Wrapped in a Postgres advisory lock that guards same-schedule
-   * duplicate work; Agor remains single-daemon for branch-wide
-   * concurrency (see top-of-file docblock). On SQLite the lock is a
-   * no-op.
+   * Admission later uses a short PostgreSQL schedule-row lock. Cron parsing,
+   * rendering, and executor launch never run while that lock is held.
    */
   private async processSchedule(schedule: Schedule, now: number): Promise<void> {
     const tz = resolveScheduleTz(schedule.timezone_mode, schedule.timezone);
@@ -585,26 +803,21 @@ export class SchedulerService {
    * Steps:
    * 1. Look up the schedule's branch (cascaded delete means it should
    *    always exist; we still handle null defensively).
-   * 2. Dedup against `sessions(schedule_id, scheduled_run_at)`.
+   * 2. Dedup against the tenant-scoped occurrence identity
+   *    `(schedule_id, scheduled_run_at)`.
    * 3. Enforce `allow_concurrent_runs` against any active session spawned
    *    by the SAME SCHEDULE. Different schedules on the same branch do not
    *    block one another.
    * 4. Render prompt template (Handlebars).
    * 5. Look up creator's unix_username for execution context.
    * 6. Create session with schedule metadata + `schedule_id` FK.
-   *    A partial unique index on (schedule_id, scheduled_run_at) acts
-   *    as the DB-level race guard — if a concurrent path raced past
-   *    the dedup check, the insert fails and we treat it as dedup.
+   *    PostgreSQL's partial unique index on
+   *    (tenant_id, schedule_id, scheduled_run_at) acts as the DB-level
+   *    race guard; SQLite uses its standalone two-column equivalent.
    * 7. Attach MCP servers and trigger prompt.
-   * 8. Update schedule metadata (last_run_at, last_run_session_id,
-   *    next_run_at).
-   * 9. Enforce retention policy (oldest sessions on this schedule_id
-   *    are deleted).
-   *
-   * NOTE (multi-daemon, deferred): the per-schedule advisory lock and
-   * partial unique index guard same-schedule races. They deliberately do
-   * not serialize sibling schedules on the same branch, matching the
-   * schedule-scoped meaning of `allow_concurrent_runs=false`.
+   * 8. Enforce retention, update schedule metadata, then mark scheduler
+   *    initialization complete. The bounded incomplete-Session scan owns
+   *    recovery independently of cron grace/cursor state.
    */
   private async spawnScheduledSession(
     schedule: Schedule,
@@ -614,14 +827,30 @@ export class SchedulerService {
   ): Promise<Session | null> {
     const { source, triggeredBy } = options;
     const manual = source === 'manual';
+    const branch = await this.withTenantDatabase(() =>
+      this.branchRepo.findById(schedule.branch_id)
+    );
+    if (!branch) {
+      throw new ScheduleNotReadyError(
+        'schedule_incomplete',
+        `Schedule ${schedule.schedule_id} references missing branch ${schedule.branch_id}`
+      );
+    }
+
+    // Prepare all configuration outside the admission transaction. The only
+    // work performed while the schedule row is locked is existing/busy checks
+    // and the session insert.
+    const renderedPrompt = renderSchedulePrompt(schedule.prompt, branch, schedule, scheduledRunAt);
+    const { creator, unixUsername } = await this.resolveCreatorUnixUsername(schedule);
+    let resolvedConfig: Awaited<ReturnType<typeof resolveScheduleAgenticToolConfig>>;
     try {
-      normalizePersistedScheduleAgenticToolConfig(schedule.agentic_tool_config);
+      resolvedConfig = await this.withTenantDatabase(() =>
+        resolveScheduleAgenticToolConfig(this.db, schedule)
+      );
     } catch (error) {
       if (!(error instanceof InvalidScheduleAgenticToolConfigError)) throw error;
       const removedTool = !isAgenticToolName(schedule.agentic_tool_config.agentic_tool);
-      if (!manual) {
-        await this.advanceScheduleCursor(schedule, now);
-      }
+      if (!manual) await this.advanceScheduleCursor(schedule, now);
       throw new ScheduleNotReadyError(
         removedTool ? 'schedule_agentic_tool_removed' : 'schedule_invalid_config',
         removedTool
@@ -629,212 +858,310 @@ export class SchedulerService {
           : error.message
       );
     }
+    const cfg = resolvedConfig.config;
+    const effectiveMcpIds =
+      schedule.mcp_server_ids !== undefined
+        ? schedule.mcp_server_ids
+        : branch.mcp_server_ids && branch.mcp_server_ids.length > 0
+          ? branch.mcp_server_ids
+          : [];
+    const candidateSessionId = generateId() as SessionID;
+    const candidateTaskId = generateId() as import('@agor/core/types').TaskID;
 
-    const branch = await this.withTenantDatabase(() =>
-      this.branchRepo.findById(schedule.branch_id)
-    );
-    if (!branch) {
-      console.error(
-        `❌ Schedule ${schedule.schedule_id} references missing branch ${schedule.branch_id}`
-      );
-      throw new ScheduleNotReadyError(
-        'schedule_incomplete',
-        `Schedule ${schedule.schedule_id} references missing branch ${schedule.branch_id}`
-      );
-    }
+    type Admission =
+      | { outcome: 'created' | 'existing'; session: Session }
+      | { outcome: 'busy'; session: null };
 
-    // 1. Dedup: indexed (schedule_id, scheduled_run_at) lookup.
-    const existingSession = await this.withTenantDatabase(() =>
-      this.sessionRepo.findScheduleRun(schedule.schedule_id, scheduledRunAt)
-    );
-
-    if (existingSession) {
-      // Already spawned. Advance metadata so we don't keep finding this
-      // schedule due on every tick within the grace window.
-      await this.updateScheduleMetadata(schedule, scheduledRunAt, existingSession.session_id, now);
-      return existingSession;
-    }
-
-    // 2. Concurrency guard — per-schedule. An active run from this same
-    //    schedule blocks its next fire by default, but sibling schedules
-    //    on the same branch are independent and should not suppress one
-    //    another. Existence probe (LIMIT 1) — no need to count.
-    if (!schedule.allow_concurrent_runs) {
-      const active = await this.withTenantDatabase(() =>
-        this.sessionRepo.existsInScheduleWithStatuses(schedule.schedule_id, ACTIVE_SESSION_STATUSES)
-      );
-      if (active) {
-        if (manual) {
-          console.log(
-            `   ⛔ ${schedule.name}: manual run blocked — active run from this schedule present (allow_concurrent_runs=false)`
-          );
-          throw new ScheduleBusyError(schedule.name);
-        }
-        console.log(
-          `   ⏭️  ${schedule.name}: scheduled run skipped — active run from this schedule present (allow_concurrent_runs=false)`
-        );
-        await this.updateScheduleMetadata(schedule, scheduledRunAt, null, now);
-        return null;
-      }
-    }
-
-    // 3. Render prompt template.
-    const renderedPrompt = renderSchedulePrompt(schedule.prompt, branch, schedule, scheduledRunAt);
-
-    // 4. Run index = count of all sessions for this schedule + 1.
-    //    Indexed COUNT, not a full scan + filter.
-    const runIndex =
-      (await this.withTenantDatabase(() =>
-        this.sessionRepo.countByScheduleId(schedule.schedule_id)
-      )) + 1;
-
+    let admission: Admission;
     try {
-      // 5. Resolve unix_username (schedule's creator is the execution identity).
-      const { creator, unixUsername } = await this.resolveCreatorUnixUsername(schedule);
+      admission = await this.withTenantDatabase(async () => {
+        // PostgreSQL FOR UPDATE serializes the schedule-scoped concurrency
+        // decision. On SQLite occurrence uniqueness remains the race guard.
+        await this.scheduleRepo.lockForRunAdmission(schedule.schedule_id);
 
-      const resolvedConfig = await this.withTenantDatabase(() =>
-        resolveScheduleAgenticToolConfig(this.db, schedule)
+        const existing = await this.sessionRepo.findScheduleRun(
+          schedule.schedule_id,
+          scheduledRunAt
+        );
+        if (existing) return { outcome: 'existing', session: existing } as const;
+
+        if (
+          !schedule.allow_concurrent_runs &&
+          (await this.sessionRepo.existsActiveOrInitializingInSchedule(
+            schedule.schedule_id,
+            ACTIVE_SESSION_STATUSES,
+            ACTIVE_TASK_STATUSES
+          ))
+        ) {
+          return { outcome: 'busy', session: null } as const;
+        }
+
+        const runIndex = (await this.sessionRepo.countByScheduleId(schedule.schedule_id)) + 1;
+        const session: Partial<Session> = {
+          session_id: candidateSessionId,
+          branch_id: branch.branch_id,
+          agentic_tool: resolvedConfig.activeTool,
+          agentic_tool_preset_id:
+            resolvedConfig.sessionConfig.agentic_tool_preset_id ?? undefined,
+          status: SessionStatus.IDLE,
+          created_by: schedule.created_by,
+          unix_username: unixUsername,
+          scheduled_run_at: scheduledRunAt,
+          scheduled_from_branch: true,
+          schedule_id: schedule.schedule_id,
+          title: manual
+            ? `${schedule.name} — manual @ ${new Date(scheduledRunAt).toISOString()}`
+            : `${schedule.name} — ${new Date(scheduledRunAt).toISOString()}`,
+          contextFiles: cfg.context_files ?? [],
+          permission_config: resolvedConfig.sessionConfig.permission_config,
+          model_config: resolvedConfig.sessionConfig.model_config,
+          custom_context: {
+            scheduled_run: {
+              rendered_prompt: renderedPrompt,
+              run_index: runIndex,
+              initial_task_id: candidateTaskId,
+              triggered_manually: manual,
+              triggered_by: manual ? triggeredBy : undefined,
+              schedule_config_snapshot: {
+                schedule_id: schedule.schedule_id,
+                cron: schedule.cron_expression,
+                timezone: resolveScheduleTz(schedule.timezone_mode, schedule.timezone),
+                retention: schedule.retention,
+                allow_concurrent_runs: schedule.allow_concurrent_runs,
+                mcp_server_ids: effectiveMcpIds,
+              },
+            },
+          },
+        };
+        const created = await this.app
+          .service('sessions')
+          .create(session, { _agenticConfigResolved: true } as SessionParams);
+        return { outcome: 'created', session: created } as const;
+      });
+    } catch (error) {
+      // SQLite has no row-level lock and may race between the lookup and insert.
+      // PostgreSQL's corrected tenant-aware unique index is defense in depth.
+      if (!isUniqueConstraintError(error)) throw error;
+      const winner = await this.withTenantDatabase(() =>
+        this.sessionRepo.findScheduleRun(schedule.schedule_id, scheduledRunAt)
       );
-      const cfg = resolvedConfig.config;
+      if (!winner) throw error;
+      admission = { outcome: 'existing', session: winner };
+    }
 
-      // 6. Create session with schedule metadata + FK back to schedule.
-      const session: Partial<Session> = {
-        branch_id: branch.branch_id,
-        agentic_tool: resolvedConfig.activeTool,
-        agentic_tool_preset_id: resolvedConfig.sessionConfig.agentic_tool_preset_id ?? undefined,
-        status: SessionStatus.IDLE,
-        created_by: schedule.created_by,
-        unix_username: unixUsername,
-        scheduled_run_at: scheduledRunAt,
-        scheduled_from_branch: true,
+    if (admission.outcome === 'busy') {
+      console.info('[DistributedWork]', {
+        component: 'scheduler',
+        event: 'occurrence_skipped_busy',
+        instance_id: this.config.workIdentity.instanceId,
+        boot_id: this.config.workIdentity.bootId,
+        tenant_id: getCurrentTenantId(),
         schedule_id: schedule.schedule_id,
-        // Lead with the schedule name so the session list is scannable
-        // — "hourly heartbeat — 2026-05-25T14:08:00.000Z" is more useful
-        // than the generic "[Scheduled run - ...]" we used pre-#1253.
-        title: manual
-          ? `${schedule.name} — manual @ ${new Date(scheduledRunAt).toISOString()}`
-          : `${schedule.name} — ${new Date(scheduledRunAt).toISOString()}`,
-        contextFiles: cfg.context_files ?? [],
-        permission_config: resolvedConfig.sessionConfig.permission_config,
-        // DefaultModelConfig → Session.model_config. If the schedule
-        // only sets ancillary fields (e.g. Claude effort), resolve them
-        // against the same model defaults used by fresh sessions.
-        model_config: resolvedConfig.sessionConfig.model_config,
-        custom_context: {
-          scheduled_run: {
-            rendered_prompt: renderedPrompt,
-            run_index: runIndex,
-            triggered_manually: manual,
-            triggered_by: manual ? triggeredBy : undefined,
-            schedule_config_snapshot: {
-              schedule_id: schedule.schedule_id,
-              cron: schedule.cron_expression,
-              timezone: resolveScheduleTz(schedule.timezone_mode, schedule.timezone),
-              retention: schedule.retention,
-              allow_concurrent_runs: schedule.allow_concurrent_runs,
+        scheduled_run_at: scheduledRunAt,
+        source,
+      });
+      if (manual) throw new ScheduleBusyError(schedule.name);
+      await this.updateScheduleMetadata(schedule, scheduledRunAt, null, now);
+      return null;
+    }
+
+    const recovering = admission.outcome === 'existing';
+    console.info('[DistributedWork]', {
+      component: 'scheduler',
+      event: recovering ? 'occurrence_claim_lost_reconciling' : 'occurrence_claim_won',
+      instance_id: this.config.workIdentity.instanceId,
+      boot_id: this.config.workIdentity.bootId,
+      tenant_id: getCurrentTenantId(),
+      schedule_id: schedule.schedule_id,
+      session_id: admission.session.session_id,
+      scheduled_run_at: scheduledRunAt,
+      source,
+    });
+    if (
+      recovering &&
+      (await this.withTenantDatabase(() =>
+        this.sessionRepo.isScheduledInitializationComplete(admission.session.session_id)
+      ))
+    ) {
+      return admission.session;
+    }
+    await this.config.testHooks?.afterSessionAdmission?.(admission.session);
+
+    await this.initializeScheduledSession({
+      schedule,
+      session: admission.session,
+      creator,
+      fallbackPrompt: renderedPrompt,
+      fallbackMcpIds: effectiveMcpIds,
+      recovering,
+    });
+
+    // Finalization is ordered retention -> cursor -> completion marker. The
+    // marker, rather than the cron cursor, lets the bounded recovery scan find
+    // manual occurrences and failures that outlive the cron grace window.
+    await this.enforceRetentionPolicy(schedule);
+    await this.config.testHooks?.afterRetention?.(admission.session);
+    await this.updateScheduleMetadata(schedule, scheduledRunAt, admission.session.session_id, now);
+    await this.config.testHooks?.afterMetadata?.(admission.session);
+    await this.withTenantDatabase(() =>
+      this.sessionRepo.markScheduledInitializationComplete(admission.session.session_id)
+    );
+    return admission.session;
+  }
+
+  private async recoverIncompleteSession(
+    sessionId: SessionID,
+    scheduleId: ScheduleID,
+    scheduledRunAt: number,
+    now: number
+  ): Promise<void> {
+    const session = await this.withTenantDatabase(() => this.sessionRepo.findById(sessionId));
+    if (
+      !session ||
+      session.schedule_id !== scheduleId ||
+      session.scheduled_run_at !== scheduledRunAt
+    ) {
+      return;
+    }
+    if (
+      await this.withTenantDatabase(() =>
+        this.sessionRepo.isScheduledInitializationComplete(session.session_id)
+      )
+    ) {
+      return;
+    }
+    const schedule = await this.withTenantDatabase(() => this.scheduleRepo.findById(scheduleId));
+    if (!schedule) return;
+    const branch = await this.withTenantDatabase(() => this.branchRepo.findById(session.branch_id));
+    if (!branch) return;
+    const creator = await this.withTenantDatabase(() => this.userRepo.findById(session.created_by));
+    if (!creator) throw new Error(`Scheduled Session creator ${session.created_by} not found`);
+    const fallbackMcpIds =
+      schedule.mcp_server_ids !== undefined
+        ? schedule.mcp_server_ids
+        : branch.mcp_server_ids && branch.mcp_server_ids.length > 0
+          ? branch.mcp_server_ids
+          : [];
+
+    await this.initializeScheduledSession({
+      schedule,
+      session,
+      creator,
+      fallbackPrompt: renderSchedulePrompt(schedule.prompt, branch, schedule, scheduledRunAt),
+      fallbackMcpIds,
+      recovering: true,
+    });
+    await this.enforceRetentionPolicy(schedule);
+    await this.updateScheduleMetadata(schedule, scheduledRunAt, session.session_id, now);
+    await this.withTenantDatabase(() =>
+      this.sessionRepo.markScheduledInitializationComplete(session.session_id)
+    );
+  }
+
+  private async initializeScheduledSession(input: {
+    schedule: Schedule;
+    session: Session;
+    creator: User;
+    fallbackPrompt: string;
+    fallbackMcpIds: readonly string[];
+    recovering: boolean;
+  }): Promise<Task> {
+    const { schedule, session, creator } = input;
+    const stored = session.custom_context?.scheduled_run;
+    const existingTasks = await this.withTenantDatabase(() =>
+      this.taskRepo.findBySession(session.session_id)
+    );
+    const initialTaskId =
+      stored?.initial_task_id ??
+      existingTasks[0]?.task_id ??
+      // Deterministic legacy fallback: table-local UUID identity may equal the
+      // Session ID and is safe across every recovering daemon.
+      (session.session_id as import('@agor/core/types').TaskID);
+    const renderedPrompt = stored?.rendered_prompt ?? input.fallbackPrompt;
+    const snapshotMcpIds = stored?.schedule_config_snapshot?.mcp_server_ids;
+    const effectiveMcpIds = snapshotMcpIds ?? input.fallbackMcpIds;
+
+    if (!stored?.initial_task_id) {
+      await this.app.service('sessions').patch(
+        session.session_id,
+        {
+          custom_context: {
+            ...session.custom_context,
+            scheduled_run: {
+              ...stored,
+              rendered_prompt: renderedPrompt,
+              run_index: stored?.run_index ?? 1,
+              initial_task_id: initialTaskId,
             },
           },
         },
-      };
-
-      // Use service for session creation (triggers WebSocket events).
-      // The partial unique index on (schedule_id, scheduled_run_at)
-      // catches any concurrent path that raced past the dedup check —
-      // we surface that as a normal dedup hit rather than an error.
-      const sessionsService = this.app.service('sessions');
-      const sessionCreateParams: SessionParams = { _agenticConfigResolved: true };
-      let createdSession: Session;
-      try {
-        createdSession = await sessionsService.create(session, sessionCreateParams);
-      } catch (err) {
-        if (isUniqueConstraintError(err)) {
-          const winner = await this.withTenantDatabase(() =>
-            this.sessionRepo.findScheduleRun(schedule.schedule_id, scheduledRunAt)
-          );
-          if (winner) {
-            console.log(
-              `      🪞 ${schedule.name}: lost the spawn race — using existing session ${shortId(winner.session_id)}`
-            );
-            await this.updateScheduleMetadata(schedule, scheduledRunAt, winner.session_id, now);
-            return winner;
-          }
-        }
-        throw err;
-      }
-      console.log(
-        `      ✅ Spawned ${manual ? 'manual' : 'scheduled'} session for ${schedule.name} (run #${runIndex})` +
-          (manual && triggeredBy ? ` triggered_by=${triggeredBy.substring(0, 8)}` : '')
+        { provider: undefined }
       );
-
-      // 7. Attach MCP servers BEFORE triggering prompt.
-      // Precedence: schedule config (if defined) > branch defaults.
-      // An explicit empty array in schedule means "no MCPs" — does NOT
-      // fall through to branch.
-      const effectiveMcpIds =
-        schedule.mcp_server_ids !== undefined
-          ? schedule.mcp_server_ids
-          : branch.mcp_server_ids && branch.mcp_server_ids.length > 0
-            ? branch.mcp_server_ids
-            : [];
-
-      if (effectiveMcpIds.length > 0) {
-        for (const serverId of effectiveMcpIds) {
-          try {
-            await this.withTenantDatabase(() =>
-              this.sessionMCPRepo.addServer(
-                createdSession.session_id as SessionID,
-                serverId as MCPServerID
-              )
-            );
-            emitServiceEvent(this.app, {
-              path: 'session-mcp-servers',
-              event: 'created',
-              data: {
-                session_id: createdSession.session_id,
-                mcp_server_id: serverId,
-                enabled: true,
-                added_at: new Date(),
-              },
-            });
-          } catch {
-            // Silently skip deleted/invalid MCP servers
-          }
-        }
-      }
-
-      // 8. Trigger prompt execution (creates task and starts agent).
-      const promptService = this.app.service('/sessions/:id/prompt');
-      const tenantId = getCurrentTenantId();
-      await promptService.create(
-        {
-          prompt: renderedPrompt,
-          permissionMode: createdSession.permission_config?.mode || 'acceptEdits',
-          stream: true,
-        },
-        {
-          route: { id: createdSession.session_id },
-          provider: undefined, // Bypass auth for internal scheduler call
-          user: creator, // Pass creator user for session token generation
-          ...(tenantId ? { tenant: { tenant_id: tenantId, source: 'explicit' as const } } : {}),
-        } as import('@agor/core/types').AuthenticatedParams & { route: { id: string } }
-      );
-
-      // 9. Update schedule metadata (last_run_at, last_run_session_id, next_run_at).
-      await this.updateScheduleMetadata(
-        schedule,
-        scheduledRunAt,
-        createdSession.session_id as SessionID,
-        now
-      );
-
-      // 10. Enforce retention policy.
-      await this.enforceRetentionPolicy(schedule);
-
-      return createdSession;
-    } catch (error) {
-      console.error(`      ❌ Failed to spawn scheduled session:`, sanitizeDbError(error));
-      throw error;
     }
+
+    for (const serverId of effectiveMcpIds) {
+      try {
+        await this.withTenantDatabase(() =>
+          this.sessionMCPRepo.addServer(session.session_id, serverId as MCPServerID)
+        );
+        emitServiceEvent(this.app, {
+          path: 'session-mcp-servers',
+          event: 'created',
+          data: {
+            session_id: session.session_id,
+            mcp_server_id: serverId,
+            enabled: true,
+            added_at: new Date(),
+          },
+        });
+      } catch (error) {
+        // Preserve settled behavior for an optional server deleted between
+        // schedule configuration and initialization. Transient database
+        // failures must escape so this occurrence remains recoverable.
+        if (!(error instanceof EntityNotFoundError)) throw error;
+        console.warn('[DistributedWork]', {
+          component: 'scheduler',
+          event: 'mcp_attachment_missing',
+          instance_id: this.config.workIdentity.instanceId,
+          boot_id: this.config.workIdentity.bootId,
+          tenant_id: getCurrentTenantId(),
+          schedule_id: schedule.schedule_id,
+          session_id: session.session_id,
+          mcp_server_id: serverId,
+        });
+      }
+    }
+    await this.config.testHooks?.afterMcpAttachments?.(session);
+
+    const tenantId = getCurrentTenantId();
+    const task = (await this.app.service('/sessions/:id/prompt').create(
+      {
+        prompt: renderedPrompt,
+        permissionMode: session.permission_config?.mode || 'acceptEdits',
+        stream: true,
+        idempotencyTaskId: initialTaskId,
+      },
+      {
+        route: { id: session.session_id },
+        provider: undefined,
+        user: creator,
+        ...(tenantId ? { tenant: { tenant_id: tenantId, source: 'explicit' as const } } : {}),
+      } as import('@agor/core/types').AuthenticatedParams & { route: { id: string } }
+    )) as Task;
+    await this.config.testHooks?.afterPromptDispatch?.(task);
+
+    console.info('[DistributedWork]', {
+      component: 'scheduler',
+      event: input.recovering ? 'occurrence_recovered' : 'occurrence_initialized',
+      instance_id: this.config.workIdentity.instanceId,
+      boot_id: this.config.workIdentity.bootId,
+      tenant_id: tenantId,
+      schedule_id: schedule.schedule_id,
+      session_id: session.session_id,
+      task_id: task.task_id,
+      task_status: task.status,
+    });
+    return task;
   }
 
   /**
@@ -845,7 +1172,8 @@ export class SchedulerService {
     schedule: Schedule,
     scheduledRunAt: number,
     lastRunSessionId: SessionID | null,
-    now: number
+    now: number,
+    attempt = 0
   ): Promise<void> {
     try {
       const tz = resolveScheduleTz(schedule.timezone_mode, schedule.timezone);
@@ -859,6 +1187,16 @@ export class SchedulerService {
 
       await this.withTenantDatabase(() => this.scheduleRepo.update(schedule.schedule_id, updates));
     } catch (error) {
+      if (isSQLiteBusyError(error) && attempt < 5) {
+        await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+        return this.updateScheduleMetadata(
+          schedule,
+          scheduledRunAt,
+          lastRunSessionId,
+          now,
+          attempt + 1
+        );
+      }
       console.error(`      ❌ Failed to update schedule metadata:`, sanitizeDbError(error));
       throw error;
     }
@@ -889,28 +1227,33 @@ export class SchedulerService {
   private async enforceRetentionPolicy(schedule: Schedule): Promise<void> {
     if (schedule.retention === 0) return;
 
-    try {
-      // Indexed query, newest-first; slice past the keep-count for deletion.
-      const mine = await this.withTenantDatabase(() =>
-        this.sessionRepo.findByScheduleId(schedule.schedule_id, {
-          orderByScheduledRunAt: 'desc',
-        })
-      );
-      const sessionsToDelete = mine.slice(schedule.retention);
+    // Indexed query, newest-first; slice past the keep-count for deletion.
+    const mine = await this.withTenantDatabase(() =>
+      this.sessionRepo.findByScheduleId(schedule.schedule_id, {
+        orderByScheduledRunAt: 'desc',
+      })
+    );
+    const sessionsToDelete = mine.slice(schedule.retention);
 
-      if (sessionsToDelete.length > 0) {
-        const sessionService = this.app.service('sessions');
-        for (const session of sessionsToDelete) {
+    if (sessionsToDelete.length > 0) {
+      const sessionService = this.app.service('sessions');
+      for (const session of sessionsToDelete) {
+        try {
           await sessionService.remove(session.session_id, { provider: undefined });
+        } catch (error) {
+          // Concurrent reconcilers may have deleted the same retained-out row.
+          // Re-read once; absence is idempotent success, presence is a real
+          // failure and keeps the schedule due for another bounded retry.
+          const stillPresent = await this.withTenantDatabase(() =>
+            this.sessionRepo.findById(session.session_id)
+          );
+          if (stillPresent) throw error;
         }
-
-        console.log(
-          `      🗑️  Deleted ${sessionsToDelete.length} old sessions on schedule ${schedule.name} (retention: ${schedule.retention})`
-        );
       }
-    } catch (error) {
-      console.error(`      ❌ Failed to enforce retention policy:`, sanitizeDbError(error));
-      // Don't throw - retention failure shouldn't block scheduling
+
+      console.log(
+        `      🗑️  Deleted ${sessionsToDelete.length} old sessions on schedule ${schedule.name} (retention: ${schedule.retention})`
+      );
     }
   }
 }

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -105,29 +105,12 @@ import {
 } from '../utils/agentic-configuration-sources.js';
 import { buildSessionCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
-
-type SchedulerWorkLogLevel = 'info' | 'warn' | 'error';
-type SchedulerWorkLogValue = string | number | boolean | null | undefined;
-
-function formatWorkLogValue(value: Exclude<SchedulerWorkLogValue, undefined>): string {
-  return typeof value === 'string' ? JSON.stringify(value) : String(value);
-}
-
-/** Extract only a bounded, non-payload error category for shared logs. */
-function schedulerErrorCode(error: unknown): string {
-  let current = error;
-  const seen = new Set<unknown>();
-  for (let depth = 0; depth < 8 && current && !seen.has(current); depth += 1) {
-    seen.add(current);
-    if (typeof current !== 'object') break;
-    const record = current as { code?: unknown; cause?: unknown };
-    if (typeof record.code === 'string' && /^[A-Za-z0-9_]{1,64}$/.test(record.code)) {
-      return record.code;
-    }
-    current = record.cause;
-  }
-  return 'operation_failed';
-}
+import {
+  formatStructuredLog,
+  type StructuredLogLevel,
+  type StructuredLogValue,
+  structuredLogErrorCode,
+} from '../utils/structured-log.js';
 
 /**
  * Best-effort detection of the partial-unique-index conflict raised by
@@ -389,25 +372,17 @@ export class SchedulerService {
   }
 
   private logWorkEvent(
-    level: SchedulerWorkLogLevel,
+    level: StructuredLogLevel,
     event: string,
-    fields: Record<string, SchedulerWorkLogValue> = {}
+    fields: Record<string, StructuredLogValue> = {}
   ): void {
-    const allFields: Record<string, SchedulerWorkLogValue> = {
+    const message = formatStructuredLog('[distributed-work.scheduler]', {
       event,
       instance_id: this.config.workIdentity.instanceId,
       boot_id: this.config.workIdentity.bootId,
       tenant_id: getCurrentTenantId(),
       ...fields,
-    };
-    const details = Object.entries(allFields)
-      .filter(
-        (entry): entry is [string, Exclude<SchedulerWorkLogValue, undefined>] =>
-          entry[1] !== undefined
-      )
-      .map(([key, value]) => `${key}=${formatWorkLogValue(value)}`)
-      .join(' ');
-    const message = `[distributed-work.scheduler] ${details}`;
+    });
     if (level === 'error') console.error(message);
     else if (level === 'warn') console.warn(message);
     else console.info(message);
@@ -448,23 +423,18 @@ export class SchedulerService {
   private scheduleNextTick(delayMs: number): void {
     if (!this.isRunning) return;
     this.timerHandle = setTimeout(async () => {
-      let stats: SchedulerTickStats = {
-        candidates: 0,
-        recoveryCandidates: 0,
-        dueCandidates: 0,
-        processed: 0,
-        failures: 1,
-      };
+      let stats: SchedulerTickStats | null = null;
       try {
         stats = await this.tick();
       } catch (error) {
         this.logWorkEvent('error', 'scan_failed', {
-          error_code: schedulerErrorCode(error),
+          error_code: structuredLogErrorCode(error),
         });
       }
       if (!this.isRunning) return;
-      this.idleRounds = stats.candidates === 0 ? this.idleRounds + 1 : 0;
-      const saturated = stats.candidates >= this.config.scanBatchSize;
+      const candidates = stats?.candidates ?? 0;
+      this.idleRounds = candidates === 0 ? this.idleRounds + 1 : 0;
+      const saturated = candidates >= this.config.scanBatchSize;
       const nextDelay = saturated
         ? Math.round(50 + this.config.random() * 200)
         : boundedBackoffDelay(
@@ -509,6 +479,7 @@ export class SchedulerService {
       if (!ref.tenantId) {
         stats.failures += 1;
         this.logWorkEvent('error', 'recovery_missing_tenant', {
+          schedule_id: ref.scheduleId,
           session_id: ref.sessionId,
         });
         continue;
@@ -522,8 +493,9 @@ export class SchedulerService {
         stats.failures += 1;
         this.logWorkEvent('error', 'recovery_failed', {
           tenant_id: ref.tenantId,
+          schedule_id: ref.scheduleId,
           session_id: ref.sessionId,
-          error_code: schedulerErrorCode(error),
+          error_code: structuredLogErrorCode(error),
         });
       }
     }
@@ -554,7 +526,7 @@ export class SchedulerService {
         this.logWorkEvent('error', 'schedule_processing_failed', {
           tenant_id: ref.tenantId,
           schedule_id: ref.scheduleId,
-          error_code: schedulerErrorCode(error),
+          error_code: structuredLogErrorCode(error),
         });
         // Continue processing other schedules
       }
@@ -574,6 +546,7 @@ export class SchedulerService {
   private async findIncompleteSessionRefs(): Promise<
     Array<{
       sessionId: SessionID;
+      scheduleId?: ScheduleID;
       scheduledRunAt: number;
       tenantId?: TenantID | string;
     }>
@@ -594,6 +567,7 @@ export class SchedulerService {
       }
       return refs.map((ref) => ({
         sessionId: ref.session_id,
+        scheduleId: ref.schedule_id,
         scheduledRunAt: ref.scheduled_run_at,
         tenantId: tenantId ?? ref.tenant_id,
       }));
@@ -686,7 +660,7 @@ export class SchedulerService {
         ).catch((error) => {
           this.logWorkEvent('error', 'cursor_advance_failed', {
             schedule_id: schedule.schedule_id,
-            error_code: schedulerErrorCode(error),
+            error_code: structuredLogErrorCode(error),
           });
         });
       }
@@ -901,8 +875,7 @@ export class SchedulerService {
           session_id: candidateSessionId,
           branch_id: branch.branch_id,
           agentic_tool: resolvedConfig.activeTool,
-          agentic_tool_preset_id:
-            resolvedConfig.sessionConfig.agentic_tool_preset_id ?? undefined,
+          agentic_tool_preset_id: resolvedConfig.sessionConfig.agentic_tool_preset_id ?? undefined,
           status: SessionStatus.IDLE,
           created_by: schedule.created_by,
           unix_username: unixUsername,
@@ -1147,7 +1120,7 @@ export class SchedulerService {
       existingTasks[0]?.task_id ??
       // Deterministic legacy fallback: table-local UUID identity may equal the
       // Session ID and is safe across every recovering daemon.
-      (session.session_id as import('@agor/core/types').TaskID);
+      (session.session_id as TaskID);
     const existingInitialTask = existingTasks.find((task) => task.task_id === initialTaskId);
     let creator = input.creator;
     if (!creator && (!existingInitialTask || isTaskPendingDispatch(existingInitialTask))) {

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -82,7 +82,12 @@ import type {
   User,
   UUID,
 } from '@agor/core/types';
-import { isAgenticToolName, SessionStatus, TaskStatus } from '@agor/core/types';
+import {
+  isAgenticToolName,
+  isTaskPendingDispatch,
+  SessionStatus,
+  TaskStatus,
+} from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import {
   getNextRunTime,
@@ -1055,8 +1060,6 @@ export class SchedulerService {
       );
     }
     const schedule = await this.withTenantDatabase(() => this.scheduleRepo.findById(scheduleId));
-    const creator = await this.withTenantDatabase(() => this.userRepo.findById(session.created_by));
-    if (!creator) throw new Error(`Scheduled Session creator ${session.created_by} not found`);
 
     // Every occurrence admitted by the HA scheduler snapshots its rendered
     // prompt and effective MCP IDs before the Session insert. A live Schedule
@@ -1086,7 +1089,6 @@ export class SchedulerService {
     await this.initializeScheduledSession({
       scheduleId,
       session,
-      creator,
       fallbackPrompt,
       fallbackMcpIds: fallbackMcpIds ?? [],
       recovering: true,
@@ -1152,12 +1154,12 @@ export class SchedulerService {
   private async initializeScheduledSession(input: {
     scheduleId: ScheduleID;
     session: Session;
-    creator: User;
+    creator?: User;
     fallbackPrompt: string;
     fallbackMcpIds: readonly string[];
     recovering: boolean;
   }): Promise<Task> {
-    const { scheduleId, session, creator } = input;
+    const { scheduleId, session } = input;
     const stored = session.custom_context?.scheduled_run;
     const existingTasks = await this.withTenantDatabase(() =>
       this.taskRepo.findBySession(session.session_id)
@@ -1168,6 +1170,17 @@ export class SchedulerService {
       // Deterministic legacy fallback: table-local UUID identity may equal the
       // Session ID and is safe across every recovering daemon.
       (session.session_id as import('@agor/core/types').TaskID);
+    const existingInitialTask = existingTasks.find((task) => task.task_id === initialTaskId);
+    let creator = input.creator;
+    if (!creator && (!existingInitialTask || isTaskPendingDispatch(existingInitialTask))) {
+      const recoveredCreator = await this.withTenantDatabase(() =>
+        this.userRepo.findById(session.created_by)
+      );
+      if (!recoveredCreator) {
+        throw new Error(`Scheduled Session creator ${session.created_by} not found`);
+      }
+      creator = recoveredCreator;
+    }
     const renderedPrompt = stored?.rendered_prompt ?? input.fallbackPrompt;
     const snapshotMcpIds = stored?.schedule_config_snapshot?.mcp_server_ids;
     const effectiveMcpIds = snapshotMcpIds ?? input.fallbackMcpIds;
@@ -1235,7 +1248,7 @@ export class SchedulerService {
       {
         route: { id: session.session_id },
         provider: undefined,
-        user: creator,
+        ...(creator ? { user: creator } : {}),
         ...(tenantId ? { tenant: { tenant_id: tenantId, source: 'explicit' as const } } : {}),
       } as import('@agor/core/types').AuthenticatedParams & { route: { id: string } }
     )) as Task;

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -339,6 +339,12 @@ export class SchedulerService {
   constructor(db: TenantScopeAwareDatabase, app: Application, config: SchedulerConfig = {}) {
     this.app = app;
     this.db = db;
+    const workIdentity = config.workIdentity ?? app.get('distributedWorkIdentity');
+    if (!workIdentity) {
+      throw new Error(
+        'Scheduler requires the daemon application distributed-work identity or an explicit test identity'
+      );
+    }
     this.config = {
       tickInterval: config.tickInterval ?? 30000, // 30 seconds
       gracePeriod: config.gracePeriod ?? 120000, // 2 minutes
@@ -352,12 +358,7 @@ export class SchedulerService {
       maxIdleInterval: config.maxIdleInterval ?? 60_000,
       jitterRatio: config.jitterRatio ?? 0.2,
       random: config.random ?? Math.random,
-      workIdentity:
-        config.workIdentity ??
-        ({
-          instanceId: process.env.AGOR_DAEMON_INSTANCE_ID ?? process.env.HOSTNAME ?? 'daemon',
-          bootId: generateId(),
-        } satisfies DistributedWorkIdentity),
+      workIdentity,
       testHooks: config.testHooks,
     };
     this.branchRepo = new BranchRepository(db);

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -39,8 +39,10 @@
  */
 
 import { materializeAgenticToolConfiguration } from '@agor/agentic-tools/config';
+import { analyticsLogger } from '@agor/core/analytics';
 import {
   InvalidScheduleAgenticToolConfigError,
+  isTenantAgenticToolEnabled,
   normalizePersistedScheduleAgenticToolConfig,
   unixUserModeRequiresUsername,
 } from '@agor/core/config';
@@ -66,7 +68,7 @@ import {
   TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
-import { Forbidden } from '@agor/core/feathers';
+import { BadRequest, Forbidden } from '@agor/core/feathers';
 import type {
   Branch,
   MCPServerID,
@@ -94,8 +96,8 @@ import {
   materializedAgenticToolConfigurationToScheduleConfig,
   scheduleAgenticToolConfigToSource,
 } from '../utils/agentic-configuration-sources.js';
+import { buildSessionCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
-import type { SessionParams } from './sessions.js';
 
 /**
  * Session statuses that count as "actively consuming the branch" for
@@ -491,7 +493,7 @@ export class SchedulerService {
         }
         try {
           await runWithTenantContext(ref.tenantId, () =>
-            this.recoverIncompleteSession(ref.sessionId, ref.scheduleId, ref.scheduledRunAt, now)
+            this.recoverIncompleteSession(ref.sessionId, ref.scheduledRunAt, now)
           );
           stats.processed += 1;
         } catch (error) {
@@ -549,7 +551,6 @@ export class SchedulerService {
   private async findIncompleteSessionRefs(): Promise<
     Array<{
       sessionId: SessionID;
-      scheduleId: ScheduleID;
       scheduledRunAt: number;
       tenantId?: TenantID | string;
     }>
@@ -570,7 +571,6 @@ export class SchedulerService {
       }
       return refs.map((ref) => ({
         sessionId: ref.session_id,
-        scheduleId: ref.schedule_id,
         scheduledRunAt: ref.scheduled_run_at,
         tenantId: tenantId ?? ref.tenant_id,
       }));
@@ -836,7 +836,6 @@ export class SchedulerService {
         `Schedule ${schedule.schedule_id} references missing branch ${schedule.branch_id}`
       );
     }
-
     // Prepare all configuration outside the admission transaction. The only
     // work performed while the schedule row is locked is existing/busy checks
     // and the session insert.
@@ -859,6 +858,13 @@ export class SchedulerService {
       );
     }
     const cfg = resolvedConfig.config;
+    if (
+      !(await this.withTenantDatabase(() =>
+        isTenantAgenticToolEnabled(resolvedConfig.activeTool, this.db)
+      ))
+    ) {
+      throw new BadRequest(`${resolvedConfig.activeTool} is disabled for this workspace`);
+    }
     const effectiveMcpIds =
       schedule.mcp_server_ids !== undefined
         ? schedule.mcp_server_ids
@@ -933,9 +939,11 @@ export class SchedulerService {
             },
           },
         };
-        const created = await this.app
-          .service('sessions')
-          .create(session, { _agenticConfigResolved: true } as SessionParams);
+        // This is an already-materialized internal occurrence admission, not a
+        // public Session create. Keep the schedule lock around only the row
+        // checks and repository insert; Feathers validation/hooks (including
+        // Unix process launch side effects) belong outside this critical path.
+        const created = await this.sessionRepo.create(session);
         return { outcome: 'created', session: created } as const;
       });
     } catch (error) {
@@ -947,6 +955,20 @@ export class SchedulerService {
       );
       if (!winner) throw error;
       admission = { outcome: 'existing', session: winner };
+    }
+
+    if (admission.outcome === 'created') {
+      emitServiceEvent(this.app, {
+        path: 'sessions',
+        event: 'created',
+        data: admission.session,
+        id: admission.session.session_id,
+      });
+      analyticsLogger.track(
+        'session.created',
+        buildSessionCreatedAnalyticsProperties(admission.session),
+        { userId: admission.session.created_by }
+      );
     }
 
     if (admission.outcome === 'busy') {
@@ -988,7 +1010,7 @@ export class SchedulerService {
     await this.config.testHooks?.afterSessionAdmission?.(admission.session);
 
     await this.initializeScheduledSession({
-      schedule,
+      scheduleId: schedule.schedule_id,
       session: admission.session,
       creator,
       fallbackPrompt: renderedPrompt,
@@ -996,31 +1018,24 @@ export class SchedulerService {
       recovering,
     });
 
-    // Finalization is ordered retention -> cursor -> completion marker. The
-    // marker, rather than the cron cursor, lets the bounded recovery scan find
-    // manual occurrences and failures that outlive the cron grace window.
-    await this.enforceRetentionPolicy(schedule);
-    await this.config.testHooks?.afterRetention?.(admission.session);
-    await this.updateScheduleMetadata(schedule, scheduledRunAt, admission.session.session_id, now);
-    await this.config.testHooks?.afterMetadata?.(admission.session);
-    await this.withTenantDatabase(() =>
-      this.sessionRepo.markScheduledInitializationComplete(admission.session.session_id)
-    );
+    await this.finalizeScheduledSession({
+      schedule,
+      scheduleId: schedule.schedule_id,
+      session: admission.session,
+      scheduledRunAt,
+      now,
+      runTestHooks: true,
+    });
     return admission.session;
   }
 
   private async recoverIncompleteSession(
     sessionId: SessionID,
-    scheduleId: ScheduleID,
     scheduledRunAt: number,
     now: number
   ): Promise<void> {
     const session = await this.withTenantDatabase(() => this.sessionRepo.findById(sessionId));
-    if (
-      !session ||
-      session.schedule_id !== scheduleId ||
-      session.scheduled_run_at !== scheduledRunAt
-    ) {
+    if (!session?.scheduled_from_branch || session.scheduled_run_at !== scheduledRunAt) {
       return;
     }
     if (
@@ -1030,43 +1045,119 @@ export class SchedulerService {
     ) {
       return;
     }
+    const stored = session.custom_context?.scheduled_run;
+    const scheduleId = (session.schedule_id ?? stored?.schedule_config_snapshot?.schedule_id) as
+      | ScheduleID
+      | undefined;
+    if (!scheduleId) {
+      throw new Error(
+        `Scheduled Session ${session.session_id} has no live or snapshotted schedule identity`
+      );
+    }
     const schedule = await this.withTenantDatabase(() => this.scheduleRepo.findById(scheduleId));
-    if (!schedule) return;
-    const branch = await this.withTenantDatabase(() => this.branchRepo.findById(session.branch_id));
-    if (!branch) return;
     const creator = await this.withTenantDatabase(() => this.userRepo.findById(session.created_by));
     if (!creator) throw new Error(`Scheduled Session creator ${session.created_by} not found`);
-    const fallbackMcpIds =
-      schedule.mcp_server_ids !== undefined
-        ? schedule.mcp_server_ids
-        : branch.mcp_server_ids && branch.mcp_server_ids.length > 0
-          ? branch.mcp_server_ids
-          : [];
+
+    // Every occurrence admitted by the HA scheduler snapshots its rendered
+    // prompt and effective MCP IDs before the Session insert. A live Schedule
+    // is therefore optional during recovery: ON DELETE SET NULL must not turn
+    // an admitted occurrence into permanently invisible work.
+    let fallbackPrompt = stored?.rendered_prompt;
+    let fallbackMcpIds = stored?.schedule_config_snapshot?.mcp_server_ids;
+    if ((fallbackPrompt === undefined || fallbackMcpIds === undefined) && schedule) {
+      const branch = await this.withTenantDatabase(() =>
+        this.branchRepo.findById(session.branch_id)
+      );
+      if (!branch) return;
+      fallbackPrompt ??= renderSchedulePrompt(schedule.prompt, branch, schedule, scheduledRunAt);
+      fallbackMcpIds ??=
+        schedule.mcp_server_ids !== undefined
+          ? schedule.mcp_server_ids
+          : branch.mcp_server_ids && branch.mcp_server_ids.length > 0
+            ? branch.mcp_server_ids
+            : [];
+    }
+    if (fallbackPrompt === undefined) {
+      throw new Error(
+        `Scheduled Session ${session.session_id} has no snapshotted prompt and its Schedule no longer exists`
+      );
+    }
 
     await this.initializeScheduledSession({
-      schedule,
+      scheduleId,
       session,
       creator,
-      fallbackPrompt: renderSchedulePrompt(schedule.prompt, branch, schedule, scheduledRunAt),
-      fallbackMcpIds,
+      fallbackPrompt,
+      fallbackMcpIds: fallbackMcpIds ?? [],
       recovering: true,
     });
-    await this.enforceRetentionPolicy(schedule);
-    await this.updateScheduleMetadata(schedule, scheduledRunAt, session.session_id, now);
+    await this.finalizeScheduledSession({
+      schedule,
+      scheduleId,
+      session,
+      scheduledRunAt,
+      now,
+      runTestHooks: false,
+    });
+  }
+
+  /**
+   * Finalize one initialized occurrence without requiring its live Schedule.
+   * Ordering is retention -> schedule cursor -> Session marker. If schedule
+   * deletion wins a race during finalization, snapshot-backed initialization
+   * is still complete and the FK-independent marker may safely be written.
+   */
+  private async finalizeScheduledSession(input: {
+    schedule: Schedule | null;
+    scheduleId: ScheduleID;
+    session: Session;
+    scheduledRunAt: number;
+    now: number;
+    runTestHooks: boolean;
+  }): Promise<void> {
+    const { schedule, scheduleId, session, scheduledRunAt, now, runTestHooks } = input;
+    if (schedule) {
+      try {
+        await this.enforceRetentionPolicy(schedule);
+        if (runTestHooks) await this.config.testHooks?.afterRetention?.(session);
+        await this.updateScheduleMetadata(schedule, scheduledRunAt, session.session_id, now);
+        if (runTestHooks) await this.config.testHooks?.afterMetadata?.(session);
+      } catch (error) {
+        const stillExists = await this.withTenantDatabase(() =>
+          this.scheduleRepo.findById(scheduleId)
+        );
+        if (stillExists || !(error instanceof EntityNotFoundError)) throw error;
+        this.logDeletedScheduleRecovery(scheduleId, session.session_id);
+      }
+    } else {
+      this.logDeletedScheduleRecovery(scheduleId, session.session_id);
+    }
     await this.withTenantDatabase(() =>
       this.sessionRepo.markScheduledInitializationComplete(session.session_id)
     );
   }
 
+  private logDeletedScheduleRecovery(scheduleId: ScheduleID, sessionId: SessionID): void {
+    console.info('[DistributedWork]', {
+      component: 'scheduler',
+      event: 'occurrence_recovered_after_schedule_delete',
+      instance_id: this.config.workIdentity.instanceId,
+      boot_id: this.config.workIdentity.bootId,
+      tenant_id: getCurrentTenantId(),
+      schedule_id: scheduleId,
+      session_id: sessionId,
+    });
+  }
+
   private async initializeScheduledSession(input: {
-    schedule: Schedule;
+    scheduleId: ScheduleID;
     session: Session;
     creator: User;
     fallbackPrompt: string;
     fallbackMcpIds: readonly string[];
     recovering: boolean;
   }): Promise<Task> {
-    const { schedule, session, creator } = input;
+    const { scheduleId, session, creator } = input;
     const stored = session.custom_context?.scheduled_run;
     const existingTasks = await this.withTenantDatabase(() =>
       this.taskRepo.findBySession(session.session_id)
@@ -1125,7 +1216,7 @@ export class SchedulerService {
           instance_id: this.config.workIdentity.instanceId,
           boot_id: this.config.workIdentity.bootId,
           tenant_id: getCurrentTenantId(),
-          schedule_id: schedule.schedule_id,
+          schedule_id: scheduleId,
           session_id: session.session_id,
           mcp_server_id: serverId,
         });
@@ -1156,7 +1247,7 @@ export class SchedulerService {
       instance_id: this.config.workIdentity.instanceId,
       boot_id: this.config.workIdentity.bootId,
       tenant_id: tenantId,
-      schedule_id: schedule.schedule_id,
+      schedule_id: scheduleId,
       session_id: session.session_id,
       task_id: task.task_id,
       task_status: task.status,
@@ -1233,7 +1324,34 @@ export class SchedulerService {
         orderByScheduledRunAt: 'desc',
       })
     );
-    const sessionsToDelete = mine.slice(schedule.retention);
+    const overflow = mine.slice(schedule.retention);
+    const sessionsToDelete: Session[] = [];
+    for (const session of overflow) {
+      const initializationComplete = await this.withTenantDatabase(() =>
+        this.sessionRepo.isScheduledInitializationComplete(session.session_id)
+      );
+      const sessionTasks = await this.withTenantDatabase(() =>
+        this.taskRepo.findBySession(session.session_id)
+      );
+      const active =
+        ACTIVE_SESSION_STATUSES.includes(session.status) ||
+        !initializationComplete ||
+        sessionTasks.some((task) => ACTIVE_TASK_STATUSES.includes(task.status));
+      if (active) {
+        console.info('[DistributedWork]', {
+          component: 'scheduler',
+          event: 'retention_skipped_active_occurrence',
+          instance_id: this.config.workIdentity.instanceId,
+          boot_id: this.config.workIdentity.bootId,
+          tenant_id: getCurrentTenantId(),
+          schedule_id: schedule.schedule_id,
+          session_id: session.session_id,
+          session_status: session.status,
+        });
+        continue;
+      }
+      sessionsToDelete.push(session);
+    }
 
     if (sessionsToDelete.length > 0) {
       const sessionService = this.app.service('sessions');

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -40,6 +40,7 @@ import type {
   SessionID,
   Task,
   TaskID,
+  TaskPendingDispatchStatus,
   UUID,
 } from '@agor/core/types';
 import {
@@ -139,7 +140,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   /** Atomic daemon-side launch-intent fence plus its Session projection. */
   async claimDispatchAndProjectSession(
     taskId: string,
-    expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
+    expectedStatus: TaskPendingDispatchStatus,
     updates: Partial<Task>,
     params?: TaskParams
   ): Promise<TaskDispatchClaimResult> {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -136,14 +136,18 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     this.heartbeatCallbackRunner = new ExecutorHeartbeatCallbackRunner(heartbeatConfig);
   }
 
-  /** Atomic daemon-side claim for the durable task launch-intent transition. */
-  async claimDispatch(
+  /** Atomic daemon-side launch-intent fence plus its Session projection. */
+  async claimDispatchAndProjectSession(
     taskId: string,
     expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
     updates: Partial<Task>,
     params?: TaskParams
   ): Promise<TaskDispatchClaimResult> {
-    const result = await this.taskRepo.claimDispatch(taskId, expectedStatus, updates);
+    const result = await this.taskRepo.claimDispatchAndProjectSession(
+      taskId,
+      expectedStatus,
+      updates
+    );
     if (result.outcome === 'claimed') {
       emitServiceEvent(this.app, {
         path: 'tasks',

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -18,6 +18,7 @@ import {
 import {
   enqueueTenantDatabasePostCommitCallback,
   shortId,
+  type TaskDispatchClaimResult,
   TaskRepository,
   type TenantScopeAwareDatabase,
   type TerminationClaimInput,
@@ -133,6 +134,26 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     this.db = db;
     const heartbeatConfig = resolveExecutorHeartbeatConfig(app.get?.('config')?.execution);
     this.heartbeatCallbackRunner = new ExecutorHeartbeatCallbackRunner(heartbeatConfig);
+  }
+
+  /** Atomic daemon-side claim for the durable task launch-intent transition. */
+  async claimDispatch(
+    taskId: string,
+    expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
+    updates: Partial<Task>,
+    params?: TaskParams
+  ): Promise<TaskDispatchClaimResult> {
+    const result = await this.taskRepo.claimDispatch(taskId, expectedStatus, updates);
+    if (result.outcome === 'claimed') {
+      emitServiceEvent(this.app, {
+        path: 'tasks',
+        event: 'patched',
+        data: result.task,
+        params,
+        id: result.task.task_id,
+      });
+    }
+    return result;
   }
 
   /**

--- a/apps/agor-daemon/src/setup/distributed-work-identity.test.ts
+++ b/apps/agor-daemon/src/setup/distributed-work-identity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Application } from '../declarations.js';
+import { initializeDistributedWorkIdentity } from './distributed-work-identity.js';
+
+function makeApplicationSettings() {
+  const settings = new Map<string, unknown>();
+  const app = {
+    get: vi.fn((name: string) => settings.get(name)),
+    set: vi.fn((name: string, value: unknown) => {
+      settings.set(name, value);
+      return app;
+    }),
+  } as unknown as Pick<Application, 'get' | 'set'>;
+  return { app, settings };
+}
+
+describe('daemon distributed-work identity lifecycle', () => {
+  it('generates once and shares the same app-owned identity with every consumer', () => {
+    const { app } = makeApplicationSettings();
+    const generateBootId = vi.fn(() => 'boot-one');
+
+    const initialized = initializeDistributedWorkIdentity(app, {
+      configuredInstanceId: 'runtime-a',
+      environment: { AGOR_DAEMON_INSTANCE_ID: 'env-b', HOSTNAME: 'host-c' },
+      generateBootId,
+    });
+    const repeated = initializeDistributedWorkIdentity(app, {
+      configuredInstanceId: 'must-not-replace-runtime-a',
+      environment: {},
+      generateBootId,
+    });
+    const schedulerConsumer = app.get('distributedWorkIdentity');
+    const futureWorkerConsumer = app.get('distributedWorkIdentity');
+
+    expect(generateBootId).toHaveBeenCalledOnce();
+    expect(repeated).toBe(initialized);
+    expect(schedulerConsumer).toBe(initialized);
+    expect(futureWorkerConsumer).toBe(initialized);
+  });
+});

--- a/apps/agor-daemon/src/setup/distributed-work-identity.test.ts
+++ b/apps/agor-daemon/src/setup/distributed-work-identity.test.ts
@@ -20,12 +20,10 @@ describe('daemon distributed-work identity lifecycle', () => {
     const generateBootId = vi.fn(() => 'boot-one');
 
     const initialized = initializeDistributedWorkIdentity(app, {
-      configuredInstanceId: 'runtime-a',
       environment: { AGOR_DAEMON_INSTANCE_ID: 'env-b', HOSTNAME: 'host-c' },
       generateBootId,
     });
     const repeated = initializeDistributedWorkIdentity(app, {
-      configuredInstanceId: 'must-not-replace-runtime-a',
       environment: {},
       generateBootId,
     });
@@ -33,6 +31,7 @@ describe('daemon distributed-work identity lifecycle', () => {
     const futureWorkerConsumer = app.get('distributedWorkIdentity');
 
     expect(generateBootId).toHaveBeenCalledOnce();
+    expect(initialized.instanceId).toBe('env-b');
     expect(repeated).toBe(initialized);
     expect(schedulerConsumer).toBe(initialized);
     expect(futureWorkerConsumer).toBe(initialized);

--- a/apps/agor-daemon/src/setup/distributed-work-identity.ts
+++ b/apps/agor-daemon/src/setup/distributed-work-identity.ts
@@ -1,0 +1,25 @@
+import {
+  type CreateDistributedWorkIdentityOptions,
+  createDistributedWorkIdentity,
+  type DistributedWorkIdentity,
+} from '@agor/core/coordination';
+import type { Application } from '../declarations.js';
+
+export type InitializeDistributedWorkIdentityOptions = CreateDistributedWorkIdentityOptions;
+
+/**
+ * Own the process-wide distributed-work diagnostic identity on the Feathers
+ * application. Repeated initialization is idempotent so no second boot ID can
+ * be generated accidentally within one application/process incarnation.
+ */
+export function initializeDistributedWorkIdentity(
+  app: Pick<Application, 'get' | 'set'>,
+  options: InitializeDistributedWorkIdentityOptions
+): DistributedWorkIdentity {
+  const existing = app.get('distributedWorkIdentity');
+  if (existing) return existing;
+
+  const identity = createDistributedWorkIdentity(options);
+  app.set('distributedWorkIdentity', identity);
+  return identity;
+}

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -842,7 +842,7 @@ export function createSocketIOConfig(
       });
 
       // Route terminal tab commands. The daemon emits this server-side via
-      // io.to() (terminals.ts) AFTER enforcing branch RBAC on the HTTP
+      // Socket.IO room targeting (terminals.ts) AFTER enforcing branch RBAC on the HTTP
       // create() path. We must NOT let browsers emit it directly — doing so
       // would let a user with 'view'-only on a branch open a Zellij tab
       // (and a shell) inside that branch, bypassing the HTTP RBAC gate.

--- a/apps/agor-daemon/src/startup.test.ts
+++ b/apps/agor-daemon/src/startup.test.ts
@@ -101,6 +101,7 @@ function makeStartupContextWithGuardedDb(fixtures: StartupFixtures = {}) {
     getSocketServer: vi.fn(() => null),
     sessionsService,
     terminalsService: null,
+    distributedWorkIdentity: { instanceId: 'startup-test', bootId: 'startup-test-boot' },
   } as unknown as StartupContext;
 
   return { ctx, baseDb, tasksService, sessionsService };

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -701,7 +701,6 @@ export async function startup(ctx: StartupContext): Promise<void> {
     schedulerService = new SchedulerService(db, app, {
       tickInterval: 30000, // 30 seconds
       gracePeriod: 120000, // 2 minutes
-      debug: process.env.NODE_ENV !== 'production',
       unixUserMode: config.execution?.unix_user_mode ?? 'simple',
       // Static mode keeps the historical single-tenant scope. Auth-resolved
       // multi-tenant mode leaves this undefined so the scheduler discovers due
@@ -711,7 +710,6 @@ export async function startup(ctx: StartupContext): Promise<void> {
     });
     app.set('scheduler', schedulerService);
     schedulerService.start();
-    console.log('🔄 Scheduler started (tick interval: 30s)');
   }
 
   // 7. Start Knowledge embedding indexer (no-op unless semantic search is configured)
@@ -776,7 +774,6 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
       // Stop scheduler
       if (schedulerService) {
-        console.log('🔄 Stopping scheduler...');
         schedulerService.stop();
       }
 

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -14,6 +14,7 @@ import {
   resolveExecutorHeartbeatConfig,
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
+import type { DistributedWorkIdentity } from '@agor/core/coordination';
 import {
   MessagesRepository,
   runWithTenantContext,
@@ -68,6 +69,8 @@ export interface StartupContext {
   /** Services returned from registerServices() */
   sessionsService: SessionsServiceImpl;
   terminalsService: TerminalsService | null;
+  /** One diagnostic identity owned by this daemon application/process. */
+  distributedWorkIdentity: DistributedWorkIdentity;
 }
 
 // ---------------------------------------------------------------------------
@@ -704,6 +707,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
       // multi-tenant mode leaves this undefined so the scheduler discovers due
       // schedule tenant metadata at the DB boundary on each tick.
       tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
+      workIdentity: ctx.distributedWorkIdentity,
     });
     app.set('scheduler', schedulerService);
     schedulerService.start();

--- a/apps/agor-daemon/src/utils/build-initial-user-message.test.ts
+++ b/apps/agor-daemon/src/utils/build-initial-user-message.test.ts
@@ -1,0 +1,24 @@
+import type { MessageID, SessionID, TaskID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { buildInitialUserMessage } from './build-initial-user-message.js';
+
+describe('buildInitialUserMessage', () => {
+  it('preserves a stable identity for idempotent producer recovery', () => {
+    const messageId = 'stable-initial-message' as MessageID;
+    const message = buildInitialUserMessage({
+      messageId,
+      sessionId: 'session-1' as SessionID,
+      taskId: 'task-1' as TaskID,
+      index: 0,
+      timestamp: '2026-08-06T00:00:00.000Z',
+      content: 'recover me',
+    });
+
+    expect(message).toMatchObject({
+      message_id: messageId,
+      task_id: 'task-1',
+      role: 'user',
+      content: 'recover me',
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/build-initial-user-message.ts
+++ b/apps/agor-daemon/src/utils/build-initial-user-message.ts
@@ -19,6 +19,8 @@ import { MessageRole } from '@agor/core/types';
 const CONTENT_PREVIEW_MAX_CHARS = 200;
 
 export interface BuildInitialUserMessageInput {
+  /** Stable identity for idempotent producers; generated for ordinary prompts. */
+  messageId?: Message['message_id'];
   sessionId: SessionID;
   /** Task this message opens. Optional only for v1 orphan-fallback paths. */
   taskId: TaskID | undefined;
@@ -43,7 +45,7 @@ export function buildInitialUserMessage(input: BuildInitialUserMessageInput): Me
       ? input.content.slice(0, CONTENT_PREVIEW_MAX_CHARS)
       : safeStringify(input.content).slice(0, CONTENT_PREVIEW_MAX_CHARS);
   return {
-    message_id: generateId() as UUID as Message['message_id'],
+    message_id: input.messageId ?? (generateId() as UUID as Message['message_id']),
     session_id: input.sessionId,
     task_id: input.taskId,
     type: input.type ?? 'user',

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -16,10 +16,7 @@
 
 import type { Application } from '@agor/core/feathers';
 import type { Paginated, Params, SessionID, Task } from '@agor/core/types';
-import { EXECUTING_TASK_STATUSES, isTaskExecuting } from '@agor/core/types';
-
-/** Statuses considered "active" — an executor may still be doing work. */
-export const ACTIVE_TASK_STATUSES = EXECUTING_TASK_STATUSES;
+import { isTaskExecuting } from '@agor/core/types';
 
 function recencyKey(t: Task): number {
   return new Date(t.started_at || t.created_at).getTime();

--- a/apps/agor-daemon/src/utils/structured-log.test.ts
+++ b/apps/agor-daemon/src/utils/structured-log.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatStructuredLog, structuredLogErrorCode } from './structured-log.js';
+
+describe('structured operational logs', () => {
+  it('formats bounded key=value fields and skips undefined values', () => {
+    expect(
+      formatStructuredLog('[component]', {
+        event: 'started',
+        id: 'abc 123',
+        count: 2,
+        enabled: true,
+        omitted: undefined,
+      })
+    ).toBe('[component] event="started" id="abc 123" count=2 enabled=true');
+  });
+
+  it('extracts only bounded error codes through causes', () => {
+    const error = Object.assign(new Error('outer'), {
+      cause: Object.assign(new Error('inner'), { code: 'SQLITE_BUSY' }),
+    });
+
+    expect(structuredLogErrorCode(error)).toBe('SQLITE_BUSY');
+    expect(structuredLogErrorCode(new Error('raw message is not logged'))).toBe('operation_failed');
+  });
+});

--- a/apps/agor-daemon/src/utils/structured-log.ts
+++ b/apps/agor-daemon/src/utils/structured-log.ts
@@ -1,0 +1,42 @@
+export type StructuredLogLevel = 'info' | 'warn' | 'error';
+export type StructuredLogValue = string | number | boolean | null | undefined;
+
+const MAX_STRING_LOG_VALUE_LENGTH = 256;
+
+function truncateLogString(value: string): string {
+  if (value.length <= MAX_STRING_LOG_VALUE_LENGTH) return value;
+  return `${value.slice(0, MAX_STRING_LOG_VALUE_LENGTH - 1)}…`;
+}
+
+export function formatStructuredLogValue(value: Exclude<StructuredLogValue, undefined>): string {
+  return typeof value === 'string' ? JSON.stringify(truncateLogString(value)) : String(value);
+}
+
+export function formatStructuredLog(
+  prefix: string,
+  fields: Record<string, StructuredLogValue>
+): string {
+  const details = Object.entries(fields)
+    .filter(
+      (entry): entry is [string, Exclude<StructuredLogValue, undefined>] => entry[1] !== undefined
+    )
+    .map(([key, value]) => `${key}=${formatStructuredLogValue(value)}`)
+    .join(' ');
+  return details ? `${prefix} ${details}` : prefix;
+}
+
+/** Extract only a bounded, non-payload error category for operational logs. */
+export function structuredLogErrorCode(error: unknown): string {
+  let current = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current && !seen.has(current); depth += 1) {
+    seen.add(current);
+    if (typeof current !== 'object') break;
+    const record = current as { code?: unknown; cause?: unknown };
+    if (typeof record.code === 'string' && /^[A-Za-z0-9_]{1,64}$/.test(record.code)) {
+      return record.code;
+    }
+    current = record.cause;
+  }
+  return 'operation_failed';
+}

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -1,0 +1,197 @@
+# Scheduler HA and recoverable occurrence initialization (2026-08-05)
+
+## Decision
+
+The first daemon-HA scheduler slice uses the existing scheduled `Session` plus its
+initial `Task` as the durable occurrence/recovery record. It does **not** add a
+`schedule_runs` table.
+
+That choice is deliberate:
+
+- `sessions(tenant_id, schedule_id, scheduled_run_at)` already represents exactly
+  one accepted occurrence and is already the product-visible run history.
+- the Session is inserted before MCP attachment or prompt work and snapshots the
+  rendered prompt, effective MCP IDs, runtime configuration, and a stable
+  `initial_task_id`;
+- a stable Task insert plus an atomic `CREATED|QUEUED -> DISPATCHING` transition
+  makes prompt recovery idempotent and fences stale starters;
+- an internal, nullable `sessions.scheduler_init_completed_at` marker is written
+  only after initialization, retention, and schedule metadata are durable. A
+  bounded scan of NULL markers recovers both cron and manual occurrences without
+  depending on the cron grace window.
+
+A new run ledger would duplicate Session/Task state, introduce reconciliation and
+retention questions for a second history, and make “manual run is in progress but
+has no Session yet” a new product-visible semantic. None of that is needed for this
+failure window. Revisit a separate ledger only if a future requirement must persist
+skipped/rejected occurrences as first-class history or coordinate work before a
+Session can exist.
+
+## Current-state audit before this change
+
+The old flow was:
+
+1. every 30 seconds, discover every enabled schedule whose `next_run_at` was due;
+2. derive the latest cron occurrence (two-minute grace, no backfill) or minute-round
+   `run-now`;
+3. look for an existing `(schedule_id, scheduled_run_at)` Session;
+4. check active Sessions when `allow_concurrent_runs=false`;
+5. render the prompt and materialize user/preset defaults;
+6. insert an IDLE Session; the partial unique index resolved only same-occurrence
+   insert races;
+7. attach configured MCP servers;
+8. call `/sessions/:id/prompt`, which created a Task and moved it to DISPATCHING;
+9. advance schedule metadata;
+10. attempt retention best-effort.
+
+Cron and manual triggers in the same minute intentionally share the same occurrence
+identity. A repeated manual click returns the existing Session. A cron concurrency
+collision is skipped and advances the cursor; a manual collision returns
+`schedule_busy`. `allow_concurrent_runs` is schedule-scoped, not branch-scoped.
+
+Three audit corrections mattered:
+
+- comments claimed a per-schedule advisory lock existed, but the scheduler never
+  called the advisory-lock helper;
+- source schema defined PostgreSQL `sessions_schedule_run_unique` as
+  `(tenant_id, schedule_id, scheduled_run_at)`, while migrated databases still had
+  the historical `(schedule_id, scheduled_run_at)` index; migration 0071 repairs
+  that mismatch;
+- `session_mcp_servers_pk` was only a non-unique index in both dialects, so concurrent
+  recovery could duplicate attachments. The new migrations deduplicate legacy rows
+  and make it a real dialect-appropriate unique index.
+
+## Kill-point audit and settled recovery behavior
+
+| Kill point                               | Old result                                                                              | New result                                                                                                          |
+| ---------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Before Session insert                    | Due cursor remains; later tick retries                                                  | Same                                                                                                                |
+| During/after Session insert              | Insert may win, but later schedulers returned it and permanently skipped initialization | Unique Session is the durable occurrence; later scheduler reconciles it                                             |
+| During MCP attachment                    | Partial attachment set, never repaired                                                  | Effective MCP IDs are snapshotted; attachment is insert-on-conflict idempotent and retried                          |
+| Before initial Task insert               | Prompt permanently lost                                                                 | Stable `initial_task_id` is already in Session; retry creates that Task                                             |
+| After Task insert while CREATED          | CREATED was outside scheduler recovery/startup orphan handling                          | Retry reuses the same Task and atomically claims DISPATCHING                                                        |
+| Two daemons starting the Task            | Process-local session lock did not cross daemon boundaries                              | row-locked expected-state transition has one winner; losers return durable state                                    |
+| After DISPATCHING                        | Runtime supervision owns the durable launch intent                                      | Same ownership, now explicit: scheduler does not replay DISPATCHING work                                            |
+| After prompt dispatch, before metadata   | Existing Session caused metadata advance, but initialization was not checked            | Task state is reconciled, then retention and metadata run                                                           |
+| During retention                         | failure was swallowed after metadata, so cleanup could be missed indefinitely           | retention precedes metadata; absence after a concurrent delete is idempotent, other failures leave the schedule due |
+| After metadata, before completion marker | occurrence was usually treated complete because the cursor had advanced                 | bounded incomplete-Session discovery reconciles once more, then writes the marker                                   |
+| After completion marker                  | occurrence is complete                                                                  | Same; every prior required step is already durable                                                                  |
+
+A process kill cannot be represented by a thrown JavaScript exception, so scheduler
+tests inject crashes immediately after Session admission, MCP attachment, prompt
+dispatch, retention, and metadata. Repository tests separately cover the Task-create
+and Task-dispatch boundaries.
+
+## Coordination and transaction model
+
+All daemons scan. There is no fleet leader and no external lock service.
+
+Occurrence admission is one short tenant transaction:
+
+1. `SELECT` the schedule row `FOR UPDATE` on PostgreSQL;
+2. re-check the occurrence unique key;
+3. when concurrency is disabled, check for an active Session **or** its initialization
+   window (no Task / nonterminal Task);
+4. insert the Session;
+5. commit.
+
+Rendering, configuration resolution, MCP attachment, prompt dispatch, retention, and
+executor launch are not performed while that row lock is held. SQLite keeps its
+standalone behavior; same-occurrence uniqueness is its race guard and bounded
+`SQLITE_BUSY` retry protects concurrent final metadata updates.
+
+No scheduler claim survives a transaction, so there is intentionally no expiring
+lease, owner token, or generation column in this slice. Durable transition state is
+the fence:
+
+- the Session unique key elects the occurrence;
+- the stable Task primary key elects prompt creation;
+- Task status conditionally moving to DISPATCHING elects the launcher;
+- the existing heartbeat/runtime supervisor owns work after DISPATCHING.
+
+Adding an expiring scheduler lease would create a dangerous pause-after-expiry window
+around executor launch unless every side effect were independently fenced. The
+idempotent state transitions already provide the stronger and smaller design.
+
+## Scanning, recovery bound, and diagnostics
+
+Defaults:
+
+- due-schedule and incomplete-Session scans are independently limited to 25 rows;
+- incomplete discovery uses a `(created_at, session_id)` keyset cursor and wraps;
+  the cursor advances regardless of per-row success so one poison batch cannot
+  permanently starve newer recoveries. It is only scan fairness state—the NULL
+  database marker remains the durable authority and every wrap retries failures;
+- a full batch drains again after 50–250 ms;
+- startup waits a uniform 0–30 seconds;
+- empty scans back off to at most 60 seconds with +/-20% jitter;
+- therefore an already-running replacement notices an incomplete occurrence in
+  the current recovery page within at most **72 seconds** of scan delay, and a
+  newly started replacement within **30 seconds**, plus database/application
+  work time. With a recovery backlog, add at most one 50–250 ms saturated-drain
+  delay plus processing time for each preceding 25-row page. This is independent
+  of cron grace and does not require another manual `run-now` request.
+
+The 72-second cap remains below the two-minute cron grace. Jitter only reduces herd
+contention; uniqueness and atomic transitions own correctness. Clock/random samples
+are injectable or pure for deterministic tests.
+
+Structured `[DistributedWork]` logs include component/event, daemon instance ID,
+boot ID, tenant/schedule/session/task IDs, occurrence time, source, Task status, and
+per-scan candidate/processed/failure counts. Events distinguish occurrence admission
+wins, losses/reconciliation, busy skips, initialization, and recovery. Prompt text,
+MCP credentials, task tokens, and other secrets are not logged. Lease expiration is
+not reported because the scheduler has no lease.
+
+## Tenant boundary
+
+System discovery has one narrow `scheduler_discovery` RLS capability. It can select
+only enabled schedule routing rows and scheduled Sessions whose internal completion
+marker is NULL. The repository queries project only routing IDs, occurrence time,
+and `tenant_id`, with predicates and batch limits; prompts/configuration are not
+visible in system scope. The capability is transaction-local. Each candidate is then
+reloaded and processed under its trusted tenant context; Session, Task, MCP, schedule
+metadata, retention, and realtime events remain in that scope. PostgreSQL integration
+coverage checks system routing, tenant reload isolation, concurrent admission, and
+Task fencing.
+
+## Thin reusable foundation and non-goals
+
+Reusable pieces introduced by this slice are intentionally low-level:
+
+- `DistributedWorkIdentity` for instance/boot diagnostics;
+- pure bounded backoff, jitter, and startup-offset helpers with injected randomness;
+- repository-level stable-ID pending Task creation;
+- repository-level atomic expected-state dispatch claim.
+
+There is no `DistributedWorkController`, generic state-machine runner, universal lease
+table, consensus abstraction, leader election, or automatic retry framework.
+Scheduler still owns its occurrence state machine.
+
+## PostgreSQL basis
+
+The design follows PostgreSQL's documented behavior:
+
+- row locks are held until transaction end, so admission transactions must remain
+  short: <https://www.postgresql.org/docs/17/explicit-locking.html>;
+- under READ COMMITTED, each statement receives a fresh snapshot, and the row-lock
+  wait is followed by re-checking durable state:
+  <https://www.postgresql.org/docs/16/transaction-iso.html>;
+- `SKIP LOCKED` is appropriate for queue-like consumers but provides an inconsistent
+  view, so this slice does not use it for schedule correctness:
+  <https://www.postgresql.org/docs/18/sql-select.html>;
+- transaction-scoped advisory locks exist, but a durable schedule row is available
+  and clearer here: <https://www.postgresql.org/docs/current/functions-admin.html>.
+
+## Follow-on candidates
+
+1. Session queue draining now benefits from the cross-daemon Task dispatch fence, but
+   its queue-position selection and session readiness decision still need a complete
+   HA audit before claiming multi-daemon safety.
+2. Gateway listeners and other background consumers should reuse identity/delay
+   helpers only; their owner-specific state machines should remain local.
+3. Work that must hold ownership across external calls should add database-time lease
+   expiry plus an opaque generation/token and require every state transition to match
+   that generation. Do this only for a concrete second/third consumer.
+4. Task DISPATCHING supervision and process ownership are the next daemon-HA boundary;
+   this scheduler slice intentionally stops at durable launch intent.

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -129,6 +129,26 @@ Adding an expiring scheduler lease would create a dangerous pause-after-expiry w
 around executor launch unless every side effect were independently fenced. The
 idempotent state transitions already provide the stronger and smaller design.
 
+### Diagnostic identity lifecycle
+
+The daemon composition root creates exactly one immutable `DistributedWorkIdentity`
+when it creates the Feathers application, stores that object on the application, and
+injects the same object into SchedulerService. Future background consumers should read
+that app-owned identity rather than creating worker-local identities.
+
+`instanceId` precedence is the existing explicit runtime identifier
+`external_launch.instance_id`, then `AGOR_DAEMON_INSTANCE_ID`, then `HOSTNAME`, then
+the safe `daemon` fallback. Whitespace-only candidates are ignored and selected values
+are trimmed. The platform should supply a stable value when diagnostics must correlate
+one daemon instance across restarts; the fallback is intentionally only a label.
+`bootId` is generated exactly once at application initialization and identifies that
+one process incarnation.
+
+Both fields are diagnostic log correlation only. Neither is an authorization,
+fencing, lease, liveness, ownership, or correctness boundary. In particular, using
+the already-settled external-launch runtime identifier as the first diagnostic source
+does not transfer launch auth semantics into `@agor/core/coordination`.
+
 ## Scanning, recovery bound, and diagnostics
 
 Defaults:
@@ -176,7 +196,7 @@ case), concurrent admission, and Task fencing.
 
 Reusable pieces introduced by this slice are intentionally low-level:
 
-- `DistributedWorkIdentity` for instance/boot diagnostics;
+- a pure `DistributedWorkIdentity` factory for app-owned instance/boot diagnostics;
 - pure bounded backoff, jitter, and startup-offset helpers with injected randomness;
 - repository-level stable-ID pending Task creation;
 - repository-level atomic expected-state dispatch claim.

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -125,6 +125,21 @@ removing the creator after durable dispatch therefore cannot strand the schedule
 completion marker. Those checks still apply while the Task is absent or pending,
 because crossing DISPATCHING would launch new work.
 
+The remaining operator-visible poison case is a persistent failure before that
+dispatch fence (for example, the creator is deleted or launch configuration remains
+invalid after occurrence admission). Recovery keeps retrying and leaves the internal
+completion marker NULL, which intentionally prevents a non-concurrent schedule from
+silently skipping durable, accepted work. Today the repair path is operator action
+(fix the configuration/user or delete/terminalize the incomplete Session); a future
+policy can add a bounded give-up marker once the product contract for retry count,
+age, and failure surfacing is explicit.
+
+Mixed-version daemon fleets are also transitional-risky: migration 0071 backfills
+historical markers, but an old daemon that admits a scheduled Session after the
+migration will not write the new initialization snapshot/marker. Upgrade all
+scheduler daemons together; mixed fleets may temporarily duplicate initial prompt
+work until every daemon is running the fenced implementation.
+
 Adding an expiring scheduler lease would create a dangerous pause-after-expiry window
 around executor launch unless every side effect were independently fenced. The
 idempotent state transitions already provide the stronger and smaller design.

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -172,12 +172,13 @@ The 72-second cap remains below the two-minute cron grace. Jitter only reduces h
 contention; uniqueness and atomic transitions own correctness. Clock/random samples
 are injectable or pure for deterministic tests.
 
-Structured `[DistributedWork]` logs include component/event, daemon instance ID,
-boot ID, tenant/schedule/session/task IDs, occurrence time, source, Task status, and
-per-scan candidate/processed/failure counts. Events distinguish occurrence admission
-wins, losses/reconciliation, busy skips, initialization, and recovery. Prompt text,
-MCP credentials, task tokens, and other secrets are not logged. Lease expiration is
-not reported because the scheduler has no lease.
+Bounded `[distributed-work.<component>]` `key=value` logs include event, daemon
+instance ID, boot ID, trusted tenant/schedule/session/task IDs, occurrence time,
+source, Task status, and activity-scan candidate/processed/failure counts. Idle scans
+are omitted. Events distinguish occurrence admission wins, losses/reconciliation,
+busy skips, initialization, and recovery. Prompt text, schedule names, user identity,
+MCP credentials, task tokens, raw errors, and other secrets are not logged. Lease
+expiration is not reported because the scheduler has no lease.
 
 ## Tenant boundary
 

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -136,18 +136,18 @@ when it creates the Feathers application, stores that object on the application,
 injects the same object into SchedulerService. Future background consumers should read
 that app-owned identity rather than creating worker-local identities.
 
-`instanceId` precedence is the existing explicit runtime identifier
-`external_launch.instance_id`, then `AGOR_DAEMON_INSTANCE_ID`, then `HOSTNAME`, then
-the safe `daemon` fallback. Whitespace-only candidates are ignored and selected values
-are trimmed. The platform should supply a stable value when diagnostics must correlate
-one daemon instance across restarts; the fallback is intentionally only a label.
+`instanceId` precedence is `AGOR_DAEMON_INSTANCE_ID`, then `HOSTNAME`, then the safe
+`daemon` fallback. Whitespace-only candidates are ignored and selected values are
+trimmed. The platform should supply a stable value when diagnostics must correlate one
+daemon instance across restarts; the fallback is intentionally only a label. A dedicated
+YAML `deployment.instance_id` may be added later with the HA configuration contract;
+no existing unrelated configuration field is reused for this identity.
 `bootId` is generated exactly once at application initialization and identifies that
 one process incarnation.
 
 Both fields are diagnostic log correlation only. Neither is an authorization,
-fencing, lease, liveness, ownership, or correctness boundary. In particular, using
-the already-settled external-launch runtime identifier as the first diagnostic source
-does not transfer launch auth semantics into `@agor/core/coordination`.
+fencing, lease, liveness, ownership, or correctness boundary. External-launch assertion
+binding remains a separate security concern and is not read or changed by this identity.
 
 ## Scanning, recovery bound, and diagnostics
 

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -73,7 +73,7 @@ Three audit corrections mattered:
 | After Task insert while CREATED                         | CREATED was outside scheduler recovery/startup orphan handling                          | Retry reuses the same Task and atomically claims DISPATCHING plus its Session RUNNING/task-list projection                                                            |
 | Two daemons starting the Task                           | Process-local session lock did not cross daemon boundaries                              | row-locked expected-state transition has one winner; losers return durable state                                                                                      |
 | After DISPATCHING, before transcript/service projection | SQLite could leave an IDLE Session without its Task/message projection                  | Task claim + Session projection are one dialect-native transaction; the stable initial message ID lets recovery repair the transcript idempotently                    |
-| After durable DISPATCHING projection                    | Runtime supervision owns the durable launch intent                                      | Same ownership, now explicit: scheduler does not replay DISPATCHING work                                                                                              |
+| After durable DISPATCHING projection                    | Runtime supervision owns the durable launch intent                                      | Scheduler repairs the stable transcript projection and finalizes initialization without replaying work or re-running mutable creator/tool/preset launch admission     |
 | After prompt dispatch, before metadata                  | Existing Session caused metadata advance, but initialization was not checked            | Task state is reconciled, then retention and metadata run                                                                                                             |
 | During retention                                        | failure was swallowed after metadata, so cleanup could be missed indefinitely           | retention precedes metadata; active/incomplete overflow runs are deferred, absence after a concurrent delete is idempotent, and other failures leave the schedule due |
 | After metadata, before completion marker                | occurrence was usually treated complete because the cursor had advanced                 | bounded incomplete-Session discovery reconciles once more, then writes the marker                                                                                     |
@@ -116,6 +116,14 @@ the fence:
 - Task status conditionally moving to DISPATCHING elects the launcher and
   atomically projects RUNNING/task membership onto the Session in both dialects;
 - the existing heartbeat/runtime supervisor owns work after DISPATCHING.
+
+Once the stable initial Task is no longer CREATED/QUEUED, recovery is deliberately
+a projection-only path. It verifies the Task identity and snapshotted prompt, repairs
+the deterministic initial message if needed, and returns before tool enablement,
+preset materialization, or creator lookup. Disabling a tool, deleting a preset, or
+removing the creator after durable dispatch therefore cannot strand the scheduler
+completion marker. Those checks still apply while the Task is absent or pending,
+because crossing DISPATCHING would launch new work.
 
 Adding an expiring scheduler lease would create a dangerous pause-after-expiry window
 around executor launch unless every side effect were independently fenced. The

--- a/docs/internal/scheduler-ha-recovery-2026-08-05.md
+++ b/docs/internal/scheduler-ha-recovery-2026-08-05.md
@@ -63,19 +63,21 @@ Three audit corrections mattered:
 
 ## Kill-point audit and settled recovery behavior
 
-| Kill point                               | Old result                                                                              | New result                                                                                                          |
-| ---------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Before Session insert                    | Due cursor remains; later tick retries                                                  | Same                                                                                                                |
-| During/after Session insert              | Insert may win, but later schedulers returned it and permanently skipped initialization | Unique Session is the durable occurrence; later scheduler reconciles it                                             |
-| During MCP attachment                    | Partial attachment set, never repaired                                                  | Effective MCP IDs are snapshotted; attachment is insert-on-conflict idempotent and retried                          |
-| Before initial Task insert               | Prompt permanently lost                                                                 | Stable `initial_task_id` is already in Session; retry creates that Task                                             |
-| After Task insert while CREATED          | CREATED was outside scheduler recovery/startup orphan handling                          | Retry reuses the same Task and atomically claims DISPATCHING                                                        |
-| Two daemons starting the Task            | Process-local session lock did not cross daemon boundaries                              | row-locked expected-state transition has one winner; losers return durable state                                    |
-| After DISPATCHING                        | Runtime supervision owns the durable launch intent                                      | Same ownership, now explicit: scheduler does not replay DISPATCHING work                                            |
-| After prompt dispatch, before metadata   | Existing Session caused metadata advance, but initialization was not checked            | Task state is reconciled, then retention and metadata run                                                           |
-| During retention                         | failure was swallowed after metadata, so cleanup could be missed indefinitely           | retention precedes metadata; absence after a concurrent delete is idempotent, other failures leave the schedule due |
-| After metadata, before completion marker | occurrence was usually treated complete because the cursor had advanced                 | bounded incomplete-Session discovery reconciles once more, then writes the marker                                   |
-| After completion marker                  | occurrence is complete                                                                  | Same; every prior required step is already durable                                                                  |
+| Kill point                                              | Old result                                                                              | New result                                                                                                                                                            |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Before Session insert                                   | Due cursor remains; later tick retries                                                  | Same                                                                                                                                                                  |
+| During/after Session insert                             | Insert may win, but later schedulers returned it and permanently skipped initialization | Unique Session is the durable occurrence; later scheduler reconciles it                                                                                               |
+| Schedule deleted after Session insert                   | FK became NULL and the occurrence disappeared from recovery                             | Discovery does not require the live FK; the Session snapshot finishes prompt/MCP initialization, then skips deleted-schedule metadata/retention                       |
+| During MCP attachment                                   | Partial attachment set, never repaired                                                  | Effective MCP IDs are snapshotted; attachment is insert-on-conflict idempotent and retried                                                                            |
+| Before initial Task insert                              | Prompt permanently lost                                                                 | Stable `initial_task_id` is already in Session; retry creates that Task                                                                                               |
+| After Task insert while CREATED                         | CREATED was outside scheduler recovery/startup orphan handling                          | Retry reuses the same Task and atomically claims DISPATCHING plus its Session RUNNING/task-list projection                                                            |
+| Two daemons starting the Task                           | Process-local session lock did not cross daemon boundaries                              | row-locked expected-state transition has one winner; losers return durable state                                                                                      |
+| After DISPATCHING, before transcript/service projection | SQLite could leave an IDLE Session without its Task/message projection                  | Task claim + Session projection are one dialect-native transaction; the stable initial message ID lets recovery repair the transcript idempotently                    |
+| After durable DISPATCHING projection                    | Runtime supervision owns the durable launch intent                                      | Same ownership, now explicit: scheduler does not replay DISPATCHING work                                                                                              |
+| After prompt dispatch, before metadata                  | Existing Session caused metadata advance, but initialization was not checked            | Task state is reconciled, then retention and metadata run                                                                                                             |
+| During retention                                        | failure was swallowed after metadata, so cleanup could be missed indefinitely           | retention precedes metadata; active/incomplete overflow runs are deferred, absence after a concurrent delete is idempotent, and other failures leave the schedule due |
+| After metadata, before completion marker                | occurrence was usually treated complete because the cursor had advanced                 | bounded incomplete-Session discovery reconciles once more, then writes the marker                                                                                     |
+| After completion marker                                 | occurrence is complete                                                                  | Same; every prior required step is already durable                                                                                                                    |
 
 A process kill cannot be represented by a thrown JavaScript exception, so scheduler
 tests inject crashes immediately after Session admission, MCP attachment, prompt
@@ -96,7 +98,12 @@ Occurrence admission is one short tenant transaction:
 5. commit.
 
 Rendering, configuration resolution, MCP attachment, prompt dispatch, retention, and
-executor launch are not performed while that row lock is held. SQLite keeps its
+executor launch are not performed while that row lock is held. Admission uses the
+already-materialized Session repository path rather than the public Feathers create
+pipeline. Realtime/analytics and Unix-access synchronization run after admission;
+the shared Unix side effect is now a deferred `sessions.created` event consumer so
+ordinary and scheduled Session creation cannot launch a process while holding a
+tenant transaction. SQLite keeps its
 standalone behavior; same-occurrence uniqueness is its race guard and bounded
 `SQLITE_BUSY` retry protects concurrent final metadata updates.
 
@@ -106,7 +113,8 @@ the fence:
 
 - the Session unique key elects the occurrence;
 - the stable Task primary key elects prompt creation;
-- Task status conditionally moving to DISPATCHING elects the launcher;
+- Task status conditionally moving to DISPATCHING elects the launcher and
+  atomically projects RUNNING/task membership onto the Session in both dialects;
 - the existing heartbeat/runtime supervisor owns work after DISPATCHING.
 
 Adding an expiring scheduler lease would create a dangerous pause-after-expiry window
@@ -147,13 +155,14 @@ not reported because the scheduler has no lease.
 
 System discovery has one narrow `scheduler_discovery` RLS capability. It can select
 only enabled schedule routing rows and scheduled Sessions whose internal completion
-marker is NULL. The repository queries project only routing IDs, occurrence time,
+marker is NULL, including an incomplete Session whose live schedule FK was nulled by
+schedule deletion. The repository queries project only routing IDs, occurrence time,
 and `tenant_id`, with predicates and batch limits; prompts/configuration are not
 visible in system scope. The capability is transaction-local. Each candidate is then
 reloaded and processed under its trusted tenant context; Session, Task, MCP, schedule
 metadata, retention, and realtime events remain in that scope. PostgreSQL integration
-coverage checks system routing, tenant reload isolation, concurrent admission, and
-Task fencing.
+coverage checks system routing, tenant reload isolation (including the deleted-schedule
+case), concurrent admission, and Task fencing.
 
 ## Thin reusable foundation and non-goals
 

--- a/docs/internal/schedules-first-class-design-2026-05-24.md
+++ b/docs/internal/schedules-first-class-design-2026-05-24.md
@@ -17,7 +17,10 @@ Promote schedules from a one-per-branch blob of columns on `branches` into a fir
 - **Migration** is a single PR: add `schedules`, backfill existing enabled schedules with `timezone_mode='utc'`, ship UI, and drop the four `schedule_*` columns + `data.schedule` JSON blob from `branches` in the same migration. (Per Max — no PR stacking.)
 - **Modal** rewrite — **prompt textarea up top**, compact agent picker, advanced settings collapsed. Add IANA tz dropdown only when `mode=local`.
 - **RBAC:** the schedules service reuses the branch-tier helpers that sessions already uses (`ensureBranchPermission`, `loadBranch`, `injectCreatedBy`, etc. — see §4.4). Tier requirements mirror sessions: `view` to list/get, `session` to create, `session`-for-own / `all`-for-others to patch, `all` to delete, `prompt`-or-own-`session` to `run_now`. Same `config.execution.branch_rbac` feature flag. One new helper: `scopeScheduleQuery` (SQL-JOIN find filter).
-- **Cross-cutting:** HA design ([#1252](https://github.com/preset-io/agor/pull/1252)) wants Postgres advisory locks around the tick — first-class schedules makes the locked region per-schedule instead of per-tick, which is the right scaling shape anyway.
+- **Cross-cutting (updated 2026-08-05):** the original HA draft proposed
+  PostgreSQL advisory locks, but no scheduler callsite ever acquired one. The
+  implemented first HA slice uses a short schedule-row `FOR UPDATE` admission
+  lock plus durable Session/Task identities and transitions; see §7d.
 
 Recommended data-model shape (one paragraph): a `schedules` row owns its own cron, timezone-mode, prompt, agentic-tool config, and enabled flag; `(enabled, next_run_at)` index drives the scheduler; sessions get a nullable `schedule_id` FK so "click a run, open the session" is one join; multiple schedules per branch fall out for free.
 
@@ -113,19 +116,19 @@ schedule?: {
 
 [`apps/agor-daemon/src/services/scheduler.ts`](../../apps/agor-daemon/src/services/scheduler.ts) — single file, ~700 lines.
 
-| Concern             | Where                                                                       | Notes                                                                                                               |
-| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Tick interval       | [`:113`](../../apps/agor-daemon/src/services/scheduler.ts#L113)             | `30_000ms`, configurable                                                                                            |
-| Grace window        | [`:114`](../../apps/agor-daemon/src/services/scheduler.ts#L114)             | `120_000ms`; "fire most recent missed run, no backfill"                                                             |
-| `setInterval` start | [`:142`](../../apps/agor-daemon/src/services/scheduler.ts#L142)             | This is the line [#1252 §HA](https://github.com/preset-io/agor/pull/1252) wants wrapped in a Postgres advisory lock |
-| Due query           | [`:212-220`](../../apps/agor-daemon/src/services/scheduler.ts#L212-L220)    | `findAll().filter(enabled)` — in-memory                                                                             |
-| Cron parser         | [`cron.ts:8`](../../packages/core/src/utils/cron.ts#L8)                     | `cron-parser` v5                                                                                                    |
-| Cron tz             | [`cron.ts:21,39,85,105,130,158`](../../packages/core/src/utils/cron.ts#L21) | Hardcoded `'UTC'` everywhere                                                                                        |
-| Dedup               | [`:439-441`](../../apps/agor-daemon/src/services/scheduler.ts#L439-L441)    | `findAll()` then `.find(scheduled_run_at === ...)`                                                                  |
-| Concurrency guard   | [`:449-470`](../../apps/agor-daemon/src/services/scheduler.ts#L449-L470)    | Cron = silent skip; manual = `ScheduleBusyError` → 409                                                              |
-| Spawn               | [`:483-526`](../../apps/agor-daemon/src/services/scheduler.ts#L483-L526)    | Normal `sessions.create()` with markers                                                                             |
-| Metadata write-back | [`:644-649`](../../apps/agor-daemon/src/services/scheduler.ts#L644-L649)    | Updates `schedule_last_triggered_at`, `schedule_next_run_at`                                                        |
-| Retention           | [`:665-705`](../../apps/agor-daemon/src/services/scheduler.ts#L665-L705)    | `findAll()` then sort DESC by `scheduled_run_at`, slice(N) → delete                                                 |
+| Concern             | Where                                                                       | Notes                                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Tick interval       | [`:113`](../../apps/agor-daemon/src/services/scheduler.ts#L113)             | `30_000ms`, configurable                                                                                                |
+| Grace window        | [`:114`](../../apps/agor-daemon/src/services/scheduler.ts#L114)             | `120_000ms`; "fire most recent missed run, no backfill"                                                                 |
+| `setInterval` start | [`:142`](../../apps/agor-daemon/src/services/scheduler.ts#L142)             | Historical implementation; the HA slice replaced this with jittered `setTimeout` scans and did not add an advisory lock |
+| Due query           | [`:212-220`](../../apps/agor-daemon/src/services/scheduler.ts#L212-L220)    | `findAll().filter(enabled)` — in-memory                                                                                 |
+| Cron parser         | [`cron.ts:8`](../../packages/core/src/utils/cron.ts#L8)                     | `cron-parser` v5                                                                                                        |
+| Cron tz             | [`cron.ts:21,39,85,105,130,158`](../../packages/core/src/utils/cron.ts#L21) | Hardcoded `'UTC'` everywhere                                                                                            |
+| Dedup               | [`:439-441`](../../apps/agor-daemon/src/services/scheduler.ts#L439-L441)    | `findAll()` then `.find(scheduled_run_at === ...)`                                                                      |
+| Concurrency guard   | [`:449-470`](../../apps/agor-daemon/src/services/scheduler.ts#L449-L470)    | Cron = silent skip; manual = `ScheduleBusyError` → 409                                                                  |
+| Spawn               | [`:483-526`](../../apps/agor-daemon/src/services/scheduler.ts#L483-L526)    | Normal `sessions.create()` with markers                                                                                 |
+| Metadata write-back | [`:644-649`](../../apps/agor-daemon/src/services/scheduler.ts#L644-L649)    | Updates `schedule_last_triggered_at`, `schedule_next_run_at`                                                            |
+| Retention           | [`:665-705`](../../apps/agor-daemon/src/services/scheduler.ts#L665-L705)    | `findAll()` then sort DESC by `scheduled_run_at`, slice(N) → delete                                                     |
 
 ### 3.3 Session-as-run encoding
 
@@ -814,26 +817,20 @@ Keep 30s — it's the right granularity (cron's minimum is 1min so 30s gives 2 t
 Today: `sessionRepo.findAll() → .filter(branch_id) → .find(scheduled_run_at)` ([`scheduler.ts:439-441`](../../apps/agor-daemon/src/services/scheduler.ts#L439-L441)).
 Proposed: `SELECT 1 FROM sessions WHERE schedule_id = ? AND scheduled_run_at = ? LIMIT 1` using `sessions_schedule_run_unique`. Indexed lookup.
 
-### 7d. HA / lock semantics (cross-ref #1252)
+### 7d. HA / lock semantics (updated 2026-08-05)
 
-[#1252](https://github.com/preset-io/agor/pull/1252) §T2 calls for a Postgres advisory lock around the scheduler tick ([`scheduler.ts:142`](../../apps/agor-daemon/src/services/scheduler.ts#L142)). With first-class schedules the right shape is **per-schedule** locking, not per-tick — and we're shipping that in V1.
+The V1 design text previously claimed that a per-schedule PostgreSQL advisory lock
+was implemented. It was not: the scheduler never called the helper, and holding a
+transaction while spawning would have violated the short-transaction requirement.
 
-```ts
-// pseudocode — runs once per due schedule, inside the tick loop
-const lockKey = hashScheduleId(schedule.schedule_id); // stable bigint
-const acquired = await db.execute(sql`SELECT pg_try_advisory_xact_lock(${lockKey})`);
-if (!acquired) continue; // another holder is handling this schedule
-// spawn session, advance metadata...
-// transaction commit auto-releases the lock
-```
+The first actual HA slice uses a short `FOR UPDATE` lock on the durable schedule row
+only for occurrence admission and the schedule-scoped concurrency check. Session
+uniqueness, stable initial Task identity, and the atomic Task DISPATCHING transition
+own correctness after commit. SQLite keeps occurrence uniqueness as its race guard.
+The unused advisory-lock helpers were removed.
 
-**Important V1 scope note: Agor is single-daemon today.** The per-schedule lock guards _same-schedule_ duplicate work — useful as forward-positioning if multi-daemon ever lands — but on its own it does NOT preserve the branch-wide `allow_concurrent_runs=false` invariant across daemons. Two daemons could lock two different schedules on the same branch and both pass the branch-level concurrency check. Branch-scoped advisory locking (or a fully serialized scheduler leader) is deferred until multi-daemon is actually supported.
-
-What V1 _does_ protect — even forward into multi-daemon — is duplicate same-schedule runs: a partial unique index `sessions_schedule_run_unique ON (schedule_id, scheduled_run_at) WHERE schedule_id IS NOT NULL AND scheduled_run_at IS NOT NULL` causes the second `(schedule_id, scheduled_run_at)` insert to fail at the DB layer; the scheduler catches the unique-violation as a dedup hit. This guard is dialect-neutral.
-
-**SQLite path:** the advisory-lock attempt is a no-op (`tryAdvisoryXactLock` short-circuits via `isPostgresDatabase`). SQLite is single-node by definition; the unique index alone protects against intra-process check-then-create races between the cron tick and manual run-now paths.
-
-**Coordination with #1252:** that PR's recommended advisory-lock helper lives in `packages/core/src/db/database-wrapper.ts` (`tryAdvisoryXactLock`, `advisoryLockKeyForUuid`) — we built it as part of this work.
+See [scheduler HA and recoverable occurrence initialization](./scheduler-ha-recovery-2026-08-05.md)
+for the implemented state machine, kill-point audit, and recovery bounds.
 
 ---
 
@@ -910,7 +907,8 @@ Max wrote it. Concepts that translate:
 - **Drop** the four `branches.schedule_*` columns + `data.schedule` blob in the same migration (§5.3)
 - Schedules CRUD service (Feathers + REST + WebSocket events)
 - Branch-tier RBAC wired via existing helpers, gated by `execution.branch_rbac` (§4.4)
-- Scheduler reads from `schedules`, honors `timezone_mode`, takes per-schedule `pg_try_advisory_xact_lock` (§7d)
+- Scheduler reads from `schedules`, honors `timezone_mode`, and uses the
+  schedule-row/session/task coordination model documented in §7d
 - New modal with prompt-on-top, local-mode default, IANA tz dropdown
 - Runs side panel
 - 6 MCP tools (§4.3): `agor_schedules_{list,get,create,patch,delete,run_now}`
@@ -936,7 +934,10 @@ Max wrote it. Concepts that translate:
 2. ✅ **Default `timezone_mode = 'local'`.** Backfilled rows get `'utc'` to preserve current behavior. See §4.2.
 3. ✅ **Single PR** — no stacking. `schedules` create + backfill + old-column drop all in one migration per dialect, transaction-wrapped. See §5.3.
 4. ✅ **MCP tool surface — standard CRUD.** Six tools: `agor_schedules_list`, `agor_schedules_get`, `agor_schedules_create`, `agor_schedules_patch`, `agor_schedules_delete`, `agor_schedules_run_now`. Mirrors `agor_branches_*` / `agor_sessions_*` / `agor_boards_*` conventions. See §4.3.
-5. ✅ **Per-schedule Postgres advisory lock in V1.** Cheap (`pg_try_advisory_xact_lock(hash(schedule_id))` per row) and forward-compatible with #1252 HA. SQLite single-node tick stays lock-free. See §7d.
+5. ✅ **HA correction (2026-08-05).** V1 never acquired its claimed advisory
+   lock. The implemented prerequisite uses a short PostgreSQL schedule-row lock,
+   occurrence uniqueness, stable initial Task identity, and an atomic dispatch
+   fence. SQLite remains standalone. See §7d.
 
 ### All RBAC questions resolved (from Max, 2026-05-24)
 
@@ -964,4 +965,4 @@ Non-blocking follow-ups, called out where they live:
 
 - **[#1246 — global search design](https://github.com/preset-io/agor/pull/1246)** — schedules should be a searchable entity in V1 (name + description). Same pattern as branches/sessions/boards in #1246's static registry. Also: that PR's `?focus=<id>` work on SessionCanvas is what "Open in canvas" in the runs view (§6c) would use.
 - **[#1251 — reconnection & state refresh](https://github.com/preset-io/agor/pull/1251)** — minor: when the daemon reconnects after a long drop, the schedules list should be in the rehydrate set. No structural overlap.
-- **[#1252 — daemon HA](https://github.com/preset-io/agor/pull/1252)** — direct overlap. The recommended Postgres advisory lock around the scheduler tick ([`scheduler.ts:142`](../../apps/agor-daemon/src/services/scheduler.ts#L142)) is per-tick today; first-class schedules unlocks per-schedule locking, which is the right HA shape. See §7d. Coordinate ordering with that work.
+- **[#1252 — daemon HA](https://github.com/preset-io/agor/pull/1252)** — direct overlap. The advisory-lock proposal was never implemented; the first actual scheduler HA slice is the schedule-row/Session/Task model in §7d.

--- a/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
+++ b/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
@@ -1,0 +1,71 @@
+-- These index replacements need brief table locks. Fail fast instead of
+-- queueing behind a long transaction and blocking unrelated application work.
+SET LOCAL lock_timeout = '3s';
+--> statement-breakpoint
+
+-- Durable completion marker for recoverable scheduler initialization. Existing
+-- scheduled Sessions predate recovery and are treated as already complete.
+ALTER TABLE "sessions" ADD COLUMN "scheduler_init_completed_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "sessions"
+SET "scheduler_init_completed_at" = COALESCE("updated_at", "created_at")
+WHERE "scheduled_from_branch" = true;
+--> statement-breakpoint
+CREATE INDEX "sessions_scheduler_init_pending_idx"
+  ON "sessions" ("created_at", "session_id")
+  WHERE "scheduled_from_branch" = true
+    AND "schedule_id" IS NOT NULL
+    AND "scheduled_run_at" IS NOT NULL
+    AND "scheduler_init_completed_at" IS NULL;
+--> statement-breakpoint
+
+-- The source schema has been tenant-aware since app-level multitenancy landed,
+-- but the historical migration still leaves this index as
+-- (schedule_id, scheduled_run_at). Repair migrated databases to match source.
+DROP INDEX IF EXISTS "sessions_schedule_run_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "sessions_schedule_run_unique"
+  ON "sessions" ("tenant_id", "schedule_id", "scheduled_run_at")
+  WHERE "schedule_id" IS NOT NULL AND "scheduled_run_at" IS NOT NULL;
+--> statement-breakpoint
+
+-- Recovery may attach the same MCP server from more than one scheduler process.
+-- Dedupe legacy rows before replacing the non-unique index with a tenant-aware
+-- idempotency constraint.
+DELETE FROM "session_mcp_servers" AS duplicate
+USING "session_mcp_servers" AS keeper
+WHERE duplicate."tenant_id" = keeper."tenant_id"
+  AND duplicate."session_id" = keeper."session_id"
+  AND duplicate."mcp_server_id" = keeper."mcp_server_id"
+  AND duplicate.ctid > keeper.ctid;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "session_mcp_servers_pk";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "session_mcp_servers_pk"
+  ON "session_mcp_servers" ("tenant_id", "session_id", "mcp_server_id");
+--> statement-breakpoint
+
+-- System discovery exposes only enabled due schedule routing metadata. The
+-- daemon immediately leaves this capability and reloads the schedule under its
+-- trusted tenant scope before reading prompt/config content or mutating work.
+DROP POLICY IF EXISTS "scheduler_discovery" ON "schedules";
+--> statement-breakpoint
+CREATE POLICY "scheduler_discovery" ON "schedules"
+  FOR SELECT
+  USING (
+    "enabled" = true
+    AND current_setting('agor.system_scope', true) = 'scheduler_discovery'
+  );
+
+--> statement-breakpoint
+DROP POLICY IF EXISTS "scheduler_recovery_discovery" ON "sessions";
+--> statement-breakpoint
+CREATE POLICY "scheduler_recovery_discovery" ON "sessions"
+  FOR SELECT
+  USING (
+    "scheduled_from_branch" = true
+    AND "schedule_id" IS NOT NULL
+    AND "scheduled_run_at" IS NOT NULL
+    AND "scheduler_init_completed_at" IS NULL
+    AND current_setting('agor.system_scope', true) = 'scheduler_discovery'
+  );

--- a/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
+++ b/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
@@ -78,3 +78,8 @@ CREATE POLICY "scheduler_recovery_discovery" ON "sessions"
     AND "scheduler_init_completed_at" IS NULL
     AND current_setting('agor.system_scope', true) = 'scheduler_discovery'
   );
+--> statement-breakpoint
+
+-- Keep the fail-fast lock timeout local to this migration's brief table-locking
+-- DDL so later migrations applied in the same Drizzle batch inherit defaults.
+SET LOCAL lock_timeout = DEFAULT;

--- a/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
+++ b/packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql
@@ -14,7 +14,6 @@ WHERE "scheduled_from_branch" = true;
 CREATE INDEX "sessions_scheduler_init_pending_idx"
   ON "sessions" ("created_at", "session_id")
   WHERE "scheduled_from_branch" = true
-    AND "schedule_id" IS NOT NULL
     AND "scheduled_run_at" IS NOT NULL
     AND "scheduler_init_completed_at" IS NULL;
 --> statement-breakpoint
@@ -32,6 +31,17 @@ CREATE UNIQUE INDEX "sessions_schedule_run_unique"
 -- Recovery may attach the same MCP server from more than one scheduler process.
 -- Dedupe legacy rows before replacing the non-unique index with a tenant-aware
 -- idempotency constraint.
+UPDATE "session_mcp_servers" AS target
+SET "enabled" = aggregate."enabled"
+FROM (
+  SELECT "tenant_id", "session_id", "mcp_server_id", bool_or("enabled") AS "enabled"
+  FROM "session_mcp_servers"
+  GROUP BY "tenant_id", "session_id", "mcp_server_id"
+) AS aggregate
+WHERE target."tenant_id" = aggregate."tenant_id"
+  AND target."session_id" = aggregate."session_id"
+  AND target."mcp_server_id" = aggregate."mcp_server_id";
+--> statement-breakpoint
 DELETE FROM "session_mcp_servers" AS duplicate
 USING "session_mcp_servers" AS keeper
 WHERE duplicate."tenant_id" = keeper."tenant_id"
@@ -64,7 +74,6 @@ CREATE POLICY "scheduler_recovery_discovery" ON "sessions"
   FOR SELECT
   USING (
     "scheduled_from_branch" = true
-    AND "schedule_id" IS NOT NULL
     AND "scheduled_run_at" IS NOT NULL
     AND "scheduler_init_completed_at" IS NULL
     AND current_setting('agor.system_scope', true) = 'scheduler_discovery'

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1785800000000,
       "tag": "0070_tenant_portability_deferrable_fks",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1785888000000,
+      "tag": "0071_scheduler_ha_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0074_scheduler_ha_indexes.sql
+++ b/packages/core/drizzle/sqlite/0074_scheduler_ha_indexes.sql
@@ -9,7 +9,6 @@ WHERE `scheduled_from_branch` = 1;
 CREATE INDEX `sessions_scheduler_init_pending_idx`
   ON `sessions` (`created_at`, `session_id`)
   WHERE `scheduled_from_branch` = 1
-    AND `schedule_id` IS NOT NULL
     AND `scheduled_run_at` IS NOT NULL
     AND `scheduler_init_completed_at` IS NULL;
 --> statement-breakpoint
@@ -17,6 +16,14 @@ CREATE INDEX `sessions_scheduler_init_pending_idx`
 -- Recovery may attach the same MCP server from more than one scheduler process.
 -- Remove legacy duplicates before turning the misleading non-unique "pk" index
 -- into the idempotency constraint its name and repository contract imply.
+UPDATE `session_mcp_servers`
+SET `enabled` = (
+  SELECT MAX(source.`enabled`)
+  FROM `session_mcp_servers` AS source
+  WHERE source.`session_id` = `session_mcp_servers`.`session_id`
+    AND source.`mcp_server_id` = `session_mcp_servers`.`mcp_server_id`
+);
+--> statement-breakpoint
 DELETE FROM `session_mcp_servers`
 WHERE rowid NOT IN (
   SELECT MIN(rowid)

--- a/packages/core/drizzle/sqlite/0074_scheduler_ha_indexes.sql
+++ b/packages/core/drizzle/sqlite/0074_scheduler_ha_indexes.sql
@@ -1,0 +1,30 @@
+-- Durable completion marker for recoverable scheduler initialization. Existing
+-- scheduled Sessions predate recovery and are treated as already complete.
+ALTER TABLE `sessions` ADD COLUMN `scheduler_init_completed_at` integer;
+--> statement-breakpoint
+UPDATE `sessions`
+SET `scheduler_init_completed_at` = COALESCE(`updated_at`, `created_at`)
+WHERE `scheduled_from_branch` = 1;
+--> statement-breakpoint
+CREATE INDEX `sessions_scheduler_init_pending_idx`
+  ON `sessions` (`created_at`, `session_id`)
+  WHERE `scheduled_from_branch` = 1
+    AND `schedule_id` IS NOT NULL
+    AND `scheduled_run_at` IS NOT NULL
+    AND `scheduler_init_completed_at` IS NULL;
+--> statement-breakpoint
+
+-- Recovery may attach the same MCP server from more than one scheduler process.
+-- Remove legacy duplicates before turning the misleading non-unique "pk" index
+-- into the idempotency constraint its name and repository contract imply.
+DELETE FROM `session_mcp_servers`
+WHERE rowid NOT IN (
+  SELECT MIN(rowid)
+  FROM `session_mcp_servers`
+  GROUP BY `session_id`, `mcp_server_id`
+);
+--> statement-breakpoint
+DROP INDEX IF EXISTS `session_mcp_servers_pk`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_mcp_servers_pk`
+  ON `session_mcp_servers` (`session_id`, `mcp_server_id`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1785452400000,
       "tag": "0073_uploads",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "6",
+      "when": 1785888000000,
+      "tag": "0074_scheduler_ha_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -412,6 +412,7 @@
     "dev": "concurrently -k -n js,dts -c cyan,magenta \"TSUP_CLEAN=false NODE_OPTIONS='--max-old-space-size=4096' tsup --watch\" \"tsc -p tsconfig.build.json --emitDeclarationOnly --noEmit false --watch --preserveWatchOutput\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:postgres": "tsx src/db/scripts/test-postgres.ts",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -262,6 +262,12 @@
       "import": "./dist/sessions/index.js",
       "require": "./dist/sessions/index.cjs"
     },
+    "./coordination": {
+      "source": "./src/coordination/index.ts",
+      "types": "./dist/coordination/index.d.ts",
+      "import": "./dist/coordination/index.js",
+      "require": "./dist/coordination/index.cjs"
+    },
     "./models/browser": {
       "source": "./src/models/browser.ts",
       "types": "./dist/models/browser.d.ts",

--- a/packages/core/src/coordination/index.test.ts
+++ b/packages/core/src/coordination/index.test.ts
@@ -1,5 +1,78 @@
 import { describe, expect, it } from 'vitest';
-import { boundedBackoffDelay, initialWorkOffset, jitterDelay } from './index';
+import {
+  boundedBackoffDelay,
+  createDistributedWorkIdentity,
+  initialWorkOffset,
+  jitterDelay,
+} from './index';
+
+describe('distributed work diagnostic identity', () => {
+  it('uses configured, daemon-env, hostname, then fallback precedence', () => {
+    const generateBootId = () => 'boot-1';
+    expect(
+      createDistributedWorkIdentity({
+        configuredInstanceId: ' configured ',
+        environment: { AGOR_DAEMON_INSTANCE_ID: ' env ', HOSTNAME: ' host ' },
+        fallbackInstanceId: 'fallback',
+        generateBootId,
+      }).instanceId
+    ).toBe('configured');
+    expect(
+      createDistributedWorkIdentity({
+        environment: { AGOR_DAEMON_INSTANCE_ID: ' env ', HOSTNAME: ' host ' },
+        fallbackInstanceId: 'fallback',
+        generateBootId,
+      }).instanceId
+    ).toBe('env');
+    expect(
+      createDistributedWorkIdentity({
+        environment: { HOSTNAME: ' host ' },
+        fallbackInstanceId: 'fallback',
+        generateBootId,
+      }).instanceId
+    ).toBe('host');
+    expect(
+      createDistributedWorkIdentity({ fallbackInstanceId: ' fallback ', generateBootId }).instanceId
+    ).toBe('fallback');
+    expect(createDistributedWorkIdentity({ generateBootId }).instanceId).toBe('daemon');
+  });
+
+  it('trims values and skips invalid empty precedence candidates', () => {
+    expect(
+      createDistributedWorkIdentity({
+        configuredInstanceId: '   ',
+        environment: { AGOR_DAEMON_INSTANCE_ID: '\t', HOSTNAME: '  stable-host  ' },
+        fallbackInstanceId: '  fallback  ',
+        generateBootId: () => '  boot-trimmed  ',
+      })
+    ).toEqual({ instanceId: 'stable-host', bootId: 'boot-trimmed' });
+
+    expect(
+      createDistributedWorkIdentity({
+        configuredInstanceId: '',
+        environment: { AGOR_DAEMON_INSTANCE_ID: '', HOSTNAME: '' },
+        fallbackInstanceId: ' ',
+        generateBootId: () => 'boot-fallback',
+      }).instanceId
+    ).toBe('daemon');
+  });
+
+  it('uses the injected boot ID generator once and rejects an empty result', () => {
+    let calls = 0;
+    const identity = createDistributedWorkIdentity({
+      generateBootId: () => {
+        calls += 1;
+        return 'deterministic-boot';
+      },
+    });
+
+    expect(identity).toEqual({ instanceId: 'daemon', bootId: 'deterministic-boot' });
+    expect(calls).toBe(1);
+    expect(() => createDistributedWorkIdentity({ generateBootId: () => '  ' })).toThrow(
+      'boot ID generator returned an empty value'
+    );
+  });
+});
 
 describe('distributed work delay helpers', () => {
   it('computes deterministic symmetric jitter', () => {

--- a/packages/core/src/coordination/index.test.ts
+++ b/packages/core/src/coordination/index.test.ts
@@ -7,51 +7,34 @@ import {
 } from './index';
 
 describe('distributed work diagnostic identity', () => {
-  it('uses configured, daemon-env, hostname, then fallback precedence', () => {
+  it('uses daemon-env, hostname, then daemon precedence', () => {
     const generateBootId = () => 'boot-1';
     expect(
       createDistributedWorkIdentity({
-        configuredInstanceId: ' configured ',
         environment: { AGOR_DAEMON_INSTANCE_ID: ' env ', HOSTNAME: ' host ' },
-        fallbackInstanceId: 'fallback',
-        generateBootId,
-      }).instanceId
-    ).toBe('configured');
-    expect(
-      createDistributedWorkIdentity({
-        environment: { AGOR_DAEMON_INSTANCE_ID: ' env ', HOSTNAME: ' host ' },
-        fallbackInstanceId: 'fallback',
         generateBootId,
       }).instanceId
     ).toBe('env');
     expect(
       createDistributedWorkIdentity({
         environment: { HOSTNAME: ' host ' },
-        fallbackInstanceId: 'fallback',
         generateBootId,
       }).instanceId
     ).toBe('host');
-    expect(
-      createDistributedWorkIdentity({ fallbackInstanceId: ' fallback ', generateBootId }).instanceId
-    ).toBe('fallback');
     expect(createDistributedWorkIdentity({ generateBootId }).instanceId).toBe('daemon');
   });
 
   it('trims values and skips invalid empty precedence candidates', () => {
     expect(
       createDistributedWorkIdentity({
-        configuredInstanceId: '   ',
         environment: { AGOR_DAEMON_INSTANCE_ID: '\t', HOSTNAME: '  stable-host  ' },
-        fallbackInstanceId: '  fallback  ',
         generateBootId: () => '  boot-trimmed  ',
       })
     ).toEqual({ instanceId: 'stable-host', bootId: 'boot-trimmed' });
 
     expect(
       createDistributedWorkIdentity({
-        configuredInstanceId: '',
         environment: { AGOR_DAEMON_INSTANCE_ID: '', HOSTNAME: '' },
-        fallbackInstanceId: ' ',
         generateBootId: () => 'boot-fallback',
       }).instanceId
     ).toBe('daemon');

--- a/packages/core/src/coordination/index.test.ts
+++ b/packages/core/src/coordination/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { boundedBackoffDelay, initialWorkOffset, jitterDelay } from './index';
+
+describe('distributed work delay helpers', () => {
+  it('computes deterministic symmetric jitter', () => {
+    expect(jitterDelay(1_000, 0.2, 0)).toBe(800);
+    expect(jitterDelay(1_000, 0.2, 0.5)).toBe(1_000);
+    expect(jitterDelay(1_000, 0.2, 1)).toBe(1_200);
+  });
+
+  it('caps exponential idle backoff before jitter', () => {
+    const policy = { baseDelayMs: 1_000, maxDelayMs: 2_000, jitterRatio: 0.1 };
+    expect(boundedBackoffDelay(0, policy, 0.5)).toBe(1_000);
+    expect(boundedBackoffDelay(1, policy, 0.5)).toBe(2_000);
+    expect(boundedBackoffDelay(20, policy, 1)).toBe(2_200);
+  });
+
+  it('computes a deterministic uniform startup offset', () => {
+    expect(initialWorkOffset(30_000, 0)).toBe(0);
+    expect(initialWorkOffset(30_000, 0.25)).toBe(7_500);
+    expect(initialWorkOffset(30_000, 1)).toBe(30_000);
+  });
+});

--- a/packages/core/src/coordination/index.ts
+++ b/packages/core/src/coordination/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Small, process-agnostic helpers for distributed database work.
+ *
+ * This is deliberately not a worker framework. Resource owners still define
+ * their own durable state machine and database transitions. These helpers only
+ * standardize diagnostic identity and deterministic delay policy.
+ */
+
+export interface DistributedWorkIdentity {
+  /** Stable for a configured daemon instance (for example a pod name). */
+  instanceId: string;
+  /** Unique for one daemon process lifetime. */
+  bootId: string;
+}
+
+export interface BackoffPolicy {
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Fractional symmetric jitter. `0.2` means +/-20%. */
+  jitterRatio: number;
+}
+
+function assertRandomSample(sample: number): void {
+  if (!Number.isFinite(sample) || sample < 0 || sample > 1) {
+    throw new Error(`Random sample must be between 0 and 1; received ${sample}`);
+  }
+}
+
+/** Apply bounded symmetric jitter using an injected random sample. */
+export function jitterDelay(delayMs: number, jitterRatio: number, randomSample: number): number {
+  if (!Number.isFinite(delayMs) || delayMs < 0) throw new Error('delayMs must be non-negative');
+  if (!Number.isFinite(jitterRatio) || jitterRatio < 0 || jitterRatio > 1) {
+    throw new Error('jitterRatio must be between 0 and 1');
+  }
+  assertRandomSample(randomSample);
+  const multiplier = 1 - jitterRatio + randomSample * jitterRatio * 2;
+  return Math.max(0, Math.round(delayMs * multiplier));
+}
+
+/**
+ * Exponential idle backoff capped before jitter is applied. Correctness must
+ * never depend on this delay; owners choose a cap below their recovery bound.
+ */
+export function boundedBackoffDelay(
+  idleRounds: number,
+  policy: BackoffPolicy,
+  randomSample: number
+): number {
+  if (!Number.isInteger(idleRounds) || idleRounds < 0) {
+    throw new Error('idleRounds must be a non-negative integer');
+  }
+  if (policy.baseDelayMs <= 0 || policy.maxDelayMs < policy.baseDelayMs) {
+    throw new Error('Backoff delays must be positive and maxDelayMs >= baseDelayMs');
+  }
+  const uncapped = policy.baseDelayMs * 2 ** Math.min(idleRounds, 30);
+  return jitterDelay(Math.min(uncapped, policy.maxDelayMs), policy.jitterRatio, randomSample);
+}
+
+/** Uniform startup offset in the inclusive range 0..maxDelayMs. */
+export function initialWorkOffset(maxDelayMs: number, randomSample: number): number {
+  if (!Number.isFinite(maxDelayMs) || maxDelayMs < 0) {
+    throw new Error('maxDelayMs must be non-negative');
+  }
+  assertRandomSample(randomSample);
+  return Math.round(maxDelayMs * randomSample);
+}

--- a/packages/core/src/coordination/index.ts
+++ b/packages/core/src/coordination/index.ts
@@ -7,10 +7,67 @@
  */
 
 export interface DistributedWorkIdentity {
-  /** Stable for a configured daemon instance (for example a pod name). */
-  instanceId: string;
-  /** Unique for one daemon process lifetime. */
-  bootId: string;
+  /**
+   * Diagnostic daemon-instance label. It is stable across restarts only when
+   * the deployment supplies a stable configured/environment value.
+   *
+   * This is not an authorization, fencing, lease, liveness, or correctness
+   * boundary.
+   */
+  readonly instanceId: string;
+  /**
+   * Diagnostic identity for one daemon process incarnation.
+   *
+   * This is not an authorization, fencing, lease, liveness, or correctness
+   * boundary.
+   */
+  readonly bootId: string;
+}
+
+export interface DistributedWorkIdentityEnvironment {
+  readonly AGOR_DAEMON_INSTANCE_ID?: string;
+  readonly HOSTNAME?: string;
+}
+
+export interface CreateDistributedWorkIdentityOptions {
+  /** Existing explicit runtime-instance configuration, when one is settled. */
+  configuredInstanceId?: string;
+  /** Explicit environment snapshot supplied by the daemon composition root. */
+  environment?: DistributedWorkIdentityEnvironment;
+  /** Safe diagnostic fallback (default: `daemon`). */
+  fallbackInstanceId?: string;
+  /** Process-incarnation ID generator, injected so lifecycle ownership is explicit and tests are deterministic. */
+  generateBootId: () => string;
+}
+
+function normalizedNonEmpty(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+/**
+ * Create one diagnostic identity at a process/application composition root.
+ *
+ * Instance precedence is explicit configuration, AGOR_DAEMON_INSTANCE_ID,
+ * HOSTNAME, then the safe fallback. This helper is deliberately stateless: it
+ * does not cache, register, heartbeat, claim, lease, fence, or confer any
+ * authority. The caller owns creating it exactly once and sharing the result.
+ */
+export function createDistributedWorkIdentity(
+  options: CreateDistributedWorkIdentityOptions
+): DistributedWorkIdentity {
+  const environment = options.environment ?? {};
+  const instanceId =
+    normalizedNonEmpty(options.configuredInstanceId) ??
+    normalizedNonEmpty(environment.AGOR_DAEMON_INSTANCE_ID) ??
+    normalizedNonEmpty(environment.HOSTNAME) ??
+    normalizedNonEmpty(options.fallbackInstanceId) ??
+    'daemon';
+  const bootId = normalizedNonEmpty(options.generateBootId());
+  if (!bootId) throw new Error('Distributed work boot ID generator returned an empty value');
+
+  return Object.freeze({ instanceId, bootId });
 }
 
 export interface BackoffPolicy {

--- a/packages/core/src/coordination/index.ts
+++ b/packages/core/src/coordination/index.ts
@@ -30,12 +30,8 @@ export interface DistributedWorkIdentityEnvironment {
 }
 
 export interface CreateDistributedWorkIdentityOptions {
-  /** Existing explicit runtime-instance configuration, when one is settled. */
-  configuredInstanceId?: string;
   /** Explicit environment snapshot supplied by the daemon composition root. */
   environment?: DistributedWorkIdentityEnvironment;
-  /** Safe diagnostic fallback (default: `daemon`). */
-  fallbackInstanceId?: string;
   /** Process-incarnation ID generator, injected so lifecycle ownership is explicit and tests are deterministic. */
   generateBootId: () => string;
 }
@@ -49,20 +45,20 @@ function normalizedNonEmpty(value: unknown): string | undefined {
 /**
  * Create one diagnostic identity at a process/application composition root.
  *
- * Instance precedence is explicit configuration, AGOR_DAEMON_INSTANCE_ID,
- * HOSTNAME, then the safe fallback. This helper is deliberately stateless: it
- * does not cache, register, heartbeat, claim, lease, fence, or confer any
- * authority. The caller owns creating it exactly once and sharing the result.
+ * Instance precedence is AGOR_DAEMON_INSTANCE_ID, HOSTNAME, then the safe
+ * `daemon` fallback. A dedicated YAML deployment identity may be added later
+ * with the HA configuration contract; unrelated configuration must not be
+ * reused here. This helper is deliberately stateless: it does not cache,
+ * register, heartbeat, claim, lease, fence, or confer any authority. The
+ * caller owns creating it exactly once and sharing the result.
  */
 export function createDistributedWorkIdentity(
   options: CreateDistributedWorkIdentityOptions
 ): DistributedWorkIdentity {
   const environment = options.environment ?? {};
   const instanceId =
-    normalizedNonEmpty(options.configuredInstanceId) ??
     normalizedNonEmpty(environment.AGOR_DAEMON_INSTANCE_ID) ??
     normalizedNonEmpty(environment.HOSTNAME) ??
-    normalizedNonEmpty(options.fallbackInstanceId) ??
     'daemon';
   const bootId = normalizedNonEmpty(options.generateBootId());
   if (!bootId) throw new Error('Distributed work boot ID generator returned an empty value');

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -228,69 +228,6 @@ export async function lockRowForUpdate(
 }
 
 /**
- * Try to acquire a per-key Postgres transaction-scoped advisory lock.
- *
- * Used by the scheduler (and other multi-daemon work-distribution code)
- * to ensure that two daemons don't both spawn a session for the same
- * schedule on the same tick. The lock is automatically released at
- * transaction commit/rollback.
- *
- * - PostgreSQL: executes `SELECT pg_try_advisory_xact_lock($1)`. Returns
- *   `true` if this transaction won the lock, `false` otherwise (the
- *   caller should skip whatever it was about to do).
- * - SQLite: returns `true`. SQLite is single-node by definition — no
- *   cross-process coordination needed.
- *
- * Must be called from inside a transaction (`db.transaction(...)`) on
- * Postgres; on SQLite it's safe to call outside a transaction.
- *
- * @param tx - Transaction context (or db on SQLite)
- * @param db - Database instance (used for dialect detection only)
- * @param key - 64-bit signed integer key derived from the resource ID.
- *   See `advisoryLockKeyForUuid` for a stable UUID→bigint hash.
- */
-export async function tryAdvisoryXactLock(
-  tx: Database,
-  db: Database,
-  key: bigint
-): Promise<boolean> {
-  if (!isPostgresDatabase(db)) return true;
-  // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for raw SQL execution
-  const result = (await (tx as any).execute(
-    sql`SELECT pg_try_advisory_xact_lock(${key.toString()}::bigint) AS acquired`
-  )) as { rows?: Array<{ acquired: boolean }> } | Array<{ acquired: boolean }>;
-  // postgres.js returns an array; pg returns { rows: [...] }. Handle both.
-  const row = Array.isArray(result) ? result[0] : result.rows?.[0];
-  return row?.acquired === true;
-}
-
-/**
- * Stable 64-bit hash of a UUID string for use as a Postgres advisory
- * lock key. Postgres advisory keys are bigint (signed 64-bit), so we
- * fold the UUID's 128 bits down with a simple FNV-1a-style mix and
- * clamp into the signed range.
- *
- * Deterministic per UUID, so a schedule's lock key is stable across
- * processes and restarts. Hash quality is not load-bearing — we only
- * need "low collision rate across the modest number of schedules
- * actually due in the same tick"; any two-bigint cell of the hash
- * space is fine.
- */
-export function advisoryLockKeyForUuid(uuid: string): bigint {
-  // FNV-1a 64-bit
-  const FNV_OFFSET = 0xcbf29ce484222325n;
-  const FNV_PRIME = 0x100000001b3n;
-  const MASK_64 = 0xffffffffffffffffn;
-  let hash = FNV_OFFSET;
-  for (let i = 0; i < uuid.length; i++) {
-    hash ^= BigInt(uuid.charCodeAt(i));
-    hash = (hash * FNV_PRIME) & MASK_64;
-  }
-  // Convert unsigned 64-bit to signed (Postgres bigint is signed).
-  return hash > 0x7fffffffffffffffn ? hash - 0x10000000000000000n : hash;
-}
-
-/**
  * Raw SQL query result type
  */
 export type RawQueryResult = {

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -121,6 +121,7 @@ describe('Postgres multitenancy schema coverage', () => {
     expect(migration).toContain(
       'ON "session_mcp_servers" ("tenant_id", "session_id", "mcp_server_id")'
     );
+    expect(migration).toContain('bool_or("enabled")');
     expect(migration.match(/CREATE UNIQUE INDEX/g)).toHaveLength(2);
   });
 });

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -101,4 +101,26 @@ describe('Postgres multitenancy schema coverage', () => {
     expect(migration).toContain("= 'upload_maintenance'");
     expect(migration).not.toContain('WITH CHECK');
   });
+
+  it('limits scheduler discovery to enabled rows and an explicit capability', () => {
+    const migration = readRepoFile('packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql');
+
+    expect(migration).toContain('FOR SELECT');
+    expect(migration).toContain('"enabled" = true');
+    expect(migration).toContain('"scheduler_init_completed_at" IS NULL');
+    expect(migration).toContain('"scheduled_from_branch" = true');
+    expect(migration).toContain("current_setting('agor.system_scope', true)");
+    expect(migration).toContain("= 'scheduler_discovery'");
+    expect(migration).not.toContain('WITH CHECK');
+  });
+
+  it('repairs scheduler occurrence and MCP idempotency indexes as tenant-aware uniques', () => {
+    const migration = readRepoFile('packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql');
+
+    expect(migration).toContain('ON "sessions" ("tenant_id", "schedule_id", "scheduled_run_at")');
+    expect(migration).toContain(
+      'ON "session_mcp_servers" ("tenant_id", "session_id", "mcp_server_id")'
+    );
+    expect(migration.match(/CREATE UNIQUE INDEX/g)).toHaveLength(2);
+  });
 });

--- a/packages/core/src/db/repositories/schedules.test.ts
+++ b/packages/core/src/db/repositories/schedules.test.ts
@@ -325,6 +325,23 @@ describe('ScheduleRepository.findDue', () => {
 
     expect(refs).toEqual([{ schedule_id: due.schedule_id }]);
   });
+
+  dbTest('findDueRefs enforces the scheduler batch limit', async ({ db }) => {
+    const ctx = await setupContext(db);
+    const now = Date.now();
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        ctx.scheduleRepo.create({
+          ...scheduleData({ name: `due-${index}`, next_run_at: now - 5_000 + index }),
+          branch_id: ctx.branchId,
+          created_by: ctx.userId,
+        })
+      )
+    );
+
+    expect(await ctx.scheduleRepo.findDueRefs(now, 2)).toHaveLength(2);
+    await expect(ctx.scheduleRepo.findDueRefs(now, 0)).rejects.toThrow(/between 1 and 1000/);
+  });
 });
 
 describe('ScheduleRepository.findAccessibleSchedules', () => {

--- a/packages/core/src/db/repositories/schedules.ts
+++ b/packages/core/src/db/repositories/schedules.ts
@@ -259,7 +259,10 @@ export class ScheduleRepository implements BaseRepository<Schedule, Partial<Sche
    * workers can enter the correct tenant DB scope before loading schedule
    * contents or spawning sessions.
    */
-  async findDueRefs(now: number = Date.now()): Promise<DueScheduleRef[]> {
+  async findDueRefs(now: number = Date.now(), limit = 25): Promise<DueScheduleRef[]> {
+    if (!Number.isInteger(limit) || limit <= 0 || limit > 1_000) {
+      throw new RepositoryError('Due schedule discovery limit must be between 1 and 1000');
+    }
     const tenantColumn = (schedules as unknown as { tenant_id?: unknown }).tenant_id;
     const columns =
       isPostgresDatabase(this.db) && tenantColumn
@@ -270,6 +273,7 @@ export class ScheduleRepository implements BaseRepository<Schedule, Partial<Sche
       .from(schedules)
       .where(this.dueCondition(now))
       .orderBy(asc(schedules.next_run_at))
+      .limit(limit)
       .all();
 
     return (rows as Array<{ schedule_id: string; tenant_id?: unknown }>).map((row) => ({
@@ -278,6 +282,15 @@ export class ScheduleRepository implements BaseRepository<Schedule, Partial<Sche
         ? { tenant_id: row.tenant_id }
         : {}),
     }));
+  }
+
+  /**
+   * Serialize the short admission decision for one schedule on PostgreSQL.
+   * Call inside an existing tenant database scope/transaction. No rendering,
+   * launching, or other external work belongs under this row lock.
+   */
+  async lockForRunAdmission(scheduleId: ScheduleID): Promise<void> {
+    await lockRowForUpdate(this.db, this.db, schedules, eq(schedules.schedule_id, scheduleId));
   }
 
   /**

--- a/packages/core/src/db/repositories/session-mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/session-mcp-servers.test.ts
@@ -132,6 +132,17 @@ describe('SessionMCPServerRepository.addServer', () => {
     expect(servers[0].mcp_server_id).toBe(server1.mcp_server_id);
   });
 
+  dbTest('deduplicates five concurrent attachments', async ({ db }) => {
+    const { session, server1 } = await setupTestData(db);
+    const repo = new SessionMCPServerRepository(db);
+
+    await Promise.all(
+      Array.from({ length: 5 }, () => repo.addServer(session.session_id, server1.mcp_server_id))
+    );
+
+    expect(await repo.listServers(session.session_id)).toHaveLength(1);
+  });
+
   dbTest('should re-enable disabled server when added again', async ({ db }) => {
     const { session, server1 } = await setupTestData(db);
     const repo = new SessionMCPServerRepository(db);

--- a/packages/core/src/db/repositories/session-mcp-servers.ts
+++ b/packages/core/src/db/repositories/session-mcp-servers.ts
@@ -42,32 +42,9 @@ export class SessionMCPServerRepository {
         throw new EntityNotFoundError('MCPServer', serverId);
       }
 
-      // Check if relationship already exists
-      const existing = await select(this.db)
-        .from(sessionMcpServers)
-        .where(
-          and(
-            eq(sessionMcpServers.session_id, sessionId),
-            eq(sessionMcpServers.mcp_server_id, serverId)
-          )
-        )
-        .one();
-
-      if (existing) {
-        // Already exists, just ensure it's enabled
-        await update(this.db, sessionMcpServers)
-          .set({ enabled: true })
-          .where(
-            and(
-              eq(sessionMcpServers.session_id, sessionId),
-              eq(sessionMcpServers.mcp_server_id, serverId)
-            )
-          )
-          .run();
-        return;
-      }
-
-      // Create new relationship
+      // Insert-first instead of check-then-insert: the unique index is the
+      // durable idempotency guard when two recovering daemons attach the same
+      // server concurrently.
       const newRelationship: SessionMCPServerInsert = {
         session_id: sessionId,
         mcp_server_id: serverId,
@@ -75,7 +52,16 @@ export class SessionMCPServerRepository {
         added_at: new Date(),
       };
 
-      await insert(this.db, sessionMcpServers).values(newRelationship).run();
+      await insert(this.db, sessionMcpServers).values(newRelationship).onConflictDoNothing().run();
+      await update(this.db, sessionMcpServers)
+        .set({ enabled: true })
+        .where(
+          and(
+            eq(sessionMcpServers.session_id, sessionId),
+            eq(sessionMcpServers.mcp_server_id, serverId)
+          )
+        )
+        .run();
     } catch (error) {
       if (error instanceof EntityNotFoundError) throw error;
       throw new RepositoryError(

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -1394,6 +1394,45 @@ describe('SessionRepository schedule-link queries', () => {
     }
   );
 
+  dbTest(
+    'keeps incomplete scheduled Sessions discoverable after schedule deletion',
+    async ({ db }) => {
+      const repo = new SessionRepository(db);
+      const branch = await createTestBranch(db);
+      const scheduleId = await createTestSchedule(db, branch.branch_id);
+      const created = await repo.create(
+        createSessionData({
+          branch_id: branch.branch_id,
+          schedule_id: scheduleId,
+          scheduled_run_at: 1_700_000_000_000,
+          scheduled_from_branch: true,
+          custom_context: {
+            scheduled_run: {
+              rendered_prompt: 'durable prompt',
+              run_index: 1,
+              schedule_config_snapshot: {
+                schedule_id: scheduleId,
+                cron: '0 * * * *',
+                timezone: 'UTC',
+                retention: 1,
+                mcp_server_ids: [],
+              },
+            },
+          },
+        })
+      );
+
+      await new ScheduleRepository(db).delete(scheduleId);
+
+      expect((await repo.findById(created.session_id))?.schedule_id).toBeUndefined();
+      const pending = await repo.findIncompleteScheduledRefs(10);
+      expect(pending.find((ref) => ref.session_id === created.session_id)).toMatchObject({
+        session_id: created.session_id,
+        scheduled_run_at: 1_700_000_000_000,
+      });
+    }
+  );
+
   dbTest('findScheduleRun does not match a different scheduled_run_at', async ({ db }) => {
     const repo = new SessionRepository(db);
     const branch = await createTestBranch(db);

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -94,6 +94,7 @@ function createPostgresStyleSessionRow(overrides?: Partial<SessionRow> & { tenan
     scheduled_run_at: null,
     scheduled_from_branch: false,
     schedule_id: null,
+    scheduler_init_completed_at: null,
     ready_for_prompt: false,
     archived: false,
     archived_reason: null,
@@ -1350,6 +1351,48 @@ describe('SessionRepository schedule-link queries', () => {
     const found = await repo.findScheduleRun(scheduleId, 1_700_000_000_000);
     expect(found).toBeNull();
   });
+
+  dbTest(
+    'discovers and idempotently completes pending scheduled initialization',
+    async ({ db }) => {
+      const repo = new SessionRepository(db);
+      const branch = await createTestBranch(db);
+      const scheduleId = await createTestSchedule(db, branch.branch_id);
+      const created = await repo.create(
+        createSessionData({
+          branch_id: branch.branch_id,
+          schedule_id: scheduleId,
+          scheduled_run_at: 1_700_000_000_000,
+          scheduled_from_branch: true,
+        })
+      );
+      await repo.create(
+        createSessionData({
+          branch_id: branch.branch_id,
+          schedule_id: scheduleId,
+          scheduled_run_at: 1_700_000_000_001,
+          scheduled_from_branch: true,
+        })
+      );
+
+      const firstPage = await repo.findIncompleteScheduledRefs(1);
+      const secondPage = await repo.findIncompleteScheduledRefs(1, firstPage[0]);
+      expect(firstPage).toHaveLength(1);
+      expect(secondPage).toHaveLength(1);
+      expect(secondPage[0].session_id).not.toBe(firstPage[0].session_id);
+
+      expect((await repo.findIncompleteScheduledRefs(10)).map((ref) => ref.session_id)).toContain(
+        created.session_id
+      );
+      expect(await repo.isScheduledInitializationComplete(created.session_id)).toBe(false);
+      expect(await repo.markScheduledInitializationComplete(created.session_id)).toBe(true);
+      expect(await repo.markScheduledInitializationComplete(created.session_id)).toBe(false);
+      expect(await repo.isScheduledInitializationComplete(created.session_id)).toBe(true);
+      expect(
+        (await repo.findIncompleteScheduledRefs(10)).map((ref) => ref.session_id)
+      ).not.toContain(created.session_id);
+    }
+  );
 
   dbTest('findScheduleRun does not match a different scheduled_run_at', async ({ db }) => {
     const repo = new SessionRepository(db);

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -6,12 +6,20 @@
 
 import type { BranchID, Session, SessionID, SessionUpdate, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
-import { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId, shortId } from '../../lib/ids';
 import { getSessionUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isPostgresDatabase,
+  lockRowForUpdate,
+  select,
+  txAsDb,
+  update,
+} from '../database-wrapper';
 import { sanitizeDbError } from '../sanitize-error';
 import {
   branches,
@@ -20,6 +28,7 @@ import {
   type SessionInsert,
   type SessionRow,
   sessions,
+  tasks,
 } from '../schema';
 import {
   AmbiguousIdError,
@@ -39,6 +48,19 @@ import { deepMerge } from './merge-utils';
 export interface SessionWithLastMessage extends Session {
   last_message?: string;
 }
+
+export interface IncompleteScheduledSessionRef {
+  session_id: SessionID;
+  schedule_id: import('@agor/core/types').ScheduleID;
+  scheduled_run_at: number;
+  created_at: number;
+  tenant_id?: string;
+}
+
+export type IncompleteScheduledSessionCursor = Pick<
+  IncompleteScheduledSessionRef,
+  'created_at' | 'session_id'
+>;
 
 type SessionArchiveReason = NonNullable<Session['archived_reason']>;
 
@@ -982,9 +1004,10 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    * Find the session that corresponds to one specific scheduled run.
    *
    * Used by the scheduler to dedup: "is there already a session for
-   * (schedule_id, scheduled_run_at)?". Uses the covering index
-   * `sessions_schedule_run_unique (schedule_id, scheduled_run_at)` so the
-   * lookup is O(log n), not an O(n) full table scan.
+   * (schedule_id, scheduled_run_at)?". PostgreSQL uses the tenant-aware
+   * covering index `sessions_schedule_run_unique
+   * (tenant_id, schedule_id, scheduled_run_at)`; SQLite uses the standalone
+   * two-column equivalent. The lookup is O(log n), not a full table scan.
    *
    * Returns the matching session (with branch_board_id + url populated
    * like the other readers in this repo) or null if no match.
@@ -1015,6 +1038,80 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         error
       );
     }
+  }
+
+  /** Bounded routing-only discovery for recoverable scheduler initialization. */
+  async findIncompleteScheduledRefs(
+    limit = 25,
+    after?: IncompleteScheduledSessionCursor
+  ): Promise<IncompleteScheduledSessionRef[]> {
+    if (!Number.isInteger(limit) || limit <= 0 || limit > 1_000) {
+      throw new RepositoryError('Incomplete scheduled Session limit must be between 1 and 1000');
+    }
+    const tenantColumn = (sessions as unknown as { tenant_id?: unknown }).tenant_id;
+    const columns = {
+      session_id: sessions.session_id,
+      schedule_id: sessions.schedule_id,
+      scheduled_run_at: sessions.scheduled_run_at,
+      created_at: sessions.created_at,
+      ...(isPostgresDatabase(this.db) && tenantColumn ? { tenant_id: tenantColumn } : {}),
+    };
+    const afterCondition = after
+      ? or(
+          gt(sessions.created_at, new Date(after.created_at)),
+          and(
+            eq(sessions.created_at, new Date(after.created_at)),
+            gt(sessions.session_id, after.session_id)
+          )
+        )
+      : undefined;
+    const rows = await select(this.db, columns)
+      .from(sessions)
+      .where(
+        and(
+          eq(sessions.scheduled_from_branch, true),
+          isNotNull(sessions.schedule_id),
+          isNotNull(sessions.scheduled_run_at),
+          isNull(sessions.scheduler_init_completed_at),
+          afterCondition
+        )
+      )
+      .orderBy(asc(sessions.created_at), asc(sessions.session_id))
+      .limit(limit)
+      .all();
+    return (rows as Array<Record<string, unknown>>).map((row) => ({
+      session_id: row.session_id as SessionID,
+      schedule_id: row.schedule_id as import('@agor/core/types').ScheduleID,
+      scheduled_run_at: Number(row.scheduled_run_at),
+      created_at:
+        row.created_at instanceof Date
+          ? row.created_at.getTime()
+          : new Date(row.created_at as string | number).getTime(),
+      ...(typeof row.tenant_id === 'string' ? { tenant_id: row.tenant_id } : {}),
+    }));
+  }
+
+  async isScheduledInitializationComplete(sessionId: SessionID): Promise<boolean> {
+    const row = await select(this.db, { completedAt: sessions.scheduler_init_completed_at })
+      .from(sessions)
+      .where(eq(sessions.session_id, sessionId))
+      .one();
+    return row?.completedAt != null;
+  }
+
+  /** Conditional/idempotent completion marker written after schedule finalization. */
+  async markScheduledInitializationComplete(sessionId: SessionID): Promise<boolean> {
+    const result = await update(this.db, sessions)
+      .set({ scheduler_init_completed_at: new Date() })
+      .where(
+        and(
+          eq(sessions.session_id, sessionId),
+          eq(sessions.scheduled_from_branch, true),
+          isNull(sessions.scheduler_init_completed_at)
+        )
+      )
+      .run();
+    return result.rowsAffected === 1;
   }
 
   /**
@@ -1123,6 +1220,51 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     } catch (error) {
       throw new RepositoryError(
         `Failed to probe sessions in schedule: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Scheduler admission probe covering both an active Session and the narrow
+   * initialization window before its first Task reaches DISPATCHING. A
+   * completed scheduled session is IDLE with only terminal tasks and does not
+   * block the next occurrence.
+   */
+  async existsActiveOrInitializingInSchedule(
+    scheduleId: import('@agor/core/types').ScheduleID,
+    activeSessionStatuses: ReadonlyArray<Session['status']>,
+    activeTaskStatuses: ReadonlyArray<import('@agor/core/types').Task['status']>
+  ): Promise<boolean> {
+    const activeSession =
+      activeSessionStatuses.length > 0
+        ? inArray(sessions.status, [...activeSessionStatuses])
+        : sql`false`;
+    const taskIsActive =
+      activeTaskStatuses.length > 0 ? inArray(tasks.status, [...activeTaskStatuses]) : sql`false`;
+    try {
+      const row = await select(this.db, { one: sql<number>`1` })
+        .from(sessions)
+        .where(
+          and(
+            eq(sessions.schedule_id, scheduleId),
+            or(
+              activeSession,
+              // New scheduled Sessions remain initialization-active until the
+              // scheduler writes its internal completion marker. Migrations
+              // backfill historical Sessions so old no-Task rows do not block
+              // a schedule forever.
+              isNull(sessions.scheduler_init_completed_at),
+              sql`EXISTS (SELECT 1 FROM ${tasks} WHERE ${tasks.session_id} = ${sessions.session_id} AND ${taskIsActive})`
+            )
+          )
+        )
+        .limit(1)
+        .one();
+      return row != null;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to probe active or initializing scheduled sessions: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -1180,9 +1180,8 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
 
   /**
    * True iff at least one session in this branch has a status in the
-   * given set. Generic primitive — the caller owns the policy
-   * (e.g. the scheduler's "active statuses" list lives in `scheduler.ts`
-   * next to the concurrency-guard call site, not here).
+   * given set. Generic primitive — the caller owns the policy and selects
+   * the appropriate canonical lifecycle set from `@agor/core/types`.
    *
    * Implemented as an existence probe (`SELECT 1 ... LIMIT 1`) rather
    * than a COUNT so busy branches don't pay the cost of counting every
@@ -1240,15 +1239,15 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    */
   async existsActiveOrInitializingInSchedule(
     scheduleId: import('@agor/core/types').ScheduleID,
-    activeSessionStatuses: ReadonlyArray<Session['status']>,
-    activeTaskStatuses: ReadonlyArray<import('@agor/core/types').Task['status']>
+    activeSessionStatuses: ReadonlySet<Session['status']>,
+    activeTaskStatuses: ReadonlySet<import('@agor/core/types').Task['status']>
   ): Promise<boolean> {
     const activeSession =
-      activeSessionStatuses.length > 0
+      activeSessionStatuses.size > 0
         ? inArray(sessions.status, [...activeSessionStatuses])
         : sql`false`;
     const taskIsActive =
-      activeTaskStatuses.length > 0 ? inArray(tasks.status, [...activeTaskStatuses]) : sql`false`;
+      activeTaskStatuses.size > 0 ? inArray(tasks.status, [...activeTaskStatuses]) : sql`false`;
     try {
       const row = await select(this.db, { one: sql<number>`1` })
         .from(sessions)

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -51,7 +51,13 @@ export interface SessionWithLastMessage extends Session {
 
 export interface IncompleteScheduledSessionRef {
   session_id: SessionID;
-  schedule_id: import('@agor/core/types').ScheduleID;
+  /**
+   * The live FK is nullable because deleting a schedule must not erase the
+   * scheduler's ability to finish an occurrence admitted before that delete.
+   * Recovery uses the schedule ID snapshotted in custom_context when this is
+   * absent; system discovery needs only the Session and tenant routing IDs.
+   */
+  schedule_id?: import('@agor/core/types').ScheduleID;
   scheduled_run_at: number;
   created_at: number;
   tenant_id?: string;
@@ -1070,7 +1076,6 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       .where(
         and(
           eq(sessions.scheduled_from_branch, true),
-          isNotNull(sessions.schedule_id),
           isNotNull(sessions.scheduled_run_at),
           isNull(sessions.scheduler_init_completed_at),
           afterCondition
@@ -1081,7 +1086,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       .all();
     return (rows as Array<Record<string, unknown>>).map((row) => ({
       session_id: row.session_id as SessionID,
-      schedule_id: row.schedule_id as import('@agor/core/types').ScheduleID,
+      ...(typeof row.schedule_id === 'string'
+        ? { schedule_id: row.schedule_id as import('@agor/core/types').ScheduleID }
+        : {}),
       scheduled_run_at: Number(row.scheduled_run_at),
       created_at:
         row.created_at instanceof Date

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -55,7 +55,7 @@ export interface IncompleteScheduledSessionRef {
    * The live FK is nullable because deleting a schedule must not erase the
    * scheduler's ability to finish an occurrence admitted before that delete.
    * Recovery uses the schedule ID snapshotted in custom_context when this is
-   * absent; system discovery needs only the Session and tenant routing IDs.
+   * absent; system discovery projects this only as bounded diagnostic context.
    */
   schedule_id?: import('@agor/core/types').ScheduleID;
   scheduled_run_at: number;

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1793,6 +1793,57 @@ function createPendingInput(overrides: {
 }
 
 describe('TaskRepository.createPending', () => {
+  dbTest('reconciles concurrent stable-ID creation to one task', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const taskId = generateId();
+    const input = createPendingInput({ session_id: sessionId, status: TaskStatus.CREATED });
+
+    const tasks = await Promise.all(
+      Array.from({ length: 5 }, () => taskRepo.createPending({ ...input, task_id: taskId }))
+    );
+
+    expect(new Set(tasks.map((task) => task.task_id))).toEqual(new Set([taskId]));
+    expect(await taskRepo.findBySession(sessionId)).toHaveLength(1);
+  });
+
+  dbTest('atomically fences concurrent dispatch claims', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const task = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.CREATED })
+    );
+
+    const claims = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        taskRepo.claimDispatch(task.task_id, TaskStatus.CREATED, {
+          status: TaskStatus.DISPATCHING,
+          started_at: new Date('2026-08-05T00:00:00Z').toISOString(),
+        })
+      )
+    );
+
+    expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
+    expect(claims.filter((claim) => claim.outcome === 'already_claimed')).toHaveLength(4);
+    expect((await taskRepo.findById(task.task_id))?.status).toBe(TaskStatus.DISPATCHING);
+  });
+
+  dbTest('clears queue position when claiming a queued task for dispatch', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const queued = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+    );
+
+    const claim = await taskRepo.claimDispatch(queued.task_id, TaskStatus.QUEUED, {
+      status: TaskStatus.DISPATCHING,
+    });
+
+    expect(claim.outcome).toBe('claimed');
+    expect(claim.task.queue_position).toBeUndefined();
+    expect((await taskRepo.findById(queued.task_id))?.queue_position).toBeUndefined();
+  });
+
   dbTest(
     'should create QUEUED task with queue_position=1 when no other queued tasks',
     async ({ db }) => {

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Task, UUID } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -1816,7 +1816,7 @@ describe('TaskRepository.createPending', () => {
 
     const claims = await Promise.all(
       Array.from({ length: 5 }, () =>
-        taskRepo.claimDispatch(task.task_id, TaskStatus.CREATED, {
+        taskRepo.claimDispatchAndProjectSession(task.task_id, TaskStatus.CREATED, {
           status: TaskStatus.DISPATCHING,
           started_at: new Date('2026-08-05T00:00:00Z').toISOString(),
         })
@@ -1826,6 +1826,11 @@ describe('TaskRepository.createPending', () => {
     expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
     expect(claims.filter((claim) => claim.outcome === 'already_claimed')).toHaveLength(4);
     expect((await taskRepo.findById(task.task_id))?.status).toBe(TaskStatus.DISPATCHING);
+    await expect(new SessionRepository(db).findById(sessionId)).resolves.toMatchObject({
+      status: SessionStatus.RUNNING,
+      ready_for_prompt: false,
+      tasks: [task.task_id],
+    });
   });
 
   dbTest('clears queue position when claiming a queued task for dispatch', async ({ db }) => {
@@ -1835,7 +1840,7 @@ describe('TaskRepository.createPending', () => {
       createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
     );
 
-    const claim = await taskRepo.claimDispatch(queued.task_id, TaskStatus.QUEUED, {
+    const claim = await taskRepo.claimDispatchAndProjectSession(queued.task_id, TaskStatus.QUEUED, {
       status: TaskStatus.DISPATCHING,
     });
 

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -4,7 +4,7 @@
  * Tests for type-safe CRUD operations on tasks with short ID support.
  */
 
-import type { Task, UUID } from '@agor/core/types';
+import type { Task, TaskPendingDispatchStatus, UUID } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
@@ -1777,7 +1777,7 @@ describe('TaskRepository edge cases', () => {
  */
 function createPendingInput(overrides: {
   session_id: string;
-  status: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED;
+  status: TaskPendingDispatchStatus;
   full_prompt?: string;
   metadata?: Parameters<TaskRepository['createPending']>[0]['metadata'];
 }): Parameters<TaskRepository['createPending']>[0] {

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -14,7 +14,7 @@ import type {
   TerminationCause,
   UUID,
 } from '@agor/core/types';
-import { isTerminalTaskStatus, TaskStatus } from '@agor/core/types';
+import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 import { and, eq, inArray, like, sql } from 'drizzle-orm';
 import { generateId, shortId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -28,7 +28,7 @@ import {
   txAsDb,
   update,
 } from '../database-wrapper';
-import { type TaskInsert, type TaskRow, tasks } from '../schema';
+import { sessions, type TaskInsert, type TaskRow, tasks } from '../schema';
 import {
   AmbiguousIdError,
   type BaseRepository,
@@ -1017,7 +1017,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    * intent, transcript/session state, or spawn a second executor after losing
    * this transition.
    */
-  async claimDispatch(
+  async claimDispatchAndProjectSession(
     id: string,
     expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
     updates: Partial<Task>
@@ -1058,6 +1058,33 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
           data: insertData.data,
         })
         .where(eq(tasks.task_id, fullId))
+        .run();
+
+      // The launch-intent transition and its Session projection are one
+      // durable state change. PostgreSQL request scopes already provide an
+      // outer transaction, but standalone SQLite does not; keeping this write
+      // inside the task-claim transaction closes the kill point where a Task
+      // could be DISPATCHING while its Session remained IDLE and omitted the
+      // task from data.tasks.
+      await lockRowForUpdate(txDb, this.db, sessions, eq(sessions.session_id, current.session_id));
+      const sessionRow = await select(txDb)
+        .from(sessions)
+        .where(eq(sessions.session_id, current.session_id))
+        .one();
+      if (!sessionRow) {
+        throw new EntityNotFoundError('Session', current.session_id);
+      }
+      const sessionTasks = sessionRow.data.tasks.includes(current.task_id)
+        ? sessionRow.data.tasks
+        : [...sessionRow.data.tasks, current.task_id];
+      await update(txDb, sessions)
+        .set({
+          status: SessionStatus.RUNNING,
+          ready_for_prompt: false,
+          updated_at: new Date(),
+          data: { ...sessionRow.data, tasks: sessionTasks },
+        })
+        .where(eq(sessions.session_id, current.session_id))
         .run();
       return { outcome: 'claimed', task: merged };
     });

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -124,6 +124,11 @@ export interface TerminationSettlementResult {
   task: Task;
 }
 
+export interface TaskDispatchClaimResult {
+  outcome: 'claimed' | 'already_claimed' | 'condition_changed';
+  task: Task;
+}
+
 /**
  * Task repository implementation
  */
@@ -924,6 +929,8 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    * overwrites these on the way to RUNNING.
    */
   async createPending(input: {
+    /** Optional stable identity used by idempotent internal producers. */
+    task_id?: UUID;
     session_id: SessionID;
     full_prompt: string;
     created_by: string;
@@ -931,6 +938,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     metadata?: TaskMetadata;
   }): Promise<Task> {
     const taskBase: Partial<Task> = {
+      task_id: input.task_id,
       session_id: input.session_id,
       full_prompt: input.full_prompt,
       created_by: input.created_by,
@@ -951,8 +959,24 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       tool_use_count: 0,
     };
 
-    if (input.status === TaskStatus.CREATED) {
+    if (input.status === TaskStatus.CREATED && !input.task_id) {
       return this.create(taskBase);
+    }
+
+    if (input.status === TaskStatus.CREATED) {
+      const insertData = this.taskToInsert(taskBase);
+      await insert(this.db, tasks).values(insertData).onConflictDoNothing().run();
+      const row = await select(this.db).from(tasks).where(eq(tasks.task_id, input.task_id!)).one();
+      if (!row) throw new RepositoryError('Failed to retrieve idempotent pending task');
+      const existing = this.rowToTask(row);
+      if (
+        existing.session_id !== input.session_id ||
+        existing.created_by !== input.created_by ||
+        existing.full_prompt !== input.full_prompt
+      ) {
+        throw new RepositoryError(`Task identity ${input.task_id} is already in use`);
+      }
+      return existing;
     }
 
     // QUEUED: serialize the read-then-insert in a transaction so concurrent
@@ -982,6 +1006,60 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         throw new RepositoryError('Failed to retrieve created queued task');
       }
       return this.rowToTask(row);
+    });
+  }
+
+  /**
+   * Atomically claim the CREATED/QUEUED -> DISPATCHING transition.
+   *
+   * The row lock and expected-state check are the fence. A second daemon that
+   * read the old state may do preparatory work, but it cannot write launch
+   * intent, transcript/session state, or spawn a second executor after losing
+   * this transition.
+   */
+  async claimDispatch(
+    id: string,
+    expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
+    updates: Partial<Task>
+  ): Promise<TaskDispatchClaimResult> {
+    return this.mutateLockedTask(id, async (txDb, currentRow, fullId) => {
+      const current = this.rowToTask(currentRow);
+      if (current.status !== expectedStatus) {
+        return {
+          outcome:
+            current.status === TaskStatus.DISPATCHING || current.status === TaskStatus.RUNNING
+              ? 'already_claimed'
+              : 'condition_changed',
+          task: current,
+        };
+      }
+      if (updates.status !== TaskStatus.DISPATCHING) {
+        throw new RepositoryError('Dispatch claim must transition to dispatching');
+      }
+
+      const merged: Task = {
+        ...deepMerge(current, updates),
+        task_id: current.task_id,
+        session_id: current.session_id,
+        created_by: current.created_by,
+        created_at: current.created_at,
+        // Queue ownership ends at the durable launch-intent transition.
+        queue_position: undefined,
+      };
+      const insertData = this.taskToInsert(merged);
+      await update(txDb, tasks)
+        .set({
+          status: insertData.status,
+          queue_position: insertData.queue_position,
+          started_at: insertData.started_at,
+          executor_connected_at: insertData.executor_connected_at,
+          completed_at: insertData.completed_at,
+          last_executor_heartbeat_at: insertData.last_executor_heartbeat_at,
+          data: insertData.data,
+        })
+        .where(eq(tasks.task_id, fullId))
+        .run();
+      return { outcome: 'claimed', task: merged };
     });
   }
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -10,7 +10,9 @@ import type {
   SdkFailure,
   SessionID,
   Task,
+  TaskID,
   TaskMetadata,
+  TaskPendingDispatchStatus,
   TerminationCause,
   UUID,
 } from '@agor/core/types';
@@ -930,11 +932,11 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    */
   async createPending(input: {
     /** Optional stable identity used by idempotent internal producers. */
-    task_id?: UUID;
+    task_id?: TaskID;
     session_id: SessionID;
     full_prompt: string;
     created_by: string;
-    status: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED;
+    status: TaskPendingDispatchStatus;
     metadata?: TaskMetadata;
   }): Promise<Task> {
     const taskBase: Partial<Task> = {
@@ -1019,7 +1021,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    */
   async claimDispatchAndProjectSession(
     id: string,
-    expectedStatus: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED,
+    expectedStatus: TaskPendingDispatchStatus,
     updates: Partial<Task>
   ): Promise<TaskDispatchClaimResult> {
     return this.mutateLockedTask(id, async (txDb, currentRow, fullId) => {

--- a/packages/core/src/db/scheduler-ha.postgres.test.ts
+++ b/packages/core/src/db/scheduler-ha.postgres.test.ts
@@ -157,7 +157,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('scheduler HA (PostgreSQL)'
     const claims = await Promise.all(
       Array.from({ length: 5 }, () =>
         runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
-          new TaskRepository(scoped).claimDispatch(taskId, TaskStatus.CREATED, {
+          new TaskRepository(scoped).claimDispatchAndProjectSession(taskId, TaskStatus.CREATED, {
             status: TaskStatus.DISPATCHING,
           })
         )
@@ -218,6 +218,13 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('scheduler HA (PostgreSQL)'
     const byId = new Map(discovered.map((ref) => [ref.schedule_id, ref.tenant_id]));
     expect(byId.get(a.scheduleId)).toBe(a.tenantId);
     expect(byId.get(b.scheduleId)).toBe(b.tenantId);
+
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      await new ScheduleRepository(scoped).delete(a.scheduleId);
+      expect((await new SessionRepository(scoped).findById(pendingA.session_id))?.schedule_id).toBe(
+        undefined
+      );
+    });
 
     const recoveries = await runWithSystemDatabaseScope(
       db,

--- a/packages/core/src/db/scheduler-ha.postgres.test.ts
+++ b/packages/core/src/db/scheduler-ha.postgres.test.ts
@@ -1,0 +1,232 @@
+/**
+ * PostgreSQL integration for scheduler occurrence admission/recovery.
+ *
+ * Run with:
+ *   AGOR_DB_DIALECT=postgresql \
+ *   AGOR_TEST_POSTGRES_URL=postgresql://user:pw@host:5432/db \
+ *   pnpm --filter @agor/core exec vitest run src/db/scheduler-ha.postgres.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../lib/ids';
+import type { SessionID, TaskID, UUID } from '../types/id';
+import type { ScheduleID } from '../types/schedule';
+import { SessionStatus } from '../types/session';
+import { TaskStatus } from '../types/task';
+import { createDatabase, type Database } from './client';
+import { isPostgresDatabase } from './database-wrapper';
+import { initializeDatabase } from './migrate';
+import {
+  BranchRepository,
+  RepoRepository,
+  ScheduleRepository,
+  SessionRepository,
+  TaskRepository,
+  UsersRepository,
+} from './repositories';
+import { runWithSystemDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+let branchUnique = Date.now() % 1_000_000;
+
+interface TenantSeed {
+  tenantId: string;
+  userId: UUID;
+  branchId: UUID;
+  scheduleId: ScheduleID;
+}
+
+async function seedTenant(db: Database, tenantId: string, enabled = true): Promise<TenantSeed> {
+  return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const user = await new UsersRepository(scoped).create({
+      email: `${tenantId}-${generateId()}@example.com`,
+      name: `Scheduler ${tenantId}`,
+    });
+    const repo = await new RepoRepository(scoped).create({
+      repo_id: generateId(),
+      slug: `scheduler-ha-${tenantId}-${generateId()}`,
+      name: `Scheduler HA ${tenantId}`,
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/scheduler-ha.git',
+      local_path: `/tmp/${generateId()}`,
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(scoped).create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `scheduler-ha-${tenantId}`,
+      ref: 'main',
+      branch_unique_id: branchUnique++,
+      path: `/tmp/${generateId()}`,
+      created_by: user.user_id,
+    });
+    const schedule = await new ScheduleRepository(scoped).create({
+      schedule_id: generateId() as ScheduleID,
+      branch_id: branch.branch_id,
+      created_by: user.user_id,
+      name: `Scheduler HA ${tenantId}`,
+      cron_expression: '* * * * *',
+      timezone_mode: 'utc',
+      prompt: 'recover me',
+      agentic_tool_config: { agentic_tool: 'claude-code' },
+      enabled,
+      next_run_at: Date.now() - 1_000,
+      retention: 0,
+    });
+    return {
+      tenantId,
+      userId: user.user_id as UUID,
+      branchId: branch.branch_id as UUID,
+      scheduleId: schedule.schedule_id,
+    };
+  });
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)('scheduler HA (PostgreSQL)', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    await initializeDatabase(db);
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+  });
+
+  afterAll(async () => {
+    await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+  });
+
+  it('serializes five occurrence admissions to one durable Session', async () => {
+    const seed = await seedTenant(db, `scheduler-five-${generateId()}`);
+    const scheduledRunAt = Date.now();
+
+    const ids = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+          const schedules = new ScheduleRepository(scoped);
+          const sessions = new SessionRepository(scoped);
+          await schedules.lockForRunAdmission(seed.scheduleId);
+          const existing = await sessions.findScheduleRun(seed.scheduleId, scheduledRunAt);
+          if (existing) return existing.session_id;
+          const created = await sessions.create({
+            session_id: generateId() as SessionID,
+            branch_id: seed.branchId,
+            created_by: seed.userId,
+            agentic_tool: 'claude-code',
+            status: SessionStatus.IDLE,
+            scheduled_from_branch: true,
+            scheduled_run_at: scheduledRunAt,
+            schedule_id: seed.scheduleId,
+          });
+          return created.session_id;
+        })
+      )
+    );
+
+    expect(new Set(ids).size).toBe(1);
+    await runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+      expect(await new SessionRepository(scoped).findByScheduleId(seed.scheduleId)).toHaveLength(1);
+    });
+  });
+
+  it('fences five dispatchers after idempotent task recovery', async () => {
+    const seed = await seedTenant(db, `scheduler-task-${generateId()}`);
+    const session = await runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+      new SessionRepository(scoped).create({
+        session_id: generateId() as SessionID,
+        branch_id: seed.branchId,
+        created_by: seed.userId,
+        agentic_tool: 'claude-code',
+      })
+    );
+    const taskId = generateId() as TaskID;
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+          new TaskRepository(scoped).createPending({
+            task_id: taskId,
+            session_id: session.session_id,
+            created_by: seed.userId,
+            full_prompt: 'recover me',
+            status: TaskStatus.CREATED,
+          })
+        )
+      )
+    );
+    const claims = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+          new TaskRepository(scoped).claimDispatch(taskId, TaskStatus.CREATED, {
+            status: TaskStatus.DISPATCHING,
+          })
+        )
+      )
+    );
+
+    expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
+    expect(claims.filter((claim) => claim.outcome === 'already_claimed')).toHaveLength(4);
+  });
+
+  it('keeps tenant reloads isolated while narrow system discovery returns routing refs', async () => {
+    const a = await seedTenant(db, `scheduler-tenant-a-${generateId()}`);
+    const b = await seedTenant(db, `scheduler-tenant-b-${generateId()}`);
+    await seedTenant(db, `scheduler-disabled-${generateId()}`, false);
+
+    const visibleToA = await runWithTenantDatabaseScope(db, a.tenantId, (scoped) =>
+      new ScheduleRepository(scoped).findDueRefs(Date.now() + 60_000, 100)
+    );
+    expect(visibleToA.map((ref) => ref.schedule_id)).toEqual([a.scheduleId]);
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      expect(await new ScheduleRepository(scoped).findById(b.scheduleId)).toBeNull();
+    });
+
+    const pendingA = await runWithTenantDatabaseScope(db, a.tenantId, (scoped) =>
+      new SessionRepository(scoped).create({
+        session_id: generateId() as SessionID,
+        branch_id: a.branchId,
+        created_by: a.userId,
+        agentic_tool: 'claude-code',
+        scheduled_from_branch: true,
+        scheduled_run_at: Date.now(),
+        schedule_id: a.scheduleId,
+      })
+    );
+    const pendingB = await runWithTenantDatabaseScope(db, b.tenantId, (scoped) =>
+      new SessionRepository(scoped).create({
+        session_id: generateId() as SessionID,
+        branch_id: b.branchId,
+        created_by: b.userId,
+        agentic_tool: 'claude-code',
+        scheduled_from_branch: true,
+        scheduled_run_at: Date.now(),
+        schedule_id: b.scheduleId,
+      })
+    );
+    const tenantARecoveries = await runWithTenantDatabaseScope(db, a.tenantId, (scoped) =>
+      new SessionRepository(scoped).findIncompleteScheduledRefs(100)
+    );
+    expect(tenantARecoveries.map((ref) => ref.session_id)).toContain(pendingA.session_id);
+    expect(tenantARecoveries.map((ref) => ref.session_id)).not.toContain(pendingB.session_id);
+
+    const discovered = await runWithSystemDatabaseScope(
+      db,
+      'scheduler integration discovery',
+      (systemDb) => new ScheduleRepository(systemDb).findDueRefs(Date.now() + 60_000, 100),
+      { capability: 'scheduler_discovery' }
+    );
+    const byId = new Map(discovered.map((ref) => [ref.schedule_id, ref.tenant_id]));
+    expect(byId.get(a.scheduleId)).toBe(a.tenantId);
+    expect(byId.get(b.scheduleId)).toBe(b.tenantId);
+
+    const recoveries = await runWithSystemDatabaseScope(
+      db,
+      'scheduler integration recovery discovery',
+      (systemDb) => new SessionRepository(systemDb).findIncompleteScheduledRefs(100),
+      { capability: 'scheduler_discovery' }
+    );
+    const recoveryTenants = new Map(recoveries.map((ref) => [ref.session_id, ref.tenant_id]));
+    expect(recoveryTenants.get(pendingA.session_id)).toBe(a.tenantId);
+    expect(recoveryTenants.get(pendingB.session_id)).toBe(b.tenantId);
+  });
+});

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -16,6 +16,7 @@ import type {
   SandpackConfig,
   Session,
   Task,
+  TaskID,
   UserExternalIdentity,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
@@ -120,6 +121,10 @@ export const sessions = pgTable(
       (): import('drizzle-orm/pg-core').AnyPgColumn => schedules.schedule_id,
       { onDelete: 'set null' }
     ),
+    // Internal scheduler recovery marker. Existing rows are backfilled by the
+    // migration; new occurrences remain NULL until initialization, retention,
+    // and schedule metadata are durable.
+    scheduler_init_completed_at: t.timestamp('scheduler_init_completed_at'),
 
     // UI state (materialized for efficient highlighting queries)
     ready_for_prompt: t.bool('ready_for_prompt').notNull().default(false),
@@ -184,10 +189,12 @@ export const sessions = pgTable(
           scheduled_run?: {
             rendered_prompt: string; // Template after Handlebars rendering
             run_index: number; // 1st, 2nd, 3rd run for this schedule
+            initial_task_id?: TaskID; // Stable task identity for scheduler recovery
             schedule_config_snapshot?: {
               cron: string;
               timezone: string;
               retention: number;
+              mcp_server_ids?: string[];
             };
           };
         };
@@ -236,6 +243,11 @@ export const sessions = pgTable(
       .on(table.tenant_id, table.schedule_id, table.scheduled_run_at)
       // Both columns must be non-null — see SQLite mirror.
       .where(sql`${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL`),
+    schedulerInitPendingIdx: index('sessions_scheduler_init_pending_idx')
+      .on(table.created_at, table.session_id)
+      .where(
+        sql`${table.scheduled_from_branch} = true AND ${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
+      ),
   })
 );
 
@@ -1576,8 +1588,12 @@ export const sessionMcpServers = pgTable(
   },
   (table) => ({
     tenantIdx: index('session_mcp_servers_tenant_id_idx').on(table.tenant_id),
-    // Composite primary key
-    pk: index('session_mcp_servers_pk').on(table.session_id, table.mcp_server_id),
+    // Tenant-aware idempotency guard for recovery and concurrent attachment.
+    pk: uniqueIndex('session_mcp_servers_pk').on(
+      table.tenant_id,
+      table.session_id,
+      table.mcp_server_id
+    ),
     // Indexes for queries
     sessionIdx: index('session_mcp_servers_session_idx').on(table.session_id),
     serverIdx: index('session_mcp_servers_server_idx').on(table.mcp_server_id),

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -246,7 +246,7 @@ export const sessions = pgTable(
     schedulerInitPendingIdx: index('sessions_scheduler_init_pending_idx')
       .on(table.created_at, table.session_id)
       .where(
-        sql`${table.scheduled_from_branch} = true AND ${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
+        sql`${table.scheduled_from_branch} = true AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
       ),
   })
 );

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -16,7 +16,6 @@ import type {
   SandpackConfig,
   Session,
   Task,
-  TaskID,
   UserExternalIdentity,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
@@ -184,20 +183,8 @@ export const sessions = pgTable(
         last_context_update_at?: string; // ISO 8601 timestamp
 
         // Custom context for Handlebars templates
-        custom_context?: Record<string, unknown> & {
-          // Scheduled run metadata (populated by scheduler)
-          scheduled_run?: {
-            rendered_prompt: string; // Template after Handlebars rendering
-            run_index: number; // 1st, 2nd, 3rd run for this schedule
-            initial_task_id?: TaskID; // Stable task identity for scheduler recovery
-            schedule_config_snapshot?: {
-              cron: string;
-              timezone: string;
-              retention: number;
-              mcp_server_ids?: string[];
-            };
-          };
-        };
+        // Keep scheduler/gateway/user context owned by the canonical Session type.
+        custom_context?: Session['custom_context'];
 
         // Read-only metadata retained for historical sessions created by the
         // removed experimental Claude CLI integration. No runtime consumes it.

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -16,7 +16,6 @@ import type {
   SandpackConfig,
   Session,
   Task,
-  TaskID,
   UserExternalIdentity,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
@@ -171,20 +170,8 @@ export const sessions = sqliteTable(
         last_context_update_at?: string; // ISO 8601 timestamp
 
         // Custom context for Handlebars templates
-        custom_context?: Record<string, unknown> & {
-          // Scheduled run metadata (populated by scheduler)
-          scheduled_run?: {
-            rendered_prompt: string; // Template after Handlebars rendering
-            run_index: number; // 1st, 2nd, 3rd run for this schedule
-            initial_task_id?: TaskID; // Stable task identity for scheduler recovery
-            schedule_config_snapshot?: {
-              cron: string;
-              timezone: string;
-              retention: number;
-              mcp_server_ids?: string[];
-            };
-          };
-        };
+        // Keep scheduler/gateway/user context owned by the canonical Session type.
+        custom_context?: Session['custom_context'];
 
         // Read-only metadata retained for historical sessions created by the
         // removed experimental Claude CLI integration. No runtime consumes it.

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -16,6 +16,7 @@ import type {
   SandpackConfig,
   Session,
   Task,
+  TaskID,
   UserExternalIdentity,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
@@ -107,6 +108,10 @@ export const sessions = sqliteTable(
       (): import('drizzle-orm/sqlite-core').AnySQLiteColumn => schedules.schedule_id,
       { onDelete: 'set null' }
     ),
+    // Internal scheduler recovery marker. Existing rows are backfilled by the
+    // migration; new occurrences remain NULL until initialization, retention,
+    // and schedule metadata are durable.
+    scheduler_init_completed_at: t.timestamp('scheduler_init_completed_at'),
 
     // UI state (materialized for efficient highlighting queries)
     ready_for_prompt: t.bool('ready_for_prompt').notNull().default(false),
@@ -171,10 +176,12 @@ export const sessions = sqliteTable(
           scheduled_run?: {
             rendered_prompt: string; // Template after Handlebars rendering
             run_index: number; // 1st, 2nd, 3rd run for this schedule
+            initial_task_id?: TaskID; // Stable task identity for scheduler recovery
             schedule_config_snapshot?: {
               cron: string;
               timezone: string;
               retention: number;
+              mcp_server_ids?: string[];
             };
           };
         };
@@ -227,6 +234,11 @@ export const sessions = sqliteTable(
       // both are set. Non-scheduled sessions (schedule_id NULL) must
       // coexist freely.
       .where(sql`${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL`),
+    schedulerInitPendingIdx: index('sessions_scheduler_init_pending_idx')
+      .on(table.created_at, table.session_id)
+      .where(
+        sql`${table.scheduled_from_branch} = true AND ${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
+      ),
   })
 );
 
@@ -1520,8 +1532,8 @@ export const sessionMcpServers = sqliteTable(
     added_at: t.timestamp('added_at').notNull(),
   },
   (table) => ({
-    // Composite primary key
-    pk: index('session_mcp_servers_pk').on(table.session_id, table.mcp_server_id),
+    // Idempotency guard for recovery and concurrent attachment.
+    pk: uniqueIndex('session_mcp_servers_pk').on(table.session_id, table.mcp_server_id),
     // Indexes for queries
     sessionIdx: index('session_mcp_servers_session_idx').on(table.session_id),
     serverIdx: index('session_mcp_servers_server_idx').on(table.mcp_server_id),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -237,7 +237,7 @@ export const sessions = sqliteTable(
     schedulerInitPendingIdx: index('sessions_scheduler_init_pending_idx')
       .on(table.created_at, table.session_id)
       .where(
-        sql`${table.scheduled_from_branch} = true AND ${table.schedule_id} IS NOT NULL AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
+        sql`${table.scheduled_from_branch} = true AND ${table.scheduled_run_at} IS NOT NULL AND ${table.scheduler_init_completed_at} IS NULL`
       ),
   })
 );

--- a/packages/core/src/db/scripts/test-postgres.ts
+++ b/packages/core/src/db/scripts/test-postgres.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Run every PostgreSQL integration test against its own temporary database.
+ *
+ * Several suites deliberately create or alter fixed catalog objects. Running
+ * those files concurrently in one database is unsafe, but serializing every
+ * file makes the PostgreSQL lane unnecessarily slow. This runner preserves
+ * file-level parallelism while isolating each file at the database boundary.
+ *
+ * The role in AGOR_TEST_POSTGRES_URL must have CREATEDB. PostgreSQL tests use a
+ * non-superuser, non-BYPASSRLS role so their tenant-isolation assertions remain
+ * meaningful.
+ */
+
+import { spawn } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const testRoot = join(packageRoot, 'src');
+const defaultConcurrency = 3;
+const maxConcurrency = 8;
+
+async function findPostgresTests(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return findPostgresTests(path);
+      return entry.isFile() && entry.name.endsWith('.postgres.test.ts') ? [path] : [];
+    })
+  );
+  return files.flat().sort();
+}
+
+function resolveConcurrency(): number {
+  const configured = process.env.AGOR_POSTGRES_TEST_CONCURRENCY?.trim();
+  if (!configured) return defaultConcurrency;
+  const parsed = Number(configured);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maxConcurrency) {
+    throw new Error(
+      `AGOR_POSTGRES_TEST_CONCURRENCY must be an integer from 1 to ${maxConcurrency}`
+    );
+  }
+  return parsed;
+}
+
+function databaseUrl(baseUrl: string, databaseName: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+async function runTestFile(file: string, url: string): Promise<number> {
+  const displayName = basename(file);
+  const relativeFile = relative(packageRoot, file);
+  console.log(`\n[postgres:${displayName}] starting`);
+  return new Promise<number>((resolveRun, rejectRun) => {
+    const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+    const child = spawn(command, ['exec', 'vitest', 'run', relativeFile], {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        AGOR_DB_DIALECT: 'postgresql',
+        AGOR_TEST_POSTGRES_URL: url,
+      },
+      stdio: 'inherit',
+    });
+    child.once('error', rejectRun);
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        console.error(`[postgres:${displayName}] terminated by ${signal}`);
+        resolveRun(1);
+        return;
+      }
+      const exitCode = code ?? 1;
+      console.log(`[postgres:${displayName}] ${exitCode === 0 ? 'passed' : 'failed'}`);
+      resolveRun(exitCode);
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.AGOR_TEST_POSTGRES_URL?.trim();
+  if (!baseUrl) {
+    throw new Error('AGOR_TEST_POSTGRES_URL is required');
+  }
+  const postgresUrl = baseUrl;
+  const parsedUrl = new URL(postgresUrl);
+  if (parsedUrl.protocol !== 'postgres:' && parsedUrl.protocol !== 'postgresql:') {
+    throw new Error('AGOR_TEST_POSTGRES_URL must be a PostgreSQL URL');
+  }
+
+  const files = await findPostgresTests(testRoot);
+  if (files.length === 0) throw new Error('No *.postgres.test.ts files found');
+
+  const concurrency = Math.min(resolveConcurrency(), files.length);
+  const runId = `${Date.now().toString(36)}_${process.pid.toString(36)}`;
+  const control = postgres(postgresUrl, { max: 1 });
+  const results = new Array<number>(files.length);
+  let nextIndex = 0;
+
+  console.log(`Running ${files.length} PostgreSQL test files with concurrency ${concurrency}`);
+
+  async function worker(): Promise<void> {
+    while (nextIndex < files.length) {
+      const index = nextIndex++;
+      const file = files[index];
+      if (!file) throw new Error(`Missing PostgreSQL test file at index ${index}`);
+      const databaseName = `agor_test_${runId}_${index}`;
+      const isolatedUrl = databaseUrl(postgresUrl, databaseName);
+      try {
+        await control.unsafe(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+        results[index] = await runTestFile(file, isolatedUrl);
+      } catch (error) {
+        results[index] = 1;
+        console.error(
+          `[postgres:${basename(file)}] ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        try {
+          await control.unsafe(
+            `DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)} WITH (FORCE)`
+          );
+        } catch (error) {
+          results[index] = 1;
+          console.error(
+            `[postgres:${basename(file)}] cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      }
+    }
+  }
+
+  try {
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  } finally {
+    await control.end();
+  }
+
+  const failures = results.filter((code) => code !== 0).length;
+  if (failures > 0) {
+    throw new Error(`${failures} of ${files.length} PostgreSQL test files failed`);
+  }
+  console.log(`\nAll ${files.length} PostgreSQL test files passed`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -13,7 +13,10 @@ export interface TenantDatabaseScope {
 }
 
 /** Narrow RLS capabilities available to explicit system database work. */
-export type SystemDatabaseCapability = 'gateway_listener_discovery' | 'upload_maintenance';
+export type SystemDatabaseCapability =
+  | 'gateway_listener_discovery'
+  | 'scheduler_discovery'
+  | 'upload_maintenance';
 
 export interface TenantContextScope {
   tenantId: TenantID | string;

--- a/packages/core/src/db/tenant-portability.postgres.test.ts
+++ b/packages/core/src/db/tenant-portability.postgres.test.ts
@@ -11,6 +11,7 @@
  *   pnpm --filter @agor/core exec vitest run src/db/tenant-portability.postgres.test.ts
  */
 
+import { rmSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -491,19 +492,26 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant portability (Postgr
     await deleteTenantData(db, source);
     await rm(sourceFs, { recursive: true, force: true });
 
-    // A destination whose PARENT is a regular file: classification sees the root
-    // as absent (empty FS portion, so the DB restores and commits), but staging —
-    // which runs after the commit — cannot mkdir under a non-directory and throws.
-    const brokenParent = join(scratch, `${rehomed}-broken`);
-    await writeFile(brokenParent, 'not a directory');
-    const brokenFsRoot = join(brokenParent, 'root');
+    // Remove one already-verified filesystem payload from the archive while the
+    // database restore is in flight. Staging runs only after that transaction
+    // commits, so the missing file deterministically faults the filesystem tail.
+    const archivedPayloadPath = join(archive, 'files', 'repos', 'org', 'file-a.txt');
+    const archivedPayload = await readFile(archivedPayloadPath);
+    let faultInjected = false;
+    const goodFsRoot = join(scratch, `${rehomed}-fs`);
     await expect(
       importTenant(db, {
         archivePath: archive,
         tenantId: rehomed,
-        filesystemRoot: brokenFsRoot,
+        filesystemRoot: goodFsRoot,
+        log: () => {
+          if (faultInjected) return;
+          faultInjected = true;
+          rmSync(archivedPayloadPath);
+        },
       })
     ).rejects.toThrow();
+    await writeFile(archivedPayloadPath, archivedPayload);
 
     // The re-homed database committed despite the filesystem-tail failure.
     const afterFailure = await inspectTenant(db, rehomed);
@@ -511,7 +519,6 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant portability (Postgr
 
     // Retry against a healthy destination root: the database is recognised as
     // already applied (no re-insert) and only the filesystem portion completes.
-    const goodFsRoot = join(scratch, `${rehomed}-fs`);
     const retried = await importTenant(db, {
       archivePath: archive,
       tenantId: rehomed,

--- a/packages/core/src/db/tenant-write-gate.postgres.test.ts
+++ b/packages/core/src/db/tenant-write-gate.postgres.test.ts
@@ -22,7 +22,12 @@ import { RepoRepository } from './repositories/repos';
 import { SessionRepository } from './repositories/sessions';
 import * as pg from './schema.postgres';
 import { deleteTenantData } from './tenant-deletion';
-import { runWithTenantContext, runWithTenantDatabaseScope } from './tenant-scope';
+import {
+  createTenantScopedDatabaseProxy,
+  runWithoutTenantDatabaseScope,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+} from './tenant-scope';
 import { bindRepositoryToTenantUnitOfWork } from './tenant-unit-of-work';
 import {
   acquireTenantWriteGate,
@@ -244,7 +249,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant write gate (Postgre
     // Bind a repository to the unit-of-work boundary and drive it with ONLY a
     // tenant identity in context (no ambient DB scope) — the gateway / MCP /
     // custom-route shape that never reaches the request-hook gate check.
-    const sessionRepo = bindRepositoryToTenantUnitOfWork(db as never, new SessionRepository(db));
+    const tenantScopedDb = createTenantScopedDatabaseProxy(db);
+    const sessionRepo = bindRepositoryToTenantUnitOfWork(
+      tenantScopedDb,
+      new SessionRepository(tenantScopedDb)
+    );
 
     const { generation } = await acquireTenantWriteGate(db, tenant, { reason: 'freeze' });
 
@@ -304,10 +313,12 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant write gate (Postgre
         await assertTenantWriteGateGeneration(scoped, tenant, generation);
 
         // Kick off a forced re-acquire from the other connection; it must block.
-        forced = acquireTenantWriteGate(other, tenant, { force: true }).then((result) => {
-          forcedSettled = true;
-          return result;
-        });
+        forced = runWithoutTenantDatabaseScope(() =>
+          acquireTenantWriteGate(other, tenant, { force: true }).then((result) => {
+            forcedSettled = true;
+            return result;
+          })
+        );
 
         // Give the blocked acquire ample time to prove it cannot proceed.
         await new Promise((resolve) => setTimeout(resolve, 300));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
 export * from './api/index.js';
 export * from './config/index.js';
 export { getBranchesDir, getBranchPath, getReposDir } from './config/index.js';
+export * from './coordination/index.js';
 export * from './db/index.js';
 export * from './design/board-backgrounds.js';
 export * from './environment/render-snapshot.js';

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -656,6 +656,13 @@ export interface ScheduledRunMetadata {
   run_index: number;
 
   /**
+   * Stable identity of the occurrence's initial task. The scheduler persists
+   * this with the session before creating the task so recovery can reconcile
+   * the same prompt after a daemon crash without creating a second task.
+   */
+  initial_task_id?: TaskID;
+
+  /**
    * Whether this run was triggered manually via execute-now (vs. cron tick).
    */
   triggered_manually?: boolean;
@@ -688,6 +695,8 @@ export interface ScheduledRunMetadata {
     retention: number;
     /** Concurrency policy at run time (applies to both cron and manual paths) */
     allow_concurrent_runs?: boolean;
+    /** Effective MCP attachment snapshot used by crash recovery. */
+    mcp_server_ids?: string[];
   };
 }
 

--- a/packages/core/src/types/task.test.ts
+++ b/packages/core/src/types/task.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { isTaskExecuting, isTaskPendingDispatch, TaskStatus } from './task';
+import {
+  isTaskExecuting,
+  isTaskPendingDispatch,
+  NONTERMINAL_TASK_STATUSES,
+  TaskStatus,
+  TERMINAL_TASK_STATUSES,
+} from './task';
 
 describe('task execution helpers', () => {
   it('identifies only states that still need a daemon dispatch claim', () => {
@@ -9,6 +15,15 @@ describe('task execution helpers', () => {
     expect(isTaskPendingDispatch({ status: TaskStatus.RUNNING })).toBe(false);
     expect(isTaskPendingDispatch({ status: TaskStatus.COMPLETED })).toBe(false);
     expect(isTaskPendingDispatch({ status: TaskStatus.FAILED })).toBe(false);
+  });
+
+  it('keeps terminal and nonterminal status collections exhaustive and disjoint', () => {
+    expect(
+      [...NONTERMINAL_TASK_STATUSES].filter((status) => TERMINAL_TASK_STATUSES.has(status))
+    ).toEqual([]);
+    expect([...NONTERMINAL_TASK_STATUSES, ...TERMINAL_TASK_STATUSES].sort()).toEqual(
+      Object.values(TaskStatus).sort()
+    );
   });
 
   it('identifies executor-owned task states', () => {

--- a/packages/core/src/types/task.test.ts
+++ b/packages/core/src/types/task.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { isTaskExecuting, TaskStatus } from './task';
+import { isTaskExecuting, isTaskPendingDispatch, TaskStatus } from './task';
 
 describe('task execution helpers', () => {
+  it('identifies only states that still need a daemon dispatch claim', () => {
+    expect(isTaskPendingDispatch({ status: TaskStatus.CREATED })).toBe(true);
+    expect(isTaskPendingDispatch({ status: TaskStatus.QUEUED })).toBe(true);
+    expect(isTaskPendingDispatch({ status: TaskStatus.DISPATCHING })).toBe(false);
+    expect(isTaskPendingDispatch({ status: TaskStatus.RUNNING })).toBe(false);
+    expect(isTaskPendingDispatch({ status: TaskStatus.COMPLETED })).toBe(false);
+    expect(isTaskPendingDispatch({ status: TaskStatus.FAILED })).toBe(false);
+  });
+
   it('identifies executor-owned task states', () => {
     expect(isTaskExecuting({ status: TaskStatus.DISPATCHING })).toBe(true);
     expect(isTaskExecuting({ status: TaskStatus.RUNNING })).toBe(true);

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -171,6 +171,19 @@ export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
 }
 
 /**
+ * A Task whose daemon-side launch claim has not yet become durable.
+ *
+ * Every other status is downstream of the CREATED/QUEUED -> DISPATCHING
+ * fence (or terminal) and must never be sent through launch admission again
+ * merely to reconcile projections around that durable Task.
+ */
+export function isTaskPendingDispatch(task: Pick<Task, 'status'>): task is Pick<Task, 'status'> & {
+  status: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED;
+} {
+  return task.status === TaskStatus.CREATED || task.status === TaskStatus.QUEUED;
+}
+
+/**
  * Task states owned by an active executor turn. These block starting another
  * task in the same session and should be stopped/failed before queue drain can
  * continue. CREATED and QUEUED are intentionally excluded: CREATED is a

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -20,6 +20,9 @@ export const TaskStatus = {
 
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
+/** Task states that have not yet crossed the daemon's durable dispatch fence. */
+export type TaskPendingDispatchStatus = typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED;
+
 export type ExecutorMode = 'local' | 'templated';
 
 export const ExecutorPulseKind = {
@@ -166,6 +169,11 @@ export const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatu
   TaskStatus.TIMED_OUT,
 ]);
 
+/** Every persisted Task status that still represents unfinished work. */
+export const NONTERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>(
+  Object.values(TaskStatus).filter((status) => !TERMINAL_TASK_STATUSES.has(status))
+);
+
 export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
   return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
 }
@@ -178,7 +186,7 @@ export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
  * merely to reconcile projections around that durable Task.
  */
 export function isTaskPendingDispatch(task: Pick<Task, 'status'>): task is Pick<Task, 'status'> & {
-  status: typeof TaskStatus.CREATED | typeof TaskStatus.QUEUED;
+  status: TaskPendingDispatchStatus;
 } {
   return task.status === TaskStatus.CREATED || task.status === TaskStatus.QUEUED;
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     'models/gemini-shared': 'src/models/gemini-shared.ts', // Shared Gemini metadata/constants
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
     'sessions/index': 'src/sessions/index.ts', // Session config defaults resolution
+    'coordination/index': 'src/coordination/index.ts', // Pure distributed-work identity and delay mechanics
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini)
     'client/claude-system-suppression': 'src/client/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
     'tools/mcp/http-headers': 'src/tools/mcp/http-headers.ts', // MCP custom HTTP header utilities

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -141,7 +141,6 @@ const checks = [
     // Baseline of existing raw transaction call sites. New work should use the
     // Agor store/tenant transaction wrapper once introduced.
     baseline: {
-      'packages/core/src/db/database-wrapper.ts': 1,
       // Tenant scopes use one transaction for agor.tenant_id. Narrow system
       // capabilities use a second transaction path so their RLS GUC is local
       // to one pooled connection checkout and cannot leak after discovery.


### PR DESCRIPTION
## Summary

- make scheduled-occurrence admission safe when multiple daemon instances scan the same shared PostgreSQL database
- recover scheduled sessions left incomplete between session insertion, MCP attachment, initial-task creation, and durable dispatch
- add a deliberately small coordination layer for database time, deterministic jitter/backoff, and fenced task dispatch
- preserve SQLite/standalone behavior and tenant isolation

## Design

- PostgreSQL remains the durable authority; there is no fleet leader, external lock service, or long-lived scheduler transaction.
- Existing scheduled `Session` plus its stable initial `Task` are the occurrence and recovery record, so this slice does **not** add a `schedule_runs` table.
- The existing `(tenant_id, schedule_id, scheduled_run_at)` uniqueness constraint is the final duplicate-admission guard.
- Scheduler work is bounded and jittered. PostgreSQL discovery uses narrow tenant-aware RLS policies; initialization/recovery carries the trusted tenant through every repository and event boundary.
- Initial dispatch is fenced by an atomic task-state transition. MCP attachment and initial-task creation are idempotent, and session metadata records completion only after dispatch is durably accepted.
- Cron/manual collisions and `allow_concurrent_runs` retain explicit behavior documented in the internal audit.

## Failure and recovery semantics

- A replacement daemon can resume an occurrence after session creation, MCP attachment, or initial-task creation. Once the stable Task is durably dispatching, reconciliation bypasses mutable creator/tool/preset launch admission and only repairs deterministic projections.
- A worker that loses the dispatch fence cannot act as the current owner.
- Recovery scans use bounded batches with keyset progress so one tenant/schedule cannot permanently monopolize a pass.
- Legacy scheduled sessions are migrated as initialization-complete to avoid replaying historical prompts.
- No database transaction or connection is held while rendering, launching, or calling an external service.

Detailed current-state, kill-point, and non-goals audit:

- `docs/internal/scheduler-ha-recovery-2026-08-05.md`

## Schema changes

- PostgreSQL migration: `packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql`
- SQLite migration: `packages/core/drizzle/sqlite/0074_scheduler_ha_indexes.sql`

## Validation

- [x] `pnpm i`
- [x] `pnpm check`
- [x] Core targeted suites: **230 passed, 3 skipped**
- [x] Daemon targeted suites: **250 passed**
- [x] SQLite/standalone regression coverage
- [x] Deterministic coordination, kill-point, duplicate-admission, and tenant-boundary coverage
- [ ] PostgreSQL integration suite executed locally — the suite was added but skipped here because `AGOR_TEST_POSTGRES_URL` is not configured

## Follow-ups / non-goals

This intentionally does not introduce a generic distributed worker controller. Follow-on consumers should reuse only the low-level database-time/fence/jitter primitives where their concrete state machines justify them; executor queueing and other daemon-owned work may require different claim schemas and lease semantics.

