### PR TITLE
Board interaction cleanups

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,14 +19,9 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { Layout, theme, Upload } from 'antd';
+import { Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import {
-  type ImperativePanelHandle,
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-} from 'react-resizable-panels';
+import { type ImperativePanelHandle, Panel, PanelGroup } from 'react-resizable-panels';
 import { useLocation, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
@@ -104,6 +99,7 @@ import {
   toContentRelativePercent,
   toViewportRelativePercent,
 } from './panelSizing';
+import { WorkspaceResizeHandle } from './WorkspaceResizeHandle';
 
 const { Content } = Layout;
 
@@ -362,7 +358,6 @@ export const App: React.FC<AppProps> = ({
   // stays quiet across unrelated entity patches), a call-time
   // `agorStore.getState()` read inside a handler, or pushed down into the
   // component that actually consumes the map (SettingsModal, UrlStateBridge).
-  const { token } = theme.useToken();
   const { showWarning, showError } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
@@ -1531,31 +1526,10 @@ export const App: React.FC<AppProps> = ({
                 />
               )}
             </Panel>
-            <PanelResizeHandle
-              style={{
-                position: 'relative',
-                width: leftPanelCollapsed ? '0px' : '4px',
-                background: token.colorBorderSecondary,
-                cursor: leftPanelCollapsed ? 'default' : 'col-resize',
-                transition: 'background 0.2s',
-                pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
-                overflow: 'visible',
-                zIndex: 10,
-              }}
+            <WorkspaceResizeHandle
+              disabled={leftPanelCollapsed}
               onDragging={(isDragging) => {
                 leftPanelResizeDraggingRef.current = isDragging;
-              }}
-              onMouseEnter={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorPrimary;
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorBorderSecondary;
-                }
               }}
             />
             <Panel id="content-panel" order={2} defaultSize={contentPanelWidthPercent} minSize={40}>
@@ -1654,23 +1628,9 @@ export const App: React.FC<AppProps> = ({
                 </Panel>
                 {(sessionPanelTargetOpen || !eventStreamPanelCollapsed) && (
                   <>
-                    <PanelResizeHandle
-                      style={{
-                        width: '4px',
-                        background: token.colorBorderSecondary,
-                        cursor: 'col-resize',
-                        transition: 'background 0.2s',
-                      }}
+                    <WorkspaceResizeHandle
                       onDragging={(isDragging) => {
                         rightPanelResizeDraggingRef.current = isDragging;
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorPrimary;
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorBorderSecondary;
                       }}
                     />
                     <Panel

--- a/apps/agor-ui/src/components/App/WorkspaceResizeHandle.tsx
+++ b/apps/agor-ui/src/components/App/WorkspaceResizeHandle.tsx
@@ -1,0 +1,42 @@
+import { theme } from 'antd';
+import { useState } from 'react';
+import { PanelResizeHandle } from 'react-resizable-panels';
+
+interface WorkspaceResizeHandleProps {
+  /** Render as an inert 0-width divider (used while the adjacent panel is collapsed). */
+  disabled?: boolean;
+  onDragging?: (isDragging: boolean) => void;
+}
+
+/** Vertical panel divider: 4px visible line, 12px grab target. */
+export function WorkspaceResizeHandle({
+  disabled = false,
+  onDragging,
+}: WorkspaceResizeHandleProps) {
+  const { token } = theme.useToken();
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <PanelResizeHandle
+      style={{
+        position: 'relative',
+        width: disabled ? '0px' : '4px',
+        background: !disabled && hovered ? token.colorPrimary : token.colorBorderSecondary,
+        cursor: disabled ? 'default' : 'col-resize',
+        transition: 'background 0.2s',
+        pointerEvents: disabled ? 'none' : 'auto',
+        overflow: 'visible',
+        zIndex: 10,
+      }}
+      onDragging={onDragging}
+    >
+      {!disabled && (
+        <div
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          style={{ position: 'absolute', top: 0, bottom: 0, left: -4, right: -4 }}
+        />
+      )}
+    </PanelResizeHandle>
+  );
+}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -21,6 +21,7 @@ import type {
 import {
   BorderOutlined,
   CommentOutlined,
+  CompassOutlined,
   DeleteOutlined,
   FileMarkdownOutlined,
   MinusOutlined,
@@ -62,6 +63,7 @@ import {
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -532,6 +534,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const [activeTool, setActiveTool] = useState<
       'select' | 'zone' | 'comment' | 'eraser' | 'markdown'
     >('select');
+
+    const [miniMapVisible, setMiniMapVisible] = useLocalStorage<boolean>(
+      'agor:board-minimap-visible',
+      true
+    );
 
     // Zone drawing state (drag-to-draw)
     const [drawingZone, setDrawingZone] = useState<{
@@ -2825,20 +2832,42 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   </ControlButton>
                 </span>
               </Tooltip>
+              <Tooltip
+                title={miniMapVisible ? 'Hide Minimap' : 'Show Minimap'}
+                placement="right"
+                mouseEnterDelay={0.3}
+              >
+                <span>
+                  <ControlButton
+                    aria-label={miniMapVisible ? 'Hide Minimap' : 'Show Minimap'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMiniMapVisible(!miniMapVisible);
+                    }}
+                    style={{
+                      background: miniMapVisible ? token.colorFillSecondary : 'transparent',
+                    }}
+                  >
+                    <CompassOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
+              </Tooltip>
             </Controls>
-            <MiniMap
-              nodeColor={miniMapNodeColor}
-              onClick={handleMiniMapClick}
-              pannable
-              zoomable
-              style={{
-                backgroundColor: token.colorBgElevated,
-                border: `1px solid ${token.colorBorder}`,
-              }}
-              maskColor="rgba(0, 0, 0, 0.5)"
-              maskStrokeColor={token.colorPrimary}
-              maskStrokeWidth={2}
-            />
+            {miniMapVisible && (
+              <MiniMap
+                nodeColor={miniMapNodeColor}
+                onClick={handleMiniMapClick}
+                pannable
+                zoomable
+                style={{
+                  backgroundColor: token.colorBgElevated,
+                  border: `1px solid ${token.colorBorder}`,
+                }}
+                maskColor="rgba(0, 0, 0, 0.5)"
+                maskStrokeColor={token.colorPrimary}
+                maskStrokeWidth={2}
+              />
+            )}
             <RemoteCursorLayer
               client={client}
               boardId={(board?.board_id as BoardID | null) ?? null}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -393,199 +393,12 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           position: 'relative',
         }}
       >
-        {/* Toolbar - ALWAYS rendered, visibility controlled by CSS only */}
-        <div
-          className="nodrag nopan"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onPointerUp={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          style={{
-            position: 'absolute',
-            top: '-44px',
-            left: '50%',
-            transform: `translateX(-50%) scale(${scale})`,
-            transformOrigin: 'center bottom',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '6px',
-            background: token.colorBgElevated,
-            border: `1px solid ${token.colorBorder}`,
-            borderRadius: token.borderRadius,
-            boxShadow: token.boxShadowSecondary,
-            zIndex: 1000,
-            userSelect: 'none',
-            // CSS-only visibility control (no DOM changes). When the
-            // connection gate is closed we also dim and block clicks so the
-            // toolbar reads as read-only and never accidentally fires.
-            opacity: toolbarVisible ? (mutationDisabled ? 0.5 : 1) : 0,
-            pointerEvents: toolbarVisible && !mutationDisabled ? 'auto' : 'none',
-            transition: 'opacity 0.15s ease',
-          }}
-        >
-          {/* Border Color Picker */}
+        {/* Toolbar — mounted only while the zone is selected (toolbarVisible
+            keeps a 100ms grace so quick re-selects don't flicker). Keeps the
+            other ~11 controls out of the DOM/accessibility tree per zone. */}
+        {toolbarVisible && (
           <div
             className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Border
-            </span>
-            <ColorPicker
-              value={borderColor}
-              onChange={handleBorderColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors,
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: borderColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change border color"
-              />
-            </ColorPicker>
-          </div>
-          <div
-            style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Background Color Picker */}
-          <div
-            className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Fill
-            </span>
-            <ColorPicker
-              value={backgroundColor}
-              onChange={handleBackgroundColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors.map(
-                    (c) =>
-                      `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
-                        .toString(16)
-                        .padStart(2, '0')}`
-                  ),
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: backgroundColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change background color"
-              />
-            </ColorPicker>
-          </div>
-          <div
-            style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Lock/Unlock Button */}
-          <button
-            type="button"
             onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -593,40 +406,339 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
             onPointerUp={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              if (mutationDisabled) return;
-              handleToggleLock();
             }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
             style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
-              border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+              position: 'absolute',
+              top: '-44px',
+              left: '50%',
+              transform: `translateX(-50%) scale(${scale})`,
+              transformOrigin: 'center bottom',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center',
+              gap: '8px',
+              padding: '6px',
+              background: token.colorBgElevated,
+              border: `1px solid ${token.colorBorder}`,
+              borderRadius: token.borderRadius,
+              boxShadow: token.boxShadowSecondary,
+              zIndex: 1000,
               userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
+              // When the connection gate is closed, dim and block clicks so the
+              // toolbar reads as read-only and never accidentally fires.
+              opacity: mutationDisabled ? 0.5 : 1,
+              pointerEvents: mutationDisabled ? 'none' : 'auto',
             }}
-            title={data.locked ? 'Unlock zone' : 'Lock zone'}
           >
-            {data.locked ? (
-              <LockOutlined
+            {/* Border Color Picker */}
+            <div
+              className="nodrag nopan"
+              onPointerDown={(e) => {
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.stopPropagation();
+              }}
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <span
                 style={{
-                  fontSize: '12px',
-                  color: token.colorWarning,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontWeight: 500,
+                  userSelect: 'none',
+                  lineHeight: 1,
                 }}
+              >
+                Border
+              </span>
+              <ColorPicker
+                value={borderColor}
+                onChange={handleBorderColorChange}
+                trigger="click"
+                destroyTooltipOnHide
+                showText={false}
+                format="hex"
+                presets={[
+                  {
+                    label: 'Presets',
+                    colors: colors,
+                  },
+                  ...(recentColors.length > 0
+                    ? [
+                        {
+                          label: 'Recent',
+                          colors: recentColors,
+                        },
+                      ]
+                    : []),
+                ]}
+              >
+                <button
+                  type="button"
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '3px',
+                    backgroundColor: borderColor,
+                    border: `1px solid ${token.colorBorder}`,
+                    userSelect: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    boxShadow: token.boxShadowSecondary,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  title="Change border color"
+                />
+              </ColorPicker>
+            </div>
+            <div
+              style={{
+                width: '1px',
+                height: '24px',
+                backgroundColor: token.colorBorder,
+                margin: '0 2px',
+                alignSelf: 'center',
+              }}
+            />
+            {/* Background Color Picker */}
+            <div
+              className="nodrag nopan"
+              onPointerDown={(e) => {
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.stopPropagation();
+              }}
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontWeight: 500,
+                  userSelect: 'none',
+                  lineHeight: 1,
+                }}
+              >
+                Fill
+              </span>
+              <ColorPicker
+                value={backgroundColor}
+                onChange={handleBackgroundColorChange}
+                trigger="click"
+                destroyTooltipOnHide
+                showText={false}
+                format="hex"
+                presets={[
+                  {
+                    label: 'Presets',
+                    colors: colors.map(
+                      (c) =>
+                        `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
+                          .toString(16)
+                          .padStart(2, '0')}`
+                    ),
+                  },
+                  ...(recentColors.length > 0
+                    ? [
+                        {
+                          label: 'Recent',
+                          colors: recentColors,
+                        },
+                      ]
+                    : []),
+                ]}
+              >
+                <button
+                  type="button"
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '3px',
+                    backgroundColor: backgroundColor,
+                    border: `1px solid ${token.colorBorder}`,
+                    userSelect: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    boxShadow: token.boxShadowSecondary,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  title="Change background color"
+                />
+              </ColorPicker>
+            </div>
+            <div
+              style={{
+                width: '1px',
+                height: '24px',
+                backgroundColor: token.colorBorder,
+                margin: '0 2px',
+                alignSelf: 'center',
+              }}
+            />
+            {/* Lock/Unlock Button */}
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                handleToggleLock();
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              style={{
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
+                border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+              title={data.locked ? 'Unlock zone' : 'Lock zone'}
+            >
+              {data.locked ? (
+                <LockOutlined
+                  style={{
+                    fontSize: '12px',
+                    color: token.colorWarning,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                />
+              ) : (
+                <UnlockOutlined
+                  style={{
+                    fontSize: '12px',
+                    color: token.colorText,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                />
+              )}
+            </button>
+            {verticalDivider}
+            {/* Layer (z-order) controls */}
+            <div
+              className="nodrag nopan"
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              {renderActionButton(
+                'to-back',
+                'Send to back',
+                <VerticalAlignBottomOutlined style={layerIconStyle} />,
+                () => handleReorder('back')
+              )}
+              {renderActionButton(
+                'send-backward',
+                'Send backward',
+                <CaretDownOutlined style={layerIconStyle} />,
+                () => handleReorder('backward')
+              )}
+              {renderActionButton(
+                'bring-forward',
+                'Bring forward',
+                <CaretUpOutlined style={layerIconStyle} />,
+                () => handleReorder('forward')
+              )}
+              {renderActionButton(
+                'to-front',
+                'Bring to front',
+                <VerticalAlignTopOutlined style={layerIconStyle} />,
+                () => handleReorder('front')
+              )}
+            </div>
+            {verticalDivider}
+            {/* Label font-size stepper */}
+            <div
+              className="nodrag nopan"
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <FontSizeOutlined
+                style={{ fontSize: '12px', color: token.colorTextSecondary }}
+                title="Label font size"
               />
-            ) : (
-              <UnlockOutlined
+              {renderActionButton(
+                'font-smaller',
+                'Smaller label',
+                <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>−</span>,
+                () => handleFontSizeStep(-ZONE_FONT_SIZE_STEP),
+                atMinFontSize
+              )}
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: '20px',
+                  textAlign: 'center',
+                  userSelect: 'none',
+                }}
+              >
+                {Math.round(labelFontSize)}
+              </span>
+              {renderActionButton(
+                'font-larger',
+                'Larger label',
+                <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>+</span>,
+                () => handleFontSizeStep(ZONE_FONT_SIZE_STEP),
+                atMaxFontSize
+              )}
+            </div>
+            {verticalDivider}
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                setConfigModalOpen(true);
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              style={{
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: token.colorBgContainer,
+                border: `1px solid ${token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+              title="Configure zone"
+            >
+              <SettingOutlined
                 style={{
                   fontSize: '12px',
                   color: token.colorText,
@@ -635,168 +747,58 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
                   justifyContent: 'center',
                 }}
               />
-            )}
-          </button>
-          {verticalDivider}
-          {/* Layer (z-order) controls */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            {renderActionButton(
-              'to-back',
-              'Send to back',
-              <VerticalAlignBottomOutlined style={layerIconStyle} />,
-              () => handleReorder('back')
-            )}
-            {renderActionButton(
-              'send-backward',
-              'Send backward',
-              <CaretDownOutlined style={layerIconStyle} />,
-              () => handleReorder('backward')
-            )}
-            {renderActionButton(
-              'bring-forward',
-              'Bring forward',
-              <CaretUpOutlined style={layerIconStyle} />,
-              () => handleReorder('forward')
-            )}
-            {renderActionButton(
-              'to-front',
-              'Bring to front',
-              <VerticalAlignTopOutlined style={layerIconStyle} />,
-              () => handleReorder('front')
-            )}
-          </div>
-          {verticalDivider}
-          {/* Label font-size stepper */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <FontSizeOutlined
-              style={{ fontSize: '12px', color: token.colorTextSecondary }}
-              title="Label font size"
-            />
-            {renderActionButton(
-              'font-smaller',
-              'Smaller label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>−</span>,
-              () => handleFontSizeStep(-ZONE_FONT_SIZE_STEP),
-              atMinFontSize
-            )}
-            <span
+            </button>
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                setDeleteModalOpen(true);
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = token.colorError;
+                e.currentTarget.style.borderColor = token.colorError;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = token.colorTextSecondary;
+                e.currentTarget.style.borderColor = token.colorBorder;
+              }}
               style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontVariantNumeric: 'tabular-nums',
-                minWidth: '20px',
-                textAlign: 'center',
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: token.colorBgContainer,
+                border: `1px solid ${token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
                 userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                color: token.colorTextSecondary,
               }}
+              title="Delete zone"
             >
-              {Math.round(labelFontSize)}
-            </span>
-            {renderActionButton(
-              'font-larger',
-              'Larger label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>+</span>,
-              () => handleFontSizeStep(ZONE_FONT_SIZE_STEP),
-              atMaxFontSize
-            )}
+              <DeleteOutlined
+                style={{
+                  fontSize: '12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              />
+            </button>
           </div>
-          {verticalDivider}
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setConfigModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
-              border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-            }}
-            title="Configure zone"
-          >
-            <SettingOutlined
-              style={{
-                fontSize: '12px',
-                color: token.colorText,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            />
-          </button>
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setDeleteModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = token.colorError;
-              e.currentTarget.style.borderColor = token.colorError;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = token.colorTextSecondary;
-              e.currentTarget.style.borderColor = token.colorBorder;
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
-              border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-              color: token.colorTextSecondary,
-            }}
-            title="Delete zone"
-          >
-            <DeleteOutlined
-              style={{
-                fontSize: '12px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            />
-          </button>
-        </div>
+        )}
         <div
           style={{
             pointerEvents: 'auto',


### PR DESCRIPTION
- Zone toolbar mounts only while the zone is selected, instead of sitting in the DOM at opacity 0 — keeps ~11 controls per zone out of the accessibility tree and event flow.
- Panel resize handles get a 12px grab target (4px visible) via a shared `WorkspaceResizeHandle`.
- The minimap is toggleable from the board controls, persisted per browser.