### PR TITLE
fix(daemon): redact database startup logs

### DIFF
--- a/apps/agor-daemon/src/setup/database.test.ts
+++ b/apps/agor-daemon/src/setup/database.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeDatabase } from './database.js';
+
+const dbMocks = vi.hoisted(() => ({
+  checkMigrationStatus: vi.fn(),
+  createDatabaseAsync: vi.fn(),
+  createTenantScopedDatabaseProxy: vi.fn(),
+  runWithSystemDatabaseScope: vi.fn(),
+  seedInitialData: vi.fn(),
+}));
+
+vi.mock('@agor/core/db', async (importOriginal) => ({
+  ...(await importOriginal()),
+  ...dbMocks,
+}));
+
+describe('initializeDatabase logging', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    const rawDb = {};
+    const scopedDb = {};
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    dbMocks.createDatabaseAsync.mockResolvedValue(rawDb);
+    dbMocks.createTenantScopedDatabaseProxy.mockReturnValue(scopedDb);
+    dbMocks.checkMigrationStatus.mockResolvedValue({ hasPending: false, pending: [] });
+    dbMocks.runWithSystemDatabaseScope.mockImplementation(
+      async (_db, _operation, run: () => Promise<void>) => run()
+    );
+    dbMocks.seedInitialData.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    logSpy.mockRestore();
+  });
+
+  it.each([
+    {
+      backend: 'postgresql',
+      url: 'postgresql://PG_USER_SENTINEL:PG_PASSWORD_SENTINEL@PG_HOST_SENTINEL:5432/agor?sslmode=PG_QUERY_SENTINEL',
+      sentinels: [
+        'PG_USER_SENTINEL',
+        'PG_PASSWORD_SENTINEL',
+        'PG_HOST_SENTINEL',
+        'PG_QUERY_SENTINEL',
+      ],
+    },
+    {
+      backend: 'sqlite',
+      url: 'file:/tmp/SQLITE_PATH_SENTINEL.db?mode=SQLITE_QUERY_SENTINEL',
+      sentinels: ['SQLITE_PATH_SENTINEL', 'SQLITE_QUERY_SENTINEL'],
+    },
+  ])(
+    'logs only the $backend backend for a hostile connection string',
+    async ({ backend, url, sentinels }) => {
+      await initializeDatabase(url, { skipFirstRunAdminBootstrap: true });
+
+      expect(logSpy).toHaveBeenCalledWith(`[database] connecting backend=${backend}`);
+      const logged = logSpy.mock.calls.flat().map(String).join('\n');
+      for (const sentinel of sentinels) expect(logged).not.toContain(sentinel);
+
+      expect(dbMocks.createDatabaseAsync).toHaveBeenCalledWith({ url });
+      expect(dbMocks.checkMigrationStatus).toHaveBeenCalledTimes(1);
+      expect(dbMocks.seedInitialData).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/apps/agor-daemon/src/setup/database.test.ts
+++ b/apps/agor-daemon/src/setup/database.test.ts
@@ -1,12 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initializeDatabase } from './database.js';
 
+const fsMocks = vi.hoisted(() => ({
+  access: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
 const dbMocks = vi.hoisted(() => ({
   checkMigrationStatus: vi.fn(),
   createDatabaseAsync: vi.fn(),
   createTenantScopedDatabaseProxy: vi.fn(),
   runWithSystemDatabaseScope: vi.fn(),
   seedInitialData: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal()),
+  ...fsMocks,
 }));
 
 vi.mock('@agor/core/db', async (importOriginal) => ({
@@ -22,6 +32,8 @@ describe('initializeDatabase logging', () => {
     const scopedDb = {};
 
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    fsMocks.access.mockResolvedValue(undefined);
+    fsMocks.mkdir.mockResolvedValue(undefined);
     dbMocks.createDatabaseAsync.mockResolvedValue(rawDb);
     dbMocks.createTenantScopedDatabaseProxy.mockReturnValue(scopedDb);
     dbMocks.checkMigrationStatus.mockResolvedValue({ hasPending: false, pending: [] });
@@ -33,6 +45,7 @@ describe('initializeDatabase logging', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     logSpy.mockRestore();
   });
 
@@ -52,6 +65,11 @@ describe('initializeDatabase logging', () => {
       url: 'file:/tmp/SQLITE_PATH_SENTINEL.db?mode=SQLITE_QUERY_SENTINEL',
       sentinels: ['SQLITE_PATH_SENTINEL', 'SQLITE_QUERY_SENTINEL'],
     },
+    {
+      backend: 'sqlite',
+      url: 'libsql://LIBSQL_HOST_SENTINEL/agor?authToken=LIBSQL_QUERY_SENTINEL',
+      sentinels: ['LIBSQL_HOST_SENTINEL', 'LIBSQL_QUERY_SENTINEL'],
+    },
   ])(
     'logs only the $backend backend for a hostile connection string',
     async ({ backend, url, sentinels }) => {
@@ -66,4 +84,31 @@ describe('initializeDatabase logging', () => {
       expect(dbMocks.seedInitialData).toHaveBeenCalledTimes(1);
     }
   );
+
+  it('uses the configured dialect fallback without logging the URL', async () => {
+    vi.stubEnv('AGOR_DB_DIALECT', 'sqlite');
+    const url = ':memory:FALLBACK_SENTINEL';
+
+    await initializeDatabase(url, { skipFirstRunAdminBootstrap: true });
+
+    expect(logSpy).toHaveBeenCalledWith('[database] connecting backend=sqlite');
+    expect(logSpy.mock.calls.flat().map(String).join('\n')).not.toContain('FALLBACK_SENTINEL');
+    expect(dbMocks.createDatabaseAsync).toHaveBeenCalledWith({ url });
+  });
+
+  it('does not log a hostile SQLite directory when creating it', async () => {
+    const url = 'file:/tmp/SQLITE_DIRECTORY_SENTINEL/agor.db';
+    fsMocks.access.mockRejectedValueOnce(new Error('missing directory'));
+
+    await initializeDatabase(url, { skipFirstRunAdminBootstrap: true });
+
+    expect(fsMocks.mkdir).toHaveBeenCalledWith('/tmp/SQLITE_DIRECTORY_SENTINEL', {
+      recursive: true,
+    });
+    expect(logSpy).toHaveBeenCalledWith('[database] creating sqlite directory');
+    expect(logSpy.mock.calls.flat().map(String).join('\n')).not.toContain(
+      'SQLITE_DIRECTORY_SENTINEL'
+    );
+    expect(dbMocks.createDatabaseAsync).toHaveBeenCalledWith({ url });
+  });
 });

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -11,7 +11,9 @@ import {
   checkMigrationStatus,
   createDatabaseAsync,
   createTenantScopedDatabaseProxy,
+  detectDialectFromUrl,
   formatPendingMigrationsMessage,
+  getDatabaseDialect,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   seedInitialData,
@@ -47,7 +49,7 @@ async function ensureDatabaseDirectory(dbPath: string): Promise<void> {
   try {
     await access(dbDir, constants.F_OK);
   } catch {
-    console.log(`📁 Creating database directory: ${dbDir}`);
+    console.log('[database] creating sqlite directory');
     await mkdir(dbDir, { recursive: true });
   }
 
@@ -110,9 +112,8 @@ export async function initializeDatabase(
     skipFirstRunAdminBootstrap?: boolean;
   } = {}
 ): Promise<DatabaseInitResult> {
-  console.log(
-    `[database] connecting backend=${dbPath.startsWith('file:') ? 'sqlite' : 'postgresql'}`
-  );
+  const dialect = detectDialectFromUrl(dbPath) ?? getDatabaseDialect();
+  console.log(`[database] connecting backend=${dialect}`);
 
   // Ensure directory exists for SQLite
   await ensureDatabaseDirectory(dbPath);

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -110,7 +110,9 @@ export async function initializeDatabase(
     skipFirstRunAdminBootstrap?: boolean;
   } = {}
 ): Promise<DatabaseInitResult> {
-  console.log(`📦 Connecting to database: ${dbPath}`);
+  console.log(
+    `[database] connecting backend=${dbPath.startsWith('file:') ? 'sqlite' : 'postgresql'}`
+  );
 
   // Ensure directory exists for SQLite
   await ensureDatabaseDirectory(dbPath);

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -49,6 +49,7 @@ export * from './pending-migrations';
 export * from './repositories';
 export * from './sanitize-error';
 export * from './schema';
+export { detectDialectFromUrl, getDatabaseDialect } from './schema-factory';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';
 // Tenant database lifecycle primitives. Filesystem-backed portability operations


### PR DESCRIPTION
## Summary

Database startup logging interpolated raw connection URLs and SQLite directory paths, which could expose credentials, tokens, hosts, and filesystem details in operational logs.

This change:
- emits fixed backend-only connection events and a fixed, path-free SQLite directory event
- reuses the canonical core dialect detection and configured fallback for PostgreSQL, file SQLite, LibSQL, and nonstandard configured URLs
- preserves the original database URL handoff and existing directory creation, migration, seeding, and tenant-scoping behavior

## Validation

- 5 focused daemon database tests
- 28 core client tests
- source-aware core, daemon, and changed-test typechecks
- Biome on all changed files
- multitenancy and daemon-filesystem boundary guards
- cumulative diff and whitespace checks

## Coordination with #2134

This overlaps the shared database-directory setup changed by [#2134](https://github.com/preset-io/agor/pull/2134). Integration must retain this PR's path-free directory event while adopting #2134's `secureOwnerDirectory` behavior.

## Risks and rollback

Risk is limited to startup event wording and dialect labeling; canonical dialect reuse reduces drift from connection behavior. There is no schema or data migration. Rollback is to revert the two commits in this PR.
