### PR TITLE
fix(executor): validate session Unix identity before claim

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -157,6 +157,7 @@ import {
 } from './utils/session-task-state.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
+import { launchPendingTask } from './utils/session-unix-identity.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';
 import {
@@ -1209,211 +1210,214 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       config.execution?.executor_command_template ? 'templated' : 'local'
     );
 
-    if (!isTaskPendingDispatch(task)) return task;
-
     // Atomically claim queued/created → launch status. Process-local session
     // locks reduce contention, but this expected-state transition is the
     // cross-daemon fence that prevents duplicate executor launches.
-    const dispatchClaim = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
-      await assertTenantWritable(tenantDb, tenantId);
-      return tasksService.claimDispatchAndProjectSession(
-        task.task_id,
-        task.status,
-        {
-          ...launchState,
-          ...(launchState.executor_mode
-            ? { sdk_watchdog_mode: resolveSdkWatchdogConfig(config.execution).mode }
-            : {}),
-          queue_position: undefined,
-          message_range: {
-            start_index: messageStartIndex,
-            end_index: messageStartIndex + 1,
-            start_timestamp: startTimestamp,
-            end_timestamp: startTimestamp,
-          },
-          git_state: {
-            ref_at_start: refAtStart,
-            sha_at_start: gitStateAtStart,
-          },
-        },
-        { ...params, provider: undefined }
-      );
-    });
-    if (dispatchClaim.outcome !== 'claimed') {
-      const workIdentity = app.get('distributedWorkIdentity');
-      console.info(
-        formatStructuredLog('[distributed-work.task-dispatch]', {
-          event: 'claim_lost',
-          instance_id: workIdentity?.instanceId,
-          boot_id: workIdentity?.bootId,
-          tenant_id: tenantId,
-          task_id: task.task_id,
-          session_id: task.session_id,
-          observed_status: dispatchClaim.task.status,
-        })
-      );
-      if (shouldReconcileStableInitialMessage(dispatchClaim.task, stableInitialMessageId)) {
-        await reconcileStableInitialUserMessage(
-          dispatchClaim.task,
-          params,
-          stableInitialMessageId,
+    return launchPendingTask({
+      db,
+      tenantId,
+      execution: config.execution,
+      task,
+      session,
+      claimDispatch: (pendingTask) =>
+        tasksService.claimDispatchAndProjectSession(
+          pendingTask.task_id,
+          pendingTask.status,
           {
+            ...launchState,
+            ...(launchState.executor_mode
+              ? { sdk_watchdog_mode: resolveSdkWatchdogConfig(config.execution).mode }
+              : {}),
+            queue_position: undefined,
+            message_range: {
+              start_index: messageStartIndex,
+              end_index: messageStartIndex + 1,
+              start_timestamp: startTimestamp,
+              end_timestamp: startTimestamp,
+            },
+            git_state: {
+              ref_at_start: refAtStart,
+              sha_at_start: gitStateAtStart,
+            },
+          },
+          { ...params, provider: undefined }
+        ),
+      onClaimNotWon: async (dispatchClaim) => {
+        const workIdentity = app.get('distributedWorkIdentity');
+        console.info(
+          formatStructuredLog('[distributed-work.task-dispatch]', {
+            event: 'claim_lost',
+            instance_id: workIdentity?.instanceId,
+            boot_id: workIdentity?.bootId,
+            tenant_id: tenantId,
+            task_id: task.task_id,
+            session_id: task.session_id,
+            observed_status: dispatchClaim.task.status,
+          })
+        );
+        if (shouldReconcileStableInitialMessage(dispatchClaim.task, stableInitialMessageId)) {
+          await reconcileStableInitialUserMessage(
+            dispatchClaim.task,
+            params,
+            stableInitialMessageId,
+            {
+              messageStartIndex,
+              startTimestamp,
+              messageSource: runtimeMessageSource,
+            }
+          );
+        }
+        return dispatchClaim.task;
+      },
+      onClaimed: async (updatedTask) => {
+        // Alt D — write the user-message row before spawning. Gated by kill switch.
+        // The executor's createUserMessage has a skip-if-exists guard so a duplicate
+        // write is harmless if the daemon path is enabled.
+        // Prefer task.metadata.source (set when the task was queued) over the
+        // request's messageSource — the latter applies only to this drain tick.
+        if (stableInitialMessageId) {
+          await reconcileStableInitialUserMessage(updatedTask, params, stableInitialMessageId, {
             messageStartIndex,
             startTimestamp,
             messageSource: runtimeMessageSource,
-          }
-        );
-      }
-      return dispatchClaim.task;
-    }
-    const updatedTask = dispatchClaim.task;
-
-    // Alt D — write the user-message row before spawning. Gated by kill switch.
-    // The executor's createUserMessage has a skip-if-exists guard so a duplicate
-    // write is harmless if the daemon path is enabled.
-    // Prefer task.metadata.source (set when the task was queued) over the
-    // request's messageSource — the latter applies only to this drain tick.
-    if (stableInitialMessageId) {
-      await reconcileStableInitialUserMessage(updatedTask, params, stableInitialMessageId, {
-        messageStartIndex,
-        startTimestamp,
-        messageSource: runtimeMessageSource,
-      });
-    } else {
-      await ensureInitialUserMessage(task, params, {
-        messageStartIndex,
-        startTimestamp,
-        messageSource: runtimeMessageSource,
-      });
-    }
-
-    // Re-apply the Session projection through Feathers so hooks/realtime see
-    // the transition. TaskRepository.claimDispatchAndProjectSession already
-    // committed the same projection atomically with the Task fence; this
-    // service patch is no longer correctness-critical on SQLite and is
-    // intentionally idempotent.
-    //
-    // The session-status flip used to fall out of `TasksService.create` when
-    // the IDLE path created a task with `status: RUNNING` directly. Now the
-    // IDLE path creates `status: CREATED` and we patch the task here, which
-    // `TasksService.patch` does NOT mirror onto the session. Without this
-    // explicit patch, `session.status` stays IDLE while a task is RUNNING,
-    // causing the queue gate in the prompt route to wave subsequent prompts
-    // through instead of queuing them.
-    await app.service('sessions').patch(
-      task.session_id,
-      {
-        status: SessionStatus.RUNNING,
-        ready_for_prompt: false,
-        tasks: [...session.tasks, task.task_id],
-      },
-      params
-    );
-
-    // Tag the bytes shipped to the executor with `[Prompted by: ...]` when a
-    // non-owner is prompting. The prompter identity comes from `task.created_by`
-    // (NOT `params.user`): every persisted Task row requires `created_by`
-    // (`createPending` for the prompt/queue/callback paths, `create`/`createMany`
-    // for pre-created tasks run via `/tasks/:id/run`), so it survives the queue
-    // / hook / drain hop intact. `params.user` can drop on hook-triggered drains
-    // that don't carry `queued_by_user_id` and is therefore not authoritative.
-    // See `./utils/build-prompter-prefix.ts` for the helper + tests.
-    const { prompt: promptForExecutor } = await buildPrompterPrefixedPrompt({
-      rawPrompt: task.full_prompt,
-      sessionCreatedBy: session.created_by,
-      prompterUserId: task.created_by,
-      usersRepo: bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db)),
-    });
-
-    const useStreaming = options.stream !== false;
-    const sessionId = task.session_id;
-    const taskId = task.task_id;
-
-    // Background spawn + failure handling. Returning the patched Task to the
-    // caller before this resolves matches the previous behavior — the HTTP
-    // response should not block on the executor process being live.
-    // deferInFreshTenantScope uses a fresh DB connection and tenant RLS scope
-    // instead of inheriting a stale committed transaction.
-    deferInFreshTenantScope(params, async () => {
-      try {
-        console.log(
-          `🚀 [Daemon] Routing ${session.agentic_tool} to Feathers/WebSocket executor (task ${shortId(taskId)})`
-        );
-
-        await sessionsService.executeTask(
-          sessionId,
-          {
-            taskId,
-            prompt: promptForExecutor,
-            permissionMode: options.permissionMode,
-            stream: useStreaming,
+          });
+        } else {
+          await ensureInitialUserMessage(task, params, {
+            messageStartIndex,
+            startTimestamp,
             messageSource: runtimeMessageSource,
-          },
-          params
-        );
+          });
+        }
 
-        console.log(
-          `✅ [Daemon] Executor spawned for session ${shortId(sessionId)}, waiting for task completion`
-        );
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(
-          `❌ [Daemon] Executor spawn failed for session=${shortId(sessionId)} task=${shortId(taskId)} agent=${session.agentic_tool} unix_username=${session.unix_username ?? 'null'}: ${errorMessage}`,
-          error
-        );
-        await safePatch(
-          'tasks',
-          taskId,
+        // Re-apply the Session projection through Feathers so hooks/realtime see
+        // the transition. TaskRepository.claimDispatchAndProjectSession already
+        // committed the same projection atomically with the Task fence; this
+        // service patch is no longer correctness-critical on SQLite and is
+        // intentionally idempotent.
+        //
+        // The session-status flip used to fall out of `TasksService.create` when
+        // the IDLE path created a task with `status: RUNNING` directly. Now the
+        // IDLE path creates `status: CREATED` and we patch the task here, which
+        // `TasksService.patch` does NOT mirror onto the session. Without this
+        // explicit patch, `session.status` stays IDLE while a task is RUNNING,
+        // causing the queue gate in the prompt route to wave subsequent prompts
+        // through instead of queuing them.
+        await app.service('sessions').patch(
+          task.session_id,
           {
-            status: TaskStatus.FAILED,
-            completed_at: new Date().toISOString(),
-            error_message: errorMessage,
+            status: SessionStatus.RUNNING,
+            ready_for_prompt: false,
+            tasks: [...session.tasks, task.task_id],
           },
-          'Task',
           params
         );
 
-        // Synthesize a system message so the chat surfaces *why* the agent
-        // didn't respond. Without this the transcript shows only the user
-        // prompt and silence even though the task list reads FAILED.
-        try {
-          // Recompute the next index instead of trusting `messageStartIndex
-          // + 1` — the daemon-write user-message above is wrapped in a
-          // try/catch and may have been swallowed, leaving a gap at
-          // `messageStartIndex`. countMessages always reports the live row
-          // count, so it lands the system error at the true tail whether
-          // the user-message row exists or not (no gap, no collision).
-          const errorContent = `⚠️ The agent failed to start.\n\n${errorMessage}`;
-          await appendSystemMessage({
-            app,
-            db,
-            sessionId,
-            taskId,
-            content: errorContent,
-            role: MessageRole.ASSISTANT,
-            metadata: { is_meta: true },
-            params,
-          });
-        } catch (sysErr) {
-          console.warn(
-            '[Daemon] Failed to write system error message after spawn failure:',
-            sysErr
-          );
-        }
+        // Tag the bytes shipped to the executor with `[Prompted by: ...]` when a
+        // non-owner is prompting. The prompter identity comes from `task.created_by`
+        // (NOT `params.user`): every persisted Task row requires `created_by`
+        // (`createPending` for the prompt/queue/callback paths, `create`/`createMany`
+        // for pre-created tasks run via `/tasks/:id/run`), so it survives the queue
+        // / hook / drain hop intact. `params.user` can drop on hook-triggered drains
+        // that don't carry `queued_by_user_id` and is therefore not authoritative.
+        // See `./utils/build-prompter-prefix.ts` for the helper + tests.
+        const { prompt: promptForExecutor } = await buildPrompterPrefixedPrompt({
+          rawPrompt: task.full_prompt,
+          sessionCreatedBy: session.created_by,
+          prompterUserId: task.created_by,
+          usersRepo: bindRepositoryToTenantUnitOfWork(db, new UsersRepository(db)),
+        });
 
-        try {
-          app.service('tasks').emit('failed', {
-            task_id: taskId,
-            session_id: sessionId,
-            error_message: errorMessage,
-          });
-        } catch (emitErr) {
-          console.warn('[Daemon] Failed to emit tasks:failed event:', emitErr);
-        }
-      }
+        const useStreaming = options.stream !== false;
+        const sessionId = task.session_id;
+        const taskId = task.task_id;
+
+        // Background spawn + failure handling. Returning the patched Task to the
+        // caller before this resolves matches the previous behavior — the HTTP
+        // response should not block on the executor process being live.
+        // deferInFreshTenantScope uses a fresh DB connection and tenant RLS scope
+        // instead of inheriting a stale committed transaction.
+        deferInFreshTenantScope(params, async () => {
+          try {
+            console.log(
+              `🚀 [Daemon] Routing ${session.agentic_tool} to Feathers/WebSocket executor (task ${shortId(taskId)})`
+            );
+
+            await sessionsService.executeTask(
+              sessionId,
+              {
+                taskId,
+                prompt: promptForExecutor,
+                permissionMode: options.permissionMode,
+                stream: useStreaming,
+                messageSource: runtimeMessageSource,
+              },
+              params
+            );
+
+            console.log(
+              `✅ [Daemon] Executor spawned for session ${shortId(sessionId)}, waiting for task completion`
+            );
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(
+              `❌ [Daemon] Executor spawn failed for session=${shortId(sessionId)} task=${shortId(taskId)} agent=${session.agentic_tool} unix_username=${session.unix_username ?? 'null'}: ${errorMessage}`,
+              error
+            );
+            await safePatch(
+              'tasks',
+              taskId,
+              {
+                status: TaskStatus.FAILED,
+                completed_at: new Date().toISOString(),
+                error_message: errorMessage,
+              },
+              'Task',
+              params
+            );
+
+            // Synthesize a system message so the chat surfaces *why* the agent
+            // didn't respond. Without this the transcript shows only the user
+            // prompt and silence even though the task list reads FAILED.
+            try {
+              // Recompute the next index instead of trusting `messageStartIndex
+              // + 1` — the daemon-write user-message above is wrapped in a
+              // try/catch and may have been swallowed, leaving a gap at
+              // `messageStartIndex`. countMessages always reports the live row
+              // count, so it lands the system error at the true tail whether
+              // the user-message row exists or not (no gap, no collision).
+              const errorContent = `⚠️ The agent failed to start.\n\n${errorMessage}`;
+              await appendSystemMessage({
+                app,
+                db,
+                sessionId,
+                taskId,
+                content: errorContent,
+                role: MessageRole.ASSISTANT,
+                metadata: { is_meta: true },
+                params,
+              });
+            } catch (sysErr) {
+              console.warn(
+                '[Daemon] Failed to write system error message after spawn failure:',
+                sysErr
+              );
+            }
+
+            try {
+              app.service('tasks').emit('failed', {
+                task_id: taskId,
+                session_id: sessionId,
+                error_message: errorMessage,
+              });
+            } catch (emitErr) {
+              console.warn('[Daemon] Failed to emit tasks:failed event:', emitErr);
+            }
+          }
+        });
+
+        return updatedTask;
+      },
     });
-
-    return updatedTask;
   }
 
   // ============================================================================

--- a/apps/agor-daemon/src/register-routes.unix-identity.postgres.test.ts
+++ b/apps/agor-daemon/src/register-routes.unix-identity.postgres.test.ts
@@ -1,0 +1,185 @@
+import {
+  BranchRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  generateId,
+  initializeDatabase,
+  isPostgresDatabase,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+  type TaskDispatchClaimResult,
+  TaskRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Task, TaskPendingDispatchStatus, TenantID, UUID } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { launchPendingTask } from './utils/session-unix-identity.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+let branchUniqueId = 100_000;
+
+const tenantHiddenMatrix = (['delegated', 'strict'] as const).flatMap((mode) =>
+  [false, true].flatMap((branchRbac) =>
+    ([TaskStatus.CREATED, TaskStatus.QUEUED] as const).map((status) => ({
+      mode,
+      branchRbac,
+      status,
+    }))
+  )
+);
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'production pre-claim Unix identity tenant isolation (PostgreSQL RLS)',
+  () => {
+    let rawDb: Database;
+    let db: ReturnType<typeof createTenantScopedDatabaseProxy>;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      db = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'Unix identity launch RLS test database',
+      });
+    });
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it.each(tenantHiddenMatrix)(
+      '$mode with branch_rbac=$branchRbac rejects a creator visible only to another tenant and leaves $status pending',
+      async ({ mode, branchRbac, status }) => {
+        const activeTenantId = `unix-launch-active-${generateId()}` as TenantID;
+        const outsideTenantId = `unix-launch-outside-${generateId()}` as TenantID;
+        const creatorId = generateId() as UUID;
+        const suffix = creatorId.slice(-12);
+        const stampedUsername = `alice-${suffix}`;
+
+        await runWithTenantDatabaseScope(db, outsideTenantId, (tenantDb) =>
+          new UsersRepository(tenantDb).create({
+            user_id: creatorId,
+            email: `${suffix}@outside.example`,
+            unix_username: stampedUsername,
+          })
+        );
+        await expect(
+          runWithTenantDatabaseScope(db, outsideTenantId, (tenantDb) =>
+            new UsersRepository(tenantDb).findById(creatorId)
+          )
+        ).resolves.toMatchObject({
+          user_id: creatorId,
+          unix_username: stampedUsername,
+        });
+        await expect(
+          runWithTenantDatabaseScope(db, activeTenantId, (tenantDb) =>
+            new UsersRepository(tenantDb).findById(creatorId)
+          )
+        ).resolves.toBeNull();
+
+        const { session, task } = await runWithTenantDatabaseScope(
+          db,
+          activeTenantId,
+          async (tenantDb) => {
+            const repo = await new RepoRepository(tenantDb).create({
+              repo_id: generateId(),
+              slug: `unix-launch-${generateId()}`,
+              name: 'Unix launch RLS test',
+              repo_type: 'remote',
+              remote_url: 'https://example.invalid/unix-launch.git',
+              local_path: `/tmp/${generateId()}`,
+              default_branch: 'main',
+            });
+            const branch = await new BranchRepository(tenantDb).create({
+              branch_id: generateId(),
+              repo_id: repo.repo_id,
+              name: `unix-launch-${suffix}`,
+              ref: 'main',
+              branch_unique_id: branchUniqueId++,
+              path: `/tmp/${generateId()}`,
+              created_by: creatorId,
+            });
+            const session = await new SessionRepository(tenantDb).create({
+              session_id: generateId(),
+              branch_id: branch.branch_id,
+              created_by: creatorId,
+              agentic_tool: 'codex',
+              unix_username: stampedUsername,
+            });
+            const task = await new TaskRepository(tenantDb).createPending({
+              session_id: session.session_id,
+              created_by: creatorId,
+              full_prompt: 'prove RLS-hidden creator rejection',
+              status,
+            });
+            return { session, task };
+          }
+        );
+
+        const events: string[] = [];
+        const originalFindById = UsersRepository.prototype.findById;
+        const creatorLookup = vi
+          .spyOn(UsersRepository.prototype, 'findById')
+          .mockImplementation(async function (id: string) {
+            events.push('lookup');
+            return originalFindById.call(this, id);
+          });
+        const claimDispatch = vi.fn(
+          async (pendingTask: Task & { status: TaskPendingDispatchStatus }) => {
+            events.push('claim');
+            return new TaskRepository(db).claimDispatchAndProjectSession(
+              pendingTask.task_id,
+              pendingTask.status,
+              { status: TaskStatus.DISPATCHING }
+            );
+          }
+        );
+        const deferExecutorSpawn = vi.fn(() => events.push('defer'));
+        const continueClaimedLaunch = vi.fn(async (claimedTask: Task) => {
+          deferExecutorSpawn();
+          return claimedTask;
+        });
+        const onClaimNotWon = vi.fn(async (claim: TaskDispatchClaimResult) => claim.task);
+
+        let error: unknown;
+        let creatorLookupCalls: string[][] = [];
+        try {
+          await launchPendingTask({
+            db,
+            tenantId: activeTenantId,
+            execution: { unix_user_mode: mode, branch_rbac: branchRbac },
+            task,
+            session,
+            claimDispatch,
+            onClaimed: continueClaimedLaunch,
+            onClaimNotWon,
+          });
+        } catch (cause) {
+          error = cause;
+        } finally {
+          creatorLookupCalls = creatorLookup.mock.calls.map(([id]) => [id]);
+          creatorLookup.mockRestore();
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/Session creator not found/);
+        expect(events).toEqual(['lookup']);
+        expect(creatorLookupCalls).toEqual([[creatorId]]);
+        expect(claimDispatch).not.toHaveBeenCalled();
+        expect(continueClaimedLaunch).not.toHaveBeenCalled();
+        expect(deferExecutorSpawn).not.toHaveBeenCalled();
+        expect(onClaimNotWon).not.toHaveBeenCalled();
+        await expect(
+          runWithTenantDatabaseScope(db, activeTenantId, (tenantDb) =>
+            new TaskRepository(tenantDb).findById(task.task_id)
+          )
+        ).resolves.toMatchObject({ status });
+      }
+    );
+  }
+);

--- a/apps/agor-daemon/src/register-routes.unix-identity.test.ts
+++ b/apps/agor-daemon/src/register-routes.unix-identity.test.ts
@@ -1,0 +1,334 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { UnixUserMode } from '@agor/core/config';
+import {
+  BranchRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  generateId,
+  initializeDatabase,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+  type TaskDispatchClaimResult,
+  TaskRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Session, Task, TaskPendingDispatchStatus, TenantID, UUID } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { launchPendingTask } from './utils/session-unix-identity.js';
+
+const readSource = (relativePath: string): string =>
+  readFileSync(join(__dirname, relativePath), 'utf8');
+
+const activeTenantId = 'tenant-active' as TenantID;
+let branchUniqueId = 1;
+let activeDb: ReturnType<typeof createTenantScopedDatabaseProxy>;
+const databaseDirectories: string[] = [];
+
+async function createTestDatabase(label: string) {
+  const directory = mkdtempSync(join(tmpdir(), `agor-${label}-`));
+  databaseDirectories.push(directory);
+  const rawDb = createDatabase({ url: `file:${join(directory, 'test.db')}` });
+  await initializeDatabase(rawDb);
+  return rawDb;
+}
+
+beforeAll(async () => {
+  activeDb = createTenantScopedDatabaseProxy(await createTestDatabase('launch-active-tenant'));
+});
+
+afterAll(() => {
+  for (const directory of databaseDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+type CreatorState = 'matching' | 'mismatched' | 'missing';
+
+async function createPendingLaunch(input: {
+  creatorState: CreatorState;
+  status: TaskPendingDispatchStatus;
+}): Promise<{ session: Session; task: Task }> {
+  const creatorId = generateId() as UUID;
+  const suffix = creatorId.slice(-12);
+  const stampedUsername = `alice-${suffix}`;
+  if (input.creatorState === 'matching' || input.creatorState === 'mismatched') {
+    await runWithTenantDatabaseScope(activeDb, activeTenantId, (tenantDb) =>
+      new UsersRepository(tenantDb).create({
+        user_id: creatorId,
+        email: `${suffix}@active.example`,
+        unix_username: input.creatorState === 'matching' ? stampedUsername : `bob-${suffix}`,
+      })
+    );
+  }
+
+  return runWithTenantDatabaseScope(activeDb, activeTenantId, async (tenantDb) => {
+    const repo = await new RepoRepository(tenantDb).create({
+      repo_id: generateId(),
+      slug: `unix-launch-${generateId()}`,
+      name: 'Unix launch test',
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/unix-launch.git',
+      local_path: `/tmp/${generateId()}`,
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(tenantDb).create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `unix-launch-${suffix}`,
+      ref: 'main',
+      branch_unique_id: branchUniqueId++,
+      path: `/tmp/${generateId()}`,
+      created_by: creatorId,
+    });
+    const session = await new SessionRepository(tenantDb).create({
+      session_id: generateId(),
+      branch_id: branch.branch_id,
+      created_by: creatorId,
+      agentic_tool: 'codex',
+      unix_username: stampedUsername,
+    });
+    const task = await new TaskRepository(tenantDb).createPending({
+      session_id: session.session_id,
+      created_by: creatorId,
+      full_prompt: 'prove the pre-claim launch boundary',
+      status: input.status,
+    });
+    return { session, task };
+  });
+}
+
+async function exerciseProductionLaunchSeam(input: {
+  mode: UnixUserMode;
+  branchRbac: boolean;
+  creatorState: CreatorState;
+  status: TaskPendingDispatchStatus;
+}) {
+  const { session, task } = await createPendingLaunch(input);
+  const events: string[] = [];
+  const originalFindById = UsersRepository.prototype.findById;
+  const creatorLookup = vi
+    .spyOn(UsersRepository.prototype, 'findById')
+    .mockImplementation(async function (id: string) {
+      events.push('lookup');
+      return originalFindById.call(this, id);
+    });
+  const claimDispatch = vi.fn(async (pendingTask: Task & { status: TaskPendingDispatchStatus }) => {
+    events.push('claim');
+    return new TaskRepository(activeDb).claimDispatchAndProjectSession(
+      pendingTask.task_id,
+      pendingTask.status,
+      { status: TaskStatus.DISPATCHING }
+    );
+  });
+  const deferExecutorSpawn = vi.fn(() => events.push('defer'));
+  const continueClaimedLaunch = vi.fn(async (claimedTask: Task) => {
+    deferExecutorSpawn();
+    return claimedTask;
+  });
+  const onClaimNotWon = vi.fn(async (claim: TaskDispatchClaimResult) => claim.task);
+
+  let result: Task | undefined;
+  let error: unknown;
+  let creatorLookupCalls: string[][] = [];
+  try {
+    result = await launchPendingTask({
+      db: activeDb,
+      tenantId: activeTenantId,
+      execution: {
+        unix_user_mode: input.mode,
+        branch_rbac: input.branchRbac,
+      },
+      task,
+      session,
+      claimDispatch,
+      onClaimed: continueClaimedLaunch,
+      onClaimNotWon,
+    });
+  } catch (cause) {
+    error = cause;
+  } finally {
+    creatorLookupCalls = creatorLookup.mock.calls.map(([id]) => [id]);
+    creatorLookup.mockRestore();
+  }
+
+  return {
+    task,
+    result,
+    error,
+    events,
+    creatorLookupCalls,
+    claimDispatch,
+    continueClaimedLaunch,
+    deferExecutorSpawn,
+    onClaimNotWon,
+    persisted: await runWithTenantDatabaseScope(activeDb, activeTenantId, (tenantDb) =>
+      new TaskRepository(tenantDb).findById(task.task_id)
+    ),
+  };
+}
+
+const guardedMatrix = (['delegated', 'strict'] as const).flatMap((mode) =>
+  [false, true].map((branchRbac) => ({ mode, branchRbac }))
+);
+const unguardedMatrix = (['simple', 'insulated'] as const).flatMap((mode) =>
+  [false, true].flatMap((branchRbac) =>
+    ([TaskStatus.CREATED, TaskStatus.QUEUED] as const).map((status) => ({
+      mode,
+      branchRbac,
+      status,
+    }))
+  )
+);
+const rejectedMatrix = guardedMatrix.flatMap(({ mode, branchRbac }) =>
+  (['mismatched', 'missing'] as const).flatMap((creatorState) =>
+    ([TaskStatus.CREATED, TaskStatus.QUEUED] as const).map((status) => ({
+      mode,
+      branchRbac,
+      creatorState,
+      status,
+    }))
+  )
+);
+
+describe('production pre-claim Unix identity orchestration', () => {
+  it.each(guardedMatrix)(
+    '$mode with branch_rbac=$branchRbac looks up a matching creator before claim and remains launch-eligible',
+    async ({ mode, branchRbac }) => {
+      const observed = await exerciseProductionLaunchSeam({
+        mode,
+        branchRbac,
+        creatorState: 'matching',
+        status: TaskStatus.QUEUED,
+      });
+
+      expect(observed.error).toBeUndefined();
+      expect(observed.events).toEqual(['lookup', 'claim', 'defer']);
+      expect(observed.creatorLookupCalls).toEqual([[observed.task.created_by]]);
+      expect(observed.claimDispatch).toHaveBeenCalledOnce();
+      expect(observed.continueClaimedLaunch).toHaveBeenCalledOnce();
+      expect(observed.deferExecutorSpawn).toHaveBeenCalledOnce();
+      expect(observed.onClaimNotWon).not.toHaveBeenCalled();
+      expect(observed.result?.status).toBe(TaskStatus.DISPATCHING);
+      expect(observed.persisted?.status).toBe(TaskStatus.DISPATCHING);
+    }
+  );
+
+  it.each(rejectedMatrix)(
+    '$mode with branch_rbac=$branchRbac rejects $creatorState creator before claim/spawn and leaves $status pending',
+    async ({ mode, branchRbac, creatorState, status }) => {
+      const observed = await exerciseProductionLaunchSeam({
+        mode,
+        branchRbac,
+        creatorState,
+        status,
+      });
+
+      expect(observed.error).toBeInstanceOf(Error);
+      expect((observed.error as Error).message).toMatch(
+        creatorState === 'mismatched'
+          ? /Session security context has changed/
+          : /Session creator not found/
+      );
+      expect(observed.events).toEqual(['lookup']);
+      expect(observed.creatorLookupCalls).toEqual([[observed.task.created_by]]);
+      expect(observed.claimDispatch).not.toHaveBeenCalled();
+      expect(observed.continueClaimedLaunch).not.toHaveBeenCalled();
+      expect(observed.deferExecutorSpawn).not.toHaveBeenCalled();
+      expect(observed.onClaimNotWon).not.toHaveBeenCalled();
+      expect(observed.persisted?.status).toBe(status);
+    }
+  );
+
+  it.each(unguardedMatrix)(
+    '$mode with branch_rbac=$branchRbac does not look up a missing creator and preserves $status claim behavior',
+    async ({ mode, branchRbac, status }) => {
+      const observed = await exerciseProductionLaunchSeam({
+        mode,
+        branchRbac,
+        creatorState: 'missing',
+        status,
+      });
+
+      expect(observed.error).toBeUndefined();
+      expect(observed.events).toEqual(['claim', 'defer']);
+      expect(observed.creatorLookupCalls).toEqual([]);
+      expect(observed.claimDispatch).toHaveBeenCalledOnce();
+      expect(observed.continueClaimedLaunch).toHaveBeenCalledOnce();
+      expect(observed.deferExecutorSpawn).toHaveBeenCalledOnce();
+      expect(observed.onClaimNotWon).not.toHaveBeenCalled();
+      expect(observed.result?.status).toBe(TaskStatus.DISPATCHING);
+      expect(observed.persisted?.status).toBe(TaskStatus.DISPATCHING);
+    }
+  );
+});
+
+describe('production launch convergence', () => {
+  const routesSource = readSource('register-routes.ts');
+  const spawnStart = routesSource.indexOf('async function spawnTaskExecutor(');
+  const promptStart = routesSource.indexOf("'/sessions/:id/prompt'", spawnStart);
+  const spawnTaskExecutor = routesSource.slice(spawnStart, promptStart);
+
+  it('wires the production claim and deferred spawn through the tested orchestration seam', () => {
+    const launchOrchestration = spawnTaskExecutor.indexOf('return launchPendingTask({');
+    const dispatchClaim = spawnTaskExecutor.indexOf(
+      'tasksService.claimDispatchAndProjectSession(',
+      launchOrchestration
+    );
+    const claimedContinuation = spawnTaskExecutor.indexOf(
+      'onClaimed: async (updatedTask)',
+      dispatchClaim
+    );
+    const executorSpawn = spawnTaskExecutor.indexOf(
+      'deferInFreshTenantScope(params, async () =>',
+      claimedContinuation
+    );
+
+    expect(spawnStart).toBeGreaterThan(0);
+    expect(launchOrchestration).toBeGreaterThan(0);
+    expect(dispatchClaim).toBeGreaterThan(launchOrchestration);
+    expect(claimedContinuation).toBeGreaterThan(dispatchClaim);
+    expect(executorSpawn).toBeGreaterThan(claimedContinuation);
+    expect(spawnTaskExecutor).not.toContain('branchRbacEnabled');
+  });
+
+  it('converges direct prompts, explicit runs, and queue drains on the guarded launch seam', () => {
+    const runStart = routesSource.indexOf("'/tasks/:id/run'", promptStart);
+    const spawnPromptStart = routesSource.indexOf("'/sessions/:id/spawn-prompt'", runStart);
+    const queueStart = routesSource.indexOf('async function processNextQueuedTaskInternal(');
+    const queueEnd = routesSource.indexOf('// Inject queue processor', queueStart);
+
+    const promptRoute = routesSource.slice(promptStart, runStart);
+    const runRoute = routesSource.slice(runStart, spawnPromptStart);
+    const queueDrain = routesSource.slice(queueStart, queueEnd);
+
+    expect(promptRoute).toContain('const admitted = await spawnTaskExecutor(');
+    expect(runRoute).toContain('spawnFn: spawnTaskExecutor');
+    expect(queueDrain).toContain('const admitted = await spawnTaskExecutor(');
+  });
+
+  it('routes reactive/fleet drains and representative callback/scheduled work to that queue seam', () => {
+    const hooksSource = readSource('register-hooks.ts');
+    const startupSource = readSource('startup.ts');
+    const tasksSource = readSource('services/tasks.ts');
+    const schedulerSource = readSource('services/scheduler.ts');
+
+    expect(hooksSource).toContain(
+      'await sessionsService.triggerQueueProcessing(session.session_id, queueParams);'
+    );
+    expect(startupSource).toContain('const sessionQueueWorker = new SessionQueueWorker(db, {');
+    expect(startupSource).toContain(
+      'ctx.sessionsService.triggerQueueProcessing(sessionId, params as never)'
+    );
+    expect(tasksSource).toContain('const createCallbackTask = () =>');
+    expect(tasksSource).toContain('status: TaskStatus.QUEUED');
+    expect(tasksSource).toContain(
+      'await this.triggerQueueProcessingAfterCommit(targetSessionId, {});'
+    );
+    expect(schedulerSource).toContain("this.app.service('/sessions/:id/prompt').create(");
+    expect(schedulerSource).toContain('idempotencyTaskId: initialTaskId');
+  });
+});

--- a/apps/agor-daemon/src/register-routes.unix-identity.test.ts
+++ b/apps/agor-daemon/src/register-routes.unix-identity.test.ts
@@ -46,21 +46,21 @@ afterAll(() => {
   }
 });
 
-type CreatorState = 'matching' | 'mismatched' | 'missing';
+type IdentityState = 'matching' | 'mismatched' | 'missingCreator' | 'missingUsername';
 
 async function createPendingLaunch(input: {
-  creatorState: CreatorState;
+  identityState: IdentityState;
   status: TaskPendingDispatchStatus;
 }): Promise<{ session: Session; task: Task }> {
   const creatorId = generateId() as UUID;
   const suffix = creatorId.slice(-12);
-  const stampedUsername = `alice-${suffix}`;
-  if (input.creatorState === 'matching' || input.creatorState === 'mismatched') {
+  const stampedUsername = input.identityState === 'missingUsername' ? null : `alice-${suffix}`;
+  if (input.identityState !== 'missingCreator') {
     await runWithTenantDatabaseScope(activeDb, activeTenantId, (tenantDb) =>
       new UsersRepository(tenantDb).create({
         user_id: creatorId,
         email: `${suffix}@active.example`,
-        unix_username: input.creatorState === 'matching' ? stampedUsername : `bob-${suffix}`,
+        unix_username: input.identityState === 'mismatched' ? `bob-${suffix}` : stampedUsername,
       })
     );
   }
@@ -104,7 +104,7 @@ async function createPendingLaunch(input: {
 async function exerciseProductionLaunchSeam(input: {
   mode: UnixUserMode;
   branchRbac: boolean;
-  creatorState: CreatorState;
+  identityState: IdentityState;
   status: TaskPendingDispatchStatus;
 }) {
   const { session, task } = await createPendingLaunch(input);
@@ -184,11 +184,11 @@ const unguardedMatrix = (['simple', 'insulated'] as const).flatMap((mode) =>
   )
 );
 const rejectedMatrix = guardedMatrix.flatMap(({ mode, branchRbac }) =>
-  (['mismatched', 'missing'] as const).flatMap((creatorState) =>
+  (['mismatched', 'missingCreator', 'missingUsername'] as const).flatMap((identityState) =>
     ([TaskStatus.CREATED, TaskStatus.QUEUED] as const).map((status) => ({
       mode,
       branchRbac,
-      creatorState,
+      identityState,
       status,
     }))
   )
@@ -201,7 +201,7 @@ describe('production pre-claim Unix identity orchestration', () => {
       const observed = await exerciseProductionLaunchSeam({
         mode,
         branchRbac,
-        creatorState: 'matching',
+        identityState: 'matching',
         status: TaskStatus.QUEUED,
       });
 
@@ -218,23 +218,27 @@ describe('production pre-claim Unix identity orchestration', () => {
   );
 
   it.each(rejectedMatrix)(
-    '$mode with branch_rbac=$branchRbac rejects $creatorState creator before claim/spawn and leaves $status pending',
-    async ({ mode, branchRbac, creatorState, status }) => {
+    '$mode with branch_rbac=$branchRbac rejects $identityState identity before claim/spawn and leaves $status pending',
+    async ({ mode, branchRbac, identityState, status }) => {
       const observed = await exerciseProductionLaunchSeam({
         mode,
         branchRbac,
-        creatorState,
+        identityState,
         status,
       });
 
       expect(observed.error).toBeInstanceOf(Error);
       expect((observed.error as Error).message).toMatch(
-        creatorState === 'mismatched'
+        identityState === 'mismatched'
           ? /Session security context has changed/
-          : /Session creator not found/
+          : identityState === 'missingCreator'
+            ? /Session creator not found/
+            : /requires a unix_username/
       );
-      expect(observed.events).toEqual(['lookup']);
-      expect(observed.creatorLookupCalls).toEqual([[observed.task.created_by]]);
+      expect(observed.events).toEqual(identityState === 'missingUsername' ? [] : ['lookup']);
+      expect(observed.creatorLookupCalls).toEqual(
+        identityState === 'missingUsername' ? [] : [[observed.task.created_by]]
+      );
       expect(observed.claimDispatch).not.toHaveBeenCalled();
       expect(observed.continueClaimedLaunch).not.toHaveBeenCalled();
       expect(observed.deferExecutorSpawn).not.toHaveBeenCalled();
@@ -249,7 +253,7 @@ describe('production pre-claim Unix identity orchestration', () => {
       const observed = await exerciseProductionLaunchSeam({
         mode,
         branchRbac,
-        creatorState: 'missing',
+        identityState: 'missingCreator',
         status,
       });
 

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -29,6 +29,7 @@ import type {
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
 import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
+import { assertSessionUnixIdentityMatchesCreator } from './session-unix-identity.js';
 
 /**
  * Check if a user has the superadmin role (or deprecated 'owner' alias).
@@ -1227,23 +1228,7 @@ export function validateSessionUnixUsername(
       return context;
     }
 
-    // Load session creator to check current unix_username
-    const creator = await userRepo.findById(session.created_by);
-
-    if (!creator) {
-      throw new Forbidden(`Session creator not found: ${session.created_by}`);
-    }
-
-    // DEFENSIVE CHECK: Creator's current unix_username must match session's
-    if (creator.unix_username !== session.unix_username) {
-      throw new Forbidden(
-        `Session security context has changed. ` +
-          `Session was created with unix_username="${session.unix_username}" ` +
-          `but creator's current unix_username="${creator.unix_username || 'null'}". ` +
-          `Cannot execute this session with a different unix user. ` +
-          `SDK session data is stored in the original user's home directory and cannot be accessed.`
-      );
-    }
+    await assertSessionUnixIdentityMatchesCreator(session, userRepo);
 
     return context;
   };

--- a/apps/agor-daemon/src/utils/session-unix-identity.ts
+++ b/apps/agor-daemon/src/utils/session-unix-identity.ts
@@ -1,0 +1,85 @@
+import type { AgorExecutionSettings } from '@agor/core/config';
+import { unixUserModeRequiresUsername } from '@agor/core/config';
+import {
+  assertTenantWritable,
+  runWithTenantDatabaseScope,
+  type TaskDispatchClaimResult,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import { Forbidden } from '@agor/core/feathers';
+import type { InternalUser, Session, Task, TaskPendingDispatchStatus } from '@agor/core/types';
+import { isTaskPendingDispatch } from '@agor/core/types';
+
+type SessionUnixIdentity = Pick<Session, 'created_by' | 'unix_username'>;
+
+type SessionCreatorLookup = {
+  findById(id: string): Promise<Pick<InternalUser, 'unix_username'> | null>;
+};
+
+/** Refuse execution when a Session's immutable Unix identity no longer matches its creator. */
+export async function assertSessionUnixIdentityMatchesCreator(
+  session: SessionUnixIdentity,
+  usersRepository: SessionCreatorLookup
+): Promise<void> {
+  const creator = await usersRepository.findById(session.created_by);
+  if (!creator) {
+    throw new Forbidden(`Session creator not found: ${session.created_by}`);
+  }
+
+  const stampedUnixUsername = session.unix_username ?? null;
+  const currentUnixUsername = creator.unix_username ?? null;
+  if (currentUnixUsername !== stampedUnixUsername) {
+    throw new Forbidden(
+      `Session security context has changed. ` +
+        `Session was created with unix_username="${stampedUnixUsername ?? 'null'}" ` +
+        `but creator's current unix_username="${currentUnixUsername ?? 'null'}". ` +
+        `Cannot execute this session with a different unix user. ` +
+        `SDK session data is stored in the original user's home directory and cannot be accessed.`
+    );
+  }
+}
+
+interface PendingTaskLaunchInput {
+  db: TenantScopeAwareDatabase;
+  tenantId: string;
+  execution: AgorExecutionSettings | undefined;
+  task: Task;
+  session: SessionUnixIdentity;
+  claimDispatch: (
+    task: Task & { status: TaskPendingDispatchStatus }
+  ) => Promise<TaskDispatchClaimResult>;
+  onClaimed: (task: Task) => Promise<Task>;
+  onClaimNotWon: (claim: TaskDispatchClaimResult) => Promise<Task>;
+}
+
+/**
+ * Run the pending check, point-in-time Unix identity fence, and durable claim in
+ * production order, then continue outside the short tenant transaction.
+ */
+export async function launchPendingTask({
+  db,
+  tenantId,
+  execution,
+  task,
+  session,
+  claimDispatch,
+  onClaimed,
+  onClaimNotWon,
+}: PendingTaskLaunchInput): Promise<Task> {
+  if (!isTaskPendingDispatch(task)) return task;
+
+  const dispatchClaim = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+    await assertTenantWritable(tenantDb, tenantId);
+    const unixUserMode = execution?.unix_user_mode ?? 'simple';
+    if (unixUserModeRequiresUsername(unixUserMode)) {
+      // Fresh point-in-time fence only: user updates are not locked across the later spawn.
+      await assertSessionUnixIdentityMatchesCreator(session, new UsersRepository(tenantDb));
+    }
+    return claimDispatch(task);
+  });
+
+  return dispatchClaim.outcome === 'claimed'
+    ? onClaimed(dispatchClaim.task)
+    : onClaimNotWon(dispatchClaim);
+}

--- a/apps/agor-daemon/src/utils/session-unix-identity.ts
+++ b/apps/agor-daemon/src/utils/session-unix-identity.ts
@@ -10,6 +10,7 @@ import {
 import { Forbidden } from '@agor/core/feathers';
 import type { InternalUser, Session, Task, TaskPendingDispatchStatus } from '@agor/core/types';
 import { isTaskPendingDispatch } from '@agor/core/types';
+import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
 
 type SessionUnixIdentity = Pick<Session, 'created_by' | 'unix_username'>;
 
@@ -73,6 +74,7 @@ export async function launchPendingTask({
     await assertTenantWritable(tenantDb, tenantId);
     const unixUserMode = execution?.unix_user_mode ?? 'simple';
     if (unixUserModeRequiresUsername(unixUserMode)) {
+      assertUnixUsernameSatisfiesMode(session.unix_username, unixUserMode, 'the session');
       // Fresh point-in-time fence only: user updates are not locked across the later spawn.
       await assertSessionUnixIdentityMatchesCreator(session, new UsersRepository(tenantDb));
     }


### PR DESCRIPTION
## Linked issue

Fixes #2244

## Summary

- validate the session creator's current Unix identity at the common task-launch boundary
- apply the guard in `delegated` and `strict` modes independently of branch RBAC
- refuse stale, missing, or tenant-hidden creators before task claim or executor spawn

## Why / context

Session Unix identity validation was coupled to branch authorization. With branch RBAC disabled, a session could retain a stale Unix username and still launch work as the wrong operating-system user.

Moving the check to the shared launch fence keeps access-control policy and process identity enforcement separate. Refused tasks remain pending and unclaimed.

## Implementation notes

- Reuses a shared session/creator identity assertion from both the service hook and task-launch path.
- Performs the tenant-scoped creator lookup after confirming the task is pending and before the atomic dispatch claim.
- Preserves existing behavior for `simple` and `insulated` Unix modes without an additional user lookup.
- Covers prompt, explicit run, reactive and fleet queue drains, callbacks, and schedules through their common launch path.

## Validation / test plan

- [x] Focused Unix identity and launch suites: 111 passed
- [x] Target PostgreSQL/RLS matrix: 8 passed, 0 failed, 0 skipped
- [x] Repository PostgreSQL integration: 124 passed, 0 failed, 0 skipped
- [x] Daemon regression suite: 2,439 passed
- [x] Daemon typecheck
- [x] Biome on changed files and pre-commit hook
- [x] `pnpm check:multitenancy-boundaries`
- [x] `git diff --check`

## Risks / rollout / rollback

Identity validation is intentionally point-in-time; a username can still change after validation. A refused queued task remains pending until the identity is restored or a new session is used.

No schema, migration, dependency, or configuration changes are required. Rollback is a commit revert.

## Out of scope / follow-ups

This change does not add identity generations, row locking, or an external executor process integration test.
