### PR TITLE
feat(docs): add Agor Cloud landing page

### DIFF
--- a/apps/agor-docs/app/(docs)/[...mdxPath]/page.tsx
+++ b/apps/agor-docs/app/(docs)/[...mdxPath]/page.tsx
@@ -110,7 +110,8 @@ export default async function Page(props: PageProps) {
   const pathname = `/${params.mdxPath?.join('/') ?? ''}`;
 
   // "Full" layout pages (theme.layout: 'full' in _meta.ts, e.g. the hero
-  // A/B variants) skip the docs Wrapper entirely — same treatment as the
+  // A/B variants and the Agor Cloud landing page) skip the docs Wrapper
+  // entirely — same treatment as the
   // root "/" route (app/page.tsx), which never goes through Wrapper at all.
   // Wrapper's sidebar/TOC/copy-page shell only *hides* sub-pieces for
   // layout:'full'; it doesn't collapse the two-column shell itself, so

--- a/apps/agor-docs/app/styles.css
+++ b/apps/agor-docs/app/styles.css
@@ -267,6 +267,18 @@ code span[style*="--shiki-dark:#6A737D"] {
   order: 4;
 }
 
+/* The CTA is an <a> (links to /cloud), so it also matches
+ * `nav > a:not(:first-child)` above (order: 3). Re-assert order: 1 and its
+ * link color at higher specificity so it keeps its slot before search. */
+.nextra-navbar nav a.navbar-cloud-cta {
+  order: 1;
+  color: rgb(61, 180, 170);
+}
+
+.nextra-navbar nav a.navbar-cloud-cta:hover {
+  color: var(--agor-teal-light, #7fe8df);
+}
+
 /* Docs content headings — adopt the marketing display font (Space Grotesk)
  * and a light tint so pages read less like a wall of white. Distinct from
  * the teal link color; scoped away from the landing page (its headings carry

--- a/apps/agor-docs/components/AgorCloudLanding.module.css
+++ b/apps/agor-docs/components/AgorCloudLanding.module.css
@@ -1,0 +1,719 @@
+/* Agor Cloud marketing landing page.
+ *
+ * Shares the site's landing visual language (see LandingPage.module.css): the
+ * root class is named `landingShell` on purpose so the global
+ * `body:has([class*="landingShell"])` rules in app/styles.css apply: full-bleed
+ * opt-out of the docs content panel, forced-dark navbar glass, and the dark
+ * hero treatment even when the reader has the light docs theme selected. Tokens
+ * and the reveal system are duplicated here (not imported) so this page stays
+ * self-contained. */
+
+/* Visually-hidden helper for screen-reader-only text. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.landingShell {
+  --font-display-stack: var(--font-display), "Space Grotesk", system-ui, sans-serif;
+  --font-body-stack: var(--font-body), "Hanken Grotesk", system-ui, sans-serif;
+  --font-mono-stack: var(--font-mono-label), "JetBrains Mono", ui-monospace, monospace;
+  --landing-ink: #eafff9;
+  --landing-muted: #9fc4bd;
+  --landing-line: rgba(255, 255, 255, 0.12);
+  --landing-teal: #34e6c4;
+  --landing-gradient: linear-gradient(90deg, #2e9a92 0%, #34e6c4 50%, #a8f5ed 100%);
+  --landing-amber: #e8c468;
+  position: relative;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  margin-top: -4rem;
+  color: var(--landing-ink);
+  font-family: var(--font-body-stack);
+  background:
+    radial-gradient(circle at 82% 8%, rgba(46, 154, 146, 0.12), transparent 34rem),
+    linear-gradient(180deg, #07100f 0%, #0a1614 36%, #081210 72%, #07100f 100%);
+  /* clip (not hidden) keeps sticky/absolute glows contained without creating a
+   * scroll container. */
+  overflow: clip;
+}
+
+/* Force the dark background even under the light docs theme (matches the
+ * homepage landing treatment). */
+:global(.dark) .landingShell {
+  background:
+    radial-gradient(circle at 82% 8%, rgba(46, 154, 146, 0.12), transparent 34rem),
+    linear-gradient(180deg, #07100f 0%, #0a1614 36%, #081210 72%, #07100f 100%);
+}
+
+.landingShell > section,
+.landingShell > footer {
+  position: relative;
+  z-index: 1;
+}
+
+/* --- Reveal-on-scroll system (IntersectionObserver stamps .isVisible) ------ */
+.landingShell [data-reveal] {
+  opacity: 0;
+  transform: translateY(30px);
+  transition:
+    opacity 680ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms),
+    transform 680ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms),
+    translate 300ms ease,
+    border-color 300ms ease,
+    box-shadow 300ms ease;
+  will-change: opacity, transform;
+}
+
+.landingShell .isVisible {
+  opacity: 1;
+  transform: none;
+  will-change: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landingShell [data-reveal],
+  .landingShell .isVisible {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+/* --- Shared section scaffolding ------------------------------------------- */
+.section {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(64px, 9vw, 104px) clamp(20px, 4vw, 28px);
+}
+
+.sectionHead {
+  max-width: 860px;
+  margin: 0 auto clamp(40px, 5vw, 60px);
+  text-align: center;
+}
+
+.eyebrow {
+  display: block;
+  margin: 0 0 18px;
+  color: var(--landing-teal);
+  font-family: var(--font-mono-stack);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.section h2 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-family: var(--font-body-stack);
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
+  font-weight: 100;
+  letter-spacing: -0.03em;
+  line-height: 1.04;
+}
+
+.lead {
+  max-width: 62ch;
+  margin: 20px auto 0;
+  color: var(--landing-muted);
+  font-size: clamp(1.02rem, 1.4vw, 1.2rem);
+  line-height: 1.65;
+}
+
+.headingAccent {
+  font-weight: 600;
+  background: linear-gradient(110deg, #34e6c4, #7ad9ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.headingStrong {
+  font-weight: 700;
+  color: var(--landing-ink);
+}
+
+/* --- Buttons (mirrors LandingPage primary/secondary) ---------------------- */
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 0 22px;
+  border: 0;
+  border-radius: 999px;
+  font: inherit;
+  font-family: var(--font-display-stack);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.landingShell .primaryButton {
+  color: #031311;
+  background: linear-gradient(135deg, #2e9a92 0%, #34e6c4 100%);
+  box-shadow: 0 16px 34px rgba(52, 230, 196, 0.28);
+}
+
+.landingShell .primaryButton:hover {
+  color: #031311;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 44px rgba(52, 230, 196, 0.36);
+}
+
+.landingShell .secondaryButton {
+  border: 1px solid var(--landing-line);
+  color: var(--landing-ink);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+}
+
+.landingShell .secondaryButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(52, 230, 196, 0.35);
+  color: var(--landing-ink);
+}
+
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible {
+  outline: 2px solid #a8f5ed;
+  outline-offset: 3px;
+}
+
+/* --- Hero ----------------------------------------------------------------- */
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 64px);
+  padding: 120px clamp(20px, 4vw, 28px) 96px;
+  text-align: center;
+  overflow: hidden;
+}
+
+/* Soft radial glows behind the hero copy: CSS only, reduced-motion safe. */
+.heroGlow {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(46% 40% at 50% 12%, rgba(52, 230, 196, 0.18), transparent 70%),
+    radial-gradient(38% 34% at 82% 70%, rgba(122, 217, 255, 0.1), transparent 70%),
+    radial-gradient(40% 40% at 12% 60%, rgba(46, 154, 146, 0.12), transparent 70%);
+}
+
+.heroInner {
+  position: relative;
+  z-index: 1;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: clamp(30px, 3.4vw, 52px) clamp(22px, 4vw, 56px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 28px;
+  background: rgba(7, 16, 15, 0.42);
+  backdrop-filter: blur(9px) saturate(1.15);
+  -webkit-backdrop-filter: blur(9px) saturate(1.15);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .heroInner {
+    background: rgba(7, 16, 15, 0.82);
+  }
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 22px;
+  padding: 7px 15px;
+  border: 1px solid rgba(52, 230, 196, 0.22);
+  border-radius: 100px;
+  background: rgba(7, 16, 15, 0.7);
+  color: var(--landing-teal);
+  font-family: var(--font-mono-stack);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.heroBadgeDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--landing-teal);
+  box-shadow: 0 0 0 3px rgba(52, 230, 196, 0.2);
+}
+
+.hero h1 {
+  max-width: 20ch;
+  margin: 0 auto;
+  color: var(--landing-ink);
+  font-family: var(--font-body-stack);
+  font-size: clamp(2.9rem, 6vw, 5.1rem);
+  font-weight: 100;
+  letter-spacing: -0.03em;
+  line-height: 1.02;
+}
+
+.heroSub {
+  max-width: 60ch;
+  margin: 24px auto 0;
+  color: var(--landing-muted);
+  font-size: clamp(1.05rem, 1.5vw, 1.28rem);
+  line-height: 1.62;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 34px;
+}
+
+.metaLine {
+  margin: 26px 0 0;
+  color: #6f928c;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+}
+
+/* --- Card grids ----------------------------------------------------------- */
+.grid {
+  display: grid;
+  gap: 20px;
+}
+
+.grid2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.grid3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.card {
+  padding: 26px;
+  border: 1px solid rgba(52, 230, 196, 0.12);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(15, 34, 31, 0.7), rgba(10, 22, 20, 0.5));
+  transition:
+    translate 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.card:hover {
+  translate: 0 -5px;
+  border-color: rgba(52, 230, 196, 0.32);
+}
+
+.cardIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  margin-bottom: 16px;
+  border: 1px solid rgba(52, 230, 196, 0.22);
+  border-radius: 12px;
+  background: rgba(52, 230, 196, 0.08);
+  color: var(--landing-teal);
+}
+
+.card h3 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-family: var(--font-display-stack);
+  font-size: 1.17rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.card p {
+  margin: 10px 0 0;
+  color: var(--landing-muted);
+  font-size: 0.95rem;
+  line-height: 1.62;
+}
+
+/* Pivot line under the "why graduate" grid. */
+.pivot {
+  max-width: 52ch;
+  margin: clamp(36px, 4vw, 48px) auto 0;
+  text-align: center;
+  color: var(--landing-ink);
+  font-size: clamp(1.15rem, 1.8vw, 1.5rem);
+  font-weight: 300;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
+/* --- Deployment options --------------------------------------------------- */
+.deployGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.deployCard {
+  display: flex;
+  flex-direction: column;
+  padding: 28px;
+  border: 1px solid rgba(52, 230, 196, 0.14);
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(15, 34, 31, 0.72), rgba(10, 22, 20, 0.5));
+  transition:
+    translate 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.deployCard:hover {
+  translate: 0 -5px;
+  border-color: rgba(52, 230, 196, 0.3);
+}
+
+.deployCardFeatured {
+  border-color: rgba(52, 230, 196, 0.4);
+  box-shadow: 0 20px 50px rgba(52, 230, 196, 0.12);
+}
+
+.badge {
+  align-self: flex-start;
+  margin-bottom: 16px;
+  padding: 4px 11px;
+  border-radius: 999px;
+  font-family: var(--font-mono-stack);
+  font-size: 0.66rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.badgeNow {
+  background: rgba(52, 230, 196, 0.16);
+  color: var(--landing-teal);
+}
+
+.badgeAws {
+  background: rgba(122, 217, 255, 0.14);
+  color: #9bdcff;
+}
+
+.badgeEnterprise {
+  background: rgba(232, 196, 104, 0.14);
+  color: var(--landing-amber);
+}
+
+.deployCard h3 {
+  margin: 0 0 6px;
+  color: var(--landing-ink);
+  font-family: var(--font-display-stack);
+  font-size: 1.28rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.deployCard p {
+  margin: 10px 0 0;
+  color: var(--landing-muted);
+  font-size: 0.95rem;
+  line-height: 1.62;
+}
+
+.deployNote {
+  margin: 28px auto 0;
+  max-width: 56ch;
+  text-align: center;
+  color: #6f928c;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* --- Trust / security band (tinted, full-bleed) --------------------------- */
+.band {
+  position: relative;
+  border-top: 1px solid rgba(52, 230, 196, 0.1);
+  border-bottom: 1px solid rgba(52, 230, 196, 0.1);
+  background:
+    radial-gradient(60% 100% at 50% 0%, rgba(46, 154, 146, 0.12), transparent 70%),
+    rgba(6, 13, 12, 0.55);
+}
+
+.trustLayout {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: clamp(32px, 5vw, 64px);
+  align-items: start;
+}
+
+.trustLayout .sectionHead {
+  margin: 0;
+  text-align: left;
+}
+
+.trustLayout .lead {
+  margin-left: 0;
+}
+
+.trustList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trustItem {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+.trustCheck {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(52, 230, 196, 0.12);
+  color: var(--landing-teal);
+  flex-shrink: 0;
+}
+
+.trustItem strong {
+  display: block;
+  color: var(--landing-ink);
+  font-family: var(--font-display-stack);
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.trustItem span {
+  color: var(--landing-muted);
+  font-size: 0.94rem;
+  line-height: 1.58;
+}
+
+/* --- "Who runs it" split -------------------------------------------------- */
+.operator {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(32px, 5vw, 56px);
+  align-items: center;
+}
+
+.operator h2 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-family: var(--font-body-stack);
+  font-size: clamp(2rem, 3.4vw, 3rem);
+  font-weight: 100;
+  letter-spacing: -0.03em;
+  line-height: 1.06;
+}
+
+.operator p {
+  margin: 18px 0 0;
+  color: var(--landing-muted);
+  font-size: 1.02rem;
+  line-height: 1.68;
+}
+
+.operatorStats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.stat {
+  padding: 22px;
+  border: 1px solid rgba(52, 230, 196, 0.12);
+  border-radius: 16px;
+  background: rgba(10, 22, 20, 0.5);
+}
+
+.statValue {
+  display: block;
+  color: var(--landing-ink);
+  font-family: var(--font-display-stack);
+  font-size: 1.7rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.statLabel {
+  display: block;
+  margin-top: 6px;
+  color: var(--landing-muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+/* --- Final CTA ------------------------------------------------------------ */
+.finalCta {
+  padding-bottom: clamp(72px, 9vw, 112px);
+}
+
+.ctaCard {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: clamp(40px, 6vw, 68px) clamp(24px, 4vw, 56px);
+  border: 1px solid rgba(52, 230, 196, 0.2);
+  border-radius: 28px;
+  background:
+    radial-gradient(70% 120% at 50% 0%, rgba(52, 230, 196, 0.14), transparent 70%),
+    linear-gradient(180deg, rgba(15, 34, 31, 0.8), rgba(8, 18, 16, 0.7));
+  text-align: center;
+}
+
+.ctaCard h2 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-family: var(--font-body-stack);
+  font-size: clamp(2.1rem, 3.6vw, 3.3rem);
+  font-weight: 100;
+  letter-spacing: -0.03em;
+  line-height: 1.04;
+}
+
+.ctaCard p {
+  max-width: 52ch;
+  margin: 18px auto 0;
+  color: var(--landing-muted);
+  font-size: 1.05rem;
+  line-height: 1.62;
+}
+
+.ctaCard .heroActions {
+  margin-top: 30px;
+}
+
+/* --- Footer --------------------------------------------------------------- */
+.footer {
+  border-top: 1px solid rgba(52, 230, 196, 0.12);
+  padding: 48px clamp(20px, 4vw, 28px);
+}
+
+.footerInner {
+  max-width: 1180px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px 40px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footerBrand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--landing-ink);
+}
+
+.footerBrand strong {
+  font-family: var(--font-display-stack);
+  font-size: 1.15rem;
+}
+
+.footerBrand p {
+  margin: 2px 0 0;
+  color: var(--landing-muted);
+  font-size: 0.85rem;
+}
+
+.footerLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 22px;
+  align-items: center;
+}
+
+/* `.landingShell` prefix out-ranks the global `.dark a` link-color rule so
+ * anchor and <button> footer links render identically. */
+.landingShell .footerLink {
+  color: var(--landing-muted);
+  font-size: 0.92rem;
+  text-decoration: none;
+  border: 0;
+  background: none;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s ease;
+}
+
+.landingShell .footerLink:hover {
+  color: var(--landing-teal);
+}
+
+.landingShell .footerLink:focus-visible {
+  outline: 2px solid #a8f5ed;
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* --- Responsive ----------------------------------------------------------- */
+@media (max-width: 900px) {
+  .grid3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .deployGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .trustLayout,
+  .operator {
+    grid-template-columns: 1fr;
+  }
+
+  .trustLayout .sectionHead,
+  .operator {
+    text-align: left;
+  }
+}
+
+@media (max-width: 620px) {
+  .grid2,
+  .grid3 {
+    grid-template-columns: 1fr;
+  }
+
+  .operatorStats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .heroActions .primaryButton,
+  .heroActions .secondaryButton {
+    width: 100%;
+    max-width: 340px;
+  }
+}

--- a/apps/agor-docs/components/AgorCloudLanding.tsx
+++ b/apps/agor-docs/components/AgorCloudLanding.tsx
@@ -1,0 +1,574 @@
+'use client';
+
+import {
+  Activity,
+  BookOpen,
+  Boxes,
+  Cloud,
+  Eye,
+  GitBranch,
+  KeyRound,
+  type LucideIcon,
+  RefreshCw,
+  ScrollText,
+  Server,
+  ShieldCheck,
+  SlidersHorizontal,
+  Users,
+} from 'lucide-react';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL, PRESET_URL, presetUtm } from '../lib/links';
+import { getBasePath, LOGO_MARK_PATH } from '../lib/siteMetadata';
+import styles from './AgorCloudLanding.module.css';
+import { HubSpotFormModal } from './HubSpotFormModal';
+import { HubSpotMeetingModal } from './HubSpotMeetingModal';
+
+const basePath = getBasePath();
+
+// Link to the existing announcement (kept as the long-form companion to this
+// conversion-focused page).
+const ANNOUNCEMENT_HREF = '/blog/agor-cloud';
+
+// The operational reality of self-hosting a multi-user Agor: the honest case
+// for a managed offering, without disparaging the open product. Grounded in the
+// Agor Cloud announcement post.
+const opsBurden: Array<{ icon: LucideIcon; title: string; body: string }> = [
+  {
+    icon: Server,
+    title: 'Stateful to operate',
+    body: 'A database that needs backups, migrations, and a tested recovery story for when something breaks.',
+  },
+  {
+    icon: Boxes,
+    title: 'Isolation that holds',
+    body: 'Per-user, per-branch boundaries so one developer’s session, worktree, or runaway process never stomps another’s.',
+  },
+  {
+    icon: RefreshCw,
+    title: 'Always patched',
+    body: 'Same-day fixes when the next CVE lands in Node, Postgres, the kernel, or any dependency in the stack.',
+  },
+  {
+    icon: Eye,
+    title: 'Eyes on everything',
+    body: 'Observability across a fleet of dev environments and an audit trail your security team will actually accept.',
+  },
+];
+
+// What Agor Cloud manages. Every claim maps to shipped capability in the
+// agor-cloud control plane (EKS + Karpenter, per-team workspaces & roles,
+// WorkOS social sign-on, BYOK, CI session genealogy).
+const capabilities: Array<{ icon: LucideIcon; title: string; body: ReactNode }> = [
+  {
+    icon: Cloud,
+    title: 'Fully managed, always current',
+    body: 'Runs on autoscaling Kubernetes with tuned node pools and resource budgets. New releases land on Cloud after they’re validated against our own production traffic, never yours.',
+  },
+  {
+    icon: Users,
+    title: 'Segment into isolated workspaces',
+    body: 'Run multiple Agor workspaces under one account and segment them by team, project, or sensitivity. Each workspace is its own tenant, with a separate database and strict boundaries between them, so you can dial isolation up exactly where it matters.',
+  },
+  {
+    icon: KeyRound,
+    title: 'Bring your own keys',
+    body: 'Claude, Codex, Gemini: your keys, billed by your provider. We don’t proxy your tokens, mark them up, or take a cut, so there’s no incentive to burn more of them.',
+  },
+  {
+    icon: SlidersHorizontal,
+    title: 'Sign-in that fits',
+    body: 'Social sign-on today through a SOC 2 Type II identity provider, with enterprise SSO on the roadmap. Team roles decide who can see and do what.',
+  },
+  {
+    icon: GitBranch,
+    title: 'CI-ready agents',
+    body: 'CI-triggered sessions appear on your board in real time, keep the context that built the branch, and stay live to resume once the job ends.',
+  },
+  {
+    icon: Activity,
+    title: 'Kept alive for you',
+    body: 'Health checks, auto-recovery, and capacity management for the fleet of environments underneath your team. You build; we keep the lights on.',
+  },
+];
+
+// Governance & observability: the strongest enterprise differentiation. Each
+// item is grounded: audit_events, team roles + per-tenant RLS isolation, usage
+// tiers/quotas, Datadog + executor accounting.
+const governance: Array<{ icon: LucideIcon; title: string; body: string }> = [
+  {
+    icon: ScrollText,
+    title: 'Audit trail',
+    body: 'Session creation, prompt submissions, branch and owner changes, and admin actions, all recorded with secret-safe metadata.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Roles & access control',
+    body: 'Team roles (owner, admin, member) decide who can see and do what. Access is scoped per workspace and every privileged change is auditable, so the right people reach the right work and nothing more.',
+  },
+  {
+    icon: SlidersHorizontal,
+    title: 'Usage tiers & quotas',
+    body: 'Per-team tiers and workspace quotas keep usage visible and bounded, so a busy team can’t surprise the rest of the org.',
+  },
+  {
+    icon: Activity,
+    title: 'Real observability',
+    body: 'Structured logs, metrics, and executor-level accounting via Datadog, the same signals we use to run it, surfaced for your team too.',
+  },
+];
+
+// Deployment models. (a) is live in the private beta; (b) MPC is architected
+// and offered as a conversation; (c) full on-prem/BYOC is a later enterprise
+// tier. Maturity is signalled honestly via the badge.
+const deployments: Array<{
+  badge: string;
+  badgeClass: string;
+  title: string;
+  body: string;
+  featured?: boolean;
+}> = [
+  {
+    badge: 'Available in beta',
+    badgeClass: styles.badgeNow,
+    title: 'Agor Cloud (hosted)',
+    body: 'A managed, single-tenant Agor instance on our infrastructure. Up in minutes, always on the latest secured release, hardened to sit safely on the public internet.',
+    featured: true,
+  },
+  {
+    badge: 'In your AWS',
+    badgeClass: styles.badgeAws,
+    title: 'Managed private cloud',
+    body: 'We deploy and operate Agor inside your own AWS account, so data and compute stay in your tenancy, with private network access to your VPC. Talk to us about fit.',
+  },
+  {
+    badge: 'Enterprise',
+    badgeClass: styles.badgeEnterprise,
+    title: 'Private cloud / on-prem',
+    body: 'For organizations that need to operate the whole stack themselves. A larger engagement we scope with enterprise teams, so reach out to start the conversation.',
+  },
+];
+
+// Security posture. Worded deliberately: SOC 2 is *in progress*, never claimed
+// complete; pen testing / review framed as part of how the service is operated.
+const security: Array<{ title: string; body: string }> = [
+  {
+    title: 'Hardened by default',
+    body: 'The open-source flags that widen attack surface (shared dev boxes, broad bypass modes) are off in Cloud. We know which knobs belong in which position because we run it ourselves.',
+  },
+  {
+    title: 'Unix-level isolation',
+    body: 'Sessions, worktrees, and environments run as distinct Unix users, with filesystem permissions enforcing the boundaries between users, branches, and agents as defense-in-depth.',
+  },
+  {
+    title: 'Independently reviewed',
+    body: 'Built against a documented threat model, with independent security review and penetration testing as part of how the service is operated.',
+  },
+  {
+    title: 'SOC 2 Type II in progress',
+    body: 'Our SOC 2 Type II audit is underway, and identity is handled by a SOC 2 Type II provider. Your AI keys stay yours and never route through us.',
+  },
+];
+
+export function AgorCloudLanding() {
+  const shellRef = useRef<HTMLElement>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isDemoOpen, setIsDemoOpen] = useState(false);
+  // Which CTA opened the (single, shared) beta form, stamped into the form's
+  // hidden source_page field for attribution, matching the site convention.
+  const [formSource, setFormSource] = useState('cloud-page-hero');
+
+  const openForm = (source: string) => {
+    setFormSource(source);
+    setIsFormOpen(true);
+  };
+
+  // Reveal-on-scroll with a safety net. The entrance animation is a
+  // progressive enhancement; content must NEVER be stranded invisible. The
+  // reveal fires as sections scroll in (like LandingPage), but a timeout
+  // backstop reveals anything still hidden, covering contexts where the
+  // observer never gets a scroll event (embedded iframes / board previews
+  // whose inner window doesn't scroll, JS-throttled tabs, or fast scrolls the
+  // observer misses). Reduced motion shows everything immediately.
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) {
+      return;
+    }
+    const items = Array.from(shell.querySelectorAll<HTMLElement>('[data-reveal]'));
+    if (!items.length) {
+      return;
+    }
+    const revealAll = () => {
+      items.forEach((item) => {
+        item.classList.add(styles.isVisible);
+      });
+    };
+    if (
+      typeof IntersectionObserver === 'undefined' ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      revealAll();
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add(styles.isVisible);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: '0px 0px -8% 0px', threshold: 0.08 }
+    );
+    items.forEach((item) => {
+      observer.observe(item);
+    });
+    // Backstop: if the reader hasn't triggered reveals through scrolling,
+    // reveal everything so nothing stays blank. Below-fold sections simply
+    // appear without the entrance animation, a fine trade for never showing
+    // an empty page.
+    const fallback = window.setTimeout(revealAll, 1400);
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(fallback);
+    };
+  }, []);
+
+  return (
+    // <main> with Nextra's skip-nav id; the "full" layout provides no main
+    // landmark of its own, so this is the page's only one.
+    <main ref={shellRef} id="nextra-skip-nav" className={styles.landingShell}>
+      {/* --- Hero --- */}
+      <section className={styles.hero}>
+        <div className={styles.heroGlow} aria-hidden="true" />
+        <div className={styles.heroInner} data-reveal>
+          <p className={styles.heroBadge}>
+            <span className={styles.heroBadgeDot} aria-hidden="true" />
+            Agor Cloud · Private beta
+          </p>
+          <h1>
+            Fully managed Agor for your <span className={styles.headingStrong}>whole team</span>
+          </h1>
+          <p className={styles.heroSub}>
+            Agor is open, and yours to run. Agor Cloud is for teams who’d rather not. We operate a
+            hardened, always-current Agor for you, with scaling, isolation, governance, and
+            observability handled, so your team can focus on the work, not the platform underneath
+            it.
+          </p>
+          <div className={styles.heroActions}>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={() => openForm('cloud-page-hero')}
+            >
+              Request an invite
+            </button>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => setIsDemoOpen(true)}
+            >
+              Book a demo
+            </button>
+            <Link href={ANNOUNCEMENT_HREF} className={styles.secondaryButton}>
+              <BookOpen size={17} aria-hidden="true" />
+              Read the announcement
+            </Link>
+          </div>
+          <p className={styles.metaLine}>Built and operated by the team behind Preset Cloud.</p>
+        </div>
+      </section>
+
+      {/* --- Why teams graduate from self-hosting --- */}
+      <section className={styles.section} data-reveal>
+        <div className={styles.sectionHead}>
+          <span className={styles.eyebrow}>Open source, minus the ops</span>
+          <h2>
+            You can run Agor yourself.
+            <br />
+            Most teams <span className={styles.headingStrong}>shouldn’t have to</span>.
+          </h2>
+          <p className={styles.lead}>
+            Agor is source-available under BSL 1.1, and running it in production yourself is
+            permitted and supported. But operating it well for a whole team becomes its own
+            full-time job:
+          </p>
+        </div>
+        <div className={`${styles.grid} ${styles.grid2}`}>
+          {opsBurden.map((item) => (
+            <article className={styles.card} key={item.title}>
+              <span className={styles.cardIcon}>
+                <item.icon size={20} aria-hidden="true" />
+              </span>
+              <h3>{item.title}</h3>
+              <p>{item.body}</p>
+            </article>
+          ))}
+        </div>
+        <p className={styles.pivot}>
+          Agor Cloud is us doing that once,{' '}
+          <span className={styles.headingAccent}>well, for everyone</span>.
+        </p>
+      </section>
+
+      {/* --- Capabilities --- */}
+      <section className={styles.section} data-reveal>
+        <div className={styles.sectionHead}>
+          <span className={styles.eyebrow}>Fully managed</span>
+          <h2>
+            Everything running, <span className={styles.headingAccent}>nothing to babysit</span>
+          </h2>
+          <p className={styles.lead}>
+            The same platform you know from the open project, operated for you with the rigor Preset
+            brings to Preset Cloud.
+          </p>
+        </div>
+        <div className={`${styles.grid} ${styles.grid3}`}>
+          {capabilities.map((item) => (
+            <article className={styles.card} key={item.title}>
+              <span className={styles.cardIcon}>
+                <item.icon size={20} aria-hidden="true" />
+              </span>
+              <h3>{item.title}</h3>
+              <p>{item.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* --- Governance & observability (differentiator) --- */}
+      <div className={styles.band}>
+        <section className={styles.section} data-reveal>
+          <div className={styles.sectionHead}>
+            <span className={styles.eyebrow}>Governance &amp; observability</span>
+            <h2>
+              See everything. <span className={styles.headingStrong}>Prove anything</span>.
+            </h2>
+            <p className={styles.lead}>
+              When Agor becomes part of how your team ships, you need to see what’s happening in it,
+              and so does whoever runs your next security review.
+            </p>
+          </div>
+          <div className={`${styles.grid} ${styles.grid2}`}>
+            {governance.map((item) => (
+              <article className={styles.card} key={item.title}>
+                <span className={styles.cardIcon}>
+                  <item.icon size={20} aria-hidden="true" />
+                </span>
+                <h3>{item.title}</h3>
+                <p>{item.body}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* --- Deployment options --- */}
+      <section className={styles.section} data-reveal>
+        <div className={styles.sectionHead}>
+          <span className={styles.eyebrow}>Deploy your way</span>
+          <h2>
+            Three ways to <span className={styles.headingAccent}>run it</span>
+          </h2>
+          <p className={styles.lead}>
+            Start on our infrastructure and move closer to your own as your requirements grow. The
+            same Agor, in the topology your security team needs.
+          </p>
+        </div>
+        <div className={styles.deployGrid}>
+          {deployments.map((item) => (
+            <article
+              className={
+                item.featured
+                  ? `${styles.deployCard} ${styles.deployCardFeatured}`
+                  : styles.deployCard
+              }
+              key={item.title}
+            >
+              <span className={`${styles.badge} ${item.badgeClass}`}>{item.badge}</span>
+              <h3>{item.title}</h3>
+              <p>{item.body}</p>
+            </article>
+          ))}
+        </div>
+        <p className={styles.deployNote}>
+          Network topology is a conversation, not a checkbox. Tell us what your security team needs
+          and we’ll work out the shape.
+        </p>
+      </section>
+
+      {/* --- Security & trust --- */}
+      <div className={styles.band}>
+        <section className={styles.section} data-reveal>
+          <div className={styles.trustLayout}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Security</span>
+              <h2>
+                Hardened for the <span className={styles.headingStrong}>public internet</span>
+              </h2>
+              <p className={styles.lead}>
+                Some of Agor’s capabilities are great inside a trusted network and risky on the open
+                internet. Cloud is built the other way around, so your team can use it from
+                anywhere, mobile included, with no VPN gymnastics.
+              </p>
+            </div>
+            <ul className={styles.trustList}>
+              {security.map((item) => (
+                <li className={styles.trustItem} key={item.title}>
+                  <span className={styles.trustCheck} aria-hidden="true">
+                    <ShieldCheck size={15} />
+                  </span>
+                  <span>
+                    <strong>{item.title}</strong>
+                    <span>{item.body}</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </div>
+
+      {/* --- Who operates it --- */}
+      <section className={styles.section} data-reveal>
+        <div className={styles.operator}>
+          <div>
+            <span className={styles.eyebrow}>Who runs it</span>
+            <h2>
+              Operated by the team behind <span className={styles.headingStrong}>Preset Cloud</span>
+            </h2>
+            <p>
+              Preset runs Preset Cloud, a managed Apache Superset service used by thousands of
+              teams. Agor Cloud is operated with the same on-call rigor, by the people building
+              Agor. You get hands-on onboarding, a direct line for feedback, and features
+              prioritized around what early teams actually need.
+            </p>
+          </div>
+          <div className={styles.operatorStats}>
+            <div className={styles.stat}>
+              <span className={styles.statValue}>Trust the makers</span>
+              <span className={styles.statLabel}>
+                The team that wrote Agor keeps it running, and they know which knobs matter.
+              </span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statValue}>Same-day patching</span>
+              <span className={styles.statLabel}>
+                When a zero-day lands, the fix ships that day. You don’t track changelogs.
+              </span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statValue}>No on-call for you</span>
+              <span className={styles.statLabel}>
+                We’re on-call for Agor, so your team stays on-call for your product.
+              </span>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statValue}>Feedback loop</span>
+              <span className={styles.statLabel}>
+                A direct channel to the builders. Feature requests welcome.
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* --- Final CTA --- */}
+      <section className={`${styles.section} ${styles.finalCta}`} data-reveal>
+        <div className={styles.ctaCard}>
+          <h2>
+            Bring your team to <span className={styles.headingAccent}>Agor Cloud</span>
+          </h2>
+          <p>
+            We’re onboarding teams into the private beta now. Tell us about your team and use case,
+            and we’ll take it from there: a quick fit call, then you’re set up in minutes.
+          </p>
+          <div className={styles.heroActions}>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={() => openForm('cloud-page-final')}
+            >
+              Request an invite
+            </button>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => setIsDemoOpen(true)}
+            >
+              Book a demo
+            </button>
+            <Link href={ANNOUNCEMENT_HREF} className={styles.secondaryButton}>
+              Read the announcement
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* --- Footer --- */}
+      <footer className={styles.footer} data-reveal>
+        <div className={styles.footerInner}>
+          <div className={styles.footerBrand}>
+            {/* Decorative: the adjacent wordmark already names the product. */}
+            {/* biome-ignore lint/performance/noImgElement: Static docs asset */}
+            <img src={`${basePath}${LOGO_MARK_PATH}`} alt="" width="40" height="40" />
+            <div>
+              <strong>Agor Cloud</strong>
+              <p>Fully managed Agor for teams.</p>
+            </div>
+          </div>
+          <div className={styles.footerLinks}>
+            <Link href={ANNOUNCEMENT_HREF} className={styles.footerLink}>
+              Announcement
+            </Link>
+            <Link href="/guide/getting-started" className={styles.footerLink}>
+              Self-host
+            </Link>
+            <Link
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.footerLink}
+            >
+              GitHub
+            </Link>
+            <Link
+              href={DISCORD_INVITE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.footerLink}
+            >
+              Discord
+            </Link>
+            <Link
+              href={`${PRESET_URL}${presetUtm('agor-cloud-footer')}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.footerLink}
+            >
+              Preset
+            </Link>
+            <button
+              type="button"
+              className={styles.footerLink}
+              onClick={() => openForm('cloud-page-footer')}
+            >
+              Request an invite
+            </button>
+          </div>
+        </div>
+      </footer>
+
+      <HubSpotFormModal
+        isOpen={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        title="Request an Agor Cloud invite"
+        sourceCta={formSource}
+      />
+      <HubSpotMeetingModal isOpen={isDemoOpen} onClose={() => setIsDemoOpen(false)} />
+    </main>
+  );
+}

--- a/apps/agor-docs/components/NavbarCloudCTA.tsx
+++ b/apps/agor-docs/components/NavbarCloudCTA.tsx
@@ -1,20 +1,14 @@
-'use client';
+import Link from 'next/link';
 
-import { useState } from 'react';
-import { HubSpotFormModal } from './HubSpotFormModal';
-
-// Navbar "Agor Cloud" entry — pops the beta-signup modal (same flow as the
-// landing-page CTAs) instead of navigating. Rendered as <Navbar> children;
-// styles.css slots it left of the search input via flex order.
+// Navbar "Agor Cloud" entry: links to the Agor Cloud landing page (/cloud)
+// instead of popping the beta modal. The request-invite form now lives behind
+// the CTAs on that page. Rendered as <Navbar> children; styles.css slots it
+// left of the search input via flex order (`.navbar-cloud-cta`), including an
+// anchor-specific override so switching from <button> to <a> keeps its place.
 export function NavbarCloudCTA() {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
-    <>
-      <button type="button" className="navbar-cloud-cta" onClick={() => setIsOpen(true)}>
-        Agor Cloud
-      </button>
-      <HubSpotFormModal isOpen={isOpen} onClose={() => setIsOpen(false)} sourceCta="navbar" />
-    </>
+    <Link href="/cloud" className="navbar-cloud-cta">
+      Agor Cloud
+    </Link>
   );
 }

--- a/apps/agor-docs/components/index.ts
+++ b/apps/agor-docs/components/index.ts
@@ -1,3 +1,4 @@
+export { AgorCloudLanding } from './AgorCloudLanding';
 export { default as Aurora } from './Aurora/Aurora';
 export { BlogCard } from './BlogCard';
 export { BlogIndex } from './BlogIndex';

--- a/apps/agor-docs/content/_meta.ts
+++ b/apps/agor-docs/content/_meta.ts
@@ -26,6 +26,18 @@ export default {
   'selfware-is-dead': heroVariantMeta,
   'dev-team': heroVariantMeta,
   'costs-under-control': heroVariantMeta,
+  // Agor Cloud marketing landing page. Reached via the navbar "Agor Cloud"
+  // link (see NavbarCloudCTA); hidden from the sidebar and rendered full-bleed
+  // like the homepage via `theme.layout: 'full'`. The request-invite form
+  // stays behind the on-page CTAs.
+  cloud: {
+    title: 'Agor Cloud',
+    type: 'page',
+    display: 'hidden',
+    theme: {
+      layout: 'full',
+    },
+  },
   // Navbar links are separate from the content folders so Docs and Blog can
   // also remain in the shared root sidebar on every content surface.
   'docs-navbar': { title: 'Docs', type: 'page', href: '/guide' },

--- a/apps/agor-docs/content/cloud.mdx
+++ b/apps/agor-docs/content/cloud.mdx
@@ -1,0 +1,9 @@
+---
+title: Agor Cloud
+description: Fully managed Agor for your whole team, with scaling, isolation, governance, and observability handled. Bring your own keys, deploy hosted or in your own AWS, and request an invite to the private beta.
+image: /images/blog/agor-cloud.png
+---
+
+import { AgorCloudLanding } from '../components';
+
+<AgorCloudLanding />


### PR DESCRIPTION
## Summary

Adds a conversion-focused **Agor Cloud** marketing landing page at `/cloud`, and repoints the navbar "Agor Cloud" link to it. The request-invite form now lives behind the on-page CTAs instead of opening straight from the navbar.

## Page structure

- **Hero** with the primary "Request an invite" CTA (plus Book a demo and Read the announcement).
- **Why teams graduate** from self-hosting, honoring the open product without disparaging it.
- **Capabilities**: managed Kubernetes, segment into isolated workspaces, bring your own keys, sign-in, CI-ready agents, auto-recovery.
- **Governance & observability**: audit trail, roles & access control, usage tiers/quotas, Datadog.
- **Deployment options**: hosted, managed private cloud in your AWS, private/on-prem, with honest maturity labels.
- **Security & trust**, **who operates it**, **final CTA**, and footer. The invite CTA repeats at hero, final, and footer.

## Implementation notes

- New `AgorCloudLanding` component + CSS module, reusing the existing HubSpot form/meeting modals and the site's landing visual language (forced-dark shell, reveal-on-scroll, reduced-motion).
- **Full-bleed rendering:** `content/_meta.ts` drops the sidebar (`layout: 'full'`) and the `[...mdxPath]` route renders `fullBleed` frontmatter pages bare (no TOC or Copy-page chrome), matching the homepage's `app/page.tsx`.
- **Reveal safety net:** a timeout backstop reveals content even where the observer never sees a scroll event (embedded iframes / board previews), so sections are never stranded invisible.
- **Navbar** CTA is now a `<Link>` to `/cloud`; a small `styles.css` override preserves its slot after the button-to-link switch.

## Copy grounding

Capability claims were validated against the private `agor-cloud` repo. Deliberately conservative wording:

- **SOC 2 Type II** is described as **in progress**, never certified.
- **Enterprise SSO, managed private cloud, and on-prem** are framed as roadmap or "talk to us", not shipped.
- No em-dashes; negative-parallelism density trimmed per the tropes house-style guide.

## Validation

- `pnpm i` clean. Docs `typecheck`, `next build` (static export, 52 pages including `/cloud`), `validate:social-metadata`, and `validate:brand-assets` all pass.
- `biome` lint clean across the repo.
- Verified live at desktop and mobile widths via the branch dev environment (hero, every section, responsive stacks, reveal-on-scroll).
- Note: `pnpm check` surfaces a **pre-existing, unrelated** failure (multitenancy baseline drift in `apps/agor-daemon/src/setup/socketio.ts`, 18 vs baseline 17) that this PR does not touch.

## Claims to confirm (product / legal)

- Pen-test and SOC 2 status wording (the announcement post asserts pen-tested plus SOC 2 in flight; worded conservatively here).
- Whether to present managed-private-cloud / on-prem pre-GA, and any plan limits on the number of workspaces.

## Preview

`pnpm --filter @agor/docs dev`, then open `/cloud` (or use the branch dev environment at `/cloud`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
