### PR TITLE
fix: make HA environment startup ACL-safe

### DIFF
--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -33,7 +33,7 @@ x-daemon-common: &daemon-common
   build:
     context: .
     dockerfile: docker/Dockerfile
-    target: production-source
+    target: production-source-ha
     args:
       AGOR_BUILD_SHA: ${AGOR_BUILD_SHA:-dev}
   environment: *daemon-environment
@@ -46,7 +46,6 @@ x-daemon-common: &daemon-common
     # Nested Docker mounts are intentional. This is not per-user isolation.
     - agor-ha-user-home:/home/agor
     - agor-ha-home:/home/agor/.agor
-    - ./docker/ha/config.yaml:/home/agor/.agor/config.yaml:ro
   restart: unless-stopped
   healthcheck:
     test:
@@ -95,10 +94,7 @@ services:
 
   migrate:
     <<: *daemon-common
-    entrypoint: ['/bin/sh', '-ec']
-    command:
-      - >-
-        agor db migrate --yes --offline-cutover
+    command: ['agor', 'db', 'migrate', '--yes', '--offline-cutover']
     restart: 'no'
     healthcheck:
       disable: true
@@ -108,7 +104,7 @@ services:
 
   daemon-a:
     <<: *daemon-common
-    entrypoint: ['agor-daemon']
+    command: ['agor-daemon']
     environment:
       <<: *daemon-environment
       AGOR_DAEMON_INSTANCE_ID: daemon-a
@@ -123,7 +119,7 @@ services:
 
   daemon-b:
     <<: *daemon-common
-    entrypoint: ['agor-daemon']
+    command: ['agor-daemon']
     environment:
       <<: *daemon-environment
       AGOR_DAEMON_INSTANCE_ID: daemon-b

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -263,3 +263,25 @@ USER agor
 
 EXPOSE ${DAEMON_PORT:-3030}
 ENTRYPOINT ["docker-entrypoint-prod.sh"]
+
+# ============================================================================
+# Stage 4c: Production-from-source HA smoke runtime
+# ============================================================================
+# Branch worktrees can be protected by host ACLs that the container's `agor`
+# user cannot read through a bind mount. Bake the non-secret HA configuration
+# into the image instead, then materialize it atomically into the shared Agor
+# home at container startup. Secrets remain runtime environment variables.
+FROM production-source AS production-source-ha
+
+USER root
+COPY docker/ha/config.yaml /tmp/agor-ha-config.yaml
+COPY docker/ha/docker-entrypoint.sh /tmp/agor-ha-entrypoint
+# COPY can preserve restrictive worktree ACLs, including on an implicitly
+# created parent directory. `install` creates clean files and permissions.
+RUN install -d -o root -g root -m 0755 /etc/agor \
+  && install -o root -g root -m 0444 /tmp/agor-ha-config.yaml /etc/agor/ha-config.yaml \
+  && install -o root -g root -m 0555 /tmp/agor-ha-entrypoint /usr/local/bin/agor-ha-entrypoint \
+  && rm /tmp/agor-ha-config.yaml /tmp/agor-ha-entrypoint
+USER agor
+
+ENTRYPOINT ["/usr/local/bin/agor-ha-entrypoint"]

--- a/docker/ha/docker-entrypoint.sh
+++ b/docker/ha/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# The named Agor-home volume may outlive an image rebuild. Refresh the
+# checked-in, non-secret HA configuration on every container start so the
+# volume cannot retain an obsolete config. Atomic rename also makes concurrent
+# migrate/daemon startup safe when they share the volume.
+mkdir -p "$HOME/.agor"
+config_tmp="$(mktemp "$HOME/.agor/.config.yaml.XXXXXX")"
+trap 'rm -f "$config_tmp"' EXIT HUP INT TERM
+cat /etc/agor/ha-config.yaml >"$config_tmp"
+chmod 0444 "$config_tmp"
+mv -f "$config_tmp" "$HOME/.agor/config.yaml"
+trap - EXIT HUP INT TERM
+
+exec "$@"


### PR DESCRIPTION
## Summary

- add an HA-specific production image target that bakes in the checked-in, non-secret HA configuration
- materialize that configuration atomically into the shared Agor home on every container start
- avoid host worktree ACL failures by creating clean image files with explicit ownership and modes
- let the HA entrypoint wrap both migrations and daemon startup

## Why

Agor-managed worktrees can carry restrictive POSIX ACLs. The HA Compose variant bind-mounted `docker/ha/config.yaml` directly from the worktree, so the unprivileged `agor` user in the container could receive `EACCES` and the environment would never become ready.

The new image stage avoids that host-permission dependency while preserving runtime environment variables for secrets. Refreshing the config atomically also prevents a persistent named volume from retaining stale configuration across image rebuilds.

## Validation

- `pnpm i`
- `pnpm exec vitest run src/ha-support.test.ts` — 13 passed
- `AGOR_HA_INTEGRATION=1 AGOR_HA_INTEGRATION_START=1 ... pnpm test:ha:docker` — passed full two-daemon Docker HA integration
- live Agor `ha` environment — ingress, both daemons, PostgreSQL, and Redis healthy; `/readyz` returned HTTP 200
- `pnpm check` — typecheck and lint passed, then stopped on a pre-existing duplicate `DAEMON-FS-CAP-170` in `scripts/daemon-filesystem-exceptions.json`

## Additional test note

A broad daemon test invocation completed 2,412 tests successfully and had one unrelated failure in `cursor-models.test.ts` because the live Cursor API rejected the available API key; the targeted HA suite passes.
