### PR TITLE
feat(mcp): the marketplace catalog, from browse to a running session

### DIFF
--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -138,7 +138,8 @@ describe('marketplace install, as it lands in the database', () => {
 
     const [server] = await installedServers();
     expect(server).toMatchObject({
-      name: 'mcp',
+      // The publisher, not the protocol word `com.deepwiki/mcp` ends with.
+      name: 'deepwiki',
       scope: 'session',
       catalog_entry_name: DEEPWIKI,
       owner_user_id: user.user_id,

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -56,12 +56,14 @@ const CURATED = {
   curated: true,
   verified: false,
   probed_auth_type: 'none',
+  permission_disclosure: 'Reads public GitHub repository content only.',
 } as unknown as MCPCatalogEntry;
 
 const CONNECT_REQUEST = {
   catalog_key: DEEPWIKI,
   branch_id: 'branch-1',
   agentic_tool: 'claude-code' as const,
+  acknowledged_disclosure: 'Reads public GitHub repository content only.',
 };
 
 /**

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -122,6 +122,45 @@ describe('mcp-catalog/connect', () => {
     expect(result.starter_prompt).toBe('List the issues assigned to me this cycle.');
   });
 
+  it('names the server after its publisher, not the protocol word in its path', async () => {
+    // The name is the `<name>` in every `mcp__<name>__<tool>` the model reads.
+    // Taking the last path segment made it the literal word "mcp" for 38 of the
+    // 50 curated entries, so two installs in one session were indistinguishable.
+    const entry = {
+      ...CURATED,
+      name: 'com.deepwiki/mcp',
+      title: undefined,
+    } as unknown as MCPCatalogEntry;
+    const { app, created } = buildApp(entry);
+
+    await createMCPCatalogConnectService(app).create(
+      { ...request, catalog_key: 'com.deepwiki/mcp' },
+      params
+    );
+
+    expect(created.mcpServers[0]).toMatchObject({
+      name: 'deepwiki',
+      display_name: 'Deepwiki',
+    });
+  });
+
+  it('names a refused entry the way the drawer does', async () => {
+    const entry = {
+      ...CURATED,
+      name: 'io.sentry/mcp',
+      title: undefined,
+      probed_auth_type: 'oauth',
+    } as unknown as MCPCatalogEntry;
+    const { app } = buildApp(entry);
+
+    await expect(
+      createMCPCatalogConnectService(app).create(
+        { ...request, catalog_key: 'io.sentry/mcp' },
+        params
+      )
+    ).rejects.toThrow(/^Sentry requires authentication/);
+  });
+
   it('lands on a session with the server attached', async () => {
     const { app, created } = buildApp(CURATED);
 

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -23,6 +23,7 @@ const CURATED: MCPCatalogEntry = {
   title: 'Linear',
   benefit: 'Read and update your Linear issues.',
   starter_prompt: 'List the issues assigned to me this cycle.',
+  permission_disclosure: 'Reads and writes issues in the Linear workspaces you authorise.',
   transport: 'streamable-http',
   remote_url: 'https://mcp.linear.app/mcp',
   has_remote: true,
@@ -94,6 +95,7 @@ const request = {
   catalog_key: LINEAR,
   branch_id: 'branch-1',
   agentic_tool: 'claude-code' as const,
+  acknowledged_disclosure: CURATED.permission_disclosure as string,
 };
 
 describe('mcp-catalog/connect', () => {
@@ -318,6 +320,30 @@ describe('mcp-catalog/connect', () => {
       expect.anything(),
       expect.objectContaining({ mcpCatalogInstall: { entry_name: LINEAR } })
     );
+  });
+
+  it('refuses a connect that never showed what the server can access', async () => {
+    const { app, created } = buildApp(CURATED);
+
+    await expect(
+      createMCPCatalogConnectService(app).create(
+        { ...request, acknowledged_disclosure: '' },
+        params
+      )
+    ).rejects.toThrow(/acknowledged_disclosure is required/);
+    expect(created.mcpServers).toHaveLength(0);
+  });
+
+  it('refuses a disclosure that no longer matches the catalog row', async () => {
+    const { app, created } = buildApp(CURATED);
+
+    await expect(
+      createMCPCatalogConnectService(app).create(
+        { ...request, acknowledged_disclosure: 'Reads nothing at all.' },
+        params
+      )
+    ).rejects.toThrow(/has changed since it was shown/);
+    expect(created.mcpServers).toHaveLength(0);
   });
 
   it('refuses an uncurated entry', async () => {

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -334,6 +334,15 @@ describe('mcp-catalog/connect', () => {
     expect(created.mcpServers).toHaveLength(0);
   });
 
+  it('refuses an entry that states nothing about what it can access', async () => {
+    const { app, created } = buildApp({ ...CURATED, permission_disclosure: undefined });
+
+    await expect(createMCPCatalogConnectService(app).create(request, params)).rejects.toThrow(
+      /states nothing about what it can access/
+    );
+    expect(created.mcpServers).toHaveLength(0);
+  });
+
   it('refuses a disclosure that no longer matches the catalog row', async () => {
     const { app, created } = buildApp(CURATED);
 

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -21,31 +21,16 @@
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import { probeRemoteAuthType } from '@agor/core/mcp-catalog';
 import type {
-  AgenticToolName,
   AuthenticatedParams,
   CreateMCPServerInput,
+  MCPCatalogConnectData,
+  MCPCatalogConnectResult,
   MCPCatalogEntry,
   MCPServer,
   MCPTransport,
   Session,
   UserID,
 } from '@agor/core/types';
-
-export interface MCPCatalogConnectData {
-  /** Catalog entry UUID or its reverse-DNS registry name. */
-  catalog_key: string;
-  branch_id: string;
-  agentic_tool: AgenticToolName;
-}
-
-export interface MCPCatalogConnectResult {
-  mcp_server: MCPServer;
-  session: Session;
-  /** The entry's curated demonstration prompt, for the new session's composer. */
-  starter_prompt?: string;
-  /** True when an existing install was reused rather than a second row created. */
-  reused_existing_server: boolean;
-}
 
 /** Catalog transports, as `mcp_servers` names them. */
 function toServerTransport(entry: MCPCatalogEntry): MCPTransport {

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -143,6 +143,32 @@ function assertConnectableEntry(entry: MCPCatalogEntry): asserts entry is MCPCat
 }
 
 /**
+ * Refuse a connect whose caller did not carry the entry's own access
+ * disclosure back with it.
+ *
+ * The disclosure states what the agent will be able to reach once the server is
+ * attached, and it is the last thing shown before that happens. Leaving the
+ * rule in the drawer would leave the endpoint open to any client that skipped
+ * the drawer — the marketplace's own UI is not the only caller a Feathers
+ * service has. Comparing the text, rather than accepting a boolean, also means
+ * a client holding a disclosure the curator has since rewritten is told to
+ * re-read it instead of connecting against the old one.
+ */
+function assertDisclosureAcknowledged(entry: MCPCatalogEntry, acknowledged: unknown): void {
+  const shown = typeof acknowledged === 'string' ? acknowledged.trim() : '';
+  if (!shown) {
+    throw new BadRequest(
+      `acknowledged_disclosure is required: connecting ${entry.name} must follow showing what it can access`
+    );
+  }
+  if (shown !== (entry.permission_disclosure ?? '').trim()) {
+    throw new BadRequest(
+      `The access disclosure for ${entry.name} has changed since it was shown; review it again before connecting`
+    );
+  }
+}
+
+/**
  * The entry's authentication requirement, probing when the catalog has not
  * recorded one yet.
  *
@@ -233,6 +259,7 @@ export function createMCPCatalogConnectService(
       }
 
       assertConnectableEntry(entry);
+      assertDisclosureAcknowledged(entry, data.acknowledged_disclosure);
       await resolveAuthRequirement(entry);
 
       const userId = params.user?.user_id as UserID | undefined;

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -155,13 +155,23 @@ function assertConnectableEntry(entry: MCPCatalogEntry): asserts entry is MCPCat
  * re-read it instead of connecting against the old one.
  */
 function assertDisclosureAcknowledged(entry: MCPCatalogEntry, acknowledged: unknown): void {
+  const stored = (entry.permission_disclosure ?? '').trim();
+  // Curation requires a disclosure on every entry it writes, so this is a
+  // curation gap rather than a caller's mistake — say that, instead of telling
+  // the user prose they never saw has changed.
+  if (!stored) {
+    throw new BadRequest(
+      `${entry.name} states nothing about what it can access, so it cannot be connected`
+    );
+  }
+
   const shown = typeof acknowledged === 'string' ? acknowledged.trim() : '';
   if (!shown) {
     throw new BadRequest(
       `acknowledged_disclosure is required: connecting ${entry.name} must follow showing what it can access`
     );
   }
-  if (shown !== (entry.permission_disclosure ?? '').trim()) {
+  if (shown !== stored) {
     throw new BadRequest(
       `The access disclosure for ${entry.name} has changed since it was shown; review it again before connecting`
     );

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -31,26 +31,11 @@ import type {
   Session,
   UserID,
 } from '@agor/core/types';
+import { catalogDisplayName, catalogServerSlug } from '@agor/core/types';
 
 /** Catalog transports, as `mcp_servers` names them. */
 function toServerTransport(entry: MCPCatalogEntry): MCPTransport {
   return entry.transport === 'sse' ? 'sse' : 'http';
-}
-
-/**
- * A readable, tool-namespace-safe server name from a reverse-DNS catalog name.
- *
- * `io.github.github/github-mcp-server` becomes `github-mcp-server`: the full
- * identity stays on `catalog_entry_name`, while this is what shows up in every
- * `mcp__<name>__<tool>` the agent sees.
- */
-function serverNameFor(entry: MCPCatalogEntry): string {
-  const lastSegment = entry.name.split('/').pop() ?? entry.name;
-  const slug = lastSegment
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug || 'mcp-server';
 }
 
 /**
@@ -132,12 +117,12 @@ function assertConnectableEntry(entry: MCPCatalogEntry): asserts entry is MCPCat
 } {
   if (!entry.curated) {
     throw new Forbidden(
-      `Only reviewed catalog entries can be connected; ${entry.name} has not been reviewed`
+      `Only reviewed catalog entries can be connected; ${catalogDisplayName(entry)} has not been reviewed`
     );
   }
   if (!entry.has_remote || !entry.remote_url || entry.transport === 'stdio') {
     throw new BadRequest(
-      `${entry.name} has no remote endpoint; locally-run MCP servers are configured by an admin`
+      `${catalogDisplayName(entry)} has no remote endpoint; locally-run MCP servers are configured by an admin`
     );
   }
 }
@@ -161,19 +146,19 @@ function assertDisclosureAcknowledged(entry: MCPCatalogEntry, acknowledged: unkn
   // the user prose they never saw has changed.
   if (!stored) {
     throw new BadRequest(
-      `${entry.name} states nothing about what it can access, so it cannot be connected`
+      `${catalogDisplayName(entry)} states nothing about what it can access, so it cannot be connected`
     );
   }
 
   const shown = typeof acknowledged === 'string' ? acknowledged.trim() : '';
   if (!shown) {
     throw new BadRequest(
-      `acknowledged_disclosure is required: connecting ${entry.name} must follow showing what it can access`
+      `acknowledged_disclosure is required: connecting ${catalogDisplayName(entry)} must follow showing what it can access`
     );
   }
   if (shown !== stored) {
     throw new BadRequest(
-      `The access disclosure for ${entry.name} has changed since it was shown; review it again before connecting`
+      `The access disclosure for ${catalogDisplayName(entry)} has changed since it was shown; review it again before connecting`
     );
   }
 }
@@ -198,9 +183,13 @@ async function resolveAuthRequirement(
   if (probed === 'none') return;
 
   if (probed === 'oauth' || probed === 'credentials') {
-    throw new BadRequest(`${entry.name} requires authentication, which is not supported yet`);
+    throw new BadRequest(
+      `${catalogDisplayName(entry)} requires authentication, which is not supported yet`
+    );
   }
-  throw new BadRequest(`${entry.name} could not be reached, so it cannot be connected`);
+  throw new BadRequest(
+    `${catalogDisplayName(entry)} could not be reached, so it cannot be connected`
+  );
 }
 
 export interface MCPCatalogConnectService {
@@ -276,8 +265,8 @@ export function createMCPCatalogConnectService(
       const existing = await findExistingInstall(entry, userId, params);
 
       const createInput: CreateMCPServerInput = {
-        name: serverNameFor(entry),
-        display_name: entry.title ?? entry.name,
+        name: catalogServerSlug(entry.name),
+        display_name: catalogDisplayName(entry),
         description: entry.benefit ?? entry.description,
         transport: toServerTransport(entry),
         url: entry.remote_url,
@@ -314,7 +303,7 @@ export function createMCPCatalogConnectService(
             branch_id: data.branch_id,
             agentic_tool: data.agentic_tool,
             status: 'idle',
-            title: entry.title ?? entry.name,
+            title: catalogDisplayName(entry),
           },
           params
         )) as Session;

--- a/apps/agor-daemon/src/services/mcp-catalog.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog.ts
@@ -54,6 +54,7 @@ export type MCPCatalogParams = QueryParams<{
   curated?: boolean;
   has_remote?: boolean;
   probed_auth_type?: MCPCatalogProbedAuthType;
+  probed_auth_types?: MCPCatalogProbedAuthType[];
   sort?: MCPCatalogSort;
 }> &
   AuthenticatedParams;
@@ -85,6 +86,9 @@ export class MCPCatalogService {
     if (typeof query.has_remote === 'boolean') filters.has_remote = query.has_remote;
     if (typeof query.probed_auth_type === 'string') {
       filters.probed_auth_type = query.probed_auth_type as MCPCatalogProbedAuthType;
+    }
+    if (Array.isArray(query.probed_auth_types)) {
+      filters.probed_auth_types = query.probed_auth_types as MCPCatalogProbedAuthType[];
     }
     if (typeof query.sort === 'string') filters.sort = query.sort as MCPCatalogSort;
     // Withdrawn servers are excluded unless a caller asks for a specific state.

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1799,6 +1799,7 @@ function AppContent() {
   const marketplacePageElement = (
     <MarketplacePage
       client={client}
+      connected={connected}
       currentUser={currentUser}
       onUserSettingsClick={() => setOpenUserSettings(true)}
       onLogout={logout}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -66,6 +66,7 @@ import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
   ARTIFACT_FULLSCREEN_ROUTE_PATHS,
   KNOWLEDGE_ROUTE_PATHS,
+  MARKETPLACE_ROUTE_PATHS,
   routeUsesDeviceRouter,
 } from './surfaces/surfaceRegistry';
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
@@ -165,6 +166,11 @@ const loadKnowledgePage = cacheRouteLoader(
   () => import('./pages/KnowledgePage'),
   (module) => ({ default: module.KnowledgePage })
 );
+const loadMarketplacePage = cacheRouteLoader(
+  'marketplace',
+  () => import('./pages/MarketplacePage'),
+  (module) => ({ default: module.MarketplacePage })
+);
 const loadArtifactFullscreenPage = cacheRouteLoader(
   'artifact-fullscreen',
   () => import('./pages/ArtifactFullscreenPage'),
@@ -193,6 +199,7 @@ const MarketingVideoPage = lazy(() =>
 
 const AgorApp = lazy(loadAgorApp);
 const KnowledgePage = lazy(loadKnowledgePage);
+const MarketplacePage = lazy(loadMarketplacePage);
 const ArtifactFullscreenPage = lazy(loadArtifactFullscreenPage);
 const MobileApp = lazy(loadMobileApp);
 const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
@@ -200,6 +207,7 @@ const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
 const routeModuleLoaders = {
   workspace: loadAgorApp,
   knowledge: loadKnowledgePage,
+  marketplace: loadMarketplacePage,
   'artifact-fullscreen': loadArtifactFullscreenPage,
   demo: loadStreamdownDemoPage,
   mobile: loadMobileApp,
@@ -1788,6 +1796,15 @@ function AppContent() {
     />
   );
 
+  const marketplacePageElement = (
+    <MarketplacePage
+      client={client}
+      currentUser={currentUser}
+      onUserSettingsClick={() => setOpenUserSettings(true)}
+      onLogout={logout}
+    />
+  );
+
   const artifactFullscreenElement = (
     <ArtifactFullscreenPage
       client={client}
@@ -1944,6 +1961,13 @@ function AppContent() {
           {/* Knowledge route shell. `/kb` is a short alias for the same surface. */}
           {KNOWLEDGE_ROUTE_PATHS.map((path) => (
             <Route key={path} path={path} element={knowledgePageElement} />
+          ))}
+
+          {/* MCP marketplace: browse the catalog and connect a server. Its own
+                surface because it reads the global catalog table, not the
+                tenant's board/session store. */}
+          {MARKETPLACE_ROUTE_PATHS.map((path) => (
+            <Route key={path} path={path} element={marketplacePageElement} />
           ))}
 
           {/* Lightweight artifact fullscreen surface. Uses the shared auth shell,

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -86,6 +86,39 @@ describe('AppHeader Knowledge Base button', () => {
   });
 });
 
+describe('AppHeader Marketplace button', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders a promoted top-level Marketplace entry, not a gear-menu item', () => {
+    renderHeader();
+
+    const button = screen.getByRole('link', { name: 'Marketplace' });
+    expect(button).toHaveAttribute('href', '/ui/marketplace');
+  });
+
+  it('navigates to /marketplace via SPA navigation on plain click', () => {
+    renderHeader();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Marketplace' }));
+
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/marketplace');
+  });
+
+  it('lets modifier clicks fall through to the browser', () => {
+    renderHeader();
+
+    const button = screen.getByRole('link', { name: 'Marketplace' });
+    button.removeAttribute('href');
+
+    const eventWasNotCancelled = fireEvent.click(button, { metaKey: true });
+
+    expect(eventWasNotCancelled).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
 describe('AppHeader settings dropdown', () => {
   beforeEach(() => {
     mockNavigate.mockClear();

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -86,43 +86,35 @@ describe('AppHeader Knowledge Base button', () => {
   });
 });
 
-describe('AppHeader Marketplace button', () => {
+describe('AppHeader navigation entries', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
   });
 
-  it('renders a promoted top-level Marketplace entry, not a gear-menu item', () => {
+  it('advertises exactly these surfaces', () => {
     renderHeader();
 
-    const button = screen.getByRole('link', { name: 'Marketplace' });
-    expect(button).toHaveAttribute('href', '/ui/marketplace');
+    // The whole set, so adding or removing an entry has to be a deliberate
+    // edit here rather than something that slips in. Marketplace is absent on
+    // purpose: the surface answers at /marketplace but is not advertised while
+    // the feature is incomplete, so re-adding the link should fail this and
+    // make whoever does it confirm that decision has been reversed.
+    const linkNames = screen
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('aria-label') ?? link.textContent?.trim());
+
+    expect(linkNames).toEqual(['Knowledge Base']);
   });
 
-  it('shows the word without hovering — the label is why it earned a top-level slot', () => {
+  it('does not link to the marketplace from anywhere in the header', () => {
     renderHeader();
 
-    // Visible text, not a tooltip or an aria-label standing in for one.
-    expect(screen.getByText('Marketplace')).toBeVisible();
-  });
+    const marketplaceLinks = screen
+      .getAllByRole('link')
+      .filter((link) => (link.getAttribute('href') ?? '').includes('marketplace'));
 
-  it('navigates to /marketplace via SPA navigation on plain click', () => {
-    renderHeader();
-
-    fireEvent.click(screen.getByRole('link', { name: 'Marketplace' }));
-
-    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/marketplace');
-  });
-
-  it('lets modifier clicks fall through to the browser', () => {
-    renderHeader();
-
-    const button = screen.getByRole('link', { name: 'Marketplace' });
-    button.removeAttribute('href');
-
-    const eventWasNotCancelled = fireEvent.click(button, { metaKey: true });
-
-    expect(eventWasNotCancelled).toBe(true);
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(marketplaceLinks).toEqual([]);
+    expect(screen.queryByText('Marketplace')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -98,6 +98,13 @@ describe('AppHeader Marketplace button', () => {
     expect(button).toHaveAttribute('href', '/ui/marketplace');
   });
 
+  it('shows the word without hovering — the label is why it earned a top-level slot', () => {
+    renderHeader();
+
+    // Visible text, not a tooltip or an aria-label standing in for one.
+    expect(screen.getByText('Marketplace')).toBeVisible();
+  });
+
   it('navigates to /marketplace via SPA navigation on plain click', () => {
     renderHeader();
 

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import type { ActiveUser, AgorClient, Board, BoardID, Branch, User } from '@agor-live/client';
-import { BulbOutlined } from '@ant-design/icons';
+import { BulbOutlined, ShopOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { memo, useMemo } from 'react';
@@ -99,6 +99,16 @@ const RecentBoardPills: React.FC<{
   );
 };
 
+/**
+ * True when a click on an `href`-bearing Button should be handled by the
+ * router. Modified clicks and middle clicks keep the browser's native
+ * open-in-new-tab behaviour, which the `href` exists to preserve.
+ */
+function isPlainLeftClick(event: React.MouseEvent): boolean {
+  if (event.defaultPrevented) return false;
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
+
 const AppHeaderInner: React.FC<AppHeaderProps> = ({
   user,
   presenceClient = null,
@@ -125,6 +135,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const { token } = theme.useToken();
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
+  const marketplaceHref = useHref('/marketplace');
   const { themeMode, setThemeMode } = useTheme();
 
   // Entity state via narrow store subscriptions rather than props. Each
@@ -285,6 +296,21 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           boardById={boardById}
           onSettingsClick={onSettingsClick}
         />
+        <Tooltip title="Marketplace">
+          <Button
+            type="text"
+            icon={<ShopOutlined style={{ fontSize: token.fontSizeLG }} />}
+            href={marketplaceHref}
+            aria-label="Marketplace"
+            onClick={(event) => {
+              if (isPlainLeftClick(event)) {
+                event.preventDefault();
+                navigate('/marketplace');
+              }
+            }}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          />
+        </Tooltip>
         <Tooltip title="Knowledge Base">
           <Button
             type="text"
@@ -292,18 +318,10 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             href={knowledgeHref}
             aria-label="Knowledge Base"
             onClick={(event) => {
-              if (event.defaultPrevented) return;
-              if (
-                event.button !== 0 ||
-                event.metaKey ||
-                event.ctrlKey ||
-                event.shiftKey ||
-                event.altKey
-              ) {
-                return;
+              if (isPlainLeftClick(event)) {
+                event.preventDefault();
+                navigate('/knowledge');
               }
-              event.preventDefault();
-              navigate('/knowledge');
             }}
             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           />

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import type { ActiveUser, AgorClient, Board, BoardID, Branch, User } from '@agor-live/client';
-import { BulbOutlined, ShopOutlined } from '@ant-design/icons';
+import { BulbOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { memo, useMemo } from 'react';
@@ -135,7 +135,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const { token } = theme.useToken();
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
-  const marketplaceHref = useHref('/marketplace');
   const { themeMode, setThemeMode } = useTheme();
 
   // Entity state via narrow store subscriptions rather than props. Each
@@ -296,26 +295,9 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           boardById={boardById}
           onSettingsClick={onSettingsClick}
         />
-        {/* Labelled, where the rest of this row is icon-only: a marketplace is a
-            surface people are meant to come back to, and an icon alone is a
-            weaker invitation than the word. No tooltip — it would only repeat
-            what is already on screen. */}
-        <Button
-          type="text"
-          // Decorative beside the visible word — without this the icon's own
-          // label joins the accessible name ("shop Marketplace").
-          icon={<ShopOutlined aria-hidden style={{ fontSize: token.fontSizeLG }} />}
-          href={marketplaceHref}
-          onClick={(event) => {
-            if (isPlainLeftClick(event)) {
-              event.preventDefault();
-              navigate('/marketplace');
-            }
-          }}
-          style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
-        >
-          Marketplace
-        </Button>
+        {/* No Marketplace entry: the surface exists and answers at
+            /marketplace, but is not advertised while the feature is
+            incomplete. */}
         <Tooltip title="Knowledge Base">
           <Button
             type="text"

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -296,21 +296,26 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           boardById={boardById}
           onSettingsClick={onSettingsClick}
         />
-        <Tooltip title="Marketplace">
-          <Button
-            type="text"
-            icon={<ShopOutlined style={{ fontSize: token.fontSizeLG }} />}
-            href={marketplaceHref}
-            aria-label="Marketplace"
-            onClick={(event) => {
-              if (isPlainLeftClick(event)) {
-                event.preventDefault();
-                navigate('/marketplace');
-              }
-            }}
-            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-          />
-        </Tooltip>
+        {/* Labelled, where the rest of this row is icon-only: a marketplace is a
+            surface people are meant to come back to, and an icon alone is a
+            weaker invitation than the word. No tooltip — it would only repeat
+            what is already on screen. */}
+        <Button
+          type="text"
+          // Decorative beside the visible word — without this the icon's own
+          // label joins the accessible name ("shop Marketplace").
+          icon={<ShopOutlined aria-hidden style={{ fontSize: token.fontSizeLG }} />}
+          href={marketplaceHref}
+          onClick={(event) => {
+            if (isPlainLeftClick(event)) {
+              event.preventDefault();
+              navigate('/marketplace');
+            }
+          }}
+          style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
+        >
+          Marketplace
+        </Button>
         <Tooltip title="Knowledge Base">
           <Button
             type="text"

--- a/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
@@ -9,10 +9,15 @@
  */
 
 import type { MCPCatalogEntry } from '@agor/core/types';
-import { SafetyCertificateOutlined } from '@ant-design/icons';
+import {
+  CheckCircleOutlined,
+  LockOutlined,
+  QuestionCircleOutlined,
+  SafetyCertificateOutlined,
+} from '@ant-design/icons';
 import { Avatar, Card, Flex, Space, Tag, Tooltip, Typography, theme } from 'antd';
 import { memo } from 'react';
-import { capabilityLabel, entryTitle } from './catalogPresentation';
+import { capabilityLabel, connectStatus, entryTitle } from './catalogPresentation';
 
 const { Text, Paragraph } = Typography;
 
@@ -28,6 +33,10 @@ const CatalogCardInner: React.FC<CatalogCardProps> = ({ entry, onOpen }) => {
   const title = entryTitle(entry);
   const capabilities = entry.capabilities ?? [];
   const overflow = capabilities.length - VISIBLE_CAPABILITIES;
+  // Whether pressing Connect will get anywhere, on the card rather than after
+  // the disclosure — most curated entries want an account this phase cannot ask
+  // for, so discovering it at the button is discovering it too late.
+  const connect = connectStatus(entry);
 
   return (
     <Card
@@ -87,6 +96,21 @@ const CatalogCardInner: React.FC<CatalogCardProps> = ({ entry, onOpen }) => {
           ))}
           {overflow > 0 && <Text type="secondary">+{overflow}</Text>}
         </Space>
+
+        <Tooltip title={connect.detail}>
+          <Space size={token.marginXXS} align="center">
+            {connect.readiness === 'ready' ? (
+              <CheckCircleOutlined style={{ color: token.colorSuccess }} />
+            ) : connect.readiness === 'unchecked' ? (
+              <QuestionCircleOutlined style={{ color: token.colorTextTertiary }} />
+            ) : (
+              <LockOutlined style={{ color: token.colorTextTertiary }} />
+            )}
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              {connect.label}
+            </Text>
+          </Space>
+        </Tooltip>
       </Flex>
     </Card>
   );

--- a/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
@@ -1,0 +1,95 @@
+/**
+ * One catalog entry in the browse grid.
+ *
+ * The badge is `curated` and only `curated`. The row also carries a `verified`
+ * boolean — a registry name match — which is deliberately not rendered: it
+ * reads backwards exactly where curation was most careful, because the vendor
+ * endpoints a Preset engineer hand-picked from vendor docs never appeared in
+ * the registry under a matching name.
+ */
+
+import type { MCPCatalogEntry } from '@agor/core/types';
+import { SafetyCertificateOutlined } from '@ant-design/icons';
+import { Avatar, Card, Flex, Space, Tag, Tooltip, Typography, theme } from 'antd';
+import { memo } from 'react';
+import { capabilityLabel, entryTitle } from './catalogPresentation';
+
+const { Text, Paragraph } = Typography;
+
+export interface CatalogCardProps {
+  entry: MCPCatalogEntry;
+  onOpen: (entry: MCPCatalogEntry) => void;
+}
+
+const VISIBLE_CAPABILITIES = 3;
+
+const CatalogCardInner: React.FC<CatalogCardProps> = ({ entry, onOpen }) => {
+  const { token } = theme.useToken();
+  const title = entryTitle(entry);
+  const capabilities = entry.capabilities ?? [];
+  const overflow = capabilities.length - VISIBLE_CAPABILITIES;
+
+  return (
+    <Card
+      hoverable
+      size="small"
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${title}`}
+      onClick={() => onOpen(entry)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onOpen(entry);
+        }
+      }}
+      style={{ height: '100%' }}
+      styles={{ body: { height: '100%' } }}
+    >
+      <Flex vertical gap={token.marginXS} style={{ height: '100%' }}>
+        <Flex gap={token.marginSM} align="flex-start">
+          <Avatar shape="square" size={40} src={entry.icon_url} style={{ flexShrink: 0 }}>
+            {title.charAt(0).toUpperCase()}
+          </Avatar>
+          <Flex vertical style={{ minWidth: 0, flex: 1 }}>
+            <Space size={token.marginXXS} align="center">
+              <Text strong ellipsis>
+                {title}
+              </Text>
+              {entry.curated && (
+                <Tooltip title="Reviewed by Preset">
+                  <SafetyCertificateOutlined
+                    aria-label="Reviewed by Preset"
+                    style={{ color: token.colorPrimary }}
+                  />
+                </Tooltip>
+              )}
+            </Space>
+            <Text type="secondary" ellipsis style={{ fontSize: token.fontSizeSM }}>
+              {entry.name}
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Paragraph
+          type={entry.benefit ? undefined : 'secondary'}
+          ellipsis={{ rows: 2 }}
+          style={{ marginBottom: 0, minHeight: token.fontSize * 2 * token.lineHeight }}
+        >
+          {entry.benefit ?? entry.description ?? 'No description published.'}
+        </Paragraph>
+
+        <Space size={[token.marginXXS, token.marginXXS]} wrap>
+          {capabilities.slice(0, VISIBLE_CAPABILITIES).map((capability) => (
+            <Tag key={capability} style={{ marginInlineEnd: 0 }}>
+              {capabilityLabel(capability)}
+            </Tag>
+          ))}
+          {overflow > 0 && <Text type="secondary">+{overflow}</Text>}
+        </Space>
+      </Flex>
+    </Card>
+  );
+};
+
+export const CatalogCard = memo(CatalogCardInner);

--- a/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
@@ -34,8 +34,8 @@ const CatalogCardInner: React.FC<CatalogCardProps> = ({ entry, onOpen }) => {
   const capabilities = entry.capabilities ?? [];
   const overflow = capabilities.length - VISIBLE_CAPABILITIES;
   // Whether pressing Connect will get anywhere, on the card rather than after
-  // the disclosure — most curated entries want an account this phase cannot ask
-  // for, so discovering it at the button is discovering it too late.
+  // the disclosure — most curated entries want an account the marketplace has
+  // no way to ask for, so discovering it at the button is discovering it late.
   const connect = connectStatus(entry);
 
   return (

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Consent is the drawer's own rule, so it is asserted against the drawer.
+ *
+ * Driving it through `CatalogTab` meant closing and reopening to change which
+ * entry is shown, which mounts the AntD Form and its Selects a second time —
+ * the cost this package's vitest config already singles out. Here the entry is
+ * a prop, so the same invariant is one mount, and a stronger statement: the
+ * hazard is consent surviving a change of entry, and that is checked directly
+ * rather than through a close/reopen that only approximates it.
+ */
+
+import type { Branch, MCPCatalogEntry, MCPCatalogEntryID } from '@agor/core/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CatalogDetailDrawer } from './CatalogDetailDrawer';
+
+const DEEPWIKI = {
+  catalog_entry_id: 'entry-deepwiki' as MCPCatalogEntryID,
+  created_at: new Date(0),
+  updated_at: new Date(0),
+  name: 'com.deepwiki/mcp',
+  title: 'DeepWiki',
+  benefit: 'Ask questions about any public GitHub repository.',
+  permission_disclosure: 'Reads public GitHub repository content only.',
+  capabilities: ['docs'],
+  has_remote: true,
+  has_package: false,
+  curated: true,
+  verified: false,
+  remote_url: 'https://mcp.deepwiki.com/mcp',
+  transport: 'streamable-http',
+  probed_auth_type: 'none',
+} as unknown as MCPCatalogEntry;
+
+const LINEAR = {
+  ...DEEPWIKI,
+  catalog_entry_id: 'entry-linear' as MCPCatalogEntryID,
+  name: 'app.linear/linear',
+  title: 'Linear',
+  permission_disclosure: 'Reads and writes issues in the Linear workspaces you authorise.',
+} as unknown as MCPCatalogEntry;
+
+const BRANCHES = [{ branch_id: 'branch-1', name: 'mkt-slice' }] as unknown as Branch[];
+
+function renderDrawer(entry: MCPCatalogEntry) {
+  const view = render(
+    <CatalogDetailDrawer
+      entry={entry}
+      open
+      onClose={vi.fn()}
+      branches={BRANCHES}
+      branchesLoading={false}
+      branchesError={null}
+      defaultBranchId="branch-1"
+      connecting={false}
+      connectError={null}
+      onConnect={vi.fn()}
+    />
+  );
+  const show = (next: MCPCatalogEntry) =>
+    view.rerender(
+      <CatalogDetailDrawer
+        entry={next}
+        open
+        onClose={vi.fn()}
+        branches={BRANCHES}
+        branchesLoading={false}
+        branchesError={null}
+        defaultBranchId="branch-1"
+        connecting={false}
+        connectError={null}
+        onConnect={vi.fn()}
+      />
+    );
+  return { show };
+}
+
+const connectButton = () => screen.getByRole('button', { name: /Connect/ });
+
+describe('CatalogDetailDrawer consent', () => {
+  it('gates connect on the disclosure being acknowledged', () => {
+    renderDrawer(DEEPWIKI);
+
+    expect(screen.getByText(DEEPWIKI.permission_disclosure as string)).toBeVisible();
+    expect(connectButton()).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeEnabled();
+  });
+
+  it("does not carry one server's acknowledgement to the next one shown", () => {
+    const { show } = renderDrawer(DEEPWIKI);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(connectButton()).toBeEnabled();
+
+    show(LINEAR);
+
+    expect(screen.getByText(LINEAR.permission_disclosure as string)).toBeVisible();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(connectButton()).toBeDisabled();
+  });
+
+  it('withdraws consent when the disclosure it was given for is rewritten', () => {
+    // A reseed can rewrite what an entry discloses. Consent was given for the
+    // old words, and the endpoint's contract is the text — so the same entry
+    // saying something new has to be acknowledged again.
+    const { show } = renderDrawer(DEEPWIKI);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(connectButton()).toBeEnabled();
+
+    show({
+      ...DEEPWIKI,
+      permission_disclosure: 'Now also writes to your repositories.',
+    } as MCPCatalogEntry);
+
+    expect(screen.getByText('Now also writes to your repositories.')).toBeVisible();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(connectButton()).toBeDisabled();
+  });
+});

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -50,7 +50,15 @@ export interface CatalogDetailDrawerProps {
   defaultBranchId: string | null;
   connecting: boolean;
   connectError: string | null;
-  onConnect: (input: { branchId: string; agenticTool: AgenticToolName }) => void;
+  /**
+   * `acknowledgedDisclosure` is the exact text this drawer put on screen, so
+   * what the connect request claims was shown cannot drift from what was.
+   */
+  onConnect: (input: {
+    branchId: string;
+    agenticTool: AgenticToolName;
+    acknowledgedDisclosure: string;
+  }) => void;
 }
 
 export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
@@ -66,18 +74,17 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
   onConnect,
 }) => {
   const { token } = theme.useToken();
-  const [acknowledged, setAcknowledged] = useState(false);
   const [branchId, setBranchId] = useState<string | undefined>();
   const [agenticTool, setAgenticTool] = useState<AgenticToolName>(DEFAULT_AGENT);
 
   const entryId = entry?.catalog_entry_id;
 
-  // A fresh entry is a fresh first-time connect: the acknowledgement never
-  // carries across servers.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on entry identity, not on a value the effect reads
-  useEffect(() => {
-    setAcknowledged(false);
-  }, [entryId]);
+  // The acknowledgement records *which* server was acknowledged, rather than a
+  // boolean an effect resets when the entry changes. An effect would leave one
+  // render in which the new server's disclosure sits above an already-enabled
+  // connect button, carrying consent from the server before it.
+  const [acknowledgedEntryId, setAcknowledgedEntryId] = useState<string | null>(null);
+  const acknowledged = entryId !== undefined && acknowledgedEntryId === entryId;
 
   const branchOptions = useMemo(
     () =>
@@ -99,6 +106,7 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
 
   const blockedReason = entry ? connectBlockedReason(entry) : undefined;
   const title = entry ? entryTitle(entry) : '';
+  const disclosure = entry?.permission_disclosure ?? FALLBACK_DISCLOSURE;
   const canConnect = Boolean(!blockedReason && acknowledged && branchId && !connecting);
 
   return (
@@ -177,11 +185,13 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
             message="What this can access"
             description={
               <Flex vertical gap={token.marginXS}>
-                <Text>{entry.permission_disclosure ?? FALLBACK_DISCLOSURE}</Text>
+                <Text>{disclosure}</Text>
                 {!blockedReason && (
                   <Checkbox
                     checked={acknowledged}
-                    onChange={(event) => setAcknowledged(event.target.checked)}
+                    onChange={(event) =>
+                      setAcknowledgedEntryId(event.target.checked ? (entryId ?? null) : null)
+                    }
                   >
                     I understand what this server can access
                   </Checkbox>
@@ -225,7 +235,10 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
                 icon={<ThunderboltOutlined />}
                 loading={connecting}
                 disabled={!canConnect}
-                onClick={() => branchId && onConnect({ branchId, agenticTool })}
+                onClick={() =>
+                  branchId &&
+                  onConnect({ branchId, agenticTool, acknowledgedDisclosure: disclosure })
+                }
               >
                 Connect &amp; try it
               </Button>

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -1,0 +1,242 @@
+/**
+ * Detail view for one catalog entry, and the only place a connect starts.
+ *
+ * `REQ-SEC-1`: the "What this can access" disclosure is rendered expanded, is
+ * not collapsible, and sits between the user and the connect control — which
+ * stays disabled until it is acknowledged. Reading it is the last thing that
+ * happens before a server the agent will obey gets attached to a session, so it
+ * is a gate rather than a panel.
+ */
+
+import type { AgenticToolName, Branch, MCPCatalogEntry } from '@agor/core/types';
+import { SafetyCertificateOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Avatar,
+  Button,
+  Checkbox,
+  Drawer,
+  Flex,
+  Form,
+  Select,
+  Space,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
+import { capabilityLabel, connectBlockedReason, entryTitle } from './catalogPresentation';
+
+const { Title, Paragraph, Text, Link } = Typography;
+
+const DEFAULT_AGENT: AgenticToolName = 'claude-code';
+
+const AGENT_OPTIONS = AVAILABLE_AGENTS.map((agent) => ({
+  label: agent.name,
+  value: agent.id,
+}));
+
+const FALLBACK_DISCLOSURE =
+  'This server has published no access statement. Anything it exposes becomes available to the agent in the session you connect it to.';
+
+export interface CatalogDetailDrawerProps {
+  entry: MCPCatalogEntry | null;
+  open: boolean;
+  onClose: () => void;
+  branches: Branch[];
+  branchesLoading: boolean;
+  branchesError: string | null;
+  defaultBranchId: string | null;
+  connecting: boolean;
+  connectError: string | null;
+  onConnect: (input: { branchId: string; agenticTool: AgenticToolName }) => void;
+}
+
+export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
+  entry,
+  open,
+  onClose,
+  branches,
+  branchesLoading,
+  branchesError,
+  defaultBranchId,
+  connecting,
+  connectError,
+  onConnect,
+}) => {
+  const { token } = theme.useToken();
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [branchId, setBranchId] = useState<string | undefined>();
+  const [agenticTool, setAgenticTool] = useState<AgenticToolName>(DEFAULT_AGENT);
+
+  const entryId = entry?.catalog_entry_id;
+
+  // A fresh entry is a fresh first-time connect: the acknowledgement never
+  // carries across servers.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on entry identity, not on a value the effect reads
+  useEffect(() => {
+    setAcknowledged(false);
+  }, [entryId]);
+
+  const branchOptions = useMemo(
+    () =>
+      branches.map((branch) => ({
+        label: branch.name as string,
+        value: branch.branch_id as string,
+      })),
+    [branches]
+  );
+
+  useEffect(() => {
+    if (branchId && branchOptions.some((option) => option.value === branchId)) return;
+    const preferred =
+      defaultBranchId && branchOptions.some((option) => option.value === defaultBranchId)
+        ? defaultBranchId
+        : branchOptions[0]?.value;
+    setBranchId(preferred);
+  }, [branchOptions, defaultBranchId, branchId]);
+
+  const blockedReason = entry ? connectBlockedReason(entry) : undefined;
+  const title = entry ? entryTitle(entry) : '';
+  const canConnect = Boolean(!blockedReason && acknowledged && branchId && !connecting);
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      width={480}
+      destroyOnHidden
+      title={
+        entry && (
+          <Space align="center">
+            <Avatar shape="square" src={entry.icon_url}>
+              {title.charAt(0).toUpperCase()}
+            </Avatar>
+            <Text strong>{title}</Text>
+            {entry.curated && (
+              <Tag color="success" icon={<SafetyCertificateOutlined />}>
+                Reviewed by Preset
+              </Tag>
+            )}
+          </Space>
+        )
+      }
+    >
+      {entry && (
+        <Flex vertical gap={token.margin}>
+          <div>
+            <Title level={4} style={{ marginTop: 0, marginBottom: token.marginXXS }}>
+              {entry.benefit ?? entry.description ?? title}
+            </Title>
+            {entry.benefit && entry.description && (
+              <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+                {entry.description}
+              </Paragraph>
+            )}
+            <Text type="secondary" copyable style={{ fontSize: token.fontSizeSM }}>
+              {entry.name}
+            </Text>
+          </div>
+
+          {(entry.website_url || entry.repository_url) && (
+            <Space size={token.margin} wrap>
+              {entry.website_url && (
+                <Link href={entry.website_url} target="_blank" rel="noopener noreferrer">
+                  Website
+                </Link>
+              )}
+              {entry.repository_url && (
+                <Link href={entry.repository_url} target="_blank" rel="noopener noreferrer">
+                  Source
+                </Link>
+              )}
+            </Space>
+          )}
+
+          {(entry.capabilities?.length ?? 0) > 0 && (
+            <div>
+              <Text strong>What you can do</Text>
+              <Space
+                size={[token.marginXXS, token.marginXXS]}
+                wrap
+                style={{ marginTop: token.marginXS }}
+              >
+                {entry.capabilities?.map((capability) => (
+                  <Tag key={capability} color="processing" style={{ marginInlineEnd: 0 }}>
+                    {capabilityLabel(capability)}
+                  </Tag>
+                ))}
+              </Space>
+            </div>
+          )}
+
+          <Alert
+            type="warning"
+            showIcon
+            message="What this can access"
+            description={
+              <Flex vertical gap={token.marginXS}>
+                <Text>{entry.permission_disclosure ?? FALLBACK_DISCLOSURE}</Text>
+                {!blockedReason && (
+                  <Checkbox
+                    checked={acknowledged}
+                    onChange={(event) => setAcknowledged(event.target.checked)}
+                  >
+                    I understand what this server can access
+                  </Checkbox>
+                )}
+              </Flex>
+            }
+          />
+
+          {blockedReason ? (
+            <Alert type="info" showIcon message={blockedReason} />
+          ) : (
+            <Flex vertical gap={token.marginXS}>
+              <Form layout="vertical" size="middle" component="div">
+                <Form.Item label="Branch" style={{ marginBottom: token.marginXS }}>
+                  <Select
+                    showSearch
+                    optionFilterProp="label"
+                    loading={branchesLoading}
+                    value={branchId}
+                    onChange={setBranchId}
+                    options={branchOptions}
+                    placeholder={branchesLoading ? 'Loading branches…' : 'Select a branch'}
+                    notFoundContent={branchesLoading ? 'Loading branches…' : 'No branches yet'}
+                  />
+                </Form.Item>
+                <Form.Item label="Agent" style={{ marginBottom: 0 }}>
+                  <Select<AgenticToolName>
+                    value={agenticTool}
+                    onChange={setAgenticTool}
+                    options={AGENT_OPTIONS}
+                  />
+                </Form.Item>
+              </Form>
+
+              {branchesError && <Alert type="error" showIcon message={branchesError} />}
+              {connectError && <Alert type="error" showIcon message={connectError} />}
+
+              <Button
+                type="primary"
+                block
+                icon={<ThunderboltOutlined />}
+                loading={connecting}
+                disabled={!canConnect}
+                onClick={() => branchId && onConnect({ branchId, agenticTool })}
+              >
+                Connect &amp; try it
+              </Button>
+              <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+                Opens a new session on that branch with {title} attached and a starter prompt ready
+                to send.
+              </Text>
+            </Flex>
+          )}
+        </Flex>
+      )}
+    </Drawer>
+  );
+};

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -79,13 +79,6 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
 
   const entryId = entry?.catalog_entry_id;
 
-  // The acknowledgement records *which* server was acknowledged, rather than a
-  // boolean an effect resets when the entry changes. An effect would leave one
-  // render in which the new server's disclosure sits above an already-enabled
-  // connect button, carrying consent from the server before it.
-  const [acknowledgedEntryId, setAcknowledgedEntryId] = useState<string | null>(null);
-  const acknowledged = entryId !== undefined && acknowledgedEntryId === entryId;
-
   const branchOptions = useMemo(
     () =>
       branches.map((branch) => ({
@@ -107,6 +100,16 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
   const blockedReason = entry ? connectBlockedReason(entry) : undefined;
   const title = entry ? entryTitle(entry) : '';
   const disclosure = entry?.permission_disclosure ?? FALLBACK_DISCLOSURE;
+
+  // Consent records the server *and* the words it was given for, rather than a
+  // boolean some effect resets. A boolean leaves one render in which a newly
+  // opened server's disclosure sits above an already-enabled button; keying on
+  // the server alone still lets a re-opened entry arrive pre-consented after
+  // curation rewrote what it discloses. The endpoint's contract is the text, so
+  // this is too.
+  const [consent, setConsent] = useState<{ entryId: string; disclosure: string } | null>(null);
+  const acknowledged =
+    entryId !== undefined && consent?.entryId === entryId && consent.disclosure === disclosure;
   const canConnect = Boolean(!blockedReason && acknowledged && branchId && !connecting);
 
   return (
@@ -190,7 +193,11 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
                   <Checkbox
                     checked={acknowledged}
                     onChange={(event) =>
-                      setAcknowledgedEntryId(event.target.checked ? (entryId ?? null) : null)
+                      setConsent(
+                        event.target.checked && entryId !== undefined
+                          ? { entryId, disclosure }
+                          : null
+                      )
                     }
                   >
                     I understand what this server can access

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -26,7 +26,7 @@ import {
 } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
-import { capabilityLabel, connectBlockedReason, entryTitle } from './catalogPresentation';
+import { capabilityLabel, connectStatus, entryTitle } from './catalogPresentation';
 
 const { Title, Paragraph, Text, Link } = Typography;
 
@@ -97,7 +97,8 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
     setBranchId(preferred);
   }, [branchOptions, defaultBranchId, branchId]);
 
-  const blockedReason = entry ? connectBlockedReason(entry) : undefined;
+  const connect = entry ? connectStatus(entry) : undefined;
+  const blockedReason = connect?.readiness === 'blocked' ? connect.detail : undefined;
   const title = entry ? entryTitle(entry) : '';
   const disclosure = entry?.permission_disclosure ?? FALLBACK_DISCLOSURE;
 
@@ -116,7 +117,7 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
     <Drawer
       open={open}
       onClose={onClose}
-      width={480}
+      size={480}
       destroyOnHidden
       title={
         entry && (
@@ -180,6 +181,15 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
                 ))}
               </Space>
             </div>
+          )}
+
+          {connect && connect.readiness !== 'blocked' && (
+            <Alert
+              type={connect.readiness === 'ready' ? 'success' : 'info'}
+              showIcon
+              message={connect.label}
+              description={connect.detail}
+            />
           )}
 
           <Alert

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -187,6 +187,42 @@ describe('catalog browsing', () => {
     expect(screen.queryByText('Could not load the catalog')).not.toBeInTheDocument();
   });
 
+  it('does not blame filters for an empty catalog', async () => {
+    // A fresh daemon answers /health for a minute or two before curation
+    // finishes seeding. "No servers match" reads as "your filters excluded
+    // everything" when nothing is filtering, which sends people hunting for a
+    // frontend bug that isn't there.
+    catalogRows = [];
+    renderTab();
+
+    expect(await screen.findByText('No servers in the catalog yet')).toBeVisible();
+    expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeInTheDocument();
+  });
+
+  it('still blames the filters when the filters are to blame', async () => {
+    renderTab();
+    await screen.findByRole('button', { name: 'Open DeepWiki' });
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search MCP servers' }), {
+      target: { value: 'nothing-matches-this' },
+    });
+
+    expect(await screen.findByText('No servers match')).toBeVisible();
+    expect(screen.queryByText('No servers in the catalog yet')).not.toBeInTheDocument();
+  });
+
+  it('picks the catalog back up once seeding finishes', async () => {
+    catalogRows = [];
+    renderTab();
+    await screen.findByText('No servers in the catalog yet');
+
+    catalogRows = [DEEPWIKI, LINEAR];
+    fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+
+    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+  });
+
   it('pushes filters and page bounds to the server rather than filtering in the browser', async () => {
     renderTab();
     await screen.findByRole('button', { name: 'Open DeepWiki' });

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -66,12 +66,7 @@ function makeClient(): AgorClient {
     }
     if (path === 'branches') {
       return {
-        find: async () => ({
-          total: 1,
-          limit: 200,
-          skip: 0,
-          data: [{ branch_id: 'branch-1', name: 'mkt-slice' }],
-        }),
+        findAll: async () => [{ branch_id: 'branch-1', name: 'mkt-slice' }],
       };
     }
     if (path === 'mcp-catalog/connect') {
@@ -176,6 +171,19 @@ describe('connect', () => {
     await waitFor(() => expect(connect).toBeEnabled());
   });
 
+  it("does not carry one server's acknowledgement to the next one opened", async () => {
+    const deepwiki = await openDrawer();
+    fireEvent.click(deepwiki.getByRole('checkbox'));
+    await waitFor(() => expect(deepwiki.getByRole('button', { name: /Connect/ })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Linear' }));
+
+    const linear = within(await screen.findByRole('dialog'));
+    expect(linear.getByRole('checkbox')).not.toBeChecked();
+    expect(linear.getByRole('button', { name: /Connect/ })).toBeDisabled();
+  });
+
   it('connects by catalog key alone and lands in the new session with the prompt loaded', async () => {
     const drawer = await openDrawer();
     fireEvent.click(drawer.getByRole('checkbox'));
@@ -188,6 +196,9 @@ describe('connect', () => {
       catalog_key: 'entry-deepwiki',
       branch_id: 'branch-1',
       agentic_tool: 'claude-code',
+      // The exact text the drawer rendered, so the daemon can refuse a connect
+      // that skipped the disclosure or is holding a stale one.
+      acknowledged_disclosure: DEEPWIKI.permission_disclosure,
     });
 
     await waitFor(() =>

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -1,0 +1,223 @@
+import type { SessionID } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { sessionPath } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CatalogTab } from './CatalogTab';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const SESSION_ID = '019fd25a-7065-75f8-b6e6-f1963f9817d6';
+
+const DEEPWIKI = {
+  catalog_entry_id: 'entry-deepwiki',
+  created_at: new Date(0),
+  updated_at: new Date(0),
+  name: 'com.deepwiki/mcp',
+  title: 'DeepWiki',
+  benefit: 'Ask questions about any public GitHub repository.',
+  permission_disclosure: 'Reads public GitHub repository content only.',
+  starter_prompt: 'Explain how authentication works in a repo I name.',
+  capabilities: ['docs', 'code-search'],
+  has_remote: true,
+  has_package: false,
+  curated: true,
+  verified: false,
+  remote_url: 'https://mcp.deepwiki.com/mcp',
+  transport: 'streamable-http',
+  probed_auth_type: 'none',
+};
+
+const LINEAR = {
+  ...DEEPWIKI,
+  catalog_entry_id: 'entry-linear',
+  name: 'app.linear/linear',
+  title: 'Linear',
+};
+
+/** Every catalog read the page makes, in call order, so queries can be asserted. */
+let catalogQueries: Array<Record<string, unknown>>;
+let catalogRows: (typeof DEEPWIKI)[];
+let connectCalls: Array<Record<string, unknown>>;
+let connectImpl: (data: Record<string, unknown>) => Promise<unknown>;
+
+function makeClient(): AgorClient {
+  const service = (path: string) => {
+    if (path === 'mcp-catalog') {
+      return {
+        find: async ({ query }: { query: Record<string, unknown> }) => {
+          catalogQueries.push(query);
+          // The unfiltered size probe asks for a single row.
+          const filtered =
+            typeof query.search === 'string'
+              ? catalogRows.filter((row) =>
+                  row.name.toLowerCase().includes(String(query.search).toLowerCase())
+                )
+              : catalogRows;
+          return { total: filtered.length, limit: 24, skip: 0, data: filtered };
+        },
+      };
+    }
+    if (path === 'branches') {
+      return {
+        find: async () => ({
+          total: 1,
+          limit: 200,
+          skip: 0,
+          data: [{ branch_id: 'branch-1', name: 'mkt-slice' }],
+        }),
+      };
+    }
+    if (path === 'mcp-catalog/connect') {
+      return {
+        create: async (data: Record<string, unknown>) => {
+          connectCalls.push(data);
+          return connectImpl(data);
+        },
+      };
+    }
+    throw new Error(`unexpected service: ${path}`);
+  };
+  return { service } as unknown as AgorClient;
+}
+
+function renderTab() {
+  return render(
+    <MemoryRouter>
+      <CatalogTab client={makeClient()} />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  catalogQueries = [];
+  catalogRows = [DEEPWIKI, LINEAR];
+  connectCalls = [];
+  connectImpl = async () => ({
+    mcp_server: { mcp_server_id: 'server-1' },
+    session: { session_id: SESSION_ID },
+    starter_prompt: DEEPWIKI.starter_prompt,
+    reused_existing_server: false,
+  });
+  mockNavigate.mockClear();
+  localStorage.clear();
+});
+
+describe('catalog browsing', () => {
+  it('renders a card per entry', async () => {
+    renderTab();
+    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open Linear' })).toBeInTheDocument();
+  });
+
+  it('pushes filters and page bounds to the server rather than filtering in the browser', async () => {
+    renderTab();
+    await screen.findByRole('button', { name: 'Open DeepWiki' });
+
+    const listQuery = catalogQueries.find((query) => query.$limit === 24);
+    expect(listQuery).toMatchObject({ sort: 'popularity', $limit: 24, $skip: 0 });
+  });
+
+  it('hides the match count until something is actually filtering (REQ-CAT-3)', async () => {
+    renderTab();
+    await screen.findByRole('button', { name: 'Open DeepWiki' });
+    expect(screen.queryByText(/servers match/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch', { name: /Reviewed by Preset/i }));
+    expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
+    expect(catalogQueries.some((query) => query.curated === true)).toBe(true);
+  });
+
+  it('debounces search into one server-side query', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderTab();
+      await screen.findByRole('button', { name: 'Open DeepWiki' });
+      const before = catalogQueries.length;
+
+      const input = screen.getByRole('textbox', { name: 'Search MCP servers' });
+      for (const value of ['d', 'de', 'dee', 'deep']) {
+        fireEvent.change(input, { target: { value } });
+      }
+      expect(catalogQueries.length).toBe(before);
+
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(catalogQueries.length).toBe(before + 1));
+      expect(catalogQueries.at(-1)).toMatchObject({ search: 'deep' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('connect', () => {
+  async function openDrawer() {
+    renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
+    return within(await screen.findByRole('dialog'));
+  }
+
+  it('shows the access disclosure expanded and blocks connect until it is acknowledged', async () => {
+    const drawer = await openDrawer();
+
+    expect(drawer.getByText('What this can access')).toBeVisible();
+    expect(drawer.getByText(DEEPWIKI.permission_disclosure)).toBeVisible();
+
+    const connect = drawer.getByRole('button', { name: /Connect/ });
+    expect(connect).toBeDisabled();
+
+    fireEvent.click(drawer.getByRole('checkbox'));
+    await waitFor(() => expect(connect).toBeEnabled());
+  });
+
+  it('connects by catalog key alone and lands in the new session with the prompt loaded', async () => {
+    const drawer = await openDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
+
+    fireEvent.click(drawer.getByRole('button', { name: /Connect/ }));
+
+    await waitFor(() => expect(connectCalls).toHaveLength(1));
+    expect(connectCalls[0]).toEqual({
+      catalog_key: 'entry-deepwiki',
+      branch_id: 'branch-1',
+      agentic_tool: 'claude-code',
+    });
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(sessionPath(SESSION_ID as SessionID))
+    );
+    expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBe(DEEPWIKI.starter_prompt);
+  });
+
+  it('keeps the drawer open and reports why when connect fails', async () => {
+    connectImpl = async () => {
+      throw new Error('DeepWiki requires authentication, which is not supported yet');
+    };
+    const drawer = await openDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
+
+    fireEvent.click(drawer.getByRole('button', { name: /Connect/ }));
+
+    expect(await drawer.findByText(/requires authentication/)).toBeVisible();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('offers no connect control for an entry that has not been reviewed', async () => {
+    catalogRows = [{ ...DEEPWIKI, curated: false }];
+    renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
+    const drawer = within(await screen.findByRole('dialog'));
+
+    expect(drawer.getByText(/Only servers reviewed by Preset/)).toBeVisible();
+    expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
+    expect(drawer.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -56,13 +56,14 @@ function makeClient(): AgorClient {
         find: async ({ query }: { query: Record<string, unknown> }) => {
           catalogQueries.push(query);
           if (catalogFindError) throw catalogFindError;
-          // The unfiltered size probe asks for a single row.
-          const filtered =
-            typeof query.search === 'string'
-              ? catalogRows.filter((row) =>
-                  row.name.toLowerCase().includes(String(query.search).toLowerCase())
-                )
-              : catalogRows;
+          const verdicts = query.probed_auth_types as string[] | undefined;
+          const filtered = catalogRows
+            .filter((row) =>
+              typeof query.search === 'string'
+                ? row.name.toLowerCase().includes(String(query.search).toLowerCase())
+                : true
+            )
+            .filter((row) => (verdicts ? verdicts.includes(row.probed_auth_type) : true));
           return { total: filtered.length, limit: 24, skip: 0, data: filtered };
         },
       };
@@ -204,15 +205,39 @@ describe('catalog browsing', () => {
     expect(catalogQueries.some((query) => query.curated === true)).toBe(true);
   });
 
-  it('filters to servers that need no account', async () => {
+  it('keeps unprobed servers when hiding account-only ones', async () => {
+    // A stock install has never run a registry sync, so every curated row is
+    // `unknown`. A filter that demanded `none` could only ever return nothing,
+    // while the cards beside it called those same entries connectable.
+    catalogRows = [
+      { ...DEEPWIKI, probed_auth_type: 'unknown' },
+      { ...LINEAR, probed_auth_type: 'unknown' },
+    ];
     renderTab();
     await screen.findByRole('button', { name: 'Open DeepWiki' });
 
-    fireEvent.click(screen.getByRole('switch', { name: /need no account/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
+
+    expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
+  });
+
+  it('drops servers known to need an account', async () => {
+    catalogRows = [
+      { ...DEEPWIKI, probed_auth_type: 'unknown' },
+      { ...LINEAR, probed_auth_type: 'oauth' },
+    ];
+    renderTab();
+    await screen.findByRole('button', { name: 'Open Linear' });
+
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
 
     await waitFor(() =>
-      expect(catalogQueries.some((query) => query.probed_auth_type === 'none')).toBe(true)
+      expect(screen.queryByRole('button', { name: 'Open Linear' })).not.toBeInTheDocument()
     );
+    expect(screen.getByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(catalogQueries.at(-1)?.probed_auth_types).toEqual(['none', 'unknown']);
   });
 
   it('debounces search into one server-side query', async () => {

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -39,6 +39,7 @@ const LINEAR = {
   catalog_entry_id: 'entry-linear',
   name: 'app.linear/linear',
   title: 'Linear',
+  permission_disclosure: 'Reads and writes issues in the Linear workspaces you authorise.',
 };
 
 /** Every catalog read the page makes, in call order, so queries can be asserted. */
@@ -182,6 +183,33 @@ describe('connect', () => {
     const linear = within(await screen.findByRole('dialog'));
     expect(linear.getByRole('checkbox')).not.toBeChecked();
     expect(linear.getByRole('button', { name: /Connect/ })).toBeDisabled();
+  });
+
+  it('withdraws consent when the disclosure it was given for is rewritten', async () => {
+    const drawer = await openDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
+
+    // A reseed rewrites what this server discloses while the drawer is open.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    catalogRows = [{ ...DEEPWIKI, permission_disclosure: 'Now also writes to your repositories.' }];
+    fireEvent.click(screen.getByRole('switch', { name: /Reviewed by Preset/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
+
+    const reopened = within(await screen.findByRole('dialog'));
+    expect(reopened.getByText('Now also writes to your repositories.')).toBeVisible();
+    expect(reopened.getByRole('checkbox')).not.toBeChecked();
+    expect(reopened.getByRole('button', { name: /Connect/ })).toBeDisabled();
+  });
+
+  it('offers no connect control for an entry that discloses nothing', async () => {
+    catalogRows = [{ ...DEEPWIKI, permission_disclosure: '' }];
+    renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
+    const drawer = within(await screen.findByRole('dialog'));
+
+    expect(drawer.getByText(/has not stated what it can access/)).toBeVisible();
+    expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
   });
 
   it('connects by catalog key alone and lands in the new session with the prompt loaded', async () => {

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -318,35 +318,11 @@ describe('connect', () => {
     await waitFor(() => expect(connect).toBeEnabled());
   });
 
-  it("does not carry one server's acknowledgement to the next one opened", async () => {
-    const deepwiki = await openDrawer();
-    fireEvent.click(deepwiki.getByRole('checkbox'));
-    await waitFor(() => expect(deepwiki.getByRole('button', { name: /Connect/ })).toBeEnabled());
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Open Linear' }));
-
-    const linear = within(await screen.findByRole('dialog'));
-    expect(linear.getByRole('checkbox')).not.toBeChecked();
-    expect(linear.getByRole('button', { name: /Connect/ })).toBeDisabled();
-  });
-
-  it('withdraws consent when the disclosure it was given for is rewritten', async () => {
-    const drawer = await openDrawer();
-    fireEvent.click(drawer.getByRole('checkbox'));
-    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
-
-    // A reseed rewrites what this server discloses while the drawer is open.
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-    catalogRows = [{ ...DEEPWIKI, permission_disclosure: 'Now also writes to your repositories.' }];
-    fireEvent.click(screen.getByRole('switch', { name: /Reviewed by Preset/i }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
-
-    const reopened = within(await screen.findByRole('dialog'));
-    expect(reopened.getByText('Now also writes to your repositories.')).toBeVisible();
-    expect(reopened.getByRole('checkbox')).not.toBeChecked();
-    expect(reopened.getByRole('button', { name: /Connect/ })).toBeDisabled();
-  });
+  // Consent's two withdrawal rules — a different entry, and the same entry
+  // with rewritten wording — are asserted in `CatalogDetailDrawer.test.tsx`.
+  // Reaching them from here meant closing and reopening the drawer, mounting
+  // the AntD Form and its Selects twice; the drawer takes the entry as a prop
+  // and states the same invariant in one mount.
 
   it('offers no connect control for an entry that discloses nothing', async () => {
     catalogRows = [{ ...DEEPWIKI, permission_disclosure: '' }];

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -1,7 +1,7 @@
 import type { SessionID } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { sessionPath } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CatalogTab } from './CatalogTab';
@@ -47,6 +47,7 @@ let catalogQueries: Array<Record<string, unknown>>;
 let catalogRows: (typeof DEEPWIKI)[];
 let connectCalls: Array<Record<string, unknown>>;
 let connectImpl: (data: Record<string, unknown>) => Promise<unknown>;
+let catalogFindError: Error | null;
 
 function makeClient(): AgorClient {
   const service = (path: string) => {
@@ -54,6 +55,7 @@ function makeClient(): AgorClient {
       return {
         find: async ({ query }: { query: Record<string, unknown> }) => {
           catalogQueries.push(query);
+          if (catalogFindError) throw catalogFindError;
           // The unfiltered size probe asks for a single row.
           const filtered =
             typeof query.search === 'string'
@@ -83,10 +85,10 @@ function makeClient(): AgorClient {
   return { service } as unknown as AgorClient;
 }
 
-function renderTab() {
+function renderTab({ connected = true }: { connected?: boolean } = {}) {
   return render(
     <MemoryRouter>
-      <CatalogTab client={makeClient()} />
+      <CatalogTab client={makeClient()} connected={connected} />
     </MemoryRouter>
   );
 }
@@ -94,6 +96,7 @@ function renderTab() {
 beforeEach(() => {
   catalogQueries = [];
   catalogRows = [DEEPWIKI, LINEAR];
+  catalogFindError = null;
   connectCalls = [];
   connectImpl = async () => ({
     mcp_server: { mcp_server_id: 'server-1' },
@@ -112,6 +115,77 @@ describe('catalog browsing', () => {
     expect(screen.getByRole('button', { name: 'Open Linear' })).toBeInTheDocument();
   });
 
+  it('reads nothing until the socket can answer, and never calls that an empty catalog', async () => {
+    // The cold path: `/marketplace` as the entry URL. `client` exists from the
+    // moment the socket is being built, so a surface that fetches on its
+    // presence asks an unauthenticated socket and is refused.
+    const { container } = renderTab({ connected: false });
+    // Let any effect that was going to fire, fire.
+    await act(() => Promise.resolve());
+
+    expect(catalogQueries).toHaveLength(0);
+    expect(container.querySelectorAll('.ant-skeleton').length).toBeGreaterThan(0);
+    expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
+    expect(screen.queryByText('Could not load the catalog')).not.toBeInTheDocument();
+  });
+
+  it('says the daemon is unreachable rather than spinning silently', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderTab({ connected: false });
+      await act(() => Promise.resolve());
+      expect(screen.queryByText('Not connected to the Agor daemon')).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(screen.getByText('Not connected to the Agor daemon')).toBeVisible();
+      expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('loads once the socket connects, without a remount', async () => {
+    const client = makeClient();
+    const { rerender } = render(
+      <MemoryRouter>
+        <CatalogTab client={client} connected={false} />
+      </MemoryRouter>
+    );
+    expect(catalogQueries).toHaveLength(0);
+
+    rerender(
+      <MemoryRouter>
+        <CatalogTab client={client} connected={true} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+  });
+
+  it('renders a failed read as a failure, not as an empty catalog', async () => {
+    catalogFindError = new Error('NotAuthenticated: Authentication required');
+    renderTab();
+
+    expect(await screen.findByText('Could not load the catalog')).toBeVisible();
+    expect(screen.getByText(/Authentication required/)).toBeVisible();
+    expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
+  });
+
+  it('recovers from a failed read when retried', async () => {
+    catalogFindError = new Error('boom');
+    renderTab();
+    await screen.findByText('Could not load the catalog');
+
+    catalogFindError = null;
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(screen.queryByText('Could not load the catalog')).not.toBeInTheDocument();
+  });
+
   it('pushes filters and page bounds to the server rather than filtering in the browser', async () => {
     renderTab();
     await screen.findByRole('button', { name: 'Open DeepWiki' });
@@ -128,6 +202,17 @@ describe('catalog browsing', () => {
     fireEvent.click(screen.getByRole('switch', { name: /Reviewed by Preset/i }));
     expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
     expect(catalogQueries.some((query) => query.curated === true)).toBe(true);
+  });
+
+  it('filters to servers that need no account', async () => {
+    renderTab();
+    await screen.findByRole('button', { name: 'Open DeepWiki' });
+
+    fireEvent.click(screen.getByRole('switch', { name: /need no account/i }));
+
+    await waitFor(() =>
+      expect(catalogQueries.some((query) => query.probed_auth_type === 'none')).toBe(true)
+    );
   });
 
   it('debounces search into one server-side query', async () => {

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -1,0 +1,216 @@
+/**
+ * The Catalog: browse the MCP catalog, open an entry, connect it.
+ *
+ * Filtering and paging happen in SQL — the grid renders one page and never the
+ * result set, because the catalog reaches thousands of rows once registry
+ * ingestion is on.
+ */
+
+import type { AgenticToolName, MCPCatalogCategory, MCPCatalogEntry } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { sessionPath } from '@agor-live/client';
+import { Alert, Col, Empty, Flex, Pagination, Row, Skeleton, Typography, theme } from 'antd';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { savePromptDraft } from '../../utils/promptDrafts';
+import { CatalogCard } from './CatalogCard';
+import { CatalogDetailDrawer } from './CatalogDetailDrawer';
+import { CatalogToolbar } from './CatalogToolbar';
+import { DEFAULT_SORT } from './catalogPresentation';
+import {
+  CATALOG_PAGE_SIZE,
+  type CatalogFilterState,
+  isFilterActive,
+  useCatalogSearch,
+} from './useCatalogSearch';
+import {
+  getLastConnectBranchId,
+  rememberConnectBranchId,
+  useConnectTargets,
+} from './useConnectTargets';
+
+const { Text } = Typography;
+
+const GRID_SPANS = { xs: 24, sm: 12, lg: 8, xxl: 6 } as const;
+
+const INITIAL_FILTERS: CatalogFilterState = {
+  search: '',
+  reviewedOnly: false,
+  sort: DEFAULT_SORT,
+};
+
+/**
+ * The grid is memoized separately from the toolbar so a filter change that
+ * leaves the page identical (e.g. re-selecting the same sort) doesn't rebuild
+ * every card.
+ */
+const CatalogGrid = memo<{
+  entries: MCPCatalogEntry[];
+  onOpen: (entry: MCPCatalogEntry) => void;
+}>(({ entries, onOpen }) => (
+  <Row gutter={[16, 16]}>
+    {entries.map((entry) => (
+      <Col key={entry.catalog_entry_id} {...GRID_SPANS}>
+        <CatalogCard entry={entry} onOpen={onOpen} />
+      </Col>
+    ))}
+  </Row>
+));
+
+export interface CatalogTabProps {
+  client: AgorClient;
+}
+
+export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+
+  const [filters, setFilters] = useState<CatalogFilterState>(INITIAL_FILTERS);
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<MCPCatalogEntry | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  const { entries, matchCount, catalogSize, loading, error } = useCatalogSearch(
+    client,
+    filters,
+    page
+  );
+  const {
+    branches,
+    loading: branchesLoading,
+    error: branchesError,
+  } = useConnectTargets(client, selected !== null);
+
+  // Any narrowing invalidates the current offset — page 4 of an unfiltered
+  // catalog is usually past the end of a filtered one.
+  const applyFilter = useCallback((patch: Partial<CatalogFilterState>) => {
+    setFilters((current) => ({ ...current, ...patch }));
+    setPage(1);
+  }, []);
+
+  const onSearchChange = useCallback((search: string) => applyFilter({ search }), [applyFilter]);
+  const onCategoryChange = useCallback(
+    (category?: MCPCatalogCategory) => applyFilter({ category }),
+    [applyFilter]
+  );
+  const onCapabilityChange = useCallback(
+    (capability?: string) => applyFilter({ capability }),
+    [applyFilter]
+  );
+  const onReviewedOnlyChange = useCallback(
+    (reviewedOnly: boolean) => applyFilter({ reviewedOnly }),
+    [applyFilter]
+  );
+  const onSortChange = useCallback(
+    (sort: CatalogFilterState['sort']) => applyFilter({ sort }),
+    [applyFilter]
+  );
+
+  const openEntry = useCallback((entry: MCPCatalogEntry) => {
+    setConnectError(null);
+    setSelected(entry);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setSelected(null);
+    setConnectError(null);
+  }, []);
+
+  // `REQ-CAT-3`: the count is a filtering aid, so it appears only once
+  // filtering is happening.
+  const matchSummary = useMemo(
+    () =>
+      isFilterActive(filters) && catalogSize !== null
+        ? { matched: matchCount, total: catalogSize }
+        : null,
+    [filters, catalogSize, matchCount]
+  );
+
+  const handleConnect = useCallback(
+    async ({ branchId, agenticTool }: { branchId: string; agenticTool: AgenticToolName }) => {
+      if (!selected) return;
+      setConnecting(true);
+      setConnectError(null);
+      try {
+        const result = await client.service('mcp-catalog/connect').create({
+          catalog_key: selected.catalog_entry_id,
+          branch_id: branchId,
+          agentic_tool: agenticTool,
+        });
+        rememberConnectBranchId(branchId);
+        if (result.starter_prompt) {
+          savePromptDraft(result.session.session_id, result.starter_prompt);
+        }
+        setSelected(null);
+        navigate(sessionPath(result.session.session_id));
+      } catch (err: unknown) {
+        setConnectError(err instanceof Error ? err.message : 'Could not connect this server');
+      } finally {
+        setConnecting(false);
+      }
+    },
+    [client, navigate, selected]
+  );
+
+  return (
+    <Flex vertical gap={token.margin}>
+      <CatalogToolbar
+        search={filters.search}
+        category={filters.category}
+        capability={filters.capability}
+        reviewedOnly={filters.reviewedOnly}
+        sort={filters.sort}
+        onSearchChange={onSearchChange}
+        onCategoryChange={onCategoryChange}
+        onCapabilityChange={onCapabilityChange}
+        onReviewedOnlyChange={onReviewedOnlyChange}
+        onSortChange={onSortChange}
+        matchSummary={matchSummary}
+      />
+
+      {error ? (
+        <Alert type="error" showIcon message="Could not load the catalog" description={error} />
+      ) : loading && entries.length === 0 ? (
+        <Row gutter={[16, 16]}>
+          {Array.from({ length: 6 }, (_, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder grid
+            <Col key={index} {...GRID_SPANS}>
+              <Skeleton active paragraph={{ rows: 2 }} />
+            </Col>
+          ))}
+        </Row>
+      ) : entries.length === 0 ? (
+        <Empty description="No servers match" />
+      ) : (
+        <CatalogGrid entries={entries} onOpen={openEntry} />
+      )}
+
+      {matchCount > CATALOG_PAGE_SIZE && (
+        <Flex justify="flex-end" align="center" gap={token.margin}>
+          {loading && <Text type="secondary">Loading…</Text>}
+          <Pagination
+            current={page}
+            pageSize={CATALOG_PAGE_SIZE}
+            total={matchCount}
+            showSizeChanger={false}
+            onChange={setPage}
+          />
+        </Flex>
+      )}
+
+      <CatalogDetailDrawer
+        entry={selected}
+        open={selected !== null}
+        onClose={closeDrawer}
+        branches={branches}
+        branchesLoading={branchesLoading}
+        branchesError={branchesError}
+        defaultBranchId={getLastConnectBranchId()}
+        connecting={connecting}
+        connectError={connectError}
+        onConnect={handleConnect}
+      />
+    </Flex>
+  );
+};

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -9,8 +9,8 @@
 import type { AgenticToolName, MCPCatalogCategory, MCPCatalogEntry } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { sessionPath } from '@agor-live/client';
-import { Alert, Col, Empty, Flex, Pagination, Row, Skeleton, Typography, theme } from 'antd';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { Alert, Button, Col, Empty, Flex, Pagination, Row, Skeleton, theme } from 'antd';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { savePromptDraft } from '../../utils/promptDrafts';
 import { CatalogCard } from './CatalogCard';
@@ -29,13 +29,12 @@ import {
   useConnectTargets,
 } from './useConnectTargets';
 
-const { Text } = Typography;
-
 const GRID_SPANS = { xs: 24, sm: 12, lg: 8, xxl: 6 } as const;
 
 const INITIAL_FILTERS: CatalogFilterState = {
   search: '',
   reviewedOnly: false,
+  connectableOnly: false,
   sort: DEFAULT_SORT,
 };
 
@@ -44,6 +43,28 @@ const INITIAL_FILTERS: CatalogFilterState = {
  * leaves the page identical (e.g. re-selecting the same sort) doesn't rebuild
  * every card.
  */
+/**
+ * True once `active` has held for `delayMs`.
+ *
+ * A normal load is connected inside a second, so announcing every one of those
+ * would be noise. A disconnection that outlasts the delay is the case worth
+ * naming — otherwise the skeleton spins forever and says nothing.
+ */
+function useSettledFlag(active: boolean, delayMs: number): boolean {
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setSettled(false);
+      return;
+    }
+    const timer = setTimeout(() => setSettled(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [active, delayMs]);
+  return settled;
+}
+
+const DISCONNECT_NOTICE_DELAY_MS = 2000;
+
 const CatalogGrid = memo<{
   entries: MCPCatalogEntry[];
   onOpen: (entry: MCPCatalogEntry) => void;
@@ -58,10 +79,12 @@ const CatalogGrid = memo<{
 ));
 
 export interface CatalogTabProps {
-  client: AgorClient;
+  client: AgorClient | null;
+  /** The socket has connected and authenticated, so reads will be answered. */
+  connected: boolean;
 }
 
-export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
+export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
 
@@ -70,9 +93,11 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
   const [selected, setSelected] = useState<MCPCatalogEntry | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const showDisconnected = useSettledFlag(!connected, DISCONNECT_NOTICE_DELAY_MS);
 
-  const { entries, matchCount, catalogSize, loading, error } = useCatalogSearch(
+  const { entries, status, matchCount, catalogSize, error, retry } = useCatalogSearch(
     client,
+    connected,
     filters,
     page
   );
@@ -80,7 +105,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
     branches,
     loading: branchesLoading,
     error: branchesError,
-  } = useConnectTargets(client, selected !== null);
+  } = useConnectTargets(client, connected && selected !== null);
 
   // Any narrowing invalidates the current offset — page 4 of an unfiltered
   // catalog is usually past the end of a filtered one.
@@ -102,6 +127,10 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
     (reviewedOnly: boolean) => applyFilter({ reviewedOnly }),
     [applyFilter]
   );
+  const onConnectableOnlyChange = useCallback(
+    (connectableOnly: boolean) => applyFilter({ connectableOnly }),
+    [applyFilter]
+  );
   const onSortChange = useCallback(
     (sort: CatalogFilterState['sort']) => applyFilter({ sort }),
     [applyFilter]
@@ -121,10 +150,10 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
   // filtering is happening.
   const matchSummary = useMemo(
     () =>
-      isFilterActive(filters) && catalogSize !== null
+      status === 'ready' && isFilterActive(filters) && catalogSize !== null
         ? { matched: matchCount, total: catalogSize }
         : null,
-    [filters, catalogSize, matchCount]
+    [status, filters, catalogSize, matchCount]
   );
 
   const handleConnect = useCallback(
@@ -137,7 +166,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
       agenticTool: AgenticToolName;
       acknowledgedDisclosure: string;
     }) => {
-      if (!selected) return;
+      if (!selected || !client) return;
       setConnecting(true);
       setConnectError(null);
       try {
@@ -169,35 +198,59 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
         category={filters.category}
         capability={filters.capability}
         reviewedOnly={filters.reviewedOnly}
+        connectableOnly={filters.connectableOnly}
         sort={filters.sort}
         onSearchChange={onSearchChange}
         onCategoryChange={onCategoryChange}
         onCapabilityChange={onCapabilityChange}
         onReviewedOnlyChange={onReviewedOnlyChange}
+        onConnectableOnlyChange={onConnectableOnlyChange}
         onSortChange={onSortChange}
         matchSummary={matchSummary}
       />
 
-      {error ? (
-        <Alert type="error" showIcon message="Could not load the catalog" description={error} />
-      ) : loading && entries.length === 0 ? (
-        <Row gutter={[16, 16]}>
-          {Array.from({ length: 6 }, (_, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder grid
-            <Col key={index} {...GRID_SPANS}>
-              <Skeleton active paragraph={{ rows: 2 }} />
-            </Col>
-          ))}
-        </Row>
+      {showDisconnected && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Not connected to the Agor daemon"
+          description="The catalog will load as soon as the connection is back."
+        />
+      )}
+
+      {/* `empty` is only reachable from a read that returned. A failed read
+          renders as a failure, never as a catalog with nothing in it. */}
+      {status === 'error' ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Could not load the catalog"
+          description={error}
+          action={
+            <Button size="small" onClick={retry}>
+              Retry
+            </Button>
+          }
+        />
+      ) : status === 'loading' ? (
+        showDisconnected ? null : (
+          <Row gutter={[16, 16]}>
+            {Array.from({ length: 6 }, (_, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder grid
+              <Col key={index} {...GRID_SPANS}>
+                <Skeleton active paragraph={{ rows: 2 }} />
+              </Col>
+            ))}
+          </Row>
+        )
       ) : entries.length === 0 ? (
         <Empty description="No servers match" />
       ) : (
         <CatalogGrid entries={entries} onOpen={openEntry} />
       )}
 
-      {matchCount > CATALOG_PAGE_SIZE && (
+      {status === 'ready' && matchCount > CATALOG_PAGE_SIZE && (
         <Flex justify="flex-end" align="center" gap={token.margin}>
-          {loading && <Text type="secondary">Loading…</Text>}
           <Pagination
             current={page}
             pageSize={CATALOG_PAGE_SIZE}

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -128,7 +128,15 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
   );
 
   const handleConnect = useCallback(
-    async ({ branchId, agenticTool }: { branchId: string; agenticTool: AgenticToolName }) => {
+    async ({
+      branchId,
+      agenticTool,
+      acknowledgedDisclosure,
+    }: {
+      branchId: string;
+      agenticTool: AgenticToolName;
+      acknowledgedDisclosure: string;
+    }) => {
       if (!selected) return;
       setConnecting(true);
       setConnectError(null);
@@ -137,6 +145,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client }) => {
           catalog_key: selected.catalog_entry_id,
           branch_id: branchId,
           agentic_tool: agenticTool,
+          acknowledged_disclosure: acknowledgedDisclosure,
         });
         rememberConnectBranchId(branchId);
         if (result.starter_prompt) {

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -244,7 +244,17 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => 
           </Row>
         )
       ) : entries.length === 0 ? (
-        <Empty description="No servers match" />
+        // "No servers match" means the filters excluded everything. With
+        // nothing filtering there is nothing to have excluded, so an empty read
+        // is an empty catalog — which on a fresh daemon means seeding has not
+        // finished, several quiet minutes after `/health` starts answering.
+        isFilterActive(filters) ? (
+          <Empty description="No servers match" />
+        ) : (
+          <Empty description="No servers in the catalog yet">
+            <Button onClick={retry}>Check again</Button>
+          </Empty>
+        )
       ) : (
         <CatalogGrid entries={entries} onOpen={openEntry} />
       )}

--- a/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
@@ -37,6 +37,7 @@ export interface CatalogToolbarProps {
   category?: MCPCatalogCategory;
   capability?: string;
   reviewedOnly: boolean;
+  connectableOnly: boolean;
   sort: MCPCatalogSort;
   /** Debounced search term, for controlled resets (e.g. "clear filters"). */
   search: string;
@@ -44,6 +45,7 @@ export interface CatalogToolbarProps {
   onCategoryChange: (value?: MCPCatalogCategory) => void;
   onCapabilityChange: (value?: string) => void;
   onReviewedOnlyChange: (value: boolean) => void;
+  onConnectableOnlyChange: (value: boolean) => void;
   onSortChange: (value: MCPCatalogSort) => void;
   /** `null` while the unfiltered catalog size is still unknown. */
   matchSummary: { matched: number; total: number } | null;
@@ -53,12 +55,14 @@ const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
   category,
   capability,
   reviewedOnly,
+  connectableOnly,
   sort,
   search,
   onSearchChange,
   onCategoryChange,
   onCapabilityChange,
   onReviewedOnlyChange,
+  onConnectableOnlyChange,
   onSortChange,
   matchSummary,
 }) => {
@@ -81,7 +85,7 @@ const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
 
   return (
     <Card size="small" styles={{ body: { padding: token.padding } }}>
-      <Space direction="vertical" size={token.paddingSM} style={{ width: '100%' }}>
+      <Space orientation="vertical" size={token.paddingSM} style={{ width: '100%' }}>
         <Input
           size="large"
           allowClear
@@ -120,6 +124,17 @@ const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
                 checked={reviewedOnly}
                 onChange={onReviewedOnlyChange}
                 aria-label="Show only servers reviewed by Preset"
+              />
+            </Space>
+          </Col>
+          <Col flex="none">
+            <Space size={token.marginXS}>
+              <Text type="secondary">Connectable now</Text>
+              <Switch
+                size="small"
+                checked={connectableOnly}
+                onChange={onConnectableOnlyChange}
+                aria-label="Show only servers that need no account"
               />
             </Space>
           </Col>

--- a/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
@@ -10,7 +10,19 @@
 
 import type { MCPCatalogCategory, MCPCatalogSort } from '@agor/core/types';
 import { SearchOutlined } from '@ant-design/icons';
-import { Card, Col, Input, Row, Segmented, Select, Space, Switch, Typography, theme } from 'antd';
+import {
+  Card,
+  Col,
+  Input,
+  Row,
+  Segmented,
+  Select,
+  Space,
+  Switch,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import { memo, useEffect, useRef, useState } from 'react';
 import {
   ALL_CATEGORIES,
@@ -129,12 +141,18 @@ const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
           </Col>
           <Col flex="none">
             <Space size={token.marginXS}>
-              <Text type="secondary">Connectable now</Text>
+              {/* Named for what it removes, because what it keeps includes
+                  endpoints nobody has checked yet. */}
+              <Tooltip title="Hides servers Agor knows need an account. Unchecked endpoints stay — connecting is what checks them.">
+                <Text type="secondary" style={{ cursor: 'help' }}>
+                  Hide account-only
+                </Text>
+              </Tooltip>
               <Switch
                 size="small"
                 checked={connectableOnly}
                 onChange={onConnectableOnlyChange}
-                aria-label="Show only servers that need no account"
+                aria-label="Hide servers known to need an account"
               />
             </Space>
           </Col>

--- a/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
@@ -1,0 +1,146 @@
+/**
+ * Search and every filter, in one toolbar directly under the page header
+ * (REQ-CAT-2). Splitting them across regions makes the user hunt for the
+ * control that is narrowing their results.
+ *
+ * The search box keeps its own value and publishes a debounced one, so typing
+ * re-renders this component and nothing else — the grid below it only re-renders
+ * once a query actually changes.
+ */
+
+import type { MCPCatalogCategory, MCPCatalogSort } from '@agor/core/types';
+import { SearchOutlined } from '@ant-design/icons';
+import { Card, Col, Input, Row, Segmented, Select, Space, Switch, Typography, theme } from 'antd';
+import { memo, useEffect, useRef, useState } from 'react';
+import {
+  ALL_CATEGORIES,
+  CAPABILITY_GROUPS,
+  CATEGORY_OPTIONS,
+  type CategoryFilter,
+  capabilityLabel,
+  SORT_OPTIONS,
+} from './catalogPresentation';
+
+const { Text } = Typography;
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+const CAPABILITY_OPTIONS = CAPABILITY_GROUPS.map((group) => ({
+  label: group.label,
+  options: group.capabilities.map((capability) => ({
+    label: capabilityLabel(capability),
+    value: capability,
+  })),
+}));
+
+export interface CatalogToolbarProps {
+  category?: MCPCatalogCategory;
+  capability?: string;
+  reviewedOnly: boolean;
+  sort: MCPCatalogSort;
+  /** Debounced search term, for controlled resets (e.g. "clear filters"). */
+  search: string;
+  onSearchChange: (value: string) => void;
+  onCategoryChange: (value?: MCPCatalogCategory) => void;
+  onCapabilityChange: (value?: string) => void;
+  onReviewedOnlyChange: (value: boolean) => void;
+  onSortChange: (value: MCPCatalogSort) => void;
+  /** `null` while the unfiltered catalog size is still unknown. */
+  matchSummary: { matched: number; total: number } | null;
+}
+
+const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
+  category,
+  capability,
+  reviewedOnly,
+  sort,
+  search,
+  onSearchChange,
+  onCategoryChange,
+  onCapabilityChange,
+  onReviewedOnlyChange,
+  onSortChange,
+  matchSummary,
+}) => {
+  const { token } = theme.useToken();
+  const [draft, setDraft] = useState(search);
+
+  // Keep the box in step when the term is reset from outside; typing already
+  // owns `draft`, so this only fires on an external change.
+  useEffect(() => {
+    setDraft((current) => (current.trim() === search.trim() ? current : search));
+  }, [search]);
+
+  const publish = useRef(onSearchChange);
+  publish.current = onSearchChange;
+
+  useEffect(() => {
+    const timer = setTimeout(() => publish.current(draft), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [draft]);
+
+  return (
+    <Card size="small" styles={{ body: { padding: token.padding } }}>
+      <Space direction="vertical" size={token.paddingSM} style={{ width: '100%' }}>
+        <Input
+          size="large"
+          allowClear
+          prefix={<SearchOutlined />}
+          placeholder="Search MCP servers…"
+          aria-label="Search MCP servers"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+        />
+        <Segmented<CategoryFilter>
+          options={CATEGORY_OPTIONS}
+          value={category ?? ALL_CATEGORIES}
+          onChange={(value) =>
+            onCategoryChange(value === ALL_CATEGORIES ? undefined : (value as MCPCatalogCategory))
+          }
+        />
+        <Row gutter={[token.paddingSM, token.paddingSM]} align="middle">
+          <Col flex="auto" style={{ minWidth: 220 }}>
+            <Select
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              style={{ width: '100%' }}
+              placeholder="Filter by capability (e.g. Issues, Logs, Databases)"
+              aria-label="Filter by capability"
+              value={capability ?? undefined}
+              onChange={(value?: string) => onCapabilityChange(value || undefined)}
+              options={CAPABILITY_OPTIONS}
+            />
+          </Col>
+          <Col flex="none">
+            <Space size={token.marginXS}>
+              <Text type="secondary">Reviewed only</Text>
+              <Switch
+                size="small"
+                checked={reviewedOnly}
+                onChange={onReviewedOnlyChange}
+                aria-label="Show only servers reviewed by Preset"
+              />
+            </Space>
+          </Col>
+          <Col flex="none">
+            <Select<MCPCatalogSort>
+              value={sort}
+              onChange={onSortChange}
+              aria-label="Sort servers"
+              style={{ width: 200 }}
+              options={SORT_OPTIONS}
+            />
+          </Col>
+        </Row>
+        {matchSummary && (
+          <Text type="secondary">
+            {matchSummary.matched} of {matchSummary.total} servers match
+          </Text>
+        )}
+      </Space>
+    </Card>
+  );
+};
+
+export const CatalogToolbar = memo(CatalogToolbarInner);

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   capabilityLabel,
   connectBlockedReason,
+  connectStatus,
   DEFAULT_SORT,
   entryTitle,
 } from './catalogPresentation';
@@ -89,6 +90,32 @@ describe('connectBlockedReason', () => {
     expect(connectBlockedReason(entry({ probed_auth_type: 'unreachable' }))).toMatch(
       /could not be reached/i
     );
+  });
+});
+
+describe('connectStatus', () => {
+  it('says an unprobed entry may still ask for an account, rather than promising either way', () => {
+    const status = connectStatus(entry({ probed_auth_type: 'unknown' }));
+    expect(status.readiness).toBe('unchecked');
+    expect(status.detail).toMatch(/may ask for an account/i);
+    // Still connectable — the endpoint probes on demand, and this is the only
+    // way to find out on an install that has never run a registry sync.
+    expect(connectBlockedReason(entry({ probed_auth_type: 'unknown' }))).toBeUndefined();
+  });
+
+  it('says outright when no account is needed', () => {
+    expect(connectStatus(entry()).readiness).toBe('ready');
+  });
+
+  it('carries a card-sized label for every blocked reason', () => {
+    expect(connectStatus(entry({ curated: false }))).toMatchObject({
+      readiness: 'blocked',
+      label: 'Not reviewed',
+    });
+    expect(connectStatus(entry({ probed_auth_type: 'oauth' }))).toMatchObject({
+      readiness: 'blocked',
+      label: 'Needs an account',
+    });
   });
 });
 

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -1,0 +1,92 @@
+import type { MCPCatalogEntry, MCPCatalogEntryID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  capabilityLabel,
+  connectBlockedReason,
+  DEFAULT_SORT,
+  entryTitle,
+} from './catalogPresentation';
+
+function entry(overrides: Partial<MCPCatalogEntry> = {}): MCPCatalogEntry {
+  return {
+    catalog_entry_id: 'id' as MCPCatalogEntryID,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+    name: 'com.example/mcp',
+    has_remote: true,
+    has_package: false,
+    curated: true,
+    verified: false,
+    remote_url: 'https://mcp.example.com/mcp',
+    transport: 'streamable-http',
+    probed_auth_type: 'none',
+    ...overrides,
+  };
+}
+
+describe('entryTitle', () => {
+  it('prefers a real title when one exists', () => {
+    expect(entryTitle(entry({ title: '  DeepWiki  ' }))).toBe('DeepWiki');
+  });
+
+  it('falls back to the publisher label, because curation never fills title', () => {
+    expect(entryTitle(entry({ name: 'io.github.github/github-mcp-server' }))).toBe('Github');
+    expect(entryTitle(entry({ name: 'co.huggingface/hf-mcp-server' }))).toBe('Huggingface');
+  });
+
+  it('skips protocol-name subdomains so a publisher is not labelled "Mcp"', () => {
+    expect(entryTitle(entry({ name: 'com.figma.mcp/mcp' }))).toBe('Figma');
+  });
+
+  it('keeps the registry name when no label survives', () => {
+    expect(entryTitle(entry({ name: 'mcp/mcp' }))).toBe('mcp/mcp');
+  });
+});
+
+describe('capabilityLabel', () => {
+  it('humanizes a machine tag', () => {
+    expect(capabilityLabel('pull-requests')).toBe('Pull requests');
+    expect(capabilityLabel('ci-cd')).toBe('Ci cd');
+  });
+});
+
+describe('connectBlockedReason', () => {
+  it('allows a curated, remote, no-auth entry', () => {
+    expect(connectBlockedReason(entry())).toBeUndefined();
+  });
+
+  it('treats an unprobed entry as connectable — connect probes on demand', () => {
+    expect(connectBlockedReason(entry({ probed_auth_type: 'unknown' }))).toBeUndefined();
+  });
+
+  it('refuses an entry that has not been reviewed', () => {
+    expect(connectBlockedReason(entry({ curated: false }))).toMatch(/reviewed by Preset/i);
+  });
+
+  it('refuses a locally-run server', () => {
+    expect(
+      connectBlockedReason(entry({ transport: 'stdio', has_remote: false, remote_url: undefined }))
+    ).toMatch(/runs locally/i);
+  });
+
+  it.each(['oauth', 'credentials'] as const)(
+    'refuses %s auth while only the no-auth branch exists',
+    (authType) => {
+      expect(connectBlockedReason(entry({ probed_auth_type: authType }))).toMatch(
+        /needs an account/i
+      );
+    }
+  );
+
+  it('refuses an unreachable endpoint', () => {
+    expect(connectBlockedReason(entry({ probed_auth_type: 'unreachable' }))).toMatch(
+      /could not be reached/i
+    );
+  });
+});
+
+describe('sort default', () => {
+  it("is curated rank, not the spec's install count — nothing counts installs", () => {
+    expect(DEFAULT_SORT).toBe('popularity');
+  });
+});

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -1,11 +1,13 @@
 import type { MCPCatalogEntry, MCPCatalogEntryID } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
+  CONNECTABLE_PROBE_VERDICTS,
   capabilityLabel,
   connectBlockedReason,
   connectStatus,
   DEFAULT_SORT,
   entryTitle,
+  isConnectable,
 } from './catalogPresentation';
 
 function entry(overrides: Partial<MCPCatalogEntry> = {}): MCPCatalogEntry {
@@ -116,6 +118,26 @@ describe('connectStatus', () => {
       readiness: 'blocked',
       label: 'Needs an account',
     });
+  });
+});
+
+describe('isConnectable', () => {
+  it('agrees with the card: an unprobed entry is connectable', () => {
+    expect(isConnectable(entry({ probed_auth_type: 'unknown' }))).toBe(true);
+    expect(connectStatus(entry({ probed_auth_type: 'unknown' })).readiness).not.toBe('blocked');
+  });
+
+  it('excludes what the card calls blocked', () => {
+    expect(isConnectable(entry({ probed_auth_type: 'oauth' }))).toBe(false);
+    expect(isConnectable(entry({ probed_auth_type: 'unreachable' }))).toBe(false);
+    expect(isConnectable(entry({ curated: false }))).toBe(false);
+  });
+
+  it('is the rule the query filter sends, so the two cannot drift', () => {
+    // Every verdict the filter keeps must be one the presentation also keeps.
+    for (const verdict of CONNECTABLE_PROBE_VERDICTS) {
+      expect(isConnectable(entry({ probed_auth_type: verdict }))).toBe(true);
+    }
   });
 });
 

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -20,6 +20,7 @@ function entry(overrides: Partial<MCPCatalogEntry> = {}): MCPCatalogEntry {
     remote_url: 'https://mcp.example.com/mcp',
     transport: 'streamable-http',
     probed_auth_type: 'none',
+    permission_disclosure: 'Reads public repository content only.',
     ...overrides,
   };
 }
@@ -77,6 +78,12 @@ describe('connectBlockedReason', () => {
       );
     }
   );
+
+  it('refuses an entry that discloses nothing, so no button can promise a connect', () => {
+    expect(connectBlockedReason(entry({ permission_disclosure: undefined }))).toMatch(
+      /has not stated what it can access/i
+    );
+  });
 
   it('refuses an unreachable endpoint', () => {
     expect(connectBlockedReason(entry({ probed_auth_type: 'unreachable' }))).toMatch(

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -1,0 +1,156 @@
+/**
+ * Display vocabulary for the catalog's closed enums.
+ *
+ * The stored values are machine tags (`dev-tools`, `pull-requests`); these are
+ * what a user reads. Kept beside the marketplace rather than in `@agor/core`
+ * because they are presentation, not part of the catalog contract.
+ */
+
+import type { MCPCatalogCategory, MCPCatalogEntry, MCPCatalogSort } from '@agor/core/types';
+import { MCP_CATALOG_CATEGORIES } from '@agor/core/types';
+
+export const CATEGORY_LABELS: Record<MCPCatalogCategory, string> = {
+  'dev-tools': 'Dev tools',
+  'data-storage': 'Data & storage',
+  productivity: 'Productivity',
+  messaging: 'Messaging',
+  observability: 'Observability',
+  search: 'Search',
+};
+
+export const ALL_CATEGORIES = 'all' as const;
+
+export type CategoryFilter = MCPCatalogCategory | typeof ALL_CATEGORIES;
+
+export const CATEGORY_OPTIONS: Array<{ label: string; value: CategoryFilter }> = [
+  { label: 'All', value: ALL_CATEGORIES },
+  ...MCP_CATALOG_CATEGORIES.map((category) => ({
+    label: CATEGORY_LABELS[category],
+    value: category as CategoryFilter,
+  })),
+];
+
+/**
+ * Capability tags, grouped the way the closed set is grouped in
+ * `@agor/core/types`. A flat 30-entry dropdown is unscannable; the groups are
+ * the same "what is this for" split the vocabulary was designed around.
+ */
+export const CAPABILITY_GROUPS: Array<{ label: string; capabilities: string[] }> = [
+  {
+    label: 'Building software',
+    capabilities: [
+      'code-repos',
+      'issues',
+      'pull-requests',
+      'ci-cd',
+      'deployments',
+      'code-search',
+      'docs',
+      'design',
+      'security-scan',
+    ],
+  },
+  {
+    label: 'Data',
+    capabilities: ['databases', 'sql', 'schema', 'files', 'datasets'],
+  },
+  {
+    label: 'Getting work done',
+    capabilities: ['tasks', 'projects', 'notes', 'crm', 'payments', 'content-cms', 'automations'],
+  },
+  {
+    label: 'Talking to people',
+    capabilities: ['messages', 'channels', 'email'],
+  },
+  {
+    label: 'Knowing what is happening',
+    capabilities: [
+      'metrics',
+      'logs',
+      'traces',
+      'alerts',
+      'incidents',
+      'analytics',
+      'feature-flags',
+    ],
+  },
+  {
+    label: 'Finding things out',
+    capabilities: ['web-search', 'web-scrape', 'network-checks'],
+  },
+];
+
+/** `pull-requests` → `Pull requests`. */
+export function capabilityLabel(capability: string): string {
+  const spaced = capability.replace(/-/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Sort options.
+ *
+ * The spec's "Most installs" default has no data source: nothing counts
+ * installs, and the registry publishes no popularity signal. `popularity` is
+ * the repository's curated-first, hand-assigned-rank ordering, so it is the
+ * default and is labelled for what it actually is.
+ */
+export const SORT_OPTIONS: Array<{ label: string; value: MCPCatalogSort }> = [
+  { label: 'Sort: Recommended', value: 'popularity' },
+  { label: 'Sort: Recently updated', value: 'recently_updated' },
+  { label: 'Sort: A–Z', value: 'name' },
+];
+
+export const DEFAULT_SORT: MCPCatalogSort = 'popularity';
+
+/**
+ * Display name for an entry.
+ *
+ * `title` is owned by the registry mirror, and curation deliberately leaves it
+ * alone — so on an install with registry sync off (the default) no entry has
+ * one, and rendering `name` directly would label the whole catalog with
+ * reverse-DNS strings like `com.deepwiki/mcp`. The publisher label carries the
+ * identity a user recognizes, so it stands in until a real title arrives.
+ *
+ * It cannot recover casing: `com.deepwiki` reads "Deepwiki", not "DeepWiki".
+ * Curated titles are the fix for that, not more derivation.
+ */
+export function entryTitle(entry: MCPCatalogEntry): string {
+  const title = entry.title?.trim();
+  if (title) return title;
+
+  const [domain = ''] = entry.name.split('/');
+  // Publishers routinely register the server under a subdomain — `com.figma.mcp`
+  // — so the trailing label is often the protocol's name rather than theirs.
+  const publisher = domain
+    .split('.')
+    .filter((label) => label && !GENERIC_NAME_LABELS.has(label.toLowerCase()))
+    .pop();
+  if (!publisher) return entry.name;
+  return publisher.charAt(0).toUpperCase() + publisher.slice(1);
+}
+
+const GENERIC_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api', 'www']);
+
+/**
+ * Why an entry cannot be connected yet, or `undefined` when it can.
+ *
+ * Mirrors the server-side rules in `mcp-catalog-connect`: uncurated entries are
+ * browse-only, and only the no-auth branch exists. `unknown` is deliberately
+ * treated as connectable — the seeded catalog has never been probed on an
+ * install with registry sync off, and connect probes on demand.
+ */
+export function connectBlockedReason(entry: MCPCatalogEntry): string | undefined {
+  if (!entry.curated) {
+    return 'Only servers reviewed by Preset can be connected from the marketplace.';
+  }
+  if (!entry.has_remote || !entry.remote_url || entry.transport === 'stdio') {
+    return 'This server runs locally rather than over the network. An admin configures it directly.';
+  }
+  if (entry.probed_auth_type === 'oauth' || entry.probed_auth_type === 'credentials') {
+    return 'This server needs an account. Signing in from the marketplace is not available yet.';
+  }
+  if (entry.probed_auth_type === 'unreachable') {
+    return 'This server could not be reached the last time Agor checked.';
+  }
+  return undefined;
+}

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -152,5 +152,12 @@ export function connectBlockedReason(entry: MCPCatalogEntry): string | undefined
   if (entry.probed_auth_type === 'unreachable') {
     return 'This server could not be reached the last time Agor checked.';
   }
+  // Connecting is gated on accepting what the server can reach, so an entry
+  // that states nothing has no acceptance to give. Curation requires one, so
+  // this is unreachable today — but it is what keeps a curation gap from
+  // rendering a connect button that can only fail.
+  if (!entry.permission_disclosure?.trim()) {
+    return 'This server has not stated what it can access, so it cannot be connected yet.';
+  }
   return undefined;
 }

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -12,7 +12,7 @@ import type {
   MCPCatalogProbedAuthType,
   MCPCatalogSort,
 } from '@agor/core/types';
-import { MCP_CATALOG_CATEGORIES } from '@agor/core/types';
+import { catalogDisplayName, MCP_CATALOG_CATEGORIES } from '@agor/core/types';
 
 export const CATEGORY_LABELS: Record<MCPCatalogCategory, string> = {
   'dev-tools': 'Dev tools',
@@ -110,31 +110,11 @@ export const DEFAULT_SORT: MCPCatalogSort = 'popularity';
 /**
  * Display name for an entry.
  *
- * `title` is owned by the registry mirror, and curation deliberately leaves it
- * alone — so on an install with registry sync off (the default) no entry has
- * one, and rendering `name` directly would label the whole catalog with
- * reverse-DNS strings like `com.deepwiki/mcp`. The publisher label carries the
- * identity a user recognizes, so it stands in until a real title arrives.
- *
- * It cannot recover casing: `com.deepwiki` reads "Deepwiki", not "DeepWiki".
- * Curated titles are the fix for that, not more derivation.
+ * The rule lives in `@agor/core` because connect needs it too — it names the
+ * created server and writes the refusals a user reads. Two derivations of "what
+ * is this server called" is how the agent ended up seeing `mcp__mcp__<tool>`.
  */
-export function entryTitle(entry: MCPCatalogEntry): string {
-  const title = entry.title?.trim();
-  if (title) return title;
-
-  const [domain = ''] = entry.name.split('/');
-  // Publishers routinely register the server under a subdomain — `com.figma.mcp`
-  // — so the trailing label is often the protocol's name rather than theirs.
-  const publisher = domain
-    .split('.')
-    .filter((label) => label && !GENERIC_NAME_LABELS.has(label.toLowerCase()))
-    .pop();
-  if (!publisher) return entry.name;
-  return publisher.charAt(0).toUpperCase() + publisher.slice(1);
-}
-
-const GENERIC_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api', 'www']);
+export const entryTitle = catalogDisplayName;
 
 /**
  * What a user would find out by pressing Connect, said before they press it.

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -132,32 +132,82 @@ export function entryTitle(entry: MCPCatalogEntry): string {
 const GENERIC_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api', 'www']);
 
 /**
- * Why an entry cannot be connected yet, or `undefined` when it can.
+ * What a user would find out by pressing Connect, said before they press it.
  *
- * Mirrors the server-side rules in `mcp-catalog-connect`: uncurated entries are
- * browse-only, and only the no-auth branch exists. `unknown` is deliberately
- * treated as connectable — the seeded catalog has never been probed on an
- * install with registry sync off, and connect probes on demand.
+ * Only the no-auth branch is wired, and most curated entries need an account —
+ * so without this the default experience is accepting a disclosure and then
+ * being refused. `unknown` is its own case rather than being folded into
+ * either side: the endpoint probes on demand and may well succeed, but a
+ * catalog that has never been probed cannot promise it will.
  */
-export function connectBlockedReason(entry: MCPCatalogEntry): string | undefined {
-  if (!entry.curated) {
-    return 'Only servers reviewed by Preset can be connected from the marketplace.';
-  }
+export type ConnectReadiness = 'ready' | 'unchecked' | 'blocked';
+
+export interface ConnectStatus {
+  readiness: ConnectReadiness;
+  /** Short enough for a card tag. */
+  label: string;
+  /** A sentence, for the drawer. */
+  detail: string;
+}
+
+const CONNECT_STATUSES = {
+  notReviewed: {
+    readiness: 'blocked',
+    label: 'Not reviewed',
+    detail: 'Only servers reviewed by Preset can be connected from the marketplace.',
+  },
+  local: {
+    readiness: 'blocked',
+    label: 'Runs locally',
+    detail:
+      'This server runs locally rather than over the network. An admin configures it directly.',
+  },
+  needsAccount: {
+    readiness: 'blocked',
+    label: 'Needs an account',
+    detail: 'This server needs an account. Signing in from the marketplace is not available yet.',
+  },
+  unreachable: {
+    readiness: 'blocked',
+    label: 'Unreachable',
+    detail: 'This server could not be reached the last time Agor checked.',
+  },
+  undisclosed: {
+    readiness: 'blocked',
+    label: 'No access statement',
+    detail: 'This server has not stated what it can access, so it cannot be connected yet.',
+  },
+  unchecked: {
+    readiness: 'unchecked',
+    label: 'Not checked yet',
+    detail:
+      'Agor has not checked this endpoint, so it may ask for an account. Connecting checks it — and stops there if it does.',
+  },
+  ready: {
+    readiness: 'ready',
+    label: 'No account needed',
+    detail: 'This server needs no account, so connecting it takes one step.',
+  },
+} as const satisfies Record<string, ConnectStatus>;
+
+export function connectStatus(entry: MCPCatalogEntry): ConnectStatus {
+  if (!entry.curated) return CONNECT_STATUSES.notReviewed;
   if (!entry.has_remote || !entry.remote_url || entry.transport === 'stdio') {
-    return 'This server runs locally rather than over the network. An admin configures it directly.';
+    return CONNECT_STATUSES.local;
   }
   if (entry.probed_auth_type === 'oauth' || entry.probed_auth_type === 'credentials') {
-    return 'This server needs an account. Signing in from the marketplace is not available yet.';
+    return CONNECT_STATUSES.needsAccount;
   }
-  if (entry.probed_auth_type === 'unreachable') {
-    return 'This server could not be reached the last time Agor checked.';
-  }
-  // Connecting is gated on accepting what the server can reach, so an entry
-  // that states nothing has no acceptance to give. Curation requires one, so
-  // this is unreachable today — but it is what keeps a curation gap from
-  // rendering a connect button that can only fail.
-  if (!entry.permission_disclosure?.trim()) {
-    return 'This server has not stated what it can access, so it cannot be connected yet.';
-  }
-  return undefined;
+  if (entry.probed_auth_type === 'unreachable') return CONNECT_STATUSES.unreachable;
+  // Curation requires a disclosure, so this is unreachable today — but it is
+  // what keeps a curation gap from offering a connect that could only fail.
+  if (!entry.permission_disclosure?.trim()) return CONNECT_STATUSES.undisclosed;
+  if (entry.probed_auth_type !== 'none') return CONNECT_STATUSES.unchecked;
+  return CONNECT_STATUSES.ready;
+}
+
+/** Why connecting is refused outright, or `undefined` when it may proceed. */
+export function connectBlockedReason(entry: MCPCatalogEntry): string | undefined {
+  const status = connectStatus(entry);
+  return status.readiness === 'blocked' ? status.detail : undefined;
 }

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -6,7 +6,12 @@
  * because they are presentation, not part of the catalog contract.
  */
 
-import type { MCPCatalogCategory, MCPCatalogEntry, MCPCatalogSort } from '@agor/core/types';
+import type {
+  MCPCatalogCategory,
+  MCPCatalogEntry,
+  MCPCatalogProbedAuthType,
+  MCPCatalogSort,
+} from '@agor/core/types';
 import { MCP_CATALOG_CATEGORIES } from '@agor/core/types';
 
 export const CATEGORY_LABELS: Record<MCPCatalogCategory, string> = {
@@ -190,6 +195,20 @@ const CONNECT_STATUSES = {
   },
 } as const satisfies Record<string, ConnectStatus>;
 
+/**
+ * Probe verdicts that are not a refusal.
+ *
+ * The same rule the cards state: `none` is confirmed open, and `unknown` has
+ * simply never been checked — connect probes it on demand and stops cleanly if
+ * it turns out to need an account. Registry sync is off by default, so every
+ * seeded row is `unknown`; a filter that demanded `none` could only ever return
+ * nothing, while the card beside it called the entry connectable.
+ *
+ * Exported so the toolbar's filter and `connectStatus` cannot drift into
+ * disagreeing about what "connectable" means.
+ */
+export const CONNECTABLE_PROBE_VERDICTS: MCPCatalogProbedAuthType[] = ['none', 'unknown'];
+
 export function connectStatus(entry: MCPCatalogEntry): ConnectStatus {
   if (!entry.curated) return CONNECT_STATUSES.notReviewed;
   if (!entry.has_remote || !entry.remote_url || entry.transport === 'stdio') {
@@ -204,6 +223,14 @@ export function connectStatus(entry: MCPCatalogEntry): ConnectStatus {
   if (!entry.permission_disclosure?.trim()) return CONNECT_STATUSES.undisclosed;
   if (entry.probed_auth_type !== 'none') return CONNECT_STATUSES.unchecked;
   return CONNECT_STATUSES.ready;
+}
+
+/** Whether the "connectable now" filter would keep this entry. */
+export function isConnectable(entry: MCPCatalogEntry): boolean {
+  return (
+    connectStatus(entry).readiness !== 'blocked' &&
+    CONNECTABLE_PROBE_VERDICTS.includes(entry.probed_auth_type)
+  );
 }
 
 /** Why connecting is refused outright, or `undefined` when it may proceed. */

--- a/apps/agor-ui/src/components/Marketplace/index.ts
+++ b/apps/agor-ui/src/components/Marketplace/index.ts
@@ -1,0 +1,1 @@
+export { CatalogTab } from './CatalogTab';

--- a/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
+++ b/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
@@ -16,6 +16,7 @@
 import type { MCPCatalogCategory, MCPCatalogEntry, MCPCatalogSort } from '@agor/core/types';
 import type { AgorClient, FindResult } from '@agor-live/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { CONNECTABLE_PROBE_VERDICTS } from './catalogPresentation';
 
 /** The catalog service always paginates; an array is only a defensive fallback. */
 function asPage(result: FindResult<MCPCatalogEntry>): { data: MCPCatalogEntry[]; total: number } {
@@ -73,7 +74,7 @@ function buildQuery(filters: CatalogFilterState, page: number): Record<string, u
     ...(filters.category ? { category: filters.category } : {}),
     ...(filters.capability ? { capability: filters.capability } : {}),
     ...(filters.reviewedOnly ? { curated: true } : {}),
-    ...(filters.connectableOnly ? { probed_auth_type: 'none' } : {}),
+    ...(filters.connectableOnly ? { probed_auth_types: CONNECTABLE_PROBE_VERDICTS } : {}),
     sort: filters.sort,
     $limit: CATALOG_PAGE_SIZE,
     $skip: (page - 1) * CATALOG_PAGE_SIZE,

--- a/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
+++ b/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
@@ -7,11 +7,15 @@
  * deliberately not hydrated into the workspace store, which models a
  * fully-loaded tenant-scoped collection kept live by socket events. The catalog
  * has no writers a browser can observe and nothing to keep live.
+ *
+ * Reads wait for `ready`. The client object exists from the moment the socket
+ * is being built, well before it has connected and authenticated, so a surface
+ * that fetches on `client !== null` asks an anonymous socket and is refused.
  */
 
 import type { MCPCatalogCategory, MCPCatalogEntry, MCPCatalogSort } from '@agor/core/types';
 import type { AgorClient, FindResult } from '@agor-live/client';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /** The catalog service always paginates; an array is only a defensive fallback. */
 function asPage(result: FindResult<MCPCatalogEntry>): { data: MCPCatalogEntry[]; total: number } {
@@ -27,23 +31,39 @@ export interface CatalogFilterState {
   category?: MCPCatalogCategory;
   capability?: string;
   reviewedOnly: boolean;
+  connectableOnly: boolean;
   sort: MCPCatalogSort;
 }
 
 export function isFilterActive(filters: CatalogFilterState): boolean {
   return Boolean(
-    filters.search.trim() || filters.category || filters.capability || filters.reviewedOnly
+    filters.search.trim() ||
+      filters.category ||
+      filters.capability ||
+      filters.reviewedOnly ||
+      filters.connectableOnly
   );
 }
 
+/**
+ * Load state as three exclusive cases.
+ *
+ * A boolean pair let "the read failed" and "the catalog has nothing to show"
+ * reach the same branch, and an empty grid is the more plausible-looking of
+ * the two — so a broken read rendered as an honest-looking answer. `empty` is
+ * now only reachable from a read that actually returned.
+ */
+export type CatalogStatus = 'loading' | 'ready' | 'error';
+
 export interface CatalogSearchResult {
   entries: MCPCatalogEntry[];
-  /** Rows matching the active filters. */
+  status: CatalogStatus;
+  /** Rows matching the active filters. Meaningful only when `ready`. */
   matchCount: number;
   /** Rows in the catalog with no filters applied, for "N of M". */
   catalogSize: number | null;
-  loading: boolean;
   error: string | null;
+  retry: () => void;
 }
 
 function buildQuery(filters: CatalogFilterState, page: number): Record<string, unknown> {
@@ -53,6 +73,7 @@ function buildQuery(filters: CatalogFilterState, page: number): Record<string, u
     ...(filters.category ? { category: filters.category } : {}),
     ...(filters.capability ? { capability: filters.capability } : {}),
     ...(filters.reviewedOnly ? { curated: true } : {}),
+    ...(filters.connectableOnly ? { probed_auth_type: 'none' } : {}),
     sort: filters.sort,
     $limit: CATALOG_PAGE_SIZE,
     $skip: (page - 1) * CATALOG_PAGE_SIZE,
@@ -60,28 +81,41 @@ function buildQuery(filters: CatalogFilterState, page: number): Record<string, u
 }
 
 export function useCatalogSearch(
-  client: AgorClient,
+  client: AgorClient | null,
+  ready: boolean,
   filters: CatalogFilterState,
   page: number
 ): CatalogSearchResult {
   const [entries, setEntries] = useState<MCPCatalogEntry[]>([]);
+  const [status, setStatus] = useState<CatalogStatus>('loading');
   const [matchCount, setMatchCount] = useState(0);
   const [catalogSize, setCatalogSize] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryToken, setRetryToken] = useState(0);
 
   // Responses can land out of order — a cheap `$skip` page overtaking a slow
   // search. Only the newest request may write state.
   const requestSeq = useRef(0);
 
-  const { search, category, capability, reviewedOnly, sort } = filters;
+  const { search, category, capability, reviewedOnly, connectableOnly, sort } = filters;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryToken is a manual re-run trigger, not a value the effect reads
   useEffect(() => {
+    if (!client || !ready) {
+      // Not a result, so not an empty one. Hold the loading state until the
+      // socket can actually answer.
+      setStatus('loading');
+      return;
+    }
+
     const seq = ++requestSeq.current;
     let cancelled = false;
-    setLoading(true);
+    setStatus('loading');
 
-    const query = buildQuery({ search, category, capability, reviewedOnly, sort }, page);
+    const query = buildQuery(
+      { search, category, capability, reviewedOnly, connectableOnly, sort },
+      page
+    );
     client
       .service('mcp-catalog')
       .find({ query })
@@ -91,33 +125,44 @@ export function useCatalogSearch(
         setEntries(matched.data);
         setMatchCount(matched.total);
         setError(null);
+        setStatus('ready');
       })
       .catch((err: unknown) => {
         if (cancelled || seq !== requestSeq.current) return;
         setEntries([]);
         setMatchCount(0);
         setError(err instanceof Error ? err.message : 'Could not load the catalog');
-      })
-      .finally(() => {
-        if (cancelled || seq !== requestSeq.current) return;
-        setLoading(false);
+        setStatus('error');
       });
 
     return () => {
       cancelled = true;
     };
-  }, [client, search, category, capability, reviewedOnly, sort, page]);
+  }, [
+    client,
+    ready,
+    search,
+    category,
+    capability,
+    reviewedOnly,
+    connectableOnly,
+    sort,
+    page,
+    retryToken,
+  ]);
 
   // The unfiltered size is the M in "N of M". It changes only when ingestion
-  // runs, so it is read once rather than alongside every filtered page.
+  // runs, so it is read once rather than alongside every filtered page. A
+  // failure here only costs the count, never the grid.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryToken is a manual re-run trigger, not a value the effect reads
   useEffect(() => {
+    if (!client || !ready) return;
     let cancelled = false;
     client
       .service('mcp-catalog')
       .find({ query: { $limit: 1 } })
       .then((result) => {
-        if (cancelled) return;
-        setCatalogSize(asPage(result).total);
+        if (!cancelled) setCatalogSize(asPage(result).total);
       })
       .catch(() => {
         if (!cancelled) setCatalogSize(null);
@@ -125,7 +170,9 @@ export function useCatalogSearch(
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [client, ready, retryToken]);
 
-  return { entries, matchCount, catalogSize, loading, error };
+  const retry = useCallback(() => setRetryToken((token) => token + 1), []);
+
+  return { entries, status, matchCount, catalogSize, error, retry };
 }

--- a/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
+++ b/apps/agor-ui/src/components/Marketplace/useCatalogSearch.ts
@@ -1,0 +1,131 @@
+/**
+ * Paged reads of `/mcp-catalog`.
+ *
+ * The catalog is a global table that grows to thousands of registry rows, and
+ * every predicate, the ordering and the page bounds already resolve in SQL. So
+ * this fetches one page at a time and never holds the result set — it is
+ * deliberately not hydrated into the workspace store, which models a
+ * fully-loaded tenant-scoped collection kept live by socket events. The catalog
+ * has no writers a browser can observe and nothing to keep live.
+ */
+
+import type { MCPCatalogCategory, MCPCatalogEntry, MCPCatalogSort } from '@agor/core/types';
+import type { AgorClient, FindResult } from '@agor-live/client';
+import { useEffect, useRef, useState } from 'react';
+
+/** The catalog service always paginates; an array is only a defensive fallback. */
+function asPage(result: FindResult<MCPCatalogEntry>): { data: MCPCatalogEntry[]; total: number } {
+  return Array.isArray(result)
+    ? { data: result, total: result.length }
+    : { data: result.data, total: result.total };
+}
+
+export const CATALOG_PAGE_SIZE = 24;
+
+export interface CatalogFilterState {
+  search: string;
+  category?: MCPCatalogCategory;
+  capability?: string;
+  reviewedOnly: boolean;
+  sort: MCPCatalogSort;
+}
+
+export function isFilterActive(filters: CatalogFilterState): boolean {
+  return Boolean(
+    filters.search.trim() || filters.category || filters.capability || filters.reviewedOnly
+  );
+}
+
+export interface CatalogSearchResult {
+  entries: MCPCatalogEntry[];
+  /** Rows matching the active filters. */
+  matchCount: number;
+  /** Rows in the catalog with no filters applied, for "N of M". */
+  catalogSize: number | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function buildQuery(filters: CatalogFilterState, page: number): Record<string, unknown> {
+  const search = filters.search.trim();
+  return {
+    ...(search ? { search } : {}),
+    ...(filters.category ? { category: filters.category } : {}),
+    ...(filters.capability ? { capability: filters.capability } : {}),
+    ...(filters.reviewedOnly ? { curated: true } : {}),
+    sort: filters.sort,
+    $limit: CATALOG_PAGE_SIZE,
+    $skip: (page - 1) * CATALOG_PAGE_SIZE,
+  };
+}
+
+export function useCatalogSearch(
+  client: AgorClient,
+  filters: CatalogFilterState,
+  page: number
+): CatalogSearchResult {
+  const [entries, setEntries] = useState<MCPCatalogEntry[]>([]);
+  const [matchCount, setMatchCount] = useState(0);
+  const [catalogSize, setCatalogSize] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Responses can land out of order — a cheap `$skip` page overtaking a slow
+  // search. Only the newest request may write state.
+  const requestSeq = useRef(0);
+
+  const { search, category, capability, reviewedOnly, sort } = filters;
+
+  useEffect(() => {
+    const seq = ++requestSeq.current;
+    let cancelled = false;
+    setLoading(true);
+
+    const query = buildQuery({ search, category, capability, reviewedOnly, sort }, page);
+    client
+      .service('mcp-catalog')
+      .find({ query })
+      .then((result) => {
+        if (cancelled || seq !== requestSeq.current) return;
+        const matched = asPage(result);
+        setEntries(matched.data);
+        setMatchCount(matched.total);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled || seq !== requestSeq.current) return;
+        setEntries([]);
+        setMatchCount(0);
+        setError(err instanceof Error ? err.message : 'Could not load the catalog');
+      })
+      .finally(() => {
+        if (cancelled || seq !== requestSeq.current) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, search, category, capability, reviewedOnly, sort, page]);
+
+  // The unfiltered size is the M in "N of M". It changes only when ingestion
+  // runs, so it is read once rather than alongside every filtered page.
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .service('mcp-catalog')
+      .find({ query: { $limit: 1 } })
+      .then((result) => {
+        if (cancelled) return;
+        setCatalogSize(asPage(result).total);
+      })
+      .catch(() => {
+        if (!cancelled) setCatalogSize(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  return { entries, matchCount, catalogSize, loading, error };
+}

--- a/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
+++ b/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
@@ -1,0 +1,78 @@
+/**
+ * Branches a connect can land in.
+ *
+ * The marketplace is its own surface and never starts the workspace store, so
+ * it reads the branch list directly rather than through the store's normalized
+ * maps. It is also lazy: browsing the catalog costs nothing until a drawer
+ * opens and a destination is actually needed.
+ */
+
+import type { Branch } from '@agor/core/types';
+import type { AgorClient, FindResult } from '@agor-live/client';
+import { useEffect, useState } from 'react';
+
+const BRANCH_LIMIT = 200;
+const LAST_BRANCH_KEY = 'agor-marketplace-branch';
+
+export interface ConnectTargets {
+  branches: Branch[];
+  loading: boolean;
+  error: string | null;
+}
+
+function toArray(result: FindResult<Branch>): Branch[] {
+  return Array.isArray(result) ? result : result.data;
+}
+
+export function useConnectTargets(client: AgorClient, enabled: boolean): ConnectTargets {
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || loaded) return;
+    let cancelled = false;
+    setLoading(true);
+
+    client
+      .service('branches')
+      .find({ query: { archived: false, $limit: BRANCH_LIMIT } })
+      .then((result) => {
+        if (cancelled) return;
+        setBranches(toArray(result));
+        setError(null);
+        setLoaded(true);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Could not load your branches');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, enabled, loaded]);
+
+  return { branches, loading, error };
+}
+
+/** The branch the user last connected into, so the picker is usually pre-answered. */
+export function getLastConnectBranchId(): string | null {
+  try {
+    return localStorage.getItem(LAST_BRANCH_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function rememberConnectBranchId(branchId: string): void {
+  try {
+    localStorage.setItem(LAST_BRANCH_KEY, branchId);
+  } catch {
+    // localStorage full or unavailable
+  }
+}

--- a/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
+++ b/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
@@ -19,14 +19,14 @@ export interface ConnectTargets {
   error: string | null;
 }
 
-export function useConnectTargets(client: AgorClient, enabled: boolean): ConnectTargets {
+export function useConnectTargets(client: AgorClient | null, enabled: boolean): ConnectTargets {
   const [branches, setBranches] = useState<Branch[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (!enabled || loaded) return;
+    if (!client || !enabled || loaded) return;
     let cancelled = false;
     setLoading(true);
 

--- a/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
+++ b/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
@@ -8,20 +8,15 @@
  */
 
 import type { Branch } from '@agor/core/types';
-import type { AgorClient, FindResult } from '@agor-live/client';
+import type { AgorClient } from '@agor-live/client';
 import { useEffect, useState } from 'react';
 
-const BRANCH_LIMIT = 200;
 const LAST_BRANCH_KEY = 'agor-marketplace-branch';
 
 export interface ConnectTargets {
   branches: Branch[];
   loading: boolean;
   error: string | null;
-}
-
-function toArray(result: FindResult<Branch>): Branch[] {
-  return Array.isArray(result) ? result : result.data;
 }
 
 export function useConnectTargets(client: AgorClient, enabled: boolean): ConnectTargets {
@@ -35,12 +30,15 @@ export function useConnectTargets(client: AgorClient, enabled: boolean): Connect
     let cancelled = false;
     setLoading(true);
 
+    // Every accessible branch, not a first page. A branch missing from this
+    // list is a destination the user simply cannot pick, with nothing on screen
+    // to say why — so a silent cap here reads as "you have no such branch".
     client
       .service('branches')
-      .find({ query: { archived: false, $limit: BRANCH_LIMIT } })
+      .findAll({ query: { archived: false } })
       .then((result) => {
         if (cancelled) return;
-        setBranches(toArray(result));
+        setBranches(result);
         setError(null);
         setLoaded(true);
       })

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -66,6 +66,7 @@ import {
 import { getContextWindowGradient } from '../../utils/contextWindow';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
+import { deletePromptDraft, getPromptDraft, savePromptDraft } from '../../utils/promptDrafts';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
@@ -407,33 +408,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       .map((server) => server!);
   }, [sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds]);
 
-  // Per-session draft storage (localStorage-backed to survive unmounts)
-  const DRAFT_KEY_PREFIX = 'agor-draft-';
-  const getDraft = React.useCallback((sessionId: string): string => {
-    try {
-      return localStorage.getItem(`${DRAFT_KEY_PREFIX}${sessionId}`) || '';
-    } catch {
-      return '';
-    }
-  }, []);
-  const saveDraft = React.useCallback((sessionId: string, value: string) => {
-    try {
-      if (value.trim()) {
-        localStorage.setItem(`${DRAFT_KEY_PREFIX}${sessionId}`, value);
-      } else {
-        localStorage.removeItem(`${DRAFT_KEY_PREFIX}${sessionId}`);
-      }
-    } catch {
-      // localStorage full or unavailable
-    }
-  }, []);
-  const deleteDraft = React.useCallback((sessionId: string) => {
-    try {
-      localStorage.removeItem(`${DRAFT_KEY_PREFIX}${sessionId}`);
-    } catch {
-      // ignore
-    }
-  }, []);
+  // Per-session draft storage (localStorage-backed to survive unmounts).
+  // Aliased as stable callbacks because they're threaded through props and
+  // effect deps below.
+  const getDraft = React.useCallback(getPromptDraft, []);
+  const saveDraft = React.useCallback(savePromptDraft, []);
+  const deleteDraft = React.useCallback(deletePromptDraft, []);
 
   // Input value lives entirely inside PromptInput (local state).
   // The parent reads it imperatively via promptRef / inputValueRef — no

--- a/apps/agor-ui/src/pages/MarketplacePage.tsx
+++ b/apps/agor-ui/src/pages/MarketplacePage.tsx
@@ -12,7 +12,7 @@
 import type { User } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { ArrowLeftOutlined, ShopOutlined } from '@ant-design/icons';
-import { Alert, Button, Layout, Space, Typography, theme } from 'antd';
+import { Button, Layout, Space, Typography, theme } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { BrandLogo } from '../components/BrandLogo';
 import { GlobalUserMenu } from '../components/GlobalUserMenu';
@@ -25,6 +25,15 @@ const HEADER_HEIGHT = 56;
 
 export interface MarketplacePageProps {
   client: AgorClient | null;
+  /**
+   * The daemon socket has connected and authenticated.
+   *
+   * The client object exists from the moment the socket is being built, so
+   * this — not `client !== null` — is what says a read will be answered. The
+   * workspace shell blocks its whole render until it is true; a lightweight
+   * surface renders immediately and has to carry the distinction itself.
+   */
+  connected: boolean;
   currentUser?: User | null;
   onUserSettingsClick?: () => void;
   onLogout?: () => void;
@@ -32,6 +41,7 @@ export interface MarketplacePageProps {
 
 export const MarketplacePage: React.FC<MarketplacePageProps> = ({
   client,
+  connected,
   currentUser,
   onUserSettingsClick,
   onLogout,
@@ -89,16 +99,7 @@ export const MarketplacePage: React.FC<MarketplacePageProps> = ({
           <Paragraph type="secondary" style={{ marginBottom: token.margin }}>
             Attach tools to your agents — browse, review permissions, connect.
           </Paragraph>
-          {client ? (
-            <CatalogTab client={client} />
-          ) : (
-            <Alert
-              type="warning"
-              showIcon
-              message="Not connected to the Agor daemon"
-              description="The catalog needs a live connection to load."
-            />
-          )}
+          <CatalogTab client={client} connected={connected} />
         </div>
       </Content>
     </Layout>

--- a/apps/agor-ui/src/pages/MarketplacePage.tsx
+++ b/apps/agor-ui/src/pages/MarketplacePage.tsx
@@ -1,0 +1,106 @@
+/**
+ * Marketplace surface: browse the MCP catalog and connect a server.
+ *
+ * A standalone surface rather than a workspace route — it reads the global
+ * catalog table and does not need the tenant's boards, sessions or canvas, so
+ * it keeps the same lightweight chrome as Knowledge.
+ *
+ * The Catalog is the only tab in this slice. My Servers, Sessions and
+ * Credentials arrive with the data models behind them.
+ */
+
+import type { User } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { ArrowLeftOutlined, ShopOutlined } from '@ant-design/icons';
+import { Alert, Button, Layout, Space, Typography, theme } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import { BrandLogo } from '../components/BrandLogo';
+import { GlobalUserMenu } from '../components/GlobalUserMenu';
+import { CatalogTab } from '../components/Marketplace';
+
+const { Header, Content } = Layout;
+const { Text, Title, Paragraph } = Typography;
+
+const HEADER_HEIGHT = 56;
+
+export interface MarketplacePageProps {
+  client: AgorClient | null;
+  currentUser?: User | null;
+  onUserSettingsClick?: () => void;
+  onLogout?: () => void;
+}
+
+export const MarketplacePage: React.FC<MarketplacePageProps> = ({
+  client,
+  currentUser,
+  onUserSettingsClick,
+  onLogout,
+}) => {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+
+  return (
+    <Layout style={{ height: '100vh', background: token.colorBgLayout }}>
+      <Header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          height: HEADER_HEIGHT,
+          padding: `0 ${token.padding}px`,
+          background: token.colorBgContainer,
+          borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        }}
+      >
+        <Space size={token.marginSM}>
+          <Button
+            type="text"
+            aria-label="Back to workspace"
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate('/')}
+          />
+          <BrandLogo level={3} style={{ marginTop: -4 }} />
+          <Text
+            strong
+            style={{ display: 'inline-flex', alignItems: 'center', gap: token.sizeUnit }}
+          >
+            <ShopOutlined style={{ color: token.colorTextSecondary }} />
+            Marketplace
+          </Text>
+        </Space>
+        <GlobalUserMenu
+          user={currentUser}
+          onUserSettingsClick={onUserSettingsClick}
+          onLogout={onLogout}
+        />
+      </Header>
+
+      <Content
+        style={{
+          height: `calc(100vh - ${HEADER_HEIGHT}px)`,
+          overflow: 'auto',
+          padding: token.paddingLG,
+        }}
+      >
+        <div style={{ maxWidth: 1400, margin: '0 auto' }}>
+          <Title level={3} style={{ marginTop: 0, marginBottom: token.marginXXS }}>
+            Marketplace
+          </Title>
+          <Paragraph type="secondary" style={{ marginBottom: token.margin }}>
+            Attach tools to your agents — browse, review permissions, connect.
+          </Paragraph>
+          {client ? (
+            <CatalogTab client={client} />
+          ) : (
+            <Alert
+              type="warning"
+              showIcon
+              message="Not connected to the Agor daemon"
+              description="The catalog needs a live connection to load."
+            />
+          )}
+        </div>
+      </Content>
+    </Layout>
+  );
+};

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
@@ -43,6 +43,22 @@ describe('surface route registry', () => {
     }
   );
 
+  it.each(['/marketplace'])('classifies %s as Marketplace', (path) => {
+    expect(getRouteSurface(path).id).toBe('marketplace');
+    expect(isWorkspaceRoutePath(path)).toBe(false);
+    // Browsing the catalog must not spin up the board/session store.
+    expect(routeStartsWorkspaceRuntime(path)).toBe(false);
+    expect(routeUsesDeviceRouter(path)).toBe(false);
+    expect(routeUsesSharedUserSettings(path)).toBe(true);
+  });
+
+  it.each(['/marketplaces', '/marketplace/extra'])(
+    'does not treat similarly prefixed path %s as Marketplace',
+    (path) => {
+      expect(getRouteSurface(path).id).toBe('workspace');
+    }
+  );
+
   it.each(['/a/artifact/fullscreen'])('classifies %s as Artifact fullscreen', (path) => {
     expect(getRouteSurface(path).id).toBe('artifact-fullscreen');
     expect(isKnowledgeRoutePath(path)).toBe(false);

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -1,7 +1,12 @@
 import { matchPath } from 'react-router-dom';
 import { surfaceTitle } from '../branding/brand';
 
-export type RouteSurfaceId = 'workspace' | 'knowledge' | 'artifact-fullscreen' | 'demo';
+export type RouteSurfaceId =
+  | 'workspace'
+  | 'knowledge'
+  | 'marketplace'
+  | 'artifact-fullscreen'
+  | 'demo';
 
 export interface RouteSurfaceDefinition {
   id: RouteSurfaceId;
@@ -65,6 +70,21 @@ export const KNOWLEDGE_SURFACE = defineSurface({
   branding: surfaceTitle('Knowledge'),
 });
 
+export const MARKETPLACE_ROUTE_PATHS = ['/marketplace'] as const;
+
+export const MARKETPLACE_SURFACE = defineSurface({
+  id: 'marketplace',
+  label: 'Marketplace',
+  routePaths: MARKETPLACE_ROUTE_PATHS,
+  // Browsing the catalog reads a paginated global table, not the tenant's
+  // boards and sessions, so the workspace store stays cold until connect
+  // navigates into a session.
+  startsWorkspaceRuntime: false,
+  usesDeviceRouter: false,
+  usesSharedUserSettings: true,
+  branding: surfaceTitle('Marketplace'),
+});
+
 export const ARTIFACT_FULLSCREEN_ROUTE_PATHS = ['/a/:artifactShortId/fullscreen'] as const;
 
 export const ARTIFACT_FULLSCREEN_SURFACE = defineSurface({
@@ -101,6 +121,7 @@ export const WORKSPACE_SURFACE = defineSurface({
 
 export const SURFACE_REGISTRY = [
   KNOWLEDGE_SURFACE,
+  MARKETPLACE_SURFACE,
   ARTIFACT_FULLSCREEN_SURFACE,
   DEMO_SURFACE,
   WORKSPACE_SURFACE,

--- a/apps/agor-ui/src/utils/promptDrafts.ts
+++ b/apps/agor-ui/src/utils/promptDrafts.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-session composer drafts.
+ *
+ * localStorage-backed so a draft survives the session panel unmounting, and
+ * shared so anything that wants to seed a composer writes through the same key
+ * the panel reads — the marketplace connect flow pre-loads a starter prompt
+ * into a session it has just created, on a surface that never mounts the panel.
+ */
+
+const DRAFT_KEY_PREFIX = 'agor-draft-';
+
+const draftKey = (sessionId: string): string => `${DRAFT_KEY_PREFIX}${sessionId}`;
+
+export function getPromptDraft(sessionId: string): string {
+  try {
+    return localStorage.getItem(draftKey(sessionId)) || '';
+  } catch {
+    return '';
+  }
+}
+
+/** Store a draft, or clear it when the value is blank. */
+export function savePromptDraft(sessionId: string, value: string): void {
+  try {
+    if (value.trim()) {
+      localStorage.setItem(draftKey(sessionId), value);
+    } else {
+      localStorage.removeItem(draftKey(sessionId));
+    }
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+export function deletePromptDraft(sessionId: string): void {
+  try {
+    localStorage.removeItem(draftKey(sessionId));
+  } catch {
+    // ignore
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -48,6 +48,7 @@ export type {
   BoardsService,
   BranchesService,
   ClientInput,
+  FindResult,
   GatewayChannelsService,
   MessagesService,
   ReposCloneService,

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -33,6 +33,9 @@ import type {
   KnowledgeSearchResult,
   KnowledgeSemanticSettingsPatch,
   KnowledgeSemanticSettingsPublic,
+  MCPCatalogConnectData,
+  MCPCatalogConnectResult,
+  MCPCatalogEntry,
   MCPServer,
   Message,
   OpenCodeModelCatalog,
@@ -209,6 +212,8 @@ export interface ServiceTypes {
   'card-types': CardType; // CardType CRUD
   artifacts: Artifact;
   'mcp-servers': MCPServer;
+  'mcp-catalog': MCPCatalogEntry;
+  'mcp-catalog/connect': MCPCatalogConnectResult;
   'kb/namespaces': KnowledgeNamespace;
   'kb/documents': KnowledgeDocument;
   'kb/versions': KnowledgeDocumentVersion;
@@ -340,6 +345,16 @@ export interface OpenCodeAuthService {
 
 export interface OpenCodeModelsService {
   find(params?: Params): Promise<OpenCodeModelCatalog>;
+}
+
+/**
+ * Marketplace connect command endpoint.
+ *
+ * Create-only: it installs one catalog entry and returns the session that can
+ * use it. There is nothing to read back, so it exposes no find/get.
+ */
+export interface MCPCatalogConnectService {
+  create(data: MCPCatalogConnectData, params?: Params): Promise<MCPCatalogConnectResult>;
 }
 
 /**
@@ -681,6 +696,8 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'card-types'): AgorService<CardType>;
   service(path: 'users'): UsersService;
   service(path: 'mcp-servers'): AgorService<MCPServer>;
+  service(path: 'mcp-catalog'): AgorService<MCPCatalogEntry>;
+  service(path: 'mcp-catalog/connect'): MCPCatalogConnectService;
   service(path: 'templates'): TemplatesService;
 
   // Generic fallback for custom routes and dynamic paths

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -13,6 +13,7 @@ export type {
   BoardsService,
   BranchesService,
   ClientInput,
+  FindResult,
   GatewayChannelsService,
   MessagesBulkService,
   MessagesService,

--- a/packages/core/src/db/repositories/mcp-catalog.test.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.test.ts
@@ -289,6 +289,48 @@ describe('MCPCatalogRepository filter semantics', () => {
     ]);
   });
 
+  dbTest('matches any one of several probe verdicts', async ({ db }) => {
+    const repository = new MCPCatalogRepository(db);
+    // Each verdict has to describe the row's current endpoint, or the
+    // repository discards it as stale.
+    await repository.upsertRegistryEntry({
+      name: 'a.example/open',
+      remote_url: 'https://open.example.com/mcp',
+    });
+    await repository.upsertRegistryEntry({
+      name: 'b.example/locked',
+      remote_url: 'https://locked.example.com/mcp',
+    });
+    await repository.upsertRegistryEntry({ name: 'c.example/unprobed' });
+    await repository.recordProbeResult('a.example/open', {
+      probed_auth_type: 'none',
+      probed_at: new Date(),
+      probed_url: 'https://open.example.com/mcp',
+    });
+    await repository.recordProbeResult('b.example/locked', {
+      probed_auth_type: 'oauth',
+      probed_at: new Date(),
+      probed_url: 'https://locked.example.com/mcp',
+    });
+
+    // What the marketplace's "hide account-only" filter asks for: everything
+    // not known to refuse, which on an install that never probed is all of it.
+    const connectable = await repository.findAll({ probed_auth_types: ['none', 'unknown'] });
+    expect(connectable.map((entry) => entry.name).sort()).toEqual([
+      'a.example/open',
+      'c.example/unprobed',
+    ]);
+    expect(await repository.count({ probed_auth_types: ['none', 'unknown'] })).toBe(2);
+  });
+
+  dbTest('returns nothing for an empty probe-verdict allowlist', async ({ db }) => {
+    const repository = new MCPCatalogRepository(db);
+    await repository.upsertRegistryEntry({ name: 'a.example/one' });
+
+    expect(await repository.findAll({ probed_auth_types: [] })).toEqual([]);
+    expect(await repository.count({ probed_auth_types: [] })).toBe(0);
+  });
+
   dbTest('returns nothing for an empty name allowlist', async ({ db }) => {
     const repository = new MCPCatalogRepository(db);
     await repository.upsertRegistryEntry({ name: 'a.example/one' });

--- a/packages/core/src/db/repositories/mcp-catalog.ts
+++ b/packages/core/src/db/repositories/mcp-catalog.ts
@@ -334,6 +334,10 @@ export class MCPCatalogRepository {
         sql`(${mcpCatalogEntries.registry_status} IS NULL OR ${mcpCatalogEntries.registry_status} <> ${filters.exclude_registry_status})`
       );
     }
+    if (filters.probed_auth_types) {
+      if (filters.probed_auth_types.length === 0) return [sql`1 = 0`];
+      conditions.push(inArray(mcpCatalogEntries.probed_auth_type, filters.probed_auth_types));
+    }
     if (filters.names) {
       // An empty allowlist means "nothing matches", which `inArray` cannot express.
       if (filters.names.length === 0) return [sql`1 = 0`];

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   boardObjectQueryValidator,
   branchQueryValidator,
+  mcpCatalogQueryValidator,
   mcpServerQueryValidator,
   sessionQueryValidator,
   typedValidateQuery,
@@ -140,5 +141,30 @@ describe('mcpServerQueryValidator', () => {
       enabled: true,
       forUserId: '019e8e1c',
     });
+  });
+});
+
+describe('mcpCatalogQueryValidator', () => {
+  it('preserves a set of probe verdicts, which one filter genuinely needs', async () => {
+    const context = {
+      params: {
+        query: { probed_auth_types: ['none', 'unknown'], curated: 'true', unknown: 'removed' },
+      },
+    };
+
+    await typedValidateQuery(mcpCatalogQueryValidator)(context);
+
+    // `removeAdditional: 'all'` strips anything unlisted, so a filter the
+    // schema does not name reaches SQL as no filter at all.
+    expect(context.params.query).toEqual({
+      probed_auth_types: ['none', 'unknown'],
+      curated: true,
+    });
+  });
+
+  it('refuses a probe verdict outside the closed set', async () => {
+    const context = { params: { query: { probed_auth_types: ['none', 'sudo'] } } };
+
+    await expect(typedValidateQuery(mcpCatalogQueryValidator)(context)).rejects.toThrow();
   });
 });

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -301,6 +301,14 @@ export const mcpCatalogQuerySchema = Type.Intersect(
       probed_auth_type: Type.Optional(
         Type.Union(MCP_CATALOG_PROBED_AUTH_TYPES.map((value) => Type.Literal(value)))
       ),
+      // The plural has to be named here too: `removeAdditional: 'all'` would
+      // otherwise strip it silently and the filter would reach SQL as no filter
+      // at all, which is how a control ends up looking like it works.
+      probed_auth_types: Type.Optional(
+        Type.Array(Type.Union(MCP_CATALOG_PROBED_AUTH_TYPES.map((value) => Type.Literal(value))), {
+          maxItems: MCP_CATALOG_PROBED_AUTH_TYPES.length,
+        })
+      ),
       // Asking for a lifecycle state by name opts out of the default exclusion
       // of withdrawn servers, so it has to survive validation rather than be
       // stripped as an unknown key.

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
+import { catalogServerSlug } from '../types/mcp-catalog';
 import { load as loadYaml } from '../yaml';
 import {
   CuratedCatalogError,
@@ -223,6 +224,29 @@ describe('loadCuratedCatalog', () => {
       expect(entry.starter_prompt.length).toBeGreaterThan(0);
       expect(entry.permission_disclosure.length).toBeGreaterThan(0);
     }
+  });
+
+  it('gives every curated entry a distinct server name', async () => {
+    const entries = await loadCuratedCatalog();
+
+    // `catalogServerSlug` is the `<name>` in every `mcp__<name>__<tool>`, and
+    // the executor builds its config as an object keyed on it
+    // (`query-builder.ts`, `mcpConfig[server.name] = …`) with no unique index
+    // behind it. Two curated entries sharing a slug means the second install in
+    // a session silently replaces the first and one server never loads.
+    //
+    // Uniqueness is a property of the whole file, not of the derivation: a
+    // second entry under a publisher already present — `com.atlassian/jira`
+    // beside `com.atlassian/atlassian-mcp-server` — reintroduces it without
+    // touching a line of code.
+    const bySlug = new Map<string, string[]>();
+    for (const entry of entries) {
+      const slug = catalogServerSlug(entry.name);
+      bySlug.set(slug, [...(bySlug.get(slug) ?? []), entry.name]);
+    }
+    const collisions = [...bySlug.entries()].filter(([, names]) => names.length > 1);
+
+    expect(collisions).toEqual([]);
   });
 
   it('pairs every curated remote with a transport so the connect flow need not guess', async () => {

--- a/packages/core/src/types/mcp-catalog.test.ts
+++ b/packages/core/src/types/mcp-catalog.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { catalogDisplayName, catalogServerSlug } from './mcp-catalog';
+
+describe('catalogServerSlug', () => {
+  it('names the publisher, not the protocol word the path usually carries', () => {
+    // This is the `<name>` in every `mcp__<name>__<tool>` the model reads.
+    expect(catalogServerSlug('com.deepwiki/mcp')).toBe('deepwiki');
+    expect(catalogServerSlug('io.sentry/mcp')).toBe('sentry');
+    expect(catalogServerSlug('io.github.github/github-mcp-server')).toBe('github');
+  });
+
+  it('skips a protocol subdomain to reach the publisher', () => {
+    expect(catalogServerSlug('com.figma.mcp/mcp')).toBe('figma');
+    expect(catalogServerSlug('io.sanity.www/mcp')).toBe('sanity');
+  });
+
+  it('keeps distinct publishers distinct — the whole point', () => {
+    // The previous rule took the last path segment, so all of these were `mcp`
+    // and two installs in one session produced indistinguishable tool names.
+    const names = ['com.deepwiki/mcp', 'com.context7/mcp', 'io.sentry/mcp', 'com.slack/mcp'];
+    expect(new Set(names.map(catalogServerSlug)).size).toBe(names.length);
+  });
+
+  it('falls back to the path segment when no publisher survives', () => {
+    expect(catalogServerSlug('mcp/weather-tools')).toBe('weather-tools');
+    expect(catalogServerSlug('mcp/mcp')).toBe('mcp-server');
+  });
+
+  it('produces a tool-namespace-safe slug', () => {
+    expect(catalogServerSlug('com.Monday/monday.com')).toBe('monday');
+    expect(catalogServerSlug('co.hugging_face/mcp')).toBe('hugging-face');
+  });
+});
+
+describe('catalogDisplayName', () => {
+  it('prefers a curated title', () => {
+    expect(catalogDisplayName({ name: 'com.deepwiki/mcp', title: '  DeepWiki  ' })).toBe(
+      'DeepWiki'
+    );
+  });
+
+  it('stands the publisher in when the registry never supplied a title', () => {
+    expect(catalogDisplayName({ name: 'com.deepwiki/mcp' })).toBe('Deepwiki');
+    expect(catalogDisplayName({ name: 'com.figma.mcp/mcp' })).toBe('Figma');
+  });
+
+  it('keeps the registry name when nothing identifying is left', () => {
+    expect(catalogDisplayName({ name: 'mcp/mcp' })).toBe('mcp/mcp');
+  });
+
+  it('agrees with the slug about which half is the identity', () => {
+    // One rule, two formattings. Drift here is what produced `mcp__mcp__<tool>`.
+    for (const name of [
+      'com.deepwiki/mcp',
+      'io.github.github/github-mcp-server',
+      'io.sanity.www/mcp',
+    ]) {
+      expect(catalogServerSlug(name)).toBe(catalogDisplayName({ name }).toLowerCase());
+    }
+  });
+});

--- a/packages/core/src/types/mcp-catalog.test.ts
+++ b/packages/core/src/types/mcp-catalog.test.ts
@@ -48,14 +48,38 @@ describe('catalogDisplayName', () => {
     expect(catalogDisplayName({ name: 'mcp/mcp' })).toBe('mcp/mcp');
   });
 
-  it('agrees with the slug about which half is the identity', () => {
+  it('reads the same identity segment out of the name as the slug does', () => {
     // One rule, two formattings. Drift here is what produced `mcp__mcp__<tool>`.
+    // Asserted as "both track the name", not as an equality between the two
+    // outputs: they coincide only for an untitled entry, and reading that
+    // coincidence as the contract is how `title` ends up feeding the slug.
     for (const name of [
       'com.deepwiki/mcp',
       'io.github.github/github-mcp-server',
       'io.sanity.www/mcp',
     ]) {
-      expect(catalogServerSlug(name)).toBe(catalogDisplayName({ name }).toLowerCase());
+      expect(catalogDisplayName({ name }).toLowerCase()).toBe(catalogServerSlug(name));
     }
+
+    // A different publisher moves both.
+    expect(catalogServerSlug('com.other/mcp')).not.toBe(catalogServerSlug('com.deepwiki/mcp'));
+    expect(catalogDisplayName({ name: 'com.other/mcp' })).not.toBe(
+      catalogDisplayName({ name: 'com.deepwiki/mcp' })
+    );
+  });
+
+  it('lets a curated title move the screen label without moving the tool namespace', () => {
+    // `curated.yaml` accepts `title`, and `deriveSharedColumns` prefers
+    // `curation.title ?? registry.title` — a live path, not a hypothetical. The
+    // slug is an agent-visible namespace: editing display copy must never
+    // rename the tools a running session already knows.
+    const name = 'com.deepwiki/mcp';
+
+    expect(catalogDisplayName({ name })).toBe('Deepwiki');
+    expect(catalogDisplayName({ name, title: 'DeepWiki' })).toBe('DeepWiki');
+    expect(catalogDisplayName({ name, title: 'Devin Wiki Search' })).toBe('Devin Wiki Search');
+
+    // Same name, three labels, one namespace.
+    expect(catalogServerSlug(name)).toBe('deepwiki');
   });
 });

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -253,6 +253,82 @@ export interface MCPCatalogEntry {
   probed_auth_scheme?: string;
 }
 
+/**
+ * Reverse-DNS labels that name the protocol rather than the publisher.
+ *
+ * Vendors routinely register the server under one — `com.figma.mcp/mcp` — so
+ * the trailing label of either half is frequently the word "mcp" rather than
+ * anything identifying.
+ */
+const GENERIC_CATALOG_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api', 'www']);
+
+/**
+ * The identifying half of a reverse-DNS catalog name, lowercased.
+ *
+ * `com.deepwiki/mcp` → `deepwiki`, `io.github.github/github-mcp-server` →
+ * `github`, `io.sanity.www/mcp` → `sanity`. Undefined when every label is
+ * generic, which callers resolve their own way rather than guessing here.
+ *
+ * Shared because both sides of the wire need this and disagreed: the catalog
+ * UI derived the publisher while connect took the last path segment, so the
+ * server name the agent saw was the word "mcp" for 38 of 50 curated entries.
+ * One rule, two formattings — never two rules.
+ */
+function catalogPublisherSegment(name: string): string | undefined {
+  const [domain = ''] = name.split('/');
+  return domain
+    .split('.')
+    .filter((label) => label && !GENERIC_CATALOG_NAME_LABELS.has(label.toLowerCase()))
+    .pop()
+    ?.toLowerCase();
+}
+
+/**
+ * What to call a catalog entry on screen.
+ *
+ * A curated title wins. Otherwise the publisher stands in, because `title` is
+ * the registry mirror's column and registry sync is off by default — rendering
+ * `name` would label the whole catalog with reverse-DNS strings.
+ *
+ * It cannot recover casing: `com.deepwiki` reads "Deepwiki", not "DeepWiki".
+ * Curated titles are the fix for that, not more derivation.
+ */
+export function catalogDisplayName(entry: Pick<MCPCatalogEntry, 'name' | 'title'>): string {
+  const title = entry.title?.trim();
+  if (title) return title;
+  const publisher = catalogPublisherSegment(entry.name);
+  if (!publisher) return entry.name;
+  return publisher.charAt(0).toUpperCase() + publisher.slice(1);
+}
+
+/**
+ * The name an installed server carries into the agent's tool namespace.
+ *
+ * This is the `<name>` in every `mcp__<name>__<tool>` the model reads, so it
+ * has to identify the server: two installs sharing one produce tool names
+ * nothing can tell apart. The path segment is the wrong half of the identity —
+ * it is usually the protocol's own name — so the publisher supplies it, and the
+ * path segment is only a fallback for a name with no publisher left in it.
+ */
+export function catalogServerSlug(name: string): string {
+  const slugify = (value: string): string =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  const fromPublisher = slugify(catalogPublisherSegment(name) ?? '');
+  if (fromPublisher) return fromPublisher;
+
+  // The path segment only helps when it is not the same generic word, or the
+  // fallback would reintroduce exactly the collision this exists to avoid.
+  const segment = name.split('/').pop() ?? '';
+  const fromSegment = GENERIC_CATALOG_NAME_LABELS.has(segment.toLowerCase())
+    ? ''
+    : slugify(segment);
+  return fromSegment || 'mcp-server';
+}
+
 /** Sort keys the catalog service accepts. */
 export type MCPCatalogSort = 'popularity' | 'name' | 'recently_updated' | 'relevance';
 

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -281,6 +281,14 @@ export interface MCPCatalogFilters {
    * drop withdrawn servers without naming every state that is still live.
    */
   exclude_registry_status?: string;
+  /**
+   * Match any one of several probe verdicts.
+   *
+   * "Not known to need an account" spans two verdicts — probed open, and never
+   * probed — and a single-value filter cannot say that. Callers that mean a set
+   * pass one; the singular field stays for callers that mean exactly one.
+   */
+  probed_auth_types?: MCPCatalogProbedAuthType[];
   names?: string[];
   sort?: MCPCatalogSort;
   limit?: number;

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -336,6 +336,20 @@ export interface MCPCatalogConnectData {
   catalog_key: string;
   branch_id: string;
   agentic_tool: AgenticToolName;
+  /**
+   * The `permission_disclosure` the user was shown and accepted.
+   *
+   * Connecting a server puts its tools, and their descriptions, inside every
+   * prompt of the session it is attached to, so the disclosure is the last
+   * thing between a user and that decision. A client-side checkbox cannot be
+   * the only place that rule lives: the endpoint would accept a connect from
+   * any caller that never rendered it. Sending back the text — rather than a
+   * bare `true` — means a client cannot satisfy the check without having had
+   * the disclosure in hand, and a stale one no longer matches the row.
+   *
+   * It does not prove a human read the words. It proves the protocol ran.
+   */
+  acknowledged_disclosure: string;
 }
 
 /** What a successful connect hands back to the caller. */

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -10,7 +10,10 @@
 // registry or from a file checked into this repository — so the table is
 // deliberately global. See `packages/core/src/db/tenant-deletion-manifest.ts`.
 
+import type { AgenticToolName } from './agentic-tool';
 import type { UUID } from './id';
+import type { MCPServer } from './mcp';
+import type { Session } from './session';
 
 /**
  * MCP catalog entry ID (branded UUID).
@@ -319,6 +322,30 @@ export interface MCPCatalogCurationUpsert {
   /** Used when the registry has not (yet) published the server. */
   remote_url?: string;
   transport?: MCPCatalogTransport;
+}
+
+/**
+ * Request body of `POST /mcp-catalog/connect`.
+ *
+ * A catalog key and where the session should live, and nothing else. URL,
+ * transport, and auth come from the catalog row server-side, so this cannot be
+ * used to register an arbitrary server.
+ */
+export interface MCPCatalogConnectData {
+  /** Catalog entry UUID or its reverse-DNS registry name. */
+  catalog_key: string;
+  branch_id: string;
+  agentic_tool: AgenticToolName;
+}
+
+/** What a successful connect hands back to the caller. */
+export interface MCPCatalogConnectResult {
+  mcp_server: MCPServer;
+  session: Session;
+  /** The entry's curated demonstration prompt, for the new session's composer. */
+  starter_prompt?: string;
+  /** True when an existing install was reused rather than a second row created. */
+  reused_existing_server: boolean;
 }
 
 /** Result of probing one entry, written back onto the row. */

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -273,6 +273,13 @@ const GENERIC_CATALOG_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api
  * UI derived the publisher while connect took the last path segment, so the
  * server name the agent saw was the word "mcp" for 38 of 50 curated entries.
  * One rule, two formattings — never two rules.
+ *
+ * The publisher is the identity only while what is connectable is curated.
+ * `io.github.<user>/<repo>` inverts it — every server one GitHub user
+ * publishes shares a publisher and differs only in the path — so the day
+ * uncurated registry entries become installable, this needs a disambiguating
+ * suffix rather than a special case. `curated-loader.test.ts` holds the
+ * uniqueness invariant that would otherwise notice too late.
  */
 function catalogPublisherSegment(name: string): string | undefined {
   const [domain = ''] = name.split('/');


### PR DESCRIPTION
> **Decision update (2026-08-13, after this PR was written).** Kamil and Max have agreed to
> **drop the MCP registry connection entirely** and ship the curated list as a static file inside
> the package — no `mcp_catalog_entries` table, no ingestion worker, no periodic sync. The file
> will also carry per-server "auto mode" OAuth defaults.
>
> **This PR is still correct and still merges as-is.** Nothing here renders or depends on
> registry-sourced rows, and installs already reference a catalog entry by *name* held on the
> server row, with no foreign key to the table. Reasoning in the text below that argues from
> registry behaviour (unattended ingestion, withdrawal-and-republication) describes machinery
> that is going away — the conclusions it supports are unchanged, since a file-backed catalog is
> keyed by the same name.
>
> The conversion lands as its own PR off `main` after this stack merges. Plan:
> `docs/internal/mcp-catalog-file-backed-2026-08-13.md`.

---

## The MCP marketplace: browse, review what a server can reach, connect

This is **Slice 2B** of the MCP marketplace. **#2240** (`mcp-private-servers-2a`) has since merged, so this now targets `main` directly and the diff is 2B's eleven commits.

## The marketplace is not linked from the navbar — on purpose

**There is no entry point in the UI. Reach the page by typing `/ui/marketplace`.**

Nothing is wrong with the page: this is product timing. Kamil's call is that users should not discover the marketplace until the whole feature is finished, so the header link is removed while the rest ships. The route, the surface registration and the lazy module all stay, `/ui/marketplace` answers normally, and re-advertising it later is putting one button back.

The header's tests pin the *set* of advertised surfaces rather than each one's presence, so restoring the link fails a test that says Marketplace is absent deliberately — the next person to reach for it has to confirm the decision is being reversed.

## What a reviewer can actually click

Boot the daemon and UI, then:

1. **Hard-load `/ui/marketplace` as the entry URL.** The catalog loads on a cold page load, which is its own commit here because that path did not always work — the surface opts out of the workspace runtime, and the shell's "wait until the socket is authenticated" gate turned out to be part of it.
2. **The catalog.** ~50 curated entries, each a card with its title, registry name, what it's for, capability tags, and its probe verdict.
3. **The filters**, all of which narrow the SQL read rather than the rendered page:
   - free-text **search** over name, title, and description
   - **category** tabs (Dev tools, Data & storage, Productivity, Messaging, Observability, Search)
   - **capability** tag filter
   - **Reviewed only**
   - **Hide account-only** — the connectable filter
4. **The detail drawer.** Click any card. It carries the benefit copy, the capability tags, the probe verdict, and a **"What this can access"** panel — the access disclosure. Connect is disabled until you tick *"I understand what this server can access."*
5. **Connect.** Pick a branch and an agent, and `Connect & try it` lands you in a new session on that branch with the server attached and the entry's starter prompt already in the composer.

Good entries to try a real connect against: **Deepwiki** or **Context7** — both open endpoints.

## The access disclosure is enforced at the endpoint, not just in the drawer

The drawer's checkbox is a real gate for the drawer, but a Feathers service has callers that never rendered it. `POST /mcp-catalog/connect` now requires the entry's own `permission_disclosure` text back on the request.

Returning the text rather than a boolean means a caller cannot pass without having held it, and a client carrying a disclosure the curator has since rewritten is told to re-read rather than connecting against the old wording. The daemon cannot prove a human read the words — it can prove the protocol ran, and that is the part worth enforcing at a boundary.

The acknowledgement is also bound to *which* entry was acknowledged rather than a boolean reset by an effect, which previously left one render where a newly-opened server's disclosure sat above an already-enabled button.

## The connectable filter now means what the cards mean

The toggle asked for `probed_auth_type: 'none'`. Registry sync is off by default and nothing else probes, so every seeded row stays `unknown` and the filter could only ever return nothing — while the card beside it read "Not checked yet" and the endpoint connected fine.

The presentation was right, so the filter moved to it. Unprobed entries are kept, because connect probes on demand and refuses cleanly when the endpoint turns out to want an account. What the toggle removes is what Agor already knows will refuse, and the label says that instead of over-promising "Connectable now".

Measured against a seeded catalog, before and after:

| query | rows |
| --- | --- |
| no filter | 50 |
| `probed_auth_types=[none,unknown]` — what the toggle sends now | **50** |
| `probed_auth_types=[none]` — what it effectively asked for before | **0** |
| `probed_auth_types=[oauth]` — control | 0 |

Saying that needed one filter the data layer could not express, so `MCPCatalogFilters` gains a plural `probed_auth_types` beside the singular, in the shape `names` already uses. The query schema names it too — `removeAdditional: 'all'` would otherwise drop it silently and the filter would reach SQL as no filter at all, which is how a control ends up looking like it works.

## Scope — API-key and OAuth connect are 2C

Connect here handles **`none`-auth entries only**. An entry that probes as `oauth` or `credentials` is refused with a clear message rather than half-connected. Those two branches need the credential model that does not exist yet, and they land in **2C**. Their absence is deliberate, not an oversight.

Nothing renders uncurated registry rows, and registry sync stays off by default.

## Verification

- Full `typecheck` and `lint` clean (incl. the biome frontend colour/CSS plugins).
- **daemon** — 2653 passed. One failure, `cursor-models.test.ts`, which fails on the dev host and passes in CI.
- **agor-ui** — 1410 passed. `BoardFormFields.test.tsx` and `BoardEditModal.test.tsx` flake under full-suite parallelism on the dev host and pass in isolation; neither is in this diff.
- **core** — 304 passed across the catalog types, repository, loader and query-validation suites.
- Driven in a real browser against a seeded catalog: hard-loaded `/ui/marketplace` as the entry URL, confirmed cards render, narrowed with search (50 → 1), opened the drawer, confirmed `Connect & try it` is disabled before acknowledging and enabled after, and completed a `none`-auth connect to Deepwiki that landed on a session with the server attached (`MCP 1`) and the starter prompt in the composer.
- Also driven at the endpoint: a connect with no `acknowledged_disclosure` and one carrying stale text are both refused, and neither creates an `mcp_servers` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


