### PR TITLE
fix(mcp-oauth): request JSON token responses

### DIFF
--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -14,6 +14,7 @@ import {
   __seedAuthCodeTokenCacheForTests,
   __seedDynamicClientCacheForTests,
   clearAuthCodeTokenCache,
+  completeMCPOAuthFlow,
   discoverAuthorizationServerFromMcpOrigin,
   discoverResourceMetadataUrl,
   getAuthCodeTokenCacheStats,
@@ -22,6 +23,61 @@ import {
   resolveResourceMetadataUrl,
   startMCPOAuthFlow,
 } from './oauth-mcp-transport';
+
+// ---------------------------------------------------------------------------
+// completeMCPOAuthFlow — token exchange request contract
+// ---------------------------------------------------------------------------
+
+describe('completeMCPOAuthFlow token exchange', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    clearAuthCodeTokenCache();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('requests a JSON token response for providers such as GitHub', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'gho_example', scope: 'repo', token_type: 'bearer' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      ) as unknown as typeof fetch;
+
+    const result = await completeMCPOAuthFlow(
+      {
+        metadataUrl: 'https://github.example/.well-known/oauth-protected-resource',
+        tokenEndpoint: 'https://github.com/login/oauth/access_token',
+        redirectUri: 'http://127.0.0.1:3000/oauth/callback',
+        pkceVerifier: 'verifier',
+        clientId: 'client-id',
+        state: 'state',
+        authorizationUrl: 'https://github.com/login/oauth/authorize',
+      },
+      'authorization-code',
+      'state'
+    );
+
+    expect(result.access_token).toBe('gho_example');
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://github.com/login/oauth/access_token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
+      })
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // clearAuthCodeTokenCache — cache clearing semantics

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -652,6 +652,10 @@ async function exchangeCodeForToken(
   // fall back to body params for public clients or providers that don't support Basic auth.
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
+    // GitHub's classic OAuth endpoint returns a form-encoded response by
+    // default. Request JSON explicitly so the response follows the OAuth token
+    // response shape parsed below.
+    Accept: 'application/json',
   };
 
   if (clientSecret) {


### PR DESCRIPTION
## Summary

- send `Accept: application/json` when exchanging an OAuth authorization code
- add a caller-level regression test that asserts the token exchange request contract

## Why

GitHub's classic `/login/oauth/access_token` endpoint returns an `application/x-www-form-urlencoded` response by default. The authorization-code exchange then calls `response.json()`, causing authentication to fail after the browser flow succeeds.

GitHub documents `Accept: application/json` as the way to request the OAuth JSON token response. This keeps the fix at the HTTP content-negotiation boundary and avoids guessing the response format from untrusted body text.

Supersedes #2192 with the narrower fix discussed in review.

## Validation

- `pnpm --filter @agor/core test src/tools/mcp/oauth-mcp-transport.test.ts` (37 passing)
- `pnpm exec biome check packages/core/src/tools/mcp/oauth-mcp-transport.ts packages/core/src/tools/mcp/oauth-mcp-transport.test.ts`
