### PR TITLE
fix(security): gate the update verb — any authenticated user could PUT-replace any board, card, or session

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1112,6 +1112,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       create: [requireMinimumRole(ROLES.MEMBER, 'create card types')],
+      update: [requireMinimumRole(ROLES.MEMBER, 'update card types')],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update card types')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete card types')],
     },
@@ -1126,6 +1127,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create cards'), injectCreatedBy()],
+      update: [requireMinimumRole(ROLES.MEMBER, 'update cards')],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update cards')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete cards')],
     },
@@ -1409,6 +1411,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create board comments'), injectCreatedBy()],
+      update: [requireMinimumRole(ROLES.MEMBER, 'update board comments')],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update board comments')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete board comments')],
     },
@@ -2556,6 +2559,61 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Sessions hooks
   // ============================================================================
 
+  // SessionsService.update delegates straight to patch, so both verbs mutate a
+  // session the same way and must clear the same authorization chain.
+  const sessionWriteGuards = [
+    // created_by and unix_username select the OS identity a session executes as.
+    // The unix_user_mode tiers that make them load-bearing are configured
+    // independently of branch_rbac, so their immutability cannot be conditional
+    // on it — an open-access instance can still be running delegated or strict.
+    ensureSessionImmutability(),
+    ...(branchRbacEnabled
+      ? [
+          resolveSessionContext(),
+          loadSession(sessionsService),
+          loadBranchFromSession(branchRepository),
+          // Branch permission by patch type:
+          //   - Prompt-flow patches (tasks, archived, status, …) are bookkeeping
+          //     emitted by /sessions/:id/prompt and /sessions/:id/stop on behalf
+          //     of the authenticated user. They need only the same tier as
+          //     prompting the session (session-tier for own, prompt-tier for
+          //     others), matching the permission table in CLAUDE.md.
+          //   - Everything else is session metadata and still requires 'all'.
+          // Mixed-field patches fail isPromptFlowPatchOnly and fall through to
+          // the strict 'all' path, so there's no partial-trust footgun.
+          (context: HookContext) => {
+            if (isPromptFlowPatchOnly(context.data)) {
+              return ensureCanPromptInSession(superadminOpts)(context);
+            }
+            return ensureBranchPermission(
+              'all',
+              'update session metadata',
+              superadminOpts
+            )(context);
+          },
+        ]
+      : []),
+    // Validate user has prompt permission on callback target session's branch.
+    // Skip for internal calls (no provider) — patches from dispatchCompletionCallbacks
+    // spread the existing callback_config (which includes callback_session_id) and must
+    // not be blocked by this check.
+    async (context: HookContext) => {
+      const patchCbConfig = (context.data as Record<string, unknown> | undefined)
+        ?.callback_config as { callback_session_id?: string } | undefined;
+      if (patchCbConfig?.callback_session_id && context.params.provider) {
+        const userId =
+          (context.params as { user?: { user_id: string } }).user?.user_id || 'unknown';
+        await ensureCanPromptTargetSession(
+          patchCbConfig.callback_session_id,
+          userId,
+          context.app,
+          branchRepository
+        );
+      }
+      return context;
+    },
+  ];
+
   app.service('sessions').hooks({
     before: {
       all: [typedValidateQuery(sessionQueryValidator), requireAuth, executorRuntimeScopeGuard()],
@@ -2650,54 +2708,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           return context;
         },
       ],
-      patch: [
-        ...(branchRbacEnabled
-          ? [
-              ensureSessionImmutability(), // Prevent changing session.created_by and unix_username
-              resolveSessionContext(),
-              loadSession(sessionsService),
-              loadBranchFromSession(branchRepository),
-              // Branch permission by patch type:
-              //   - Prompt-flow patches (tasks, archived, status, …) are bookkeeping
-              //     emitted by /sessions/:id/prompt and /sessions/:id/stop on behalf
-              //     of the authenticated user. They need only the same tier as
-              //     prompting the session (session-tier for own, prompt-tier for
-              //     others), matching the permission table in CLAUDE.md.
-              //   - Everything else is session metadata and still requires 'all'.
-              // Mixed-field patches fail isPromptFlowPatchOnly and fall through to
-              // the strict 'all' path, so there's no partial-trust footgun.
-              (context: HookContext) => {
-                if (isPromptFlowPatchOnly(context.data)) {
-                  return ensureCanPromptInSession(superadminOpts)(context);
-                }
-                return ensureBranchPermission(
-                  'all',
-                  'update session metadata',
-                  superadminOpts
-                )(context);
-              },
-            ]
-          : []),
-        // Validate user has prompt permission on callback target session's branch.
-        // Skip for internal calls (no provider) — patches from dispatchCompletionCallbacks
-        // spread the existing callback_config (which includes callback_session_id) and must
-        // not be blocked by this check.
-        async (context) => {
-          const patchCbConfig = (context.data as Record<string, unknown> | undefined)
-            ?.callback_config as { callback_session_id?: string } | undefined;
-          if (patchCbConfig?.callback_session_id && context.params.provider) {
-            const userId =
-              (context.params as { user?: { user_id: string } }).user?.user_id || 'unknown';
-            await ensureCanPromptTargetSession(
-              patchCbConfig.callback_session_id,
-              userId,
-              context.app,
-              branchRepository
-            );
-          }
-          return context;
-        },
-      ],
+      update: sessionWriteGuards,
+      patch: sessionWriteGuards,
       remove: [
         ...(branchRbacEnabled
           ? [
@@ -3029,6 +3041,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       findBySlug: [ensureCanViewBoard('view this board')],
       findBySlugOrId: [ensureCanViewBoard('view this board')],
       create: [requireMinimumRole(ROLES.MEMBER, 'create boards'), injectCreatedBy()],
+      // Whole-row replacement carries the same authorization as patch. The
+      // `_action` dispatcher below is patch-only: those atomic board-object
+      // operations are addressed through PATCH and have no PUT equivalent.
+      update: [
+        requireMinimumRole(ROLES.MEMBER, 'update boards'),
+        ensureCanMutateBoard('update this board'),
+      ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update boards'),
         ensureCanMutateBoard('update this board'),

--- a/apps/agor-daemon/src/register-hooks.update-gating.test.ts
+++ b/apps/agor-daemon/src/register-hooks.update-gating.test.ts
@@ -1,0 +1,341 @@
+/**
+ * `update` is a first-class Feathers verb: every service registered through
+ * DrizzleService inherits a working `update()` and, unless `app.use(...)`
+ * narrows the exposed method list, Feathers routes `PUT /<service>/:id` to it.
+ *
+ * A hook block that names `create`/`patch`/`remove` but not `update` therefore
+ * leaves whole-row replacement guarded by nothing but the service's `all`
+ * chain — usually just `requireAuth`. These tests enumerate the hooks the real
+ * registration code installs and fail when that shape reappears.
+ */
+
+import { feathers, feathersExpress, rest } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks';
+import { ARTIFACTS_SERVICE_TRANSPORT_METHODS } from './services/artifacts';
+import { GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS } from './services/gateway-channels';
+import { GROUPS_SERVICE_TRANSPORT_METHODS } from './services/groups';
+import { KNOWLEDGE_GRAPH_SERVICE_TRANSPORT_METHODS } from './services/knowledge-graph';
+import { SCHEDULES_SERVICE_TRANSPORT_METHODS } from './services/schedules';
+import { TASKS_SERVICE_TRANSPORT_METHODS } from './services/tasks';
+import { USERS_SERVICE_TRANSPORT_METHODS } from './services/users';
+
+type RegisteredHook = (context: HookContext) => unknown;
+type CapturedHooks = { before: Record<string, RegisteredHook[]> };
+
+/**
+ * Run `registerHooks` against a recording stand-in for the Feathers app and
+ * return the before-hook map per service path, for one RBAC mode.
+ *
+ * Several hook blocks spread their branch permission hooks in only when
+ * `branchRbacEnabled` is true, so each mode is captured and asserted on its
+ * own — see {@link RBAC_MODES}.
+ */
+const captureRegisteredHooks = (branchRbacEnabled: boolean): Map<string, CapturedHooks> => {
+  const captured = new Map<string, CapturedHooks>();
+  const app = {
+    service(path: string) {
+      return {
+        hooks(hooks: { before?: Record<string, RegisteredHook[]> }) {
+          const key = path.replace(/^\//, '');
+          const entry = captured.get(key) ?? { before: {} };
+          for (const [method, chain] of Object.entries(hooks?.before ?? {})) {
+            entry.before[method] = [...(entry.before[method] ?? []), ...(chain ?? [])];
+          }
+          captured.set(key, entry);
+        },
+      };
+    },
+    use() {},
+    publish() {},
+  };
+
+  registerHooks({
+    db: {} as RegisterHooksContext['db'],
+    app: app as unknown as RegisterHooksContext['app'],
+    config: {
+      database: { dialect: 'postgresql' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'update-gating-test' },
+    } as RegisterHooksContext['config'],
+    jwtSecret: 'update-gating-test-secret',
+    // The HA gates are `before.all` entries, so they cannot satisfy or defeat a
+    // per-verb invariant; standalone keeps the captured map to the real hooks.
+    deployment: { mode: 'standalone' },
+    branchRbacEnabled,
+    requireAuth: async (context) => context,
+    superadminOpts: { allowSuperadmin: true },
+    sessionsService: {} as RegisterHooksContext['sessionsService'],
+    messagesService: {} as RegisterHooksContext['messagesService'],
+    boardsService: undefined,
+    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    usersRepository: {} as RegisterHooksContext['usersRepository'],
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+  });
+
+  return captured;
+};
+
+/**
+ * Both RBAC modes, kept separate on purpose.
+ *
+ * Merging them would let a verb gated only under `branchRbacEnabled: true`
+ * satisfy the invariant while sitting wide open in the default mode, which is
+ * exactly the shape these tests exist to catch.
+ */
+const RBAC_MODES = [
+  { name: 'rbac disabled', branchRbacEnabled: false },
+  { name: 'rbac enabled', branchRbacEnabled: true },
+] as const;
+
+const WRITE_METHODS = ['create', 'patch', 'remove'] as const;
+
+/**
+ * Services that gate a write verb but deliberately leave `update` ungated,
+ * because `update` is not reachable from any transport.
+ *
+ * Two distinct reasons appear below, and they are not interchangeable:
+ *
+ *  - a prose string — "no update method": the service object never defines one,
+ *    so Feathers' default method list (which it filters by
+ *    `typeof service[method]`) does not include it.
+ *  - a methods array: `app.use(path, service, { methods: [...] })` in
+ *    register-services.ts pins the exposed surface and leaves `update` out,
+ *    whether or not the service object defines one. For a DrizzleService
+ *    subclass the pin is the only thing keeping the inherited `update` off the
+ *    wire.
+ *
+ * The second kind is the array register-services.ts actually spreads into
+ * `app.use`, not prose describing it, and the "pinned methods list" test below
+ * asserts it omits `update`. Adding `'update'` to one of those constants
+ * therefore fails the suite at the constant, where the mistake is made — the
+ * author has to gate the verb and drop the exemption.
+ *
+ * Prose entries are still unverified claims about the service object, so check
+ * the source before adding one.
+ */
+const UPDATE_NOT_ROUTED: Record<string, string | readonly string[]> = {
+  'admin/local-actions': 'no update method — the service exposes create only',
+  'agentic-tool-presets': 'no update method — AgenticToolPresetsService is not a DrizzleService',
+  'agentic-tool-settings':
+    'no update method — TenantAgenticToolSettingsService is not a DrizzleService',
+  artifacts: ARTIFACTS_SERVICE_TRANSPORT_METHODS,
+  'artifacts/:id/console': 'no update method — custom route exposes create only',
+  'artifacts/:id/runtime-response/:requestId':
+    'no update method — custom route exposes create only',
+  'artifacts/:id/sandpack-error': 'no update method — custom route exposes create only',
+  'artifacts/:id/trust': 'no update method — custom route exposes create only',
+  'gateway-channels': GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS,
+  groups: GROUPS_SERVICE_TRANSPORT_METHODS,
+  'kb/graph': KNOWLEDGE_GRAPH_SERVICE_TRANSPORT_METHODS,
+  'me/artifact-trust-grants': 'no update method — custom route exposes find and remove only',
+  schedules: SCHEDULES_SERVICE_TRANSPORT_METHODS,
+  tasks: TASKS_SERVICE_TRANSPORT_METHODS,
+  users: USERS_SERVICE_TRANSPORT_METHODS,
+};
+
+/** Services gating a sibling write verb but leaving `update` on the `all` chain. */
+const findUngated = (captured: Map<string, CapturedHooks>): string[] => {
+  const ungated: string[] = [];
+  for (const [path, hooks] of captured) {
+    const gatedSiblings = WRITE_METHODS.filter((method) => hooks.before[method]?.length);
+    if (gatedSiblings.length === 0) continue;
+    if (hooks.before.update?.length) continue;
+    if (path in UPDATE_NOT_ROUTED) continue;
+    ungated.push(`${path} (gates ${gatedSiblings.join('/')})`);
+  }
+  return ungated;
+};
+
+describe.each(RBAC_MODES)('update-verb hook gating ($name)', ({ branchRbacEnabled }) => {
+  const captured = captureRegisteredHooks(branchRbacEnabled);
+
+  it('gates update wherever a sibling write verb is gated', () => {
+    expect(
+      findUngated(captured),
+      'These services gate a write verb but leave PUT /<service>/:id on the `all` chain only. ' +
+        'Give update the same gate its siblings have, or — if update is not routed — add it to ' +
+        'UPDATE_NOT_ROUTED with the reason.'
+    ).toEqual([]);
+  });
+
+  it('keeps every UPDATE_NOT_ROUTED entry earning its place', () => {
+    for (const [path, reason] of Object.entries(UPDATE_NOT_ROUTED)) {
+      const described = Array.isArray(reason) ? 'methods list omits update' : reason;
+      expect(captured.has(path), `${path} no longer registers hooks — drop the exemption`).toBe(
+        true
+      );
+      expect(
+        captured.get(path)?.before.update ?? [],
+        `${path} now gates update (${described}) — drop the exemption`
+      ).toEqual([]);
+    }
+  });
+
+  it('detects a dropped gate', () => {
+    // The invariant above is only worth having if it fails when a gate goes
+    // missing, so re-run it against a copy of the real registration with
+    // boards' update chain deleted. boards is the least ambiguous canary: its
+    // registration names 'update' in an explicit methods array, so the verb is
+    // certainly routed.
+    const tampered = captureRegisteredHooks(branchRbacEnabled);
+    const boards = tampered.get('boards');
+    if (!boards) throw new Error('boards registers no hooks');
+    delete boards.before.update;
+
+    expect(findUngated(tampered)).toEqual(['boards (gates create/patch/remove)']);
+  });
+});
+
+describe.each(RBAC_MODES)(
+  'update is refused for under-privileged callers ($name)',
+  ({ branchRbacEnabled }) => {
+    const captured = captureRegisteredHooks(branchRbacEnabled);
+
+    const runUpdateHooks = async (
+      path: string,
+      role: string,
+      data: Record<string, unknown> = {}
+    ) => {
+      const chain = captured.get(path)?.before.update;
+      if (!chain?.length) throw new Error(`${path} registers no before-update hooks`);
+      const context = {
+        path,
+        method: 'update',
+        id: '00000000-0000-7000-8000-000000000001',
+        data,
+        params: {
+          provider: 'rest',
+          query: {},
+          user: { user_id: '00000000-0000-7000-8000-0000000000ff', role },
+        },
+      } as unknown as HookContext;
+      for (const hook of chain) await hook(context);
+      return context;
+    };
+
+    it.each([
+      ['boards', 'update boards'],
+      ['cards', 'update cards'],
+      ['card-types', 'update card types'],
+      ['board-comments', 'update board comments'],
+    ])('refuses a viewer rewriting %s', async (path) => {
+      await expect(runUpdateHooks(path, 'viewer')).rejects.toMatchObject({ name: 'Forbidden' });
+    });
+
+    it.each(['viewer', 'member', 'admin'])(
+      'refuses a %s replacing a message whatever their role',
+      async (role) => {
+        // Messages are the one write surface here that is not role-gated:
+        // whole-row replacement is outside the public Message contract, so it is
+        // refused for every external caller and left off the transport method
+        // list entirely (see register-services.messages-boundary.test.ts).
+        await expect(runUpdateHooks('messages', role)).rejects.toMatchObject({ name: 'Forbidden' });
+      }
+    );
+
+    it.each(['created_by', 'unix_username'])(
+      'refuses a PUT that reassigns session.%s',
+      async (field) => {
+        // The reattribution primitive the whole fix exists to protect. These two
+        // fields select the OS identity a session executes as, so a PUT carrying
+        // them must be refused in either RBAC mode — branch_rbac and
+        // unix_user_mode are configured independently.
+        await expect(
+          runUpdateHooks('sessions', 'viewer', {
+            [field]: '00000000-0000-7000-8000-00000000beef',
+          })
+        ).rejects.toMatchObject({ name: 'Forbidden' });
+      }
+    );
+
+    it('holds sessions.update to the same chain as sessions.patch', () => {
+      // SessionsService.update calls this.patch directly rather than going back
+      // through the service proxy, so patch's before-hooks never re-run for it.
+      // Anything short of the same chain is a route to patch's writes without
+      // patch's branch-permission checks.
+      const sessions = captured.get('sessions');
+
+      // The recorder copies each chain into its own array, so this compares hook
+      // function references pairwise rather than an array against itself.
+      expect(sessions?.before.update).not.toBe(sessions?.before.patch);
+      expect(sessions?.before.update).toEqual(sessions?.before.patch);
+      expect(sessions?.before.update?.length).toBeGreaterThan(0);
+    });
+  }
+);
+
+describe('enabling branch RBAC only adds session guards', () => {
+  it('never shortens the sessions write chain', () => {
+    const open = captureRegisteredHooks(false).get('sessions');
+    const rbac = captureRegisteredHooks(true).get('sessions');
+
+    expect(rbac?.before.update?.length).toBeGreaterThan(open?.before.update?.length ?? 0);
+  });
+});
+
+describe('pinned methods list', () => {
+  const pinned = Object.entries(UPDATE_NOT_ROUTED).filter(
+    (entry): entry is [string, readonly string[]] => Array.isArray(entry[1])
+  );
+
+  it('covers every exemption that claims a pinned list', () => {
+    // Guards the filter above: if the constants stopped being arrays (inlined
+    // back into register-services.ts, say) this suite would silently assert
+    // nothing while still reading as green.
+    expect(pinned.map(([path]) => path)).toEqual([
+      'artifacts',
+      'gateway-channels',
+      'groups',
+      'kb/graph',
+      'schedules',
+      'tasks',
+      'users',
+    ]);
+  });
+
+  it.each(pinned)('%s exposes no update verb', (path, methods) => {
+    expect(
+      methods,
+      `${path} now exposes update, so PUT /${path}/:id is routed. Gate the verb in ` +
+        'register-hooks.ts and drop its UPDATE_NOT_ROUTED entry.'
+    ).not.toContain('update');
+  });
+});
+
+describe('Feathers method-list enforcement', () => {
+  it('refuses PUT for a service whose exposed methods omit update', async () => {
+    // UPDATE_NOT_ROUTED leans on this behaviour for every "methods list omits
+    // update" entry: a DrizzleService still has a callable update(), and only
+    // the registration's method list keeps it off the wire.
+    const service = {
+      async get(id: string) {
+        return { id };
+      },
+      async update(id: string, data: Record<string, unknown>) {
+        return { id, ...data };
+      },
+    };
+
+    const app = feathersExpress(feathers());
+    app.configure(rest());
+    app.use('/narrowed', service, { methods: ['get'] });
+    app.use('/wide', service);
+    const server = await app.listen(0);
+    const { port } = server.address() as { port: number };
+
+    const put = (path: string) =>
+      fetch(`http://127.0.0.1:${port}/${path}/1`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+
+    try {
+      expect((await put('narrowed')).status).toBe(405);
+      expect((await put('wide')).status).toBe(200);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/apps/agor-daemon/src/register-services.gateway-upload.test.ts
+++ b/apps/agor-daemon/src/register-services.gateway-upload.test.ts
@@ -1,13 +1,13 @@
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { GatewayChannelsService } from './services/gateway-channels.js';
+import {
+  GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS,
+  GatewayChannelsService,
+} from './services/gateway-channels.js';
 
 describe('gateway channel executor upload registration', () => {
   it('exposes the implemented streaming callback method', () => {
-    const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
-
     expect(typeof GatewayChannelsService.prototype.uploadFileStreamFromExecutor).toBe('function');
-    expect(source).toContain("'uploadFileStreamFromExecutor'");
-    expect(source).not.toContain("'uploadFileFromExecutor'");
+    expect(GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS).toContain('uploadFileStreamFromExecutor');
+    expect(GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS).not.toContain('uploadFileFromExecutor');
   });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -93,7 +93,10 @@ import {
   tenantUserChannelName,
 } from './realtime/routing.js';
 import { createAgenticToolPresetsService } from './services/agentic-tool-presets.js';
-import { createArtifactsService } from './services/artifacts.js';
+import {
+  ARTIFACTS_SERVICE_TRANSPORT_METHODS,
+  createArtifactsService,
+} from './services/artifacts.js';
 import { createBoardCommentsService } from './services/board-comments.js';
 import { createBoardObjectsService } from './services/board-objects.js';
 import { setupBoardOwnersService } from './services/board-owners.js';
@@ -114,13 +117,17 @@ import { prepareSessionForExecutorStart } from './services/executor-startup.js';
 import { createFileService } from './services/file.js';
 import { createFilesService } from './services/files.js';
 import { createGatewayService } from './services/gateway.js';
-import { createGatewayChannelsService } from './services/gateway-channels.js';
+import {
+  createGatewayChannelsService,
+  GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS,
+} from './services/gateway-channels.js';
 import { createGatewayChannelsAppInfoService } from './services/gateway-channels-app-info.js';
 import { createGatewayChannelsTestService } from './services/gateway-channels-test.js';
 import { registerGitHubAppSetupRoutes } from './services/github-app-setup.js';
 import {
   createGroupMembershipsService,
   createGroupsService,
+  GROUPS_SERVICE_TRANSPORT_METHODS,
   setupBoardAlignedBranchesService,
   setupBoardGroupGrantsService,
   setupBranchEffectiveAccessService,
@@ -129,7 +136,10 @@ import {
 } from './services/groups.js';
 import { createKnowledgeDocumentEditsService } from './services/knowledge-document-edits.js';
 import { createKnowledgeDocumentsService } from './services/knowledge-documents.js';
-import { createKnowledgeGraphService } from './services/knowledge-graph.js';
+import {
+  createKnowledgeGraphService,
+  KNOWLEDGE_GRAPH_SERVICE_TRANSPORT_METHODS,
+} from './services/knowledge-graph.js';
 import { createKnowledgeIndexingStatusService } from './services/knowledge-indexing.js';
 import { createKnowledgeNamespacesService } from './services/knowledge-namespaces.js';
 import { createKnowledgeReindexService } from './services/knowledge-reindex.js';
@@ -155,18 +165,21 @@ import { createMCPServersService } from './services/mcp-servers.js';
 import { createMessagesService, MESSAGES_SERVICE_TRANSPORT_METHODS } from './services/messages.js';
 import { performOAuthDisconnect } from './services/oauth-disconnect.js';
 import { createReposService } from './services/repos.js';
-import { createSchedulesService } from './services/schedules.js';
+import {
+  createSchedulesService,
+  SCHEDULES_SERVICE_TRANSPORT_METHODS,
+} from './services/schedules.js';
 import { createSessionEnvSelectionsService } from './services/session-env-selections.js';
 import { createSessionMCPServersService } from './services/session-mcp-servers.js';
 import { createSessionStreamsService } from './services/session-streams.js';
 import { createSessionsService } from './services/sessions.js';
-import { createTasksService } from './services/tasks.js';
+import { createTasksService, TASKS_SERVICE_TRANSPORT_METHODS } from './services/tasks.js';
 import { TASKS_SERVICE_CUSTOM_EVENTS } from './services/tasks-events.js';
 import { createTemplatesService } from './services/templates.js';
 import { createTenantAgenticToolSettingsService } from './services/tenant-agentic-tools.js';
 import { TerminalsService } from './services/terminals.js';
 import { createThreadSessionMapService } from './services/thread-session-map.js';
-import { createUsersService } from './services/users.js';
+import { createUsersService, USERS_SERVICE_TRANSPORT_METHODS } from './services/users.js';
 import { requestExecutorTermination } from './termination-coordinator.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
@@ -284,17 +297,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.service('/session-streams').publish(() => []);
 
   app.use('/tasks', createTasksService(db, app), {
-    methods: [
-      'find',
-      'get',
-      'create',
-      'patch',
-      'remove',
-      'connectExecutor',
-      'reportTerminationComplete',
-      'reportRuntimeTelemetry',
-      'reportSdkHealthFailure',
-    ],
+    methods: [...TASKS_SERVICE_TRANSPORT_METHODS],
     // Custom events not in this list are dropped at the FeathersJS transport
     // boundary — they fire on the local EventEmitter but never reach socket
     // clients. Keep this in sync with every `app.service('tasks').emit(...)`
@@ -397,15 +400,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     }),
     {
       events: ['agor-query'],
-      methods: [
-        'find',
-        'get',
-        'create',
-        'patch',
-        'remove',
-        'publishFromExecutor',
-        'validateFromExecutor',
-      ],
+      methods: [...ARTIFACTS_SERVICE_TRANSPORT_METHODS],
     }
   );
   app.use('/board-comments', createBoardCommentsService(db));
@@ -451,7 +446,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   }
 
   app.use('/groups', createGroupsService(db), {
-    methods: ['find', 'get', 'create', 'patch', 'remove'],
+    methods: [...GROUPS_SERVICE_TRANSPORT_METHODS],
   });
   app.use('/group-memberships', createGroupMembershipsService(db), {
     methods: ['find', 'create', 'remove'],
@@ -472,7 +467,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // First-class schedules. RBAC hooks wired in register-hooks.ts.
   // See docs/internal/schedules-first-class-design-2026-05-24.md §4.4.
   app.use('/schedules', createSchedulesService(db), {
-    methods: ['find', 'get', 'create', 'patch', 'remove'],
+    methods: [...SCHEDULES_SERVICE_TRANSPORT_METHODS],
   });
 
   // ============================================================================
@@ -520,7 +515,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     methods: ['create'],
   });
   app.use('/kb/graph', createKnowledgeGraphService(db), {
-    methods: ['find', 'create', 'link', 'neighbors'],
+    methods: [...KNOWLEDGE_GRAPH_SERVICE_TRANSPORT_METHODS],
   });
 
   // ============================================================================
@@ -550,7 +545,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   {
     app.use('/gateway-channels', createGatewayChannelsService(db), {
-      methods: ['find', 'get', 'create', 'patch', 'remove', 'uploadFileStreamFromExecutor'],
+      methods: [...GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS],
     });
 
     // Sub-path service for the connection probe. A sub-path does NOT inherit
@@ -783,17 +778,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // custom RPCs like `getGitEnvironment` and avatar sync helpers. Listing `update` here makes Feathers' hook
   // wiring throw "Can not apply hooks. 'update' is not a function" at startup.
   app.use('/users', usersService, {
-    methods: [
-      'find',
-      'get',
-      'create',
-      'patch',
-      'remove',
-      'getGitEnvironment',
-      'getAvatarSettings',
-      'updateAvatarSettings',
-      'syncAvatars',
-    ],
+    methods: [...USERS_SERVICE_TRANSPORT_METHODS],
   });
 
   // Bootstrap superadmin users

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -148,6 +148,21 @@ interface ArtifactValidationResult {
   diagnostics: ArtifactValidationDiagnostic[];
 }
 
+/**
+ * Public Artifact transport surface. `update` is deliberately absent: the
+ * service's own `update()` strips provenance, but leaving the verb off the wire
+ * is what keeps `PUT /artifacts/:id` unreachable rather than merely gated.
+ */
+export const ARTIFACTS_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+  'publishFromExecutor',
+  'validateFromExecutor',
+] as const;
+
 export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
   branch_id?: BranchID;

--- a/apps/agor-daemon/src/services/gateway-channels.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.ts
@@ -48,6 +48,19 @@ type PersistedGatewayChannelWriteData =
   | PersistedGatewayChannelCreateData
   | PersistedGatewayChannelPatchData;
 
+/**
+ * Public GatewayChannel transport surface. `update` is deliberately absent so
+ * whole-row `PUT` never reaches the inherited DrizzleService implementation.
+ */
+export const GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+  'uploadFileStreamFromExecutor',
+] as const;
+
 export class GatewayChannelsService extends DrizzleService<
   GatewayChannel,
   PersistedGatewayChannelWriteData

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -77,6 +77,18 @@ export function branchGroupGrantPermissionLevelOrDefault(value: unknown): Branch
   return nextCan;
 }
 
+/**
+ * Public Group transport surface. The service is a plain object, not a
+ * DrizzleService, and defines no `update`; pinning the list keeps it that way.
+ */
+export const GROUPS_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+] as const;
+
 export function createGroupsService(db: TenantScopeAwareDatabase) {
   const repo = new GroupRepository(db);
   return {

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -47,6 +47,17 @@ export interface KnowledgeNamespaceGraphRequest {
   includeOtherUserDrafts?: boolean;
 }
 
+/**
+ * Public knowledge-graph transport surface. The service is not a
+ * DrizzleService and defines no `update`; pinning the list keeps it that way.
+ */
+export const KNOWLEDGE_GRAPH_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'create',
+  'link',
+  'neighbors',
+] as const;
+
 export type KnowledgeGraphParams = QueryParams<
   KnowledgeGraphNeighborsQuery & KnowledgeNamespaceGraphRequest
 > &

--- a/apps/agor-daemon/src/services/schedules.ts
+++ b/apps/agor-daemon/src/services/schedules.ts
@@ -44,6 +44,18 @@ import {
 } from '../utils/agentic-configuration-sources.js';
 import { assertServiceWriteFields, pickWriteFields } from '../utils/write-data-boundary.js';
 
+/**
+ * Public Schedule transport surface. `update` is deliberately absent so
+ * whole-row `PUT` never reaches the inherited DrizzleService implementation.
+ */
+export const SCHEDULES_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+] as const;
+
 export type ScheduleParams = QueryParams<{
   branch_id?: BranchID;
   enabled?: boolean;

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -91,6 +91,22 @@ function isCompletionSideEffectTaskStatus(status: Task['status'] | undefined): b
   return status !== undefined && COMPLETION_SIDE_EFFECT_TASK_STATUSES.has(status);
 }
 
+/**
+ * Public Task transport surface. `update` is deliberately absent so whole-row
+ * `PUT` never reaches the inherited DrizzleService implementation.
+ */
+export const TASKS_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+  'connectExecutor',
+  'reportTerminationComplete',
+  'reportRuntimeTelemetry',
+  'reportSdkHealthFailure',
+] as const;
+
 export type TaskParams = QueryParams<{
   session_id?: string;
   status?: Task['status'];

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -99,6 +99,23 @@ function tenantInsertValues(params?: Params): { tenant_id?: string } {
   return tenantId && usersTableHasTenantColumn() ? { tenant_id: tenantId } : {};
 }
 
+/**
+ * Public User transport surface. UsersService is not a DrizzleService and
+ * defines no `update` — listing the verb here would make Feathers' hook wiring
+ * throw "Can not apply hooks. 'update' is not a function" at startup.
+ */
+export const USERS_SERVICE_TRANSPORT_METHODS = [
+  'find',
+  'get',
+  'create',
+  'patch',
+  'remove',
+  'getGitEnvironment',
+  'getAvatarSettings',
+  'updateAvatarSettings',
+  'syncAvatars',
+] as const;
+
 export const LOCAL_AUTH_LOOKUP_PARAM = Symbol('agor.users.local-auth-lookup');
 export const AUTH_INTERNAL_USER_LOOKUP_PARAM = Symbol('agor.users.auth-internal-lookup');
 

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -357,36 +357,42 @@ describe('request-scoped RBAC loading', () => {
     });
   });
 
-  it('resolves id-addressed message context from the stored record, not spoofed query', async () => {
-    const existingMessage = {
-      message_id: 'message-cache-1',
-      session_id: session.session_id,
-    };
-    const ctx = {
-      path: 'messages',
-      method: 'get',
-      id: existingMessage.message_id,
-      params: {
-        provider: 'rest',
-        query: { session_id: 'spoofed-session' },
-        user: { user_id: USER_ID, role: ROLES.MEMBER },
-      },
-      service: {
-        get: vi.fn(async () => existingMessage),
-      },
-    } as unknown as HookContext;
+  // Every id-addressed verb must resolve here. A verb missing from the branch
+  // falls through to the `session_id not found` throw, which surfaces as a 500
+  // and denies the request for the wrong reason.
+  it.each(['get', 'update', 'patch', 'remove'])(
+    'resolves id-addressed message %s context from the stored record, not spoofed query',
+    async (method) => {
+      const existingMessage = {
+        message_id: 'message-cache-1',
+        session_id: session.session_id,
+      };
+      const ctx = {
+        path: 'messages',
+        method,
+        id: existingMessage.message_id,
+        params: {
+          provider: 'rest',
+          query: { session_id: 'spoofed-session' },
+          user: { user_id: USER_ID, role: ROLES.MEMBER },
+        },
+        service: {
+          get: vi.fn(async () => existingMessage),
+        },
+      } as unknown as HookContext;
 
-    await resolveSessionContext()(ctx);
+      await resolveSessionContext()(ctx);
 
-    expect(ctx.params.sessionId).toBe(session.session_id);
-    expect(
-      (ctx.params as { _agorPrefetchedRecord?: { record: unknown } })._agorPrefetchedRecord
-    ).toMatchObject({
-      id: existingMessage.message_id,
-      idField: 'message_id',
-      record: existingMessage,
-    });
-  });
+      expect(ctx.params.sessionId).toBe(session.session_id);
+      expect(
+        (ctx.params as { _agorPrefetchedRecord?: { record: unknown } })._agorPrefetchedRecord
+      ).toMatchObject({
+        id: existingMessage.message_id,
+        idField: 'message_id',
+        record: existingMessage,
+      });
+    }
+  );
 });
 
 describe('paginateClientSide', () => {

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -920,13 +920,14 @@ export function resolveSessionContext() {
         sessionId = data?.session_id;
       } else if (
         context.method === 'get' ||
+        context.method === 'update' ||
         context.method === 'patch' ||
         context.method === 'remove'
       ) {
         // Id-addressed nested resources must authorize against the stored
         // parent session, not a client-supplied session_id in data/query. The
-        // prefetched record is reused by DrizzleService.get/patch/remove, so
-        // this safety read does not add a second primary-key read later.
+        // prefetched record is reused by DrizzleService.get/update/patch/remove,
+        // so this safety read does not add a second primary-key read later.
         if (context.id) {
           try {
             // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type

--- a/context/guides/extending-feathers-services.md
+++ b/context/guides/extending-feathers-services.md
@@ -117,6 +117,7 @@ app.service('boards').hooks({
   before: {
     all: [validateQuery, requireAuth],
     create: [requireMinimumRole('member', 'create boards')],
+    update: [requireMinimumRole('member', 'update boards')],
     patch: [requireMinimumRole('member', 'update boards')],
     remove: [requireMinimumRole('admin', 'delete boards')],
     // Hooks apply to custom methods too!
@@ -145,6 +146,20 @@ app.service('boards').hooks({
   },
 });
 ```
+
+> **Gate `update` wherever you gate `patch`.** On a `DrizzleService` they are
+> the same operation, not two tiers of one. `DrizzleService.update`
+> (`apps/agor-daemon/src/adapters/drizzle.ts:376-385`) and the single-id branch
+> of `patch` (`:417-425`) are the same three lines — `get` the row, then
+> `repository.update(id, stripTenantMutation(data))` — and the repositories take
+> a `Partial<T>` they merge over the current row. So `update` is _not_
+> whole-row replacement, and omitted columns are _not_ nulled: a `PUT` writes
+> exactly the columns a `PATCH` with the same body would.
+>
+> Listing `'update'` in `methods` (step 2 above) routes `PUT /<service>/:id` to
+> it. A hook block that names `create`/`patch`/`remove` but not `update` leaves
+> that route guarded by the `all` chain alone — usually just `requireAuth`.
+> Either gate the verb, or leave it out of `methods` so it is never routed.
 
 ### 4. Client usage
 


### PR DESCRIPTION
## Impact

Five Feathers services gated `create`/`patch`/`remove` but omitted `update` from their hook lists, leaving only `all: [..., requireAuth]`. `DrizzleService.update` is inherited and routed, so **any authenticated user — including a `viewer` — could `PUT /<service>/:id` and replace any row wholesale**: any board, card, card type, board comment, or session.

`sessions` is the serious one, and it is a **guard bypass, not merely an ungated write**. `SessionsService.update` calls `this.patch` directly rather than going back through the service proxy, so patch's before-hooks never re-run for it. `PUT /sessions/:id` therefore reached patch's writes while skipping the entire chain patch is protected by:

- `ensureSessionImmutability` — the guard that stops `created_by` and `unix_username` being rewritten
- `resolveSessionContext` / `loadSession` / `loadBranchFromSession`
- the branch-permission check (`prompt`-tier for prompt-flow fields, `all` for session metadata)

Rewriting `created_by`/`unix_username` is the reattribution primitive that RBAC and the Unix isolation modes are built on.

## Fix

`update` now carries the same gate as its siblings on `card-types`, `cards`, `board-comments`, and `boards`. For `sessions`, both verbs share a single `sessionWriteGuards` chain, so they cannot drift apart again.

**`ensureSessionImmutability` also moves out of the `branchRbacEnabled` spread** and now runs for every session write. It was previously installed only when branch RBAC was on, so on a default `branch_rbac: false` instance neither `PUT` nor `PATCH` refused a payload carrying `created_by`/`unix_username`. Those two fields select the OS identity a session executes as, and the `unix_user_mode` tiers that make them load-bearing (`delegated`, `insulated`, `strict`) are configured **independently** of `branch_rbac` — so an open-access instance running `delegated` was accepting reattribution. Immutability of identity fields is not a branch-permission concern and should never have been conditional on one. This widens the fix to `patch` as well; verified safe, since the hook has no `params.provider` check and therefore already applied to every internal caller whenever RBAC was enabled.

**Scope note:** that decoupling is specific to **session immutability** — the one guard whose correctness does not depend on branch RBAC. This PR does not otherwise disentangle identity from `branchRbacEnabled`; the broader cleanup (collapsing `ctx.branchRbacEnabled` into `executionMode.appRbacEnabled` across ~38 call sites, so the conflation cannot recur elsewhere) is **agor#2244** and lands separately.

`resolveSessionContext` learned the `update` method, keeping its id-addressed verb list complete rather than repeating the exact omission this PR fixes.

Reachability was confirmed per service against its `app.use()` registration rather than assumed. An explicit `methods` array is enforced by both the REST and socket.io transports, and Feathers' default list is filtered by method existence:

- `boards` names `'update'` in an explicit `methods` array — certainly routed.
- `cards`, `card-types`, `board-comments` register with no `methods` list, so they take the Feathers default.
- `sessions` passes only `events`, so it also takes the default.
- `artifacts`, `tasks`, `users`, `gateway-channels`, `groups`, `schedules`, `kb/graph` pin a `methods` list that omits `update` — left alone.

There are no internal service-level `.update()` callers on any of the five services (internal daemon code mutates through repositories, which bypass hooks), so the new gates break nothing.

## Fixing the source of the pattern

`context/guides/extending-feathers-services.md` is the canonical worked example contributors copy, and it **taught this exact bug**: line 100 puts `'update'` in the `methods` array, so the verb is routed, while the hook block gates `all`/`create`/`patch`/`remove`/`clone`/`fromBlob` and not `update`. Every service that got this wrong got it wrong by following the guide.

The example now gates `update`, plus a note recording why the omission looks harmless and isn't: on a `DrizzleService`, `update` and `patch` are **the same operation**. `DrizzleService.update` (`adapters/drizzle.ts:376-385`) and the single-id branch of `patch` (`:417-425`) are the same three lines — `get` the row, then `repository.update(id, stripTenantMutation(data))` — and the repositories take a `Partial<T>` they merge over the current row. So `update` is *not* whole-row replacement and omitted columns are *not* nulled: a `PUT` writes exactly the columns a `PATCH` with the same body would. There is no reading under which `patch` needs a gate and `update` does not.

This is the highest-leverage change here: it acts before the next service is written, rather than catching it after.

## The durable part

`register-hooks.update-gating.test.ts` is the point of the PR. It enumerates the hooks `registerHooks` actually installs and fails when any service gates one of `create`/`patch`/`remove` but not `update`.

**Each RBAC mode is asserted on its own.** An earlier version merged the two captures, which meant a gate installed only under `branchRbacEnabled: true` could satisfy the invariant while the verb sat wide open in the default mode — the precise shape of the `ensureSessionImmutability` bug above. Per-mode assertion is what makes it load-bearing.

It also pins behaviour, not just hook presence: under-privileged callers are refused on each service, a `PUT` reassigning `session.created_by` or `session.unix_username` is refused in **both** RBAC modes, and `PUT` against a service whose `methods` list omits `update` returns 405 while an unnarrowed one returns 200.

Verified the invariant has not rotted against current `main`: with the source reverted to `origin/main` and the test kept, it fails and names exactly `card-types`, `cards`, `board-comments`, `sessions`, `boards`. The immutability assertions were likewise verified to fail with that one-line hoist reverted.

### The exemption list now asserts itself

`UPDATE_NOT_ROUTED` was prose *about another file* — its own doc comment admitted the gap, and nothing checked it. All 15 entries were accurate, so this is about the next author rather than a live bug, and `ArtifactsService` shows why it matters: it has a real `update()` override with provenance stripping, gates `create`/`patch`/`remove`, and relies **solely** on `'update'` being absent from its `methods` array. An author adding `'update'` there would have got an ungated write **and a green suite**.

Extending the `MESSAGES_SERVICE_TRANSPORT_METHODS` pattern, the seven services claiming a pinned list now export it (`ARTIFACTS_SERVICE_TRANSPORT_METHODS` and friends), `register-services.ts` spreads the constant, and the exemption entry **is** that array rather than a sentence describing it. The test asserts each one omits `update`, so the failure now lands on the constant, where the mistake is made. A coverage assertion pins the seven paths, so the check cannot quietly degrade to asserting nothing if a constant is inlined again.

Confirmed failing before passing: temporarily adding `'update'` to the artifacts list fails with *"artifacts now exposes update, so PUT /artifacts/:id is routed"*, and passes once reverted.

This closes the known limit the file previously documented. It uses exported constants rather than booting `registerServices` under vitest — an earlier attempt at that hit an untranspiled-TS resolve error in `node_modules`, and the constants bind the same claim without the service graph.

`register-services.gateway-upload.test.ts` scanned `register-services.ts` **source text** for `'uploadFileStreamFromExecutor'`; since that literal moved into the constant, it now asserts against the constant itself — same intent, and no longer coupled to where the string is typed.

## Changes against the original branch

This was written a week ago against a `main` 70 commits older. Re-deriving the affected set shrank it from seven services to five:

- **`mcp-servers` — dropped, fixed on `main` independently.** `main` now gates `update` with `requireMinimumRole(ADMIN)`. The rebase silently produced a *duplicate* `update:` key in that object literal (identical values, so it still typechecked); removed. The unmerged Phase 2A branch (`mcp-private-servers-2a`) replaces this service's role gates with an ownership-and-policy authorizer — **2A supersedes this service entirely**, and this PR now touches nothing there, so the two cannot collide. The invariant's canary test was moved off `mcp-servers` onto `boards` for the same reason.
- **`messages` — dropped, fixed on `main` more thoroughly than here.** `update` is now off `MESSAGES_SERVICE_TRANSPORT_METHODS` (with its own test asserting that), and `protectExternalWidgetMessageWrites` unconditionally throws `Forbidden` for external callers. That is strictly stronger than the role/RBAC chain this branch was adding. `main`'s version kept as-is; the test now asserts the stronger property that *every* role is refused.
- No new services on `main` have the ungated shape, and no exemption went stale: all seven pinned `methods` lists still omit `update` — now asserted rather than re-checked by hand.

## Testing

`pnpm typecheck` (21/21) and `pnpm lint` clean. Core suite green (3572 passed). Daemon suite: 2451 passed, 1 failure in `cursor-models.test.ts` ("Invalid User API Key") — confirmed pre-existing by reproducing it on a clean checkout of the branch head.
