### PR TITLE
fix(gateway): redact sensitive alignment log fields

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -209,6 +209,7 @@ function makeGatewayHarness(args: {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.mocked(materializeAgenticToolConfiguration).mockClear();
   vi.mocked(getBaseUrl).mockReset();
   vi.mocked(getBaseUrl).mockResolvedValue('https://agor.example.com');
@@ -279,247 +280,135 @@ describe('GatewayService user alignment operational logs', () => {
     name: sensitive.name,
   } as User;
 
-  function capturedOutput(...spies: Array<{ mock: { calls: unknown[][] } }>): string {
-    return spies
+  function resolveAlignedUser(service: GatewayService) {
+    return service as unknown as {
+      resolveAlignedUser(opts: {
+        platform: string;
+        externalId: string | undefined;
+        email: unknown;
+        userMap: Record<string, string> | undefined;
+      }): Promise<User | null>;
+    };
+  }
+
+  async function createAlignedMessage(
+    platform: 'Slack' | 'GitHub' | 'Shortcut',
+    matchedUser: User | null = null,
+    includeEmail = true
+  ) {
+    const channelType = platform.toLowerCase() as 'slack' | 'github' | 'shortcut';
+    const channel = {
+      ...slackChannel,
+      channel_type: channelType,
+      agor_user_id: null,
+      config: { [`align_${channelType}_users`]: true },
+    } as unknown as GatewayChannel;
+    const sendMessage = vi.fn(async () => 'sent');
+    if (channelType !== 'slack') {
+      vi.mocked(getConnector).mockReturnValue({ sendMessage } as never);
+    }
+    const { service } = makeGatewayHarness({
+      channel,
+      alignedUser: matchedUser,
+      connector: { sendMessage },
+    });
+    const metadata: Record<string, unknown> = {
+      ...(channelType === 'slack' ? { channel_type: 'im' } : { processing_comment_id: 42 }),
+      ...(channelType === 'slack' ? {} : { [`${channelType}_user`]: sensitive.externalId }),
+      ...(includeEmail ? { [`${channelType}_user_email`]: sensitive.email } : {}),
+    };
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      user_name: sensitive.slackUsername,
+      metadata,
+    });
+
+    return { result, sendMessage };
+  }
+
+  function expectNoSensitiveValues(...spies: Array<{ mock: { calls: unknown[][] } }>): void {
+    const output = spies
       .flatMap((spy) => spy.mock.calls)
       .flat()
       .join(' ');
-  }
-
-  function expectNoSensitiveValues(output: string): void {
     for (const value of Object.values(sensitive)) {
       expect(output).not.toContain(value);
     }
   }
 
-  it('logs a user_map success with only the provider, source, and Agor user short ID', async () => {
-    const { service } = makeGatewayHarness({ alignedUser });
+  it('logs exact user_map and email-fallback outcomes without external identities', async () => {
+    const { service, findByEmailForAlignment } = makeGatewayHarness({ alignedUser });
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    const matched = await (
-      service as unknown as {
-        resolveAlignedUser(opts: {
-          platform: string;
-          externalId: string | undefined;
-          email: unknown;
-          userMap: Record<string, string> | undefined;
-        }): Promise<User | null>;
-      }
-    ).resolveAlignedUser({
+    const userMapMatched = await resolveAlignedUser(service).resolveAlignedUser({
       platform: 'GitHub',
       externalId: sensitive.externalId,
       email: undefined,
       userMap: { [sensitive.externalId]: sensitive.mappedEmail },
     });
-
-    expect(matched).toBe(alignedUser);
-    expect(log).toHaveBeenCalledWith(
-      `[gateway] GitHub user alignment succeeded: source=user_map agor_user=${shortId(alignedUser.user_id)}`
-    );
-    expectNoSensitiveValues(capturedOutput(log));
-    log.mockRestore();
-  });
-
-  it('logs a stale user_map and email fallback without either external identity', async () => {
-    const { service, findByEmailForAlignment } = makeGatewayHarness({ alignedUser });
     findByEmailForAlignment.mockResolvedValueOnce(null).mockResolvedValueOnce(alignedUser);
-    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    const matched = await (
-      service as unknown as {
-        resolveAlignedUser(opts: {
-          platform: string;
-          externalId: string | undefined;
-          email: unknown;
-          userMap: Record<string, string> | undefined;
-        }): Promise<User | null>;
-      }
-    ).resolveAlignedUser({
+    const emailMatched = await resolveAlignedUser(service).resolveAlignedUser({
       platform: 'Shortcut',
       externalId: sensitive.externalId,
       email: sensitive.email,
       userMap: { [sensitive.externalId]: sensitive.mappedEmail },
     });
 
-    expect(matched).toBe(alignedUser);
-    expect(warn).toHaveBeenCalledWith(
-      '[gateway] Shortcut user alignment failed: source=user_map result=agor_user_not_found'
-    );
-    expect(log).toHaveBeenCalledWith(
-      `[gateway] Shortcut user alignment succeeded: source=email agor_user=${shortId(alignedUser.user_id)}`
-    );
-    expectNoSensitiveValues(capturedOutput(log, warn));
-    log.mockRestore();
-    warn.mockRestore();
+    expect([userMapMatched, emailMatched]).toEqual([alignedUser, alignedUser]);
+    expect(log.mock.calls).toEqual([
+      [
+        `[gateway] GitHub user alignment succeeded: source=user_map agor_user=${shortId(alignedUser.user_id)}`,
+      ],
+      [
+        `[gateway] Shortcut user alignment succeeded: source=email agor_user=${shortId(alignedUser.user_id)}`,
+      ],
+    ]);
+    expect(warn.mock.calls).toEqual([
+      ['[gateway] Shortcut user alignment failed: source=user_map result=agor_user_not_found'],
+    ]);
+    expectNoSensitiveValues(log, warn);
   });
 
   it('logs a Slack alignment success without email, name, username, or thread identity', async () => {
-    const channel = {
-      ...slackChannel,
-      agor_user_id: null,
-      config: { align_slack_users: true },
-    } as GatewayChannel;
-    const { service } = makeGatewayHarness({ channel, alignedUser, user: alignedUser });
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-    const result = await service.create({
-      channel_key: channel.channel_key,
-      thread_id: sensitive.threadId,
-      text: 'hello',
-      user_name: sensitive.slackUsername,
-      metadata: {
-        channel_type: 'im',
-        slack_user_email: sensitive.email,
-      },
-    });
+    const { result } = await createAlignedMessage('Slack', alignedUser);
 
     expect(result).toMatchObject({ success: true, created: true });
     expect(log).toHaveBeenCalledWith(
       `[gateway] Slack user alignment succeeded: agor_user=${shortId(alignedUser.user_id)}`
     );
-    expectNoSensitiveValues(capturedOutput(log));
-    log.mockRestore();
+    expectNoSensitiveValues(log);
   });
 
-  it('keeps the Slack account-miss message user-facing while logging only the outcome', async () => {
-    const channel = {
-      ...slackChannel,
-      agor_user_id: null,
-      config: { align_slack_users: true },
-    } as GatewayChannel;
-    const sendMessage = vi.fn(async () => 'sent');
-    const { service } = makeGatewayHarness({
-      channel,
-      alignedUser: null,
-      connector: { sendMessage },
-    });
-    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  it.each([
+    ['Slack', true, sensitive.email],
+    ['Slack', false, null],
+    ['GitHub', true, `@${sensitive.externalId}`],
+    ['Shortcut', true, null],
+  ] as const)(
+    '$0 rejection (identity email available: $1)',
+    async (platform, includeEmail, expectedContent) => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const { result, sendMessage } = await createAlignedMessage(platform, null, includeEmail);
 
-    const result = await service.create({
-      channel_key: channel.channel_key,
-      thread_id: sensitive.threadId,
-      text: 'hello',
-      user_name: sensitive.slackUsername,
-      metadata: {
-        channel_type: 'im',
-        slack_user_email: sensitive.email,
-      },
-    });
-
-    expect(result).toEqual({ success: false, sessionId: '', created: false });
-    expect(log).toHaveBeenCalledWith(
-      '[gateway] Slack user alignment failed: result=agor_user_not_found'
-    );
-    expectNoSensitiveValues(capturedOutput(log));
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadId: sensitive.threadId,
-        text: expect.stringContaining(sensitive.email),
-      })
-    );
-    log.mockRestore();
-  });
-
-  it('logs a fixed Slack identity-unavailable category without username or thread identity', async () => {
-    const channel = {
-      ...slackChannel,
-      agor_user_id: null,
-      config: { align_slack_users: true },
-    } as GatewayChannel;
-    const sendMessage = vi.fn(async () => 'sent');
-    const { service } = makeGatewayHarness({ channel, connector: { sendMessage } });
-    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-    const result = await service.create({
-      channel_key: channel.channel_key,
-      thread_id: sensitive.threadId,
-      text: 'hello',
-      user_name: sensitive.slackUsername,
-      metadata: { channel_type: 'im' },
-    });
-
-    expect(result).toEqual({ success: false, sessionId: '', created: false });
-    expect(log).toHaveBeenCalledWith(
-      '[gateway] Slack user alignment failed: result=identity_email_unavailable'
-    );
-    expectNoSensitiveValues(capturedOutput(log));
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ threadId: sensitive.threadId })
-    );
-    log.mockRestore();
-  });
-
-  it('keeps the GitHub rejection user-facing while logging only the fixed outcome', async () => {
-    const channel = {
-      ...slackChannel,
-      channel_type: 'github',
-      agor_user_id: null,
-      config: { align_github_users: true },
-    } as GatewayChannel;
-    const sendMessage = vi.fn(async () => 'sent');
-    vi.mocked(getConnector).mockReturnValue({ sendMessage } as never);
-    const { service } = makeGatewayHarness({ channel, alignedUser: null });
-    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-    const result = await service.create({
-      channel_key: channel.channel_key,
-      thread_id: sensitive.threadId,
-      text: 'hello',
-      metadata: {
-        github_user: sensitive.externalId,
-        github_user_email: sensitive.email,
-        processing_comment_id: 42,
-      },
-    });
-
-    expect(result).toEqual({ success: false, sessionId: '', created: false });
-    expect(log).toHaveBeenCalledWith(
-      '[gateway] GitHub user alignment failed: result=agor_user_not_found'
-    );
-    expectNoSensitiveValues(capturedOutput(log));
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadId: sensitive.threadId,
-        text: expect.stringContaining(`@${sensitive.externalId}`),
-      })
-    );
-    log.mockRestore();
-  });
-
-  it('keeps Shortcut routing fields out of its fixed alignment-failure log', async () => {
-    const channel = {
-      ...slackChannel,
-      channel_type: 'shortcut',
-      agor_user_id: null,
-      config: { align_shortcut_users: true },
-    } as GatewayChannel;
-    const sendMessage = vi.fn(async () => 'sent');
-    vi.mocked(getConnector).mockReturnValue({ sendMessage } as never);
-    const { service } = makeGatewayHarness({ channel, alignedUser: null });
-    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-    const result = await service.create({
-      channel_key: channel.channel_key,
-      thread_id: sensitive.threadId,
-      text: 'hello',
-      metadata: {
-        shortcut_user: sensitive.externalId,
-        shortcut_user_email: sensitive.email,
-        processing_comment_id: 42,
-      },
-    });
-
-    expect(result).toEqual({ success: false, sessionId: '', created: false });
-    expect(log).toHaveBeenCalledWith(
-      '[gateway] Shortcut user alignment failed: result=agor_user_not_found'
-    );
-    expectNoSensitiveValues(capturedOutput(log));
-    expect(sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ threadId: sensitive.threadId })
-    );
-    log.mockRestore();
-  });
+      expect(result).toEqual({ success: false, sessionId: '', created: false });
+      expect(log.mock.calls).toEqual([
+        [
+          `[gateway] ${platform} user alignment failed: result=${includeEmail ? 'agor_user_not_found' : 'identity_email_unavailable'}`,
+        ],
+      ]);
+      expectNoSensitiveValues(log);
+      expect(sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: sensitive.threadId,
+          ...(expectedContent ? { text: expect.stringContaining(expectedContent) } : {}),
+        })
+      );
+    }
+  );
 });
 
 describe('GatewayService multi-tenant process state', () => {

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -108,6 +108,7 @@ function makeGatewayHarness(args: {
   connector?: Record<string, unknown>;
   db?: TenantScopeAwareDatabase;
   user?: User;
+  alignedUser?: User | null;
 }) {
   const channel = args.channel ?? slackChannel;
   const executionUser = args.user ?? user;
@@ -175,8 +176,14 @@ function makeGatewayHarness(args: {
       return mapping;
     }),
   };
+  const findByEmailForAlignment = vi.fn(async () => args.alignedUser ?? null);
   (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
   (service as unknown as { threadMapRepo: typeof threadMapRepo }).threadMapRepo = threadMapRepo;
+  (
+    service as unknown as {
+      usersRepo: { findByEmailForAlignment: typeof findByEmailForAlignment };
+    }
+  ).usersRepo = { findByEmailForAlignment };
   (
     service as unknown as { outboundRepo: { findUnconsumedByChannelAndThread: unknown } }
   ).outboundRepo = {
@@ -197,6 +204,7 @@ function makeGatewayHarness(args: {
     setMCPServers,
     channelRepo,
     threadMapRepo,
+    findByEmailForAlignment,
   };
 }
 
@@ -252,6 +260,265 @@ describe('gateway tenant metadata helpers', () => {
 
     expect(tenantIdFromGatewayChannel(channel)).toBe('tenant-channel');
     expect(Object.keys(channel)).not.toContain('tenant_id');
+  });
+});
+
+describe('GatewayService user alignment operational logs', () => {
+  const sensitive = {
+    email: 'hostile-email-sentinel@example.test',
+    mappedEmail: 'hostile-mapped-email-sentinel@example.test',
+    externalId: 'hostile-external-id-sentinel',
+    name: 'hostile-name-sentinel',
+    slackUsername: 'hostile-slack-username-sentinel',
+    threadId: 'hostile-thread-id-sentinel',
+  };
+  const alignedUser = {
+    ...user,
+    user_id: '019fd900-0000-7000-8000-000000000001' as UserID,
+    email: sensitive.email,
+    name: sensitive.name,
+  } as User;
+
+  function capturedOutput(...spies: Array<{ mock: { calls: unknown[][] } }>): string {
+    return spies
+      .flatMap((spy) => spy.mock.calls)
+      .flat()
+      .join(' ');
+  }
+
+  function expectNoSensitiveValues(output: string): void {
+    for (const value of Object.values(sensitive)) {
+      expect(output).not.toContain(value);
+    }
+  }
+
+  it('logs a user_map success with only the provider, source, and Agor user short ID', async () => {
+    const { service } = makeGatewayHarness({ alignedUser });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const matched = await (
+      service as unknown as {
+        resolveAlignedUser(opts: {
+          platform: string;
+          externalId: string | undefined;
+          email: unknown;
+          userMap: Record<string, string> | undefined;
+        }): Promise<User | null>;
+      }
+    ).resolveAlignedUser({
+      platform: 'GitHub',
+      externalId: sensitive.externalId,
+      email: undefined,
+      userMap: { [sensitive.externalId]: sensitive.mappedEmail },
+    });
+
+    expect(matched).toBe(alignedUser);
+    expect(log).toHaveBeenCalledWith(
+      `[gateway] GitHub user alignment succeeded: source=user_map agor_user=${shortId(alignedUser.user_id)}`
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    log.mockRestore();
+  });
+
+  it('logs a stale user_map and email fallback without either external identity', async () => {
+    const { service, findByEmailForAlignment } = makeGatewayHarness({ alignedUser });
+    findByEmailForAlignment.mockResolvedValueOnce(null).mockResolvedValueOnce(alignedUser);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const matched = await (
+      service as unknown as {
+        resolveAlignedUser(opts: {
+          platform: string;
+          externalId: string | undefined;
+          email: unknown;
+          userMap: Record<string, string> | undefined;
+        }): Promise<User | null>;
+      }
+    ).resolveAlignedUser({
+      platform: 'Shortcut',
+      externalId: sensitive.externalId,
+      email: sensitive.email,
+      userMap: { [sensitive.externalId]: sensitive.mappedEmail },
+    });
+
+    expect(matched).toBe(alignedUser);
+    expect(warn).toHaveBeenCalledWith(
+      '[gateway] Shortcut user alignment failed: source=user_map result=agor_user_not_found'
+    );
+    expect(log).toHaveBeenCalledWith(
+      `[gateway] Shortcut user alignment succeeded: source=email agor_user=${shortId(alignedUser.user_id)}`
+    );
+    expectNoSensitiveValues(capturedOutput(log, warn));
+    log.mockRestore();
+    warn.mockRestore();
+  });
+
+  it('logs a Slack alignment success without email, name, username, or thread identity', async () => {
+    const channel = {
+      ...slackChannel,
+      agor_user_id: null,
+      config: { align_slack_users: true },
+    } as GatewayChannel;
+    const { service } = makeGatewayHarness({ channel, alignedUser, user: alignedUser });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      user_name: sensitive.slackUsername,
+      metadata: {
+        channel_type: 'im',
+        slack_user_email: sensitive.email,
+      },
+    });
+
+    expect(result).toMatchObject({ success: true, created: true });
+    expect(log).toHaveBeenCalledWith(
+      `[gateway] Slack user alignment succeeded: agor_user=${shortId(alignedUser.user_id)}`
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    log.mockRestore();
+  });
+
+  it('keeps the Slack account-miss message user-facing while logging only the outcome', async () => {
+    const channel = {
+      ...slackChannel,
+      agor_user_id: null,
+      config: { align_slack_users: true },
+    } as GatewayChannel;
+    const sendMessage = vi.fn(async () => 'sent');
+    const { service } = makeGatewayHarness({
+      channel,
+      alignedUser: null,
+      connector: { sendMessage },
+    });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      user_name: sensitive.slackUsername,
+      metadata: {
+        channel_type: 'im',
+        slack_user_email: sensitive.email,
+      },
+    });
+
+    expect(result).toEqual({ success: false, sessionId: '', created: false });
+    expect(log).toHaveBeenCalledWith(
+      '[gateway] Slack user alignment failed: result=agor_user_not_found'
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: sensitive.threadId,
+        text: expect.stringContaining(sensitive.email),
+      })
+    );
+    log.mockRestore();
+  });
+
+  it('logs a fixed Slack identity-unavailable category without username or thread identity', async () => {
+    const channel = {
+      ...slackChannel,
+      agor_user_id: null,
+      config: { align_slack_users: true },
+    } as GatewayChannel;
+    const sendMessage = vi.fn(async () => 'sent');
+    const { service } = makeGatewayHarness({ channel, connector: { sendMessage } });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      user_name: sensitive.slackUsername,
+      metadata: { channel_type: 'im' },
+    });
+
+    expect(result).toEqual({ success: false, sessionId: '', created: false });
+    expect(log).toHaveBeenCalledWith(
+      '[gateway] Slack user alignment failed: result=identity_email_unavailable'
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: sensitive.threadId })
+    );
+    log.mockRestore();
+  });
+
+  it('keeps the GitHub rejection user-facing while logging only the fixed outcome', async () => {
+    const channel = {
+      ...slackChannel,
+      channel_type: 'github',
+      agor_user_id: null,
+      config: { align_github_users: true },
+    } as GatewayChannel;
+    const sendMessage = vi.fn(async () => 'sent');
+    vi.mocked(getConnector).mockReturnValue({ sendMessage } as never);
+    const { service } = makeGatewayHarness({ channel, alignedUser: null });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      metadata: {
+        github_user: sensitive.externalId,
+        github_user_email: sensitive.email,
+        processing_comment_id: 42,
+      },
+    });
+
+    expect(result).toEqual({ success: false, sessionId: '', created: false });
+    expect(log).toHaveBeenCalledWith(
+      '[gateway] GitHub user alignment failed: result=agor_user_not_found'
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: sensitive.threadId,
+        text: expect.stringContaining(`@${sensitive.externalId}`),
+      })
+    );
+    log.mockRestore();
+  });
+
+  it('keeps Shortcut routing fields out of its fixed alignment-failure log', async () => {
+    const channel = {
+      ...slackChannel,
+      channel_type: 'shortcut',
+      agor_user_id: null,
+      config: { align_shortcut_users: true },
+    } as GatewayChannel;
+    const sendMessage = vi.fn(async () => 'sent');
+    vi.mocked(getConnector).mockReturnValue({ sendMessage } as never);
+    const { service } = makeGatewayHarness({ channel, alignedUser: null });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await service.create({
+      channel_key: channel.channel_key,
+      thread_id: sensitive.threadId,
+      text: 'hello',
+      metadata: {
+        shortcut_user: sensitive.externalId,
+        shortcut_user_email: sensitive.email,
+        processing_comment_id: 42,
+      },
+    });
+
+    expect(result).toEqual({ success: false, sessionId: '', created: false });
+    expect(log).toHaveBeenCalledWith(
+      '[gateway] Shortcut user alignment failed: result=agor_user_not_found'
+    );
+    expectNoSensitiveValues(capturedOutput(log));
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: sensitive.threadId })
+    );
+    log.mockRestore();
   });
 });
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -787,12 +787,12 @@ export class GatewayService {
       const matched = await this.usersRepo.findByEmailForAlignment(mappedEmail);
       if (matched) {
         console.log(
-          `[gateway] ${platform} user aligned via user_map: ${externalId} → ${mappedEmail} → Agor user ${shortId(matched.user_id)}`
+          `[gateway] ${platform} user alignment succeeded: source=user_map agor_user=${shortId(matched.user_id)}`
         );
         return matched;
       }
       console.warn(
-        `[gateway] user_map entry ${externalId} → ${mappedEmail} but no Agor user with that email`
+        `[gateway] ${platform} user alignment failed: source=user_map result=agor_user_not_found`
       );
     }
 
@@ -802,7 +802,7 @@ export class GatewayService {
       const matched = await this.usersRepo.findByEmailForAlignment(normalizedEmail);
       if (matched) {
         console.log(
-          `[gateway] ${platform} user aligned via email: ${externalId ?? 'unknown'} (${normalizedEmail}) → Agor user ${shortId(matched.user_id)}`
+          `[gateway] ${platform} user alignment succeeded: source=email agor_user=${shortId(matched.user_id)}`
         );
         return matched;
       }
@@ -1882,11 +1882,11 @@ export class GatewayService {
 
         if (matchedUser) {
           console.log(
-            `[gateway] Slack user aligned: ${email} → Agor user ${shortId(matchedUser.user_id)} (${matchedUser.name || matchedUser.email})`
+            `[gateway] Slack user alignment succeeded: agor_user=${shortId(matchedUser.user_id)}`
           );
           user = await usersService.get(matchedUser.user_id);
         } else {
-          console.log(`[gateway] Slack user alignment failed: no Agor user with email ${email}`);
+          console.log('[gateway] Slack user alignment failed: result=agor_user_not_found');
           this.sendSystemMessage(
             channel,
             data.thread_id,
@@ -1902,9 +1902,7 @@ export class GatewayService {
         // Alignment is enabled but email couldn't be resolved (missing
         // users:read.email scope, Slack API error, or no email on profile).
         // Reject instead of silently falling back to channel owner.
-        console.log(
-          `[gateway] Slack user alignment failed: could not resolve email for Slack user ${data.user_name ?? 'unknown'} (thread=${data.thread_id})`
-        );
+        console.log('[gateway] Slack user alignment failed: result=identity_email_unavailable');
         this.sendSystemMessage(
           channel,
           data.thread_id,
@@ -1936,9 +1934,7 @@ export class GatewayService {
         user = await usersService.get(matchedUser.user_id);
       } else {
         // Reject — no silent fallback to channel owner.
-        console.log(
-          `[gateway] GitHub user alignment failed: no Agor mapping for ${githubLogin ?? 'unknown'} (thread=${data.thread_id})`
-        );
+        console.log('[gateway] GitHub user alignment failed: result=agor_user_not_found');
         // Edit the Processing comment with rejection message (if we have one)
         if (data.metadata?.processing_comment_id) {
           try {
@@ -1977,9 +1973,7 @@ export class GatewayService {
       } else {
         // Reject — no silent fallback to channel owner. Deliver the rejection by
         // editing the "👀 on it" ack (or a fresh comment if the ack is absent).
-        console.log(
-          `[gateway] Shortcut user alignment failed: no Agor mapping for ${shortcutMemberId ?? 'unknown'} (thread=${data.thread_id})`
-        );
+        console.log('[gateway] Shortcut user alignment failed: result=agor_user_not_found');
         try {
           const connector = getConnector(channel.channel_type as ChannelType, channel.config);
           await connector.sendMessage({


### PR DESCRIPTION
## Summary

Redact sensitive user and channel details from gateway alignment logs while retaining useful operational context.

## Why / root cause

Gateway alignment paths logged raw identity and delivery metadata. Depending on the provider and outcome, those arguments could include emails, names, external IDs, Slack usernames, or thread IDs.

## Implementation

- Emit fixed alignment outcomes with provider/source context instead of raw identity or delivery values.
- Retain only safe Agor short IDs where a user identifier is operationally useful.
- Cover success, fallback, account-miss, identity-unavailable, and provider-rejection outcomes with consolidated regression tests.
- Keep user-facing messages, delivery behavior, and routing unchanged.

Operational logs now use fixed outcomes/provider/source plus safe Agor short IDs and omit emails, names, external IDs, Slack usernames, and thread IDs.

## Validation

- Focused gateway tests: 47/47 passed
- Source-aware daemon TypeScript check: passed
- Biome checks on both changed files: passed
- Multitenancy boundary guard: passed
- Diff boundary and whitespace checks: passed

## Risks / rollback

The main operational tradeoff is reduced raw identity detail in gateway logs; troubleshooting should use the retained outcome/provider/source fields and safe Agor short IDs. No routing or user-facing behavior changes are expected. Roll back by reverting the two commits in this PR if the reduced log detail impedes operations.
