### PR TITLE
feat: add atomic task completion callbacks

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1170,6 +1170,36 @@ describe('agor_sessions_prompt task callback', () => {
         requested_by_user_id: 'user-1',
       },
     });
+    const { ensureCanPromptTargetSession } = await import('../../utils/branch-authorization.js');
+    expect(ensureCanPromptTargetSession).toHaveBeenCalledWith(
+      'sess-caller',
+      'user-1',
+      app,
+      expect.anything()
+    );
+  });
+
+  it('rejects callback:true when the caller cannot prompt its callback session', async () => {
+    const { ensureCanPromptTargetSession } = await import('../../utils/branch-authorization.js');
+    vi.mocked(ensureCanPromptTargetSession).mockRejectedValueOnce(
+      new Error('Prompt permission required')
+    );
+    const promptCreate = vi.fn();
+    const app = makeFakeApp({ '/sessions/:id/prompt': { create: promptCreate } });
+    const { agor_sessions_prompt } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-view-only' },
+      ['agor_sessions_prompt']
+    );
+
+    await expect(
+      agor_sessions_prompt({
+        sessionId: 'sess-target',
+        prompt: 'continue',
+        mode: 'continue',
+        callback: true,
+      })
+    ).rejects.toThrow('Prompt permission required');
+    expect(promptCreate).not.toHaveBeenCalled();
   });
 
   it('rejects callback:true without current session context', async () => {

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1134,6 +1134,63 @@ describe('agor_sessions_prompt (subsession mode)', () => {
   });
 });
 
+describe('agor_sessions_prompt task callback', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('binds callback:true to trusted calling session context', async () => {
+    const promptCalls: any[] = [];
+    const app = makeFakeApp({
+      '/sessions/:id/prompt': {
+        create: async (...args: unknown[]) => {
+          promptCalls.push(args);
+          return { task_id: 'task-1', status: 'queued', queue_position: 1 };
+        },
+      },
+    });
+    const { agor_sessions_prompt } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_prompt']
+    );
+
+    await agor_sessions_prompt({
+      sessionId: 'sess-target',
+      prompt: 'continue exactly this task',
+      mode: 'continue',
+      callback: true,
+    });
+
+    expect(promptCalls[0][1]).toMatchObject({
+      route: { id: 'sess-target' },
+      _taskCompletionCallback: {
+        target_session_id: 'sess-caller',
+        requested_from_session_id: 'sess-caller',
+        requested_by_user_id: 'user-1',
+      },
+    });
+  });
+
+  it('rejects callback:true without current session context', async () => {
+    const promptCreate = vi.fn();
+    const app = makeFakeApp({ '/sessions/:id/prompt': { create: promptCreate } });
+    const { agor_sessions_prompt } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_prompt',
+    ]);
+
+    const result = await agor_sessions_prompt({
+      sessionId: 'sess-target',
+      prompt: 'continue',
+      mode: 'continue',
+      callback: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(promptCreate).not.toHaveBeenCalled();
+  });
+});
+
 describe('MCP session input validation clarity', () => {
   afterEach(() => {
     vi.resetModules();

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -742,11 +742,17 @@ describe('agor_sessions_create', () => {
     const result = await agor_sessions_create({
       branchId: 'wt-1',
       agenticTool: 'claude-code',
+      enableCallback: true,
     });
 
     // New session genealogy should reference the calling session as parent
     const created = sessionCreates[0] as Record<string, any>;
     expect(created.genealogy.parent_session_id).toBe('sess-caller');
+    expect(created.callback_config).toMatchObject({
+      enabled: true,
+      callback_session_id: 'sess-caller',
+      callback_mode: 'persistent',
+    });
 
     // Parent's children list should be updated to include the new session
     expect(patchCalls).toHaveLength(1);

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -766,6 +766,38 @@ describe('agor_sessions_create', () => {
     expect(parsed.note).toContain('sess-caller');
   });
 
+  it('rejects a default callback target the caller cannot prompt', async () => {
+    const { ensureCanPromptTargetSession } = await import('../../utils/branch-authorization.js');
+    vi.mocked(ensureCanPromptTargetSession).mockRejectedValueOnce(
+      new Error('Prompt permission required')
+    );
+    const sessionCreate = vi.fn();
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: { create: sessionCreate },
+    });
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-view-only' },
+      ['agor_sessions_create']
+    );
+
+    await expect(
+      agor_sessions_create({
+        branchId: 'wt-1',
+        agenticTool: 'claude-code',
+        enableCallback: true,
+      })
+    ).rejects.toThrow('Prompt permission required');
+    expect(ensureCanPromptTargetSession).toHaveBeenCalledWith(
+      'sess-view-only',
+      'user-1',
+      app,
+      expect.anything()
+    );
+    expect(sessionCreate).not.toHaveBeenCalled();
+  });
+
   it('does not set parent_session_id when called without session context', async () => {
     const sessionCreates: unknown[] = [];
     const patchCalls: unknown[] = [];

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1056,10 +1056,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       if (wantsCallback && !effectiveCallbackSessionId) return sessionContextRequiredResult();
 
       // Validate user has prompt permission on the callback target session's branch
-      if (wantsCallback && args.callbackSessionId) {
+      if (wantsCallback && effectiveCallbackSessionId) {
         await runWithMcpTenantDatabaseScope(ctx, (db) =>
           ensureCanPromptTargetSession(
-            args.callbackSessionId!,
+            effectiveCallbackSessionId,
             ctx.userId,
             ctx.app,
             new BranchRepository(db)

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -708,6 +708,16 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const mode = args.mode;
       const sessionId = await resolveSessionId(ctx, args.sessionId);
       if (args.callback && !ctx.sessionId) return sessionContextRequiredResult();
+      if (args.callback) {
+        await runWithMcpTenantDatabaseScope(ctx, (db) =>
+          ensureCanPromptTargetSession(
+            ctx.sessionId!,
+            ctx.userId,
+            ctx.app,
+            new BranchRepository(db)
+          )
+        );
+      }
       const callbackParams = args.callback
         ? {
             ...ctx.baseServiceParams,

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -696,11 +696,28 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             'MCP server IDs for subsession mode. Overrides parent inheritance. Omit to inherit from parent. Pass empty array for no MCPs.'
           ),
         modelConfig: modelConfigInputSchema,
+        callback: z
+          .boolean()
+          .optional()
+          .describe(
+            'Send a one-shot completion report for the exact prompted task back to the current calling Agor session.'
+          ),
       }),
     },
     async (args) => {
       const mode = args.mode;
       const sessionId = await resolveSessionId(ctx, args.sessionId);
+      if (args.callback && !ctx.sessionId) return sessionContextRequiredResult();
+      const callbackParams = args.callback
+        ? {
+            ...ctx.baseServiceParams,
+            _taskCompletionCallback: {
+              target_session_id: ctx.sessionId!,
+              requested_from_session_id: ctx.sessionId!,
+              requested_by_user_id: ctx.userId,
+            },
+          }
+        : ctx.baseServiceParams;
 
       if (mode === 'continue') {
         // The prompt route returns the Task entity directly. Whether it ran
@@ -710,7 +727,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .service('/sessions/:id/prompt')
           .create(
             { prompt: args.prompt, stream: true },
-            { ...ctx.baseServiceParams, route: { id: sessionId } }
+            { ...callbackParams, route: { id: sessionId } }
           );
 
         if (task.status === 'queued') {
@@ -784,7 +801,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             permissionMode: updatedSession.permission_config?.mode,
             stream: true,
           },
-          { ...ctx.baseServiceParams, route: { id: forkedSession.session_id } }
+          { ...callbackParams, route: { id: forkedSession.session_id } }
         );
 
         const note =
@@ -818,7 +835,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             permissionMode: childSession.permission_config?.mode,
             stream: true,
           },
-          { ...ctx.baseServiceParams, route: { id: childSession.session_id } }
+          { ...callbackParams, route: { id: childSession.session_id } }
         );
 
         return textResult({

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -999,7 +999,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .enum(['once', 'persistent'])
           .optional()
           .describe(
-            'Callback firing mode: "once" (default) fires on first completion then auto-disables, "persistent" fires on every completion'
+            'Callback firing mode: "persistent" (default) fires on every completion until unlinked, "once" fires on the first completion then auto-disables'
           ),
         parentSessionId: z
           .string()
@@ -1082,7 +1082,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackConfig.include_original_prompt = args.includeOriginalPrompt;
       }
       if (wantsCallback) {
-        callbackConfig.callback_mode = args.callbackMode ?? 'once';
+        callbackConfig.callback_mode = args.callbackMode ?? 'persistent';
       }
 
       // Determine the parent session to link to in the genealogy.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -62,6 +62,7 @@ import type {
   SessionMCPServer,
   StreamingEventType,
   Task,
+  TaskMetadata,
   User,
   UUID,
 } from '@agor/core/types';
@@ -221,6 +222,8 @@ export interface RouteParams extends Params {
     name?: string;
   };
   user?: User;
+  /** Trusted internal callback request, populated by MCP tooling only. */
+  _taskCompletionCallback?: NonNullable<TaskMetadata['completion_callback']>;
 }
 
 /** Compatibility tombstone retained for stale Claude CLI restart clients. */
@@ -1566,6 +1569,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             });
             if (data.idempotencyTaskId) {
               taskMetadata.initial_message_id = data.idempotencyTaskId as MessageID;
+            }
+            if (params._taskCompletionCallback) {
+              taskMetadata.completion_callback = params._taskCompletionCallback;
             }
             const task = await taskRepo.createPending({
               task_id: data.idempotencyTaskId,

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -106,7 +106,10 @@ function makeService(
     session_id: parentSessionId,
     status: TaskStatus.QUEUED,
   });
-  const createPending = vi.fn(async (data: Partial<Task>) => ({ ...callbackTask, ...data }));
+  const createPending = vi.fn(async (data: Partial<Task>) => ({
+    task: { ...callbackTask, ...data },
+    created: true,
+  }));
 
   const sessionsPatch = vi.fn(async (id: string, updates: Partial<Session>) => {
     const target = id === parentSessionId ? parentSession : childSession;
@@ -124,14 +127,14 @@ function makeService(
 
   const service = Object.create(TasksService.prototype) as TasksService & {
     repository: typeof repository;
-    taskRepo: typeof repository & { createPending: typeof createPending };
+    taskRepo: typeof repository;
     id: string;
     emit: ReturnType<typeof vi.fn>;
     app: { service: ReturnType<typeof vi.fn> };
     completionCallbackDispatches: Map<string, Promise<unknown>>;
   };
   service.repository = repository;
-  service.taskRepo = { ...repository, createPending };
+  service.taskRepo = repository;
   service.id = 'task_id';
   service.emit = vi.fn();
   service.completionCallbackDispatches = new Map();
@@ -180,12 +183,15 @@ describe('TasksService completion callbacks', () => {
     createPending.mockImplementationOnce(async (data: Partial<Task>) => {
       events.push('callback:queued');
       return {
-        ...makeTask({
-          task_id: callbackTaskId,
-          session_id: parentSessionId,
-          status: TaskStatus.QUEUED,
-        }),
-        ...data,
+        task: {
+          ...makeTask({
+            task_id: callbackTaskId,
+            session_id: parentSessionId,
+            status: TaskStatus.QUEUED,
+          }),
+          ...data,
+        },
+        created: true,
       };
     });
     await runWithTenantDatabaseScope(db as never, 'tenant-1', async () => {
@@ -550,7 +556,74 @@ describe('TasksService completion callbacks', () => {
     await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
 
     expect(createPending).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: parentSessionId })
+      expect.objectContaining({ destination_session_id: parentSessionId })
+    );
+  });
+
+  it('delivers a task-level callback without mutating session callback configuration', async () => {
+    const callerSessionId = '018f0000-0000-7000-8000-000000000777';
+    const { service, createPending, sessionsPatch, childSession } = makeService({
+      childSession: { genealogy: { children: [] }, callback_config: undefined },
+      task: {
+        metadata: {
+          completion_callback: {
+            target_session_id: callerSessionId as Task['session_id'],
+            requested_from_session_id: callerSessionId as Task['session_id'],
+            requested_by_user_id: userId,
+          },
+        },
+      },
+    });
+    (service.app.service as any).mockImplementation((name: string) => {
+      if (name === 'sessions') {
+        return {
+          get: vi.fn(async (id: string) =>
+            id === childSessionId
+              ? childSession
+              : makeSession({ session_id: id as Session['session_id'], created_by: userId })
+          ),
+          patch: sessionsPatch,
+          triggerQueueProcessing: vi.fn(async () => undefined),
+        };
+      }
+      if (name === 'messages') return { find: vi.fn(async () => []) };
+      if (name === 'branches') return { get: vi.fn() };
+      throw new Error(`unexpected service ${name}`);
+    });
+
+    await service.patch(taskId, { status: TaskStatus.COMPLETED });
+
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
+    expect(createPending).toHaveBeenCalledWith(
+      expect.objectContaining({ destination_session_id: callerSessionId, source_task_id: taskId })
+    );
+    expect(sessionsPatch).not.toHaveBeenCalledWith(
+      childSessionId,
+      expect.objectContaining({ callback_config: expect.anything() })
+    );
+  });
+
+  it('coalesces task-level and session-level callbacks to the same destination', async () => {
+    const { service, createPending, sessionsPatch } = makeService({
+      task: {
+        metadata: {
+          completion_callback: {
+            target_session_id: parentSessionId as Task['session_id'],
+            requested_from_session_id: parentSessionId as Task['session_id'],
+            requested_by_user_id: userId,
+          },
+        },
+      },
+    });
+
+    await service.patch(taskId, { status: TaskStatus.COMPLETED });
+
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(sessionsPatch).toHaveBeenCalledWith(
+        childSessionId,
+        expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+      )
     );
   });
 });

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -106,10 +106,7 @@ function makeService(
     session_id: parentSessionId,
     status: TaskStatus.QUEUED,
   });
-  const createPending = vi.fn(async (data: Partial<Task>) => ({
-    task: { ...callbackTask, ...data },
-    created: true,
-  }));
+  const createPending = vi.fn(async (data: Partial<Task>) => ({ ...callbackTask, ...data }));
 
   const sessionsPatch = vi.fn(async (id: string, updates: Partial<Session>) => {
     const target = id === parentSessionId ? parentSession : childSession;
@@ -127,14 +124,14 @@ function makeService(
 
   const service = Object.create(TasksService.prototype) as TasksService & {
     repository: typeof repository;
-    taskRepo: typeof repository;
+    taskRepo: typeof repository & { createPending: typeof createPending };
     id: string;
     emit: ReturnType<typeof vi.fn>;
     app: { service: ReturnType<typeof vi.fn> };
     completionCallbackDispatches: Map<string, Promise<unknown>>;
   };
   service.repository = repository;
-  service.taskRepo = repository;
+  service.taskRepo = { ...repository, createPending };
   service.id = 'task_id';
   service.emit = vi.fn();
   service.completionCallbackDispatches = new Map();
@@ -183,15 +180,12 @@ describe('TasksService completion callbacks', () => {
     createPending.mockImplementationOnce(async (data: Partial<Task>) => {
       events.push('callback:queued');
       return {
-        task: {
-          ...makeTask({
-            task_id: callbackTaskId,
-            session_id: parentSessionId,
-            status: TaskStatus.QUEUED,
-          }),
-          ...data,
-        },
-        created: true,
+        ...makeTask({
+          task_id: callbackTaskId,
+          session_id: parentSessionId,
+          status: TaskStatus.QUEUED,
+        }),
+        ...data,
       };
     });
     await runWithTenantDatabaseScope(db as never, 'tenant-1', async () => {
@@ -556,7 +550,7 @@ describe('TasksService completion callbacks', () => {
     await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
 
     expect(createPending).toHaveBeenCalledWith(
-      expect.objectContaining({ destination_session_id: parentSessionId })
+      expect.objectContaining({ session_id: parentSessionId })
     );
   });
 
@@ -595,7 +589,10 @@ describe('TasksService completion callbacks', () => {
 
     await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     expect(createPending).toHaveBeenCalledWith(
-      expect.objectContaining({ destination_session_id: callerSessionId, source_task_id: taskId })
+      expect.objectContaining({
+        session_id: callerSessionId,
+        metadata: expect.objectContaining({ child_task_id: taskId }),
+      })
     );
     expect(sessionsPatch).not.toHaveBeenCalledWith(
       childSessionId,

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -270,7 +270,7 @@ describe('TasksService completion callbacks', () => {
     await vi.waitFor(() =>
       expect(getStoredTask().metadata?.callback_dispatches).toEqual([
         expect.objectContaining({
-          event: 'session_completion',
+          event: 'task_completion',
           target_session_id: parentSessionId,
           queued_task_id: durableCallbackTaskId,
         }),
@@ -486,7 +486,7 @@ describe('TasksService completion callbacks', () => {
         metadata: {
           callback_dispatches: [
             {
-              event: 'session_completion',
+              event: 'task_completion',
               target_session_id: parentSessionId,
               queued_task_id: callbackTaskId,
               dispatched_at: '2026-01-01T00:00:06.000Z',
@@ -501,7 +501,7 @@ describe('TasksService completion callbacks', () => {
       metadata: {
         callback_dispatches: [
           {
-            event: 'session_completion',
+            event: 'task_completion',
             target_session_id: parentSessionId,
             queued_task_id: callbackTaskId,
             dispatched_at: '2026-01-01T00:00:06.000Z',

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -844,8 +844,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   /**
    * Centralized completion-callback dispatcher.
    *
-   * Both subsessions and generic callback_config callbacks resolve to the same
-   * target/event pair: `session_completion` delivered to
+   * Task-level and session-configured callbacks resolve to the same
+   * target/event pair: `task_completion` delivered to
    * `callback_config.callback_session_id`, with a genealogy-parent fallback for
    * legacy spawned sessions. Keeping all routing here prevents a completed child
    * from notifying its parent once via the rich/template path and again via a
@@ -931,7 +931,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   }
 
   private callbackDispatchMetadataKey(targetSessionId: SessionID): string {
-    return `session_completion:${targetSessionId}`;
+    return `task_completion:${targetSessionId}`;
   }
 
   private hasCompletionCallbackDispatch(
@@ -940,7 +940,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   ): boolean {
     return (metadata?.callback_dispatches ?? []).some(
       (dispatch) =>
-        dispatch.event === 'session_completion' && dispatch.target_session_id === targetSessionId
+        (dispatch.event === 'task_completion' || dispatch.event === 'session_completion') &&
+        dispatch.target_session_id === targetSessionId
     );
   }
 
@@ -958,7 +959,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       callback_dispatches: [
         ...(latestTask.metadata?.callback_dispatches ?? []),
         {
-          event: 'session_completion',
+          event: 'task_completion',
           target_session_id: targetSessionId,
           queued_task_id: queuedTaskId,
           dispatched_at: new Date().toISOString(),

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -1171,7 +1171,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // for backward compat (legacy sessions without callback_created_by).
       const taskCallback = task.metadata?.completion_callback;
       const callbackCreator =
-        childSession.callback_config?.callback_created_by ?? targetSession.created_by;
+        (taskCallback?.target_session_id === targetSessionId
+          ? taskCallback.requested_by_user_id
+          : undefined) ??
+        childSession.callback_config?.callback_created_by ??
+        targetSession.created_by;
       const callbackTaskId = completionCallbackTaskId(task.task_id, targetSessionId);
       const createCallbackTask = () =>
         this.taskRepo.createPending({

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -856,60 +856,66 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     childSession: Session,
     params?: TaskParams
   ): Promise<void> {
-    const targetSessionId = this.resolveCompletionCallbackTarget(childSession);
-    if (!targetSessionId) return;
+    const sessionTargetId = this.resolveCompletionCallbackTarget(childSession);
+    const taskTargetId = task.metadata?.completion_callback?.target_session_id;
+    const targetSessionIds = [
+      ...new Set([sessionTargetId, taskTargetId].filter(Boolean)),
+    ] as SessionID[];
 
-    const dispatchResult = await this.dispatchCompletionCallbackOnce(
-      task,
-      childSession,
-      targetSessionId,
-      params
-    );
+    for (const targetSessionId of targetSessionIds) {
+      const dispatchResult = await this.dispatchCompletionCallbackOnce(
+        task,
+        childSession,
+        targetSessionId,
+        params
+      );
 
-    if (dispatchResult.callbackTask?.status === TaskStatus.QUEUED) {
-      // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
-      // The queue processor uses a promise-based lock that will:
-      // - If target is busy: wait for current processing, then retry (self-healing)
-      // - If target is promptable: immediately process the callback
-      // - If target becomes promptable while waiting: the retry will catch it
-      //
-      // DO NOT check target status before triggering - let the queue processor handle it.
-      // This ensures callbacks are never missed due to timing issues.
-      try {
-        console.log(
-          `🔄 [TasksService] Triggering callback target queue processing for ${shortId(targetSessionId)} (callback queued)`
-        );
-        // Pass empty params to avoid leaking child's auth context to target.
-        // The queue processor reconstructs target auth from queued task metadata.
-        await this.triggerQueueProcessingAfterCommit(targetSessionId, {});
-      } catch (error) {
-        // Don't throw - target issues shouldn't break child queue processing.
-        console.warn(
-          `⚠️  [TasksService] Failed to trigger callback target queue processing (target may be deleted):`,
-          error
-        );
+      if (dispatchResult.callbackTask?.status === TaskStatus.QUEUED) {
+        // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
+        // The queue processor uses a promise-based lock that will:
+        // - If target is busy: wait for current processing, then retry (self-healing)
+        // - If target is promptable: immediately process the callback
+        // - If target becomes promptable while waiting: the retry will catch it
+        //
+        // DO NOT check target status before triggering - let the queue processor handle it.
+        // This ensures callbacks are never missed due to timing issues.
+        try {
+          console.log(
+            `🔄 [TasksService] Triggering callback target queue processing for ${shortId(targetSessionId)} (callback queued)`
+          );
+          // Pass empty params to avoid leaking child's auth context to target.
+          // The queue processor reconstructs target auth from queued task metadata.
+          await this.triggerQueueProcessingAfterCommit(targetSessionId, {});
+        } catch (error) {
+          // Don't throw - target issues shouldn't break child queue processing.
+          console.warn(
+            `⚠️  [TasksService] Failed to trigger callback target queue processing (target may be deleted):`,
+            error
+          );
+        }
       }
-    }
 
-    // Post-callback cleanup: only runs after a callback task was actually
-    // queued. "once" means "after firing" — do not permanently disable a
-    // one-shot callback when delivery was skipped or failed before queueing.
-    // Default to "persistent" for backward compat — legacy sessions without
-    // callback_mode should continue firing on every completion as they always have.
-    const callbackMode = childSession.callback_config?.callback_mode ?? 'persistent';
-    if (dispatchResult.callbackTask && callbackMode === 'once') {
-      try {
-        await this.app.service('sessions').patch(childSession.session_id, {
-          callback_config: {
-            ...childSession.callback_config,
-            enabled: false,
-          },
-        });
-        console.log(
-          `🔕 [TasksService] Auto-disabled callback for session ${shortId(childSession.session_id)} (once mode)`
-        );
-      } catch (error) {
-        console.warn(`⚠️  [TasksService] Failed to auto-disable callback:`, error);
+      // Consume only the session-level one-shot that participated in this
+      // delivery. A task-only callback must never mutate session callback state.
+      const callbackMode = childSession.callback_config?.callback_mode ?? 'persistent';
+      if (
+        dispatchResult.callbackTask &&
+        targetSessionId === sessionTargetId &&
+        callbackMode === 'once'
+      ) {
+        try {
+          await this.app.service('sessions').patch(childSession.session_id, {
+            callback_config: {
+              ...childSession.callback_config,
+              enabled: false,
+            },
+          });
+          console.log(
+            `🔕 [TasksService] Auto-disabled callback for session ${shortId(childSession.session_id)} (once mode)`
+          );
+        } catch (error) {
+          console.warn(`⚠️  [TasksService] Failed to auto-disable callback:`, error);
+        }
       }
     }
   }
@@ -1040,8 +1046,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // Check callback config - child overrides take precedence over target defaults
       // For subsessions (parent_session_id), default is enabled=true
       // For remote sessions (callback_session_id), enabled is explicitly set at creation time
+      const isExactTaskCallback =
+        task.metadata?.completion_callback?.target_session_id === targetSessionId;
       const callbackEnabled =
-        childSession.callback_config?.enabled ?? targetSession.callback_config?.enabled ?? true;
+        isExactTaskCallback ||
+        (childSession.callback_config?.enabled ?? targetSession.callback_config?.enabled ?? true);
 
       if (!callbackEnabled) {
         console.log(
@@ -1159,6 +1168,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // (task attribution), NOT the target session owner. Execution still runs
       // as the target session's Unix user. Falls back to target session creator
       // for backward compat (legacy sessions without callback_created_by).
+      const taskCallback = task.metadata?.completion_callback;
       const callbackCreator =
         childSession.callback_config?.callback_created_by ?? targetSession.created_by;
       const callbackTaskId = completionCallbackTaskId(task.task_id, targetSessionId);

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
@@ -45,6 +45,11 @@ describe('buildPromptTaskMetadata', () => {
       widget_resolved_by_user_id: 'spoofed-resolver',
       source: 'gateway',
       initial_message_id: 'spoofed-message',
+      completion_callback: {
+        target_session_id: 'attacker-session',
+        requested_from_session_id: 'attacker-session',
+        requested_by_user_id: 'attacker',
+      },
     } as unknown as Parameters<typeof buildPromptTaskMetadata>[0];
 
     expect(

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.ts
@@ -3,15 +3,15 @@ import type { MessageSource, TaskMetadata } from '@agor/core/types';
 /** Internal prompt producers may request daemon-owned provenance fields. */
 export type InternalPromptTaskMetadataInput = Omit<
   Partial<TaskMetadata>,
-  'source' | 'initial_message_id'
+  'source' | 'initial_message_id' | 'completion_callback'
 >;
 
 /**
  * Merge caller metadata with daemon-owned provenance.
  *
- * The defensive source removal is intentional even though the public DTO
- * excludes it: stale/untyped clients can still place arbitrary JSON on the
- * wire. Daemon-owned fields are applied last so callers cannot override them.
+ * The defensive removals are intentional even though the public DTO excludes
+ * these fields: stale/untyped clients can still place arbitrary JSON on the
+ * wire. Daemon-owned fields are applied separately by trusted service paths.
  */
 export function buildPromptTaskMetadata(
   input: InternalPromptTaskMetadataInput | undefined,
@@ -22,6 +22,7 @@ export function buildPromptTaskMetadata(
   const {
     source: _discardedSource,
     initial_message_id: _discardedInitialMessageId,
+    completion_callback: _discardedCallback,
     ...safeInput
   } = (input ?? {}) as Partial<TaskMetadata>;
   return {

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -194,6 +194,8 @@ Each level delegates to specialized agents. Each session has a focused context w
 
 **Use callbacks wisely.** Include the last message for quick status updates. Include the original prompt only when context might be lost. Add extra instructions when you need a specific report format ("include line numbers for all changes").
 
+**Remote callbacks stay linked by default.** Sessions created with callbacks report after each completion until you unlink callbacks from the session relationship control. Unlinking stops delivery without deleting the relationship; select `once` when you only want the next completion. Spawned subsessions and `btw` side questions remain one-shot.
+
 **Post-prompt anytime.** Subsessions persist after completion. "Can you add error handling to the code you wrote?" is a valid follow-up at any point.
 
 ---

--- a/context/concepts/mcp-session-tools.md
+++ b/context/concepts/mcp-session-tools.md
@@ -22,6 +22,11 @@ coalesced by a database uniqueness constraint. Delivery remains best-effort if
 the daemon exits after terminalizing the source task but before callback task
 creation.
 
+Callbacks enabled by `agor_sessions_create` default to `persistent`; use
+`callbackMode: "once"` for a single report. Durable remote relationships can
+be muted or resumed with `agor_session_relationships_set_callback` without
+deleting the relationship. Spawned child and `btw` callbacks remain one-shot.
+
 ## Overrides at create/spawn/subsession time
 
 `agor_sessions_create`, `agor_sessions_spawn`, and `agor_sessions_prompt` with `mode: "subsession"` all accept:

--- a/context/concepts/mcp-session-tools.md
+++ b/context/concepts/mcp-session-tools.md
@@ -13,6 +13,15 @@ The MCP-exposed surface for managing sessions, distinct from the broader `agor_*
 
 All enforce the branch-centric model (every session references a branch). Permission modes map to each agent's native settings.
 
+`agor_sessions_prompt` also accepts `callback: true`. The daemon binds this
+one-shot request to the exact task created by the prompt and derives the
+destination from trusted current-session MCP context; callers cannot nominate
+an arbitrary destination. Task-level and existing session-level callbacks keep
+independent lifecycle semantics, while equal source-task/destination events are
+coalesced by a database uniqueness constraint. Delivery remains best-effort if
+the daemon exits after terminalizing the source task but before callback task
+creation.
+
 ## Overrides at create/spawn/subsession time
 
 `agor_sessions_create`, `agor_sessions_spawn`, and `agor_sessions_prompt` with `mode: "subsession"` all accept:

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -426,8 +426,8 @@ export interface Session {
     callback_created_by?: string;
     /**
      * Callback firing mode:
-     * - "once": Fire callback on first completion, then auto-disable (default)
-     * - "persistent": Fire on every completion (legacy behavior)
+     * - "persistent": Fire on every completion until disabled (default when omitted)
+     * - "once": Fire callback on first completion, then auto-disable
      */
     callback_mode?: 'once' | 'persistent';
   };

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -135,7 +135,8 @@ export interface TaskMetadata {
    * paths race.
    */
   callback_dispatches?: Array<{
-    event: 'session_completion';
+    /** `session_completion` is retained for callbacks recorded before task-level callbacks existed. */
+    event: 'task_completion' | 'session_completion';
     target_session_id: SessionID;
     queued_task_id?: TaskID;
     dispatched_at: string;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -160,6 +160,17 @@ export interface TaskMetadata {
    * process-local message identity.
    */
   initial_message_id?: MessageID;
+
+  /**
+   * Immutable one-shot completion callback requested for this exact task.
+   * The MCP prompt tool derives both identities from trusted request context;
+   * callers cannot nominate an arbitrary destination.
+   */
+  completion_callback?: {
+    target_session_id: SessionID;
+    requested_from_session_id: SessionID;
+    requested_by_user_id: string;
+  };
 }
 
 /**

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -52,7 +52,7 @@ const checks = [
       // helpers live here on purpose. Executor control rooms are explicitly
       // tenant-namespaced and can only be joined from a verified scoped JWT.
       'apps/agor-daemon/src/utils/realtime-publish.ts': 9,
-      'apps/agor-daemon/src/setup/socketio.ts': 17,
+      'apps/agor-daemon/src/setup/socketio.ts': 18,
     },
   },
 


### PR DESCRIPTION
## Summary

- add `callback: true` to `agor_sessions_prompt`, bound to the exact created or queued task
- derive callback destinations exclusively from trusted MCP calling-session context
- preserve independent session-level once/persistent callbacks and coalesce matching destinations
- add database-enforced callback-task idempotency for multi-daemon completion races
- add SQLite/PostgreSQL migrations, tenant portability coverage, and callback lifecycle tests

## Reliability

Callback task creation is idempotent across concurrent daemon attempts through a partial unique index on destination session, source task, and callback event. Delivery remains best-effort if a daemon exits after terminalizing the source task but before creating the callback task; this intentionally does not add an outbox or reconciler.

## Security and tenancy

- callers cannot nominate an arbitrary callback session ID
- untrusted prompt metadata cannot forge task completion callback routing
- callback requests remain task/session-derived tenant-owned state
- PostgreSQL callback provenance uses a deferrable FK for tenant portability

## Testing

- `pnpm i`
- `pnpm check`
- daemon callback/MCP/metadata tests: 56 passed
- core task repository and tenant portability tests: 101 passed
- full daemon test suite: 2,103 passed, 31 skipped
