### PR TITLE
fix(daemon): unify effective config and strict-mode bootstrap

### DIFF
--- a/apps/agor-cli/src/commands/init.test.ts
+++ b/apps/agor-cli/src/commands/init.test.ts
@@ -12,6 +12,7 @@ import { load as loadYaml } from '@agor/core/yaml';
 import { spawn as spawnPty } from 'node-pty';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  assertInitSupportsConfiguredDatabase,
   createInstallTelemetryConfig,
   isFreshInitState,
   parseInitialAgenticTools,
@@ -217,6 +218,18 @@ async function runInteractiveReinit(home: string): Promise<{
     });
   });
 }
+
+describe('database support', () => {
+  it('accepts SQLite initialization', () => {
+    expect(() => assertInitSupportsConfiguredDatabase('sqlite')).not.toThrow();
+  });
+
+  it('fails clearly instead of mixing a SQLite client with the PostgreSQL schema', () => {
+    expect(() => assertInitSupportsConfiguredDatabase('postgresql')).toThrow(
+      /supports SQLite installations only/
+    );
+  });
+});
 
 describe('safe init state detection', () => {
   it('treats a pre-created empty .agor mount as fresh', () => {

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -94,6 +94,14 @@ export function parseInitialAgenticTools(value: string): InstallableAgenticTool[
   return [...new Set(normalized as InstallableAgenticTool[])];
 }
 
+export function assertInitSupportsConfiguredDatabase(dialect = process.env.AGOR_DB_DIALECT): void {
+  if (dialect === 'postgresql') {
+    throw new Error(
+      '`agor init` currently supports SQLite installations only. For PostgreSQL deployments, configure the deployment environment and run `agor db migrate --yes`; the daemon will bootstrap required database state.'
+    );
+  }
+}
+
 export default class Init extends Command {
   private initialDaemonConfig: NonNullable<AgorConfig['daemon']> = {};
   private initialConfig: AgorConfig = getDefaultConfig();
@@ -270,6 +278,7 @@ export default class Init extends Command {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Init);
+    assertInitSupportsConfiguredDatabase();
     this.nonInteractive = flags['non-interactive'];
     const requestedTools = flags['agentic-tools'] ?? process.env.AGOR_AGENTIC_TOOLS;
     if (requestedTools !== undefined) {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -257,7 +257,7 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
   });
 
-  it('rejects repo reads outside the token branch, including another tenant repo', async () => {
+  it('preserves tenant context and rejects a repo outside the token branch', async () => {
     const context = ctx({
       path: 'repos',
       method: 'get',

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -235,8 +235,65 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
   });
 
+  it('allows get only for the repo resolved from the token-scoped branch', async () => {
+    const context = ctx({
+      path: 'repos',
+      method: 'get',
+      id: 'repo-1',
+      app: {
+        service: (path: string) => {
+          expect(path).toBe('branches');
+          return {
+            get: async (branchId: string, params: HookContext['params']) => {
+              expect(branchId).toBe('branch-1');
+              expect(params.provider).toBeUndefined();
+              return { branch_id: branchId, repo_id: 'repo-1' };
+            },
+          };
+        },
+      } as HookContext['app'],
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it('rejects repo reads outside the token branch, including another tenant repo', async () => {
+    const context = ctx({
+      path: 'repos',
+      method: 'get',
+      id: 'tenant-b-repo',
+      params: {
+        authentication: { payload },
+        query: {},
+        provider: 'socketio',
+        tenant: { tenant_id: 'tenant-a' },
+      },
+      app: {
+        service: () => ({
+          get: async (_branchId: string, params: HookContext['params']) => {
+            expect(params.tenant?.tenant_id).toBe('tenant-a');
+            return { branch_id: 'branch-1', repo_id: 'tenant-a-repo' };
+          },
+        }),
+      } as HookContext['app'],
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/repo scope/);
+  });
+
+  it.each(['find', 'create', 'patch', 'remove'])(
+    'rejects executor tokens for repos.%s',
+    async (method) => {
+      const context = ctx({ path: 'repos', method, id: method === 'find' ? undefined : 'repo-1' });
+
+      await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+        /not valid for this endpoint/
+      );
+    }
+  );
+
   it('rejects executor tokens on unrecognized endpoints', async () => {
-    const context = ctx({ path: 'repos', method: 'find' });
+    const context = ctx({ path: 'unknown', method: 'find' });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
       /not valid for this endpoint/

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -1,5 +1,5 @@
 import { Forbidden } from '@agor/core/feathers';
-import type { AuthenticatedParams, HookContext, Params } from '@agor/core/types';
+import type { AuthenticatedParams, BranchID, HookContext, Params } from '@agor/core/types';
 import {
   EXECUTOR_SESSION_TOKEN_PURPOSE,
   EXECUTOR_SESSION_TOKEN_TYPE,
@@ -174,6 +174,25 @@ async function requireMessageReadScope(
   expectExistingMatch(taskId, existing.task_id, 'task');
 }
 
+async function requireRepoReadScope(
+  context: HookContext,
+  id: string | undefined,
+  scope: Scope
+): Promise<void> {
+  if (context.method !== 'get' || !id) {
+    throw new Forbidden('Executor token is not valid for this endpoint');
+  }
+
+  const branchId = expectClaim(scope.branchId, 'branch') as BranchID;
+  // Resolve the allowed repo from the token-scoped branch under the request's
+  // trusted tenant context. Never authorize from the client-supplied repo id.
+  const branch = await context.app.service('branches').get(branchId, {
+    ...context.params,
+    provider: undefined,
+  });
+  expectExistingMatch(String(branch.repo_id), id, 'repo');
+}
+
 type AuthHook = (context: HookContext) => Promise<HookContext>;
 
 export function scopeExecutorRuntimeAuth(requireAuth: AuthHook): AuthHook {
@@ -316,6 +335,8 @@ export function executorRuntimeScopeGuard() {
           throw new Forbidden('Executor token branch scope is required for this request');
         }
       }
+    } else if (path === 'repos') {
+      await requireRepoReadScope(context, id, scope);
     } else if (path === 'messages/bulk') {
       if (context.method !== 'create') {
         throw new Forbidden('Executor token is not valid for this endpoint');

--- a/apps/agor-daemon/src/config-immutability.contract.test.ts
+++ b/apps/agor-daemon/src/config-immutability.contract.test.ts
@@ -16,6 +16,27 @@ function sourceFiles(dir: string): string[] {
 }
 
 describe('immutable config.yaml boundary', () => {
+  it('daemon runtime sources cannot reload persisted config after bootstrap', () => {
+    const allowed = new Set([resolve(sourceRoot, 'index.ts')]);
+    const offenders = sourceFiles(sourceRoot).filter(
+      (file) =>
+        !allowed.has(resolve(file)) &&
+        /\b(?:loadConfig|loadConfigSync|loadConfigFromFile|isBranchRbacEnabled|isUnixImpersonationEnabled|isUnixGroupRefreshNeeded|getDaemonUser)\b/.test(
+          readFileSync(file, 'utf8')
+        )
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('daemon production sources cannot import test-only config reset helpers', () => {
+    const offenders = sourceFiles(sourceRoot).filter(
+      (file) =>
+        !file.endsWith('build-resolved-config-slice.ts') &&
+        /\bresetResolvedConfigSliceForTests\b/.test(readFileSync(file, 'utf8'))
+    );
+    expect(offenders).toEqual([]);
+  });
+
   it('daemon production sources cannot import YAML persistence helpers', () => {
     const offenders = sourceFiles(sourceRoot).filter((file) =>
       /\b(createInitialConfig|rewriteConfigForTests|saveConfigForTests)\b/.test(

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -7,6 +7,7 @@
  * - Application instance
  */
 
+import type { AgorConfig } from '@agor/core/config';
 import type { DistributedWorkIdentity } from '@agor/core/coordination';
 import type {
   TaskDispatchClaimResult,
@@ -29,6 +30,7 @@ import type {
   CreateHookContext as CoreCreateHookContext,
   HookContext as CoreHookContext,
   CreateSessionInput,
+  DeepReadonly,
   Params as FeathersParams,
   Message,
   Repo,
@@ -55,6 +57,8 @@ export type HookContext<T = unknown> = CoreHookContext<T>;
  * Application type for the daemon
  */
 export type Application = ExpressApplication & {
+  get(name: 'config'): DeepReadonly<AgorConfig>;
+  set(name: 'config', value: DeepReadonly<AgorConfig>): ExpressApplication;
   get(name: 'distributedWorkIdentity'): DistributedWorkIdentity | undefined;
   set(name: 'distributedWorkIdentity', value: DistributedWorkIdentity): ExpressApplication;
 };

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -74,6 +74,8 @@ import { setBundledUiFallbackHeaders, setBundledUiStaticHeaders } from './setup/
 import { configureSwagger } from './setup/swagger.js';
 import { loadDaemonVersion } from './setup/version.js';
 import { startup } from './startup.js';
+import { configureResolvedConfigSlice } from './utils/build-resolved-config-slice.js';
+import { deepFreezeClone } from './utils/deep-freeze.js';
 import { ensureOpenSourceTelemetryEnvEnabledConfig } from './utils/open-source-telemetry-config.js';
 import { shouldEmitOpenSourceTelemetryDaemonActive } from './utils/open-source-telemetry-heartbeat.js';
 import { startOpenSourceTelemetryUsageSummaryInterval } from './utils/open-source-telemetry-usage.js';
@@ -213,8 +215,12 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   await configureAnalyticsLogger(config);
   const envTelemetryConfig = ensureOpenSourceTelemetryEnvEnabledConfig(config);
   if (envTelemetryConfig.changed) config = envTelemetryConfig.config;
-  configureOpenSourceTelemetryLogger(config);
-  if (config.telemetry?.enabled === undefined) {
+  // Detach the snapshot before freezing so callers that supplied
+  // DaemonStartOptions.config retain ownership of their object graph.
+  const effectiveConfig = deepFreezeClone(config);
+  configureResolvedConfigSlice(effectiveConfig);
+  configureOpenSourceTelemetryLogger(effectiveConfig);
+  if (effectiveConfig.telemetry?.enabled === undefined) {
     console.warn(
       'ℹ  Community telemetry is not configured; no telemetry will be sent. ' +
         'Set AGOR_TELEMETRY=1/0 or edit telemetry.enabled in operator-managed config.yaml.'
@@ -222,7 +228,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   }
 
   // Surface a clear migration note for accepted-but-ignored upgrade keys.
-  warnDeprecatedConfig(config);
+  warnDeprecatedConfig(effectiveConfig);
 
   // --------------------------------------------------------------------------
   // Auth configuration
@@ -269,19 +275,13 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // Ports, daemon URL, credentials
   // --------------------------------------------------------------------------
   const envPort = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : undefined;
-  const DAEMON_PORT = envPort ?? config.daemon?.port ?? 3030;
-  const DAEMON_HOST = process.env.DAEMON_HOST ?? config.daemon?.host ?? 'localhost';
+  const DAEMON_PORT = envPort ?? effectiveConfig.daemon?.port ?? 3030;
+  const DAEMON_HOST = process.env.DAEMON_HOST ?? effectiveConfig.daemon?.host ?? 'localhost';
 
   const envUiPort = process.env.UI_PORT ? Number.parseInt(process.env.UI_PORT, 10) : undefined;
-  const UI_PORT = envUiPort || config.ui?.port || 5173;
+  const UI_PORT = envUiPort || effectiveConfig.ui?.port || 5173;
 
-  // Handle INSTANCE_LABEL env var override (for Docker deployments)
-  if (process.env.INSTANCE_LABEL) {
-    config.daemon = config.daemon || {};
-    config.daemon.instanceLabel = process.env.INSTANCE_LABEL;
-  }
-
-  const daemonUrl = config.daemon?.public_url || `http://localhost:${DAEMON_PORT}`;
+  const daemonUrl = effectiveConfig.daemon?.public_url || `http://localhost:${DAEMON_PORT}`;
   configureDaemonUrl(daemonUrl);
 
   // Wire the configured executor command template + impersonation user so the
@@ -289,7 +289,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // their own config-threading code. Local-subprocess remains the default
   // when execution.executor_command_template is unset (no behavior change
   // for existing deployments).
-  configureExecutor(config.execution, {
+  configureExecutor(effectiveConfig.execution, {
     requireTenantContext: multiTenancy.mode === 'required_from_auth',
   });
 
@@ -320,7 +320,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // Infinity (truthy), and Express interprets `trust proxy = Infinity` as
   // "trust everything" — which is the exact spoofing posture we are
   // defending against. Reject non-finite values (Infinity, NaN) to 0.
-  const rawHops = Number(config.daemon?.trust_proxy_hops ?? 0);
+  const rawHops = Number(effectiveConfig.daemon?.trust_proxy_hops ?? 0);
   const trustProxyHops = Number.isFinite(rawHops) ? Math.max(0, Math.floor(rawHops)) : 0;
   app.set('trust proxy', trustProxyHops);
   if (trustProxyHops > 0) {
@@ -346,13 +346,13 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   //   - CORS mode/origins (plus legacy daemon.cors_* backcompat)
   //   - CORS_ORIGIN env var precedence
   //   - credentials:true + wildcard/reflect rejection at load time
-  const resolvedSecurity: ResolvedSecurity = resolveSecurity(config, {
+  const resolvedSecurity: ResolvedSecurity = resolveSecurity(effectiveConfig, {
     daemonUrl,
     corsOriginEnv: process.env.CORS_ORIGIN,
-    legacyCorsOrigins: config.daemon?.cors_origins,
+    legacyCorsOrigins: effectiveConfig.daemon?.cors_origins,
     legacyAllowSandpack:
-      config.daemon?.cors_allow_sandpack !== undefined
-        ? config.daemon.cors_allow_sandpack
+      effectiveConfig.daemon?.cors_allow_sandpack !== undefined
+        ? effectiveConfig.daemon.cors_allow_sandpack
         : undefined,
   });
 
@@ -374,7 +374,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // and let the cors helper drop credentials so the daemon stays usable.
   // `execution.deployment_mode` is intentionally read defensively — the key
   // may not yet be defined in older configs.
-  const deploymentMode = (config.execution as { deployment_mode?: string } | undefined)
+  const deploymentMode = (effectiveConfig.execution as { deployment_mode?: string } | undefined)
     ?.deployment_mode;
   if (isWildcard) {
     const banner =
@@ -572,7 +572,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const jwtResolution = await resolvePersistedSecret({
     name: 'JWT secret',
     envVar: 'AGOR_JWT_SECRET',
-    existing: config.daemon?.jwtSecret,
+    existing: effectiveConfig.daemon?.jwtSecret,
     configKey: 'daemon.jwtSecret',
   });
   const jwtSecret = jwtResolution.value;
@@ -592,7 +592,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // process.env in their constructor. Resolving it here (rather than later in
   // startup()) is what lets deployments that keep the secret in config.yaml
   // (daemon.masterSecret), not an env var, boot on Postgres.
-  const masterSecretSource = await resolveMasterSecretIntoEnv(config);
+  const masterSecretSource = await resolveMasterSecretIntoEnv(effectiveConfig);
   console.log(
     masterSecretSource === 'env'
       ? '🔐 API key encryption enabled (AGOR_MASTER_SECRET set)'
@@ -611,7 +611,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     // `allow_web_terminal: false` kill-switch is enforced on the WebSocket
     // transport too. Without this the terminal:* relay events would still
     // accept traffic when the HTTP modal is disabled.
-    webTerminalEnabled: config.execution?.allow_web_terminal !== false,
+    webTerminalEnabled: effectiveConfig.execution?.allow_web_terminal !== false,
     // Build info for the version-sync banner. Emitted as the `server-info`
     // welcome event on every connect (and reconnect), so UI tabs can detect
     // FE/BE drift after a deploy without waiting for the next /health poll.
@@ -629,29 +629,29 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const { db } = await initializeDatabase(DB_PATH, {
     tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
     requireTenantScope: multiTenancy.mode === 'required_from_auth',
-    skipFirstRunAdminBootstrap: config.external_launch?.enabled === true,
+    skipFirstRunAdminBootstrap: effectiveConfig.external_launch?.enabled === true,
     // The URL may come from DATABASE_URL, but operators still need to size the
     // per-replica pool from config.yaml. Keep this deliberately limited to max:
     // the public idleTimeout setting is documented in milliseconds while the
     // postgres.js client boundary uses seconds, and `min` is not implemented.
-    pool: config.database?.postgresql?.pool?.max
-      ? { max: config.database.postgresql.pool.max }
+    pool: effectiveConfig.database?.postgresql?.pool?.max
+      ? { max: effectiveConfig.database.postgresql.pool.max }
       : undefined,
   });
-  configureUploadStagingStoreFromConfig(config, undefined, db);
+  configureUploadStagingStoreFromConfig(effectiveConfig, undefined, db);
 
   // --------------------------------------------------------------------------
   // RBAC flags
   // --------------------------------------------------------------------------
-  const branchRbacEnabled = config.execution?.branch_rbac === true;
-  const allowSuperadmin = config.execution?.allow_superadmin === true;
+  const branchRbacEnabled = effectiveConfig.execution?.branch_rbac === true;
+  const allowSuperadmin = effectiveConfig.execution?.allow_superadmin === true;
   const superadminOpts = { allowSuperadmin };
 
   // Stash the shared Drizzle handle on the Feathers app so lifecycle
   // utilities that are not constructed with a database argument can resolve
   // it via `getDb(app)`. Services using constructor injection are unaffected.
   app.set('database', db);
-  app.set('config', config);
+  app.set('config', effectiveConfig);
 
   if (openSourceTelemetryLogger.isEnabled()) {
     const startupTelemetryProperties = {
@@ -665,7 +665,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       os_family: platform(),
       node_major: Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10),
       branch_rbac: branchRbacEnabled,
-      unix_user_mode: config.execution?.unix_user_mode ?? 'simple',
+      unix_user_mode: effectiveConfig.execution?.unix_user_mode ?? 'simple',
     };
 
     openSourceTelemetryLogger.track({
@@ -673,7 +673,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       properties: startupTelemetryProperties,
     });
 
-    const daemonActive = shouldEmitOpenSourceTelemetryDaemonActive(config);
+    const daemonActive = shouldEmitOpenSourceTelemetryDaemonActive(effectiveConfig);
     if (daemonActive.shouldEmit) {
       openSourceTelemetryLogger.track({
         event: 'daemon.active',
@@ -685,18 +685,20 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     }
 
     if (
-      config.telemetry?.last_reported_version &&
-      config.telemetry.last_reported_version !== AGOR_VERSION
+      effectiveConfig.telemetry?.last_reported_version &&
+      effectiveConfig.telemetry.last_reported_version !== AGOR_VERSION
     ) {
       openSourceTelemetryLogger.track({
         event: 'daemon.upgraded',
         properties: {
-          from_version: config.telemetry.last_reported_version,
+          from_version: effectiveConfig.telemetry.last_reported_version,
           to_version: AGOR_VERSION,
         },
       });
     }
-    startOpenSourceTelemetryUsageSummaryInterval(db, { tenantId: multiTenancy.static_tenant_id });
+    startOpenSourceTelemetryUsageSummaryInterval(db, effectiveConfig, {
+      tenantId: multiTenancy.static_tenant_id,
+    });
   }
 
   // --------------------------------------------------------------------------
@@ -705,7 +707,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const services = await registerServices({
     db,
     app,
-    config,
+    config: effectiveConfig,
     jwtSecret,
     daemonUrl,
     bundledUiAvailable,
@@ -723,7 +725,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   registerHooks({
     db,
     app,
-    config,
+    config: effectiveConfig,
     jwtSecret,
     branchRbacEnabled,
     requireAuth,
@@ -744,7 +746,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   await registerRoutes({
     db,
     app,
-    config,
+    config: effectiveConfig,
     jwtSecret,
     branchRbacEnabled,
     requireAuth,
@@ -776,7 +778,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   await startup({
     app,
     db,
-    config,
+    config: effectiveConfig,
     DAEMON_PORT,
     DAEMON_HOST,
     safeService,

--- a/apps/agor-daemon/src/integrations/opencode/auth-service.test.ts
+++ b/apps/agor-daemon/src/integrations/opencode/auth-service.test.ts
@@ -84,7 +84,7 @@ const discovery = {
 };
 
 function service() {
-  return createOpenCodeAuthService(db);
+  return createOpenCodeAuthService(db, loadConfigSync());
 }
 
 beforeEach(() => {

--- a/apps/agor-daemon/src/integrations/opencode/auth-service.ts
+++ b/apps/agor-daemon/src/integrations/opencode/auth-service.ts
@@ -1,8 +1,9 @@
-import { loadConfigSync } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { BadRequest, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
+  DeepReadonly,
   OpenCodeOAuthAttempt,
   OpenCodeOAuthAttemptPatch,
   OpenCodeOAuthConnectRequest,
@@ -99,12 +100,15 @@ function scheduleAttemptPrune(attempt: StoredOAuthAttempt): void {
 }
 
 export class OpenCodeAuthService {
-  constructor(private readonly db: TenantScopeAwareDatabase) {}
+  constructor(
+    private readonly db: TenantScopeAwareDatabase,
+    private readonly config: DeepReadonly<AgorConfig>
+  ) {}
 
   private credentialContext(
     params?: AuthenticatedParams
   ): Promise<AuthenticatedOpenCodeSubjectContext> {
-    return resolveAuthenticatedOpenCodeSubjectContext(this.db, params);
+    return resolveAuthenticatedOpenCodeSubjectContext(this.db, this.config, params);
   }
 
   private async execute(
@@ -153,12 +157,11 @@ export class OpenCodeAuthService {
   async find(
     params?: AuthenticatedParams & { query?: { branch_id?: unknown } }
   ): Promise<OpenCodeProviderSettings> {
-    const config = loadConfigSync();
-    const context = await resolveAuthenticatedOpenCodeSubjectContext(this.db, params, config);
+    const context = await resolveAuthenticatedOpenCodeSubjectContext(this.db, this.config, params);
     const directory = await resolveOpenCodeConfigurationDirectory({
       db: this.db,
       context,
-      config,
+      config: this.config,
       params,
     });
     const result = await this.execute(context, {
@@ -402,6 +405,9 @@ export class OpenCodeAuthService {
   }
 }
 
-export function createOpenCodeAuthService(db: TenantScopeAwareDatabase) {
-  return new OpenCodeAuthService(db);
+export function createOpenCodeAuthService(
+  db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>
+) {
+  return new OpenCodeAuthService(db, config);
 }

--- a/apps/agor-daemon/src/integrations/opencode/credential-namespace.ts
+++ b/apps/agor-daemon/src/integrations/opencode/credential-namespace.ts
@@ -5,7 +5,7 @@ import {
   type OpenCodeNativeUnixUserMode,
   resolveOpenCodeCredentialNamespace,
 } from '@agor/agentic-tool-opencode/daemon';
-import { type AgorConfig, isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import { type AgorConfig, isTenantAgenticToolEnabled } from '@agor/core/config';
 import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
@@ -13,7 +13,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
-import type { AuthenticatedParams, UserID } from '@agor/core/types';
+import type { AuthenticatedParams, DeepReadonly, UserID } from '@agor/core/types';
 import {
   getHomedirFromUsername,
   resolveUnixUserForImpersonation,
@@ -47,8 +47,8 @@ export type AuthenticatedOpenCodeSubjectContext = OpenCodeCredentialNamespace & 
 /** Resolve the authenticated caller's one native OpenCode execution context. */
 export async function resolveAuthenticatedOpenCodeSubjectContext(
   db: TenantScopeAwareDatabase,
-  params?: AuthenticatedParams,
-  config: AgorConfig = loadConfigSync()
+  config: DeepReadonly<AgorConfig>,
+  params?: AuthenticatedParams
 ): Promise<AuthenticatedOpenCodeSubjectContext> {
   const callerId = params?.user?.user_id as UserID | undefined;
   if (!callerId) throw new NotAuthenticated('Sign in before using OpenCode.');

--- a/apps/agor-daemon/src/integrations/opencode/index.ts
+++ b/apps/agor-daemon/src/integrations/opencode/index.ts
@@ -5,15 +5,15 @@ import { createOpenCodeModelsService } from './models-service.js';
 
 /** Thin host composition for package-owned OpenCode auth and catalog operations. */
 export function registerOpenCodeServices(
-  ctx: Pick<RegisterServicesContext, 'app' | 'db' | 'requireAuth'>
+  ctx: Pick<RegisterServicesContext, 'app' | 'db' | 'config' | 'requireAuth'>
 ): void {
-  ctx.app.use('/opencode-auth', createOpenCodeAuthService(ctx.db));
+  ctx.app.use('/opencode-auth', createOpenCodeAuthService(ctx.db, ctx.config));
   ctx.app
     .service('/opencode-auth')
     .hooks({ before: { all: [ctx.requireAuth, executorRuntimeScopeGuard()] } });
   ctx.app.service('/opencode-auth').publish(() => []);
 
-  ctx.app.use('/opencode-models', createOpenCodeModelsService(ctx.db));
+  ctx.app.use('/opencode-models', createOpenCodeModelsService(ctx.db, ctx.config));
   ctx.app
     .service('/opencode-models')
     .hooks({ before: { all: [ctx.requireAuth, executorRuntimeScopeGuard()] } });

--- a/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
@@ -66,7 +66,7 @@ const catalog = {
 };
 
 function service() {
-  return createOpenCodeModelsService(db);
+  return createOpenCodeModelsService(db, loadConfigSync());
 }
 
 beforeEach(() => {

--- a/apps/agor-daemon/src/integrations/opencode/models-service.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.ts
@@ -1,8 +1,8 @@
 import { resolvePackagedOpenCodeBinary } from '@agor/agentic-tool-opencode/runtime/binary';
-import { loadConfigSync } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
-import type { AuthenticatedParams, OpenCodeModelCatalog } from '@agor/core/types';
+import type { AuthenticatedParams, DeepReadonly, OpenCodeModelCatalog } from '@agor/core/types';
 import type { ExecutorCommandResult } from '../../utils/spawn-executor.js';
 import { resolveAuthenticatedOpenCodeSubjectContext } from './credential-namespace.js';
 import { startOpenCodeExecutorInvocation } from './executor-command.js';
@@ -12,10 +12,10 @@ const MODEL_CATALOG_FAILURE = 'OpenCode model catalog could not be loaded. Try a
 
 async function readModelCatalog(
   db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>,
   params?: AuthenticatedParams
 ): Promise<OpenCodeModelCatalog> {
-  const config = loadConfigSync();
-  const context = await resolveAuthenticatedOpenCodeSubjectContext(db, params, config);
+  const context = await resolveAuthenticatedOpenCodeSubjectContext(db, config, params);
   let result: ExecutorCommandResult;
   try {
     await resolvePackagedOpenCodeBinary();
@@ -43,16 +43,22 @@ async function readModelCatalog(
 }
 
 export class OpenCodeModelsService {
-  constructor(private readonly db: TenantScopeAwareDatabase) {}
+  constructor(
+    private readonly db: TenantScopeAwareDatabase,
+    private readonly config: DeepReadonly<AgorConfig>
+  ) {}
 
   async find(params?: AuthenticatedParams): Promise<OpenCodeModelCatalog> {
     if (Object.keys(params?.query ?? {}).length > 0) {
       throw new BadRequest('OpenCode model catalog does not accept query parameters.');
     }
-    return readModelCatalog(this.db, params);
+    return readModelCatalog(this.db, this.config, params);
   }
 }
 
-export function createOpenCodeModelsService(db: TenantScopeAwareDatabase) {
-  return new OpenCodeModelsService(db);
+export function createOpenCodeModelsService(
+  db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>
+) {
+  return new OpenCodeModelsService(db, config);
 }

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -141,6 +141,7 @@ describe('agor_branches_update', () => {
     const branchesPatch = vi.fn(async (_id, data) => ({ branch_id: 'branch-1', ...data }));
     const branchesGet = vi.fn(async () => ({ branch_id: 'branch-1' }));
     const app = {
+      get: () => ({ execution: { branch_rbac: true, allow_superadmin: false } }),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
         throw new Error(`Unexpected service call: ${name}`);
@@ -170,6 +171,7 @@ describe('agor_branches_update', () => {
     const sessionsGet = vi.fn(async () => ({ session_id: 'session-1', branch_id: 'branch-1' }));
     const branchesPatch = vi.fn(async () => ({ branch_id: 'branch-1', notes: 'updated' }));
     const app = {
+      get: () => ({ execution: { branch_rbac: true, allow_superadmin: false } }),
       service(name: string) {
         if (name === 'sessions') return { get: sessionsGet };
         if (name === 'branches') return { patch: branchesPatch };
@@ -197,6 +199,7 @@ describe('agor_branches_update', () => {
       needs_attention: false,
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
         throw new Error(`Unexpected service call: ${name}`);
@@ -218,6 +221,7 @@ describe('agor_branches_update', () => {
       needs_attention: true,
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
         throw new Error(`Unexpected service call: ${name}`);
@@ -235,6 +239,7 @@ describe('agor_branches_update', () => {
   it('returns an actionable error when branchId is omitted without session context', async () => {
     const sessionsGet = vi.fn();
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'sessions') return { get: sessionsGet };
         throw new Error(`Unexpected service call: ${name}`);
@@ -272,6 +277,7 @@ describe('agor_branches_create', () => {
       default_branch: 'main',
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
@@ -317,6 +323,7 @@ describe('agor_branches_create', () => {
       default_branch: 'main',
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
@@ -377,6 +384,7 @@ describe('agor_branches_create', () => {
       default_branch: 'main',
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
@@ -421,6 +429,7 @@ describe('agor_branches_create', () => {
       throw new Error('boards.get should not be called when auto-creating a board');
     });
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: boardsGet, create: boardsCreate };
@@ -474,6 +483,7 @@ describe('agor_branches_create', () => {
     const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
     const boardsCreate = vi.fn(async () => ({ board_id: 'board-auto', name: 'Helper' }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: vi.fn(), create: boardsCreate };
@@ -517,6 +527,7 @@ describe('agor_branches_create', () => {
       primary_teammate_id: 'other-teammate',
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch };
         if (name === 'boards') return { get: boardsGet, create: boardsCreate };
@@ -559,6 +570,7 @@ describe('agor_branches_create', () => {
   it('rejects passing both boardId and createBoard=true', async () => {
     const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch: vi.fn() };
         if (name === 'boards')
@@ -589,6 +601,7 @@ describe('agor_branches_create', () => {
     const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
     const boardsCreate = vi.fn();
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'repos') return { get: reposGet, createBranch: vi.fn() };
         if (name === 'boards') return { get: vi.fn(), create: boardsCreate };
@@ -738,6 +751,7 @@ describe('agor_branches_set_zone', () => {
       zone_id: undefined,
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet };
         if (name === 'board-objects') {
@@ -783,6 +797,7 @@ describe('agor_branches_set_zone', () => {
     }));
     const findByBranchId = vi.fn();
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet };
         if (name === 'board-objects') {
@@ -861,6 +876,7 @@ describe('agor_branches_set_zone', () => {
       status: 'running',
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet };
         if (name === 'sessions') return { get: sessionsGet };
@@ -927,6 +943,7 @@ describe('agor_branches_set_zone', () => {
     const boardObjectsPatch = vi.fn();
     const promptCreate = vi.fn();
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { get: branchesGet };
         if (name === 'sessions') return { get: sessionsGet };
@@ -1007,6 +1024,7 @@ describe('agor_branches_list', () => {
       skip: 0,
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { find: findFn };
         throw new Error(`Unexpected service call: ${name}`);
@@ -1095,6 +1113,7 @@ describe('agor_branches_list', () => {
       skip: 0,
     }));
     const app = {
+      get: () => ({}),
       service(name: string) {
         if (name === 'branches') return { find: findFn };
         throw new Error(`Unexpected service call: ${name}`);
@@ -1231,6 +1250,7 @@ describe('agor_branches_cleanup_candidates', () => {
       branchesFind,
       reposGet,
       app: {
+        get: () => ({}),
         service(name: string) {
           if (name === 'branches') return { find: branchesFind };
           if (name === 'repos') return { get: reposGet };
@@ -1551,6 +1571,7 @@ describe('agor_teammates_list', () => {
         ReturnType<BranchRepository['findTeammateBranches']>
       >);
     const app = {
+      get: () => ({}),
       service(name: string) {
         throw new Error(`Unexpected service call: ${name}`);
       },
@@ -1598,6 +1619,7 @@ describe('agor_teammates_list', () => {
       scheduledLegacyBranch,
     ] as Awaited<ReturnType<BranchRepository['findTeammateBranches']>>);
     const app = {
+      get: () => ({}),
       service(name: string) {
         throw new Error(`Unexpected service call: ${name}`);
       },
@@ -1633,6 +1655,7 @@ describe('agor_teammates_list', () => {
       .spyOn(BranchRepository.prototype, 'findTeammateBranches')
       .mockResolvedValue([]);
     const app = {
+      get: () => ({ execution: { branch_rbac: true, allow_superadmin: true } }),
       service(name: string) {
         throw new Error(`Unexpected service call: ${name}`);
       },
@@ -1663,6 +1686,7 @@ describe('agor_teammates_list', () => {
       .spyOn(BranchRepository.prototype, 'findTeammateBranches')
       .mockResolvedValue([]);
     const app = {
+      get: () => ({ execution: { branch_rbac: true, allow_superadmin: false } }),
       service(name: string) {
         throw new Error(`Unexpected service call: ${name}`);
       },

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1,4 +1,3 @@
-import { isBranchRbacEnabled, loadConfig } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
 import type {
   Board,
@@ -126,10 +125,10 @@ function notesPreview(notes: string | undefined, maxLength = 200): string | null
 }
 
 async function shouldScopeTeammateDiscoveryToUser(ctx: McpContext): Promise<boolean> {
-  if (!isBranchRbacEnabled()) return false;
+  if (ctx.app.get('config').execution?.branch_rbac !== true) return false;
   if (ctx.authenticatedUser?._isServiceAccount) return false;
 
-  const config = await loadConfig();
+  const config = ctx.app.get('config');
   const allowSuperadmin = config.execution?.allow_superadmin === true;
   return !isSuperAdmin(ctx.authenticatedUser?.role, allowSuperadmin);
 }
@@ -366,7 +365,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         {
           logPrefix: '[MCP branches.cleanupCandidates.status]',
           asUser: await runWithMcpTenantDatabaseScope(ctx, (db) =>
-            resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id)
+            resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id, ctx.app.get('config'))
           ),
         }
       );
@@ -1084,7 +1083,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // Handle owner additions/removals via the owners service (includes unix sync hooks)
       const ownerErrors: string[] = [];
       if (hasOwnerChanges) {
-        if (!isBranchRbacEnabled()) {
+        if (ctx.app.get('config').execution?.branch_rbac !== true) {
           ownerErrors.push(
             'Owner changes ignored: branch RBAC is not enabled. Enable branch_rbac in config to manage owners.'
           );

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -71,6 +71,7 @@ vi.mock('../../utils/upload-staging.js', () => ({
 type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
 function makeFakeApp(services: Record<string, ServiceStub>) {
   return {
+    get: () => ({}),
     service: (name: string) => {
       const svc = services[name];
       if (!svc) throw new Error(`Unexpected service call: ${name}`);

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1246,7 +1246,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         {
           logPrefix: `[Upload materialize ${ctx.sessionId}]`,
           asUser: await runWithMcpTenantDatabaseScope(ctx, (db) =>
-            resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id)
+            resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id, ctx.app.get('config'))
           ),
         }
       );
@@ -1738,7 +1738,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
           {
             logPrefix: `[Gateway Slack upload ${target.channel.id}]`,
             asUser: await runWithMcpTenantDatabaseScope(ctx, (db) =>
-              resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id)
+              resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id, ctx.app.get('config'))
             ),
           }
         );

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -731,7 +731,7 @@ async function runBranchKnowledgeCommand(
     {
       logPrefix: `[Knowledge ${command}]`,
       asUser: await runWithMcpTenantDatabaseScope(ctx, (db) =>
-        resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id)
+        resolveExecutorReadAsUser(db, ctx.authenticatedUser.user_id, ctx.app.get('config'))
       ),
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -89,7 +89,11 @@ async function registerAndGetTool(ctx: { userId: string; role?: string }): Promi
   } as unknown as McpServer;
 
   registerMessageTools(fakeServer, {
-    app: {} as any,
+    app: {
+      get: () => ({
+        execution: { branch_rbac: mockIsBranchRbacEnabled() },
+      }),
+    } as any,
     db: {} as any,
     userId: ctx.userId as import('@agor/core/types').UserID,
     sessionId: 'sess-0001' as import('@agor/core/types').SessionID,

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -1,4 +1,3 @@
-import { isBranchRbacEnabled } from '@agor/core/config';
 import {
   and,
   asc,
@@ -180,7 +179,7 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       // every matching row into daemon memory.
       const fetchLimit = Math.min(limit + 100, 200);
       const allRows = await runWithMcpTenantDatabaseScope(ctx, async (db) => {
-        if (isBranchRbacEnabled()) {
+        if (ctx.app.get('config').execution?.branch_rbac === true) {
           const userRole = ctx.authenticatedUser?.role as string | undefined;
           if (!isSuperAdmin(userRole)) {
             conditions.push(

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -10,8 +10,6 @@ import { AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
 import { analyticsLogger } from '@agor/core/analytics';
 import {
   type AgorConfig,
-  isUnixImpersonationEnabled,
-  loadConfig,
   type ResolvedDeploymentConfig,
   resolveExecutionSecurityMode,
   resolveMultiTenancyConfig,
@@ -67,6 +65,7 @@ import type {
   BoardID,
   Branch,
   BranchID,
+  DeepReadonly,
   GroupID,
   HookContext,
   MCPServer,
@@ -210,14 +209,13 @@ export function shouldValidateRepoEnvironmentPayload(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
-async function getManagedEnvExecutionMode() {
-  const config = await loadConfig();
+function getManagedEnvExecutionMode(config: DeepReadonly<AgorConfig>) {
   return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
 }
 
-function validateRepoEnvPolicyHook() {
+function validateRepoEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
   return async (context: HookContext) => {
-    const mode = await getManagedEnvExecutionMode();
+    const mode = getManagedEnvExecutionMode(config);
     const items = Array.isArray(context.data) ? context.data : [context.data];
 
     for (const item of items as Array<Record<string, unknown>>) {
@@ -261,7 +259,7 @@ function branchEnvFieldsFromItem(item: Partial<Branch>) {
   };
 }
 
-function validateBranchEnvPolicyHook() {
+function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
   return async (context: HookContext) => {
     const items = Array.isArray(context.data) ? context.data : [context.data];
     const shouldValidate = (items as Array<Record<string, unknown>>).some((item) =>
@@ -269,7 +267,7 @@ function validateBranchEnvPolicyHook() {
     );
     if (!shouldValidate) return context;
 
-    const mode = await getManagedEnvExecutionMode();
+    const mode = getManagedEnvExecutionMode(config);
     for (const raw of items as Array<Partial<Branch>>) {
       let item = raw;
       if (context.method === 'patch' && context.id !== null && context.id !== undefined) {
@@ -1434,17 +1432,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create repositories'),
         requireAdminForEnvConfig(),
-        validateRepoEnvPolicyHook(),
+        validateRepoEnvPolicyHook(config),
       ],
       update: [
         requireMinimumRole(ROLES.MEMBER, 'update repositories'),
         requireAdminForEnvConfig(),
-        validateRepoEnvPolicyHook(),
+        validateRepoEnvPolicyHook(config),
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update repositories'),
         requireAdminForEnvConfig(),
-        validateRepoEnvPolicyHook(),
+        validateRepoEnvPolicyHook(config),
       ],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete repositories')],
     },
@@ -1477,17 +1475,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create branches'),
         requireAdminForEnvConfig(),
-        validateBranchEnvPolicyHook(),
+        validateBranchEnvPolicyHook(config),
         injectCreatedBy(),
       ],
       update: [
         requireMinimumRole(ROLES.MEMBER, 'update branches'),
         requireAdminForEnvConfig(),
-        validateBranchEnvPolicyHook(),
+        validateBranchEnvPolicyHook(config),
       ],
       patch: [
         requireAdminForEnvConfig(),
-        validateBranchEnvPolicyHook(),
+        validateBranchEnvPolicyHook(config),
         ...(branchRbacEnabled
           ? [
               loadBranch(branchRepository),
@@ -2442,7 +2440,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               params: {
                 userId: user.user_id,
                 password: data?.password, // Pass through for password sync
-                configureGitSafeDirectory: isUnixImpersonationEnabled(), // Configure git when impersonating
+                configureGitSafeDirectory:
+                  resolveExecutionSecurityMode(config).unixImpersonationEnabled, // Configure git when impersonating
               },
             },
             { logPrefix: '[Executor/user.create]' }
@@ -2512,7 +2511,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               params: {
                 userId: user.user_id,
                 password: data?.password, // Pass through for password sync
-                configureGitSafeDirectory: isUnixImpersonationEnabled(), // Configure git when impersonating
+                configureGitSafeDirectory:
+                  resolveExecutionSecurityMode(config).unixImpersonationEnabled, // Configure git when impersonating
               },
             },
             { logPrefix: '[Executor/user.patch]' }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -597,7 +597,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // Config, context, file, files, terminals
   // ============================================================================
 
-  const configService = createConfigService(db);
+  const configService = createConfigService(db, config);
   configService.app = app;
   // Host ACL/user/group operations exist only on a self-hosted daemon host. Hosted
   // registration is intentionally absent rather than forwarding privileged
@@ -626,7 +626,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     },
   });
 
-  app.use('/check-auth', createCheckAuthService(db));
+  app.use('/check-auth', createCheckAuthService(db, config));
   app.service('/check-auth').hooks({ before: { create: [ctx.requireAuth] } });
 
   registerOpenCodeServices(ctx);

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -14,12 +14,7 @@
 
 import { createHash } from 'node:crypto';
 import * as path from 'node:path';
-import {
-  getDaemonBaseUrl,
-  loadConfig,
-  PAGINATION,
-  resolveUserEnvironment,
-} from '@agor/core/config';
+import { getDaemonBaseUrl, PAGINATION, resolveUserEnvironment } from '@agor/core/config';
 import {
   ArtifactRepository,
   ArtifactTrustGrantRepository,
@@ -508,7 +503,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       },
       {
         logPrefix: `[ArtifactsService.publish ${branch.branch_id}]`,
-        asUser: await resolveExecutorReadAsUser(this.dbRef, params.user?.user_id),
+        asUser: await resolveExecutorReadAsUser(
+          this.dbRef,
+          params.user?.user_id,
+          this.app.get('config')
+        ),
       }
     );
     if (!result.success) {
@@ -944,7 +943,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       },
       {
         logPrefix: `[ArtifactsService.land ${branchId}]`,
-        asUser: await resolveExecutorReadAsUser(this.dbRef, params.user?.user_id),
+        asUser: await resolveExecutorReadAsUser(
+          this.dbRef,
+          params.user?.user_id,
+          this.app.get('config')
+        ),
       }
     );
     if (!result.success) {
@@ -1330,7 +1333,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // Instance-wide trust is meaningful only on single-user instances. On
       // multi-user setups it would mean "trust any artifact published by any
       // user on this server with my secrets" — too broad. Reject.
-      const config = await loadConfig();
+      const config = this.app.get('config');
       const unixMode = config.execution?.unix_user_mode ?? 'simple';
       if (unixMode !== 'simple') {
         throw new Error(
@@ -1643,7 +1646,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       },
       {
         logPrefix: `[ArtifactsService.validate ${branch.branch_id}]`,
-        asUser: await resolveExecutorReadAsUser(this.dbRef, params.user?.user_id),
+        asUser: await resolveExecutorReadAsUser(
+          this.dbRef,
+          params.user?.user_id,
+          this.app.get('config')
+        ),
       }
     );
     if (!result.success) {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -46,6 +46,7 @@ function createRenderEnvHarness(opts: {
     },
   }));
   const app = {
+    get: () => ({}),
     sessionTokenService: {
       generateToken: vi.fn(async () => 'executor-token'),
     },
@@ -92,6 +93,7 @@ function createPatchHarness(opts: {
     find: vi.fn(async () => []),
   };
   const app = {
+    get: () => ({}),
     sessionTokenService: {
       generateToken: vi.fn(async () => 'executor-token'),
     },
@@ -169,6 +171,7 @@ function createServiceHarness() {
   const branchesService = { find: vi.fn(async () => []), emit: vi.fn() };
 
   const app = {
+    get: () => ({}),
     sessionTokenService: {
       generateToken: vi.fn(async () => 'executor-token'),
     },
@@ -211,6 +214,7 @@ function createFindHarness(opts: {
   branchIdsInZone: BranchID[];
 }) {
   const app = {
+    get: () => ({}),
     service(path: string) {
       throw new Error(`Unknown service: ${path}`);
     },
@@ -1013,6 +1017,7 @@ describe('BranchesService one-shot teammate creation wiring', () => {
   function createTeammateWiringHarness() {
     const boardsEmit = vi.fn();
     const app = {
+      get: () => ({}),
       service(path: string) {
         if (path === 'boards') return { emit: boardsEmit };
         throw new Error(`Unknown service: ${path}`);
@@ -1736,6 +1741,7 @@ describe('BranchesService teammate home Knowledge namespace guard', () => {
     });
 
     const app = {
+      get: () => ({}),
       service(path: string) {
         if (path === 'branches') return { find: vi.fn(async () => []) };
         throw new Error(`Unknown service: ${path}`);
@@ -1888,7 +1894,7 @@ describe('BranchesService.create permission defaults', () => {
         default_dangerously_allow_session_sharing: true,
       });
 
-      const app = { service: vi.fn() } as unknown as Application;
+      const app = { get: () => ({}), service: vi.fn() } as unknown as Application;
       const service = new BranchesService(db, app);
       const branch = (await service.create({
         repo_id: repo.repo_id,
@@ -1932,7 +1938,7 @@ describe('BranchesService.create permission defaults', () => {
         default_others_fs_access: 'write',
       });
 
-      const app = { service: vi.fn() } as unknown as Application;
+      const app = { get: () => ({}), service: vi.fn() } as unknown as Application;
       const service = new BranchesService(db, app);
       const branch = (await service.create({
         repo_id: repo.repo_id,
@@ -1979,6 +1985,7 @@ describe('BranchesService environment health recovery', () => {
       },
     };
     const app = {
+      get: () => ({}),
       service(path: string) {
         if (path === 'repos') return { get: vi.fn(async () => ({ repo_id: 'repo-1' })) };
         throw new Error(`Unknown service: ${path}`);

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -14,8 +14,6 @@ import {
   ensureBranchCloneDepthAllowed,
   ensureBranchStorageModeAllowed,
   getBranchesDir,
-  loadConfig,
-  loadConfigSync,
   PAGINATION,
   resolveBranchStorageConfig,
   resolveExecutionSecurityMode,
@@ -210,7 +208,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   private async getManagedEnvExecutionMode(): Promise<ManagedEnvExecutionMode> {
-    const config = await loadConfig();
+    const config = this.app.get('config');
     return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
   }
 
@@ -353,7 +351,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     asUser?: string;
     env: Record<string, string>;
   }> {
-    const config = await loadConfig();
+    const config = this.app.get('config');
     const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
     return this.withTenantDatabase(params, async () => {
       let asUser: string | undefined;
@@ -671,7 +669,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     ensureBranchStorageModeAllowed(storageMode);
     if (
       storageMode === 'worktree' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth'
     ) {
       throw new BadRequest(
         "storage_mode='worktree' is unavailable in hosted multi-tenant mode; use clone storage."
@@ -1298,7 +1296,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // mode so we don't try to sudo on hosts without passwordless sudoers
       // (#1140 root cause; #1143 fixed the branch-remove sister bug by
       // centralizing the gate inside the resolver itself).
-      const asUser = await resolveGitImpersonationForBranch(this.db, branch);
+      const asUser = await resolveGitImpersonationForBranch(
+        this.db,
+        branch,
+        this.app.get('config')
+      );
 
       // Generate session token for executor authentication. Hook chain
       // enforces auth before we get here, so non-null assertion is safe.
@@ -1556,7 +1558,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
     if (
       (branch.storage_mode ?? 'worktree') === 'worktree' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth'
     ) {
       throw new BadRequest(
         'Historical worktree branches cannot be restored in hosted multi-tenant mode.'
@@ -1609,7 +1611,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       },
       {
         logPrefix: `[BranchesService.unarchive.status ${branch.name}]`,
-        asUser: await resolveExecutorReadAsUser(this.db, params?.user?.user_id),
+        asUser: await resolveExecutorReadAsUser(
+          this.db,
+          params?.user?.user_id,
+          this.app.get('config')
+        ),
       }
     );
     if (!statusResult.success) {
@@ -1683,10 +1689,12 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               restoreMode: true,
               // Unix group isolation
               initUnixGroup,
-              ...(initUnixGroup ? { daemonUser: loadConfigSync().daemon?.unix_user } : {}),
+              ...(initUnixGroup ? { daemonUser: this.app.get('config').daemon?.unix_user } : {}),
               fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
               useReference:
-                storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
+                storageMode === 'clone' &&
+                !!repo.local_path &&
+                shouldUseCloneReferencePath(this.app.get('config')),
             },
           },
           {
@@ -2547,7 +2555,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     // Resolve host IP + unix GID (matches executor's renderEnvironmentTemplates).
-    const config = await loadConfig();
+    const config = this.app.get('config');
     const hostIpAddress = resolveHostIpAddress(config.daemon?.host_ip_address);
     const unixGid = branch.unix_group ? getGidFromGroupName(branch.unix_group) : undefined;
 

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -18,7 +18,7 @@
 
 import { getAgenticToolIntegration, TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
 import { loadManagedAgenticToolSdk } from '@agor/core/agentic-integrations';
-import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
+import { type AgorConfig, isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
 import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
@@ -30,6 +30,7 @@ import type {
   AuthCheckResult,
   AuthCheckStatus,
   AuthenticatedParams,
+  DeepReadonly,
   UserID,
 } from '@agor/core/types';
 import { isAgenticToolName } from '@agor/core/types';
@@ -245,9 +246,10 @@ function resultFromKeyStatus(status: AuthCheckStatus, rejectedHint: string): Aut
  */
 async function probeCodexAuthFile(
   userId: UserID | undefined,
-  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
+  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>,
+  config: DeepReadonly<AgorConfig>
 ): Promise<AuthCheckResult> {
-  const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+  const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase, config);
   if (!identity.ok) {
     // A missing unix_username is a real configuration gap (no credential can
     // exist for this user yet). An unsupported mode means the daemon cannot
@@ -309,7 +311,10 @@ async function probeCodexAuthFile(
   );
 }
 
-export function createCheckAuthService(db: TenantScopeAwareDatabase) {
+export function createCheckAuthService(
+  db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>
+) {
   return {
     async create(
       data: { tool: string; apiKey?: string; validateNative?: boolean },
@@ -391,7 +396,7 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
         // Filesystem validation can require an ephemeral Cloud executor, so it
         // is reserved for an explicit user action.
         return data.validateNative
-          ? probeCodexAuthFile(userId, withTenantDatabase)
+          ? probeCodexAuthFile(userId, withTenantDatabase, config)
           : unknown('ChatGPT login is configured but has not been validated.');
       }
 

--- a/apps/agor-daemon/src/services/codex-auth-import.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.test.ts
@@ -64,7 +64,7 @@ function makeApp() {
     get: vi.fn(async () => ({ agentic_auth_methods: { 'claude-code': 'api_key' } })),
     patch: vi.fn(async () => ({})),
   };
-  return { app: { service: () => usersService }, usersService };
+  return { app: { get: () => loadConfigSyncMock(), service: () => usersService }, usersService };
 }
 
 const AUTH_PARAMS = {

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -59,7 +59,11 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
       const parsed = parseCodexAuthJson(data?.authJson);
       if (!parsed.ok) throw new BadRequest(parsed.error);
 
-      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      const identity = await resolveCodexUnixIdentity(
+        userId,
+        withTenantDatabase,
+        app.get('config')
+      );
       if (!identity.ok) {
         throw new BadRequest(
           `Cannot determine which Unix account should hold this Codex login: ${identity.message}`

--- a/apps/agor-daemon/src/services/codex-auth-logout.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-logout.test.ts
@@ -42,7 +42,7 @@ function makeApp(
   }
 ) {
   const usersService = { get: vi.fn(async () => current), patch: vi.fn(async () => ({})) };
-  return { app: { service: () => usersService }, usersService };
+  return { app: { get: () => loadConfigSyncMock(), service: () => usersService }, usersService };
 }
 
 function service(app: { service: () => unknown }) {

--- a/apps/agor-daemon/src/services/codex-auth-logout.ts
+++ b/apps/agor-daemon/src/services/codex-auth-logout.ts
@@ -67,7 +67,11 @@ export function createCodexAuthLogoutService(app: AppLike, db: TenantScopeAwareD
       const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
         runWithTenantDatabaseScope(db, tenantId, work);
 
-      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      const identity = await resolveCodexUnixIdentity(
+        userId,
+        withTenantDatabase,
+        app.get('config')
+      );
       if (!identity.ok) {
         throw new BadRequest(
           `Cannot determine which Unix account holds this Codex login: ${identity.message}`

--- a/apps/agor-daemon/src/services/codex-auth-shared.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.test.ts
@@ -5,7 +5,7 @@
  * home guarantee. Delegated WITHOUT a template keeps the simple-mode local
  * process behavior but still requires a unix_username.
  */
-import { loadConfigSync } from '@agor/core/config';
+import { loadConfigSync, resolveEffectiveConfig } from '@agor/core/config';
 import { type TenantScopedDatabase, UsersRepository } from '@agor/core/db';
 import type { UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,7 @@ vi.mock('@agor/core/config', async (importOriginal) => {
   return {
     ...actual,
     loadConfigSync: vi.fn(),
+    resolveEffectiveConfig: vi.fn((config) => config),
   };
 });
 
@@ -29,6 +30,7 @@ vi.mock('@agor/core/db', async (importOriginal) => {
 import { resolveCodexUnixIdentity } from './codex-auth-shared.js';
 
 const loadConfigSyncMock = vi.mocked(loadConfigSync);
+const resolveEffectiveConfigMock = vi.mocked(resolveEffectiveConfig);
 const usersRepositoryMock = vi.mocked(UsersRepository);
 
 const USER_ID = 'user-1' as UserID;
@@ -39,10 +41,26 @@ const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolveEffectiveConfigMock.mockImplementation((config) => config);
   // Regular function (not arrow) so `new UsersRepository(...)` works: a
   // constructor returning an object yields that object.
   usersRepositoryMock.mockImplementation(function mockRepo() {
     return { findById } as never;
+  });
+});
+
+it('routes credentials using deployment environment overrides from the effective config', async () => {
+  loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
+  resolveEffectiveConfigMock.mockReturnValue({ execution: { unix_user_mode: 'strict' } } as never);
+  findById.mockResolvedValue({ user_id: USER_ID, unix_username: 'root' });
+
+  await expect(
+    resolveCodexUnixIdentity(USER_ID, withTenantDatabase, resolveEffectiveConfig(loadConfigSync()))
+  ).resolves.toEqual({
+    ok: true,
+    unixUser: 'root',
+    reportedUnixUser: 'root',
+    userId: USER_ID,
   });
 });
 
@@ -56,7 +74,13 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
       },
     } as never);
 
-    await expect(resolveCodexUnixIdentity(USER_ID, withTenantDatabase)).resolves.toEqual({
+    await expect(
+      resolveCodexUnixIdentity(
+        USER_ID,
+        withTenantDatabase,
+        resolveEffectiveConfig(loadConfigSync())
+      )
+    ).resolves.toEqual({
       ok: false,
       reason: 'unsupported-mode',
       message: expect.stringContaining('persistent-per-user'),
@@ -72,7 +96,11 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
       },
     } as never);
 
-    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+    const result = await resolveCodexUnixIdentity(
+      USER_ID,
+      withTenantDatabase,
+      resolveEffectiveConfig(loadConfigSync())
+    );
 
     expect(result).toEqual({
       ok: false,
@@ -90,7 +118,11 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
     } as never);
     findById.mockResolvedValue({ user_id: USER_ID, unix_username: 'alice' });
 
-    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+    const result = await resolveCodexUnixIdentity(
+      USER_ID,
+      withTenantDatabase,
+      resolveEffectiveConfig(loadConfigSync())
+    );
 
     // No impersonation in delegated mode — auth.json lives in the daemon
     // user's home, exactly like simple mode.
@@ -108,7 +140,11 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
     } as never);
     findById.mockResolvedValue({ user_id: USER_ID, unix_username: null });
 
-    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+    const result = await resolveCodexUnixIdentity(
+      USER_ID,
+      withTenantDatabase,
+      resolveEffectiveConfig(loadConfigSync())
+    );
 
     expect(result).toEqual({
       ok: false,
@@ -125,7 +161,11 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
       },
     } as never);
 
-    const result = await resolveCodexUnixIdentity(USER_ID, withTenantDatabase);
+    const result = await resolveCodexUnixIdentity(
+      USER_ID,
+      withTenantDatabase,
+      resolveEffectiveConfig(loadConfigSync())
+    );
 
     expect(result).toEqual({
       ok: true,
@@ -150,7 +190,13 @@ describe('resolveCodexUnixIdentity — delegated mode', () => {
     } as never);
     findById.mockResolvedValue({ user_id: USER_ID, unix_username: 'alice' });
 
-    await expect(resolveCodexUnixIdentity(USER_ID, withTenantDatabase)).resolves.toEqual({
+    await expect(
+      resolveCodexUnixIdentity(
+        USER_ID,
+        withTenantDatabase,
+        resolveEffectiveConfig(loadConfigSync())
+      )
+    ).resolves.toEqual({
       ok: true,
       unixUser: null,
       reportedUnixUser: 'alice',

--- a/apps/agor-daemon/src/services/codex-auth-shared.ts
+++ b/apps/agor-daemon/src/services/codex-auth-shared.ts
@@ -17,13 +17,19 @@
  */
 
 import {
+  type AgorConfig,
   hasTenantSafeExecutorCredentialHome,
-  loadConfigSync,
   unixUserModeRequiresUsername,
 } from '@agor/core/config';
 import { type TenantScopedDatabase, UsersRepository } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
-import type { AgenticAuthMethods, AuthenticatedParams, User, UserID } from '@agor/core/types';
+import type {
+  AgenticAuthMethods,
+  AuthenticatedParams,
+  DeepReadonly,
+  User,
+  UserID,
+} from '@agor/core/types';
 import {
   resolveUnixUserForImpersonation,
   type UnixUserMode,
@@ -33,6 +39,7 @@ import type { CodexAuthSummary } from '../utils/codex-auth-file.js';
 import { writeCodexAuthViaExecutor } from '../utils/executor-codex-auth.js';
 
 export interface AppLike {
+  get(name: 'config'): DeepReadonly<AgorConfig>;
   service(path: string): unknown;
 }
 
@@ -76,9 +83,9 @@ export type CodexUnixIdentityResolution =
  */
 export async function resolveCodexUnixIdentity(
   userId: UserID | undefined,
-  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
+  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>,
+  config: DeepReadonly<AgorConfig>
 ): Promise<CodexUnixIdentityResolution> {
-  const config = loadConfigSync();
   const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
 
   if (!hasTenantSafeExecutorCredentialHome(config)) {

--- a/apps/agor-daemon/src/services/codex-device-auth.test.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.test.ts
@@ -53,7 +53,7 @@ function makeApp() {
     get: vi.fn(async () => ({ agentic_auth_methods: {} })),
     patch: vi.fn(async () => ({})),
   };
-  return { app: { service: () => usersService }, usersService };
+  return { app: { get: () => loadConfigSyncMock(), service: () => usersService }, usersService };
 }
 
 const AUTH_PARAMS = {

--- a/apps/agor-daemon/src/services/codex-device-auth.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.ts
@@ -405,7 +405,11 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
 
       // Resolve the destination identity up front so a strict-mode user with
       // no unix_username fails fast instead of after approving the code.
-      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      const identity = await resolveCodexUnixIdentity(
+        userId,
+        withTenantDatabase,
+        app.get('config')
+      );
       if (!identity.ok) {
         throw new BadRequest(
           `Cannot determine which Unix account should hold this Codex login: ${identity.message}`

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -9,12 +9,13 @@
  */
 
 import { TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
-import { type ApiKeyName, loadConfig, resolveApiKey } from '@agor/core/config';
+import { type AgorConfig, type ApiKeyName, resolveApiKey } from '@agor/core/config';
 import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   AgenticToolName,
   AuthenticatedParams,
+  DeepReadonly,
   Params,
   TaskID,
   UserID,
@@ -96,7 +97,10 @@ export class ConfigService {
   /** App reference injected after registration for cross-service calls */
   app?: Application;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private readonly config: DeepReadonly<AgorConfig>
+  ) {
     this.db = db;
   }
 
@@ -234,8 +238,7 @@ export class ConfigService {
       (tenantDb) => resolveApiKey(keyName, { userId, db: tenantDb, tool })
     );
     if (result.useNativeAuth) {
-      const config = await loadConfig();
-      if (config.multi_tenancy?.mode === 'required_from_auth') {
+      if (this.config.multi_tenancy?.mode === 'required_from_auth') {
         throw new BadRequest(
           'Shared machine subscription authentication is unavailable in hosted multitenant mode'
         );
@@ -256,6 +259,9 @@ export class ConfigService {
 /**
  * Service factory function
  */
-export function createConfigService(db: TenantScopeAwareDatabase): ConfigService {
-  return new ConfigService(db);
+export function createConfigService(
+  db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>
+): ConfigService {
+  return new ConfigService(db, config);
 }

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -30,7 +30,7 @@ describe('FileService executor failures', () => {
     const service = new FileService(
       { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
       null as never,
-      { settings: { authentication: { secret: 'test' } } } as never
+      { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
     );
 
     await expect(
@@ -79,7 +79,7 @@ describe('FileService executor failures', () => {
       const service = new FileService(
         { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
         null as never,
-        { settings: { authentication: { secret: 'test' } } } as never
+        { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
       );
       const params = {
         query: { branch_id: 'branch-1' },

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -95,7 +95,11 @@ export class FileService
       },
       {
         logPrefix: `[FileService ${branchId}]`,
-        asUser: await resolveExecutorReadAsUser(this.db, params?.user?.user_id),
+        asUser: await resolveExecutorReadAsUser(
+          this.db,
+          params?.user?.user_id,
+          this.app.get('config')
+        ),
       }
     );
   }

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -126,7 +126,11 @@ export class FilesService {
           // In strict mode, autocomplete runs as the requesting Unix user.
           // In simple/insulated mode this stays undefined so default installs
           // do not require sudo and configured executor defaults can apply.
-          asUser: await resolveExecutorReadAsUser(this.db, currentUser ?? currentUserId),
+          asUser: await resolveExecutorReadAsUser(
+            this.db,
+            currentUser ?? currentUserId,
+            this.app.get('config')
+          ),
         }
       );
 

--- a/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
+++ b/apps/agor-daemon/src/services/hosted-repo-policy.test.ts
@@ -20,7 +20,7 @@ describe('hosted repository storage policy canonical boundaries', () => {
   it('rejects worktree rows through the exposed branches.create boundary', async () => {
     const service = new BranchesService(
       {} as never,
-      { service: vi.fn() } as unknown as Application
+      { get: () => ({}), service: vi.fn() } as unknown as Application
     );
 
     await expect(
@@ -32,7 +32,10 @@ describe('hosted repository storage policy canonical boundaries', () => {
   });
 
   it('rejects bulk conversion to local repositories', async () => {
-    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+    const service = new ReposService(
+      {} as never,
+      { get: () => ({}), service: vi.fn() } as unknown as Application
+    );
 
     await expect(service.patch(null, { repo_type: 'local' })).rejects.toThrow(
       /Bulk conversion to local repositories is unavailable/
@@ -42,7 +45,10 @@ describe('hosted repository storage policy canonical boundaries', () => {
   it('allows unrelated updates to historical local repository rows', async () => {
     const patched = { repo_id: 'repo-1', repo_type: 'local', slug: 'renamed' } as Repo;
     const adapterPatch = vi.spyOn(DrizzleService.prototype, 'patch').mockResolvedValue(patched);
-    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+    const service = new ReposService(
+      {} as never,
+      { get: () => ({}), service: vi.fn() } as unknown as Application
+    );
 
     await expect(service.patch('repo-1', { slug: 'renamed' })).resolves.toBe(patched);
     expect(adapterPatch).toHaveBeenCalledWith('repo-1', { slug: 'renamed' }, undefined);

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -78,7 +78,7 @@ describe('ReposService.addLocalRepository executor boundary', () => {
         credentialFindingCount: 0,
       },
     });
-    const app = { service: vi.fn() } as unknown as Application;
+    const app = { get: () => ({}), service: vi.fn() } as unknown as Application;
     const service = new ReposService({} as never, app);
     const create = vi.spyOn(service, 'create').mockResolvedValue({
       repo_id: 'repo-id',
@@ -111,7 +111,10 @@ describe('ReposService.addLocalRepository executor boundary', () => {
       success: false,
       error: { code: 'GIT_REPO_INSPECT_FAILED', message: 'Not a valid git repository' },
     });
-    const service = new ReposService({} as never, { service: vi.fn() } as unknown as Application);
+    const service = new ReposService(
+      {} as never,
+      { get: () => ({}), service: vi.fn() } as unknown as Application
+    );
     const create = vi.spyOn(service, 'create');
     await expect(
       service.addLocalRepository({ path: '/bad', slug: 'local/bad' }, {
@@ -150,6 +153,7 @@ describe('ReposService.createBranch Git lifecycle identity', () => {
       find: vi.fn(async () => ({ data: [] })),
     };
     const app = {
+      get: () => ({}),
       settings: { authentication: { secret: 'test-secret' } },
       service: vi.fn((name: string) => {
         if (name === 'boards') return { get: vi.fn(async () => ({ objects: {} })) };
@@ -194,6 +198,7 @@ describe('ReposService.cloneRepository Git lifecycle identity', () => {
 
     const repos = { patch: vi.fn() };
     const app = {
+      get: () => ({}),
       settings: { authentication: { secret: 'test-secret' } },
       service: vi.fn((name: string) => {
         if (name === 'repos') return repos;

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -19,7 +19,6 @@ import {
   getReposDir,
   isValidGitUrl,
   isValidSlug,
-  loadConfigSync,
   normalizeRepoUrl,
   PAGINATION,
   resolveBranchStorageConfig,
@@ -136,7 +135,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   ): Promise<Repo | Repo[]> {
     const rows = Array.isArray(data) ? data : [data];
     if (
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth' &&
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth' &&
       rows.some((row) => row.repo_type === 'local')
     ) {
       throw new BadRequest(
@@ -153,7 +152,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   ): Promise<Repo | Repo[]> {
     if (
       data.repo_type === 'local' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth'
     ) {
       if (!id) {
         throw new BadRequest(
@@ -268,7 +267,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // lifecycle identity; the post-clone group initialization grants the
     // creator access. Requesting-user impersonation cannot create the first
     // slug directory in strict mode.
-    const asUser = await resolveGitImpersonationForUser(this.db, userId);
+    const asUser = await resolveGitImpersonationForUser(this.db, userId, this.app.get('config'));
 
     // Pre-create the repo row with `clone_status: 'cloning'` so failures stay
     // queryable via `agor_repos_get(repoId)`. Pre-#1126 the row was only
@@ -329,7 +328,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           createDbRecord: true,
           userId: userId as string | undefined,
           initUnixGroup,
-          ...(initUnixGroup ? { daemonUser: loadConfigSync().daemon?.unix_user } : {}),
+          ...(initUnixGroup ? { daemonUser: this.app.get('config').daemon?.unix_user } : {}),
         },
       },
       {
@@ -486,7 +485,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     if (
       effectiveType === 'local' &&
       current.repo_type !== 'local' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth'
     ) {
       throw new BadRequest(
         'Local repository registration is unavailable in hosted multi-tenant mode.'
@@ -510,7 +509,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     data: { path: string; slug?: string },
     params?: RepoParams
   ): Promise<Repo> {
-    if (resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth') {
+    if (resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth') {
       throw new BadRequest(
         'Local repository registration is unavailable in hosted multi-tenant mode.'
       );
@@ -525,7 +524,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     }
 
     const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
-    const asUser = await resolveExecutorReadAsUser(this.db, userId);
+    const asUser = await resolveExecutorReadAsUser(this.db, userId, this.app.get('config'));
     const inspection = await runExecutorCommand(
       {
         command: 'git.repo.inspect',
@@ -658,7 +657,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     ensureBranchStorageModeAllowed(storageMode);
     if (
       storageMode === 'worktree' &&
-      resolveMultiTenancyConfig(loadConfigSync()).mode === 'required_from_auth'
+      resolveMultiTenancyConfig(this.app.get('config')).mode === 'required_from_auth'
     ) {
       throw new BadRequest(
         "storage_mode='worktree' is unavailable in hosted multi-tenant mode; use clone storage."
@@ -924,7 +923,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       // branch through its group/ACL, but cannot create a child beneath the
       // daemon-owned worktree root or mutate the base repo's .git/worktrees.
       // Keep resolveExecutorReadAsUser for read/probe commands only.
-      const asUser = await resolveGitImpersonationForUser(this.db, userId);
+      const asUser = await resolveGitImpersonationForUser(this.db, userId, this.app.get('config'));
 
       spawnExecutorFireAndForget(
         {
@@ -937,10 +936,12 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             userId: userId as string | undefined,
             // Unix group isolation (only when unix_user_mode is non-simple)
             initUnixGroup,
-            ...(initUnixGroup ? { daemonUser: loadConfigSync().daemon?.unix_user } : {}),
+            ...(initUnixGroup ? { daemonUser: this.app.get('config').daemon?.unix_user } : {}),
             fixBasicPermissions: !executionMode.appRbacEnabled && !initUnixGroup,
             useReference:
-              storageMode === 'clone' && !!repo.local_path && shouldUseCloneReferencePath(),
+              storageMode === 'clone' &&
+              !!repo.local_path &&
+              shouldUseCloneReferencePath(this.app.get('config')),
           },
         },
         {
@@ -997,7 +998,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       this.db,
       (serviceParams as Partial<AuthenticatedParams> | undefined)?.user?.user_id as
         | UserID
-        | undefined
+        | undefined,
+      this.app.get('config')
     );
 
     return runExecutorCommand(

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -93,6 +93,7 @@ import { buildBranchShellTabName, buildZellijSessionName, TerminalsService } fro
 function makeApp() {
   const emit = vi.fn();
   return {
+    get: () => ({ execution: { branch_rbac: false, unix_user_mode: 'simple' } }),
     emit,
     // The service subscribes to executor ready/error app events in its
     // constructor; a no-op recorder keeps that wiring from throwing under test.

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { createUserProcessEnvironment, loadConfig } from '@agor/core/config';
+import { createUserProcessEnvironment } from '@agor/core/config';
 import {
   BranchRepository,
   getCurrentTenantId,
@@ -182,7 +182,7 @@ export class TerminalsService {
     // This prevents members from opening a terminal tab in a branch they
     // cannot see or prompt in.
     if (data.branchId && params?.provider) {
-      const config = await loadConfig();
+      const config = this.app.get('config');
       const rbacEnabled = config.execution?.branch_rbac === true;
       if (rbacEnabled) {
         const userId = params?.user?.user_id as UserID | undefined;
@@ -435,7 +435,7 @@ export class TerminalsService {
         if (branch) {
           const branchTabName = buildBranchShellTabName(branch);
           const channel = `user/${userId}/terminal`;
-          const unixUserMode = (await loadConfig()).execution?.unix_user_mode ?? 'simple';
+          const unixUserMode = this.app.get('config').execution?.unix_user_mode ?? 'simple';
 
           // Gate ALL executor-directed choreography on readiness. For a normal
           // warm reuse (the executor acked ready this daemon session) this
@@ -526,7 +526,7 @@ export class TerminalsService {
 
     try {
       // Resolve Unix user for impersonation
-      const config = await loadConfig();
+      const config = this.app.get('config');
       const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
       const executorUser = config.execution?.executor_unix_user;
 

--- a/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
+++ b/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
@@ -1,81 +1,57 @@
 /**
- * Build the daemon-resolved config slice that gets embedded in executor
- * payloads. See `@agor/core/config` for the schema, and
- * `context/explorations/daemon-fs-decoupling.md` §1.5 (H1) for why.
- *
- * Reads via `loadConfigSync()`, which is stat-validated and cached — calling
- * this on every spawn is cheap.
- *
- * Lives in its own file rather than inside `spawn-executor.ts` so that file
- * can stay focused on subprocess / template / sudo / env-routing concerns.
+ * Build the immutable daemon-resolved config slice embedded in executor payloads.
+ * The full effective config remains owned by the Feathers application; this
+ * module caches only the non-secret executor projection initialized at startup.
  */
 
 import {
-  loadConfigSync,
+  type AgorConfig,
   type ResolvedConfigSlice,
   resolveExecutorHeartbeatConfig,
   resolveSdkWatchdogConfig,
 } from '@agor/core/config';
+import type { DeepReadonly } from '@agor/core/types';
+import { deepFreeze } from './deep-freeze.js';
+
+let configuredSlice: DeepReadonly<ResolvedConfigSlice> | undefined;
 
 /**
- * Inject a daemon-resolved config slice into an executor payload if the
- * caller didn't already provide one.
- *
- * Compares `payload.resolvedConfig !== undefined` rather than using
- * `'resolvedConfig' in payload`. A caller passing
- * `{ resolvedConfig: undefined }` should still get the daemon-built slice —
- * `JSON.stringify()` drops `undefined` anyway, so an `in`-based check would
- * silently ship an empty payload and the executor would fall back to
- * handler defaults.
- *
- * Returns a NEW payload object when injection happens, otherwise the
- * original reference unchanged.
+ * Initialize the process-wide executor projection from the app's effective snapshot.
+ * Replacement is intentional for tests that start multiple daemon apps in one process.
  */
-export function withResolvedConfig<T extends { resolvedConfig?: unknown }>(payload: T): T {
-  if (payload.resolvedConfig !== undefined) {
-    return payload;
-  }
-  return { ...payload, resolvedConfig: buildResolvedConfigSlice() };
+export function configureResolvedConfigSlice(config: DeepReadonly<AgorConfig>): void {
+  configuredSlice = deepFreeze(buildResolvedConfigSlice(config));
 }
 
-export function buildResolvedConfigSlice(): ResolvedConfigSlice {
-  try {
-    const config = loadConfigSync();
-    // Build by omitting sections whose values are all undefined, so the
-    // in-memory shape matches what survives JSON serialization across
-    // stdin to the executor. Tests assert this shape directly, so it must
-    // be true on both sides of the wire.
-    //
-    // `satisfies` makes the daemon-side producer type-check against the
-    // same schema the executor uses to parse the payload (both pulled from
-    // @agor/core/config). Adding a new field to ResolvedConfigSlice
-    // without sourcing it here is a compile error.
-    const slice: ResolvedConfigSlice = {};
-    const executionSlice: NonNullable<ResolvedConfigSlice['execution']> = {};
-    const permissionTimeoutMs = config.execution?.permission_timeout_ms;
-    if (permissionTimeoutMs !== undefined) {
-      executionSlice.permission_timeout_ms = permissionTimeoutMs;
-    }
-    const heartbeat = resolveExecutorHeartbeatConfig(config.execution);
-    executionSlice.executor_heartbeat = {
-      enabled: heartbeat.enabled,
-      interval_ms: heartbeat.interval_ms,
-    };
-    executionSlice.sdk_watchdog = resolveSdkWatchdogConfig(config.execution);
-    if (Object.keys(executionSlice).length > 0) {
-      slice.execution = executionSlice;
-    }
-    const hostIpAddress = config.daemon?.host_ip_address;
-    if (hostIpAddress !== undefined) {
-      slice.daemon = { host_ip_address: hostIpAddress };
-    }
-    return slice satisfies ResolvedConfigSlice;
-  } catch (error) {
-    // Don't fail a spawn over a config read error — handlers have defaults.
-    console.warn(
-      '[Executor] Failed to resolve config slice; handlers will fall back to defaults:',
-      error instanceof Error ? error.message : String(error)
-    );
-    return {};
+/** Test-only reset for daemon instances constructed in the same process. */
+export function resetResolvedConfigSliceForTests(): void {
+  configuredSlice = undefined;
+}
+
+export function withResolvedConfig<T extends { resolvedConfig?: unknown }>(payload: T): T {
+  if (payload.resolvedConfig !== undefined) return payload;
+  if (!configuredSlice) {
+    throw new Error('Executor config slice was not initialized from the effective daemon config');
   }
+  return { ...payload, resolvedConfig: configuredSlice };
+}
+
+export function buildResolvedConfigSlice(config: DeepReadonly<AgorConfig>): ResolvedConfigSlice {
+  const slice: ResolvedConfigSlice = {};
+  const executionSlice: NonNullable<ResolvedConfigSlice['execution']> = {};
+  const permissionTimeoutMs = config.execution?.permission_timeout_ms;
+  if (permissionTimeoutMs !== undefined) {
+    executionSlice.permission_timeout_ms = permissionTimeoutMs;
+  }
+  const heartbeat = resolveExecutorHeartbeatConfig(config.execution);
+  executionSlice.executor_heartbeat = {
+    enabled: heartbeat.enabled,
+    interval_ms: heartbeat.interval_ms,
+  };
+  executionSlice.sdk_watchdog = resolveSdkWatchdogConfig(config.execution);
+  if (Object.keys(executionSlice).length > 0) slice.execution = executionSlice;
+
+  const hostIpAddress = config.daemon?.host_ip_address;
+  if (hostIpAddress !== undefined) slice.daemon = { host_ip_address: hostIpAddress };
+  return slice satisfies ResolvedConfigSlice;
 }

--- a/apps/agor-daemon/src/utils/clone-reference.ts
+++ b/apps/agor-daemon/src/utils/clone-reference.ts
@@ -1,4 +1,5 @@
-import { loadConfigSync } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
+import type { DeepReadonly } from '@agor/core/types';
 
 /**
  * Decide whether clone-mode branch creation should borrow objects from the
@@ -13,7 +14,6 @@ import { loadConfigSync } from '@agor/core/config';
  * commands run as the daemon/executor identity that owns the managed object
  * cache.
  */
-export function shouldUseCloneReferencePath(): boolean {
-  const config = loadConfigSync();
+export function shouldUseCloneReferencePath(config: DeepReadonly<AgorConfig>): boolean {
   return (config.execution?.unix_user_mode ?? 'simple') !== 'strict';
 }

--- a/apps/agor-daemon/src/utils/deep-freeze.test.ts
+++ b/apps/agor-daemon/src/utils/deep-freeze.test.ts
@@ -1,0 +1,29 @@
+import type { AgorConfig } from '@agor/core/config';
+import type { DeepReadonly } from '@agor/core/types';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { deepFreeze, deepFreezeClone } from './deep-freeze.js';
+
+describe('deepFreeze', () => {
+  it('recursively freezes the effective configuration snapshot', () => {
+    const frozen = deepFreeze<AgorConfig>({ execution: { unix_user_mode: 'strict' } });
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.execution)).toBe(true);
+    expect(() => {
+      (frozen.execution as { unix_user_mode?: string }).unix_user_mode = 'simple';
+    }).toThrow();
+  });
+
+  it('preserves deep-readonly typing through optional configuration sections', () => {
+    const frozen = deepFreeze<AgorConfig>({ execution: { unix_user_mode: 'strict' } });
+    expectTypeOf(frozen).toEqualTypeOf<DeepReadonly<AgorConfig>>();
+  });
+
+  it('does not freeze nested objects owned by the caller', () => {
+    const input: AgorConfig = { execution: { unix_user_mode: 'strict' } };
+    const frozen = deepFreezeClone(input);
+    expect(frozen).not.toBe(input);
+    expect(frozen.execution).not.toBe(input.execution);
+    expect(Object.isFrozen(frozen.execution)).toBe(true);
+    expect(Object.isFrozen(input.execution)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/deep-freeze.ts
+++ b/apps/agor-daemon/src/utils/deep-freeze.ts
@@ -1,0 +1,15 @@
+import type { DeepReadonly } from '@agor/core/types';
+
+/** Recursively freeze a plain configuration snapshot and return its deep-readonly view. */
+export function deepFreeze<T>(value: T): DeepReadonly<T> {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value as DeepReadonly<T>;
+}
+
+/** Clone plain configuration data before freezing so the caller retains ownership. */
+export function deepFreezeClone<T>(value: T): DeepReadonly<T> {
+  return deepFreeze(structuredClone(value));
+}

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.test.ts
@@ -37,19 +37,25 @@ beforeEach(() => {
 
 describe('resolveExecutorReadAsUser', () => {
   it('does not force sudo in simple mode', async () => {
-    await expect(resolveExecutorReadAsUser(db, user)).resolves.toBeUndefined();
+    await expect(
+      resolveExecutorReadAsUser(db, user, mocks.loadConfigSync())
+    ).resolves.toBeUndefined();
   });
 
   it('leaves insulated mode to configured executor defaults', async () => {
     mocks.loadConfigSync.mockReturnValue({
       execution: { unix_user_mode: 'insulated', executor_unix_user: 'agor_executor' },
     });
-    await expect(resolveExecutorReadAsUser(db, user)).resolves.toBeUndefined();
+    await expect(
+      resolveExecutorReadAsUser(db, user, mocks.loadConfigSync())
+    ).resolves.toBeUndefined();
   });
 
   it('returns the requesting unix_username in strict mode', async () => {
     mocks.loadConfigSync.mockReturnValue({ execution: { unix_user_mode: 'strict' } });
-    await expect(resolveExecutorReadAsUser(db, user)).resolves.toBe('alice');
+    await expect(resolveExecutorReadAsUser(db, user, mocks.loadConfigSync())).resolves.toBe(
+      'alice'
+    );
   });
 
   it('reports the requesting unix_username to a delegated executor command template', async () => {
@@ -61,19 +67,25 @@ describe('resolveExecutorReadAsUser', () => {
     });
     mocks.findById.mockResolvedValue(user);
 
-    await expect(resolveExecutorReadAsUser(db, user.user_id)).resolves.toBe('alice');
+    await expect(resolveExecutorReadAsUser(db, user.user_id, mocks.loadConfigSync())).resolves.toBe(
+      'alice'
+    );
     expect(mocks.findById).toHaveBeenCalledWith(user.user_id);
   });
 
   it('does not turn delegated local execution into sudo impersonation', async () => {
     mocks.loadConfigSync.mockReturnValue({ execution: { unix_user_mode: 'delegated' } });
-    await expect(resolveExecutorReadAsUser(db, user)).resolves.toBeUndefined();
+    await expect(
+      resolveExecutorReadAsUser(db, user, mocks.loadConfigSync())
+    ).resolves.toBeUndefined();
   });
 
   it('loads a user id and fails clearly when strict mode lacks unix_username', async () => {
     mocks.loadConfigSync.mockReturnValue({ execution: { unix_user_mode: 'strict' } });
     mocks.findById.mockResolvedValue({ user_id: user.user_id });
-    await expect(resolveExecutorReadAsUser(db, user.user_id)).rejects.toThrow(/unix_username/);
+    await expect(
+      resolveExecutorReadAsUser(db, user.user_id, mocks.loadConfigSync())
+    ).rejects.toThrow(/unix_username/);
   });
 
   it('fails before launch when a delegated command template lacks unix_username', async () => {
@@ -85,6 +97,8 @@ describe('resolveExecutorReadAsUser', () => {
     });
     mocks.findById.mockResolvedValue({ user_id: user.user_id });
 
-    await expect(resolveExecutorReadAsUser(db, user.user_id)).rejects.toThrow(/unix_username/);
+    await expect(
+      resolveExecutorReadAsUser(db, user.user_id, mocks.loadConfigSync())
+    ).rejects.toThrow(/unix_username/);
   });
 });

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.ts
@@ -1,6 +1,6 @@
-import { loadConfigSync } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import type { User, UserID } from '@agor/core/types';
+import type { DeepReadonly, User, UserID } from '@agor/core/types';
 import { resolveUnixUserForImpersonation } from '@agor/core/unix';
 
 /**
@@ -16,9 +16,9 @@ import { resolveUnixUserForImpersonation } from '@agor/core/unix';
  */
 export async function resolveExecutorReadAsUser(
   db: TenantScopeAwareDatabase,
-  userOrId: User | UserID | string | undefined | null
+  userOrId: User | UserID | string | undefined | null,
+  config: DeepReadonly<AgorConfig>
 ): Promise<string | undefined> {
-  const config = loadConfigSync();
   const unixMode = config.execution?.unix_user_mode ?? 'simple';
   const needsRequestingUser =
     unixMode === 'strict' ||

--- a/apps/agor-daemon/src/utils/git-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.test.ts
@@ -56,21 +56,30 @@ afterEach(() => {
 describe('resolveGitImpersonationForUser', () => {
   it('returns undefined in open-access default (no RBAC, simple mode) — #1140', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(false);
-    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(result).toBeUndefined();
   });
 
   it('returns daemon user when group refresh is needed (insulated/strict)', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
-    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(result).toBe('agorpg');
   });
 
-  it('returns undefined when group refresh is needed but daemon user not configured', async () => {
+  it('falls back to the process user when group refresh is needed but daemon user is omitted', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
     mockGetDaemonUser.mockReturnValue(undefined);
-    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
-    expect(result).toBeUndefined();
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
+    expect(result).toBeTruthy();
   });
 
   // The resolver is the SOLE gate — callers (including service-account paths
@@ -79,11 +88,17 @@ describe('resolveGitImpersonationForUser', () => {
   // `userId ?` check (as repos.ts did in #1143) doesn't regress.
   it('accepts an undefined userId and still applies the group-refresh gate', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(false);
-    const noUser = await resolveGitImpersonationForUser(fakeDb, undefined);
+    const noUser = await resolveGitImpersonationForUser(fakeDb, undefined, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(noUser).toBeUndefined();
 
     mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
-    const refreshNeeded = await resolveGitImpersonationForUser(fakeDb, undefined);
+    const refreshNeeded = await resolveGitImpersonationForUser(fakeDb, undefined, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(refreshNeeded).toBe('agorpg');
   });
 });
@@ -96,13 +111,19 @@ describe('resolveGitImpersonationForBranch', () => {
   // so the caller no longer needs to duplicate the check.
   it('returns undefined in open-access default — #1140 (clone) + #1143 (branch.remove)', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(false);
-    const result = await resolveGitImpersonationForBranch(fakeDb, fakeBranch);
+    const result = await resolveGitImpersonationForBranch(fakeDb, fakeBranch, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(result).toBeUndefined();
   });
 
   it('delegates to resolveGitImpersonationForUser using branch.created_by', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
-    const result = await resolveGitImpersonationForBranch(fakeDb, fakeBranch);
+    const result = await resolveGitImpersonationForBranch(fakeDb, fakeBranch, {
+      execution: { unix_user_mode: mockIsUnixGroupRefreshNeeded() ? 'strict' : 'simple' },
+      daemon: { unix_user: mockGetDaemonUser() },
+    });
     expect(result).toBe('agorpg');
   });
 });

--- a/apps/agor-daemon/src/utils/git-impersonation.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.ts
@@ -19,8 +19,10 @@
  * required.
  */
 
+import { userInfo } from 'node:os';
+import { type AgorConfig, resolveExecutionSecurityMode } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import type { Branch, UserID } from '@agor/core/types';
+import type { Branch, DeepReadonly, UserID } from '@agor/core/types';
 
 /**
  * Resolve the configured daemon user for `sudo -u` group-refresh wrapping,
@@ -32,8 +34,8 @@ import type { Branch, UserID } from '@agor/core/types';
  * single source of truth prevents the drift that caused #1143 — the same
  * stale gate copy-pasted across files.
  *
- * Dynamic config import is intentional: `loadConfigSync` reads from disk
- * and we don't want to pay that cost at module-load time.
+ * The effective daemon configuration is supplied explicitly so this helper
+ * cannot drift from deployment environment overrides.
  *
  * Note: existence-validation of the returned daemon user (e.g. via
  * `validateResolvedUnixUser`) is the responsibility of strict/insulated
@@ -41,23 +43,22 @@ import type { Branch, UserID } from '@agor/core/types';
  * answers "do we need a wrap, and if so, as whom?" — it does not vouch
  * for the resolved user.
  */
-export async function resolveDaemonUserForGroupRefresh(): Promise<string | undefined> {
-  const { getDaemonUser, isUnixGroupRefreshNeeded } = await import('@agor/core/config');
-
-  // No supplemental groups → no need for sudo. Avoids requiring sudoers
-  // for users on the default open-access setup. (#1140, #1143)
-  if (!isUnixGroupRefreshNeeded()) {
+export function resolveDaemonUserForGroupRefresh(
+  config: DeepReadonly<AgorConfig>
+): string | undefined {
+  if (!resolveExecutionSecurityMode(config).unixGroupRefreshNeeded) return undefined;
+  try {
+    return config.daemon?.unix_user ?? userInfo().username;
+  } catch {
     return undefined;
   }
-
-  return getDaemonUser();
 }
 
 /**
  * Resolve Unix user for git operations.
  *
  * Returns the daemon user when group refresh via `sudo -u` is needed
- * (non-simple unix_user_mode — see `isUnixGroupRefreshNeeded`). Returns
+ * (non-simple unix_user_mode). Returns
  * `undefined` in simple mode so callers spawn directly without sudo wrap
  * (#1140), regardless of app-level branch RBAC.
  *
@@ -72,9 +73,10 @@ export async function resolveDaemonUserForGroupRefresh(): Promise<string | undef
  */
 export async function resolveGitImpersonationForUser(
   _db: TenantScopeAwareDatabase,
-  _userId: UserID | undefined
+  _userId: UserID | undefined,
+  config: DeepReadonly<AgorConfig>
 ): Promise<string | undefined> {
-  return resolveDaemonUserForGroupRefresh();
+  return resolveDaemonUserForGroupRefresh(config);
 }
 
 /**
@@ -84,7 +86,8 @@ export async function resolveGitImpersonationForUser(
  */
 export async function resolveGitImpersonationForBranch(
   db: TenantScopeAwareDatabase,
-  branch: Branch
+  branch: Branch,
+  config: DeepReadonly<AgorConfig>
 ): Promise<string | undefined> {
-  return resolveGitImpersonationForUser(db, branch.created_by);
+  return resolveGitImpersonationForUser(db, branch.created_by, config);
 }

--- a/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
+++ b/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
 import {
   and,
   branches,
@@ -18,7 +18,7 @@ import {
   normalizeTelemetryProvider,
   openSourceTelemetryLogger,
 } from '@agor/core/telemetry';
-import type { Session, TenantID } from '@agor/core/types';
+import type { DeepReadonly, Session, TenantID } from '@agor/core/types';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
@@ -92,12 +92,12 @@ async function getTaskUsageRows(
 }
 
 export async function flushOpenSourceTelemetryUsageSummary(
-  db: TenantScopeAwareDatabase
+  db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>
 ): Promise<void> {
   if (!openSourceTelemetryLogger.isEnabled()) return;
 
   const { day, start, end } = previousUtcDayRange();
-  const config = await loadConfig();
   if (config.telemetry?.last_usage_summary_day === day || lastUsageSummaryDayInProcess === day)
     return;
 
@@ -162,20 +162,21 @@ export interface OpenSourceTelemetryUsageSummaryIntervalOptions {
 
 export function startOpenSourceTelemetryUsageSummaryInterval(
   db: TenantScopeAwareDatabase,
+  config: DeepReadonly<AgorConfig>,
   options: OpenSourceTelemetryUsageSummaryIntervalOptions
 ): NodeJS.Timeout {
   // Check hourly, but emit at most once per UTC day. The DB query only runs
   // when the previous day has not yet been reported, keeping steady-state
   // overhead to one config read per hour.
   const run = (): void => {
-    runWithTenantContext(options.tenantId, () => flushOpenSourceTelemetryUsageSummary(db)).catch(
-      (error) => {
-        console.warn(
-          '[telemetry] failed to emit usage summary:',
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-    );
+    runWithTenantContext(options.tenantId, () =>
+      flushOpenSourceTelemetryUsageSummary(db, config)
+    ).catch((error) => {
+      console.warn(
+        '[telemetry] failed to emit usage summary:',
+        error instanceof Error ? error.message : String(error)
+      );
+    });
   };
 
   const startupTimer = setTimeout(run, 30_000);

--- a/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
@@ -10,9 +10,14 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { __resetConfigCacheForTests } from '@agor/core/config';
+import { __resetConfigCacheForTests, loadConfigSync } from '@agor/core/config';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildResolvedConfigSlice, withResolvedConfig } from './build-resolved-config-slice';
+import {
+  buildResolvedConfigSlice,
+  configureResolvedConfigSlice,
+  resetResolvedConfigSliceForTests,
+  withResolvedConfig,
+} from './build-resolved-config-slice';
 
 describe('buildResolvedConfigSlice', () => {
   let tempDir: string;
@@ -21,12 +26,19 @@ describe('buildResolvedConfigSlice', () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-rcs-'));
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
     __resetConfigCacheForTests();
+    configureResolvedConfigSlice(loadConfigSync());
   });
 
   afterEach(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
     __resetConfigCacheForTests();
+    resetResolvedConfigSliceForTests();
+  });
+
+  it('fails closed before initialization from the effective daemon config', () => {
+    resetResolvedConfigSliceForTests();
+    expect(() => withResolvedConfig({ command: 'prompt' })).toThrow(/not initialized/);
   });
 
   /**
@@ -42,7 +54,7 @@ describe('buildResolvedConfigSlice', () => {
 
   it('surfaces permission_timeout_ms from execution.*', async () => {
     await writeConfigYaml('execution:\n  permission_timeout_ms: 1234\n');
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     expect(slice).toMatchObject({
       execution: { permission_timeout_ms: 1234 },
     });
@@ -61,7 +73,7 @@ describe('buildResolvedConfigSlice', () => {
         '',
       ].join('\n')
     );
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     expect(slice.execution?.executor_heartbeat).toEqual({ enabled: false, interval_ms: 2500 });
     expect(slice.execution?.executor_heartbeat).not.toHaveProperty('stale_after_ms');
     expect(slice.execution?.executor_heartbeat).not.toHaveProperty('callback');
@@ -69,14 +81,14 @@ describe('buildResolvedConfigSlice', () => {
 
   it('surfaces daemon.host_ip_address', async () => {
     await writeConfigYaml('daemon:\n  host_ip_address: 10.0.0.5\n');
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     expect(slice).toMatchObject({
       daemon: { host_ip_address: '10.0.0.5' },
     });
   });
 
   it('freezes heartbeat and observe-only watchdog defaults into the payload', () => {
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     expect(slice).toEqual({
       execution: {
         executor_heartbeat: { enabled: true, interval_ms: 10_000 },
@@ -100,7 +112,7 @@ describe('buildResolvedConfigSlice', () => {
         '',
       ].join('\n')
     );
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     // The slice is shipped to the executor as JSON via stdin; this asserts
     // the in-memory shape and the wire shape are identical so tests on
     // either side stay honest.
@@ -126,7 +138,10 @@ describe('buildResolvedConfigSlice', () => {
         '',
       ].join('\n')
     );
-    const slice = buildResolvedConfigSlice() as Record<string, Record<string, unknown>>;
+    const slice = buildResolvedConfigSlice(loadConfigSync()) as Record<
+      string,
+      Record<string, unknown>
+    >;
     // Allowed fields surface.
     expect(slice.execution?.permission_timeout_ms).toBe(60_000);
     expect(slice.execution?.executor_heartbeat).toEqual({ enabled: true, interval_ms: 10_000 });
@@ -151,7 +166,7 @@ describe('buildResolvedConfigSlice', () => {
         '',
       ].join('\n')
     );
-    const slice = buildResolvedConfigSlice();
+    const slice = buildResolvedConfigSlice(loadConfigSync());
     const parsed = ResolvedConfigSliceSchema.parse(slice);
     expect(parsed).toEqual(slice);
   });
@@ -183,12 +198,14 @@ describe('withResolvedConfig', () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-with-rc-'));
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
     __resetConfigCacheForTests();
+    configureResolvedConfigSlice(loadConfigSync());
   });
 
   afterEach(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
     __resetConfigCacheForTests();
+    resetResolvedConfigSliceForTests();
   });
 
   it('injects a daemon-resolved slice when the payload has no resolvedConfig', () => {

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -24,6 +24,12 @@ services:
       - AGOR_DB_DIALECT=postgresql
       - DATABASE_URL=postgresql://agor_app:agor_dev_secret@postgres:5432/agor
 
+      # PostgreSQL startup skips the SQLite-only `agor init`, so provide the
+      # stable development secrets that production supplies via its secret
+      # manager. These values are intentionally local-environment-only.
+      - AGOR_JWT_SECRET=${AGOR_JWT_SECRET:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+      - AGOR_MASTER_SECRET=${AGOR_MASTER_SECRET:-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}
+
       # Enable RBAC + Unix integration
       - AGOR_RBAC_ENABLED=${AGOR_RBAC_ENABLED:-true}
       - AGOR_UNIX_USER_MODE=${AGOR_UNIX_USER_MODE:-insulated}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -240,10 +240,16 @@ CLIENT_PID=$!
 
 echo "✅ Watch modes started (git, core, agentic tools, executor, and client will rebuild on file changes)"
 
-# Initialize database and configure daemon settings for Docker
-# (idempotent: creates database on first run, preserves JWT secrets on subsequent runs)
-echo "📦 Initializing Agor environment..."
-pnpm agor init --skip-if-exists --non-interactive --agentic-tools "${AGOR_AGENTIC_TOOLS:-none}" --daemon-port "${DAEMON_PORT:-3030}" --daemon-host "${DAEMON_HOST:-0.0.0.0}"
+# `agor init` is the SQLite installation bootstrap and intentionally creates
+# ~/.agor/agor.db. PostgreSQL deployments get their database state from the
+# migrations and daemon bootstrap below, and receive stable development
+# secrets from the postgres Compose overlay.
+if [ "${AGOR_DB_DIALECT:-sqlite}" = "postgresql" ]; then
+  echo "⏭️  Skipping SQLite agor init for PostgreSQL deployment"
+else
+  echo "📦 Initializing Agor environment..."
+  pnpm agor init --skip-if-exists --non-interactive --agentic-tools "${AGOR_AGENTIC_TOOLS:-none}" --daemon-port "${DAEMON_PORT:-3030}" --daemon-host "${DAEMON_HOST:-0.0.0.0}"
+fi
 
 # Run database migrations (idempotent: safe to run on every start)
 # This ensures schema is up-to-date even when using existing database volumes
@@ -264,7 +270,7 @@ echo "$ADMIN_OUTPUT"
 # CLI (direct DB write, no Feathers hook), so the normal after-create hook that calls
 # unix.sync-user never fires. Provision the OS account explicitly here while we still have
 # a clean pre-daemon window and sudoers access.
-if [ "$AGOR_SET_UNIX_MODE" = "strict" ]; then
+if [ "${AGOR_UNIX_USER_MODE:-simple}" = "strict" ]; then
   echo "🔒 Provisioning bootstrap admin OS user (strict mode)..."
   pnpm agor local ensure-user --username admin || echo "⚠️  Could not provision admin OS user — check sudoers"
 fi

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -105,8 +105,14 @@ describe('resolveEffectiveConfig', () => {
       DAEMON_HOST: 'env-host',
       AGOR_RBAC_ENABLED: 'true',
       AGOR_UNIX_USER_MODE: 'delegated',
+      INSTANCE_LABEL: 'replica-a',
     });
-    expect(resolved.daemon).toMatchObject({ host: 'env-host', port: 4321, mcpEnabled: true });
+    expect(resolved.daemon).toMatchObject({
+      host: 'env-host',
+      port: 4321,
+      mcpEnabled: true,
+      instanceLabel: 'replica-a',
+    });
     expect(resolved.execution).toMatchObject({ branch_rbac: true, unix_user_mode: 'delegated' });
     expect(resolved.multi_tenancy?.mode).toBe('static');
     expect(input).toEqual({ daemon: { host: 'yaml-host', port: 1234 } });

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -1021,6 +1021,7 @@ export function resolveEffectiveConfig(
       ...(env.AGOR_DAEMON_UNIX_USER ? { unix_user: env.AGOR_DAEMON_UNIX_USER } : {}),
       ...(env.AGOR_JWT_SECRET ? { jwtSecret: env.AGOR_JWT_SECRET } : {}),
       ...(env.AGOR_MASTER_SECRET ? { masterSecret: env.AGOR_MASTER_SECRET } : {}),
+      ...(env.INSTANCE_LABEL ? { instanceLabel: env.INSTANCE_LABEL } : {}),
     },
     ui: { ...defaults.ui, ...config.ui },
     execution: {

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -185,6 +185,10 @@ export type PartialKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
  * // All fields and nested fields are readonly
  * ```
  */
-export type DeepReadonly<T> = {
-  readonly [K in keyof T]: T[K] extends Record<string, unknown> ? DeepReadonly<T[K]> : T[K];
-};
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly (infer Item)[]
+    ? readonly DeepReadonly<Item>[]
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -188,7 +188,7 @@ export type PartialKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export type DeepReadonly<T> = T extends (...args: never[]) => unknown
   ? T
   : T extends readonly (infer Item)[]
-    ? readonly DeepReadonly<Item>[]
+    ? DeepReadonly<Item>[]
     : T extends object
       ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
       : T;

--- a/scripts/run-postgres-integration-tests.mjs
+++ b/scripts/run-postgres-integration-tests.mjs
@@ -11,6 +11,10 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const workspaces = ['packages/core', 'apps/agor-daemon'];
 const defaultConcurrency = 3;
 const maxConcurrency = 8;
+// Each isolated suite initializes the full schema. On shared CI runners, three
+// concurrent migration passes can legitimately exceed Vitest's 10s hook
+// default even though the database and migrations are healthy.
+const hookTimeoutMs = 30_000;
 const childTerminationGraceMs = 5_000;
 const activeChildren = new Set();
 const activeProcessTrees = new Set();
@@ -137,6 +141,7 @@ function runVitest({ workspaceRoot, relativeTest, reportFile, appUrl, adminUrl }
         vitestEntrypoint,
         'run',
         '--no-file-parallelism',
+        `--hookTimeout=${hookTimeoutMs}`,
         '--reporter=default',
         '--reporter=json',
         `--outputFile.json=${reportFile}`,


### PR DESCRIPTION
## Summary

This PR fixes three production/runtime issues uncovered while validating strict-mode Git setup in the full PostgreSQL environment:

1. **Scoped executor repository access for Git `safe.directory`**
   - Allows an executor token to call only `repos.get` for the repository derived from its token-scoped branch.
   - Keeps repository listing, mutations, mismatched IDs, and cross-tenant access forbidden.
   - Restores both the branch worktree and main repository checkout to Git's trusted paths.

2. **Canonical effective daemon configuration**
   - Resolves persisted configuration and supported deployment environment overrides once during bootstrap.
   - Recursively freezes a detached effective snapshot and exposes it through typed `app.get('config')`.
   - Migrates daemon runtime services, hooks, MCP tools, authentication, terminals, repository/branch lifecycle, telemetry, and executor helpers away from rereading persisted YAML.
   - Sends executors a narrow, frozen, non-secret projection derived from the same effective snapshot.
   - Adds contract coverage preventing direct and indirect persisted-config reads in daemon production paths.

3. **Restore the PostgreSQL `full` environment bootstrap**
   - Stops running SQLite-only `agor init` in PostgreSQL containers.
   - Makes `agor init` fail clearly when configured for PostgreSQL instead of creating an inconsistent SQLite setup.
   - Fixes strict Unix provisioning to use `AGOR_UNIX_USER_MODE`.
   - Supplies stable development-only secrets in the PostgreSQL Compose overlay.

## Production symptoms

### Git safe-directory warning and functional gap

Strict-mode sessions repeatedly logged:

```text
[codex git.safe-directory] Failed to load repo <repo_id> for safe.directory setup: Executor token is not valid for this endpoint
```

`configureSessionGitSafeDirectories()` could add the branch worktree before the denied request, but it could not retrieve the repository's main `local_path`. That main checkout is commonly owned by another Unix account and is exactly the path that needs explicit trust in strict/insulated deployments.

### Credentials routed to the wrong Unix home

During manual strict-mode testing, Alice's Codex subscription login succeeded but wrote `auth.json` to:

```text
/home/agor/.codex/auth.json
```

instead of:

```text
/home/alice/.codex/auth.json
```

The credential path called `loadConfigSync()`, which saw persisted/default `simple` mode and missed the deployment override `AGOR_UNIX_USER_MODE=strict`. An audit found the same raw-config pattern across daemon runtime code.

### PostgreSQL full environment failed during startup

The PostgreSQL entrypoint called `agor init`, although that installer deliberately initializes SQLite. A prior skip-condition change exposed the mismatch, causing startup to attempt PostgreSQL-shaped seed operations against SQLite.

## Authorization and tenant boundary

The executor repository capability is deliberately narrow:

1. Accept only `method === 'get'` for the `repos` service.
2. Resolve the authorized repository from the trusted `scope.branchId`.
3. Preserve the request's trusted tenant context during internal branch lookup.
4. Compare the requested repository ID with the branch's `repo_id`.
5. Reject every other repository method or target.

The client-supplied repository ID is never treated as authorization input.

## Effective-config architecture

Daemon startup now owns configuration resolution:

1. Load persisted configuration or the caller-provided startup configuration.
2. Apply supported deployment environment overrides, including `INSTANCE_LABEL`.
3. Complete startup-only projections such as agentic-tool and telemetry normalization.
4. Clone and recursively freeze the resulting snapshot.
5. Store it as `app.get('config'): DeepReadonly<AgorConfig>`.
6. Inject that snapshot—or a narrow slice—into runtime consumers.

The persisted loaders remain available to CLI/config-management boundaries. A daemon contract test prevents runtime code from importing raw loaders or convenience helpers that indirectly reload persisted configuration.

## Validation

### Automated

- `pnpm i`
- Daemon typecheck passed.
- Core config tests: **117 passed**.
- Effective-config freeze/projection/contract tests passed.
- Executor authorization tests passed.
- Git safe-directory handler tests passed.
- Reviewer-focused affected suites passed, including MCP configuration paths.
- Full daemon suite: **2,448 passed**, with one unrelated Cursor SDK test dependent on a locally invalid Cursor credential.
- `pnpm check` passed typecheck, lint, short-ID, and multitenancy stages, then encountered a pre-existing duplicate `DAEMON-FS-CAP-170` registry entry.

### Manual full-environment verification

Using the PostgreSQL `full` variant with `unix_user_mode: strict`:

- Environment boots successfully.
- Alice and Bob have provisioned Unix accounts.
- Claude sessions execute successfully as Alice.
- Codex subscription credentials now land in Alice's home and work.
- Codex API-key authentication works.
- Session startup no longer emits `Executor token is not valid for this endpoint` during Git safe-directory setup.

## Review

The PR received iterative reviews from:

- Codex reviewer session
- Claude Opus 4.6 architecture review focused on effective configuration

Review feedback covering immutability, caller-owned object freezing, `INSTANCE_LABEL` ordering, indirect raw-config helpers, deep-readonly typing, executor projection state, and operator precedence was addressed. Both review loops report no remaining substantive blockers.
