### PR TITLE
fix(executor): pass the managed agentic tool runtime to sessions

### DIFF
--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.0';
+export const AGOR_INTEGRATION_VERSION = '0.24.1';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/config/env-resolver.test.ts
+++ b/packages/core/src/config/env-resolver.test.ts
@@ -451,3 +451,53 @@ describe('createUserProcessEnvironment — git identity mirroring', () => {
     expect(env.GIT_AUTHOR_EMAIL).toBe('carol@example.com'); // mirrored from committer
   });
 });
+
+// Session executors are spawned with `preparedEnv` built by
+// createUserProcessEnvironment(), which takes precedence over spawn-executor's
+// own env forwarding. If the managed agentic tool vars are not allowlisted here
+// the executor runs with AGOR_MANAGED_AGENTIC_TOOLS unset, falls back to
+// importing the vendor SDK by bare specifier, and every session dies with
+// "Cannot find package '@openai/codex-sdk'".
+describe('createUserProcessEnvironment — managed agentic tool runtime', () => {
+  const MANAGED_VARS = {
+    AGOR_VERSION: '0.24.0',
+    AGOR_AGENTIC_TOOLS_DIR: '/opt/agor/agentic-tools',
+    AGOR_MANAGED_AGENTIC_TOOLS: '1',
+  } as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    for (const [key, value] of Object.entries(MANAGED_VARS)) {
+      saved[key] = process.env[key];
+      process.env[key] = value;
+    }
+  });
+
+  afterAll(() => {
+    for (const key of Object.keys(MANAGED_VARS)) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  dbTest('passes the managed integration runtime through to the executor', async ({ db }) => {
+    const userId = await createUserWithEnv(db, {});
+
+    const env = await createUserProcessEnvironment(userId, db);
+
+    expect(env.AGOR_MANAGED_AGENTIC_TOOLS).toBe('1');
+    expect(env.AGOR_VERSION).toBe('0.24.0');
+    expect(env.AGOR_AGENTIC_TOOLS_DIR).toBe('/opt/agor/agentic-tools');
+  });
+
+  dbTest('still withholds internal secrets', async ({ db }) => {
+    process.env.AGOR_MASTER_SECRET = 'super-secret';
+    try {
+      const userId = await createUserWithEnv(db, {});
+      const env = await createUserProcessEnvironment(userId, db);
+      expect(env.AGOR_MASTER_SECRET).toBeUndefined();
+    } finally {
+      delete process.env.AGOR_MASTER_SECRET;
+    }
+  });
+});

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -89,6 +89,21 @@ export const ALLOWED_ENV_VARS = new Set([
 
   // Agor session context (safe for executor/sessions)
   'DAEMON_URL',
+
+  // Managed agentic tool runtime. These locate the version-aligned integration
+  // tree (~/.agor/agentic-tools/<version>/<tool>) that loadManagedAgenticToolSdk
+  // resolves against; they are host runtime metadata, identical for every
+  // tenant, and carry no credentials.
+  //
+  // They must be allowlisted, not merely forwarded: session executors are
+  // spawned with `preparedEnv` built by createUserProcessEnvironment(), which
+  // takes precedence over spawn-executor's own forwarding. Without them here
+  // the executor sees AGOR_MANAGED_AGENTIC_TOOLS unset, falls back to importing
+  // the vendor SDK by bare specifier, and every session fails with
+  // "Cannot find package '@openai/codex-sdk'".
+  'AGOR_VERSION',
+  'AGOR_AGENTIC_TOOLS_DIR',
+  'AGOR_MANAGED_AGENTIC_TOOLS',
 ]);
 
 /**


### PR DESCRIPTION
fix(executor): pass the managed agentic tool runtime to sessions

Every session on 0.24.0 fails as soon as it loads an agentic tool:

    Cannot find package '@openai/codex-sdk' imported from
    .../dist/core/agentic-integrations.js

loadManagedAgenticToolSdk() only imports the vendor SDK by bare specifier when
AGOR_MANAGED_AGENTIC_TOOLS !== '1'. That fallback exists for source checkouts,
where the vendor package is a workspace dependency. In a packaged install it
resolves nothing, so the bare import throws.

The daemon does set the variable — bin/agor-daemon.js defaults AGOR_VERSION,
AGOR_AGENTIC_TOOLS_DIR and AGOR_MANAGED_AGENTIC_TOOLS — but it never reaches the
executor. Session executors are spawned with `preparedEnv` (register-services.ts),
built by createUserProcessEnvironment(), and `preparedEnv` takes precedence over
spawn-executor's own forwarding:

    const source = options.preparedEnv ?? (asUser ? executorEnvironmentForImpersonation(env) : env);

createUserProcessEnvironment() builds a deliberately minimal allowlisted
environment and never inherits process.env, so the three variables were dropped.
executorEnvironmentForImpersonation() already forwards them, which is why only
the `preparedEnv` path was affected.

Allowlist them. They locate the version-aligned integration tree, are identical
for every tenant, and carry no credentials — the same rationale already recorded
on the impersonation path. Secrets stay excluded; a test covers that.

Adds a regression test that fails without this change with
"expected undefined to be '1'".

## Impact

**Every session on 0.24.0 fails** when it loads an agentic tool — all six tools, all sessions. Managed integrations install and `agor doctor` reports `ready`, because the CLI process *does* have the variables; only the spawned executor does not. That is why the release smoke passed and this only appears at first prompt.

## Verification

- Regression test fails without the change (`expected undefined to be '1'`) and passes with it
- Secrets remain excluded — covered by a second test asserting `AGOR_MASTER_SECRET` is still withheld
- `@agor/core` config suite: 651 passing
- lint clean

Worth a 0.24.1 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)