### PR TITLE
chore(agor-live): raise package-content file budget to 2600

### DIFF
--- a/packages/agor-live/scripts/check-package-content.mjs
+++ b/packages/agor-live/scripts/check-package-content.mjs
@@ -2,7 +2,12 @@ import { execFileSync } from 'node:child_process';
 import { rmSync } from 'node:fs';
 
 const limits = {
-  files: 2400,
+  // Raised from 2400 once main measured 2419: the Redis HA foundation, the MCP
+  // catalog data layer (which ships its own dist tree plus curated.yaml), and
+  // the MCP protocol work all landed after the budget was first set. The
+  // headroom is deliberately modest so the ratchet still trips on the next
+  // unexplained jump rather than absorbing it silently.
+  files: 2600,
   // A modest byte increase buys a much larger inode/package reduction: select
   // high-fanout pure-JS trees are bundled into dist instead of extracted as
   // hundreds of dependency files during a cold global npm install.


### PR DESCRIPTION
## Linked issue

Refs #2201

## Summary

- Raise the `agor-live` package-content file budget from 2400 to 2600 (`packages/agor-live/scripts/check-package-content.mjs`)
- Document why the ceiling moved, so the next raise is a decision rather than a reflex

## Why / context

`./build.sh` (and therefore every publish) currently fails at its last gate:

```
Package content: 2419 files, 21.73 MiB packed, 90.59 MiB unpacked
Error: agor-live package-content budget exceeded:
- files: 2419 > 2400
```

The 2400 ceiling was set in #2201 when the global install was slimmed, and has never been adjusted since. Main has grown 19 files past it, so the check is blocking releases outright.

The growth is accounted for by work that landed after the budget was set:

- #2230 — Redis-backed HA foundation
- #2081 — MCP marketplace catalog data layer, which ships its own `mcp-catalog` dist tree plus `curated.yaml`
- #2232 — modern + stateless legacy MCP protocols

Only the file count tripped. Both byte budgets still pass: 21.73/23 MiB packed, 90.59/95 MiB unpacked.

This is currently blocking recovery of a hosted instance. `agor-2` is running a locally built `0.24.4` whose six `@agor-live/*` wrapper packages were never published — npm has all seven packages only at 0.24.3 — so the daemon fails `assertConfiguredAgenticToolsAligned` at boot and never binds its port. `agor install --sync` cannot repair it, because the packages it fetches do not exist. The fix is to publish a complete, version-aligned set, and this preflight is what stands in the way.

## Implementation notes

2600 is a deliberately modest raise (~7.5% headroom over today's 2419) rather than a large round number. The check is a ratchet whose value is tripping on the *next* unexplained jump; setting it far above current usage would quietly disable it.

The byte budgets are left untouched, but they are worth watching — packed is at 94% of its limit and unpacked at 95%. Whoever crosses those next should measure where the bytes come from before raising, rather than treating it as routine:

```bash
npm pack --dry-run --json --ignore-scripts \
  | jq -r '.[0].files[].path' | cut -d/ -f1-3 | sort | uniq -c | sort -rn | head -20
```

## Validation / test plan

- [x] `./build.sh --dry-run` on the affected host reproduced the failure at 2419 files
- [ ] `./build.sh --dry-run` re-run after this lands, expected to pass the content check and reach the publish preview
- [ ] Full publish (`./build.sh --bump patch` → 0.24.5) once merged

## Risks / rollout / rollback

Low risk: the change affects a publish-time preflight only, with no runtime or packaged-code impact. Rollback is reverting one constant.

The real risk this exposes is upstream of the check. `agor-live` is deployed by building from a local checkout (`./build.sh && npm i -g .`), which does not publish. Since #2201 made the agent SDKs exact-version `@agor-live/*` packages resolved from the registry at runtime, a build-and-install-locally deploy can produce a daemon whose dependencies were never published — which is exactly the state `agor-2` is in.

## Out of scope / follow-ups

- Move publishing into CI on tag. There is no release workflow today, so publishing is a manual step from a developer machine (currently the production host), which is how a version got installed that npm never received.
- Add a post-publish gate asserting all six `@agor-live/*@<version>` resolve before the base package is tagged `latest`.
- Reconsider the boot-time hard exit added in #2228 (`apps/agor-daemon/src/setup/agentic-tool-alignment.ts`). #2201's original design failed lazily — a missing tool broke only sessions that selected it. Refusing to bind the port because one optional agent package is absent turns a per-session dependency into a full outage.
