### PR TITLE
Preserve executor environment through user impersonation

### DIFF
--- a/packages/core/src/unix/run-as-user.test.ts
+++ b/packages/core/src/unix/run-as-user.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildSpawnArgs, escapeShellArg } from './run-as-user.js';
 
@@ -140,7 +144,7 @@ describe('run-as-user', () => {
         // Script references ENVFILE from $1, not interpolated. Uses `set -eu`
         // so a failed source aborts BEFORE rm+exec (fail-closed).
         expect(result.args[5]).toBe(
-          'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec "$@"'
+          'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec env "$@"'
         );
         // Positional args: separator, envFilePath, then the real command
         expect(result.args[6]).toBe('--');
@@ -149,17 +153,72 @@ describe('run-as-user', () => {
         expect(result.args[9]).toBe('script.js');
       });
 
+      it('makes sourced secrets and positional env visible before command input handling', () => {
+        const directory = mkdtempSync(join(tmpdir(), 'agor-run-as-user-'));
+        const envFilePath = join(directory, 'agor-env-startup');
+        const secret = "secret with 'quotes'=and\nnewlines";
+        const env = {
+          LOG_LEVEL: 'warn',
+          NODE_ENV: 'production',
+          GIT_CONFIG_PARAMETERS:
+            "'transfer.credentialsInUrl'='die' 'http.extraHeader'='quoted value'",
+          HOSTILE_VALUE: "spaces 'quotes' = equals\nand newlines",
+        };
+        const commandArgs = [
+          '-e',
+          'process.stdout.write(JSON.stringify({ secret: process.env.ANTHROPIC_API_KEY, logLevel: process.env.LOG_LEVEL, nodeEnv: process.env.NODE_ENV, gitConfig: process.env.GIT_CONFIG_PARAMETERS, hostile: process.env.HOSTILE_VALUE }))',
+        ];
+        writeFileSync(envFilePath, `ANTHROPIC_API_KEY=${escapeShellArg(secret)}\n`, {
+          mode: 0o600,
+        });
+
+        try {
+          const result = buildSpawnArgs(process.execPath, commandArgs, {
+            asUser: 'alice',
+            envFilePath,
+            env,
+          });
+          expect(result.args.slice(8)).toEqual([
+            ...Object.entries(env).map(([key, value]) => `${key}=${value}`),
+            process.execPath,
+            ...commandArgs,
+          ]);
+          const output = execFileSync('bash', result.args.slice(4), { encoding: 'utf8' });
+
+          expect(JSON.parse(output)).toEqual({
+            secret,
+            logLevel: env.LOG_LEVEL,
+            nodeEnv: env.NODE_ENV,
+            gitConfig: env.GIT_CONFIG_PARAMETERS,
+            hostile: env.HOSTILE_VALUE,
+          });
+          expect(existsSync(envFilePath)).toBe(false);
+        } finally {
+          rmSync(directory, { recursive: true, force: true });
+        }
+      });
+
+      it('rejects invalid inline env names before spawn', () => {
+        expect(() =>
+          buildSpawnArgs('node', ['executor.js'], {
+            asUser: 'alice',
+            envFilePath: '/tmp/agor-env-nonce',
+            env: { 'INVALID-NAME': 'value' },
+          })
+        ).toThrow('buildSpawnArgs: invalid env var name: "INVALID-NAME"');
+      });
+
       it('inner script is fail-closed (set -eu aborts before exec on source failure)', () => {
         const result = buildSpawnArgs('node', [], {
           asUser: 'alice',
           envFilePath: '/tmp/agor-env-x',
         });
         // `set -eu` MUST appear before the source step so that a failed
-        // `.  "$ENVFILE"` prevents the `exec "$@"` from launching with
+        // `.  "$ENVFILE"` prevents the `exec env "$@"` from launching with
         // missing secrets.
         const script = result.args[5];
         expect(script.indexOf('set -eu')).toBeLessThan(script.indexOf('. "$ENVFILE"'));
-        expect(script.indexOf('. "$ENVFILE"')).toBeLessThan(script.indexOf('exec "$@"'));
+        expect(script.indexOf('. "$ENVFILE"')).toBeLessThan(script.indexOf('exec env "$@"'));
       });
 
       it('REGRESSION: does NOT contain any secret values in argv', () => {
@@ -321,14 +380,14 @@ describe('run-as-user', () => {
 
       it('default (shell: false) keeps argv-mode behaviour for executor callers', () => {
         // Belt-and-braces: the executor spawn path must continue to use
-        // `exec "$@"` so that `node executor.js --stdin` runs without an
+        // `exec env "$@"` so that `node executor.js --stdin` runs without an
         // extra shell layer. Adding `shell` must not regress it.
         const result = buildSpawnArgs('node', ['executor.js', '--stdin'], {
           asUser: 'alice',
           envFilePath: '/tmp/agor-env-default',
         });
         expect(result.args[5]).toBe(
-          'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec "$@"'
+          'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec env "$@"'
         );
         expect(result.args.slice(8)).toEqual(['node', 'executor.js', '--stdin']);
       });

--- a/packages/core/src/unix/run-as-user.test.ts
+++ b/packages/core/src/unix/run-as-user.test.ts
@@ -112,6 +112,15 @@ describe('run-as-user', () => {
         expect(result.args[5]).toContain("node 'script.js'");
       });
 
+      it('rejects invalid env names before building the inline shell command', () => {
+        expect(() =>
+          buildSpawnArgs('node', ['executor.js'], {
+            asUser: 'alice',
+            env: { 'INVALID-NAME': 'value' },
+          })
+        ).toThrow('buildSpawnArgs: invalid env var name: "INVALID-NAME"');
+      });
+
       it('ignores env vars when not impersonating', () => {
         const result = buildSpawnArgs('node', ['script.js'], {
           env: { NODE_ENV: 'test' },

--- a/packages/core/src/unix/run-as-user.ts
+++ b/packages/core/src/unix/run-as-user.ts
@@ -146,7 +146,7 @@ export interface BuildSpawnArgsOptions {
    *
    * WARNING: values passed this way end up in the process's argv and are
    * visible via `ps`, `/proc/<pid>/cmdline`, audit logs, etc. Never pass
-   * secrets (API keys, tokens) via `env` alone when impersonating — use
+   * secrets (API keys, tokens) via `env` when impersonating — use
    * `writeUserEnvFile` + `envFilePath` instead.
    */
   env?: Record<string, string>;
@@ -156,8 +156,9 @@ export interface BuildSpawnArgsOptions {
    *
    * When set together with `asUser`, the generated command sources this file
    * inside the impersonated shell, then removes it, then `exec`s the real
-   * command. The env values never appear in argv. The path itself is in argv
-   * but it is not secret.
+   * command. Values sourced from the file never appear in argv. Non-secret
+   * values passed separately through `env` do appear in argv. The path itself
+   * is in argv but it is not secret.
    *
    * Use `writeUserEnvFile` to produce a path that is owned by the target
    * user with mode 0600.
@@ -170,7 +171,7 @@ export interface BuildSpawnArgsOptions {
   /**
    * Treat `command` as a shell string (like `sh -c`) rather than an argv
    * entry. Affects the impersonated + `envFilePath` code path only — where
-   * the default emits `exec "$@"` (argv mode, suitable for `buildSpawnArgs(
+   * the default emits `exec env "$@"` (argv mode, suitable for `buildSpawnArgs(
    * 'node', ['executor.js'], ...)`) and shell-mode emits `exec bash -c "$CMD"`
    * (suitable for user-authored commands like
    * `docker compose -p $NAME up -d --build` that embed env prefixes, `$(...)`
@@ -206,9 +207,9 @@ export interface BuildSpawnArgsOptions {
  * // Spawn zellij as another user with env vars
  * const { cmd, args } = buildSpawnArgs('zellij', ['attach', 'session1'], {
  *   asUser: 'alice',
- *   env: { GITHUB_TOKEN: 'xxx', TERM: 'xterm-256color' }
+ *   env: { DAEMON_URL: 'http://localhost:3030', TERM: 'xterm-256color' }
  * });
- * // Inner command: env GITHUB_TOKEN='xxx' TERM='xterm-256color' zellij 'attach' 'session1'
+ * // Inner command: env DAEMON_URL='http://localhost:3030' TERM='xterm-256color' zellij 'attach' 'session1'
  * pty.spawn(cmd, args, { cwd });
  *
  * // No impersonation - env should be passed to spawn() directly
@@ -269,6 +270,13 @@ export function buildSpawnArgs(
       );
     }
 
+    const envEntries = Object.entries(env ?? {});
+    for (const [key] of envEntries) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+        throw new Error(`buildSpawnArgs: invalid env var name: ${JSON.stringify(key)}`);
+      }
+    }
+
     if (shell) {
       // Shell-mode: `command` is a user-authored shell string (possibly with
       // env-var prefixes, `$(...)` subshells, `&&` chaining, etc.). Any args
@@ -278,11 +286,11 @@ export function buildSpawnArgs(
       // Non-secret env vars are prepended via `env KEY='val' ...` so they
       // reach the process without bypassing the envFilePath secret path.
       let envPrefix = '';
-      if (env && Object.keys(env).length > 0) {
-        const envEntries = Object.entries(env)
+      if (envEntries.length > 0) {
+        const serializedEnvEntries = envEntries
           .map(([key, value]) => `${key}=${escapeShellArg(value)}`)
           .join(' ');
-        envPrefix = `env ${envEntries} `;
+        envPrefix = `env ${serializedEnvEntries} `;
       }
       const escapedArgs = args.map(escapeShellArg).join(' ');
       const userCommand =
@@ -312,18 +320,33 @@ export function buildSpawnArgs(
     // binary with a known argv shape.
     //
     // Inner bash script:
-    //   $1 = env file path, $2... = real command + args
+    //   $1 = env file path, $2... = non-secret KEY=value entries + real command + args
     //   - set -eu: if source fails, abort BEFORE rm+exec so we never
     //     launch the real process with missing secrets
     //   - source env into current shell (set -a auto-exports)
     //   - unlink file before exec so it does not linger on disk
-    //   - exec preserves env into the target process
+    //   - `env "$@"` applies non-secret values passed as positional arguments
+    //     without interpolating them into the shell script
+    //   - exec preserves both sourced secrets and explicit env into the target process
+    const envArgs = envEntries.map(([key, value]) => `${key}=${value}`);
     const innerScript =
-      'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec "$@"';
+      'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec env "$@"';
 
     return {
       cmd: 'sudo',
-      args: ['-n', '-u', asUser, 'bash', '-c', innerScript, '--', envFilePath, command, ...args],
+      args: [
+        '-n',
+        '-u',
+        asUser,
+        'bash',
+        '-c',
+        innerScript,
+        '--',
+        envFilePath,
+        ...envArgs,
+        command,
+        ...args,
+      ],
     };
   }
 

--- a/packages/core/src/unix/run-as-user.ts
+++ b/packages/core/src/unix/run-as-user.ts
@@ -253,6 +253,13 @@ export function buildSpawnArgs(
     throw new Error(`buildSpawnArgs: invalid Unix username: ${JSON.stringify(asUser)}`);
   }
 
+  const envEntries = Object.entries(env ?? {});
+  for (const [key] of envEntries) {
+    if (!isValidEnvVarName(key)) {
+      throw new Error(`buildSpawnArgs: invalid env var name: ${JSON.stringify(key)}`);
+    }
+  }
+
   // Prefer env-file sourcing: secrets stay out of argv entirely.
   if (envFilePath) {
     // Structural validation only. The path is passed as a positional argv
@@ -273,13 +280,6 @@ export function buildSpawnArgs(
       throw new Error(
         `buildSpawnArgs: envFilePath contains control characters: ${JSON.stringify(envFilePath)}`
       );
-    }
-
-    const envEntries = Object.entries(env ?? {});
-    for (const [key] of envEntries) {
-      if (!isValidEnvVarName(key)) {
-        throw new Error(`buildSpawnArgs: invalid env var name: ${JSON.stringify(key)}`);
-      }
     }
 
     if (shell) {

--- a/packages/core/src/unix/run-as-user.ts
+++ b/packages/core/src/unix/run-as-user.ts
@@ -49,6 +49,11 @@ export function escapeShellArg(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
+/** Check whether a name is a valid shell environment-variable identifier. */
+export function isValidEnvVarName(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
 /**
  * Options for runAsUser
  */
@@ -272,7 +277,7 @@ export function buildSpawnArgs(
 
     const envEntries = Object.entries(env ?? {});
     for (const [key] of envEntries) {
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      if (!isValidEnvVarName(key)) {
         throw new Error(`buildSpawnArgs: invalid env var name: ${JSON.stringify(key)}`);
       }
     }

--- a/packages/core/src/unix/user-env-file.test.ts
+++ b/packages/core/src/unix/user-env-file.test.ts
@@ -96,4 +96,18 @@ describe('prepareImpersonationEnv', () => {
       input: `ANTHROPIC_API_KEY=${escapeShellArg(secret)}\n`,
     });
   });
+
+  it('rejects invalid defined names before writing a secret env file', () => {
+    expect(() =>
+      prepareImpersonationEnv({
+        asUser: 'alice',
+        env: {
+          ANTHROPIC_API_KEY: 'sk-ant-secret-that-must-not-reach-disk',
+          'INVALID-NAME': 'value',
+        },
+      })
+    ).toThrow('prepareImpersonationEnv: invalid env var name: "INVALID-NAME"');
+
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/unix/user-env-file.test.ts
+++ b/packages/core/src/unix/user-env-file.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildSpawnArgs, escapeShellArg } from './run-as-user.js';
+import {
+  attachEnvFileCleanup,
+  type CleanupTarget,
+  prepareImpersonationEnv,
+} from './user-env-file.js';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+
+function cleanupTarget(listeners: Map<string, () => void>): CleanupTarget {
+  return {
+    once(event, listener) {
+      listeners.set(event, listener);
+    },
+  };
+}
+
+describe('attachEnvFileCleanup', () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('skips privileged cleanup when the launch wrapper already removed the env file', () => {
+    const listeners = new Map<string, () => void>();
+
+    attachEnvFileCleanup(cleanupTarget(listeners), {
+      envFilePath: join(tmpdir(), `agor-env-absent-${process.pid}-${Date.now()}`),
+      asUser: 'alice',
+    });
+    listeners.get('exit')?.();
+
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('removes a failed-launch file once across error and exit cleanup', () => {
+    const listeners = new Map<string, () => void>();
+    const path = join(tmpdir(), `agor-env-failed-${process.pid}-${Date.now()}`);
+    writeFileSync(path, 'TOKEN=secret\n', { mode: 0o600 });
+    vi.mocked(execFileSync).mockImplementation((_file, args) => {
+      const cleanupPath = args?.at(-1);
+      if (!cleanupPath) throw new Error('expected cleanup path');
+      unlinkSync(cleanupPath);
+      return Buffer.alloc(0);
+    });
+
+    attachEnvFileCleanup(cleanupTarget(listeners), { envFilePath: path, asUser: 'alice' });
+    listeners.get('error')?.();
+    listeners.get('exit')?.();
+
+    expect(existsSync(path)).toBe(false);
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'sudo',
+      ['-n', '-u', 'alice', 'rm', '-f', '--', path],
+      expect.objectContaining({ stdio: 'ignore' })
+    );
+  });
+});
+
+describe('prepareImpersonationEnv', () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('keeps real secret values out of argv while preserving non-secret startup env', () => {
+    const secret = "sk-ant-secret with 'quotes'=and\nnewlines";
+    const inlineEnv = {
+      LOG_LEVEL: 'warn',
+      NODE_ENV: 'production',
+      GIT_CONFIG_PARAMETERS: "'transfer.credentialsInUrl'='die'",
+    };
+    const prepared = prepareImpersonationEnv({
+      asUser: 'alice',
+      env: { ANTHROPIC_API_KEY: secret, ...inlineEnv },
+    });
+    const spawnArgs = buildSpawnArgs('node', ['executor.js', '--stdin'], {
+      asUser: 'alice',
+      env: prepared.inlineEnv,
+      envFilePath: prepared.envFilePath,
+    });
+
+    expect(prepared.inlineEnv).toEqual(inlineEnv);
+    expect(spawnArgs.args.slice(8)).toEqual([
+      ...Object.entries(inlineEnv).map(([key, value]) => `${key}=${value}`),
+      'node',
+      'executor.js',
+      '--stdin',
+    ]);
+    expect([spawnArgs.cmd, ...spawnArgs.args].join('\n')).not.toContain(secret);
+    expect(vi.mocked(execFileSync).mock.calls[0]?.[2]).toMatchObject({
+      input: `ANTHROPIC_API_KEY=${escapeShellArg(secret)}\n`,
+    });
+  });
+});

--- a/packages/core/src/unix/user-env-file.ts
+++ b/packages/core/src/unix/user-env-file.ts
@@ -17,7 +17,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { unlinkSync } from 'node:fs';
+import { existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -180,6 +180,7 @@ export function attachEnvFileCleanup(
   const capturedPath = envFilePath;
   const capturedAsUser = asUser;
   const cleanup = () => {
+    if (!existsSync(capturedPath)) return;
     if (capturedAsUser) {
       tryUnlinkEnvFileAsUser(capturedAsUser, capturedPath);
     } else {

--- a/packages/core/src/unix/user-env-file.ts
+++ b/packages/core/src/unix/user-env-file.ts
@@ -21,7 +21,7 @@ import { existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { escapeShellArg } from './run-as-user.js';
+import { escapeShellArg, isValidEnvVarName } from './run-as-user.js';
 import { splitSecretEnv } from './secret-env.js';
 import { isValidUnixUsername } from './user-manager.js';
 
@@ -80,7 +80,7 @@ export function writeUserEnvFile(asUser: string, env: Record<string, string>): s
   // else to avoid injection into the sourced file.
   const lines: string[] = [];
   for (const [key, value] of Object.entries(env)) {
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    if (!isValidEnvVarName(key)) {
       throw new Error(`writeUserEnvFile: invalid env var name: ${JSON.stringify(key)}`);
     }
     lines.push(`${key}=${escapeShellArg(value)}`);
@@ -213,6 +213,11 @@ export function prepareImpersonationEnv(options: {
   env: Record<string, string | undefined>;
 }): PreparedImpersonationEnv {
   const { asUser, env } = options;
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined && !isValidEnvVarName(key)) {
+      throw new Error(`prepareImpersonationEnv: invalid env var name: ${JSON.stringify(key)}`);
+    }
+  }
   const { secret, inline } = splitSecretEnv(env);
   const envFilePath = Object.keys(secret).length > 0 ? writeUserEnvFile(asUser, secret) : undefined;
   return { inlineEnv: inline, envFilePath };

--- a/scripts/daemon-filesystem-exceptions.json
+++ b/scripts/daemon-filesystem-exceptions.json
@@ -294,6 +294,20 @@
     "reviewDate": null
   },
   {
+    "id": "DAEMON-FS-CAP-170",
+    "class": "A",
+    "file": "packages/core/src/unix/user-env-file.ts",
+    "import": "node:fs",
+    "symbol": "existsSync",
+    "local": "existsSync",
+    "operation": "call:existsSync@cleanup#1",
+    "owner": "daemon host/operator runtime",
+    "boundary": "deployment-local host capability",
+    "rationale": "Skips privileged safety-net cleanup after the target-user launch wrapper has already removed its env file.",
+    "reviewTarget": null,
+    "reviewDate": null
+  },
+  {
     "id": "DAEMON-FS-CAP-064",
     "class": "A",
     "file": "packages/core/src/unix/user-env-file.ts",


### PR DESCRIPTION
## Root cause

When user impersonation used env-file mode, the launch wrapper sourced secret variables from the protected file but executed the target command without applying the separately prepared inline, non-secret environment. As a result, non-secret executor variables were dropped whenever secret-file propagation was active.

## Implementation

- Validate every defined environment-variable name against one shared shell-identifier rule before splitting variables or writing any secret file.
- Keep secret values in the target-user-owned, mode-0600 env file, source and remove that file before exec, and pass validated non-secret `KEY=value` entries as positional arguments to `env`.
- Make parent-side safety-net cleanup idempotent when the impersonated wrapper has already removed the env file.
- Extend Unix launch, env-file, cleanup, validation-ordering, and boundary coverage.

## Impact

Impersonated executors now receive both protected secret variables and inline non-secret variables. Malformed defined environment names fail before any secret material is written. Existing no-secret and non-impersonated paths remain unchanged.

## Validation

- 47 core Unix tests passed.
- 43 configured daemon tests passed.
- Core typecheck passed.
- Biome passed on all five changed files.
- Daemon filesystem and multitenancy boundary guards passed.
- Cumulative diff checks passed.

## Security boundary

Secret values remain out of the command line and are transferred through the protected env file. Only explicitly classified non-secret values are passed as positional `KEY=value` arguments and may therefore be visible through process inspection. Name validation happens before secret-file creation, and cleanup remains bounded to the generated env-file path.

## Risks and rollback

The main compatibility risk is earlier rejection of malformed defined environment-variable names. Process-argument visibility for non-secret values is intentional and documented. If rollback is required, revert this PR; that restores the previous launch behavior, including the non-secret environment loss in env-file mode.

N5/DEP0040 is not included and remains deferred.
