### PR TITLE
fix(ui): keep the session model chip inside its own border

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -183,6 +183,32 @@ describe('SessionFooter', () => {
     expect(screen.getByTestId('model-chip')).toBeInTheDocument();
   });
 
+  it('Model chip truncates a long provider/model id instead of overflowing its border', () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        session={
+          {
+            ...baseSession,
+            agentic_tool: 'opencode',
+            model_config: {
+              model: 'kimi-for-coding-highspeed',
+              provider: 'kimi-for-coding',
+              mode: 'exact',
+            },
+          } as unknown as Session
+        }
+      />,
+      { wrapper: Wrapper }
+    );
+    const chip = screen.getByTestId('model-chip');
+    const label = 'kimi-for-coding/kimi-for-coding-highspeed';
+    // Full id stays reachable on hover even when the chip has to ellipsize.
+    expect(chip).toHaveAttribute('title', label);
+    expect(chip.style.maxWidth).toBe('100%');
+    expect(within(chip).getByText(label).style.textOverflow).toBe('ellipsis');
+  });
+
   it('Timer chip renders as a plain div when footerTimerTask is present', () => {
     const timerTask = {
       task_id: 't1',

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1376,24 +1376,17 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                 <Tag
                   icon={<RobotOutlined />}
                   color="default"
+                  truncate
+                  title={modelName}
                   style={{
                     cursor: managedByPreset ? 'default' : 'pointer',
                     height: 22,
                     display: 'inline-flex',
                     alignItems: 'center',
-                    maxWidth: 180,
                   }}
                   data-testid="model-chip"
                 >
-                  <span
-                    style={{
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {modelName}
-                  </span>
+                  {modelName}
                 </Tag>
               </Popover>
             )}

--- a/apps/agor-ui/src/components/Tag/Tag.test.tsx
+++ b/apps/agor-ui/src/components/Tag/Tag.test.tsx
@@ -1,0 +1,78 @@
+import { RobotOutlined } from '@ant-design/icons';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Tag } from './Tag';
+
+const LONG_LABEL = 'kimi-for-coding/kimi-for-coding-highspeed';
+
+describe('Tag', () => {
+  it('renders the outlined variant by default', () => {
+    render(<Tag data-testid="tag">plain</Tag>);
+    expect(screen.getByTestId('tag').className).toContain('outlined');
+  });
+
+  it('clips the label, not the tag, so a long value stays inside the border', () => {
+    render(
+      <Tag icon={<RobotOutlined />} truncate data-testid="tag">
+        {LONG_LABEL}
+      </Tag>
+    );
+    const root = screen.getByTestId('tag');
+    // The tag itself must stay unclipped — `overflow: hidden` here would eat
+    // antd's click ripple; `minWidth: 0` is what lets it shrink instead.
+    expect(root.style.overflow).toBe('');
+    expect(root.style.maxWidth).toBe('100%');
+    expect(root.style.minWidth).toBe('0');
+    const label = screen.getByText(LONG_LABEL);
+    expect(label).not.toBe(root);
+    expect(label.style.minWidth).toBe('0');
+    expect(label.style.overflow).toBe('hidden');
+    expect(label.style.textOverflow).toBe('ellipsis');
+  });
+
+  it('gives an icon-less tag its own label box to clip', () => {
+    render(
+      <Tag truncate data-testid="tag">
+        {LONG_LABEL}
+      </Tag>
+    );
+    // antd renders bare children when there is no icon, and a flex root makes
+    // ellipsis on the root inert — so truncate has to supply the label box.
+    const label = screen.getByText(LONG_LABEL);
+    expect(label).not.toBe(screen.getByTestId('tag'));
+    expect(label.style.overflow).toBe('hidden');
+    expect(label.style.textOverflow).toBe('ellipsis');
+  });
+
+  it('keeps truncating when the caller also styles another part', () => {
+    render(
+      <Tag icon={<RobotOutlined />} truncate styles={{ icon: { fontSize: 20 } }}>
+        {LONG_LABEL}
+      </Tag>
+    );
+    expect(screen.getByText(LONG_LABEL).style.textOverflow).toBe('ellipsis');
+    expect(screen.getByRole('img', { name: 'robot' }).style.fontSize).toBe('20px');
+  });
+
+  it('leaves layout untouched without truncate', () => {
+    render(
+      <Tag icon={<RobotOutlined />} data-testid="tag">
+        {LONG_LABEL}
+      </Tag>
+    );
+    expect(screen.getByTestId('tag').style.maxWidth).toBe('');
+    expect(screen.getByText(LONG_LABEL).style.textOverflow).toBe('');
+  });
+
+  it('lets a caller style override the truncation defaults', () => {
+    render(
+      <Tag icon={<RobotOutlined />} truncate style={{ maxWidth: 120 }} data-testid="tag">
+        {LONG_LABEL}
+      </Tag>
+    );
+    const root = screen.getByTestId('tag');
+    expect(root.style.maxWidth).toBe('120px');
+    expect(root.style.display).toBe('inline-flex');
+    expect(screen.getByText(LONG_LABEL).style.textOverflow).toBe('ellipsis');
+  });
+});

--- a/apps/agor-ui/src/components/Tag/Tag.tsx
+++ b/apps/agor-ui/src/components/Tag/Tag.tsx
@@ -1,9 +1,41 @@
 import type { TagProps as AntTagProps } from 'antd';
 import { Tag as AntTag } from 'antd';
-import { forwardRef } from 'react';
+import { type CSSProperties, forwardRef } from 'react';
 
 export interface TagProps extends AntTagProps {
-  // All antd Tag props are inherited
+  /**
+   * Grow up to the available width, then ellipsize inside the border instead of
+   * painting past it. Needs an ancestor with a definite width — a percentage
+   * max-width is inert under a shrink-to-fit parent (table cell, `inline-block`
+   * wrapper), so pass a numeric `style.maxWidth` there too.
+   */
+  truncate?: boolean;
+}
+
+/** `minWidth` (not `overflow: hidden`) lets the tag shrink, so the click ripple stays unclipped. */
+const TRUNCATE_STYLE: CSSProperties = {
+  maxWidth: '100%',
+  minWidth: 0,
+  display: 'inline-flex',
+  alignItems: 'center',
+};
+
+/** The label is a flex item, so `minWidth` is what defeats its min-content floor. */
+const TRUNCATE_LABEL_STYLE: CSSProperties = {
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+};
+
+/** Merge per key: styling one part must not silently drop the truncation. */
+function withTruncateStyles(styles: AntTagProps['styles']): AntTagProps['styles'] {
+  if (typeof styles === 'function') {
+    return (info: Parameters<typeof styles>[0]) => {
+      const resolved = styles(info);
+      return { ...resolved, content: { ...TRUNCATE_LABEL_STYLE, ...resolved?.content } };
+    };
+  }
+  return { ...styles, content: { ...TRUNCATE_LABEL_STYLE, ...styles?.content } };
 }
 
 /**
@@ -13,8 +45,24 @@ export interface TagProps extends AntTagProps {
  * consistent outlined styling across the application.
  */
 const TagComponent = forwardRef<HTMLSpanElement, TagProps>(
-  ({ variant = 'outlined', ...props }, ref) => {
-    return <AntTag ref={ref} variant={variant} {...props} />;
+  ({ variant = 'outlined', truncate = false, icon, style, styles, children, ...props }, ref) => {
+    return (
+      <AntTag
+        ref={ref}
+        variant={variant}
+        icon={icon}
+        style={truncate ? { ...TRUNCATE_STYLE, ...style } : style}
+        styles={truncate ? withTruncateStyles(styles) : styles}
+        {...props}
+      >
+        {/* antd only moves children into a styleable span when an icon is set. */}
+        {truncate && !icon && children != null ? (
+          <span style={TRUNCATE_LABEL_STYLE}>{children}</span>
+        ) : (
+          children
+        )}
+      </AntTag>
+    );
   }
 );
 


### PR DESCRIPTION
## Summary

- Add an opt-in `truncate` prop to the shared `Tag` wrapper that owns chip-label truncation correctly in one place
- Use it for the session footer model chip, replacing a hand-rolled inner span and a hard `maxWidth: 180` cap
- The chip now grows with the available info-bar width and ellipsizes only when it has to, with the full `provider/model` id on hover

## Why / context

On sessions whose model id is long — OpenCode reports `provider/model`, e.g. `kimi-for-coding/kimi-for-coding-highspeed` — the label rendered straight through the chip's border and background instead of being clipped.

Root cause: the chip capped itself at `maxWidth: 180` and put `overflow`/`text-overflow` on a custom inner `<span>`. Neither rule could take effect.

- When a tag has an `icon`, antd moves the children into its own content span, so the custom span sat *inside* that element — and `text-overflow` does not apply to an inline box anyway.
- That content span is a flex item whose automatic minimum size is its min-content width. For nowrap text that is the full label width, so it never shrank and the text escaped the 180px border box.

## Screenshot
<img width="276" height="84" alt="Screenshot 2026-08-07 at 17 12 29" src="https://github.com/user-attachments/assets/275c4e13-cc01-425f-8e20-2f37916817e7" />


## Implementation notes

`truncate` keeps the tricky part in the owning component rather than at each call site, per the styling hierarchy in `context/guidelines/frontend.md` (AntD semantic `styles` API above inline style, both above CSS, and no `.ant-*` overrides):

- The **label box** clips and ellipsizes itself — antd's content span via `styles.content` when there is an icon, or a span this wrapper supplies when there is not (antd renders bare children in that case, and ellipsis on a flex root is inert).
- The **root** gets `minWidth: 0`, not `overflow: hidden`. Zeroing the min-content floor is what lets the chip shrink; clipping the root would also clip the click ripple antd renders inside the tag, so a clickable chip would lose its press feedback.
- Caller-supplied `styles` are **merged per key**, so styling one part (say the icon) cannot silently drop truncation. `style` merges the same way, with the caller winning on conflicts.
- The prop's doc comment states the one precondition: a percentage max-width needs an ancestor with a definite width, so a shrink-to-fit parent (table cell, `inline-block` wrapper) should also pass a numeric `style.maxWidth`.

Call sites stay declarative — the model chip is now `<Tag icon={...} truncate title={modelName}>`.

## Validation / test plan

- [x] `pnpm vitest run` in `apps/agor-ui` — 187 files, 1277 tests pass
- [x] 6 cases in the new `Tag.test.tsx` pin the contract: label clips while the root stays unclipped, the icon-less path gets its own label box, truncation survives a caller styling another part, and `truncate` off leaves layout untouched
- [x] 1 case in `SessionFooter.test.tsx` covers the reported `kimi-for-coding/kimi-for-coding-highspeed` chip
- [x] Biome clean on every touched file; pre-commit hooks ran normally
- [x] `pnpm typecheck` — no new errors. The 7 pre-existing errors under these paths (stale `packages/client` build artifacts: `reasoningEffortLevels`, `isAgenticToolName`) are identical before and after this branch, and `Tag.tsx` reports none
- [ ] Rendered before/after not captured here — the dev UI requires a signed-in session. Easiest check: open a session whose model id is longer than the chip and confirm the label ellipsizes inside the border and reads in full on hover

## Risks / rollout / rollback

Low. `truncate` defaults to `false`, so all 28 existing `Tag` consumers render byte-identically; only the model chip opts in. No API, data, or config changes. Rollback is reverting the commit.

Known trade-off: without the 180px cap, a very long id can claim the whole info-bar row and wrap the neighbouring chips (tokens, context, IDs) onto an extra line in a narrow panel. That is the intended direction — the hard cap is what produced the reported bug — but it is worth a look if the footer feels tall on small panels.

## Out of scope / follow-ups

- `Pill.tsx` still hand-rolls the same clipping for `IssuePill`/`PullRequestPill` (`pillTextStyle`, `maxWidth: 220`). Migrating those to `truncate` is the natural next step and matches the "converge repeated pill treatments" follow-up in the frontend guidelines.
- The `{cursor, height: 22, display: 'inline-flex', alignItems: 'center'}` chip style is still duplicated across the footer info-bar chips and `SessionMcpFooterControl`; extracting a small footer-chip component would remove it.
