### PR TITLE
fix(realtime): enforce Knowledge ACLs on events

### DIFF
--- a/apps/agor-daemon/src/register-hooks.knowledge-realtime.test.ts
+++ b/apps/agor-daemon/src/register-hooks.knowledge-realtime.test.ts
@@ -1,0 +1,143 @@
+import type { BranchRepository, SessionRepository } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { feathers, socketio } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type RegisterHooksContext,
+  registerHooks,
+  suppressKnowledgeCommandRealtimeEvent,
+} from './register-hooks';
+import { emitServiceEvent } from './utils/emit-service-event';
+import { KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS } from './utils/knowledge-realtime-publish';
+import { configureRealtimePublish } from './utils/realtime-publish';
+
+describe('Knowledge command realtime suppression', () => {
+  it('registers the suppression after-hook on the exact command services', () => {
+    const registered = new Map<string, Array<{ after?: { create?: unknown[] } }>>();
+    const app = {
+      service(path: string) {
+        return {
+          hooks(hooks: { after?: { create?: unknown[] } }) {
+            if ((KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS as readonly string[]).includes(path)) {
+              registered.set(path, [...(registered.get(path) ?? []), hooks]);
+            }
+          },
+        };
+      },
+      use() {},
+      publish() {},
+    };
+
+    registerHooks({
+      db: {} as RegisterHooksContext['db'],
+      app: app as RegisterHooksContext['app'],
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'registration-test' },
+      } as RegisterHooksContext['config'],
+      jwtSecret: 'registration-test-secret',
+      branchRbacEnabled: false,
+      requireAuth: async (context) => context,
+      superadminOpts: { allowSuperadmin: true },
+      sessionsService: {} as RegisterHooksContext['sessionsService'],
+      messagesService: {} as RegisterHooksContext['messagesService'],
+      boardsService: undefined,
+      branchRepository: {} as RegisterHooksContext['branchRepository'],
+      usersRepository: {} as RegisterHooksContext['usersRepository'],
+      sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+      deployment: { mode: 'standalone' },
+    });
+
+    expect([...registered.keys()].sort()).toEqual(
+      [...KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS].sort()
+    );
+    for (const hookRegistrations of registered.values()) {
+      expect(
+        hookRegistrations.some(({ after }) =>
+          after?.create?.includes(suppressKnowledgeCommandRealtimeEvent)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it.each(KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS)(
+    'preserves the %s response without a local event or Redis relay',
+    async (path) => {
+      const app = feathers() as Application;
+      app.configure(socketio());
+      const relay = { relay: vi.fn(), setRelayHandler: vi.fn() };
+      configureRealtimePublish({
+        app,
+        branchRbacEnabled: false,
+        branchRepository: {} as BranchRepository,
+        sessionsRepository: {} as SessionRepository,
+        multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+        realtimeRelay: relay,
+      });
+
+      app.use(
+        'kb/documents',
+        {
+          async get() {
+            return { document_id: 'document-1' };
+          },
+        },
+        { methods: ['get'] }
+      );
+      app.use(
+        path,
+        {
+          async create() {
+            if (path === 'kb/document-edits') {
+              emitServiceEvent(app, {
+                path: 'kb/documents',
+                event: 'patched',
+                data: { document_id: 'document-1', title: 'Updated' },
+              });
+            }
+            return { path, callerOnly: 'preserved' };
+          },
+        },
+        { methods: ['create'] }
+      );
+      app.service(path).hooks({
+        after: { create: [suppressKnowledgeCommandRealtimeEvent] },
+      });
+
+      const commandEvent = vi.fn();
+      const documentEvent = vi.fn();
+      app.service(path).on('created', commandEvent);
+      app.service('kb/documents').on('patched', documentEvent);
+      await app.setup();
+      try {
+        await expect(app.service(path).create({})).resolves.toEqual({
+          path,
+          callerOnly: 'preserved',
+        });
+        expect(commandEvent).not.toHaveBeenCalled();
+        expect(relay.relay).not.toHaveBeenCalledWith(expect.objectContaining({ path }));
+
+        if (path === 'kb/document-edits') {
+          expect(documentEvent).toHaveBeenCalledOnce();
+          await vi.waitFor(() =>
+            expect(relay.relay).toHaveBeenCalledWith(
+              expect.objectContaining({ path: 'kb/documents', event: 'patched' })
+            )
+          );
+        }
+      } finally {
+        await app.teardown();
+      }
+    }
+  );
+
+  it('sets context.event to null without changing the result', () => {
+    const result = { callerOnly: true };
+    const context = { event: 'created', result } as HookContext;
+
+    expect(suppressKnowledgeCommandRealtimeEvent(context)).toBe(context);
+    expect(context.event).toBeNull();
+    expect(context.result).toBe(result);
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -497,6 +497,12 @@ export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'mcp-servers/test-oauth',
 ] as const;
 
+/** Caller-specific Knowledge command responses must never become service events. */
+export function suppressKnowledgeCommandRealtimeEvent(context: HookContext): HookContext {
+  context.event = null;
+  return context;
+}
+
 /**
  * Service endpoints whose implementation retains process-local credentials,
  * provider handshakes, or native runtime state. Keep this inventory exported
@@ -1651,6 +1657,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth, requireMinimumRole(ROLES.MEMBER, 'edit knowledge documents')],
     },
+    after: {
+      create: [suppressKnowledgeCommandRealtimeEvent],
+    },
   });
 
   safeService('kb/versions')?.hooks({
@@ -1662,6 +1671,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('kb/search')?.hooks({
     before: {
       all: [requireAuth],
+    },
+    after: {
+      create: [suppressKnowledgeCommandRealtimeEvent],
     },
   });
 
@@ -1680,6 +1692,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('kb/indexing/reindex')?.hooks({
     before: {
       all: [requireAuth, requireMinimumRole(ROLES.ADMIN, 'reindex Knowledge embeddings')],
+    },
+    after: {
+      create: [suppressKnowledgeCommandRealtimeEvent],
     },
   });
 

--- a/apps/agor-daemon/src/services/knowledge-access.ts
+++ b/apps/agor-daemon/src/services/knowledge-access.ts
@@ -1,11 +1,22 @@
-import type { KnowledgeNamespaceRepository, KnowledgeSearchRepository } from '@agor/core/db';
+import type {
+  KnowledgeDocumentRepository,
+  KnowledgeNamespaceRepository,
+  KnowledgeSearchRepository,
+} from '@agor/core/db';
 import type {
   KnowledgeDocument,
+  KnowledgeGraphNode,
   KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceID,
   User,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES } from '@agor/core/types';
+import {
+  hasMinimumRole,
+  KNOWLEDGE_DOCUMENT_URI_PREFIX,
+  KNOWLEDGE_UNIT_URI_PREFIX,
+  parseKnowledgeUri,
+  ROLES,
+} from '@agor/core/types';
 
 const KNOWLEDGE_NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
   none: 0,
@@ -97,6 +108,65 @@ export async function canWriteKnowledgeDocument(
     hasKnowledgeNamespacePermission(namespacePermission, 'write') &&
     canWriteKnowledgeDocumentOverlay(document, user)
   );
+}
+
+function graphNodeDocumentId(node: KnowledgeGraphNode): string | undefined {
+  if (node.document_id) return node.document_id;
+  if (node.uri.startsWith(KNOWLEDGE_DOCUMENT_URI_PREFIX)) {
+    return node.uri.slice(KNOWLEDGE_DOCUMENT_URI_PREFIX.length);
+  }
+  return undefined;
+}
+
+function graphNodeUnitId(node: KnowledgeGraphNode): string | undefined {
+  if (node.unit_id) return node.unit_id;
+  if (node.uri.startsWith(KNOWLEDGE_UNIT_URI_PREFIX)) {
+    return node.uri.slice(KNOWLEDGE_UNIT_URI_PREFIX.length);
+  }
+  return undefined;
+}
+
+export function isKnowledgeDocumentGraphNode(node: KnowledgeGraphNode): boolean {
+  return Boolean(
+    node.node_type === 'document' ||
+      node.node_type === 'document_unit' ||
+      node.document_id ||
+      graphNodeDocumentId(node) ||
+      graphNodeUnitId(node) ||
+      parseKnowledgeUri(node.uri)
+  );
+}
+
+/** Resolve a graph node through the same active document/namespace boundary as graph reads. */
+export async function resolveKnowledgeGraphNodeDocument(
+  documents: KnowledgeDocumentRepository,
+  namespaces: KnowledgeNamespaceRepository,
+  node: KnowledgeGraphNode
+): Promise<KnowledgeDocument | null> {
+  const documentId = graphNodeDocumentId(node);
+  const unitId = graphNodeUnitId(node);
+  const parsed = parseKnowledgeUri(node.uri);
+  const document = documentId
+    ? await documents.findById(documentId)
+    : unitId
+      ? await documents.findByUnitId(unitId)
+      : parsed
+        ? await documents.findByNamespaceSlugAndPath(parsed.namespace_slug, parsed.path)
+        : null;
+  if (!document || document.archived) return null;
+  const namespace = await namespaces.findById(document.namespace_id);
+  return !namespace || namespace.archived ? null : document;
+}
+
+export async function canReadKnowledgeGraphNode(
+  documents: KnowledgeDocumentRepository,
+  namespaces: KnowledgeNamespaceRepository,
+  node: KnowledgeGraphNode,
+  user?: User
+): Promise<boolean> {
+  const document = await resolveKnowledgeGraphNodeDocument(documents, namespaces, node);
+  if (!document && isKnowledgeDocumentGraphNode(node)) return false;
+  return document ? canReadKnowledgeDocument(namespaces, document, user) : true;
 }
 
 export async function canReadKnowledgeSearchResult(

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -30,9 +30,12 @@ import {
 } from '@agor/core/types';
 import {
   canReadKnowledgeDocument,
+  canReadKnowledgeGraphNode,
   canWriteKnowledgeDocument,
   hasKnowledgeNamespacePermission,
   isKnowledgeAdmin,
+  isKnowledgeDocumentGraphNode,
+  resolveKnowledgeGraphNodeDocument,
   resolveKnowledgeNamespacePermission,
 } from './knowledge-access.js';
 
@@ -169,26 +172,11 @@ export class KnowledgeGraphService {
     return undefined;
   }
 
-  private documentIdFromNode(node: KnowledgeGraphNode): string | undefined {
-    if (node.document_id) return node.document_id;
-    if (node.uri.startsWith(KNOWLEDGE_DOCUMENT_URI_PREFIX)) {
-      return node.uri.slice(KNOWLEDGE_DOCUMENT_URI_PREFIX.length);
-    }
-    return undefined;
-  }
-
   private unitIdFromRef(ref: KnowledgeNodeRef): string | undefined {
     const unitId = ref.unit_id ?? ref.unitId;
     if (unitId) return unitId;
     if (ref.uri?.startsWith(KNOWLEDGE_UNIT_URI_PREFIX))
       return ref.uri.slice(KNOWLEDGE_UNIT_URI_PREFIX.length);
-    return undefined;
-  }
-
-  private unitIdFromNode(node: KnowledgeGraphNode): string | undefined {
-    if (node.unit_id) return node.unit_id;
-    if (node.uri.startsWith(KNOWLEDGE_UNIT_URI_PREFIX))
-      return node.uri.slice(KNOWLEDGE_UNIT_URI_PREFIX.length);
     return undefined;
   }
 
@@ -201,17 +189,6 @@ export class KnowledgeGraphService {
         ref.namespace ??
         ref.path ??
         parseKnowledgeUri(ref.uri)
-    );
-  }
-
-  private isDocumentNode(node: KnowledgeGraphNode): boolean {
-    return Boolean(
-      node.node_type === 'document' ||
-        node.node_type === 'document_unit' ||
-        node.document_id ||
-        this.documentIdFromNode(node) ||
-        this.unitIdFromNode(node) ||
-        parseKnowledgeUri(node.uri)
     );
   }
 
@@ -234,8 +211,10 @@ export class KnowledgeGraphService {
 
   private async assertCanLinkRef(ref: KnowledgeNodeRef, user?: User): Promise<void> {
     const node = await this.graph.findNode(ref);
-    const document = node ? await this.documentForNode(node) : await this.documentForRef(ref);
-    if (!document && (node ? this.isDocumentNode(node) : this.isDocumentRef(ref))) {
+    const document = node
+      ? await resolveKnowledgeGraphNodeDocument(this.documents, this.namespaces, node)
+      : await this.documentForRef(ref);
+    if (!document && (node ? isKnowledgeDocumentGraphNode(node) : this.isDocumentRef(ref))) {
       throw new NotFound('Knowledge document not found');
     }
     if (!document) return;
@@ -244,24 +223,8 @@ export class KnowledgeGraphService {
     }
   }
 
-  private async documentForNode(node: KnowledgeGraphNode): Promise<KnowledgeDocument | null> {
-    const documentId = this.documentIdFromNode(node);
-    if (documentId) {
-      return this.activeDocument(await this.documents.findById(documentId));
-    }
-    const unitId = this.unitIdFromNode(node);
-    if (unitId) return this.activeDocument(await this.documents.findByUnitId(unitId));
-    const parsed = parseKnowledgeUri(node.uri);
-    if (!parsed) return null;
-    return this.activeDocument(
-      await this.documents.findByNamespaceSlugAndPath(parsed.namespace_slug, parsed.path)
-    );
-  }
-
   private async canReadNode(node: KnowledgeGraphNode, user?: User): Promise<boolean> {
-    const document = await this.documentForNode(node);
-    if (!document && this.isDocumentNode(node)) return false;
-    return document ? this.canRead(document, user) : true;
+    return canReadKnowledgeGraphNode(this.documents, this.namespaces, node, user);
   }
 
   private attributionUserId(params?: KnowledgeGraphParams, requestedUserId?: UserID | null) {

--- a/apps/agor-daemon/src/utils/knowledge-realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/knowledge-realtime-publish.test.ts
@@ -200,7 +200,7 @@ describe('Knowledge realtime ACL resolution', () => {
     }
   );
 
-  dbTest('requires graph readers to pass both document endpoints', async ({ db }) => {
+  dbTest('resolves graph endpoints once and requires readers to pass both', async ({ db }) => {
     const owner = await seedUser(db, 'owner');
     const firstOnly = await seedUser(db, 'first-only');
     const both = await seedUser(db, 'both');
@@ -227,9 +227,22 @@ describe('Knowledge realtime ACL resolution', () => {
       created_by: owner.user_id,
     });
 
+    const findDocument = vi.spyOn(KnowledgeDocumentRepository.prototype, 'findById');
+    try {
+      expect(
+        await resolve({ db, data: edge, path: 'kb/graph', users: [firstOnly, both, admin] })
+      ).toEqual(new Set([both.user_id, admin.user_id]));
+      expect(findDocument).toHaveBeenCalledTimes(2);
+    } finally {
+      findDocument.mockRestore();
+    }
+
+    await new KnowledgeDocumentRepository(db).update(second.document.document_id, {
+      archived: true,
+    });
     expect(
       await resolve({ db, data: edge, path: 'kb/graph', users: [firstOnly, both, admin] })
-    ).toEqual(new Set([both.user_id, admin.user_id]));
+    ).toEqual(new Set());
   });
 
   dbTest(

--- a/apps/agor-daemon/src/utils/knowledge-realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/knowledge-realtime-publish.test.ts
@@ -1,0 +1,292 @@
+import {
+  type Database,
+  GroupRepository,
+  generateId,
+  KnowledgeDocumentRepository,
+  KnowledgeGraphRepository,
+  KnowledgeNamespaceRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { KnowledgeDocument, User, UserID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import {
+  KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS,
+  resolveKnowledgeRealtimeUserIds,
+} from './knowledge-realtime-publish';
+
+async function seedUser(
+  db: Database,
+  label: string,
+  role: User['role'] = ROLES.MEMBER
+): Promise<User> {
+  return new UsersRepository(db).create({
+    user_id: generateId() as UserID,
+    email: `${label}-${generateId()}@test.local`,
+    name: label,
+    role,
+  }) as Promise<User>;
+}
+
+async function seedDocument(
+  db: Database,
+  owner: User,
+  slug: string,
+  visibility: KnowledgeDocument['visibility'] = 'public'
+) {
+  const namespace = await new KnowledgeNamespaceRepository(db).create({
+    slug,
+    display_name: slug,
+    others_can: 'none',
+  });
+  const document = await new KnowledgeDocumentRepository(db).create({
+    namespace_id: namespace.namespace_id,
+    path: 'page.md',
+    title: 'Page',
+    visibility,
+    status: 'published',
+    edit_policy: 'owner',
+    content_text: '# Page',
+    created_by: owner.user_id,
+  });
+  return { namespace, document };
+}
+
+function appWithServices(services: Record<string, unknown> = {}): Application {
+  return {
+    service: vi.fn((path: string) => {
+      const service = services[path];
+      if (!service) throw new Error(`Unexpected service: ${path}`);
+      return service;
+    }),
+  } as unknown as Application;
+}
+
+async function resolve(options: {
+  db: Database;
+  data: unknown;
+  path: string;
+  users: User[];
+  event?: string;
+  app?: Application;
+}) {
+  const app = options.app ?? appWithServices();
+  return resolveKnowledgeRealtimeUserIds({
+    app,
+    db: options.db,
+    data: options.data,
+    context: { path: options.path, id: null, event: options.event ?? 'patched', app },
+    userIds: options.users.map((user) => user.user_id),
+  });
+}
+
+describe('Knowledge realtime ACL resolution', () => {
+  for (const path of KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS) {
+    dbTest(`suppresses only the created event on ${path}`, async ({ db }) => {
+      const current = await seedUser(db, `current-${path.replaceAll('/', '-')}`);
+      const app = appWithServices();
+      await expect(
+        resolveKnowledgeRealtimeUserIds({
+          app,
+          db,
+          data: {},
+          context: { path, id: null, event: 'created', app },
+          userIds: [current.user_id],
+        })
+      ).resolves.toEqual(new Set());
+      await expect(
+        resolveKnowledgeRealtimeUserIds({
+          app,
+          db,
+          data: {},
+          context: { path, id: null, event: 'patched', app },
+          userIds: [current.user_id],
+        })
+      ).resolves.toEqual(new Set([current.user_id]));
+    });
+  }
+
+  dbTest('reloads current roles and discards unresolved principals', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const demoted = await seedUser(db, 'demoted', ROLES.ADMIN);
+    const promoted = await seedUser(db, 'promoted');
+    const removed = await seedUser(db, 'removed', ROLES.ADMIN);
+    const { document } = await seedDocument(db, owner, 'current-principals');
+    const users = new UsersRepository(db);
+
+    await users.update(demoted.user_id, { role: ROLES.MEMBER });
+    await users.update(promoted.user_id, { role: ROLES.ADMIN });
+    await users.delete(removed.user_id);
+
+    const app = appWithServices();
+    const resolved = await resolveKnowledgeRealtimeUserIds({
+      app,
+      db,
+      data: document,
+      context: {
+        path: 'kb/documents',
+        id: document.document_id,
+        event: 'patched',
+        app,
+      },
+      userIds: [demoted.user_id, promoted.user_id, removed.user_id, generateId()],
+    });
+
+    expect(resolved).toEqual(new Set([promoted.user_id]));
+  });
+
+  dbTest(
+    'rechecks direct and group access on every event and preserves admin access',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const direct = await seedUser(db, 'direct');
+      const grouped = await seedUser(db, 'grouped');
+      const denied = await seedUser(db, 'denied');
+      const admin = await seedUser(db, 'admin', ROLES.ADMIN);
+      const superadmin = await seedUser(db, 'superadmin', ROLES.SUPERADMIN);
+      const { namespace, document } = await seedDocument(db, owner, 'direct-group');
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const groups = new GroupRepository(db);
+      const group = await groups.create({ name: 'Readers', slug: 'readers' });
+      await groups.addMember(group.group_id, grouped.user_id);
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: direct.user_id,
+        permission: 'read',
+      });
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'group',
+        subject_id: group.group_id,
+        permission: 'read',
+      });
+
+      const users = [direct, grouped, denied, admin, superadmin];
+      expect(await resolve({ db, data: document, path: 'kb/documents', users })).toEqual(
+        new Set([direct.user_id, grouped.user_id, admin.user_id, superadmin.user_id])
+      );
+
+      await namespaces.removeNamespaceAclEntry(namespace.namespace_id, 'user', direct.user_id);
+      await groups.removeMember(group.group_id, grouped.user_id);
+      expect(await resolve({ db, data: document, path: 'kb/documents', users })).toEqual(
+        new Set([admin.user_id, superadmin.user_id])
+      );
+    }
+  );
+
+  dbTest(
+    'applies the private-document creator overlay after namespace read access',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const reader = await seedUser(db, 'reader');
+      const admin = await seedUser(db, 'admin', ROLES.ADMIN);
+      const { namespace, document } = await seedDocument(db, owner, 'private-overlay', 'private');
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      for (const subject of [owner, reader]) {
+        await namespaces.upsertNamespaceAclEntry({
+          namespace_id: namespace.namespace_id,
+          subject_type: 'user',
+          subject_id: subject.user_id,
+          permission: 'read',
+        });
+      }
+
+      expect(
+        await resolve({ db, data: document, path: 'kb/documents', users: [owner, reader, admin] })
+      ).toEqual(new Set([owner.user_id, admin.user_id]));
+    }
+  );
+
+  dbTest('requires graph readers to pass both document endpoints', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const firstOnly = await seedUser(db, 'first-only');
+    const both = await seedUser(db, 'both');
+    const admin = await seedUser(db, 'admin', ROLES.ADMIN);
+    const first = await seedDocument(db, owner, 'graph-first');
+    const second = await seedDocument(db, owner, 'graph-second');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    for (const [namespaceId, reader] of [
+      [first.namespace.namespace_id, firstOnly],
+      [first.namespace.namespace_id, both],
+      [second.namespace.namespace_id, both],
+    ] as const) {
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespaceId,
+        subject_type: 'user',
+        subject_id: reader.user_id,
+        permission: 'read',
+      });
+    }
+    const edge = await new KnowledgeGraphRepository(db).link({
+      source: { document_id: first.document.document_id },
+      target: { document_id: second.document.document_id },
+      edge_type: 'references',
+      created_by: owner.user_id,
+    });
+
+    expect(
+      await resolve({ db, data: edge, path: 'kb/graph', users: [firstOnly, both, admin] })
+    ).toEqual(new Set([both.user_id, admin.user_id]));
+  });
+
+  dbTest(
+    'maps future comment replies to their parent document and fails closed when absent',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const reader = await seedUser(db, 'reader');
+      const { namespace, document } = await seedDocument(db, owner, 'comment-parent');
+      await new KnowledgeNamespaceRepository(db).upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: reader.user_id,
+        permission: 'read',
+      });
+      const get = vi.fn(async (id: string) => {
+        if (id === 'parent-present') return { document_id: document.document_id };
+        throw new Error('missing parent');
+      });
+      const app = appWithServices({ 'kb/document-comments': { get } });
+
+      expect(
+        await resolve({
+          db,
+          app,
+          data: { parent_comment_id: 'parent-present' },
+          path: 'kb/document-comments',
+          users: [reader],
+        })
+      ).toEqual(new Set([reader.user_id]));
+      expect(
+        await resolve({
+          db,
+          app,
+          data: { parent_comment_id: 'parent-missing' },
+          path: 'kb/document-comments',
+          users: [reader],
+        })
+      ).toEqual(new Set());
+    }
+  );
+
+  dbTest('fails closed for former namespace readers after namespace removal', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const reader = await seedUser(db, 'reader');
+    const admin = await seedUser(db, 'admin', ROLES.ADMIN);
+    const { namespace } = await seedDocument(db, owner, 'removed-namespace');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: reader.user_id,
+      permission: 'read',
+    });
+    await namespaces.delete(namespace.namespace_id);
+
+    expect(
+      await resolve({ db, data: namespace, path: 'kb/namespaces', users: [reader, admin] })
+    ).toEqual(new Set([admin.user_id]));
+  });
+});

--- a/apps/agor-daemon/src/utils/knowledge-realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/knowledge-realtime-publish.ts
@@ -1,0 +1,233 @@
+import {
+  KnowledgeDocumentRepository,
+  KnowledgeGraphRepository,
+  KnowledgeNamespaceRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { HookContext, KnowledgeDocument, KnowledgeGraphNode, User } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import {
+  canReadKnowledgeDocument,
+  canReadKnowledgeGraphNode,
+  hasKnowledgeNamespacePermission,
+  isKnowledgeAdmin,
+  resolveKnowledgeNamespacePermission,
+} from '../services/knowledge-access.js';
+
+export const KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS = [
+  'kb/search',
+  'kb/document-edits',
+  'kb/indexing/reindex',
+] as const;
+
+const SUPPRESSED_CREATE_PATHS = new Set<string>(KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS);
+const ADMIN_ONLY_PATHS = new Set(['kb/settings', 'kb/indexing/status']);
+const DOCUMENT_PATHS = new Set(['kb/documents', 'kb/versions']);
+const INTERNAL_KNOWLEDGE_ADMIN = { role: ROLES.ADMIN } as User;
+
+type KnowledgePublishContext = Pick<HookContext, 'path' | 'id' | 'event' | 'app'>;
+
+export function isKnowledgeRealtimeSuppressedEvent(
+  path: string,
+  event: string | null | undefined
+): boolean {
+  return event === 'created' && SUPPRESSED_CREATE_PATHS.has(path.replace(/^\//, ''));
+}
+
+function records(data: unknown): Record<string, unknown>[] {
+  const values = Array.isArray(data) ? data : [data];
+  const result: Record<string, unknown>[] = [];
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    result.push(record);
+    for (const key of ['document', 'namespace', 'comment', 'edge']) {
+      const nested = record[key];
+      if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+        result.push(nested as Record<string, unknown>);
+      }
+    }
+  }
+  return result;
+}
+
+function idsFrom(data: unknown, ...keys: string[]): string[] {
+  const ids = new Set<string>();
+  for (const record of records(data)) {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === 'string' && value.length > 0) ids.add(value);
+    }
+  }
+  return [...ids];
+}
+
+async function loadDocuments(
+  documents: KnowledgeDocumentRepository,
+  documentIds: string[]
+): Promise<KnowledgeDocument[] | null> {
+  if (documentIds.length === 0) return null;
+  const loaded = await Promise.all(documentIds.map((id) => documents.findById(id)));
+  return loaded.every((document): document is KnowledgeDocument => document !== null)
+    ? loaded
+    : null;
+}
+
+async function readableDocumentUserIds(
+  namespaces: KnowledgeNamespaceRepository,
+  documents: KnowledgeDocument[] | null,
+  users: User[]
+): Promise<Set<string>> {
+  const authorized = new Set<string>();
+  if (!documents) return authorized;
+  for (const user of users) {
+    if (
+      await everyAsync(documents, (document) =>
+        canReadKnowledgeDocument(namespaces, document, user)
+      )
+    ) {
+      authorized.add(user.user_id);
+    }
+  }
+  return authorized;
+}
+
+async function everyAsync<T>(values: T[], predicate: (value: T) => Promise<boolean>) {
+  for (const value of values) {
+    if (!(await predicate(value))) return false;
+  }
+  return true;
+}
+
+async function commentDocumentId(app: Application, data: unknown): Promise<string | undefined> {
+  const [direct] = idsFrom(data, 'document_id', 'documentId');
+  if (direct) return direct;
+
+  const [parentId] = idsFrom(data, 'parent_comment_id', 'parentCommentId');
+  if (!parentId) return undefined;
+  try {
+    const parent = (await app.service('kb/document-comments').get(parentId, {
+      provider: undefined,
+      user: INTERNAL_KNOWLEDGE_ADMIN,
+    } as never)) as { document_id?: unknown; documentId?: unknown };
+    const documentId = parent.document_id ?? parent.documentId;
+    return typeof documentId === 'string' && documentId.length > 0 ? documentId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the current reader set for one shared Knowledge event.
+ *
+ * User principals and the reader set are reloaded for every event so role and
+ * direct/group revocation take effect immediately. `null` means the event is
+ * not owned by Knowledge; an empty set means a Knowledge parent or ACL could
+ * not be resolved and publication must fail closed (trusted service
+ * connections are added by the caller).
+ */
+export async function resolveKnowledgeRealtimeUserIds(options: {
+  app: Application;
+  db: TenantScopeAwareDatabase | undefined;
+  data: unknown;
+  context: KnowledgePublishContext;
+  userIds: string[];
+}): Promise<Set<string> | null> {
+  const path = options.context.path?.replace(/^\//, '');
+  if (!path?.startsWith('kb/')) return null;
+  if (isKnowledgeRealtimeSuppressedEvent(path, options.context.event)) return new Set();
+  if (!options.db) return new Set();
+
+  const userRepository = new UsersRepository(options.db);
+  const users = (
+    await Promise.all(options.userIds.map((userId) => userRepository.findById(userId)))
+  ).filter((user): user is User => user !== null);
+
+  if (SUPPRESSED_CREATE_PATHS.has(path)) {
+    return new Set(users.map((user) => user.user_id));
+  }
+
+  if (ADMIN_ONLY_PATHS.has(path)) {
+    return new Set(users.filter(isKnowledgeAdmin).map((user) => user.user_id));
+  }
+
+  const namespaces = new KnowledgeNamespaceRepository(options.db);
+  const documents = new KnowledgeDocumentRepository(options.db);
+
+  if (path === 'kb/namespaces') {
+    const namespaceIds = idsFrom(options.data, 'namespace_id', 'namespaceId');
+    if (namespaceIds.length === 0 && typeof options.context.id === 'string') {
+      namespaceIds.push(options.context.id);
+    }
+    const authorized = new Set<string>();
+    if (namespaceIds.length === 0) return authorized;
+    for (const user of users) {
+      if (
+        await everyAsync(namespaceIds, async (namespaceId) =>
+          hasKnowledgeNamespacePermission(
+            await resolveKnowledgeNamespacePermission(namespaces, namespaceId, user),
+            'read'
+          )
+        )
+      ) {
+        authorized.add(user.user_id);
+      }
+    }
+    return authorized;
+  }
+
+  if (DOCUMENT_PATHS.has(path)) {
+    const documentIds = idsFrom(options.data, 'document_id', 'documentId');
+    if (
+      documentIds.length === 0 &&
+      path === 'kb/documents' &&
+      typeof options.context.id === 'string'
+    ) {
+      documentIds.push(options.context.id);
+    }
+    return readableDocumentUserIds(namespaces, await loadDocuments(documents, documentIds), users);
+  }
+
+  if (path === 'kb/document-comments') {
+    const documentId = await commentDocumentId(options.app, options.data);
+    return readableDocumentUserIds(
+      namespaces,
+      await loadDocuments(documents, documentId ? [documentId] : []),
+      users
+    );
+  }
+
+  if (path === 'kb/graph') {
+    const nodeIds = idsFrom(
+      options.data,
+      'source_node_id',
+      'sourceNodeId',
+      'target_node_id',
+      'targetNodeId'
+    );
+    if (nodeIds.length === 0) return new Set();
+    const graph = new KnowledgeGraphRepository(options.db);
+    const nodes = await Promise.all(
+      nodeIds.map((nodeId) => graph.findNode({ node_id: nodeId }, { includeArchived: true }))
+    );
+    if (!nodes.every((node): node is KnowledgeGraphNode => node !== null)) return new Set();
+
+    const authorized = new Set<string>();
+    for (const user of users) {
+      if (
+        await everyAsync(nodes, (node) =>
+          canReadKnowledgeGraphNode(documents, namespaces, node, user)
+        )
+      ) {
+        authorized.add(user.user_id);
+      }
+    }
+    return authorized;
+  }
+
+  // Unknown or future Knowledge payloads must declare a parent mapping before
+  // they can be safely shared.
+  return new Set();
+}

--- a/apps/agor-daemon/src/utils/knowledge-realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/knowledge-realtime-publish.ts
@@ -10,9 +10,10 @@ import type { HookContext, KnowledgeDocument, KnowledgeGraphNode, User } from '@
 import { ROLES } from '@agor/core/types';
 import {
   canReadKnowledgeDocument,
-  canReadKnowledgeGraphNode,
   hasKnowledgeNamespacePermission,
   isKnowledgeAdmin,
+  isKnowledgeDocumentGraphNode,
+  resolveKnowledgeGraphNodeDocument,
   resolveKnowledgeNamespacePermission,
 } from '../services/knowledge-access.js';
 
@@ -214,17 +215,18 @@ export async function resolveKnowledgeRealtimeUserIds(options: {
     );
     if (!nodes.every((node): node is KnowledgeGraphNode => node !== null)) return new Set();
 
-    const authorized = new Set<string>();
-    for (const user of users) {
-      if (
-        await everyAsync(nodes, (node) =>
-          canReadKnowledgeGraphNode(documents, namespaces, node, user)
-        )
-      ) {
-        authorized.add(user.user_id);
+    const resolvedDocuments = await Promise.all(
+      nodes.map((node) => resolveKnowledgeGraphNodeDocument(documents, namespaces, node))
+    );
+    const documentsById = new Map<string, KnowledgeDocument>();
+    for (const [index, document] of resolvedDocuments.entries()) {
+      if (!document) {
+        if (isKnowledgeDocumentGraphNode(nodes[index])) return new Set();
+        continue;
       }
+      documentsById.set(document.document_id, document);
     }
-    return authorized;
+    return readableDocumentUserIds(namespaces, [...documentsById.values()], users);
   }
 
   // Unknown or future Knowledge payloads must declare a parent mapping before

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,11 +1,18 @@
 import {
+  type Database,
+  generateId,
   getCurrentTenantId,
+  KnowledgeDocumentRepository,
+  KnowledgeNamespaceRepository,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
+  UsersRepository,
 } from '@agor/core/db';
-import type { Branch, BranchPermissionLevel, Session, User } from '@agor/core/types';
+import type { Branch, BranchPermissionLevel, Session, User, UserID } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS } from './knowledge-realtime-publish';
 import type {
   RealtimeAccessBranchRepository,
   RealtimeAccessSessionRepository,
@@ -394,7 +401,249 @@ describe('HA Feathers publication relay', () => {
       ])
     );
   });
+
+  for (const path of KNOWLEDGE_REALTIME_SUPPRESSED_CREATE_PATHS) {
+    dbTest(
+      `suppresses only created ${path} events at local and Redis boundaries`,
+      async ({ db }) => {
+        const tenantConnection = {
+          user: await seedRealtimeUser(db, `event-${path.replaceAll('/', '-')}`),
+        };
+        let remoteHandler: ((envelope: any) => Promise<void> | void) | undefined;
+        const relay = {
+          relay: vi.fn(),
+          setRelayHandler: vi.fn((handler) => {
+            remoteHandler = handler;
+          }),
+        };
+        const app = makeApp([tenantConnection], {}, { 'tenant:tenant-a': [tenantConnection] });
+        configureRealtimePublish({
+          app,
+          db,
+          branchRbacEnabled: false,
+          branchRepository: {} as never,
+          sessionsRepository: {} as never,
+          multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+          realtimeRelay: relay,
+        });
+        const createdEnvelope = {
+          version: 1 as const,
+          tenantId: 'tenant-a',
+          path,
+          event: 'created',
+          method: 'create',
+          data: { boundary: 'created' },
+        };
+
+        const createdChannel = await app.runPublish(createdEnvelope.data, {
+          path,
+          event: createdEnvelope.event,
+          method: createdEnvelope.method,
+          params: {},
+        });
+        expect(createdChannel.connections).toEqual([]);
+        expect(relay.relay).not.toHaveBeenCalled();
+
+        await remoteHandler?.(createdEnvelope);
+        expect(app.emit).not.toHaveBeenCalled();
+
+        const patchedEnvelope = {
+          version: 1 as const,
+          tenantId: 'tenant-a',
+          path,
+          event: 'patched',
+          method: 'patch',
+          data: { boundary: 'non-created' },
+        };
+
+        const patchedChannel = await app.runPublish(patchedEnvelope.data, {
+          path,
+          event: patchedEnvelope.event,
+          method: patchedEnvelope.method,
+          params: {},
+        });
+        expect(patchedChannel.connections).toEqual([tenantConnection]);
+        expect(relay.relay).toHaveBeenCalledWith(patchedEnvelope);
+
+        await remoteHandler?.(patchedEnvelope);
+        expect(app.emit).toHaveBeenCalledOnce();
+        const receivedChannel = app.emit.mock.calls[0]?.[2] as FakeChannel;
+        expect(receivedChannel.connections).toEqual([tenantConnection]);
+      }
+    );
+  }
+
+  dbTest(
+    're-authorizes Knowledge readers on the receiving replica after revocation',
+    async ({ db }) => {
+      const reader = await seedRealtimeUser(db, 'reader');
+      const owner = await seedRealtimeUser(db, 'owner');
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const namespace = await namespaces.create({
+        slug: 'relay-revocation',
+        display_name: 'Relay revocation',
+        others_can: 'none',
+      });
+      const document = await new KnowledgeDocumentRepository(db).create({
+        namespace_id: namespace.namespace_id,
+        path: 'page.md',
+        title: 'Page',
+        content_text: '# Page',
+        visibility: 'public',
+        created_by: owner.user_id,
+      });
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: reader.user_id,
+        permission: 'read',
+      });
+
+      const readerConnection = { user: reader };
+      const serviceConnection = { user: { _isServiceAccount: true, role: 'service' } };
+      let remoteHandler: ((envelope: any) => Promise<void> | void) | undefined;
+      const relay = {
+        relay: vi.fn(),
+        setRelayHandler: vi.fn((handler) => {
+          remoteHandler = handler;
+        }),
+      };
+      const app = makeApp(
+        [readerConnection, serviceConnection],
+        {},
+        {
+          authenticated: [readerConnection, serviceConnection],
+          'tenant:tenant-a': [readerConnection, serviceConnection],
+        }
+      );
+      const r = repos({ branch: branch('unused'), permissions: {} });
+      configureRealtimePublish({
+        app,
+        db,
+        branchRbacEnabled: false,
+        multiTenancy: {
+          mode: 'required_from_auth',
+          static_tenant_id: 'unused' as never,
+          auth_claim: 'tenant_id',
+        },
+        realtimeRelay: relay,
+        ...r,
+      });
+
+      await namespaces.removeNamespaceAclEntry(namespace.namespace_id, 'user', reader.user_id);
+      await remoteHandler?.({
+        version: 1,
+        tenantId: 'tenant-a',
+        path: 'kb/documents',
+        event: 'patched',
+        method: 'patch',
+        id: document.document_id,
+        data: document,
+      });
+
+      expect(app.emit).toHaveBeenCalledOnce();
+      const channel = app.emit.mock.calls[0]?.[2] as FakeChannel;
+      expect(channel.connections).toEqual([serviceConnection]);
+      expect(channel.connections).not.toContain(readerConnection);
+    }
+  );
+
+  dbTest('reloads current Knowledge principals on the receiving replica', async ({ db }) => {
+    const { document, connections, promotedConnection, serviceConnection } =
+      await seedCurrentKnowledgePrincipals(db, 'relay');
+    let remoteHandler: ((envelope: any) => Promise<void> | void) | undefined;
+    const relay = {
+      relay: vi.fn(),
+      setRelayHandler: vi.fn((handler) => {
+        remoteHandler = handler;
+      }),
+    };
+    const app = makeApp(
+      connections,
+      {},
+      {
+        authenticated: connections,
+        'tenant:tenant-a': connections,
+      }
+    );
+    const r = repos({ branch: branch('unused'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      db,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'unused' as never,
+        auth_claim: 'tenant_id',
+      },
+      realtimeRelay: relay,
+      ...r,
+    });
+
+    await remoteHandler?.({
+      version: 1,
+      tenantId: 'tenant-a',
+      path: 'kb/documents',
+      event: 'patched',
+      method: 'patch',
+      id: document.document_id,
+      data: document,
+    });
+
+    expect(app.emit).toHaveBeenCalledOnce();
+    const channel = app.emit.mock.calls[0]?.[2] as FakeChannel;
+    expect(channel.connections).toEqual([promotedConnection, serviceConnection]);
+  });
 });
+
+async function seedRealtimeUser(
+  db: Database,
+  label: string,
+  role: User['role'] = ROLES.MEMBER
+): Promise<User> {
+  return new UsersRepository(db).create({
+    user_id: generateId() as UserID,
+    email: `${label}-${generateId()}@test.local`,
+    name: label,
+    role,
+  }) as Promise<User>;
+}
+
+async function seedCurrentKnowledgePrincipals(db: Database, label: string) {
+  const owner = await seedRealtimeUser(db, `${label}-owner`);
+  const demoted = await seedRealtimeUser(db, `${label}-demoted`, ROLES.ADMIN);
+  const promoted = await seedRealtimeUser(db, `${label}-promoted`);
+  const removed = await seedRealtimeUser(db, `${label}-removed`, ROLES.ADMIN);
+  const namespace = await new KnowledgeNamespaceRepository(db).create({
+    slug: `${label}-current-principals`,
+    display_name: `${label} current principals`,
+    others_can: 'none',
+  });
+  const document = await new KnowledgeDocumentRepository(db).create({
+    namespace_id: namespace.namespace_id,
+    path: 'page.md',
+    title: 'Page',
+    content_text: '# Page',
+    visibility: 'public',
+    created_by: owner.user_id,
+  });
+  const users = new UsersRepository(db);
+  await users.update(demoted.user_id, { role: ROLES.MEMBER });
+  await users.update(promoted.user_id, { role: ROLES.ADMIN });
+  await users.delete(removed.user_id);
+
+  const promotedConnection = { user: promoted };
+  const serviceConnection = { user: { _isServiceAccount: true, role: 'service' } };
+  const connections = [
+    { user: demoted },
+    promotedConnection,
+    { user: removed },
+    // Tenant RLS-hidden and absent principals both resolve to null locally.
+    { user: user(generateId(), ROLES.ADMIN) },
+    serviceConnection,
+  ];
+  return { document, connections, promotedConnection, serviceConnection };
+}
 
 function repos(options: {
   branch: Branch;
@@ -438,6 +687,134 @@ describe('configureRealtimePublish', () => {
 
     expect(channel.connections).toHaveLength(2);
   });
+
+  dbTest('enforces Knowledge ACLs independently of branch RBAC', async ({ db }) => {
+    const owner = await seedRealtimeUser(db, 'owner');
+    const allowed = await seedRealtimeUser(db, 'allowed');
+    const denied = await seedRealtimeUser(db, 'denied');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'rbac-independent',
+      display_name: 'RBAC independent',
+      others_can: 'none',
+    });
+    const document = await new KnowledgeDocumentRepository(db).create({
+      namespace_id: namespace.namespace_id,
+      path: 'page.md',
+      title: 'Page',
+      content_text: '# Page',
+      visibility: 'public',
+      created_by: owner.user_id,
+    });
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: allowed.user_id,
+      permission: 'read',
+    });
+    const allowedConnection = { user: allowed };
+    const deniedConnection = { user: denied };
+    const serviceConnection = { user: { _isServiceAccount: true, role: 'service' } };
+
+    for (const branchRbacEnabled of [false, true]) {
+      const app = makeApp([allowedConnection, deniedConnection, serviceConnection]);
+      const r = repos({ branch: branch('unused'), permissions: {} });
+      configureRealtimePublish({ app, db, branchRbacEnabled, ...r });
+
+      const channel = await app.runPublish(document, {
+        path: 'kb/documents',
+        method: 'patch',
+        event: 'patched',
+        id: document.document_id,
+        params: {},
+      });
+
+      expect(channel.connections).toEqual([allowedConnection, serviceConnection]);
+    }
+  });
+
+  dbTest('reloads current Knowledge principals without reconnecting', async ({ db }) => {
+    const { document, connections, promotedConnection, serviceConnection } =
+      await seedCurrentKnowledgePrincipals(db, 'local');
+    const app = makeApp(
+      connections,
+      {},
+      {
+        authenticated: connections,
+        'tenant:tenant-a': connections,
+      }
+    );
+    const r = repos({ branch: branch('unused'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      db,
+      branchRbacEnabled: false,
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+      ...r,
+    });
+
+    const channel = await app.runPublish(document, {
+      path: 'kb/documents',
+      method: 'patch',
+      event: 'patched',
+      id: document.document_id,
+      params: {},
+    });
+
+    expect(channel.connections).toEqual([promotedConnection, serviceConnection]);
+  });
+
+  dbTest(
+    'contains Knowledge events to the resolved tenant before applying document ACLs',
+    async ({ db }) => {
+      const owner = await seedRealtimeUser(db, 'owner');
+      const tenantAUser = await seedRealtimeUser(db, 'tenant-a-user');
+      const tenantBUser = await seedRealtimeUser(db, 'tenant-b-user');
+      const namespace = await new KnowledgeNamespaceRepository(db).create({
+        slug: 'tenant-contained',
+        display_name: 'Tenant contained',
+        others_can: 'read',
+      });
+      const document = await new KnowledgeDocumentRepository(db).create({
+        namespace_id: namespace.namespace_id,
+        path: 'page.md',
+        title: 'Page',
+        content_text: '# Page',
+        visibility: 'public',
+        created_by: owner.user_id,
+      });
+      const tenantAConnection = { user: tenantAUser };
+      const tenantBConnection = { user: tenantBUser };
+      const app = makeApp(
+        [tenantAConnection, tenantBConnection],
+        {},
+        {
+          authenticated: [tenantAConnection, tenantBConnection],
+          'tenant:tenant-a': [tenantAConnection],
+          'tenant:tenant-b': [tenantBConnection],
+        }
+      );
+      const r = repos({ branch: branch('unused'), permissions: {} });
+      configureRealtimePublish({
+        app,
+        db,
+        branchRbacEnabled: false,
+        multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+        ...r,
+      });
+
+      const channel = await app.runPublish(document, {
+        path: 'kb/documents',
+        method: 'patch',
+        event: 'patched',
+        id: document.document_id,
+        params: {},
+      });
+
+      expect(channel.connections).toEqual([tenantAConnection]);
+      expect(channel.connections).not.toContain(tenantBConnection);
+    }
+  );
 
   it('scopes broadcasts to the resolved tenant channel in static multi-tenancy mode', async () => {
     const tenantUser = user('tenant-user');

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -409,6 +409,8 @@ describe('HA Feathers publication relay', () => {
         const tenantConnection = {
           user: await seedRealtimeUser(db, `event-${path.replaceAll('/', '-')}`),
         };
+        const serviceConnection = { user: { _isServiceAccount: true, role: 'service' } };
+        const connections = [tenantConnection, serviceConnection];
         let remoteHandler: ((envelope: any) => Promise<void> | void) | undefined;
         const relay = {
           relay: vi.fn(),
@@ -416,7 +418,7 @@ describe('HA Feathers publication relay', () => {
             remoteHandler = handler;
           }),
         };
-        const app = makeApp([tenantConnection], {}, { 'tenant:tenant-a': [tenantConnection] });
+        const app = makeApp(connections, {}, { 'tenant:tenant-a': connections });
         configureRealtimePublish({
           app,
           db,
@@ -462,13 +464,13 @@ describe('HA Feathers publication relay', () => {
           method: patchedEnvelope.method,
           params: {},
         });
-        expect(patchedChannel.connections).toEqual([tenantConnection]);
+        expect(patchedChannel.connections).toEqual(connections);
         expect(relay.relay).toHaveBeenCalledWith(patchedEnvelope);
 
         await remoteHandler?.(patchedEnvelope);
         expect(app.emit).toHaveBeenCalledOnce();
         const receivedChannel = app.emit.mock.calls[0]?.[2] as FakeChannel;
-        expect(receivedChannel.connections).toEqual([tenantConnection]);
+        expect(receivedChannel.connections).toEqual(connections);
       }
     );
   }

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -15,6 +15,10 @@ import {
 import { tenantChannelName } from '../realtime/routing.js';
 import { isSuperAdmin } from './branch-authorization.js';
 import {
+  isKnowledgeRealtimeSuppressedEvent,
+  resolveKnowledgeRealtimeUserIds,
+} from './knowledge-realtime-publish.js';
+import {
   type RealtimeAccessBranchRepository,
   RealtimeAccessCache,
   type RealtimeAccessSessionRepository,
@@ -212,6 +216,7 @@ export const REDIS_FEATHERS_DENIED_PATHS = new Set([
 
 function mayEnterRedisRelay(path: string, event: string): boolean {
   if (REDIS_FEATHERS_DENIED_PATHS.has(path)) return false;
+  if (isKnowledgeRealtimeSuppressedEvent(path, event)) return false;
   // Runtime DOM/status results can contain secret-derived values. CRUD events
   // for Artifact metadata remain ordinary tenant-authorized service payloads.
   if (path === 'artifacts' && event === 'agor-query') return false;
@@ -481,6 +486,27 @@ function filterToServiceConnections(authenticated: PublishChannel): PublishChann
   return authenticated.filter((connection: unknown) => isServiceConnection(connection));
 }
 
+function uniqueUserIds(authenticated: PublishChannel): string[] {
+  const userIds = new Set<string>();
+  for (const connection of authenticated.connections as unknown[]) {
+    if (isServiceConnection(connection)) continue;
+    const userId = userFromConnection(connection)?.user_id;
+    if (typeof userId === 'string') userIds.add(userId);
+  }
+  return [...userIds];
+}
+
+function filterToUserIdsOrServices(
+  authenticated: PublishChannel,
+  userIds: Set<string>
+): PublishChannel {
+  return authenticated.filter((connection: unknown) => {
+    if (isServiceConnection(connection)) return true;
+    const userId = userFromConnection(connection)?.user_id;
+    return typeof userId === 'string' && userIds.has(userId);
+  });
+}
+
 /**
  * Delivery set for a streaming event. Streaming chunks are the dominant
  * always-on realtime cost, so they bypass the tenant-wide broadcast and go to:
@@ -714,6 +740,18 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
           allowSuperadmin
         );
       }
+
+      const knowledgeUserIds = await resolveKnowledgeRealtimeUserIds({
+        app,
+        db,
+        data,
+        context,
+        userIds: uniqueUserIds(tenantScoped),
+      });
+      if (knowledgeUserIds) {
+        return filterToUserIdsOrServices(tenantScoped, knowledgeUserIds);
+      }
+
       if (!branchRbacEnabled) return tenantScoped;
 
       const scope = await resolvePublishScope(data, context, accessCache);

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -700,6 +700,10 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
 
   const resolveLocalDelivery = async (data: unknown, context: HookContext) => {
     const authenticated = app.channel('authenticated');
+    if (context.path && isKnowledgeRealtimeSuppressedEvent(context.path, context.event)) {
+      return { delivery: authenticated.filter(() => false), tenantId: undefined };
+    }
+
     let tenantScoped = authenticated;
     let tenantId: string | undefined;
     if (multiTenancy) {


### PR DESCRIPTION
## Linked issue

Fixes #2110

## Summary

- authorize Knowledge realtime events against current namespace, document, and graph visibility
- reload tenant-scoped principals per event so role and ACL changes apply without reconnecting
- suppress only automatic `created` events for command-style Knowledge endpoints while preserving nested document updates

## Why / context

Knowledge service methods already enforce namespace ACLs, but realtime publication fell through to tenant-wide delivery. That allowed authenticated users without namespace access to receive private Knowledge payloads over the socket even when direct reads correctly failed.

## Implementation notes

- Applies Knowledge authorization before the branch-RBAC decision for both local delivery and Redis relay receivers.
- Preserves trusted service connections while failing closed for missing principals, unresolved parents, and unknown Knowledge paths.
- Reuses shared Knowledge access checks for namespace ACLs, private-document visibility, and graph endpoint intersection.
- Keeps command responses unchanged for `kb/search`, `kb/document-edits`, and `kb/indexing/reindex`; legitimate non-`created` events remain publishable.

## Validation / test plan

- [x] Focused Knowledge resolver, hook, local publisher, Redis relay, and service tests: 112/112
- [x] Daemon typecheck
- [x] Biome on changed files
- [x] `pnpm check:multitenancy-boundaries`
- [x] `pnpm check:realtime-boundaries`
- [x] `git diff --check`

## Risks / rollout / rollback

Per-event principal and ACL reloads add database queries in exchange for immediate revocation semantics. Redis coverage exercises deterministic sender/receiver boundaries rather than a background multi-process deployment. No schema or migration changes are required.

Rollback is a commit revert; no data rollback is needed.

## Out of scope / follow-ups

Live PostgreSQL/RLS and background multi-process Redis runs were outside this change's accepted proof boundary.
