### PR TITLE
fix(ha): harden startup and realtime tenant boundaries

### DIFF
--- a/apps/agor-daemon/src/realtime/routing.test.ts
+++ b/apps/agor-daemon/src/realtime/routing.test.ts
@@ -16,6 +16,13 @@ describe('realtime routing boundary', () => {
     );
   });
 
+  it('encodes room delimiters so tenant and resource namespaces cannot collide', () => {
+    expect(tenantChannelName('a:board:b:presence')).toBe('tenant:a%3Aboard%3Ab%3Apresence');
+    expect(tenantChannelName('a:board:b:presence')).not.toBe(boardPresenceRoomName('a', 'b'));
+    expect(tenantUserChannelName('a:user:b', 'c')).not.toBe(tenantUserChannelName('a', 'b:user:c'));
+    expect(tenantChannelName('a%3Aboard')).toBe('tenant:a%253Aboard');
+  });
+
   it('emits only through the explicit native HA event inventory', () => {
     expect(HA_NATIVE_SOCKET_EVENT_INVENTORY).toEqual([
       'cursor-moved',

--- a/apps/agor-daemon/src/realtime/routing.test.ts
+++ b/apps/agor-daemon/src/realtime/routing.test.ts
@@ -26,14 +26,28 @@ describe('realtime routing boundary', () => {
       'oauth:disconnected',
     ]);
     const target = { emit: vi.fn() };
-    emitHaNativeSocketEvent(target, 'cursor-left', {
+    const emitter = { to: vi.fn(() => target) };
+    emitHaNativeSocketEvent(emitter, boardPresenceRoomName('tenant-a', 'board-a'), 'cursor-left', {
       userId: 'user-a',
       boardId: '019fe5bc-65cf-7095-b160-454363604446' as never,
       timestamp: 1,
     });
+    expect(emitter.to).toHaveBeenCalledWith('tenant:tenant-a:board:board-a:presence');
     expect(target.emit).toHaveBeenCalledWith('cursor-left', {
       userId: 'user-a',
       boardId: '019fe5bc-65cf-7095-b160-454363604446',
+      timestamp: 1,
+    });
+  });
+
+  it('rejects unqualified rooms at the typed HA boundary', () => {
+    const emitter = { to: vi.fn(() => ({ emit: vi.fn() })) };
+    // This assertion is compile-time coverage: removing the tenant room brand
+    // makes the @ts-expect-error unused and fails the repository typecheck.
+    // @ts-expect-error native cross-replica rooms must be tenant-qualified
+    emitHaNativeSocketEvent(emitter, 'board-a', 'cursor-left', {
+      userId: 'user-a',
+      boardId: '019fe5bc-65cf-7095-b160-454363604446' as never,
       timestamp: 1,
     });
   });

--- a/apps/agor-daemon/src/realtime/routing.ts
+++ b/apps/agor-daemon/src/realtime/routing.ts
@@ -6,27 +6,37 @@ import type {
   PresenceUpdatedEvent,
 } from '@agor/core/types';
 
-declare const tenantBoundSocketRoom: unique symbol;
+declare const tenantQualifiedSocketRoom: unique symbol;
 
 /**
- * A room proven to carry tenant context in its name. Native Socket.IO packets
- * can cross the Redis adapter only when addressed to this branded type.
+ * A room whose structured name includes an encoded tenant component. Native
+ * Socket.IO packets can cross the Redis adapter only when addressed to this
+ * branded type. The brand proves construction through this module; call sites
+ * remain responsible for supplying tenant identity from trusted auth context.
  */
-export type TenantBoundSocketRoom = string & {
-  readonly [tenantBoundSocketRoom]: true;
+export type TenantQualifiedSocketRoom = string & {
+  readonly [tenantQualifiedSocketRoom]: true;
 };
 
+/** Escape the room delimiter injectively while preserving ordinary UUID/slugs. */
+function socketRoomComponent(value: string): string {
+  return value.replaceAll('%', '%25').replaceAll(':', '%3A');
+}
+
 /** One authoritative naming scheme for Socket.IO rooms and Feathers channels. */
-export function tenantChannelName(tenantId: string): TenantBoundSocketRoom {
-  return `tenant:${tenantId}` as TenantBoundSocketRoom;
+export function tenantChannelName(tenantId: string): TenantQualifiedSocketRoom {
+  return `tenant:${socketRoomComponent(tenantId)}` as TenantQualifiedSocketRoom;
 }
 
-export function tenantUserChannelName(tenantId: string, userId: string): TenantBoundSocketRoom {
-  return `tenant:${tenantId}:user:${userId}` as TenantBoundSocketRoom;
+export function tenantUserChannelName(tenantId: string, userId: string): TenantQualifiedSocketRoom {
+  return `tenant:${socketRoomComponent(tenantId)}:user:${socketRoomComponent(userId)}` as TenantQualifiedSocketRoom;
 }
 
-export function boardPresenceRoomName(tenantId: string, boardId: string): TenantBoundSocketRoom {
-  return `tenant:${tenantId}:board:${boardId}:presence` as TenantBoundSocketRoom;
+export function boardPresenceRoomName(
+  tenantId: string,
+  boardId: string
+): TenantQualifiedSocketRoom {
+  return `tenant:${socketRoomComponent(tenantId)}:board:${socketRoomComponent(boardId)}:presence` as TenantQualifiedSocketRoom;
 }
 
 interface HaNativeSocketPayloads {
@@ -58,12 +68,14 @@ export const HA_NATIVE_SOCKET_EVENT_INVENTORY = [
   'oauth:disconnected',
 ] as const satisfies readonly (keyof HaNativeSocketPayloads)[];
 
+type HaNativeSocketEvent = (typeof HA_NATIVE_SOCKET_EVENT_INVENTORY)[number];
+
 type NativeSocketTarget = {
   emit(event: string, payload: unknown): unknown;
 };
 
 type NativeSocketRoomEmitter = {
-  to(room: TenantBoundSocketRoom): NativeSocketTarget;
+  to(room: TenantQualifiedSocketRoom): NativeSocketTarget;
 };
 
 /**
@@ -73,9 +85,9 @@ type NativeSocketRoomEmitter = {
  * a plain string/global emitter a type error rather than relying on every call
  * site to remember tenant qualification.
  */
-export function emitHaNativeSocketEvent<Event extends keyof HaNativeSocketPayloads>(
+export function emitHaNativeSocketEvent<Event extends HaNativeSocketEvent>(
   emitter: NativeSocketRoomEmitter,
-  room: TenantBoundSocketRoom,
+  room: TenantQualifiedSocketRoom,
   event: Event,
   payload: HaNativeSocketPayloads[Event]
 ): void {

--- a/apps/agor-daemon/src/realtime/routing.ts
+++ b/apps/agor-daemon/src/realtime/routing.ts
@@ -6,17 +6,27 @@ import type {
   PresenceUpdatedEvent,
 } from '@agor/core/types';
 
+declare const tenantBoundSocketRoom: unique symbol;
+
+/**
+ * A room proven to carry tenant context in its name. Native Socket.IO packets
+ * can cross the Redis adapter only when addressed to this branded type.
+ */
+export type TenantBoundSocketRoom = string & {
+  readonly [tenantBoundSocketRoom]: true;
+};
+
 /** One authoritative naming scheme for Socket.IO rooms and Feathers channels. */
-export function tenantChannelName(tenantId: string): string {
-  return `tenant:${tenantId}`;
+export function tenantChannelName(tenantId: string): TenantBoundSocketRoom {
+  return `tenant:${tenantId}` as TenantBoundSocketRoom;
 }
 
-export function tenantUserChannelName(tenantId: string, userId: string): string {
-  return `tenant:${tenantId}:user:${userId}`;
+export function tenantUserChannelName(tenantId: string, userId: string): TenantBoundSocketRoom {
+  return `tenant:${tenantId}:user:${userId}` as TenantBoundSocketRoom;
 }
 
-export function boardPresenceRoomName(tenantId: string, boardId: string): string {
-  return `tenant:${tenantId}:board:${boardId}:presence`;
+export function boardPresenceRoomName(tenantId: string, boardId: string): TenantBoundSocketRoom {
+  return `tenant:${tenantId}:board:${boardId}:presence` as TenantBoundSocketRoom;
 }
 
 interface HaNativeSocketPayloads {
@@ -52,15 +62,22 @@ type NativeSocketTarget = {
   emit(event: string, payload: unknown): unknown;
 };
 
+type NativeSocketRoomEmitter = {
+  to(room: TenantBoundSocketRoom): NativeSocketTarget;
+};
+
 /**
  * Audited boundary for native cross-replica packets. Other room-targeted
  * Socket.IO emissions must opt into `.local` so a missed feature gate cannot
- * silently put a new payload onto Redis.
+ * silently put a new payload onto Redis. Requiring the room separately makes
+ * a plain string/global emitter a type error rather than relying on every call
+ * site to remember tenant qualification.
  */
 export function emitHaNativeSocketEvent<Event extends keyof HaNativeSocketPayloads>(
-  target: NativeSocketTarget,
+  emitter: NativeSocketRoomEmitter,
+  room: TenantBoundSocketRoom,
   event: Event,
   payload: HaNativeSocketPayloads[Event]
 ): void {
-  target.emit(event, payload);
+  emitter.to(room).emit(event, payload);
 }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1912,7 +1912,7 @@ async function registerMCPServices(
         event.oauth_mode === 'per_user' && pendingFlow.userId
           ? tenantUserChannelName(pendingFlow.tenantId, pendingFlow.userId)
           : tenantChannelName(pendingFlow.tenantId);
-      emitHaNativeSocketEvent(app.io.to(room), 'oauth:completed', event);
+      emitHaNativeSocketEvent(app.io, room, 'oauth:completed', event);
     } else if (pendingFlow.socketId) {
       // Standalone defensive fallback: exact originating socket only. Never
       // globally broadcast OAuth attempt metadata or authorization URLs.
@@ -2882,7 +2882,7 @@ async function registerMCPServices(
           result.oauthMode === 'shared'
             ? tenantChannelName(tenantId)
             : tenantUserChannelName(tenantId, params.user.user_id);
-        emitHaNativeSocketEvent(app.io.to(room), 'oauth:disconnected', {
+        emitHaNativeSocketEvent(app.io, room, 'oauth:disconnected', {
           mcp_server_id: data.mcp_server_id as MCPServerID,
         });
       }

--- a/apps/agor-daemon/src/services/mcp-catalog-ingestion.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-ingestion.ts
@@ -96,21 +96,14 @@ export function resolveMCPCatalogOptions(
 }
 
 /**
- * Assumes one daemon per database.
+ * Safe to run independently on every daemon sharing one PostgreSQL database.
  *
- * `running` below is an in-process boolean, so it stops this worker overlapping
- * itself and nothing more. Two daemons against one Postgres both wake on their
- * own six-hour interval and both read-modify-write the same rows: the `data`
- * blob merges are read-then-write with no row lock, so a concurrent pair is
- * last-writer-wins, and two INSERTs of the same new `name` race the unique index
- * into a violation that surfaces as `entryFailures`. The previous run-long
- * transaction serialized this by accident; per-row units do not.
- *
- * The damage is bounded — the mirror is reconstructable from the registry and
- * `curated.yaml`, and the next run corrects it — so this is a correctness
- * limitation, not a data-loss risk. Serializing properly wants a
- * `pg_advisory_lock` around the run, which is tracked separately rather than
- * bolted on here.
+ * `running` is deliberately process-local: it prevents one worker overlapping
+ * itself, while repository writes converge across daemons through conflict-safe
+ * inserts and locked row reloads inside per-entry transactions. Cross-daemon
+ * runs are not leader-elected, so they may duplicate registry requests and auth
+ * probes; the opt-in registry sync and bounded probe budget limit that redundant
+ * third-party work without making correctness depend on one elected worker.
  */
 export class MCPCatalogIngestionWorker {
   private intervalHandle?: ReturnType<typeof setInterval>;

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -363,7 +363,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
               const branchHint = data.default_branch
                 ? ` Default Branch was set to '${data.default_branch}' — verify it exists on the remote.`
                 : '';
-              emitHaNativeSocketEvent(io.to(tenantChannelName(tenantId)), 'repo:cloneError', {
+              emitHaNativeSocketEvent(io, tenantChannelName(tenantId), 'repo:cloneError', {
                 slug,
                 url: remoteUrl,
                 error: `Clone failed (exit code ${code}). Check that the repository URL is correct and accessible.${branchHint}`,

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -594,7 +594,8 @@ export function createSocketIOConfig(
 
         if (previousBoardId && previousBoardId !== data.boardId) {
           emitHaNativeSocketEvent(
-            socket.broadcast.to(boardPresenceRoomName(tenantId, previousBoardId)),
+            socket.broadcast,
+            boardPresenceRoomName(tenantId, previousBoardId),
             'cursor-left',
             {
               userId,
@@ -614,7 +615,8 @@ export function createSocketIOConfig(
 
         // Broadcast cursor position only to tabs actively watching this board.
         emitHaNativeSocketEvent(
-          socket.broadcast.to(boardPresenceRoomName(tenantId, data.boardId)),
+          socket.broadcast,
+          boardPresenceRoomName(tenantId, data.boardId),
           'cursor-moved',
           broadcastData
         );
@@ -633,7 +635,8 @@ export function createSocketIOConfig(
             timestamp: data.timestamp,
           };
           emitHaNativeSocketEvent(
-            socket.broadcast.to(tenantChannelName(tenantId)),
+            socket.broadcast,
+            tenantChannelName(tenantId),
             'presence-updated',
             presenceData
           );
@@ -651,7 +654,8 @@ export function createSocketIOConfig(
         if (!fs.data.authorizedBoardIds?.has(data.boardId)) return;
 
         emitHaNativeSocketEvent(
-          socket.broadcast.to(boardPresenceRoomName(tenantId, data.boardId)),
+          socket.broadcast,
+          boardPresenceRoomName(tenantId, data.boardId),
           'cursor-left',
           {
             userId,

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1159,6 +1159,50 @@ describe('configureRealtimePublish streaming scope', () => {
     expect(unionConnections(result)).toEqual([subscribed]);
   });
 
+  it('intersects an unprefixed session stream room with the resolved tenant channel', async () => {
+    // Session UUIDs are globally unique and subscribe is tenant-authorized, but
+    // defend in depth against stale/forged membership: even if both tenants sit
+    // in the same stream room, only the event tenant may receive its chunks.
+    const tenantA = { user: user('tenant-a-user') };
+    const tenantB = { user: user('tenant-b-user') };
+    const app = makeApp(
+      [tenantA, tenantB],
+      {},
+      {
+        authenticated: [tenantA, tenantB],
+        'tenant:tenant-a': [tenantA],
+        'tenant:tenant-b': [tenantB],
+        'session-stream:s1': [tenantA, tenantB],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'unused' as never,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'tenant-a-only' },
+      {
+        ...streamingContext,
+        params: { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+      }
+    );
+
+    expect(unionConnections(result)).toEqual([tenantA]);
+    expect(unionConnections(result)).not.toContain(tenantB);
+  });
+
   it('still delivers streaming chunks to service-account connections (gateway/Slack)', async () => {
     const viewer = { user: user('viewer') };
     const service = { user: { _isServiceAccount: true, role: 'service' } };

--- a/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
@@ -21,7 +21,7 @@
 
 import { sql } from 'drizzle-orm';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { createDatabase, type Database } from '../client';
+import { createDatabase, type Database, type SystemDatabase } from '../client';
 import { executeRaw } from '../database-wrapper';
 import { initializeDatabase } from '../migrate';
 import { runWithSystemDatabaseScope, runWithTenantDatabaseScope } from '../tenant-scope';
@@ -38,6 +38,71 @@ const UNSCOPED_WRITE = `test.unscoped-${suffix}/mcp`;
 const TENANT_WRITE = `test.tenant-${suffix}/mcp`;
 const TX_PREFIX = `test.tx-${suffix}`;
 const CONCURRENT_SEED = `test.concurrent-seed-${suffix}/mcp`;
+const INTERLEAVED_SOURCES = `test.interleaved-sources-${suffix}/mcp`;
+const INTERLEAVED_REGISTRY = `test.interleaved-registry-${suffix}/mcp`;
+
+async function waitForBlockedCatalogRowLock(db: Database): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [row] = (await executeRaw(
+      db,
+      sql`
+        SELECT count(*)::int AS count
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND wait_event_type = 'Lock'
+          AND query ILIKE '%mcp_catalog_entries%'
+          AND query ILIKE '%FOR UPDATE%'
+      `
+    )) as Array<{ count: number }>;
+    if ((row?.count ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('Timed out waiting for the catalog writer to block on its row lock');
+}
+
+/**
+ * Hold a catalog row in one capability transaction, start a second writer, and
+ * release only after PostgreSQL proves that writer reached the row lock.
+ */
+async function interleaveCatalogWriters<HeldResult, BlockedResult>(
+  db: Database,
+  name: string,
+  holdingWork: (scoped: SystemDatabase) => Promise<HeldResult>,
+  blockedWork: () => Promise<BlockedResult>
+): Promise<[HeldResult, BlockedResult]> {
+  let reportLocked!: () => void;
+  const locked = new Promise<void>((resolve) => {
+    reportLocked = resolve;
+  });
+  let releaseLock!: () => void;
+  const release = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+
+  const holder = runWithSystemDatabaseScope(
+    db,
+    'hold catalog row for forced writer interleaving',
+    async (scoped) => {
+      await executeRaw(
+        scoped as never,
+        sql`SELECT 1 FROM mcp_catalog_entries WHERE name = ${name} FOR UPDATE`
+      );
+      reportLocked();
+      await release;
+      return holdingWork(scoped);
+    },
+    { capability: 'mcp_catalog_ingestion' }
+  );
+
+  await locked;
+  const blocked = blockedWork();
+  try {
+    await waitForBlockedCatalogRowLock(db);
+  } finally {
+    releaseLock();
+  }
+  return Promise.all([holder, blocked]);
+}
 
 describePostgres('mcp_catalog_entries row-level security', () => {
   let db: Database;
@@ -127,6 +192,103 @@ describePostgres('mcp_catalog_entries row-level security', () => {
       category: 'dev-tools',
     });
     expect(await repository.count({ names: [CONCURRENT_SEED] })).toBe(1);
+  });
+
+  it('reloads the registry half after a stale curation writer acquires the row lock', async () => {
+    await runWithSystemDatabaseScope(
+      db,
+      'seed interleaved catalog source test',
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_SOURCES,
+          title: 'Old registry title',
+          version: '1',
+          registry_updated_at: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      { capability: 'mcp_catalog_ingestion' }
+    );
+
+    await interleaveCatalogWriters(
+      db,
+      INTERLEAVED_SOURCES,
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_SOURCES,
+          title: 'Fresh registry title',
+          version: '2',
+          registry_updated_at: new Date('2026-02-01T00:00:00.000Z'),
+        }),
+      () =>
+        runWithSystemDatabaseScope(
+          db,
+          'interleaved stale curation writer',
+          (scoped) =>
+            new MCPCatalogRepository(scoped as never).upsertCuration({
+              name: INTERLEAVED_SOURCES,
+              category: 'dev-tools',
+              capabilities: ['code-repos'],
+              description: 'Curated description',
+              benefit: 'Benefit',
+              starter_prompt: 'Prompt',
+              permission_disclosure: 'Disclosure',
+              verified: true,
+            }),
+          { capability: 'mcp_catalog_ingestion' }
+        )
+    );
+
+    expect(await repository.findByName(INTERLEAVED_SOURCES)).toMatchObject({
+      title: 'Fresh registry title',
+      description: 'Curated description',
+      version: '2',
+      curated: true,
+    });
+  });
+
+  it('does not let a stale registry publication overwrite a newer one', async () => {
+    await runWithSystemDatabaseScope(
+      db,
+      'seed interleaved registry test',
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_REGISTRY,
+          title: 'Initial registry title',
+          version: '1',
+          registry_updated_at: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      { capability: 'mcp_catalog_ingestion' }
+    );
+
+    const outcomes = await interleaveCatalogWriters(
+      db,
+      INTERLEAVED_REGISTRY,
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_REGISTRY,
+          title: 'Newest registry title',
+          version: '3',
+          registry_updated_at: new Date('2026-03-01T00:00:00.000Z'),
+        }),
+      () =>
+        runWithSystemDatabaseScope(
+          db,
+          'interleaved stale registry publication',
+          (scoped) =>
+            new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+              name: INTERLEAVED_REGISTRY,
+              title: 'Stale registry title',
+              version: '2',
+              registry_updated_at: new Date('2026-02-01T00:00:00.000Z'),
+            }),
+          { capability: 'mcp_catalog_ingestion' }
+        )
+    );
+    expect(outcomes).toEqual(['updated', 'unchanged']);
+
+    expect(await repository.findByName(INTERLEAVED_REGISTRY)).toMatchObject({
+      title: 'Newest registry title',
+      version: '3',
+    });
   });
 
   it('refuses a write made without any system capability', async () => {

--- a/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
@@ -40,6 +40,7 @@ const TX_PREFIX = `test.tx-${suffix}`;
 const CONCURRENT_SEED = `test.concurrent-seed-${suffix}/mcp`;
 const INTERLEAVED_SOURCES = `test.interleaved-sources-${suffix}/mcp`;
 const INTERLEAVED_REGISTRY = `test.interleaved-registry-${suffix}/mcp`;
+const INTERLEAVED_PROBE = `test.interleaved-probe-${suffix}/mcp`;
 
 async function waitForBlockedCatalogRowLock(db: Database): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -288,6 +289,50 @@ describePostgres('mcp_catalog_entries row-level security', () => {
     expect(await repository.findByName(INTERLEAVED_REGISTRY)).toMatchObject({
       title: 'Newest registry title',
       version: '3',
+    });
+  });
+
+  it('discards a stale probe result after a concurrent endpoint move', async () => {
+    const oldUrl = 'https://old.example.test/mcp';
+    const newUrl = 'https://new.example.test/mcp';
+    await runWithSystemDatabaseScope(
+      db,
+      'seed interleaved probe test',
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_PROBE,
+          remote_url: oldUrl,
+          registry_updated_at: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      { capability: 'mcp_catalog_ingestion' }
+    );
+
+    await interleaveCatalogWriters(
+      db,
+      INTERLEAVED_PROBE,
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertRegistryEntry({
+          name: INTERLEAVED_PROBE,
+          remote_url: newUrl,
+          registry_updated_at: new Date('2026-02-01T00:00:00.000Z'),
+        }),
+      () =>
+        runWithSystemDatabaseScope(
+          db,
+          'interleaved stale probe writer',
+          (scoped) =>
+            new MCPCatalogRepository(scoped as never).recordProbeResult(INTERLEAVED_PROBE, {
+              probed_auth_type: 'none',
+              probed_at: new Date('2026-01-15T00:00:00.000Z'),
+              probed_url: oldUrl,
+            }),
+          { capability: 'mcp_catalog_ingestion' }
+        )
+    );
+
+    expect(await repository.findByName(INTERLEAVED_PROBE)).toMatchObject({
+      remote_url: newUrl,
+      probed_auth_type: 'unknown',
     });
   });
 

--- a/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
@@ -41,6 +41,7 @@ const CONCURRENT_SEED = `test.concurrent-seed-${suffix}/mcp`;
 const INTERLEAVED_SOURCES = `test.interleaved-sources-${suffix}/mcp`;
 const INTERLEAVED_REGISTRY = `test.interleaved-registry-${suffix}/mcp`;
 const INTERLEAVED_PROBE = `test.interleaved-probe-${suffix}/mcp`;
+const INTERLEAVED_RETIREMENT = `test.interleaved-retirement-${suffix}/mcp`;
 
 async function waitForBlockedCatalogRowLock(db: Database): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -334,6 +335,41 @@ describePostgres('mcp_catalog_entries row-level security', () => {
       remote_url: newUrl,
       probed_auth_type: 'unknown',
     });
+  });
+
+  it('treats a concurrent retirement deletion as already absent', async () => {
+    await runWithSystemDatabaseScope(
+      db,
+      'seed interleaved retirement test',
+      (scoped) =>
+        new MCPCatalogRepository(scoped as never).upsertCuration({
+          name: INTERLEAVED_RETIREMENT,
+          category: 'dev-tools',
+          capabilities: ['code-repos'],
+          benefit: 'Benefit',
+          starter_prompt: 'Prompt',
+          permission_disclosure: 'Disclosure',
+          verified: true,
+        }),
+      { capability: 'mcp_catalog_ingestion' }
+    );
+
+    const outcomes = await interleaveCatalogWriters(
+      db,
+      INTERLEAVED_RETIREMENT,
+      (scoped) => new MCPCatalogRepository(scoped as never).retireCuration(INTERLEAVED_RETIREMENT),
+      () =>
+        runWithSystemDatabaseScope(
+          db,
+          'interleaved duplicate curation retirement',
+          (scoped) =>
+            new MCPCatalogRepository(scoped as never).retireCuration(INTERLEAVED_RETIREMENT),
+          { capability: 'mcp_catalog_ingestion' }
+        )
+    );
+
+    expect(outcomes).toEqual(['deleted', 'absent']);
+    expect(await repository.findByName(INTERLEAVED_RETIREMENT)).toBeNull();
   });
 
   it('refuses a write made without any system capability', async () => {

--- a/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.postgres.test.ts
@@ -37,6 +37,7 @@ const CAPABILITY_WRITE = `test.capability-${suffix}/mcp`;
 const UNSCOPED_WRITE = `test.unscoped-${suffix}/mcp`;
 const TENANT_WRITE = `test.tenant-${suffix}/mcp`;
 const TX_PREFIX = `test.tx-${suffix}`;
+const CONCURRENT_SEED = `test.concurrent-seed-${suffix}/mcp`;
 
 describePostgres('mcp_catalog_entries row-level security', () => {
   let db: Database;
@@ -97,6 +98,35 @@ describePostgres('mcp_catalog_entries row-level security', () => {
     );
 
     expect(await repository.findByName(CAPABILITY_WRITE)).not.toBeNull();
+  });
+
+  it('lets two daemons seed the same curated natural key concurrently', async () => {
+    const seedFromDaemon = () =>
+      runWithSystemDatabaseScope(
+        db,
+        'concurrent mcp catalog seed test',
+        (scoped) =>
+          new MCPCatalogRepository(scoped as never).upsertCuration({
+            name: CONCURRENT_SEED,
+            category: 'dev-tools',
+            capabilities: ['code-repos'],
+            benefit: 'Benefit',
+            starter_prompt: 'Prompt',
+            permission_disclosure: 'Disclosure',
+            verified: true,
+          }),
+        { capability: 'mcp_catalog_ingestion' }
+      );
+
+    await expect(Promise.all([seedFromDaemon(), seedFromDaemon()])).resolves.toEqual(
+      expect.arrayContaining(['created', 'updated'])
+    );
+    expect(await repository.findByName(CONCURRENT_SEED)).toMatchObject({
+      name: CONCURRENT_SEED,
+      curated: true,
+      category: 'dev-tools',
+    });
+    expect(await repository.count({ names: [CONCURRENT_SEED] })).toBe(1);
   });
 
   it('refuses a write made without any system capability', async () => {

--- a/packages/core/src/db/repositories/mcp-catalog.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.test.ts
@@ -337,6 +337,52 @@ describe('serializeCapabilityTags', () => {
   });
 });
 
+describe('concurrent catalog writers', () => {
+  dbTest('tolerates concurrent daemon curation seeding of the same natural key', async ({ db }) => {
+    const daemonA = new MCPCatalogRepository(db);
+    const daemonB = new MCPCatalogRepository(db);
+
+    await expect(
+      Promise.all([
+        daemonA.upsertCuration(curation('com.concurrent/mcp')),
+        daemonB.upsertCuration(curation('com.concurrent/mcp')),
+      ])
+    ).resolves.toEqual(expect.arrayContaining(['created', 'updated']));
+
+    expect(await daemonA.findByName('com.concurrent/mcp')).toMatchObject({
+      name: 'com.concurrent/mcp',
+      curated: true,
+      category: 'dev-tools',
+    });
+    expect(await daemonA.count({ names: ['com.concurrent/mcp'] })).toBe(1);
+  });
+
+  dbTest('merges simultaneous first registry and curation writes', async ({ db }) => {
+    const registryDaemon = new MCPCatalogRepository(db);
+    const curationDaemon = new MCPCatalogRepository(db);
+
+    await Promise.all([
+      registryDaemon.upsertRegistryEntry({
+        name: 'com.concurrent/mixed',
+        title: 'Registry title',
+        version: '1.0.0',
+      }),
+      curationDaemon.upsertCuration(
+        curation('com.concurrent/mixed', { description: 'Curated description' })
+      ),
+    ]);
+
+    expect(await registryDaemon.findByName('com.concurrent/mixed')).toMatchObject({
+      name: 'com.concurrent/mixed',
+      title: 'Registry title',
+      description: 'Curated description',
+      version: '1.0.0',
+      curated: true,
+    });
+    expect(await registryDaemon.count({ names: ['com.concurrent/mixed'] })).toBe(1);
+  });
+});
+
 describe('field ownership across writers', () => {
   const curation = (
     overrides: Partial<MCPCatalogCurationUpsert> = {}

--- a/packages/core/src/db/repositories/mcp-catalog.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.ts
@@ -619,8 +619,9 @@ export class MCPCatalogRepository {
    * until they do, the file remains the source of truth for what is offered.
    */
   async retireWithdrawnEntry(name: string): Promise<'deleted' | 'retired-curated' | 'absent'> {
-    const existing = await this.rawByName(name);
-    if (!existing) return 'absent';
+    const observed = await this.rawByName(name);
+    if (!observed) return 'absent';
+    const existing = await this.lockedRawByName(name);
 
     if (!existing.curated) {
       await deleteFrom(this.db, mcpCatalogEntries)
@@ -670,8 +671,9 @@ export class MCPCatalogRepository {
    * exactly the stale-verdict-on-a-new-endpoint case the invalidation prevents.
    */
   async recordProbeResult(name: string, result: MCPCatalogProbeResult): Promise<void> {
-    const existing = await this.rawByName(name);
-    if (!existing) return;
+    const observed = await this.rawByName(name);
+    if (!observed) return;
+    const existing = await this.lockedRawByName(name);
     if (existing.remote_url !== result.probed_url) return;
 
     await update(this.db, mcpCatalogEntries)
@@ -717,8 +719,10 @@ export class MCPCatalogRepository {
    * outright — there is nothing underneath it to fall back to.
    */
   async retireCuration(name: string): Promise<'deleted' | 'uncurated' | 'absent'> {
-    const existing = await this.rawByName(name);
-    if (!existing?.curated) return 'absent';
+    const observed = await this.rawByName(name);
+    if (!observed?.curated) return 'absent';
+    const existing = await this.lockedRawByName(name);
+    if (!existing.curated) return 'absent';
 
     const data = existing.data ?? {};
     // "Live", not "ever mirrored": a withdrawn registry source clears all three

--- a/packages/core/src/db/repositories/mcp-catalog.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.ts
@@ -25,7 +25,7 @@ import type {
 import { and, asc, eq, inArray, type SQL, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
 import { type MCPCatalogEntryInsert, type MCPCatalogEntryRow, mcpCatalogEntries } from '../schema';
 import { RepositoryError } from './base';
 
@@ -403,6 +403,23 @@ export class MCPCatalogRepository {
   }
 
   /**
+   * Serialize source-side read/merge/write operations for one natural key.
+   *
+   * Valid PostgreSQL catalog writes run inside the system-capability transaction,
+   * so this lock is held through the following reload and update. Reloading after
+   * the lock is essential: the optimistic read used to choose insert vs update
+   * may predate a peer daemon's committed registry or curation write.
+   */
+  private async lockedRawByName(name: string): Promise<MCPCatalogEntryRow> {
+    await lockRowForUpdate(this.db, this.db, mcpCatalogEntries, eq(mcpCatalogEntries.name, name));
+    const current = await this.rawByName(name);
+    if (!current) {
+      throw new RepositoryError(`MCP catalog entry ${name} disappeared while acquiring its lock`);
+    }
+    return current;
+  }
+
+  /**
    * Apply one registry record.
    *
    * Returns `'created'`, `'updated'`, or `'unchanged'`. A record whose
@@ -458,16 +475,13 @@ export class MCPCatalogRepository {
         .run();
       if (inserted.rowsAffected > 0) return 'created';
 
-      // Another daemon may have seeded the same natural key after our SELECT.
-      // Reload its row and merge this writer's source half instead of turning a
-      // harmless startup race into a unique-constraint failure.
-      existing = await this.rawByName(entry.name);
-      if (!existing) {
-        throw new RepositoryError(
-          `MCP catalog entry ${entry.name} conflicted during insert but could not be reloaded`
-        );
-      }
+      // Another daemon seeded the same natural key after our SELECT. Fall
+      // through to the same locked reload used for an already-existing row.
     }
+
+    // Do not derive shared/blob columns from the optimistic read above. A peer
+    // may have committed either source half since then; lock and reload first.
+    existing = await this.lockedRawByName(entry.name);
 
     const storedAt = existing.registry_updated_at
       ? new Date(existing.registry_updated_at).getTime()
@@ -561,15 +575,14 @@ export class MCPCatalogRepository {
         .run();
       if (inserted.rowsAffected > 0) return 'created';
 
-      // Every HA daemon reconciles curated.yaml on startup. A peer can insert
-      // this name between our read and write, so merge onto the winning row.
-      existing = await this.rawByName(entry.name);
-      if (!existing) {
-        throw new RepositoryError(
-          `MCP catalog entry ${entry.name} conflicted during insert but could not be reloaded`
-        );
-      }
+      // A peer inserted this name after our SELECT. Fall through to the same
+      // locked reload used for an already-existing row.
     }
+
+    // Registry ingestion and curated.yaml reconciliation own different halves
+    // of this row. Serialize and reload so neither can re-save a stale copy of
+    // the other's half.
+    existing = await this.lockedRawByName(entry.name);
 
     const existingData = existing.data ?? {};
     const shared = deriveSharedColumns(existingData.registry ?? {}, curationSide);

--- a/packages/core/src/db/repositories/mcp-catalog.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.ts
@@ -414,7 +414,7 @@ export class MCPCatalogRepository {
     entry: MCPCatalogRegistryUpsert
   ): Promise<'created' | 'updated' | 'unchanged'> {
     const now = new Date();
-    const existing = await this.rawByName(entry.name);
+    let existing = await this.rawByName(entry.name);
 
     const registryColumns = {
       version: entry.version ?? null,
@@ -452,8 +452,21 @@ export class MCPCatalogRepository {
         },
         ...registryColumns,
       };
-      await insert(this.db, mcpCatalogEntries).values(row).run();
-      return 'created';
+      const inserted = await insert(this.db, mcpCatalogEntries)
+        .values(row)
+        .onConflictDoNothing()
+        .run();
+      if (inserted.rowsAffected > 0) return 'created';
+
+      // Another daemon may have seeded the same natural key after our SELECT.
+      // Reload its row and merge this writer's source half instead of turning a
+      // harmless startup race into a unique-constraint failure.
+      existing = await this.rawByName(entry.name);
+      if (!existing) {
+        throw new RepositoryError(
+          `MCP catalog entry ${entry.name} conflicted during insert but could not be reloaded`
+        );
+      }
     }
 
     const storedAt = existing.registry_updated_at
@@ -506,7 +519,7 @@ export class MCPCatalogRepository {
    */
   async upsertCuration(entry: MCPCatalogCurationUpsert): Promise<'created' | 'updated'> {
     const now = new Date();
-    const existing = await this.rawByName(entry.name);
+    let existing = await this.rawByName(entry.name);
 
     // Rewritten in full each seed rather than merged into what is already
     // stored: dropping `title` from `curated.yaml` has to hand that field back
@@ -534,7 +547,7 @@ export class MCPCatalogRepository {
 
     if (!existing) {
       const shared = deriveSharedColumns({}, curationSide);
-      await insert(this.db, mcpCatalogEntries)
+      const inserted = await insert(this.db, mcpCatalogEntries)
         .values({
           catalog_entry_id: generateId(),
           created_at: now,
@@ -544,8 +557,18 @@ export class MCPCatalogRepository {
           data: { capabilities: entry.capabilities, curation: curationSide },
           ...curationColumns,
         } satisfies MCPCatalogEntryInsert)
+        .onConflictDoNothing()
         .run();
-      return 'created';
+      if (inserted.rowsAffected > 0) return 'created';
+
+      // Every HA daemon reconciles curated.yaml on startup. A peer can insert
+      // this name between our read and write, so merge onto the winning row.
+      existing = await this.rawByName(entry.name);
+      if (!existing) {
+        throw new RepositoryError(
+          `MCP catalog entry ${entry.name} conflicted during insert but could not be reloaded`
+        );
+      }
     }
 
     const existingData = existing.data ?? {};

--- a/packages/core/src/db/repositories/mcp-catalog.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.ts
@@ -410,9 +410,14 @@ export class MCPCatalogRepository {
    * the lock is essential: the optimistic read used to choose insert vs update
    * may predate a peer daemon's committed registry or curation write.
    */
-  private async lockedRawByName(name: string): Promise<MCPCatalogEntryRow> {
+  private async lockedRawByNameOrNull(name: string): Promise<MCPCatalogEntryRow | null> {
     await lockRowForUpdate(this.db, this.db, mcpCatalogEntries, eq(mcpCatalogEntries.name, name));
-    const current = await this.rawByName(name);
+    return this.rawByName(name);
+  }
+
+  /** An upsert that observed or lost an insert race expects the row to remain. */
+  private async requireLockedRawByName(name: string): Promise<MCPCatalogEntryRow> {
+    const current = await this.lockedRawByNameOrNull(name);
     if (!current) {
       throw new RepositoryError(`MCP catalog entry ${name} disappeared while acquiring its lock`);
     }
@@ -481,7 +486,7 @@ export class MCPCatalogRepository {
 
     // Do not derive shared/blob columns from the optimistic read above. A peer
     // may have committed either source half since then; lock and reload first.
-    existing = await this.lockedRawByName(entry.name);
+    existing = await this.requireLockedRawByName(entry.name);
 
     const storedAt = existing.registry_updated_at
       ? new Date(existing.registry_updated_at).getTime()
@@ -582,7 +587,7 @@ export class MCPCatalogRepository {
     // Registry ingestion and curated.yaml reconciliation own different halves
     // of this row. Serialize and reload so neither can re-save a stale copy of
     // the other's half.
-    existing = await this.lockedRawByName(entry.name);
+    existing = await this.requireLockedRawByName(entry.name);
 
     const existingData = existing.data ?? {};
     const shared = deriveSharedColumns(existingData.registry ?? {}, curationSide);
@@ -621,7 +626,8 @@ export class MCPCatalogRepository {
   async retireWithdrawnEntry(name: string): Promise<'deleted' | 'retired-curated' | 'absent'> {
     const observed = await this.rawByName(name);
     if (!observed) return 'absent';
-    const existing = await this.lockedRawByName(name);
+    const existing = await this.lockedRawByNameOrNull(name);
+    if (!existing) return 'absent';
 
     if (!existing.curated) {
       await deleteFrom(this.db, mcpCatalogEntries)
@@ -673,7 +679,8 @@ export class MCPCatalogRepository {
   async recordProbeResult(name: string, result: MCPCatalogProbeResult): Promise<void> {
     const observed = await this.rawByName(name);
     if (!observed) return;
-    const existing = await this.lockedRawByName(name);
+    const existing = await this.lockedRawByNameOrNull(name);
+    if (!existing) return;
     if (existing.remote_url !== result.probed_url) return;
 
     await update(this.db, mcpCatalogEntries)
@@ -721,7 +728,8 @@ export class MCPCatalogRepository {
   async retireCuration(name: string): Promise<'deleted' | 'uncurated' | 'absent'> {
     const observed = await this.rawByName(name);
     if (!observed?.curated) return 'absent';
-    const existing = await this.lockedRawByName(name);
+    const existing = await this.lockedRawByNameOrNull(name);
+    if (!existing) return 'absent';
     if (!existing.curated) return 'absent';
 
     const data = existing.data ?? {};

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -40,15 +40,14 @@ const checks = [
       'apps/agor-daemon/src/register-hooks.ts': 1,
       // OAuth HA hints use the audited native-event inventory; authorization
       // URLs and standalone socket hints are explicitly local-only.
-      'apps/agor-daemon/src/register-services.ts': 5,
+      'apps/agor-daemon/src/register-services.ts': 1,
       // HA fork/spawn now use the tenant-aware Feathers event helper instead
       // of raw global Socket.IO broadcasts.
-      'apps/agor-daemon/src/register-routes.ts': 6,
+      'apps/agor-daemon/src/register-routes.ts': 4,
       'apps/agor-daemon/src/startup.ts': 1,
       'apps/agor-daemon/src/services/artifacts.test.ts': 1,
       'apps/agor-daemon/src/services/artifacts.ts': 1,
       'apps/agor-daemon/src/services/boards.ts': 2,
-      'apps/agor-daemon/src/services/repos.ts': 1,
       // The tenant-aware realtime facade: tenant/session channel join, the
       // publish handler, session-stream and tenant+task executor-control joins,
       // the existence-gated room lookup (existingChannel — used by publish +

--- a/scripts/check-realtime-boundaries.mjs
+++ b/scripts/check-realtime-boundaries.mjs
@@ -28,6 +28,16 @@ function isPotentialClusterBroadcast(receiver, aliases) {
   );
 }
 
+function isHaNativeBoundaryImplementation(node, file) {
+  if (!file.endsWith(join('apps', 'agor-daemon', 'src', 'realtime', 'routing.ts'))) return false;
+  for (let current = node.parent; current; current = current.parent) {
+    if (ts.isFunctionDeclaration(current) && current.name?.text === 'emitHaNativeSocketEvent') {
+      return true;
+    }
+  }
+  return false;
+}
+
 const violations = [];
 for (const file of sourceFiles(SOURCE_ROOT)) {
   const source = ts.createSourceFile(
@@ -63,6 +73,17 @@ for (const file of sourceFiles(SOURCE_ROOT)) {
   function visit(node) {
     if (
       ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'emitHaNativeSocketEvent' &&
+      node.arguments.length !== 4
+    ) {
+      const position = source.getLineAndCharacterOfPosition(node.getStart(source));
+      violations.push(
+        `${relative(ROOT, file)}:${position.line + 1}:${position.character + 1} HA native emit must pass emitter, branded tenant room, event, and payload`
+      );
+    }
+    if (
+      ts.isCallExpression(node) &&
       ts.isPropertyAccessExpression(node.expression) &&
       node.expression.name.text === 'emit'
     ) {
@@ -70,11 +91,12 @@ for (const file of sourceFiles(SOURCE_ROOT)) {
       const receiverText = receiver.getText();
       if (
         isPotentialClusterBroadcast(receiver, clusterAliases) &&
-        !receiverText.includes('.local')
+        !receiverText.includes('.local') &&
+        !isHaNativeBoundaryImplementation(node, file)
       ) {
         const position = source.getLineAndCharacterOfPosition(node.getStart(source));
         violations.push(
-          `${relative(ROOT, file)}:${position.line + 1}:${position.character + 1} raw room/global Socket.IO emit must use .local or emitHaNativeSocketEvent()`
+          `${relative(ROOT, file)}:${position.line + 1}:${position.character + 1} raw room/global Socket.IO emit must use .local or the tenant-bound emitHaNativeSocketEvent()`
         );
       }
     }

--- a/scripts/daemon-filesystem-exceptions.json
+++ b/scripts/daemon-filesystem-exceptions.json
@@ -1596,7 +1596,7 @@
     "reviewDate": null
   },
   {
-    "id": "DAEMON-FS-CAP-170",
+    "id": "DAEMON-FS-CAP-183",
     "class": "A",
     "file": "packages/core/src/agentic-integrations.ts",
     "import": "<non-literal-dynamic-import>",


### PR DESCRIPTION
## Summary

- make concurrent MCP catalog registry/curation first-writes idempotent across daemon replicas, then reload and merge the winning row
- require native cross-replica Socket.IO broadcasts to use a branded, tenant-qualified room through the audited HA emitter
- add cross-tenant negative coverage for session streams and native room delivery, plus SQLite and live Postgres concurrency regressions
- tighten the static realtime boundary checker and refresh lowered security-boundary inventories

## Why

A clean two-daemon HA boot exposed a catalog unique-key race when both replicas seeded the same global catalog row. Native Socket.IO HA broadcasts also accepted arbitrary room strings, leaving tenant qualification dependent on call-site discipline. This change fixes the startup race and makes the cross-replica realtime contract explicit and statically auditable.

## Tenant and security review

- MCP catalog rows remain intentionally global/public; writes still require the narrow `mcp_catalog_ingestion` system capability.
- Concurrent insert handling does not bypass RLS or enumerate tenant data.
- Every native event permitted to cross replicas now targets a branded tenant-qualified room.
- Session-stream delivery retains subscription authorization and intersects the authenticated tenant channel; a same-session-ID cross-tenant negative test proves suppression.
- Process-local terminal rooms remain local-only and web terminals are disabled in the HA profile.
- This is not a claim of full production HA readiness: live multi-tenant, multi-replica failure-injection and sustained load evidence remain follow-up certification work.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check` — 21 typecheck tasks and 15 build tasks passed; lint and boundary checks passed
- daemon realtime/socket tests — 141 passed
- realtime routing tests — 3 passed
- SQLite MCP catalog suite — 45 passed
- live Postgres MCP catalog suite using the HA app role (`NOSUPERUSER`, `NOBYPASSRLS`) — 8 passed
- full HA Docker failure harness — passed cross-replica Feathers/native delivery, anonymous denial, daemon failover/reconnect, Redis readiness failure/recovery/no replay, MCP, and GitHub state scenarios

## Environment

The managed `ha` environment remains running and healthy at `http://10.33.92.175:6997` (`admin@agor.live` / `admin`).

## Coordination checkpoint

Current program status and remaining production-readiness work:
https://agor.sandbox.preset.zone/ui/knowledge/agor-cloud-team/architecture/daemon-ha-program-checkpoint-2026-08.md
