### PR TITLE
Fix board area overflowing below the fold

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1451,7 +1451,18 @@ export const App: React.FC<AppProps> = ({
           instanceDescription={instanceDescription}
         />
         {topBanner}
-        <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
+        {/* flex:1 + minHeight:0 pin the workspace to the viewport remainder;
+            without them the flex item's auto min-height lets board content
+            overflow below the fold by the header height. */}
+        <Content
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            display: 'flex',
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
           <PanelGroup
             id="main-layout"
             direction="horizontal"

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -1,7 +1,10 @@
 /* biome-ignore-all lint/plugin/noFirstPartyCss: React Flow integration, tool cursors, and resize hit areas require third-party selectors */
-/* Adjust MiniMap panel to have more bottom spacing */
+/* Small lift so the minimap clears the React Flow attribution. (Was 75px,
+   compensating for the canvas overflowing the fold by the header height —
+   fixed at the source: SessionCanvas defaults to 100% of its panel and the
+   app shell pins Content to the viewport remainder.) */
 .react-flow__panel.react-flow__minimap.bottom.right {
-  margin-bottom: 75px;
+  margin-bottom: 20px;
 }
 
 /* Theme-aware React Flow controls */

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -460,7 +460,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onCommentSelect,
       staticCursors,
       staticCursorScale,
-      height = '100vh',
+      // Fill the hosting panel, not the viewport: inside the app shell the
+      // canvas sits below the 64px header, so a 100vh default overflowed the
+      // fold by exactly the header height (bottom toolbar/minimap clipped).
+      // Surfaces needing viewport sizing pass an explicit height.
+      height = '100%',
     }: SessionCanvasProps,
     ref
   ) => {


### PR DESCRIPTION
SessionCanvas defaulted its root height to 100vh, but inside the app shell it sits below the 64px header — the canvas bottom (controls, minimap) always rendered below the fold. The shell's `Content` flex item also had auto min-height, letting board content overflow the same way. Canvas now defaults to 100% of its hosting panel, Content is pinned with `flex:1; min-height:0`, and the minimap's 75px bottom-margin hack that compensated for the overflow drops to a small attribution clearance.