### PR TITLE
fix(ui): show pointer for clickable environment controls

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -528,7 +528,7 @@ const BranchCardComponent = ({
           <EnvironmentPill
             repo={repo}
             branch={branch}
-            onEdit={() => onOpenSettings?.(branch.branch_id)}
+            onEdit={onOpenSettings ? () => onOpenSettings(branch.branch_id) : undefined}
             onStartEnvironment={onStartEnvironment}
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -98,6 +98,20 @@ describe('EnvironmentPill', () => {
     expect(screen.getByText('env').parentElement).toHaveStyle({ cursor: 'default' });
   });
 
+  it('shows a pointer only for an enabled configure control', () => {
+    const { rerender } = render(<EnvironmentPill {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Configure environment' })).toHaveStyle({
+      cursor: 'pointer',
+    });
+
+    rerender(<EnvironmentPill {...defaultProps} onEdit={undefined} />);
+
+    const configureButton = screen.getByRole('button', { name: 'Configure environment' });
+    expect(configureButton).toBeDisabled();
+    expect(configureButton).not.toHaveStyle({ cursor: 'pointer' });
+  });
+
   it('can hide only the destructive nuke action while preserving other controls', () => {
     render(<EnvironmentPill {...defaultProps} showNukeEnvironment={false} />);
 

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -75,11 +75,19 @@ export function EnvironmentPill({
       <Tooltip title="Click to configure environment (optional)">
         <Tag
           color="default"
-          style={{ cursor: 'pointer', userSelect: 'none', opacity: 0.6 }}
-          onClick={(e) => {
-            e.stopPropagation();
-            onEdit?.();
+          style={{
+            cursor: onEdit ? 'pointer' : 'default',
+            userSelect: 'none',
+            opacity: 0.6,
           }}
+          onClick={
+            onEdit
+              ? (e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }
+              : undefined
+          }
         >
           <Space size={4}>
             <GlobalOutlined style={{ fontSize: 12 }} />
@@ -373,14 +381,17 @@ export function EnvironmentPill({
           <Button
             type="text"
             size="small"
+            aria-label="Configure environment"
             icon={<EditOutlined />}
             onClick={handleEdit}
+            disabled={!onEdit}
             style={{
               padding: 0,
               height: 22,
               width: 22,
               minWidth: 22,
               borderLeft: `1px solid ${token.colorBorderSecondary}`,
+              ...(onEdit ? { cursor: 'pointer' } : {}),
             }}
           />
         </Tooltip>


### PR DESCRIPTION
## Summary
- show a pointer cursor only for enabled environment configure controls
- preserve non-interactive and disabled semantics with accessible labeling

## Validation
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui exec vitest run src/components/EnvironmentPill/EnvironmentPill.test.tsx`
- `git diff --check`

All checks passed.