### PR TITLE
fix(daemon): slow blocked queue recovery sweeps

### DIFF
--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -54,5 +54,7 @@ describe('prompt and widget transaction scopes', () => {
     expect(drain).toContain(
       'reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, taskParams)'
     );
+    expect(drain).not.toContain('event=drain_started');
+    expect(drain).toContain('event=dispatched');
   });
 });

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -40,4 +40,19 @@ describe('prompt and widget transaction scopes', () => {
     expect(prompt).toContain('buildPromptTaskMetadata(data.metadata, messageSource, createdBy');
     expect(run).toContain('messageSource: normalizeMessageSource(data.messageSource, params)');
   });
+
+  it('restores the queued user before hooked Session recovery under branch RBAC', () => {
+    const start = source.indexOf('async function processNextQueuedTaskInternal(');
+    const end = source.indexOf('// Inject queue processor into sessions service.', start);
+    const drain = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(0);
+    const userLookup = drain.indexOf('userRepo.findById(userId)');
+    const sessionRead = drain.indexOf('sessionsService.get(sessionId, taskParams)');
+    expect(userLookup).toBeGreaterThan(0);
+    expect(sessionRead).toBeGreaterThan(userLookup);
+    expect(drain).toContain(
+      'reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, taskParams)'
+    );
+  });
 });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2861,10 +2861,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
-    console.log(
-      `[task-queue] event=drain_started session_id=${JSON.stringify(sessionId)} task_id=${JSON.stringify(nextTask.task_id)} queue_position=${nextTask.queue_position ?? 'null'}`
-    );
-
     // Re-read the task — defend against the case where it was already drained
     // by a concurrent caller, or removed by an admin via DELETE /tasks/:id.
     const stillQueued = await taskRepo.findById(nextTask.task_id);

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2842,21 +2842,24 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
-    const queuedSession = await runWithTenantDatabaseScope(db, getCurrentTenantId(), () =>
-      sessionsService.get(sessionId, params)
-    );
-    const session = await reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, params);
-
-    if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
-      return;
-    }
-
+    // Recovery triggers carry trusted tenant routing but no request user. Restore
+    // the durable enqueuer identity before entering hooked Session reads/repairs
+    // so branch RBAC applies exactly as it did at admission time.
     const userId = nextTask.metadata?.queued_by_user_id ?? nextTask.created_by;
     const userRepo = bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db));
     const queuedByUser = userId ? await userRepo.findById(userId) : undefined;
     const taskParams: RouteParams = queuedByUser
       ? ({ ...params, user: queuedByUser } as RouteParams)
       : params;
+
+    const queuedSession = await runWithTenantDatabaseScope(db, getCurrentTenantId(), () =>
+      sessionsService.get(sessionId, taskParams)
+    );
+    const session = await reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, taskParams);
+
+    if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
+      return;
+    }
 
     console.log(
       `[task-queue] event=drain_started session_id=${JSON.stringify(sessionId)} task_id=${JSON.stringify(nextTask.task_id)} queue_position=${nextTask.queue_position ?? 'null'}`

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2842,35 +2842,25 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
+    const queuedSession = await runWithTenantDatabaseScope(db, getCurrentTenantId(), () =>
+      sessionsService.get(sessionId, params)
+    );
+    const session = await reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, params);
+
+    if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
+      return;
+    }
+
     const userId = nextTask.metadata?.queued_by_user_id ?? nextTask.created_by;
     const userRepo = bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db));
     const queuedByUser = userId ? await userRepo.findById(userId) : undefined;
-
     const taskParams: RouteParams = queuedByUser
-      ? ({
-          ...params,
-          user: queuedByUser,
-        } as RouteParams)
+      ? ({ ...params, user: queuedByUser } as RouteParams)
       : params;
 
     console.log(
-      `📬 Processing queued task ${shortId(nextTask.task_id)} ` +
-        `(position ${nextTask.queue_position}) ` +
-        `with user context: ${queuedByUser ? shortId(queuedByUser.user_id) : 'none'}`
+      `[task-queue] event=drain_started session_id=${JSON.stringify(sessionId)} task_id=${JSON.stringify(nextTask.task_id)} queue_position=${nextTask.queue_position ?? 'null'}`
     );
-
-    const queuedSession = await runWithTenantDatabaseScope(db, getCurrentTenantId(), () =>
-      sessionsService.get(sessionId, taskParams)
-    );
-    const session = await reconcileSessionPromptStateIfStuck(queuedSession, taskRepo, taskParams);
-
-    if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
-      console.log(
-        `⏸️  [Queue] Session ${shortId(sessionId)} is ${session.status}, task ${shortId(nextTask.task_id)} waiting in queue ` +
-          `(will be processed when session becomes IDLE via patch hook)`
-      );
-      return;
-    }
 
     // Re-read the task — defend against the case where it was already drained
     // by a concurrent caller, or removed by an admin via DELETE /tasks/:id.
@@ -2910,7 +2900,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
     console.log(
-      `✅ Queue head ${shortId(admitted.task_id)} observed as ${admitted.status} for session ${shortId(sessionId)}`
+      `[task-queue] event=dispatched session_id=${JSON.stringify(sessionId)} task_id=${JSON.stringify(admitted.task_id)} status=${JSON.stringify(admitted.status)}`
     );
   }
 

--- a/apps/agor-daemon/src/services/session-queue-worker.test.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.test.ts
@@ -61,6 +61,7 @@ describe('SessionQueueWorker', () => {
 
   it('waits for the recovery cadence after a short page instead of hot-polling a blocker', async () => {
     vi.useFakeTimers();
+    const info = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const discover = vi.fn(async () => [ref('tenant-a', 'session-a')]);
     const processSession = vi.fn(async () => undefined);
     const worker = new SessionQueueWorker({} as never, {
@@ -78,6 +79,7 @@ describe('SessionQueueWorker', () => {
     expect(processSession).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1);
     expect(processSession).toHaveBeenCalledTimes(2);
+    expect(info.mock.calls.flat().join('\n')).not.toContain('recovery_sweep_found_work');
     worker.stop();
   });
 

--- a/apps/agor-daemon/src/services/session-queue-worker.test.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.test.ts
@@ -1,6 +1,6 @@
 import type { QueuedSessionCursor, QueuedSessionRef } from '@agor/core/db';
 import type { SessionID } from '@agor/core/types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionQueueWorker } from './session-queue-worker.js';
 
 const ref = (tenant: string, session: string): QueuedSessionRef => ({
@@ -10,6 +10,11 @@ const ref = (tenant: string, session: string): QueuedSessionRef => ({
 });
 
 describe('SessionQueueWorker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it('carries each discovered tenant into deferred queue processing', async () => {
     const processSession = vi.fn(async () => undefined);
     const worker = new SessionQueueWorker({} as never, {
@@ -36,6 +41,7 @@ describe('SessionQueueWorker', () => {
     const pages = [[ref('tenant-a', 'session-a')], []] as QueuedSessionRef[][];
     const worker = new SessionQueueWorker({} as never, {
       workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      scanBatchSize: 1,
       discover: async (cursor) => {
         cursors.push(cursor);
         return pages.shift() ?? [];
@@ -51,5 +57,57 @@ describe('SessionQueueWorker', () => {
       { tenant_id: 'tenant-a', session_id: 'session-a' },
       undefined,
     ]);
+  });
+
+  it('waits for the recovery cadence after a short page instead of hot-polling a blocker', async () => {
+    vi.useFakeTimers();
+    const discover = vi.fn(async () => [ref('tenant-a', 'session-a')]);
+    const processSession = vi.fn(async () => undefined);
+    const worker = new SessionQueueWorker({} as never, {
+      workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      discover,
+      processSession,
+      recoveryIntervalMs: 60_000,
+      random: () => 0.5,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(processSession).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(processSession).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(processSession).toHaveBeenCalledTimes(2);
+    worker.stop();
+  });
+
+  it('bounds saturated recovery work and resumes from its fairness cursor', async () => {
+    vi.useFakeTimers();
+    const pages = [[ref('tenant-a', 'session-a')], [ref('tenant-a', 'session-b')], []];
+    const discover = vi.fn(async () => pages.shift() ?? []);
+    const processSession = vi.fn(async () => undefined);
+    const worker = new SessionQueueWorker({} as never, {
+      workIdentity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      scanBatchSize: 1,
+      maxPagesPerSweep: 2,
+      discover,
+      processSession,
+      recoveryIntervalMs: 60_000,
+      random: () => 0.5,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(15_300);
+    expect(processSession).toHaveBeenCalledTimes(2);
+    expect(discover).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(59_849);
+    expect(discover).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(discover).toHaveBeenCalledTimes(3);
+    expect(discover).toHaveBeenLastCalledWith({
+      tenant_id: 'tenant-a',
+      session_id: 'session-b',
+    });
+    worker.stop();
   });
 });

--- a/apps/agor-daemon/src/services/session-queue-worker.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.ts
@@ -21,6 +21,9 @@ export interface SessionQueueWorkerOptions {
   workIdentity: DistributedWorkIdentity;
   processSession: (sessionId: SessionID, params: AuthenticatedParams) => Promise<void>;
   scanBatchSize?: number;
+  maxPagesPerSweep?: number;
+  /** Delay between completed recovery sweeps. Ordinary queue draining is event-driven. */
+  recoveryIntervalMs?: number;
   random?: () => number;
   /** Test seam; production discovery always uses the repository/RLS path. */
   discover?: (after?: QueuedSessionCursor) => Promise<QueuedSessionRef[]>;
@@ -39,7 +42,12 @@ export class SessionQueueWorker {
   private stopped = false;
   private cursor: QueuedSessionCursor | undefined;
   private idleRounds = 0;
+  private sweepComplete = false;
+  private sweepFound = 0;
+  private pagesInSweep = 0;
   private readonly scanBatchSize: number;
+  private readonly maxPagesPerSweep: number;
+  private readonly recoveryIntervalMs: number;
   private readonly random: () => number;
 
   constructor(
@@ -47,6 +55,8 @@ export class SessionQueueWorker {
     private readonly options: SessionQueueWorkerOptions
   ) {
     this.scanBatchSize = options.scanBatchSize ?? 25;
+    this.maxPagesPerSweep = options.maxPagesPerSweep ?? 10;
+    this.recoveryIntervalMs = options.recoveryIntervalMs ?? 60_000;
     this.random = options.random ?? Math.random;
   }
 
@@ -85,7 +95,13 @@ export class SessionQueueWorker {
     let found = 0;
     try {
       found = await this.checkOnce();
-      this.idleRounds = found === 0 ? this.idleRounds + 1 : 0;
+      this.idleRounds = 0;
+      if (this.sweepComplete && this.sweepFound > 0) {
+        console.log(
+          `[distributed-work.task-queue] event=recovery_sweep_found_work instance_id=${JSON.stringify(this.options.workIdentity.instanceId)} boot_id=${JSON.stringify(this.options.workIdentity.bootId)} session_refs_examined=${this.sweepFound}`
+        );
+        this.sweepFound = 0;
+      }
     } catch (error) {
       this.idleRounds += 1;
       console.warn(
@@ -95,8 +111,9 @@ export class SessionQueueWorker {
       this.running = false;
     }
 
-    const delay =
-      found >= this.scanBatchSize
+    const delay = this.sweepComplete
+      ? jitterDelay(this.recoveryIntervalMs, 0.1, this.random())
+      : found >= this.scanBatchSize
         ? jitterDelay(150, 2 / 3, this.random())
         : boundedBackoffDelay(
             this.idleRounds,
@@ -125,9 +142,14 @@ export class SessionQueueWorker {
 
   /** One bounded scan, exposed for deterministic tests and operational probes. */
   async checkOnce(): Promise<number> {
+    this.sweepComplete = false;
     const refs = await this.discover();
+    this.sweepFound += refs.length;
+    this.pagesInSweep += 1;
     if (refs.length === 0) {
       if (this.cursor) this.cursor = undefined;
+      this.pagesInSweep = 0;
+      this.sweepComplete = true;
       return 0;
     }
     const last = refs.at(-1)!;
@@ -156,6 +178,18 @@ export class SessionQueueWorker {
           `[distributed-work.task-queue] event=process_failed instance_id=${JSON.stringify(this.options.workIdentity.instanceId)} boot_id=${JSON.stringify(this.options.workIdentity.bootId)} tenant_id=${JSON.stringify(tenantId)} session_id=${JSON.stringify(ref.session_id)} error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`
         );
       }
+    }
+    // A short keyset page is the end of this recovery sweep. Do not immediately
+    // reconsider known-blocked queue heads: normal terminal/session patch hooks
+    // wake them immediately, while the next sweep recovers missed events.
+    if (refs.length < this.scanBatchSize) {
+      this.cursor = undefined;
+      this.pagesInSweep = 0;
+      this.sweepComplete = true;
+    } else if (this.pagesInSweep >= this.maxPagesPerSweep) {
+      // Preserve the keyset cursor so the next bounded sweep resumes fairly.
+      this.pagesInSweep = 0;
+      this.sweepComplete = true;
     }
     return refs.length;
   }

--- a/apps/agor-daemon/src/services/session-queue-worker.ts
+++ b/apps/agor-daemon/src/services/session-queue-worker.ts
@@ -43,7 +43,6 @@ export class SessionQueueWorker {
   private cursor: QueuedSessionCursor | undefined;
   private idleRounds = 0;
   private sweepComplete = false;
-  private sweepFound = 0;
   private pagesInSweep = 0;
   private readonly scanBatchSize: number;
   private readonly maxPagesPerSweep: number;
@@ -96,12 +95,6 @@ export class SessionQueueWorker {
     try {
       found = await this.checkOnce();
       this.idleRounds = 0;
-      if (this.sweepComplete && this.sweepFound > 0) {
-        console.log(
-          `[distributed-work.task-queue] event=recovery_sweep_found_work instance_id=${JSON.stringify(this.options.workIdentity.instanceId)} boot_id=${JSON.stringify(this.options.workIdentity.bootId)} session_refs_examined=${this.sweepFound}`
-        );
-        this.sweepFound = 0;
-      }
     } catch (error) {
       this.idleRounds += 1;
       console.warn(
@@ -144,7 +137,6 @@ export class SessionQueueWorker {
   async checkOnce(): Promise<number> {
     this.sweepComplete = false;
     const refs = await this.discover();
-    this.sweepFound += refs.length;
     this.pagesInSweep += 1;
     if (refs.length === 0) {
       if (this.cursor) this.cursor = undefined;

--- a/context/concepts/task-queueing.md
+++ b/context/concepts/task-queueing.md
@@ -53,6 +53,13 @@ queued Session refs and then reloads/processes each Session inside its trusted
 tenant scope. There is no permanent leader and no worker lease: overlapping
 scans are expected, while the Session+Task claim elects the only launcher.
 
+Ordinary draining is event-driven by the committed terminal/Session projection.
+The worker is a missed-event and restart recovery sweep, not a low-latency poller:
+it pages quickly through at most 250 Session refs per sweep, preserves its
+keyset cursor when saturated, then waits about one minute before continuing. A
+known-busy queue head is therefore not fully hydrated every few seconds, while
+a missed wakeup remains durably recoverable.
+
 The scan cursor, startup offset, bounded backoff, and jitter are contention
 etiquette and fairness only. A process-local `SessionTurnLocks` map and
 `queueRetryScheduled` set similarly coalesce work inside one daemon; process


### PR DESCRIPTION
## Summary

- make ordinary queued-task draining explicitly event-driven while retaining durable recovery
- replace the 3–4 second blocked-session reconsideration loop with bounded recovery sweeps at roughly one-minute cadence
- preserve keyset fairness across saturated sweeps and cap each sweep at 250 session references
- preserve the durable queued-user identity across hooked Session reads and stuck-state repair so branch RBAC remains enforced
- enforce a strict queue logging contract: no info-level attempt/sweep log unless dispatch progresses
- retain the structured `dispatched` event plus actionable worker lifecycle and failure logs

## Root cause

`SessionQueueWorker` reset its idle backoff whenever it discovered any queued row, even when processing made no progress because the owning session was still running. For a short page, a non-empty scan followed by the cursor's empty scan produced a repeating roughly 3–4 second cycle on every daemon replica.

## Behavior after this change

- normal terminal/session transitions still trigger queue draining immediately
- duplicate triggers remain safe through the existing Session+Task dispatch claim
- missed events and daemon restarts are recovered within the slower sweep interval
- recovery scans process at most 10 pages of 25 session refs before yielding for about one minute
- tenant-scoped processing and cross-daemon claim semantics are unchanged

## Estimated impact for one blocked queued session per replica

| Metric | Before | After |
| --- | ---: | ---: |
| Blocked reconsiderations/minute | ~17–20 | ~1 |
| Application queries/minute | ~85–100 | ~5 |
| User lookups while busy/minute | ~17–20 | ~1 |
| Queue attempt/recovery info logs while blocked/minute | ~34–40 | 0 |
| Normal completion drain latency | immediate | immediate |
| Missed-event recovery latency | ~3–4 seconds | ~54–66 seconds |

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-daemon exec vitest run src/services/session-queue-worker.test.ts src/services/session-queue-worker.postgres.test.ts src/services/tasks.executor-heartbeat.test.ts src/services/tasks.callbacks.test.ts src/register-routes.prompt-scope.test.ts src/startup.test.ts`
  - 48 passed
- `pnpm --dir apps/agor-daemon exec vitest run src/register-routes.prompt-scope.test.ts src/services/session-queue-worker.test.ts src/services/tasks.executor-heartbeat.test.ts`
  - 18 passed after review remediation
  - 1 PostgreSQL integration test skipped because the external test database was not configured



- `pnpm --dir apps/agor-daemon exec vitest run src/services/session-queue-worker.test.ts src/register-routes.prompt-scope.test.ts src/services/tasks.executor-heartbeat.test.ts src/services/tasks.callbacks.test.ts`
  - 33 passed after strict logging follow-up
- `pnpm check:multitenancy-boundaries`
