### PR TITLE
fix(db): sanitize invalid JSON unicode before persistence

### DIFF
--- a/packages/core/src/db/repositories/messages.postgres.test.ts
+++ b/packages/core/src/db/repositories/messages.postgres.test.ts
@@ -1,0 +1,112 @@
+import { type Message, MessageRole, type UUID } from '@agor/core/types';
+import { sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import { createDatabase, type Database } from '../client';
+import { executeRaw } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { sanitizeDbError } from '../sanitize-error';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { BranchRepository } from './branches';
+import { MessagesRepository } from './messages';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const describePostgres =
+  postgresUrl && process.env.AGOR_DB_DIALECT === 'postgresql' ? describe : describe.skip;
+
+describePostgres('MessagesRepository PostgreSQL Unicode persistence', () => {
+  let db: Database;
+  beforeAll(async () => {
+    db = createDatabase({ url: postgresUrl!, dialect: 'postgresql' });
+    await initializeDatabase(db);
+  });
+
+  it('reproduces PostgreSQL rejection without exposing the parameter in diagnostics', async () => {
+    const actualNul = String.fromCharCode(0);
+    const loneHighSurrogate = String.fromCharCode(0xd800);
+    let failure: unknown;
+    try {
+      await executeRaw(
+        db,
+        sql`SELECT ${JSON.stringify({ content: `secret${actualNul}${loneHighSurrogate}` })}::jsonb`
+      );
+    } catch (error) {
+      failure = error;
+    }
+    const diagnostic = sanitizeDbError(failure);
+    expect(diagnostic).toMatchObject({ code: '22P05', message: 'Database operation failed' });
+    expect(JSON.stringify(diagnostic)).not.toContain('secret');
+  });
+
+  it('round-trips sanitized create, bulk create, update, and metadata mutation', async () => {
+    const actualNul = String.fromCharCode(0);
+    const loneHighSurrogate = String.fromCharCode(0xd800);
+    const loneLowSurrogate = String.fromCharCode(0xdc00);
+    await runWithTenantDatabaseScope(db, 'default', async (scoped) => {
+      const repos = new RepoRepository(scoped);
+      const repo = await repos.create({
+        slug: `nul-${generateId()}`,
+        name: 'test',
+        repo_type: 'remote',
+        remote_url: 'https://example.invalid/repo.git',
+        local_path: '/tmp/repo',
+        default_branch: 'main',
+      });
+      const branch = await new BranchRepository(scoped).create({
+        repo_id: repo.repo_id,
+        name: 'test',
+        path: '/tmp/test',
+        ref: 'main',
+        branch_unique_id: Math.floor(Math.random() * 1_000_000),
+        created_by: generateId() as UUID,
+      });
+      const sessions = new SessionRepository(scoped);
+      const session = await sessions.create({
+        branch_id: branch.branch_id,
+        title: 'test',
+        created_by: generateId() as UUID,
+      });
+      await sessions.update(session.session_id, {
+        custom_context: { provider_payload: `value${actualNul}${loneHighSurrogate}` },
+      });
+      expect((await sessions.findById(session.session_id))?.custom_context).toEqual({
+        provider_payload: 'value��',
+      });
+      const repository = new MessagesRepository(scoped);
+      const message = (index: number, content: string): Message => ({
+        message_id: generateId(),
+        session_id: session.session_id,
+        type: 'assistant',
+        role: MessageRole.ASSISTANT,
+        index,
+        timestamp: new Date().toISOString(),
+        content_preview: content,
+        content,
+      });
+      const first = await repository.create(message(0, `zip${actualNul}${loneHighSurrogate}😀`));
+      expect(first.content).toBe('zip��😀');
+      const [second] = await repository.createMany([message(1, `bulk${loneLowSurrogate}`)]);
+      expect(second.content).toBe('bulk�');
+      const finalized = await repository.update(first.message_id, {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'read-binary',
+            content: `updated${actualNul}${loneHighSurrogate}`,
+          },
+        ] as Message['content'],
+        content_preview: `updated${actualNul}`,
+      });
+      expect(finalized.content).toEqual([
+        { type: 'tool_result', tool_use_id: 'read-binary', content: 'updated��' },
+      ]);
+      expect(finalized.content_preview).toBe('updated�');
+      expect(
+        (await repository.mutateMetadataLocked(first.message_id, () => ({ value: actualNul })))
+          .message.metadata
+      ).toEqual({ value: '�' });
+    });
+  });
+});

--- a/packages/core/src/db/repositories/messages.postgres.test.ts
+++ b/packages/core/src/db/repositories/messages.postgres.test.ts
@@ -88,14 +88,30 @@ describePostgres('MessagesRepository PostgreSQL Unicode persistence', () => {
             type: 'tool_result',
             tool_use_id: 'read-binary',
             content: `updated${actualNul}${loneHighSurrogate}`,
+            provider_payload: { [`bad${actualNul}key`]: `value${loneLowSurrogate}` },
           },
         ] as Message['content'],
         content_preview: `updated${actualNul}`,
+        tool_uses: [
+          {
+            id: 'read-binary',
+            name: 'read',
+            input: { [`path${actualNul}`]: `file${loneHighSurrogate}` },
+          },
+        ],
       });
       expect(finalized.content).toEqual([
-        { type: 'tool_result', tool_use_id: 'read-binary', content: 'updated��' },
+        {
+          type: 'tool_result',
+          tool_use_id: 'read-binary',
+          content: 'updated��',
+          provider_payload: { 'bad�key': 'value�' },
+        },
       ]);
       expect(finalized.content_preview).toBe('updated�');
+      expect(finalized.tool_uses).toEqual([
+        { id: 'read-binary', name: 'read', input: { 'path�': 'file�' } },
+      ]);
       expect(
         (await repository.mutateMetadataLocked(first.message_id, () => ({ value: actualNul })))
           .message.metadata

--- a/packages/core/src/db/repositories/messages.postgres.test.ts
+++ b/packages/core/src/db/repositories/messages.postgres.test.ts
@@ -2,13 +2,14 @@ import { type Message, MessageRole, type UUID } from '@agor/core/types';
 import { sql } from 'drizzle-orm';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../../lib/ids';
+import { JSON_SANITIZER_LIMITS } from '../../utils/sanitize-json';
 import { createDatabase, type Database } from '../client';
 import { executeRaw } from '../database-wrapper';
 import { initializeDatabase } from '../migrate';
 import { sanitizeDbError } from '../sanitize-error';
 import { runWithTenantDatabaseScope } from '../tenant-scope';
 import { BranchRepository } from './branches';
-import { MessagesRepository } from './messages';
+import { MESSAGE_CONTENT_OMITTED, MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 
@@ -116,6 +117,15 @@ describePostgres('MessagesRepository PostgreSQL Unicode persistence', () => {
         (await repository.mutateMetadataLocked(first.message_id, () => ({ value: actualNul })))
           .message.metadata
       ).toEqual({ value: '�' });
+
+      const oversized = new Array(JSON_SANITIZER_LIMITS.maxNodes).fill(null);
+      const omitted = await repository.update(first.message_id, {
+        content: oversized as Message['content'],
+        content_preview: 'should not survive',
+      });
+      expect(omitted.content).toBe(MESSAGE_CONTENT_OMITTED);
+      expect(omitted.content_preview).toBe(MESSAGE_CONTENT_OMITTED);
+      expect(omitted.metadata).toEqual({ persistence_omission: { reason: 'size' } });
     });
   });
 });

--- a/packages/core/src/db/repositories/messages.postgres.test.ts
+++ b/packages/core/src/db/repositories/messages.postgres.test.ts
@@ -62,17 +62,10 @@ describePostgres('MessagesRepository PostgreSQL Unicode persistence', () => {
         branch_unique_id: Math.floor(Math.random() * 1_000_000),
         created_by: generateId() as UUID,
       });
-      const sessions = new SessionRepository(scoped);
-      const session = await sessions.create({
+      const session = await new SessionRepository(scoped).create({
         branch_id: branch.branch_id,
         title: 'test',
         created_by: generateId() as UUID,
-      });
-      await sessions.update(session.session_id, {
-        custom_context: { provider_payload: `value${actualNul}${loneHighSurrogate}` },
-      });
-      expect((await sessions.findById(session.session_id))?.custom_context).toEqual({
-        provider_payload: 'value��',
       });
       const repository = new MessagesRepository(scoped);
       const message = (index: number, content: string): Message => ({

--- a/packages/core/src/db/repositories/messages.test.ts
+++ b/packages/core/src/db/repositories/messages.test.ts
@@ -509,6 +509,25 @@ describe('MessagesRepository.update', () => {
     expect(updated.metadata).toEqual({ model: 'claude-3' }); // Preserved
   });
 
+  dbTest('sanitizes all JSON and preview fields on finalization update', async ({ db }) => {
+    const messages = new MessagesRepository(db);
+    const sessionId = await createTestSession(db);
+    const created = await messages.create(
+      createMessageData({ session_id: sessionId, content: 'Original', metadata: { keep: true } })
+    );
+
+    const updated = await messages.update(created.message_id, {
+      content: [{ type: 'tool_result', content: 'binary\0result' }] as Message['content'],
+      content_preview: 'binary\0preview',
+      tool_uses: [{ id: 'tool-1', name: 'read', input: { 'bad\0key': '\ud800' } }],
+    });
+
+    expect(updated.content).toEqual([{ type: 'tool_result', content: 'binary�result' }]);
+    expect(updated.content_preview).toBe('binary�preview');
+    expect(updated.tool_uses).toEqual([{ id: 'tool-1', name: 'read', input: { 'bad�key': '�' } }]);
+    expect(updated.metadata).toEqual({ keep: true });
+  });
+
   dbTest('should throw error for non-existent message', async ({ db }) => {
     const messages = new MessagesRepository(db);
 

--- a/packages/core/src/db/repositories/messages.test.ts
+++ b/packages/core/src/db/repositories/messages.test.ts
@@ -9,9 +9,10 @@ import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/typ
 import { MessageRole } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId } from '../../lib/ids';
+import { JSON_SANITIZER_LIMITS } from '../../utils/sanitize-json';
 import { dbTest } from '../test-helpers';
 import { BranchRepository } from './branches';
-import { MessagesRepository } from './messages';
+import { MESSAGE_CONTENT_OMITTED, MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { TaskRepository } from './tasks';
@@ -527,6 +528,28 @@ describe('MessagesRepository.update', () => {
     expect(updated.tool_uses).toEqual([{ id: 'tool-1', name: 'read', input: { 'bad�key': '�' } }]);
     expect(updated.metadata).toEqual({ keep: true });
   });
+
+  dbTest(
+    'persists a bounded placeholder when final content exceeds the safety budget',
+    async ({ db }) => {
+      const messages = new MessagesRepository(db);
+      const sessionId = await createTestSession(db);
+      const created = await messages.create(createMessageData({ session_id: sessionId }));
+      const oversized = new Array(JSON_SANITIZER_LIMITS.maxNodes).fill(null);
+
+      const updated = await messages.update(created.message_id, {
+        content: oversized as Message['content'],
+        content_preview: 'untrusted preview',
+        metadata: { secret: 'must be dropped' },
+      });
+
+      expect(updated.content).toBe(MESSAGE_CONTENT_OMITTED);
+      expect(updated.content_preview).toBe(MESSAGE_CONTENT_OMITTED);
+      expect(updated.tool_uses).toBeUndefined();
+      expect(updated.metadata).toEqual({ persistence_omission: { reason: 'size' } });
+      expect(updated.metadata).not.toHaveProperty('secret');
+    }
+  );
 
   dbTest('should throw error for non-existent message', async ({ db }) => {
     const messages = new MessagesRepository(db);

--- a/packages/core/src/db/repositories/messages.test.ts
+++ b/packages/core/src/db/repositories/messages.test.ts
@@ -118,6 +118,27 @@ async function createTestTask(db: any, sessionId: SessionID): Promise<TaskID> {
 // ============================================================================
 
 describe('MessagesRepository.create', () => {
+  dbTest('sanitizes PostgreSQL-invalid Unicode in JSON and preview fields', async ({ db }) => {
+    const actualNul = String.fromCharCode(0);
+    const loneHighSurrogate = String.fromCharCode(0xd800);
+    const loneLowSurrogate = String.fromCharCode(0xdc00);
+    const repository = new MessagesRepository(db);
+    const sessionId = await createTestSession(db);
+    const original = createMessageData({
+      session_id: sessionId,
+      content_preview: `preview${actualNul}${loneHighSurrogate}`,
+      content: [
+        { type: 'tool_result', content: `binary${actualNul}${loneLowSurrogate} 😀` },
+      ] as Message['content'],
+      metadata: { nested: [actualNul] } as Message['metadata'],
+    });
+
+    const created = await repository.create(original);
+    expect(created.content_preview).toBe('preview��');
+    expect(created.content).toEqual([{ type: 'tool_result', content: 'binary�� 😀' }]);
+    expect(created.metadata).toEqual({ nested: ['�'] });
+    expect(original.content_preview).toBe(`preview${actualNul}${loneHighSurrogate}`);
+  });
   dbTest('should create message with all fields including task_id', async ({ db }) => {
     const messages = new MessagesRepository(db);
     const sessionId = await createTestSession(db);
@@ -197,6 +218,15 @@ describe('MessagesRepository.create', () => {
 // ============================================================================
 
 describe('MessagesRepository.createMany', () => {
+  dbTest('sanitizes every row in bulk inserts', async ({ db }) => {
+    const repository = new MessagesRepository(db);
+    const sessionId = await createTestSession(db);
+    const created = await repository.createMany([
+      createMessageData({ session_id: sessionId, index: 0, content: 'a\0' }),
+      createMessageData({ session_id: sessionId, index: 1, content: 'b\ud800' }),
+    ]);
+    expect(created.map((message) => message.content)).toEqual(['a�', 'b�']);
+  });
   dbTest('should bulk insert multiple messages and preserve order', async ({ db }) => {
     const messages = new MessagesRepository(db);
     const sessionId = await createTestSession(db);

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -7,6 +7,7 @@
 
 import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
 import { and, eq, inArray } from 'drizzle-orm';
+import { sanitizeJsonValue, sanitizeUnicodeString } from '../../utils/sanitize-json';
 import type { Database } from '../client';
 import {
   deleteFrom,
@@ -74,13 +75,13 @@ export class MessagesRepository {
       role: message.role,
       index: message.index,
       timestamp: new Date(message.timestamp),
-      content_preview: message.content_preview,
+      content_preview: sanitizeUnicodeString(message.content_preview),
       parent_tool_use_id: message.parent_tool_use_id || null,
-      data: {
+      data: sanitizeJsonValue({
         content: message.content,
         tool_uses: message.tool_uses,
         metadata: message.metadata,
-      },
+      }),
     };
   }
 
@@ -147,7 +148,7 @@ export class MessagesRepository {
             metadata?: Message['metadata'];
           };
           const updatedRow = await update(txDb, messages)
-            .set({ data: { ...data, metadata } })
+            .set({ data: sanitizeJsonValue({ ...data, metadata }) })
             .where(eq(messages.message_id, messageId))
             .returning()
             .one();

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -7,7 +7,7 @@
 
 import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
 import { and, eq, inArray } from 'drizzle-orm';
-import { sanitizeJsonValue } from '../../utils/sanitize-json';
+import { JsonSanitizationError, sanitizeJsonValue } from '../../utils/sanitize-json';
 import type { Database } from '../client';
 import {
   deleteFrom,
@@ -20,6 +20,16 @@ import {
 } from '../database-wrapper';
 import { type MessageInsert, type MessageRow, messages } from '../schema';
 import { visibleSessionReferenceAccessExists } from './branch-access';
+
+export const MESSAGE_CONTENT_OMITTED =
+  '[Message content omitted: payload could not be safely persisted]';
+
+function omittedMessageData(reason: JsonSanitizationError['category']): MessageInsert['data'] {
+  return {
+    content: MESSAGE_CONTENT_OMITTED,
+    metadata: { persistence_omission: { reason } },
+  };
+}
 
 export class MessagesRepository {
   constructor(private db: Database) {}
@@ -66,6 +76,23 @@ export class MessagesRepository {
    * Convert Message to database row
    */
   private messageToRow(message: Message): MessageInsert {
+    let contentPreview: string;
+    let data: MessageInsert['data'];
+    try {
+      contentPreview = sanitizeJsonValue(message.content_preview);
+      data = sanitizeJsonValue({
+        content: message.content,
+        tool_uses: message.tool_uses,
+        metadata: message.metadata,
+      });
+    } catch (error) {
+      if (!(error instanceof JsonSanitizationError)) throw error;
+      console.warn(
+        `[messages.persistence] content omitted category=${error.category} message_id=${message.message_id}`
+      );
+      contentPreview = MESSAGE_CONTENT_OMITTED;
+      data = omittedMessageData(error.category);
+    }
     return {
       message_id: message.message_id,
       created_at: new Date(),
@@ -75,13 +102,9 @@ export class MessagesRepository {
       role: message.role,
       index: message.index,
       timestamp: new Date(message.timestamp),
-      content_preview: sanitizeJsonValue(message.content_preview),
+      content_preview: contentPreview,
       parent_tool_use_id: message.parent_tool_use_id || null,
-      data: sanitizeJsonValue({
-        content: message.content,
-        tool_uses: message.tool_uses,
-        metadata: message.metadata,
-      }),
+      data,
     };
   }
 
@@ -147,8 +170,18 @@ export class MessagesRepository {
             tool_uses?: Message['tool_uses'];
             metadata?: Message['metadata'];
           };
+          let sanitizedData: MessageInsert['data'];
+          try {
+            sanitizedData = sanitizeJsonValue({ ...data, metadata });
+          } catch (error) {
+            if (!(error instanceof JsonSanitizationError)) throw error;
+            console.warn(
+              `[messages.persistence] content omitted category=${error.category} message_id=${messageId}`
+            );
+            sanitizedData = omittedMessageData(error.category);
+          }
           const updatedRow = await update(txDb, messages)
-            .set({ data: sanitizeJsonValue({ ...data, metadata }) })
+            .set({ data: sanitizedData })
             .where(eq(messages.message_id, messageId))
             .returning()
             .one();

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -7,7 +7,7 @@
 
 import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
 import { and, eq, inArray } from 'drizzle-orm';
-import { sanitizeJsonValue, sanitizeUnicodeString } from '../../utils/sanitize-json';
+import { sanitizeJsonValue } from '../../utils/sanitize-json';
 import type { Database } from '../client';
 import {
   deleteFrom,
@@ -75,7 +75,7 @@ export class MessagesRepository {
       role: message.role,
       index: message.index,
       timestamp: new Date(message.timestamp),
-      content_preview: sanitizeUnicodeString(message.content_preview),
+      content_preview: sanitizeJsonValue(message.content_preview),
       parent_tool_use_id: message.parent_tool_use_id || null,
       data: sanitizeJsonValue({
         content: message.content,

--- a/packages/core/src/db/sanitize-error.test.ts
+++ b/packages/core/src/db/sanitize-error.test.ts
@@ -10,6 +10,7 @@ describe('sanitizeDbError', () => {
       new Error('duplicate key value violates unique constraint "sessions_schedule_run_unique"'),
       {
         code: '23505',
+        routine: 'json_errsave_error',
         constraint_name: 'sessions_schedule_run_unique',
         detail: 'Key (rendered_prompt)=(SECRET_SENTINEL) already exists',
       }
@@ -34,6 +35,8 @@ describe('sanitizeDbError', () => {
     expect(output).toContain('Database constraint violation');
     expect(output).toContain('sessions_schedule_run_unique');
     expect(output).toContain('23505');
+    expect(output).toContain('json_errsave_error');
+    expect(output.length).toBeLessThan(1024);
   });
 
   it('sanitizes RepositoryError output without changing its cause semantics', () => {
@@ -57,6 +60,23 @@ describe('sanitizeDbError', () => {
     expect(output).not.toContain('SECRET_SENTINEL');
     expect(output).toContain('Database operation failed');
     expect(output).toContain('22P02');
+  });
+
+  it('does not format large query parameters or secret-like tool output', () => {
+    const secret = 'sk-secret-sentinel';
+    const failure = Object.assign(new Error(`Failed query\nparams: ${secret}`), {
+      params: [{ tool_result: `${secret}${'PK\\x00'.repeat(300_000)}` }],
+      cause: Object.assign(new Error('invalid JSON parameter'), {
+        code: '22P05',
+        routine: 'json_errsave_error',
+      }),
+    });
+    const output = inspect(sanitizeDbError(failure));
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain('PK');
+    expect(output).toContain('22P05');
+    expect(output).toContain('json_errsave_error');
+    expect(output.length).toBeLessThan(1024);
   });
 
   it('only includes strictly validated database metadata', () => {

--- a/packages/core/src/db/sanitize-error.ts
+++ b/packages/core/src/db/sanitize-error.ts
@@ -9,6 +9,7 @@ export interface SanitizedDbError {
   message: string;
   code?: string;
   constraint?: string;
+  routine?: string;
 }
 
 type ErrorRecord = Record<string, unknown>;
@@ -61,6 +62,7 @@ export function isDatabaseUniqueConstraintError(error: unknown): boolean {
 export function sanitizeDbError(error: unknown): SanitizedDbError {
   let code: string | undefined;
   let constraint: string | undefined;
+  let routine: string | undefined;
   let current: unknown = error;
   const seen = new Set<unknown>();
 
@@ -82,6 +84,13 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     ) {
       constraint = candidateConstraint;
     }
+    if (
+      !routine &&
+      typeof record?.routine === 'string' &&
+      DATABASE_IDENTIFIER.test(record.routine)
+    ) {
+      routine = record.routine;
+    }
 
     current = record?.cause;
   }
@@ -98,5 +107,6 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     message,
     ...(code ? { code } : {}),
     ...(constraint ? { constraint } : {}),
+    ...(routine ? { routine } : {}),
   };
 }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -29,7 +29,6 @@ import {
   foreignKey,
   index,
   integer,
-  jsonb,
   pgTable,
   primaryKey,
   text,
@@ -37,6 +36,7 @@ import {
   uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
+import { sanitizeJsonValue } from '../utils/sanitize-json';
 
 // PostgreSQL bytea column mapped to Node.js Buffer
 const bytea = customType<{ data: Buffer | null; driverData: Buffer | null }>({
@@ -45,11 +45,17 @@ const bytea = customType<{ data: Buffer | null; driverData: Buffer | null }>({
   },
 });
 
+const safeJsonb = customType<{ data: unknown; driverData: string }>({
+  dataType: () => 'jsonb',
+  toDriver: (value) => JSON.stringify(sanitizeJsonValue(value)),
+  fromDriver: (value) => (typeof value === 'string' ? JSON.parse(value) : value),
+});
+
 // PostgreSQL-specific type helpers (inline to avoid factory pattern type issues)
 const t = {
   timestamp: (name: string) => timestamp(name, { mode: 'date', withTimezone: true }),
   bool: (name: string) => boolean(name),
-  json: <T>(name: string) => jsonb(name).$type<T>(),
+  json: <T>(name: string) => safeJsonb(name).$type<T>(),
 } as const;
 
 /**

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -29,6 +29,7 @@ import {
   foreignKey,
   index,
   integer,
+  jsonb,
   pgTable,
   primaryKey,
   text,
@@ -36,7 +37,6 @@ import {
   uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
-import { sanitizeJsonValue } from '../utils/sanitize-json';
 
 // PostgreSQL bytea column mapped to Node.js Buffer
 const bytea = customType<{ data: Buffer | null; driverData: Buffer | null }>({
@@ -45,17 +45,11 @@ const bytea = customType<{ data: Buffer | null; driverData: Buffer | null }>({
   },
 });
 
-const safeJsonb = customType<{ data: unknown; driverData: string }>({
-  dataType: () => 'jsonb',
-  toDriver: (value) => JSON.stringify(sanitizeJsonValue(value)),
-  fromDriver: (value) => (typeof value === 'string' ? JSON.parse(value) : value),
-});
-
 // PostgreSQL-specific type helpers (inline to avoid factory pattern type issues)
 const t = {
   timestamp: (name: string) => timestamp(name, { mode: 'date', withTimezone: true }),
   bool: (name: string) => boolean(name),
-  json: <T>(name: string) => safeJsonb(name).$type<T>(),
+  json: <T>(name: string) => jsonb(name).$type<T>(),
 } as const;
 
 /**

--- a/packages/core/src/utils/sanitize-json.test.ts
+++ b/packages/core/src/utils/sanitize-json.test.ts
@@ -22,6 +22,18 @@ describe('JSON persistence sanitizer', () => {
     expect(input.nested[1]).toEqual({ bad: '\0' });
   });
 
+  it('sanitizes object keys and rejects replacement collisions', () => {
+    expect(sanitizeJsonValue({ 'bad\0key': 'value' })).toEqual({ 'bad�key': 'value' });
+    expect(() => sanitizeJsonValue({ 'bad\0key': 1, 'bad�key': 2 })).toThrow(/key_collision/);
+  });
+
+  it('allows repeated references while rejecting actual cycles', () => {
+    const shared = { value: '\0' };
+    const result = sanitizeJsonValue({ first: shared, second: shared });
+    expect(result).toEqual({ first: { value: '�' }, second: { value: '�' } });
+    expect(result.first).not.toBe(result.second);
+  });
+
   it('rejects cycles, excessive depth, unsupported values, and excessive strings predictably', () => {
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;
@@ -34,5 +46,18 @@ describe('JSON persistence sanitizer', () => {
     expect(() =>
       sanitizeJsonValue({ value: 'x'.repeat(JSON_SANITIZER_LIMITS.maxStringCodeUnits + 1) })
     ).toThrow(/size/);
+    expect(() =>
+      sanitizeJsonValue('x'.repeat(JSON_SANITIZER_LIMITS.maxStringCodeUnits + 1))
+    ).toThrow(/size/);
+    expect(() =>
+      sanitizeJsonValue({ ['x'.repeat(JSON_SANITIZER_LIMITS.maxStringCodeUnits + 1)]: true })
+    ).toThrow(/size/);
+  });
+
+  it('rejects huge flat arrays and objects at the work budget', () => {
+    expect(() => sanitizeJsonValue(new Array(JSON_SANITIZER_LIMITS.maxNodes + 1))).toThrow(/size/);
+    const flat: Record<string, number> = {};
+    for (let index = 0; index < JSON_SANITIZER_LIMITS.maxNodes; index++) flat[index] = index;
+    expect(() => sanitizeJsonValue(flat)).toThrow(/size/);
   });
 });

--- a/packages/core/src/utils/sanitize-json.test.ts
+++ b/packages/core/src/utils/sanitize-json.test.ts
@@ -34,6 +34,13 @@ describe('JSON persistence sanitizer', () => {
     expect(result.first).not.toBe(result.second);
   });
 
+  it('preserves sparse-array JSON semantics and rejects custom array properties', () => {
+    expect(sanitizeJsonValue(new Array(3))).toEqual([null, null, null]);
+    const custom = ['value'] as string[] & { extra?: string };
+    custom.extra = 'not JSON array data';
+    expect(() => sanitizeJsonValue(custom)).toThrow(/unsupported/);
+  });
+
   it('rejects cycles, excessive depth, unsupported values, and excessive strings predictably', () => {
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;

--- a/packages/core/src/utils/sanitize-json.test.ts
+++ b/packages/core/src/utils/sanitize-json.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  JSON_SANITIZER_LIMITS,
+  JsonSanitizationError,
+  sanitizeJsonValue,
+  sanitizeUnicodeString,
+} from './sanitize-json';
+
+describe('JSON persistence sanitizer', () => {
+  it('replaces NUL and lone surrogates while preserving valid Unicode exactly', () => {
+    const normal = 'emoji 😀 e\u0301 العربية\nline';
+    expect(sanitizeUnicodeString(`a\0b\ud800c\udc00d`)).toBe('a�b�c�d');
+    expect(sanitizeUnicodeString(normal)).toBe(normal);
+  });
+
+  it('clones nested arrays and plain objects without mutation', () => {
+    const input = { nested: ['ok', { bad: '\0' }] };
+    const result = sanitizeJsonValue(input);
+    expect(result).toEqual({ nested: ['ok', { bad: '�' }] });
+    expect(result).not.toBe(input);
+    expect(result.nested).not.toBe(input.nested);
+    expect(input.nested[1]).toEqual({ bad: '\0' });
+  });
+
+  it('rejects cycles, excessive depth, unsupported values, and excessive strings predictably', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => sanitizeJsonValue(cyclic)).toThrowError(JsonSanitizationError);
+    let deep: Record<string, unknown> = {};
+    const root = deep;
+    for (let i = 0; i < JSON_SANITIZER_LIMITS.maxDepth + 2; i++) deep = deep.next = {};
+    expect(() => sanitizeJsonValue(root)).toThrow(/depth/);
+    expect(() => sanitizeJsonValue({ value: BigInt(1) })).toThrow(/unsupported/);
+    expect(() =>
+      sanitizeJsonValue({ value: 'x'.repeat(JSON_SANITIZER_LIMITS.maxStringCodeUnits + 1) })
+    ).toThrow(/size/);
+  });
+});

--- a/packages/core/src/utils/sanitize-json.ts
+++ b/packages/core/src/utils/sanitize-json.ts
@@ -1,0 +1,100 @@
+const REPLACEMENT_CHARACTER = '\uFFFD';
+
+export const JSON_SANITIZER_LIMITS = {
+  maxDepth: 100,
+  maxNodes: 100_000,
+  maxStringCodeUnits: 16 * 1024 * 1024,
+} as const;
+
+export class JsonSanitizationError extends Error {
+  constructor(public readonly category: 'cycle' | 'depth' | 'size' | 'unsupported') {
+    super(`JSON value cannot be sanitized: ${category}`);
+    this.name = 'JsonSanitizationError';
+  }
+}
+
+export function sanitizeUnicodeString(value: string): string {
+  let output: string | undefined;
+  for (let index = 0; index < value.length; index++) {
+    const unit = value.charCodeAt(index);
+    if (unit === 0) {
+      output ??= value.slice(0, index);
+      output += REPLACEMENT_CHARACTER;
+    } else if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        if (output !== undefined) output += value[index] + value[index + 1];
+        index++;
+      } else {
+        output ??= value.slice(0, index);
+        output += REPLACEMENT_CHARACTER;
+      }
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      output ??= value.slice(0, index);
+      output += REPLACEMENT_CHARACTER;
+    } else if (output !== undefined) output += value[index];
+  }
+  return output ?? value;
+}
+
+/** Clone and sanitize a JSON-compatible value without recursive call-stack growth. */
+export function sanitizeJsonValue<T>(input: T): T {
+  if (typeof input === 'string') return sanitizeUnicodeString(input) as T;
+  if (input === null || typeof input === 'boolean' || typeof input === 'number') {
+    if (typeof input === 'number' && !Number.isFinite(input))
+      throw new JsonSanitizationError('unsupported');
+    return input;
+  }
+  if (typeof input !== 'object') throw new JsonSanitizationError('unsupported');
+
+  const root: unknown = Array.isArray(input) ? [] : {};
+  const stack: Array<{
+    source: object;
+    target: Record<string, unknown> | unknown[];
+    depth: number;
+  }> = [{ source: input, target: root as Record<string, unknown> | unknown[], depth: 0 }];
+  const seen = new WeakSet<object>();
+  let nodes = 0;
+  let stringCodeUnits = 0;
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    if (seen.has(frame.source)) throw new JsonSanitizationError('cycle');
+    seen.add(frame.source);
+    if (frame.depth > JSON_SANITIZER_LIMITS.maxDepth) throw new JsonSanitizationError('depth');
+    if (++nodes > JSON_SANITIZER_LIMITS.maxNodes) throw new JsonSanitizationError('size');
+    const proto = Object.getPrototypeOf(frame.source);
+    if (!Array.isArray(frame.source) && proto !== Object.prototype && proto !== null)
+      throw new JsonSanitizationError('unsupported');
+
+    for (const key of Object.keys(frame.source)) {
+      const value = (frame.source as Record<string, unknown>)[key];
+      let sanitized: unknown;
+      if (value === undefined) {
+        if (Array.isArray(frame.target)) frame.target[Number(key)] = null;
+        continue;
+      }
+      if (typeof value === 'string') {
+        stringCodeUnits += value.length;
+        if (stringCodeUnits > JSON_SANITIZER_LIMITS.maxStringCodeUnits)
+          throw new JsonSanitizationError('size');
+        sanitized = sanitizeUnicodeString(value);
+      } else if (value === null || typeof value === 'boolean' || typeof value === 'number') {
+        if (typeof value === 'number' && !Number.isFinite(value))
+          throw new JsonSanitizationError('unsupported');
+        sanitized = value;
+      } else if (typeof value === 'object') {
+        const child: unknown = Array.isArray(value) ? [] : {};
+        sanitized = child;
+        stack.push({
+          source: value,
+          target: child as Record<string, unknown> | unknown[],
+          depth: frame.depth + 1,
+        });
+      } else throw new JsonSanitizationError('unsupported');
+      if (Array.isArray(frame.target)) frame.target[Number(key)] = sanitized;
+      else frame.target[key] = sanitized;
+    }
+  }
+  return root as T;
+}

--- a/packages/core/src/utils/sanitize-json.ts
+++ b/packages/core/src/utils/sanitize-json.ts
@@ -2,12 +2,16 @@ const REPLACEMENT_CHARACTER = '\uFFFD';
 
 export const JSON_SANITIZER_LIMITS = {
   maxDepth: 100,
+  /** Containers plus array slots and object properties visited. */
   maxNodes: 100_000,
+  /** UTF-16 code units across every string value and object key. */
   maxStringCodeUnits: 16 * 1024 * 1024,
 } as const;
 
 export class JsonSanitizationError extends Error {
-  constructor(public readonly category: 'cycle' | 'depth' | 'size' | 'unsupported') {
+  constructor(
+    public readonly category: 'cycle' | 'depth' | 'size' | 'unsupported' | 'key_collision'
+  ) {
     super(`JSON value cannot be sanitized: ${category}`);
     this.name = 'JsonSanitizationError';
   }
@@ -37,9 +41,50 @@ export function sanitizeUnicodeString(value: string): string {
   return output ?? value;
 }
 
-/** Clone and sanitize a JSON-compatible value without recursive call-stack growth. */
+type JsonContainer = Record<string, unknown> | unknown[];
+type EnterFrame = { kind: 'enter'; source: object; target: JsonContainer; depth: number };
+type ExitFrame = { kind: 'exit'; source: object };
+
+function boundedEnumerableKeys(source: object, remaining: number): string[] {
+  if (Array.isArray(source)) {
+    if (source.length > remaining) throw new JsonSanitizationError('size');
+    return Object.keys(source);
+  }
+  const keys: string[] = [];
+  for (const key in source) {
+    if (!Object.hasOwn(source, key)) continue;
+    if (keys.length >= remaining) throw new JsonSanitizationError('size');
+    keys.push(key);
+  }
+  return keys;
+}
+
+function defineJsonProperty(target: JsonContainer, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Clone and normalize a JSON-compatible value for persistence without recursive
+ * call-stack growth. Work is capped before enumerating/copying large flat
+ * containers. Object keys are normalized too; a normalization collision is
+ * rejected rather than silently overwriting data.
+ */
 export function sanitizeJsonValue<T>(input: T): T {
-  if (typeof input === 'string') return sanitizeUnicodeString(input) as T;
+  let workUnits = 0;
+  let stringCodeUnits = 0;
+  const countString = (value: string): string => {
+    stringCodeUnits += value.length;
+    if (stringCodeUnits > JSON_SANITIZER_LIMITS.maxStringCodeUnits)
+      throw new JsonSanitizationError('size');
+    return sanitizeUnicodeString(value);
+  };
+
+  if (typeof input === 'string') return countString(input) as T;
   if (input === null || typeof input === 'boolean' || typeof input === 'number') {
     if (typeof input === 'number' && !Number.isFinite(input))
       throw new JsonSanitizationError('unsupported');
@@ -47,53 +92,56 @@ export function sanitizeJsonValue<T>(input: T): T {
   }
   if (typeof input !== 'object') throw new JsonSanitizationError('unsupported');
 
-  const root: unknown = Array.isArray(input) ? [] : {};
-  const stack: Array<{
-    source: object;
-    target: Record<string, unknown> | unknown[];
-    depth: number;
-  }> = [{ source: input, target: root as Record<string, unknown> | unknown[], depth: 0 }];
-  const seen = new WeakSet<object>();
-  let nodes = 0;
-  let stringCodeUnits = 0;
+  const root: JsonContainer = Array.isArray(input) ? [] : {};
+  const stack: Array<EnterFrame | ExitFrame> = [
+    { kind: 'enter', source: input, target: root, depth: 0 },
+  ];
+  const activePath = new WeakSet<object>();
 
   while (stack.length > 0) {
     const frame = stack.pop()!;
-    if (seen.has(frame.source)) throw new JsonSanitizationError('cycle');
-    seen.add(frame.source);
+    if (frame.kind === 'exit') {
+      activePath.delete(frame.source);
+      continue;
+    }
+    if (activePath.has(frame.source)) throw new JsonSanitizationError('cycle');
     if (frame.depth > JSON_SANITIZER_LIMITS.maxDepth) throw new JsonSanitizationError('depth');
-    if (++nodes > JSON_SANITIZER_LIMITS.maxNodes) throw new JsonSanitizationError('size');
     const proto = Object.getPrototypeOf(frame.source);
     if (!Array.isArray(frame.source) && proto !== Object.prototype && proto !== null)
       throw new JsonSanitizationError('unsupported');
 
-    for (const key of Object.keys(frame.source)) {
+    const remaining = JSON_SANITIZER_LIMITS.maxNodes - workUnits - 1;
+    if (remaining < 0) throw new JsonSanitizationError('size');
+    const keys = boundedEnumerableKeys(frame.source, remaining);
+    const entryCount = Array.isArray(frame.source) ? frame.source.length : keys.length;
+    workUnits += 1 + entryCount;
+    if (workUnits > JSON_SANITIZER_LIMITS.maxNodes) throw new JsonSanitizationError('size');
+
+    activePath.add(frame.source);
+    stack.push({ kind: 'exit', source: frame.source });
+    for (let index = keys.length - 1; index >= 0; index--) {
+      const key = keys[index];
       const value = (frame.source as Record<string, unknown>)[key];
+      const targetKey = Array.isArray(frame.target) ? key : countString(key);
+      if (!Array.isArray(frame.target) && Object.hasOwn(frame.target, targetKey))
+        throw new JsonSanitizationError('key_collision');
+
       let sanitized: unknown;
       if (value === undefined) {
-        if (Array.isArray(frame.target)) frame.target[Number(key)] = null;
+        if (Array.isArray(frame.target)) defineJsonProperty(frame.target, targetKey, null);
         continue;
       }
-      if (typeof value === 'string') {
-        stringCodeUnits += value.length;
-        if (stringCodeUnits > JSON_SANITIZER_LIMITS.maxStringCodeUnits)
-          throw new JsonSanitizationError('size');
-        sanitized = sanitizeUnicodeString(value);
-      } else if (value === null || typeof value === 'boolean' || typeof value === 'number') {
+      if (typeof value === 'string') sanitized = countString(value);
+      else if (value === null || typeof value === 'boolean' || typeof value === 'number') {
         if (typeof value === 'number' && !Number.isFinite(value))
           throw new JsonSanitizationError('unsupported');
         sanitized = value;
       } else if (typeof value === 'object') {
-        const child: unknown = Array.isArray(value) ? [] : {};
+        const child: JsonContainer = Array.isArray(value) ? [] : {};
         sanitized = child;
-        stack.push({
-          source: value,
-          target: child as Record<string, unknown> | unknown[],
-          depth: frame.depth + 1,
-        });
+        stack.push({ kind: 'enter', source: value, target: child, depth: frame.depth + 1 });
       } else throw new JsonSanitizationError('unsupported');
-      if (Array.isArray(frame.target)) frame.target[Number(key)] = sanitized;
-      else frame.target[key] = sanitized;
+      defineJsonProperty(frame.target, targetKey, sanitized);
     }
   }
   return root as T;

--- a/packages/core/src/utils/sanitize-json.ts
+++ b/packages/core/src/utils/sanitize-json.ts
@@ -1,3 +1,5 @@
+import { toUSVString } from 'node:util';
+
 const REPLACEMENT_CHARACTER = '\uFFFD';
 
 export const JSON_SANITIZER_LIMITS = {
@@ -18,27 +20,7 @@ export class JsonSanitizationError extends Error {
 }
 
 export function sanitizeUnicodeString(value: string): string {
-  let output: string | undefined;
-  for (let index = 0; index < value.length; index++) {
-    const unit = value.charCodeAt(index);
-    if (unit === 0) {
-      output ??= value.slice(0, index);
-      output += REPLACEMENT_CHARACTER;
-    } else if (unit >= 0xd800 && unit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        if (output !== undefined) output += value[index] + value[index + 1];
-        index++;
-      } else {
-        output ??= value.slice(0, index);
-        output += REPLACEMENT_CHARACTER;
-      }
-    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
-      output ??= value.slice(0, index);
-      output += REPLACEMENT_CHARACTER;
-    } else if (output !== undefined) output += value[index];
-  }
-  return output ?? value;
+  return toUSVString(value).replaceAll('\0', REPLACEMENT_CHARACTER);
 }
 
 type JsonContainer = Record<string, unknown> | unknown[];

--- a/packages/core/src/utils/sanitize-json.ts
+++ b/packages/core/src/utils/sanitize-json.ts
@@ -48,7 +48,15 @@ type ExitFrame = { kind: 'exit'; source: object };
 function boundedEnumerableKeys(source: object, remaining: number): string[] {
   if (Array.isArray(source)) {
     if (source.length > remaining) throw new JsonSanitizationError('size');
-    return Object.keys(source);
+    const keys: string[] = [];
+    for (const key in source) {
+      if (!Object.hasOwn(source, key)) continue;
+      const index = Number(key);
+      if (!Number.isInteger(index) || index < 0 || index >= source.length || String(index) !== key)
+        throw new JsonSanitizationError('unsupported');
+      keys.push(key);
+    }
+    return keys;
   }
   const keys: string[] = [];
   for (const key in source) {
@@ -92,7 +100,7 @@ export function sanitizeJsonValue<T>(input: T): T {
   }
   if (typeof input !== 'object') throw new JsonSanitizationError('unsupported');
 
-  const root: JsonContainer = Array.isArray(input) ? [] : {};
+  const root: JsonContainer = Array.isArray(input) ? new Array(input.length).fill(null) : {};
   const stack: Array<EnterFrame | ExitFrame> = [
     { kind: 'enter', source: input, target: root, depth: 0 },
   ];
@@ -137,7 +145,7 @@ export function sanitizeJsonValue<T>(input: T): T {
           throw new JsonSanitizationError('unsupported');
         sanitized = value;
       } else if (typeof value === 'object') {
-        const child: JsonContainer = Array.isArray(value) ? [] : {};
+        const child: JsonContainer = Array.isArray(value) ? new Array(value.length).fill(null) : {};
         sanitized = child;
         stack.push({ kind: 'enter', source: value, target: child, depth: frame.depth + 1 });
       } else throw new JsonSanitizationError('unsupported');

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -3,6 +3,7 @@ import {
   executeToolTask,
   installProviderConnection,
   resolveApiKeyForTask,
+  settleTaskFailure,
 } from './base-executor.js';
 
 vi.mock('./git-safe-directory.js', () => ({
@@ -86,6 +87,44 @@ describe('resolveApiKeyForTask', () => {
         'codex' as never
       )
     ).rejects.toThrow('fetch failed');
+  });
+});
+
+describe('settleTaskFailure', () => {
+  it('does not persist Drizzle query parameters in task or transcript diagnostics', async () => {
+    const secret = 'secret-binary-tool-result';
+    const taskPatch = vi.fn().mockResolvedValue(undefined);
+    const messageCreate = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') return { patch: taskPatch };
+        if (name === 'messages') {
+          return {
+            find: vi.fn().mockResolvedValue({ total: 0, data: [] }),
+            create: messageCreate,
+          };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+    const failure = Object.assign(new Error(`Failed query: update messages params: ${secret}`), {
+      query: 'update messages',
+      params: [secret],
+      cause: { code: '22P05' },
+    });
+
+    await settleTaskFailure(client, 'session-1' as never, 'task-1' as never, failure, {
+      status: 'failed',
+      error_message: failure.message,
+    });
+
+    const persisted = JSON.stringify({
+      message: messageCreate.mock.calls,
+      task: taskPatch.mock.calls,
+    });
+    expect(persisted).not.toContain(secret);
+    expect(persisted).not.toContain('update messages');
+    expect(persisted).toContain('Database operation failed');
   });
 });
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -10,7 +10,7 @@ import {
   type ApiKeyName,
   stripProviderCredentialEnvironment,
 } from '@agor/core/config';
-import { generateId, shortId } from '@agor/core/db';
+import { generateId, sanitizeDbError, shortId } from '@agor/core/db';
 import type {
   AgenticToolName,
   ContextUsageSnapshot,
@@ -79,7 +79,7 @@ async function appendTaskFailureMessage(
       },
     });
   } catch (error) {
-    console.error('[executor] Failed to create task failure message:', error);
+    console.error('[executor.message.persist] failed', sanitizeDbError(error));
   }
 }
 
@@ -668,7 +668,7 @@ export async function executeToolTask(params: {
   } catch (error) {
     if (daemonOwnsTerminality()) return;
     const err = error instanceof Error ? error : new Error(String(error));
-    console.error(`[${toolName}] Execution failed:`, err);
+    console.error(`[${toolName}] execution failed category=task_execution`);
 
     // Capture git SHA at task end (even for failed tasks)
     const gitStateAtEnd = await captureGitStateForSession(client, sessionId, 'end');

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -25,6 +25,7 @@ import type {
 import { MessageRole, PROVIDER_CREDENTIAL_FIELDS } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import { getCurrentBranch, getGitState } from '../../git/index.js';
+import { formatExecutorFailure } from '../../safe-executor-error.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import type { AgorClient } from '../../services/feathers-client.js';
@@ -50,6 +51,7 @@ async function appendTaskFailureMessage(
   taskId: TaskID,
   failure: Error
 ): Promise<void> {
+  const safeFailure = formatExecutorFailure(failure);
   try {
     const existingMessages = await client.service('messages').find({
       query: { session_id: sessionId, $limit: 0 },
@@ -69,8 +71,8 @@ async function appendTaskFailureMessage(
       role: MessageRole.SYSTEM,
       index: messageCount,
       timestamp: new Date().toISOString(),
-      content: failure.message,
-      content_preview: failure.message.substring(0, 200),
+      content: safeFailure,
+      content_preview: safeFailure.substring(0, 200),
       metadata: {
         is_task_failure: true,
         ...(failure instanceof MissingCredentialError
@@ -93,7 +95,10 @@ export async function settleTaskFailure(
   // Terminal task hooks may drain the next queued turn, so reserve the current
   // transcript index before publishing terminality. Message failure stays best-effort.
   await appendTaskFailureMessage(client, sessionId, taskId, failure);
-  await client.service('tasks').patch(taskId, patch);
+  await client.service('tasks').patch(taskId, {
+    ...patch,
+    ...(patch.error_message ? { error_message: formatExecutorFailure(failure) } : {}),
+  });
 }
 
 /**
@@ -679,7 +684,7 @@ export async function executeToolTask(params: {
       completed_at: new Date().toISOString(),
       // Surface the actual failure reason so the UI / DB show what went wrong,
       // instead of the task silently flipping to FAILED with no context.
-      error_message: err.message || String(err),
+      error_message: formatExecutorFailure(err),
     };
 
     // Add git_state if we captured a SHA

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -38,6 +38,7 @@ import type { AgorClient } from '../../services/feathers-client.js';
 import {
   captureGitStateAtTaskEnd,
   createStreamingCallbacks,
+  settleTaskFailure,
   stampGitStateAtTaskStart,
 } from './base-executor.js';
 import { configureSessionGitSafeDirectories } from './git-safe-directory.js';
@@ -279,10 +280,6 @@ function getNextMessageIndexFrom(messages: ReadonlyArray<Message>): number {
   return messages.length;
 }
 
-async function getNextMessageIndex(client: AgorClient, sessionId: SessionID): Promise<number> {
-  return getNextMessageIndexFrom(await getSessionMessages(client, sessionId));
-}
-
 async function createUserMessage(args: {
   client: AgorClient;
   sessionId: SessionID;
@@ -418,26 +415,6 @@ async function updateToolMessage(args: {
   await args.client.service('messages').patch(args.messageId, {
     content,
     content_preview: preview.substring(0, 200),
-  });
-}
-
-async function createSystemErrorMessage(args: {
-  client: AgorClient;
-  sessionId: SessionID;
-  taskId: TaskID;
-  message: string;
-}): Promise<void> {
-  const index = await getNextMessageIndex(args.client, args.sessionId);
-  await args.client.service('messages').create({
-    message_id: generateId() as MessageID,
-    session_id: args.sessionId,
-    task_id: args.taskId,
-    type: 'system',
-    role: MessageRole.SYSTEM,
-    index,
-    timestamp: new Date().toISOString(),
-    content: args.message,
-    content_preview: args.message.substring(0, 200),
   });
 }
 
@@ -648,7 +625,7 @@ export async function executeCursorTask(params: {
     }
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
-    console.error('[cursor] Execution failed:', err);
+    console.error('[cursor] execution failed category=task_execution');
     const gitStateAtEnd = await captureGitStateAtTaskEnd(client, sessionId);
     const taskPatch: Partial<Task> = {
       status: 'failed',
@@ -662,8 +639,7 @@ export async function executeCursorTask(params: {
         sha_at_end: gitStateAtEnd.sha,
       };
     }
-    await client.service('tasks').patch(taskId, taskPatch);
-    await createSystemErrorMessage({ client, sessionId, taskId, message: err.message });
+    await settleTaskFailure(client, sessionId, taskId, err, taskPatch);
     throw err;
   } finally {
     params.abortController.signal.removeEventListener('abort', abortHandler);

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -174,7 +174,7 @@ export async function executeOpenCodeTask(params: {
     });
   } catch (error) {
     const failure = error instanceof Error ? error : new Error(String(error));
-    console.error('[opencode] Execution failed:', failure);
+    console.error('[opencode] execution failed category=task_execution');
 
     if (isOpenCodeCleanupUnverifiedError(failure)) {
       // Keep the task active. Executor exit hands containment to the daemon;

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -391,7 +391,7 @@ export class AgorExecutor {
     process.on('SIGINT', () => shutdown('SIGINT'));
 
     process.on('uncaughtException', async (error) => {
-      console.error('[executor] uncaught exception category=process_failure');
+      console.error('[executor] Uncaught exception:', error);
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
         `uncaughtException: ${error instanceof Error ? error.message : String(error)}`
@@ -400,7 +400,7 @@ export class AgorExecutor {
     });
 
     process.on('unhandledRejection', async (reason) => {
-      console.error('[executor] unhandled rejection category=process_failure');
+      console.error('[executor] Unhandled rejection:', reason);
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
         `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}`

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -29,6 +29,7 @@ import { patchConsole } from '@agor/core/utils/logger';
 import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
+import { formatExecutorFailure } from './safe-executor-error.js';
 import { getSdkActivityVersion, markSdkHealthAbort, SdkWatchdog } from './sdk-watchdog.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
@@ -131,10 +132,7 @@ export class AgorExecutor {
         return;
       }
       console.error('[executor] fatal error category=task_startup');
-      await this.tryMarkTaskTerminal(
-        TaskStatus.FAILED,
-        error instanceof Error ? error.message : String(error)
-      );
+      await this.tryMarkTaskTerminal(TaskStatus.FAILED, formatExecutorFailure(error));
       process.exit(1);
     }
   }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -130,7 +130,7 @@ export class AgorExecutor {
         process.exit(0);
         return;
       }
-      console.error('[executor] Fatal error:', error);
+      console.error('[executor] fatal error category=task_startup');
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
         error instanceof Error ? error.message : String(error)
@@ -391,7 +391,7 @@ export class AgorExecutor {
     process.on('SIGINT', () => shutdown('SIGINT'));
 
     process.on('uncaughtException', async (error) => {
-      console.error('[executor] Uncaught exception:', error);
+      console.error('[executor] uncaught exception category=process_failure');
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
         `uncaughtException: ${error instanceof Error ? error.message : String(error)}`
@@ -400,7 +400,7 @@ export class AgorExecutor {
     });
 
     process.on('unhandledRejection', async (reason) => {
-      console.error('[executor] Unhandled rejection:', reason);
+      console.error('[executor] unhandled rejection category=process_failure');
       await this.tryMarkTaskTerminal(
         TaskStatus.FAILED,
         `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}`

--- a/packages/executor/src/safe-executor-error.test.ts
+++ b/packages/executor/src/safe-executor-error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { formatExecutorFailure } from './safe-executor-error';
+
+describe('formatExecutorFailure', () => {
+  it('removes Drizzle query text, parameters, and secrets', () => {
+    const secret = 'super-secret-tool-result';
+    const error = Object.assign(
+      new Error(`Failed query: update messages set data=$1 params: ${secret}`),
+      { query: 'update messages set data=$1', params: [secret], cause: { code: '22P05' } }
+    );
+    const output = formatExecutorFailure(error);
+    expect(output).toBe('Database operation failed (22P05)');
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain('update messages');
+  });
+
+  it('preserves ordinary provider failures within a bounded length', () => {
+    expect(formatExecutorFailure(new Error('Provider authentication failed'))).toBe(
+      'Provider authentication failed'
+    );
+    expect(formatExecutorFailure(new Error('x'.repeat(2_000))).length).toBeLessThanOrEqual(1_024);
+  });
+});

--- a/packages/executor/src/safe-executor-error.test.ts
+++ b/packages/executor/src/safe-executor-error.test.ts
@@ -14,6 +14,15 @@ describe('formatExecutorFailure', () => {
     expect(output).not.toContain('update messages');
   });
 
+  it('recognizes a transported Drizzle error from its message alone', () => {
+    const secret = 'transported-secret';
+    const output = formatExecutorFailure(
+      new Error(`Failed query: update messages set data=$1\nparams: ${secret}`)
+    );
+    expect(output).toBe('Database operation failed');
+    expect(output).not.toContain(secret);
+  });
+
   it('preserves ordinary provider failures within a bounded length', () => {
     expect(formatExecutorFailure(new Error('Provider authentication failed'))).toBe(
       'Provider authentication failed'

--- a/packages/executor/src/safe-executor-error.ts
+++ b/packages/executor/src/safe-executor-error.ts
@@ -2,6 +2,11 @@ import { sanitizeDbError } from '@agor/core/db';
 
 const MAX_FAILURE_MESSAGE_LENGTH = 1_024;
 
+function hasDrizzleMessageShape(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  return value.startsWith('Failed query:') && value.includes('params:');
+}
+
 function isDatabaseFailure(error: unknown): boolean {
   let current: unknown = error;
   const seen = new Set<unknown>();
@@ -12,6 +17,7 @@ function isDatabaseFailure(error: unknown): boolean {
     if (
       'query' in value ||
       'params' in value ||
+      hasDrizzleMessageShape(value.message) ||
       (typeof value.code === 'string' && /^[0-9A-Z]{5}$/.test(value.code))
     )
       return true;

--- a/packages/executor/src/safe-executor-error.ts
+++ b/packages/executor/src/safe-executor-error.ts
@@ -1,0 +1,32 @@
+import { sanitizeDbError } from '@agor/core/db';
+
+const MAX_FAILURE_MESSAGE_LENGTH = 1_024;
+
+function isDatabaseFailure(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current && !seen.has(current); depth++) {
+    seen.add(current);
+    if (typeof current !== 'object') return false;
+    const value = current as Record<string, unknown>;
+    if (
+      'query' in value ||
+      'params' in value ||
+      (typeof value.code === 'string' && /^[0-9A-Z]{5}$/.test(value.code))
+    )
+      return true;
+    current = value.cause;
+  }
+  return false;
+}
+
+/** Safe text for durable task/message diagnostics; never includes DB query parameters. */
+export function formatExecutorFailure(error: unknown): string {
+  if (isDatabaseFailure(error)) {
+    const diagnostic = sanitizeDbError(error);
+    return diagnostic.code ? `${diagnostic.message} (${diagnostic.code})` : diagnostic.message;
+  }
+  const text = error instanceof Error ? error.message : String(error);
+  if (text.length <= MAX_FAILURE_MESSAGE_LENGTH) return text;
+  return `${text.slice(0, MAX_FAILURE_MESSAGE_LENGTH - 1)}…`;
+}


### PR DESCRIPTION
## Summary

- sanitize PostgreSQL-incompatible NUL bytes and lone UTF-16 surrogates at the shared message repository boundary
- cover message create, bulk create, patch/finalization, previews, and locked metadata updates
- keep the executor paths that handled the demonstrated persistence failure from logging Drizzle SQL parameters or raw tool/provider payloads
- degrade sanitizer-policy failures (oversized, cyclic, unsupported, or colliding transcript payloads) to a fixed bounded omission placeholder while preserving message identity and task/session scoping
- intentionally leave unrelated JSONB columns and oversized-payload policy unchanged

## Why

Agent tool results can contain raw binary-like content, such as ZIP data read from `.docx` or image files. PostgreSQL rejects an actual U+0000 in JSONB with SQLSTATE `22P05`, which previously caused final message persistence to fail and could crash the executor while dumping the full Drizzle parameter payload into logs.

The scope is deliberately narrow: messages are the untrusted transcript boundary implicated by the production failure. A global PostgreSQL JSONB type override was removed because it would change behavior and add traversal cost to every structural JSONB write. Oversized transcript omission/truncation is a separate product policy rather than part of this Unicode correctness fix.

## Sanitizer contract

The shared utility:

- replaces NUL and only unpaired UTF-16 surrogates with U+FFFD
- preserves valid surrogate pairs, emoji, combining marks, RTL text, newlines, and ordinary Unicode
- handles arrays and plain JSON objects without mutating inputs
- rejects cycles, excessive depth/node/string budgets, non-finite numbers, and unsupported non-JSON values
- uses Node’s built-in `util.toUSVString()` for lone-surrogate normalization

Tenant IDs, ownership, authorization state, RLS context, timestamps, predicates, and binary columns are not transformed.

## Testing

- `pnpm i`
- core suite: 3,586 passed, 86 skipped
- focused executor persistence/client tests: 17 passed
- focused daemon message-boundary tests: 15 passed
- `pnpm test:postgres:docker`: real PostgreSQL/RLS integration suite passed, including actual U+0000 reproduction and final `tool_result` update regression
- `pnpm typecheck`: 21/21 tasks passed
- `pnpm lint`: passed, including 330 frontend design-system fixtures
- full executor suite still has unrelated installed SDK/mock environment failures; focused affected paths pass
- `pnpm check` previously reached and passed typecheck, lint, short-ID, and multitenancy checks, then stopped on the existing unrelated `DAEMON-FS-CAP-170: duplicate stable ID` registry error

