### PR TITLE
feat(docs): add Google Tag Manager (GTM-WL3Q29NW)

### DIFF
--- a/apps/agor-docs/app/layout.tsx
+++ b/apps/agor-docs/app/layout.tsx
@@ -73,6 +73,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${displayFont.variable} ${bodyFont.variable} ${monoFont.variable}`}
     >
       <Head>
+        {/* Google Tag Manager (container GTM-WL3Q29NW). Loaded as high in the
+            head as possible so downstream tags fire early. */}
+        <Script id="gtm-loader" strategy="afterInteractive">
+          {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-WL3Q29NW');`}
+        </Script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content={DEFAULT_DESCRIPTION} />
         <meta name="theme-color" content={THEME_COLOR} />
@@ -125,6 +130,17 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </Head>
       <body>
+        {/* Google Tag Manager (noscript) — must sit immediately after the
+            opening body tag. */}
+        <noscript>
+          <iframe
+            title="Google Tag Manager"
+            src="https://www.googletagmanager.com/ns.html?id=GTM-WL3Q29NW"
+            height="0"
+            width="0"
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
         <DocsAuroraBackground />
         {children}
         {/* HubSpot tracking / embed loader (portal 246818610). */}


### PR DESCRIPTION
## What

Installs Google Tag Manager (container `GTM-WL3Q29NW`) on the **agor-docs** public site.

Both snippets from GTM's install instructions are added to `apps/agor-docs/app/layout.tsx`:

- **Loader** — inline `next/script` placed as high in `<Head>` as possible so downstream tags fire early.
- **`<noscript>` fallback iframe** — placed immediately after the opening `<body>` tag.

## How

Follows the existing house pattern in the same file, where Microsoft Clarity and HubSpot are already wired up as inline `next/script` tags (`strategy="afterInteractive"`). No new dependencies.

## Notes

- The docs app has no Content-Security-Policy, so `googletagmanager.com` loads without allowlisting (same as the existing Clarity/HubSpot scripts).
- GTM's raw `<body>` snippet uses inline `style`/attributes; rewritten as valid JSX (`style={{ display: 'none', visibility: 'hidden' }}`, added an `iframe title` for a11y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)