### PR TITLE
fix(client): preserve messages across realtime fetch races

### DIFF
--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -33,6 +33,7 @@ interface MockClientOptions {
   failTaskMessageFetch?: boolean;
   /** When true, `session-streams.create` blocks until releaseCreate() is called. */
   deferCreate?: boolean;
+  deferTaskMessageFetch?: string;
 }
 
 function createMockClient(opts: MockClientOptions) {
@@ -40,12 +41,17 @@ function createMockClient(opts: MockClientOptions) {
   // tests can assert the subscribe-before-hydrate ordering and dispose races.
   const order: string[] = [];
 
+  const messageFetchResolvers: Array<() => void> = [];
   const messageFindAll = vi.fn(async ({ query }: { query: Record<string, unknown> }) => {
     if (typeof query.task_id === 'string') {
       if (opts.failTaskMessageFetch) {
         throw new Error('latest-task message fetch failed');
       }
-      return opts.messagesByTask[query.task_id] ?? [];
+      const snapshot = [...(opts.messagesByTask[query.task_id] ?? [])];
+      if (opts.deferTaskMessageFetch === query.task_id) {
+        await new Promise<void>((resolve) => messageFetchResolvers.push(resolve));
+      }
+      return snapshot;
     }
     // Eager path: every message for the session.
     return Object.values(opts.messagesByTask).flat();
@@ -144,6 +150,9 @@ function createMockClient(opts: MockClientOptions) {
     emitServiceEvent,
     order,
     releaseCreate: releaseCreateFn,
+    releaseMessageFetch: () => {
+      for (const resolve of messageFetchResolvers.splice(0)) resolve();
+    },
   };
 }
 
@@ -236,6 +245,64 @@ describe('ReactiveSessionHandle bootstrap hydration', () => {
 
     expect(handle.state.loading).toBe(false);
     expect(messageFindAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReactiveSessionHandle message snapshot reconciliation', () => {
+  it.each([
+    ['immediate', TaskStatus.CREATED],
+    ['drained queue', TaskStatus.DISPATCHING],
+  ])(
+    'does not lose a realtime user message during a stale %s task fetch',
+    async (_path, status) => {
+      const opts: MockClientOptions = { tasks: [], messagesByTask: {} };
+      const mock = createMockClient(opts);
+      const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+      await handle.ready();
+
+      const task = makeTask('new-task', status);
+      mock.emitServiceEvent('tasks', 'created', task);
+      opts.deferTaskMessageFetch = task.task_id;
+      const loading = handle.loadTaskMessages(task.task_id);
+      await vi.waitFor(() => expect(mock.messageFindAll).toHaveBeenCalled());
+
+      const created = makeMessage(task.task_id, 2);
+      const patched = { ...created, content_preview: 'patched metadata' } as Message;
+      const earlier = makeMessage(task.task_id, 1);
+      mock.emitServiceEvent('messages', 'created', created);
+      mock.emitServiceEvent('messages', 'created', created); // duplicate delivery
+      mock.emitServiceEvent('messages', 'patched', patched); // reordered update
+      mock.emitServiceEvent('messages', 'created', earlier); // out-of-order index
+      mock.emitServiceEvent('messages', 'created', {
+        ...makeMessage(task.task_id, 1),
+        message_id: 'other-session-message',
+        session_id: 'session-2',
+      });
+      mock.releaseMessageFetch();
+      await loading;
+
+      expect(handle.getTaskMessages(task.task_id)).toEqual([earlier, patched]);
+    }
+  );
+
+  it('does not resurrect a message removed while a reconnect/refetch snapshot is in flight', async () => {
+    const existing = makeMessage('task-1', 0);
+    const opts: MockClientOptions = {
+      tasks: [makeTask('task-1', TaskStatus.COMPLETED)],
+      messagesByTask: { 'task-1': [existing] },
+    };
+    const mock = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    await handle.ready();
+
+    opts.deferTaskMessageFetch = 'task-1';
+    const resync = handle.resync();
+    await vi.waitFor(() => expect(mock.messageFindAll).toHaveBeenCalledTimes(2));
+    mock.emitServiceEvent('messages', 'removed', existing);
+    mock.releaseMessageFetch();
+    await resync;
+
+    expect(handle.getTaskMessages('task-1')).toEqual([]);
   });
 });
 

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -250,18 +250,24 @@ describe('ReactiveSessionHandle bootstrap hydration', () => {
 
 describe('ReactiveSessionHandle message snapshot reconciliation', () => {
   it.each([
-    ['immediate', TaskStatus.CREATED],
-    ['drained queue', TaskStatus.DISPATCHING],
+    ['immediate', false],
+    ['drained queue', true],
   ])(
     'does not lose a realtime user message during a stale %s task fetch',
-    async (_path, status) => {
+    async (_path, startsQueued) => {
       const opts: MockClientOptions = { tasks: [], messagesByTask: {} };
       const mock = createMockClient(opts);
       const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
       await handle.ready();
 
-      const task = makeTask('new-task', status);
+      const task = makeTask('new-task', startsQueued ? TaskStatus.QUEUED : TaskStatus.CREATED);
       mock.emitServiceEvent('tasks', 'created', task);
+      if (startsQueued) {
+        mock.emitServiceEvent('tasks', 'patched', {
+          ...task,
+          status: TaskStatus.DISPATCHING,
+        });
+      }
       opts.deferTaskMessageFetch = task.task_id;
       const loading = handle.loadTaskMessages(task.task_id);
       await vi.waitFor(() => expect(mock.messageFindAll).toHaveBeenCalled());

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -312,10 +312,7 @@ export class ReactiveSessionHandle {
 
   async loadTaskMessages(taskId: string): Promise<Message[]> {
     this.assertNotDisposed();
-    const messages = await this.fetchMessagesWithoutRealtimeGap(
-      { task_id: taskId, $sort: { index: 1 } },
-      (message) => message.task_id === taskId
-    );
+    const messages = await this.fetchTaskMessagesWithoutRealtimeGap(taskId);
     this.updateState((prev) => {
       const nextByTask = new Map(prev.messagesByTask);
       nextByTask.set(taskId, sortMessagesByIndex(messages));
@@ -387,6 +384,20 @@ export class ReactiveSessionHandle {
       this.cancelMessageFetch(fetchSequence);
       throw error;
     }
+  }
+
+  private async fetchTaskMessagesWithoutRealtimeGap(taskId: string): Promise<Message[]> {
+    return this.fetchMessagesWithoutRealtimeGap(
+      { task_id: taskId, $sort: { index: 1 } },
+      (message) => message.task_id === taskId && this.matchesSession(message.session_id)
+    );
+  }
+
+  private async fetchSessionMessagesWithoutRealtimeGap(): Promise<Message[]> {
+    return this.fetchMessagesWithoutRealtimeGap(
+      { session_id: this.sessionId, $sort: { index: 1 } },
+      (message) => this.matchesSession(message.session_id)
+    );
   }
 
   unloadTaskMessages(taskId: string): void {
@@ -467,10 +478,7 @@ export class ReactiveSessionHandle {
       let loadedTaskIds = new Set<string>();
 
       if (this.options.taskHydration === 'eager') {
-        const allMessages = await this.fetchMessagesWithoutRealtimeGap(
-          { session_id: this.sessionId, $sort: { index: 1 } },
-          (message) => this.matchesSession(message.session_id)
-        );
+        const allMessages = await this.fetchSessionMessagesWithoutRealtimeGap();
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
       } else if (this.options.taskHydration === 'lazy') {
@@ -483,9 +491,8 @@ export class ReactiveSessionHandle {
         const latestTask = findLatestHydratableTask(tasks);
         if (latestTask) {
           try {
-            const latestMessages = await this.fetchMessagesWithoutRealtimeGap(
-              { task_id: latestTask.task_id, $sort: { index: 1 } },
-              (message) => message.task_id === latestTask.task_id
+            const latestMessages = await this.fetchTaskMessagesWithoutRealtimeGap(
+              latestTask.task_id
             );
             messagesByTask.set(latestTask.task_id, sortMessagesByIndex(latestMessages));
             loadedTaskIds.add(latestTask.task_id);
@@ -1089,10 +1096,7 @@ export class ReactiveSessionHandle {
       let loadedTaskIds = this.stateSnapshot.loadedTaskIds;
 
       if (this.options.taskHydration === 'eager') {
-        const allMessages = await this.fetchMessagesWithoutRealtimeGap(
-          { session_id: this.sessionId, $sort: { index: 1 } },
-          (message) => this.matchesSession(message.session_id)
-        );
+        const allMessages = await this.fetchSessionMessagesWithoutRealtimeGap();
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
       } else if (this.options.taskHydration === 'lazy') {
@@ -1106,10 +1110,7 @@ export class ReactiveSessionHandle {
         if (toRefresh.size > 0) {
           const refreshedByTask = new Map<string, Message[]>();
           for (const taskId of toRefresh) {
-            const taskMessages = await this.fetchMessagesWithoutRealtimeGap(
-              { task_id: taskId, $sort: { index: 1 } },
-              (message) => message.task_id === taskId
-            );
+            const taskMessages = await this.fetchTaskMessagesWithoutRealtimeGap(taskId);
             refreshedByTask.set(taskId, sortMessagesByIndex(taskMessages));
           }
           messagesByTask = refreshedByTask;

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -88,6 +88,10 @@ export interface ReactiveSessionState {
 
 type Listener = () => void;
 
+type MessageMutation =
+  | { sequence: number; kind: 'upsert'; message: Message }
+  | { sequence: number; kind: 'remove'; message: Message };
+
 interface QueueFindResult {
   data?: Task[];
 }
@@ -155,6 +159,14 @@ export class ReactiveSessionHandle {
   private readonly disposeCallbacks: Array<() => void> = [];
   private readyPromise: Promise<void>;
   private disposed = false;
+  private messageMutationSequence = 0;
+  private messageFetchTokenSequence = 0;
+  // A DB snapshot and the realtime stream are two independently scheduled
+  // deliveries. Journal mutations only while a snapshot is in flight, then
+  // replay them over that snapshot so a late stale response cannot erase a
+  // message that was already observed live (or resurrect a removed one).
+  private readonly messageFetches = new Map<number, number>();
+  private readonly messageMutations: MessageMutation[] = [];
 
   /**
    * The canonical (full-UUID) session id. When this handle was constructed with
@@ -300,12 +312,10 @@ export class ReactiveSessionHandle {
 
   async loadTaskMessages(taskId: string): Promise<Message[]> {
     this.assertNotDisposed();
-    const messages = await this.client.service('messages').findAll({
-      query: {
-        task_id: taskId,
-        $sort: { index: 1 },
-      },
-    });
+    const messages = await this.fetchMessagesWithoutRealtimeGap(
+      { task_id: taskId, $sort: { index: 1 } },
+      (message) => message.task_id === taskId
+    );
     this.updateState((prev) => {
       const nextByTask = new Map(prev.messagesByTask);
       nextByTask.set(taskId, sortMessagesByIndex(messages));
@@ -319,6 +329,64 @@ export class ReactiveSessionHandle {
       };
     });
     return messages;
+  }
+
+  private beginMessageFetch(): number {
+    this.messageFetchTokenSequence += 1;
+    this.messageFetches.set(this.messageFetchTokenSequence, this.messageMutationSequence);
+    return this.messageFetchTokenSequence;
+  }
+
+  private recordMessageMutation(kind: 'upsert' | 'remove', message: Message): void {
+    this.messageMutationSequence += 1;
+    if (this.messageFetches.size > 0) {
+      this.messageMutations.push({ sequence: this.messageMutationSequence, kind, message });
+    }
+  }
+
+  private finishMessageFetch(
+    fetchToken: number,
+    snapshot: Message[],
+    belongsToFetch: (message: Message) => boolean
+  ): Message[] {
+    const fetchSequence = this.messageFetches.get(fetchToken);
+    if (fetchSequence === undefined) return sortMessagesByIndex(snapshot);
+    const byId = new Map(snapshot.map((message) => [message.message_id, message]));
+    for (const mutation of this.messageMutations) {
+      if (mutation.sequence <= fetchSequence || !belongsToFetch(mutation.message)) continue;
+      if (mutation.kind === 'remove') byId.delete(mutation.message.message_id);
+      else byId.set(mutation.message.message_id, mutation.message);
+    }
+    this.cancelMessageFetch(fetchToken);
+    return sortMessagesByIndex([...byId.values()]);
+  }
+
+  private cancelMessageFetch(fetchToken: number): void {
+    this.messageFetches.delete(fetchToken);
+    if (this.messageFetches.size === 0) {
+      this.messageMutations.length = 0;
+      return;
+    }
+    const oldestActiveFetch = Math.min(...this.messageFetches.values());
+    const firstNeeded = this.messageMutations.findIndex(
+      (mutation) => mutation.sequence > oldestActiveFetch
+    );
+    if (firstNeeded === -1) this.messageMutations.length = 0;
+    else if (firstNeeded > 0) this.messageMutations.splice(0, firstNeeded);
+  }
+
+  private async fetchMessagesWithoutRealtimeGap(
+    query: Record<string, unknown>,
+    belongsToFetch: (message: Message) => boolean
+  ): Promise<Message[]> {
+    const fetchSequence = this.beginMessageFetch();
+    try {
+      const snapshot = await this.client.service('messages').findAll({ query });
+      return this.finishMessageFetch(fetchSequence, snapshot, belongsToFetch);
+    } catch (error) {
+      this.cancelMessageFetch(fetchSequence);
+      throw error;
+    }
   }
 
   unloadTaskMessages(taskId: string): void {
@@ -399,12 +467,10 @@ export class ReactiveSessionHandle {
       let loadedTaskIds = new Set<string>();
 
       if (this.options.taskHydration === 'eager') {
-        const allMessages = await this.client.service('messages').findAll({
-          query: {
-            session_id: this.sessionId,
-            $sort: { index: 1 },
-          },
-        });
+        const allMessages = await this.fetchMessagesWithoutRealtimeGap(
+          { session_id: this.sessionId, $sort: { index: 1 } },
+          (message) => this.matchesSession(message.session_id)
+        );
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
       } else if (this.options.taskHydration === 'lazy') {
@@ -417,12 +483,10 @@ export class ReactiveSessionHandle {
         const latestTask = findLatestHydratableTask(tasks);
         if (latestTask) {
           try {
-            const latestMessages = await this.client.service('messages').findAll({
-              query: {
-                task_id: latestTask.task_id,
-                $sort: { index: 1 },
-              },
-            });
+            const latestMessages = await this.fetchMessagesWithoutRealtimeGap(
+              { task_id: latestTask.task_id, $sort: { index: 1 } },
+              (message) => message.task_id === latestTask.task_id
+            );
             messagesByTask.set(latestTask.task_id, sortMessagesByIndex(latestMessages));
             loadedTaskIds.add(latestTask.task_id);
           } catch {
@@ -653,6 +717,7 @@ export class ReactiveSessionHandle {
 
     const onMessageCreated = (message: Message) => {
       if (!this.matchesSession(message.session_id)) return;
+      this.recordMessageMutation('upsert', message);
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
         nextStreaming.delete(message.message_id);
@@ -693,6 +758,7 @@ export class ReactiveSessionHandle {
     const onMessagePatched = (message: Message) => {
       const taskId = message.task_id;
       if (!this.matchesSession(message.session_id) || !taskId) return;
+      this.recordMessageMutation('upsert', message);
       this.updateState((prev) => {
         const current = prev.messagesByTask.get(taskId);
         if (!current) return prev;
@@ -712,6 +778,7 @@ export class ReactiveSessionHandle {
 
     const onMessageRemoved = (message: Message) => {
       if (!this.matchesSession(message.session_id)) return;
+      this.recordMessageMutation('remove', message);
       const taskId = message.task_id;
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
@@ -1022,12 +1089,10 @@ export class ReactiveSessionHandle {
       let loadedTaskIds = this.stateSnapshot.loadedTaskIds;
 
       if (this.options.taskHydration === 'eager') {
-        const allMessages = await this.client.service('messages').findAll({
-          query: {
-            session_id: this.sessionId,
-            $sort: { index: 1 },
-          },
-        });
+        const allMessages = await this.fetchMessagesWithoutRealtimeGap(
+          { session_id: this.sessionId, $sort: { index: 1 } },
+          (message) => this.matchesSession(message.session_id)
+        );
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
       } else if (this.options.taskHydration === 'lazy') {
@@ -1041,12 +1106,10 @@ export class ReactiveSessionHandle {
         if (toRefresh.size > 0) {
           const refreshedByTask = new Map<string, Message[]>();
           for (const taskId of toRefresh) {
-            const taskMessages = await this.client.service('messages').findAll({
-              query: {
-                task_id: taskId,
-                $sort: { index: 1 },
-              },
-            });
+            const taskMessages = await this.fetchMessagesWithoutRealtimeGap(
+              { task_id: taskId, $sort: { index: 1 } },
+              (message) => message.task_id === taskId
+            );
             refreshedByTask.set(taskId, sortMessagesByIndex(taskMessages));
           }
           messagesByTask = refreshedByTask;


### PR DESCRIPTION
## Summary

- reconcile message API snapshots with realtime creates, patches, and removals that arrive while a fetch is in flight
- prevent a stale task hydration response from hiding a newly submitted user message until reload
- preserve backend IDs, deduplication, transcript index ordering, lazy/eager hydration, and session/task isolation

## Root cause

The initial user message was durably persisted and delivered to the executor, but the reactive client could start loading the new task's transcript before that message appeared in its database snapshot. If the realtime `created` event arrived while the stale request was pending, the eventual snapshot replacement could discard the live update. Reloading restored the message because it remained in the database.

The client now journals message mutations only while a snapshot is in flight and replays them over the returned snapshot. This also prevents stale snapshots from resurrecting messages removed during reconnect/refetch.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --dir packages/client test -- reactive-session.test.ts` (28 tests)
- deterministic coverage for immediate and queued/drained prompts, duplicate delivery, reordered patches/indexes, reconnect/refetch removal, and cross-session isolation

## Performance

No daemon prompt acknowledgement or executor startup path changed. Reconciliation is an in-memory client operation bounded to active message fetches.
