### PR TITLE
fix(ui): stabilize zone trigger modal state

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -4,6 +4,7 @@ import type {
   BoardEntityObject,
   Branch,
   CardWithType,
+  MCPServer,
   Repo,
   Session,
   User,
@@ -254,7 +255,7 @@ describe('SessionCanvas store-selector re-render isolation', () => {
     expect(cardNodeRenders).toBe(cardNodeBaseline);
   });
 
-  it('a patch to a slice SessionCanvas does not select leaves the whole canvas un-rendered', async () => {
+  it('patches to unselected or modal-only slices leave the closed canvas un-rendered', async () => {
     render(
       <ConnectionProvider
         value={{
@@ -295,6 +296,22 @@ describe('SessionCanvas store-selector re-render isolation', () => {
 
     // The memo+selector boundary holds: SessionCanvas itself — not just the leaf
     // node memos — was insulated from the unrelated store change.
+    expect(sessionCanvasRenders).toBe(canvasBaseline);
+    expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
+    expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
+    expect(cardNodeRenders).toBe(cardNodeBaseline);
+
+    // MCP data is consumed only by the conditional zone-trigger modal. Keeping
+    // that subscription at the modal boundary means marketplace/auth updates
+    // cannot wake the entire canvas while the modal is closed.
+    act(() => {
+      agorStore.setState({
+        mcpServerById: new Map<string, MCPServer>([
+          ['mcp-1', { mcp_server_id: 'mcp-1', name: 'MCP' } as unknown as MCPServer],
+        ]),
+      });
+    });
+
     expect(sessionCanvasRenders).toBe(canvasBaseline);
     expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
     expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -10,7 +10,6 @@ import type {
   Branch,
   BranchID,
   CardWithType,
-  MCPServer,
   Repo,
   Session,
   SpawnConfig,
@@ -63,7 +62,7 @@ import {
 import { useMutationGate } from '../../contexts/ConnectionContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
 import { useStableCallback } from '../../hooks/useStableCallback';
-import { useAgorStore } from '../../store/agorStore';
+import { agorStore, useAgorStore } from '../../store/agorStore';
 import {
   makeBoardObjectsForBoardSelector,
   makeSessionsForBranchSelector,
@@ -72,7 +71,6 @@ import {
   selectCommentById,
   selectMcpServerById,
   selectRepoById,
-  selectSessionsByBranch,
   selectUserById,
 } from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
@@ -371,47 +369,47 @@ const EMPTY_BOARD_ENTITY_OBJECTS: BoardEntityObject[] = Object.freeze(
 
 interface BranchZoneTriggerModalProps {
   modal: {
+    actionId: number;
     branchId: BranchID;
     zoneName: string;
     zoneId: string;
     trigger: ZoneTrigger;
+    sessions: readonly Session[];
   };
   client: AgorClient | null;
-  branches: Branch[];
+  branch: Branch | undefined;
   board: Board | null;
   availableAgents: AgenticToolOption[];
-  mcpServerById: Map<string, MCPServer>;
   currentUser: User | null;
   onCancel: () => void;
   onExecute: React.ComponentProps<typeof ZoneTriggerModal>['onExecute'];
 }
 
-// The zone-trigger modal needs the full sessionsByBranch map to offer source
-// session choices, but that map changes on every streaming session patch. Keep
-// that subscription behind this tiny conditional child so the main canvas does
-// not rebuild every React Flow node while the modal is closed.
+// Keep modal-only subscriptions behind this conditional boundary. The session
+// choices are already snapshotted into the action at drop time, so this child
+// deliberately does not subscribe to streaming session state at all. MCP data
+// remains live because it supplies picker options rather than action defaults.
 const BranchZoneTriggerModal = React.memo(
   ({
     modal,
     client,
-    branches,
+    branch,
     board,
     availableAgents,
-    mcpServerById,
     currentUser,
     onCancel,
     onExecute,
   }: BranchZoneTriggerModalProps) => {
-    const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+    const mcpServerById = useAgorStore(selectMcpServerById);
 
     return (
       <ZoneTriggerModal
+        actionId={modal.actionId}
         open={true}
         onCancel={onCancel}
         client={client}
-        branchId={modal.branchId}
-        branch={branches.find((wt) => wt.branch_id === modal.branchId)}
-        sessionsByBranch={sessionsByBranch}
+        branch={branch}
+        sessions={modal.sessions}
         zoneName={modal.zoneName}
         trigger={modal.trigger}
         boardName={board?.name}
@@ -475,7 +473,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const commentById = useAgorStore(selectCommentById);
     const cardById = useAgorStore(selectCardById);
     const userById = useAgorStore(selectUserById);
-    const mcpServerById = useAgorStore(selectMcpServerById);
 
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
@@ -555,12 +552,111 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const [markdownWidth, setMarkdownWidth] = useState(500); // Default width
 
     // Branch zone trigger modal state
+    const nextBranchTriggerActionIdRef = useRef(0);
     const [branchTriggerModal, setBranchTriggerModal] = useState<{
+      actionId: number;
       branchId: BranchID;
       zoneName: string;
       zoneId: string;
       trigger: ZoneTrigger;
+      sessions: readonly Session[];
     } | null>(null);
+    const handleCancelBranchTrigger = useCallback(() => setBranchTriggerModal(null), []);
+    const handleExecuteBranchTrigger = useStableCallback(
+      async ({
+        sessionId,
+        action,
+        renderedTemplate,
+        agent,
+        agenticToolPresetId,
+        modelConfig,
+        permissionMode,
+        mcpServerIds,
+      }: Parameters<React.ComponentProps<typeof ZoneTriggerModal>['onExecute']>[0]) => {
+        const triggerModal = branchTriggerModal;
+        if (!client || !triggerModal) {
+          console.error('❌ Cannot execute trigger: client or trigger action not available');
+          setBranchTriggerModal(null);
+          return;
+        }
+
+        try {
+          let targetSessionId = sessionId;
+
+          // If creating new session, create it first
+          if (sessionId === 'new') {
+            const newSession = await client.service('sessions').create({
+              branch_id: triggerModal.branchId,
+              agentic_tool: (agent || 'claude-code') as AgenticToolName,
+              agentic_tool_preset_id: agenticToolPresetId,
+              description: `Session from zone "${triggerModal.zoneName}"`,
+              status: 'idle',
+              model_config: modelConfig
+                ? {
+                    ...modelConfig,
+                    updated_at: new Date().toISOString(),
+                  }
+                : undefined,
+              permission_config: permissionMode
+                ? {
+                    mode: permissionMode,
+                  }
+                : undefined,
+            });
+            targetSessionId = newSession.session_id;
+
+            // Attach MCP servers if provided
+            if (mcpServerIds && mcpServerIds.length > 0) {
+              for (const serverId of mcpServerIds) {
+                await client
+                  .service(`sessions/${targetSessionId}/mcp-servers`)
+                  .create({ mcpServerId: serverId });
+              }
+            }
+          }
+
+          // Execute action and capture the session the user should land on so
+          // we can route through the normal session-click pipe afterward.
+          let resultSessionId: string | undefined;
+          switch (action) {
+            case 'prompt': {
+              await client.sessions.prompt(targetSessionId, renderedTemplate, {
+                permissionMode,
+              });
+              resultSessionId = targetSessionId;
+              break;
+            }
+            case 'fork': {
+              const forkedSession = (await client
+                .service(`sessions/${targetSessionId}/fork`)
+                .create({})) as Session;
+              await client.sessions.prompt(forkedSession.session_id, renderedTemplate, {
+                permissionMode,
+              });
+              resultSessionId = forkedSession.session_id;
+              break;
+            }
+            case 'spawn': {
+              const spawnedSession = (await client
+                .service(`sessions/${targetSessionId}/spawn`)
+                .create({})) as Session;
+              await client.sessions.prompt(spawnedSession.session_id, renderedTemplate, {
+                permissionMode,
+              });
+              resultSessionId = spawnedSession.session_id;
+              break;
+            }
+          }
+
+          // Use the same URL/recenter/flag-cleanup path as a session-card click.
+          if (resultSessionId) onSessionClick?.(resultSessionId);
+        } catch (error) {
+          console.error('❌ Failed to execute zone trigger:', error);
+        } finally {
+          setBranchTriggerModal(null);
+        }
+      }
+    );
 
     // Debounce timer ref for position updates
     const layoutUpdateTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -1957,10 +2053,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     } else {
                       // Default: show_picker - open modal for session selection
                       setBranchTriggerModal({
+                        actionId: ++nextBranchTriggerActionIdRef.current,
                         branchId: nodeId as BranchID,
                         zoneName: zoneData.label,
                         zoneId,
                         trigger,
+                        sessions:
+                          agorStore.getState().sessionsByBranch.get(nodeId) ?? EMPTY_SESSIONS,
                       });
                     }
                   }
@@ -2993,110 +3092,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         {branchTriggerModal && (
           <BranchZoneTriggerModal
             modal={branchTriggerModal}
-            onCancel={() => setBranchTriggerModal(null)}
+            onCancel={handleCancelBranchTrigger}
             client={client}
-            branches={branches}
+            branch={branches.find((branch) => branch.branch_id === branchTriggerModal.branchId)}
             board={board}
             availableAgents={availableAgents}
-            mcpServerById={mcpServerById}
             currentUser={currentUserId ? userById.get(currentUserId) || null : null}
-            onExecute={async ({
-              sessionId,
-              action,
-              renderedTemplate,
-              agent,
-              agenticToolPresetId,
-              modelConfig,
-              permissionMode,
-              mcpServerIds,
-            }) => {
-              if (!client) {
-                console.error('❌ Cannot execute trigger: client not available');
-                setBranchTriggerModal(null);
-                return;
-              }
-
-              try {
-                let targetSessionId = sessionId;
-
-                // If creating new session, create it first
-                if (sessionId === 'new') {
-                  const newSession = await client.service('sessions').create({
-                    branch_id: branchTriggerModal.branchId,
-                    agentic_tool: (agent || 'claude-code') as AgenticToolName,
-                    agentic_tool_preset_id: agenticToolPresetId,
-                    description: `Session from zone "${branchTriggerModal.zoneName}"`,
-                    status: 'idle',
-                    model_config: modelConfig
-                      ? {
-                          ...modelConfig,
-                          updated_at: new Date().toISOString(),
-                        }
-                      : undefined,
-                    permission_config: permissionMode
-                      ? {
-                          mode: permissionMode,
-                        }
-                      : undefined,
-                  });
-                  targetSessionId = newSession.session_id;
-
-                  // Attach MCP servers if provided
-                  if (mcpServerIds && mcpServerIds.length > 0) {
-                    for (const serverId of mcpServerIds) {
-                      await client
-                        .service(`sessions/${targetSessionId}/mcp-servers`)
-                        .create({ mcpServerId: serverId });
-                    }
-                  }
-                }
-
-                // Execute action and capture the session the user
-                // should land on so we can route through the normal
-                // session-click pipe afterward (same URL push as
-                // handleCreateSession / a card click).
-                let resultSessionId: string | undefined;
-                switch (action) {
-                  case 'prompt': {
-                    await client.sessions.prompt(targetSessionId, renderedTemplate, {
-                      permissionMode,
-                    });
-                    resultSessionId = targetSessionId;
-                    break;
-                  }
-                  case 'fork': {
-                    const forkedSession = (await client
-                      .service(`sessions/${targetSessionId}/fork`)
-                      .create({})) as Session;
-                    await client.sessions.prompt(forkedSession.session_id, renderedTemplate, {
-                      permissionMode,
-                    });
-                    resultSessionId = forkedSession.session_id;
-                    break;
-                  }
-                  case 'spawn': {
-                    const spawnedSession = (await client
-                      .service(`sessions/${targetSessionId}/spawn`)
-                      .create({})) as Session;
-                    await client.sessions.prompt(spawnedSession.session_id, renderedTemplate, {
-                      permissionMode,
-                    });
-                    resultSessionId = spawnedSession.session_id;
-                    break;
-                  }
-                }
-
-                // Open the session the trigger landed on (new for
-                // fork/spawn/new-session, existing for prompt). Routes
-                // through the same handler as a session-card click, so
-                // URL push + recenter + flag cleanup all run in lockstep.
-                if (resultSessionId) onSessionClick?.(resultSessionId);
-              } catch (error) {
-                console.error('❌ Failed to execute zone trigger:', error);
-              } finally {
-                setBranchTriggerModal(null);
-              }
-            }}
+            onExecute={handleExecuteBranchTrigger}
           />
         )}
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -1,7 +1,11 @@
-import type { BranchID, Session } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import type { AgorClient, BranchID, Session } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderTemplate } from '../../../utils/templates';
 import { ZoneTriggerModal } from './ZoneTriggerModal';
+
+vi.mock('../../../utils/templates', () => ({ renderTemplate: vi.fn() }));
 
 function EffortField({
   value,
@@ -23,9 +27,7 @@ function EffortField({
   );
 }
 
-// Isolate the modal's own smart-default selection logic from its heavy config
-// children — the regression lives entirely in ZoneTriggerModal's render-time
-// useMemo, which runs regardless of what these children render.
+// Isolate the modal transaction behavior from its heavy configuration children.
 vi.mock('../../AgentSelectionGrid', () => ({
   AgentSelectionGrid: ({
     agents,
@@ -70,6 +72,16 @@ vi.mock('../../AgenticToolConfigurationPicker', async () => {
 });
 
 const BRANCH_ID = 'branch-1' as BranchID;
+const CLIENT = {} as AgorClient;
+const renderTemplateMock = vi.mocked(renderTemplate);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 const makeSession = (id: string, status: string, lastUpdated: string, title: string): Session =>
   ({
@@ -83,6 +95,200 @@ const makeSession = (id: string, status: string, lastUpdated: string, title: str
     last_updated: lastUpdated,
   }) as unknown as Session;
 
+beforeEach(() => {
+  renderTemplateMock.mockReset();
+});
+
+describe('ZoneTriggerModal action snapshot', () => {
+  it('preserves prompt and form edits across equivalent parent data with new identities', async () => {
+    const request = deferred<string>();
+    renderTemplateMock.mockReturnValue(request.promise);
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const props = {
+      actionId: 1,
+      open: true,
+      onCancel: () => {},
+      client: CLIENT,
+      branch: { branch_id: BRANCH_ID, mcp_server_ids: ['initial-mcp'] } as never,
+      sessions: [] as Session[],
+      zoneName: 'Review',
+      trigger: { template: 'Review {{ branch.name }}', behavior: 'show_picker' as const },
+      boardName: 'Board',
+      boardCustomContext: { sprint: 7 },
+      availableAgents: [],
+      mcpServerById: new Map(),
+      currentUser: { default_mcp_server_ids: ['user-mcp'] } as never,
+      onExecute,
+    };
+    const { rerender } = render(<ZoneTriggerModal {...props} />);
+
+    const prompt = screen.getByRole('textbox', { name: 'Prompt (editable)' });
+    fireEvent.change(prompt, { target: { value: 'My edited prompt' } });
+    fireEvent.click(screen.getByText('Agentic Tool Configuration (optional)'));
+    const effort = await screen.findByLabelText('zone-effort');
+    fireEvent.change(effort, { target: { value: 'xhigh' } });
+
+    rerender(
+      <ZoneTriggerModal
+        {...props}
+        branch={{ branch_id: BRANCH_ID, mcp_server_ids: ['initial-mcp'] } as never}
+        sessions={[]}
+        trigger={{ template: 'Review {{ branch.name }}', behavior: 'show_picker' }}
+        boardCustomContext={{ sprint: 7 }}
+        mcpServerById={new Map()}
+        currentUser={{ default_mcp_server_ids: ['user-mcp'] } as never}
+      />
+    );
+
+    expect(renderTemplateMock).toHaveBeenCalledTimes(1);
+    expect(prompt).toHaveValue('My edited prompt');
+    expect(effort).toHaveValue('xhigh');
+    expect(screen.getByRole('button', { name: 'Execute Trigger' })).toBeEnabled();
+    await act(async () => {
+      request.resolve('Rendered once');
+      await request.promise;
+    });
+    expect(prompt).toHaveValue('My edited prompt');
+  });
+
+  it('rerenders once and resets the prompt when the user deliberately changes session', async () => {
+    renderTemplateMock.mockImplementation(async (_client, _template, context) => {
+      const session = context.session as { description?: string } | undefined;
+      return `Prompt for ${session?.description}`;
+    });
+    const older = {
+      ...makeSession('s-old', 'completed', '2026-06-01T00:00:00.000Z', 'Older session'),
+      description: 'older',
+    } as Session;
+    const newer = {
+      ...makeSession('s-new', 'completed', '2026-06-20T00:00:00.000Z', 'Newer session'),
+      description: 'newer',
+    } as Session;
+
+    render(
+      <ZoneTriggerModal
+        actionId={1}
+        open
+        onCancel={() => {}}
+        client={CLIENT}
+        branch={undefined}
+        sessions={[older, newer]}
+        zoneName="Review"
+        trigger={{ template: 'Template', behavior: 'show_picker' }}
+        availableAgents={[]}
+        mcpServerById={new Map()}
+        onExecute={async () => {}}
+      />
+    );
+
+    const prompt = screen.getByRole('textbox', { name: 'Prompt (editable)' });
+    await waitFor(() => expect(prompt).toHaveValue('Prompt for newer'));
+    fireEvent.change(prompt, { target: { value: 'Edited newer prompt' } });
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    const olderOptions = await screen.findAllByText(/Older session/);
+    fireEvent.click(olderOptions.at(-1) as HTMLElement);
+
+    await waitFor(() => expect(prompt).toHaveValue('Prompt for older'));
+    expect(renderTemplateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts a clean render exactly once for a new zone action or reopened action', async () => {
+    const zoneA = deferred<string>();
+    const zoneB = deferred<string>();
+    const reopenedZoneA = deferred<string>();
+    renderTemplateMock
+      .mockReturnValueOnce(zoneA.promise)
+      .mockReturnValueOnce(zoneB.promise)
+      .mockReturnValueOnce(reopenedZoneA.promise);
+    const common = {
+      open: true,
+      onCancel: () => {},
+      client: CLIENT,
+      branch: undefined,
+      sessions: [] as Session[],
+      availableAgents: [],
+      mcpServerById: new Map(),
+      onExecute: async () => {},
+    };
+    const { rerender } = render(
+      <ZoneTriggerModal
+        {...common}
+        actionId={1}
+        zoneName="Zone A"
+        trigger={{ template: 'Template A', behavior: 'show_picker' }}
+      />
+    );
+    let prompt = screen.getByRole('textbox', { name: 'Prompt (editable)' });
+    expect(prompt).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Execute Trigger' })).toBeDisabled();
+    zoneA.resolve('Rendered A');
+    await waitFor(() => expect(prompt).toHaveValue('Rendered A'));
+    fireEvent.change(prompt, { target: { value: 'Edited A' } });
+
+    rerender(
+      <ZoneTriggerModal
+        {...common}
+        actionId={2}
+        zoneName="Zone B"
+        trigger={{ template: 'Template B', behavior: 'show_picker' }}
+      />
+    );
+    prompt = screen.getByRole('textbox', { name: 'Prompt (editable)' });
+    expect(screen.getByText('Zone Trigger: Zone B')).toBeInTheDocument();
+    expect(prompt).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Execute Trigger' })).toBeDisabled();
+    zoneB.resolve('Rendered B');
+    await waitFor(() => expect(prompt).toHaveValue('Rendered B'));
+
+    rerender(
+      <ZoneTriggerModal
+        {...common}
+        actionId={3}
+        zoneName="Zone A"
+        trigger={{ template: 'Template A', behavior: 'show_picker' }}
+      />
+    );
+    prompt = screen.getByRole('textbox', { name: 'Prompt (editable)' });
+    expect(prompt).toHaveValue('');
+    reopenedZoneA.resolve('Reopened A');
+    await waitFor(() => expect(prompt).toHaveValue('Reopened A'));
+    expect(renderTemplateMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('shares the initial render request when Strict Mode replays effects', async () => {
+    const request = deferred<string>();
+    renderTemplateMock.mockReturnValue(request.promise);
+
+    render(
+      <StrictMode>
+        <ZoneTriggerModal
+          actionId={1}
+          open
+          onCancel={() => {}}
+          client={CLIENT}
+          branch={undefined}
+          sessions={[]}
+          zoneName="Strict"
+          trigger={{ template: 'Strict template', behavior: 'show_picker' }}
+          availableAgents={[]}
+          mcpServerById={new Map()}
+          onExecute={async () => {}}
+        />
+      </StrictMode>
+    );
+
+    expect(renderTemplateMock).toHaveBeenCalledTimes(1);
+    request.resolve('Strict rendered');
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Prompt (editable)' })).toHaveValue(
+        'Strict rendered'
+      )
+    );
+    expect(renderTemplateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('ZoneTriggerModal smart-default session selection', () => {
   it('resolves the most-recent session without mutating the frozen store bucket', () => {
     const older = makeSession('s-old', 'completed', '2026-06-01T00:00:00.000Z', 'Older session');
@@ -92,17 +298,15 @@ describe('ZoneTriggerModal smart-default session selection', () => {
     // bucket. Sorting such an array in place throws, so the modal must sort a
     // copy. Freeze here to reproduce the store's contract.
     const frozenBucket = Object.freeze([older, newer]);
-    const sessionsByBranch = new Map<string, Session[]>([[BRANCH_ID, frozenBucket]]);
-
     expect(() =>
       render(
         <ZoneTriggerModal
+          actionId={1}
           open
           onCancel={() => {}}
           client={null}
-          branchId={BRANCH_ID}
           branch={undefined}
-          sessionsByBranch={sessionsByBranch}
+          sessions={frozenBucket}
           zoneName="Zone"
           trigger={{ template: 'do {{thing}}' } as never}
           availableAgents={[]}
@@ -126,12 +330,12 @@ describe('ZoneTriggerModal smart-default session selection', () => {
 
     render(
       <ZoneTriggerModal
+        actionId={1}
         open
         onCancel={() => {}}
         client={null}
-        branchId={BRANCH_ID}
         branch={undefined}
-        sessionsByBranch={new Map([[BRANCH_ID, [historical]]])}
+        sessions={[historical]}
         zoneName="Zone"
         trigger={{ template: 'do {{thing}}' } as never}
         availableAgents={[]}
@@ -148,12 +352,12 @@ describe('ZoneTriggerModal smart-default session selection', () => {
     const onExecute = vi.fn().mockResolvedValue(undefined);
     render(
       <ZoneTriggerModal
+        actionId={1}
         open
         onCancel={() => {}}
         client={null}
-        branchId={BRANCH_ID}
         branch={undefined}
-        sessionsByBranch={new Map()}
+        sessions={[]}
         zoneName="Zone"
         trigger={{
           template: 'prompt',
@@ -192,12 +396,12 @@ describe('ZoneTriggerModal reasoning effort', () => {
 
     render(
       <ZoneTriggerModal
+        actionId={1}
         open
         onCancel={() => {}}
         client={null}
-        branchId={BRANCH_ID}
         branch={{ mcp_server_ids: ['branch-mcp'] } as never}
-        sessionsByBranch={new Map([[BRANCH_ID, [claudeSession]]])}
+        sessions={[claudeSession]}
         zoneName="Zone"
         trigger={{ template: 'prompt' } as never}
         availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
@@ -235,12 +439,12 @@ describe('ZoneTriggerModal reasoning effort', () => {
 
     render(
       <ZoneTriggerModal
+        actionId={1}
         open
         onCancel={() => {}}
         client={null}
-        branchId={BRANCH_ID}
         branch={undefined}
-        sessionsByBranch={new Map([[BRANCH_ID, [codexSession]]])}
+        sessions={[codexSession]}
         zoneName="Zone"
         trigger={{ template: 'prompt' } as never}
         availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
@@ -268,12 +472,12 @@ describe('ZoneTriggerModal reasoning effort', () => {
     const onExecute = vi.fn().mockResolvedValue(undefined);
     render(
       <ZoneTriggerModal
+        actionId={1}
         open
         onCancel={() => {}}
         client={null}
-        branchId={BRANCH_ID}
         branch={undefined}
-        sessionsByBranch={new Map()}
+        sessions={[]}
         zoneName="Zone"
         trigger={{ template: 'prompt' } as never}
         availableAgents={[{ id: 'codex', name: 'Codex' } as never]}
@@ -321,12 +525,12 @@ describe('ZoneTriggerModal reasoning effort', () => {
 
       render(
         <ZoneTriggerModal
+          actionId={1}
           open
           onCancel={() => {}}
           client={null}
-          branchId={BRANCH_ID}
           branch={undefined}
-          sessionsByBranch={new Map([[BRANCH_ID, [session]]])}
+          sessions={[session]}
           zoneName="Zone"
           trigger={{ template: 'prompt' } as never}
           availableAgents={[]}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -9,7 +9,6 @@ import type {
   AgenticToolName,
   AgorClient,
   Branch,
-  BranchID,
   DefaultModelConfig,
   EffortLevel,
   MCPServer,
@@ -25,7 +24,7 @@ import type {
 import { buildZoneTriggerContext, isAgenticToolName } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
 import { Alert, Collapse, Form, Input, Modal, Radio, Select, Space, Spin, Typography } from 'antd';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AgenticToolOption } from '../../../types';
 import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
 // Async server-side renderer — keeps Handlebars out of the browser bundle so
@@ -39,12 +38,13 @@ import {
 import { AgentSelectionGrid } from '../../AgentSelectionGrid';
 
 interface ZoneTriggerModalProps {
+  /** Stable for one drop action; changes only when a new trigger action opens. */
+  actionId: number;
   open: boolean;
   onCancel: () => void;
   client: AgorClient | null;
-  branchId: BranchID;
   branch: Branch | undefined;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessions: readonly Session[];
   zoneName: string;
   trigger: ZoneTrigger;
   boardName?: string;
@@ -66,13 +66,12 @@ interface ZoneTriggerModalProps {
   }) => Promise<void>;
 }
 
-export const ZoneTriggerModal = ({
+const ZoneTriggerModalAction = ({
   open,
   onCancel,
   client,
-  branchId,
   branch,
-  sessionsByBranch,
+  sessions,
   zoneName,
   trigger,
   boardName,
@@ -85,26 +84,74 @@ export const ZoneTriggerModal = ({
 }: ZoneTriggerModalProps) => {
   const [form] = Form.useForm();
 
+  // A zone-trigger action is an editing transaction. Snapshot every value
+  // that supplies defaults or template context at its boundary so realtime
+  // store updates cannot silently restart that transaction. The exported
+  // boundary below remounts this component for each new actionId.
+  const [initial] = useState(() => {
+    const branchSessions = sessions.filter(
+      (session): session is Session & { agentic_tool: AgenticToolName } =>
+        isAgenticToolName(session.agentic_tool)
+    );
+    const runningSessions = branchSessions.filter((session) => session.status === 'running');
+    const defaultSession = [
+      ...(runningSessions.length > 0 ? runningSessions : branchSessions),
+    ].sort(
+      (a, b) =>
+        new Date(b.last_updated || b.created_at).getTime() -
+        new Date(a.last_updated || a.created_at).getTime()
+    )[0]?.session_id;
+    const mode = branchSessions.length > 0 ? ('reuse_existing' as const) : ('create_new' as const);
+
+    return {
+      client,
+      branch,
+      branchSessions,
+      zoneName,
+      trigger: { ...trigger },
+      boardName,
+      boardDescription,
+      boardCustomContext,
+      currentUser,
+      mode,
+      selectedSessionId: defaultSession || '',
+      selectedAgent:
+        trigger.agent === undefined
+          ? ('claude-code' as const)
+          : isAgenticToolName(trigger.agent)
+            ? trigger.agent
+            : null,
+    };
+  });
+  const branchSessions = initial.branchSessions;
+
   // Primary mode: create new or reuse existing
-  const [mode, setMode] = useState<'create_new' | 'reuse_existing'>('create_new');
+  const [mode, setMode] = useState<'create_new' | 'reuse_existing'>(initial.mode);
 
   // Agent selection (only for create_new mode)
-  const [selectedAgent, setSelectedAgent] = useState<AgenticToolName | null>('claude-code');
+  const [selectedAgent, setSelectedAgent] = useState<AgenticToolName | null>(initial.selectedAgent);
   const requiresSupportedToolSelection =
-    mode === 'create_new' && selectedAgent === null && trigger.agent !== undefined;
+    mode === 'create_new' && selectedAgent === null && initial.trigger.agent !== undefined;
 
   // Session selection (only for reuse mode)
-  const [selectedSessionId, setSelectedSessionId] = useState<string>('');
+  const [selectedSessionId, setSelectedSessionId] = useState<string>(initial.selectedSessionId);
 
   // Action selection (only for reuse mode)
   const [selectedAction, setSelectedAction] = useState<'prompt' | 'fork' | 'spawn'>('prompt');
 
-  // Editable rendered template (user can modify before executing)
-  const [editableTemplate, setEditableTemplate] = useState<string>('');
-
-  // Drives a Spin overlay so the user doesn't see the raw `{{...}}` flash
-  // before the daemon's rendered content arrives.
-  const [isRendering, setIsRendering] = useState<boolean>(true);
+  const initialTemplateTarget =
+    initial.mode === 'reuse_existing' ? `session:${initial.selectedSessionId}` : 'new';
+  const [templateState, setTemplateState] = useState({
+    target: initialTemplateTarget,
+    value: initial.client ? '' : initial.trigger.template,
+    isRendering: Boolean(initial.client),
+  });
+  const templateEditRevisionRef = useRef(0);
+  const templateRenderRequestRef = useRef<{
+    target: string;
+    editRevision: number;
+    promise: Promise<string>;
+  } | null>(null);
 
   // Explicit state for session config (survives form mount/unmount cycles)
   const [sessionConfig, setSessionConfig] = useState<{
@@ -115,65 +162,20 @@ export const ZoneTriggerModal = ({
     mcpServerIds?: string[];
   }>({});
 
-  // Filter sessions for this branch using O(1) Map lookup
-  const branchSessions = useMemo(() => {
-    return (sessionsByBranch.get(branchId) || []).filter(
-      (session): session is Session & { agentic_tool: AgenticToolName } =>
-        isAgenticToolName(session.agentic_tool)
-    );
-  }, [sessionsByBranch, branchId]);
-
-  // Smart default: Most recent active/completed session
-  const smartDefaultSession = useMemo(() => {
-    if (branchSessions.length === 0) return '';
-
-    // Prioritize running sessions
-    const runningSessions = branchSessions.filter((s) => s.status === 'running');
-    if (runningSessions.length > 0) {
-      // Most recently updated running session
-      return runningSessions.sort(
-        (a, b) =>
-          new Date(b.last_updated || b.created_at).getTime() -
-          new Date(a.last_updated || a.created_at).getTime()
-      )[0].session_id;
-    }
-
-    // Otherwise most recent session
-    return [...branchSessions].sort(
-      (a, b) =>
-        new Date(b.last_updated || b.created_at).getTime() -
-        new Date(a.last_updated || a.created_at).getTime()
-    )[0].session_id;
-  }, [branchSessions]);
-
   // Get the currently selected session (for pre-populating form on reuse)
   const selectedSession = useMemo(() => {
     return branchSessions.find((s) => s.session_id === selectedSessionId);
   }, [selectedSessionId, branchSessions]);
 
-  // Reset to defaults when modal opens
-  useEffect(() => {
-    if (open) {
-      // Default to 'reuse_existing' if sessions are available, otherwise 'create_new'
-      setMode(branchSessions.length > 0 ? 'reuse_existing' : 'create_new');
-      setSelectedSessionId(smartDefaultSession);
-      setSelectedAction('prompt');
-      setSelectedAgent(
-        trigger.agent === undefined
-          ? 'claude-code'
-          : isAgenticToolName(trigger.agent)
-            ? trigger.agent
-            : null
-      );
-      form.resetFields();
-      setSessionConfig({}); // Clear session config state
-    }
-  }, [open, smartDefaultSession, form, branchSessions.length, trigger.agent]);
-
   // Pre-populate form AND state when creating new session
   // Priority: Most recent session > User defaults > System defaults
+  const formInitializationRef = useRef<string | null>(null);
   useEffect(() => {
     if (mode === 'create_new' && selectedAgent) {
+      const initializationKey = `new:${selectedAgent}`;
+      if (formInitializationRef.current === initializationKey) return;
+      formInitializationRef.current = initializationKey;
+
       // Find the most recent session for this branch (create a copy to avoid mutating the array)
       const mostRecentSession =
         branchSessions.length > 0
@@ -185,15 +187,16 @@ export const ZoneTriggerModal = ({
           : null;
 
       // Get user defaults for this agent as fallback
-      const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
+      const agentDefaults =
+        initial.currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
       const recentAgentSession =
         mostRecentSession?.agentic_tool === selectedAgent ? mostRecentSession : undefined;
 
       // MCP inheritance: branch config > user defaults
       const effectiveMcpServerIds =
-        branch?.mcp_server_ids && branch.mcp_server_ids.length > 0
-          ? branch.mcp_server_ids
-          : currentUser?.default_mcp_server_ids || [];
+        initial.branch?.mcp_server_ids && initial.branch.mcp_server_ids.length > 0
+          ? initial.branch.mcp_server_ids
+          : initial.currentUser?.default_mcp_server_ids || [];
 
       // Calculate config values (priority: most recent session > user defaults)
       const configValues = {
@@ -208,11 +211,15 @@ export const ZoneTriggerModal = ({
       form.setFieldsValue(configValues);
       setSessionConfig(configValues);
     }
-  }, [mode, selectedAgent, currentUser, branchSessions, form, branch?.mcp_server_ids]);
+  }, [mode, selectedAgent, initial, branchSessions, form]);
 
   // Pre-populate form with selected session's config when reusing
   useEffect(() => {
     if (mode === 'reuse_existing' && selectedSession) {
+      const initializationKey = `existing:${selectedSession.session_id}`;
+      if (formInitializationRef.current === initializationKey) return;
+      formInitializationRef.current = initializationKey;
+
       // Pre-populate with session's current config
       form.setFieldsValue({
         agent: selectedSession.agentic_tool,
@@ -224,30 +231,42 @@ export const ZoneTriggerModal = ({
     }
   }, [mode, selectedSession, form]);
 
-  // Render template preview (server-side via daemon /templates).
-  // We fetch on every dependency change; consecutive renders share the
-  // socket.io connection, and stale responses are dropped via the cancelled
-  // flag. For the user-facing preview we want the raw template (with
-  // unresolved `{{...}}`) on failure rather than a silently-blank textarea.
+  const templateTarget = mode === 'reuse_existing' ? `session:${selectedSessionId}` : 'new';
+  const templateStateMatchesTarget = templateState.target === templateTarget;
+  const editableTemplate = templateStateMatchesTarget ? templateState.value : '';
+  const isRendering = Boolean(
+    initial.client && (!templateStateMatchesTarget || templateState.isRendering)
+  );
+
+  // Render once for the initial target, and once for each deliberate target
+  // change. Reuse an in-flight request when Strict Mode replays the effect.
   useEffect(() => {
-    let cancelled = false;
-    if (!client) {
-      setEditableTemplate(trigger.template);
-      setIsRendering(false);
+    if (!initial.client) {
+      setTemplateState((current) => {
+        if (
+          current.target === templateTarget &&
+          current.value === initial.trigger.template &&
+          !current.isRendering
+        ) {
+          return current;
+        }
+        return { target: templateTarget, value: initial.trigger.template, isRendering: false };
+      });
       return;
     }
+
     const selectedSessionForCtx =
       mode === 'reuse_existing' && selectedSessionId
         ? branchSessions.find((s) => s.session_id === selectedSessionId)
         : undefined;
     const context = buildZoneTriggerContext({
-      branch,
+      branch: initial.branch,
       board: {
-        name: boardName,
-        description: boardDescription,
-        custom_context: boardCustomContext,
+        name: initial.boardName,
+        description: initial.boardDescription,
+        custom_context: initial.boardCustomContext,
       },
-      zone: { label: zoneName },
+      zone: { label: initial.zoneName },
       session: selectedSessionForCtx
         ? {
             description: selectedSessionForCtx.description,
@@ -256,29 +275,33 @@ export const ZoneTriggerModal = ({
         : undefined,
     });
 
-    setIsRendering(true);
-    renderTemplate(client, trigger.template, context, 'raw').then((rendered) => {
-      if (!cancelled) {
-        setEditableTemplate(rendered);
-        setIsRendering(false);
-      }
-    });
+    let request = templateRenderRequestRef.current;
+    if (!request || request.target !== templateTarget) {
+      templateEditRevisionRef.current += 1;
+      request = {
+        target: templateTarget,
+        editRevision: templateEditRevisionRef.current,
+        promise: renderTemplate(initial.client, initial.trigger.template, context, 'raw'),
+      };
+      templateRenderRequestRef.current = request;
+      setTemplateState({ target: templateTarget, value: '', isRendering: true });
+    }
 
+    let active = true;
+    const activeRequest = request;
+    void activeRequest.promise.then((rendered) => {
+      if (!active || templateRenderRequestRef.current !== activeRequest) return;
+      setTemplateState((current) => ({
+        target: templateTarget,
+        value:
+          templateEditRevisionRef.current === activeRequest.editRevision ? rendered : current.value,
+        isRendering: false,
+      }));
+    });
     return () => {
-      cancelled = true;
+      active = false;
     };
-  }, [
-    client,
-    trigger.template,
-    branch,
-    boardName,
-    boardDescription,
-    boardCustomContext,
-    zoneName,
-    mode,
-    selectedSessionId,
-    branchSessions,
-  ]);
+  }, [initial, mode, selectedSessionId, branchSessions, templateTarget]);
 
   const handleExecute = async () => {
     if (mode === 'create_new') {
@@ -328,7 +351,7 @@ export const ZoneTriggerModal = ({
 
   return (
     <Modal
-      title={`Zone Trigger: ${zoneName}`}
+      title={`Zone Trigger: ${initial.zoneName}`}
       open={open}
       onCancel={onCancel}
       onOk={handleExecute}
@@ -473,7 +496,7 @@ export const ZoneTriggerModal = ({
                         tool={selectedAgent}
                         mcpServerById={mcpServerById}
                         showHelpText={true}
-                        client={client}
+                        client={initial.client}
                       />
                     ) : mode === 'reuse_existing' ? (
                       <AgenticToolConfigForm
@@ -497,7 +520,15 @@ export const ZoneTriggerModal = ({
           <Spin spinning={isRendering} delay={200} description="Rendering template…">
             <Input.TextArea
               value={editableTemplate}
-              onChange={(e) => setEditableTemplate(e.target.value)}
+              aria-label="Prompt (editable)"
+              onChange={(e) => {
+                templateEditRevisionRef.current += 1;
+                setTemplateState({
+                  target: templateTarget,
+                  value: e.target.value,
+                  isRendering: false,
+                });
+              }}
               rows={8}
               style={{
                 fontFamily: 'monospace',
@@ -512,3 +543,7 @@ export const ZoneTriggerModal = ({
     </Modal>
   );
 };
+
+export const ZoneTriggerModal = (props: ZoneTriggerModalProps) => (
+  <ZoneTriggerModalAction key={props.actionId} {...props} />
+);


### PR DESCRIPTION
## Summary

- snapshot zone-trigger template context, session choices, and initial form defaults once per drop action
- preserve prompt/config edits across parent rerenders, realtime updates, equivalent replacement objects, and React Strict Mode effect replay
- reset exactly once for a new drop action or deliberate target-session change, without showing a stale template
- move modal-only store reads behind the conditional modal boundary and remove the canvas-wide MCP subscription
- pass the modal its exact session snapshot instead of the entire `sessionsByBranch` map

## Root cause

The modal's initialization and async template-rendering effects depended on store-derived maps, arrays, and entity objects whose identities can change during ordinary realtime traffic. Those changes restarted template rendering, toggled the loading state, rewrote Ant Design form values, and could overwrite in-progress edits.

The async renderer made this particularly visible: every effect restart cleared the editable prompt, displayed the spinner, and later applied another rendered result.

## Behavior contract

- A drop action receives a unique action identity.
- Zone/template/context/session defaults are captured once for that action.
- User edits survive unrelated renders and pending async results.
- Selecting a different target session deliberately renders that target once.
- A new drop, reopen, or zone change starts a clean action without briefly showing the previous template.
- Session-store updates after opening do not alter the action's session choices.
- Live MCP picker options remain scoped to the mounted modal and do not wake the canvas while it is closed.

## Validation

- `pnpm i` — passed; workspace already up to date
- focused UI tests — 19 passed
  - `ZoneTriggerModal.test.tsx`
  - `SessionCanvas.rerender.test.tsx`
- Biome on touched files — passed
- UI typecheck — passed
- `git diff --check` — passed
- real UI drag/drop flow verified: a typed prompt remained unchanged after a realtime board update

### Repository-wide check note

`pnpm check` passed typecheck, lint, frontend design-system fixtures, short-ID checks, and multitenancy-boundary checks, then stopped in the daemon filesystem-boundary check because current `main` already contains duplicate registry ID `DAEMON-FS-CAP-170` in `scripts/daemon-filesystem-exceptions.json`. This PR does not modify that registry.
