### PR TITLE
fix(docs): hero A/B variant CTAs open the contact form, not the meeting iframe

### DIFF
--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -820,7 +820,9 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
               <button
                 type="button"
                 className={styles.primaryButton}
-                onClick={() => (variant ? setIsDemoFormOpen(true) : openBetaForm('landing-hero'))}
+                onClick={() =>
+                  openBetaForm(variant ? `landing-hero-${heroVariant}` : 'landing-hero')
+                }
               >
                 {variant ? variant.ctaLabel : 'Sign up for Agor Cloud'}
               </button>


### PR DESCRIPTION
## Summary

The 8 homepage hero A/B variant pages' primary CTA button was opening the "Book a call" meeting-scheduler iframe (`HubSpotMeetingModal`) instead of the contact/signup form (`HubSpotFormModal`) — the same form the real `/` homepage's hero CTA correctly opens.

This mattered because attribution (`source_page`) is only recorded via a hidden field on the contact form; the meeting iframe has no equivalent mechanism. Every variant's conversions were landing in an unattributed bucket instead of being tied back to the specific ad/variant that drove them.

- All hero CTAs (control **and** variants) now open the contact form.
- Variant pages tag attribution as `landing-hero-<variant-key>` (e.g. `landing-hero-technical-collaboration`, `landing-hero-cost-control`); the control page keeps its existing `landing-hero` value, unchanged.
- The separate "Book a demo" CTAs elsewhere on the shared landing page (control section, final CTA section) are untouched — those intentionally open the meeting iframe and are a distinct action from this hero CTA.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Live click simulation via Chrome DevTools Protocol against `/not-alone` and `/costs-under-control`: confirmed the contact form (not the meeting iframe) opens, and the hidden `source_page` input carries the correct per-variant value.
- [x] Confirmed the control (`/`) page's hero CTA behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)