### PR TITLE
fix(gateway): supervise listener startup retries

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -11,7 +11,7 @@ import {
   runWithTenantDatabaseScope,
   shortId,
 } from '@agor/core/db';
-import { getConnector } from '@agor/core/gateway';
+import { GatewayListenerError, getConnector } from '@agor/core/gateway';
 import type { GatewayChannel, SessionID, ThreadSessionMap, User, UserID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -1478,6 +1478,88 @@ describe('GatewayService durable listener delivery fences', () => {
     finishCallback();
     await stopping;
     expect(releaseListener).toHaveBeenCalledWith(channelId, 'owner-token');
+  });
+});
+
+describe('GatewayService listener retry supervision', () => {
+  const makeSupervisor = () => {
+    const service = new GatewayService(
+      { run: vi.fn() } as never,
+      { service: vi.fn(), get: vi.fn() } as never
+    );
+    (service as unknown as { durableListenerOwnership: boolean }).durableListenerOwnership = false;
+    const channel = attachHiddenTenant(
+      {
+        ...slackChannel,
+        id: 'retry-channel' as never,
+        config: { bot_token: 'redacted', app_token: 'redacted' },
+      },
+      { tenant_id: 'tenant-a' }
+    );
+    const channelRepo = {
+      findById: vi.fn(async () => channel),
+      releaseListener: vi.fn(async () => true),
+      listenerClaimIsCurrent: vi.fn(async () => true),
+    };
+    (service as unknown as { channelRepo: unknown }).channelRepo = channelRepo;
+    const start = () =>
+      runWithTenantContext('tenant-a', () =>
+        (
+          service as unknown as {
+            startChannelListener(c: GatewayChannel, tenant: string): Promise<void>;
+          }
+        ).startChannelListener(channel, 'tenant-a')
+      );
+    return { service, channel, channelRepo, start };
+  };
+
+  it('parks permanent failures until an explicit channel refresh', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { service, channel, start } = makeSupervisor();
+    vi.mocked(getConnector).mockReturnValue({
+      sendMessage: vi.fn(),
+      startListening: vi.fn(async () => {
+        throw new GatewayListenerError('slack_bot_token_invalid', 'permanent', 'replace token');
+      }),
+      stopListening: vi.fn(),
+    });
+    await start();
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(vi.mocked(getConnector)).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('retry=operator_action'));
+    await runWithTenantContext('tenant-a', () => service.startListenerForChannel(channel.id));
+    expect(vi.mocked(getConnector)).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('backs off transient failures, recovers, and cancels retries on disable', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const { service, channel, channelRepo, start } = makeSupervisor();
+    const startListening = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Authorization: Bearer secret'))
+      .mockResolvedValue(undefined);
+    vi.mocked(getConnector).mockReturnValue({
+      sendMessage: vi.fn(),
+      startListening,
+      stopListening: vi.fn(),
+    });
+    await start();
+    expect(startListening).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(startListening).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(startListening).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('event=recovered'));
+
+    await runWithTenantContext('tenant-a', () => service.stopChannelListener(channel.id));
+    channelRepo.findById.mockResolvedValue({ ...channel, enabled: false });
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(startListening).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });
 

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1499,6 +1499,7 @@ describe('GatewayService listener retry supervision', () => {
     const channelRepo = {
       findById: vi.fn(async () => channel),
       releaseListener: vi.fn(async () => true),
+      renewListener: vi.fn(async () => null),
       listenerClaimIsCurrent: vi.fn(async () => true),
     };
     (service as unknown as { channelRepo: unknown }).channelRepo = channelRepo;
@@ -1558,6 +1559,108 @@ describe('GatewayService listener retry supervision', () => {
     await runWithTenantContext('tenant-a', () => service.stopChannelListener(channel.id));
     channelRepo.findById.mockResolvedValue({ ...channel, enabled: false });
     await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(startListening).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('lets refreshed config supersede a retry startup already in flight', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { service, channel, channelRepo, start } = makeSupervisor();
+    let finishOldStart!: () => void;
+    const oldStart = new Promise<void>((resolve) => {
+      finishOldStart = resolve;
+    });
+    const oldStop = vi.fn(async () => undefined);
+    const oldStartListening = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockImplementationOnce(() => oldStart);
+    const freshStartListening = vi.fn(async () => undefined);
+    vi.mocked(getConnector).mockImplementation((_type, config) =>
+      (config as { version?: string }).version === 'fresh'
+        ? {
+            sendMessage: vi.fn(),
+            startListening: freshStartListening,
+            stopListening: vi.fn(),
+          }
+        : {
+            sendMessage: vi.fn(),
+            startListening: oldStartListening,
+            stopListening: oldStop,
+          }
+    );
+
+    await start();
+    const retryStarted = vi.advanceTimersByTimeAsync(10_000);
+    await vi.waitFor(() => expect(oldStartListening).toHaveBeenCalledTimes(2));
+    channelRepo.findById.mockResolvedValue({
+      ...channel,
+      config: { ...channel.config, version: 'fresh' },
+    });
+    await runWithTenantContext('tenant-a', () => service.startListenerForChannel(channel.id));
+    expect(freshStartListening).toHaveBeenCalledOnce();
+    finishOldStart();
+    await retryStarted;
+    expect(oldStop).toHaveBeenCalled();
+    const active = (
+      service as unknown as { activeListeners: Map<string, { startListening?: unknown }> }
+    ).activeListeners.get(`tenant-a\0${channel.id}`);
+    expect(active?.startListening).toBe(freshStartListening);
+    vi.useRealTimers();
+  });
+
+  it('does not start a retry transport after its durable lease is lost', async () => {
+    const { service, channel, channelRepo } = makeSupervisor();
+    (service as unknown as { durableListenerOwnership: boolean }).durableListenerOwnership = true;
+    const startListening = vi.fn(async () => undefined);
+    vi.mocked(getConnector).mockReturnValue({ sendMessage: vi.fn(), startListening });
+    channelRepo.renewListener.mockResolvedValue(null);
+    const lease = {
+      channel_id: channel.id,
+      claim_token: 'lost-owner',
+      generation: 1,
+      claimed_at: '2026-08-10T00:00:00.000Z',
+      lease_expires_at: '2026-08-10T00:00:30.000Z',
+      instance_id: 'daemon-a',
+      boot_id: 'boot-a',
+      checkpoint: null,
+    };
+
+    await runWithTenantContext('tenant-a', () =>
+      (
+        service as unknown as {
+          startChannelListener(
+            c: GatewayChannel,
+            tenant: string,
+            lease: typeof lease
+          ): Promise<void>;
+        }
+      ).startChannelListener(channel, 'tenant-a', lease)
+    );
+    expect(startListening).not.toHaveBeenCalled();
+    expect(channelRepo.releaseListener).not.toHaveBeenCalled();
+  });
+
+  it('reschedules safely when retry preparation fails', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { channelRepo, start } = makeSupervisor();
+    const startListening = vi.fn().mockRejectedValue(new Error('provider secret payload'));
+    vi.mocked(getConnector).mockReturnValue({
+      sendMessage: vi.fn(),
+      startListening,
+      stopListening: vi.fn(),
+    });
+    await start();
+    channelRepo.findById.mockRejectedValueOnce(new Error('database details'));
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(warn).toHaveBeenLastCalledWith(expect.stringContaining('event=start_retry_scheduled'));
+    expect(warn.mock.calls.flat().join(' ')).not.toMatch(/secret payload|database details/);
+    await vi.advanceTimersByTimeAsync(20_000);
     expect(startListening).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
   });

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -57,6 +57,7 @@ import {
   formatGatewayFollowUpRoutingMessage,
   formatGatewaySessionCreatedMessage,
   formatGatewaySystemPayload,
+  gatewayListenerFailure,
   getConnector,
   hasConnector,
   isSlackWriteTargetAllowed,
@@ -144,11 +145,22 @@ interface ActiveGatewayListenerLease extends GatewayListenerLease {
   tenant_id: TenantID | string;
 }
 
+interface GatewayListenerRetryState {
+  tenantId: TenantID | string;
+  channel: GatewayChannel;
+  lease?: GatewayListenerLease;
+  attempt: number;
+  timer?: NodeJS.Timeout;
+  generation: number;
+}
+
 const GATEWAY_LISTENER_LEASE_MS = 30_000;
 const GATEWAY_LISTENER_SCAN_BATCH = 25;
 const GATEWAY_LISTENER_RENEW_SCAN_MAX_MS = 5_000;
 const GATEWAY_EVENT_PROCESSING_LEASE_MS = 2 * 60_000;
 const GATEWAY_LISTENER_STOP_TIMEOUT_MS = 5_000;
+const GATEWAY_LISTENER_RETRY_BASE_MS = 5_000;
+const GATEWAY_LISTENER_RETRY_MAX_MS = 5 * 60_000;
 
 async function withGatewayTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
@@ -712,6 +724,9 @@ export class GatewayService {
   private activeListeners = new Map<string, GatewayConnector>();
   /** PostgreSQL-only durable ownership diagnostics/fences for local listeners. */
   private activeListenerLeases = new Map<string, ActiveGatewayListenerLease>();
+  /** Failed starts, scoped by tenant + channel. A durable owner retains its lease while waiting. */
+  private listenerRetries = new Map<string, GatewayListenerRetryState>();
+  private listenerRetryGeneration = 0;
   private listenerTimer: NodeJS.Timeout | null = null;
   private listenerScanRunning = false;
   private listenerStopped = false;
@@ -3164,7 +3179,7 @@ export class GatewayService {
     for (const ref of refs) {
       await this.runWithListenerTenantIdentity(ref.tenant_id, async () => {
         const key = this.listenerKey(ref.tenant_id, ref.channel_id);
-        if (this.activeListeners.has(key)) return;
+        if (this.activeListeners.has(key) || this.listenerRetries.has(key)) return;
         const channel = await this.channelRepo.findById(ref.channel_id);
         if (!channel?.enabled) return;
         if (tenantIdFromGatewayChannel(channel) !== ref.tenant_id) {
@@ -3179,11 +3194,7 @@ export class GatewayService {
         // Provider authentication/connect is external network work and must not
         // hold up the bounded/fair discovery cursor. The channel-row claim
         // prevents a second start while this promise is in flight.
-        void this.startChannelListener(channel, ref.tenant_id).catch((error) => {
-          console.warn(
-            `[distributed-work.gateway-listener] event=start_failed tenant_id=${JSON.stringify(ref.tenant_id)} channel_id=${JSON.stringify(ref.channel_id)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
-          );
-        });
+        void this.startChannelListener(channel, ref.tenant_id);
       }).catch((error) => {
         console.warn(
           `[distributed-work.gateway-listener] event=candidate_failed tenant_id=${JSON.stringify(ref.tenant_id)} channel_id=${JSON.stringify(ref.channel_id)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
@@ -3314,6 +3325,7 @@ export class GatewayService {
       async (scopedDb) => isPostgresDatabase(scopedDb)
     );
     const channel = await this.channelRepo.findById(channelId);
+    await this.cancelListenerRetry(tenantId, channelId, true);
     if (!channel) {
       console.warn(`[gateway] Cannot manage listener: channel ${channelId} not found`);
       return;
@@ -3368,7 +3380,14 @@ export class GatewayService {
     const key = this.listenerKey(tenantId, channelId);
     const connector = this.activeListeners.get(key);
     const lease = this.activeListenerLeases.get(key);
+    const retry = this.listenerRetries.get(key);
+    if (retry?.timer) clearTimeout(retry.timer);
+    this.listenerRetries.delete(key);
     if (!connector) {
+      this.activeListenerLeases.delete(key);
+      if (lease && options.releaseClaim !== false) {
+        await this.channelRepo.releaseListener(lease.channel_id, lease.claim_token);
+      }
       return true; // Not listening
     }
 
@@ -3442,6 +3461,11 @@ export class GatewayService {
       lease = claim.lease;
     }
 
+    const priorRetry = this.listenerRetries.get(key);
+    const priorAttempt = priorRetry?.attempt ?? 0;
+    if (priorRetry?.timer) clearTimeout(priorRetry.timer);
+    this.listenerRetries.delete(key);
+
     return runWithoutTenantDatabaseScope(async () => {
       let connector: GatewayConnector | undefined;
       try {
@@ -3486,10 +3510,9 @@ export class GatewayService {
             try {
               await withGatewayTimeout(connector.stopListening(), GATEWAY_LISTENER_STOP_TIMEOUT_MS);
               stopped = true;
-            } catch (stopError) {
-              console.error(
-                `[gateway] Failed to stop listener that completed startup after drain/fence loss for channel "${channel.name}":`,
-                stopError
+            } catch (_stopError) {
+              console.warn(
+                `[gateway.listener] event=stop_failed channel_id=${JSON.stringify(channel.id)} code=transport_stop_failed`
               );
             }
           }
@@ -3504,28 +3527,102 @@ export class GatewayService {
         if (lease) {
           this.activeListenerLeases.set(key, { ...lease, tenant_id: listenerTenantId });
         }
-        console.log(`[gateway] Listener started for channel "${channel.name}"`);
+        console.log(
+          `[gateway.listener] event=${priorAttempt > 0 ? 'recovered' : 'started'} channel_id=${JSON.stringify(channel.id)} provider=${channel.channel_type}`
+        );
       } catch (error) {
-        console.error(`[gateway] Failed to start listener for channel "${channel.name}":`, error);
+        const failure = gatewayListenerFailure(error);
         let stopped = !connector;
         if (connector?.stopListening) {
           try {
             await withGatewayTimeout(connector.stopListening(), GATEWAY_LISTENER_STOP_TIMEOUT_MS);
             stopped = true;
-          } catch (stopError) {
-            console.error(
-              `[gateway] Failed to stop partially-started listener for channel "${channel.name}":`,
-              stopError
+          } catch (_stopError) {
+            console.warn(
+              `[gateway.listener] event=stop_failed channel_id=${JSON.stringify(channel.id)} code=transport_stop_failed`
             );
           }
         }
-        if (lease && stopped) {
-          await this.runWithListenerTenantIdentity(listenerTenantId, () =>
-            this.channelRepo.releaseListener(channel.id, lease!.claim_token)
-          ).catch(() => undefined);
+        if (!stopped) {
+          // An uncertain transport is fenced by lease expiry; never overlap it.
+          return;
         }
+        this.recordListenerFailure(channel, listenerTenantId, lease, failure, priorAttempt);
       }
     });
+  }
+
+  private recordListenerFailure(
+    channel: GatewayChannel,
+    tenantId: TenantID | string,
+    lease: GatewayListenerLease | undefined,
+    failure: ReturnType<typeof gatewayListenerFailure>,
+    priorAttempt = 0
+  ): void {
+    const key = this.listenerKey(tenantId, channel.id);
+    const attempt = priorAttempt + 1;
+    const generation = ++this.listenerRetryGeneration;
+    const state: GatewayListenerRetryState = { tenantId, channel, lease, attempt, generation };
+    this.listenerRetries.set(key, state);
+    if (lease) this.activeListenerLeases.set(key, { ...lease, tenant_id: tenantId });
+
+    if (failure.kind === 'permanent') {
+      console.warn(
+        `[gateway.listener] event=start_blocked channel_id=${JSON.stringify(channel.id)} provider=${channel.channel_type} code=${failure.code} retry=operator_action`
+      );
+      return;
+    }
+
+    const delayMs = boundedBackoffDelay(
+      attempt,
+      {
+        baseDelayMs: GATEWAY_LISTENER_RETRY_BASE_MS,
+        maxDelayMs: GATEWAY_LISTENER_RETRY_MAX_MS,
+        jitterRatio: 0.2,
+      },
+      Math.random()
+    );
+    console.warn(
+      `[gateway.listener] event=start_retry_scheduled channel_id=${JSON.stringify(channel.id)} provider=${channel.channel_type} code=${failure.code} attempt=${attempt} delay_ms=${delayMs}`
+    );
+    state.timer = setTimeout(() => {
+      state.timer = undefined;
+      void this.retryChannelListener(key, generation);
+    }, delayMs);
+    state.timer.unref?.();
+  }
+
+  private async retryChannelListener(key: string, generation: number): Promise<void> {
+    const state = this.listenerRetries.get(key);
+    if (!state || state.generation !== generation || this.listenerStopped || this.listenerDraining)
+      return;
+    await this.runWithListenerTenantIdentity(state.tenantId, async () => {
+      const current = await this.channelRepo.findById(state.channel.id);
+      if (!current?.enabled || !hasListeningConfig(current)) {
+        await this.cancelListenerRetry(state.tenantId, state.channel.id, true);
+        return;
+      }
+      // A CRUD refresh changes generation and starts immediately. Timer retries
+      // use the snapshot whose credentials/config produced this failure.
+      await this.startChannelListener(state.channel, state.tenantId, state.lease);
+    });
+  }
+
+  private async cancelListenerRetry(
+    tenantId: TenantID | string,
+    channelId: string,
+    releaseClaim: boolean
+  ): Promise<void> {
+    const key = this.listenerKey(tenantId, channelId);
+    const state = this.listenerRetries.get(key);
+    if (!state) return;
+    if (state.timer) clearTimeout(state.timer);
+    this.listenerRetries.delete(key);
+    const lease = this.activeListenerLeases.get(key);
+    this.activeListenerLeases.delete(key);
+    if (releaseClaim && lease) {
+      await this.channelRepo.releaseListener(lease.channel_id, lease.claim_token);
+    }
   }
 
   private async handleListenerInboundMessage(
@@ -3662,7 +3759,13 @@ export class GatewayService {
     if (this.listenerTimer) clearTimeout(this.listenerTimer);
     this.listenerTimer = null;
     const leases = new Map(this.activeListenerLeases);
+    const retryKeys = new Set(this.listenerRetries.keys());
+    for (const retry of this.listenerRetries.values()) {
+      if (retry.timer) clearTimeout(retry.timer);
+    }
+    this.listenerRetries.clear();
     const stoppedTransports = new Set<string>();
+    for (const key of retryKeys) stoppedTransports.add(key);
     for (const listenerKey of [...this.activeListeners.keys()]) {
       const separator = listenerKey.indexOf('\0');
       const tenantId = listenerKey.slice(0, separator);

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -152,6 +152,7 @@ interface GatewayListenerRetryState {
   attempt: number;
   timer?: NodeJS.Timeout;
   generation: number;
+  lifecycleGeneration: number;
 }
 
 const GATEWAY_LISTENER_LEASE_MS = 30_000;
@@ -727,6 +728,8 @@ export class GatewayService {
   /** Failed starts, scoped by tenant + channel. A durable owner retains its lease while waiting. */
   private listenerRetries = new Map<string, GatewayListenerRetryState>();
   private listenerRetryGeneration = 0;
+  /** Cancellation fence covering timers and provider startups already in flight. */
+  private listenerLifecycleGenerations = new Map<string, number>();
   private listenerTimer: NodeJS.Timeout | null = null;
   private listenerScanRunning = false;
   private listenerStopped = false;
@@ -3099,10 +3102,10 @@ export class GatewayService {
     try {
       found = await this.reconcileListenersOnce();
       this.listenerIdleRounds = found === 0 ? this.listenerIdleRounds + 1 : 0;
-    } catch (error) {
+    } catch {
       this.listenerIdleRounds += 1;
       console.warn(
-        `[distributed-work.gateway-listener] event=scan_failed instance_id=${JSON.stringify(this.workIdentity.instanceId)} boot_id=${JSON.stringify(this.workIdentity.bootId)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
+        `[distributed-work.gateway-listener] event=scan_failed instance_id=${JSON.stringify(this.workIdentity.instanceId)} boot_id=${JSON.stringify(this.workIdentity.bootId)} code=database_unavailable`
       );
     } finally {
       this.listenerScanRunning = false;
@@ -3194,10 +3197,14 @@ export class GatewayService {
         // Provider authentication/connect is external network work and must not
         // hold up the bounded/fair discovery cursor. The channel-row claim
         // prevents a second start while this promise is in flight.
-        void this.startChannelListener(channel, ref.tenant_id);
-      }).catch((error) => {
+        void this.startChannelListener(channel, ref.tenant_id).catch(() => {
+          console.warn(
+            `[gateway.listener] event=start_failed channel_id=${JSON.stringify(channel.id)} provider=${channel.channel_type} code=supervisor_unavailable`
+          );
+        });
+      }).catch(() => {
         console.warn(
-          `[distributed-work.gateway-listener] event=candidate_failed tenant_id=${JSON.stringify(ref.tenant_id)} channel_id=${JSON.stringify(ref.channel_id)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
+          `[distributed-work.gateway-listener] event=candidate_failed tenant_id=${JSON.stringify(ref.tenant_id)} channel_id=${JSON.stringify(ref.channel_id)} code=candidate_unavailable`
         );
       });
     }
@@ -3325,6 +3332,7 @@ export class GatewayService {
       async (scopedDb) => isPostgresDatabase(scopedDb)
     );
     const channel = await this.channelRepo.findById(channelId);
+    this.invalidateListenerLifecycle(tenantId, channelId);
     await this.cancelListenerRetry(tenantId, channelId, true);
     if (!channel) {
       console.warn(`[gateway] Cannot manage listener: channel ${channelId} not found`);
@@ -3378,6 +3386,7 @@ export class GatewayService {
       'Missing tenant context while stopping a gateway listener'
     );
     const key = this.listenerKey(tenantId, channelId);
+    this.invalidateListenerLifecycle(tenantId, channelId);
     const connector = this.activeListeners.get(key);
     const lease = this.activeListenerLeases.get(key);
     const retry = this.listenerRetries.get(key);
@@ -3403,13 +3412,12 @@ export class GatewayService {
       }
       stopped = true;
       console.log(`[gateway] Listener stopped for channel ${shortId(channelId)}`);
-    } catch (error) {
+    } catch {
       // A transport that ignores stop may still deliver, but every callback and
       // checkpoint remains fenced by its opaque database token. Do not release
       // the lease early; expiry is the safe takeover path.
-      console.error(
-        `[gateway] Error stopping listener for ${channelId} (old socket may still be alive):`,
-        error
+      console.warn(
+        `[gateway.listener] event=stop_failed channel_id=${JSON.stringify(channelId)} code=transport_stop_failed`
       );
     }
 
@@ -3428,7 +3436,8 @@ export class GatewayService {
   private async startChannelListener(
     channel: GatewayChannel,
     listenerTenantId: TenantID | string,
-    claimedLease?: GatewayListenerLease
+    claimedLease?: GatewayListenerLease,
+    expectedGeneration?: number
   ): Promise<void> {
     if (this.listenerStopped || this.listenerDraining) return;
     const rowTenantId = tenantIdFromGatewayChannel(channel);
@@ -3437,6 +3446,11 @@ export class GatewayService {
     }
 
     const key = this.listenerKey(listenerTenantId, channel.id);
+    if (!this.listenerLifecycleGenerations.has(key)) {
+      this.listenerLifecycleGenerations.set(key, 0);
+    }
+    const generation = expectedGeneration ?? this.listenerLifecycleGenerations.get(key) ?? 0;
+    if (this.listenerLifecycleGenerations.get(key) !== generation) return;
     if (this.activeListeners.has(key)) {
       return; // Already listening
     }
@@ -3449,6 +3463,21 @@ export class GatewayService {
     }
 
     let lease = claimedLease;
+    if (lease) {
+      const renewedLease = await this.runWithListenerTenantIdentity(listenerTenantId, () =>
+        this.channelRepo.renewListener(channel.id, lease!.claim_token, GATEWAY_LISTENER_LEASE_MS)
+      );
+      if (!renewedLease) {
+        if (this.listenerLifecycleGenerations.get(key) === generation) {
+          const retry = this.listenerRetries.get(key);
+          if (retry?.timer) clearTimeout(retry.timer);
+          this.listenerRetries.delete(key);
+          this.activeListenerLeases.delete(key);
+        }
+        return;
+      }
+      lease = renewedLease;
+    }
     if (this.durableListenerOwnership && !lease) {
       const claim = await this.channelRepo.claimListener({
         channelId: channel.id,
@@ -3464,7 +3493,6 @@ export class GatewayService {
     const priorRetry = this.listenerRetries.get(key);
     const priorAttempt = priorRetry?.attempt ?? 0;
     if (priorRetry?.timer) clearTimeout(priorRetry.timer);
-    this.listenerRetries.delete(key);
 
     return runWithoutTenantDatabaseScope(async () => {
       let connector: GatewayConnector | undefined;
@@ -3504,7 +3532,12 @@ export class GatewayService {
               this.channelRepo.listenerClaimIsCurrent(channel.id, lease!.claim_token)
             )
           : true;
-        if (this.listenerStopped || this.listenerDraining || !leaseIsCurrent) {
+        if (
+          this.listenerStopped ||
+          this.listenerDraining ||
+          this.listenerLifecycleGenerations.get(key) !== generation ||
+          !leaseIsCurrent
+        ) {
           let stopped = !connector.stopListening;
           if (connector.stopListening) {
             try {
@@ -3523,6 +3556,7 @@ export class GatewayService {
           }
           return;
         }
+        this.listenerRetries.delete(key);
         this.activeListeners.set(key, connector);
         if (lease) {
           this.activeListenerLeases.set(key, { ...lease, tenant_id: listenerTenantId });
@@ -3545,8 +3579,11 @@ export class GatewayService {
         }
         if (!stopped) {
           // An uncertain transport is fenced by lease expiry; never overlap it.
+          this.listenerRetries.delete(key);
+          this.activeListenerLeases.delete(key);
           return;
         }
+        if (this.listenerLifecycleGenerations.get(key) !== generation) return;
         this.recordListenerFailure(channel, listenerTenantId, lease, failure, priorAttempt);
       }
     });
@@ -3562,7 +3599,14 @@ export class GatewayService {
     const key = this.listenerKey(tenantId, channel.id);
     const attempt = priorAttempt + 1;
     const generation = ++this.listenerRetryGeneration;
-    const state: GatewayListenerRetryState = { tenantId, channel, lease, attempt, generation };
+    const state: GatewayListenerRetryState = {
+      tenantId,
+      channel,
+      lease,
+      attempt,
+      generation,
+      lifecycleGeneration: this.listenerLifecycleGenerations.get(key) ?? 0,
+    };
     this.listenerRetries.set(key, state);
     if (lease) this.activeListenerLeases.set(key, { ...lease, tenant_id: tenantId });
 
@@ -3594,18 +3638,47 @@ export class GatewayService {
 
   private async retryChannelListener(key: string, generation: number): Promise<void> {
     const state = this.listenerRetries.get(key);
-    if (!state || state.generation !== generation || this.listenerStopped || this.listenerDraining)
+    if (
+      !state ||
+      state.generation !== generation ||
+      this.listenerLifecycleGenerations.get(key) !== state.lifecycleGeneration ||
+      this.listenerStopped ||
+      this.listenerDraining
+    )
       return;
-    await this.runWithListenerTenantIdentity(state.tenantId, async () => {
-      const current = await this.channelRepo.findById(state.channel.id);
-      if (!current?.enabled || !hasListeningConfig(current)) {
-        await this.cancelListenerRetry(state.tenantId, state.channel.id, true);
-        return;
-      }
-      // A CRUD refresh changes generation and starts immediately. Timer retries
-      // use the snapshot whose credentials/config produced this failure.
-      await this.startChannelListener(state.channel, state.tenantId, state.lease);
-    });
+    try {
+      await this.runWithListenerTenantIdentity(state.tenantId, async () => {
+        const current = await this.channelRepo.findById(state.channel.id);
+        if (!current?.enabled || !hasListeningConfig(current)) {
+          await this.cancelListenerRetry(state.tenantId, state.channel.id, true);
+          return;
+        }
+        // A CRUD refresh changes the lifecycle generation and starts immediately.
+        await this.startChannelListener(
+          state.channel,
+          state.tenantId,
+          state.lease,
+          state.lifecycleGeneration
+        );
+      });
+    } catch {
+      if (this.listenerRetries.get(key) !== state) return;
+      this.recordListenerFailure(
+        state.channel,
+        state.tenantId,
+        state.lease,
+        gatewayListenerFailure(undefined),
+        state.attempt
+      );
+    }
+  }
+
+  private invalidateListenerLifecycle(tenantId: TenantID | string, channelId: string): void {
+    const key = this.listenerKey(tenantId, channelId);
+    this.listenerLifecycleGenerations.set(
+      key,
+      (this.listenerLifecycleGenerations.get(key) ?? 0) + 1
+    );
   }
 
   private async cancelListenerRetry(
@@ -3764,6 +3837,7 @@ export class GatewayService {
       if (retry.timer) clearTimeout(retry.timer);
     }
     this.listenerRetries.clear();
+    this.listenerLifecycleGenerations.clear();
     const stoppedTransports = new Set<string>();
     for (const key of retryKeys) stoppedTransports.add(key);
     for (const listenerKey of [...this.activeListeners.keys()]) {

--- a/packages/core/src/gateway/connectors/github.test.ts
+++ b/packages/core/src/gateway/connectors/github.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { githubIssueCommentProviderEventId } from './github';
+import { classifyGitHubInstallationError, githubIssueCommentProviderEventId } from './github';
+
+describe('classifyGitHubInstallationError', () => {
+  it('keeps an ordinary permission 403 permanent', () => {
+    expect(classifyGitHubInstallationError({ status: 403 })).toMatchObject({
+      code: 'github_credentials_invalid',
+      kind: 'permanent',
+    });
+  });
+
+  it.each([
+    { response: { headers: { 'retry-after': '60' } } },
+    { response: { headers: { 'x-ratelimit-remaining': '0' } } },
+    {
+      response: {
+        headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1234' },
+      },
+    },
+    { response: { data: { message: 'You have exceeded a secondary rate limit.' } } },
+  ])('keeps a rate-limited 403 transient', (detail) => {
+    expect(classifyGitHubInstallationError({ status: 403, ...detail })).toMatchObject({
+      code: 'github_api_unavailable',
+      kind: 'transient',
+    });
+  });
+
+  it('does not treat a reset header with remaining capacity as rate limited', () => {
+    expect(
+      classifyGitHubInstallationError({
+        status: 403,
+        response: {
+          headers: { 'x-ratelimit-remaining': '42', 'x-ratelimit-reset': '1234' },
+        },
+      })
+    ).toMatchObject({ code: 'github_credentials_invalid', kind: 'permanent' });
+  });
+});
 
 describe('githubIssueCommentProviderEventId', () => {
   it('uses the provider-stable node id when available', () => {

--- a/packages/core/src/gateway/connectors/github.ts
+++ b/packages/core/src/gateway/connectors/github.ts
@@ -31,6 +31,7 @@ import type {
   GatewayListenerOptions,
   InboundMessage,
 } from '../connector';
+import { GatewayListenerError } from '../listener-error';
 import { addToRingBuffer, escapeRegex } from './shared';
 
 // ============================================================================
@@ -431,10 +432,11 @@ export class GitHubConnector implements GatewayConnector {
       console.log(
         `[github] Authenticated as installation ${this.config.installation_id} on ${(installation.account && 'login' in installation.account ? installation.account.login : undefined) ?? 'unknown'}`
       );
-    } catch (error) {
-      console.error('[github] Failed to validate installation:', error);
-      throw new Error(
-        'GitHub App authentication failed — check app_id, private_key, and installation_id'
+    } catch {
+      throw new GatewayListenerError(
+        'github_credentials_invalid',
+        'permanent',
+        'Verify the GitHub App id, private key, installation id, and installation access.'
       );
     }
 

--- a/packages/core/src/gateway/connectors/github.ts
+++ b/packages/core/src/gateway/connectors/github.ts
@@ -76,6 +76,47 @@ const DEFAULT_STARTUP_LOOKBACK_MS = 5 * 60_000;
 /** Default mention keyword */
 const DEFAULT_MENTION_NAME = 'agor';
 
+/** Classify GitHub installation validation without exposing its response payload. */
+export function classifyGitHubInstallationError(error: unknown): GatewayListenerError {
+  const candidate =
+    typeof error === 'object' && error !== null
+      ? (error as {
+          status?: unknown;
+          message?: unknown;
+          response?: { headers?: Record<string, unknown>; data?: { message?: unknown } };
+        })
+      : {};
+  const status = Number(candidate.status);
+  const headers = candidate.response?.headers ?? {};
+  const header = (name: string): string => {
+    const value = headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()];
+    return typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+  };
+  const providerMessage = `${String(candidate.message ?? '')} ${String(
+    candidate.response?.data?.message ?? ''
+  )}`.toLowerCase();
+  const rateLimited =
+    status === 429 ||
+    (status === 403 &&
+      (header('retry-after') !== '' ||
+        header('x-ratelimit-remaining') === '0' ||
+        providerMessage.includes('secondary rate limit') ||
+        providerMessage.includes('rate limit exceeded')));
+
+  if (!rateLimited && (status === 401 || status === 403 || status === 404)) {
+    return new GatewayListenerError(
+      'github_credentials_invalid',
+      'permanent',
+      'Verify the GitHub App id, private key, installation id, and installation access.'
+    );
+  }
+  return new GatewayListenerError(
+    'github_api_unavailable',
+    'transient',
+    'GitHub is unavailable; Agor will retry automatically.'
+  );
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -432,12 +473,8 @@ export class GitHubConnector implements GatewayConnector {
       console.log(
         `[github] Authenticated as installation ${this.config.installation_id} on ${(installation.account && 'login' in installation.account ? installation.account.login : undefined) ?? 'unknown'}`
       );
-    } catch {
-      throw new GatewayListenerError(
-        'github_credentials_invalid',
-        'permanent',
-        'Verify the GitHub App id, private key, installation id, and installation access.'
-      );
+    } catch (error) {
+      throw classifyGitHubInstallationError(error);
     }
 
     // Resolve repos to watch

--- a/packages/core/src/gateway/connectors/shortcut.test.ts
+++ b/packages/core/src/gateway/connectors/shortcut.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GatewayListenerError } from '../listener-error';
 import {
   buildThreadId,
   commentMentionsAgent,
@@ -113,6 +114,23 @@ describe('ShortcutConnector', () => {
   it('formatMessage passes markdown through unchanged', () => {
     const connector = new ShortcutConnector({ api_token: 'tok', agent_member_id: 'm1' });
     expect(connector.formatMessage('**bold** and `code`')).toBe('**bold** and `code`');
+  });
+
+  it.each([
+    [401, 'permanent', 'shortcut_token_invalid'],
+    [403, 'permanent', 'shortcut_token_invalid'],
+    [429, 'transient', 'shortcut_api_unavailable'],
+    [500, 'transient', 'shortcut_api_unavailable'],
+  ] as const)('classifies startup HTTP %s as %s', async (status, kind, code) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status }))
+    );
+    const connector = new ShortcutConnector({ api_token: 'tok' });
+    const error = await connector.startListening(vi.fn()).catch((caught) => caught);
+    expect(error).toBeInstanceOf(GatewayListenerError);
+    expect(error).toMatchObject({ kind, code });
+    vi.unstubAllGlobals();
   });
 });
 

--- a/packages/core/src/gateway/connectors/shortcut.ts
+++ b/packages/core/src/gateway/connectors/shortcut.ts
@@ -48,6 +48,7 @@ import type {
   GatewayListenerOptions,
   InboundMessage,
 } from '../connector';
+import { GatewayListenerError } from '../listener-error';
 import { addToRingBuffer, escapeRegex } from './shared';
 
 // ============================================================================
@@ -374,9 +375,12 @@ export class ShortcutConnector implements GatewayConnector {
     try {
       me = await this.request<ShortcutMember>('/member');
       console.log(`[shortcut] Authenticated (token member ${me.id})`);
-    } catch (error) {
-      console.error('[shortcut] Failed to validate api_token:', error);
-      throw new Error('Shortcut authentication failed — check api_token');
+    } catch {
+      throw new GatewayListenerError(
+        'shortcut_token_invalid',
+        'permanent',
+        'Replace the Shortcut API token and verify workspace access.'
+      );
     }
 
     // Mention target: explicit override, else the token owner.

--- a/packages/core/src/gateway/connectors/shortcut.ts
+++ b/packages/core/src/gateway/connectors/shortcut.ts
@@ -127,6 +127,12 @@ const DEFAULT_POLL_INTERVAL_MS = 15_000;
 const DEFAULT_SEARCH_PAGE_SIZE = 25;
 const DEFAULT_STARTUP_LOOKBACK_MS = 5 * 60_000;
 
+class ShortcutHttpError extends Error {
+  constructor(readonly status: number) {
+    super('Shortcut API request failed');
+  }
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -276,12 +282,7 @@ export class ShortcutConnector implements GatewayConnector {
     });
 
     if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new Error(
-        `Shortcut API ${init?.method ?? 'GET'} ${path} failed: ${res.status} ${res.statusText}${
-          body ? ` — ${body.slice(0, 300)}` : ''
-        }`
-      );
+      throw new ShortcutHttpError(res.status);
     }
 
     if (res.status === 204) return undefined as T;
@@ -375,11 +376,18 @@ export class ShortcutConnector implements GatewayConnector {
     try {
       me = await this.request<ShortcutMember>('/member');
       console.log(`[shortcut] Authenticated (token member ${me.id})`);
-    } catch {
+    } catch (error) {
+      if (error instanceof ShortcutHttpError && (error.status === 401 || error.status === 403)) {
+        throw new GatewayListenerError(
+          'shortcut_token_invalid',
+          'permanent',
+          'Replace the Shortcut API token and verify workspace access.'
+        );
+      }
       throw new GatewayListenerError(
-        'shortcut_token_invalid',
-        'permanent',
-        'Replace the Shortcut API token and verify workspace access.'
+        'shortcut_api_unavailable',
+        'transient',
+        'Shortcut is unavailable; Agor will retry automatically.'
       );
     }
 

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -1902,11 +1902,30 @@ export class SlackConnector implements GatewayConnector {
       // Precompile regex patterns for performance
       botMentionPattern = new RegExp(`<@${this.botUserId}>`);
       botMentionReplacePattern = new RegExp(`<@${this.botUserId}>\\s*`, 'g');
-    } catch {
+    } catch (error) {
+      const code = extractSlackErrorDetail(error).code;
+      if (
+        code &&
+        [
+          'invalid_auth',
+          'not_authed',
+          'token_revoked',
+          'token_expired',
+          'account_inactive',
+          'missing_scope',
+          'no_permission',
+        ].includes(code)
+      ) {
+        throw new GatewayListenerError(
+          'slack_bot_token_invalid',
+          'permanent',
+          'Replace the Slack bot token and verify the required bot scopes.'
+        );
+      }
       throw new GatewayListenerError(
-        'slack_bot_token_invalid',
-        'permanent',
-        'Replace the Slack bot token and verify the required bot scopes.'
+        'slack_api_unavailable',
+        'transient',
+        'Slack is unavailable; Agor will retry automatically.'
       );
     }
 

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -42,6 +42,7 @@ import type {
   InboundFile,
   OutboundPayload,
 } from '../connector';
+import { GatewayListenerError } from '../listener-error';
 import { createSlackSdkLogger } from './slack-sdk-logger';
 
 // Block Kit table block limits (Slack docs, native block introduced Aug 2025).
@@ -1884,16 +1885,15 @@ export class SlackConnector implements GatewayConnector {
     options: GatewayListenerOptions = {}
   ): Promise<void> {
     if (!this.config.app_token) {
-      console.error('[slack] ERROR: app_token is missing from config');
-      throw new Error('Slack Socket Mode requires app_token in config');
+      throw new GatewayListenerError(
+        'slack_app_token_missing',
+        'permanent',
+        'Configure a Slack app-level token with connections:write.'
+      );
     }
 
-    this.socketMode = new SocketModeClient({
-      appToken: this.config.app_token,
-      logger: createSlackSdkLogger(),
-    });
-
-    // Fetch bot user ID for mention detection
+    // Validate the bot token before constructing Socket Mode. A listener without
+    // a bot identity cannot enforce mentions safely and must not partially start.
     let botMentionPattern: RegExp | null = null;
     let botMentionReplacePattern: RegExp | null = null;
     try {
@@ -1902,11 +1902,18 @@ export class SlackConnector implements GatewayConnector {
       // Precompile regex patterns for performance
       botMentionPattern = new RegExp(`<@${this.botUserId}>`);
       botMentionReplacePattern = new RegExp(`<@${this.botUserId}>\\s*`, 'g');
-    } catch (error) {
-      console.error('[slack] Failed to fetch bot user ID:', error);
-      console.error('[slack] This usually means the bot_token is invalid or expired');
-      console.warn('[slack] Mention detection will be disabled');
+    } catch {
+      throw new GatewayListenerError(
+        'slack_bot_token_invalid',
+        'permanent',
+        'Replace the Slack bot token and verify the required bot scopes.'
+      );
     }
+
+    this.socketMode = new SocketModeClient({
+      appToken: this.config.app_token,
+      logger: createSlackSdkLogger(),
+    });
 
     // Read config options (with defaults matching UI)
     const enableChannels = this.config.enable_channels ?? false;
@@ -2223,7 +2230,29 @@ export class SlackConnector implements GatewayConnector {
       }
     });
 
-    await this.socketMode.start();
+    try {
+      await this.socketMode.start();
+    } catch (error) {
+      this.socketMode = null;
+      const code =
+        typeof error === 'object' && error !== null
+          ? `${String((error as { code?: unknown }).code ?? '')} ${String(
+              (error as { data?: { error?: unknown } }).data?.error ?? ''
+            )}`
+          : '';
+      if (/invalid_auth|not_authed|token_revoked|account_inactive/i.test(code)) {
+        throw new GatewayListenerError(
+          'slack_app_token_invalid',
+          'permanent',
+          'Replace the Slack app-level token and verify connections:write.'
+        );
+      }
+      throw new GatewayListenerError(
+        'slack_socket_unavailable',
+        'transient',
+        'Slack Socket Mode is unavailable; Agor will retry automatically.'
+      );
+    }
   }
 
   /**

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -53,6 +53,11 @@ export {
 export type { GatewayContext } from './context';
 export { formatGatewayContext } from './context';
 export {
+  GatewayListenerError,
+  type GatewayListenerFailureKind,
+  gatewayListenerFailure,
+} from './listener-error';
+export {
   formatGatewayFollowUpRoutingMessage,
   formatGatewayMarkdownSessionReference,
   formatGatewaySessionCreatedMessage,

--- a/packages/core/src/gateway/listener-error.test.ts
+++ b/packages/core/src/gateway/listener-error.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { GatewayListenerError, gatewayListenerFailure } from './listener-error';
+
+describe('gatewayListenerFailure', () => {
+  it('preserves reviewed permanent classifications and remediation', () => {
+    const error = new GatewayListenerError('slack_bot_token_invalid', 'permanent', 'Replace it.');
+    expect(gatewayListenerFailure(error)).toBe(error);
+  });
+
+  it('turns raw provider exceptions into a bounded transient category', () => {
+    const failure = gatewayListenerFailure(
+      new Error('request failed Authorization: Bearer secret user@example.test')
+    );
+    expect(failure).toMatchObject({ code: 'provider_unavailable', kind: 'transient' });
+    expect(`${failure.code} ${failure.remediation}`).not.toMatch(/secret|@example/);
+  });
+});

--- a/packages/core/src/gateway/listener-error.ts
+++ b/packages/core/src/gateway/listener-error.ts
@@ -1,4 +1,4 @@
-export type GatewayListenerFailureKind = 'permanent' | 'transient' | 'lifecycle';
+export type GatewayListenerFailureKind = 'permanent' | 'transient';
 
 /** Safe, provider-neutral startup failure consumed by the daemon listener supervisor. */
 export class GatewayListenerError extends Error {

--- a/packages/core/src/gateway/listener-error.ts
+++ b/packages/core/src/gateway/listener-error.ts
@@ -1,0 +1,22 @@
+export type GatewayListenerFailureKind = 'permanent' | 'transient' | 'lifecycle';
+
+/** Safe, provider-neutral startup failure consumed by the daemon listener supervisor. */
+export class GatewayListenerError extends Error {
+  constructor(
+    readonly code: string,
+    readonly kind: GatewayListenerFailureKind,
+    readonly remediation: string
+  ) {
+    super(code);
+    this.name = 'GatewayListenerError';
+  }
+}
+
+export function gatewayListenerFailure(error: unknown): GatewayListenerError {
+  if (error instanceof GatewayListenerError) return error;
+  return new GatewayListenerError(
+    'provider_unavailable',
+    'transient',
+    'The provider could not be reached; Agor will retry automatically.'
+  );
+}


### PR DESCRIPTION
## Summary

- classify gateway listener startup failures as permanent or transient
- park permanent credential/configuration failures until channel configuration changes or an operator explicitly restarts the listener
- retry transient failures with bounded exponential backoff and jitter
- retain the HA listener lease while parked or backing off so replicas do not multiply retries
- cancel pending retries on disable, delete, refresh, shutdown, or ownership loss
- replace raw provider exceptions/stacks with concise sanitized lifecycle logs
- fail Slack startup before Socket Mode is constructed when the bot token is invalid, and distinguish bot-token from app-token remediation
- apply provider-specific permanent authentication classification to GitHub and Shortcut startup

## Production incident

The enabled Slack channel was rediscovered after every failed startup. Failure cleanup released its durable lease, and the HA discovery loop reclaimed it roughly 0.8–1.2 seconds after the previous attempt completed. With provider latency, production attempts repeated every 3–6 seconds. Each cycle duplicated the provider exception/stack across the Slack connector and gateway wrapper and also initiated Socket Mode despite the failed bot lookup.

After this change, the current HA owner retains and renews the lease while waiting. An invalid bot token produces one bounded event such as:

```text
[gateway.listener] event=start_blocked channel_id="…" provider=slack code=slack_bot_token_invalid retry=operator_action
```

No provider response, token, stack, channel name, user data, or message content is included.

## Testing

- `pnpm i`
- `pnpm check`
  - typecheck and lint passed
  - stopped at the pre-existing repository-wide filesystem boundary error: duplicate stable ID `DAEMON-FS-CAP-170`
- `pnpm --filter @agor/core exec vitest run src/gateway` — 226 passed
- `pnpm --filter @agor/daemon exec vitest run src/services/gateway.test.ts src/services/gateway-channels.test.ts src/services/gateway-channels-test.test.ts src/services/gateway-channels-app-info.test.ts` — 77 passed
- `pnpm check:multitenancy-boundaries`
- `pnpm check:realtime-boundaries`
- `git diff --check`

## Follow-up

The existing gateway channel API does not expose listener runtime health. A separate change can add parked/backoff/recovery status to the API and administrator UI without expanding this incident fix into a durable job framework.
