### PR TITLE
fix(daemon): finalize widget ids before message creation

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/widgets.boundary.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.boundary.test.ts
@@ -1,0 +1,251 @@
+import { feathers } from '@agor/core/feathers';
+import type { Message, MessageID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { protectExternalWidgetMessageWrites } from '../../widgets/message-boundary.js';
+
+vi.mock('../../utils/append-system-message.js', () => ({
+  appendSystemMessage: vi.fn(
+    async (opts: {
+      app: {
+        service: (name: string) => {
+          create: (data: Message, params?: unknown) => Promise<Message>;
+        };
+      };
+      sessionId: string;
+      taskId?: string;
+      content: string;
+      contentPreview?: string;
+      type?: Message['type'];
+      role?: Message['role'];
+      metadata?: Message['metadata'];
+      messageId?: MessageID;
+      params?: unknown;
+    }) => {
+      if (!opts.messageId) throw new Error('widget message ID must be generated before create');
+      return opts.app.service('messages').create(
+        {
+          message_id: opts.messageId,
+          session_id: opts.sessionId as Message['session_id'],
+          task_id: opts.taskId as Message['task_id'],
+          type: opts.type ?? 'system',
+          role: opts.role ?? MessageRole.SYSTEM,
+          index: 0,
+          timestamp: '2026-08-11T00:00:00.000Z',
+          content_preview: opts.contentPreview ?? opts.content,
+          content: opts.content,
+          metadata: opts.metadata,
+        },
+        opts.params
+      );
+    }
+  ),
+}));
+
+import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { registerWidgetTools } from './widgets.js';
+
+function makeBoundaryApp() {
+  const rows = new Map<string, Message>();
+  const createdEvents: Message[] = [];
+  const taskPatchParams: unknown[] = [];
+  const app = feathers();
+
+  app.use('messages', {
+    async create(data: Message) {
+      rows.set(data.message_id, data);
+      createdEvents.push(data);
+      return data;
+    },
+    async patch(id: string, data: Partial<Message>) {
+      const current = rows.get(id);
+      if (!current) throw new Error(`message not found: ${id}`);
+      const next = { ...current, ...data } as Message;
+      rows.set(id, next);
+      return next;
+    },
+  } as never);
+
+  const messages = app.service('messages') as unknown as {
+    hooks(hooks: { before: Record<string, Array<(context: never) => Promise<never>>> }): void;
+  };
+  messages.hooks({
+    before: {
+      create: [protectExternalWidgetMessageWrites(async (id) => rows.get(id) ?? null) as never],
+      patch: [protectExternalWidgetMessageWrites(async (id) => rows.get(id) ?? null) as never],
+    },
+  });
+
+  const services: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
+    messages: app.service('messages') as never,
+    sessions: {
+      get: async () => ({ session_id: 'sess-1', branch_id: 'branch-1', created_by: 'user-1' }),
+    },
+    users: {
+      get: async () => ({ user_id: 'user-1', env_vars: {} }),
+    },
+    tasks: {
+      find: async () => ({
+        data: [
+          {
+            task_id: 'task-host-1',
+            status: 'running',
+            created_at: '2026-08-11T00:00:00.000Z',
+            message_range: { start_index: 0, end_index: 0 },
+          },
+        ],
+        total: 1,
+        limit: 1000,
+        skip: 0,
+      }),
+      patch: async (...args: unknown[]) => {
+        taskPatchParams.push(args[2]);
+        return { task_id: args[0], ...(args[1] as Record<string, unknown>) };
+      },
+    },
+    'gateway-channels': {
+      get: async () => ({
+        id: 'channel-1',
+        name: 'Engineering Slack',
+        channel_type: 'slack',
+        target_branch_id: 'branch-1',
+        config: { bot_token: 'xoxb-redacted', app_token: 'xapp-redacted' },
+      }),
+    },
+  };
+
+  return {
+    app: {
+      service(name: string) {
+        const service = services[name];
+        if (!service) throw new Error(`Unexpected service call: ${name}`);
+        return service;
+      },
+    },
+    messageService: app.service('messages'),
+    rows,
+    createdEvents,
+    taskPatchParams,
+  };
+}
+
+function widgetContext(app: unknown): Parameters<typeof registerWidgetTools>[1] {
+  return {
+    app: app as never,
+    db: { run: vi.fn() } as never,
+    userId: 'user-1' as never,
+    sessionId: 'sess-1' as never,
+    authenticatedUser: { user_id: 'user-1', role: 'admin' } as never,
+    baseServiceParams: {
+      user: { user_id: 'user-1', role: 'admin' },
+      authenticated: true,
+      provider: 'mcp',
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    } as never,
+  };
+}
+
+async function callThroughMcp(
+  app: unknown,
+  name: string,
+  args: Record<string, unknown>
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const server = new McpServer({ name: 'widget-boundary-test', version: '1.0.0' });
+  registerWidgetTools(server, widgetContext(app));
+  const client = new Client({ name: 'widget-boundary-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    return (await client.callTool({ name, arguments: args })) as {
+      content: Array<{ type: string; text: string }>;
+    };
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+describe('widget MCP/service boundary', () => {
+  beforeEach(() => {
+    vi.mocked(appendSystemMessage).mockClear();
+  });
+
+  it('creates env widgets with their final ID through the real message boundary', async () => {
+    const fixture = makeBoundaryApp();
+    const result = await callThroughMcp(fixture.app, 'agor_widgets_request_env_vars', {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      auto_resume: true,
+    });
+    const widgetId = JSON.parse(result.content[0].text).widget_id as string;
+    const row = fixture.rows.get(widgetId);
+
+    expect(row?.message_id).toBe(widgetId);
+    expect(row?.metadata?.widget?.widget_id).toBe(widgetId);
+    expect(row?.metadata?.widget?.widget_id).not.toBe('pending');
+    expect(fixture.createdEvents).toHaveLength(1);
+    expect(fixture.createdEvents[0].metadata?.widget?.widget_id).toBe(widgetId);
+    expect(fixture.taskPatchParams[0]).toMatchObject({
+      user: { user_id: 'user-1', role: 'admin' },
+      authenticated: true,
+      provider: undefined,
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    });
+
+    await expect(
+      (fixture.messageService as never).patch(
+        widgetId,
+        { content: 'external mutation' },
+        {
+          user: { user_id: 'user-1', role: 'admin' },
+          authenticated: true,
+          provider: 'mcp',
+          tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        }
+      )
+    ).rejects.toThrow('Widget messages can only be changed through widget resolution routes');
+  });
+
+  it('uses the same final-ID invariant for gateway-token widgets', async () => {
+    const fixture = makeBoundaryApp();
+    const result = await callThroughMcp(fixture.app, 'agor_widgets_request_gateway_token', {
+      gatewayChannelId: 'channel-1',
+      reason: 'finish Slack setup',
+    });
+    const widgetId = JSON.parse(result.content[0].text).widget_id as string;
+    const row = fixture.rows.get(widgetId);
+
+    expect(row?.message_id).toBe(widgetId);
+    expect(row?.metadata?.widget?.widget_type).toBe('gateway_token');
+    expect(row?.metadata?.widget?.widget_id).toBe(widgetId);
+    expect(row?.metadata?.widget?.widget_id).not.toBe('pending');
+  });
+
+  it('still rejects a direct MCP widget create at the Feathers boundary', async () => {
+    const fixture = makeBoundaryApp();
+    await expect(
+      (fixture.messageService as never).create(
+        {
+          message_id: 'external-widget' as MessageID,
+          session_id: 'sess-1' as never,
+          type: 'widget_request',
+          role: MessageRole.SYSTEM,
+          index: 0,
+          timestamp: '2026-08-11T00:00:00.000Z',
+          content_preview: 'external',
+          content: 'external',
+          metadata: { widget: { widget_id: 'external-widget' } },
+        },
+        {
+          provider: 'mcp',
+          authenticated: true,
+          user: { user_id: 'user-1', role: 'admin' },
+          tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        }
+      )
+    ).rejects.toThrow('Widget messages can only be created by the daemon');
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/widgets.boundary.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.boundary.test.ts
@@ -48,14 +48,19 @@ vi.mock('../../utils/append-system-message.js', () => ({
 import { appendSystemMessage } from '../../utils/append-system-message.js';
 import { registerWidgetTools } from './widgets.js';
 
-function makeBoundaryApp() {
+function makeBoundaryApp(options: { createFailures?: number } = {}) {
   const rows = new Map<string, Message>();
   const createdEvents: Message[] = [];
   const taskPatchParams: unknown[] = [];
+  let remainingCreateFailures = options.createFailures ?? 0;
   const app = feathers();
 
   app.use('messages', {
     async create(data: Message) {
+      if (remainingCreateFailures > 0) {
+        remainingCreateFailures -= 1;
+        throw new Error('synthetic widget create failure');
+      }
       rows.set(data.message_id, data);
       createdEvents.push(data);
       return data;
@@ -222,6 +227,58 @@ describe('widget MCP/service boundary', () => {
     expect(row?.metadata?.widget?.widget_type).toBe('gateway_token');
     expect(row?.metadata?.widget?.widget_id).toBe(widgetId);
     expect(row?.metadata?.widget?.widget_id).not.toBe('pending');
+  });
+
+  it('does not publish a failed create and retries with a new final ID', async () => {
+    const fixture = makeBoundaryApp({ createFailures: 1 });
+
+    const failed = await callThroughMcp(fixture.app, 'agor_widgets_request_env_vars', {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      auto_resume: true,
+    });
+
+    expect(failed).toMatchObject({ isError: true });
+    expect(failed.content[0].text).toContain('synthetic widget create failure');
+    expect(fixture.rows.size).toBe(0);
+    expect(fixture.createdEvents).toHaveLength(0);
+
+    const retry = await callThroughMcp(fixture.app, 'agor_widgets_request_env_vars', {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      auto_resume: true,
+    });
+    const retryId = JSON.parse(retry.content[0].text).widget_id as string;
+
+    expect(retryId).not.toBe('pending');
+    expect(fixture.rows.get(retryId)?.metadata?.widget?.widget_id).toBe(retryId);
+    expect(fixture.createdEvents).toHaveLength(1);
+    expect(fixture.createdEvents[0].metadata?.widget?.widget_id).toBe(retryId);
+  });
+
+  it('keeps concurrent widget creates bound to their final IDs', async () => {
+    const fixture = makeBoundaryApp();
+    const results = await Promise.all(
+      Array.from({ length: 3 }, () =>
+        callThroughMcp(fixture.app, 'agor_widgets_request_env_vars', {
+          names: ['HUBSPOT_API_KEY'],
+          reason: 'call hubspot',
+          auto_resume: true,
+        })
+      )
+    );
+    const widgetIds = results.map(
+      (result) => JSON.parse(result.content[0].text).widget_id as string
+    );
+
+    expect(new Set(widgetIds).size).toBe(widgetIds.length);
+    expect(widgetIds).not.toContain('pending');
+    expect(new Set(fixture.createdEvents.map((event) => event.message_id))).toEqual(
+      new Set(widgetIds)
+    );
+    expect(
+      fixture.createdEvents.every((event) => event.metadata?.widget?.widget_id === event.message_id)
+    ).toBe(true);
   });
 
   it('still rejects a direct MCP widget create at the Feathers boundary', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -37,8 +37,10 @@ type CapturedTool = {
 
 function registerAndCapture(ctx: {
   app: unknown;
+  db?: unknown;
   userId: string;
   sessionId: string;
+  baseServiceParams?: Parameters<typeof registerWidgetTools>[1]['baseServiceParams'];
 }): Record<string, CapturedTool> {
   const captured: Record<string, CapturedTool> = {};
   const fakeServer = {
@@ -49,13 +51,13 @@ function registerAndCapture(ctx: {
 
   registerWidgetTools(fakeServer, {
     app: ctx.app as unknown as Parameters<typeof registerWidgetTools>[1]['app'],
-    db: {} as unknown as Parameters<typeof registerWidgetTools>[1]['db'],
+    db: (ctx.db ?? {}) as Parameters<typeof registerWidgetTools>[1]['db'],
     userId: ctx.userId as unknown as Parameters<typeof registerWidgetTools>[1]['userId'],
     sessionId: ctx.sessionId as unknown as Parameters<typeof registerWidgetTools>[1]['sessionId'],
     authenticatedUser: { user_id: ctx.userId, role: 'member' } as unknown as Parameters<
       typeof registerWidgetTools
     >[1]['authenticatedUser'],
-    baseServiceParams: {},
+    baseServiceParams: ctx.baseServiceParams ?? {},
   });
   return captured;
 }
@@ -144,6 +146,9 @@ function makeApp(opts: {
     messages: {
       patch: async (...args: unknown[]) => {
         calls.push({ service: 'messages', method: 'patch', args });
+        if ((args[2] as { provider?: string } | undefined)?.provider) {
+          throw new Error('external widget message writes are not allowed');
+        }
         lastMessagePatch = args[1] as Record<string, unknown>;
         return { message_id: args[0] };
       },
@@ -232,6 +237,49 @@ describe('agor_widgets_request_env_vars', () => {
       message_range: { end_index: number };
     };
     expect(patchBody.message_range.end_index).toBe(0); // index of the appended widget
+  });
+
+  it('finalizes the widget with its persisted id for MCP callers', async () => {
+    const { app, calls, patchedMessage } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+      baseServiceParams: {
+        user: { user_id: 'user-creator', role: 'member' },
+        authenticated: true,
+        provider: 'mcp',
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      },
+      db: { run: vi.fn() },
+    });
+
+    const res = await captured.agor_widgets_request_env_vars.cb({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      auto_resume: true,
+    });
+
+    const patchCall = calls.find((call) => call.service === 'messages' && call.method === 'patch');
+    expect(patchCall).toBeDefined();
+    if (!patchCall) throw new Error('Widget finalization patch was not emitted');
+    expect(patchCall?.args[0]).toBe('widget-msg-1');
+    expect(patchCall?.args[2]).toMatchObject({
+      provider: undefined,
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    });
+
+    const patchWidgetId = (patchCall.args[1] as { metadata: { widget: { widget_id: string } } })
+      .metadata.widget.widget_id;
+    expect(patchWidgetId).toBe('widget-msg-1');
+    expect(patchWidgetId).not.toBe('pending');
+    expect(patchedMessage()?.metadata).toMatchObject({
+      widget: { widget_id: 'widget-msg-1' },
+    });
+    expect(JSON.parse(res.content[0].text)).toMatchObject({
+      widget_id: 'widget-msg-1',
+      status: 'requested',
+    });
   });
 
   it('normalizes requested names before storing widget metadata and preview text', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -89,10 +89,8 @@ function makeApp(opts: {
 }): {
   app: unknown;
   calls: ServiceCall[];
-  patchedMessage(): Record<string, unknown> | undefined;
 } {
   const calls: ServiceCall[] = [];
-  let lastMessagePatch: Record<string, unknown> | undefined;
   const defaultTasks: FakeTask[] = [
     {
       task_id: 'task-host-1',
@@ -143,16 +141,6 @@ function makeApp(opts: {
         return { ...t, ...(args[1] as Record<string, unknown>) };
       },
     },
-    messages: {
-      patch: async (...args: unknown[]) => {
-        calls.push({ service: 'messages', method: 'patch', args });
-        if ((args[2] as { provider?: string } | undefined)?.provider) {
-          throw new Error('external widget message writes are not allowed');
-        }
-        lastMessagePatch = args[1] as Record<string, unknown>;
-        return { message_id: args[0] };
-      },
-    },
     '/sessions/:id/prompt': {
       create: async (...args: unknown[]) => {
         calls.push({ service: '/sessions/:id/prompt', method: 'create', args });
@@ -169,9 +157,6 @@ function makeApp(opts: {
       },
     },
     calls,
-    patchedMessage() {
-      return lastMessagePatch;
-    },
   };
 }
 
@@ -181,17 +166,23 @@ describe('agor_widgets_request_env_vars', () => {
   beforeEach(() => {
     appendStub.mockReset();
     // Default: return a freshly-created widget message row.
-    appendStub.mockImplementation(async (opts: { content: string }) => ({
-      message_id: 'widget-msg-1',
-      session_id: 'sess-1',
-      type: 'widget_request',
-      role: 'system',
-      index: 0,
-      timestamp: '2026-05-19T00:00:00.000Z',
-      content: opts.content,
-      content_preview: opts.content,
-      metadata: {},
-    }));
+    appendStub.mockImplementation(
+      async (opts: {
+        content: string;
+        messageId?: MessageID;
+        metadata?: Record<string, unknown>;
+      }) => ({
+        message_id: opts.messageId ?? ('widget-msg-1' as MessageID),
+        session_id: 'sess-1',
+        type: 'widget_request',
+        role: 'system',
+        index: 0,
+        timestamp: '2026-05-19T00:00:00.000Z',
+        content: opts.content,
+        content_preview: opts.content,
+        metadata: opts.metadata,
+      })
+    );
   });
 
   it('normal path: creates a pending widget_request and returns status "requested"', async () => {
@@ -218,7 +209,8 @@ describe('agor_widgets_request_env_vars', () => {
     // Returns the new widget_id + "requested"
     const text = JSON.parse(res.content[0].text);
     expect(text.status).toBe('requested');
-    expect(text.widget_id).toBe('widget-msg-1');
+    expect(text.widget_id).toBe(appendArgs.metadata.widget.widget_id);
+    expect(text.widget_id).not.toBe('pending');
 
     // No auto-resume task on the normal path — it fires only after the user
     // submits/dismisses, via the resolve handler.
@@ -239,8 +231,8 @@ describe('agor_widgets_request_env_vars', () => {
     expect(patchBody.message_range.end_index).toBe(0); // index of the appended widget
   });
 
-  it('finalizes the widget with its persisted id for MCP callers', async () => {
-    const { app, calls, patchedMessage } = makeApp({ sessionCreator: 'user-creator' });
+  it('generates the persisted widget id before the MCP message create', async () => {
+    const { app, calls } = makeApp({ sessionCreator: 'user-creator' });
     const captured = registerAndCapture({
       app,
       userId: 'user-creator',
@@ -260,24 +252,15 @@ describe('agor_widgets_request_env_vars', () => {
       auto_resume: true,
     });
 
-    const patchCall = calls.find((call) => call.service === 'messages' && call.method === 'patch');
-    expect(patchCall).toBeDefined();
-    if (!patchCall) throw new Error('Widget finalization patch was not emitted');
-    expect(patchCall?.args[0]).toBe('widget-msg-1');
-    expect(patchCall?.args[2]).toMatchObject({
-      provider: undefined,
-      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
-    });
-
-    const patchWidgetId = (patchCall.args[1] as { metadata: { widget: { widget_id: string } } })
-      .metadata.widget.widget_id;
-    expect(patchWidgetId).toBe('widget-msg-1');
-    expect(patchWidgetId).not.toBe('pending');
-    expect(patchedMessage()?.metadata).toMatchObject({
-      widget: { widget_id: 'widget-msg-1' },
-    });
+    const appendArgs = appendStub.mock.calls[0][0];
+    const widgetId = appendArgs.metadata.widget.widget_id;
+    expect(appendArgs.messageId).toBe(widgetId);
+    expect(widgetId).not.toBe('pending');
+    expect(
+      calls.find((call) => call.service === 'messages' && call.method === 'patch')
+    ).toBeUndefined();
     expect(JSON.parse(res.content[0].text)).toMatchObject({
-      widget_id: 'widget-msg-1',
+      widget_id: widgetId,
       status: 'requested',
     });
   });
@@ -512,9 +495,10 @@ describe('agor_widgets_request_env_vars', () => {
     expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
     expect(promptData.prompt.toLowerCase()).toContain('already configured');
     expect(promptData.metadata.system_authored).toBe(true);
-    expect(promptData.metadata.widget_id).toBe('widget-msg-1');
-    expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId('widget-msg-1' as MessageID));
-    expect(promptData.idempotencyTaskId).not.toBe('widget-msg-1');
+    const widgetId = appendStub.mock.calls[0][0].metadata.widget.widget_id;
+    expect(promptData.metadata.widget_id).toBe(widgetId);
+    expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId(widgetId as MessageID));
+    expect(promptData.idempotencyTaskId).not.toBe(widgetId);
   });
 
   it('does NOT short-circuit when even one requested name is missing', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -15,6 +15,7 @@
  * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
  */
 
+import { generateId } from '@agor/core/db';
 import type {
   ChannelType,
   EnvVarMetadata,
@@ -149,6 +150,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
         ctx.baseServiceParams
       );
       const hostTaskId = hostTask?.task_id as TaskID | undefined;
+      const widgetId = generateId() as MessageID;
 
       const created = await runWithMcpTenantDatabaseScope(ctx, (db) =>
         appendSystemMessage({
@@ -160,17 +162,17 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
           contentPreview: `Widget: env_vars (${params.names.join(', ')})`,
           type: 'widget_request',
           role: MessageRole.SYSTEM,
-          // widget_id is filled in once we know the new message_id (id == widget_id).
+          // Generate the shared ID before create so no realtime consumer can
+          // observe a temporary "pending" submit URL.
+          messageId: widgetId,
           metadata: {
             widget: {
               ...baseWidgetMeta,
-              widget_id: 'pending' as MessageID,
+              widget_id: widgetId,
             },
           },
         })
       );
-
-      const widgetId = created.message_id as MessageID;
 
       // Extend the host task's message_range.end_index so the widget is
       // counted within the task's window (mirrors the daemon-restart
@@ -195,22 +197,6 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
           );
         }
       }
-
-      // Stamp the actual widget_id onto the row (single source of truth =
-      // `metadata.widget.widget_id === message.message_id`).
-      await ctx.app.service('messages').patch(
-        widgetId,
-        {
-          metadata: {
-            ...(created.metadata ?? {}),
-            widget: { ...baseWidgetMeta, widget_id: widgetId },
-          },
-        },
-        // This lifecycle projection is daemon-owned. Keep the authenticated
-        // user and tenant context, but remove MCP transport provenance so the
-        // external Message mutation guard does not reject its own finalization.
-        { ...ctx.baseServiceParams, provider: undefined }
-      );
 
       if (presentEverywhere) {
         // Short-circuit: no form render. Auto-queue a "values already
@@ -312,6 +298,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
         ctx.baseServiceParams
       );
       const hostTaskId = hostTask?.task_id as TaskID | undefined;
+      const widgetId = generateId() as MessageID;
 
       const created = await runWithMcpTenantDatabaseScope(ctx, (db) =>
         appendSystemMessage({
@@ -323,16 +310,17 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
           contentPreview: `Widget: gateway_token (${channel.name})`,
           type: 'widget_request',
           role: MessageRole.SYSTEM,
+          // Generate the shared ID before create so no realtime consumer can
+          // observe a temporary "pending" submit URL.
+          messageId: widgetId,
           metadata: {
             widget: {
               ...baseWidgetMeta,
-              widget_id: 'pending' as MessageID,
+              widget_id: widgetId,
             },
           },
         })
       );
-
-      const widgetId = created.message_id as MessageID;
 
       if (hostTask?.message_range) {
         try {
@@ -353,17 +341,6 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
           );
         }
       }
-
-      await ctx.app.service('messages').patch(
-        widgetId,
-        {
-          metadata: {
-            ...(created.metadata ?? {}),
-            widget: { ...baseWidgetMeta, widget_id: widgetId },
-          },
-        },
-        { ...ctx.baseServiceParams, provider: undefined }
-      );
 
       return textResult({ widget_id: widgetId, status: 'requested' });
     }

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -206,7 +206,10 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
             widget: { ...baseWidgetMeta, widget_id: widgetId },
           },
         },
-        ctx.baseServiceParams
+        // This lifecycle projection is daemon-owned. Keep the authenticated
+        // user and tenant context, but remove MCP transport provenance so the
+        // external Message mutation guard does not reject its own finalization.
+        { ...ctx.baseServiceParams, provider: undefined }
       );
 
       if (presentEverywhere) {
@@ -359,7 +362,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
             widget: { ...baseWidgetMeta, widget_id: widgetId },
           },
         },
-        ctx.baseServiceParams
+        { ...ctx.baseServiceParams, provider: undefined }
       );
 
       return textResult({ widget_id: widgetId, status: 'requested' });

--- a/apps/agor-daemon/src/utils/append-system-message.ts
+++ b/apps/agor-daemon/src/utils/append-system-message.ts
@@ -37,6 +37,8 @@ export interface AppendSystemMessageOptions {
   /** Defaults to MessageRole.SYSTEM */
   role?: Message['role'];
   metadata?: Message['metadata'];
+  /** Optional daemon-generated ID to use for the row and any derived metadata. */
+  messageId?: MessageID;
   /** FeathersJS request params forwarded to the service create call */
   params?: Params;
 }
@@ -52,6 +54,7 @@ export async function appendSystemMessage(opts: AppendSystemMessageOptions): Pro
     type = 'system',
     role = MessageRole.SYSTEM,
     metadata,
+    messageId,
     params,
   } = opts;
 
@@ -59,7 +62,7 @@ export async function appendSystemMessage(opts: AppendSystemMessageOptions): Pro
   const preview = contentPreview ?? (typeof content === 'string' ? content.substring(0, 200) : '');
 
   const message: Message = {
-    message_id: generateId() as MessageID,
+    message_id: messageId ?? (generateId() as MessageID),
     session_id: sessionId as SessionID,
     task_id: taskId as TaskID | undefined,
     type,


### PR DESCRIPTION
## Linked issue

No new issue. Related lifecycle context: #2180.

## Summary

- Assign the final widget ID before creating env-var or gateway-token messages.
- Persist, emit, return, and auto-resume with the same immutable ID.
- Cover failures, retries, concurrency, and the external-provider write boundary.

## Why / context

The old lifecycle briefly treated the word `pending` as a widget identifier:

```text
Before
create widget_id="pending" ─► persist + realtime emit ─► patch to final ID
          │                                                   │
          └─ client can submit /widgets/pending/submit         └─ patch can fail
```

That made the temporary state externally observable. A fast client could submit before finalization, while a failed patch could leave a permanently unusable row.

The fixed lifecycle creates one valid state:

```text
After
generate final ID ─► create once ─► persist ─► realtime emit ─► return same ID
```

## Implementation notes

The key distinction is now explicit:

| Value | Responsibility |
|---|---|
| `widget_id` | Immutable identity, generated before creation |
| `status` | Lifecycle state such as `pending → resolving → submitted` |

Both MCP widget tools pass the generated ID into `appendSystemMessage`, which uses it for the message row and widget metadata. There is no post-create finalization patch.

Security boundaries remain intact:

- External providers still cannot create or mutate daemon-owned widget metadata.
- User, tenant, session, message, and widget ownership checks are preserved.
- The gateway-token flow remains admin-only.
- No schema or migration changes are required.

## Validation / test plan

| Evidence | Result |
|---|---|
| `pnpm check` | Passed |
| Daemon suite | 2,452 passed; 72 skipped |
| Core suite | 3,611 passed; 85 skipped |
| UI suite | 1,324 passed |
| Targeted widget/MCP/security suites | 50 passed |
| PostgreSQL integration | 127 passed |
| GitHub CI | All required checks passed |
| `git diff --check` | Passed |

Live built daemon/UI smoke coverage verified:

- [x] Env-var widgets persist and emit the final ID
- [x] Gateway-token widgets persist and emit the final ID
- [x] No `"pending"` identifier is observed
- [x] Disposable records are removed
- [x] No credential values are submitted or logged

Tests also cover create failures, retries, concurrent requests, and rejection of external widget writes.

## Screenshots / demos

Not applicable: there is no visual UI change. The live smoke test exercised the MCP, persistence, and realtime boundaries without using provider credentials.

## Risks / rollout / rollback

- **Compatibility:** lifecycle statuses are unchanged; only the transient identifier is removed.
- **Rollout:** no migration, reconnect, or provider change is required.
- **Rollback:** revert the implementation and test commits; no data rollback is needed.

## Out of scope / follow-ups

- Changes to legitimate widget status transitions.
- Provider integrations or credential-submission behavior.
