### PR TITLE
fix(mcp-oauth): restore advertised dynamic registration

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -189,6 +189,18 @@ const mcpAuthInputSchema = z
       .enum(['per_user', 'shared'])
       .optional()
       .describe("OAuth token ownership. Defaults to 'per_user' (recommended)."),
+    oauth_compatibility_mode: z
+      .enum(['strict', 'legacy'])
+      .optional()
+      .describe(
+        'OAuth compatibility policy. Defaults to strict; use legacy explicitly for older providers.'
+      ),
+    oauth_dcr_mode: z
+      .enum(['disabled', 'advertised', 'fallback'])
+      .optional()
+      .describe(
+        'Dynamic registration policy. Defaults to advertised; fallback additionally permits the legacy issuer-relative /register guess.'
+      ),
     insecure: z.boolean().optional().describe('Allow insecure auth behavior if supported.'),
   })
   .superRefine((auth, issue) => {
@@ -211,6 +223,8 @@ const mcpAuthInputSchema = z
         'oauth_scope',
         'oauth_grant_type',
         'oauth_mode',
+        'oauth_compatibility_mode',
+        'oauth_dcr_mode',
         'insecure',
       ] as const,
     };

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -74,6 +74,19 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/OAuth flow belongs to a different tenant/);
   });
 
+  it('keeps saved-server OAuth authoritative and DCR credentials request-local', () => {
+    const oauthStartBody = codeOnly.slice(
+      codeOnly.indexOf("app.use('/mcp-servers/oauth-start'"),
+      codeOnly.indexOf("app.service('mcp-servers/oauth-start').hooks")
+    );
+    expect(oauthStartBody).toMatch(
+      /runInOAuthTenantScope\s*\([\s\S]*findById\s*\(\s*savedServerId/
+    );
+    expect(oauthStartBody).toMatch(/effectiveMcpUrl\s*=\s*savedServer\?\.url\s*\?\?/);
+    expect(oauthStartBody).toMatch(/clientId:\s*savedServer\s*\?\s*clientIdFromConfig/);
+    expect(codeOnly).toMatch(/reuseDynamicClientRegistration:\s*false/);
+  });
+
   it('uses durable hashed state claims on PostgreSQL and never broadcasts raw flow state', () => {
     expect(codeOnly).toMatch(/durableOAuthFlows\.claimForCallback\s*\(\s*state\s*\)/);
     expect(codeOnly).toMatch(/cacheToken:\s*false/);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -53,6 +53,7 @@ import type {
   HookContext,
   MCPAuth,
   MCPOAuthAttemptID,
+  MCPOAuthDCRMode,
   MCPOAuthPendingFlowStatus,
   MCPServerID,
   MessageSource,
@@ -1455,7 +1456,7 @@ async function registerMCPServices(
     tokenUrlOverride?: string;
     scope?: string;
     compatibilityMode?: 'strict' | 'legacy';
-    dcrMode?: 'disabled' | 'fallback';
+    dcrMode?: MCPOAuthDCRMode;
     socketId?: string;
   };
 
@@ -1557,8 +1558,9 @@ async function registerMCPServices(
       // flow context. Daemon callers never read or populate its origin-only
       // bearer cache.
       cacheKey: opts.prefetchedAuthServerMetadata ? opts.mcpUrl : undefined,
-      // Process-global DCR credentials are not a tenant/user namespace.
-      reuseDynamicClientRegistration: !durableOAuthFlows,
+      // Process-global DCR credentials are not a tenant/user/server namespace.
+      // Daemon flows never share them, including in SQLite deployments.
+      reuseDynamicClientRegistration: false,
       resourceUri: opts.mcpUrl,
       compatibilityMode: opts.compatibilityMode,
       dcrMode: opts.dcrMode,
@@ -2230,7 +2232,7 @@ async function registerMCPServices(
         grant_type?: string;
         start_browser_flow?: boolean;
         compatibility_mode?: 'strict' | 'legacy';
-        dcr_mode?: 'disabled' | 'fallback';
+        dcr_mode?: MCPOAuthDCRMode;
       },
       params?: { connection?: { id?: string } }
     ) {
@@ -2331,7 +2333,7 @@ async function registerMCPServices(
                   clientSecret: data.client_secret,
                   scope: data.scope,
                   compatibilityMode,
-                  dcrMode: data.dcr_mode ?? 'disabled',
+                  dcrMode: data.dcr_mode,
                 });
               } catch (err) {
                 if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -2602,13 +2604,30 @@ async function registerMCPServices(
         let clientIdFromConfig: string | undefined;
         let scopeOverride: string | undefined;
         let compatibilityMode: 'strict' | 'legacy' = 'strict';
-        let dcrMode: 'disabled' | 'fallback' = 'disabled';
-        const savedServer = data.mcp_server_id
+        let dcrMode: MCPOAuthDCRMode | undefined;
+        const savedServerId = data.mcp_server_id;
+        const savedServer = savedServerId
           ? await runInOAuthTenantScope(db, tenantId, () => {
               const mcpServerRepo = new MCPServerRepository(db);
-              return mcpServerRepo.findById(data.mcp_server_id as string);
+              return mcpServerRepo.findById(savedServerId);
             })
           : null;
+
+        if (
+          savedServerId &&
+          (!savedServer?.enabled || !savedServer.url || savedServer.auth?.type !== 'oauth')
+        ) {
+          return {
+            success: false,
+            error:
+              'OAuth requires an enabled, saved MCP server in the current tenant. Save changes, then restart OAuth.',
+          };
+        }
+
+        // Once an ID is supplied, its tenant-scoped row is authoritative for
+        // the provider URL and client configuration. The duplicate payload
+        // fields remain accepted only for older callers.
+        const effectiveMcpUrl = savedServer?.url ?? data.mcp_url;
 
         // PostgreSQL is the shared authority, so reject transient or stale
         // server input before the first outbound probe. Doing this only in the
@@ -2617,7 +2636,7 @@ async function registerMCPServices(
         if (
           durableOAuthFlows &&
           (!savedServer?.enabled ||
-            savedServer.url !== data.mcp_url ||
+            savedServer.url !== effectiveMcpUrl ||
             savedServer.auth?.type !== 'oauth')
         ) {
           return {
@@ -2635,7 +2654,7 @@ async function registerMCPServices(
           clientSecretOverride = savedServer.auth.oauth_client_secret;
           scopeOverride = savedServer.auth.oauth_scope;
           compatibilityMode = savedServer.auth.oauth_compatibility_mode ?? 'strict';
-          dcrMode = savedServer.auth.oauth_dcr_mode ?? 'disabled';
+          dcrMode = savedServer.auth.oauth_dcr_mode;
           if (oauthMode === 'shared') {
             const currentUser =
               durableOAuthFlows && tenantId && userId
@@ -2649,7 +2668,7 @@ async function registerMCPServices(
           }
         }
 
-        let probeResponse = await oauthFetch(data.mcp_url, {
+        let probeResponse = await oauthFetch(effectiveMcpUrl, {
           method: 'POST',
           headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
           body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -2657,7 +2676,7 @@ async function registerMCPServices(
         });
 
         if (probeResponse.status !== 401) {
-          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(data.mcp_url);
+          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(effectiveMcpUrl);
           if (fallbackProbe) {
             console.log(
               '[OAuth Start] Handshake-level probe returned no auth requirement; ' +
@@ -2678,7 +2697,7 @@ async function registerMCPServices(
         const { resolveMCPOAuthDiscovery } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
         );
-        const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, data.mcp_url, {
+        const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
           compatibilityMode,
           allowLocalhostHttp: !durableOAuthFlows,
         });
@@ -2695,16 +2714,16 @@ async function registerMCPServices(
         let result: StartTwoPhaseOAuthResult;
         try {
           result = await startTwoPhaseMCPOAuthFlow({
-            mcpUrl: data.mcp_url,
+            mcpUrl: effectiveMcpUrl,
             wwwAuthenticate,
             resourceMetadataUrl:
               discovery.kind === 'resource-metadata' ? discovery.metadataUrl : undefined,
             prefetchedAuthServerMetadata:
               discovery.kind === 'authorization-server' ? discovery.authServerMetadata : undefined,
-            mcpServerId: data.mcp_server_id,
+            mcpServerId: savedServerId,
             userId,
             oauthMode,
-            clientId: data.client_id || clientIdFromConfig,
+            clientId: savedServer ? clientIdFromConfig : data.client_id,
             clientSecret: clientSecretOverride,
             authorizationUrlOverride,
             tokenUrlOverride,
@@ -3621,7 +3640,7 @@ async function registerMCPServices(
               tokenUrlOverride: serverConfig.auth?.oauth_token_url,
               scope: serverConfig.auth?.oauth_scope,
               compatibilityMode,
-              dcrMode: serverConfig.auth?.oauth_dcr_mode ?? 'disabled',
+              dcrMode: serverConfig.auth?.oauth_dcr_mode,
               tenantId,
               socketId: connection?.id,
             });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -62,7 +62,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES, TaskStatus } from '@agor/core/types';
+import { hasMinimumRole, isMCPOAuthGrantBindingVersion, ROLES, TaskStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import { safeOutboundFetch } from '@agor/core/utils/safe-outbound-fetch';
 import type express from 'express';
@@ -149,7 +149,6 @@ import {
   hasMCPOAuthRelevantServerConfigurationChanged,
   isMCPOAuthGrantBoundToServer,
   lockMCPOAuthGrantConfiguration,
-  MCP_OAUTH_GRANT_BINDING_VERSION,
 } from './services/mcp-oauth-grant-binding.js';
 import { MCPOAuthPendingFlowAuthority } from './services/mcp-oauth-pending-flow-authority.js';
 import { createMCPServersService } from './services/mcp-servers.js';
@@ -1779,7 +1778,7 @@ async function registerMCPServices(
           server.auth?.type !== 'oauth' ||
           (server.auth.oauth_mode ?? 'per_user') !== record.oauthMode ||
           server.url !== pendingFlow.context.resourceUri ||
-          record.configFingerprintVersion !== MCP_OAUTH_GRANT_BINDING_VERSION
+          !isMCPOAuthGrantBindingVersion(record.configFingerprintVersion)
         ) {
           throw new Error('MCP OAuth server configuration changed; restart authorization');
         }
@@ -1798,7 +1797,8 @@ async function registerMCPServices(
             redirectUri: pendingFlow.context.redirectUri,
             clientId: pendingFlow.context.clientId,
             clientSecret: pendingFlow.context.clientSecret,
-          }
+          },
+          record.configFingerprintVersion
         );
         if (fingerprint !== record.configFingerprint) {
           throw new Error('MCP OAuth grant binding changed; restart authorization');
@@ -1814,6 +1814,16 @@ async function registerMCPServices(
     pendingFlow: PendingOAuthFlow,
     logPrefix: string
   ): Promise<void> => {
+    const durableRecord = pendingFlow.durableRecord;
+    const durableGrantBindingVersion = durableRecord
+      ? (() => {
+          const version = durableRecord.configFingerprintVersion;
+          if (!isMCPOAuthGrantBindingVersion(version)) {
+            throw new Error('Unsupported MCP OAuth grant binding version');
+          }
+          return version;
+        })()
+      : undefined;
     const work = () =>
       persistOAuthToken(
         db,
@@ -1828,7 +1838,7 @@ async function registerMCPServices(
             ? {
                 grantBinding: {
                   generation: pendingFlow.durableRecord.grantGeneration,
-                  version: MCP_OAUTH_GRANT_BINDING_VERSION,
+                  version: durableGrantBindingVersion!,
                   fingerprint: pendingFlow.durableRecord.configFingerprint,
                   metadataUri: pendingFlow.context.metadataUrl,
                   resourceUri: pendingFlow.context.resourceUri,

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -67,6 +67,26 @@ function tokenFor(fingerprint: string): UserMCPOAuthToken {
 }
 
 describe('MCP OAuth grant configuration binding', () => {
+  it('preserves the version-1 missing DCR fingerprint across upgrades', () => {
+    const withoutPolicy: ServerBinding = {
+      ...server,
+      auth: { ...server.auth, oauth_dcr_mode: undefined },
+    };
+    const advertised: ServerBinding = {
+      ...server,
+      auth: { ...server.auth, oauth_dcr_mode: 'advertised' },
+    };
+    const disabled: ServerBinding = {
+      ...server,
+      auth: { ...server.auth, oauth_dcr_mode: 'disabled' },
+    };
+
+    const fingerprint = (candidate: ServerBinding) =>
+      fingerprintMCPOAuthGrantConfiguration(masterSecret, candidate, resolved);
+    expect(fingerprint(withoutPolicy)).toBe(fingerprint(disabled));
+    expect(fingerprint(withoutPolicy)).not.toBe(fingerprint(advertised));
+  });
+
   it('binds every provider, client, callback, server, mode, and version input', () => {
     const original = fingerprintMCPOAuthGrantConfiguration(masterSecret, server, resolved);
     const variants: Array<[string, ServerBinding, MCPOAuthResolvedGrantBinding]> = [

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -43,7 +43,10 @@ const resolved = {
   clientSecret: 'registered-secret',
 } satisfies MCPOAuthResolvedGrantBinding;
 
-function tokenFor(fingerprint: string): UserMCPOAuthToken {
+function tokenFor(
+  fingerprint: string,
+  version: UserMCPOAuthToken['grant_binding_version'] = MCP_OAUTH_GRANT_BINDING_VERSION
+): UserMCPOAuthToken {
   return {
     user_id: null,
     mcp_server_id: server.mcp_server_id,
@@ -57,7 +60,7 @@ function tokenFor(fingerprint: string): UserMCPOAuthToken {
     oauth_token_endpoint: resolved.tokenEndpoint,
     oauth_redirect_uri: resolved.redirectUri,
     grant_generation: 7,
-    grant_binding_version: MCP_OAUTH_GRANT_BINDING_VERSION,
+    grant_binding_version: version,
     grant_binding_fingerprint: fingerprint,
     refresh_status: 'idle',
     refresh_generation: 0,
@@ -67,7 +70,7 @@ function tokenFor(fingerprint: string): UserMCPOAuthToken {
 }
 
 describe('MCP OAuth grant configuration binding', () => {
-  it('preserves the version-1 missing DCR fingerprint across upgrades', () => {
+  it('records advertised as the effective default while preserving version-1 fingerprints', () => {
     const withoutPolicy: ServerBinding = {
       ...server,
       auth: { ...server.auth, oauth_dcr_mode: undefined },
@@ -81,10 +84,22 @@ describe('MCP OAuth grant configuration binding', () => {
       auth: { ...server.auth, oauth_dcr_mode: 'disabled' },
     };
 
-    const fingerprint = (candidate: ServerBinding) =>
+    const currentFingerprint = (candidate: ServerBinding) =>
       fingerprintMCPOAuthGrantConfiguration(masterSecret, candidate, resolved);
-    expect(fingerprint(withoutPolicy)).toBe(fingerprint(disabled));
-    expect(fingerprint(withoutPolicy)).not.toBe(fingerprint(advertised));
+    expect(currentFingerprint(withoutPolicy)).toBe(currentFingerprint(advertised));
+    expect(currentFingerprint(withoutPolicy)).not.toBe(currentFingerprint(disabled));
+
+    const legacyFingerprint = (candidate: ServerBinding) =>
+      fingerprintMCPOAuthGrantConfiguration(masterSecret, candidate, resolved, 1);
+    expect(legacyFingerprint(withoutPolicy)).toBe(legacyFingerprint(disabled));
+    expect(legacyFingerprint(withoutPolicy)).not.toBe(legacyFingerprint(advertised));
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        withoutPolicy,
+        tokenFor(legacyFingerprint(withoutPolicy), 1)
+      )
+    ).toBe(true);
   });
 
   it('binds every provider, client, callback, server, mode, and version input', () => {
@@ -140,7 +155,7 @@ describe('MCP OAuth grant configuration binding', () => {
         label
       ).not.toBe(original);
     }
-    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(1);
+    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(2);
   });
 
   it('revalidates a stored grant and rejects a configuration change', () => {
@@ -163,6 +178,17 @@ describe('MCP OAuth grant configuration binding', () => {
       hasMCPOAuthRelevantServerConfigurationChanged(server, {
         ...server,
         auth: { ...server.auth, oauth_mode: 'shared' },
+      })
+    ).toBe(true);
+
+    const withoutPolicy: ServerBinding = {
+      ...server,
+      auth: { ...server.auth, oauth_dcr_mode: undefined },
+    };
+    expect(
+      hasMCPOAuthRelevantServerConfigurationChanged(withoutPolicy, {
+        ...withoutPolicy,
+        auth: { ...withoutPolicy.auth, oauth_dcr_mode: 'disabled' },
       })
     ).toBe(true);
     expect(

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -45,6 +45,9 @@ function authBinding(auth: MCPAuth | undefined): Record<string, unknown> {
     type: auth?.type ?? 'none',
     mode: auth?.oauth_mode ?? 'per_user',
     compatibility: auth?.oauth_compatibility_mode ?? 'strict',
+    // Version 1 shipped with missing values canonicalized as `disabled`.
+    // Keep that representation stable for existing grants and pending flows;
+    // effective OAuth-start behavior may still default missing to `advertised`.
     dcr: auth?.oauth_dcr_mode ?? 'disabled',
     authorizationOverride: auth?.oauth_authorization_url ?? null,
     tokenOverride: auth?.oauth_token_url ?? null,

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -6,9 +6,15 @@ import {
   type TenantScopedDatabase,
   type UserMCPOAuthToken,
 } from '@agor/core/db';
-import type { MCPAuth, MCPServer, MCPServerID } from '@agor/core/types';
+import type {
+  MCPAuth,
+  MCPOAuthGrantBindingVersion,
+  MCPServer,
+  MCPServerID,
+} from '@agor/core/types';
+import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
 
-export const MCP_OAUTH_GRANT_BINDING_VERSION = 1 as const;
+export const MCP_OAUTH_GRANT_BINDING_VERSION = 2 as const;
 
 /**
  * Serialize an MCP server's OAuth configuration with grant creation and
@@ -40,15 +46,18 @@ export interface MCPOAuthResolvedGrantBinding {
   clientSecret?: string;
 }
 
-function authBinding(auth: MCPAuth | undefined): Record<string, unknown> {
+function authBinding(
+  auth: MCPAuth | undefined,
+  version: MCPOAuthGrantBindingVersion
+): Record<string, unknown> {
   return {
     type: auth?.type ?? 'none',
     mode: auth?.oauth_mode ?? 'per_user',
     compatibility: auth?.oauth_compatibility_mode ?? 'strict',
-    // Version 1 shipped with missing values canonicalized as `disabled`.
-    // Keep that representation stable for existing grants and pending flows;
-    // effective OAuth-start behavior may still default missing to `advertised`.
-    dcr: auth?.oauth_dcr_mode ?? 'disabled',
+    // Preserve version 1 for existing grants and pending flows. New bindings
+    // record the effective default so an explicit switch to disabled revokes a
+    // DCR-created grant just like any other relevant policy change.
+    dcr: auth?.oauth_dcr_mode ?? (version === 1 ? 'disabled' : 'advertised'),
     authorizationOverride: auth?.oauth_authorization_url ?? null,
     tokenOverride: auth?.oauth_token_url ?? null,
     configuredClientId: auth?.oauth_client_id ?? null,
@@ -62,20 +71,21 @@ function authBinding(auth: MCPAuth | undefined): Record<string, unknown> {
 export function fingerprintMCPOAuthGrantConfiguration(
   masterSecret: string,
   server: Pick<MCPServer, 'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'auth'>,
-  resolved: MCPOAuthResolvedGrantBinding
+  resolved: MCPOAuthResolvedGrantBinding,
+  version: MCPOAuthGrantBindingVersion = MCP_OAUTH_GRANT_BINDING_VERSION
 ): string {
   if (!masterSecret) throw new Error('MCP OAuth grant binding requires AGOR_MASTER_SECRET');
   const canonical = JSON.stringify({
-    version: MCP_OAUTH_GRANT_BINDING_VERSION,
+    version,
     serverId: server.mcp_server_id,
     enabled: server.enabled,
     transport: server.transport,
     serverUrl: server.url ?? null,
-    auth: authBinding(server.auth),
+    auth: authBinding(server.auth, version),
     resolved,
   });
   return createHmac('sha256', masterSecret)
-    .update('agor:mcp-oauth:grant-configuration:v1\0', 'utf8')
+    .update(`agor:mcp-oauth:grant-configuration:v${version}\0`, 'utf8')
     .update(canonical, 'utf8')
     .digest('hex');
 }
@@ -87,7 +97,7 @@ function relevantServerConfiguration(server: Partial<MCPServer> | null | undefin
     enabled: server.enabled,
     transport: server.transport,
     url: server.url ?? null,
-    auth: authBinding(server.auth),
+    auth: authBinding(server.auth, MCP_OAUTH_GRANT_BINDING_VERSION),
   });
 }
 
@@ -109,7 +119,7 @@ export function isMCPOAuthGrantBoundToServer(
   grant: UserMCPOAuthToken
 ): boolean {
   if (
-    grant.grant_binding_version !== MCP_OAUTH_GRANT_BINDING_VERSION ||
+    !isMCPOAuthGrantBindingVersion(grant.grant_binding_version) ||
     !grant.grant_binding_fingerprint ||
     !grant.oauth_metadata_uri ||
     !grant.oauth_resource_uri ||
@@ -123,16 +133,21 @@ export function isMCPOAuthGrantBoundToServer(
   }
   try {
     return (
-      fingerprintMCPOAuthGrantConfiguration(masterSecret, server, {
-        resourceUri: grant.oauth_resource_uri,
-        metadataUrl: grant.oauth_metadata_uri,
-        issuer: grant.oauth_issuer,
-        authorizationEndpoint: grant.oauth_authorization_endpoint,
-        tokenEndpoint: grant.oauth_token_endpoint,
-        redirectUri: grant.oauth_redirect_uri,
-        clientId: grant.oauth_client_id,
-        clientSecret: grant.oauth_client_secret,
-      }) === grant.grant_binding_fingerprint
+      fingerprintMCPOAuthGrantConfiguration(
+        masterSecret,
+        server,
+        {
+          resourceUri: grant.oauth_resource_uri,
+          metadataUrl: grant.oauth_metadata_uri,
+          issuer: grant.oauth_issuer,
+          authorizationEndpoint: grant.oauth_authorization_endpoint,
+          tokenEndpoint: grant.oauth_token_endpoint,
+          redirectUri: grant.oauth_redirect_uri,
+          clientId: grant.oauth_client_id,
+          clientSecret: grant.oauth_client_secret,
+        },
+        grant.grant_binding_version
+      ) === grant.grant_binding_fingerprint
     );
   } catch {
     return false;

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
@@ -27,6 +27,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import type { MCPServerID, UserID } from '@agor/core/types';
+import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { lockMCPOAuthGrantConfiguration } from './mcp-oauth-grant-binding.js';
 import {
@@ -163,6 +164,9 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
 
       const claimed = await authorityB.claimForCallback(context.state);
       if (claimed.outcome !== 'claimed') throw new Error('Expected peer callback claim');
+      if (!isMCPOAuthGrantBindingVersion(claimed.flow.configFingerprintVersion)) {
+        throw new Error('Expected a supported grant binding version');
+      }
       const opened = authorityB.openClaim(claimed.flow, context.state);
       await runWithTenantDatabaseScope(dbB, bound.tenantId, async (scoped) => {
         await new UserMCPOAuthTokenRepository(scoped, masterSecret).saveToken(
@@ -176,7 +180,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
             expiresAt: new Date(Date.now() + 3_600_000),
             grantBinding: {
               generation: claimed.flow.grantGeneration,
-              version: 1,
+              version: claimed.flow.configFingerprintVersion,
               fingerprint: claimed.flow.configFingerprint,
               metadataUri: opened.context.metadataUrl,
               resourceUri: opened.context.resourceUri,

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -28,6 +28,8 @@ import type {
   MCPServerID,
   UserID,
 } from '@agor/core/types';
+import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
+import { MCP_OAUTH_GRANT_BINDING_VERSION } from './mcp-oauth-grant-binding.js';
 
 const FLOW_TTL_MS = 10 * 60 * 1000;
 
@@ -62,7 +64,7 @@ function hasOnlyExpectedMaterialShape(value: unknown): value is MCPOAuthPendingF
     typeof material.mcpServerId === 'string' &&
     (material.oauthMode === 'per_user' || material.oauthMode === 'shared') &&
     Number.isSafeInteger(material.grantGeneration) &&
-    material.configFingerprintVersion === 1 &&
+    isMCPOAuthGrantBindingVersion(material.configFingerprintVersion) &&
     typeof material.configFingerprint === 'string' &&
     typeof material.resourceUri === 'string' &&
     typeof material.issuer === 'string' &&
@@ -130,7 +132,7 @@ export class MCPOAuthPendingFlowAuthority {
         mcpServerId: input.mcpServerId,
         oauthMode: input.oauthMode,
         grantGeneration,
-        configFingerprintVersion: 1,
+        configFingerprintVersion: MCP_OAUTH_GRANT_BINDING_VERSION,
         configFingerprint: input.configFingerprint,
         resourceUri: input.context.resourceUri,
         issuer: input.context.issuer,
@@ -166,7 +168,7 @@ export class MCPOAuthPendingFlowAuthority {
         oauthMode: input.oauthMode,
         subjectUserId,
         grantGeneration,
-        configFingerprintVersion: 1,
+        configFingerprintVersion: MCP_OAUTH_GRANT_BINDING_VERSION,
         configFingerprint: input.configFingerprint,
         envelopeVersion: MCP_OAUTH_SECRET_ENVELOPE_VERSION,
         sealedMaterial,

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -1,0 +1,64 @@
+import type { AgorClient, MCPServer } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const showSuccess = vi.fn();
+const showError = vi.fn();
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({
+    showSuccess,
+    showError,
+    showInfo: vi.fn(),
+    showWarning: vi.fn(),
+  }),
+}));
+
+vi.mock('./MCPServerFormFields', async () => {
+  const { Form, Input } = await import('antd');
+  return {
+    MCPServerFormFields: () => (
+      <Form.Item label="Description" name="description">
+        <Input />
+      </Form.Item>
+    ),
+  };
+});
+
+import { MCPServerEditModal } from './MCPServerEditModal';
+
+describe('MCPServerEditModal legacy DCR compatibility', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps oauth_dcr_mode absent when an unrelated field is saved', async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const client = {
+      service: vi.fn().mockReturnValue({ patch }),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000001',
+      name: 'legacy-notion',
+      display_name: 'Legacy Notion',
+      description: 'before',
+      transport: 'http',
+      url: 'https://mcp.notion.com/mcp',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+
+    render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText('Description'), {
+      target: { value: 'after' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+    const updates = patch.mock.calls[0]?.[1] as { auth?: Record<string, unknown> };
+    expect(updates.auth).not.toHaveProperty('oauth_dcr_mode');
+    expect(showSuccess).toHaveBeenCalled();
+    expect(showError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -43,6 +43,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   const [authType, setAuthType] = useState<'none' | 'bearer' | 'jwt' | 'oauth'>('none');
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [preserveAbsentDcrMode, setPreserveAbsentDcrMode] = useState(false);
 
   // Hydrate the form when the modal opens or the user swaps to a different
   // server. Intentionally NOT keyed on `server` itself — that would clobber
@@ -53,6 +54,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     if (!open || !server) return;
 
     setTestResult(null);
+    setPreserveAbsentDcrMode(false);
     const serverAuthType = (server.auth?.type as 'none' | 'bearer' | 'jwt' | 'oauth') || 'none';
     setAuthType(serverAuthType);
     setTransport(server.transport || (server.url ? 'http' : 'stdio'));
@@ -83,6 +85,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       formValues.jwt_api_token = server.auth?.api_token;
       formValues.jwt_api_secret = server.auth?.api_secret;
     } else if (serverAuthType === 'oauth') {
+      setPreserveAbsentDcrMode(server.auth?.oauth_dcr_mode === undefined);
       formValues.oauth_authorization_url = server.auth?.oauth_authorization_url;
       formValues.oauth_token_url = server.auth?.oauth_token_url;
       formValues.oauth_client_id = server.auth?.oauth_client_id;
@@ -91,7 +94,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       formValues.oauth_grant_type = server.auth?.oauth_grant_type || 'client_credentials';
       formValues.oauth_mode = server.auth?.oauth_mode || 'per_user';
       formValues.oauth_compatibility_mode = server.auth?.oauth_compatibility_mode || 'strict';
-      formValues.oauth_dcr_mode = server.auth?.oauth_dcr_mode || 'disabled';
+      formValues.oauth_dcr_mode = server.auth?.oauth_dcr_mode || 'advertised';
     }
 
     form.setFieldsValue(formValues);
@@ -102,6 +105,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     setTransport('stdio');
     setAuthType('none');
     setTestResult(null);
+    setPreserveAbsentDcrMode(false);
     onClose();
   };
 
@@ -209,7 +213,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       const env = parseEnvJSON(values.env);
       if (env) updates.env = env;
 
-      updates.auth = buildAuthFromValues(values);
+      updates.auth = buildAuthFromValues(values, { preserveAbsentDcrMode });
 
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
 
@@ -231,7 +235,14 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       width={600}
       destroyOnHidden
     >
-      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+      <Form
+        form={form}
+        layout="vertical"
+        style={{ marginTop: 16 }}
+        onValuesChange={(changedValues) => {
+          if ('oauth_dcr_mode' in changedValues) setPreserveAbsentDcrMode(false);
+        }}
+      >
         <MCPServerFormFields
           mode="edit"
           transport={transport}

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -148,7 +148,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     ].some((v) => typeof v === 'string' && v.trim().length > 0) ||
     (typeof watchedOauthMode === 'string' && watchedOauthMode !== 'per_user') ||
     watchedCompatibilityMode === 'legacy' ||
-    watchedDcrMode === 'fallback';
+    (typeof watchedDcrMode === 'string' && watchedDcrMode !== 'advertised');
 
   const handleStartOAuthFlow = async () => {
     if (!client) {
@@ -774,7 +774,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                   <Form.Item
                     label="Client ID"
                     name="oauth_client_id"
-                    tooltip="Register an OAuth app with the provider and paste its client ID. Dynamic Client Registration is used only when explicitly enabled below."
+                    tooltip="Register an OAuth app with the provider and paste its client ID. Otherwise Agor can use a registration endpoint advertised by the provider."
                   >
                     <Input
                       placeholder="Enter client ID or {{ user.env.OAUTH_CLIENT_ID }}"
@@ -784,14 +784,17 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                   <Form.Item
                     label="Dynamic Client Registration"
                     name="oauth_dcr_mode"
-                    initialValue="disabled"
-                    tooltip="Pre-registration is preferred. Enable fallback only for a server that explicitly advertises a compatible registration endpoint."
+                    initialValue="advertised"
+                    tooltip="Advertised registration uses only validated provider metadata. Legacy fallback additionally guesses an issuer-relative /register endpoint."
                   >
                     <Select>
+                      <Select.Option value="advertised">
+                        Advertised endpoint (recommended)
+                      </Select.Option>
                       <Select.Option value="disabled">
                         Disabled — pre-registered client
                       </Select.Option>
-                      <Select.Option value="fallback">Explicit DCR fallback</Select.Option>
+                      <Select.Option value="fallback">Legacy /register fallback</Select.Option>
                     </Select>
                   </Form.Item>
                   <Form.Item

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -52,7 +52,7 @@ describe('extractOAuthConfig', () => {
       oauth_grant_type: 'authorization_code',
       oauth_mode: 'per_user',
       oauth_compatibility_mode: 'strict',
-      oauth_dcr_mode: 'disabled',
+      oauth_dcr_mode: 'advertised',
     });
   });
 
@@ -76,14 +76,17 @@ describe('extractOAuthConfig', () => {
     expect(result.oauth_mode).toBe('shared');
   });
 
-  it('defaults to strict OAuth without dynamic registration', () => {
+  it('defaults to strict OAuth with advertised registration', () => {
     expect(extractOAuthConfig({})).toMatchObject({
       oauth_compatibility_mode: 'strict',
-      oauth_dcr_mode: 'disabled',
+      oauth_dcr_mode: 'advertised',
     });
   });
 
-  it('preserves explicit legacy and DCR fallback opt-ins', () => {
+  it('preserves explicit disabled and legacy fallback policies', () => {
+    expect(extractOAuthConfig({ oauth_dcr_mode: 'disabled' })).toMatchObject({
+      oauth_dcr_mode: 'disabled',
+    });
     expect(
       extractOAuthConfig({
         oauth_compatibility_mode: 'legacy',
@@ -169,6 +172,28 @@ describe('extractOAuthConfigForTesting', () => {
 });
 
 describe('buildAuthFromValues', () => {
+  it('preserves a legacy absent DCR field across an unrelated edit', () => {
+    expect(
+      buildAuthFromValues(
+        {
+          auth_type: 'oauth',
+          oauth_dcr_mode: 'advertised',
+          oauth_scope: 'unchanged',
+        },
+        { preserveAbsentDcrMode: true }
+      )
+    ).not.toHaveProperty('oauth_dcr_mode');
+  });
+
+  it('materializes DCR after the operator changes the policy', () => {
+    expect(
+      buildAuthFromValues(
+        { auth_type: 'oauth', oauth_dcr_mode: 'fallback' },
+        { preserveAbsentDcrMode: true }
+      )
+    ).toMatchObject({ oauth_dcr_mode: 'fallback' });
+  });
+
   it('returns undefined when auth_type is none / missing / unrecognized', () => {
     expect(buildAuthFromValues({})).toBeUndefined();
     expect(buildAuthFromValues({ auth_type: 'none' })).toBeUndefined();

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -2,6 +2,7 @@ import {
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
 } from '@agor/core/tools/mcp/http-headers';
+import type { MCPOAuthDCRMode } from '@agor-live/client';
 
 /**
  * OAuth utility functions extracted from MCPServersTable for testability.
@@ -27,7 +28,7 @@ export interface OAuthConfig {
   oauth_grant_type?: string;
   oauth_mode?: 'per_user' | 'shared';
   oauth_compatibility_mode?: 'strict' | 'legacy';
-  oauth_dcr_mode?: 'disabled' | 'fallback';
+  oauth_dcr_mode?: MCPOAuthDCRMode;
 }
 
 /**
@@ -73,7 +74,10 @@ export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig
   config.oauth_mode = values.oauth_mode === 'shared' ? 'shared' : 'per_user';
   config.oauth_compatibility_mode =
     values.oauth_compatibility_mode === 'legacy' ? 'legacy' : 'strict';
-  config.oauth_dcr_mode = values.oauth_dcr_mode === 'fallback' ? 'fallback' : 'disabled';
+  config.oauth_dcr_mode =
+    values.oauth_dcr_mode === 'disabled' || values.oauth_dcr_mode === 'fallback'
+      ? values.oauth_dcr_mode
+      : 'advertised';
 
   return config;
 }
@@ -86,7 +90,7 @@ export interface TestConfig {
   scope?: string;
   grant_type?: string;
   compatibility_mode?: 'strict' | 'legacy';
-  dcr_mode?: 'disabled' | 'fallback';
+  dcr_mode?: MCPOAuthDCRMode;
 }
 
 /**
@@ -134,7 +138,10 @@ export function extractOAuthConfigForTesting(values: Record<string, unknown>): T
     config.grant_type = values.oauth_grant_type;
   }
   config.compatibility_mode = values.oauth_compatibility_mode === 'legacy' ? 'legacy' : 'strict';
-  config.dcr_mode = values.oauth_dcr_mode === 'fallback' ? 'fallback' : 'disabled';
+  config.dcr_mode =
+    values.oauth_dcr_mode === 'disabled' || values.oauth_dcr_mode === 'fallback'
+      ? values.oauth_dcr_mode
+      : 'advertised';
 
   return config;
 }
@@ -158,7 +165,7 @@ export interface BuiltAuth {
   oauth_grant_type?: string;
   oauth_mode?: 'per_user' | 'shared';
   oauth_compatibility_mode?: 'strict' | 'legacy';
-  oauth_dcr_mode?: 'disabled' | 'fallback';
+  oauth_dcr_mode?: MCPOAuthDCRMode;
 }
 
 /**
@@ -167,7 +174,10 @@ export interface BuiltAuth {
  * so callers can do `payload.auth = buildAuthFromValues(values)` without
  * an outer if/else.
  */
-export function buildAuthFromValues(values: Record<string, unknown>): BuiltAuth | undefined {
+export function buildAuthFromValues(
+  values: Record<string, unknown>,
+  options: { preserveAbsentDcrMode?: boolean } = {}
+): BuiltAuth | undefined {
   const authType = values.auth_type;
   if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') return undefined;
 
@@ -180,6 +190,9 @@ export function buildAuthFromValues(values: Record<string, unknown>): BuiltAuth 
     if (typeof values.jwt_api_secret === 'string') auth.api_secret = values.jwt_api_secret;
   } else {
     Object.assign(auth, extractOAuthConfig(values));
+    if (options.preserveAbsentDcrMode && values.oauth_dcr_mode === 'advertised') {
+      delete auth.oauth_dcr_mode;
+    }
   }
   return auth;
 }

--- a/packages/core/src/db/repositories/mcp-oauth-pending-flows.ts
+++ b/packages/core/src/db/repositories/mcp-oauth-pending-flows.ts
@@ -14,6 +14,7 @@ import type {
   MCPServerID,
   UserID,
 } from '@agor/core/types';
+import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
 import { and, eq, sql } from 'drizzle-orm';
 import type { Database } from '../client';
 import {
@@ -231,7 +232,7 @@ export class MCPOAuthPendingFlowRepository {
       !SHA256_HEX.test(input.configFingerprint) ||
       !Number.isSafeInteger(input.grantGeneration) ||
       input.grantGeneration <= 0 ||
-      input.configFingerprintVersion !== 1 ||
+      !isMCPOAuthGrantBindingVersion(input.configFingerprintVersion) ||
       input.envelopeVersion !== 1 ||
       (input.oauthMode === 'per_user' && input.subjectUserId !== input.userId) ||
       (input.oauthMode === 'shared' && input.subjectUserId !== null)

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -11,7 +11,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { MCPServerID, UserID } from '@agor/core/types';
+import type { MCPOAuthGrantBindingVersion, MCPServerID, UserID } from '@agor/core/types';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { Database } from '../client';
 import { deleteFrom, executeRaw, insert, select, update } from '../database-wrapper';
@@ -94,7 +94,7 @@ export interface SaveTokenInput {
   /** Required for every new PostgreSQL grant and checked on replacement. */
   grantBinding?: {
     generation: number;
-    version: 1;
+    version: MCPOAuthGrantBindingVersion;
     fingerprint: string;
     metadataUri: string;
     resourceUri: string;

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -1119,6 +1119,22 @@ describe('strict current MCP OAuth profile', () => {
     await expect(startStrict()).rejects.toThrow('required callback issuer');
   });
 
+  it('validates strict metadata before creating a dynamic client', async () => {
+    globalThis.fetch = strictFetch({ registrationEndpoint: true, s256: false });
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri }
+      )
+    ).rejects.toThrow('required PKCE S256');
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalledWith(
+      `${issuer}/register`,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
   it.each([undefined, 'advertised' as const])(
     'uses an advertised registration endpoint with DCR mode %s',
     async (dcrMode) => {

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -1001,6 +1001,7 @@ describe('strict current MCP OAuth profile', () => {
   const issuer = 'https://auth.example.com';
 
   beforeEach(() => {
+    clearAuthCodeTokenCache();
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -1015,9 +1016,10 @@ describe('strict current MCP OAuth profile', () => {
       metadataIssuer?: string;
       s256?: boolean;
       responseIssuer?: boolean;
+      registrationEndpoint?: boolean;
     } = {}
   ) {
-    return vi.fn().mockImplementation(async (input: string | URL) => {
+    return vi.fn().mockImplementation(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === metadataUri) {
         return new Response(
@@ -1035,10 +1037,23 @@ describe('strict current MCP OAuth profile', () => {
             issuer: overrides.metadataIssuer ?? issuer,
             authorization_endpoint: `${issuer}/authorize`,
             token_endpoint: `${issuer}/token`,
+            registration_endpoint: overrides.registrationEndpoint
+              ? `${issuer}/register`
+              : undefined,
             code_challenge_methods_supported: overrides.s256 === false ? ['plain'] : ['S256'],
             authorization_response_iss_parameter_supported: overrides.responseIssuer !== false,
           }),
           { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      if (url === `${issuer}/register` && init?.method === 'POST') {
+        return new Response(
+          JSON.stringify({
+            client_id: 'dcr-client',
+            redirect_uris: ['https://agor.example.com/mcp-servers/oauth-callback'],
+            token_endpoint_auth_method: 'none',
+          }),
+          { status: 201, headers: { 'content-type': 'application/json' } }
         );
       }
       throw new Error(`unexpected fetch: ${url}`);
@@ -1104,17 +1119,72 @@ describe('strict current MCP OAuth profile', () => {
     await expect(startStrict()).rejects.toThrow('required callback issuer');
   });
 
-  it('does not silently fall back to DCR or insecure endpoints', async () => {
+  it.each([undefined, 'advertised' as const])(
+    'uses an advertised registration endpoint with DCR mode %s',
+    async (dcrMode) => {
+      globalThis.fetch = strictFetch({ registrationEndpoint: true });
+      const context = await startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri, dcrMode }
+      );
+
+      expect(context.clientId).toBe('dcr-client');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${issuer}/register`,
+        expect.objectContaining({ method: 'POST' })
+      );
+    }
+  );
+
+  it('requires a pre-registered client when DCR is explicitly disabled', async () => {
+    globalThis.fetch = strictFetch({ registrationEndpoint: true });
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri, dcrMode: 'disabled' }
+      )
+    ).rejects.toThrow('Dynamic Client Registration is disabled');
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalledWith(
+      `${issuer}/register`,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('guesses issuer-relative /register only for explicit legacy fallback', async () => {
     globalThis.fetch = strictFetch();
     await expect(
       startMCPOAuthFlow(
         `Bearer resource_metadata="${metadataUri}"`,
         undefined,
         'https://agor.example.com/mcp-servers/oauth-callback',
-        { resourceUri }
+        { resourceUri, compatibilityMode: 'legacy', dcrMode: 'advertised' }
       )
-    ).rejects.toThrow('pre-registered client');
+    ).rejects.toThrow('does not advertise');
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalledWith(
+      `${issuer}/register`,
+      expect.objectContaining({ method: 'POST' })
+    );
 
+    globalThis.fetch = strictFetch();
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri, compatibilityMode: 'legacy', dcrMode: 'fallback' }
+      )
+    ).resolves.toMatchObject({ clientId: 'dcr-client' });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      `${issuer}/register`,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('does not relax outbound endpoint safety', async () => {
     globalThis.fetch = strictFetch();
     await expect(
       startMCPOAuthFlow(

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -971,29 +971,12 @@ export async function performMCPOAuthFlow(
         actualClientId = registration.client_id;
         clientSecret = registration.client_secret;
       } else {
-        // No DCR support and no client_id provided - check for well-known MCP registration endpoint
-        // Some MCP servers use /register at the auth server URL
-        const mcpRegisterEndpoint = `${authServerUrl}/register`;
-        try {
-          const registration = await registerDynamicClient(
-            mcpRegisterEndpoint,
-            callback.url,
-            'Agor MCP Client',
-            scopeString,
-            true,
-            true
-          );
-          actualClientId = registration.client_id;
-          clientSecret = registration.client_secret;
-        } catch {
-          throw new Error(
-            'OAuth client_id is required but the authorization server does not support ' +
-              'Dynamic Client Registration.\n\n' +
-              "Register an OAuth app in the provider's developer portal and enter " +
-              'the Client ID (and Client Secret if required) in the MCP server configuration.\n\n' +
-              'The registration attempt was rejected.'
-          );
-        }
+        throw new Error(
+          'OAuth client_id is required but the authorization server does not advertise ' +
+            'a Dynamic Client Registration endpoint (RFC 7591).\n\n' +
+            "Register an OAuth app in the provider's developer portal and enter " +
+            'the Client ID (and Client Secret if required) in the MCP server configuration.'
+        );
       }
     }
 
@@ -1301,6 +1284,54 @@ async function startMCPOAuthFlowWithAS(opts: {
       ? resourceScopesSupported.join(' ')
       : undefined;
 
+  // Validate the authorization contract before DCR creates durable state at
+  // the provider. A strict-profile rejection must not leave an unused client
+  // registration behind.
+  const tokenEndpoint = tokenUrlOverride || authServerMetadata?.token_endpoint;
+  if (!tokenEndpoint) {
+    throw new Error(
+      'No token endpoint available. Either provide oauth_token_url in the MCP server config, ' +
+        'or ensure the authorization server supports RFC 8414 metadata discovery.'
+    );
+  }
+  const authorizationEndpoint =
+    authorizationUrlOverride || authServerMetadata?.authorization_endpoint;
+  if (!authorizationEndpoint) {
+    throw new Error(
+      'No authorization endpoint available. Either provide oauth_authorization_url in the MCP server config, ' +
+        'or ensure the authorization server supports RFC 8414 metadata discovery.'
+    );
+  }
+  console.log('[MCP OAuth] OAuth endpoints resolved');
+
+  assertSafeOAuthUrl(tokenEndpoint, { allowLocalhostHttp });
+  assertSafeOAuthUrl(authorizationEndpoint, { allowLocalhostHttp });
+  if (compatibilityMode === 'strict') {
+    if (!authServerMetadata) {
+      throw new Error('Strict MCP OAuth requires authorization-server metadata');
+    }
+    if (authServerMetadata.issuer !== issuer) {
+      throw new Error('Authorization server issuer mismatch');
+    }
+    if (!authServerMetadata.code_challenge_methods_supported?.includes('S256')) {
+      throw new Error('Authorization server does not advertise required PKCE S256 support');
+    }
+    if (authServerMetadata.authorization_response_iss_parameter_supported !== true) {
+      throw new Error(
+        'Authorization server does not advertise the required callback issuer parameter'
+      );
+    }
+    if (
+      authorizationUrlOverride &&
+      authorizationUrlOverride !== authServerMetadata.authorization_endpoint
+    ) {
+      throw new Error('Strict MCP OAuth authorization endpoint override does not match metadata');
+    }
+    if (tokenUrlOverride && tokenUrlOverride !== authServerMetadata.token_endpoint) {
+      throw new Error('Strict MCP OAuth token endpoint override does not match metadata');
+    }
+  }
+
   // Client ID resolution (DCR if available)
   let actualClientId = clientId;
   let resolvedClientSecret = opts.clientSecret;
@@ -1350,52 +1381,6 @@ async function startMCPOAuthFlowWithAS(opts: {
 
   // CSRF state
   const state = crypto.randomUUID();
-
-  // Resolve token + auth endpoints
-  const tokenEndpoint = tokenUrlOverride || authServerMetadata?.token_endpoint;
-  if (!tokenEndpoint) {
-    throw new Error(
-      'No token endpoint available. Either provide oauth_token_url in the MCP server config, ' +
-        'or ensure the authorization server supports RFC 8414 metadata discovery.'
-    );
-  }
-  const authorizationEndpoint =
-    authorizationUrlOverride || authServerMetadata?.authorization_endpoint;
-  if (!authorizationEndpoint) {
-    throw new Error(
-      'No authorization endpoint available. Either provide oauth_authorization_url in the MCP server config, ' +
-        'or ensure the authorization server supports RFC 8414 metadata discovery.'
-    );
-  }
-  console.log('[MCP OAuth] OAuth endpoints resolved');
-
-  assertSafeOAuthUrl(tokenEndpoint, { allowLocalhostHttp });
-  assertSafeOAuthUrl(authorizationEndpoint, { allowLocalhostHttp });
-  if (compatibilityMode === 'strict') {
-    if (!authServerMetadata) {
-      throw new Error('Strict MCP OAuth requires authorization-server metadata');
-    }
-    if (authServerMetadata.issuer !== issuer) {
-      throw new Error('Authorization server issuer mismatch');
-    }
-    if (!authServerMetadata.code_challenge_methods_supported?.includes('S256')) {
-      throw new Error('Authorization server does not advertise required PKCE S256 support');
-    }
-    if (authServerMetadata.authorization_response_iss_parameter_supported !== true) {
-      throw new Error(
-        'Authorization server does not advertise the required callback issuer parameter'
-      );
-    }
-    if (
-      authorizationUrlOverride &&
-      authorizationUrlOverride !== authServerMetadata.authorization_endpoint
-    ) {
-      throw new Error('Strict MCP OAuth authorization endpoint override does not match metadata');
-    }
-    if (tokenUrlOverride && tokenUrlOverride !== authServerMetadata.token_endpoint) {
-      throw new Error('Strict MCP OAuth token endpoint override does not match metadata');
-    }
-  }
 
   const authUrl = new URL(authorizationEndpoint);
   authUrl.searchParams.set('response_type', 'code');

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -8,6 +8,7 @@
 
 import crypto from 'node:crypto';
 import http from 'node:http';
+import type { MCPOAuthDCRMode } from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import type { OAuthTokenResponse } from './oauth-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
@@ -1260,7 +1261,7 @@ async function startMCPOAuthFlowWithAS(opts: {
   resourceUri: string;
   issuer: string;
   compatibilityMode: 'strict' | 'legacy';
-  dcrMode: 'disabled' | 'fallback';
+  dcrMode: MCPOAuthDCRMode;
   allowLocalhostHttp: boolean;
 }): Promise<OAuthFlowContext> {
   const {
@@ -1304,9 +1305,10 @@ async function startMCPOAuthFlowWithAS(opts: {
   let actualClientId = clientId;
   let resolvedClientSecret = opts.clientSecret;
 
-  if (!actualClientId && dcrMode === 'fallback') {
+  if (!actualClientId && dcrMode !== 'disabled') {
     const registrationEndpoint =
-      authServerMetadata?.registration_endpoint || fallbackRegistrationEndpoint;
+      authServerMetadata?.registration_endpoint ||
+      (dcrMode === 'fallback' ? fallbackRegistrationEndpoint : undefined);
     if (registrationEndpoint) {
       console.log('[MCP OAuth] Using Dynamic Client Registration');
       try {
@@ -1342,7 +1344,7 @@ async function startMCPOAuthFlowWithAS(opts: {
     }
   } else if (!actualClientId) {
     throw new Error(
-      'OAuth client_id is required. Configure a pre-registered client, or explicitly enable Dynamic Client Registration fallback for this server.'
+      'OAuth client_id is required because Dynamic Client Registration is disabled for this server.'
     );
   }
 
@@ -1458,14 +1460,14 @@ export async function startMCPOAuthFlow(
     /** Exact protected resource identifier sent to authorization/token endpoints. */
     resourceUri?: string;
     compatibilityMode?: 'strict' | 'legacy';
-    dcrMode?: 'disabled' | 'fallback';
+    dcrMode?: MCPOAuthDCRMode;
     /** Exact loopback HTTP exception for standalone development only. */
     allowLocalhostHttp?: boolean;
   }
 ): Promise<OAuthFlowContext> {
   console.log('[MCP OAuth] Starting two-phase OAuth 2.1 flow');
   const compatibilityMode = options?.compatibilityMode ?? 'strict';
-  const dcrMode = options?.dcrMode ?? 'disabled';
+  const dcrMode = options?.dcrMode ?? 'advertised';
   const allowLocalhostHttp = options?.allowLocalhostHttp === true;
   const resourceUri = options?.resourceUri;
   if (!resourceUri) throw new Error('MCP OAuth requires an exact protected resource URI');

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -54,6 +54,17 @@ export interface MCPOAuthRefreshResult {
 /** Credential subject selected for the resulting MCP OAuth grant. */
 export type MCPOAuthMode = 'per_user' | 'shared';
 export type MCPOAuthDCRMode = 'disabled' | 'advertised' | 'fallback';
+export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2] as const;
+export type MCPOAuthGrantBindingVersion = (typeof MCP_OAUTH_GRANT_BINDING_VERSIONS)[number];
+
+export function isMCPOAuthGrantBindingVersion(
+  value: unknown
+): value is MCPOAuthGrantBindingVersion {
+  return (
+    typeof value === 'number' &&
+    MCP_OAUTH_GRANT_BINDING_VERSIONS.includes(value as MCPOAuthGrantBindingVersion)
+  );
+}
 
 /**
  * Secret-bearing material required to exchange an authorization code.
@@ -70,7 +81,7 @@ export interface MCPOAuthPendingFlowSealedMaterial {
   mcpServerId: MCPServerID;
   oauthMode: MCPOAuthMode;
   grantGeneration: number;
-  configFingerprintVersion: 1;
+  configFingerprintVersion: MCPOAuthGrantBindingVersion;
   configFingerprint: string;
   resourceUri: string;
   issuer: string;

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -53,6 +53,7 @@ export interface MCPOAuthRefreshResult {
 
 /** Credential subject selected for the resulting MCP OAuth grant. */
 export type MCPOAuthMode = 'per_user' | 'shared';
+export type MCPOAuthDCRMode = 'disabled' | 'advertised' | 'fallback';
 
 /**
  * Secret-bearing material required to exchange an authorization code.
@@ -121,8 +122,12 @@ export interface MCPAuth {
   oauth_grant_type?: string;
   /** Strict current MCP Authorization behavior is the default. */
   oauth_compatibility_mode?: 'strict' | 'legacy';
-  /** Dynamic Client Registration is disabled unless explicitly enabled. */
-  oauth_dcr_mode?: 'disabled' | 'fallback';
+  /**
+   * Dynamic Client Registration policy. Missing values use `advertised` for
+   * compatibility with servers that publish an RFC 7591 endpoint. The
+   * `fallback` mode additionally permits the legacy guessed `/register` URL.
+   */
+  oauth_dcr_mode?: MCPOAuthDCRMode;
   // OAuth 2.1 runtime tokens (obtained via browser flow)
   oauth_access_token?: string;
   oauth_token_expires_at?: number; // Unix timestamp in milliseconds


### PR DESCRIPTION
## Summary

- restore RFC 7591 dynamic client registration from a validated, advertised `registration_endpoint` when `oauth_dcr_mode` is missing
- preserve explicit `disabled` behavior and keep issuer-relative `/register` guessing behind the explicit `legacy` + `fallback` combination
- preserve legacy missing-mode serialization and version-1 OAuth grant/pending-flow fingerprints
- keep saved MCP server configuration tenant-scoped and authoritative, and disable process-global DCR credential reuse in daemon paths

## Root cause

PR #2234 made a missing `oauth_dcr_mode` resolve to `disabled` in core, daemon, and UI paths. Existing MCP server configurations with no stored mode therefore stopped using an RFC 7591 registration endpoint advertised in validated authorization-server metadata. Unrelated UI edits could also materialize `disabled` into those legacy configurations.

## Compatibility

Strict versus legacy callback issuer behavior is unchanged. Providers that do not return the RFC 9207 `iss` parameter still require the existing explicit **Legacy provider compatibility** setting. This PR does not add callback routes, issuer-derived redirect URIs, state namespaces, or mixed-version routing.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --dir packages/core exec vitest run src/tools/mcp/oauth-mcp-transport.test.ts` — 64 tests
- `pnpm --dir apps/agor-daemon exec vitest run src/services/mcp-oauth-grant-binding.test.ts src/register-services.oauth-callback.test.ts` — 12 tests
- `pnpm --dir apps/agor-ui exec vitest run src/components/MCPServer/mcp-oauth-utils.test.ts src/components/MCPServer/MCPServerEditModal.test.tsx` — 33 tests
