### PR TITLE
feat(boards): sober default background + redesigned CSS/background editor

### DIFF
--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.background.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.background.test.tsx
@@ -1,0 +1,86 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: test fixture asserts on a literal CSS gradient value
+import type { AgorClient, Board } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardEditModal } from './BoardEditModal';
+
+// Mock only peripheral deps; the REAL BoardFormFields + BoardBackgroundEditor
+// render so this exercises the full modal → editor lifecycle.
+const showError = vi.hoisted(() => vi.fn());
+vi.mock('@/utils/message', () => ({ useThemedMessage: () => ({ showError }) }));
+vi.mock('../JSONEditor', () => ({
+  JSONEditor: () => <textarea aria-label="Custom Context (JSON)" />,
+  validateJSON: () => Promise.resolve(),
+}));
+
+const CUSTOM_GRADIENT = 'linear-gradient(180deg, #101010, #202020)';
+
+const listedBoard = {
+  board_id: 'board-1',
+  name: 'Styled board',
+  created_by: 'owner-1',
+  created_at: '',
+  last_updated: '',
+} as Board;
+
+function makeClient(board: Board) {
+  const notFound = () => {
+    const err = new Error('not found') as Error & { code?: number };
+    err.code = 404;
+    return Promise.reject(err);
+  };
+  return {
+    service: (name: string) => {
+      if (name === 'boards') return { get: vi.fn().mockResolvedValue(board) };
+      if (name === 'boards/:id/owners' || name === 'boards/:id/group-grants') {
+        return { find: vi.fn(notFound) };
+      }
+      return { findAll: vi.fn().mockResolvedValue([]) };
+    },
+  } as unknown as AgorClient;
+}
+
+async function openCssTabAndReadBackground(): Promise<string> {
+  // Wait for the loaded form, then open the CSS tab and read the editor value.
+  await screen.findByDisplayValue('Styled board');
+  fireEvent.click(screen.getByRole('tab', { name: 'CSS' }));
+  const textarea = (await screen.findByLabelText('Custom background CSS')) as HTMLTextAreaElement;
+  return textarea.value;
+}
+
+describe('BoardEditModal — background editor persistence across reopen', () => {
+  beforeEach(() => showError.mockReset());
+
+  it('shows the saved custom background, and still shows it after close + reopen', async () => {
+    const board = { ...listedBoard, background_color: CUSTOM_GRADIENT } as Board;
+    const client = makeClient(board);
+    const onClose = vi.fn();
+
+    const view = render(
+      <AntApp>
+        <BoardEditModal board={listedBoard} client={client} open onClose={onClose} />
+      </AntApp>
+    );
+
+    expect(await openCssTabAndReadBackground()).toBe(CUSTOM_GRADIENT);
+
+    // Close (destroyOnHidden unmounts the modal content) …
+    view.rerender(
+      <AntApp>
+        <BoardEditModal board={listedBoard} client={client} open={false} onClose={onClose} />
+      </AntApp>
+    );
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Custom background CSS')).not.toBeInTheDocument()
+    );
+
+    // … and reopen: the saved value must round-trip back into Custom mode.
+    view.rerender(
+      <AntApp>
+        <BoardEditModal board={listedBoard} client={client} open onClose={onClose} />
+      </AntApp>
+    );
+    expect(await openCssTabAndReadBackground()).toBe(CUSTOM_GRADIENT);
+  });
+});

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -8,10 +8,10 @@ import type {
   User,
   UUID,
 } from '@agor-live/client';
-import { Alert, Form, Modal } from 'antd';
+import { Alert, Form, Modal, Skeleton } from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
-import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
+import { BoardFormFields, extractBoardFormValues } from '../forms/BoardFormFields';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 
 export interface BoardEditModalProps {
@@ -183,14 +183,18 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
     >
       {loadError ? (
         <Alert type="error" showIcon title="Board settings unavailable" description={loadError} />
+      ) : !loadedBoard ? (
+        // Render the form only once the full board has loaded, so its fields —
+        // including the background editor's mode — initialize from real values
+        // rather than the empty pre-load state (the cause of the mode/checkbox
+        // resetting on reopen).
+        <Skeleton active paragraph={{ rows: 6 }} style={{ marginTop: 16 }} />
       ) : (
         <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
           <BoardFormFields
-            key={board?.board_id}
+            key={loadedBoard.board_id}
             form={form}
-            initialCustomCSS={
-              isCustomCSS(loadedBoard?.background_color) || Boolean(loadedBoard?.custom_css)
-            }
+            backgroundResetSignal={loadedBoard.board_id}
             rbacEnabled={rbacEnabled}
             allUsers={allUsers}
             allGroups={allGroups}

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -76,7 +76,9 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
         }
         if (cancelled) return;
         if (ownerIds.length === 0 && fresh.created_by) ownerIds = [fresh.created_by];
-        setLoadedBoard(fresh);
+        // Populate the form BEFORE exposing loadedBoard so the background
+        // editor mounts against fully-initialized field values (rather than
+        // relying on render batching). loadedBoard is set last, below.
         form.resetFields();
         form.setFieldsValue({
           name: fresh.name,
@@ -94,6 +96,8 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
           board_group_grants: grants,
           custom_context: fresh.custom_context ? JSON.stringify(fresh.custom_context, null, 2) : '',
         });
+        // Expose the loaded board last: this is what un-gates the form render.
+        setLoadedBoard(fresh);
       } catch (error) {
         if (!cancelled) {
           const detail = error instanceof Error ? error.message : String(error);

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -18,7 +18,6 @@
  * own slot, and the footer reads `validByTab[activeTab]`.
  */
 
-import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type { Repo } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -191,7 +190,7 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
     }, ASYNC);
   });
 
-  it('submits Gold Shimmer as the default board background', async () => {
+  it('creates a board with no persisted background (uses the themed default)', async () => {
     const onCreateBoard = vi.fn();
     renderDialog({ defaultTab: 'board', onCreateBoard });
 
@@ -202,10 +201,12 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
     await waitFor(() => expect(button).not.toBeDisabled(), ASYNC);
     fireEvent.click(button);
 
+    // New boards no longer force a stored background — they start on the
+    // theme-aware default, so background_color is cleared (null).
     await waitFor(
       () =>
         expect(onCreateBoard).toHaveBeenCalledWith(
-          expect.objectContaining({ background_color: GOLD_SHIMMER_BOARD_BACKGROUND })
+          expect.objectContaining({ name: 'Launch Board', background_color: null })
         ),
       ASYNC
     );

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
@@ -1,4 +1,3 @@
-import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type { Board } from '@agor-live/client';
 import { Form } from 'antd';
 import { useCallback } from 'react';
@@ -32,14 +31,8 @@ export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef })
   };
 
   return (
-    <Form
-      form={form}
-      layout="vertical"
-      preserve
-      initialValues={{ background_color: GOLD_SHIMMER_BOARD_BACKGROUND }}
-      onValuesChange={handleValuesChange}
-    >
-      <BoardFormFields form={form} autoFocus initialCustomCSS />
+    <Form form={form} layout="vertical" preserve onValuesChange={handleValuesChange}>
+      <BoardFormFields form={form} autoFocus />
     </Form>
   );
 };

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -77,7 +77,7 @@ import {
 } from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
 import { REACT_FLOW_DRAG_HANDLE_SELECTOR } from '../../utils/reactFlowDragClasses';
-import { sanitizeBoardCss } from '../../utils/sanitizeCss';
+import { buildScopedBoardCss } from '../../utils/sanitizeCss';
 import { isDarkTheme } from '../../utils/theme';
 import { AutocompleteTextarea } from '../AutocompleteTextarea/AutocompleteTextarea';
 import BranchCard from '../BranchCard';
@@ -479,29 +479,22 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
-    const hasCustomCss = Boolean(board?.custom_css?.trim());
-    const hasUserBg = Boolean(board?.background_color?.trim());
-    // Any user-provided styling goes through the sanitized <style> tag so that
-    // background_color can't bypass the sanitizer with url()/expression()/etc.
-    const hasUserStyling = hasCustomCss || hasUserBg;
 
-    // Only the trusted defaultBackground is applied inline; anything user-provided
-    // is sanitized and routed through the scoped <style> tag below.
-    const canvasBackground = hasUserStyling ? undefined : defaultBackground;
-
-    // Sanitize and scope custom CSS for this board (enables @keyframes, animations, etc.)
+    // Sanitize + scope any user styling through the shared pipeline so the
+    // canvas and the editor preview can never diverge. Returns '' when the
+    // board is on the default, in which case we apply the trusted inline
+    // themed default instead (user styling never touches an inline style).
     const boardCssClass = board?.board_id ? `board-css-${shortId(board.board_id)}` : '';
-    const scopedCustomCss = useMemo(() => {
-      if (!hasUserStyling) return '';
-      // Prepend background_color as a CSS rule so it's at the same specificity as custom_css
-      // and goes through the same sanitizer.
-      const bgRule = hasUserBg ? `background: ${board?.background_color};\n` : '';
-      const scoped = sanitizeBoardCss(bgRule + (board?.custom_css || ''), `.${boardCssClass}`);
-      if (!scoped) return '';
-      // Respect the user's reduced-motion preference: neutralize any background
-      // animation the custom CSS introduces without touching the static look.
-      return `${scoped}\n\n@media (prefers-reduced-motion: reduce) {\n  .${boardCssClass} { animation: none !important; }\n}`;
-    }, [board?.custom_css, board?.background_color, boardCssClass, hasUserStyling, hasUserBg]);
+    const scopedCustomCss = useMemo(
+      () =>
+        buildScopedBoardCss({
+          backgroundColor: board?.background_color,
+          customCss: board?.custom_css,
+          scopeClass: boardCssClass,
+        }),
+      [board?.custom_css, board?.background_color, boardCssClass]
+    );
+    const canvasBackground = scopedCustomCss ? undefined : defaultBackground;
 
     // Board-scoped board objects: subscribe to only THIS board's bucket so
     // other boards' object churn never re-renders the canvas. The factory is

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -496,7 +496,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       // Prepend background_color as a CSS rule so it's at the same specificity as custom_css
       // and goes through the same sanitizer.
       const bgRule = hasUserBg ? `background: ${board?.background_color};\n` : '';
-      return sanitizeBoardCss(bgRule + (board?.custom_css || ''), `.${boardCssClass}`);
+      const scoped = sanitizeBoardCss(bgRule + (board?.custom_css || ''), `.${boardCssClass}`);
+      if (!scoped) return '';
+      // Respect the user's reduced-motion preference: neutralize any background
+      // animation the custom CSS introduces without touching the static look.
+      return `${scoped}\n\n@media (prefers-reduced-motion: reduce) {\n  .${boardCssClass} { animation: none !important; }\n}`;
     }, [board?.custom_css, board?.background_color, boardCssClass, hasUserStyling, hasUserBg]);
 
     // Board-scoped board objects: subscribe to only THIS board's bucket so

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -1,4 +1,3 @@
-import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type { AgorClient, Board, Branch, Session } from '@agor-live/client';
 import {
   CopyOutlined,
@@ -356,8 +355,9 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
             type="primary"
             icon={<PlusOutlined />}
             onClick={() => {
+              // New boards start on the theme-aware default (no persisted
+              // background); the editor's Default mode reflects this.
               form.resetFields();
-              form.setFieldsValue({ background_color: GOLD_SHIMMER_BOARD_BACKGROUND });
               setCreateModalOpen(true);
             }}
           >
@@ -390,7 +390,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         okText="Create"
       >
         <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
-          <BoardFormFields form={form} extra={customContextField} initialCustomCSS />
+          <BoardFormFields form={form} extra={customContextField} />
         </Form>
       </Modal>
 

--- a/apps/agor-ui/src/components/forms/BoardBackgroundEditor.test.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundEditor.test.tsx
@@ -77,11 +77,45 @@ describe('BoardBackgroundEditor', () => {
     expect(captured?.getFieldValue('custom_css')).toBeFalsy();
   });
 
-  it('selecting a preset writes its exact CSS value to the form', () => {
-    render(<Harness signal="a" initialValues={{}} />);
+  it('selecting a preset writes its exact CSS value and clears animation CSS', () => {
+    render(<Harness signal="a" initialValues={{ custom_css: 'animation: spin 2s infinite;' }} />);
     fireEvent.click(screen.getByText('Preset'));
     fireEvent.click(screen.getByRole('button', { name: new RegExp(PRESET.label, 'i') }));
     expect(captured?.getFieldValue('background_color')).toBe(PRESET.value);
+    // Applying a preset is deliberate → drops layered animation CSS.
+    expect(captured?.getFieldValue('custom_css')).toBeFalsy();
+  });
+
+  it('entering Preset mode does NOT mutate stored values until a preset is applied', () => {
+    // Custom board with a gradient + animation. Merely clicking the Preset tab
+    // to browse must not destroy either field (regression from the earlier fix
+    // that cleared custom_css on tab-enter).
+    render(
+      <Harness
+        signal="a"
+        initialValues={{ background_color: CUSTOM_GRADIENT, custom_css: 'animation: x 2s;' }}
+      />
+    );
+    fireEvent.click(screen.getByText('Preset'));
+    expect(captured?.getFieldValue('background_color')).toBe(CUSTOM_GRADIENT);
+    expect(captured?.getFieldValue('custom_css')).toBe('animation: x 2s;');
+  });
+
+  it('remount with stored custom CSS opens in Custom mode (destroyOnHidden reopen)', () => {
+    // The modal uses destroyOnHidden, so reopening fully remounts the editor.
+    // A board that stored custom styling must reopen in Custom mode showing it.
+    const { unmount } = render(
+      <Harness signal="a" initialValues={{ background_color: CUSTOM_GRADIENT }} />
+    );
+    expect((screen.getByLabelText('Custom background CSS') as HTMLTextAreaElement).value).toBe(
+      CUSTOM_GRADIENT
+    );
+    unmount();
+    render(<Harness signal="a" initialValues={{ background_color: CUSTOM_GRADIENT }} />);
+    expect((screen.getByLabelText('Custom background CSS') as HTMLTextAreaElement).value).toBe(
+      CUSTOM_GRADIENT
+    );
+    expect(screen.queryByText(DEFAULT_TEXT)).not.toBeInTheDocument();
   });
 
   it('re-syncs its mode from freshly loaded values when the reset signal changes (reopen)', () => {

--- a/apps/agor-ui/src/components/forms/BoardBackgroundEditor.test.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundEditor.test.tsx
@@ -1,0 +1,103 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: test fixtures assert on literal CSS background values
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Form, type FormInstance } from 'antd';
+import { describe, expect, it } from 'vitest';
+import { BoardBackgroundEditor, deriveBackgroundMode } from './BoardBackgroundEditor';
+import { BACKGROUND_PRESETS } from './boardBackgroundPresets';
+
+const CUSTOM_GRADIENT = 'linear-gradient(180deg, #101010, #202020)';
+const PRESET = BACKGROUND_PRESETS[0];
+
+let captured: FormInstance | null = null;
+
+function Harness({
+  signal,
+  initialValues,
+}: {
+  signal?: string;
+  initialValues?: Record<string, unknown>;
+}) {
+  const [form] = Form.useForm();
+  captured = form;
+  return (
+    <Form form={form} initialValues={initialValues} preserve>
+      <BoardBackgroundEditor form={form} resetSignal={signal} />
+    </Form>
+  );
+}
+
+const DEFAULT_TEXT = /Uses the built-in theme-aware background/i;
+
+describe('deriveBackgroundMode', () => {
+  it('returns default only when nothing is styled', () => {
+    expect(deriveBackgroundMode(undefined, undefined)).toBe('default');
+  });
+
+  it('returns preset when the background exactly matches a gallery preset', () => {
+    expect(deriveBackgroundMode(PRESET.value, undefined)).toBe('preset');
+    // Gold Shimmer is a gallery preset, so a board carrying it opens in Preset
+    // mode (it is NOT swallowed as a legacy "default").
+    expect(deriveBackgroundMode(GOLD_SHIMMER_BOARD_BACKGROUND, undefined)).toBe('preset');
+  });
+
+  it('returns custom for arbitrary CSS or any custom_css', () => {
+    expect(deriveBackgroundMode(CUSTOM_GRADIENT, undefined)).toBe('custom');
+    expect(deriveBackgroundMode(PRESET.value, 'animation: x 1s;')).toBe('custom');
+  });
+});
+
+describe('BoardBackgroundEditor', () => {
+  it('opens in Default mode with an empty board', () => {
+    render(<Harness signal="a" initialValues={{}} />);
+    expect(screen.getByText(DEFAULT_TEXT)).toBeInTheDocument();
+  });
+
+  it('opens in Custom mode and shows the saved CSS when a board has custom styling', () => {
+    render(<Harness signal="a" initialValues={{ background_color: CUSTOM_GRADIENT }} />);
+    const textarea = screen.getByLabelText('Custom background CSS') as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe(CUSTOM_GRADIENT);
+  });
+
+  it('opens in Preset mode with the matching thumbnail selected', () => {
+    render(<Harness signal="a" initialValues={{ background_color: PRESET.value }} />);
+    const selected = screen.getByRole('button', {
+      name: new RegExp(`${PRESET.label}`, 'i'),
+      pressed: true,
+    });
+    expect(selected).toBeInTheDocument();
+  });
+
+  it('switching to Default clears the stored background and custom CSS', () => {
+    render(<Harness signal="a" initialValues={{ background_color: CUSTOM_GRADIENT }} />);
+    fireEvent.click(screen.getByText('Default'));
+    expect(screen.getByText(DEFAULT_TEXT)).toBeInTheDocument();
+    expect(captured?.getFieldValue('background_color')).toBeFalsy();
+    expect(captured?.getFieldValue('custom_css')).toBeFalsy();
+  });
+
+  it('selecting a preset writes its exact CSS value to the form', () => {
+    render(<Harness signal="a" initialValues={{}} />);
+    fireEvent.click(screen.getByText('Preset'));
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(PRESET.label, 'i') }));
+    expect(captured?.getFieldValue('background_color')).toBe(PRESET.value);
+  });
+
+  it('re-syncs its mode from freshly loaded values when the reset signal changes (reopen)', () => {
+    // Reproduces the reopen bug: the editor first mounts against empty values
+    // (async board load not yet resolved), then the board's saved custom CSS
+    // arrives and the reset signal bumps — the mode must follow the new values.
+    const { rerender } = render(<Harness signal="a" initialValues={{}} />);
+    expect(screen.getByText(DEFAULT_TEXT)).toBeInTheDocument();
+
+    act(() => {
+      captured?.setFieldsValue({ background_color: CUSTOM_GRADIENT });
+    });
+    rerender(<Harness signal="b" initialValues={{}} />);
+
+    const textarea = screen.getByLabelText('Custom background CSS') as HTMLTextAreaElement;
+    expect(textarea.value).toBe(CUSTOM_GRADIENT);
+    expect(screen.queryByText(DEFAULT_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/forms/BoardBackgroundEditor.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundEditor.tsx
@@ -1,0 +1,381 @@
+import { CheckCircleFilled } from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Collapse,
+  ColorPicker,
+  Form,
+  type FormInstance,
+  Input,
+  InputNumber,
+  Segmented,
+  Select,
+  Space,
+  Typography,
+  theme,
+} from 'antd';
+import type { AggregationColor } from 'antd/es/color-picker/color';
+import { useEffect, useRef, useState } from 'react';
+import { hasBoardStyling } from '../../utils/boardBackground';
+import { validateBoardCss } from '../../utils/sanitizeCss';
+import { BoardBackgroundPreview } from './BoardBackgroundPreview';
+import { ANIMATION_PRESETS, BACKGROUND_PRESETS, findPresetByValue } from './boardBackgroundPresets';
+
+export type BackgroundMode = 'default' | 'preset' | 'custom';
+
+/** Derive which editing mode a board's stored values correspond to. */
+export function deriveBackgroundMode(
+  backgroundColor: string | undefined | null,
+  customCss: string | undefined | null
+): BackgroundMode {
+  if (!hasBoardStyling(backgroundColor, customCss)) return 'default';
+  if (!customCss?.trim() && findPresetByValue(backgroundColor)) return 'preset';
+  return 'custom';
+}
+
+export interface BoardBackgroundEditorProps {
+  form: FormInstance;
+  /**
+   * Changing this value re-syncs the mode from the current form values. Pass a
+   * per-board identity (e.g. the board id) so reopening the editor for a board
+   * always reflects its saved state — this is what fixes the checkbox/mode
+   * losing its state on reopen.
+   */
+  resetSignal?: string;
+}
+
+/**
+ * Board background editor with three clear modes:
+ *
+ *  - **Default** — clears background_color + custom_css; the board renders the
+ *    theme-aware default.
+ *  - **Preset**  — a gallery rendered with the ACTUAL background CSS (not fake
+ *    illustrations) so each thumbnail is a faithful mini-board.
+ *  - **Custom**  — raw CSS for power users, plus a compact gradient helper and
+ *    optional animation presets.
+ *
+ * A live preview using the same sanitize/scope path as the canvas sits at the
+ * top so readability against representative cards/zones is always visible.
+ */
+export function BoardBackgroundEditor({ form, resetSignal }: BoardBackgroundEditorProps) {
+  const { token } = theme.useToken();
+
+  const backgroundColor = Form.useWatch('background_color', { form, preserve: true }) as
+    | string
+    | AggregationColor
+    | undefined;
+  const customCss = Form.useWatch('custom_css', { form, preserve: true }) as string | undefined;
+
+  // Normalize the watched background to a string for preview + preset matching
+  // (ColorPicker stores an AggregationColor object until re-serialized on save).
+  const bgString =
+    typeof backgroundColor === 'string'
+      ? backgroundColor
+      : backgroundColor
+        ? backgroundColor.toHexString()
+        : undefined;
+
+  const [mode, setMode] = useState<BackgroundMode>(() =>
+    deriveBackgroundMode(form.getFieldValue('background_color'), form.getFieldValue('custom_css'))
+  );
+
+  // Re-sync the mode from the freshly-loaded form values whenever the board
+  // identity changes. Without this the mode would keep its initial value even
+  // after the async board load populates the form (the reopen bug).
+  const lastSignal = useRef(resetSignal);
+  useEffect(() => {
+    if (resetSignal !== lastSignal.current) {
+      lastSignal.current = resetSignal;
+      setMode(
+        deriveBackgroundMode(
+          form.getFieldValue('background_color'),
+          form.getFieldValue('custom_css')
+        )
+      );
+    }
+  }, [resetSignal, form]);
+
+  const selectMode = (next: BackgroundMode) => {
+    setMode(next);
+    if (next === 'default') {
+      form.setFieldsValue({ background_color: undefined, custom_css: undefined });
+    } else if (next === 'preset') {
+      // Presets are pure backgrounds — drop any layered animation CSS so the
+      // "preset" state stays unambiguous and round-trips cleanly on reopen.
+      form.setFieldsValue({ custom_css: undefined });
+      const asColor = form.getFieldValue('background_color');
+      if (asColor && typeof asColor !== 'string') {
+        form.setFieldsValue({ background_color: asColor.toHexString() });
+      }
+    } else if (next === 'custom') {
+      const asColor = form.getFieldValue('background_color');
+      if (asColor && typeof asColor !== 'string') {
+        form.setFieldsValue({ background_color: asColor.toHexString() });
+      }
+    }
+  };
+
+  const bgIssues = validateBoardCss(bgString);
+  const cssIssues = validateBoardCss(customCss);
+  const allIssues = [...bgIssues, ...cssIssues];
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <div>
+        <Typography.Text
+          type="secondary"
+          style={{ fontSize: 12, display: 'block', marginBottom: 8 }}
+        >
+          Live preview
+        </Typography.Text>
+        <BoardBackgroundPreview
+          backgroundColor={bgString}
+          customCss={customCss}
+          height={150}
+          ariaLabel="Live board background preview with sample cards and zone"
+        />
+      </div>
+
+      <Segmented<BackgroundMode>
+        block
+        value={mode}
+        onChange={selectMode}
+        options={[
+          { label: 'Default', value: 'default' },
+          { label: 'Preset', value: 'preset' },
+          { label: 'Custom CSS', value: 'custom' },
+        ]}
+        aria-label="Background mode"
+      />
+
+      {mode === 'default' && (
+        <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+          Uses the built-in theme-aware background — a sober, mostly-dark surface that adapts to
+          light and dark themes. Nothing is stored on the board.
+        </Typography.Text>
+      )}
+
+      {mode === 'preset' && (
+        <PresetGallery
+          selectedValue={bgString}
+          onSelect={(value) => form.setFieldsValue({ background_color: value })}
+          token={token}
+        />
+      )}
+
+      {mode === 'custom' && (
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          <div>
+            <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 6 }}>
+              Background
+            </Typography.Text>
+            <Form.Item name="background_color" noStyle>
+              <Input.TextArea
+                aria-label="Custom background CSS"
+                placeholder="e.g. linear-gradient(180deg, #0f131a, #090b10)"
+                rows={3}
+                style={{ fontFamily: 'monospace', fontSize: 12 }}
+              />
+            </Form.Item>
+          </div>
+
+          <GradientHelper onApply={(value) => form.setFieldsValue({ background_color: value })} />
+
+          <div>
+            <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 6 }}>
+              Animation CSS <Typography.Text type="secondary">(optional)</Typography.Text>
+            </Typography.Text>
+            <Select
+              placeholder="Load an animation preset…"
+              style={{ width: '100%', marginBottom: 8 }}
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              options={ANIMATION_PRESETS.map((preset) => ({
+                label: preset.label,
+                value: preset.value,
+              }))}
+              onChange={(value) => form.setFieldsValue({ custom_css: value || undefined })}
+            />
+            <Form.Item name="custom_css" noStyle>
+              <Input.TextArea
+                aria-label="Custom animation CSS"
+                placeholder="background-size, animation, @keyframes…"
+                rows={5}
+                style={{ fontFamily: 'monospace', fontSize: 12 }}
+              />
+            </Form.Item>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Animations are disabled automatically for visitors who prefer reduced motion.
+            </Typography.Text>
+          </div>
+        </Space>
+      )}
+
+      {allIssues.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Some CSS will be removed for safety"
+          description={
+            <ul style={{ margin: 0, paddingInlineStart: 18 }}>
+              {allIssues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          }
+        />
+      )}
+    </Space>
+  );
+}
+
+function PresetGallery({
+  selectedValue,
+  onSelect,
+  token,
+}: {
+  selectedValue: string | undefined;
+  onSelect: (value: string) => void;
+  token: { colorPrimary: string; colorTextSecondary: string; borderRadiusLG: number };
+}) {
+  return (
+    <fieldset
+      style={{
+        border: 0,
+        margin: 0,
+        padding: 0,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
+        gap: 12,
+      }}
+    >
+      <legend
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Background presets
+      </legend>
+      {BACKGROUND_PRESETS.map((preset) => {
+        const selected = selectedValue?.trim() === preset.value;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={selected}
+            aria-label={`${preset.label} (${preset.tone})`}
+            onClick={() => onSelect(preset.value)}
+            style={{
+              position: 'relative',
+              padding: 3,
+              border: `2px solid ${selected ? token.colorPrimary : 'transparent'}`,
+              borderRadius: token.borderRadiusLG + 3,
+              background: 'transparent',
+              cursor: 'pointer',
+              textAlign: 'left',
+            }}
+          >
+            <BoardBackgroundPreview
+              backgroundColor={preset.value}
+              height={72}
+              variant="thumbnail"
+              ariaLabel={`${preset.label} preview`}
+            />
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginTop: 6,
+                paddingInline: 2,
+              }}
+            >
+              <Typography.Text style={{ fontSize: 12 }}>{preset.label}</Typography.Text>
+              {selected && <CheckCircleFilled style={{ color: token.colorPrimary }} />}
+            </div>
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+function GradientHelper({ onApply }: { onApply: (value: string) => void }) {
+  const [type, setType] = useState<'linear' | 'radial'>('linear');
+  const [angle, setAngle] = useState(180);
+  // biome-ignore lint/plugin/noHardcodedColorLiteral: default seed colors for the gradient helper, user-editable
+  const [color1, setColor1] = useState('#10141f');
+  // biome-ignore lint/plugin/noHardcodedColorLiteral: default seed colors for the gradient helper, user-editable
+  const [color2, setColor2] = useState('#3a4a7a');
+
+  const apply = () => {
+    const value =
+      type === 'linear'
+        ? `linear-gradient(${angle}deg, ${color1}, ${color2})`
+        : `radial-gradient(circle at 50% 30%, ${color1}, ${color2})`;
+    onApply(value);
+  };
+
+  return (
+    <Collapse
+      ghost
+      size="small"
+      items={[
+        {
+          key: 'gradient',
+          label: <Typography.Text style={{ fontSize: 13 }}>Gradient helper</Typography.Text>,
+          children: (
+            <Space direction="vertical" size={10} style={{ width: '100%' }}>
+              <Space wrap size={10} align="center">
+                <Select<'linear' | 'radial'>
+                  value={type}
+                  onChange={setType}
+                  style={{ width: 110 }}
+                  aria-label="Gradient type"
+                  options={[
+                    { label: 'Linear', value: 'linear' },
+                    { label: 'Radial', value: 'radial' },
+                  ]}
+                />
+                {type === 'linear' && (
+                  <Space size={4} align="center">
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      Angle
+                    </Typography.Text>
+                    <InputNumber
+                      value={angle}
+                      onChange={(value) => setAngle(value ?? 0)}
+                      min={0}
+                      max={360}
+                      style={{ width: 72 }}
+                      aria-label="Gradient angle in degrees"
+                    />
+                  </Space>
+                )}
+                <ColorPicker
+                  value={color1}
+                  onChange={(c) => setColor1(c.toHexString())}
+                  aria-label="Gradient color one"
+                />
+                <ColorPicker
+                  value={color2}
+                  onChange={(c) => setColor2(c.toHexString())}
+                  aria-label="Gradient color two"
+                />
+                <Button size="small" onClick={apply}>
+                  Apply to background
+                </Button>
+              </Space>
+            </Space>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/apps/agor-ui/src/components/forms/BoardBackgroundEditor.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundEditor.tsx
@@ -98,26 +98,31 @@ export function BoardBackgroundEditor({ form, resetSignal }: BoardBackgroundEdit
   const selectMode = (next: BackgroundMode) => {
     setMode(next);
     if (next === 'default') {
+      // Explicit "use the themed default" — clear both stored fields.
       form.setFieldsValue({ background_color: undefined, custom_css: undefined });
-    } else if (next === 'preset') {
-      // Presets are pure backgrounds — drop any layered animation CSS so the
-      // "preset" state stays unambiguous and round-trips cleanly on reopen.
-      form.setFieldsValue({ custom_css: undefined });
+    } else if (next === 'preset' || next === 'custom') {
+      // Entering Preset or Custom must NOT mutate stored values — switching a
+      // tab to browse should never destroy the user's background or animation
+      // CSS. We only normalize a ColorPicker object into a hex string so the
+      // textarea/gallery can read it. A preset is applied only when the user
+      // actually clicks a thumbnail (see applyPreset).
       const asColor = form.getFieldValue('background_color');
-      if (asColor && typeof asColor !== 'string') {
-        form.setFieldsValue({ background_color: asColor.toHexString() });
-      }
-    } else if (next === 'custom') {
-      const asColor = form.getFieldValue('background_color');
-      if (asColor && typeof asColor !== 'string') {
+      if (asColor && typeof asColor !== 'string' && typeof asColor.toHexString === 'function') {
         form.setFieldsValue({ background_color: asColor.toHexString() });
       }
     }
   };
 
-  const bgIssues = validateBoardCss(bgString);
-  const cssIssues = validateBoardCss(customCss);
-  const allIssues = [...bgIssues, ...cssIssues];
+  // Applying a preset is a deliberate action: it sets the background and drops
+  // any layered animation CSS so the persisted state is an unambiguous preset
+  // that round-trips back to Preset mode on reopen.
+  const applyPreset = (value: string) => {
+    form.setFieldsValue({ background_color: value, custom_css: undefined });
+  };
+
+  // Dedupe so the same blocked-pattern warning from both fields renders once
+  // (and never produces duplicate React keys).
+  const allIssues = [...new Set([...validateBoardCss(bgString), ...validateBoardCss(customCss)])];
 
   return (
     <Space direction="vertical" size={16} style={{ width: '100%' }}>
@@ -150,17 +155,13 @@ export function BoardBackgroundEditor({ form, resetSignal }: BoardBackgroundEdit
 
       {mode === 'default' && (
         <Typography.Text type="secondary" style={{ fontSize: 13 }}>
-          Uses the built-in theme-aware background — a sober, mostly-dark surface that adapts to
+          Uses the built-in theme-aware background — a sober, restrained surface that adapts to the
           light and dark themes. Nothing is stored on the board.
         </Typography.Text>
       )}
 
       {mode === 'preset' && (
-        <PresetGallery
-          selectedValue={bgString}
-          onSelect={(value) => form.setFieldsValue({ background_color: value })}
-          token={token}
-        />
+        <PresetGallery selectedValue={bgString} onSelect={applyPreset} token={token} />
       )}
 
       {mode === 'custom' && (

--- a/apps/agor-ui/src/components/forms/BoardBackgroundPreview.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundPreview.tsx
@@ -3,8 +3,7 @@
 import { theme } from 'antd';
 import { useId, useMemo } from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
-import { hasBackgroundValue, hasBoardStyling } from '../../utils/boardBackground';
-import { sanitizeBoardCss } from '../../utils/sanitizeCss';
+import { buildScopedBoardCss } from '../../utils/sanitizeCss';
 import { isDarkTheme } from '../../utils/theme';
 
 export interface BoardBackgroundPreviewProps {
@@ -44,20 +43,15 @@ export function BoardBackgroundPreview({
   const rawId = useId().replace(/[^a-zA-Z0-9]/g, '');
   const scopeClass = `board-preview-${rawId}`;
 
-  const styled = hasBoardStyling(backgroundColor, customCss);
-  const explicitBg = hasBackgroundValue(backgroundColor);
-
-  const scopedCss = useMemo(() => {
-    if (!styled) return '';
-    const bgRule = explicitBg ? `background: ${backgroundColor};\n` : '';
-    const scoped = sanitizeBoardCss(bgRule + (customCss || ''), `.${scopeClass}`);
-    if (!scoped) return '';
-    return `${scoped}\n@media (prefers-reduced-motion: reduce) { .${scopeClass} { animation: none !important; } }`;
-  }, [styled, explicitBg, backgroundColor, customCss, scopeClass]);
+  // Same sanitize + scope + reduced-motion pipeline as the canvas.
+  const scopedCss = useMemo(
+    () => buildScopedBoardCss({ backgroundColor, customCss, scopeClass }),
+    [backgroundColor, customCss, scopeClass]
+  );
 
   // When there is no explicit styling we render the trusted themed default
   // inline (never through the sanitizer), mirroring the canvas.
-  const inlineBackground = styled ? undefined : DEFAULT_BACKGROUNDS[isDark ? 'dark' : 'light'];
+  const inlineBackground = scopedCss ? undefined : DEFAULT_BACKGROUNDS[isDark ? 'dark' : 'light'];
 
   const scale = variant === 'thumbnail' ? 0.85 : 1;
 
@@ -76,10 +70,9 @@ export function BoardBackgroundPreview({
         background: inlineBackground,
       }}
     >
-      {scopedCss && (
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitizeBoardCss strips url()/expression()/@import/etc. and scopes to this instance
-        <style dangerouslySetInnerHTML={{ __html: scopedCss }} />
-      )}
+      {/* String child (not dangerouslySetInnerHTML) — React sets it as text
+          content, so sanitized CSS cannot terminate the <style> element. */}
+      {scopedCss && <style>{scopedCss}</style>}
       {showContent && (
         <div
           style={{

--- a/apps/agor-ui/src/components/forms/BoardBackgroundPreview.tsx
+++ b/apps/agor-ui/src/components/forms/BoardBackgroundPreview.tsx
@@ -1,0 +1,240 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: translucent black/white scrims for the mini-preview overlay (zone outline, zone fill, label chip) sit on top of an arbitrary user gradient; no Ant token expresses a theme-neutral translucent scrim, so exact rgba() values are required here.
+
+import { theme } from 'antd';
+import { useId, useMemo } from 'react';
+import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
+import { hasBackgroundValue, hasBoardStyling } from '../../utils/boardBackground';
+import { sanitizeBoardCss } from '../../utils/sanitizeCss';
+import { isDarkTheme } from '../../utils/theme';
+
+export interface BoardBackgroundPreviewProps {
+  /** Background value (solid color, gradient, or CSS background). */
+  backgroundColor?: string | null;
+  /** Extra scoped CSS (animations/keyframes). */
+  customCss?: string | null;
+  /** Height of the preview surface in px. */
+  height?: number;
+  /** Render representative mini cards + a zone so contrast is visible. */
+  showContent?: boolean;
+  /** Compact spacing/typography for gallery thumbnails. */
+  variant?: 'full' | 'thumbnail';
+  /** Optional aria-label for the preview surface. */
+  ariaLabel?: string;
+}
+
+/**
+ * Renders a miniature board surface using the EXACT same sanitize + scope
+ * pipeline as the real canvas (SessionCanvas). This guarantees a faithful
+ * impression of the background at scale — the same gradient, the same
+ * sanitizer, the same reduced-motion handling — with representative mini
+ * cards and a zone laid on top so readability is immediately visible.
+ */
+export function BoardBackgroundPreview({
+  backgroundColor,
+  customCss,
+  height = 160,
+  showContent = true,
+  variant = 'full',
+  ariaLabel,
+}: BoardBackgroundPreviewProps) {
+  const { token } = theme.useToken();
+  const isDark = isDarkTheme(token);
+  // useId gives a stable, unique scope per preview instance so multiple
+  // thumbnails on screen never leak styles into one another.
+  const rawId = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const scopeClass = `board-preview-${rawId}`;
+
+  const styled = hasBoardStyling(backgroundColor, customCss);
+  const explicitBg = hasBackgroundValue(backgroundColor);
+
+  const scopedCss = useMemo(() => {
+    if (!styled) return '';
+    const bgRule = explicitBg ? `background: ${backgroundColor};\n` : '';
+    const scoped = sanitizeBoardCss(bgRule + (customCss || ''), `.${scopeClass}`);
+    if (!scoped) return '';
+    return `${scoped}\n@media (prefers-reduced-motion: reduce) { .${scopeClass} { animation: none !important; } }`;
+  }, [styled, explicitBg, backgroundColor, customCss, scopeClass]);
+
+  // When there is no explicit styling we render the trusted themed default
+  // inline (never through the sanitizer), mirroring the canvas.
+  const inlineBackground = styled ? undefined : DEFAULT_BACKGROUNDS[isDark ? 'dark' : 'light'];
+
+  const scale = variant === 'thumbnail' ? 0.85 : 1;
+
+  return (
+    <div
+      className={scopeClass}
+      role="img"
+      aria-label={ariaLabel || 'Board background preview'}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height,
+        borderRadius: token.borderRadiusLG,
+        overflow: 'hidden',
+        border: `1px solid ${token.colorBorderSecondary}`,
+        background: inlineBackground,
+      }}
+    >
+      {scopedCss && (
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitizeBoardCss strips url()/expression()/@import/etc. and scopes to this instance
+        <style dangerouslySetInnerHTML={{ __html: scopedCss }} />
+      )}
+      {showContent && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            padding: 12 * scale,
+            display: 'flex',
+            gap: 10 * scale,
+            alignItems: 'flex-start',
+            pointerEvents: 'none',
+          }}
+        >
+          {/* Mini zone */}
+          <div
+            style={{
+              flex: '0 0 42%',
+              height: `calc(100% - ${16 * scale}px)`,
+              borderRadius: token.borderRadius,
+              border: `1px dashed ${isDark ? 'rgba(255,255,255,0.28)' : 'rgba(0,0,0,0.22)'}`,
+              background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+              padding: 8 * scale,
+            }}
+          >
+            <MiniLabel text="Zone" token={token} isDark={isDark} scale={scale} muted />
+          </div>
+          {/* Mini cards */}
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10 * scale,
+            }}
+          >
+            <MiniCard
+              token={token}
+              scale={scale}
+              accent={token.colorPrimary}
+              title="Session card"
+            />
+            <MiniCard token={token} scale={scale} accent={token.colorSuccess} title="Branch card" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface TokenLike {
+  colorBgElevated: string;
+  colorBorder: string;
+  colorBorderSecondary: string;
+  colorText: string;
+  colorTextSecondary: string;
+  borderRadius: number;
+  borderRadiusLG: number;
+  colorPrimary: string;
+  colorSuccess: string;
+  boxShadowTertiary: string;
+}
+
+function MiniLabel({
+  text,
+  token,
+  isDark,
+  scale,
+  muted,
+}: {
+  text: string;
+  token: TokenLike;
+  isDark: boolean;
+  scale: number;
+  muted?: boolean;
+}) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        fontSize: 10 * scale,
+        fontWeight: 600,
+        letterSpacing: 0.3,
+        padding: `${2 * scale}px ${6 * scale}px`,
+        borderRadius: 4,
+        color: muted ? token.colorTextSecondary : token.colorText,
+        background: isDark ? 'rgba(0,0,0,0.35)' : 'rgba(255,255,255,0.6)',
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function MiniCard({
+  token,
+  scale,
+  accent,
+  title,
+}: {
+  token: TokenLike;
+  scale: number;
+  accent: string;
+  title: string;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: token.borderRadius,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        background: token.colorBgElevated,
+        boxShadow: token.boxShadowTertiary,
+        padding: 8 * scale,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6 * scale,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 * scale }}>
+        <span
+          style={{
+            width: 8 * scale,
+            height: 8 * scale,
+            borderRadius: '50%',
+            background: accent,
+            flex: '0 0 auto',
+          }}
+        />
+        <span
+          style={{
+            fontSize: 10 * scale,
+            fontWeight: 600,
+            color: token.colorText,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {title}
+        </span>
+      </div>
+      <div
+        style={{
+          height: 4 * scale,
+          width: '80%',
+          borderRadius: 2,
+          background: token.colorBorder,
+        }}
+      />
+      <div
+        style={{
+          height: 4 * scale,
+          width: '55%',
+          borderRadius: 2,
+          background: token.colorBorderSecondary,
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -9,6 +9,30 @@ import {
 } from '../permissions/RbacPermissionFields';
 import { BoardBackgroundEditor } from './BoardBackgroundEditor';
 
+/** A value carrying AntD's ColorPicker `toHexString()` serializer. */
+interface HexSerializable {
+  toHexString: () => string;
+}
+
+function hasToHexString(value: unknown): value is HexSerializable {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toHexString?: unknown }).toHexString === 'function'
+  );
+}
+
+/**
+ * Normalize the form's `background_color` to the persisted wire value: a
+ * string as-is, an AntD ColorPicker value via `toHexString()`, or `null` when
+ * empty (so the backend clears the field rather than dropping `undefined`).
+ */
+function normalizeBackgroundColor(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() ? value : null;
+  if (hasToHexString(value)) return value.toHexString();
+  return null;
+}
+
 /**
  * Extract board form values from the form instance.
  * Uses getFieldsValue(true) to include values from collapsed/unmounted fields.
@@ -25,11 +49,10 @@ export function extractBoardFormValues(form: FormInstance): Partial<Board> {
     name: values.name,
     icon: values.icon || '📋',
     description: values.description,
-    background_color: bgColor
-      ? typeof bgColor === 'string'
-        ? bgColor
-        : bgColor.toHexString()
-      : null,
+    // background_color is usually a string (gradient/CSS/hex), but the
+    // ColorPicker yields an AntD AggregationColor. Only serialize via
+    // toHexString when it's actually present; otherwise clear the field.
+    background_color: normalizeBackgroundColor(bgColor),
     custom_css: values.custom_css || null,
     access_mode: values.access_mode || 'shared',
     default_others_can:

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,87 +1,13 @@
 import type { Board, Group, User } from '@agor-live/client';
 import type { FormInstance } from 'antd';
-import { Alert, Checkbox, ColorPicker, Form, Input, Select, Space, Tabs, Typography } from 'antd';
-import { useState } from 'react';
+import { Alert, Form, Input, Space, Tabs, Typography } from 'antd';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import {
   RbacPermissionFields,
   type RbacPermissionValue,
   type RbacVisibility,
 } from '../permissions/RbacPermissionFields';
-import { BACKGROUND_PRESETS } from './boardBackgroundPresets';
-
-/**
- * Animation CSS presets — each sets background-size + animation + @keyframes.
- * Designed to pair with gradient backgrounds from BACKGROUND_PRESETS.
- */
-export const ANIMATION_PRESETS = [
-  {
-    label: 'Slow gradient shift (12s)',
-    value: `background-size: 400% 400%;
-animation: agorGradientShift 12s ease infinite;
-
-@keyframes agorGradientShift {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}`,
-  },
-  {
-    label: 'Fast gradient shift (4s)',
-    value: `background-size: 400% 400%;
-animation: agorGradientFast 4s ease infinite;
-
-@keyframes agorGradientFast {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}`,
-  },
-  {
-    label: 'Diagonal sweep (8s)',
-    value: `background-size: 400% 400%;
-animation: agorDiagonalSweep 8s linear infinite;
-
-@keyframes agorDiagonalSweep {
-  0% { background-position: 0% 0%; }
-  50% { background-position: 100% 100%; }
-  100% { background-position: 0% 0%; }
-}`,
-  },
-  {
-    label: 'Pulse zoom (6s)',
-    value: `background-size: 200% 200%;
-animation: agorPulse 6s ease-in-out infinite;
-
-@keyframes agorPulse {
-  0%, 100% { background-size: 200% 200%; background-position: center; }
-  50% { background-size: 300% 300%; background-position: center; }
-}`,
-  },
-  {
-    label: 'Horizontal scroll (20s)',
-    value: `background-size: 200% 100%;
-animation: agorHScroll 20s linear infinite;
-
-@keyframes agorHScroll {
-  0% { background-position: 0% 50%; }
-  100% { background-position: 200% 50%; }
-}`,
-  },
-  {
-    label: 'Rotate (conic, 10s)',
-    value: `animation: agorRotate 10s linear infinite;
-
-@keyframes agorRotate {
-  0% { filter: hue-rotate(0deg); }
-  100% { filter: hue-rotate(360deg); }
-}`,
-  },
-];
-
-/** Detect if a background value is custom CSS (not a simple hex color or rgba) */
-export function isCustomCSS(value: string | undefined | null): boolean {
-  if (!value) return false;
-  return !value.match(/^#[0-9a-fA-F]{3,8}$/) && !value.match(/^rgba?\(/);
-}
+import { BoardBackgroundEditor } from './BoardBackgroundEditor';
 
 /**
  * Extract board form values from the form instance.
@@ -122,8 +48,11 @@ export interface BoardFormFieldsProps {
   autoFocus?: boolean;
   /** Extra content rendered inside the "Advanced" collapse panel */
   extra?: React.ReactNode;
-  /** Initial custom CSS mode — auto-detected from board values if not provided */
-  initialCustomCSS?: boolean;
+  /**
+   * Per-board identity forwarded to the background editor so it re-syncs its
+   * mode from the freshly-loaded form values when the board changes.
+   */
+  backgroundResetSignal?: string;
   rbacEnabled?: boolean;
   allUsers?: User[];
   allGroups?: Group[];
@@ -133,22 +62,18 @@ export interface BoardFormFieldsProps {
  * Shared board form fields used in the CreateDialog BoardTab
  * and the SettingsModal BoardsTable create/edit modals.
  *
- * Renders: Name, Description, and collapsible CSS / Advanced sections.
- * Manages useCustomCSS state internally.
+ * Renders: Name, Description, and CSS / Advanced tabs.
  * Does NOT render a <Form> wrapper — the parent owns the form instance.
  */
 export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
   form,
   autoFocus,
   extra,
-  initialCustomCSS = false,
+  backgroundResetSignal,
   rbacEnabled = false,
   allUsers = [],
   allGroups = [],
 }) => {
-  const [useCustomCSS, setUseCustomCSS] = useState(initialCustomCSS);
-  const backgroundColor = Form.useWatch('background_color', { form, preserve: true });
-
   const generalFields = (
     <>
       <Form.Item label="Name" required style={{ marginBottom: 24 }}>
@@ -237,78 +162,7 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
     </Form>
   );
 
-  const cssFields = (
-    <>
-      <Space direction="vertical" style={{ width: '100%', marginBottom: 16 }}>
-        <Checkbox
-          checked={useCustomCSS}
-          onChange={(e) => {
-            setUseCustomCSS(e.target.checked);
-            if (e.target.checked) {
-              const current = form.getFieldValue('background_color');
-              if (current && typeof current !== 'string') {
-                form.setFieldsValue({ background_color: current.toHexString() });
-              }
-            }
-          }}
-        >
-          Use custom CSS background
-        </Checkbox>
-
-        {!useCustomCSS ? (
-          <Form.Item name="background_color" noStyle>
-            <ColorPicker showText format="hex" allowClear />
-          </Form.Item>
-        ) : (
-          <>
-            <Select
-              placeholder="Load a preset..."
-              style={{ width: '100%', marginBottom: 8 }}
-              allowClear
-              showSearch
-              options={BACKGROUND_PRESETS}
-              value={
-                BACKGROUND_PRESETS.some((preset) => preset.value === backgroundColor)
-                  ? backgroundColor
-                  : undefined
-              }
-              onChange={(value) => {
-                if (value) form.setFieldsValue({ background_color: value });
-              }}
-            />
-            <Form.Item name="background_color" noStyle>
-              <Input.TextArea
-                placeholder="Enter custom CSS background value (gradients, patterns, etc.)"
-                rows={3}
-                style={{ fontFamily: 'monospace', fontSize: '12px' }}
-              />
-            </Form.Item>
-          </>
-        )}
-      </Space>
-
-      {useCustomCSS && (
-        <Space direction="vertical" style={{ width: '100%' }}>
-          <Typography.Text strong style={{ fontSize: '13px' }}>
-            Animation CSS
-          </Typography.Text>
-          <Select
-            placeholder="Load an animation preset..."
-            style={{ width: '100%', marginBottom: 8 }}
-            allowClear
-            showSearch
-            options={ANIMATION_PRESETS}
-            onChange={(value) => {
-              if (value) form.setFieldsValue({ custom_css: value });
-            }}
-          />
-          <Form.Item name="custom_css" noStyle>
-            <Input.TextArea rows={6} style={{ fontFamily: 'monospace', fontSize: '12px' }} />
-          </Form.Item>
-        </Space>
-      )}
-    </>
-  );
+  const cssFields = <BoardBackgroundEditor form={form} resetSignal={backgroundResetSignal} />;
 
   return (
     <Tabs

--- a/apps/agor-ui/src/components/forms/boardBackgroundPresets.ts
+++ b/apps/agor-ui/src/components/forms/boardBackgroundPresets.ts
@@ -1,70 +1,161 @@
 // biome-ignore-all lint/plugin/noHardcodedColorLiteral: centralized user-selectable board background palette stores exact persisted gradients
 
-import { GOLD_SHIMMER_BOARD_BACKGROUND_PRESET } from '@agor/core/design/board-backgrounds';
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 
-export const BACKGROUND_PRESETS = [
+export interface BackgroundPreset {
+  /** Stable identifier used for React keys and selection. */
+  id: string;
+  /** Human-readable name shown under the thumbnail. */
+  label: string;
+  /** The exact CSS `background` value persisted to `background_color`. */
+  value: string;
+  /** Whether the preset reads as a dark or light surface (for the tone badge). */
+  tone: 'dark' | 'light';
+}
+
+/**
+ * Curated, sober background gallery.
+ *
+ * Deliberately restrained: mostly deep, low-saturation surfaces with a single
+ * quiet accent so cards, zones, and edges stay legible on top. The previous
+ * loud/dated entries (rainbow, RGB stripes, hairline B&W lines, checkerboard,
+ * conic sunbursts) were dropped for contrast/readability reasons. Gold Shimmer
+ * is retained at the end so boards that historically carried it can pin it back
+ * explicitly.
+ */
+export const BACKGROUND_PRESETS: BackgroundPreset[] = [
   {
-    label: 'Rainbow (7 colors)',
+    id: 'midnight',
+    label: 'Midnight',
+    tone: 'dark',
     value:
-      'linear-gradient(to right, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #9400d3)',
+      'radial-gradient(70% 50% at 50% -6%, rgba(99, 122, 179, 0.28) 0%, rgba(99, 122, 179, 0) 60%), linear-gradient(180deg, #10141f 0%, #0b0e17 60%, #080a11 100%)',
   },
   {
-    label: 'Multi-color gradient',
+    id: 'graphite',
+    label: 'Graphite',
+    tone: 'dark',
+    value: 'linear-gradient(180deg, #232830 0%, #171a20 55%, #101318 100%)',
+  },
+  {
+    id: 'aurora',
+    label: 'Aurora',
+    tone: 'dark',
     value:
-      'linear-gradient(124deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3, #dd00f3)',
+      'radial-gradient(65% 55% at 50% -8%, rgba(56, 189, 168, 0.24) 0%, rgba(56, 189, 168, 0) 60%), radial-gradient(50% 45% at 85% 105%, rgba(59, 130, 190, 0.18) 0%, rgba(59, 130, 190, 0) 60%), linear-gradient(180deg, #0c1418 0%, #080f12 100%)',
   },
   {
-    label: 'Pink to blue gradient',
+    id: 'nebula',
+    label: 'Nebula',
+    tone: 'dark',
     value:
-      'linear-gradient(180deg, #f093fb 0%, #f5576c 25%, #4facfe 50%, #00f2fe 75%, #43e97b 100%)',
+      'radial-gradient(60% 50% at 22% 18%, rgba(130, 80, 220, 0.30) 0%, rgba(130, 80, 220, 0) 55%), radial-gradient(55% 50% at 82% 88%, rgba(210, 70, 160, 0.22) 0%, rgba(210, 70, 160, 0) 55%), linear-gradient(180deg, #12101c 0%, #0b0912 100%)',
   },
-  GOLD_SHIMMER_BOARD_BACKGROUND_PRESET,
   {
-    label: 'Cyan/magenta grid',
+    id: 'ember',
+    label: 'Ember',
+    tone: 'dark',
     value:
-      'repeating-linear-gradient(0deg, transparent, transparent 2px, #0ff 2px, #0ff 4px), repeating-linear-gradient(90deg, transparent, transparent 2px, #f0f 2px, #f0f 4px), linear-gradient(180deg, #000, #001a1a)',
+      'radial-gradient(70% 55% at 50% -6%, rgba(214, 140, 74, 0.22) 0%, rgba(214, 140, 74, 0) 60%), linear-gradient(180deg, #17120e 0%, #0f0b08 100%)',
   },
   {
-    label: 'Diagonal stripes (colorful)',
+    id: 'fog',
+    label: 'Fog',
+    tone: 'light',
     value:
-      'repeating-linear-gradient(45deg, #ff006e 0px, #ff006e 10px, #ffbe0b 10px, #ffbe0b 20px, #8338ec 20px, #8338ec 30px, #3a86ff 30px, #3a86ff 40px)',
+      'radial-gradient(80% 60% at 50% -10%, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 60%), linear-gradient(180deg, #eef2f7 0%, #dfe6ef 100%)',
   },
   {
-    label: 'Conic gradient (warm colors)',
+    id: 'dawn',
+    label: 'Dawn',
+    tone: 'light',
     value:
-      'conic-gradient(from 45deg, #ff0080, #ff8c00, #40e0d0, #ff0080, #ff8c00, #40e0d0, #ff0080)',
+      'radial-gradient(80% 60% at 50% -10%, rgba(255, 240, 224, 0.95) 0%, rgba(255, 240, 224, 0) 60%), linear-gradient(180deg, #fbf3ec 0%, #f2e7dd 100%)',
   },
   {
-    label: 'Dark with purple/pink spots',
-    value:
-      'radial-gradient(ellipse at top, #1b2735 0%, #090a0f 100%), radial-gradient(circle at 20% 50%, rgba(120, 0, 255, 0.3) 0%, transparent 50%), radial-gradient(circle at 80% 80%, rgba(255, 0, 120, 0.3) 0%, transparent 50%)',
+    id: 'gold-shimmer',
+    label: 'Gold Shimmer',
+    tone: 'dark',
+    value: GOLD_SHIMMER_BOARD_BACKGROUND,
+  },
+];
+
+/** Lookup a preset by its persisted CSS value. */
+export function findPresetByValue(value: string | undefined | null): BackgroundPreset | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return BACKGROUND_PRESETS.find((preset) => preset.value === trimmed);
+}
+
+export interface AnimationPreset {
+  label: string;
+  value: string;
+}
+
+/**
+ * Optional animation CSS — each sets background-size + animation + @keyframes.
+ * Pairs with any gradient background. Applied only in Custom mode; disabled
+ * automatically for users who prefer reduced motion (see SessionCanvas).
+ */
+export const ANIMATION_PRESETS: AnimationPreset[] = [
+  {
+    label: 'Slow gradient shift (12s)',
+    value: `background-size: 400% 400%;
+animation: agorGradientShift 12s ease infinite;
+
+@keyframes agorGradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}`,
   },
   {
-    label: 'Quadrant blocks (conic)',
-    value:
-      'repeating-conic-gradient(from 0deg at 50% 50%, #ff006e 0deg 90deg, #8338ec 90deg 180deg, #3a86ff 180deg 270deg, #fb5607 270deg 360deg)',
+    label: 'Fast gradient shift (4s)',
+    value: `background-size: 400% 400%;
+animation: agorGradientFast 4s ease infinite;
+
+@keyframes agorGradientFast {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}`,
   },
   {
-    label: 'RGB stripes',
-    value:
-      'linear-gradient(90deg, #000 0%, #f00 20%, #000 21%, #0f0 40%, #000 41%, #00f 60%, #000 61%, #fff 80%, #000 81%)',
+    label: 'Diagonal sweep (8s)',
+    value: `background-size: 400% 400%;
+animation: agorDiagonalSweep 8s linear infinite;
+
+@keyframes agorDiagonalSweep {
+  0% { background-position: 0% 0%; }
+  50% { background-position: 100% 100%; }
+  100% { background-position: 0% 0%; }
+}`,
   },
   {
-    label: 'Fine diagonal lines (B&W)',
-    value: 'repeating-linear-gradient(45deg, #000, #000 1px, #fff 1px, #fff 2px)',
+    label: 'Pulse zoom (6s)',
+    value: `background-size: 200% 200%;
+animation: agorPulse 6s ease-in-out infinite;
+
+@keyframes agorPulse {
+  0%, 100% { background-size: 200% 200%; background-position: center; }
+  50% { background-size: 300% 300%; background-position: center; }
+}`,
   },
   {
-    label: 'Dark with magenta/cyan glow',
-    value:
-      'radial-gradient(circle at 30% 50%, rgba(255, 0, 255, 0.5), transparent 50%), radial-gradient(circle at 70% 70%, rgba(0, 255, 255, 0.5), transparent 50%), linear-gradient(180deg, #0a0a0a, #1a1a2e)',
+    label: 'Horizontal scroll (20s)',
+    value: `background-size: 200% 100%;
+animation: agorHScroll 20s linear infinite;
+
+@keyframes agorHScroll {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}`,
   },
   {
-    label: 'Sunburst (conic)',
-    value:
-      'conic-gradient(from 0deg, #ffbe0b 0deg, #fb5607 60deg, #ff006e 120deg, #8338ec 180deg, #3a86ff 240deg, #ffbe0b 300deg, #fb5607 360deg)',
-  },
-  {
-    label: 'Checkerboard (purple)',
-    value: 'repeating-linear-gradient(45deg, #606dbc, #606dbc 10px, #465298 10px, #465298 20px)',
+    label: 'Hue rotate (10s)',
+    value: `animation: agorRotate 10s linear infinite;
+
+@keyframes agorRotate {
+  0% { filter: hue-rotate(0deg); }
+  100% { filter: hue-rotate(360deg); }
+}`,
   },
 ];

--- a/apps/agor-ui/src/constants/ui.ts
+++ b/apps/agor-ui/src/constants/ui.ts
@@ -44,9 +44,14 @@ export const TEXT_TRUNCATION = {
  * Used when a board doesn't have a custom background configured.
  */
 export const DEFAULT_BACKGROUNDS = {
-  // biome-ignore lint/plugin/noHardcodedColorLiteral: centralized theme-keyed default for persisted board backgrounds
-  dark: 'radial-gradient(ellipse at top, #1b2735 0%, #090a0f 100%), radial-gradient(circle at 20% 50%, rgba(120, 0, 255, 0.3) 0%, transparent 50%), radial-gradient(circle at 80% 80%, rgba(255, 0, 120, 0.3) 0%, transparent 50%)',
+  // Sober, primarily-dark default: a deep near-black vertical base with two
+  // restrained cool glows (top-center + lower-right) for gentle depth. Quiet
+  // enough to sit behind cards and zones without competing with them.
+  // biome-ignore lint/plugin/noHardcodedColorLiteral: centralized theme-keyed default for board backgrounds
+  dark: 'radial-gradient(75% 55% at 50% -8%, rgba(86, 108, 150, 0.22) 0%, rgba(86, 108, 150, 0) 60%), radial-gradient(60% 45% at 88% 108%, rgba(64, 82, 120, 0.16) 0%, rgba(64, 82, 120, 0) 60%), linear-gradient(180deg, #0f131a 0%, #0b0e14 55%, #090b10 100%)',
+  // Light counterpart: a soft neutral paper tone with the same restrained
+  // structure so the canvas reads as intentional but calm.
   light:
-    // biome-ignore lint/plugin/noHardcodedColorLiteral: centralized theme-keyed default for persisted board backgrounds
-    'radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0) 45%), radial-gradient(circle at 50% 50%, rgba(210, 216, 224, 0.35) 35%, rgba(210, 216, 224, 0) 80%), linear-gradient(90deg, #d9dde3 0%, #ffffff 45%, #ffffff 55%, #d9dde3 100%)',
+    // biome-ignore lint/plugin/noHardcodedColorLiteral: centralized theme-keyed default for board backgrounds
+    'radial-gradient(75% 55% at 50% -8%, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0) 60%), radial-gradient(60% 45% at 88% 108%, rgba(203, 213, 229, 0.5) 0%, rgba(203, 213, 229, 0) 60%), linear-gradient(180deg, #eef1f6 0%, #e7ebf2 55%, #e2e7ef 100%)',
 } as const;

--- a/apps/agor-ui/src/utils/boardBackground.test.ts
+++ b/apps/agor-ui/src/utils/boardBackground.test.ts
@@ -1,0 +1,38 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: test fixtures assert on literal CSS background values
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
+import { describe, expect, it } from 'vitest';
+import { hasBackgroundValue, hasBoardStyling } from './boardBackground';
+
+describe('boardBackground helpers', () => {
+  describe('hasBackgroundValue', () => {
+    it('is false for empty/undefined', () => {
+      expect(hasBackgroundValue(undefined)).toBe(false);
+      expect(hasBackgroundValue(null)).toBe(false);
+      expect(hasBackgroundValue('')).toBe(false);
+      expect(hasBackgroundValue('   ')).toBe(false);
+    });
+
+    it('is true for any non-empty value, including the Gold Shimmer gradient', () => {
+      expect(hasBackgroundValue('#1a1a1a')).toBe(true);
+      expect(hasBackgroundValue('linear-gradient(180deg, #000, #111)')).toBe(true);
+      // Gold Shimmer is a real, selectable preset value — never treated as "unset".
+      expect(hasBackgroundValue(GOLD_SHIMMER_BOARD_BACKGROUND)).toBe(true);
+    });
+  });
+
+  describe('hasBoardStyling', () => {
+    it('is false only when both fields are empty', () => {
+      expect(hasBoardStyling(undefined, undefined)).toBe(false);
+      expect(hasBoardStyling('', '')).toBe(false);
+    });
+
+    it('is true when a background value is present (Gold Shimmer included)', () => {
+      expect(hasBoardStyling('#222', undefined)).toBe(true);
+      expect(hasBoardStyling(GOLD_SHIMMER_BOARD_BACKGROUND, undefined)).toBe(true);
+    });
+
+    it('is true when custom CSS is present even without a background', () => {
+      expect(hasBoardStyling(undefined, 'animation: x 2s;')).toBe(true);
+    });
+  });
+});

--- a/apps/agor-ui/src/utils/boardBackground.ts
+++ b/apps/agor-ui/src/utils/boardBackground.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared logic for resolving a board's background.
+ *
+ * A board's look is driven by two persisted fields: `background_color` (a
+ * solid color, a gradient, or any CSS `background` value) and `custom_css`
+ * (extra scoped CSS for animations/keyframes). When neither carries a value
+ * the board renders the theme-aware default (`DEFAULT_BACKGROUNDS`).
+ *
+ * These helpers are the single source of truth for "is this board styled?"
+ * and are used by both the canvas renderer and the background editor so the
+ * two never disagree about which mode a board is in.
+ *
+ * Note: there is deliberately no "legacy default" special-casing here. The old
+ * auto-assigned Gold Shimmer gradient is a real, selectable preset value, so it
+ * must render exactly as stored — treating it as "unset" would make the preset
+ * impossible to preview or apply. New boards get the sober default simply by
+ * persisting no background at all (see the boards repository).
+ */
+
+/** Whether an explicit background color/gradient value is present. */
+export function hasBackgroundValue(backgroundColor: string | undefined | null): boolean {
+  return Boolean(backgroundColor?.trim());
+}
+
+/**
+ * Whether a board carries any explicit styling (background or custom CSS).
+ * When false the board is "on the default".
+ */
+export function hasBoardStyling(
+  backgroundColor: string | undefined | null,
+  customCss: string | undefined | null
+): boolean {
+  return hasBackgroundValue(backgroundColor) || Boolean(customCss?.trim());
+}

--- a/apps/agor-ui/src/utils/sanitizeCss.test.ts
+++ b/apps/agor-ui/src/utils/sanitizeCss.test.ts
@@ -1,0 +1,110 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: sanitizer tests assert on literal CSS input/output strings
+import { describe, expect, it } from 'vitest';
+import { buildScopedBoardCss, sanitizeBoardCss, validateBoardCss } from './sanitizeCss';
+
+const SCOPE = '.board-css-abc';
+
+describe('sanitizeBoardCss', () => {
+  it('wraps raw declarations in the scope selector', () => {
+    const out = sanitizeBoardCss('background: red; color: blue;', SCOPE);
+    expect(out).toContain(`${SCOPE} {`);
+    expect(out).toContain('background: red;');
+  });
+
+  it('scopes EVERY selector in a comma-separated list (no global escape)', () => {
+    const out = sanitizeBoardCss('.foo, body, html, * { color: red }', SCOPE);
+    // Each selector is individually prefixed …
+    expect(out).toContain(`${SCOPE} .foo`);
+    expect(out).toContain(`${SCOPE} body`);
+    expect(out).toContain(`${SCOPE} html`);
+    expect(out).toContain(`${SCOPE} *`);
+    // … and no selector escapes the scope to hit the whole document.
+    expect(out).not.toMatch(/(^|[,{]\s*)(body|html|\*)\s*\{/m);
+  });
+
+  it('leaves @media preludes intact while scoping their inner selectors', () => {
+    const out = sanitizeBoardCss('@media (max-width: 600px) { body { color: red } }', SCOPE);
+    expect(out).toContain('@media (max-width: 600px)');
+    expect(out).not.toContain(`${SCOPE} @media`);
+    expect(out).toContain(`${SCOPE} body`);
+  });
+
+  it('strips `<` so it cannot terminate the host <style> element', () => {
+    const out = sanitizeBoardCss('color: red; } </style><script>alert(1)</script>', SCOPE);
+    expect(out).not.toContain('<');
+  });
+
+  it('blocks url(), @import, expression(), and javascript:', () => {
+    const out = sanitizeBoardCss(
+      'background: url(http://evil/x); @import "http://evil"; width: expression(alert(1)); color: javascript:x;',
+      SCOPE
+    );
+    expect(out).not.toMatch(/url\s*\(/i);
+    expect(out).not.toMatch(/@import/i);
+    expect(out).not.toMatch(/expression\s*\(/i);
+    expect(out).not.toMatch(/javascript\s*:/i);
+    expect(out).toContain('/* blocked */');
+  });
+
+  it('does not throw on malformed braces', () => {
+    expect(() => sanitizeBoardCss('color: red } .evil { color: blue', SCOPE)).not.toThrow();
+    expect(typeof sanitizeBoardCss('} } {{', SCOPE)).toBe('string');
+  });
+
+  it('keeps @keyframes at top level (unscoped)', () => {
+    const out = sanitizeBoardCss(
+      '@keyframes spin { from { opacity: 0 } to { opacity: 1 } }',
+      SCOPE
+    );
+    expect(out).toContain('@keyframes spin');
+    expect(out).not.toContain(`${SCOPE} @keyframes`);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(sanitizeBoardCss('', SCOPE)).toBe('');
+    expect(sanitizeBoardCss(undefined, SCOPE)).toBe('');
+  });
+});
+
+describe('buildScopedBoardCss', () => {
+  it('returns empty when the board carries no styling', () => {
+    expect(buildScopedBoardCss({ scopeClass: 'board-x' })).toBe('');
+    expect(
+      buildScopedBoardCss({ backgroundColor: '   ', customCss: '', scopeClass: 'board-x' })
+    ).toBe('');
+  });
+
+  it('prepends the background as a scoped declaration', () => {
+    const out = buildScopedBoardCss({
+      backgroundColor: 'linear-gradient(180deg, #000, #111)',
+      scopeClass: 'board-x',
+    });
+    expect(out).toContain('.board-x {');
+    expect(out).toContain('background: linear-gradient(180deg, #000, #111);');
+  });
+
+  it('appends a reduced-motion override covering the root AND descendants', () => {
+    const out = buildScopedBoardCss({
+      backgroundColor: '#123456',
+      customCss: 'animation: spin 2s infinite;',
+      scopeClass: 'board-x',
+    });
+    expect(out).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(out).toContain('.board-x, .board-x * { animation: none !important; }');
+  });
+
+  it('routes background_color through the sanitizer too', () => {
+    const out = buildScopedBoardCss({
+      backgroundColor: 'url(http://evil/x)',
+      scopeClass: 'board-x',
+    });
+    expect(out).not.toMatch(/url\s*\(/i);
+  });
+});
+
+describe('validateBoardCss', () => {
+  it('reports blocked patterns', () => {
+    expect(validateBoardCss('background: url(x)')).toHaveLength(1);
+    expect(validateBoardCss('color: red')).toHaveLength(0);
+  });
+});

--- a/apps/agor-ui/src/utils/sanitizeCss.test.ts
+++ b/apps/agor-ui/src/utils/sanitizeCss.test.ts
@@ -46,6 +46,28 @@ describe('sanitizeBoardCss', () => {
     expect(out).toContain('/* blocked */');
   });
 
+  it('blocks tokens hidden behind CSS comments', () => {
+    // The browser treats the comment as a separator; our de-obfuscation strips
+    // it before matching so the blocklist still catches the reassembled token.
+    const out = sanitizeBoardCss('background: url/**/(http://evil/x);', SCOPE);
+    // No live url() token survives (the leftover URL text is inert, not fetched).
+    expect(out).not.toMatch(/url\s*\(/i);
+    expect(out).toContain('/* blocked */');
+  });
+
+  it('blocks tokens hidden behind CSS escapes', () => {
+    // "\75 rl(" is the CSS escape for "url(". Stripping backslashes prevents
+    // the parser from reassembling it into a live url() token (the leftover
+    // "rl(" is inert — the browser loads nothing from it).
+    const out = sanitizeBoardCss('background: \\75 rl(http://evil/x);', SCOPE);
+    expect(out).not.toMatch(/url\s*\(/i);
+    expect(out).not.toContain('\\');
+  });
+
+  it('reports comment-obfuscated blocked tokens via validateBoardCss', () => {
+    expect(validateBoardCss('background: @imp/**/ort url(x)').length).toBeGreaterThan(0);
+  });
+
   it('does not throw on malformed braces', () => {
     expect(() => sanitizeBoardCss('color: red } .evil { color: blue', SCOPE)).not.toThrow();
     expect(typeof sanitizeBoardCss('} } {{', SCOPE)).toBe('string');

--- a/apps/agor-ui/src/utils/sanitizeCss.ts
+++ b/apps/agor-ui/src/utils/sanitizeCss.ts
@@ -27,6 +27,23 @@ const DANGEROUS_PATTERNS = [
 ];
 
 /**
+ * Neutralize obfuscation the browser's CSS parser would silently normalize
+ * away, so the lexical blocklist below can't be evaded by hiding a blocked
+ * token behind comments or escapes:
+ *
+ *   - `url/*x*​/(…)`      → comment acts as a separator to the parser
+ *   - `\75 rl(…)`         → CSS escape for `u`, reassembled by the parser
+ *
+ * Board backgrounds never legitimately need CSS comments or backslash escapes,
+ * so stripping both is safe and makes the subsequent pattern checks robust.
+ */
+function deobfuscateCss(css: string): string {
+  return css
+    .replace(/\/\*[\s\S]*?\*\//g, '') // strip CSS comments (incl. unterminated-safe)
+    .replace(/\\/g, ''); // strip CSS escape backslashes
+}
+
+/**
  * Check if a CSS string contains dangerous patterns.
  */
 function containsDangerousPattern(css: string): string | null {
@@ -79,8 +96,9 @@ function scopeSelectorList(selectorList: string, scopeSelector: string): string 
 export function sanitizeBoardCss(css: string | undefined, scopeSelector: string): string {
   if (!css?.trim()) return '';
 
-  // Check for dangerous patterns and strip them
-  let sanitized = css;
+  // Normalize away comment/escape obfuscation FIRST so blocked tokens can't be
+  // hidden from the pattern checks below.
+  let sanitized = deobfuscateCss(css);
   for (const pattern of DANGEROUS_PATTERNS) {
     pattern.lastIndex = 0;
     sanitized = sanitized.replace(pattern, '/* blocked */');
@@ -171,11 +189,14 @@ export function buildScopedBoardCss(params: {
 export function validateBoardCss(css: string | undefined): string[] {
   if (!css?.trim()) return [];
 
+  // Scan the de-obfuscated form so comment/escape-hidden tokens are still
+  // reported (matching what sanitizeBoardCss will strip).
+  const scanned = deobfuscateCss(css);
   const issues: string[] = [];
 
   for (const pattern of DANGEROUS_PATTERNS) {
     pattern.lastIndex = 0;
-    if (pattern.test(css)) {
+    if (pattern.test(scanned)) {
       const name = pattern.source.replace(/\\s\*\\\(/g, '()').replace(/\\s\*:/g, ':');
       issues.push(`Blocked pattern: ${name}`);
     }

--- a/apps/agor-ui/src/utils/sanitizeCss.ts
+++ b/apps/agor-ui/src/utils/sanitizeCss.ts
@@ -3,7 +3,14 @@
  *
  * Allows safe CSS properties and @keyframes while blocking XSS vectors.
  * Returns sanitized CSS scoped to a board-specific class selector.
+ *
+ * Trust boundary: board CSS is authored by users who can edit the board and is
+ * rendered for everyone viewing it, so the sanitizer must both strip active
+ * content (url()/expression()/@import/etc.) AND keep the CSS confined to the
+ * board canvas so it cannot restyle the surrounding app.
  */
+
+import { hasBoardStyling } from './boardBackground';
 
 /** Patterns that are dangerous in CSS and must be stripped */
 const DANGEROUS_PATTERNS = [
@@ -33,11 +40,36 @@ function containsDangerousPattern(css: string): string | null {
 }
 
 /**
+ * Scope a (possibly comma-separated) selector list to the board canvas.
+ *
+ * Every selector in the list is prefixed — `.foo, body` becomes
+ * `.scope .foo, .scope body` — so a selector list cannot smuggle an unscoped
+ * selector (e.g. `body`, `html`, `*`) that would escape into the whole app.
+ * At-rule preludes (e.g. `@media (...)`) are left intact; the selectors nested
+ * inside their block are scoped by the same pass.
+ */
+function scopeSelectorList(selectorList: string, scopeSelector: string): string {
+  return selectorList
+    .split(',')
+    .map((raw) => {
+      const selector = raw.trim();
+      if (!selector) return '';
+      // At-rule prelude — keep as-is; its inner rules get scoped separately.
+      if (selector.startsWith('@')) return selector;
+      return `${scopeSelector} ${selector}`;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+/**
  * Sanitize and scope custom CSS for a board canvas.
  *
  * - Strips dangerous CSS patterns (url(), expression(), @import, etc.)
+ * - Strips `<` so custom CSS can never break out of the host `<style>` element
  * - Separates @keyframes blocks from property declarations
- * - Scopes property declarations to the board's canvas element
+ * - Scopes every selector (including each entry in a selector list) to the
+ *   board's canvas element
  * - Returns empty string if input is empty or entirely dangerous
  *
  * @param css - Raw CSS input from the user
@@ -53,6 +85,11 @@ export function sanitizeBoardCss(css: string | undefined, scopeSelector: string)
     pattern.lastIndex = 0;
     sanitized = sanitized.replace(pattern, '/* blocked */');
   }
+
+  // Strip `<` entirely. It is never valid in the CSS we accept, and removing it
+  // makes it impossible to terminate the host <style> element (e.g. "</style>")
+  // regardless of which injection sink renders the result.
+  sanitized = sanitized.replace(/</g, '');
 
   // Extract @keyframes blocks (they must remain at top level, not scoped)
   const keyframesBlocks: string[] = [];
@@ -79,9 +116,12 @@ export function sanitizeBoardCss(css: string | undefined, scopeSelector: string)
     // If they wrote selectors, we still scope them under the board selector
     const hasSelector = /[^{}]+\{/.test(declarations);
     if (hasSelector) {
-      // User wrote CSS rules with selectors — scope each rule
+      // User wrote CSS rules with selectors — scope each selector in each rule.
       parts.push(
-        `${scopeSelector} { }\n${declarations.replace(/([^{}]+)\{/g, `${scopeSelector} $1{`)}`
+        `${scopeSelector} { }\n${declarations.replace(
+          /([^{}]+)\{/g,
+          (_match, selectorList: string) => `${scopeSelectorList(selectorList, scopeSelector)} {`
+        )}`
       );
     } else {
       // Raw property declarations — wrap in scoped selector
@@ -95,6 +135,33 @@ export function sanitizeBoardCss(css: string | undefined, scopeSelector: string)
   }
 
   return parts.join('\n\n');
+}
+
+/**
+ * Compose the full scoped `<style>` payload for a board background.
+ *
+ * This is the single rendering pipeline shared by the canvas and the editor
+ * preview so they cannot drift: it prepends `background_color` as a declaration
+ * (so it goes through the same sanitizer as `custom_css`), scopes everything to
+ * `scopeClass`, and appends a reduced-motion override that neutralizes any
+ * animation on the board root AND its scoped descendants.
+ *
+ * Returns an empty string when the board carries no explicit styling, in which
+ * case callers should fall back to the trusted inline themed default.
+ */
+export function buildScopedBoardCss(params: {
+  backgroundColor?: string | null;
+  customCss?: string | null;
+  scopeClass: string;
+}): string {
+  const { backgroundColor, customCss, scopeClass } = params;
+  if (!scopeClass || !hasBoardStyling(backgroundColor, customCss)) return '';
+
+  const bgRule = backgroundColor?.trim() ? `background: ${backgroundColor};\n` : '';
+  const scoped = sanitizeBoardCss(bgRule + (customCss || ''), `.${scopeClass}`);
+  if (!scoped) return '';
+
+  return `${scoped}\n\n@media (prefers-reduced-motion: reduce) {\n  .${scopeClass}, .${scopeClass} * { animation: none !important; }\n}`;
 }
 
 /**

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -8,7 +8,6 @@
 import type { Board, BoardID, BoardObject, UUID } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
-import { DEFAULT_BOARD_BACKGROUND } from '../../design/board-backgrounds';
 import { generateId, shortId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
 import { select, update } from '../database-wrapper';
@@ -114,12 +113,14 @@ async function getStoredBoardIcon(db: Database, boardId: UUID): Promise<string |
 // ============================================================================
 
 describe('BoardRepository.create', () => {
-  dbTest('defaults an omitted background to Gold Shimmer', async ({ db }) => {
+  dbTest('leaves an omitted background unset (renders the themed default)', async ({ db }) => {
     const repo = new BoardRepository(db);
 
     const created = await repo.create(createBoardData());
 
-    expect(created.background_color).toBe(DEFAULT_BOARD_BACKGROUND);
+    // No background is persisted; an unset value means "use the theme-aware
+    // default", resolved at render time rather than frozen into the row.
+    expect(created.background_color).toBeUndefined();
   });
 
   dbTest('preserves an explicitly supplied background', async ({ db }) => {

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -18,7 +18,6 @@ import { isTeammate } from '@agor/core/types';
 import { and, eq, inArray, isNull, like, ne, type SQL } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
-import { DEFAULT_BOARD_BACKGROUND } from '../../design/board-backgrounds';
 import { generateId } from '../../lib/ids';
 import { generateSlug } from '../../lib/slugs';
 import { normalizeExactEmojiShortcode } from '../../utils/emoji-shortcodes';
@@ -166,9 +165,10 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
           board.default_dangerously_allow_session_sharing ?? false,
         color: board.color,
         icon: normalizeExactEmojiShortcode(board.icon),
-        background_color: Object.hasOwn(board, 'background_color')
-          ? board.background_color
-          : DEFAULT_BOARD_BACKGROUND,
+        // No default is persisted: an unset background_color means "use the
+        // theme-aware default", resolved at render time. This keeps the
+        // product default improvable without rewriting stored boards.
+        background_color: board.background_color,
         custom_css: board.custom_css,
         objects: board.objects,
         custom_context: board.custom_context,

--- a/packages/core/src/design/board-backgrounds.ts
+++ b/packages/core/src/design/board-backgrounds.ts
@@ -1,3 +1,12 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: centralized persisted board-background gradient literals
+
+/**
+ * Gold-shimmer gradient. Historically this was force-persisted as the default
+ * `background_color` on every board at creation time; that behavior has been
+ * removed (new boards persist no background and render the theme-aware
+ * default). It remains a selectable preset in the gallery so anyone can pick it
+ * back explicitly, and so boards that still carry it render exactly as stored.
+ */
 export const GOLD_SHIMMER_BOARD_BACKGROUND =
   'linear-gradient(135deg, #f5af19 0%, #f12711 30%, #f5af19 60%, #f12711 100%)';
 
@@ -6,4 +15,10 @@ export const GOLD_SHIMMER_BOARD_BACKGROUND_PRESET = {
   value: GOLD_SHIMMER_BOARD_BACKGROUND,
 } as const;
 
+/**
+ * @deprecated Boards no longer persist a background at creation time. New
+ * boards leave `background_color` unset and render the theme-aware default
+ * (see `DEFAULT_BACKGROUNDS` in the UI). Retained only for backward-compatible
+ * imports; prefer leaving `background_color` undefined to mean "default".
+ */
 export const DEFAULT_BOARD_BACKGROUND = GOLD_SHIMMER_BOARD_BACKGROUND;

--- a/packages/core/src/design/board-backgrounds.ts
+++ b/packages/core/src/design/board-backgrounds.ts
@@ -14,11 +14,3 @@ export const GOLD_SHIMMER_BOARD_BACKGROUND_PRESET = {
   label: 'Gold Shimmer',
   value: GOLD_SHIMMER_BOARD_BACKGROUND,
 } as const;
-
-/**
- * @deprecated Boards no longer persist a background at creation time. New
- * boards leave `background_color` unset and render the theme-aware default
- * (see `DEFAULT_BACKGROUNDS` in the UI). Retained only for backward-compatible
- * imports; prefer leaving `background_color` undefined to mean "default".
- */
-export const DEFAULT_BOARD_BACKGROUND = GOLD_SHIMMER_BOARD_BACKGROUND;


### PR DESCRIPTION
## Summary

Replaces the loud gold-shimmer default board background with a **subtle, sober, theme-aware default**, and rebuilds the board **CSS/background editor** around three clear modes with a live preview and a real-CSS preset gallery. Also fixes a bug where the custom-CSS mode lost its state when the Edit Board modal was reopened.

## What changed

### New default background
- The boards repository **no longer force-persists a background** at creation. An unset `background_color` now renders a theme-aware default (`DEFAULT_BACKGROUNDS`) — a sober, mostly-dark surface (with a light counterpart) that stays quiet behind cards/zones.
- Because the default isn't persisted, it can be improved over time without rewriting existing rows.

### Redesigned background editor (`BoardBackgroundEditor`)
- **Default / Preset / Custom CSS** segmented modes.
- **Preset gallery** whose thumbnails render the **actual** background CSS (not illustrations), via a shared `BoardBackgroundPreview` that reuses the exact canvas **sanitize + scope** path, with representative mini cards + a zone so contrast/readability is visible at a glance.
- **Live preview** at the top reflecting current values.
- Retained **raw CSS** editing for power users, a compact **gradient helper** (type + 2 colors + angle), and optional **animation presets**.
- Curated the gallery to sober entries (Midnight, Graphite, Aurora, Nebula, Ember, Fog, Dawn); dropped the loud/inaccessible ones (rainbow, RGB stripes, hairline lines, checkerboard, sunbursts). **Gold Shimmer is kept** as a selectable option.

### Bug fix — custom-CSS state lost on reopen
- **Root cause:** the toggle lived in local state seeded once via `useState(initialCustomCSS)`, but the modal rendered before the board finished loading (async `get`), so it initialized to `false` and never re-synced.
- **Fix:** the modal renders the form only after the board loads (skeleton meanwhile), and the editor derives/re-syncs its mode from the loaded values via a `resetSignal`.

### Correctness fix surfaced during review
- Removed value-based "legacy default" detection. It used the Gold Shimmer literal as a *treat-as-default* sentinel, which collided with Gold Shimmer being a real preset — so the preset (and any board carrying that value) rendered as the default in the gallery, live preview, and canvas. Boards now render exactly what's stored.

### Accessibility & motion
- Labelled controls, keyboard-friendly gallery (`fieldset`/legend + `aria-pressed`), and background animations disabled under `prefers-reduced-motion` on both the canvas and the preview.

## Migration / compatibility
- **Backward compatible** — no schema change; storage model (`background_color` + `custom_css`) unchanged.
- **New boards** persist no background → sober themed default.
- **Existing boards** render exactly what they already store (no surprise, matches current production). Boards previously auto-assigned gold keep it until switched to **Default** in the editor. A deliberate one-time DB migration to flip auto-gold boards to the new default can be added later if desired — intentionally not done here to avoid breaking the Gold Shimmer preset.

## Testing
- **UI:** helpers, mode derivation, Default/Preset/Custom switching, cancel/save clearing, preset selection, and **reopen persistence**.
- **Core:** boards repository default-behavior change.
- Typecheck + build green; Biome clean on all changed files.
- **Manually verified** in the managed environment with Playwright: canvas renders stored backgrounds, gallery thumbnails + live preview render faithfully (including Gold Shimmer), and reopening lands in the correct mode.

## Files
- New: `forms/BoardBackgroundEditor.tsx`, `forms/BoardBackgroundPreview.tsx`, `utils/boardBackground.ts` (+ tests).
- Changed: `forms/BoardFormFields.tsx`, `forms/boardBackgroundPresets.ts`, `BoardEditModal.tsx`, `SettingsModal/BoardsTable.tsx`, `CreateDialog/tabs/BoardTab.tsx`, `SessionCanvas.tsx`, `constants/ui.ts`, `core/db/repositories/boards.ts`, `core/design/board-backgrounds.ts` (+ test updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
