### PR TITLE
fix(executor): force exit after flushing one-shot results

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -28,6 +28,10 @@ import { fileURLToPath } from 'node:url';
 import type { AgorExecutionSettings } from '@agor/core/config';
 import { getCurrentTenantId } from '@agor/core/db';
 import {
+  EXECUTOR_RESULT_PREFIX,
+  INTERACTIVE_EXECUTOR_EVENT_PREFIX,
+} from '@agor/core/executor-protocol';
+import {
   attachEnvFileCleanup,
   buildSpawnArgs,
   escapeShellArg,
@@ -557,8 +561,6 @@ function spawnExecutorWithTemplate(
   sendExecutorPayload(executorProcess, payload, spawnReady, logPrefix, reportExit);
 }
 
-const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';
-
 function parseExecutorResultFromStdout(stdout: string): ExecutorCommandResult | null {
   const lines = stdout
     .split(/\r?\n/)
@@ -600,8 +602,6 @@ function logChunkedOutput(prefix: string, stream: 'stdout' | 'stderr', chunk: Bu
     }
   }
 }
-
-const INTERACTIVE_EXECUTOR_EVENT_PREFIX = 'AGOR_EXECUTOR_INTERACTIVE_EVENT ';
 
 function resolveLocalExecutorLocation(options: Pick<SpawnExecutorOptions, 'cwd'> = {}) {
   const executorPath = findExecutorPath();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,12 @@
       "import": "./dist/types/index.js",
       "require": "./dist/types/index.cjs"
     },
+    "./executor-protocol": {
+      "source": "./src/executor-protocol.ts",
+      "types": "./dist/executor-protocol.d.ts",
+      "import": "./dist/executor-protocol.js",
+      "require": "./dist/executor-protocol.cjs"
+    },
     "./design/board-backgrounds": {
       "source": "./src/design/board-backgrounds.ts",
       "types": "./dist/design/board-backgrounds.d.ts",

--- a/packages/core/src/executor-protocol.ts
+++ b/packages/core/src/executor-protocol.ts
@@ -1,0 +1,3 @@
+/** Line prefixes used by the executor's stdout protocol. */
+export const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';
+export const INTERACTIVE_EXECUTOR_EVENT_PREFIX = 'AGOR_EXECUTOR_INTERACTIVE_EVENT ';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'analytics/index': 'src/analytics/index.ts', // Backend analytics logger and plugin resolution
     'telemetry/index': 'src/telemetry/index.ts', // Community install telemetry helpers
     'types/index': 'src/types/index.ts',
+    'executor-protocol': 'src/executor-protocol.ts',
     'db/index': 'src/db/index.ts',
     'db/session-guard': 'src/db/session-guard.ts', // Defensive programming for deleted sessions
     'tenant-portability/index': 'src/tenant-portability/index.ts',

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -23,6 +23,7 @@ import {
   executeInteractiveCommand,
   getRegisteredCommands,
 } from './commands/index.js';
+import { emitExecutorResult } from './executor-output.js';
 import { initializeToolRegistry, ToolRegistry } from './handlers/sdk/tool-registry.js';
 import { AgorExecutor } from './index.js';
 import {
@@ -50,10 +51,6 @@ async function readStdin(): Promise<string> {
     chunks.push(chunk as Buffer);
   }
   return Buffer.concat(chunks).toString('utf-8');
-}
-
-function emitExecutorResult(result: unknown): void {
-  console.log(`AGOR_EXECUTOR_RESULT ${JSON.stringify(result)}`);
 }
 
 function emitInteractiveEvent(event: unknown): void {
@@ -109,7 +106,8 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
     emitExecutorResult(result);
 
     if (!result.success) {
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     // DON'T exit - stay alive to stream PTY I/O
@@ -124,7 +122,9 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
   // Output result on a sentinel line so daemon parsers can suppress it from logs.
   emitExecutorResult(result);
 
-  process.exit(result.success ? 0 : 1);
+  // Let Node drain piped stdout before exiting. Calling process.exit() here can
+  // truncate executor results larger than the OS pipe buffer.
+  process.exitCode = result.success ? 0 : 1;
 }
 
 /**
@@ -188,7 +188,8 @@ async function handlePromptPayload(
         },
       })
     );
-    process.exit(0);
+    process.exitCode = 0;
+    return;
   }
 
   // =========================================================================

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -17,13 +17,14 @@
 
 import { createInterface } from 'node:readline';
 import { parseArgs } from 'node:util';
+import { INTERACTIVE_EXECUTOR_EVENT_PREFIX } from '@agor/core/executor-protocol';
 
 import {
   executeCommand,
   executeInteractiveCommand,
   getRegisteredCommands,
 } from './commands/index.js';
-import { emitExecutorResult } from './executor-output.js';
+import { completeExecutorResult, emitExecutorResult } from './executor-output.js';
 import { initializeToolRegistry, ToolRegistry } from './handlers/sdk/tool-registry.js';
 import { AgorExecutor } from './index.js';
 import {
@@ -54,7 +55,7 @@ async function readStdin(): Promise<string> {
 }
 
 function emitInteractiveEvent(event: unknown): void {
-  console.log(`AGOR_EXECUTOR_INTERACTIVE_EVENT ${JSON.stringify(event)}`);
+  console.log(`${INTERACTIVE_EXECUTOR_EVENT_PREFIX}${JSON.stringify(event)}`);
 }
 
 /**
@@ -102,13 +103,13 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
   if (payload.command === 'zellij.attach') {
     const result = await executeCommand(payload, { dryRun: options.dryRun });
 
-    // Output result on a sentinel line so daemon parsers can suppress it from logs.
-    emitExecutorResult(result);
-
     if (!result.success) {
-      process.exitCode = 1;
+      completeExecutorResult(result);
       return;
     }
+
+    // Output result on a sentinel line so daemon parsers can suppress it from logs.
+    emitExecutorResult(result);
 
     // DON'T exit - stay alive to stream PTY I/O
     // The PTY onExit handler will call process.exit() when done
@@ -120,11 +121,7 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
   const result = await executeCommand(payload, { dryRun: options.dryRun });
 
   // Output result on a sentinel line so daemon parsers can suppress it from logs.
-  emitExecutorResult(result);
-
-  // Let Node drain piped stdout before exiting. Calling process.exit() here can
-  // truncate executor results larger than the OS pipe buffer.
-  process.exitCode = result.success ? 0 : 1;
+  completeExecutorResult(result);
 }
 
 /**
@@ -150,17 +147,15 @@ async function handleInteractiveCommandMode(options: { dryRun: boolean }): Promi
         },
       }
     );
-    emitExecutorResult(result);
-    process.exitCode = result.success ? 0 : 1;
+    completeExecutorResult(result);
   } catch {
-    emitExecutorResult({
+    completeExecutorResult({
       success: false,
       error: {
         code: 'INTERACTIVE_COMMAND_PROTOCOL_INVALID',
         message: 'Interactive executor input was invalid.',
       },
     });
-    process.exitCode = 1;
   } finally {
     lines.close();
   }

--- a/packages/executor/src/executor-output.test.ts
+++ b/packages/executor/src/executor-output.test.ts
@@ -1,17 +1,15 @@
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { EXECUTOR_RESULT_PREFIX } from '@agor/core/executor-protocol';
 import { describe, expect, it } from 'vitest';
-
-import { EXECUTOR_RESULT_PREFIX } from './executor-output.js';
 
 describe('executor result output', () => {
   it('delivers a result larger than the pipe buffer before exiting', async () => {
     const modulePath = fileURLToPath(new URL('./executor-output.ts', import.meta.url));
     const payload = 'x'.repeat(512 * 1024);
     const script = [
-      `import { emitExecutorResult } from ${JSON.stringify(modulePath)};`,
-      `emitExecutorResult({ success: true, data: 'x'.repeat(${payload.length}) });`,
-      'process.exitCode = 0;',
+      `import { completeExecutorResult } from ${JSON.stringify(modulePath)};`,
+      `completeExecutorResult({ success: true, data: 'x'.repeat(${payload.length}) });`,
     ].join('\n');
 
     const child = spawn(

--- a/packages/executor/src/executor-output.test.ts
+++ b/packages/executor/src/executor-output.test.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { EXECUTOR_RESULT_PREFIX } from './executor-output.js';
+
+describe('executor result output', () => {
+  it('delivers a result larger than the pipe buffer before exiting', async () => {
+    const modulePath = fileURLToPath(new URL('./executor-output.ts', import.meta.url));
+    const payload = 'x'.repeat(512 * 1024);
+    const script = [
+      `import { emitExecutorResult } from ${JSON.stringify(modulePath)};`,
+      `emitExecutorResult({ success: true, data: 'x'.repeat(${payload.length}) });`,
+      'process.exitCode = 0;',
+    ].join('\n');
+
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', script],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+    const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+
+    expect(exitCode, stderr).toBe(0);
+    expect(stdout.endsWith('\n')).toBe(true);
+    expect(stdout.startsWith(EXECUTOR_RESULT_PREFIX)).toBe(true);
+    expect(JSON.parse(stdout.slice(EXECUTOR_RESULT_PREFIX.length))).toEqual({
+      success: true,
+      data: payload,
+    });
+  });
+});

--- a/packages/executor/src/executor-output.test.ts
+++ b/packages/executor/src/executor-output.test.ts
@@ -39,4 +39,44 @@ describe('executor result output', () => {
       data: payload,
     });
   });
+
+  it('force-exits after flushing even when a handle keeps the event loop alive', async () => {
+    const modulePath = fileURLToPath(new URL('./executor-output.ts', import.meta.url));
+    const script = [
+      `import { completeExecutorResult } from ${JSON.stringify(modulePath)};`,
+      'setInterval(() => {}, 1_000_000);',
+      `completeExecutorResult({ success: true, data: 'complete' });`,
+    ].join('\n');
+    const startedAt = Date.now();
+
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', script],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error('Executor child did not force-exit after flushing stdout'));
+      }, 5000);
+      child.once('error', reject);
+      child.once('close', (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+    const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+
+    expect(exitCode, stderr).toBe(0);
+    expect(Date.now() - startedAt).toBeLessThan(3000);
+    expect(stdout).toBe(`${EXECUTOR_RESULT_PREFIX}{"success":true,"data":"complete"}\n`);
+  });
 });

--- a/packages/executor/src/executor-output.ts
+++ b/packages/executor/src/executor-output.ts
@@ -1,0 +1,5 @@
+export const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';
+
+export function emitExecutorResult(result: unknown): void {
+  console.log(`${EXECUTOR_RESULT_PREFIX}${JSON.stringify(result)}`);
+}

--- a/packages/executor/src/executor-output.ts
+++ b/packages/executor/src/executor-output.ts
@@ -1,5 +1,11 @@
-export const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';
+import { EXECUTOR_RESULT_PREFIX } from '@agor/core/executor-protocol';
 
 export function emitExecutorResult(result: unknown): void {
   console.log(`${EXECUTOR_RESULT_PREFIX}${JSON.stringify(result)}`);
+}
+
+export function completeExecutorResult<T extends { success: boolean }>(result: T): void {
+  emitExecutorResult(result);
+  // Assigning exitCode lets Node drain piped stdout before the event loop exits.
+  process.exitCode = result.success ? 0 : 1;
 }

--- a/packages/executor/src/executor-output.ts
+++ b/packages/executor/src/executor-output.ts
@@ -5,7 +5,12 @@ export function emitExecutorResult(result: unknown): void {
 }
 
 export function completeExecutorResult<T extends { success: boolean }>(result: T): void {
-  emitExecutorResult(result);
-  // Assigning exitCode lets Node drain piped stdout before the event loop exits.
-  process.exitCode = result.success ? 0 : 1;
+  const code = result.success ? 0 : 1;
+  const line = `${EXECUTOR_RESULT_PREFIX}${JSON.stringify(result)}\n`;
+  process.exitCode = code;
+  // Write the sentinel, then force-exit once it has flushed to the (possibly piped) stdout.
+  // Lingering handles such as WebSocket timers must not keep one-shot executors alive.
+  process.stdout.write(line, () => process.exit(code));
+  // If the flush callback never fires (for example, the reader closed the pipe), still exit.
+  setTimeout(() => process.exit(code), 1000).unref();
 }


### PR DESCRIPTION
## Summary

- force one-shot executor processes to exit after their result line has flushed to stdout
- retain a one-second unref'd failsafe when the stdout callback never fires
- add regression coverage proving a lingering event-loop handle cannot hang completion

## Context

PR #2256 fixed large-result truncation by replacing immediate `process.exit()` with `process.exitCode`. Live verification then exposed a follow-up regression: Feathers/socket.io handles can keep one-shot executor processes alive until the daemon's 60-second timeout.

This follow-up writes the complete sentinel through `process.stdout.write()`, force-exits from its flush callback, and preserves the non-exiting `emitExecutorResult()` behavior used by successful `zellij.attach` sessions.

## Testing

- `pnpm --filter @agor/executor exec vitest run src/executor-output.test.ts` — 2/2 passed
- `pnpm --filter @agor/executor build` — passed
- `node packages/executor/scripts/runtime-smoke.mjs` — passed
- `packages/agor-live/build.sh --skip-install` — passed, including package-content validation
- bundled executor lingering-handle smoke — passed
- full executor suite — 572 passed; 61 unrelated environment-dependent SDK/mock failures remain
