### PR TITLE
fix(docs): point the demo scheduler at the new HubSpot meeting link

### DIFF
--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -28,8 +28,7 @@ export const PRESET_URL = 'https://preset.io';
 export const AGOR_CLOUD_INVITE_URL = `https://preset.io/contact-us-about-agor/${presetUtm('cloud-invite-cta')}`;
 
 // Agor Cloud demo / contact link (HubSpot meetings scheduler).
-export const AGOR_CLOUD_DEMO_URL =
-  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-';
+export const AGOR_CLOUD_DEMO_URL = 'https://meetings-na2.hubspot.com/zane-aitken/agor-demo';
 
 // Preset blog post defining the AI Enablement Engineer — Agor's target
 // persona. Linked from landing-page copy.


### PR DESCRIPTION
## Summary

Updates the "Book a demo" meeting scheduler link from `meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-` to `https://meetings-na2.hubspot.com/zane-aitken/agor-demo`.

`AGOR_CLOUD_DEMO_URL` in `lib/links.ts` is the single source of truth, consumed by:
- `HubSpotMeetingModal` (the embedded "Book a demo" iframe)
- `HubSpotForm`'s plain-link fallback ("Book a Demo" when no in-modal handler is passed)

So every "Book a demo" entry point across the site picks up the new scheduler with this one-line change.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Live browser check via Chrome DevTools Protocol: clicked "Book a demo" on the homepage and confirmed the embedded iframe's `src` resolves to `https://meetings-na2.hubspot.com/zane-aitken/agor-demo?embed=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)