### PR TITLE
fix: publish agentic tool wrappers under the @agor-live scope

### DIFF
--- a/apps/agor-cli/src/lib/agentic-tool-diagnostics.test.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-diagnostics.test.ts
@@ -42,7 +42,7 @@ describe('agentic tool diagnostics', () => {
       join(install, 'agor-integration.json'),
       JSON.stringify({
         agorVersion: '0.24.0',
-        packageName: '@agor/codex',
+        packageName: '@agor-live/codex',
         packageVersion: '0.24.0',
         installedAt: new Date().toISOString(),
       })

--- a/apps/agor-cli/src/lib/agentic-tool-integrations.test.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-integrations.test.ts
@@ -83,21 +83,21 @@ describe('listManagedAgorVersions', () => {
 describe('listInstalledAgenticTools', () => {
   it('lists tools that have a verified manifest', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
-    await installFixture(root, '0.24.0', 'codex', '@agor/codex');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
+    await installFixture(root, '0.24.0', 'codex', '@agor-live/codex');
 
     expect((await listInstalledAgenticTools('0.24.0')).sort()).toEqual(['claude-code', 'codex']);
   });
 
   it('skips directories whose manifest is missing or misaligned', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
     // A half-finished install: directory exists, no manifest.
     await mkdir(join(root, '0.24.0', 'codex'), { recursive: true });
     // A manifest that disagrees with the directory it lives in.
-    await installFixture(root, '0.24.0', 'gemini', '@agor/gemini', {
+    await installFixture(root, '0.24.0', 'gemini', '@agor-live/gemini', {
       agorVersion: '0.23.0',
-      packageName: '@agor/gemini',
+      packageName: '@agor-live/gemini',
       packageVersion: '0.23.0',
       installedAt: new Date().toISOString(),
     });
@@ -107,7 +107,7 @@ describe('listInstalledAgenticTools', () => {
 
   it('ignores directory names that are not known tools', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
     await mkdir(join(root, '0.24.0', 'not-a-tool'), { recursive: true });
 
     expect(await listInstalledAgenticTools('0.24.0')).toEqual(['claude-code']);
@@ -117,9 +117,9 @@ describe('listInstalledAgenticTools', () => {
 describe('findRestorableAgenticTools', () => {
   it('returns the newest older version that still has tools', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.22.0', 'gemini', '@agor/gemini');
-    await installFixture(root, '0.23.0', 'claude-code', '@agor/claude');
-    await installFixture(root, '0.23.0', 'codex', '@agor/codex');
+    await installFixture(root, '0.22.0', 'gemini', '@agor-live/gemini');
+    await installFixture(root, '0.23.0', 'claude-code', '@agor-live/claude');
+    await installFixture(root, '0.23.0', 'codex', '@agor-live/codex');
 
     const restorable = await findRestorableAgenticTools('0.24.0');
 
@@ -129,7 +129,7 @@ describe('findRestorableAgenticTools', () => {
 
   it('skips older versions whose directories hold nothing usable', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.22.0', 'gemini', '@agor/gemini');
+    await installFixture(root, '0.22.0', 'gemini', '@agor-live/gemini');
     await mkdir(join(root, '0.23.0', 'codex'), { recursive: true }); // no manifest
 
     expect((await findRestorableAgenticTools('0.24.0'))?.version).toBe('0.22.0');
@@ -137,8 +137,8 @@ describe('findRestorableAgenticTools', () => {
 
   it('never restores from the current or a newer version', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
-    await installFixture(root, '0.25.0', 'codex', '@agor/codex');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
+    await installFixture(root, '0.25.0', 'codex', '@agor-live/codex');
 
     expect(await findRestorableAgenticTools('0.24.0')).toBeNull();
   });
@@ -153,8 +153,8 @@ describe('findRestorableAgenticTools', () => {
 describe('removeManagedAgorVersion', () => {
   it('removes a version directory and leaves the others intact', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.23.0', 'claude-code', '@agor/claude');
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
+    await installFixture(root, '0.23.0', 'claude-code', '@agor-live/claude');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
 
     await removeManagedAgorVersion('0.23.0');
 
@@ -163,7 +163,7 @@ describe('removeManagedAgorVersion', () => {
 
   it('is a no-op for a version that is not installed', async () => {
     const root = await createRoot();
-    await installFixture(root, '0.24.0', 'claude-code', '@agor/claude');
+    await installFixture(root, '0.24.0', 'claude-code', '@agor-live/claude');
 
     await expect(removeManagedAgorVersion('0.19.0')).resolves.toBeUndefined();
     expect(await listManagedAgorVersions()).toEqual(['0.24.0']);

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -67,12 +67,12 @@ an actionable error with the corresponding `agor install` command.
 
 | Agentic tool | Install command | Managed package |
 | --- | --- | --- |
-| Claude Code | `agor install claude` | `@agor/claude` |
-| Codex | `agor install codex` | `@agor/codex` |
-| Gemini | `agor install gemini` | `@agor/gemini` |
-| GitHub Copilot | `agor install copilot` | `@agor/copilot` |
-| OpenCode | `agor install opencode` | `@agor/opencode` |
-| Cursor | `agor install cursor` | `@agor/cursor` |
+| Claude Code | `agor install claude` | `@agor-live/claude` |
+| Codex | `agor install codex` | `@agor-live/codex` |
+| Gemini | `agor install gemini` | `@agor-live/gemini` |
+| GitHub Copilot | `agor install copilot` | `@agor-live/copilot` |
+| OpenCode | `agor install opencode` | `@agor-live/opencode` |
+| Cursor | `agor install cursor` | `@agor-live/cursor` |
 
 For automated images and CI, run the same noninteractive commands after installing Agor:
 

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/claude",
+  "name": "@agor-live/claude",
   "version": "0.24.0",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/codex",
+  "name": "@agor-live/codex",
   "version": "0.24.0",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/copilot",
+  "name": "@agor-live/copilot",
   "version": "0.24.0",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/cursor",
+  "name": "@agor-live/cursor",
   "version": "0.24.0",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/gemini",
+  "name": "@agor-live/gemini",
   "version": "0.24.0",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agor/opencode",
+  "name": "@agor-live/opencode",
   "version": "0.24.0",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",

--- a/packages/core/src/agentic-integrations.test.ts
+++ b/packages/core/src/agentic-integrations.test.ts
@@ -34,7 +34,7 @@ async function createFakeManagedClaude(version: string): Promise<string> {
   const packageDirectory = join(
     getAgenticToolInstallDir('claude-code', version),
     'node_modules',
-    '@agor',
+    '@agor-live',
     'claude'
   );
   const vendorDirectory = join(
@@ -47,7 +47,7 @@ async function createFakeManagedClaude(version: string): Promise<string> {
   await mkdir(vendorDirectory, { recursive: true });
   await writeFile(
     join(packageDirectory, 'package.json'),
-    JSON.stringify({ name: '@agor/claude', type: 'module', exports: './index.js' })
+    JSON.stringify({ name: '@agor-live/claude', type: 'module', exports: './index.js' })
   );
   await writeFile(
     join(vendorDirectory, 'package.json'),

--- a/packages/core/src/agentic-integrations.ts
+++ b/packages/core/src/agentic-integrations.ts
@@ -6,27 +6,31 @@ import { pathToFileURL } from 'node:url';
 
 export const AGENTIC_TOOL_INTEGRATIONS = {
   'claude-code': {
-    packageName: '@agor/claude',
+    packageName: '@agor-live/claude',
     vendorPackage: '@anthropic-ai/claude-agent-sdk',
     displayName: 'Claude Code',
   },
-  codex: { packageName: '@agor/codex', vendorPackage: '@openai/codex-sdk', displayName: 'Codex' },
+  codex: {
+    packageName: '@agor-live/codex',
+    vendorPackage: '@openai/codex-sdk',
+    displayName: 'Codex',
+  },
   copilot: {
-    packageName: '@agor/copilot',
+    packageName: '@agor-live/copilot',
     vendorPackage: '@github/copilot-sdk',
     displayName: 'GitHub Copilot',
   },
   gemini: {
-    packageName: '@agor/gemini',
+    packageName: '@agor-live/gemini',
     vendorPackage: '@google/gemini-cli-core',
     displayName: 'Gemini',
   },
   opencode: {
-    packageName: '@agor/opencode',
+    packageName: '@agor-live/opencode',
     vendorPackage: '@opencode-ai/sdk',
     displayName: 'OpenCode',
   },
-  cursor: { packageName: '@agor/cursor', vendorPackage: '@cursor/sdk', displayName: 'Cursor' },
+  cursor: { packageName: '@agor-live/cursor', vendorPackage: '@cursor/sdk', displayName: 'Cursor' },
 } as const;
 
 export type InstallableAgenticTool = keyof typeof AGENTIC_TOOL_INTEGRATIONS;

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agor/executor",
   "version": "0.1.0",
+  "private": true,
   "description": "Agor executor process - isolated execution environment",
   "license": "BUSL-1.1",
   "type": "module",

--- a/scripts/check-agentic-tool-packages.mjs
+++ b/scripts/check-agentic-tool-packages.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const root = new URL('..', import.meta.url).pathname;
@@ -20,7 +20,7 @@ for (const dependency of forbiddenBaseDependencies) {
 for (const id of integrations) {
   const directory = join(root, `packages/agor-${id}`);
   const pkg = JSON.parse(await readFile(join(directory, 'package.json'), 'utf8'));
-  if (pkg.name !== `@agor/${id}`) failures.push(`${id}: unexpected package name ${pkg.name}`);
+  if (pkg.name !== `@agor-live/${id}`) failures.push(`${id}: unexpected package name ${pkg.name}`);
   if (pkg.version !== base.version)
     failures.push(`${pkg.name}: ${pkg.version} != agor-live ${base.version}`);
   for (const [name, range] of Object.entries(pkg.dependencies ?? {})) {
@@ -32,6 +32,40 @@ for (const id of integrations) {
     failures.push(`${pkg.name}: source integration version does not match ${base.version}`);
   }
 }
+// Everything publishable must sit in a namespace we own on npm.
+//
+// The six integration wrappers shipped briefly as `@agor/<tool>`. `@agor` is the
+// *private* workspace scope (@agor/core, @agor/git, @agor/agentic-tools, ...) and
+// is not a namespace this project owns on the registry, so `build.sh --publish`
+// died on the very first package with "404 Scope not found". Publishable packages
+// are `agor-live` or `@agor-live/*`; anything `@agor/*` is internal and must say
+// so with `private: true`.
+const PUBLISHABLE_NAME = /^(agor-live|@agor-live\/[a-z0-9-]+)$/;
+for (const parent of ['packages', 'apps']) {
+  let entries;
+  try {
+    entries = await readdir(join(root, parent), { withFileTypes: true });
+  } catch {
+    continue;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    let pkg;
+    try {
+      pkg = JSON.parse(await readFile(join(root, parent, entry.name, 'package.json'), 'utf8'));
+    } catch {
+      continue;
+    }
+    if (pkg.private === true) continue;
+    if (!PUBLISHABLE_NAME.test(pkg.name ?? '')) {
+      failures.push(
+        `${parent}/${entry.name}: "${pkg.name}" is publishable but not under a namespace we own ` +
+          `(expected agor-live or @agor-live/*) — add "private": true if it is internal`
+      );
+    }
+  }
+}
+
 if (failures.length) {
   console.error(failures.map((failure) => `- ${failure}`).join('\n'));
   process.exit(1);


### PR DESCRIPTION
fix: publish agentic tool wrappers under the @agor-live scope

`build.sh --publish` fails on its first package:

    404 Not Found - PUT https://registry.npmjs.org/@agor%2fclaude
    Scope not found

The six integration wrappers were named `@agor/<tool>`, but `@agor` is the
*private* workspace scope — @agor/core, @agor/git, @agor/agentic-tools and
@agor/agentic-tool-opencode are all `private: true` and have never been
published. Nothing in the `@agor` namespace exists on npm and the project does
not own it. The published namespace is `@agor-live` (@agor-live/client), so the
wrappers publish there instead.

Renames only the six published wrappers. The private `@agor/*` packages keep
their names: they are bundled into agor-live/dist with package.json files
generated by build.sh and symlinked as node_modules/@agor/* by postinstall.js,
so renaming them would be a large diff with no user-visible effect.

Nothing was published before the failure — @agor/claude is the first package in
the publish order — so there is no partial release to reconcile, and no
published name changes for anyone.

Also marks @agor/executor private. It was the one remaining publishable package
outside the owned namespace, unpublished and not in build.sh's publish list.

To keep this from recurring, check:agentic-tool-packages now asserts that every
publishable workspace package is `agor-live` or `@agor-live/*`. build.sh runs
that check before publishing, so this class of mistake fails the build instead
of a release.

## Verification

Built, published the full 8-package graph to a local registry under the new names, installed it globally, and re-ran the managed-tool suite: **23/23 pass**, including containment resolving `@agor-live/opencode` inside the managed tree, SDK loading for all three tools, and the OpenCode wrapper at 1.14.33.

The new guard was confirmed to actually fire — it caught `@agor/executor` before I marked it private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)