### PR TITLE
fix(docs): swap mobile carousel scroll-jack for native side-swipe

### DIFF
--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -2438,28 +2438,15 @@
   }
 }
 
-/* --- Scroll-locked surface carousel: phones with motion allowed. The tall
- * wrapper provides the scroll budget (~55dvh per card transition, heights set
- * inline in the TSX); this block swaps the pill explorer for the pinned
- * stage. Reduced-motion phones keep the pill explorer above. --- */
-@media (max-width: 720px) and (prefers-reduced-motion: no-preference) {
-  /* Showcase carousel pins too: 4 slides x 55dvh of scroll budget + the
-   * pinned screen itself. Keep the multiplier in sync with
-   * showcaseSlides.length. */
+/* --- Phone carousels: native side-swipe via CSS scroll-snap, not a pinned
+ * scroll-jack. Both tracks are normal-height, in-flow elements — flicking
+ * vertically scrolls straight past them like any other section; a horizontal
+ * flick within the frame swipes the cards. See the matching scroll-listener
+ * effects in LandingPage.tsx that keep status line/dots/video-gating in
+ * sync with wherever a swipe settles. --- */
+@media (max-width: 720px) {
   .showcaseSection {
-    height: 320dvh;
-    padding-top: 0;
-  }
-
-  .showcaseSticky {
-    position: sticky;
-    top: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: 100dvh;
-    padding-top: 56px;
-    overflow: hidden;
+    padding: 64px 24px 0;
   }
 
   /* Match the surface carousel's look: status line + dots instead of tab
@@ -2468,7 +2455,7 @@
     display: none;
   }
 
-  /* Scroll drives the carousels on phones — no click layer. */
+  /* Swipe drives the carousels on phones — no click layer. */
   .frameAdvance {
     display: none;
   }
@@ -2482,8 +2469,34 @@
     box-shadow: none;
   }
 
+  .showcaseViewport {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .showcaseViewport::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Neutralize the desktop transform — position comes from native scroll
+   * instead — and let the track size itself to the (single) visible slide
+   * rather than the desktop 400%. */
+  .showcaseTrack {
+    width: 100%;
+    transform: none !important;
+    transition: none;
+  }
+
   .showcaseSlide {
+    width: 100%;
+    flex: 0 0 100%;
+    min-height: 0;
     padding: 0;
+    scroll-snap-align: center;
+    background: none;
   }
 
   .slideVideoFrame {
@@ -2530,19 +2543,11 @@
 
   .surfaceScrolly {
     display: block;
-    position: relative;
     margin-top: 8px;
   }
 
   .scrollySticky {
-    position: sticky;
-    top: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: 100dvh;
-    padding: 76px 0 40px;
-    overflow: hidden;
+    padding: 0;
   }
 
   .scrollyStatus {
@@ -2568,13 +2573,25 @@
     text-transform: uppercase;
   }
 
+  /* .scrollyTrack is the scroll container itself (no separate viewport
+   * wrapper needed, unlike the showcase reel above). */
   .scrollyTrack {
     display: flex;
-    will-change: transform;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .scrollyTrack::-webkit-scrollbar {
+    display: none;
   }
 
   .scrollyCard {
-    flex-shrink: 0;
+    flex: 0 0 100%;
+    box-sizing: border-box;
+    scroll-snap-align: center;
     padding: 0 24px;
   }
 

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -575,9 +575,8 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
   const [radarInView, setRadarInView] = useState(false);
   const radarScopeRef = useRef<HTMLDivElement>(null);
   const [scrollySurface, setScrollySurface] = useState(0);
-  const scrollyWrapRef = useRef<HTMLDivElement>(null);
   const scrollyTrackRef = useRef<HTMLDivElement>(null);
-  const showcasePinRef = useRef<HTMLElement>(null);
+  const showcaseViewportRef = useRef<HTMLDivElement>(null);
   const slideVideoRefs = useRef<Array<HTMLVideoElement | null>>([]);
 
   // Showcase carousel playback gating: only the active slide's video plays;
@@ -623,9 +622,9 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
-          // Very tall sections (e.g. the scroll-locked surface carousel) can
-          // never reach the 14% ratio in a phone viewport, so also reveal
-          // once the visible slice fills a third of the screen.
+          // Very tall sections can never reach the 14% ratio in a phone
+          // viewport, so also reveal once the visible slice fills a third
+          // of the screen.
           if (
             entry.isIntersecting &&
             (entry.intersectionRatio >= 0.14 ||
@@ -646,113 +645,87 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
     return () => observer.disconnect();
   }, []);
 
-  // Scroll-locked surface carousel (phones): while .surfaceScrolly's tall
-  // wrapper crosses the viewport, its sticky stage pins and vertical scroll
-  // progress maps onto the track's horizontal position. Sticky + transform
-  // only — native scrolling is never intercepted, so flicking straight
-  // through remains possible. Desktop and reduced-motion phones never match
-  // the media query (CSS shows the pill explorer instead).
+  // Native swipe carousel (phones): .scrollyTrack is itself the horizontally
+  // scrollable element (CSS scroll-snap), so a flick moves it and vertical
+  // page scroll is never touched — no pinning, no artificial section height.
+  // This listener just keeps `scrollySurface` (status line, dots) in sync
+  // with wherever the user's swipe lands, debounced to the settle rather
+  // than firing on every scroll frame.
   useEffect(() => {
-    const wrap = scrollyWrapRef.current;
     const track = scrollyTrackRef.current;
-    if (!wrap || !track) {
+    if (!track) {
       return;
     }
 
-    const media = window.matchMedia(
-      '(max-width: 720px) and (prefers-reduced-motion: no-preference)'
-    );
-    const count = productPreviews.length;
-    let raf = 0;
+    const media = window.matchMedia('(max-width: 720px)');
+    let settleTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    const update = () => {
-      raf = 0;
+    const onScroll = () => {
       if (!media.matches) {
-        track.style.transform = '';
         return;
       }
-      const rect = wrap.getBoundingClientRect();
-      const range = rect.height - window.innerHeight;
-      const progress = range > 0 ? Math.min(1, Math.max(0, -rect.top / range)) : 0;
-      // Dwell easing: each card parks flush for ~a third of its scroll
-      // segment before handing off, so pausing mid-scroll doesn't strand a
-      // card half off-screen.
-      const pos = progress * (count - 1);
-      const seg = Math.min(count - 2, Math.floor(pos));
-      const frac = pos - seg;
-      const dwell = 0.32;
-      const eased = seg + Math.min(1, Math.max(0, (frac - dwell / 2) / (1 - dwell)));
-      track.style.transform = `translateX(${(-eased * 100) / count}%)`;
-      setScrollySurface(Math.round(eased));
-    };
-    const schedule = () => {
-      if (!raf) {
-        raf = requestAnimationFrame(update);
-      }
+      clearTimeout(settleTimeout);
+      settleTimeout = setTimeout(() => {
+        const width = track.clientWidth;
+        if (!width) {
+          return;
+        }
+        const index = Math.round(track.scrollLeft / width);
+        setScrollySurface(Math.min(productPreviews.length - 1, Math.max(0, index)));
+      }, 100);
     };
 
-    update();
-    window.addEventListener('scroll', schedule, { passive: true });
-    window.addEventListener('resize', schedule);
-    media.addEventListener('change', schedule);
-
+    track.addEventListener('scroll', onScroll, { passive: true });
     return () => {
-      window.removeEventListener('scroll', schedule);
-      window.removeEventListener('resize', schedule);
-      media.removeEventListener('change', schedule);
-      if (raf) {
-        cancelAnimationFrame(raf);
-      }
+      track.removeEventListener('scroll', onScroll);
+      clearTimeout(settleTimeout);
     };
   }, []);
 
-  // Scroll-locked showcase carousel (phones): the pinned section's scroll
-  // progress simply drives setActiveShot, so the track's existing 550ms
-  // transition, tab highlighting, caption, and active-video play/pause
-  // gating stay on the exact same code path as tap navigation. Rounding to
-  // the nearest slide gives natural dwell plateaus between transitions.
+  // Same native-swipe treatment for the showcase reel, plus the reverse
+  // direction: the phone-only arrow buttons still call setActiveShot, so
+  // scroll the viewport to match whenever that state changes elsewhere.
   useEffect(() => {
-    const pin = showcasePinRef.current;
-    if (!pin) {
+    const viewport = showcaseViewportRef.current;
+    if (!viewport) {
       return;
     }
 
-    const media = window.matchMedia(
-      '(max-width: 720px) and (prefers-reduced-motion: no-preference)'
-    );
-    const count = showcaseSlides.length;
-    let raf = 0;
+    const media = window.matchMedia('(max-width: 720px)');
+    let settleTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    const update = () => {
-      raf = 0;
+    const onScroll = () => {
       if (!media.matches) {
         return;
       }
-      const rect = pin.getBoundingClientRect();
-      const range = rect.height - window.innerHeight;
-      if (range <= 0) {
-        return;
-      }
-      const progress = Math.min(1, Math.max(0, -rect.top / range));
-      setActiveShot(Math.round(progress * (count - 1)));
-    };
-    const schedule = () => {
-      if (!raf) {
-        raf = requestAnimationFrame(update);
-      }
+      clearTimeout(settleTimeout);
+      settleTimeout = setTimeout(() => {
+        const width = viewport.clientWidth;
+        if (!width) {
+          return;
+        }
+        const index = Math.round(viewport.scrollLeft / width);
+        setActiveShot(Math.min(showcaseSlides.length - 1, Math.max(0, index)));
+      }, 100);
     };
 
-    window.addEventListener('scroll', schedule, { passive: true });
-    window.addEventListener('resize', schedule);
-
+    viewport.addEventListener('scroll', onScroll, { passive: true });
     return () => {
-      window.removeEventListener('scroll', schedule);
-      window.removeEventListener('resize', schedule);
-      if (raf) {
-        cancelAnimationFrame(raf);
-      }
+      viewport.removeEventListener('scroll', onScroll);
+      clearTimeout(settleTimeout);
     };
   }, []);
+
+  useEffect(() => {
+    const viewport = showcaseViewportRef.current;
+    if (!viewport || !window.matchMedia('(max-width: 720px)').matches) {
+      return;
+    }
+    const target = activeShot * viewport.clientWidth;
+    if (Math.abs(viewport.scrollLeft - target) > 2) {
+      viewport.scrollTo({ left: target, behavior: 'smooth' });
+    }
+  }, [activeShot]);
 
   // Phones show the radar detail card as a fixed bottom overlay; fade it in
   // only while the radar itself is on screen so it never floats over
@@ -881,7 +854,7 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
         </div>
       </section>
 
-      <section className={styles.showcaseSection} data-reveal ref={showcasePinRef}>
+      <section className={styles.showcaseSection} data-reveal>
         {/* Section divider: the docs pages' mint aurora as a thin curtain
             hanging from the seam with the problem section. */}
         <div className={styles.showcaseDivider} aria-hidden="true">
@@ -937,8 +910,10 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
             <span className={styles.scrollyStatusTitle}>{showcaseSlides[activeShot].label}</span>
           </div>
           <div className={styles.showcaseFrame}>
-            <div className={styles.showcaseViewport}>
-              {/* Track is 400% wide with 25% slides — keep in sync with showcaseSlides.length */}
+            <div className={styles.showcaseViewport} ref={showcaseViewportRef}>
+              {/* Track is 400% wide with 25% slides on desktop; phones scroll it
+                  natively instead (see .showcaseTrack's phone override). Keep
+                  the 25%/400% math in sync with showcaseSlides.length. */}
               <div
                 className={styles.showcaseTrack}
                 style={{ transform: `translateX(-${activeShot * 25}%)` }}
@@ -1210,15 +1185,10 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
             </button>
           </div>
         </div>
-        {/* Phone treatment (Claude Design scroll-lock-carousel mock): the
-            stage pins while vertical scroll drives the cards sideways, then
-            hands scrolling back to the page. Heights are inline because they
-            depend on the surface count. */}
-        <div
-          className={styles.surfaceScrolly}
-          ref={scrollyWrapRef}
-          style={{ height: `calc(${productPreviews.length * 55}dvh + 100dvh)` }}
-        >
+        {/* Phone treatment: cards swipe natively via CSS scroll-snap on
+            .scrollyTrack — a normal-height section, so vertical page scroll
+            is never intercepted. */}
+        <div className={styles.surfaceScrolly}>
           <div className={styles.scrollySticky}>
             <div className={styles.scrollyStatus}>
               {/* Same treatment as the showcase status: numeric ornament is
@@ -1234,11 +1204,7 @@ export function LandingPage({ heroVariant }: LandingPageProps = {}) {
                 {productPreviews[scrollySurface].title}
               </span>
             </div>
-            <div
-              className={styles.scrollyTrack}
-              ref={scrollyTrackRef}
-              style={{ width: `${productPreviews.length * 100}%` }}
-            >
+            <div className={styles.scrollyTrack} ref={scrollyTrackRef}>
               {productPreviews.map((preview) => (
                 <article
                   key={preview.title}


### PR DESCRIPTION
## Summary

Fixes the "scroll locking" feel reported on the two phone-only homepage carousels (the "So much more than a chat box" reel and the capabilities explorer). They technically never called `preventDefault` — flicking straight through was always physically possible — but each pinned via `position: sticky` inside an artificially tall wrapper (up to `320dvh`), so clearing one section required several screens' worth of vertical scrolling. That reads as locked even though it wasn't, and people were bouncing off it.

- Both carousels are now normal-height sections using native CSS scroll-snap (`overflow-x: auto; scroll-snap-type: x mandatory`) — an actual side-swipe carousel.
- Vertical page scroll is completely unaffected now — no more pinning, no artificial height. A horizontal swipe within the frame moves the cards.
- A debounced scroll listener on the swipeable element keeps the status line / dots / video-autoplay-gating in sync with wherever a swipe settles, replacing the old vertical-scroll-progress math.
- The showcase reel shares its track/slide classes with the desktop (transform-driven, click-through) treatment, so the phone override neutralizes the inline transform via `!important` — necessary since inline styles always outrank stylesheet rules otherwise. Desktop itself is untouched.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean (one non-blocking `!important` warning, which is required here — see code comment)
- [x] Live browser checks via Chrome DevTools Protocol at phone width (390px): both carousels measure ~500px tall instead of several viewport-heights; `overflow-x`/`scroll-snap-type` are active on the scrollable element; a simulated horizontal scroll correctly updates the slide status/title text after the debounce.
- [x] Same checks at desktop width (1440px): confirmed via computed styles that `.showcaseTrack` still gets its transform and 400% width, and the viewport stays `overflow: hidden` (no scroll-snap container) — desktop renders identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)