### PR TITLE
Make session task queues safe across daemons

### DIFF
--- a/apps/agor-cli/src/commands/session/load-claude.ts
+++ b/apps/agor-cli/src/commands/session/load-claude.ts
@@ -159,7 +159,7 @@ export default class SessionLoadClaude extends BaseCommand {
         const end = Math.min(i + batchSize, totalMessages);
         const batch = messages.slice(i, end);
 
-        await messagesBulkService.createMany(batch);
+        await messagesBulkService.create(batch);
 
         this.log(`${chalk.blue('●')} Processed ${end}/${totalMessages} messages...`);
       }

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -287,6 +287,7 @@ export interface BoardsServiceImpl extends Service<Board, Partial<Board>, Feathe
  * Messages service with custom methods (server-side implementation)
  */
 export interface MessagesServiceImpl extends Service<Message, Partial<Message>, FeathersParams> {
+  findByIdForScopeCheck(messageId: import('@agor/core/types').MessageID): Promise<Message | null>;
   createMany(data: Array<Partial<Message>>): Promise<Message[]>;
 }
 

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -14,6 +14,7 @@
  *     creation.
  */
 
+import type { MessageID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -22,6 +23,7 @@ vi.mock('../../utils/append-system-message.js', () => ({
 }));
 
 import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { widgetAutoResumeTaskId } from '../../utils/durable-task-id.js';
 import { registerWidgetTools } from './widgets.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
@@ -454,11 +456,17 @@ describe('agor_widgets_request_env_vars', () => {
       (c) => c.service === '/sessions/:id/prompt' && c.method === 'create'
     );
     expect(promptCall).toBeDefined();
-    const promptData = promptCall?.args[0] as { prompt: string; metadata: Record<string, unknown> };
+    const promptData = promptCall?.args[0] as {
+      prompt: string;
+      idempotencyTaskId: string;
+      metadata: Record<string, unknown>;
+    };
     expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
     expect(promptData.prompt.toLowerCase()).toContain('already configured');
     expect(promptData.metadata.system_authored).toBe(true);
     expect(promptData.metadata.widget_id).toBe('widget-msg-1');
+    expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId('widget-msg-1' as MessageID));
+    expect(promptData.idempotencyTaskId).not.toBe('widget-msg-1');
   });
 
   it('does NOT short-circuit when even one requested name is missing', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -31,6 +31,7 @@ import { getRequiredSecretFields, hasMinimumRole, MessageRole, ROLES } from '@ag
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { widgetAutoResumeTaskId } from '../../utils/durable-task-id.js';
 import { findHostTaskForSession } from '../../utils/session-tasks.js';
 import {
   type EnvVarsParams,
@@ -219,6 +220,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
             {
               prompt,
               messageSource: 'agor',
+              idempotencyTaskId: widgetAutoResumeTaskId(widgetId),
               metadata: {
                 system_authored: true,
                 widget_id: widgetId,

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -67,6 +67,7 @@ import type {
   GroupID,
   HookContext,
   MCPServer,
+  MessageID,
   Paginated,
   Params,
   Session,
@@ -173,6 +174,7 @@ import {
   resolveTenantIdForDeferredScope,
 } from './utils/tenant-db-scope.js';
 import { enforcePublicWriteFields, markWriteDataPrepared } from './utils/write-data-boundary.js';
+import { protectExternalWidgetMessageWrites } from './widgets/message-boundary.js';
 
 const DEBUG_MCP_TOKENS =
   process.env.AGOR_DEBUG_MCP_TOKENS === '1' || process.env.DEBUG?.includes('mcp-tokens');
@@ -554,6 +556,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     requireAuth,
     superadminOpts,
     sessionsService,
+    messagesService,
     boardsService,
     branchRepository,
     usersRepository,
@@ -928,6 +931,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Messages hooks
   // ============================================================================
 
+  const protectWidgetMessageWrites = protectExternalWidgetMessageWrites((messageId) =>
+    messagesService.findByIdForScopeCheck(messageId as MessageID)
+  );
+
   app.service('messages').hooks({
     before: {
       all: [requireAuth, executorRuntimeScopeGuard()],
@@ -949,6 +956,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create messages'),
+        protectWidgetMessageWrites,
         ...(branchRbacEnabled
           ? [
               resolveSessionContext(),
@@ -968,6 +976,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           AGENTIC_TOOL_DISPLAY_NAMES
         ),
       ],
+      update: [protectWidgetMessageWrites],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),
         ...(branchRbacEnabled
@@ -978,6 +987,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
             ]
           : []),
+        protectWidgetMessageWrites,
       ],
       remove: [
         requireMinimumRole(ROLES.MEMBER, 'delete messages'),
@@ -989,6 +999,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
             ]
           : []),
+        protectWidgetMessageWrites,
       ],
     },
     after: {

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -13,6 +13,9 @@ describe('prompt and widget transaction scopes', () => {
     expect(promptStart).toBeGreaterThan(0);
     expect(prompt).toContain('registerLongAuthenticatedRoute(');
     expect(prompt).toContain('bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db))');
+    expect(prompt).toContain(
+      'isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool)'
+    );
     expect(prompt).not.toContain(
       "registerAuthenticatedRoute(\n    app,\n    '/sessions/:id/prompt'"
     );

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('prompt and widget transaction scopes', () => {
+  const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
+
+  it('uses the long-route identity scope and short Task repository units for prompt admission', () => {
+    const promptStart = source.indexOf("'/sessions/:id/prompt'");
+    const promptEnd = source.indexOf("'/tasks/:id/run'", promptStart);
+    const prompt = source.slice(promptStart - 100, promptEnd);
+
+    expect(promptStart).toBeGreaterThan(0);
+    expect(prompt).toContain('registerLongAuthenticatedRoute(');
+    expect(prompt).toContain('bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db))');
+    expect(prompt).not.toContain(
+      "registerAuthenticatedRoute(\n    app,\n    '/sessions/:id/prompt'"
+    );
+  });
+
+  it('does not keep a route-wide tenant transaction over widget external work', () => {
+    for (const path of ["'/widgets/:id/submit'", "'/widgets/:id/dismiss'"]) {
+      const start = source.indexOf(path);
+      const route = source.slice(start - 100, start + 900);
+      expect(start).toBeGreaterThan(0);
+      expect(route).toContain('registerLongAuthenticatedRoute(');
+    }
+  });
+});

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -29,4 +29,15 @@ describe('prompt and widget transaction scopes', () => {
       expect(route).toContain('registerLongAuthenticatedRoute(');
     }
   });
+
+  it('routes prompt admission and explicit Task runs through server-owned provenance', () => {
+    const promptStart = source.indexOf("'/sessions/:id/prompt'");
+    const runStart = source.indexOf("'/tasks/:id/run'", promptStart);
+    const prompt = source.slice(promptStart, runStart);
+    const run = source.slice(runStart, source.indexOf("'/sessions/:id/spawn-prompt'", runStart));
+
+    expect(prompt).toContain('normalizeMessageSource(data.messageSource, params)');
+    expect(prompt).toContain('buildPromptTaskMetadata(data.metadata, messageSource, createdBy');
+    expect(run).toContain('messageSource: normalizeMessageSource(data.messageSource, params)');
+  });
 });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -9,7 +9,6 @@
 import { Transform } from 'node:stream';
 import {
   type AgorConfig,
-  isTenantAgenticToolEnabled,
   resolveBranchStorageConfig,
   resolveMultiTenancyConfig,
   resolveSdkWatchdogConfig,
@@ -140,7 +139,7 @@ import {
 } from './utils/mcp-header-secrets.js';
 import {
   buildPromptTaskMetadata,
-  type PromptTaskMetadataInput,
+  type InternalPromptTaskMetadataInput,
 } from './utils/prompt-task-metadata.js';
 import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
 import {
@@ -162,6 +161,7 @@ import {
 } from './utils/task-initial-message.js';
 import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
+import { isAgenticToolEnabledForTenant } from './utils/tenant-agentic-tool-validation.js';
 import {
   createTenantDatabaseScopeAroundHook,
   deferWithTenantContext,
@@ -173,6 +173,7 @@ import {
   type StagedMulterFile,
 } from './utils/upload.js';
 import { getUploadStagingStore } from './utils/upload-staging.js';
+import { assertExternalWidgetMessageCreateAllowed } from './widgets/message-boundary.js';
 import { WidgetResolutionStore } from './widgets/resolution-store.js';
 import { resolveWidget } from './widgets/submissions.js';
 
@@ -714,6 +715,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     '/messages/bulk',
     {
       async create(data: unknown, params: RouteParams) {
+        assertExternalWidgetMessageCreateAllowed(data);
         return messagesService.createMany(data as Message[]);
       },
     },
@@ -1161,12 +1163,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       agenticToolEnabled,
       messageStartIndex,
       session: loadedSession,
-    } = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+    } = await runWithTenantDatabaseScope(db, tenantId, async () => {
       const session = await sessionsService.get(task.session_id, params);
       const agenticTool = requireActiveAgenticTool(session.agentic_tool);
       return {
         session,
-        agenticToolEnabled: await isTenantAgenticToolEnabled(agenticTool, tenantDb),
+        agenticToolEnabled: await isAgenticToolEnabledForTenant(db, tenantId, agenticTool),
         // Recompute message_range.start_index against the live message count.
         messageStartIndex: await sessionsRepository.countMessages(task.session_id),
       };
@@ -1410,13 +1412,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           stream?: boolean;
           messageSource?: MessageSource;
           /**
-           * Optional extra task metadata merged onto the queued/created task.
-           * Used by internal callers (e.g. widget submissions) to stamp
+           * Internal-only task metadata merged onto the queued/created task.
+           * Used by daemon callers (e.g. widget submissions) to stamp
            * traceability fields like `system_authored` / `widget_id`.
-           * Transport provenance (`source`) is daemon-owned and deliberately
-           * excluded/sanitized even for stale or untyped clients.
+           * External transports are rejected, and the metadata builder also
+           * strips every internal field defensively for untrusted callers.
            */
-          metadata?: PromptTaskMetadataInput;
+          metadata?: InternalPromptTaskMetadataInput;
           /**
            * Internal-only stable task identity for idempotent producers such
            * as the scheduler. External callers may not set this field.
@@ -1437,6 +1439,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!data.prompt) throw new Error('Prompt required');
         if (data.idempotencyTaskId && params.provider) {
           throw new Forbidden('idempotencyTaskId is internal-only');
+        }
+        if (data.metadata !== undefined && params.provider) {
+          throw new Forbidden('Task metadata is internal-only');
         }
         const promptTenantId = getCurrentTenantId();
         if (!promptTenantId) throw new Error('Missing active tenant context for prompt admission');
@@ -1485,7 +1490,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         try {
           const activeAgenticTool = requireActiveAgenticTool(session.agentic_tool);
-          if (!(await isTenantAgenticToolEnabled(activeAgenticTool, db))) {
+          if (!(await isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool))) {
             throw new Forbidden(`${activeAgenticTool} is disabled for this workspace`);
           }
           session = await sessionsService.materializeAgenticToolPreset(session, params);
@@ -1555,7 +1560,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
             }
 
-            const taskMetadata = buildPromptTaskMetadata(data.metadata, messageSource, createdBy);
+            const taskMetadata = buildPromptTaskMetadata(data.metadata, messageSource, createdBy, {
+              trustedInternalMetadata: !params.provider,
+            });
             if (data.idempotencyTaskId) {
               taskMetadata.initial_message_id = data.idempotencyTaskId as MessageID;
             }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -156,6 +156,10 @@ import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';
+import {
+  shouldReconcileStableInitialMessage,
+  stableInitialMessageIdForTask,
+} from './utils/task-initial-message.js';
 import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
@@ -169,6 +173,7 @@ import {
   type StagedMulterFile,
 } from './utils/upload.js';
 import { getUploadStagingStore } from './utils/upload-staging.js';
+import { WidgetResolutionStore } from './widgets/resolution-store.js';
 import { resolveWidget } from './widgets/submissions.js';
 
 const DEBUG_AUTH_EVENTS =
@@ -997,7 +1002,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   ): Promise<void> {
     if (config.execution?.daemon_writes_user_message === false) return;
 
-    const messageRepo = new MessagesRepository(db);
+    const messageRepo = bindRepositoryToTenantUnitOfWork(db, new MessagesRepository(db));
     if (input.stableMessageId) {
       const existing = await messageRepo.findById(input.stableMessageId);
       if (existing) {
@@ -1131,6 +1136,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   ): Promise<Task> {
     const tenantId = getCurrentTenantId();
     if (!tenantId) throw new Error('Missing active tenant context for task executor startup');
+    const stableInitialMessageId = stableInitialMessageIdForTask(
+      task,
+      options.stableInitialMessageId
+    );
     const persistedMessageSource = task.metadata?.source ?? options.messageSource;
     const runtimeMessageSource =
       persistedMessageSource === 'gateway' || persistedMessageSource === 'agor'
@@ -1141,8 +1150,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // deterministic projection repair. Do not make that reconciliation depend
     // on mutable launch-time state (tool enablement, preset validity, or user
     // defaults): no new executor launch will occur on this path.
-    if (options.stableInitialMessageId && !isTaskPendingDispatch(task)) {
-      await reconcileStableInitialUserMessage(task, params, options.stableInitialMessageId, {
+    if (shouldReconcileStableInitialMessage(task, stableInitialMessageId)) {
+      await reconcileStableInitialUserMessage(task, params, stableInitialMessageId, {
         messageSource: runtimeMessageSource,
       });
       return task;
@@ -1222,11 +1231,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           observed_status: dispatchClaim.task.status,
         })
       );
-      if (options.stableInitialMessageId) {
+      if (shouldReconcileStableInitialMessage(dispatchClaim.task, stableInitialMessageId)) {
         await reconcileStableInitialUserMessage(
           dispatchClaim.task,
           params,
-          options.stableInitialMessageId,
+          stableInitialMessageId,
           {
             messageStartIndex,
             startTimestamp,
@@ -1243,8 +1252,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // write is harmless if the daemon path is enabled.
     // Prefer task.metadata.source (set when the task was queued) over the
     // request's messageSource — the latter applies only to this drain tick.
-    if (options.stableInitialMessageId) {
-      await reconcileStableInitialUserMessage(updatedTask, params, options.stableInitialMessageId, {
+    if (stableInitialMessageId) {
+      await reconcileStableInitialUserMessage(updatedTask, params, stableInitialMessageId, {
         messageStartIndex,
         startTimestamp,
         messageSource: runtimeMessageSource,
@@ -1390,7 +1399,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Prompt endpoint
   // ============================================================================
 
-  registerAuthenticatedRoute(
+  registerLongAuthenticatedRoute(
     app,
     '/sessions/:id/prompt',
     {
@@ -1445,7 +1454,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         let session = await sessionsService.get(id, params);
         id = session.session_id;
-        const taskRepo = new TaskRepository(db);
+        const taskRepo = bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db));
 
         const reconcileDurablyDispatchedTask = async (): Promise<Task | null> => {
           if (!data.idempotencyTaskId) return null;
@@ -1463,7 +1472,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           await reconcileStableInitialUserMessage(
             prior,
             params,
-            data.idempotencyTaskId as MessageID
+            prior.metadata?.initial_message_id ?? (data.idempotencyTaskId as MessageID)
           );
           return prior;
         };
@@ -1547,6 +1556,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             }
 
             const taskMetadata = buildPromptTaskMetadata(data.metadata, messageSource, createdBy);
+            if (data.idempotencyTaskId) {
+              taskMetadata.initial_message_id = data.idempotencyTaskId as MessageID;
+            }
             const task = await taskRepo.createPending({
               task_id: data.idempotencyTaskId,
               session_id: id as SessionID,
@@ -2837,14 +2849,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     const source =
       persistedSource === 'gateway' || persistedSource === 'agor' ? persistedSource : undefined;
     const scheduledInitialTaskId = queuedSession.custom_context?.scheduled_run?.initial_task_id;
+    const stableInitialMessageId = stableInitialMessageIdForTask(
+      stillQueued,
+      scheduledInitialTaskId === stillQueued.task_id
+        ? (scheduledInitialTaskId as MessageID)
+        : undefined
+    );
     const admitted = await spawnTaskExecutor(
       stillQueued,
       {
         stream: true,
         messageSource: source,
-        ...(scheduledInitialTaskId === stillQueued.task_id
-          ? { stableInitialMessageId: scheduledInitialTaskId as MessageID }
-          : {}),
+        ...(stableInitialMessageId ? { stableInitialMessageId } : {}),
       },
       taskParams
     );
@@ -2962,16 +2978,34 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // auto-resume task queueing, and the `widget:resolved` broadcast.
   // ============================================================================
 
+  const widgetResolutionMessages = bindRepositoryToTenantUnitOfWork(db, new MessagesRepository(db));
+  const widgetResolutionBranches = bindRepositoryToTenantUnitOfWork(db, new BranchRepository(db));
   const widgetResolverDeps = {
     // biome-ignore lint/suspicious/noExplicitAny: Feathers Application shape
     app: app as any,
+    resolutionStore: new WidgetResolutionStore(widgetResolutionMessages, (message) =>
+      emitServiceEvent(app, {
+        path: 'messages',
+        event: 'patched',
+        data: message,
+        id: message.message_id,
+      })
+    ),
+    publishResolved: (payload: Record<string, unknown>) =>
+      emitServiceEvent(app, {
+        path: 'messages',
+        event: 'widget:resolved',
+        data: payload,
+        method: 'patch',
+        id: payload.widget_id as string,
+      }),
     isBranchOwner: async (branchId: string, userId: UUID) =>
-      branchRepository.isOwner(branchId as import('@agor/core/types').BranchID, userId),
+      widgetResolutionBranches.isOwner(branchId as import('@agor/core/types').BranchID, userId),
     resolveBranchPermission: async (branch: import('@agor/core/types').Branch, userId: UUID) =>
-      branchRepository.resolveUserPermission(branch, userId),
+      widgetResolutionBranches.resolveUserPermission(branch, userId),
   };
 
-  registerAuthenticatedRoute(
+  registerLongAuthenticatedRoute(
     app,
     '/widgets/:id/submit',
     {
@@ -2995,7 +3029,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
-  registerAuthenticatedRoute(
+  registerLongAuthenticatedRoute(
     app,
     '/widgets/:id/dismiss',
     {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -17,6 +17,7 @@ import {
   resolveTenantContext,
 } from '@agor/core/config';
 import {
+  assertTenantWritable,
   BranchRepository,
   bindRepositoryToTenantUnitOfWork,
   generateId,
@@ -919,15 +920,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   );
 
   /**
-   * Per-session "turn" lock — single source of truth for "who's allowed to
-   * spawn an executor for this session right now" mutual exclusion. Shared
-   * by `/sessions/:id/prompt`'s idle branch, `/tasks/:id/run`, and the
-   * queue processor's drain loop. See `utils/session-turn-lock.ts`.
-   *
-   * Without this, two concurrent prompts on the same idle session could
-   * both observe `status === 'idle'` and both spawn executors — a race
-   * that pre-dates the `/tasks/:id/run` route but is now fixed across all
-   * three entry points.
+   * Per-session local turn coalescing. This reduces redundant preparatory
+   * reads and duplicate drain triggers inside one daemon; it is not a
+   * correctness authority. Queue-position admission and the Session+Task
+   * dispatch fence in PostgreSQL are authoritative across daemons.
    */
   const sessionTurnLocks: SessionTurnLocks = new Map();
 
@@ -1099,8 +1095,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
    * spawnTaskExecutor — sole transition point for `tasks.status` going from
    * `created` / `queued` → `dispatching`.
    *
-   * Both the IDLE branch of POST /sessions/:id/prompt and the queued-task
-   * drainer call this helper. Centralising the transition guarantees that:
+   * Both POST /sessions/:id/prompt's immediate queue-head attempt and the
+   * queued-task drainer call this helper. Centralising the transition
+   * guarantees that:
    *
    *   - `message_range.start_index`, `git_state.{ref,sha}_at_start`, and
    *     `started_at` are recomputed against fresh state right before the
@@ -1187,28 +1184,31 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // Atomically claim queued/created → launch status. Process-local session
     // locks reduce contention, but this expected-state transition is the
     // cross-daemon fence that prevents duplicate executor launches.
-    const dispatchClaim = await tasksService.claimDispatchAndProjectSession(
-      task.task_id,
-      task.status,
-      {
-        ...launchState,
-        ...(launchState.executor_mode
-          ? { sdk_watchdog_mode: resolveSdkWatchdogConfig(config.execution).mode }
-          : {}),
-        queue_position: undefined,
-        message_range: {
-          start_index: messageStartIndex,
-          end_index: messageStartIndex + 1,
-          start_timestamp: startTimestamp,
-          end_timestamp: startTimestamp,
+    const dispatchClaim = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+      await assertTenantWritable(tenantDb, tenantId);
+      return tasksService.claimDispatchAndProjectSession(
+        task.task_id,
+        task.status,
+        {
+          ...launchState,
+          ...(launchState.executor_mode
+            ? { sdk_watchdog_mode: resolveSdkWatchdogConfig(config.execution).mode }
+            : {}),
+          queue_position: undefined,
+          message_range: {
+            start_index: messageStartIndex,
+            end_index: messageStartIndex + 1,
+            start_timestamp: startTimestamp,
+            end_timestamp: startTimestamp,
+          },
+          git_state: {
+            ref_at_start: refAtStart,
+            sha_at_start: gitStateAtStart,
+          },
         },
-        git_state: {
-          ref_at_start: refAtStart,
-          sha_at_start: gitStateAtStart,
-        },
-      },
-      { ...params, provider: undefined }
-    );
+        { ...params, provider: undefined }
+      );
+    });
     if (dispatchClaim.outcome !== 'claimed') {
       const workIdentity = app.get('distributedWorkIdentity');
       console.info(
@@ -1429,6 +1429,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (data.idempotencyTaskId && params.provider) {
           throw new Forbidden('idempotencyTaskId is internal-only');
         }
+        const promptTenantId = getCurrentTenantId();
+        if (!promptTenantId) throw new Error('Missing active tenant context for prompt admission');
+        await runWithTenantDatabaseScope(db, promptTenantId, (tenantDb) =>
+          assertTenantWritable(tenantDb, promptTenantId)
+        );
 
         // Validate and normalize messageSource
         const messageSource = normalizeMessageSource(data.messageSource, params);
@@ -1507,17 +1512,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           throw new Error('Cannot send prompt: session is currently stopping');
         }
 
-        // The route is one path: always materialize a Task. Whether it runs
-        // immediately or gets queued is the *response*, not a different code
-        // path. Sentinels and queue-position assignment live in
-        // `taskRepo.createPending` so callers don't reassemble them by hand.
-        //
-        // Wrapped in `withSessionTurnLock` so the queue-vs-idle decision and
-        // the subsequent spawn are atomic with respect to other entry points
-        // (`/tasks/:id/run`, the queue drainer). Without this, two concurrent
-        // prompts on an idle session could both observe `status === 'idle'`
-        // and both spawn executors. Inside the lock the session is re-read,
-        // so the decision is made against the freshest possible state.
+        // Every prompt first takes one durable queue position. The subsequent
+        // Session+Task database claim decides whether this Task leaves the
+        // queue immediately or remains queued. This avoids a split
+        // read-session/create-CREATED race: two daemons can admit concurrently,
+        // but only the durable head can claim the idle Session.
         if (!params.user?.user_id) {
           throw new NotAuthenticated('Authentication required to prompt a session');
         }
@@ -1540,126 +1539,72 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               params
             );
 
-            // A scheduled occurrence owns a stable initial task ID persisted
-            // with its session. Reconciliation always targets that row rather
-            // than inferring idempotence from process-local locks or creating a
-            // second queued prompt after another daemon starts it.
-            if (data.idempotencyTaskId) {
-              const prior = await taskRepo.findById(data.idempotencyTaskId);
-              if (prior && prior.session_id !== id) {
-                throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
-              }
-              const task = await taskRepo.createPending({
-                task_id: data.idempotencyTaskId,
-                session_id: id as SessionID,
-                full_prompt: data.prompt,
-                created_by: createdBy,
-                status: TaskStatus.CREATED,
-              });
-              if (!prior) {
-                // createPending is conflict-tolerant: another daemon can win
-                // between the pre-read and insert. In that case this is only a
-                // harmless same-ID realtime catch-up event, not a correctness
-                // dependency.
-                emitServiceEvent(app, {
-                  path: 'tasks',
-                  event: 'created',
-                  data: task,
-                  params,
-                  id: task.task_id,
-                });
-              }
-              return await spawnTaskExecutor(
-                task,
-                {
-                  permissionMode: data.permissionMode,
-                  stream: data.stream !== false,
-                  messageSource,
-                  stableInitialMessageId: data.idempotencyTaskId as MessageID,
-                },
-                params
-              );
+            const prior = data.idempotencyTaskId
+              ? await taskRepo.findById(data.idempotencyTaskId)
+              : null;
+            if (prior && prior.session_id !== id) {
+              throw new Conflict(`Task identity ${data.idempotencyTaskId} is already in use`);
             }
 
-            const queuedTasks = await taskRepo.findQueued(id as SessionID);
-            const shouldQueue =
-              !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||
-              queuedTasks.length > 0;
-
-            if (shouldQueue) {
-              const queuedTask = await taskRepo.createPending({
-                session_id: id as SessionID,
-                full_prompt: data.prompt,
-                created_by: createdBy,
-                status: TaskStatus.QUEUED,
-                metadata: buildPromptTaskMetadata(data.metadata, messageSource, createdBy),
-              });
-              await tasksService.autoTitleSession(queuedTask, params);
-
-              console.log(
-                `📬 [Prompt] Auto-queued task for session ${shortId(id)} at position ${queuedTask.queue_position} ` +
-                  `(session status: ${lockedSession.status}, existing queue items: ${queuedTasks.length})`
-              );
-
-              app.service('tasks').emit('queued', queuedTask);
-
-              if (sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt)) {
-                deferInFreshTenantScope(params, async () => {
-                  try {
-                    await sessionsService.triggerQueueProcessing(id as SessionID, params);
-                  } catch (error) {
-                    console.error(
-                      `❌ [Prompt] Failed to trigger queue processing after auto-queue:`,
-                      error
-                    );
-                  }
-                });
-              }
-
-              // Uniform response: the entity is always a Task. Caller inspects
-              // `task.status` (`'queued'` here) and `task.queue_position` to know
-              // what happened.
-              return queuedTask;
-            }
-
-            console.log(`   Session agent: ${lockedSession.agentic_tool}`);
-            console.log(
-              `   Session permission_config.mode: ${lockedSession.permission_config?.mode || 'not set'}`
-            );
-
-            // Idle path: create a CREATED task, then hand off to spawnTaskExecutor
-            // which is the sole place that populates message_range / git_state,
-            // writes the user-message row, and spawns the executor. Both this
-            // path and processNextQueuedTask go through that helper so behavior
-            // stays in lockstep.
-            const idleTaskMetadata = buildPromptTaskMetadata(data.metadata, messageSource);
+            const taskMetadata = buildPromptTaskMetadata(data.metadata, messageSource, createdBy);
             const task = await taskRepo.createPending({
+              task_id: data.idempotencyTaskId,
               session_id: id as SessionID,
               full_prompt: data.prompt,
               created_by: createdBy,
-              status: TaskStatus.CREATED,
-              metadata: Object.keys(idleTaskMetadata).length > 0 ? idleTaskMetadata : undefined,
+              status: TaskStatus.QUEUED,
+              metadata: Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined,
             });
             await tasksService.autoTitleSession(task, params);
-            // Bypassing the service means no native 'created' emit; do it here
-            // so reactive clients see the new task before the executor spawns.
-            emitServiceEvent(app, {
-              path: 'tasks',
-              event: 'created',
-              data: task,
-              params,
-              id: task.task_id,
-            });
 
-            return await spawnTaskExecutor(
+            if (!prior) {
+              // Repository admission bypasses TasksService.create. Publish the
+              // entity before its possible patched/dispatch event so reactive
+              // clients observe a coherent lifecycle.
+              emitServiceEvent(app, {
+                path: 'tasks',
+                event: 'created',
+                data: task,
+                params,
+                id: task.task_id,
+              });
+            }
+
+            const admitted = await spawnTaskExecutor(
               task,
               {
                 permissionMode: data.permissionMode,
                 stream: data.stream !== false,
                 messageSource,
+                ...(data.idempotencyTaskId
+                  ? { stableInitialMessageId: data.idempotencyTaskId as MessageID }
+                  : {}),
               },
               params
             );
+
+            if (admitted.status === TaskStatus.QUEUED) {
+              console.log(
+                `📬 [Prompt] Queued task for session ${shortId(id)} at position ${admitted.queue_position} ` +
+                  `(observed session status: ${lockedSession.status})`
+              );
+              app.service('tasks').emit('queued', admitted);
+
+              // Immediate triggers are a latency hint. Durable all-daemon
+              // discovery remains the recovery path if this process dies or
+              // another claim changes the Session after our observation.
+              deferInFreshTenantScope(params, async () => {
+                try {
+                  await sessionsService.triggerQueueProcessing(id as SessionID, params);
+                } catch (error) {
+                  console.error(`❌ [Prompt] Failed to trigger queued Task processing:`, error);
+                }
+              });
+            }
+
+            // Uniform response: QUEUED means durable wait; DISPATCHING/RUNNING
+            // means this or another daemon already won the launch claim.
+            return admitted;
           },
           { waiterTimeoutMs: 30_000 }
         );
@@ -1774,11 +1719,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           }
         }
 
-        // Acquire the session-turn lock before validating session state and
-        // spawning. This is what closes the race against concurrent
-        // /tasks/:id/run on different tasks of the same session, against
-        // /sessions/:id/prompt's idle branch, and against the queue
-        // drainer — they all serialize through `sessionTurnLocks`.
+        // The local lock coalesces same-process contenders. The repository's
+        // Session-first dispatch claim is authoritative against other daemons
+        // and also refuses to jump a durable prompt queue.
         return await withSessionTurnLock(
           sessionTurnLocks,
           task.session_id,
@@ -1803,7 +1746,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               );
             }
 
-            return await runExistingTask(
+            const result = await runExistingTask(
               task,
               {
                 permissionMode: data.permissionMode,
@@ -1816,6 +1759,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 spawnFn: spawnTaskExecutor,
               }
             );
+            if (result.status === TaskStatus.CREATED) {
+              throw new Conflict(
+                `Cannot run task ${shortId(taskId)}: another Task or queued prompt owns the Session turn.`
+              );
+            }
+            return result;
           },
           { waiterTimeoutMs: 30_000 }
         );
@@ -2680,10 +2629,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Queue listing — task-centric (was message-centric pre-never-lose-prompt).
   // The queue is the set of tasks with status='queued', ranked by
   // queue_position. Each queued task carries the full prompt + metadata; on
-  // drain it transitions queued → running via spawnTaskExecutor.
+  // drain it transitions queued → dispatching via spawnTaskExecutor.
   //
-  // Enqueueing goes through `POST /sessions/:id/prompt` — the daemon decides
-  // run-vs-queue based on session state and reports it back via `task.status`.
+  // Enqueueing goes through `POST /sessions/:id/prompt`: every admission first
+  // takes a durable position, then the database claim decides whether it may
+  // leave the queue immediately and reports the actual status to the caller.
   // ============================================================================
 
   registerAuthenticatedRoute(
@@ -2710,14 +2660,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
-  // Queue processing implementation — task-centric. Acquires the shared
-  // `sessionTurnLocks` (declared near the top of registerRoutes) so the
-  // drainer can't race `/sessions/:id/prompt` or `/tasks/:id/run` for the
-  // same session. The retry-on-existing-lock indirection (vs. a plain
-  // `withSessionTurnLock` wrapper) preserves the original "if drain is in
-  // flight, schedule a retry instead of stacking concurrent drainers"
-  // semantics — important because callbacks can fire processNextQueuedTask
-  // from arbitrary points in the lifecycle.
+  // Queue processing implementation — task-centric. `sessionTurnLocks` and
+  // `queueRetryScheduled` only coalesce duplicate work inside this daemon.
+  // They may disappear on process death without losing correctness: the
+  // durable queue head plus Session-first dispatch claim are authoritative,
+  // and the all-daemon queue worker rediscovers missed work.
   const queueRetryScheduled = new Set<SessionID>();
 
   async function processNextQueuedTask(sessionId: SessionID, params: RouteParams): Promise<void> {
@@ -2844,7 +2791,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
-    const userId = nextTask.metadata?.queued_by_user_id;
+    const userId = nextTask.metadata?.queued_by_user_id ?? nextTask.created_by;
     const userRepo = bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db));
     const queuedByUser = userId ? await userRepo.findById(userId) : undefined;
 
@@ -2882,23 +2829,34 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
-    // spawnTaskExecutor handles the QUEUED → RUNNING transition (recomputes
+    // spawnTaskExecutor handles the QUEUED → DISPATCHING claim (recomputes
     // message_range/git_state, writes the user-message row, appends to
     // session.tasks, spawns the executor). We pass the messageSource from
     // task.metadata so callback styling survives the queue → run hop.
     const persistedSource = nextTask.metadata?.source;
     const source =
       persistedSource === 'gateway' || persistedSource === 'agor' ? persistedSource : undefined;
-    await spawnTaskExecutor(
+    const scheduledInitialTaskId = queuedSession.custom_context?.scheduled_run?.initial_task_id;
+    const admitted = await spawnTaskExecutor(
       stillQueued,
       {
         stream: true,
         messageSource: source,
+        ...(scheduledInitialTaskId === stillQueued.task_id
+          ? { stableInitialMessageId: scheduledInitialTaskId as MessageID }
+          : {}),
       },
       taskParams
     );
-
-    console.log(`✅ Queued task drained for session ${shortId(sessionId)}`);
+    if (admitted.status === TaskStatus.QUEUED) {
+      taskQueueDebug(
+        `⏸️  Queue head ${shortId(admitted.task_id)} remains queued after a lost/changed claim`
+      );
+      return;
+    }
+    console.log(
+      `✅ Queue head ${shortId(admitted.task_id)} observed as ${admitted.status} for session ${shortId(sessionId)}`
+    );
   }
 
   // Inject queue processor into sessions service.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1449,11 +1449,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           assertTenantWritable(tenantDb, promptTenantId)
         );
 
-        // Validate and normalize messageSource
+        // Derive external provenance server-side. Only provider-less,
+        // daemon-internal producers may preserve an explicit gateway source.
         const messageSource = normalizeMessageSource(data.messageSource, params);
         if (messageSource !== data.messageSource && data.messageSource !== undefined) {
           console.warn(
-            `[Daemon] Invalid messageSource value: ${data.messageSource}, defaulted based on provider`
+            `[Daemon] Ignored caller-supplied messageSource: ${data.messageSource}; using ${messageSource ?? 'no source'}`
           );
         }
 

--- a/apps/agor-daemon/src/register-services.messages-boundary.test.ts
+++ b/apps/agor-daemon/src/register-services.messages-boundary.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { MESSAGES_SERVICE_TRANSPORT_METHODS } from './services/messages';
+
+describe('Messages service transport boundary', () => {
+  it('does not expose replacement or raw bulk insertion around widget hooks', () => {
+    expect(MESSAGES_SERVICE_TRANSPORT_METHODS).not.toContain('update');
+    expect(MESSAGES_SERVICE_TRANSPORT_METHODS).not.toContain('createMany');
+    expect(MESSAGES_SERVICE_TRANSPORT_METHODS).toEqual(
+      expect.arrayContaining(['find', 'get', 'create', 'patch', 'remove'])
+    );
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -126,7 +126,7 @@ import { createKnowledgeVersionsService } from './services/knowledge-versions.js
 import { createLeaderboardService } from './services/leaderboard.js';
 import { createLocalActionsService } from './services/local-actions.js';
 import { createMCPServersService } from './services/mcp-servers.js';
-import { createMessagesService } from './services/messages.js';
+import { createMessagesService, MESSAGES_SERVICE_TRANSPORT_METHODS } from './services/messages.js';
 import { performOAuthDisconnect } from './services/oauth-disconnect.js';
 import { createReposService } from './services/repos.js';
 import { createSchedulesService } from './services/schedules.js';
@@ -280,18 +280,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
 
   app.use('/messages', messagesService, {
-    methods: [
-      'find',
-      'get',
-      'create',
-      'update',
-      'patch',
-      'remove',
-      'findBySession',
-      'findByTask',
-      'findByRange',
-      'createMany',
-    ],
+    methods: [...MESSAGES_SERVICE_TRANSPORT_METHODS],
     events: [
       'queued',
       'streaming:start',

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -19,6 +19,21 @@ import type {
 import { DrizzleService, type Query } from '../adapters/drizzle';
 
 /**
+ * Public Message transport surface. Full replacement and raw bulk insertion
+ * stay daemon-internal so they cannot bypass widget lifecycle hooks.
+ */
+export const MESSAGES_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+  'findBySession',
+  'findByTask',
+  'findByRange',
+] as const;
+
+/**
  * Message service params
  */
 export type MessageParams = QueryParams<{

--- a/apps/agor-daemon/src/services/session-queue-worker.test.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.test.ts
@@ -1,0 +1,55 @@
+import type { QueuedSessionCursor, QueuedSessionRef } from '@agor/core/db';
+import type { SessionID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionQueueWorker } from './session-queue-worker.js';
+
+const ref = (tenant: string, session: string): QueuedSessionRef => ({
+  tenant_id: tenant,
+  session_id: session as SessionID,
+  first_queued_at: 1,
+});
+
+describe('SessionQueueWorker', () => {
+  it('carries each discovered tenant into deferred queue processing', async () => {
+    const processSession = vi.fn(async () => undefined);
+    const worker = new SessionQueueWorker({} as never, {
+      workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      discover: async () => [ref('tenant-a', 'session-a'), ref('tenant-b', 'session-b')],
+      processSession,
+    });
+
+    await expect(worker.checkOnce()).resolves.toBe(2);
+    expect(processSession).toHaveBeenNthCalledWith(
+      1,
+      'session-a',
+      expect.objectContaining({ tenant: expect.objectContaining({ tenant_id: 'tenant-a' }) })
+    );
+    expect(processSession).toHaveBeenNthCalledWith(
+      2,
+      'session-b',
+      expect.objectContaining({ tenant: expect.objectContaining({ tenant_id: 'tenant-b' }) })
+    );
+  });
+
+  it('advances a fairness cursor and wraps only after an empty page', async () => {
+    const cursors: Array<QueuedSessionCursor | undefined> = [];
+    const pages = [[ref('tenant-a', 'session-a')], []] as QueuedSessionRef[][];
+    const worker = new SessionQueueWorker({} as never, {
+      workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      discover: async (cursor) => {
+        cursors.push(cursor);
+        return pages.shift() ?? [];
+      },
+      processSession: async () => undefined,
+    });
+
+    await worker.checkOnce();
+    await worker.checkOnce();
+    await worker.checkOnce();
+    expect(cursors).toEqual([
+      undefined,
+      { tenant_id: 'tenant-a', session_id: 'session-a' },
+      undefined,
+    ]);
+  });
+});

--- a/apps/agor-daemon/src/services/session-queue-worker.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.ts
@@ -1,0 +1,154 @@
+import {
+  boundedBackoffDelay,
+  type DistributedWorkIdentity,
+  initialWorkOffset,
+  jitterDelay,
+} from '@agor/core/coordination';
+import {
+  type QueuedSessionCursor,
+  type QueuedSessionRef,
+  runWithSystemDatabaseScope,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+import type { AuthenticatedParams, SessionID, TenantID } from '@agor/core/types';
+
+export interface SessionQueueWorkerOptions {
+  tenantId?: TenantID | string;
+  workIdentity: DistributedWorkIdentity;
+  processSession: (sessionId: SessionID, params: AuthenticatedParams) => Promise<void>;
+  scanBatchSize?: number;
+  random?: () => number;
+  /** Test seam; production discovery always uses the repository/RLS path. */
+  discover?: (after?: QueuedSessionCursor) => Promise<QueuedSessionRef[]>;
+}
+
+/**
+ * All-daemon recovery scanner for durable Session Task queues.
+ *
+ * It owns no lease and elects no leader. Every daemon may discover the same
+ * bounded routing refs; the Session+Task repository claim elects the only
+ * launcher. Cursor/backoff/jitter are contention etiquette and fairness only.
+ */
+export class SessionQueueWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private stopped = false;
+  private cursor: QueuedSessionCursor | undefined;
+  private idleRounds = 0;
+  private readonly scanBatchSize: number;
+  private readonly random: () => number;
+
+  constructor(
+    private readonly db: TenantScopeAwareDatabase,
+    private readonly options: SessionQueueWorkerOptions
+  ) {
+    this.scanBatchSize = options.scanBatchSize ?? 25;
+    this.random = options.random ?? Math.random;
+  }
+
+  start(): void {
+    if (this.timer || this.running) return;
+    this.stopped = false;
+    this.schedule(initialWorkOffset(30_000, this.random()));
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private schedule(delayMs: number): void {
+    if (this.stopped) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.runLoopIteration();
+    }, delayMs);
+    this.timer.unref?.();
+  }
+
+  private async runLoopIteration(): Promise<void> {
+    if (this.running || this.stopped) return;
+    this.running = true;
+    let found = 0;
+    try {
+      found = await this.checkOnce();
+      this.idleRounds = found === 0 ? this.idleRounds + 1 : 0;
+    } catch (error) {
+      this.idleRounds += 1;
+      console.warn(
+        `[distributed-work.task-queue] event=scan_failed instance_id=${JSON.stringify(this.options.workIdentity.instanceId)} boot_id=${JSON.stringify(this.options.workIdentity.bootId)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
+      );
+    } finally {
+      this.running = false;
+    }
+
+    const delay =
+      found >= this.scanBatchSize
+        ? jitterDelay(150, 2 / 3, this.random())
+        : boundedBackoffDelay(
+            this.idleRounds,
+            { baseDelayMs: 1_000, maxDelayMs: 30_000, jitterRatio: 0.2 },
+            this.random()
+          );
+    this.schedule(delay);
+  }
+
+  private async discover(): Promise<QueuedSessionRef[]> {
+    if (this.options.discover) return this.options.discover(this.cursor);
+    const find = (scopedDb: TenantScopedDatabase) =>
+      new TaskRepository(scopedDb).findQueuedSessionRefs(this.scanBatchSize, this.cursor);
+
+    if (this.options.tenantId) {
+      return runWithTenantDatabaseScope(this.db, this.options.tenantId, find);
+    }
+    return runWithSystemDatabaseScope(
+      this.db,
+      'Session Task queue discovery',
+      (systemDb) =>
+        new TaskRepository(systemDb).findQueuedSessionRefs(this.scanBatchSize, this.cursor),
+      { capability: 'task_queue_discovery' }
+    );
+  }
+
+  /** One bounded scan, exposed for deterministic tests and operational probes. */
+  async checkOnce(): Promise<number> {
+    const refs = await this.discover();
+    if (refs.length === 0) {
+      if (this.cursor) this.cursor = undefined;
+      return 0;
+    }
+    const last = refs.at(-1)!;
+    this.cursor = {
+      session_id: last.session_id,
+      ...(last.tenant_id ? { tenant_id: last.tenant_id } : {}),
+    };
+
+    for (const ref of refs) {
+      const tenantId = this.options.tenantId ?? ref.tenant_id;
+      if (!tenantId) {
+        console.error(
+          `[distributed-work.task-queue] event=route_missing_tenant session_id=${JSON.stringify(ref.session_id)}`
+        );
+        continue;
+      }
+      const params: AuthenticatedParams = {
+        tenant: { tenant_id: tenantId as TenantID, source: 'explicit' },
+      };
+      try {
+        await runWithTenantContext(tenantId, () =>
+          this.options.processSession(ref.session_id, params)
+        );
+      } catch (error) {
+        console.warn(
+          `[distributed-work.task-queue] event=process_failed instance_id=${JSON.stringify(this.options.workIdentity.instanceId)} boot_id=${JSON.stringify(this.options.workIdentity.bootId)} tenant_id=${JSON.stringify(tenantId)} session_id=${JSON.stringify(ref.session_id)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
+        );
+      }
+    }
+    return refs.length;
+  }
+}

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -1,6 +1,7 @@
 import { runWithTenantDatabaseScope } from '@agor/core/db';
 import { type Session, type Task, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { completionCallbackTaskId } from '../utils/durable-task-id.js';
 import { TasksService } from './tasks';
 
 const childSessionId = '018f0000-0000-7000-8000-000000000101';
@@ -8,6 +9,10 @@ const parentSessionId = '018f0000-0000-7000-8000-000000000102';
 const taskId = '018f0000-0000-7000-8000-000000000201';
 const callbackTaskId = '018f0000-0000-7000-8000-000000000301';
 const userId = '018f0000-0000-7000-8000-000000000401';
+const durableCallbackTaskId = completionCallbackTaskId(
+  taskId as Task['task_id'],
+  parentSessionId as Session['session_id']
+);
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -226,6 +231,7 @@ describe('TasksService completion callbacks', () => {
     await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     expect(createPending).toHaveBeenCalledWith(
       expect.objectContaining({
+        task_id: durableCallbackTaskId,
         session_id: parentSessionId,
         status: TaskStatus.QUEUED,
         metadata: expect.objectContaining({
@@ -259,7 +265,7 @@ describe('TasksService completion callbacks', () => {
         expect.objectContaining({
           event: 'session_completion',
           target_session_id: parentSessionId,
-          queued_task_id: callbackTaskId,
+          queued_task_id: durableCallbackTaskId,
         }),
       ])
     );

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -240,6 +240,7 @@ describe('TasksService completion callbacks', () => {
           child_session_id: childSessionId,
           child_task_id: taskId,
           queued_by_user_id: userId,
+          initial_message_id: durableCallbackTaskId,
         }),
       })
     );

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -35,6 +35,7 @@ import type {
   AuthenticatedParams,
   ContentBlock,
   ExecutorTerminationCompleteInput,
+  MessageID,
   Paginated,
   QueryParams,
   RuntimeTelemetryInput,
@@ -1160,9 +1161,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // for backward compat (legacy sessions without callback_created_by).
       const callbackCreator =
         childSession.callback_config?.callback_created_by ?? targetSession.created_by;
+      const callbackTaskId = completionCallbackTaskId(task.task_id, targetSessionId);
       const createCallbackTask = () =>
         this.taskRepo.createPending({
-          task_id: completionCallbackTaskId(task.task_id, targetSessionId),
+          task_id: callbackTaskId,
           session_id: targetSessionId,
           full_prompt: callbackMessage,
           created_by: callbackCreator,
@@ -1173,6 +1175,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             child_session_id: childSession.session_id,
             child_task_id: task.task_id,
             queued_by_user_id: callbackCreator,
+            initial_message_id: callbackTaskId as MessageID,
           },
         });
       const tenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -16,7 +16,10 @@ import {
   resolveSdkWatchdogConfig,
 } from '@agor/core/config';
 import {
+  assertTenantWritable,
   enqueueTenantDatabasePostCommitCallback,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
   shortId,
   type TaskDispatchClaimResult,
   TaskRepository,
@@ -29,6 +32,7 @@ import {
 import { type Application, BadRequest, Conflict } from '@agor/core/feathers';
 import { deriveTitleFromPrompt } from '@agor/core/sessions';
 import type {
+  AuthenticatedParams,
   ContentBlock,
   ExecutorTerminationCompleteInput,
   Paginated,
@@ -57,6 +61,7 @@ import {
   requestExecutorTermination,
 } from '../termination-coordinator.js';
 import { appendSystemMessage } from '../utils/append-system-message.js';
+import { completionCallbackTaskId } from '../utils/durable-task-id.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import {
   type ExecutorHeartbeatCallbackPayload,
@@ -86,20 +91,21 @@ function isCompletionSideEffectTaskStatus(status: Task['status'] | undefined): b
 export type TaskParams = QueryParams<{
   session_id?: string;
   status?: Task['status'];
-}> & {
-  /**
-   * Internal-only: terminal task patches normally drain queued work for the
-   * owning session. Heartbeat-loss handling must not auto-start queued prompts.
-   */
-  suppressTerminalQueueProcessing?: boolean;
-  /**
-   * Internal-only escape hatch for preserving an ephemeral BTW fork after
-   * terminal transition. Most callers should leave this unset.
-   */
-  suppressBtwCleanup?: boolean;
-  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
-  _agorSqlSessionAccessUserId?: UUID;
-};
+}> &
+  AuthenticatedParams & {
+    /**
+     * Internal-only: terminal task patches normally drain queued work for the
+     * owning session. Heartbeat-loss handling must not auto-start queued prompts.
+     */
+    suppressTerminalQueueProcessing?: boolean;
+    /**
+     * Internal-only escape hatch for preserving an ephemeral BTW fork after
+     * terminal transition. Most callers should leave this unset.
+     */
+    suppressBtwCleanup?: boolean;
+    /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+    _agorSqlSessionAccessUserId?: UUID;
+  };
 
 interface CompletionCallbackDispatchResult {
   callbackTask?: Task;
@@ -859,7 +865,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       params
     );
 
-    if (dispatchResult.callbackTask) {
+    if (dispatchResult.callbackTask?.status === TaskStatus.QUEUED) {
       // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
       // The queue processor uses a promise-based lock that will:
       // - If target is busy: wait for current processing, then retry (self-healing)
@@ -1154,26 +1160,39 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // for backward compat (legacy sessions without callback_created_by).
       const callbackCreator =
         childSession.callback_config?.callback_created_by ?? targetSession.created_by;
-      const callbackTask = await this.taskRepo.createPending({
-        session_id: targetSessionId,
-        full_prompt: callbackMessage,
-        created_by: callbackCreator,
-        status: TaskStatus.QUEUED,
-        metadata: {
-          is_agor_callback: true,
-          source: 'agor',
-          child_session_id: childSession.session_id,
-          child_task_id: task.task_id,
-          queued_by_user_id: callbackCreator,
-        },
-      });
+      const createCallbackTask = () =>
+        this.taskRepo.createPending({
+          task_id: completionCallbackTaskId(task.task_id, targetSessionId),
+          session_id: targetSessionId,
+          full_prompt: callbackMessage,
+          created_by: callbackCreator,
+          status: TaskStatus.QUEUED,
+          metadata: {
+            is_agor_callback: true,
+            source: 'agor',
+            child_session_id: childSession.session_id,
+            child_task_id: task.task_id,
+            queued_by_user_id: callbackCreator,
+          },
+        });
+      const tenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
+      const callbackTask = tenantId
+        ? await runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+            await assertTenantWritable(tenantDb, tenantId);
+            return createCallbackTask();
+          })
+        : await createCallbackTask();
 
-      // Emit so reactive-session subscribers see the new queued task.
-      this.emit?.('queued', callbackTask);
-
-      console.log(
-        `🔔 Queued callback task ${shortId(callbackTask.task_id)} on session ${shortId(targetSessionId)} from child ${shortId(childSession.session_id)}`
-      );
+      if (callbackTask.status === TaskStatus.QUEUED) {
+        // Stable identity can return a previously admitted Task. Only publish
+        // a queue notification while it is actually queued; a concurrently
+        // claimed or completed callback needs reconciliation, not another
+        // apparent enqueue.
+        this.emit?.('queued', callbackTask);
+        console.log(
+          `🔔 Queued callback task ${shortId(callbackTask.task_id)} on session ${shortId(targetSessionId)} from child ${shortId(childSession.session_id)}`
+        );
+      }
 
       // NOTE: Queue processing is handled by the centralized dispatcher after
       // it confirms a callback task was actually queued.

--- a/apps/agor-daemon/src/startup.test.ts
+++ b/apps/agor-daemon/src/startup.test.ts
@@ -135,7 +135,6 @@ describe('startup tenant database scope', () => {
     await expect(cleanupOrphanStatuses(ctx)).resolves.toMatchObject({
       orphanedTasks: [],
       orphanedSessions: [],
-      queuedTasks: [],
       sessionsResetFromOrphanedTasks: 0,
     });
     expect(baseDb.marker).toHaveBeenCalled();
@@ -173,7 +172,7 @@ describe('startup tenant database scope', () => {
     expect(baseDb.marker).not.toHaveBeenCalled();
   });
 
-  it('cleans every queued task when recovery spans multiple pages', async () => {
+  it('preserves every durable queued task for the fleet queue worker', async () => {
     const queuedTasks = Array.from({ length: 1001 }, (_, index) =>
       makeTask({ task_id: `queued-${index}`, status: TaskStatus.QUEUED })
     );
@@ -181,9 +180,9 @@ describe('startup tenant database scope', () => {
 
     await cleanupOrphanStatuses(ctx);
 
-    expect(tasksService.patch).toHaveBeenCalledTimes(queuedTasks.length);
-    expect(tasksService.find).toHaveBeenCalledWith(
-      expect.objectContaining({ query: expect.objectContaining({ $skip: 1000 }) })
+    expect(tasksService.patch).not.toHaveBeenCalled();
+    expect(tasksService.find).not.toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ status: TaskStatus.QUEUED }) })
     );
   });
 });

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -24,7 +24,7 @@ import {
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
-import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
+import { isTerminalTaskStatus, SessionStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
 import { containAllTrackedExecutors } from './executor-tracking.js';
 import { ExecutorHeartbeatSupervisor } from './services/executor-heartbeat-supervisor.js';
@@ -32,6 +32,7 @@ import type { GatewayService } from './services/gateway.js';
 import { HealthMonitor } from './services/health-monitor.js';
 import { KnowledgeEmbeddingIndexer } from './services/knowledge-embedding-indexer.js';
 import { SchedulerService } from './services/scheduler.js';
+import { SessionQueueWorker } from './services/session-queue-worker.js';
 import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { scrubManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
@@ -150,7 +151,6 @@ interface OrphanCleanupResult {
   orphanedTasks: Task[];
   orphanedSessions: Session[];
   sessionIdsWithOrphanedTasks: Set<string>;
-  queuedTasks: Task[];
   sessionsResetFromOrphanedTasks: number;
 }
 
@@ -217,29 +217,10 @@ async function cleanupOrphanStatusesInTenantScope(
     }
   }
 
-  // Wipe the queue BEFORE making any session promptable. Running tasks are marked STOPPED above,
-  // which invalidates the ordering premise of anything waiting behind them — a queued prompt
-  // typically depends on whatever was running first. Wiping here prevents the session after-patch
-  // hook (triggered below) from draining queued tasks that should be discarded.
-  const queuedTasks = await collectAllPages<Task>(
-    (skip) =>
-      tasksService.find({
-        query: { status: TaskStatus.QUEUED, $limit: 1000, $skip: skip },
-        ...startupParams,
-      }) as Promise<Task[] | Paginated<Task>>
-  );
-
-  if (queuedTasks.length > 0) {
-    for (const task of queuedTasks) {
-      await tasksService.patch(
-        task.task_id,
-        {
-          status: TaskStatus.STOPPED,
-        },
-        startupParams as never
-      );
-    }
-  }
+  // QUEUED Tasks are durable user intent. Leave them intact across daemon
+  // restarts; the fleet-wide queue worker will discover and attempt them after
+  // startup cleanup has made their Session promptable again. Active runtime
+  // cleanup above is intentionally separate from durable queue recovery.
 
   // Find all orphaned sessions (RUNNING, STOPPING, AWAITING_PERMISSION, AWAITING_INPUT, TIMED_OUT)
   const orphanedSessions: Session[] = [];
@@ -319,13 +300,12 @@ async function cleanupOrphanStatusesInTenantScope(
   // see SessionPromptState in @agor/core/types), so it is the normal resting
   // state of every read session. Discriminate by the session's most recent
   // task: only sessions whose latest task was non-terminal at boot (just
-  // orphan-stopped / queue-wiped above, or still in an executing state) were
+  // orphan-stopped above, or still in an executing state) were
   // actually interrupted; read sessions have a terminal latest task from a
   // previous run and must be left untouched.
-  const bootInterruptedTaskIds = new Set<string>([
-    ...orphanedTasks.map((t: Task) => t.task_id as string),
-    ...queuedTasks.map((t: Task) => t.task_id as string),
-  ]);
+  const bootInterruptedTaskIds = new Set<string>(
+    orphanedTasks.map((t: Task) => t.task_id as string)
+  );
 
   const idleNotReadySessions = await collectAllPages<Session>(
     (skip) =>
@@ -369,7 +349,7 @@ async function cleanupOrphanStatusesInTenantScope(
   const cleanupParts: string[] = [
     `${orphanedTasks.length} orphaned task(s) stopped`,
     `${orphanedSessions.length} active session(s) reset`,
-    `${queuedTasks.length} queued task(s) stopped`,
+    'durable queued task(s) preserved',
   ];
   if (sessionsResetFromOrphanedTasks > 0) {
     cleanupParts.push(`${sessionsResetFromOrphanedTasks} task-owned session(s) reset`);
@@ -384,7 +364,6 @@ async function cleanupOrphanStatusesInTenantScope(
     orphanedTasks,
     orphanedSessions,
     sessionIdsWithOrphanedTasks,
-    queuedTasks,
     sessionsResetFromOrphanedTasks,
   };
 }
@@ -694,7 +673,19 @@ export async function startup(ctx: StartupContext): Promise<void> {
     console.log('💓 Executor heartbeat disabled');
   }
 
-  // 6. Start scheduler service (background worker)
+  // 6. Start the all-daemon durable Session queue scanner. Discovery is
+  // bounded and may overlap freely; the database dispatch claim, not this
+  // timer, elects the launcher.
+  const queueMultiTenancy = resolveMultiTenancyConfig(config);
+  const sessionQueueWorker = new SessionQueueWorker(db, {
+    tenantId: queueMultiTenancy.mode === 'static' ? queueMultiTenancy.static_tenant_id : undefined,
+    workIdentity: ctx.distributedWorkIdentity,
+    processSession: (sessionId, params) =>
+      ctx.sessionsService.triggerQueueProcessing(sessionId, params as never),
+  });
+  sessionQueueWorker.start();
+
+  // 7. Start scheduler service (background worker)
   let schedulerService: SchedulerService | null = null;
   {
     const multiTenancy = resolveMultiTenancyConfig(config);
@@ -712,7 +703,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     schedulerService.start();
   }
 
-  // 7. Start Knowledge embedding indexer (no-op unless semantic search is configured)
+  // 8. Start Knowledge embedding indexer (no-op unless semantic search is configured)
   let knowledgeEmbeddingIndexer: KnowledgeEmbeddingIndexer | null = null;
   knowledgeEmbeddingIndexer = new KnowledgeEmbeddingIndexer(db, {
     tenantId: startupTenantParams(config).tenant.tenant_id,
@@ -721,7 +712,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
   app.set('knowledgeEmbeddingIndexer', knowledgeEmbeddingIndexer);
   console.log('🧠 Knowledge embedding indexer started');
 
-  // 8. Initialize gateway listeners. Static mode preserves the historical
+  // 9. Initialize gateway listeners. Static mode preserves the historical
   // tenant. Auth-resolved mode performs narrow global ID discovery, then
   // reloads and starts each channel under its immutable tenant identity.
   const gatewayService = safeService('gateway') as unknown as GatewayService | undefined;
@@ -736,7 +727,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     });
   }
 
-  // 8. Graceful shutdown handler
+  // 10. Graceful shutdown handler
   const shutdown = async (signal: string) => {
     console.log(`\n⏳ Received ${signal}, shutting down gracefully...`);
 
@@ -751,6 +742,10 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
       // Stop heartbeat supervisor
       heartbeatSupervisor.stop();
+
+      // Stop durable Session queue discovery. Any in-flight database claim is
+      // still safe; stop only prevents the next local scan.
+      sessionQueueWorker.stop();
 
       await containAllTrackedExecutors();
 

--- a/apps/agor-daemon/src/utils/durable-task-id.test.ts
+++ b/apps/agor-daemon/src/utils/durable-task-id.test.ts
@@ -1,0 +1,26 @@
+import type { MessageID, SessionID, TaskID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { completionCallbackTaskId, widgetAutoResumeTaskId } from './durable-task-id.js';
+
+const uuidV7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('durable internal Task identities', () => {
+  it('derives a stable widget Task identity distinct from the widget Message', () => {
+    const widgetId = '019f0000-0000-7000-8000-000000000010' as MessageID;
+    const taskId = widgetAutoResumeTaskId(widgetId);
+    expect(widgetAutoResumeTaskId(widgetId)).toBe(taskId);
+    expect(taskId).not.toBe(widgetId);
+    expect(taskId).toMatch(uuidV7);
+  });
+
+  it('derives a target-specific callback identity from the source Task', () => {
+    const source = '019f0000-0000-7000-8000-000000000001' as TaskID;
+    const target = '019f0000-0000-7000-8000-000000000002' as SessionID;
+    const taskId = completionCallbackTaskId(source, target);
+    expect(completionCallbackTaskId(source, target)).toBe(taskId);
+    expect(taskId).toMatch(uuidV7);
+    expect(
+      completionCallbackTaskId(source, '019f0000-0000-7000-8000-000000000003' as SessionID)
+    ).not.toBe(taskId);
+  });
+});

--- a/apps/agor-daemon/src/utils/durable-task-id.ts
+++ b/apps/agor-daemon/src/utils/durable-task-id.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+import type { MessageID, SessionID, TaskID } from '@agor/core/types';
+
+function stableTaskId(sourceId: string, domain: string, discriminator = ''): TaskID {
+  const digest = createHash('sha256')
+    .update(`${domain}\0${sourceId}\0${discriminator}`)
+    .digest('hex');
+  const source = sourceId.replaceAll('-', '').toLowerCase();
+  const timestampPrefix = /^[0-9a-f]{12}/.test(source) ? source.slice(0, 12) : digest.slice(0, 12);
+  const compact = `${timestampPrefix}7${digest.slice(0, 19)}`.split('');
+  compact[16] = ['8', '9', 'a', 'b'][Number.parseInt(digest[19] ?? '0', 16) % 4]!;
+  const value = compact.join('');
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}` as TaskID;
+}
+
+/** One durable Task per source completion event and callback target. */
+export function completionCallbackTaskId(sourceTaskId: TaskID, targetSessionId: SessionID): TaskID {
+  return stableTaskId(sourceTaskId, 'session_completion', targetSessionId);
+}
+
+/** One durable auto-resume Task per widget message. */
+export function widgetAutoResumeTaskId(widgetId: MessageID): TaskID {
+  return stableTaskId(widgetId, 'widget_auto_resume');
+}

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
@@ -7,6 +7,7 @@ describe('buildPromptTaskMetadata', () => {
       source: 'cli-repl',
       system_authored: true,
       queued_by_user_id: 'spoofed-user',
+      initial_message_id: 'spoofed-message-id',
     } as unknown as Parameters<typeof buildPromptTaskMetadata>[0];
 
     expect(buildPromptTaskMetadata(input, 'gateway', 'actual-user')).toEqual({

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
@@ -10,7 +10,11 @@ describe('buildPromptTaskMetadata', () => {
       initial_message_id: 'spoofed-message-id',
     } as unknown as Parameters<typeof buildPromptTaskMetadata>[0];
 
-    expect(buildPromptTaskMetadata(input, 'gateway', 'actual-user')).toEqual({
+    expect(
+      buildPromptTaskMetadata(input, 'gateway', 'actual-user', {
+        trustedInternalMetadata: true,
+      })
+    ).toEqual({
       system_authored: true,
       queued_by_user_id: 'actual-user',
       source: 'gateway',
@@ -21,6 +25,34 @@ describe('buildPromptTaskMetadata', () => {
     const input = { source: 'cli-repl' } as unknown as Parameters<
       typeof buildPromptTaskMetadata
     >[0];
-    expect(buildPromptTaskMetadata(input, undefined)).toEqual({});
+    expect(
+      buildPromptTaskMetadata(input, undefined, undefined, {
+        trustedInternalMetadata: true,
+      })
+    ).toEqual({});
+  });
+
+  it('drops every daemon-owned provenance field for an external caller', () => {
+    const input = {
+      is_agor_callback: true,
+      callback_dispatches: [{ event: 'session_completion' }],
+      child_session_id: 'child-session',
+      child_task_id: 'child-task',
+      queued_by_user_id: 'spoofed-user',
+      system_authored: true,
+      widget_id: 'spoofed-widget',
+      widget_resolved_by_user_id: 'spoofed-resolver',
+      source: 'gateway',
+      initial_message_id: 'spoofed-message',
+    } as unknown as Parameters<typeof buildPromptTaskMetadata>[0];
+
+    expect(
+      buildPromptTaskMetadata(input, 'agor', 'authenticated-user', {
+        trustedInternalMetadata: false,
+      })
+    ).toEqual({
+      queued_by_user_id: 'authenticated-user',
+      source: 'agor',
+    });
   });
 });

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildPromptTaskMetadata } from './prompt-task-metadata.js';
+import { normalizeMessageSource } from './task-runner.js';
 
 describe('buildPromptTaskMetadata', () => {
   it('drops a stale legacy source and makes normalized provenance authoritative', () => {
@@ -48,6 +49,19 @@ describe('buildPromptTaskMetadata', () => {
 
     expect(
       buildPromptTaskMetadata(input, 'agor', 'authenticated-user', {
+        trustedInternalMetadata: false,
+      })
+    ).toEqual({
+      queued_by_user_id: 'authenticated-user',
+      source: 'agor',
+    });
+  });
+
+  it('persists server-derived provenance when an external prompt spoofs gateway source', () => {
+    const source = normalizeMessageSource('gateway', { provider: 'rest' });
+
+    expect(
+      buildPromptTaskMetadata(undefined, source, 'authenticated-user', {
         trustedInternalMetadata: false,
       })
     ).toEqual({

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.ts
@@ -1,7 +1,7 @@
 import type { MessageSource, TaskMetadata } from '@agor/core/types';
 
 /** Caller-supplied prompt metadata may not claim transport provenance. */
-export type PromptTaskMetadataInput = Omit<Partial<TaskMetadata>, 'source'>;
+export type PromptTaskMetadataInput = Omit<Partial<TaskMetadata>, 'source' | 'initial_message_id'>;
 
 /**
  * Merge caller metadata with daemon-owned provenance.
@@ -15,7 +15,11 @@ export function buildPromptTaskMetadata(
   source: MessageSource | undefined,
   queuedByUserId?: string
 ): TaskMetadata {
-  const { source: _discardedSource, ...safeInput } = (input ?? {}) as Partial<TaskMetadata>;
+  const {
+    source: _discardedSource,
+    initial_message_id: _discardedInitialMessageId,
+    ...safeInput
+  } = (input ?? {}) as Partial<TaskMetadata>;
   return {
     ...safeInput,
     ...(queuedByUserId ? { queued_by_user_id: queuedByUserId } : {}),

--- a/apps/agor-daemon/src/utils/prompt-task-metadata.ts
+++ b/apps/agor-daemon/src/utils/prompt-task-metadata.ts
@@ -1,7 +1,10 @@
 import type { MessageSource, TaskMetadata } from '@agor/core/types';
 
-/** Caller-supplied prompt metadata may not claim transport provenance. */
-export type PromptTaskMetadataInput = Omit<Partial<TaskMetadata>, 'source' | 'initial_message_id'>;
+/** Internal prompt producers may request daemon-owned provenance fields. */
+export type InternalPromptTaskMetadataInput = Omit<
+  Partial<TaskMetadata>,
+  'source' | 'initial_message_id'
+>;
 
 /**
  * Merge caller metadata with daemon-owned provenance.
@@ -11,9 +14,10 @@ export type PromptTaskMetadataInput = Omit<Partial<TaskMetadata>, 'source' | 'in
  * wire. Daemon-owned fields are applied last so callers cannot override them.
  */
 export function buildPromptTaskMetadata(
-  input: PromptTaskMetadataInput | undefined,
+  input: InternalPromptTaskMetadataInput | undefined,
   source: MessageSource | undefined,
-  queuedByUserId?: string
+  queuedByUserId: string | undefined,
+  options: { trustedInternalMetadata: boolean }
 ): TaskMetadata {
   const {
     source: _discardedSource,
@@ -21,7 +25,7 @@ export function buildPromptTaskMetadata(
     ...safeInput
   } = (input ?? {}) as Partial<TaskMetadata>;
   return {
-    ...safeInput,
+    ...(options.trustedInternalMetadata ? safeInput : {}),
     ...(queuedByUserId ? { queued_by_user_id: queuedByUserId } : {}),
     ...(source ? { source } : {}),
   };

--- a/apps/agor-daemon/src/utils/session-turn-lock.ts
+++ b/apps/agor-daemon/src/utils/session-turn-lock.ts
@@ -1,24 +1,22 @@
 /**
- * Per-session "turn" lock — single source of truth for "who's allowed to
- * transition `session.status: idle → running` right now" mutual exclusion.
+ * Per-session process-local turn coalescer.
  *
- * Acquired by every code path that decides between spawning an executor
- * immediately vs. queueing:
+ * Used by code paths that prepare or drain one Session turn:
  *
- *   - `POST /sessions/:id/prompt` (idle branch) — create CREATED task + spawn,
- *     or fall through to queue if a concurrent caller already flipped the
- *     session to RUNNING while we waited for the lock.
+ *   - `POST /sessions/:id/prompt` — durably enqueue, then attempt the queue-head
+ *     dispatch claim.
  *   - `POST /tasks/:id/run` — claim a pre-existing CREATED task and spawn it.
- *   - The queue processor's drain loop (`processNextQueuedTask`) — pop the
- *     next QUEUED task and spawn it.
+ *   - The queue processor's drain loop (`processNextQueuedTask`) — inspect the
+ *     next QUEUED task and attempt its dispatch claim.
  *
  * Mutual exclusion is per-session-ID; different sessions never block each
- * other. Single-process only: multi-instance deployments would additionally
- * need a row-level DB lock or atomic conditional UPDATE on `sessions.status`.
+ * other. This Map is intentionally not correctness state: every daemon owns a
+ * different Map and process death erases it. Durable queue-position admission
+ * and the Session-first Task dispatch claim provide cross-daemon correctness.
  *
- * Both this helper and the queue processor share the same `Map<SessionID,
- * Promise<void>>` instance — that's what makes the "no two callers spawn
- * concurrently for the same session" invariant hold across all entry points.
+ * Both this helper and the queue processor share one local Map only to reduce
+ * redundant preparation and noisy claim losses. Tests for this helper pin
+ * coalescing behavior, not the one-active-turn invariant.
  */
 import type { SessionID } from '@agor/core/types';
 

--- a/apps/agor-daemon/src/utils/task-initial-message.test.ts
+++ b/apps/agor-daemon/src/utils/task-initial-message.test.ts
@@ -1,0 +1,34 @@
+import type { MessageID, Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  shouldReconcileStableInitialMessage,
+  stableInitialMessageIdForTask,
+} from './task-initial-message';
+
+describe('stable Task initial-message reconciliation', () => {
+  const stableId = 'widget-task-id' as MessageID;
+
+  it('keeps a busy-session widget Task transcript-free until queue drain claims it', () => {
+    const queued = {
+      status: TaskStatus.QUEUED,
+      metadata: { initial_message_id: stableId },
+    } as Pick<Task, 'status' | 'metadata'>;
+
+    const resolvedId = stableInitialMessageIdForTask(queued);
+    expect(resolvedId).toBe(stableId);
+    expect(shouldReconcileStableInitialMessage(queued, resolvedId)).toBe(false);
+
+    const claimed = { ...queued, status: TaskStatus.DISPATCHING };
+    expect(shouldReconcileStableInitialMessage(claimed, resolvedId)).toBe(true);
+  });
+
+  it('supports legacy scheduled Tasks while preferring persisted identity', () => {
+    const persisted = 'persisted-id' as MessageID;
+    const fallback = 'scheduled-id' as MessageID;
+    expect(
+      stableInitialMessageIdForTask({ metadata: { initial_message_id: persisted } }, fallback)
+    ).toBe(persisted);
+    expect(stableInitialMessageIdForTask({ metadata: undefined }, fallback)).toBe(fallback);
+  });
+});

--- a/apps/agor-daemon/src/utils/task-initial-message.ts
+++ b/apps/agor-daemon/src/utils/task-initial-message.ts
@@ -1,0 +1,18 @@
+import type { MessageID, Task } from '@agor/core/types';
+import { isTaskPendingDispatch } from '@agor/core/types';
+
+/** Resolve the durable transcript identity carried by an idempotent Task. */
+export function stableInitialMessageIdForTask(
+  task: Pick<Task, 'metadata'>,
+  legacyFallback?: MessageID
+): MessageID | undefined {
+  return task.metadata?.initial_message_id ?? legacyFallback;
+}
+
+/** A loser repairs projection only after another claimant crossed the fence. */
+export function shouldReconcileStableInitialMessage(
+  task: Pick<Task, 'status'>,
+  stableMessageId: MessageID | undefined
+): stableMessageId is MessageID {
+  return stableMessageId !== undefined && !isTaskPendingDispatch(task);
+}

--- a/apps/agor-daemon/src/utils/task-runner.test.ts
+++ b/apps/agor-daemon/src/utils/task-runner.test.ts
@@ -114,20 +114,20 @@ describe('runExistingTask', () => {
 });
 
 describe('normalizeMessageSource', () => {
-  it('passes through valid values', () => {
+  it('derives agor provenance for every external request', () => {
     expect(normalizeMessageSource('agor', { provider: 'rest' })).toBe('agor');
-    expect(normalizeMessageSource('gateway', { provider: 'rest' })).toBe('gateway');
-  });
-
-  it('returns undefined for undefined input', () => {
-    expect(normalizeMessageSource(undefined, { provider: 'rest' })).toBeUndefined();
-  });
-
-  it('falls back to "agor" for invalid values from external callers', () => {
+    expect(normalizeMessageSource('gateway', { provider: 'rest' })).toBe('agor');
+    expect(normalizeMessageSource(undefined, { provider: 'socketio' })).toBe('agor');
     expect(normalizeMessageSource('bogus' as unknown as 'agor', { provider: 'rest' })).toBe('agor');
   });
 
-  it('falls back to undefined for invalid values from internal calls', () => {
+  it('preserves valid provenance only for trusted internal requests', () => {
+    expect(normalizeMessageSource('agor', {})).toBe('agor');
+    expect(normalizeMessageSource('gateway', {})).toBe('gateway');
+  });
+
+  it('omits absent or invalid provenance for internal requests', () => {
+    expect(normalizeMessageSource(undefined, {})).toBeUndefined();
     expect(normalizeMessageSource('bogus' as unknown as 'agor', {})).toBeUndefined();
   });
 });

--- a/apps/agor-daemon/src/utils/task-runner.ts
+++ b/apps/agor-daemon/src/utils/task-runner.ts
@@ -3,17 +3,15 @@
  *
  * Used by `POST /tasks/:id/run` (the pure-REST executor trigger added for
  * issue #1118). Sits one level above `spawnTaskExecutor` — the canonical
- * "transition created/queued → running and fork the executor" primitive in
+ * "claim created/queued → dispatching, then fork the executor" primitive in
  * `register-routes.ts` — and adds a status revalidation step to defend
  * against patches landing between the route's initial check and the spawn
  * handoff.
  *
- * Mutual exclusion across concurrent callers is handled by
- * `withSessionTurnLock` (see `session-turn-lock.ts`), wrapped around this
- * call by the route handler. Keeping the lock concern in the route lets the
- * same session-level lock cover both `/tasks/:id/run` and
- * `/sessions/:id/prompt`, closing the cross-route race that a per-task
- * lock would miss.
+ * `withSessionTurnLock` may coalesce same-process callers around this helper,
+ * but it is not mutual exclusion across daemons. The TaskRepository's
+ * Session-first dispatch claim is the authority that closes cross-route and
+ * cross-daemon races between different Tasks for the same Session.
  */
 
 import { shortId } from '@agor/core/db';
@@ -42,9 +40,8 @@ export interface RunExistingTaskDeps {
 
 /**
  * Re-fetch a task, verify it's still in `created` state, and hand off to
- * the spawn function. Caller is responsible for any session-level locking
- * (see `withSessionTurnLock`) — this helper only concerns itself with task
- * state.
+ * the spawn function. A caller may use a local Session lock to reduce
+ * contention; the spawn function must still take the durable database claim.
  *
  * Throws:
  *   - `NotFound` if the task disappeared between the route's lookup and

--- a/apps/agor-daemon/src/utils/task-runner.ts
+++ b/apps/agor-daemon/src/utils/task-runner.ts
@@ -72,17 +72,15 @@ export async function runExistingTask(
 }
 
 /**
- * Normalize a caller-supplied `messageSource` field. Mirrors the gate used
- * by `/sessions/:id/prompt` so the two routes behave identically: invalid
- * values fall back to `'agor'` for socket/REST callers and `undefined` for
- * internal calls.
+ * Resolve message provenance at the transport boundary. External callers
+ * always represent an Agor-authored request, regardless of any stale or
+ * forged `messageSource` field on the wire. Trusted daemon-internal callers
+ * may explicitly preserve gateway provenance.
  */
 export function normalizeMessageSource(
   input: MessageSource | undefined,
   params: Params
 ): MessageSource | undefined {
-  if (input !== undefined && input !== 'gateway' && input !== 'agor') {
-    return params.provider ? 'agor' : undefined;
-  }
-  return input;
+  if (params.provider) return 'agor';
+  return input === 'gateway' || input === 'agor' ? input : undefined;
 }

--- a/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.test.ts
@@ -1,0 +1,77 @@
+import { isTenantAgenticToolEnabled } from '@agor/core/config';
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  initializeDatabase,
+  isPostgresDatabase,
+  MissingTenantDatabaseScopeError,
+  runWithTenantDatabaseScope,
+  TenantAgenticToolSettingsRepository,
+} from '@agor/core/db';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { isAgenticToolEnabledForTenant } from './tenant-agentic-tool-validation';
+
+beforeAll(() => {
+  process.env.AGOR_MASTER_SECRET ||= 'tenant-agentic-tool-validation-test-secret';
+});
+
+describe('isAgenticToolEnabledForTenant', () => {
+  dbTest('opens the guarded short tenant scope and observes disabled policy', async ({ db }) => {
+    const guarded = createTenantScopedDatabaseProxy(db, {
+      requireScope: true,
+      label: 'prompt validation test db',
+    });
+    await runWithTenantDatabaseScope(guarded, 'disabled-tenant', (tenantDb) =>
+      new TenantAgenticToolSettingsRepository(tenantDb).patch('codex', { enabled: false })
+    );
+
+    await expect(isAgenticToolEnabledForTenant(guarded, 'disabled-tenant', 'codex')).resolves.toBe(
+      false
+    );
+    await expect(isTenantAgenticToolEnabled('codex', guarded)).rejects.toBeInstanceOf(
+      MissingTenantDatabaseScopeError
+    );
+  });
+});
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'isAgenticToolEnabledForTenant (PostgreSQL)',
+  () => {
+    let rawDb: Database;
+    let guardedDb: ReturnType<typeof createTenantScopedDatabaseProxy>;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      guardedDb = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'PostgreSQL prompt validation test db',
+      });
+    });
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('reads the requested tenant disabled setting without leaking another tenant', async () => {
+      const enabledTenant = `prompt-enabled-${Date.now()}`;
+      const disabledTenant = `prompt-disabled-${Date.now()}`;
+      await runWithTenantDatabaseScope(guardedDb, disabledTenant, (tenantDb) =>
+        new TenantAgenticToolSettingsRepository(tenantDb).patch('codex', { enabled: false })
+      );
+
+      await expect(isAgenticToolEnabledForTenant(guardedDb, disabledTenant, 'codex')).resolves.toBe(
+        false
+      );
+      await expect(isAgenticToolEnabledForTenant(guardedDb, enabledTenant, 'codex')).resolves.toBe(
+        true
+      );
+    });
+  }
+);

--- a/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.ts
+++ b/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.ts
@@ -1,0 +1,21 @@
+import { isTenantAgenticToolEnabled } from '@agor/core/config';
+import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
+import type { AgenticToolName } from '@agor/core/types';
+
+/**
+ * Read tenant-owned agentic-tool policy in one short tenant database unit.
+ *
+ * Long-running orchestration routes carry tenant identity without retaining a
+ * PostgreSQL transaction. Keeping this wrapper next to their launch helpers
+ * prevents a direct repository read from silently escaping RLS (static mode)
+ * or failing the guarded database proxy (required-from-auth mode).
+ */
+export async function isAgenticToolEnabledForTenant(
+  db: TenantScopeAwareDatabase,
+  tenantId: string,
+  tool: AgenticToolName
+): Promise<boolean> {
+  return runWithTenantDatabaseScope(db, tenantId, (tenantDb) =>
+    isTenantAgenticToolEnabled(tool, tenantDb)
+  );
+}

--- a/apps/agor-daemon/src/widgets/message-boundary.test.ts
+++ b/apps/agor-daemon/src/widgets/message-boundary.test.ts
@@ -1,0 +1,183 @@
+import { feathers } from '@agor/core/feathers';
+import type { HookContext, Message, MessageID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertExternalWidgetMessageCreateAllowed,
+  protectExternalWidgetMessageWrites,
+} from './message-boundary';
+
+const externalParams = { provider: 'rest' } as never;
+
+function widgetMessage(status: 'pending' | 'resolving' | 'submitted'): Message {
+  const messageId = 'widget-message' as MessageID;
+  return {
+    message_id: messageId,
+    session_id: 'session-1' as never,
+    type: 'widget_request',
+    role: MessageRole.SYSTEM,
+    index: 0,
+    timestamp: '2026-08-06T00:00:00.000Z',
+    content_preview: 'Resolve',
+    content: 'Resolve',
+    metadata: {
+      widget: {
+        widget_id: messageId,
+        widget_type: 'test',
+        schema_version: 1,
+        params: {},
+        status,
+        requested_at: '2026-08-06T00:00:00.000Z',
+        ...(status === 'resolving'
+          ? {
+              resolution_claim: {
+                token: 'claim-token',
+                action: 'submit' as const,
+                claimed_at: '2026-08-06T00:00:01.000Z',
+                claimed_by: 'user-1' as never,
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+function ordinaryMessage(): Message {
+  return {
+    message_id: 'ordinary-message' as MessageID,
+    session_id: 'session-1' as never,
+    type: 'user',
+    role: MessageRole.USER,
+    index: 1,
+    timestamp: '2026-08-06T00:00:02.000Z',
+    content_preview: 'hello',
+    content: 'hello',
+  };
+}
+
+function makeTransportService(seed: Message[]) {
+  const rows = new Map(seed.map((message) => [message.message_id as string, message]));
+  const app = feathers();
+  app.use('messages', {
+    async create(data: Message) {
+      rows.set(data.message_id, data);
+      return data;
+    },
+    async update(id: string, data: Partial<Message>) {
+      const next = { ...rows.get(id)!, ...data } as Message;
+      rows.set(id, next);
+      return next;
+    },
+    async patch(id: string, data: Partial<Message>) {
+      const next = { ...rows.get(id)!, ...data } as Message;
+      rows.set(id, next);
+      return next;
+    },
+    async remove(id: string) {
+      const current = rows.get(id)!;
+      rows.delete(id);
+      return current;
+    },
+  } as never);
+  const service = app.service('messages') as unknown as {
+    hooks(hooks: {
+      before: Record<
+        'create' | 'update' | 'patch' | 'remove',
+        Array<(context: HookContext) => Promise<HookContext>>
+      >;
+    }): void;
+    create(data: Message, params?: unknown): Promise<Message>;
+    update(id: string, data: Partial<Message>, params?: unknown): Promise<Message>;
+    patch(id: string, data: Partial<Message>, params?: unknown): Promise<Message>;
+    remove(id: string, params?: unknown): Promise<Message>;
+  };
+  const boundary = protectExternalWidgetMessageWrites(async (id) => rows.get(id) ?? null);
+  service.hooks({
+    before: {
+      create: [boundary],
+      update: [boundary],
+      patch: [boundary],
+      remove: [boundary],
+    },
+  });
+  return { rows, service };
+}
+
+describe('external widget Message boundary', () => {
+  let pending: Message;
+  let resolving: Message;
+
+  beforeEach(() => {
+    pending = widgetMessage('pending');
+    resolving = { ...widgetMessage('resolving'), message_id: 'resolving-widget' as MessageID };
+  });
+
+  it('rejects transport creation of widget messages and widget metadata', async () => {
+    const { service } = makeTransportService([]);
+    await expect(service.create(pending, externalParams)).rejects.toThrow(
+      'only be created by the daemon'
+    );
+    await expect(
+      service.create(
+        {
+          ...ordinaryMessage(),
+          metadata: pending.metadata,
+        },
+        externalParams
+      )
+    ).rejects.toThrow('only be created by the daemon');
+    expect(() => assertExternalWidgetMessageCreateAllowed([ordinaryMessage(), pending])).toThrow(
+      'only be created by the daemon'
+    );
+  });
+
+  it('rejects transport attempts to reset or replace a live widget claim', async () => {
+    const { rows, service } = makeTransportService([pending, resolving]);
+    await expect(
+      service.patch(
+        resolving.message_id,
+        {
+          metadata: {
+            widget: { ...resolving.metadata!.widget!, status: 'pending' },
+          },
+        },
+        externalParams
+      )
+    ).rejects.toThrow('daemon-owned');
+    await expect(service.update(resolving.message_id, pending, externalParams)).rejects.toThrow(
+      'not available to external callers'
+    );
+    expect(rows.get(resolving.message_id)?.metadata?.widget?.status).toBe('resolving');
+  });
+
+  it('rejects removal while pending or resolving but permits terminal cleanup', async () => {
+    const terminal = widgetMessage('submitted');
+    terminal.message_id = 'terminal-widget' as MessageID;
+    const { rows, service } = makeTransportService([pending, resolving, terminal]);
+
+    await expect(service.remove(pending.message_id, externalParams)).rejects.toThrow(
+      'cannot be removed externally'
+    );
+    await expect(service.remove(resolving.message_id, externalParams)).rejects.toThrow(
+      'cannot be removed externally'
+    );
+    await expect(service.remove(terminal.message_id, externalParams)).resolves.toMatchObject({
+      message_id: terminal.message_id,
+    });
+    expect(rows.has(terminal.message_id)).toBe(false);
+  });
+
+  it('keeps ordinary patching and trusted internal widget work available', async () => {
+    const ordinary = ordinaryMessage();
+    const { rows, service } = makeTransportService([ordinary, pending]);
+
+    await expect(
+      service.patch(ordinary.message_id, { content: 'edited' }, externalParams)
+    ).resolves.toMatchObject({ content: 'edited' });
+    await expect(
+      service.patch(pending.message_id, { content: 'daemon projection' })
+    ).resolves.toMatchObject({ content: 'daemon projection' });
+    expect(rows.get(pending.message_id)?.content).toBe('daemon projection');
+  });
+});

--- a/apps/agor-daemon/src/widgets/message-boundary.ts
+++ b/apps/agor-daemon/src/widgets/message-boundary.ts
@@ -1,0 +1,72 @@
+import { Forbidden } from '@agor/core/feathers';
+import type { HookContext, Message, MessageID } from '@agor/core/types';
+
+export type WidgetMessageLoader = (messageId: MessageID) => Promise<Message | null>;
+
+const TERMINAL_WIDGET_STATUSES = new Set(['submitted', 'dismissed', 'already_present']);
+
+function declaresWidgetMessage(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const record = data as Record<string, unknown>;
+  const metadata = record.metadata;
+  return (
+    record.type === 'widget_request' ||
+    (!!metadata && typeof metadata === 'object' && !Array.isArray(metadata) && 'widget' in metadata)
+  );
+}
+
+/** Reject public single/bulk DTOs that attempt to mint daemon-owned widgets. */
+export function assertExternalWidgetMessageCreateAllowed(data: unknown): void {
+  const writes = Array.isArray(data) ? data : [data];
+  if (writes.some(declaresWidgetMessage)) {
+    throw new Forbidden('Widget messages can only be created by the daemon');
+  }
+}
+
+/**
+ * Keep widget creation and lifecycle state behind daemon-owned routes.
+ *
+ * The durable resolution token only fences cooperating writers. External
+ * generic Message CRUD must not be able to mint a widget, replace/patch its
+ * metadata, or remove an in-flight claim and thereby reopen its external
+ * effect. Internal calls remain available for trusted daemon projections.
+ */
+export function protectExternalWidgetMessageWrites(loadMessage: WidgetMessageLoader) {
+  return async (context: HookContext): Promise<HookContext> => {
+    if (!context.params.provider) return context;
+
+    if (context.method === 'create') {
+      assertExternalWidgetMessageCreateAllowed(context.data);
+      return context;
+    }
+
+    // Complete replacement is not part of the public Message contract. Apart
+    // from lacking a safe field allowlist, it could erase a widget claim in
+    // one write. The transport method is also omitted at registration.
+    if (context.method === 'update') {
+      throw new Forbidden('Message replacement is not available to external callers');
+    }
+
+    if (context.method !== 'patch' && context.method !== 'remove') return context;
+    if (context.id === null || context.id === undefined) {
+      throw new Forbidden('Bulk external message mutation is not supported');
+    }
+    if (context.method === 'patch' && declaresWidgetMessage(context.data)) {
+      throw new Forbidden('Widget lifecycle metadata is daemon-owned');
+    }
+
+    const message = await loadMessage(String(context.id) as MessageID);
+    const widget = message?.metadata?.widget;
+    const isWidget = message?.type === 'widget_request' || widget !== undefined;
+    if (!isWidget) return context;
+
+    if (context.method === 'patch') {
+      throw new Forbidden('Widget messages can only be changed through widget resolution routes');
+    }
+
+    if (!widget || !TERMINAL_WIDGET_STATUSES.has(widget.status)) {
+      throw new Forbidden('Pending or resolving widget messages cannot be removed externally');
+    }
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/widgets/registry.ts
+++ b/apps/agor-daemon/src/widgets/registry.ts
@@ -74,6 +74,12 @@ export interface WidgetRegistryEntry<TParams, TSubmit, TResultMeta> {
    * `params` is the original agent-provided params stored on the widget row —
    * available so the handler can cross-check the submit body against what was
    * originally requested (e.g. env_vars validates names match exactly).
+   *
+   * The durable resolver releases a live claim after this method reports an
+   * error so the user can correct and retry the widget. Implementations must
+   * make that deliberate retry safe (normally by writing desired state
+   * idempotently). Daemon death after an unknown outcome is different: the
+   * claim stays `resolving` and is not replayed.
    */
   applySubmit: (ctx: WidgetSubmitCtx, submit: TSubmit, params: TParams) => Promise<void>;
   /**

--- a/apps/agor-daemon/src/widgets/resolution-store.test.ts
+++ b/apps/agor-daemon/src/widgets/resolution-store.test.ts
@@ -1,0 +1,129 @@
+import type { Message, MessageID, UserID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { WidgetResolutionStore } from './resolution-store';
+
+function createAtomicRepository() {
+  let message: Message = {
+    message_id: 'widget-1' as MessageID,
+    session_id: 'session-1' as never,
+    type: 'widget_request',
+    role: 'system' as never,
+    index: 0,
+    timestamp: '2026-08-06T00:00:00.000Z',
+    content_preview: 'Resolve',
+    content: 'Resolve',
+    metadata: {
+      widget: {
+        widget_id: 'widget-1' as MessageID,
+        widget_type: 'test',
+        schema_version: 1,
+        params: {},
+        status: 'pending',
+        requested_at: '2026-08-06T00:00:00.000Z',
+      },
+    },
+  };
+  let tail = Promise.resolve();
+  const repository = {
+    mutateMetadataLocked(
+      _id: MessageID,
+      mutation: (metadata: Message['metadata'], current: Message) => Message['metadata'] | null
+    ) {
+      const result = tail.then(() => {
+        const metadata = mutation(message.metadata, message);
+        if (metadata === null) return { changed: false, message };
+        message = { ...message, metadata };
+        return { changed: true, message };
+      });
+      tail = result.then(() => undefined);
+      return result;
+    },
+  };
+  return {
+    repository,
+    get message() {
+      return message;
+    },
+  };
+}
+
+describe('WidgetResolutionStore', () => {
+  it('elects one resolver across daemon-local store instances and conflicting actions', async () => {
+    const state = createAtomicRepository();
+    const stores = Array.from({ length: 5 }, () => new WidgetResolutionStore(state.repository));
+    const claims = await Promise.all(
+      stores.map((store, index) =>
+        store.claim('widget-1' as MessageID, {
+          token: `claim-${index}`,
+          action: index % 2 === 0 ? 'submit' : 'dismiss',
+          claimedAt: '2026-08-06T00:00:01.000Z',
+          claimedBy: `user-${index}` as UserID,
+        })
+      )
+    );
+
+    expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
+    expect(state.message.metadata?.widget?.status).toBe('resolving');
+  });
+
+  it('only lets the opaque claim token complete the resolution', async () => {
+    const state = createAtomicRepository();
+    const store = new WidgetResolutionStore(state.repository);
+    await store.claim('widget-1' as MessageID, {
+      token: 'winner',
+      action: 'submit',
+      claimedAt: '2026-08-06T00:00:01.000Z',
+      claimedBy: 'user-1' as UserID,
+    });
+
+    expect(
+      await store.complete('widget-1' as MessageID, 'loser', {
+        status: 'submitted',
+        resolvedAt: '2026-08-06T00:00:02.000Z',
+        submittedBy: 'user-2' as UserID,
+      })
+    ).toMatchObject({ outcome: 'claim_lost' });
+    expect(
+      await store.complete('widget-1' as MessageID, 'winner', {
+        status: 'submitted',
+        resolvedAt: '2026-08-06T00:00:02.000Z',
+        submittedBy: 'user-1' as UserID,
+        resultMeta: { names: ['TOKEN'] },
+      })
+    ).toMatchObject({ outcome: 'updated' });
+    expect(state.message.metadata?.widget).toMatchObject({
+      status: 'submitted',
+      submitted_by: 'user-1',
+      result_meta: { names: ['TOKEN'] },
+    });
+    expect(state.message.metadata?.widget?.resolution_claim).toBeUndefined();
+  });
+
+  it('durably diagnoses a reported failure and permits a deliberate retry', async () => {
+    const state = createAtomicRepository();
+    const store = new WidgetResolutionStore(state.repository);
+    await store.claim('widget-1' as MessageID, {
+      token: 'winner',
+      action: 'submit',
+      claimedAt: '2026-08-06T00:00:01.000Z',
+      claimedBy: 'user-1' as UserID,
+    });
+    await store.fail('widget-1' as MessageID, 'winner', {
+      failedAt: '2026-08-06T00:00:02.000Z',
+      errorCode: 'external_failure',
+    });
+
+    expect(state.message.metadata?.widget).toMatchObject({
+      status: 'pending',
+      resolution_failure: { error_code: 'external_failure' },
+    });
+    expect(
+      await new WidgetResolutionStore(state.repository).claim('widget-1' as MessageID, {
+        token: 'retry',
+        action: 'submit',
+        claimedAt: '2026-08-06T00:00:03.000Z',
+        claimedBy: 'user-1' as UserID,
+      })
+    ).toMatchObject({ outcome: 'claimed' });
+  });
+});

--- a/apps/agor-daemon/src/widgets/resolution-store.ts
+++ b/apps/agor-daemon/src/widgets/resolution-store.ts
@@ -1,0 +1,130 @@
+import type { MessagesRepository } from '@agor/core/db';
+import type { Message, MessageID, UserID, WidgetMessageMetadata } from '@agor/core/types';
+
+export interface WidgetResolutionClaimInput {
+  token: string;
+  action: 'submit' | 'dismiss';
+  claimedAt: string;
+  claimedBy: UserID;
+}
+
+export type WidgetResolutionClaimResult =
+  | { outcome: 'claimed'; message: Message }
+  | { outcome: 'not_pending'; message: Message };
+
+export type WidgetResolutionFinishResult =
+  | { outcome: 'updated'; message: Message }
+  | { outcome: 'claim_lost'; message: Message };
+
+type LockedMetadataRepository = Pick<MessagesRepository, 'mutateMetadataLocked'>;
+
+/**
+ * Durable widget-resolution state machine.
+ *
+ * Every method is one short Message-row transaction. Registry handlers and
+ * other external work run only after `claim` commits and before `complete` or
+ * `fail` starts. An abandoned `resolving` claim is intentionally never
+ * reclaimed automatically: the daemon cannot know whether the prior external
+ * handler completed before dying, so replay could duplicate secret writes or
+ * connector restarts. The persisted claim is the recovery diagnosis. A
+ * handler that reports failure releases its claim back to `pending` with a
+ * secret-free diagnosis; registry handlers must make a deliberate retry after
+ * a reported error safe.
+ */
+export class WidgetResolutionStore {
+  constructor(
+    private readonly messages: LockedMetadataRepository,
+    private readonly onChanged?: (message: Message) => void
+  ) {}
+
+  async claim(
+    widgetId: MessageID,
+    input: WidgetResolutionClaimInput
+  ): Promise<WidgetResolutionClaimResult> {
+    const result = await this.messages.mutateMetadataLocked(widgetId, (metadata) => {
+      const widget = metadata?.widget;
+      if (widget?.status !== 'pending') return null;
+      return {
+        ...metadata,
+        widget: {
+          ...widget,
+          status: 'resolving',
+          resolution_claim: {
+            token: input.token,
+            action: input.action,
+            claimed_at: input.claimedAt,
+            claimed_by: input.claimedBy,
+          },
+          resolution_failure: undefined,
+        },
+      };
+    });
+    if (!result.changed) return { outcome: 'not_pending', message: result.message };
+    this.publishChanged(result.message);
+    return { outcome: 'claimed', message: result.message };
+  }
+
+  async complete(
+    widgetId: MessageID,
+    token: string,
+    input: {
+      status: 'submitted' | 'dismissed';
+      resolvedAt: string;
+      submittedBy: UserID;
+      resultMeta?: unknown;
+    }
+  ): Promise<WidgetResolutionFinishResult> {
+    return this.finish(widgetId, token, (widget) => ({
+      ...widget,
+      status: input.status,
+      resolved_at: input.resolvedAt,
+      submitted_by: input.submittedBy,
+      ...(input.resultMeta !== undefined ? { result_meta: input.resultMeta } : {}),
+      resolution_claim: undefined,
+      resolution_failure: undefined,
+    }));
+  }
+
+  async fail(
+    widgetId: MessageID,
+    token: string,
+    input: { failedAt: string; errorCode: string }
+  ): Promise<WidgetResolutionFinishResult> {
+    return this.finish(widgetId, token, (widget) => ({
+      ...widget,
+      status: 'pending',
+      resolution_claim: undefined,
+      resolution_failure: {
+        failed_at: input.failedAt,
+        error_code: input.errorCode,
+      },
+    }));
+  }
+
+  private async finish(
+    widgetId: MessageID,
+    token: string,
+    update: (widget: WidgetMessageMetadata) => WidgetMessageMetadata
+  ): Promise<WidgetResolutionFinishResult> {
+    const result = await this.messages.mutateMetadataLocked(widgetId, (metadata) => {
+      const widget = metadata?.widget;
+      if (widget?.status !== 'resolving' || widget.resolution_claim?.token !== token) {
+        return null;
+      }
+      return { ...metadata, widget: update(widget) };
+    });
+    if (!result.changed) return { outcome: 'claim_lost', message: result.message };
+    this.publishChanged(result.message);
+    return { outcome: 'updated', message: result.message };
+  }
+
+  private publishChanged(message: Message): void {
+    try {
+      this.onChanged?.(message);
+    } catch (error) {
+      // Persistence already committed. Realtime delivery is best effort and a
+      // later transcript reload observes the durable state.
+      console.warn('[widgets] failed to publish durable resolution state:', error);
+    }
+  }
+}

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -38,7 +38,12 @@ interface MockEvent {
   payload: unknown;
 }
 
-function makeApp(records: { message: Message; session: Session; branch: Branch }) {
+function makeApp(
+  records: { message: Message; session: Session; branch: Branch },
+  options: {
+    promptCreate?: (data: unknown, params: unknown) => Promise<unknown>;
+  } = {}
+) {
   const calls: MockServiceCall[] = [];
   const events: MockEvent[] = [];
   let currentMessage = records.message;
@@ -119,6 +124,7 @@ function makeApp(records: { message: Message; session: Session; branch: Branch }
           data,
           params,
         });
+        if (options.promptCreate) return options.promptCreate(data, params);
         return { task_id: 'task-mock' };
       },
     },
@@ -590,6 +596,75 @@ describe('resolveWidget', () => {
     expect(failed.metadata.widget.resolution_failure?.error_code).toBeTruthy();
     expect(JSON.stringify(failed)).not.toContain('secret-key');
     expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('does not reopen the claim when prompt admission fails after its Task committed', async () => {
+    const { applySubmit } = registerTestWidget();
+    const fixtures = makeFixtures();
+    const committedTaskIds: string[] = [];
+    const state = makeApp(fixtures, {
+      promptCreate: async (data) => {
+        const taskId = (data as { idempotencyTaskId: string }).idempotencyTaskId;
+        committedTaskIds.push(taskId);
+        throw new Error('response lost after durable Task commit');
+      },
+    });
+    const resolve = () =>
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        {
+          app: state.app as never,
+          resolutionStore: state.resolutionStore,
+          isBranchOwner: async () => false,
+        }
+      );
+
+    await expect(resolve()).rejects.toThrow('response lost after durable Task commit');
+    expect(state.currentMessage.metadata?.widget?.status).toBe('resolving');
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+    expect(committedTaskIds).toEqual([widgetAutoResumeTaskId('widget-msg-1' as MessageID)]);
+
+    await expect(resolve()).rejects.toThrow(/already resolving/);
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+    expect(
+      state.calls.filter(
+        (call) => call.service === '/sessions/:id/prompt' && call.method === 'create'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('does not replay side effects when terminal completion has an unknown outcome', async () => {
+    const { applySubmit } = registerTestWidget();
+    const fixtures = makeFixtures();
+    const state = makeApp(fixtures);
+    vi.spyOn(state.resolutionStore, 'complete').mockRejectedValueOnce(
+      new Error('transient completion failure')
+    );
+    const resolve = () =>
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        {
+          app: state.app as never,
+          resolutionStore: state.resolutionStore,
+          isBranchOwner: async () => false,
+        }
+      );
+
+    await expect(resolve()).rejects.toThrow('transient completion failure');
+    expect(state.currentMessage.metadata?.widget?.status).toBe('resolving');
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+    expect(
+      state.calls.filter(
+        (call) => call.service === '/sessions/:id/prompt' && call.method === 'create'
+      )
+    ).toHaveLength(1);
+
+    await expect(resolve()).rejects.toThrow(/already resolving/);
+    expect(applySubmit).toHaveBeenCalledTimes(1);
   });
 
   it('serializes concurrent resolutions on the same widget — only one applySubmit fires', async () => {

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -16,9 +16,10 @@
  */
 
 import { BadRequest } from '@agor/core/feathers';
-import type { Branch, Message, Session, UserID } from '@agor/core/types';
+import type { Branch, Message, MessageID, Session, UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { widgetAutoResumeTaskId } from '../utils/durable-task-id.js';
 import { _resetWidgetRegistryForTests, registerWidget, type WidgetRegistryEntry } from './registry';
 import { canResolveWidget, resolveWidget } from './submissions';
 
@@ -291,6 +292,7 @@ describe('resolveWidget', () => {
     expect(promptCall).toBeDefined();
     const promptData = promptCall?.data as {
       prompt: string;
+      idempotencyTaskId: string;
       metadata: { system_authored: boolean; widget_id: string };
     };
     expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
@@ -298,6 +300,8 @@ describe('resolveWidget', () => {
     expect(promptData.prompt).not.toContain('secret-key');
     expect(promptData.metadata.system_authored).toBe(true);
     expect(promptData.metadata.widget_id).toBe('widget-msg-1');
+    expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId('widget-msg-1' as MessageID));
+    expect(promptData.idempotencyTaskId).not.toBe('widget-msg-1');
 
     // WebSocket event fired.
     const event = events.find((e) => e.event === 'widget:resolved');

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { widgetAutoResumeTaskId } from '../utils/durable-task-id.js';
 import { _resetWidgetRegistryForTests, registerWidget, type WidgetRegistryEntry } from './registry';
+import { WidgetResolutionStore } from './resolution-store';
 import { canResolveWidget, resolveWidget } from './submissions';
 
 interface MockServiceCall {
@@ -41,6 +42,20 @@ function makeApp(records: { message: Message; session: Session; branch: Branch }
   const calls: MockServiceCall[] = [];
   const events: MockEvent[] = [];
   let currentMessage = records.message;
+  const resolutionStore = new WidgetResolutionStore({
+    async mutateMetadataLocked(_id, mutation) {
+      const metadata = mutation(currentMessage.metadata, currentMessage);
+      if (metadata === null) return { changed: false, message: currentMessage };
+      currentMessage = { ...currentMessage, metadata };
+      calls.push({
+        service: 'messages',
+        method: 'patch',
+        id: currentMessage.message_id,
+        data: { metadata },
+      });
+      return { changed: true, message: currentMessage };
+    },
+  });
 
   const services = {
     messages: {
@@ -119,6 +134,7 @@ function makeApp(records: { message: Message; session: Session; branch: Branch }
 
   return {
     app,
+    resolutionStore,
     calls,
     events,
     get currentMessage() {
@@ -253,13 +269,13 @@ describe('resolveWidget', () => {
   it('submits a pending widget: dispatches to applySubmit, patches status, queues auto-resume, broadcasts', async () => {
     const { applySubmit } = registerTestWidget();
     const fixtures = makeFixtures();
-    const { app, calls, events } = makeApp(fixtures);
+    const { app, calls, events, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
 
     expect(result).toEqual({
@@ -271,7 +287,15 @@ describe('resolveWidget', () => {
 
     // Message was patched with submitted status + result_meta + resolved_at +
     // submitted_by. The secret value MUST NOT appear in the patch.
-    const messagePatch = calls.find((c) => c.service === 'messages' && c.method === 'patch');
+    const messagePatch = calls
+      .filter(
+        (c) =>
+          c.service === 'messages' &&
+          c.method === 'patch' &&
+          (c.data as { metadata?: { widget?: { status?: string } } }).metadata?.widget?.status ===
+            'submitted'
+      )
+      .at(-1);
     expect(messagePatch).toBeDefined();
     const patchedData = messagePatch?.data as {
       metadata: {
@@ -293,15 +317,21 @@ describe('resolveWidget', () => {
     const promptData = promptCall?.data as {
       prompt: string;
       idempotencyTaskId: string;
-      metadata: { system_authored: boolean; widget_id: string };
+      metadata: {
+        system_authored: boolean;
+        widget_id: string;
+        widget_resolved_by_user_id: string;
+      };
     };
     expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
     expect(promptData.prompt).toContain('global');
     expect(promptData.prompt).not.toContain('secret-key');
     expect(promptData.metadata.system_authored).toBe(true);
     expect(promptData.metadata.widget_id).toBe('widget-msg-1');
+    expect(promptData.metadata.widget_resolved_by_user_id).toBe('creator-user-id');
     expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId('widget-msg-1' as MessageID));
     expect(promptData.idempotencyTaskId).not.toBe('widget-msg-1');
+    expect(calls.indexOf(promptCall!)).toBeLessThan(calls.indexOf(messagePatch!));
 
     // WebSocket event fired.
     const event = events.find((e) => e.event === 'widget:resolved');
@@ -312,14 +342,14 @@ describe('resolveWidget', () => {
   it('rejects a submission from a non-creator without prompt-tier RBAC', async () => {
     registerTestWidget();
     const fixtures = makeFixtures({ branchOthersCan: 'session' });
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
         { user_id: 'someone-else' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/session creator|prompt/);
   });
@@ -327,42 +357,49 @@ describe('resolveWidget', () => {
   it('allows a submission from a non-creator with prompt-tier RBAC', async () => {
     registerTestWidget();
     const fixtures = makeFixtures({ branchOthersCan: 'prompt' });
-    const { app } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
       { user_id: 'someone-else' as UserID },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
     expect(result.status).toBe('submitted');
+    const promptCall = calls.find(
+      (call) => call.service === '/sessions/:id/prompt' && call.method === 'create'
+    );
+    expect(promptCall?.params).toMatchObject({ user: { user_id: 'creator-user-id' } });
+    expect(promptCall?.data).toMatchObject({
+      metadata: { widget_resolved_by_user_id: 'someone-else' },
+    });
   });
 
   it('rejects a double-submit (idempotency: status must be pending)', async () => {
     registerTestWidget();
     const fixtures = makeFixtures({ widgetStatus: 'submitted' });
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'k', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/already submitted/);
   });
 
   it('rejects an unknown widget type on submit (registry miss)', async () => {
     const fixtures = makeFixtures({ widgetType: 'unknown_type' });
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: {} },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/not registered/);
   });
@@ -370,13 +407,13 @@ describe('resolveWidget', () => {
   it('skips auto-resume task when auto_resume: false', async () => {
     registerTestWidget();
     const fixtures = makeFixtures({ autoResume: false });
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'submit', body: { value: 'k', scope: 'global' } },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
 
     expect(result.auto_resume_queued).toBe(false);
@@ -387,13 +424,13 @@ describe('resolveWidget', () => {
     const applySubmit = vi.fn(async () => {});
     registerTestWidget(applySubmit);
     const fixtures = makeFixtures();
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
 
     expect(result.status).toBe('dismissed');
@@ -409,13 +446,13 @@ describe('resolveWidget', () => {
 
   it('dismissal works even for an unknown widget type (fallback prompt)', async () => {
     const fixtures = makeFixtures({ widgetType: 'unknown_type' });
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
 
     expect(result.status).toBe('dismissed');
@@ -435,14 +472,14 @@ describe('resolveWidget', () => {
       }
     });
     const fixtures = makeFixtures();
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'dismiss' },
         { user_id: 'creator-user-id' as UserID, role: 'member' },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/admin/i);
 
@@ -458,14 +495,14 @@ describe('resolveWidget', () => {
       }
     });
     const fixtures = makeFixtures();
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'dismiss' },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/admin/i);
 
@@ -479,13 +516,13 @@ describe('resolveWidget', () => {
       }
     });
     const fixtures = makeFixtures();
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     const result = await resolveWidget(
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID, role: 'admin' },
-      { app: app as never, isBranchOwner: async () => false }
+      { app: app as never, resolutionStore, isBranchOwner: async () => false }
     );
 
     expect(result.status).toBe('dismissed');
@@ -494,14 +531,14 @@ describe('resolveWidget', () => {
   it('throws NotAuthenticated when caller is undefined', async () => {
     registerTestWidget();
     const fixtures = makeFixtures();
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'k', scope: 'global' } },
         undefined,
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/Authentication/);
   });
@@ -509,19 +546,19 @@ describe('resolveWidget', () => {
   it('rejects an invalid submit body (Zod schema mismatch)', async () => {
     registerTestWidget();
     const fixtures = makeFixtures();
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { scope: 'invalid-scope' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/Invalid submit/);
   });
 
-  it('propagates structured per-field applySubmit errors without patching the widget', async () => {
+  it('propagates applySubmit errors and durably diagnoses the claimed attempt', async () => {
     const { applySubmit } = registerTestWidget(
       vi.fn(async () => {
         throw new BadRequest('Field validation failed', {
@@ -530,27 +567,35 @@ describe('resolveWidget', () => {
       })
     );
     const fixtures = makeFixtures();
-    const { app, calls } = makeApp(fixtures);
+    const { app, calls, resolutionStore } = makeApp(fixtures);
 
     await expect(
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       )
     ).rejects.toMatchObject({
       data: { field_errors: { HUBSPOT_API_KEY: 'Invalid saved value selection' } },
     });
 
     expect(applySubmit).toHaveBeenCalledTimes(1);
-    expect(calls.find((c) => c.service === 'messages' && c.method === 'patch')).toBeUndefined();
+    const patches = calls.filter((c) => c.service === 'messages' && c.method === 'patch');
+    expect(patches).toHaveLength(2);
+    const failed = patches.at(-1)?.data as {
+      metadata: { widget: { status: string; resolution_failure?: { error_code: string } } };
+    };
+    expect(failed.metadata.widget.status).toBe('pending');
+    expect(failed.metadata.widget.resolution_failure?.error_code).toBeTruthy();
+    expect(JSON.stringify(failed)).not.toContain('secret-key');
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
   });
 
   it('serializes concurrent resolutions on the same widget — only one applySubmit fires', async () => {
     const { applySubmit } = registerTestWidget();
     const fixtures = makeFixtures();
-    const { app } = makeApp(fixtures);
+    const { app, resolutionStore } = makeApp(fixtures);
 
     // Two callers hit submit in the same tick. The lock should let one
     // through to terminal state; the second sees `status !== 'pending'` and
@@ -560,13 +605,13 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'one', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       ),
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'two', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, isBranchOwner: async () => false }
+        { app: app as never, resolutionStore, isBranchOwner: async () => false }
       ),
     ]);
 

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -250,78 +250,81 @@ async function doResolveWidget(
     throw new Forbidden(`Widget ${widgetId} is already ${status}; cannot ${action.kind} again.`);
   }
 
-  try {
-    if (action.kind === 'submit') {
-      // The registry entry and parsed payload are established before the
-      // claim; only the durable winner reaches this external-work boundary.
+  if (action.kind === 'submit') {
+    // The registry entry and parsed payload are established before the claim;
+    // only the durable winner reaches this external-work boundary. A handler
+    // that explicitly reports failure is the sole safe case for reopening the
+    // widget: no later admission/completion failure may replay this effect.
+    try {
       await entry!.applySubmit(ctx, parsedSubmit, widget.params);
-      resultMeta = entry!.buildResultMeta(parsedSubmit);
-      autoResumePrompt = entry!.buildAutoResumePrompt(resultMeta, widget.params);
+    } catch (error) {
+      await deps.resolutionStore.fail(widget.widget_id, claimToken, {
+        failedAt: new Date().toISOString(),
+        errorCode: structuredLogErrorCode(error),
+      });
+      throw error;
     }
-
-    // 6. Admit auto-resume before publishing terminal widget state. If this
-    // process dies after admission, the stable Task and initial-message IDs
-    // remain discoverable by another daemon's queue worker.
-    let autoResumeQueued = false;
-    if (widget.auto_resume !== false && autoResumePrompt) {
-      await deps.app.service('/sessions/:id/prompt').create(
-        {
-          prompt: autoResumePrompt,
-          messageSource: 'agor',
-          idempotencyTaskId: widgetAutoResumeTaskId(widget.widget_id),
-          metadata: {
-            system_authored: true,
-            widget_id: widget.widget_id,
-            widget_resolved_by_user_id: caller.user_id,
-          },
-        },
-        {
-          // Stable widget identity must also have stable Task attribution.
-          // The widget row records the actual resolver separately.
-          user: { user_id: session.created_by },
-          route: { id: message.session_id },
-        }
-      );
-      autoResumeQueued = true;
-    }
-
-    // 7. Only the claim token can publish the terminal resolution.
-    const newStatus: WidgetMessageMetadata['status'] =
-      action.kind === 'submit' ? 'submitted' : 'dismissed';
-    const resolvedAt = new Date().toISOString();
-    const finished = await deps.resolutionStore.complete(widget.widget_id, claimToken, {
-      status: newStatus,
-      resolvedAt,
-      submittedBy: caller.user_id,
-      resultMeta,
-    });
-    if (finished.outcome !== 'updated') {
-      throw new Conflict(`Widget ${widgetId} resolution claim was lost before completion`);
-    }
-
-    // 8. Broadcast on the messages service's room (per-session subscribers
-    // are already wired up to that channel — see register-services.ts).
-    const resolvedPayload = {
-      widget_id: widget.widget_id,
-      session_id: message.session_id,
-      status: newStatus,
-      result_meta: resultMeta,
-      resolved_at: resolvedAt,
-      submitted_by: caller.user_id,
-    };
-    if (deps.publishResolved) deps.publishResolved(resolvedPayload);
-    else deps.app.service('messages').emit?.('widget:resolved', resolvedPayload);
-
-    return {
-      widget_id: widget.widget_id,
-      status: newStatus,
-      auto_resume_queued: autoResumeQueued,
-    };
-  } catch (error) {
-    await deps.resolutionStore.fail(widget.widget_id, claimToken, {
-      failedAt: new Date().toISOString(),
-      errorCode: structuredLogErrorCode(error),
-    });
-    throw error;
+    resultMeta = entry!.buildResultMeta(parsedSubmit);
+    autoResumePrompt = entry!.buildAutoResumePrompt(resultMeta, widget.params);
   }
+
+  // 6. Admit auto-resume before publishing terminal widget state. If this
+  // process dies or any downstream operation fails after admission, the
+  // stable Task remains recoverable while this claim stays `resolving`; never
+  // reopen it and replay an already-completed external effect.
+  let autoResumeQueued = false;
+  if (widget.auto_resume !== false && autoResumePrompt) {
+    await deps.app.service('/sessions/:id/prompt').create(
+      {
+        prompt: autoResumePrompt,
+        messageSource: 'agor',
+        idempotencyTaskId: widgetAutoResumeTaskId(widget.widget_id),
+        metadata: {
+          system_authored: true,
+          widget_id: widget.widget_id,
+          widget_resolved_by_user_id: caller.user_id,
+        },
+      },
+      {
+        // Stable widget identity must also have stable Task attribution.
+        // The widget row records the actual resolver separately.
+        user: { user_id: session.created_by },
+        route: { id: message.session_id },
+      }
+    );
+    autoResumeQueued = true;
+  }
+
+  // 7. Only the claim token can publish the terminal resolution.
+  const newStatus: WidgetMessageMetadata['status'] =
+    action.kind === 'submit' ? 'submitted' : 'dismissed';
+  const resolvedAt = new Date().toISOString();
+  const finished = await deps.resolutionStore.complete(widget.widget_id, claimToken, {
+    status: newStatus,
+    resolvedAt,
+    submittedBy: caller.user_id,
+    resultMeta,
+  });
+  if (finished.outcome !== 'updated') {
+    throw new Conflict(`Widget ${widgetId} resolution claim was lost before completion`);
+  }
+
+  // 8. Broadcast on the messages service's room (per-session subscribers
+  // are already wired up to that channel — see register-services.ts).
+  const resolvedPayload = {
+    widget_id: widget.widget_id,
+    session_id: message.session_id,
+    status: newStatus,
+    result_meta: resultMeta,
+    resolved_at: resolvedAt,
+    submitted_by: caller.user_id,
+  };
+  if (deps.publishResolved) deps.publishResolved(resolvedPayload);
+  else deps.app.service('messages').emit?.('widget:resolved', resolvedPayload);
+
+  return {
+    widget_id: widget.widget_id,
+    status: newStatus,
+    auto_resume_queued: autoResumeQueued,
+  };
 }

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -35,6 +35,7 @@ import type {
   WidgetMessageMetadata,
 } from '@agor/core/types';
 import { PERMISSION_RANK, resolveBranchPermission } from '../utils/branch-authorization.js';
+import { widgetAutoResumeTaskId } from '../utils/durable-task-id.js';
 import { getWidget, type WidgetSubmitCtx } from './registry.js';
 
 /**
@@ -263,6 +264,9 @@ async function doResolveWidget(
       {
         prompt: autoResumePrompt,
         messageSource: 'agor',
+        // The widget message is the durable occurrence identity. Concurrent
+        // resolvers converge on one Task even if both observed `pending`.
+        idempotencyTaskId: widgetAutoResumeTaskId(widget.widget_id),
         // Stamp traceability fields onto the queued task so the UI can
         // distinguish system-authored auto-resume prompts from user-typed
         // ones, and so the resulting task links back to its widget.

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -9,14 +9,14 @@
  *   1. Load the widget message row by `widget_id` (message_id == widget_id).
  *   2. Authorize: caller is session creator OR has prompt-tier branch RBAC.
  *   3. Idempotency: status MUST be 'pending'.
- *   4. Dispatch to the registry (`applySubmit` for submit; no side-effect
- *      for dismiss).
- *   5. Patch `metadata.widget.status` to 'submitted' / 'dismissed' along
- *      with `result_meta` and `resolved_at`.
+ *   4. Durably claim `pending -> resolving` with an opaque token.
+ *   5. The sole claimant dispatches to the registry (`applySubmit` for
+ *      submit; no external side-effect for dismiss).
  *   6. Queue a system-authored auto-resume task via the existing
  *      `/sessions/:id/prompt` route (the "Never lose a prompt" #1068 path),
  *      unless `auto_resume === false`.
- *   7. Broadcast `widget:resolved` on the per-session Feathers room.
+ *   7. Token-check `resolving -> submitted|dismissed` with result metadata.
+ *   8. Broadcast `widget:resolved` on the per-session Feathers room.
  *
  * Critical security invariant: the `applySubmit` handler is the ONLY place
  * the raw submit body reaches; from `result_meta` onward, no
@@ -24,7 +24,8 @@
  * design doc for the path-by-path enumeration.
  */
 
-import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import { generateId } from '@agor/core/db';
+import { Conflict, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import type {
   Branch,
   Message,
@@ -36,7 +37,9 @@ import type {
 } from '@agor/core/types';
 import { PERMISSION_RANK, resolveBranchPermission } from '../utils/branch-authorization.js';
 import { widgetAutoResumeTaskId } from '../utils/durable-task-id.js';
+import { structuredLogErrorCode } from '../utils/structured-log.js';
 import { getWidget, type WidgetSubmitCtx } from './registry.js';
+import type { WidgetResolutionStore } from './resolution-store.js';
 
 /**
  * Minimal Feathers-like surface the resolver needs. Typed against a subset
@@ -53,6 +56,10 @@ export interface WidgetResolverApp {
 
 export interface WidgetResolverDeps {
   app: WidgetResolverApp;
+  /** Durable, short-transaction state machine shared by every daemon. */
+  resolutionStore: WidgetResolutionStore;
+  /** Tenant-scoped custom-event publisher; production must not emit globally. */
+  publishResolved?(payload: Record<string, unknown>): void;
   /** Branch ownership lookup — pulled out so tests can stub without RBAC plumbing. */
   isBranchOwner(branchId: string, userId: UserID): Promise<boolean>;
   /** Optional group-aware effective branch permission lookup. */
@@ -100,15 +107,9 @@ export function canResolveWidget(
 }
 
 /**
- * Per-widget in-process serialization. Two concurrent submits (e.g. two
- * browser tabs both posting in the small window between the status check
- * and the message.patch) would each pass the `status === 'pending'` gate
- * and both run side effects: doubled auto-resume tasks, surprise writes.
- *
- * The lock guards the critical section (status check → applySubmit →
- * message.patch → tasks.create). Sufficient for single-daemon deployments,
- * which is the only deployment shape today. A multi-daemon setup would need
- * a DB-level optimistic check; we accept that trade today.
+ * Per-widget in-process coalescing. Correctness comes from the durable
+ * `WidgetResolutionStore` claim; this map only avoids needless same-process
+ * contention and duplicate auth/config reads.
  */
 const inFlightResolutions = new Map<string, Promise<WidgetResolutionResult>>();
 
@@ -128,9 +129,9 @@ export async function resolveWidget(
     throw new NotAuthenticated('Authentication required to resolve a widget');
   }
 
-  // Serialize concurrent resolutions for the same widget (see comment on
-  // `inFlightResolutions`). The second caller will await the first's
-  // outcome and then hit the `status !== 'pending'` rejection.
+  // Coalesce same-process resolutions. Another daemon can still race here;
+  // the durable pending → resolving claim below elects the sole side-effect
+  // owner across the fleet.
   const existing = inFlightResolutions.get(widgetId);
   if (existing) {
     await existing.catch(() => {}); // swallow — we re-check status below
@@ -198,6 +199,7 @@ async function doResolveWidget(
 
   let resultMeta: unknown | undefined;
   let autoResumePrompt: string | undefined;
+  let parsedSubmit: unknown;
 
   // Context for the registry hooks, built for BOTH paths so a widget can gate
   // who may dismiss it (authorizeDismiss), not just who may submit.
@@ -221,11 +223,7 @@ async function doResolveWidget(
     if (!parsed.success) {
       throw new Forbidden(`Invalid submit payload: ${parsed.error.message}`);
     }
-    const submit = parsed.data;
-
-    await entry.applySubmit(ctx, submit, widget.params);
-    resultMeta = entry.buildResultMeta(submit);
-    autoResumePrompt = entry.buildAutoResumePrompt(resultMeta, widget.params);
+    parsedSubmit = parsed.data;
   } else {
     // dismiss — an admin-only widget gates this so a member-level dismissal
     // can't terminally decline a flow its submit path would have rejected.
@@ -237,68 +235,93 @@ async function doResolveWidget(
       : `[Agor] User dismissed a widget request. Do not re-request immediately — ask whether to proceed without, or move on to other work.`;
   }
 
-  // 5. Patch the widget message — flip status, stamp resolution.
-  const newStatus: WidgetMessageMetadata['status'] =
-    action.kind === 'submit' ? 'submitted' : 'dismissed';
-  const updatedWidget: WidgetMessageMetadata = {
-    ...widget,
-    status: newStatus,
-    resolved_at: new Date().toISOString(),
-    submitted_by: caller.user_id,
-    ...(resultMeta !== undefined ? { result_meta: resultMeta } : {}),
-  };
-  await deps.app.service('messages').patch(widgetId, {
-    metadata: {
-      ...(message.metadata ?? {}),
-      widget: updatedWidget,
-    },
+  // 5. Commit the cross-daemon ownership claim before any submit side effect.
+  // No DB transaction remains open while the registry handler, prompt
+  // admission, or any other external/service work runs.
+  const claimToken = generateId();
+  const claim = await deps.resolutionStore.claim(widget.widget_id, {
+    token: claimToken,
+    action: action.kind,
+    claimedAt: new Date().toISOString(),
+    claimedBy: caller.user_id,
   });
-
-  // 6. Auto-resume task (skipped when the agent set auto_resume:false on
-  //    the original tool call). Goes through `/sessions/:id/prompt` so the
-  //    idle-vs-queued branching is identical to a user-typed prompt — the
-  //    "Never lose a prompt" #1068 path.
-  let autoResumeQueued = false;
-  if (widget.auto_resume !== false && autoResumePrompt) {
-    await deps.app.service('/sessions/:id/prompt').create(
-      {
-        prompt: autoResumePrompt,
-        messageSource: 'agor',
-        // The widget message is the durable occurrence identity. Concurrent
-        // resolvers converge on one Task even if both observed `pending`.
-        idempotencyTaskId: widgetAutoResumeTaskId(widget.widget_id),
-        // Stamp traceability fields onto the queued task so the UI can
-        // distinguish system-authored auto-resume prompts from user-typed
-        // ones, and so the resulting task links back to its widget.
-        metadata: {
-          system_authored: true,
-          widget_id: widget.widget_id,
-        },
-      },
-      {
-        // Internal call — no `provider` so RBAC hooks bypass. Submitter is
-        // attributed (`created_by`) for audit; see §5.3 of the design.
-        user: { user_id: caller.user_id },
-        route: { id: message.session_id },
-      }
-    );
-    autoResumeQueued = true;
+  if (claim.outcome !== 'claimed') {
+    const status = claim.message.metadata?.widget?.status ?? 'unavailable';
+    throw new Forbidden(`Widget ${widgetId} is already ${status}; cannot ${action.kind} again.`);
   }
 
-  // 7. Broadcast on the messages service's room (per-session subscribers
-  //    are already wired up to that channel — see register-services.ts).
-  deps.app.service('messages').emit?.('widget:resolved', {
-    widget_id: widget.widget_id,
-    session_id: message.session_id,
-    status: newStatus,
-    result_meta: resultMeta,
-    resolved_at: updatedWidget.resolved_at,
-    submitted_by: caller.user_id,
-  });
+  try {
+    if (action.kind === 'submit') {
+      // The registry entry and parsed payload are established before the
+      // claim; only the durable winner reaches this external-work boundary.
+      await entry!.applySubmit(ctx, parsedSubmit, widget.params);
+      resultMeta = entry!.buildResultMeta(parsedSubmit);
+      autoResumePrompt = entry!.buildAutoResumePrompt(resultMeta, widget.params);
+    }
 
-  return {
-    widget_id: widget.widget_id,
-    status: newStatus,
-    auto_resume_queued: autoResumeQueued,
-  };
+    // 6. Admit auto-resume before publishing terminal widget state. If this
+    // process dies after admission, the stable Task and initial-message IDs
+    // remain discoverable by another daemon's queue worker.
+    let autoResumeQueued = false;
+    if (widget.auto_resume !== false && autoResumePrompt) {
+      await deps.app.service('/sessions/:id/prompt').create(
+        {
+          prompt: autoResumePrompt,
+          messageSource: 'agor',
+          idempotencyTaskId: widgetAutoResumeTaskId(widget.widget_id),
+          metadata: {
+            system_authored: true,
+            widget_id: widget.widget_id,
+            widget_resolved_by_user_id: caller.user_id,
+          },
+        },
+        {
+          // Stable widget identity must also have stable Task attribution.
+          // The widget row records the actual resolver separately.
+          user: { user_id: session.created_by },
+          route: { id: message.session_id },
+        }
+      );
+      autoResumeQueued = true;
+    }
+
+    // 7. Only the claim token can publish the terminal resolution.
+    const newStatus: WidgetMessageMetadata['status'] =
+      action.kind === 'submit' ? 'submitted' : 'dismissed';
+    const resolvedAt = new Date().toISOString();
+    const finished = await deps.resolutionStore.complete(widget.widget_id, claimToken, {
+      status: newStatus,
+      resolvedAt,
+      submittedBy: caller.user_id,
+      resultMeta,
+    });
+    if (finished.outcome !== 'updated') {
+      throw new Conflict(`Widget ${widgetId} resolution claim was lost before completion`);
+    }
+
+    // 8. Broadcast on the messages service's room (per-session subscribers
+    // are already wired up to that channel — see register-services.ts).
+    const resolvedPayload = {
+      widget_id: widget.widget_id,
+      session_id: message.session_id,
+      status: newStatus,
+      result_meta: resultMeta,
+      resolved_at: resolvedAt,
+      submitted_by: caller.user_id,
+    };
+    if (deps.publishResolved) deps.publishResolved(resolvedPayload);
+    else deps.app.service('messages').emit?.('widget:resolved', resolvedPayload);
+
+    return {
+      widget_id: widget.widget_id,
+      status: newStatus,
+      auto_resume_queued: autoResumeQueued,
+    };
+  } catch (error) {
+    await deps.resolutionStore.fail(widget.widget_id, claimToken, {
+      failedAt: new Date().toISOString(),
+      errorCode: structuredLogErrorCode(error),
+    });
+    throw error;
+  }
 }

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1143,7 +1143,6 @@ function AppContent() {
     try {
       await client.sessions.prompt(sessionId, prompt, {
         permissionMode,
-        messageSource: 'agor',
       });
 
       // Clear the draft after sending

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -265,8 +265,7 @@ function DaemonRestartNotice({
     try {
       await client.sessions.prompt(
         sessionId,
-        'Please resume where you left off before the daemon restarted.',
-        { messageSource: 'agor' }
+        'Please resume where you left off before the daemon restarted.'
       );
       setResumed(true);
     } catch (err) {

--- a/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
@@ -67,6 +67,29 @@ export const WidgetBlock: React.FC<WidgetBlockProps> = ({ message, client }) => 
     return null;
   }
 
+  if (widget.status === 'resolving') {
+    return (
+      <Card
+        size="small"
+        style={{
+          margin: `${token.sizeUnit * 1.5}px 0`,
+          background: token.colorBgContainer,
+          border: `1px solid ${token.colorBorder}`,
+        }}
+      >
+        <Space>
+          <ExclamationCircleOutlined style={{ color: token.colorTextSecondary }} />
+          <Space direction="vertical" size={0}>
+            <Text strong>Completing request</Text>
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              This request is already in progress.
+            </Text>
+          </Space>
+        </Space>
+      </Card>
+    );
+  }
+
   const Component = widgetComponents.get(widget.widget_type);
 
   if (!Component) {
@@ -116,6 +139,8 @@ function renderStatusBadge(status: WidgetMessageMetadata['status']): React.React
           <CheckCircleOutlined /> already configured
         </>
       );
+    case 'resolving':
+      return <Text>resolving</Text>;
     default:
       return <Text>pending</Text>;
   }

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -3063,7 +3063,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   case 'prompt': {
                     await client.sessions.prompt(targetSessionId, renderedTemplate, {
                       permissionMode,
-                      messageSource: 'agor',
                     });
                     resultSessionId = targetSessionId;
                     break;
@@ -3074,7 +3073,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       .create({})) as Session;
                     await client.sessions.prompt(forkedSession.session_id, renderedTemplate, {
                       permissionMode,
-                      messageSource: 'agor',
                     });
                     resultSessionId = forkedSession.session_id;
                     break;
@@ -3085,7 +3083,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       .create({})) as Session;
                     await client.sessions.prompt(spawnedSession.session_id, renderedTemplate, {
                       permissionMode,
-                      messageSource: 'agor',
                     });
                     resultSessionId = spawnedSession.session_id;
                     break;

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -130,9 +130,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       // Send the prompt to the forked session to actually execute it
       // Skip if prompt is empty (allows forking without initial prompt)
       if (prompt.trim()) {
-        await client.sessions.prompt(forkedSession.session_id, prompt, {
-          messageSource: 'agor',
-        });
+        await client.sessions.prompt(forkedSession.session_id, prompt);
       }
 
       return forkedSession;
@@ -170,9 +168,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
 
       // Send the prompt to the forked session
       if (prompt.trim()) {
-        await client.sessions.prompt(forkedSession.session_id, prompt, {
-          messageSource: 'agor',
-        });
+        await client.sessions.prompt(forkedSession.session_id, prompt);
       }
 
       return forkedSession;
@@ -206,9 +202,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
 
       // Send the prompt to the spawned session to actually execute it
       if (config.prompt?.trim()) {
-        await client.sessions.prompt(spawnedSession.session_id, config.prompt, {
-          messageSource: 'agor',
-        });
+        await client.sessions.prompt(spawnedSession.session_id, config.prompt);
       }
 
       return spawnedSession;

--- a/context/concepts/task-queueing.md
+++ b/context/concepts/task-queueing.md
@@ -25,6 +25,9 @@ client's earlier Session GET.
    assigns `max(queue_position) + 1`. The Session row is the per-queue
    sequencer; an ordinary transaction without this lock is insufficient under
    PostgreSQL `READ COMMITTED`. A partial unique index is defense in depth.
+   The prompt endpoint carries tenant identity through a long-route scope;
+   admission itself is a bound short repository unit, so the Session lock is
+   released before title/config work, claim preparation, or event delivery.
 2. **Attempt the head** — the prompt route immediately offers that Task to
    `spawnTaskExecutor`. If the Session is promptable and the Task is the
    durable queue head, it may leave the queue without waiting for a later scan.
@@ -34,8 +37,8 @@ client's earlier Session GET.
    Session promptability, and the expected Task state. The winning transaction
    writes `queued|created -> dispatching` and the Session's running projection.
 4. **Launch after commit** — only `outcome: 'claimed'` may schedule executor
-   launch (a loser may only perform deterministic transcript repair for a
-   stable internal occurrence). No transaction is held while spawning an
+   launch (a loser may only perform deterministic transcript repair after the
+   winner has crossed the fence). No transaction is held while spawning an
    executor or doing external work. The authenticated executor later claims
    `dispatching -> running`.
 
@@ -59,7 +62,18 @@ Queued rows survive daemon restart. Completion, Stop, callbacks, widgets,
 scheduled initialization, and the recovery worker may all trigger draining;
 duplicate triggers converge at the same durable claim. Callback and widget
 occurrences use deterministic Task IDs so competing producers converge on one
-queued row and one position.
+queued row and one position. Their stable initial-message identity is persisted
+in `Task.metadata.initial_message_id`; a later drainer therefore writes exactly
+the same transcript row. A losing admission that still observes `queued` writes
+no transcript row.
+
+Widget submit/dismiss uses a separate short Message-row claim before registry
+or connector work. Only `pending -> resolving` may perform that work; the
+opaque claim token alone may publish `submitted|dismissed`. An interrupted
+attempt remains durably `resolving` and is not replayed automatically because
+the prior side effect may already have happened. A handler that reports an
+error releases the widget to `pending` with a secret-free failure code for an
+explicit retry; handlers must make that reported-error retry idempotent.
 
 ## Invariants
 
@@ -81,6 +95,7 @@ queued row and one position.
 - Fleet recovery: `apps/agor-daemon/src/services/session-queue-worker.ts`
 - Local coalescer: `apps/agor-daemon/src/utils/session-turn-lock.ts`
 - Producer identities: `apps/agor-daemon/src/utils/durable-task-id.ts`
+- Widget resolution fence: `apps/agor-daemon/src/widgets/resolution-store.ts`
 - Reactive client: `packages/client/src/reactive-session.ts`
 
 For post-claim executor lifecycle, heartbeat, SDK pulse/watchdog, and

--- a/context/concepts/task-queueing.md
+++ b/context/concepts/task-queueing.md
@@ -1,55 +1,87 @@
 # Task Queueing
 
-**Tasks are the queueable unit. Sessions accept prompts. The Task entity itself
-encodes whether the prompt ran or got queued.**
+**Tasks are the queueable unit. Sessions accept prompts. PostgreSQL is the
+durable authority for admission, ordering, and dispatch across daemons.**
 
 ## Wire shape
 
-`POST /sessions/:id/prompt` always returns a `Task`. Callers inspect:
+`POST /sessions/:id/prompt` always returns the persisted `Task`. Callers inspect:
 
-- `task.status === 'queued'` → session was busy; the task is waiting and will
-  drain automatically when the session goes idle.
-- `task.status === 'dispatching'` → daemon persisted launch intent and is starting an executor.
-- `task.status === 'running'` → the executor connected and claimed the task.
-- `task.queue_position` → ordering within the session's queue (lowest drains
-  first), populated only while QUEUED.
+- `task.status === 'queued'` — the task has a durable position and is waiting;
+- `task.status === 'dispatching'` — launch intent is durable and an executor is
+  being started;
+- `task.status === 'running'` — the authenticated executor claimed the task;
+- `task.queue_position` — ordering within the Session queue (lowest first),
+  populated only while `queued`.
 
-There is no separate "queued vs ran" envelope. The route does not take a
-`queue: true` flag. Callers don't ask, the response answers.
+There is no separate “queued vs ran” envelope and no `queue: true` request flag.
+The response is the result of the admission attempt, not a decision based on a
+client's earlier Session GET.
 
-## Lifecycle
+## Durable admission and dispatch
 
-1. **Materialize** — the route always creates a Task via
-   `TaskRepository.createPending({ status })`. CREATED if the session is idle
-   with no queue, QUEUED otherwise. Sentinel values (`message_range.start_index = -1`,
-   `git_state.sha_at_start = ''`) are stamped here and stay until the
-   QUEUED → DISPATCHING/RUNNING launch transition.
-2. **Drain** — when a session reaches a terminal task state, the queue
-   processor picks the lowest `queue_position` and hands it to
-   `spawnTaskExecutor`, which is the _sole_ place that pins
-   `message_range`/`git_state`, writes the initial user-message row, persists
-   DISPATCHING, and spawns the executor. After authentication, the executor
-   atomically claims DISPATCHING → RUNNING.
-3. **Race safety** — `createPending` wraps the `max(queue_position) + 1`
-   read-then-insert in a transaction so concurrent writers can't collide on
-   identical positions.
+1. **Admit** — every prompt first creates a `queued` Task. While holding a
+   short lock on the owning Session row, `TaskRepository.createPending`
+   assigns `max(queue_position) + 1`. The Session row is the per-queue
+   sequencer; an ordinary transaction without this lock is insufficient under
+   PostgreSQL `READ COMMITTED`. A partial unique index is defense in depth.
+2. **Attempt the head** — the prompt route immediately offers that Task to
+   `spawnTaskExecutor`. If the Session is promptable and the Task is the
+   durable queue head, it may leave the queue without waiting for a later scan.
+   Otherwise the route returns the still-queued Task and its actual position.
+3. **Claim** — `claimDispatchAndProjectSession` locks Session first, then Task,
+   and atomically checks the queue head, absence of another executing Task,
+   Session promptability, and the expected Task state. The winning transaction
+   writes `queued|created -> dispatching` and the Session's running projection.
+4. **Launch after commit** — only `outcome: 'claimed'` may schedule executor
+   launch (a loser may only perform deterministic transcript repair for a
+   stable internal occurrence). No transaction is held while spawning an
+   executor or doing external work. The authenticated executor later claims
+   `dispatching -> running`.
+
+`created` remains supported for the explicit `POST /tasks/:id` then
+`POST /tasks/:id/run` workflow. It cannot jump an existing queued prompt or a
+different executing Task.
+
+## Fleet-wide draining and recovery
+
+Every daemon runs a bounded `SessionQueueWorker`. It discovers routing-only
+queued Session refs and then reloads/processes each Session inside its trusted
+tenant scope. There is no permanent leader and no worker lease: overlapping
+scans are expected, while the Session+Task claim elects the only launcher.
+
+The scan cursor, startup offset, bounded backoff, and jitter are contention
+etiquette and fairness only. A process-local `SessionTurnLocks` map and
+`queueRetryScheduled` set similarly coalesce work inside one daemon; process
+death or duplicate triggers cannot affect correctness.
+
+Queued rows survive daemon restart. Completion, Stop, callbacks, widgets,
+scheduled initialization, and the recovery worker may all trigger draining;
+duplicate triggers converge at the same durable claim. Callback and widget
+occurrences use deterministic Task IDs so competing producers converge on one
+queued row and one position.
+
+## Invariants
+
+1. At most one Task is in an executing state for a Session.
+2. Concurrent enqueue produces one durable order decision per Task.
+3. Only the durable queue head may claim dispatch.
+4. A Task claim has one winner; losing daemons do not launch.
+5. Terminal Task state is immutable.
+6. Queue state survives daemon/process loss.
+7. System discovery exposes only routing refs; mutation always re-enters the
+   discovered tenant scope.
+8. SQLite preserves the same user-visible ordering and lifecycle without
+   pretending to provide multi-daemon authority.
 
 ## Key files
 
-- Repo: `packages/core/src/db/repositories/tasks.ts` (`createPending`,
-  `findQueued`, `getNextQueued`)
-- Route: `apps/agor-daemon/src/register-routes.ts` (`/sessions/:id/prompt`,
-  `spawnTaskExecutor`, `processNextQueuedTask`)
-- Reactive client: `packages/client/src/reactive-session.ts` (handles
-  `tasks:created`/`tasks:queued`/`tasks:patched` events)
+- Persistence: `packages/core/src/db/repositories/tasks.ts`
+- Admission/launch/drain: `apps/agor-daemon/src/register-routes.ts`
+- Fleet recovery: `apps/agor-daemon/src/services/session-queue-worker.ts`
+- Local coalescer: `apps/agor-daemon/src/utils/session-turn-lock.ts`
+- Producer identities: `apps/agor-daemon/src/utils/durable-task-id.ts`
+- Reactive client: `packages/client/src/reactive-session.ts`
 
-## Rationale
-
-The queue was originally implemented at the message layer (`messages.status='queued'`).
-Tasks are the natural queueable unit: each prompt is exactly one task, the task
-already carries the prompt + metadata + lifecycle, and the executor only needs
-to know "give me the next task to run." Migration to task-level queueing
-landed in `never-lose-prompt` (sqlite/0040, postgres/0030).
-
-For the post-launch lifecycle, executor heartbeat, SDK pulse/watchdog, and
+For post-claim executor lifecycle, heartbeat, SDK pulse/watchdog, and
 termination ownership, see [task-runtime-state.md](task-runtime-state.md).

--- a/context/concepts/task-queueing.md
+++ b/context/concepts/task-queueing.md
@@ -71,9 +71,14 @@ Widget submit/dismiss uses a separate short Message-row claim before registry
 or connector work. Only `pending -> resolving` may perform that work; the
 opaque claim token alone may publish `submitted|dismissed`. An interrupted
 attempt remains durably `resolving` and is not replayed automatically because
-the prior side effect may already have happened. A handler that reports an
-error releases the widget to `pending` with a secret-free failure code for an
-explicit retry; handlers must make that reported-error retry idempotent.
+the prior side effect may already have happened. Only an `applySubmit` handler
+that explicitly reports failure before returning releases the widget to
+`pending` with a secret-free failure code for an explicit retry; handlers must
+make that reported-error retry idempotent. Prompt-admission or completion
+failures after `applySubmit` succeeds leave the claim `resolving` so the effect
+cannot be replayed. Widget creation and lifecycle metadata are daemon-owned:
+generic external Message create/update/patch cannot mint or alter a widget,
+and pending/resolving widgets cannot be externally removed.
 
 ## Invariants
 

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -14,12 +14,11 @@ safe release.
 ```text
 Prompt
   |
-  +-- busy session --> QUEUED
-  `-- available ----> CREATED
-                         |
-                         | daemon persists launch intent
-                         v
-                     DISPATCHING
+  `-- durable admission --> QUEUED
+                               |
+                     queue-head/Session claim
+                               v
+                          DISPATCHING
                          |
                          | authenticated executor claims task
                          v
@@ -99,6 +98,10 @@ still block admission until it is dispatched or settled.
 Queue materialization and draining are documented separately in
 [task-queueing.md](task-queueing.md).
 
+Prompt admission normally enters through `queued` even for an idle Session, so
+ordering and idle-vs-waiting are one database decision. `created` remains for
+the explicit create-then-run API and scheduled compatibility/reconciliation.
+
 ## The runtime facts stored on a task
 
 | Fact                         | What it answers                                                        | What it does not answer                  |
@@ -138,6 +141,10 @@ an explicit mapping-review point.
 ### Daemon heartbeat supervisor
 
 - A task remains `dispatching` until an authenticated executor claims it.
+- The dispatch claim and Session projection commit before any executor launch.
+  A daemon death in that gap therefore leaves durable, diagnosable launch
+  intent rather than silently returning the prompt to the queue. Re-enqueueing
+  automatically would be unsafe because the external launch may have happened.
 - The default dispatch connection deadline is five minutes.
 - A local dispatch that misses the deadline enters termination coordination.
 - A templated/remote dispatch records a warning and keeps waiting because the
@@ -210,6 +217,12 @@ admission/UI projection:
   state and may trigger queue processing;
 - reconciliation repairs a failed/not-ready session when no non-queued task
   still owns that busy state.
+
+`queued` Tasks are not startup orphans and are never wiped during daemon
+startup. The all-daemon queue worker rediscovers them. Fleet-safe ownership and
+cross-tenant reconciliation of already-`dispatching`/running work remains the
+runtime-supervision contract; this queue layer deliberately does not redesign
+heartbeat, containment, or startup orphan ownership.
 
 `Session.ready_for_prompt` is also used as an attention/acknowledgement flag. It
 is not equivalent to promptability and must not be checked alone. Use the

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -259,14 +259,18 @@ transitions around (never across) external work:
 4. **Complete resolution** — a second short Message-row transaction accepts only the opaque claim token and moves `resolving -> submitted|dismissed` with sanitized result metadata.
 5. **Emit `widget:resolved`** — publish through the tenant-scoped per-session Feathers path so other connected UI clients refresh.
 
-Dismissal (`POST /widgets/:widget_id/dismiss`) follows the same path but skips step 1 and uses `buildDismissedPrompt` in step 3.
+Dismissal (`POST /widgets/:widget_id/dismiss`) follows the same claim and
+completion path, skips the registry side effect in step 2, and uses
+`buildDismissedPrompt` in step 3.
 
 **No transaction is held over external work. No timeout on a pending widget.**
 The widget is durable in the messages table; it can sit `pending` for an hour or
-a day. If a handler reports failure, the token is released back to `pending`
-with a secret-free diagnosis and an explicit retry is allowed (handlers must
-write desired state idempotently). A daemon death with an unknown external
-outcome leaves `resolving` as durable diagnosis and is not replayed blindly.
+a day. If `applySubmit` explicitly reports failure before returning, the token
+is released back to `pending` with a secret-free diagnosis and an explicit
+retry is allowed (handlers must write desired state idempotently). Once
+`applySubmit` returns, prompt-admission or completion failures leave
+`resolving`; the completed external effect is never replayed blindly. A daemon
+death with an unknown external outcome follows the same durable diagnosis.
 
 ### 3.6 What happens if the agent doesn't end its turn?
 
@@ -278,17 +282,17 @@ We do **not** rely on tool description alone for correctness; ignoring the contr
 
 ## 4. The env-var widget (concrete v1)
 
-| Piece                  | Path                                                                                                                                                                                     | Reuses                                                         |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| MCP tool               | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new)                                                                                                                                        | `registerTool` pattern from `worktrees.ts`                     |
-| MCP tool return        | `{ widget_id, status: 'requested' }` — fires immediately, agent ends turn                                                                                                                | `textResult()`                                                 |
-| Daemon submit endpoint | `POST /widgets/:widget_id/submit`, `POST /widgets/:widget_id/dismiss` (new routes)                                                                                                       | FeathersJS service `widget-submissions`                        |
-| Persistence            | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })`                                                                                             | existing users service, `encryptApiKey`, blocklist, regex      |
-| Message update         | `app.service('messages').patch(widget_id, { metadata.widget: { status, result_meta, resolved_at } })`                                                                                    | existing messages service                                      |
-| **Auto-resume task**   | `app.service('tasks').create({ session_id, role: 'user', content: buildAutoResumePrompt(rm), metadata: { system_authored: true, widget_id } })` — picks up via the existing prompt queue | "Never lose a prompt" #1068                                    |
-| Event broadcast        | `widget:resolved` Feathers event on the session room                                                                                                                                     | existing per-session room                                      |
-| UI dispatch            | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />`                                                                                    | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
-| Widget component       | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx`                                                                                                                            | form shape from `EnvVarEditor.tsx`                             |
+| Piece                  | Path                                                                                                                                                   | Reuses                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| MCP tool               | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new)                                                                                                      | `registerTool` pattern from `worktrees.ts`                     |
+| MCP tool return        | `{ widget_id, status: 'requested' }` — fires immediately, agent ends turn                                                                              | `textResult()`                                                 |
+| Daemon submit endpoint | `POST /widgets/:widget_id/submit`, `POST /widgets/:widget_id/dismiss` (new routes)                                                                     | FeathersJS service `widget-submissions`                        |
+| Persistence            | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })`                                                           | existing users service, `encryptApiKey`, blocklist, regex      |
+| Message update         | Short locked repository mutations in `WidgetResolutionStore`; generic external Message CRUD cannot alter live widget state                             | widget resolution state machine                                |
+| **Auto-resume task**   | `app.service('/sessions/:id/prompt').create({ prompt: buildAutoResumePrompt(rm), idempotencyTaskId, metadata: { system_authored: true, widget_id } })` | durable prompt admission / "Never lose a prompt" #1068         |
+| Event broadcast        | `widget:resolved` Feathers event on the session room                                                                                                   | existing per-session room                                      |
+| UI dispatch            | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />`                                                  | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
+| Widget component       | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx`                                                                                          | form shape from `EnvVarEditor.tsx`                             |
 
 ### UI sketch
 
@@ -342,7 +346,7 @@ After dismissal:
 | MCP tool return value → agent (synchronous)                             | **No**                                      | Returns `{ widget_id, status: 'requested' }`. Fires immediately, before the user has even seen the widget. Cannot contain values by definition.                                                                                                                                              |
 | UI → `POST /widgets/:id/submit`                                         | **Yes**                                     | Direct browser-to-daemon HTTP request. Auth via the user's session cookie / JWT. **This is the only place values exist on the wire**, and it never traverses the agent.                                                                                                                      |
 | Daemon submit handler → `users.patch`                                   | **Yes (encrypted in transit at app layer)** | Standard env-var write path. `encryptApiKey()` is called inside the users service before DB write.                                                                                                                                                                                           |
-| Daemon → message status update (`messages.patch`)                       | **No**                                      | Updates `metadata.widget.status` and `result_meta` (e.g. `{ names_submitted, scope }`). Explicit allow-list — we patch by field, never spread the submit body.                                                                                                                               |
+| Daemon → locked widget state update                                     | **No**                                      | `WidgetResolutionStore` updates status/claim and sanitized `result_meta`; generic external Message CRUD cannot create or mutate widget lifecycle state.                                                                                                                                      |
 | **Daemon → auto-resume task creation** (the prompt the agent next sees) | **No**                                      | `tasks.create` content is `buildAutoResumePrompt(result_meta)`. The registry's prompt-builders take `result_meta` only — they have no access to the submit body. Add unit test: prompt-builder must accept `result_meta` only, not the raw submit payload (type system + runtime assertion). |
 | `widget:resolved` Feathers event                                        | **No**                                      | Payload is `{ widget_id, status, result_meta }`.                                                                                                                                                                                                                                             |
 | Transcript reload                                                       | **No**                                      | Re-reads the message row; values were never stored on it. The auto-resume task is a normal task row containing only `result_meta`-derived text.                                                                                                                                              |

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -52,7 +52,9 @@ Add a new `MessageType` value: `'widget_request'`. A widget message is just a ro
       widget_id: MessageID,        // same as message_id — single source of truth
       widget_type: 'env_vars',     // discriminant for the widget registry
       params: { ... },             // widget-type-specific payload (validated by registry schema)
-      status: 'pending' | 'submitted' | 'dismissed' | 'timed_out',
+      status: 'pending' | 'resolving' | 'submitted' | 'dismissed' | 'already_present',
+      resolution_claim?: { token, action, claimed_at, claimed_by },
+      resolution_failure?: { failed_at, error_code },
       requested_at: ISO8601,
       resolved_at?: ISO8601,
       // RESULT_META is widget-type-specific, scrubbed of secret material.
@@ -243,20 +245,28 @@ buildDismissedPrompt: (params) =>
 
 ### 3.5 Task-queue integration (the resolution path)
 
-When `POST /widgets/:widget_id/submit` succeeds, the submit handler does four things in one transaction:
+When `POST /widgets/:widget_id/submit` succeeds, the handler uses short durable
+transitions around (never across) external work:
 
-1. **Persist values** — call `registry[widget_type].applySubmit(ctx, submit)`. For env-vars, this is `users.patch(userId, { env_vars: { [name]: { value, scope } } })`. Encryption + validation happen inside the existing users service.
-2. **Patch the widget message** — `messages.patch(widget_id, { metadata: { ..., widget: { status: 'submitted', result_meta, resolved_at } } })`. The transcript renderer flips to the "submitted" badge.
-3. **Queue the auto-resume task** (if `auto_resume !== false` was passed to the original tool call) — create a new task via the existing task-creation path with:
+1. **Claim resolution** — one short Message-row transaction moves `pending -> resolving` with an opaque token. Competing daemons and submit-vs-dismiss races lose before side effects.
+2. **Persist values** — the claimant calls `registry[widget_type].applySubmit(ctx, submit)` with no Message-row transaction held. For env-vars, this is `users.patch(userId, { env_vars: { [name]: { value, scope } } })`. Encryption + validation happen inside the existing users service.
+3. **Queue the auto-resume task** (if `auto_resume !== false` was passed to the original tool call) through prompt admission with a deterministic Task ID and durable initial-message ID:
    - `role: 'user'`
-   - `created_by_user_id: <submitter>` (audit) but `metadata.system_authored: true` and `metadata.widget_id` for traceability
+   - stable execution attribution to the Session creator; the actual submitter remains in `metadata.widget.submitted_by` and `Task.metadata.widget_resolved_by_user_id`
+   - `metadata.system_authored: true` and `metadata.widget_id` for traceability
    - `content: registry[widget_type].buildAutoResumePrompt(result_meta, params)`
    - The "Never lose a prompt" infrastructure handles queueing-vs-immediate-dispatch based on session busy state.
-4. **Emit `widget:resolved`** — broadcast on the per-session Feathers room so any other connected UI clients refresh.
+4. **Complete resolution** — a second short Message-row transaction accepts only the opaque claim token and moves `resolving -> submitted|dismissed` with sanitized result metadata.
+5. **Emit `widget:resolved`** — publish through the tenant-scoped per-session Feathers path so other connected UI clients refresh.
 
 Dismissal (`POST /widgets/:widget_id/dismiss`) follows the same path but skips step 1 and uses `buildDismissedPrompt` in step 3.
 
-**No daemon-side await. No long-running HTTP. No timeout on the widget itself.** The widget is durable in the messages table; it can sit `pending` for an hour or a day. The user, the session, or the worktree can move on freely.
+**No transaction is held over external work. No timeout on a pending widget.**
+The widget is durable in the messages table; it can sit `pending` for an hour or
+a day. If a handler reports failure, the token is released back to `pending`
+with a secret-free diagnosis and an explicit retry is allowed (handlers must
+write desired state idempotently). A daemon death with an unknown external
+outcome leaves `resolving` as durable diagnosis and is not replayed blindly.
 
 ### 3.6 What happens if the agent doesn't end its turn?
 
@@ -345,14 +355,14 @@ The only access path to values after submission is the standard env-var read pat
 `POST /widgets/:widget_id/submit` is authenticated via existing FeathersJS session auth. The handler MUST verify:
 
 1. The caller's `user_id` matches `widget_message.session.created_by` **OR** the caller has `prompt`-tier RBAC on the worktree (`others_can >= prompt`). This mirrors who can already prompt the session.
-2. The widget is still `pending` (idempotency — double-submit is a no-op, not a re-write).
-3. The widget's `requested_at` is within the configured TTL.
+2. The widget is still `pending`; a short locked `pending -> resolving` claim is
+   the cross-daemon idempotency fence.
 
 CSRF: same protections as every other authenticated daemon endpoint (existing CORS + same-origin policy + JWT).
 
 ### 5.3 RBAC and multi-user
 
-If a _different_ user submits the widget (in a `prompt`-tier multi-user setup): the env var is written to **the executor's identity's** env_vars (= session creator's), because that's whose env the agent will read at retry. **The submitting user is recorded in `result_meta.submitted_by`** for audit. Surfaced to the agent ("submitted by <user>") so the agent can adjust messaging.
+If a _different_ user submits the widget (in a `prompt`-tier multi-user setup): the env var is written to **the executor's identity's** env_vars (= session creator's), because that's whose env the agent will read at retry. **The submitting user is recorded in `metadata.widget.submitted_by` and the auto-resume Task metadata** for audit; submitted values remain excluded.
 
 This is consistent with `dangerously_allow_session_sharing: false` semantics (default-safe). When session sharing is enabled and a collaborator submits a value, the value lands in the original owner's env — that's an explicit security trade-off documented under that flag.
 
@@ -367,7 +377,7 @@ The widget message persists forever in the transcript with `{ names, status, res
 | Malicious agent crafts the `reason`/`instructions` to phish the user                                        | Inputs rendered as **markdown with a strict allow-list** (no `<script>`, no inline event handlers, no auto-load images). Reuse the same sanitizer the artifact consent modal uses.                                                                                                                 |
 | Agent uses a widget to extract a value indirectly (e.g. asks for "type your value, then say it back to me") | The widget message _names_ what's requested; an agent prompting the user to type a value in-chat _instead of_ using the widget is a UX failure but not new attack surface — same as today. Mitigation is the disclaimer copy on the widget itself: "Type values here, never paste them into chat." |
 | Submission endpoint accepts unsolicited writes (no preceding widget request)                                | Endpoint requires a valid `widget_id` matching a `pending` widget message bound to the caller's session. No widget-less submissions.                                                                                                                                                               |
-| Replay attack with a captured submit payload                                                                | Once submitted, status → `submitted`; resubmission rejected on status check.                                                                                                                                                                                                                       |
+| Replay or concurrent submit/dismiss with a captured payload                                                 | Only one locked `pending -> resolving` transition wins; all losing daemons stop before registry/external work. Terminal resubmission is rejected.                                                                                                                                                  |
 | Stored XSS via env-var name                                                                                 | Existing `^[A-Z_][A-Z0-9_]*$` regex precludes anything renderable as HTML.                                                                                                                                                                                                                         |
 
 ---

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -480,8 +480,8 @@ Scope:
 - Extend `appendSystemMessage` helper's `type` union to include `widget_request`.
 - Add `metadata.widget` shape to `Message['metadata']` type (typed via a discriminated union over `widget_type`, with `schema_version: number` baked in).
 - Daemon-side registry shape at `apps/agor-daemon/src/widgets/registry.ts` (empty in Part 1; widget types register themselves in their own PRs). The registry entry type includes `paramsSchema`, `submitSchema`, `applySubmit`, `buildResultMeta`, `buildAutoResumePrompt`, `buildDismissedPrompt`.
-- New FeathersJS service `widget-submissions` registering `POST /widgets/:widget_id/submit` and `POST /widgets/:widget_id/dismiss`. Auth: caller must match session creator OR have `prompt`-tier worktree RBAC. Idempotency: status must be `pending`.
-- Submit handler dispatches by `widget_type` to the registry (no-op for empty registry), then: patches the message row, creates an auto-resume task via the existing task-creation path (`tasks.create` with `role: 'user'`, `metadata.system_authored: true`, `metadata.widget_id`), emits `widget:resolved`.
+- Custom authenticated routes `POST /widgets/:widget_id/submit` and `POST /widgets/:widget_id/dismiss`. Auth: caller must match session creator OR have `prompt`-tier worktree RBAC. A tenant-bound `WidgetResolutionStore` durably claims `pending → resolving` before external work and fences terminal completion with the claim token.
+- Submit handlers dispatch by `widget_type` to the registry (no-op for empty registry), then use durable prompt admission with a stable Task identity for auto-resume. Generic Message mutation cannot change widget lifecycle fields. Successful resolution emits `widget:resolved`; post-effect failures remain diagnosable without reopening the external effect.
 - `widget:resolved` Feathers event on the per-session room.
 - New MCP tool domain marker (`domain: 'widgets'` for `agor_search_tools` filtering).
 - UI: `WidgetBlock` dispatcher component in `apps/agor-ui/src/components/MessageBlock/` that switches on `metadata.widget.widget_type`, plus a placeholder "Unknown widget type" fallback for forward-compat with newer widgets in older clients.

--- a/docs/internal/session-task-queue-ha-2026-08-06.md
+++ b/docs/internal/session-task-queue-ha-2026-08-06.md
@@ -1,0 +1,155 @@
+# Session Task queue HA audit
+
+**Date:** 2026-08-06  
+**Status:** stacked review requested by Max  
+**Base dependency:** this branch is temporarily stacked on scheduler HA
+[#2174](https://github.com/preset-io/agor/pull/2174), currently open. Max
+explicitly requested the stacked PR on 2026-08-06; it must be rebased onto
+`main` after #2174 lands before merge.
+
+## Decision
+
+PostgreSQL owns Session prompt order and dispatch admission. Every daemon may
+discover and attempt durable queued work; no daemon is a permanent leader.
+Correctness is one short Session-first database critical section, not the
+process-local turn-lock map, retry timers, scan cadence, or daemon identity.
+
+The scheduler base contributed two deliberately thin shared foundations reused
+here:
+
+- the `created|queued -> dispatching` Task fence and authenticated
+  `dispatching -> running` executor claim;
+- `@agor/core/coordination` diagnostic identity and bounded delay helpers.
+
+This consumer generalizes the Task fence only as far as the concrete Session
+queue requires: it locks Session before Task, checks the durable queue head and
+other executing Tasks, and writes the Session projection atomically. It does
+**not** introduce a central distributed-work controller or worker framework.
+
+## Entry-point audit
+
+| Producer/trigger                      | Path                                                       | Durable behavior after this change                                                                                                                           |
+| ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| User/API prompt                       | `POST /sessions/:id/prompt`                                | Always inserts `queued` under the Session row lock, then immediately attempts the head claim. Returns actual `queued` or claimed state.                      |
+| Explicit Task run                     | `POST /tasks/:id/run`                                      | Only `created`; durable claim refuses a queued head, busy Session, or different executing Task. A local lock is only a coalescer.                            |
+| Generic Task creation                 | `POST /tasks` / `TasksService.create`                      | May create `created`, but cannot launch without the explicit run path and its claim.                                                                         |
+| Queue selection/drain                 | `processNextQueuedTask`                                    | Reads stable `(queue_position, created_at, task_id)` order; the later Session+Task claim revalidates the head. Local retry state is not authority.           |
+| Fleet recovery                        | `SessionQueueWorker`                                       | Every daemon performs bounded routing discovery, re-enters trusted tenant scope, and triggers the same drain path. Cursor/backoff/jitter are etiquette only. |
+| Task completion                       | `TasksService.processCompletionSideEffects` and Task hooks | Post-commit trigger only. Duplicate daemon triggers converge at dispatch claim.                                                                              |
+| User Stop                             | `/sessions/:id/stop`, `stopSessionPreserveQueue`           | Preserves queued rows and triggers draining after terminal settlement/release.                                                                               |
+| Session patch hooks                   | `register-hooks.ts`                                        | Promptable Session transitions trigger the same drain path. No independent selection rule.                                                                   |
+| Completion callback                   | `TasksService.queueCallbackToSession`                      | Direct durable queued admission with deterministic identity derived from source Task + target Session. The process-local Promise map is only coalescing.     |
+| Widget submit/dismiss                 | `widgets/submissions.ts`                                   | Delegates to prompt admission with deterministic identity derived from the widget Message.                                                                   |
+| Widget already-present                | `mcp/tools/widgets.ts`                                     | Same stable prompt admission; identity is distinct from the widget Message so transcript IDs cannot collide.                                                 |
+| Scheduled initial prompt              | `services/scheduler.ts` from #2174                         | Delegates with the schedule occurrence's stable initial Task ID; no scheduler file is changed here.                                                          |
+| Gateway prompt                        | `services/gateway.ts`                                      | Delegates to the prompt route with resolved tenant/user provenance.                                                                                          |
+| MCP spawn/fork/subsession/btw prompts | `mcp/tools/sessions.ts`                                    | Delegate to the prompt route.                                                                                                                                |
+| Spawn-prompt route                    | `/sessions/:id/spawn-prompt`                               | Renders only, then delegates to the prompt route.                                                                                                            |
+| Upload notification                   | upload handler in `register-routes.ts`                     | Delegates to the prompt route with request tenant/user context.                                                                                              |
+| Queue delete                          | `TaskRepository.delete`                                    | Deletes only while status remains `queued`; a concurrent dispatch claim and delete serialize on the Task row/status predicate.                               |
+
+No other production caller writes `status='queued'` directly. The repository is
+the single queue-position allocator.
+
+## Durable invariants and proof points
+
+### One executing turn per Session
+
+`claimDispatchAndProjectSession` always locks the Session row before the Task
+row. Under that lock it rejects:
+
+- a queued Task that is not the stable queue head;
+- a `created` Task while any queued head exists;
+- any candidate while another Task is `dispatching`, `running`, `stopping`,
+  `awaiting_permission`, or `awaiting_input`;
+- any candidate whose Session projection is not promptable.
+
+The winning transaction writes Task `dispatching`, clears its queue position,
+appends the Task ID to the Session, and projects the Session to running/not
+promptable. Claimants for two different Tasks therefore serialize at the same
+row rather than at unrelated Task locks.
+
+### One ordered admission decision
+
+Queued admission locks the Session row before reading
+`max(queue_position) + 1`. PostgreSQL `READ COMMITTED` transactions without
+that lock can both read the same maximum; a uniqueness error would reject one
+user rather than decide its order. The row lock creates one decision, while the
+partial unique index remains corruption defense. SQLite uses an immediate
+transaction plus bounded busy retry and preserves existing semantics.
+
+### One claimant and no losing launch
+
+The expected Task state, queue head, competing execution, and Session
+projection are checked and written in one transaction. `spawnTaskExecutor`
+returns before initial-message/session launch projection and before its
+post-commit executor callback unless the result is `claimed`. Stable scheduled
+occurrences are the narrow exception: a loser may idempotently repair their
+deterministic transcript row, but it never launches.
+
+### Durable recovery
+
+Queued rows are never startup-orphaned or wiped. A bounded partial index
+supports one routing ref per queued Session. In auth-resolved PostgreSQL mode a
+SELECT-only RLS capability exposes queued Task routing to the scanner; content
+is not returned by the repository, and every Session is reloaded/mutated under
+the discovered tenant. Static PostgreSQL and standalone SQLite take the same
+worker path without global discovery.
+
+### Terminality
+
+Existing row-locked Task mutation rejects terminal-to-nonterminal status
+changes. Queue work does not add a second lifecycle state machine.
+
+## Tenant boundary
+
+`tasks` is tenant-owned. System queue discovery is a narrowly named
+`task_queue_discovery` capability and projects only:
+
+- `tenant_id` (PostgreSQL only),
+- `session_id`,
+- first queued timestamp.
+
+The scanner exits system scope before calling Session services. It preserves
+the discovered tenant in both async context and service params; repository
+writes use short tenant units of work and the tenant write gate. A tenant-scoped
+repository cannot find or claim another tenant's Task. PostgreSQL integration
+coverage includes that negative proof and confirms nonqueued Sessions are not
+discoverable.
+
+## Kill points and runtime handoff
+
+| Kill point                                   | Durable result                                                                             | Recovery owner                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Before queued insert commits                 | No Task admitted; request fails.                                                           | Caller may retry.                                                                                        |
+| After queued insert, before claim            | `queued` Task with stable order.                                                           | Any daemon's queue worker.                                                                               |
+| After claim, before executor launch          | `dispatching` Task + running Session projection, prompt text and launch timestamp durable. | Existing dispatch-startup/runtime supervision. Never blindly requeue: external launch may have occurred. |
+| After local launch, before executor connects | Same `dispatching` evidence.                                                               | Dispatch connection deadline and termination coordinator.                                                |
+| After executor connects                      | `running` with connection/heartbeat facts.                                                 | Existing heartbeat/watchdog/containment contract.                                                        |
+| During terminal hook/queue trigger           | Terminal Task remains immutable; queued rows remain durable.                               | Natural triggers plus fleet queue scan.                                                                  |
+
+The queue branch does not redesign heartbeat supervision, executor
+containment, or startup orphan cleanup. A required runtime HA follow-up is to
+make discovery/ownership of already-active `dispatching`/running work fully
+fleet- and tenant-aware in auth-resolved deployments. Until that work lands,
+the Task is durably diagnosed and current local/templated startup-timeout rules
+apply, but queue code must not claim that it can prove external absence.
+
+## Validation matrix
+
+| Scenario                                                             | Coverage                                                                       |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Two daemon request transactions race two prompts on one idle Session | `task-queue-ha.postgres.test.ts`                                               |
+| Five drainers race one queued Task                                   | PostgreSQL integration; exactly one claim and one simulated launch side effect |
+| Concurrent queue-position uniqueness/order                           | SQLite repository test and PostgreSQL integration                              |
+| Different Tasks race one Session                                     | SQLite repository test; Session-first claim leaves one `dispatching`           |
+| Non-head and explicit-run queue jumping                              | SQLite repository tests                                                        |
+| Stable callback/widget production                                    | Durable-ID unit tests plus callback/widget service tests                       |
+| Completion/Stop trigger convergence                                  | Existing completion/Stop tests plus durable claim race tests                   |
+| Cross-tenant discovery/claim                                         | PostgreSQL negative integration and RLS migration contract test                |
+| Queue survives startup                                               | `startup.test.ts`                                                              |
+| Standalone queue order/recovery discovery                            | SQLite repository/worker tests                                                 |
+
+PostgreSQL tests are gated by both `AGOR_TEST_POSTGRES_URL` and
+`AGOR_DB_DIALECT=postgresql`; a skipped run is not evidence of a pass and must
+be reported as skipped.

--- a/docs/internal/session-task-queue-ha-2026-08-06.md
+++ b/docs/internal/session-task-queue-ha-2026-08-06.md
@@ -111,13 +111,23 @@ the actual resolver is retained on both the widget resolution and
 authorized collaborator from conflicting on the deterministic Task identity
 after admission has already committed.
 
-A handler that reports failure releases the widget to `pending` with a
-secret-free diagnostic so the user can explicitly retry; the current registry
-handlers write desired state idempotently for that path. An abandoned
-`resolving` claim is not automatically stolen: after daemon death the system
-cannot prove whether the external operation happened, so replay would violate
-the at-most-once side-effect policy. Requesting a fresh widget is the safe
-recovery path for that indeterminate outcome.
+Only an `applySubmit` handler that explicitly reports failure before returning
+releases the widget to `pending` with a secret-free diagnostic so the user can
+explicitly retry; the current registry handlers write desired state
+idempotently for that path. Once `applySubmit` returns, failures in prompt
+admission or terminal completion leave the widget `resolving`: reopening it
+would replay an effect that already succeeded. An abandoned `resolving` claim
+is not automatically stolen: after daemon death the system cannot prove
+whether the external operation happened, so replay would violate the
+at-most-once side-effect policy. Requesting a fresh widget is the safe recovery
+path for that indeterminate outcome.
+
+The cooperating-writer token fence is backed by a service boundary:
+transport callers cannot create widgets through generic Message single/bulk
+CRUD, cannot replace or patch widget rows, and cannot remove a
+`pending|resolving` widget. Public prompt callers likewise cannot supply Task
+metadata; callback/widget provenance is accepted only from provider-less
+daemon producers and is defensively stripped otherwise.
 
 ### Durable recovery
 
@@ -151,16 +161,17 @@ discoverable.
 
 ## Kill points and runtime handoff
 
-| Kill point                                           | Durable result                                                                             | Recovery owner                                                                                           |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Before queued insert commits                         | No Task admitted; request fails.                                                           | Caller may retry.                                                                                        |
-| After queued insert, before claim                    | `queued` Task with stable order.                                                           | Any daemon's queue worker.                                                                               |
-| After claim, before executor launch                  | `dispatching` Task + running Session projection, prompt text and launch timestamp durable. | Existing dispatch-startup/runtime supervision. Never blindly requeue: external launch may have occurred. |
-| After local launch, before executor connects         | Same `dispatching` evidence.                                                               | Dispatch connection deadline and termination coordinator.                                                |
-| After executor connects                              | `running` with connection/heartbeat facts.                                                 | Existing heartbeat/watchdog/containment contract.                                                        |
-| During terminal hook/queue trigger                   | Terminal Task remains immutable; queued rows remain durable.                               | Natural triggers plus fleet queue scan.                                                                  |
-| Widget daemon dies after resolution claim            | Widget remains `resolving` with claimant/action/time.                                      | Durable diagnosis; do not replay an external effect whose outcome is unknown.                            |
-| Widget handler reports side-effect/admission failure | Widget returns to `pending` with a secret-free code and no live claim.                     | User may explicitly retry; registry handlers must make this path idempotent.                             |
+| Kill point                                            | Durable result                                                                             | Recovery owner                                                                                           |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Before queued insert commits                          | No Task admitted; request fails.                                                           | Caller may retry.                                                                                        |
+| After queued insert, before claim                     | `queued` Task with stable order.                                                           | Any daemon's queue worker.                                                                               |
+| After claim, before executor launch                   | `dispatching` Task + running Session projection, prompt text and launch timestamp durable. | Existing dispatch-startup/runtime supervision. Never blindly requeue: external launch may have occurred. |
+| After local launch, before executor connects          | Same `dispatching` evidence.                                                               | Dispatch connection deadline and termination coordinator.                                                |
+| After executor connects                               | `running` with connection/heartbeat facts.                                                 | Existing heartbeat/watchdog/containment contract.                                                        |
+| During terminal hook/queue trigger                    | Terminal Task remains immutable; queued rows remain durable.                               | Natural triggers plus fleet queue scan.                                                                  |
+| Widget daemon dies after resolution claim             | Widget remains `resolving` with claimant/action/time.                                      | Durable diagnosis; do not replay an external effect whose outcome is unknown.                            |
+| Widget `applySubmit` explicitly reports failure       | Widget returns to `pending` with a secret-free code and no live claim.                     | User may explicitly retry; registry handlers must make this path idempotent.                             |
+| Widget prompt admission/completion fails after submit | Widget remains `resolving`; a deterministic Task may already exist.                        | Do not replay the external effect; diagnose/reconcile manually.                                          |
 
 The queue branch does not redesign heartbeat supervision, executor
 containment, or startup orphan cleanup. A required runtime HA follow-up is to
@@ -182,6 +193,7 @@ apply, but queue code must not claim that it can prove external absence.
 | Widget submit-vs-dismiss / duplicate resolver race                   | SQLite repository/store tests; PostgreSQL integration when configured          |
 | Cross-tenant widget claim                                            | PostgreSQL negative integration when configured                                |
 | Prompt/widget short transaction boundaries                           | Route-boundary tests plus bound repository units                               |
+| Public widget/provenance mutation bypasses                           | Feathers transport-hook negatives plus metadata sanitizer tests                |
 | Completion/Stop trigger convergence                                  | Existing completion/Stop tests plus durable claim race tests                   |
 | Cross-tenant discovery/claim                                         | PostgreSQL negative integration and RLS migration contract test                |
 | Queue survives startup                                               | `startup.test.ts`                                                              |

--- a/docs/internal/session-task-queue-ha-2026-08-06.md
+++ b/docs/internal/session-task-queue-ha-2026-08-06.md
@@ -1,11 +1,11 @@
 # Session Task queue HA audit
 
 **Date:** 2026-08-06  
-**Status:** stacked review requested by Max  
-**Base dependency:** this branch is temporarily stacked on scheduler HA
-[#2174](https://github.com/preset-io/agor/pull/2174), currently open. Max
-explicitly requested the stacked PR on 2026-08-06; it must be rebased onto
-`main` after #2174 lands before merge.
+**Status:** implementation review in progress
+**Base dependency:** scheduler HA
+[#2174](https://github.com/preset-io/agor/pull/2174) merged on 2026-08-06. This
+branch was rebased onto its merge commit on `main`; the scheduler files remain
+owned by that landed change.
 
 ## Decision
 
@@ -39,7 +39,7 @@ other executing Tasks, and writes the Session projection atomically. It does
 | User Stop                             | `/sessions/:id/stop`, `stopSessionPreserveQueue`           | Preserves queued rows and triggers draining after terminal settlement/release.                                                                               |
 | Session patch hooks                   | `register-hooks.ts`                                        | Promptable Session transitions trigger the same drain path. No independent selection rule.                                                                   |
 | Completion callback                   | `TasksService.queueCallbackToSession`                      | Direct durable queued admission with deterministic identity derived from source Task + target Session. The process-local Promise map is only coalescing.     |
-| Widget submit/dismiss                 | `widgets/submissions.ts`                                   | Delegates to prompt admission with deterministic identity derived from the widget Message.                                                                   |
+| Widget submit/dismiss                 | `widgets/submissions.ts`                                   | Claims `pending -> resolving` durably before external work, then delegates to prompt admission with deterministic Task/message identity.                     |
 | Widget already-present                | `mcp/tools/widgets.ts`                                     | Same stable prompt admission; identity is distinct from the widget Message so transcript IDs cannot collide.                                                 |
 | Scheduled initial prompt              | `services/scheduler.ts` from #2174                         | Delegates with the schedule occurrence's stable initial Task ID; no scheduler file is changed here.                                                          |
 | Gateway prompt                        | `services/gateway.ts`                                      | Delegates to the prompt route with resolved tenant/user provenance.                                                                                          |
@@ -82,10 +82,42 @@ transaction plus bounded busy retry and preserves existing semantics.
 
 The expected Task state, queue head, competing execution, and Session
 projection are checked and written in one transaction. `spawnTaskExecutor`
-returns before initial-message/session launch projection and before its
-post-commit executor callback unless the result is `claimed`. Stable scheduled
-occurrences are the narrow exception: a loser may idempotently repair their
-deterministic transcript row, but it never launches.
+does not write the transcript/session launch projection or schedule its
+post-commit executor callback unless the result is `claimed`. Every idempotent
+producer persists `Task.metadata.initial_message_id`. A loser repairs that row
+only after it observes `dispatching|running`; a still-queued loser neither
+writes a transcript row nor launches.
+
+The prompt route uses the long-route tenant-identity pattern rather than a
+route-wide PostgreSQL transaction. Direct Task repository calls are bound to
+short tenant units of work, so queued admission commits before claim
+preparation and queue events are emitted only after that admission boundary.
+
+### Widget side-effect fence
+
+Widget resolution has its own Message-row state machine because a deterministic
+auto-resume Task cannot fence the earlier secret writes, connection probes, or
+submit-vs-dismiss decision. `WidgetResolutionStore` performs short locked
+metadata mutations:
+
+1. `pending -> resolving` plus an opaque claim token;
+2. registry/external work and durable auto-resume admission with no DB
+   transaction held;
+3. token-checked `resolving -> submitted|dismissed`.
+
+The auto-resume Task uses the Session creator as its stable execution identity;
+the actual resolver is retained on both the widget resolution and
+`Task.metadata.widget_resolved_by_user_id`. This prevents a retry by a different
+authorized collaborator from conflicting on the deterministic Task identity
+after admission has already committed.
+
+A handler that reports failure releases the widget to `pending` with a
+secret-free diagnostic so the user can explicitly retry; the current registry
+handlers write desired state idempotently for that path. An abandoned
+`resolving` claim is not automatically stolen: after daemon death the system
+cannot prove whether the external operation happened, so replay would violate
+the at-most-once side-effect policy. Requesting a fresh widget is the safe
+recovery path for that indeterminate outcome.
 
 ### Durable recovery
 
@@ -119,14 +151,16 @@ discoverable.
 
 ## Kill points and runtime handoff
 
-| Kill point                                   | Durable result                                                                             | Recovery owner                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Before queued insert commits                 | No Task admitted; request fails.                                                           | Caller may retry.                                                                                        |
-| After queued insert, before claim            | `queued` Task with stable order.                                                           | Any daemon's queue worker.                                                                               |
-| After claim, before executor launch          | `dispatching` Task + running Session projection, prompt text and launch timestamp durable. | Existing dispatch-startup/runtime supervision. Never blindly requeue: external launch may have occurred. |
-| After local launch, before executor connects | Same `dispatching` evidence.                                                               | Dispatch connection deadline and termination coordinator.                                                |
-| After executor connects                      | `running` with connection/heartbeat facts.                                                 | Existing heartbeat/watchdog/containment contract.                                                        |
-| During terminal hook/queue trigger           | Terminal Task remains immutable; queued rows remain durable.                               | Natural triggers plus fleet queue scan.                                                                  |
+| Kill point                                           | Durable result                                                                             | Recovery owner                                                                                           |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Before queued insert commits                         | No Task admitted; request fails.                                                           | Caller may retry.                                                                                        |
+| After queued insert, before claim                    | `queued` Task with stable order.                                                           | Any daemon's queue worker.                                                                               |
+| After claim, before executor launch                  | `dispatching` Task + running Session projection, prompt text and launch timestamp durable. | Existing dispatch-startup/runtime supervision. Never blindly requeue: external launch may have occurred. |
+| After local launch, before executor connects         | Same `dispatching` evidence.                                                               | Dispatch connection deadline and termination coordinator.                                                |
+| After executor connects                              | `running` with connection/heartbeat facts.                                                 | Existing heartbeat/watchdog/containment contract.                                                        |
+| During terminal hook/queue trigger                   | Terminal Task remains immutable; queued rows remain durable.                               | Natural triggers plus fleet queue scan.                                                                  |
+| Widget daemon dies after resolution claim            | Widget remains `resolving` with claimant/action/time.                                      | Durable diagnosis; do not replay an external effect whose outcome is unknown.                            |
+| Widget handler reports side-effect/admission failure | Widget returns to `pending` with a secret-free code and no live claim.                     | User may explicitly retry; registry handlers must make this path idempotent.                             |
 
 The queue branch does not redesign heartbeat supervision, executor
 containment, or startup orphan cleanup. A required runtime HA follow-up is to
@@ -144,7 +178,10 @@ apply, but queue code must not claim that it can prove external absence.
 | Concurrent queue-position uniqueness/order                           | SQLite repository test and PostgreSQL integration                              |
 | Different Tasks race one Session                                     | SQLite repository test; Session-first claim leaves one `dispatching`           |
 | Non-head and explicit-run queue jumping                              | SQLite repository tests                                                        |
-| Stable callback/widget production                                    | Durable-ID unit tests plus callback/widget service tests                       |
+| Busy widget queues then drains one ordered transcript row            | SQLite Task/Message regression plus stable-message decision unit test          |
+| Widget submit-vs-dismiss / duplicate resolver race                   | SQLite repository/store tests; PostgreSQL integration when configured          |
+| Cross-tenant widget claim                                            | PostgreSQL negative integration when configured                                |
+| Prompt/widget short transaction boundaries                           | Route-boundary tests plus bound repository units                               |
 | Completion/Stop trigger convergence                                  | Existing completion/Stop tests plus durable claim race tests                   |
 | Cross-tenant discovery/claim                                         | PostgreSQL negative integration and RLS migration contract test                |
 | Queue survives startup                                               | `startup.test.ts`                                                              |

--- a/packages/core/drizzle/postgres/0072_task_queue_ha.sql
+++ b/packages/core/drizzle/postgres/0072_task_queue_ha.sql
@@ -1,0 +1,21 @@
+-- Keep recovery discovery bounded and cheap. This is a partial routing index;
+-- queue order within one Session remains owned by tasks_queue_idx and the
+-- queued-position uniqueness constraint.
+SET LOCAL lock_timeout = '3s';
+--> statement-breakpoint
+CREATE INDEX "tasks_queue_scan_idx"
+  ON "tasks" ("tenant_id", "session_id", "created_at")
+  WHERE "status" = 'queued';
+--> statement-breakpoint
+
+-- All daemons may discover durable queued Session routing refs. The repository
+-- projects tenant/session/timestamp only, then leaves system scope and reloads
+-- the Session under the discovered trusted tenant before any mutation.
+DROP POLICY IF EXISTS "task_queue_discovery" ON "tasks";
+--> statement-breakpoint
+CREATE POLICY "task_queue_discovery" ON "tasks"
+  FOR SELECT
+  USING (
+    "status" = 'queued'
+    AND current_setting('agor.system_scope', true) = 'task_queue_discovery'
+  );

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1785888000000,
       "tag": "0071_scheduler_ha_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1785974400000,
+      "tag": "0072_task_queue_ha",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0075_task_queue_ha.sql
+++ b/packages/core/drizzle/sqlite/0075_task_queue_ha.sql
@@ -1,0 +1,5 @@
+-- Standalone SQLite has no cross-tenant RLS capability, but uses the same
+-- bounded per-Session recovery scan.
+CREATE INDEX "tasks_queue_scan_idx"
+  ON "tasks" ("session_id", "created_at")
+  WHERE "status" = 'queued';

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1785888000000,
       "tag": "0074_scheduler_ha_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "6",
+      "when": 1785974400000,
+      "tag": "0075_task_queue_ha",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -114,7 +114,6 @@ export interface SessionPromptRequest {
   prompt: string;
   permissionMode?: PermissionMode;
   stream?: boolean;
-  messageSource?: 'gateway' | 'agor';
 }
 
 export interface QueuedSessionPromptResult {
@@ -147,14 +146,12 @@ export interface SessionsClientHelpers {
 }
 
 /**
- * Body shape for `POST /tasks/:id/run`. Matches the prompt route's options
- * so the same defaults (`stream: true`, agor messageSource for socket
- * callers) apply when explicitly triggering an already-created task.
+ * Body shape for `POST /tasks/:id/run`. Message provenance is derived by the
+ * daemon from the authenticated transport rather than accepted from callers.
  */
 export interface TaskRunRequest {
   permissionMode?: PermissionMode;
   stream?: boolean;
-  messageSource?: 'gateway' | 'agor';
 }
 
 export interface TaskRunOptions extends TaskRunRequest {
@@ -410,15 +407,12 @@ export interface TasksService extends AgorService<Task> {
   fail(id: string, data: { error: string }, params?: Params): Promise<Task>;
 }
 
-/**
- * Messages service with bulk creation support
- */
-export interface MessagesService extends AgorService<Message> {
-  /**
-   * Create multiple messages in a single request
-   * Returns array of created messages with IDs
-   */
-  createMany(data: Partial<Message>[]): Promise<Message[]>;
+/** Public Message CRUD surface. Full replacement is daemon-internal. */
+export type MessagesService = Omit<AgorService<Message>, 'update'>;
+
+/** Narrow transport contract for `POST /messages/bulk`. */
+export interface MessagesBulkService {
+  create(data: CreatePayload<Message>[], params?: Params): Promise<Message[]>;
 }
 
 /**
@@ -679,7 +673,7 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'opencode-models'): OpenCodeModelsService;
 
   // Bulk operation endpoints
-  service(path: 'messages/bulk'): MessagesService;
+  service(path: 'messages/bulk'): MessagesBulkService;
   service(path: 'tasks/bulk'): TasksService;
 
   // Standard services (CRUD only)

--- a/packages/core/src/api/write-contracts.test.ts
+++ b/packages/core/src/api/write-contracts.test.ts
@@ -5,6 +5,7 @@ import type {
   ScheduleCreateData,
   SchedulePatchData,
 } from '../types/index.js';
+import { MessageRole } from '../types/index.js';
 import type { AgorClient, ClientInput, GatewayChannelsService, SchedulesService } from './index.js';
 
 type ScheduleCreateInput = Parameters<SchedulesService['create']>[0];
@@ -85,6 +86,28 @@ function assertClientWriteBoundaries(client: AgorClient): void {
   });
   // @ts-expect-error required create fields cannot be omitted.
   void client.service('gateway-channels').create({ agentic_config: { agent: 'codex' } });
+
+  void client.service('messages/bulk').create([
+    {
+      session_id: 'session-id',
+      task_id: 'task-id',
+      role: MessageRole.USER,
+      type: 'user',
+      content: 'Imported transcript row',
+    },
+  ]);
+  // @ts-expect-error public Message CRUD does not expose full replacement.
+  void client.service('messages').update('message-id', {});
+  // @ts-expect-error bulk insertion is only available on /messages/bulk.
+  void client.service('messages').createMany([]);
+  // @ts-expect-error /messages/bulk is a narrow create-only endpoint.
+  void client.service('messages/bulk').find();
+
+  // Provenance is derived from the authenticated transport, not caller input.
+  // @ts-expect-error messageSource is daemon-owned provenance.
+  void client.sessions.prompt('session-id', 'Prompt', { messageSource: 'gateway' });
+  // @ts-expect-error messageSource is daemon-owned provenance.
+  void client.tasks.run('task-id', { messageSource: 'gateway' });
 }
 
 void assertClientWriteBoundaries;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -14,6 +14,7 @@ export type {
   BranchesService,
   ClientInput,
   GatewayChannelsService,
+  MessagesBulkService,
   MessagesService,
   ReposCloneService,
   ReposLocalService,

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -114,6 +114,16 @@ describe('Postgres multitenancy schema coverage', () => {
     expect(migration).not.toContain('WITH CHECK');
   });
 
+  it('limits task queue discovery to durable queued rows and an explicit capability', () => {
+    const migration = readRepoFile('packages/core/drizzle/postgres/0072_task_queue_ha.sql');
+
+    expect(migration).toContain('FOR SELECT');
+    expect(migration).toContain('"status" = \'queued\'');
+    expect(migration).toContain("current_setting('agor.system_scope', true)");
+    expect(migration).toContain("= 'task_queue_discovery'");
+    expect(migration).not.toContain('WITH CHECK');
+  });
+
   it('repairs scheduler occurrence and MCP idempotency indexes as tenant-aware uniques', () => {
     const migration = readRepoFile('packages/core/drizzle/postgres/0071_scheduler_ha_indexes.sql');
 

--- a/packages/core/src/db/repositories/messages.test.ts
+++ b/packages/core/src/db/repositories/messages.test.ts
@@ -616,3 +616,52 @@ describe('MessagesRepository JSON and edge cases', () => {
     expect(created.content).toBe(specialContent);
   });
 });
+
+describe('MessagesRepository.mutateMetadataLocked', () => {
+  dbTest('elects one widget resolver across concurrent SQLite writers', async ({ db }) => {
+    const sessionId = await createTestSession(db);
+    const message = createMessageData({
+      session_id: sessionId,
+      type: 'widget_request',
+      role: MessageRole.SYSTEM,
+      metadata: {
+        widget: {
+          widget_id: generateId() as MessageID,
+          widget_type: 'test',
+          schema_version: 1,
+          params: {},
+          status: 'pending',
+          requested_at: new Date().toISOString(),
+        },
+      },
+    });
+    message.metadata!.widget!.widget_id = message.message_id;
+    await new MessagesRepository(db).create(message);
+
+    const attempts = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        new MessagesRepository(db).mutateMetadataLocked(message.message_id, (metadata) => {
+          const widget = metadata?.widget;
+          if (widget?.status !== 'pending') return null;
+          return {
+            ...metadata,
+            widget: {
+              ...widget,
+              status: 'resolving',
+              resolution_claim: {
+                token: `claim-${index}`,
+                action: index % 2 === 0 ? 'submit' : 'dismiss',
+                claimed_at: new Date().toISOString(),
+                claimed_by: 'test-user' as UUID,
+              },
+            },
+          };
+        })
+      )
+    );
+
+    expect(attempts.filter((attempt) => attempt.changed)).toHaveLength(1);
+    const stored = await new MessagesRepository(db).findById(message.message_id);
+    expect(stored?.metadata?.widget?.status).toBe('resolving');
+  });
+});

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -8,12 +8,38 @@
 import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
 import { and, eq, inArray } from 'drizzle-orm';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isSQLiteDatabase,
+  lockRowForUpdate,
+  runDatabaseTransaction,
+  select,
+  update,
+} from '../database-wrapper';
 import { type MessageInsert, type MessageRow, messages } from '../schema';
 import { visibleSessionReferenceAccessExists } from './branch-access';
 
 export class MessagesRepository {
   constructor(private db: Database) {}
+
+  /** Retry a whole locked metadata mutation so SQLite re-reads after contention. */
+  private async runMetadataMutation<T>(mutation: () => Promise<T>, attempt = 0): Promise<T> {
+    try {
+      return await mutation();
+    } catch (error) {
+      const text = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+      if (
+        isSQLiteDatabase(this.db) &&
+        attempt < 4 &&
+        /SQLITE_BUSY|database is locked|database is busy/i.test(text)
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+        return this.runMetadataMutation(mutation, attempt + 1);
+      }
+      throw error;
+    }
+  }
 
   /**
    * Convert database row to Message type
@@ -86,6 +112,50 @@ export class MessagesRepository {
       .one();
 
     return row ? this.rowToMessage(row) : null;
+  }
+
+  /**
+   * Atomically transform one Message's metadata under a short row lock.
+   *
+   * The callback is deliberately synchronous: callers may decide a durable
+   * state transition while holding the lock, but cannot accidentally perform
+   * network/process work inside the transaction. Returning `null` leaves the
+   * row unchanged and returns the latest locked value to the caller.
+   */
+  async mutateMetadataLocked(
+    messageId: MessageID,
+    mutation: (metadata: Message['metadata'], message: Message) => Message['metadata'] | null
+  ): Promise<{ changed: boolean; message: Message }> {
+    return this.runMetadataMutation(() =>
+      runDatabaseTransaction(
+        this.db,
+        async (txDb) => {
+          await lockRowForUpdate(txDb, this.db, messages, eq(messages.message_id, messageId));
+          const row = await select(txDb)
+            .from(messages)
+            .where(eq(messages.message_id, messageId))
+            .one();
+          if (!row) throw new Error(`Message ${messageId} not found`);
+
+          const current = this.rowToMessage(row);
+          const metadata = mutation(current.metadata, current);
+          if (metadata === null) return { changed: false, message: current };
+
+          const data = row.data as {
+            content: Message['content'];
+            tool_uses?: Message['tool_uses'];
+            metadata?: Message['metadata'];
+          };
+          const updatedRow = await update(txDb, messages)
+            .set({ data: { ...data, metadata } })
+            .where(eq(messages.message_id, messageId))
+            .returning()
+            .one();
+          return { changed: true, message: this.rowToMessage(updatedRow) };
+        },
+        { sqliteImmediate: true }
+      )
+    );
   }
 
   /**

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -4,14 +4,15 @@
  * Tests for type-safe CRUD operations on tasks with short ID support.
  */
 
-import type { Task, TaskPendingDispatchStatus, UUID } from '@agor/core/types';
-import { SessionStatus, TaskStatus } from '@agor/core/types';
+import type { MessageID, Task, TaskPendingDispatchStatus, UUID } from '@agor/core/types';
+import { MessageRole, SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
 import { dbTest } from '../test-helpers';
 import { AmbiguousIdError, EntityNotFoundError, RepositoryError } from './base';
 import { BranchRepository } from './branches';
+import { MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { TaskRepository } from './tasks';
@@ -1975,6 +1976,105 @@ describe('TaskRepository.createPending', () => {
     expect(claim.task.queue_position).toBeUndefined();
     expect((await taskRepo.findById(queued.task_id))?.queue_position).toBeUndefined();
   });
+
+  dbTest(
+    'writes one correctly ordered widget transcript row only after busy-session drain claims it',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionRepo = new SessionRepository(db);
+      const messagesRepo = new MessagesRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const first = await taskRepo.createPending(
+        createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+      );
+      const firstClaim = await taskRepo.claimDispatchAndProjectSession(
+        first.task_id,
+        TaskStatus.QUEUED,
+        { status: TaskStatus.DISPATCHING }
+      );
+      expect(firstClaim.outcome).toBe('claimed');
+      await messagesRepo.create({
+        message_id: generateId() as MessageID,
+        session_id: sessionId,
+        task_id: first.task_id,
+        type: 'user',
+        role: MessageRole.USER,
+        index: 0,
+        timestamp: new Date().toISOString(),
+        content_preview: 'active prompt',
+        content: 'active prompt',
+      });
+
+      const widgetTaskId = generateId();
+      const widgetTask = await taskRepo.createPending({
+        ...createPendingInput({
+          session_id: sessionId,
+          status: TaskStatus.QUEUED,
+          metadata: {
+            system_authored: true,
+            widget_id: generateId() as MessageID,
+            initial_message_id: widgetTaskId as MessageID,
+          },
+        }),
+        task_id: widgetTaskId,
+      });
+      const lost = await taskRepo.claimDispatchAndProjectSession(
+        widgetTask.task_id,
+        TaskStatus.QUEUED,
+        { status: TaskStatus.DISPATCHING }
+      );
+      expect(lost).toMatchObject({
+        outcome: 'condition_changed',
+        task: { status: TaskStatus.QUEUED },
+      });
+      expect(await messagesRepo.findByTaskId(widgetTask.task_id)).toHaveLength(0);
+
+      await taskRepo.update(first.task_id, { status: TaskStatus.COMPLETED });
+      await sessionRepo.update(sessionId, {
+        status: SessionStatus.IDLE,
+        ready_for_prompt: true,
+      });
+      const drained = await taskRepo.claimDispatchAndProjectSession(
+        widgetTask.task_id,
+        TaskStatus.QUEUED,
+        {
+          status: TaskStatus.DISPATCHING,
+          message_range: {
+            start_index: 1,
+            end_index: 2,
+            start_timestamp: new Date().toISOString(),
+          },
+        }
+      );
+      expect(drained.outcome).toBe('claimed');
+      const stableMessageId = drained.task.metadata!.initial_message_id!;
+      if (!(await messagesRepo.findById(stableMessageId))) {
+        await messagesRepo.create({
+          message_id: stableMessageId,
+          session_id: sessionId,
+          task_id: widgetTask.task_id,
+          type: 'user',
+          role: MessageRole.USER,
+          index: drained.task.message_range.start_index,
+          timestamp: drained.task.message_range.start_timestamp,
+          content_preview: widgetTask.full_prompt,
+          content: widgetTask.full_prompt,
+        });
+      }
+      // A replacement daemon repeats reconciliation against the same durable
+      // identity rather than creating a random second row.
+      if (!(await messagesRepo.findById(stableMessageId))) {
+        throw new Error('stable message unexpectedly missing');
+      }
+
+      const widgetMessages = await messagesRepo.findByTaskId(widgetTask.task_id);
+      expect(widgetMessages).toHaveLength(1);
+      expect(widgetMessages[0]).toMatchObject({ message_id: stableMessageId, index: 1 });
+      expect(
+        (await messagesRepo.findBySessionId(sessionId)).map((message) => message.index)
+      ).toEqual([0, 1]);
+    }
+  );
 
   dbTest(
     'should create QUEUED task with queue_position=1 when no other queued tasks',

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1807,6 +1807,55 @@ describe('TaskRepository.createPending', () => {
     expect(await taskRepo.findBySession(sessionId)).toHaveLength(1);
   });
 
+  dbTest('reconciles concurrent stable-ID queue admission to one position', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const taskId = generateId();
+    const input = createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED });
+
+    const admitted = await Promise.all(
+      Array.from({ length: 5 }, () => taskRepo.createPending({ ...input, task_id: taskId }))
+    );
+
+    expect(new Set(admitted.map((task) => task.task_id))).toEqual(new Set([taskId]));
+    expect(new Set(admitted.map((task) => task.queue_position))).toEqual(new Set([1]));
+    expect(await taskRepo.findQueued(sessionId)).toHaveLength(1);
+  });
+
+  dbTest(
+    'recovers a stable CREATED task into queue order without changing identity',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const taskId = generateId();
+      const stableInput = createPendingInput({
+        session_id: sessionId,
+        status: TaskStatus.CREATED,
+        full_prompt: 'scheduled occurrence',
+      });
+      await taskRepo.createPending({ ...stableInput, task_id: taskId });
+      const existingHead = await taskRepo.createPending(
+        createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+      );
+
+      const recovered = await taskRepo.createPending({
+        ...stableInput,
+        status: TaskStatus.QUEUED,
+        task_id: taskId,
+      });
+
+      expect(recovered).toMatchObject({
+        task_id: taskId,
+        status: TaskStatus.QUEUED,
+        queue_position: 2,
+      });
+      expect((await taskRepo.findQueued(sessionId)).map((task) => task.task_id)).toEqual([
+        existingHead.task_id,
+        taskId,
+      ]);
+    }
+  );
+
   dbTest('atomically fences concurrent dispatch claims', async ({ db }) => {
     const taskRepo = new TaskRepository(db);
     const sessionId = await createSessionWithDeps(db);
@@ -1831,6 +1880,84 @@ describe('TaskRepository.createPending', () => {
       ready_for_prompt: false,
       tasks: [task.task_id],
     });
+  });
+
+  dbTest('serializes different Task claims to one active Session dispatch', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const [first, second] = await Promise.all([
+      taskRepo.createPending(
+        createPendingInput({ session_id: sessionId, status: TaskStatus.CREATED })
+      ),
+      taskRepo.createPending(
+        createPendingInput({ session_id: sessionId, status: TaskStatus.CREATED })
+      ),
+    ]);
+
+    const claims = await Promise.all([
+      taskRepo.claimDispatchAndProjectSession(first.task_id, TaskStatus.CREATED, {
+        status: TaskStatus.DISPATCHING,
+      }),
+      taskRepo.claimDispatchAndProjectSession(second.task_id, TaskStatus.CREATED, {
+        status: TaskStatus.DISPATCHING,
+      }),
+    ]);
+
+    expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
+    expect(claims.filter((claim) => claim.outcome === 'condition_changed')).toHaveLength(1);
+    const persisted = await taskRepo.findBySession(sessionId);
+    expect(persisted.filter((task) => task.status === TaskStatus.DISPATCHING)).toHaveLength(1);
+    await expect(new SessionRepository(db).findById(sessionId)).resolves.toMatchObject({
+      status: SessionStatus.RUNNING,
+      tasks: [claims.find((claim) => claim.outcome === 'claimed')!.task.task_id],
+    });
+  });
+
+  dbTest('only lets the durable queue head claim dispatch', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const first = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+    );
+    const second = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+    );
+
+    await expect(
+      taskRepo.claimDispatchAndProjectSession(second.task_id, TaskStatus.QUEUED, {
+        status: TaskStatus.DISPATCHING,
+      })
+    ).resolves.toMatchObject({ outcome: 'condition_changed', task: { status: TaskStatus.QUEUED } });
+    await expect(
+      taskRepo.claimDispatchAndProjectSession(first.task_id, TaskStatus.QUEUED, {
+        status: TaskStatus.DISPATCHING,
+      })
+    ).resolves.toMatchObject({ outcome: 'claimed' });
+  });
+
+  dbTest('does not let an explicit CREATED Task jump a durable prompt queue', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const queued = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
+    );
+    const created = await taskRepo.createPending(
+      createPendingInput({ session_id: sessionId, status: TaskStatus.CREATED })
+    );
+
+    await expect(
+      taskRepo.claimDispatchAndProjectSession(created.task_id, TaskStatus.CREATED, {
+        status: TaskStatus.DISPATCHING,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'condition_changed',
+      task: { status: TaskStatus.CREATED },
+    });
+    await expect(
+      taskRepo.claimDispatchAndProjectSession(queued.task_id, TaskStatus.QUEUED, {
+        status: TaskStatus.DISPATCHING,
+      })
+    ).resolves.toMatchObject({ outcome: 'claimed' });
   });
 
   dbTest('clears queue position when claiming a queued task for dispatch', async ({ db }) => {
@@ -1964,12 +2091,10 @@ describe('TaskRepository.createPending', () => {
       // createQueued TOCTOU race that existed before the read-then-insert was
       // wrapped in a transaction.
       //
-      // libsql serializes concurrent write transactions, so under contention
-      // some inserts may surface SQLITE_BUSY. Either outcome (success with
-      // unique position OR transient BUSY) is correct — what we forbid is
-      // *committed* duplicates. Successful rows must therefore have distinct,
-      // monotonically-increasing positions starting at 1.
-      const settled = await Promise.allSettled([
+      // libSQL serializes concurrent write transactions. The repository may
+      // retry transient SQLITE_BUSY, but callers still receive one successful,
+      // ordered admission decision rather than a leaked contention error.
+      const admitted = await Promise.all([
         taskRepo.createPending(
           createPendingInput({ session_id: sessionId, status: TaskStatus.QUEUED })
         ),
@@ -1981,16 +2106,7 @@ describe('TaskRepository.createPending', () => {
         ),
       ]);
 
-      const successes = settled
-        .filter((r): r is PromiseFulfilledResult<Task> => r.status === 'fulfilled')
-        .map((r) => r.value);
-
-      expect(successes.length).toBeGreaterThan(0);
-
-      const positions = successes.map((t) => t.queue_position).sort();
-      const unique = new Set(positions);
-      expect(unique.size).toBe(positions.length); // no duplicates
-      expect(positions[0]).toBe(1); // numbering starts at 1
+      expect(admitted.map((task) => task.queue_position).sort()).toEqual([1, 2, 3]);
     }
   );
 });
@@ -2035,6 +2151,33 @@ describe('TaskRepository.findQueued', () => {
       'second queued',
       'third queued',
     ]);
+  });
+
+  dbTest('discovers bounded queued Session refs with a stable cursor', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionA = await createSessionWithDeps(db);
+    const sessionB = await createSessionWithDeps(db);
+    await taskRepo.createPending(
+      createPendingInput({ session_id: sessionA, status: TaskStatus.QUEUED })
+    );
+    await taskRepo.createPending(
+      createPendingInput({ session_id: sessionA, status: TaskStatus.QUEUED })
+    );
+    await taskRepo.createPending(
+      createPendingInput({ session_id: sessionB, status: TaskStatus.QUEUED })
+    );
+
+    const firstPage = await taskRepo.findQueuedSessionRefs(1);
+    const secondPage = await taskRepo.findQueuedSessionRefs(1, firstPage[0]);
+
+    expect(firstPage).toHaveLength(1);
+    expect(secondPage).toHaveLength(1);
+    expect(new Set([firstPage[0]!.session_id, secondPage[0]!.session_id])).toEqual(
+      new Set([sessionA, sessionB])
+    );
+    expect(firstPage[0]!.tenant_id).toBeUndefined();
+    expect(Number.isFinite(firstPage[0]!.first_queued_at)).toBe(true);
+    await expect(taskRepo.findQueuedSessionRefs(0)).rejects.toThrow(/between 1 and 1000/);
   });
 });
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -1220,9 +1220,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         .run();
 
       // The launch-intent transition and its Session projection are one
-      // durable state change. PostgreSQL request scopes already provide an
-      // outer transaction, but standalone SQLite does not; keeping this write
-      // inside the task-claim transaction closes the kill point where a Task
+      // durable state change. Keeping this write inside the task-claim
+      // transaction (independent of any request-scope policy) closes the kill
+      // point where a Task
       // could be DISPATCHING while its Session remained IDLE and omitted the
       // task from data.tasks.
       const sessionTasks = sessionRow.data.tasks.includes(current.task_id)

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -16,21 +16,27 @@ import type {
   TerminationCause,
   UUID,
 } from '@agor/core/types';
-import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
-import { and, eq, inArray, like, sql } from 'drizzle-orm';
+import {
+  EXECUTING_TASK_STATUSES,
+  isTerminalTaskStatus,
+  SessionStatus,
+  sessionCanStartTask,
+  TaskStatus,
+} from '@agor/core/types';
+import { and, asc, eq, gt, inArray, like, ne, or, sql } from 'drizzle-orm';
 import { generateId, shortId } from '../../lib/ids';
 import type { Database } from '../client';
 import {
   deleteFrom,
   insert,
+  isPostgresDatabase,
   isSQLiteDatabase,
   lockRowForUpdate,
   runDatabaseTransaction,
   select,
-  txAsDb,
   update,
 } from '../database-wrapper';
-import { sessions, type TaskInsert, type TaskRow, tasks } from '../schema';
+import { type SessionRow, sessions, type TaskInsert, type TaskRow, tasks } from '../schema';
 import {
   AmbiguousIdError,
   type BaseRepository,
@@ -131,6 +137,15 @@ export interface TaskDispatchClaimResult {
   task: Task;
 }
 
+/** Routing-only row returned to the all-daemon queue recovery scanner. */
+export interface QueuedSessionRef {
+  session_id: SessionID;
+  first_queued_at: number;
+  tenant_id?: string;
+}
+
+export type QueuedSessionCursor = Pick<QueuedSessionRef, 'session_id' | 'tenant_id'>;
+
 /**
  * Task repository implementation
  */
@@ -165,6 +180,59 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
           const row = await select(txDb).from(tasks).where(eq(tasks.task_id, fullId)).one();
           if (!row) throw new EntityNotFoundError('Task', id);
           return mutation(txDb, row, fullId);
+        },
+        { sqliteImmediate: true }
+      )
+    );
+  }
+
+  /**
+   * Lock a Task together with its owning Session, always Session first.
+   *
+   * Session-first ordering is the cross-daemon turn mutex. It serializes
+   * claims for different Tasks in the same Session, whereas a Task-only lock
+   * can prevent duplicate launch of one Task but cannot prevent two distinct
+   * Tasks from launching concurrently.
+   */
+  private async mutateLockedSessionTask<T>(
+    id: string,
+    mutation: (
+      txDb: Database,
+      taskRow: TaskRow,
+      sessionRow: SessionRow,
+      fullId: string
+    ) => Promise<T>
+  ): Promise<T> {
+    const fullId = await this.resolveId(id);
+    const routing = await select(this.db, { session_id: tasks.session_id })
+      .from(tasks)
+      .where(eq(tasks.task_id, fullId))
+      .one();
+    if (!routing) throw new EntityNotFoundError('Task', id);
+
+    return this.runTaskMutation(() =>
+      runDatabaseTransaction(
+        this.db,
+        async (txDb) => {
+          await lockRowForUpdate(
+            txDb,
+            this.db,
+            sessions,
+            eq(sessions.session_id, routing.session_id)
+          );
+          const sessionRow = await select(txDb)
+            .from(sessions)
+            .where(eq(sessions.session_id, routing.session_id))
+            .one();
+          if (!sessionRow) throw new EntityNotFoundError('Session', routing.session_id);
+
+          await lockRowForUpdate(txDb, this.db, tasks, eq(tasks.task_id, fullId));
+          const taskRow = await select(txDb).from(tasks).where(eq(tasks.task_id, fullId)).one();
+          if (!taskRow) throw new EntityNotFoundError('Task', id);
+          if (taskRow.session_id !== sessionRow.session_id) {
+            throw new RepositoryError('Task changed Session during dispatch admission');
+          }
+          return mutation(txDb, taskRow, sessionRow, fullId);
         },
         { sqliteImmediate: true }
       )
@@ -920,10 +988,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    * caller would otherwise have to assemble by hand.
    *
    * For QUEUED tasks, `queue_position = max(queue_position) + 1` is computed
-   * inside a transaction so concurrent writers don't both observe the same
-   * max and collide. (The schema also carries a partial unique index on
-   * `(session_id, queue_position) WHERE status='queued'` as a belt-and-
-   * suspenders against transaction-isolation surprises.)
+   * while holding the owning Session row lock. A transaction by itself does
+   * not serialize PostgreSQL READ COMMITTED readers; the Session lock is the
+   * durable per-queue sequencer shared by every daemon. (The schema also
+   * carries a partial unique index as defense in depth.)
    *
    * Sentinel contract: while a task carries `message_range.start_index = -1`
    * and `git_state.sha_at_start = ''`, it has not yet been pinned to real
@@ -981,50 +1049,105 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       return existing;
     }
 
-    // QUEUED: serialize the read-then-insert in a transaction so concurrent
-    // callers can't both observe the same `max(queue_position)` and produce
-    // duplicate positions. Two prompts arriving in the same tick now order
-    // deterministically instead of racing.
-    return this.db.transaction(async (tx) => {
-      const positionRow = await select(txAsDb(tx), {
-        maxPos: sql<number | null>`max(${tasks.queue_position})`,
-      })
-        .from(tasks)
-        .where(sql`${tasks.session_id} = ${input.session_id} AND ${tasks.status} = 'queued'`)
-        .one();
+    // QUEUED: lock the durable Session row before max+1. This is required on
+    // PostgreSQL: two ordinary READ COMMITTED transactions can otherwise read
+    // the same max concurrently and merely turn the unique index into a loser
+    // error rather than making one ordered admission decision.
+    return this.runTaskMutation(() =>
+      runDatabaseTransaction(
+        this.db,
+        async (txDb) => {
+          await lockRowForUpdate(
+            txDb,
+            this.db,
+            sessions,
+            eq(sessions.session_id, input.session_id)
+          );
+          const sessionRow = await select(txDb)
+            .from(sessions)
+            .where(eq(sessions.session_id, input.session_id))
+            .one();
+          if (!sessionRow) throw new EntityNotFoundError('Session', input.session_id);
 
-      const nextPosition = (positionRow?.maxPos ?? 0) + 1;
-      const insertData = this.taskToInsert({
-        ...taskBase,
-        queue_position: nextPosition,
-      });
-      await insert(txAsDb(tx), tasks).values(insertData).run();
+          let existingCreated: Task | undefined;
+          if (input.task_id) {
+            await lockRowForUpdate(txDb, this.db, tasks, eq(tasks.task_id, input.task_id));
+            const existingRow = await select(txDb)
+              .from(tasks)
+              .where(eq(tasks.task_id, input.task_id))
+              .one();
+            if (existingRow) {
+              const existing = this.rowToTask(existingRow);
+              if (
+                existing.session_id !== input.session_id ||
+                existing.created_by !== input.created_by ||
+                existing.full_prompt !== input.full_prompt
+              ) {
+                throw new RepositoryError(`Task identity ${input.task_id} is already in use`);
+              }
+              if (existing.status !== TaskStatus.CREATED) return existing;
 
-      const row = await select(txAsDb(tx))
-        .from(tasks)
-        .where(eq(tasks.task_id, insertData.task_id))
-        .one();
-      if (!row) {
-        throw new RepositoryError('Failed to retrieve created queued task');
-      }
-      return this.rowToTask(row);
-    });
+              // A stable internal producer may recover a standalone SQLite
+              // crash that committed CREATED before launch admission. Move
+              // that same Task into the durable queue rather than letting it
+              // jump an already-admitted prompt or remain undiscoverable.
+              existingCreated = existing;
+            }
+          }
+
+          const positionRow = await select(txDb, {
+            maxPos: sql<number | null>`max(${tasks.queue_position})`,
+          })
+            .from(tasks)
+            .where(sql`${tasks.session_id} = ${input.session_id} AND ${tasks.status} = 'queued'`)
+            .one();
+
+          const nextPosition = (positionRow?.maxPos ?? 0) + 1;
+          if (existingCreated) {
+            await update(txDb, tasks)
+              .set({ status: TaskStatus.QUEUED, queue_position: nextPosition })
+              .where(eq(tasks.task_id, existingCreated.task_id))
+              .run();
+            return {
+              ...existingCreated,
+              status: TaskStatus.QUEUED,
+              queue_position: nextPosition,
+            };
+          }
+
+          const insertData = this.taskToInsert({
+            ...taskBase,
+            queue_position: nextPosition,
+          });
+          await insert(txDb, tasks).values(insertData).run();
+
+          const row = await select(txDb)
+            .from(tasks)
+            .where(eq(tasks.task_id, insertData.task_id))
+            .one();
+          if (!row) throw new RepositoryError('Failed to retrieve created queued task');
+          return this.rowToTask(row);
+        },
+        { sqliteImmediate: true }
+      )
+    );
   }
 
   /**
    * Atomically claim the CREATED/QUEUED -> DISPATCHING transition.
    *
-   * The row lock and expected-state check are the fence. A second daemon that
-   * read the old state may do preparatory work, but it cannot write launch
-   * intent, transcript/session state, or spawn a second executor after losing
-   * this transition.
+   * The Session row lock, queue-head check, and Task expected-state check are
+   * the fence. A Task-only fence prevents duplicate launch of one Task but is
+   * insufficient when two daemons claim different Tasks for the same Session.
+   * A loser may do preparatory reads, but it cannot write launch intent,
+   * transcript/session state, or spawn an executor.
    */
   async claimDispatchAndProjectSession(
     id: string,
     expectedStatus: TaskPendingDispatchStatus,
     updates: Partial<Task>
   ): Promise<TaskDispatchClaimResult> {
-    return this.mutateLockedTask(id, async (txDb, currentRow, fullId) => {
+    return this.mutateLockedSessionTask(id, async (txDb, currentRow, sessionRow, fullId) => {
       const current = this.rowToTask(currentRow);
       if (current.status !== expectedStatus) {
         return {
@@ -1037,6 +1160,40 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       }
       if (updates.status !== TaskStatus.DISPATCHING) {
         throw new RepositoryError('Dispatch claim must transition to dispatching');
+      }
+
+      // A queue claimant may only take the durable head. An explicit CREATED
+      // task may not jump an existing prompt queue. Both checks run under the
+      // same Session lock that serializes enqueue position assignment.
+      const queuedHead = await select(txDb, { task_id: tasks.task_id })
+        .from(tasks)
+        .where(and(eq(tasks.session_id, current.session_id), eq(tasks.status, TaskStatus.QUEUED)))
+        .orderBy(asc(tasks.queue_position), asc(tasks.created_at), asc(tasks.task_id))
+        .limit(1)
+        .one();
+      if (
+        (expectedStatus === TaskStatus.QUEUED && queuedHead?.task_id !== fullId) ||
+        (expectedStatus === TaskStatus.CREATED && queuedHead != null)
+      ) {
+        return { outcome: 'condition_changed', task: current };
+      }
+
+      const competingExecution = await select(txDb, { task_id: tasks.task_id })
+        .from(tasks)
+        .where(
+          and(
+            eq(tasks.session_id, current.session_id),
+            ne(tasks.task_id, fullId),
+            inArray(tasks.status, [...EXECUTING_TASK_STATUSES])
+          )
+        )
+        .limit(1)
+        .one();
+      if (
+        competingExecution ||
+        !sessionCanStartTask(sessionRow.status, sessionRow.ready_for_prompt)
+      ) {
+        return { outcome: 'condition_changed', task: current };
       }
 
       const merged: Task = {
@@ -1068,14 +1225,6 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       // inside the task-claim transaction closes the kill point where a Task
       // could be DISPATCHING while its Session remained IDLE and omitted the
       // task from data.tasks.
-      await lockRowForUpdate(txDb, this.db, sessions, eq(sessions.session_id, current.session_id));
-      const sessionRow = await select(txDb)
-        .from(sessions)
-        .where(eq(sessions.session_id, current.session_id))
-        .one();
-      if (!sessionRow) {
-        throw new EntityNotFoundError('Session', current.session_id);
-      }
       const sessionTasks = sessionRow.data.tasks.includes(current.task_id)
         ? sessionRow.data.tasks
         : [...sessionRow.data.tasks, current.task_id];
@@ -1100,7 +1249,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const rows = await select(this.db)
         .from(tasks)
         .where(sql`${tasks.session_id} = ${sessionId} AND ${tasks.status} = 'queued'`)
-        .orderBy(tasks.queue_position)
+        .orderBy(asc(tasks.queue_position), asc(tasks.created_at), asc(tasks.task_id))
         .all();
 
       return rows.map((row: TaskRow) => this.rowToTask(row));
@@ -1121,7 +1270,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const row = await select(this.db)
         .from(tasks)
         .where(sql`${tasks.session_id} = ${sessionId} AND ${tasks.status} = 'queued'`)
-        .orderBy(tasks.queue_position)
+        .orderBy(asc(tasks.queue_position), asc(tasks.created_at), asc(tasks.task_id))
         .limit(1)
         .one();
 
@@ -1132,6 +1281,59 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         error
       );
     }
+  }
+
+  /**
+   * Bounded routing-only discovery for all-daemon queue recovery.
+   *
+   * The cursor is fairness state only. QUEUED rows remain the durable
+   * authority, and callers wrap after an empty page. PostgreSQL system scope
+   * exposes only queued rows through the dedicated RLS capability; each
+   * returned Session must be reloaded and mutated in its trusted tenant scope.
+   */
+  async findQueuedSessionRefs(
+    limit = 25,
+    after?: QueuedSessionCursor
+  ): Promise<QueuedSessionRef[]> {
+    if (!Number.isInteger(limit) || limit <= 0 || limit > 1_000) {
+      throw new RepositoryError('Queued Session discovery limit must be between 1 and 1000');
+    }
+
+    const tenantColumn = (tasks as unknown as { tenant_id?: typeof tasks.session_id }).tenant_id;
+    const postgresTenantColumn = isPostgresDatabase(this.db) ? tenantColumn : undefined;
+    const afterCondition = postgresTenantColumn
+      ? after?.tenant_id
+        ? or(
+            gt(postgresTenantColumn, after.tenant_id),
+            and(eq(postgresTenantColumn, after.tenant_id), gt(tasks.session_id, after.session_id))
+          )
+        : undefined
+      : after
+        ? gt(tasks.session_id, after.session_id)
+        : undefined;
+    const columns = {
+      session_id: tasks.session_id,
+      first_queued_at: sql<Date | number>`min(${tasks.created_at})`,
+      ...(postgresTenantColumn ? { tenant_id: postgresTenantColumn } : {}),
+    };
+    const grouped = select(this.db, columns)
+      .from(tasks)
+      .where(and(eq(tasks.status, TaskStatus.QUEUED), afterCondition))
+      .groupBy(
+        ...(postgresTenantColumn ? [postgresTenantColumn, tasks.session_id] : [tasks.session_id])
+      );
+    const rows = postgresTenantColumn
+      ? await grouped.orderBy(asc(postgresTenantColumn), asc(tasks.session_id)).limit(limit).all()
+      : await grouped.orderBy(asc(tasks.session_id)).limit(limit).all();
+
+    return (rows as Array<Record<string, unknown>>).map((row) => ({
+      session_id: row.session_id as SessionID,
+      first_queued_at:
+        row.first_queued_at instanceof Date
+          ? row.first_queued_at.getTime()
+          : new Date(row.first_queued_at as string | number).getTime(),
+      ...(typeof row.tenant_id === 'string' ? { tenant_id: row.tenant_id } : {}),
+    }));
   }
 
   /**

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -388,6 +388,12 @@ export const tasks = pgTable(
     queuedPositionUnique: uniqueIndex('tasks_queued_position_unique')
       .on(table.tenant_id, table.session_id, table.queue_position)
       .where(sql`${table.status} = 'queued'`),
+    // Bounded all-daemon recovery discovers one routing ref per queued
+    // Session in tenant/session order. The partial predicate keeps active and
+    // historical Tasks out of this small recovery index.
+    queueScanIdx: index('tasks_queue_scan_idx')
+      .on(table.tenant_id, table.session_id, table.created_at)
+      .where(sql`${table.status} = 'queued'`),
   })
 );
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -364,6 +364,11 @@ export const tasks = sqliteTable(
     queuedPositionUnique: uniqueIndex('tasks_queued_position_unique')
       .on(table.session_id, table.queue_position)
       .where(sql`${table.status} = 'queued'`),
+    // Standalone recovery uses the same bounded Session scan without tenant
+    // routing metadata.
+    queueScanIdx: index('tasks_queue_scan_idx')
+      .on(table.session_id, table.created_at)
+      .where(sql`${table.status} = 'queued'`),
   })
 );
 

--- a/packages/core/src/db/task-queue-ha.postgres.test.ts
+++ b/packages/core/src/db/task-queue-ha.postgres.test.ts
@@ -1,0 +1,239 @@
+/**
+ * PostgreSQL integration proof for Session Task queue admission and dispatch.
+ *
+ * Run with:
+ *   AGOR_DB_DIALECT=postgresql \
+ *   AGOR_TEST_POSTGRES_URL=postgresql://user:pw@host:5432/db \
+ *   pnpm --filter @agor/core exec vitest run src/db/task-queue-ha.postgres.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../lib/ids';
+import type { SessionID, TaskID, UUID } from '../types/id';
+import { TaskStatus } from '../types/task';
+import { createDatabase, type Database } from './client';
+import { isPostgresDatabase } from './database-wrapper';
+import { initializeDatabase } from './migrate';
+import {
+  BranchRepository,
+  RepoRepository,
+  SessionRepository,
+  TaskRepository,
+  UsersRepository,
+} from './repositories';
+import { runWithSystemDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+let branchUnique = Date.now() % 1_000_000;
+
+interface TenantSeed {
+  tenantId: string;
+  userId: UUID;
+  branchId: UUID;
+}
+
+async function seedTenant(db: Database, tenantId: string): Promise<TenantSeed> {
+  return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const user = await new UsersRepository(scoped).create({
+      email: `${tenantId}-${generateId()}@example.com`,
+      name: `Queue ${tenantId}`,
+    });
+    const repo = await new RepoRepository(scoped).create({
+      repo_id: generateId(),
+      slug: `task-queue-ha-${tenantId}-${generateId()}`,
+      name: `Task queue HA ${tenantId}`,
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/task-queue-ha.git',
+      local_path: `/tmp/${generateId()}`,
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(scoped).create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `task-queue-ha-${tenantId}`,
+      ref: 'main',
+      branch_unique_id: branchUnique++,
+      path: `/tmp/${generateId()}`,
+      created_by: user.user_id,
+    });
+    return {
+      tenantId,
+      userId: user.user_id as UUID,
+      branchId: branch.branch_id as UUID,
+    };
+  });
+}
+
+async function createSession(db: Database, seed: TenantSeed): Promise<SessionID> {
+  return runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+    const session = await new SessionRepository(scoped).create({
+      session_id: generateId() as SessionID,
+      branch_id: seed.branchId,
+      created_by: seed.userId,
+      agentic_tool: 'claude-code',
+    });
+    return session.session_id;
+  });
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)('Session Task queue HA (PostgreSQL)', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    await initializeDatabase(db);
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+  });
+
+  afterAll(async () => {
+    await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+  });
+
+  it('serializes two daemon prompt admissions on one idle Session', async () => {
+    const seed = await seedTenant(db, `queue-prompt-race-${generateId()}`);
+    const sessionId = await createSession(db, seed);
+
+    const admissions = await Promise.all(
+      ['first prompt', 'second prompt'].map((fullPrompt) =>
+        runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+          // Each scope represents one daemon request/transaction.
+          const tasks = new TaskRepository(scoped);
+          const task = await tasks.createPending({
+            session_id: sessionId,
+            created_by: seed.userId,
+            full_prompt: fullPrompt,
+            status: TaskStatus.QUEUED,
+          });
+          return tasks.claimDispatchAndProjectSession(task.task_id, TaskStatus.QUEUED, {
+            status: TaskStatus.DISPATCHING,
+          });
+        })
+      )
+    );
+
+    expect(admissions.filter((admission) => admission.outcome === 'claimed')).toHaveLength(1);
+    expect(
+      admissions.filter((admission) => admission.task.status === TaskStatus.QUEUED)
+    ).toHaveLength(1);
+    await runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+      const tasks = await new TaskRepository(scoped).findBySession(sessionId);
+      expect(tasks.map((task) => task.queue_position).filter(Boolean)).toEqual([1]);
+      expect(tasks.filter((task) => task.status === TaskStatus.DISPATCHING)).toHaveLength(1);
+      expect((await new SessionRepository(scoped).findById(sessionId))?.tasks).toHaveLength(1);
+    });
+  });
+
+  it('lets one of five drainers claim and launch one queued Task', async () => {
+    const seed = await seedTenant(db, `queue-five-drainers-${generateId()}`);
+    const sessionId = await createSession(db, seed);
+    const task = await runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+      new TaskRepository(scoped).createPending({
+        session_id: sessionId,
+        created_by: seed.userId,
+        full_prompt: 'launch once',
+        status: TaskStatus.QUEUED,
+      })
+    );
+    let launches = 0;
+
+    const claims = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+          const claim = await new TaskRepository(scoped).claimDispatchAndProjectSession(
+            task.task_id,
+            TaskStatus.QUEUED,
+            { status: TaskStatus.DISPATCHING }
+          );
+          // Mirrors spawnTaskExecutor's side-effect fence: only a claimant may
+          // hand work to an executor.
+          if (claim.outcome === 'claimed') launches += 1;
+          return claim;
+        })
+      )
+    );
+
+    expect(claims.filter((claim) => claim.outcome === 'claimed')).toHaveLength(1);
+    expect(claims.filter((claim) => claim.outcome === 'already_claimed')).toHaveLength(4);
+    expect(launches).toBe(1);
+  });
+
+  it('assigns one unique ordered position under concurrent enqueue', async () => {
+    const seed = await seedTenant(db, `queue-order-${generateId()}`);
+    const sessionId = await createSession(db, seed);
+
+    const queued = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+          new TaskRepository(scoped).createPending({
+            session_id: sessionId,
+            created_by: seed.userId,
+            full_prompt: `prompt ${index}`,
+            status: TaskStatus.QUEUED,
+          })
+        )
+      )
+    );
+
+    expect(queued.map((task) => task.queue_position).sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('keeps discovery routing-only and refuses cross-tenant claim/inference', async () => {
+    const a = await seedTenant(db, `queue-tenant-a-${generateId()}`);
+    const b = await seedTenant(db, `queue-tenant-b-${generateId()}`);
+    const sessionA = await createSession(db, a);
+    const sessionB = await createSession(db, b);
+    const nonQueuedSessionB = await createSession(db, b);
+    const queuedA = await runWithTenantDatabaseScope(db, a.tenantId, (scoped) =>
+      new TaskRepository(scoped).createPending({
+        session_id: sessionA,
+        created_by: a.userId,
+        full_prompt: 'tenant A',
+        status: TaskStatus.QUEUED,
+      })
+    );
+    const queuedB = await runWithTenantDatabaseScope(db, b.tenantId, (scoped) =>
+      new TaskRepository(scoped).createPending({
+        session_id: sessionB,
+        created_by: b.userId,
+        full_prompt: 'tenant B',
+        status: TaskStatus.QUEUED,
+      })
+    );
+    const nonQueuedB = await runWithTenantDatabaseScope(db, b.tenantId, (scoped) =>
+      new TaskRepository(scoped).createPending({
+        task_id: generateId() as TaskID,
+        session_id: nonQueuedSessionB,
+        created_by: b.userId,
+        full_prompt: 'not discoverable',
+        status: TaskStatus.CREATED,
+      })
+    );
+
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      const tasks = new TaskRepository(scoped);
+      expect(await tasks.findById(queuedB.task_id)).toBeNull();
+      expect(await tasks.findById(nonQueuedB.task_id)).toBeNull();
+      await expect(
+        tasks.claimDispatchAndProjectSession(queuedB.task_id, TaskStatus.QUEUED, {
+          status: TaskStatus.DISPATCHING,
+        })
+      ).rejects.toThrow(/Task not found/);
+    });
+
+    const refs = await runWithSystemDatabaseScope(
+      db,
+      'Task queue HA integration discovery',
+      (systemDb) => new TaskRepository(systemDb).findQueuedSessionRefs(100),
+      { capability: 'task_queue_discovery' }
+    );
+    const tenantsBySession = new Map(refs.map((ref) => [ref.session_id, ref.tenant_id]));
+    expect(tenantsBySession.get(sessionA)).toBe(a.tenantId);
+    expect(tenantsBySession.get(sessionB)).toBe(b.tenantId);
+    expect(refs.some((ref) => ref.session_id === nonQueuedB.session_id)).toBe(false);
+    expect(queuedA.full_prompt).toBe('tenant A');
+    expect(Object.keys(refs[0] ?? {}).sort()).toEqual(
+      ['first_queued_at', 'session_id', 'tenant_id'].sort()
+    );
+  });
+});

--- a/packages/core/src/db/task-queue-ha.postgres.test.ts
+++ b/packages/core/src/db/task-queue-ha.postgres.test.ts
@@ -9,13 +9,15 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../lib/ids';
-import type { SessionID, TaskID, UUID } from '../types/id';
+import type { MessageID, SessionID, TaskID, UUID } from '../types/id';
+import { MessageRole } from '../types/message';
 import { TaskStatus } from '../types/task';
 import { createDatabase, type Database } from './client';
 import { isPostgresDatabase } from './database-wrapper';
 import { initializeDatabase } from './migrate';
 import {
   BranchRepository,
+  MessagesRepository,
   RepoRepository,
   SessionRepository,
   TaskRepository,
@@ -235,5 +237,75 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Session Task queue HA (Pos
     expect(Object.keys(refs[0] ?? {}).sort()).toEqual(
       ['first_queued_at', 'session_id', 'tenant_id'].sort()
     );
+  });
+
+  it('elects one widget resolver and hides the claim across tenants', async () => {
+    const a = await seedTenant(db, `widget-tenant-a-${generateId()}`);
+    const b = await seedTenant(db, `widget-tenant-b-${generateId()}`);
+    const sessionB = await createSession(db, b);
+    const widgetId = generateId() as MessageID;
+    await runWithTenantDatabaseScope(db, b.tenantId, (scoped) =>
+      new MessagesRepository(scoped).create({
+        message_id: widgetId,
+        session_id: sessionB,
+        type: 'widget_request',
+        role: MessageRole.SYSTEM,
+        index: 0,
+        timestamp: new Date().toISOString(),
+        content_preview: 'Resolve me',
+        content: 'Resolve me',
+        metadata: {
+          widget: {
+            widget_id: widgetId,
+            widget_type: 'test',
+            schema_version: 1,
+            params: {},
+            status: 'pending',
+            requested_at: new Date().toISOString(),
+          },
+        },
+      })
+    );
+
+    let externalEffects = 0;
+    const claims = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        runWithTenantDatabaseScope(db, b.tenantId, async (scoped) => {
+          const result = await new MessagesRepository(scoped).mutateMetadataLocked(
+            widgetId,
+            (metadata) => {
+              const widget = metadata?.widget;
+              if (widget?.status !== 'pending') return null;
+              return {
+                ...metadata,
+                widget: {
+                  ...widget,
+                  status: 'resolving',
+                  resolution_claim: {
+                    token: `daemon-${index}`,
+                    action: index % 2 === 0 ? 'submit' : 'dismiss',
+                    claimed_at: new Date().toISOString(),
+                    claimed_by: b.userId,
+                  },
+                },
+              };
+            }
+          );
+          // Mirrors WidgetResolutionStore: only the committed claimant may
+          // cross into registry/external work.
+          if (result.changed) externalEffects += 1;
+          return result;
+        })
+      )
+    );
+    expect(claims.filter((claim) => claim.changed)).toHaveLength(1);
+    expect(externalEffects).toBe(1);
+
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      expect(await new MessagesRepository(scoped).findById(widgetId)).toBeNull();
+      await expect(
+        new MessagesRepository(scoped).mutateMetadataLocked(widgetId, () => ({}))
+      ).rejects.toThrow(/not found/);
+    });
   });
 });

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -16,6 +16,7 @@ export interface TenantDatabaseScope {
 export type SystemDatabaseCapability =
   | 'gateway_listener_discovery'
   | 'scheduler_discovery'
+  | 'task_queue_discovery'
   | 'upload_maintenance';
 
 export interface TenantContextScope {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -1,6 +1,6 @@
 // src/types/task.ts
 import type { PersistedAgenticToolName } from './agentic-tool';
-import type { MessageID, SessionID, TaskID } from './id';
+import type { MessageID, SessionID, TaskID, UserID } from './id';
 import type { PersistedMessageSource } from './message';
 import type { ReportPath, ReportTemplate } from './report';
 
@@ -151,6 +151,15 @@ export interface TaskMetadata {
    * this prompt. Links the task back to the originating widget for audit.
    */
   widget_id?: MessageID;
+  /** User who resolved the widget; Task execution remains session-owner attributed. */
+  widget_resolved_by_user_id?: UserID;
+  /**
+   * Durable identity of the Task's first transcript row. Internal
+   * idempotent producers persist this alongside the Task so any daemon that
+   * later drains the queue can reconcile the same row instead of inventing a
+   * process-local message identity.
+   */
+  initial_message_id?: MessageID;
 }
 
 /**

--- a/packages/core/src/types/widget.ts
+++ b/packages/core/src/types/widget.ts
@@ -14,7 +14,22 @@
 import type { MessageID, UserID } from './id';
 
 /** Lifecycle status of a widget request. */
-export type WidgetStatus = 'pending' | 'submitted' | 'dismissed' | 'already_present';
+export type WidgetStatus = 'pending' | 'resolving' | 'submitted' | 'dismissed' | 'already_present';
+
+/** Durable ownership of one widget resolution attempt. */
+export interface WidgetResolutionClaim {
+  /** Opaque compare-and-set token; only this claimant may finish the attempt. */
+  token: string;
+  action: 'submit' | 'dismiss';
+  claimed_at: string;
+  claimed_by: UserID;
+}
+
+/** Secret-free diagnosis for a claimed attempt that did not finish. */
+export interface WidgetResolutionFailure {
+  failed_at: string;
+  error_code: string;
+}
 
 /**
  * Widget type discriminant. PR 1 ships the framework with no concrete
@@ -64,6 +79,10 @@ export interface WidgetMessageMetadata<
   result_meta?: TResultMeta;
   /** User who resolved the widget (may differ from session creator under prompt-tier RBAC). */
   submitted_by?: UserID;
+  /** Present while one daemon owns resolution. */
+  resolution_claim?: WidgetResolutionClaim;
+  /** Durable, secret-free diagnosis for the last reported retryable failure. */
+  resolution_failure?: WidgetResolutionFailure;
   /**
    * Whether to auto-queue a system-authored prompt back into the agent on
    * resolution. Per design D6 defaults to `true`; agents opt-out by passing

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -145,7 +145,6 @@ const checks = [
       // capabilities use a second transaction path so their RLS GUC is local
       // to one pooled connection checkout and cannot leak after discovery.
       'packages/core/src/db/tenant-scope.ts': 2,
-      'packages/core/src/db/repositories/tasks.ts': 1,
       'packages/core/src/db/repositories/branches.ts': 1,
       'packages/core/src/db/repositories/knowledge.ts': 7,
       'packages/core/src/db/repositories/repos.ts': 3,


### PR DESCRIPTION
## Base dependency

> [!NOTE]
> Scheduler HA PR #2174 has merged. This branch is rebased onto its merge commit on `main` (`f48e929e`) and does not modify scheduler files.

## Summary

- make PostgreSQL the durable authority for per-Session prompt admission, queue ordering, and `CREATED|QUEUED -> DISPATCHING` claiming
- serialize queue positions and different-Task dispatch contenders with a short Session-first row lock; only the durable queue head may claim
- keep process-local Session turn locks and retry timers as documented coalescing optimizations, never correctness state
- run bounded all-daemon queued-Session discovery using the thin `@agor/core/coordination` jitter/backoff helpers, with no permanent leader or lease
- preserve queued Tasks across daemon restart and give callbacks/widgets stable Task and initial-transcript identities
- durably fence widget submit/dismiss resolution before external effects so only one daemon may resolve a widget
- protect widget lifecycle and Task provenance from generic external mutation paths
- add a routing-only PostgreSQL RLS discovery capability, preserve tenant identity through deferred drains, and cover cross-tenant negative boundaries
- preserve standalone SQLite semantics with immediate transactions and bounded busy retry
- document the complete producer/trigger audit, invariants, kill points, and runtime-supervision handoff

## Durable invariants

1. At most one Task owns dispatch/execution for a Session.
2. Concurrent enqueue creates one unique, ordered position decision per Task.
3. Only the durable queue head may transition to `dispatching`; a `created` Task cannot jump queued work.
4. A dispatch claim has one winner, and losing daemons never spawn an executor.
5. Terminal Task states remain immutable.
6. Queued intent survives daemon/process death and is rediscovered by every daemon.
7. Shared discovery returns routing metadata only; all reads/writes after discovery re-enter the trusted tenant scope.
8. Idempotent producers persist a stable initial-message identity; a queued loser writes no premature transcript row.
9. Widget resolution claims `pending -> resolving` before registry/external work; only the opaque claim token may finish.
10. Once a widget external effect succeeds, downstream failures never reopen the claim and replay that effect.
11. Generic public Message CRUD cannot mint or mutate widget lifecycle state.
12. No database transaction is held while an executor is spawned or widget external work runs.

The detailed audit is in `docs/internal/session-task-queue-ha-2026-08-06.md`.

## Review follow-up

The first Codex review found three substantive issues, addressed in `c6417282`:

- queued widget Tasks carry `Task.metadata.initial_message_id`; losing queued claims do not reconcile early, and the common drainer consumes that durable identity
- widget submit/dismiss uses a short locked Message-row state machine; duplicate submit and submit-vs-dismiss contenders lose before side effects
- prompt and widget routes use the established long-route tenant-identity pattern, while direct repositories bind each mutation to an explicit short tenant unit of work

The second pass found four remaining boundary gaps, addressed in `6bd43426`:

- prompt agentic-tool policy validation now uses the same explicit short tenant-scope helper as launch preparation, with guarded-proxy and PostgreSQL-gated tenant-policy tests
- only an explicitly reported `applySubmit` failure may return a widget to `pending`; prompt-admission and completion failures after a successful effect remain durably `resolving`
- external Message create/bulk/update/patch/remove paths cannot create, reset, replace, or delete a live widget claim; raw replacement/bulk methods are not exposed on the Messages transport
- public prompt callers cannot supply Task metadata, and the metadata builder defensively strips all internal provenance for untrusted callers

The third pass found one provenance hole and one public client-contract mismatch, addressed in `68f73b14`:

- REST/socket prompt and explicit Task-run requests now derive `agor` provenance server-side; caller-supplied `messageSource: gateway` is ignored, while provider-less daemon gateway calls retain trusted gateway provenance
- the public `/messages` client contract no longer advertises full replacement or bulk insertion, and `/messages/bulk` is a narrow create-only contract matching the actual route; UI/CLI callers were updated accordingly
- the historical widget delivery section now reflects custom routes, `WidgetResolutionStore`, and durable prompt admission

A daemon death or downstream failure with an unknown external outcome remains durably `resolving` and is not blindly replayed.

### Final Codex review

The reused Codex reviewer re-checked exact head `68f73b14` and found **no substantive issues remaining**. The PR is stamped with `ai-reviewed-gpt-5-5`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check` — passed (typecheck, Biome/lint, short-ID and multitenancy boundary checks, and the command's required workspace builds)
- latest-head review regressions: **15 daemon tests passed**, **71 core API tests passed**
  - server-owned prompt/run provenance, durable Task metadata, route wiring, and narrowed public Message client contracts
- daemon relevant suite: **197 passed**, **1 PostgreSQL-gated skipped**
  - queue worker/tenant scope, callbacks, widgets, public lifecycle boundaries, startup preservation, scheduler compatibility, completion/Stop paths, local coalescing, and terminal routes
- core relevant suite: **213 passed**, **5 PostgreSQL-gated skipped**
  - queue admission/order/claim races, locked widget resolution, multitenancy schema/RLS, message ordering, and repository regressions

PostgreSQL concurrency/policy tests were skipped honestly because neither `AGOR_TEST_POSTGRES_URL` nor `AGOR_DB_DIALECT=postgresql` is configured in this worktree. They remain gated for a disposable PostgreSQL environment and are not represented as locally passing.

## Runtime follow-up (out of scope)

The queue layer durably diagnoses daemon death after claim and before launch as `dispatching`; it must not blindly requeue because an external launch may have occurred. Fleet-/tenant-aware recovery ownership for already-active `dispatching`/`running` work remains a task-runtime supervision follow-up. This PR does not redesign heartbeat supervision, startup orphan cleanup, executor containment, or scheduler recovery.


