### PR TITLE
fix(daemon): allow OpenCode fallback for default references

### DIFF
--- a/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
+++ b/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
@@ -285,7 +285,8 @@ describe('SessionsService direct OpenCode model selection', () => {
       default_agentic_selection: user.default_agentic_selection,
     };
 
-    for (const agentic_tool_preset_id of [
+    for (const agenticToolPresetId of [
+      undefined,
       USER_DEFAULT_AGENTIC_CONFIGURATION,
       WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
     ]) {
@@ -293,7 +294,9 @@ describe('SessionsService direct OpenCode model selection', () => {
         {
           branch_id: branchId,
           agentic_tool: 'opencode',
-          agentic_tool_preset_id,
+          ...(agenticToolPresetId === undefined
+            ? {}
+            : { agentic_tool_preset_id: agenticToolPresetId }),
           status: SessionStatus.IDLE,
           created_by: user.user_id,
         },
@@ -313,7 +316,7 @@ describe('SessionsService direct OpenCode model selection', () => {
       default_agentic_config: reloadedUser?.default_agentic_config,
       default_agentic_selection: reloadedUser?.default_agentic_selection,
     }).toEqual(defaultsBefore);
-    expect(findCatalog).toHaveBeenCalledTimes(2);
+    expect(findCatalog).toHaveBeenCalledTimes(3);
     const preset = await new AgenticToolPresetRepository(db).create(
       {
         tool: 'opencode',
@@ -335,7 +338,7 @@ describe('SessionsService direct OpenCode model selection', () => {
         { user } as never
       )
     ).rejects.toThrow(/provider and model/i);
-    expect(findCatalog).toHaveBeenCalledTimes(2);
+    expect(findCatalog).toHaveBeenCalledTimes(3);
   });
 
   dbTest('materializes selected user and workspace presets on direct create', async ({ db }) => {

--- a/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
+++ b/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
@@ -19,7 +19,12 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Session, Task, UUID } from '@agor/core/types';
-import { SessionStatus, TaskStatus, USER_DEFAULT_AGENTIC_CONFIGURATION } from '@agor/core/types';
+import {
+  SessionStatus,
+  TaskStatus,
+  USER_DEFAULT_AGENTIC_CONFIGURATION,
+  WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
+} from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { SessionsService } from './sessions';
@@ -257,15 +262,14 @@ describe('SessionsService direct OpenCode model selection', () => {
     });
   });
 
-  dbTest('persists the authenticated subject fallback as an exact pair', async ({ db }) => {
+  dbTest('uses catalog fallback only for unresolved default references', async ({ db }) => {
+    const findCatalog = vi.fn(async () => ({
+      suggestedSelection: { providerId: 'openai', modelId: 'gpt-test' },
+    }));
     const app = {
       service: (path: string) => {
         if (path === 'opencode-models') {
-          return {
-            find: async () => ({
-              suggestedSelection: { providerId: 'openai', modelId: 'gpt-test' },
-            }),
-          };
+          return { find: findCatalog };
         }
         throw new Error(`Unexpected service: ${path}`);
       },
@@ -276,22 +280,62 @@ describe('SessionsService direct OpenCode model selection', () => {
       email: `catalog-fallback-${generateId()}@example.com`,
       name: 'Catalog fallback owner',
     });
+    const defaultsBefore = {
+      default_agentic_config: user.default_agentic_config,
+      default_agentic_selection: user.default_agentic_selection,
+    };
 
-    const created = await service.create(
+    for (const agentic_tool_preset_id of [
+      USER_DEFAULT_AGENTIC_CONFIGURATION,
+      WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
+    ]) {
+      const created = await service.create(
+        {
+          branch_id: branchId,
+          agentic_tool: 'opencode',
+          agentic_tool_preset_id,
+          status: SessionStatus.IDLE,
+          created_by: user.user_id,
+        },
+        { user } as never
+      );
+
+      expect(created).toMatchObject({
+        model_config: {
+          mode: 'exact',
+          provider: 'openai',
+          model: 'gpt-test',
+        },
+      });
+    }
+    const reloadedUser = await new UsersRepository(db).findById(user.user_id);
+    expect({
+      default_agentic_config: reloadedUser?.default_agentic_config,
+      default_agentic_selection: reloadedUser?.default_agentic_selection,
+    }).toEqual(defaultsBefore);
+    expect(findCatalog).toHaveBeenCalledTimes(2);
+    const preset = await new AgenticToolPresetRepository(db).create(
       {
-        branch_id: branchId,
-        agentic_tool: 'opencode',
-        status: SessionStatus.IDLE,
-        created_by: user.user_id,
+        tool: 'opencode',
+        name: 'Incomplete preset',
+        configuration: { modelConfig: modelConfig() },
       },
-      { user } as never
+      user.user_id
     );
 
-    expect(created.model_config).toMatchObject({
-      mode: 'exact',
-      provider: 'openai',
-      model: 'gpt-test',
-    });
+    await expect(
+      service.create(
+        {
+          branch_id: branchId,
+          agentic_tool: 'opencode',
+          agentic_tool_preset_id: preset.preset_id,
+          status: SessionStatus.IDLE,
+          created_by: user.user_id,
+        },
+        { user } as never
+      )
+    ).rejects.toThrow(/provider and model/i);
+    expect(findCatalog).toHaveBeenCalledTimes(2);
   });
 
   dbTest('materializes selected user and workspace presets on direct create', async ({ db }) => {

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -370,7 +370,13 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           executionOwnerId: data.created_by as import('@agor/core/types').UserID | undefined,
         });
       } catch (error) {
-        if (!isInvalidModelConfigError(error) || configurationReference) throw error;
+        if (
+          !isInvalidModelConfigError(error) ||
+          (configurationReference &&
+            !isAgenticToolDefaultConfigurationReference(configurationReference))
+        ) {
+          throw error;
+        }
         const modelFallback = await this.resolveDirectCreateModelFallback(
           agenticTool,
           data as CreateSessionInput,

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -370,11 +370,11 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           executionOwnerId: data.created_by as import('@agor/core/types').UserID | undefined,
         });
       } catch (error) {
-        if (
-          !isInvalidModelConfigError(error) ||
-          (configurationReference &&
-            !isAgenticToolDefaultConfigurationReference(configurationReference))
-        ) {
+        const shouldUseCatalogFallback =
+          isInvalidModelConfigError(error) &&
+          (!configurationReference ||
+            isAgenticToolDefaultConfigurationReference(configurationReference));
+        if (!shouldUseCatalogFallback) {
           throw error;
         }
         const modelFallback = await this.resolveDirectCreateModelFallback(


### PR DESCRIPTION
## Linked issue

N/A

## Summary

- Allow OpenCode session creation to use the authenticated catalog suggestion when a reserved user or workspace default does not resolve to an exact provider/model.
- Persist the resolved provider/model on the session without changing the user's saved defaults.
- Keep concrete incomplete presets and cross-owner fallback paths fail-closed.

## Why / context

A configured OpenCode provider could still fail quick session creation when Agor passed a reserved default reference without an exact provider/model. `SessionsService.create()` treated every configuration reference like a concrete preset, so it skipped the catalog fallback that already exists for unresolved direct creates.

## Implementation notes

- Reuse `isAgenticToolDefaultConfigurationReference()` to distinguish reserved defaults from concrete preset IDs.
- Keep catalog lookup scoped to the authenticated execution owner.
- Reuse the existing catalog suggestion, materialization, and exact session snapshot paths; no UI, schema, migration, or new fallback algorithm.

## Validation / test plan

- [x] Focused session service suite: 15/15 passed.
- [x] OpenCode model-configuration suite: 5/5 passed.
- [x] Core preset-resolver suite: 15/15 passed.
- [x] Targeted Biome check and `git diff --check`.
- [x] Manual branch-environment validation: a configured OpenCode provider starts a session without a saved default.
- [ ] Full daemon typecheck was not completed locally because generated workspace declaration outputs were unavailable in the isolated checkout; CI will build and check the complete workspace.
- [ ] `pnpm check:multitenancy-boundaries` currently reports the pre-existing `setup/socketio.ts` baseline mismatch (18 occurrences versus 17).

## Screenshots / demos

Not applicable — backend behavior change.

## Risks / rollout / rollback

Low-risk, localized change to direct session creation. The catalog lookup remains tenant- and owner-scoped, and concrete presets still fail closed. Roll back by reverting this commit.

## Out of scope / follow-ups

- Saving or changing a user's default provider/model.
- UI, schema, migration, or provider-selection changes.
