### PR TITLE
fix(ui): make settings table page-size selector work

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -617,7 +617,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
           dataSource={filteredBranches}
           columns={columns}
           rowKey="branch_id"
-          pagination={{ pageSize: 10 }}
+          pagination={{ defaultPageSize: 10 }}
           size="small"
           onRow={(record) => ({
             onClick: () => onRowClick?.(record),

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -465,7 +465,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                 columns={cardColumns}
                 rowKey="card_id"
                 size="small"
-                pagination={{ pageSize: 20, hideOnSinglePage: true }}
+                pagination={{ defaultPageSize: 20, hideOnSinglePage: true }}
                 onRow={(record) => ({
                   onClick: () => {
                     setCardModalCard(record);

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -3846,7 +3846,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           dataSource={channels}
           columns={columns}
           rowKey="id"
-          pagination={{ pageSize: 10, showSizeChanger: true }}
+          pagination={{ defaultPageSize: 10, showSizeChanger: true }}
           size="small"
         />
       )}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -420,7 +420,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         dataSource={servers}
         columns={columns}
         rowKey="mcp_server_id"
-        pagination={{ pageSize: 10, showSizeChanger: true }}
+        pagination={{ defaultPageSize: 10, showSizeChanger: true }}
         size="small"
       />
 

--- a/apps/agor-ui/src/components/SettingsModal/TeammatesTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/TeammatesTable.test.tsx
@@ -18,6 +18,29 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   } as Repo;
 }
 
+function makeTeammate(index: number): Branch {
+  return {
+    branch_id: `branch-${index}`,
+    repo_id: 'repo-1',
+    name: `teammate-${index}`,
+    created_by: 'user-1',
+    archived: false,
+    custom_context: {
+      teammate: { kind: 'teammate', displayName: `Teammate ${index}` },
+    },
+  } as unknown as Branch;
+}
+
+/** antd only auto-renders the size changer once the row count exceeds 50. */
+function makeTeammates(count: number): Map<string, Branch> {
+  const branchById = new Map<string, Branch>();
+  for (let i = 0; i < count; i += 1) {
+    const teammate = makeTeammate(i);
+    branchById.set(teammate.branch_id, teammate);
+  }
+  return branchById;
+}
+
 describe('TeammatesTable', () => {
   it('delegates teammate creation to the shared create flow', () => {
     const onCreateTeammate = vi.fn();
@@ -37,5 +60,26 @@ describe('TeammatesTable', () => {
     fireEvent.click(screen.getByRole('button', { name: /Create AI teammate/i }));
 
     expect(onCreateTeammate).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a page size picked from the pagination size changer', async () => {
+    const repo = makeRepo();
+
+    const { container } = renderWithProviders(
+      <TeammatesTable
+        branchById={makeTeammates(60)}
+        repoById={new Map([[repo.repo_id, repo]])}
+        boardById={new Map<string, Board>()}
+        sessionsByBranch={new Map<string, Session[]>()}
+        userById={new Map<string, User>()}
+      />
+    );
+
+    expect(container.querySelectorAll('.ant-table-row')).toHaveLength(10);
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Page Size' }));
+    fireEvent.click(await screen.findByTitle('20 / page'));
+
+    expect(container.querySelectorAll('.ant-table-row')).toHaveLength(20);
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/TeammatesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/TeammatesTable.tsx
@@ -281,7 +281,7 @@ export const TeammatesTable: React.FC<TeammatesTableProps> = ({
           dataSource={teammates}
           columns={columns}
           rowKey="branch_id"
-          pagination={{ pageSize: 10 }}
+          pagination={{ defaultPageSize: 10 }}
           size="small"
           onRow={(record) => ({
             onClick: () => onRowClick?.(record),


### PR DESCRIPTION
## What

Makes the page-size selector actually work in the Settings tables. Switches the
five affected `<Table>` call sites from antd's controlled `pageSize` to the
uncontrolled `defaultPageSize`, and adds a regression test.

## Why

The size changer rendered and responded to clicks, but had no effect on the rows
shown — you could select "100 / page" and still get 10 rows. antd auto-displays
the size changer once `total > 50`, so users hit a control that looks functional
and silently does nothing.

## How

`pagination={{ pageSize: N }}` is a *controlled* prop: the supplied pagination
object is merged over the table's internal pagination state on every render. So
picking a new size updated the internal state, the table re-rendered, and the
controlled value immediately forced it back to `N`.

`defaultPageSize` seeds the initial value and then lets antd own the state.
Each call site keeps its existing `showSizeChanger` / `hideOnSinglePage` value
unchanged.

| File | Before | After |
|---|---|---|
| `SettingsModal/TeammatesTable.tsx` | `pageSize: 10` | `defaultPageSize: 10` |
| `SettingsModal/BranchesTable.tsx` | `pageSize: 10` | `defaultPageSize: 10` |
| `SettingsModal/MCPServersTable.tsx` | `pageSize: 10` | `defaultPageSize: 10` |
| `SettingsModal/GatewayChannelsTable.tsx` | `pageSize: 10` | `defaultPageSize: 10` |
| `SettingsModal/CardsTable.tsx` | `pageSize: 20` | `defaultPageSize: 20` |

### Scope notes

Two deliberate omissions, called out so they read as decisions rather than misses:

- **`UploadsTab.tsx` and `BranchModal/tabs/SessionsTab.tsx` are left alone.** Both
  set `showSizeChanger: false`, so there is no user-reachable bug there and
  changing them would be churn.
- **`showSizeChanger: true` was not added to Teammates/Branches.** The issue's
  suggested snippet includes it, but those two call sites never opted in — antd
  only auto-shows the changer past 50 rows, so forcing it true would make the
  dropdown appear on small tables where it doesn't today. That's a UX change
  beyond the reported bug. Happy to add it if you'd prefer.
- **No shared pagination config.** The issue notes a shared default would stop
  this regressing table-by-table. That seemed like scope worth agreeing on
  first — glad to follow up with it if wanted.

## Testing

- Added `applies a page size picked from the pagination size changer` to
  `TeammatesTable.test.tsx`. It renders 60 teammates, asserts 10 rows, drives the
  size changer to 20, and asserts 20 rows. **Fails on `pageSize`, passes on
  `defaultPageSize`.**
- Full `agor-ui` suite: **1323 passed** across 193 files.
- `pnpm typecheck` — 21/21 tasks pass.
- `pnpm lint` — clean.
- Manually verified against a local instance on Settings → Integrations → MCP
  Servers with 12 servers: switching 10 → 20 per page now renders all 12 rows and
  collapses the pager to a single page. Before the change the pager label updated
  but the table stayed at 10 rows across 2 pages.

**What reviewers should check:** that the initial page size is unchanged on all
five tables (10, except Cards at 20), and that the size changer now persists a
selection.

## Video demo


https://github.com/user-attachments/assets/2bc397f0-7c38-4c24-816c-ef93f51d7f8c


## Screenshots

### Before

<!-- Drag and drop before.png here -->

### After

<!-- Drag and drop after.png here -->

Closes #1917
