### PR TITLE
feat(terminals): tag terminal executors with AGOR_CLOUD_EXECUTOR_TYPE=shell

### DIFF
--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -616,7 +616,7 @@ export class TerminalsService {
         {
           logPrefix: `[TerminalsService.executor ${shortId(userId)}]`,
           asUser: finalUnixUser || undefined,
-          env: executorEnv,
+          env: { ...executorEnv, AGOR_CLOUD_EXECUTOR_TYPE: 'shell' },
           templateVariables: {
             // Mode-resolved identity for templated execution: the sudo user in
             // insulated/strict, the caller's unix_username in delegated (no

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -616,12 +616,15 @@ export class TerminalsService {
         {
           logPrefix: `[TerminalsService.executor ${shortId(userId)}]`,
           asUser: finalUnixUser || undefined,
-          env: { ...executorEnv, AGOR_CLOUD_EXECUTOR_TYPE: 'shell' },
+          env: executorEnv,
           templateVariables: {
             // Mode-resolved identity for templated execution: the sudo user in
             // insulated/strict, the caller's unix_username in delegated (no
             // sudo), and unset in simple.
             unix_user: impersonationResult.reportedUnixUser || undefined,
+            // Cloud shell classification: flows through the templated launcher
+            // (env is dropped there) so the control plane can seal shell pods.
+            executor_type: 'shell',
           },
           // Clean up map when executor exits (handles crashes too)
           onExit: () => this.handleExecutorExit(userId),

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -622,8 +622,6 @@ export class TerminalsService {
             // insulated/strict, the caller's unix_username in delegated (no
             // sudo), and unset in simple.
             unix_user: impersonationResult.reportedUnixUser || undefined,
-            // Cloud shell classification: flows through the templated launcher
-            // (env is dropped there) so the control plane can seal shell pods.
             executor_type: 'shell',
           },
           // Clean up map when executor exits (handles crashes too)

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -354,6 +354,9 @@ export function spawnExecutor(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
+        // Default so a template's `{executor_type}` always substitutes; terminals
+        // override to `shell` via their own templateVariables.
+        executor_type: 'executor',
         ...templateVariables,
         tenant_id: tenantId,
       },
@@ -1033,6 +1036,9 @@ export async function runExecutorCommand(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
+        // Default so a template's `{executor_type}` always substitutes; terminals
+        // override to `shell` via their own templateVariables.
+        executor_type: 'executor',
         ...templateVariables,
         tenant_id: tenantId,
       },

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -105,7 +105,6 @@ export interface ExecutorTemplateVariables {
   session_id?: string;
   branch_id?: string;
   log_level?: string;
-  // Executor classification (e.g. `shell`) forwarded to the templated launcher.
   executor_type?: string;
   /**
    * Trusted runtime tenant identity. This is populated from the ambient tenant
@@ -354,8 +353,6 @@ export function spawnExecutor(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
-        // Default so a template's `{executor_type}` always substitutes; terminals
-        // override to `shell` via their own templateVariables.
         executor_type: 'executor',
         ...templateVariables,
         tenant_id: tenantId,
@@ -1036,8 +1033,6 @@ export async function runExecutorCommand(
         task_id: generateTaskId(),
         unix_user: asUser,
         log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
-        // Default so a template's `{executor_type}` always substitutes; terminals
-        // override to `shell` via their own templateVariables.
         executor_type: 'executor',
         ...templateVariables,
         tenant_id: tenantId,

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -105,6 +105,8 @@ export interface ExecutorTemplateVariables {
   session_id?: string;
   branch_id?: string;
   log_level?: string;
+  // Executor classification (e.g. `shell`) forwarded to the templated launcher.
+  executor_type?: string;
   /**
    * Trusted runtime tenant identity. This is populated from the ambient tenant
    * context, shell-escaped during substitution, and is not caller-overridable
@@ -235,6 +237,7 @@ export function substituteTemplateVariables(
     session_id: variables.session_id,
     branch_id: variables.branch_id,
     log_level: variables.log_level,
+    executor_type: variables.executor_type,
     tenant_id: variables.tenant_id,
   };
 


### PR DESCRIPTION
## What

Terminal (web shell) executor spawns now set `AGOR_CLOUD_EXECUTOR_TYPE=shell` on the
executor process environment.

## Why

In an **Agor Cloud** deployment, the `agor-cloud-executor-launch` helper reads this
env var and forwards it (`metadata.executorType`) when it asks the control plane to
create the ephemeral executor pod. The control plane then labels the pod
`agor.cloud/executor-type: shell` and applies a **sealed-egress NetworkPolicy** —
an interactive user shell can reach only DNS + its own Cell daemon, never VPC
internals or the public internet. See the sibling agor-cloud PR.

Terminal executors are per-user, long-lived zellij sessions; agent-task executors are
unaffected. Outside Agor Cloud (no launch helper) the env var is simply inert.

## Change

One line in `TerminalsService`: `env: { ...executorEnv, AGOR_CLOUD_EXECUTOR_TYPE: 'shell' }`
on the terminal `spawnExecutorFireAndForget` call.
