### PR TITLE
fix(docs): restore Google Analytics tracking

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Build docs
         run: pnpm --filter @agor/docs build
         env:
+          # GA measurement IDs are public identifiers, not secrets. Keep this
+          # explicit so static exports cannot silently lose production analytics.
+          NEXT_PUBLIC_GA_ID: G-DME77D3LDH
+
+      - name: Verify production analytics export
+        run: pnpm --filter @agor/docs validate:analytics
+        env:
           NEXT_PUBLIC_GA_ID: G-DME77D3LDH
 
       - name: Setup Pages

--- a/.github/workflows/docs-pr-check.yml
+++ b/.github/workflows/docs-pr-check.yml
@@ -38,6 +38,13 @@ jobs:
 
       - name: Build docs
         run: pnpm --filter @agor/docs build
+        env:
+          NEXT_PUBLIC_GA_ID: G-DME77D3LDH
+
+      - name: Verify production analytics export
+        run: pnpm --filter @agor/docs validate:analytics
+        env:
+          NEXT_PUBLIC_GA_ID: G-DME77D3LDH
 
       - name: Verify build output
         run: |

--- a/apps/agor-docs/.env.example
+++ b/apps/agor-docs/.env.example
@@ -3,6 +3,11 @@
 # Format: G-XXXXXXXXXX
 NEXT_PUBLIC_GA_ID=
 
+# Analytics is enabled automatically by NEXT_PUBLIC_GA_ID in production.
+# Set this only to exercise the integration with `pnpm dev` locally. Use a
+# test GA property (or block the collection request) to avoid polluting data.
+NEXT_PUBLIC_ANALYTICS_DEBUG=false
+
 # Public docs origin used for canonical, Open Graph, Twitter, and sitemap URLs.
 NEXT_PUBLIC_SITE_URL=https://agor.live
 

--- a/apps/agor-docs/README.md
+++ b/apps/agor-docs/README.md
@@ -15,6 +15,23 @@ pnpm dev
 
 Open http://localhost:3001
 
+## Site analytics
+
+The public docs deployment sets `NEXT_PUBLIC_GA_ID=G-DME77D3LDH`. A measurement ID is
+public configuration, not a credential. The integration is omitted when the variable is
+unset and is otherwise enabled for production builds. To exercise it in `pnpm dev`, also
+set `NEXT_PUBLIC_ANALYTICS_DEBUG=true`; use a test property or block collection requests.
+
+Google Analytics sends one explicit `page_view` for the initial URL and each client-side
+App Router navigation. Its automatic page view is disabled to prevent duplicates. The
+site currently has no cookie-consent gate and does not interpret the browser's legacy Do
+Not Track signal; this matches the existing site-wide Microsoft Clarity and HubSpot
+loaders. Visitors can block these third-party scripts with browser privacy controls.
+
+The GitHub Pages deployment does not currently send a Content Security Policy. If one is
+added, it must allow the GA loader from `https://www.googletagmanager.com` and collection
+to `https://www.google-analytics.com` (plus the existing Clarity and HubSpot origins).
+
 ## Brand assets
 
 `public/logo-mark.svg` is the transparent Agor mark for normal web and

--- a/apps/agor-docs/app/layout.tsx
+++ b/apps/agor-docs/app/layout.tsx
@@ -2,8 +2,9 @@ import { Head } from 'nextra/components';
 import 'nextra-theme-docs/style.css';
 import { Hanken_Grotesk, JetBrains_Mono, Space_Grotesk } from 'next/font/google';
 import Script from 'next/script';
-import type { ReactNode } from 'react';
+import { type ReactNode, Suspense } from 'react';
 import { DocsAuroraBackground } from '../components/DocsAuroraBackground';
+import { GoogleAnalytics } from '../components/GoogleAnalytics';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import {
   BRAND_NAME,
@@ -18,6 +19,10 @@ import './styles.css';
 
 const basePath = getBasePath();
 const siteUrl = getSiteUrl();
+const googleAnalyticsId = process.env.NEXT_PUBLIC_GA_ID;
+const analyticsEnabled =
+  Boolean(googleAnalyticsId) &&
+  (process.env.NODE_ENV === 'production' || process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true');
 
 // Marketing type system (see LandingPage.module.css): Space Grotesk for
 // display, Hanken Grotesk for body copy, JetBrains Mono for eyebrows/labels.
@@ -127,6 +132,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <DocsAuroraBackground />
         {children}
+        {analyticsEnabled && googleAnalyticsId ? (
+          <Suspense fallback={null}>
+            <GoogleAnalytics measurementId={googleAnalyticsId} />
+          </Suspense>
+        ) : null}
         {/* HubSpot tracking / embed loader (portal 246818610). */}
         <Script
           id="hs-script-loader"

--- a/apps/agor-docs/components/GoogleAnalytics.tsx
+++ b/apps/agor-docs/components/GoogleAnalytics.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import { useEffect, useState } from 'react';
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+    __agorGaLastLocation?: string;
+  }
+}
+
+interface GoogleAnalyticsProps {
+  measurementId: string;
+}
+
+/**
+ * GA's automatic page view is disabled so App Router navigations can be
+ * counted explicitly, once. Keeping the last location on `window` also
+ * protects development Strict Mode and accidental component remounts.
+ */
+export function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!ready || !window.gtag) return;
+
+    const query = searchParams.toString();
+    const pagePath = `${pathname}${query ? `?${query}` : ''}`;
+    const pageLocation = `${window.location.origin}${pagePath}`;
+
+    if (window.__agorGaLastLocation === pageLocation) return;
+    window.__agorGaLastLocation = pageLocation;
+    window.gtag('event', 'page_view', {
+      page_location: pageLocation,
+      page_path: pagePath,
+      page_title: document.title,
+    });
+  }, [pathname, ready, searchParams]);
+
+  return (
+    <>
+      <Script
+        id="google-analytics-loader"
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+        onLoad={() => setReady(true)}
+      />
+      <Script id="google-analytics-config" strategy="afterInteractive">
+        {`window.dataLayer=window.dataLayer||[];window.gtag=function(){window.dataLayer.push(arguments)};window.gtag('js',new Date());window.gtag('config','${measurementId}',{send_page_view:false});`}
+      </Script>
+    </>
+  );
+}

--- a/apps/agor-docs/package.json
+++ b/apps/agor-docs/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit --incremental false",
     "validate:brand-assets": "tsx scripts/validate-brand-assets.ts",
     "validate:social-metadata": "tsx scripts/validate-social-metadata.ts",
+    "validate:analytics": "tsx scripts/validate-analytics.ts",
     "build:search": "pagefind --site out --output-path out/_pagefind && rm -rf public/_pagefind && cp -R out/_pagefind public/_pagefind"
   },
   "dependencies": {

--- a/apps/agor-docs/scripts/validate-analytics.ts
+++ b/apps/agor-docs/scripts/validate-analytics.ts
@@ -1,0 +1,54 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputDir = join(process.cwd(), 'out');
+const measurementId = process.env.NEXT_PUBLIC_GA_ID;
+
+if (!measurementId) {
+  throw new Error('NEXT_PUBLIC_GA_ID is required to validate the production analytics export');
+}
+
+function walk(directory: string): string[] {
+  return readdirSync(directory).flatMap(function visit(entry) {
+    const path = join(directory, entry);
+    return statSync(path).isDirectory() ? walk(path) : [path];
+  });
+}
+
+const files = walk(outputDir);
+const htmlFiles = files.filter(function isHtml(file) {
+  return file.endsWith('.html');
+});
+const javascript = files
+  .filter(function isJavaScript(file) {
+    return file.endsWith('.js');
+  })
+  .map(function readJavaScript(file) {
+    return readFileSync(file, 'utf8');
+  })
+  .join('\n');
+
+if (htmlFiles.length === 0) throw new Error('No exported HTML files found');
+
+for (const file of htmlFiles) {
+  const html = readFileSync(file, 'utf8');
+  const occurrences = html.split(measurementId).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(`${file} contains ${occurrences} analytics IDs; expected exactly one`);
+  }
+}
+
+for (const marker of ['google-analytics-loader', 'google-analytics-config', 'send_page_view']) {
+  const occurrences = javascript.split(marker).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(
+      `Built JavaScript contains ${occurrences} ${marker} markers; expected exactly one`
+    );
+  }
+}
+
+if (!javascript.includes('__agorGaLastLocation')) {
+  throw new Error('Built JavaScript is missing the duplicate page-view guard');
+}
+
+console.log(`Validated one GA integration in each of ${htmlFiles.length} exported pages.`);


### PR DESCRIPTION
## Summary

- restore Google Analytics (`G-DME77D3LDH`) after the Nextra 4 App Router migration removed the old `theme.config.tsx` integration
- explicitly track the initial page view and client-side App Router navigations once, with GA automatic page views disabled
- add production-export assertions so deployments cannot silently omit or duplicate analytics again
- document production/local configuration, privacy behavior, and CSP requirements

## Root cause

PR #1520 / commit `c61d426e` deleted the Nextra 3 `theme.config.tsx`, where the entire GA integration lived, without moving it to the new root layout. Its successful GitHub Pages deployment completed on July 1, 2026 at 02:42:55 UTC. The workflow continued supplying `NEXT_PUBLIC_GA_ID`, so the omission was not caught by the build.

The live site had no GA loader or measurement ID. It had no CSP blocking GA; Microsoft Clarity, HubSpot, Agor product telemetry, and backend analytics are separate systems.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm --filter @agor/docs typecheck`
- `NEXT_PUBLIC_GA_ID=G-DME77D3LDH pnpm --filter @agor/docs build`
- `NEXT_PUBLIC_GA_ID=G-DME77D3LDH pnpm --filter @agor/docs validate:analytics`
- direct inspection of all 49 exported HTML pages and the generated analytics chunk

No GA collection request was sent during validation, avoiding production-data pollution.

## Privacy

This restores the pre-outage collection posture. The site currently has no consent gate and does not interpret legacy Do Not Track, matching its existing site-wide Clarity and HubSpot loaders. That behavior is now documented explicitly.
