### PR TITLE
fix(docs): pair First/Last name on one row in the contact form, Email on its own

### DIFF
--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -33,6 +33,26 @@ const HUBSPOT_SCRIPT_SRC = 'https://js.hsforms.net/forms/embed/v2.js';
 // it (nav bar, hero, footer, a specific blog post, etc.) — see `sourceCta`.
 const SOURCE_FIELD_NAME = 'source_page';
 
+// The form's field-group layout (which fields share a row) is set in the
+// HubSpot form editor's UI, not here — currently First name sits alone on
+// its own row, with Email and Last name paired below it. Reparent the DOM
+// nodes into First+Last paired / Email alone instead, reusing HubSpot's own
+// form-columns-1/form-columns-2 classes (and their responsive behavior) so
+// we don't have to reimplement column layout. display:contents doesn't
+// reliably promote a <fieldset>'s children to grid/flex items across
+// browsers, which rules out a pure-CSS reorder here.
+function reorderNameFields(target: HTMLElement) {
+  const firstnameField = target.querySelector('.hs_firstname');
+  const lastnameField = target.querySelector('.hs_lastname');
+  const firstFieldset = firstnameField?.closest('fieldset');
+  const pairFieldset = lastnameField?.closest('fieldset');
+  if (!firstnameField || !lastnameField || !firstFieldset || !pairFieldset) return;
+  if (firstFieldset === pairFieldset) return; // already paired — nothing to do
+  firstFieldset.appendChild(lastnameField); // moves it out of pairFieldset
+  firstFieldset.className = firstFieldset.className.replace('form-columns-1', 'form-columns-2');
+  pairFieldset.className = pairFieldset.className.replace('form-columns-2', 'form-columns-1');
+}
+
 // HubSpot v2 renders the form inline into our target div and injects
 // whatever we pass via `css` as a <style> tag in the document head. We
 // scope everything under `.hs-form-private` (HubSpot's form class) so
@@ -172,6 +192,7 @@ export function HubSpotForm({
       target: `#${targetId}`,
       css: HUBSPOT_FORM_CSS,
       onFormReady: () => {
+        reorderNameFields(target);
         // Stamp the hidden attribution field directly in the DOM — set
         // .value and dispatch input/change so HubSpot's own listeners (and
         // any field-dependent validation) see the update, same as a user


### PR DESCRIPTION
## Summary

The Agor Cloud contact form's field layout was awkward: First name sat alone on its own row, with Email and Last name paired together on the row below. Should be First name + Last name paired, Email on its own row.

Root cause: this is HubSpot's own field-group configuration (set in the [HubSpot form editor](https://app-na2.hubspot.com/forms/246818610/editor/56f5b614-72f0-4412-9247-33b53715fda4/edit), not this repo) — the form renders as raw inline HTML (not an iframe), with each row wrapped in a `<fieldset class="form-columns-1">` or `<fieldset class="form-columns-2">`.

- First attempt: a pure CSS reorder (`display: grid` + `order`, with the fieldsets set to `display: contents` so their children become direct grid items). Didn't work — browsers don't support `display: contents` on `<fieldset>` elements, so the fieldset boxes never actually hand off layout to their children, `!important` or not.
- Fix: reparent the rendered DOM nodes in the existing `onFormReady` callback (same place the hidden `source_page` attribution field is already being manipulated) — move the Last name field into First name's fieldset and swap the two fieldsets' `form-columns-1`/`form-columns-2` classes. This reuses HubSpot's own responsive column CSS instead of reimplementing it.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Live browser check via Chrome DevTools Protocol: First name and Last name render side by side with Email full-width below at desktop width.
- [x] Same check at mobile width (380px): correctly collapses to a single stacked column via HubSpot's own responsive rules — same behavior it already had for the (wrongly paired) Email/Last name row before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)