### PR TITLE
fix(mcp-oauth): handle non-JSON (form-encoded) token responses (GitHub)

### DIFF
--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -18,6 +18,7 @@ import {
   discoverResourceMetadataUrl,
   getAuthCodeTokenCacheStats,
   isOAuthRequired,
+  parseTokenResponseBody,
   resolveMCPOAuthDiscovery,
   resolveResourceMetadataUrl,
   startMCPOAuthFlow,
@@ -664,5 +665,53 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     ).rejects.toThrow(/cacheKey is required/);
 
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTokenResponseBody — token endpoints that don't return JSON
+// ---------------------------------------------------------------------------
+
+describe('parseTokenResponseBody', () => {
+  it('parses a standard RFC 6749 JSON response', () => {
+    const parsed = parseTokenResponseBody(
+      'application/json; charset=utf-8',
+      '{"access_token":"tok","token_type":"bearer","expires_in":3600}'
+    );
+    expect(parsed.access_token).toBe('tok');
+    expect(parsed.expires_in).toBe(3600);
+  });
+
+  it("parses GitHub's form-encoded token response", () => {
+    // GitHub /login/oauth/access_token replies form-encoded unless the request
+    // sends Accept: application/json. JSON.parse dies on the leading 'a'.
+    const parsed = parseTokenResponseBody(
+      'application/x-www-form-urlencoded; charset=utf-8',
+      'access_token=gho_exampletoken&scope=repo%2Cread%3Aorg&token_type=bearer'
+    );
+    expect(parsed.access_token).toBe('gho_exampletoken');
+    expect(parsed.token_type).toBe('bearer');
+    // URL-decoded, not left as %2C
+    expect(parsed.scope).toBe('repo,read:org');
+  });
+
+  it('falls back to form parsing when Content-Type is missing or wrong', () => {
+    const parsed = parseTokenResponseBody(null, 'access_token=tok&token_type=bearer');
+    expect(parsed.access_token).toBe('tok');
+  });
+
+  it('keeps a form-encoded expires_in as a coercible string', () => {
+    // OAuthRawTokenResponse declares number | string; the caller does Number().
+    const parsed = parseTokenResponseBody(
+      'application/x-www-form-urlencoded',
+      'access_token=tok&expires_in=28800'
+    );
+    expect(Number(parsed.expires_in)).toBe(28800);
+  });
+
+  it('throws a descriptive error for a genuinely unparseable body', () => {
+    expect(() =>
+      parseTokenResponseBody('text/html', '<html><body>502 Bad Gateway</body></html>')
+    ).toThrow(/unparseable response \(content-type: text\/html\)/);
   });
 });

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -630,6 +630,54 @@ async function openBrowser(url: string): Promise<void> {
   }
 }
 
+/** Trim a provider body for safe inclusion in an error message. */
+function truncateBody(body: string, max = 200): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim();
+  return collapsed.length > max ? `${collapsed.slice(0, max)}…` : collapsed;
+}
+
+/**
+ * Parse an OAuth token-endpoint response body.
+ *
+ * RFC 6749 §5.1 mandates JSON, and we ask for it with `Accept: application/json`,
+ * but not every provider honors that — GitHub's classic token endpoint returns
+ * `application/x-www-form-urlencoded` by default. Parsing by Content-Type keeps
+ * the flow working against providers that ignore the header, and turns an opaque
+ * `Unexpected token 'a'` into an error that names the endpoint's actual shape.
+ *
+ * Form-encoded values arrive as strings; that is fine — OAuthRawTokenResponse
+ * already declares `expires_in?: number | string` and the caller coerces it.
+ */
+export function parseTokenResponseBody(
+  contentType: string | null | undefined,
+  body: string
+): OAuthRawTokenResponse {
+  const isFormEncoded = (contentType ?? '')
+    .toLowerCase()
+    .includes('application/x-www-form-urlencoded');
+
+  if (!isFormEncoded) {
+    try {
+      return JSON.parse(body) as OAuthRawTokenResponse;
+    } catch {
+      // Some providers send a form-encoded body under a wrong or missing
+      // Content-Type. Only surface the JSON failure if it isn't that.
+      if (!body.includes('=')) {
+        throw new Error(
+          `Token endpoint returned an unparseable response ` +
+            `(content-type: ${contentType || 'none'}): ${truncateBody(body)}`
+        );
+      }
+    }
+  }
+
+  const parsed: Record<string, string> = {};
+  for (const [key, value] of new URLSearchParams(body)) {
+    parsed[key] = value;
+  }
+  return parsed as OAuthRawTokenResponse;
+}
+
 /**
  * Exchange authorization code for access token
  */
@@ -652,6 +700,14 @@ async function exchangeCodeForToken(
   // fall back to body params for public clients or providers that don't support Basic auth.
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
+    // RFC 6749 §5.1 mandates a JSON token response, but GitHub's
+    // /login/oauth/access_token returns application/x-www-form-urlencoded
+    // (`access_token=gho_...&scope=...`) unless the request asks for JSON.
+    // Without this header the parse below dies on the leading 'a' with
+    // `Unexpected token 'a', "access_tok"... is not valid JSON`.
+    // Registration (registerDynamicClient) and refresh (oauth-refresh.ts)
+    // already send this; the token exchange was the only path that didn't.
+    Accept: 'application/json',
   };
 
   if (clientSecret) {
@@ -683,7 +739,7 @@ async function exchangeCodeForToken(
     throw new Error(`Token exchange failed (${response.status}): ${errorText}`);
   }
 
-  const json = (await response.json()) as OAuthRawTokenResponse;
+  const json = parseTokenResponseBody(response.headers.get('content-type'), await response.text());
   console.log(
     '[MCP OAuth] Token response keys:',
     Object.keys(json),


### PR DESCRIPTION
## Summary

- Send `Accept: application/json` on the OAuth token exchange (`exchangeCodeForToken`).
- Parse the token response by `Content-Type` instead of assuming JSON, so form-encoded responses are handled and a genuinely unparseable body yields a descriptive error.

## Why / context

Connecting an MCP server behind a **GitHub OAuth app** fails after a fully successful browser sign-in:

```
Authentication failed: Unexpected token 'a', "access_tok"... is not valid JSON
```

GitHub's classic token endpoint (`/login/oauth/access_token`) returns
`application/x-www-form-urlencoded` by default — `access_token=gho_...&scope=...` —
unless the request explicitly asks for JSON. `exchangeCodeForToken()` set only
`Content-Type` and then called `response.json()` unconditionally, so the parse
died on the leading `a` of `access_token`.

Notably this was the **only** OAuth path missing the header: dynamic client
registration (`registerDynamicClient`), `oauth-auth.ts`, and `oauth-refresh.ts`
all already send `Accept: application/json`. This change brings the token
exchange in line with them.

## Implementation notes

- `Accept: application/json` is what RFC 6749 §5.1 assumes and what makes GitHub
  return JSON.
- `parseTokenResponseBody(contentType, body)` is factored out and exported so it
  can be unit-tested directly. It parses form-encoded when the Content-Type says
  so (or when JSON parsing fails on a body that looks form-encoded), and
  otherwise reports the endpoint's actual content-type rather than an opaque
  syntax error.
- Form-encoded values arrive as strings, which the existing code already
  tolerates: `OAuthRawTokenResponse.expires_in` is typed `number | string` and
  the caller coerces with `Number()`.
- No behavior change for JSON providers (Slack's nested `authed_user` path etc.
  are unaffected).

## Validation / test plan

- [x] `pnpm --filter @agor/core test src/tools/mcp/oauth-mcp-transport.test.ts` — 41 passing, incl. 5 new cases (GitHub form-encoded, standard JSON, missing/wrong Content-Type, string `expires_in`, unparseable body)
- [x] `biome check` clean on the changed files
- [x] `tsc --noEmit` — no new errors in the touched file
- [x] Verified against the real reported error: `JSON.parse('access_token=gho_...&scope=...')` reproduces `Unexpected token 'a', "access_tok"...`; the new path returns the parsed token.