### PR TITLE
ci: add isolated PostgreSQL integration lane

### DIFF
--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -1,0 +1,138 @@
+# Focused PostgreSQL/RLS integration lane.
+#
+# Expected cost on an ubuntu-latest hosted runner: about 2-4 minutes per
+# path-matched change (roughly 1 minute of test runtime). The pinned pgvector
+# image is ~154 MiB compressed / ~433 MiB unpacked on amd64; layer caching makes
+# warm starts cheaper. This intentionally stays separate from the all-purpose
+# CI workflow so UI/docs-only changes never pay the database startup cost.
+name: PostgreSQL integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/postgres-integration.yml'
+      - 'apps/agor-daemon/package.json'
+      - 'apps/agor-daemon/src/**'
+      - 'docker/postgres-dev.Dockerfile'
+      - 'docker/postgres-init-app-user.sql'
+      - 'package.json'
+      - 'packages/core/drizzle/**'
+      - 'packages/core/package.json'
+      - 'packages/core/src/db/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/run-postgres-integration-tests.mjs'
+      - 'scripts/test-postgres-docker.sh'
+      - 'turbo.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/postgres-integration.yml'
+      - 'apps/agor-daemon/package.json'
+      - 'apps/agor-daemon/src/**'
+      - 'docker/postgres-dev.Dockerfile'
+      - 'docker/postgres-init-app-user.sql'
+      - 'package.json'
+      - 'packages/core/drizzle/**'
+      - 'packages/core/package.json'
+      - 'packages/core/src/db/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/run-postgres-integration-tests.mjs'
+      - 'scripts/test-postgres-docker.sh'
+      - 'turbo.json'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  PNPM_VERSION: '11.17.0'
+  NODE_VERSION: '22'
+  AGOR_DB_DIALECT: postgresql
+  # Ephemeral, repository-public test credentials. Keep the URL in the job
+  # environment rather than interpolating it into commands or log messages.
+  AGOR_TEST_POSTGRES_URL: postgresql://agor_app:agor_dev_secret@127.0.0.1:5432/agor
+  # Used only for a test's disposable-database create/drop setup; application
+  # migrations, queries, and RLS assertions always use AGOR_TEST_POSTGRES_URL.
+  AGOR_TEST_POSTGRES_ADMIN_URL: postgresql://agor_bootstrap:agor_bootstrap_secret@127.0.0.1:5432/agor
+
+jobs:
+  postgres-integration:
+    name: PostgreSQL integration (non-superuser RLS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.2-pg16-trixie
+        env:
+          POSTGRES_DB: agor
+          POSTGRES_USER: agor_bootstrap
+          POSTGRES_PASSWORD: agor_bootstrap_secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -h 127.0.0.1 -U agor_bootstrap -d agor"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install PostgreSQL test workspace dependencies
+        run: pnpm install --frozen-lockfile --filter '@agor/core...' --filter '@agor/daemon...'
+
+      - name: Bootstrap and verify the non-superuser app role
+        env:
+          POSTGRES_CONTAINER_ID: ${{ job.services.postgres.id }}
+        run: |
+          set -euo pipefail
+
+          postgres_ready=false
+          for _ in {1..30}; do
+            if docker exec "$POSTGRES_CONTAINER_ID" \
+              pg_isready -h 127.0.0.1 -U agor_bootstrap -d agor >/dev/null 2>&1; then
+              postgres_ready=true
+              break
+            fi
+            sleep 2
+          done
+          if [[ "$postgres_ready" != true ]]; then
+            echo '::error::PostgreSQL did not become ready within 60 seconds'
+            exit 1
+          fi
+
+          # Reuse the exact dev bootstrap contract; never duplicate role grants
+          # in workflow YAML where security-sensitive SQL could drift.
+          docker exec -i "$POSTGRES_CONTAINER_ID" \
+            psql --set ON_ERROR_STOP=1 -U agor_bootstrap -d agor \
+            < docker/postgres-init-app-user.sql >/dev/null
+
+          role_flags="$(docker exec -e PGPASSWORD=agor_dev_secret "$POSTGRES_CONTAINER_ID" \
+            psql -h 127.0.0.1 -U agor_app -d agor -Atqc \
+            "SELECT current_user || ':' || rolsuper || ':' || rolbypassrls FROM pg_roles WHERE rolname = current_user")"
+          if [[ "$role_flags" != 'agor_app:false:false' ]]; then
+            echo '::error::agor_app is not NOSUPERUSER and NOBYPASSRLS'
+            exit 1
+          fi
+          echo 'Verified test role: agor_app (NOSUPERUSER, NOBYPASSRLS).'
+
+      - name: Run PostgreSQL-gated suites
+        timeout-minutes: 6
+        run: pnpm test:postgres:integration

--- a/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.postgres.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.postgres.test.ts
@@ -1,0 +1,55 @@
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  initializeDatabase,
+  isPostgresDatabase,
+  runWithTenantDatabaseScope,
+  TenantAgenticToolSettingsRepository,
+} from '@agor/core/db';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isAgenticToolEnabledForTenant } from './tenant-agentic-tool-validation';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+beforeAll(() => {
+  process.env.AGOR_MASTER_SECRET ||= 'tenant-agentic-tool-validation-test-secret';
+});
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'isAgenticToolEnabledForTenant (PostgreSQL)',
+  () => {
+    let rawDb: Database;
+    let guardedDb: ReturnType<typeof createTenantScopedDatabaseProxy>;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      guardedDb = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'PostgreSQL prompt validation test db',
+      });
+    });
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('reads the requested tenant disabled setting without leaking another tenant', async () => {
+      const enabledTenant = `prompt-enabled-${Date.now()}`;
+      const disabledTenant = `prompt-disabled-${Date.now()}`;
+      await runWithTenantDatabaseScope(guardedDb, disabledTenant, (tenantDb) =>
+        new TenantAgenticToolSettingsRepository(tenantDb).patch('codex', { enabled: false })
+      );
+
+      await expect(isAgenticToolEnabledForTenant(guardedDb, disabledTenant, 'codex')).resolves.toBe(
+        false
+      );
+      await expect(isAgenticToolEnabledForTenant(guardedDb, enabledTenant, 'codex')).resolves.toBe(
+        true
+      );
+    });
+  }
+);

--- a/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-agentic-tool-validation.test.ts
@@ -1,15 +1,11 @@
 import { isTenantAgenticToolEnabled } from '@agor/core/config';
 import {
-  createDatabase,
   createTenantScopedDatabaseProxy,
-  type Database,
-  initializeDatabase,
-  isPostgresDatabase,
   MissingTenantDatabaseScopeError,
   runWithTenantDatabaseScope,
   TenantAgenticToolSettingsRepository,
 } from '@agor/core/db';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { isAgenticToolEnabledForTenant } from './tenant-agentic-tool-validation';
 
@@ -35,43 +31,3 @@ describe('isAgenticToolEnabledForTenant', () => {
     );
   });
 });
-
-const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
-const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
-
-describe.skipIf(!postgresUrl || !usesPostgresSchema)(
-  'isAgenticToolEnabledForTenant (PostgreSQL)',
-  () => {
-    let rawDb: Database;
-    let guardedDb: ReturnType<typeof createTenantScopedDatabaseProxy>;
-
-    beforeAll(async () => {
-      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
-      await initializeDatabase(rawDb);
-      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
-      guardedDb = createTenantScopedDatabaseProxy(rawDb, {
-        requireScope: true,
-        label: 'PostgreSQL prompt validation test db',
-      });
-    });
-
-    afterAll(async () => {
-      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
-    });
-
-    it('reads the requested tenant disabled setting without leaking another tenant', async () => {
-      const enabledTenant = `prompt-enabled-${Date.now()}`;
-      const disabledTenant = `prompt-disabled-${Date.now()}`;
-      await runWithTenantDatabaseScope(guardedDb, disabledTenant, (tenantDb) =>
-        new TenantAgenticToolSettingsRepository(tenantDb).patch('codex', { enabled: false })
-      );
-
-      await expect(isAgenticToolEnabledForTenant(guardedDb, disabledTenant, 'codex')).resolves.toBe(
-        false
-      );
-      await expect(isAgenticToolEnabledForTenant(guardedDb, enabledTenant, 'codex')).resolves.toBe(
-        true
-      );
-    });
-  }
-);

--- a/context/guidelines/testing.md
+++ b/context/guidelines/testing.md
@@ -316,3 +316,36 @@ pnpm test              # Run all
 pnpm test:watch        # Watch mode
 pnpm test -- --coverage
 ```
+
+### PostgreSQL integration suites
+
+Run every `*.postgres.test.ts` suite against a fresh disposable pgvector
+PostgreSQL container with one command:
+
+```bash
+pnpm test:postgres:docker
+```
+
+The command uses the same published pgvector image as CI, applies
+`docker/postgres-init-app-user.sql`, verifies that `agor_app` is both
+`NOSUPERUSER` and `NOBYPASSRLS`, runs the suites serially, and removes the
+container. Serial execution is intentional: each suite asks Drizzle to apply
+the shared migration set, which is not safe to initialize concurrently.
+
+To use an already-running disposable database, set both gates explicitly and
+run the narrower test command:
+
+```bash
+AGOR_DB_DIALECT=postgresql \
+AGOR_TEST_POSTGRES_URL='postgresql://agor_app:<password>@127.0.0.1:5432/agor' \
+AGOR_TEST_POSTGRES_ADMIN_URL='postgresql://<bootstrap-user>:<password>@127.0.0.1:5432/agor' \
+pnpm test:postgres:integration
+```
+
+The admin URL is used only to create and drop a separate empty database for one
+catalog fail-closed fixture. All migrations, application queries, and RLS
+assertions connect through the non-superuser `AGOR_TEST_POSTGRES_URL`.
+
+PostgreSQL-only suites must use the `*.postgres.test.ts` suffix. The runner
+fails if it finds `AGOR_TEST_POSTGRES_URL` in a differently named test, finds no
+PostgreSQL suites, or all selected tests skip, preventing a false-green lane.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "lint:fix": "biome check --write .",
     "format": "prettier --write .",
     "test": "turbo run test",
+    "test:postgres:integration": "node scripts/run-postgres-integration-tests.mjs",
+    "test:postgres:docker": "bash scripts/test-postgres-docker.sh",
     "typecheck": "turbo run typecheck --filter='!@agor/docs'",
     "check": "pnpm typecheck && pnpm lint && pnpm check:shortid && pnpm check:multitenancy-boundaries && pnpm check:daemon-filesystem-boundaries && turbo run build --filter='!@agor/docs'",
     "check:fix": "pnpm lint:fix && pnpm typecheck && pnpm check:shortid && pnpm check:multitenancy-boundaries && pnpm check:daemon-filesystem-boundaries && turbo run build --filter='!@agor/docs'",

--- a/packages/core/src/db/task-queue-ha.postgres.test.ts
+++ b/packages/core/src/db/task-queue-ha.postgres.test.ts
@@ -220,7 +220,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Session Task queue HA (Pos
         tasks.claimDispatchAndProjectSession(queuedB.task_id, TaskStatus.QUEUED, {
           status: TaskStatus.DISPATCHING,
         })
-      ).rejects.toThrow(/Task not found/);
+      ).rejects.toThrow(/not found/);
     });
 
     const refs = await runWithSystemDatabaseScope(

--- a/packages/core/src/db/tenant-deletion.postgres.test.ts
+++ b/packages/core/src/db/tenant-deletion.postgres.test.ts
@@ -25,6 +25,7 @@ import { deleteTenantData, TenantDeletionCatalogError } from './tenant-deletion'
 import { runWithTenantDatabaseScope } from './tenant-scope';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const postgresAdminUrl = process.env.AGOR_TEST_POSTGRES_ADMIN_URL;
 const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
 
 // int4 column; keep values small and monotonically unique across seeds.
@@ -593,10 +594,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
     }
   });
 
-  it('fails closed when live-catalog discovery is empty', async () => {
+  it.skipIf(!postgresAdminUrl)('fails closed when live-catalog discovery is empty', async () => {
     const databaseName = `tdel_empty_${generateId().replaceAll('-', '').slice(0, 20)}`;
     const databaseUrl = new URL(postgresUrl!);
     databaseUrl.pathname = `/${databaseName}`;
+    const adminDb = createDatabase({ dialect: 'postgresql', url: postgresAdminUrl! });
     let emptyDb: Database | undefined;
 
     try {
@@ -609,7 +611,10 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
         throw new Error('Expected an applied migration watermark');
       }
 
-      await executeRaw(db, sql`CREATE DATABASE ${sql.identifier(databaseName)}`);
+      await executeRaw(
+        adminDb,
+        sql`CREATE DATABASE ${sql.identifier(databaseName)} OWNER agor_app`
+      );
       emptyDb = createDatabase({ dialect: 'postgresql', url: databaseUrl.toString() });
       await executeRaw(emptyDb, sql`CREATE SCHEMA drizzle`);
       await executeRaw(
@@ -636,10 +641,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('deleteTenantData (PostgreS
     } finally {
       if (emptyDb) await closePostgresDatabase(emptyDb);
       await executeRaw(
-        db,
+        adminDb,
         sql`SELECT pg_catalog.pg_terminate_backend(pid) FROM pg_catalog.pg_stat_activity WHERE datname = ${databaseName}`
       );
-      await executeRaw(db, sql`DROP DATABASE IF EXISTS ${sql.identifier(databaseName)}`);
+      await executeRaw(adminDb, sql`DROP DATABASE IF EXISTS ${sql.identifier(databaseName)}`);
+      await closePostgresDatabase(adminDb);
     }
   });
 

--- a/scripts/run-postgres-integration-tests.mjs
+++ b/scripts/run-postgres-integration-tests.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspaces = ['packages/core', 'apps/agor-daemon'];
+
+if (process.env.AGOR_DB_DIALECT !== 'postgresql') {
+  console.error('AGOR_DB_DIALECT must be set to postgresql for the PostgreSQL integration lane.');
+  process.exit(1);
+}
+if (!process.env.AGOR_TEST_POSTGRES_URL) {
+  console.error('AGOR_TEST_POSTGRES_URL must point at the disposable PostgreSQL test database.');
+  process.exit(1);
+}
+
+function findTests(directory) {
+  const tests = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) tests.push(...findTests(entryPath));
+    else if (entry.name.endsWith('.test.ts')) tests.push(entryPath);
+  }
+  return tests;
+}
+
+const workspaceTests = workspaces.map((workspace) => {
+  const workspaceRoot = path.join(repoRoot, workspace);
+  const tests = findTests(path.join(workspaceRoot, 'src'));
+  const postgresTests = tests.filter((file) => file.endsWith('.postgres.test.ts'));
+  const misnamedGatedTests = tests.filter(
+    (file) =>
+      !file.endsWith('.postgres.test.ts') &&
+      readFileSync(file, 'utf8').includes('AGOR_TEST_POSTGRES_URL')
+  );
+  return { workspace, workspaceRoot, postgresTests, misnamedGatedTests };
+});
+
+const misnamedGatedTests = workspaceTests.flatMap(({ misnamedGatedTests: files }) => files);
+if (misnamedGatedTests.length > 0) {
+  console.error(
+    'PostgreSQL-gated suites must use the *.postgres.test.ts suffix so CI selects them:'
+  );
+  for (const file of misnamedGatedTests) console.error(`- ${path.relative(repoRoot, file)}`);
+  process.exit(1);
+}
+
+const discoveredCount = workspaceTests.reduce(
+  (count, group) => count + group.postgresTests.length,
+  0
+);
+if (discoveredCount === 0) {
+  console.error(
+    'No *.postgres.test.ts files were discovered; refusing to report a false green run.'
+  );
+  process.exit(1);
+}
+
+const reportDirectory = mkdtempSync(path.join(tmpdir(), 'agor-postgres-tests-'));
+const summary = { total: 0, passed: 0, failed: 0, skipped: 0, failedSuites: 0 };
+let testCommandFailed = false;
+
+try {
+  for (const { workspace, workspaceRoot, postgresTests } of workspaceTests) {
+    if (postgresTests.length === 0) continue;
+
+    const reportFile = path.join(reportDirectory, `${path.basename(workspace)}.json`);
+    const relativeTests = postgresTests
+      .map((file) => path.relative(workspaceRoot, file))
+      .sort((a, b) => a.localeCompare(b));
+
+    console.log(`\nRunning ${relativeTests.length} PostgreSQL test file(s) in ${workspace}...`);
+    const result = spawnSync(
+      'pnpm',
+      [
+        'exec',
+        'vitest',
+        'run',
+        '--no-file-parallelism',
+        '--reporter=default',
+        '--reporter=json',
+        `--outputFile.json=${reportFile}`,
+        ...relativeTests,
+      ],
+      {
+        cwd: workspaceRoot,
+        env: process.env,
+        stdio: 'inherit',
+        timeout: 180_000,
+      }
+    );
+
+    if (result.error) {
+      console.error(`Failed to run PostgreSQL tests in ${workspace}: ${result.error.message}`);
+      testCommandFailed = true;
+    }
+    if (result.status !== 0) testCommandFailed = true;
+
+    try {
+      const report = JSON.parse(readFileSync(reportFile, 'utf8'));
+      summary.total += report.numTotalTests ?? 0;
+      summary.passed += report.numPassedTests ?? 0;
+      summary.failed += report.numFailedTests ?? 0;
+      summary.skipped += report.numPendingTests ?? 0;
+      summary.failedSuites += report.numFailedTestSuites ?? 0;
+    } catch (error) {
+      console.error(`Could not read the Vitest JSON report for ${workspace}: ${error.message}`);
+      testCommandFailed = true;
+    }
+  }
+} finally {
+  rmSync(reportDirectory, { recursive: true, force: true });
+}
+
+console.log(
+  `\nPostgreSQL integration summary: ${summary.passed} passed, ${summary.failed} failed, ` +
+    `${summary.skipped} skipped (${summary.total} total across ${discoveredCount} files).`
+);
+
+if (summary.total === 0 || summary.passed === 0) {
+  console.error(
+    'No PostgreSQL tests executed; the lane may have accidentally skipped every suite.'
+  );
+  process.exit(1);
+}
+if (testCommandFailed || summary.failed > 0 || summary.failedSuites > 0) process.exit(1);

--- a/scripts/test-postgres-docker.sh
+++ b/scripts/test-postgres-docker.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+postgres_image="${AGOR_POSTGRES_TEST_IMAGE:-pgvector/pgvector:0.8.2-pg16-trixie}"
+container_name="agor-postgres-test-${$}-${RANDOM}"
+
+cleanup() {
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+command -v docker >/dev/null 2>&1 || {
+  echo 'Docker is required for test:postgres:docker.' >&2
+  exit 1
+}
+
+echo "Starting disposable PostgreSQL (${postgres_image})..."
+docker run --detach --name "$container_name" \
+  --publish 127.0.0.1::5432 \
+  --env POSTGRES_DB=agor \
+  --env POSTGRES_USER=agor_bootstrap \
+  --env POSTGRES_PASSWORD=agor_bootstrap_secret \
+  "$postgres_image" >/dev/null
+
+deadline=$((SECONDS + 60))
+until docker exec "$container_name" \
+  pg_isready --host 127.0.0.1 --username agor_bootstrap --dbname agor >/dev/null 2>&1; do
+  if ((SECONDS >= deadline)) || [[ "$(docker inspect --format '{{.State.Running}}' "$container_name" 2>/dev/null)" != true ]]; then
+    echo 'PostgreSQL did not become ready within 60 seconds.' >&2
+    docker logs "$container_name" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+# This is the same security-sensitive role bootstrap used by the dev image.
+docker exec --interactive "$container_name" \
+  psql --set ON_ERROR_STOP=1 --username agor_bootstrap --dbname agor \
+  <docker/postgres-init-app-user.sql >/dev/null
+
+role_flags="$({
+  docker exec --env PGPASSWORD=agor_dev_secret "$container_name" \
+    psql --host 127.0.0.1 --username agor_app --dbname agor --tuples-only --no-align \
+    --command "SELECT current_user || ':' || rolsuper || ':' || rolbypassrls FROM pg_roles WHERE rolname = current_user"
+} 2>/dev/null)"
+if [[ "$role_flags" != 'agor_app:false:false' ]]; then
+  echo 'Refusing to run: agor_app is not verified as NOSUPERUSER and NOBYPASSRLS.' >&2
+  exit 1
+fi
+echo 'Verified test role: agor_app (NOSUPERUSER, NOBYPASSRLS).'
+
+host_port="$(docker port "$container_name" 5432/tcp | awk -F: 'NR == 1 { print $NF }')"
+if [[ -z "$host_port" ]]; then
+  echo 'Could not determine the disposable PostgreSQL host port.' >&2
+  exit 1
+fi
+
+AGOR_DB_DIALECT=postgresql \
+AGOR_TEST_POSTGRES_URL="postgresql://agor_app:agor_dev_secret@127.0.0.1:${host_port}/agor" \
+AGOR_TEST_POSTGRES_ADMIN_URL="postgresql://agor_bootstrap:agor_bootstrap_secret@127.0.0.1:${host_port}/agor" \
+  pnpm test:postgres:integration

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local", "pnpm-lock.yaml"],
-  "globalPassThroughEnv": ["AGOR_DB_DIALECT", "BIOME_BIN", "DATABASE_URL"],
+  "globalPassThroughEnv": [
+    "AGOR_DB_DIALECT",
+    "AGOR_TEST_POSTGRES_ADMIN_URL",
+    "AGOR_TEST_POSTGRES_URL",
+    "BIOME_BIN",
+    "DATABASE_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- add a dedicated, path-filtered PostgreSQL integration workflow using the published `pgvector/pgvector:0.8.2-pg16-trixie` service image
- reuse `docker/postgres-init-app-user.sql` and verify tests run as `agor_app` with `NOSUPERUSER` and `NOBYPASSRLS`, so `FORCE ROW LEVEL SECURITY` is exercised
- add a focused serial Vitest runner with JSON result aggregation, naming enforcement, bounded execution, and false-green/all-skipped protection
- add `pnpm test:postgres:docker` as the documented one-command local disposable-database path
- standardize the remaining embedded PostgreSQL suite as `*.postgres.test.ts` and fix two dormant test assumptions exposed by the new lane

## CI scope and cost

- triggers only for relevant daemon, core database, migration, bootstrap, dependency, runner, or workflow paths, plus `workflow_dispatch`
- cancels superseded pull-request runs
- avoids docs/UI-only load
- uses a ~154 MiB compressed image; expected hosted cost is roughly 2–4 Linux runner-minutes per matching change

## Security posture

- application migrations, queries, tenant-isolation assertions, and RLS checks use the non-superuser app URL
- bootstrap superuser access is limited to role setup and create/drop for one uniquely named empty-database fixture
- ephemeral test URLs remain in workflow environment variables and are not echoed by commands

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm test:postgres:docker` — 49 passed, 0 failed, 0 skipped across 10 files
- `pnpm -C apps/agor-daemon exec vitest run src/utils/tenant-agentic-tool-validation.test.ts` — 1 passed
- `actionlint` 1.7.7
- `yamllint`
