### PR TITLE
fix(executor): drain stdout before exit so large results survive (#2222)

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -442,6 +442,7 @@ describe('configured executor spawning', () => {
     );
 
     proc.emit('exit', 0);
+    proc.emit('close', 0);
 
     await expect(promise).resolves.toEqual({
       success: false,
@@ -455,6 +456,90 @@ describe('configured executor spawning', () => {
         },
       },
     });
+  });
+
+  // Regression: https://github.com/preset-io/agor/issues/2222 — a large browse
+  // result can outrun the child's `exit`, so parsing only there dropped whatever
+  // was still unread in the pipe and reported EXECUTOR_RESULT_MISSING.
+  it.each([
+    ['local', undefined],
+    ['configured-template', 'launch {command}'],
+  ])('waits for stdio close before parsing a large %s browse result', async (_name, template) => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { runExecutorCommand } = await import('./spawn-executor');
+    const promise = runExecutorCommand(
+      { command: 'branch.files.browse' },
+      template ? { executorCommandTemplate: template } : {}
+    );
+
+    const files = Array.from({ length: 20_000 }, (_, i) => ({ path: `src/file-${i}.ts` }));
+    const line = `AGOR_EXECUTOR_RESULT ${JSON.stringify({ success: true, data: { files } })}\n`;
+    const split = Math.floor(line.length / 2);
+
+    // Only the first pipe-buffer's worth has been read when the child is reaped.
+    proc.stdout.emit('data', Buffer.from(line.slice(0, split)));
+    proc.emit('exit', 0);
+
+    let settled = false;
+    void promise.finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    proc.stdout.emit('data', Buffer.from(line.slice(split)));
+    proc.emit('close', 0);
+
+    await expect(promise).resolves.toEqual({ success: true, data: { files } });
+  });
+
+  it('settles at exit without waiting for close when the result is already complete', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { runExecutorCommand } = await import('./spawn-executor');
+
+    const promise = runExecutorCommand({ command: 'branch.files.browse' }, {});
+    proc.stdout.emit(
+      'data',
+      Buffer.from('AGOR_EXECUTOR_RESULT {"success":true,"data":{"files":[]}}\n')
+    );
+    // 'close' never arrives — a descendant that inherited stdout outlives the
+    // executor. A complete result must not wait on it.
+    proc.emit('exit', 0);
+
+    await expect(promise).resolves.toEqual({ success: true, data: { files: [] } });
+  });
+
+  it.each([
+    ['local', undefined],
+    ['configured-template', 'launch {command}'],
+  ])('keeps the timeout active for an incomplete %s result', async (_name, template) => {
+    vi.useFakeTimers();
+    try {
+      const proc = createMockProcess();
+      spawnMock.mockReturnValue(proc);
+      const { runExecutorCommand } = await import('./spawn-executor');
+      const promise = runExecutorCommand(
+        { command: 'branch.files.browse' },
+        {
+          ...(template ? { executorCommandTemplate: template } : {}),
+          timeoutMs: 25,
+        }
+      );
+
+      proc.stdout.emit('data', Buffer.from('AGOR_EXECUTOR_RESULT {"success":true'));
+      proc.emit('exit', 0);
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(promise).resolves.toMatchObject({
+        success: false,
+        error: { code: 'EXECUTOR_TIMEOUT' },
+      });
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('refuses every unscoped executor launch when tenant context is required', async () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -588,6 +588,49 @@ function parseExecutorResultFromStdout(stdout: string): ExecutorCommandResult | 
   return null;
 }
 
+/**
+ * Settle once the executor's result is complete, not merely once it has exited.
+ *
+ * `exit` fires as soon as the process is reaped, while bytes it wrote can still
+ * be sitting unread in the pipe — parsing there loses up to a full pipe buffer
+ * of output, which is the daemon-side half of #2222. `close` fires only after
+ * every stdio stream has ended, so it is the final missing-result fence.
+ *
+ * Exiting with an already-parseable result is the common case and settles
+ * immediately, so a descendant that inherited stdio and outlives the executor
+ * cannot add latency. Only an incomplete result waits for `close`, backstopped
+ * by the caller's command timeout — better a late accurate answer than a prompt
+ * EXECUTOR_RESULT_MISSING for output that was still in flight.
+ */
+function settleOnExecutorResultComplete(
+  child: ChildProcess,
+  readStdout: () => string,
+  settle: (result: ExecutorCommandResult | null, code: number | null) => void
+): void {
+  let done = false;
+  let parsed: ExecutorCommandResult | null = null;
+
+  const finish = (code: number | null) => {
+    if (done) return;
+    done = true;
+    settle(parsed, code);
+  };
+
+  child.on('exit', (code) => {
+    // Already settled (spawn error, or a close that preceded exit) — skip the
+    // parse, which walks the whole accumulated stdout.
+    if (done) return;
+    parsed = parseExecutorResultFromStdout(readStdout());
+    if (parsed) finish(code);
+  });
+
+  child.on('close', (code) => {
+    if (done) return;
+    parsed ??= parseExecutorResultFromStdout(readStdout());
+    finish(code);
+  });
+}
+
 function logChunkedOutput(prefix: string, stream: 'stdout' | 'stderr', chunk: Buffer): void {
   const text = chunk.toString();
   for (const line of text.split(/\r?\n/)) {
@@ -1151,12 +1194,11 @@ function runExecutorCommandLocal(
       });
     });
 
-    child.on('exit', (code) => {
+    const finish = (result: ExecutorCommandResult | null, code: number | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
 
-      const result = parseExecutorResultFromStdout(stdout);
       if (result) {
         resolve(result);
         return;
@@ -1174,7 +1216,9 @@ function runExecutorCommandLocal(
           },
         },
       });
-    });
+    };
+
+    settleOnExecutorResultComplete(child, () => stdout, finish);
 
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
@@ -1247,12 +1291,11 @@ function runExecutorCommandWithTemplate(
       });
     });
 
-    child.on('exit', (code) => {
+    const finish = (result: ExecutorCommandResult | null, code: number | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
 
-      const result = parseExecutorResultFromStdout(stdout);
       if (result) {
         resolve(result);
         return;
@@ -1270,7 +1313,9 @@ function runExecutorCommandWithTemplate(
           },
         },
       });
-    });
+    };
+
+    settleOnExecutorResultComplete(child, () => stdout, finish);
 
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();


### PR DESCRIPTION
## Summary

Fixes #2222. Large `branch.files.browse` / file-read results on big repos could truncate the executor's multi-megabyte `AGOR_EXECUTOR_RESULT` sentinel line, so the daemon saw exit code 0 with no parseable result and reported `EXECUTOR_RESULT_MISSING`.

There were two independent race conditions, both fixed here:

### 1. Executor exits before stdout drains (root cause)

The CLI emitted the result with `console.log(...)` and then called `process.exit()`. On POSIX, writes to a pipe are **asynchronous** — once the ~64KB kernel pipe buffer fills, the remainder sits in the stream's internal queue. `process.exit()` terminates the process **without draining that queue**, so the tail of a large result was thrown away.

- New `packages/executor/src/cli-output.ts` centralizes drain-safe stdout: `writeAndDrain`, `emitExecutorResult`, `emitInteractiveEvent`, `emitResultAndExit`, `exitAfterDrain`. Each resolves only once bytes have been handed to the OS, at which point they survive the process exiting.
- `cli.ts` routes **every** result emit and every exit through these helpers.
- `ignoreStdioWriteErrors()` is installed at startup: switching from `console.log` (which silently swallows stream errors) to `stream.write()` (which emits them) would otherwise turn a dead reader / closed pipe into an unhandled `'error'` event and a nonzero exit. We drop stdio write errors and let the normal exit path run, preserving prior behaviour.

### 2. Daemon parses on `exit` instead of `close`

The daemon parsed accumulated stdout on the child's `exit` event, which fires as soon as the process is reaped — while bytes it wrote can still be unread in the pipe. `settleOnExecutorResultComplete` now waits for `close` (all stdio streams ended) **when the result at exit is still incomplete**, so the last pipe-buffer's worth of output is no longer lost.

A complete result at `exit` settles immediately (the common case), so a descendant process that inherited stdout and outlives the executor cannot add latency. Only an incomplete result waits for `close`, backstopped by the caller's command timeout.

## Testing

- `packages/executor/src/cli-output.test.ts` — slow-sink pipe stub proves a multi-megabyte line arrives as one intact sentinel; broken-pipe write resolves instead of hanging; exit codes are correct after draining.
- `apps/agor-daemon/src/utils/spawn-executor.configured.test.ts` — regression test splits a 20k-file result across `exit` and `close` and asserts the daemon waits for `close`; a second test asserts a complete result settles at `exit` without waiting for `close`. Existing tests updated to emit `close` alongside `exit`.
- `packages/executor/scripts/runtime-smoke.mjs` — real subprocess over a real pipe (an in-process stub cannot observe what `process.exit()` discards): a 40k-file result survives exit intact, a closed-reader probe still exits 0, and static guards ensure `dist/cli.js` keeps routing through `emitResultAndExit` rather than the old `console.log` sentinel.

Unit suites verified locally: `cli-output.test.ts` (5 passed), `spawn-executor.configured.test.ts` (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)