### PR TITLE
fix(mcp-oauth): pin validated outbound sockets

### DIFF
--- a/packages/core/src/utils/safe-outbound-fetch.dns.test.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.dns.test.ts
@@ -57,10 +57,10 @@ describe('safe outbound connection-time DNS policy', () => {
     async (_label, address, family) => {
       const lookup = createPinnedLookup({ address, family });
 
-      await expect(invokeLookup(lookup, { all: true })).resolves.toEqual({
+      await expect(invokeLookup(lookup, { all: true, family })).resolves.toEqual({
         address: [{ address, family }],
       });
-      await expect(invokeLookup(lookup, { all: false })).resolves.toEqual({
+      await expect(invokeLookup(lookup, { all: false, family })).resolves.toEqual({
         address,
         family,
       });
@@ -88,6 +88,37 @@ describe('safe outbound connection-time DNS policy', () => {
         cache: false,
       })
     ).resolves.toMatchObject({ token: 'oauth-access' });
+  });
+
+  it('does not reuse a pooled socket after the pinned address changes', async () => {
+    let requests = 0;
+    server = http.createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(200, {
+        connection: 'keep-alive',
+        'content-length': '2',
+      });
+      response.end('ok');
+    });
+    await new Promise<void>((resolve, reject) => {
+      server?.once('error', reject);
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const port = (server.address() as AddressInfo).port;
+    let lookups = 0;
+    lookupMock.mockImplementation(async () => [
+      { address: lookups++ === 0 ? '127.0.0.1' : '127.0.0.2', family: 4 },
+    ]);
+    const options = { allowLocalhostHttp: true, timeoutMs: 500 };
+
+    await expect(
+      safeOutboundFetch(`http://localhost:${port}/first`, options)
+    ).resolves.toMatchObject({
+      status: 200,
+    });
+    await expect(safeOutboundFetch(`http://localhost:${port}/second`, options)).rejects.toThrow();
+    expect(requests).toBe(1);
+    expect(lookupMock).toHaveBeenCalledTimes(2);
   });
 
   it('rejects a mixed public/private DNS answer before opening a connection', async () => {
@@ -119,5 +150,12 @@ describe('safe outbound connection-time DNS policy', () => {
     await expect(
       safeOutboundFetch('https://unresolved.example/token', { timeoutMs: 30 })
     ).rejects.toThrow('Outbound OAuth timeout');
+  });
+
+  it('propagates DNS resolver failures without attempting a socket', async () => {
+    const error = new Error('getaddrinfo ENOTFOUND');
+    lookupMock.mockRejectedValue(error);
+
+    await expect(safeOutboundFetch('https://resolver-error.example/token')).rejects.toBe(error);
   });
 });

--- a/packages/core/src/utils/safe-outbound-fetch.dns.test.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.dns.test.ts
@@ -1,14 +1,93 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type dns from 'node:dns';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const lookupMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:dns/promises', () => ({ lookup: lookupMock }));
 
-import { safeOutboundFetch, UnsafeOutboundUrlError } from './safe-outbound-fetch';
+import { fetchOAuthToken } from '../tools/mcp/oauth-auth';
+import {
+  createPinnedLookup,
+  safeOutboundFetch,
+  UnsafeOutboundUrlError,
+} from './safe-outbound-fetch';
+
+let server: http.Server | undefined;
+
+interface LookupResult {
+  address: string | dns.LookupAddress[];
+  family?: number;
+}
+
+function invokeLookup(
+  lookup: ReturnType<typeof createPinnedLookup>,
+  options: dns.LookupOptions
+): Promise<LookupResult> {
+  return new Promise((resolve, reject) => {
+    lookup('provider.example', options, (error, address, family) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ address, family });
+    });
+  });
+}
 
 describe('safe outbound connection-time DNS policy', () => {
   beforeEach(() => {
     lookupMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it.each([
+    ['IPv4', '93.184.216.34', 4],
+    ['IPv6', '2606:2800:220:1:248:1893:25c8:1946', 6],
+  ] as const)(
+    'returns the pinned %s address in both Node lookup callback modes',
+    async (_label, address, family) => {
+      const lookup = createPinnedLookup({ address, family });
+
+      await expect(invokeLookup(lookup, { all: true })).resolves.toEqual({
+        address: [{ address, family }],
+      });
+      await expect(invokeLookup(lookup, { all: false })).resolves.toEqual({
+        address,
+        family,
+      });
+    }
+  );
+
+  it('lets the OAuth client-credentials path complete through Node all-address lookup', async () => {
+    server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ access_token: 'oauth-access', token_type: 'Bearer' }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server?.once('error', reject);
+      server?.listen(0, '127.0.0.1', resolve);
+    });
+    const port = (server.address() as AddressInfo).port;
+    lookupMock.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    await expect(
+      fetchOAuthToken({
+        token_url: `http://localhost:${port}/token`,
+        client_id: 'client',
+        client_secret: 'secret',
+        allowLocalhostHttp: true,
+        cache: false,
+      })
+    ).resolves.toMatchObject({ token: 'oauth-access' });
   });
 
   it('rejects a mixed public/private DNS answer before opening a connection', async () => {

--- a/packages/core/src/utils/safe-outbound-fetch.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.ts
@@ -8,6 +8,7 @@
 import { lookup } from 'node:dns/promises';
 import http from 'node:http';
 import https from 'node:https';
+import type { LookupFunction } from 'node:net';
 import { BlockList, isIP } from 'node:net';
 
 const blocked = new BlockList();
@@ -177,6 +178,22 @@ async function resolvePinnedAddress(
   return addresses[0] as { address: string; family: 4 | 6 };
 }
 
+/**
+ * Adapt one already-validated address to Node's two lookup callback contracts.
+ * `http(s).request` asks for `all: true` when auto-selecting a family and
+ * requires an address array in that mode; returning a scalar makes Node read
+ * an undefined address before it opens the socket.
+ */
+export function createPinnedLookup(pinned: { address: string; family: 4 | 6 }): LookupFunction {
+  return (_hostname, lookupOptions, callback) => {
+    if (lookupOptions.all) {
+      callback(null, [{ address: pinned.address, family: pinned.family }]);
+      return;
+    }
+    callback(null, pinned.address, pinned.family);
+  };
+}
+
 function requestBody(body: unknown): string | Uint8Array | undefined {
   if (body == null) return undefined;
   if (typeof body === 'string') return body;
@@ -204,6 +221,7 @@ async function requestOnce(
   }
   const requestImpl = url.protocol === 'https:' ? https.request : http.request;
   const maxBytes = options.maxResponseBytes ?? 1024 * 1024;
+  const pinnedLookup = createPinnedLookup(pinned);
 
   return new Promise<Response>((resolve, reject) => {
     let settled = false;
@@ -234,8 +252,7 @@ async function requestOnce(
         headers: Object.fromEntries(headers.entries()),
         // The TLS SNI/Host remain the validated URL hostname, while connection
         // address selection cannot perform a second DNS lookup.
-        lookup: (_hostname, _lookupOptions, callback) =>
-          callback(null, pinned.address, pinned.family),
+        lookup: pinnedLookup,
         servername: isIP(normalizedHostname(url)) ? undefined : normalizedHostname(url),
       },
       (response) => {

--- a/packages/core/src/utils/safe-outbound-fetch.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.ts
@@ -253,6 +253,9 @@ async function requestOnce(
         // The TLS SNI/Host remain the validated URL hostname, while connection
         // address selection cannot perform a second DNS lookup.
         lookup: pinnedLookup,
+        // Never reuse a socket opened before this request's DNS validation. A
+        // pooled global agent can bypass the lookup callback entirely.
+        agent: false,
         servername: isIP(normalizedHostname(url)) ? undefined : normalizedHostname(url),
       },
       (response) => {


### PR DESCRIPTION
## Linked issue

Fixes #2246. Related to #2234.

## Summary

- Fix Node's pinned-DNS callback for both single-address and all-address lookups.
- Prevent validated OAuth requests from reusing a socket whose destination was approved by an earlier DNS result.
- Preserve the existing SSRF, redirect, timeout, response-size, and credential-boundary protections.

## Why / context

OAuth failed before reaching the provider because the secure outbound path returned the wrong result shape when Node requested every resolved address:

```text
Before
validate hostname ─► Node asks for all addresses ─► scalar result
                                                   └─► address = undefined ─► request fails

After
validate hostname ─► Node asks for all addresses ─► address array ─► fresh socket ─► provider
```

Fixing the callback shape exposed a second security boundary: a keep-alive agent could reuse an already-open socket and skip the newly validated DNS lookup. Each protected request must connect through the address approved for **that request**, not a previous one.

## Implementation notes

| Boundary | Before | After |
|---|---|---|
| Node lookup contract | Always returned a scalar | Returns an array for `all: true`; scalar address/family otherwise |
| DNS pinning | A pooled socket could skip lookup | `agent: false` forces a fresh connection after each validation |
| TLS and HTTP identity | Existing behavior | Validated hostname remains available for SNI and the `Host` header |
| Outbound security policy | Existing SSRF/redirect/limit checks | Unchanged |

The request path is now:

```text
resolve ─► reject private/reserved results ─► pin approved address
   ─► open a fresh socket ─► send request ─► revalidate every redirect
```

Migration `0078` from #2234 intentionally invalidated incompatible legacy grants. This PR repairs reconnection; it does not restore grants already deleted by that migration.

## Validation / test plan

| Evidence | Result |
|---|---|
| Workspace install, build, and `pnpm check` | Passed |
| Full workspace test suite | 16 tasks passed |
| Focused core OAuth/security/migration suites | 151 tests passed |
| Focused daemon OAuth/realtime suites | 181 tests passed |
| GitHub CI: build, check, pack/boot/curl | Passed |
| `git diff --check` | Passed |

Production-path tests cover:

- [x] Node single-address and all-address callback shapes
- [x] IPv4 and IPv6 pinning
- [x] A fresh connection after DNS changes
- [x] Mixed public/private results and private-address rebinding
- [x] DNS errors, absolute deadlines, redirects, and response limits
- [x] Cross-origin credential/header stripping

One PostgreSQL-only targeted case remains skipped locally when no database is available; provider CI passed.

## Screenshots / demos

Not applicable: this is a backend transport/security fix exercised through the production HTTP path.

## Risks / rollout / rollback

- **Performance:** disabling pooling adds connection setup overhead to OAuth requests. This is accepted to preserve per-request DNS pinning.
- **User action:** users affected by migration `0078` must reconnect once.
- **Rollout:** no schema or migration changes in this PR.
- **Rollback:** revert the code change; no data rollback is required. Reverting does not restore previously deleted grants.

## Out of scope / follow-ups

- Restoring provider grants deleted by migration `0078`.
- Provider-side grant recovery or unrelated OAuth UI changes.
