### PR TITLE
fix(daemon): reduce Socket.IO churn logging

### DIFF
--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -36,6 +36,7 @@ import {
   type SocketIOOptions,
   tenantChannelName,
   tenantUserChannelName,
+  userRoomName,
 } from './socketio';
 
 // ---------------------------------------------------------------------------
@@ -413,6 +414,80 @@ describe('Socket.IO lifecycle logging', () => {
     );
     expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('joined user room'));
   });
+
+  it.each([
+    {
+      kind: 'full service',
+      user: {
+        user_id: 'executor-service',
+        email: 'executor@agor.internal',
+        role: 'service',
+        _isServiceAccount: true,
+      },
+      joinsUserRoom: true,
+    },
+    {
+      kind: 'terminal executor',
+      user: {
+        user_id: 'executor-service',
+        email: 'executor@agor.internal',
+        role: 'terminal-executor',
+        _isTerminalExecutor: true,
+        terminal_user_id: ALICE,
+      },
+      joinsUserRoom: false,
+    },
+  ])('logs post-connect $kind authentication as service', ({ user, joinsUserRoom }) => {
+    const { app, io } = buildHarness();
+    const socket = makeSocket('post-connect-service');
+    connect(io, socket);
+
+    const connection = {};
+    socket.feathers = connection;
+    (app as any).eventHandlers.get('login')?.({ user }, { connection });
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy).toHaveBeenCalledWith('socket authenticated: post-connect-service service');
+    expect(socket.joined.has(userRoomName('executor-service'))).toBe(joinsUserRoom);
+  });
+
+  it.each([
+    { kind: 'full service', terminalUserId: undefined, joinsUserRoom: true },
+    { kind: 'terminal executor', terminalUserId: ALICE, joinsUserRoom: false },
+  ])(
+    'deduplicates handshake $kind authentication followed by the same service login',
+    async ({ terminalUserId, joinsUserRoom }) => {
+      const { app, io } = buildHarness();
+      const socket = makeSocket('handshake-service');
+      socket.handshake.auth = {
+        token: issueRuntimeToken(
+          {
+            sub: 'executor-service',
+            type: 'service',
+            ...(terminalUserId ? { terminal_user_id: terminalUserId } : {}),
+          },
+          'test-secret',
+          '5m'
+        ),
+      };
+
+      await new Promise<void>((resolve, reject) => {
+        io.middlewares[0]?.(socket, (error?: Error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+      connect(io, socket);
+      (app as any).eventHandlers.get('login')?.(
+        { user: socket.feathers?.user },
+        { connection: socket.feathers }
+      );
+
+      expect(logSpy).toHaveBeenCalledOnce();
+      expect(logSpy).toHaveBeenCalledWith('socket authenticated: handshake-service service');
+      expect(socket.joined.has(userRoomName('executor-service'))).toBe(joinsUserRoom);
+    }
+  );
 
   it('emits an unconditional five-minute gauge and stops it when Engine.IO closes', () => {
     vi.useFakeTimers();

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -322,7 +322,7 @@ describe('Socket.IO lifecycle logging', () => {
     warnSpy.mockRestore();
   });
 
-  it('logs post-connect authentication once at info with only the short user ID', () => {
+  it('logs first authentication and identity changes but omits same-identity repeats', () => {
     const { app, io } = buildHarness();
     const socket = makeSocket('alice-sock');
     connect(io, socket);
@@ -333,12 +333,30 @@ describe('Socket.IO lifecycle logging', () => {
       { user: { user_id: ALICE, email: 'alice@example.com' } },
       { connection }
     );
+    (app as any).eventHandlers.get('login')?.(
+      { user: { user_id: ALICE, email: 'repeat@example.com' } },
+      { connection }
+    );
 
     expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy.mock.calls.flat().join(' ')).not.toContain('re-authenticated');
     expect(logSpy).toHaveBeenCalledWith(
       'socket authenticated: alice-sock user:11111111aaaaaaaaaaaa1111'
     );
     expect(logSpy.mock.calls.flat().join(' ')).not.toContain('alice@example.com');
+    expect(logSpy.mock.calls.flat().join(' ')).not.toContain('repeat@example.com');
+
+    (app as any).eventHandlers.get('login')?.(
+      { user: { user_id: BOB, email: 'bob@example.com' } },
+      { connection }
+    );
+
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'socket authenticated: alice-sock user:22222222bbbbbbbbbbbb2222'
+    );
+    expect(logSpy.mock.calls.flat().join(' ')).not.toContain('bob@example.com');
   });
 
   it('keeps post-connect authenticated sockets out of unauthenticated disconnect metrics', () => {
@@ -371,7 +389,7 @@ describe('Socket.IO lifecycle logging', () => {
   });
 
   it('uses the same single authentication signal for handshake-authenticated users', async () => {
-    const { io } = buildHarness();
+    const { app, io } = buildHarness();
     const socket = makeSocket('handshake-sock');
     socket.handshake.auth = {
       token: issueRuntimeToken({ sub: ALICE, type: 'access' }, 'test-secret', '5m'),
@@ -384,6 +402,10 @@ describe('Socket.IO lifecycle logging', () => {
       });
     });
     connect(io, socket);
+    (app as any).eventHandlers.get('login')?.(
+      { user: { user_id: ALICE } },
+      { connection: socket.feathers }
+    );
 
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
@@ -449,15 +471,17 @@ describe('Socket.IO lifecycle logging', () => {
 
   it('aggregates sockets that disconnect before authentication and resets each interval', () => {
     vi.useFakeTimers();
-    const { io } = buildHarness();
+    const { app, io } = buildHarness();
     const firstAnonymousSocket = makeSocket('anonymous-1');
     const secondAnonymousSocket = makeSocket('anonymous-2');
     const previouslyAuthenticatedSocket = makeSocket('authenticated');
-    asUser(previouslyAuthenticatedSocket, ALICE);
 
     connect(io, firstAnonymousSocket);
     connect(io, secondAnonymousSocket);
     connect(io, previouslyAuthenticatedSocket);
+    const connection = {};
+    previouslyAuthenticatedSocket.feathers = connection;
+    (app as any).eventHandlers.get('login')?.({ user: { user_id: ALICE } }, { connection });
     previouslyAuthenticatedSocket.feathers = {};
     debugSpy.mockClear();
     logSpy.mockClear();

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -341,6 +341,35 @@ describe('Socket.IO lifecycle logging', () => {
     expect(logSpy.mock.calls.flat().join(' ')).not.toContain('alice@example.com');
   });
 
+  it('keeps post-connect authenticated sockets out of unauthenticated disconnect metrics', () => {
+    vi.useFakeTimers();
+    const { app, io } = buildHarness();
+    const socket = makeSocket('post-connect-auth');
+    connect(io, socket);
+
+    const connection = {};
+    socket.feathers = connection;
+    (app as any).eventHandlers.get('login')?.({ user: { user_id: ALICE } }, { connection });
+    socket.feathers = {};
+    debugSpy.mockClear();
+    logSpy.mockClear();
+    warnSpy.mockClear();
+
+    socket.handlers.get('disconnect')?.('ping timeout');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy).toHaveBeenCalledWith(
+      '🔌 Socket.io disconnected: post-connect-auth (reason: ping timeout, remaining: 0)'
+    );
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=0'
+    );
+  });
+
   it('uses the same single authentication signal for handshake-authenticated users', async () => {
     const { io } = buildHarness();
     const socket = makeSocket('handshake-sock');

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -199,8 +199,16 @@ function buildHarness(opts: Partial<SocketIOOptions> = {}) {
     ...opts,
   } as SocketIOOptions);
   config.callback(io as any);
+  openHarnesses.add(io);
   return { io, config, app };
 }
+
+const openHarnesses = new Set<FakeIO>();
+
+afterEach(() => {
+  for (const io of openHarnesses) io.engine.closeHandler?.();
+  openHarnesses.clear();
+});
 
 function connect(io: FakeIO, socket: FakeSocket) {
   io.sockets.sockets.set(socket.id, socket);
@@ -364,11 +372,15 @@ describe('Socket.IO lifecycle logging', () => {
 
     vi.advanceTimersByTime(5 * 60 * 1000 - 5_000);
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenLastCalledWith('ws_active_connections=0');
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=0'
+    );
 
     vi.advanceTimersByTime(5 * 60 * 1000);
     expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenLastCalledWith('ws_active_connections=0');
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=0'
+    );
 
     io.engine.closeHandler?.();
     vi.advanceTimersByTime(5 * 60 * 1000);
@@ -376,10 +388,11 @@ describe('Socket.IO lifecycle logging', () => {
   });
 
   it.each(['transport close', 'client namespace disconnect'])(
-    'demotes benign disconnect reason %s below info',
+    'keeps benign authenticated disconnect reason %s below info',
     (reason) => {
       const { io } = buildHarness();
       const socket = makeSocket('browser-sock');
+      asUser(socket, ALICE);
       connect(io, socket);
 
       socket.handlers.get('disconnect')?.(reason);
@@ -393,6 +406,8 @@ describe('Socket.IO lifecycle logging', () => {
     const { io } = buildHarness();
     const transportErrorSocket = makeSocket('transport-error');
     const pingTimeoutSocket = makeSocket('ping-timeout');
+    asUser(transportErrorSocket, ALICE);
+    asUser(pingTimeoutSocket, ALICE);
     connect(io, transportErrorSocket);
     connect(io, pingTimeoutSocket);
 
@@ -401,6 +416,70 @@ describe('Socket.IO lifecycle logging', () => {
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('reason: transport error'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('reason: ping timeout'));
+  });
+
+  it('aggregates sockets that disconnect before authentication and resets each interval', () => {
+    vi.useFakeTimers();
+    const { io } = buildHarness();
+    const firstAnonymousSocket = makeSocket('anonymous-1');
+    const secondAnonymousSocket = makeSocket('anonymous-2');
+    const previouslyAuthenticatedSocket = makeSocket('authenticated');
+    asUser(previouslyAuthenticatedSocket, ALICE);
+
+    connect(io, firstAnonymousSocket);
+    connect(io, secondAnonymousSocket);
+    connect(io, previouslyAuthenticatedSocket);
+    previouslyAuthenticatedSocket.feathers = {};
+    debugSpy.mockClear();
+    logSpy.mockClear();
+    warnSpy.mockClear();
+
+    firstAnonymousSocket.handlers.get('disconnect')?.('ping timeout');
+    secondAnonymousSocket.handlers.get('disconnect')?.('client namespace disconnect');
+    previouslyAuthenticatedSocket.handlers.get('disconnect')?.('ping timeout');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Socket.io disconnected: authenticated (reason: ping timeout')
+    );
+    expect(logSpy.mock.calls.flat().join(' ')).not.toContain('anonymous-');
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=2'
+    );
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=0'
+    );
+
+    io.engine.closeHandler?.();
+    const logCountAfterClose = logSpy.mock.calls.length;
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenCalledTimes(logCountAfterClose);
+  });
+
+  it('preserves transport-error warnings while aggregating unauthenticated disconnects', () => {
+    vi.useFakeTimers();
+    const { io } = buildHarness();
+    const socket = makeSocket('transport-error');
+    connect(io, socket);
+    debugSpy.mockClear();
+
+    socket.handlers.get('disconnect')?.('transport error');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('reason: transport error'));
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(logSpy).toHaveBeenLastCalledWith(
+      'ws_active_connections=0 ws_unauthenticated_disconnects=1'
+    );
   });
 });
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -344,6 +344,10 @@ export function createSocketIOConfig(
 
     // Track active connections for periodic operational metrics.
     let activeConnections = 0;
+    // Intentionally system-global: keep only a saturated count, never socket,
+    // user, tenant, channel, or client metadata.
+    let unauthenticatedDisconnects = 0;
+    const authenticatedSockets = new WeakSet<Socket>();
 
     const logAuthenticated = (socketId: string, userId?: string) => {
       console.log(
@@ -471,6 +475,9 @@ export function createSocketIOConfig(
     // Configure Socket.io for cursor presence events
     io.on('connection', (socket) => {
       activeConnections++;
+      if (isAuthenticated(getSocketAuthState(socket))) {
+        authenticatedSockets.add(socket);
+      }
       const user = (socket as FeathersSocket).feathers?.user;
       console.debug(
         `🔌 Socket.io connection established: ${socket.id} (auth: ${user ? 'handshake' : 'anonymous'}, user: ${user ? shortId(user.user_id) : 'unknown'}, total: ${activeConnections})`
@@ -889,9 +896,19 @@ export function createSocketIOConfig(
       // Track disconnections
       socket.on('disconnect', (reason) => {
         activeConnections--;
+        const disconnectedBeforeAuthentication =
+          !authenticatedSockets.has(socket) && !isAuthenticated(getSocketAuthState(socket));
+        if (disconnectedBeforeAuthentication) {
+          unauthenticatedDisconnects = Math.min(
+            unauthenticatedDisconnects + 1,
+            Number.MAX_SAFE_INTEGER
+          );
+        }
         const message = `🔌 Socket.io disconnected: ${socket.id} (reason: ${reason}, remaining: ${activeConnections})`;
         if (reason === 'transport error') {
           console.warn(message);
+        } else if (disconnectedBeforeAuthentication) {
+          return;
         } else if (reason === 'transport close' || reason === 'client namespace disconnect') {
           console.debug(message);
         } else {
@@ -920,6 +937,7 @@ export function createSocketIOConfig(
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
+          authenticatedSockets.add(socket);
           logAuthenticated(socket.id, userId);
           // Terminal-executor identities get no user room (see connection handler).
           if (!isTerminalExecutorIdentity(result.user)) {
@@ -934,7 +952,11 @@ export function createSocketIOConfig(
     // and periods with no connection churn remain observable.
     const metricsInterval = setInterval(
       () => {
-        console.log(`ws_active_connections=${activeConnections}`);
+        const disconnectedBeforeAuthentication = unauthenticatedDisconnects;
+        unauthenticatedDisconnects = 0;
+        console.log(
+          `ws_active_connections=${activeConnections} ws_unauthenticated_disconnects=${disconnectedBeforeAuthentication}`
+        );
       },
       5 * 60 * 1000
     );

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -932,14 +932,18 @@ export function createSocketIOConfig(
     // so we need to join the user room here when the login event fires.
     app.on('login', (authResult: unknown, context: { connection?: unknown; params?: unknown }) => {
       if (!context.connection) return;
-      const result = authResult as { user?: { user_id?: string } };
+      const result = authResult as {
+        user?: { user_id?: string; _isServiceAccount?: boolean };
+      };
       const userId = result.user?.user_id;
       if (!userId) return;
 
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
-          logAuthenticated(socket, userId);
+          const isService =
+            result.user?._isServiceAccount === true || isTerminalExecutorIdentity(result.user);
+          logAuthenticated(socket, isService ? undefined : userId);
           // Terminal-executor identities get no user room (see connection handler).
           if (!isTerminalExecutorIdentity(result.user)) {
             socket.join(userRoomName(userId));

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -344,16 +344,21 @@ export function createSocketIOConfig(
 
     // Track active connections for periodic operational metrics.
     let activeConnections = 0;
-    // Intentionally system-global: keep only a saturated count, never socket,
-    // user, tenant, channel, or client metadata.
+    // Intentionally system-global: the aggregate keeps only a saturated count,
+    // never socket, user, tenant, channel, or client metadata.
     let unauthenticatedDisconnects = 0;
-    const authenticatedSockets = new WeakSet<Socket>();
+    // Weak per-socket state owns both auth-log dedupe and durable auth history.
+    const authenticatedIdentities = new WeakMap<Socket, string>();
 
-    const logAuthenticated = (socketId: string, userId?: string) => {
+    const logAuthenticated = (socket: Socket, userId?: string) => {
+      const identity = userId ? `user:${userId}` : 'service';
+      if (authenticatedIdentities.get(socket) === identity) return;
+      authenticatedIdentities.set(socket, identity);
+
       console.log(
         userId
-          ? `socket authenticated: ${socketId} user:${shortId(userId)}`
-          : `socket authenticated: ${socketId} service`
+          ? `socket authenticated: ${socket.id} user:${shortId(userId)}`
+          : `socket authenticated: ${socket.id} service`
       );
     };
 
@@ -440,7 +445,7 @@ export function createSocketIOConfig(
             (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;
             if (fs.data) fs.data.tenant = tenant;
           }
-          logAuthenticated(socket.id);
+          logAuthenticated(socket);
           return next();
         }
 
@@ -461,7 +466,7 @@ export function createSocketIOConfig(
           if (fs.data) fs.data.tenant = tenant;
         }
 
-        logAuthenticated(socket.id, user.user_id);
+        logAuthenticated(socket, user.user_id);
         next();
       } catch (error) {
         console.error(`❌ WebSocket authentication failed for ${socket.id}:`, error);
@@ -475,9 +480,6 @@ export function createSocketIOConfig(
     // Configure Socket.io for cursor presence events
     io.on('connection', (socket) => {
       activeConnections++;
-      if (isAuthenticated(getSocketAuthState(socket))) {
-        authenticatedSockets.add(socket);
-      }
       const user = (socket as FeathersSocket).feathers?.user;
       console.debug(
         `🔌 Socket.io connection established: ${socket.id} (auth: ${user ? 'handshake' : 'anonymous'}, user: ${user ? shortId(user.user_id) : 'unknown'}, total: ${activeConnections})`
@@ -897,7 +899,7 @@ export function createSocketIOConfig(
       socket.on('disconnect', (reason) => {
         activeConnections--;
         const disconnectedBeforeAuthentication =
-          !authenticatedSockets.has(socket) && !isAuthenticated(getSocketAuthState(socket));
+          !authenticatedIdentities.has(socket) && !isAuthenticated(getSocketAuthState(socket));
         if (disconnectedBeforeAuthentication) {
           unauthenticatedDisconnects = Math.min(
             unauthenticatedDisconnects + 1,
@@ -937,8 +939,7 @@ export function createSocketIOConfig(
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
-          authenticatedSockets.add(socket);
-          logAuthenticated(socket.id, userId);
+          logAuthenticated(socket, userId);
           // Terminal-executor identities get no user room (see connection handler).
           if (!isTerminalExecutorIdentity(result.user)) {
             socket.join(userRoomName(userId));


### PR DESCRIPTION
## Summary
- deduplicate repeated Socket.IO authentication logs while preserving genuine identity changes
- aggregate unauthenticated disconnects into the existing five-minute connection metric
- preserve transport-error warnings and authenticated disconnect severity

## Why
Repeated authentication and anonymous disconnect lifecycle messages create high-volume production noise. This keeps one accurate lifecycle signal at the owning layer without changing authentication, routing, tenant isolation, or connection behavior.

## Validation
- 75 focused Socket.IO tests
- source-aware daemon typecheck
- Biome and git diff checks
- fresh owned-change review and focused remediation re-review

## Notes
- The repository multitenancy checker has a pre-existing Socket.IO baseline mismatch (18 observed vs 17 allowed); this branch remains 18 vs 18 from base.
- No runtime behavior outside logging/aggregation changed.
- Logging conventions follow #2173.
