### PR TITLE
Slim mode: opt-in minimal appearance

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -46,6 +46,7 @@ import { getDaemonUrl } from './config/daemon';
 import { CanvasNavigationProvider } from './contexts/CanvasNavigationContext';
 import { ConnectionProvider } from './contexts/ConnectionContext';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
+import { UIModeProvider } from './contexts/UIModeContext';
 import {
   useAgorClient,
   useAgorData,
@@ -2039,7 +2040,9 @@ function App() {
   return (
     <BrowserRouter basename={basename}>
       <ThemeProvider>
-        <AppWrapper />
+        <UIModeProvider>
+          <AppWrapper />
+        </UIModeProvider>
       </ThemeProvider>
     </BrowserRouter>
   );

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -37,6 +37,7 @@ import {
 } from '@ant-design/icons';
 import { Popover, Space, Typography, theme } from 'antd';
 import React, { useMemo, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { copyToClipboard } from '../../utils/clipboard';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
 import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
@@ -134,9 +135,38 @@ function getToolIcon(toolName: string): React.ReactElement {
   }
 }
 
+/**
+ * One-line preview for a thought row. Structured thoughts (JSON tool
+ * references / payload echoes) read as line noise in a collapsed row —
+ * summarize them; the full content stays available on expand.
+ */
+function thoughtPreview(thought: string): string {
+  const trimmed = thought.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      const items = (Array.isArray(parsed) ? parsed : [parsed]).filter(
+        (it): it is Record<string, unknown> => !!it && typeof it === 'object'
+      );
+      const toolNames = items
+        .map((it) => (typeof it.tool_name === 'string' ? it.tool_name : null))
+        .filter((name): name is string => !!name);
+      if (toolNames.length > 0) return `Considering ${toolNames.join(', ')}`;
+      const keys = Object.keys(items[0] ?? {});
+      return keys.length > 0
+        ? `Structured note (${keys.slice(0, 3).join(', ')})`
+        : 'Structured note';
+    } catch {
+      // Not valid JSON — fall through to the raw one-liner.
+    }
+  }
+  return trimmed.replace(/\s+/g, ' ');
+}
+
 export const AgentChain = React.memo<AgentChainProps>(
   ({ messages, isTaskRunning = false, isLatest }) => {
     const { token } = theme.useToken();
+    const { isSlim } = useUIMode();
     const [expanded, setExpanded] = useState(true);
 
     // Extract chain items (thoughts and tools) from messages
@@ -412,7 +442,9 @@ export const AgentChain = React.memo<AgentChainProps>(
     const renderChainItem = (item: ChainItem, index: number) => {
       if (item.type === 'thought') {
         const thoughtContent = item.content as string;
-        const oneLine = thoughtContent.replace(/\s+/g, ' ').trim();
+        const oneLine = isSlim
+          ? thoughtPreview(thoughtContent)
+          : thoughtContent.replace(/\s+/g, ' ').trim();
 
         return (
           <ToolBlock
@@ -583,53 +615,97 @@ export const AgentChain = React.memo<AgentChainProps>(
     }
 
     return (
-      <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
-        {/* Collapsed summary - clickable */}
-        <div
-          onClick={() => setExpanded(!expanded)}
-          style={{
-            padding: token.sizeUnit * 1.5,
-            borderRadius: token.borderRadius,
-            background: token.colorBgContainer,
-            border: `1px solid ${token.colorBorder}`,
-            cursor: 'pointer',
-            transition: 'all 0.2s',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.borderColor = token.colorPrimaryBorder;
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.borderColor = token.colorBorder;
-          }}
-        >
-          <div
-            style={{ display: 'flex', alignItems: 'center', gap: token.sizeUnit, flexWrap: 'wrap' }}
-          >
-            {/* Expand/collapse icon */}
-            {expanded ? (
-              <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-            ) : (
-              <RightOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-            )}
+      <div style={{ margin: isSlim ? `${token.sizeUnit}px 0` : `${token.sizeUnit * 1.5}px 0` }}>
+        {isSlim ? (
+          <>
+            {/* Collapsed summary — borderless hover row: one chevron carries the
+            affordance, the error icon appears only when something failed. */}
+            <div
+              onClick={() => setExpanded(!expanded)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: token.sizeUnit,
+                flexWrap: 'wrap',
+                padding: `${token.sizeUnit / 2}px ${token.sizeUnit}px`,
+                borderRadius: token.borderRadiusSM,
+                background: 'transparent',
+                cursor: 'pointer',
+                transition: 'background 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = token.colorFillQuaternary;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent';
+              }}
+            >
+              {expanded ? (
+                <DownOutlined style={{ fontSize: 11, color: token.colorTextTertiary }} />
+              ) : (
+                <RightOutlined style={{ fontSize: 11, color: token.colorTextTertiary }} />
+              )}
+              {hasErrors && (
+                <CloseCircleOutlined style={{ color: token.colorError, fontSize: 14 }} />
+              )}
+              <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+                {stats.thoughtCount > 0 && `${stats.thoughtCount} thoughts`}
+                {stats.thoughtCount > 0 && stats.toolCount > 0 && ', '}
+                {stats.toolCount > 0 && `${stats.toolCount} tools`}
+              </Typography.Text>
 
-            {/* Status icon */}
-            {hasErrors ? (
-              <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
-            ) : (
-              <CheckCircleOutlined style={{ color: token.colorTextSecondary, fontSize: 16 }} />
-            )}
-
-            {/* Summary text */}
-            <Typography.Text strong>
-              <BulbOutlined /> {stats.thoughtCount > 0 && `${stats.thoughtCount} thoughts`}
-              {stats.thoughtCount > 0 && stats.toolCount > 0 && ', '}
-              {stats.toolCount > 0 && `${stats.toolCount} tools`}
-            </Typography.Text>
-
-            {/* Only show details when collapsed */}
-            {!expanded && summaryDescription}
-          </div>
-        </div>
+              {/* Only show details when collapsed */}
+              {!expanded && summaryDescription}
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Collapsed summary - clickable */}
+            <div
+              onClick={() => setExpanded(!expanded)}
+              style={{
+                padding: token.sizeUnit * 1.5,
+                borderRadius: token.borderRadius,
+                background: token.colorBgContainer,
+                border: `1px solid ${token.colorBorder}`,
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = token.colorPrimaryBorder;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = token.colorBorder;
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: token.sizeUnit,
+                  flexWrap: 'wrap',
+                }}
+              >
+                {expanded ? (
+                  <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+                ) : (
+                  <RightOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+                )}
+                {hasErrors ? (
+                  <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
+                ) : (
+                  <CheckCircleOutlined style={{ color: token.colorTextSecondary, fontSize: 16 }} />
+                )}
+                <Typography.Text strong>
+                  <BulbOutlined /> {stats.thoughtCount > 0 && `${stats.thoughtCount} thoughts`}
+                  {stats.thoughtCount > 0 && stats.toolCount > 0 && ', '}
+                  {stats.toolCount > 0 && `${stats.toolCount} tools`}
+                </Typography.Text>
+                {!expanded && summaryDescription}
+              </div>
+            </div>
+          </>
+        )}
 
         {/* Expanded chain */}
         {expanded && (

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -655,17 +655,27 @@ export const AgentChain = React.memo<AgentChainProps>(
             </Tag>
           ))}
 
-        {/* Result stats */}
-        {stats.successCount > 0 && (
-          <Tag icon={<CheckCircleOutlined />} color="success" style={{ fontSize: 11, margin: 0 }}>
-            {stats.successCount} success
-          </Tag>
-        )}
-        {stats.errorCount > 0 && (
-          <Tag icon={<CloseCircleOutlined />} color="error" style={{ fontSize: 11, margin: 0 }}>
-            {stats.errorCount} error
-          </Tag>
-        )}
+        {/* Result stats — slim: bare glyph + count, no words, no box */}
+        {stats.successCount > 0 &&
+          (isSlim ? (
+            <span style={{ color: token.colorSuccess, fontSize: 11, whiteSpace: 'nowrap' }}>
+              <CheckCircleOutlined /> {stats.successCount}
+            </span>
+          ) : (
+            <Tag icon={<CheckCircleOutlined />} color="success" style={{ fontSize: 11, margin: 0 }}>
+              {stats.successCount} success
+            </Tag>
+          ))}
+        {stats.errorCount > 0 &&
+          (isSlim ? (
+            <span style={{ color: token.colorError, fontSize: 11, whiteSpace: 'nowrap' }}>
+              <CloseCircleOutlined /> {stats.errorCount}
+            </span>
+          ) : (
+            <Tag icon={<CloseCircleOutlined />} color="error" style={{ fontSize: 11, margin: 0 }}>
+              {stats.errorCount} error
+            </Tag>
+          ))}
 
         {/* Files affected */}
         {stats.filesAffected.length > 0 && (

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -167,7 +167,9 @@ export const AgentChain = React.memo<AgentChainProps>(
   ({ messages, isTaskRunning = false, isLatest }) => {
     const { token } = theme.useToken();
     const { isSlim } = useUIMode();
-    const [expanded, setExpanded] = useState(true);
+    // Slim: chains start collapsed even inside an expanded task — expand the
+    // one you care about.
+    const [expanded, setExpanded] = useState(() => !isSlim);
 
     // Extract chain items (thoughts and tools) from messages
     const chainItems = useMemo(() => {
@@ -438,6 +440,47 @@ export const AgentChain = React.memo<AgentChainProps>(
       return -1;
     }, [chainItems]);
 
+    // Slim: fold thought payload-echoes into the tool row that follows them
+    // and coalesce consecutive calls of the same tool into one row. Trailing
+    // thoughts with no following tool keep their own rows.
+    type SlimUnit =
+      | {
+          kind: 'tools';
+          name: string;
+          entries: { item: ChainItem; index: number }[];
+          thoughts: string[];
+        }
+      | { kind: 'thought'; content: string; index: number };
+    const slimUnits = useMemo<SlimUnit[] | null>(() => {
+      if (!isSlim) return null;
+      const units: SlimUnit[] = [];
+      let pendingThoughts: string[] = [];
+      chainItems.forEach((item, index) => {
+        if (item.type === 'thought') {
+          pendingThoughts.push(item.content as string);
+          return;
+        }
+        const { toolUse } = item.content as { toolUse: ToolUseBlock };
+        const name = getToolDisplayName(toolUse.name, toolUse.input);
+        const last = units[units.length - 1];
+        if (pendingThoughts.length === 0 && last && last.kind === 'tools' && last.name === name) {
+          last.entries.push({ item, index });
+        } else {
+          units.push({
+            kind: 'tools',
+            name,
+            entries: [{ item, index }],
+            thoughts: pendingThoughts,
+          });
+          pendingThoughts = [];
+        }
+      });
+      pendingThoughts.forEach((content, i) => {
+        units.push({ kind: 'thought', content, index: chainItems.length + i });
+      });
+      return units;
+    }, [isSlim, chainItems]);
+
     // Build tool block items for rendering
     const renderChainItem = (item: ChainItem, index: number) => {
       if (item.type === 'thought') {
@@ -522,6 +565,81 @@ export const AgentChain = React.memo<AgentChainProps>(
           expandedByDefault={shouldExpandToolByDefault(toolUse.name)}
         >
           <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
+        </ToolBlock>
+      );
+    };
+
+    const renderSlimUnit = (unit: SlimUnit, unitIndex: number) => {
+      if (unit.kind === 'thought') {
+        return renderChainItem(
+          { type: 'thought', content: unit.content, message: messages[0] },
+          unit.index
+        );
+      }
+      const lastEntry = unit.entries[unit.entries.length - 1];
+      const { toolUse, toolResult } = lastEntry.item.content as {
+        toolUse: ToolUseBlock;
+        toolResult?: ToolResultBlock;
+      };
+      const hasImplicitResult = IMPLICIT_RESULT_TOOLS.has(toolUse.name);
+      const isPotentiallyRunning = lastEntry.index > lastResultToolIndex && isLatest !== false;
+      const status = deriveToolStatus({
+        hasResult: !!toolResult || hasImplicitResult,
+        isError: unit.entries.some(
+          (e) => (e.item.content as { toolResult?: ToolResultBlock }).toolResult?.is_error
+        ),
+        isPotentiallyRunning,
+        isTaskRunning,
+      });
+      const icon = renderToolStatusIcon(status);
+      const single = unit.entries.length === 1;
+      const description = single ? (getToolDescription(toolUse) ?? undefined) : undefined;
+
+      return (
+        <ToolBlock
+          key={`slim-tools-${unitIndex}-${toolUse.id}`}
+          icon={icon}
+          name={single ? unit.name : `${unit.name} × ${unit.entries.length}`}
+          description={description}
+          status={status}
+          expandedByDefault={single && shouldExpandToolByDefault(toolUse.name)}
+        >
+          {unit.thoughts.map((thought, i) =>
+            thought.trim() ? (
+              <CollapsibleText
+                // biome-ignore lint/suspicious/noArrayIndexKey: thoughts are static within a settled chain unit
+                key={`thought-${i}`}
+                maxLines={8}
+                preserveWhitespace
+                style={{
+                  fontSize: token.fontSizeSM,
+                  margin: `0 0 ${token.sizeUnit}px 0`,
+                  color: token.colorTextTertiary,
+                }}
+              >
+                {thought}
+              </CollapsibleText>
+            ) : null
+          )}
+          {unit.entries.map((entry, i) => {
+            const c = entry.item.content as { toolUse: ToolUseBlock; toolResult?: ToolResultBlock };
+            return (
+              <div
+                key={c.toolUse.id}
+                style={
+                  i > 0
+                    ? {
+                        borderTop: `1px solid ${token.colorBorderSecondary}`,
+                        marginTop: token.sizeUnit,
+                        paddingTop: token.sizeUnit,
+                      }
+                    : undefined
+                }
+              >
+                <ToolUseRenderer toolUse={c.toolUse} toolResult={c.toolResult} />
+              </div>
+            );
+          })}
         </ToolBlock>
       );
     };
@@ -718,7 +836,7 @@ export const AgentChain = React.memo<AgentChainProps>(
               gap: 2,
             }}
           >
-            {chainItems.map(renderChainItem)}
+            {slimUnits ? slimUnits.map(renderSlimUnit) : chainItems.map(renderChainItem)}
           </div>
         )}
       </div>

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -833,13 +833,18 @@ export const App: React.FC<AppProps> = ({
     applyLeftPanelState(getShowCommentsPanelState({ collapsed: true, activeTab: 'teammate' }));
   }, [applyLeftPanelState]);
 
-  // Shared by every TeammatePanelRail button: expand the panel onto
-  // whichever tab was clicked.
+  // Shared by every TeammatePanelRail button: expand the panel onto the
+  // clicked section. In slim the rail is the only tab UI, so clicking the
+  // active section again collapses the panel.
   const handleSelectTeammatePanelTab = useCallback(
     (tab: BoardTeammatePanelTab) => {
+      if (isSlim && !commentsPanelCollapsed && leftPanelTab === tab) {
+        setCommentsPanelCollapsed(true);
+        return;
+      }
       applyLeftPanelState(getSelectTeammatePanelTabState(tab));
     },
-    [applyLeftPanelState]
+    [applyLeftPanelState, isSlim, commentsPanelCollapsed, leftPanelTab, setCommentsPanelCollapsed]
   );
 
   const handleCommentSelect = useCallback((commentId: string | null) => {
@@ -1432,6 +1437,45 @@ export const App: React.FC<AppProps> = ({
   const stableOnLogout = useStableCallback(onLogout);
   const stableOnRetryConnection = useStableCallback(onRetryConnection);
 
+  const teammatePanelNode = (
+    <BoardTeammatePanel
+      client={client}
+      board={currentBoard || null}
+      activeTab={leftPanelTab}
+      onTabChange={setLeftPanelTab}
+      unreadCommentsCount={unreadCommentsCount}
+      hasUserMentions={hasUserMentions}
+      primaryTeammateBranch={primaryTeammateBranch}
+      primaryTeammateRepo={primaryTeammateRepo}
+      primaryTeammateInaccessible={primaryTeammateInaccessible}
+      currentUserId={user?.user_id}
+      selectedSessionId={effectiveSelectedSessionId}
+      onSessionClick={handleSessionClick}
+      onCreateSession={handleQuickStartSession}
+      onForkSession={stableOnForkSession}
+      onSpawnSession={stableOnSpawnSession}
+      onArchiveOrDelete={stableOnArchiveOrDeleteBranch}
+      onOpenSettings={handleOpenBranchModal}
+      onOpenSessionSettings={setSessionSettingsId}
+      onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
+      onStartEnvironment={stableOnStartEnvironment}
+      onStopEnvironment={stableOnStopEnvironment}
+      onViewLogs={setLogsModalBranchId}
+      onNukeEnvironment={stableOnNukeEnvironment}
+      onExecuteScheduleNow={stableOnExecuteScheduleNow}
+      onSendComment={handleTeammateSendComment}
+      onReplyComment={stableOnReplyComment}
+      onResolveComment={stableOnResolveComment}
+      onToggleReaction={stableOnToggleReaction}
+      onDeleteComment={stableOnDeleteComment}
+      hoveredCommentId={hoveredCommentId}
+      selectedCommentId={selectedCommentId}
+      onCollapse={handleTeammateCollapse}
+      deferSessionDetails={homeExitPanelDetailsDeferred}
+      onDeferredDetailsHydrated={handleDeferredDetailsHydrated}
+    />
+  );
+
   return (
     <AppActionsProvider value={appActionsValue}>
       <BoardSwitcherBridge setCurrentBoardId={setCurrentBoardId} />
@@ -1503,13 +1547,33 @@ export const App: React.FC<AppProps> = ({
                 ? leftPanelRailVisible
                   ? LEFT_PANEL_RAIL_WIDTH_PX
                   : 0
-                : LEFT_PANEL_MIN_WIDTH_PX
+                : isSlim
+                  ? LEFT_PANEL_MIN_WIDTH_PX + LEFT_PANEL_RAIL_WIDTH_PX
+                  : LEFT_PANEL_MIN_WIDTH_PX
             }
             onSideHandleDragging={(isDragging) => {
               leftPanelResizeDraggingRef.current = isDragging;
             }}
             sideContent={
-              leftPanelCollapsed ? (
+              isSlim ? (
+                /* Slim: the rail is the permanent navigation surface; the
+                   expanded panel renders beside it with no tab bar. */
+                <div style={{ height: '100%', display: 'flex' }}>
+                  {!leftPanelCollapsed && (
+                    <div style={{ flex: 1, minWidth: 0 }}>{teammatePanelNode}</div>
+                  )}
+                  {(leftPanelRailVisible || !leftPanelCollapsed) && (
+                    <div style={{ width: LEFT_PANEL_RAIL_WIDTH_PX, flexShrink: 0 }}>
+                      <TeammatePanelRail
+                        onSelectTab={handleSelectTeammatePanelTab}
+                        activeTab={leftPanelCollapsed ? null : leftPanelTab}
+                        unreadCommentsCount={unreadCommentsCount}
+                        hasUserMentions={hasUserMentions}
+                      />
+                    </div>
+                  )}
+                </div>
+              ) : leftPanelCollapsed ? (
                 leftPanelRailVisible && (
                   <TeammatePanelRail
                     onSelectTab={handleSelectTeammatePanelTab}
@@ -1518,42 +1582,7 @@ export const App: React.FC<AppProps> = ({
                   />
                 )
               ) : (
-                <BoardTeammatePanel
-                  client={client}
-                  board={currentBoard || null}
-                  activeTab={leftPanelTab}
-                  onTabChange={setLeftPanelTab}
-                  unreadCommentsCount={unreadCommentsCount}
-                  hasUserMentions={hasUserMentions}
-                  primaryTeammateBranch={primaryTeammateBranch}
-                  primaryTeammateRepo={primaryTeammateRepo}
-                  primaryTeammateInaccessible={primaryTeammateInaccessible}
-                  currentUserId={user?.user_id}
-                  selectedSessionId={effectiveSelectedSessionId}
-                  onSessionClick={handleSessionClick}
-                  onCreateSession={handleQuickStartSession}
-                  onForkSession={stableOnForkSession}
-                  onSpawnSession={stableOnSpawnSession}
-                  onArchiveOrDelete={stableOnArchiveOrDeleteBranch}
-                  onOpenSettings={handleOpenBranchModal}
-                  onOpenSessionSettings={setSessionSettingsId}
-                  onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
-                  onStartEnvironment={stableOnStartEnvironment}
-                  onStopEnvironment={stableOnStopEnvironment}
-                  onViewLogs={setLogsModalBranchId}
-                  onNukeEnvironment={stableOnNukeEnvironment}
-                  onExecuteScheduleNow={stableOnExecuteScheduleNow}
-                  onSendComment={handleTeammateSendComment}
-                  onReplyComment={stableOnReplyComment}
-                  onResolveComment={stableOnResolveComment}
-                  onToggleReaction={stableOnToggleReaction}
-                  onDeleteComment={stableOnDeleteComment}
-                  hoveredCommentId={hoveredCommentId}
-                  selectedCommentId={selectedCommentId}
-                  onCollapse={handleTeammateCollapse}
-                  deferSessionDetails={homeExitPanelDetailsDeferred}
-                  onDeferredDetailsHydrated={handleDeferredDetailsHydrated}
-                />
+                teammatePanelNode
               )
             }
             contentPanelWidthPercent={contentPanelWidthPercent}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1451,7 +1451,18 @@ export const App: React.FC<AppProps> = ({
           instanceDescription={instanceDescription}
         />
         {topBanner}
-        <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
+        {/* flex:1 + minHeight:0 pin the workspace to the viewport remainder;
+            without them the flex item's auto min-height lets board content
+            overflow below the fold by the header height. */}
+        <Content
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            display: 'flex',
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
           <PanelGroup
             id="main-layout"
             direction="horizontal"

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -504,22 +504,17 @@ export const App: React.FC<AppProps> = ({
     : setCommentsPanelCollapsedStored;
 
   // Slim: opening a session collapses the side panel to its rail so the
-  // canvas and session panel keep their width; closing the session restores
-  // the pre-session state unless the user re-expanded it meanwhile.
+  // canvas and session panel keep their width. It stays collapsed after the
+  // session closes — the rail is one click away.
   const sessionWasOpenRef = useRef(false);
-  const panelBeforeSessionRef = useRef(true);
   useEffect(() => {
     const wasOpen = sessionWasOpenRef.current;
     const isOpen = !!effectiveSelectedSessionId;
     sessionWasOpenRef.current = isOpen;
-    if (!isSlim) return;
-    if (isOpen && !wasOpen) {
-      panelBeforeSessionRef.current = commentsPanelCollapsedSession;
+    if (isSlim && isOpen && !wasOpen) {
       setCommentsPanelCollapsedSession(true);
-    } else if (!isOpen && wasOpen && commentsPanelCollapsedSession) {
-      setCommentsPanelCollapsedSession(panelBeforeSessionRef.current);
     }
-  }, [effectiveSelectedSessionId, isSlim, commentsPanelCollapsedSession]);
+  }, [effectiveSelectedSessionId, isSlim]);
 
   // Left panel size persistence (percentage of available width), scoped per user.
   const [commentsPanelSize, setCommentsPanelSize] = useUserLocalStorage<number>(

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -503,6 +503,24 @@ export const App: React.FC<AppProps> = ({
     ? setCommentsPanelCollapsedSession
     : setCommentsPanelCollapsedStored;
 
+  // Slim: opening a session collapses the side panel to its rail so the
+  // canvas and session panel keep their width; closing the session restores
+  // the pre-session state unless the user re-expanded it meanwhile.
+  const sessionWasOpenRef = useRef(false);
+  const panelBeforeSessionRef = useRef(true);
+  useEffect(() => {
+    const wasOpen = sessionWasOpenRef.current;
+    const isOpen = !!effectiveSelectedSessionId;
+    sessionWasOpenRef.current = isOpen;
+    if (!isSlim) return;
+    if (isOpen && !wasOpen) {
+      panelBeforeSessionRef.current = commentsPanelCollapsedSession;
+      setCommentsPanelCollapsedSession(true);
+    } else if (!isOpen && wasOpen && commentsPanelCollapsedSession) {
+      setCommentsPanelCollapsedSession(panelBeforeSessionRef.current);
+    }
+  }, [effectiveSelectedSessionId, isSlim, commentsPanelCollapsedSession]);
+
   // Left panel size persistence (percentage of available width), scoped per user.
   const [commentsPanelSize, setCommentsPanelSize] = useUserLocalStorage<number>(
     user?.user_id,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,7 +19,7 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { Layout, Upload } from 'antd';
+import { Empty, Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { useLocation, useParams } from 'react-router-dom';
@@ -488,11 +488,20 @@ export const App: React.FC<AppProps> = ({
   // is a valid no-board route, so do not auto-select localStorage/first board.
   const [currentBoardId, setCurrentBoardIdInternal] = useState(() => initialBoardId || '');
 
-  // Initialize comments panel state from localStorage (collapsed by default)
-  const [commentsPanelCollapsed, setCommentsPanelCollapsed] = useLocalStorage<boolean>(
+  // Classic persists the expanded/collapsed state across loads; slim always
+  // starts as a rail and only expands on user action (no auto-expansion after
+  // the home-exit deferral clears).
+  const [commentsPanelCollapsedStored, setCommentsPanelCollapsedStored] = useLocalStorage<boolean>(
     'agor:commentsPanelCollapsed',
     false
   );
+  const [commentsPanelCollapsedSession, setCommentsPanelCollapsedSession] = useState(true);
+  const commentsPanelCollapsed = isSlim
+    ? commentsPanelCollapsedSession
+    : commentsPanelCollapsedStored;
+  const setCommentsPanelCollapsed = isSlim
+    ? setCommentsPanelCollapsedSession
+    : setCommentsPanelCollapsedStored;
 
   // Left panel size persistence (percentage of available width), scoped per user.
   const [commentsPanelSize, setCommentsPanelSize] = useUserLocalStorage<number>(
@@ -641,11 +650,20 @@ export const App: React.FC<AppProps> = ({
   const [logsModalBranchId, setLogsModalBranchId] = useState<string | null>(null);
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
 
-  // Initialize event stream panel state from localStorage (collapsed by default)
-  const [eventStreamPanelCollapsed, setEventStreamPanelCollapsed] = useLocalStorage<boolean>(
+  // Classic persists the Live Events panel open state; slim scopes it to the
+  // session so the event stream never resurrects itself in the session slot
+  // across reloads.
+  const [eventStreamCollapsedStored, setEventStreamCollapsedStored] = useLocalStorage<boolean>(
     'agor:eventStreamPanelCollapsed',
     true
   );
+  const [eventStreamCollapsedSession, setEventStreamCollapsedSession] = useState(true);
+  const eventStreamPanelCollapsed = isSlim
+    ? eventStreamCollapsedSession
+    : eventStreamCollapsedStored;
+  const setEventStreamPanelCollapsed = isSlim
+    ? setEventStreamCollapsedSession
+    : setEventStreamCollapsedStored;
 
   // Recent-board visit tracking + the id list HomePage consumes. AppHeader owns
   // its own pill derivation from the store (so it isn't fed an unstable array),
@@ -1646,7 +1664,7 @@ export const App: React.FC<AppProps> = ({
                     setPendingToolChoiceBranchId(null);
                   }}
                 />
-              ) : (
+              ) : !eventStreamPanelCollapsed ? (
                 <EventStreamPanel
                   collapsed={false}
                   onToggleCollapse={() => setEventStreamPanelCollapsed(true)}
@@ -1658,6 +1676,19 @@ export const App: React.FC<AppProps> = ({
                   client={client}
                   branchActions={eventStreamBranchActions}
                 />
+              ) : (
+                // Transient fallback (slot open with nothing selected) — a
+                // plain empty state instead of the event stream.
+                <div
+                  style={{
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No session selected" />
+                </div>
               )
             }
           />

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,14 +19,9 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { Layout, theme, Upload } from 'antd';
+import { Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import {
-  type ImperativePanelHandle,
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-} from 'react-resizable-panels';
+import { type ImperativePanelHandle, Panel, PanelGroup } from 'react-resizable-panels';
 import { useLocation, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
@@ -104,6 +99,7 @@ import {
   toContentRelativePercent,
   toViewportRelativePercent,
 } from './panelSizing';
+import { WorkspaceResizeHandle } from './WorkspaceResizeHandle';
 
 const { Content } = Layout;
 
@@ -362,7 +358,6 @@ export const App: React.FC<AppProps> = ({
   // stays quiet across unrelated entity patches), a call-time
   // `agorStore.getState()` read inside a handler, or pushed down into the
   // component that actually consumes the map (SettingsModal, UrlStateBridge).
-  const { token } = theme.useToken();
   const { showWarning, showError } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
@@ -1531,31 +1526,10 @@ export const App: React.FC<AppProps> = ({
                 />
               )}
             </Panel>
-            <PanelResizeHandle
-              style={{
-                position: 'relative',
-                width: leftPanelCollapsed ? '0px' : '4px',
-                background: token.colorBorderSecondary,
-                cursor: leftPanelCollapsed ? 'default' : 'col-resize',
-                transition: 'background 0.2s',
-                pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
-                overflow: 'visible',
-                zIndex: 10,
-              }}
+            <WorkspaceResizeHandle
+              disabled={leftPanelCollapsed}
               onDragging={(isDragging) => {
                 leftPanelResizeDraggingRef.current = isDragging;
-              }}
-              onMouseEnter={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorPrimary;
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorBorderSecondary;
-                }
               }}
             />
             <Panel id="content-panel" order={2} defaultSize={contentPanelWidthPercent} minSize={40}>
@@ -1654,23 +1628,9 @@ export const App: React.FC<AppProps> = ({
                 </Panel>
                 {(sessionPanelTargetOpen || !eventStreamPanelCollapsed) && (
                   <>
-                    <PanelResizeHandle
-                      style={{
-                        width: '4px',
-                        background: token.colorBorderSecondary,
-                        cursor: 'col-resize',
-                        transition: 'background 0.2s',
-                      }}
+                    <WorkspaceResizeHandle
                       onDragging={(isDragging) => {
                         rightPanelResizeDraggingRef.current = isDragging;
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorPrimary;
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorBorderSecondary;
                       }}
                     />
                     <Panel

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,18 +19,14 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { Layout, theme, Upload } from 'antd';
+import { Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import {
-  type ImperativePanelHandle,
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-} from 'react-resizable-panels';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { useLocation, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { useRegisterBoardSwitcher } from '../../contexts/CanvasNavigationContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useBoardTitle } from '../../hooks/useBoardTitle';
 import { useEventStream } from '../../hooks/useEventStream';
@@ -104,6 +100,7 @@ import {
   toContentRelativePercent,
   toViewportRelativePercent,
 } from './panelSizing';
+import { WorkspaceLayout } from './WorkspaceLayout';
 
 const { Content } = Layout;
 
@@ -362,7 +359,7 @@ export const App: React.FC<AppProps> = ({
   // stays quiet across unrelated entity patches), a call-time
   // `agorStore.getState()` read inside a handler, or pushed down into the
   // component that actually consumes the map (SettingsModal, UrlStateBridge).
-  const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const { showWarning, showError } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
@@ -1452,39 +1449,38 @@ export const App: React.FC<AppProps> = ({
         />
         {topBanner}
         <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
-          <PanelGroup
-            id="main-layout"
-            direction="horizontal"
-            style={{ flex: 1 }}
-            onLayout={(sizes) => {
+          <WorkspaceLayout
+            onMainLayout={(sizes) => {
               // Persist only user drag updates. Programmatic resizing enforces
               // the responsive minimum without clobbering the user's desired size.
+              // The side panel is the first panel in classic (left) and the
+              // last in slim (right).
               if (!leftPanelCollapsed && leftPanelResizeDraggingRef.current && sizes.length >= 2) {
-                // Comments panel is the first panel (index 0)
+                const sidePanelSize = isSlim ? sizes[sizes.length - 1] : sizes[0];
                 setCommentsPanelSize(
-                  clampPercent(sizes[0], leftPanelMinSize, LEFT_PANEL_MAX_SIZE_PERCENT)
+                  clampPercent(sidePanelSize, leftPanelMinSize, LEFT_PANEL_MAX_SIZE_PERCENT)
                 );
               }
             }}
-          >
-            <Panel
-              id="teammate-panel"
-              order={1}
-              ref={commentsPanelRef}
-              collapsible
-              defaultSize={leftPanelCollapsed ? leftPanelCollapsedSize : effectiveCommentsPanelSize}
-              collapsedSize={leftPanelCollapsedSize}
-              minSize={leftPanelCollapsed ? leftPanelCollapsedSize : leftPanelMinSize}
-              maxSize={LEFT_PANEL_MAX_SIZE_PERCENT}
-              style={{
-                minWidth: leftPanelCollapsed
-                  ? leftPanelRailVisible
-                    ? LEFT_PANEL_RAIL_WIDTH_PX
-                    : 0
-                  : LEFT_PANEL_MIN_WIDTH_PX,
-              }}
-            >
-              {leftPanelCollapsed ? (
+            sidePanelSide={isSlim ? 'right' : 'left'}
+            sidePanelRef={commentsPanelRef}
+            sidePanelCollapsed={leftPanelCollapsed}
+            sidePanelCollapsedSize={leftPanelCollapsedSize}
+            sidePanelDefaultSize={effectiveCommentsPanelSize}
+            sidePanelMinSize={leftPanelMinSize}
+            sidePanelMaxSize={LEFT_PANEL_MAX_SIZE_PERCENT}
+            sidePanelMinWidthPx={
+              leftPanelCollapsed
+                ? leftPanelRailVisible
+                  ? LEFT_PANEL_RAIL_WIDTH_PX
+                  : 0
+                : LEFT_PANEL_MIN_WIDTH_PX
+            }
+            onSideHandleDragging={(isDragging) => {
+              leftPanelResizeDraggingRef.current = isDragging;
+            }}
+            sideContent={
+              leftPanelCollapsed ? (
                 leftPanelRailVisible && (
                   <TeammatePanelRail
                     onSelectTab={handleSelectTeammatePanelTab}
@@ -1529,201 +1525,142 @@ export const App: React.FC<AppProps> = ({
                   deferSessionDetails={homeExitPanelDetailsDeferred}
                   onDeferredDetailsHydrated={handleDeferredDetailsHydrated}
                 />
-              )}
-            </Panel>
-            <PanelResizeHandle
-              style={{
-                position: 'relative',
-                width: leftPanelCollapsed ? '0px' : '4px',
-                background: token.colorBorderSecondary,
-                cursor: leftPanelCollapsed ? 'default' : 'col-resize',
-                transition: 'background 0.2s',
-                pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
-                overflow: 'visible',
-                zIndex: 10,
-              }}
-              onDragging={(isDragging) => {
-                leftPanelResizeDraggingRef.current = isDragging;
-              }}
-              onMouseEnter={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorPrimary;
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!leftPanelCollapsed) {
-                  (e.currentTarget as unknown as HTMLDivElement).style.background =
-                    token.colorBorderSecondary;
-                }
-              }}
-            />
-            <Panel id="content-panel" order={2} defaultSize={contentPanelWidthPercent} minSize={40}>
-              <PanelGroup
-                id="canvas-session"
-                direction="horizontal"
-                style={{ flex: 1 }}
-                onLayout={(sizes) => {
-                  // Persist only user drag updates so panel open/close and
-                  // programmatic restores do not overwrite the user's preference.
-                  // sizes[1] is content-relative (react-resizable-panels sizes
-                  // panels relative to their own PanelGroup) — convert back to
-                  // viewport-relative before persisting, matching the frame
-                  // sessionPanelSize is stored in.
-                  if (
-                    effectiveSelectedSessionId &&
-                    rightPanelResizeDraggingRef.current &&
-                    sizes.length === 2
-                  ) {
-                    const viewportRelativeSize = toViewportRelativePercent(
-                      sizes[1],
-                      contentPanelWidthPercent
-                    );
-                    setSessionPanelSize(
-                      clampPercent(
-                        viewportRelativeSize,
-                        sessionPanelMinSize,
-                        SESSION_PANEL_MAX_SIZE_PERCENT
-                      )
-                    );
-                  }
-                }}
-              >
-                <Panel
-                  id="canvas-panel"
-                  order={1}
-                  defaultSize={sessionPanelTargetOpen ? 100 - sessionPanelSizeWithinContent : 100}
-                  minSize={CANVAS_MIN_SIZE_PERCENT}
-                >
-                  <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
-                    {isHomeSurface ? (
-                      <HomePage
-                        client={client}
-                        connected={connected}
-                        recentBoardIds={recentBoardIds}
-                        currentUserId={user?.user_id}
-                        onBoardClick={handleHomeBoardClick}
-                        onBranchClick={handleHomeBranchClick}
-                        onSessionClick={handleSessionClick}
-                        onOpenCreateDialog={handleHomeOpenCreateDialog}
-                        onOpenSettings={openSettings}
-                      />
-                    ) : (
-                      <SessionCanvas
-                        ref={sessionCanvasRef}
-                        board={currentBoard || null}
-                        client={client}
-                        branches={boardBranches}
-                        primaryTeammateId={primaryTeammateId}
-                        currentUserId={user?.user_id}
-                        selectedSessionId={effectiveSelectedSessionId}
-                        activeUrlTargetBranchId={activeUrlTargetBranchId}
-                        activeUrlTargetArtifactId={activeUrlTargetArtifactId}
-                        availableAgents={availableAgents}
-                        onSessionClick={handleSessionClick}
-                        onSessionUpdate={stableOnSessionUpdate}
-                        onSessionDelete={stableOnSessionDelete}
-                        onForkSession={stableOnForkSession}
-                        onSpawnSession={stableOnSpawnSession}
-                        onUpdateSessionMcpServers={stableOnUpdateSessionMcpServers}
-                        onOpenSettings={setSessionSettingsId}
-                        onCreateSessionForBranch={handleQuickStartSession}
-                        onOpenBranch={setBranchModalBranchId}
-                        onArchiveOrDeleteBranch={stableOnArchiveOrDeleteBranch}
-                        onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
-                        onStartEnvironment={stableOnStartEnvironment}
-                        onStopEnvironment={stableOnStopEnvironment}
-                        onViewLogs={setLogsModalBranchId}
-                        onNukeEnvironment={stableOnNukeEnvironment}
-                        onOpenCommentsPanel={handleOpenCommentsPanel}
-                        onCommentHover={setHoveredCommentId}
-                        onCommentSelect={handleCommentSelect}
-                      />
-                    )}
-                    {!isHomeSurface && (
-                      <NewSessionButton
-                        onClick={() => {
-                          const center = sessionCanvasRef.current?.getViewportCenter();
-                          setNewBranchDefaultPosition(center || null);
-                          setCreateDialogDefaultTab('teammate');
-                          setCreateDialogOpen(true);
-                        }}
-                      />
-                    )}
-                  </div>
-                </Panel>
-                {(sessionPanelTargetOpen || !eventStreamPanelCollapsed) && (
-                  <>
-                    <PanelResizeHandle
-                      style={{
-                        width: '4px',
-                        background: token.colorBorderSecondary,
-                        cursor: 'col-resize',
-                        transition: 'background 0.2s',
-                      }}
-                      onDragging={(isDragging) => {
-                        rightPanelResizeDraggingRef.current = isDragging;
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorPrimary;
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as unknown as HTMLDivElement).style.background =
-                          token.colorBorderSecondary;
-                      }}
-                    />
-                    <Panel
-                      id="session-panel"
-                      order={2}
-                      ref={sessionPanelRef}
-                      defaultSize={sessionPanelSizeWithinContent}
-                      minSize={sessionPanelMinSizeWithinContent}
-                      maxSize={sessionPanelMaxSizeWithinContent}
-                    >
-                      {effectiveSelectedSessionId ? (
-                        <SessionPanel
-                          client={client}
-                          session={selectedSession}
-                          branch={selectedSessionBranch}
-                          currentUserId={user?.user_id}
-                          sessionMcpServerIds={selectedSessionMcpServerIds}
-                          open={!!effectiveSelectedSessionId}
-                          onClose={handleCloseSessionPanel}
-                          uploadPolicy={uploadPolicy}
-                        />
-                      ) : pendingToolChoiceBranchId ? (
-                        <PendingToolChoicePanel
-                          branch={pendingToolChoiceBranch}
-                          availableAgents={availableAgents}
-                          onChoose={async (tool) => {
-                            await chooseAgenticTool(pendingToolChoiceBranchId, tool);
-                          }}
-                          onClose={handleCloseSessionPanel}
-                          onAdvancedSetup={() => {
-                            setNewSessionBranchId(pendingToolChoiceBranchId);
-                            setPendingToolChoiceBranchId(null);
-                          }}
-                        />
-                      ) : (
-                        <EventStreamPanel
-                          collapsed={false}
-                          onToggleCollapse={() => setEventStreamPanelCollapsed(true)}
-                          events={events}
-                          onClear={clearEvents}
-                          currentUserId={user?.user_id}
-                          selectedSessionId={effectiveSelectedSessionId}
-                          currentBoard={currentBoard}
-                          client={client}
-                          branchActions={eventStreamBranchActions}
-                        />
-                      )}
-                    </Panel>
-                  </>
+              )
+            }
+            contentPanelWidthPercent={contentPanelWidthPercent}
+            onContentLayout={(sizes) => {
+              // Persist only user drag updates so panel open/close and
+              // programmatic restores do not overwrite the user's preference.
+              // sizes[1] is content-relative (react-resizable-panels sizes
+              // panels relative to their own PanelGroup) — convert back to
+              // viewport-relative before persisting, matching the frame
+              // sessionPanelSize is stored in.
+              if (
+                effectiveSelectedSessionId &&
+                rightPanelResizeDraggingRef.current &&
+                sizes.length === 2
+              ) {
+                const viewportRelativeSize = toViewportRelativePercent(
+                  sizes[1],
+                  contentPanelWidthPercent
+                );
+                setSessionPanelSize(
+                  clampPercent(
+                    viewportRelativeSize,
+                    sessionPanelMinSize,
+                    SESSION_PANEL_MAX_SIZE_PERCENT
+                  )
+                );
+              }
+            }}
+            canvasDefaultSize={sessionPanelTargetOpen ? 100 - sessionPanelSizeWithinContent : 100}
+            canvasMinSize={CANVAS_MIN_SIZE_PERCENT}
+            canvasContent={
+              <>
+                {isHomeSurface ? (
+                  <HomePage
+                    client={client}
+                    connected={connected}
+                    recentBoardIds={recentBoardIds}
+                    currentUserId={user?.user_id}
+                    onBoardClick={handleHomeBoardClick}
+                    onBranchClick={handleHomeBranchClick}
+                    onSessionClick={handleSessionClick}
+                    onOpenCreateDialog={handleHomeOpenCreateDialog}
+                    onOpenSettings={openSettings}
+                  />
+                ) : (
+                  <SessionCanvas
+                    ref={sessionCanvasRef}
+                    board={currentBoard || null}
+                    client={client}
+                    branches={boardBranches}
+                    primaryTeammateId={primaryTeammateId}
+                    currentUserId={user?.user_id}
+                    selectedSessionId={effectiveSelectedSessionId}
+                    activeUrlTargetBranchId={activeUrlTargetBranchId}
+                    activeUrlTargetArtifactId={activeUrlTargetArtifactId}
+                    availableAgents={availableAgents}
+                    onSessionClick={handleSessionClick}
+                    onSessionUpdate={stableOnSessionUpdate}
+                    onSessionDelete={stableOnSessionDelete}
+                    onForkSession={stableOnForkSession}
+                    onSpawnSession={stableOnSpawnSession}
+                    onUpdateSessionMcpServers={stableOnUpdateSessionMcpServers}
+                    onOpenSettings={setSessionSettingsId}
+                    onCreateSessionForBranch={handleQuickStartSession}
+                    onOpenBranch={setBranchModalBranchId}
+                    onArchiveOrDeleteBranch={stableOnArchiveOrDeleteBranch}
+                    onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
+                    onStartEnvironment={stableOnStartEnvironment}
+                    onStopEnvironment={stableOnStopEnvironment}
+                    onViewLogs={setLogsModalBranchId}
+                    onNukeEnvironment={stableOnNukeEnvironment}
+                    onOpenCommentsPanel={handleOpenCommentsPanel}
+                    onCommentHover={setHoveredCommentId}
+                    onCommentSelect={handleCommentSelect}
+                  />
                 )}
-              </PanelGroup>
-            </Panel>
-          </PanelGroup>
+                {!isHomeSurface && (
+                  <NewSessionButton
+                    onClick={() => {
+                      const center = sessionCanvasRef.current?.getViewportCenter();
+                      setNewBranchDefaultPosition(center || null);
+                      setCreateDialogDefaultTab('teammate');
+                      setCreateDialogOpen(true);
+                    }}
+                  />
+                )}
+              </>
+            }
+            sessionSlotOpen={sessionPanelTargetOpen || !eventStreamPanelCollapsed}
+            sessionPanelRef={sessionPanelRef}
+            sessionPanelDefaultSize={sessionPanelSizeWithinContent}
+            sessionPanelMinSize={sessionPanelMinSizeWithinContent}
+            sessionPanelMaxSize={sessionPanelMaxSizeWithinContent}
+            onSessionHandleDragging={(isDragging) => {
+              rightPanelResizeDraggingRef.current = isDragging;
+            }}
+            sessionContent={
+              effectiveSelectedSessionId ? (
+                <SessionPanel
+                  client={client}
+                  session={selectedSession}
+                  branch={selectedSessionBranch}
+                  currentUserId={user?.user_id}
+                  sessionMcpServerIds={selectedSessionMcpServerIds}
+                  open={!!effectiveSelectedSessionId}
+                  onClose={handleCloseSessionPanel}
+                  uploadPolicy={uploadPolicy}
+                />
+              ) : pendingToolChoiceBranchId ? (
+                <PendingToolChoicePanel
+                  branch={pendingToolChoiceBranch}
+                  availableAgents={availableAgents}
+                  onChoose={async (tool) => {
+                    await chooseAgenticTool(pendingToolChoiceBranchId, tool);
+                  }}
+                  onClose={handleCloseSessionPanel}
+                  onAdvancedSetup={() => {
+                    setNewSessionBranchId(pendingToolChoiceBranchId);
+                    setPendingToolChoiceBranchId(null);
+                  }}
+                />
+              ) : (
+                <EventStreamPanel
+                  collapsed={false}
+                  onToggleCollapse={() => setEventStreamPanelCollapsed(true)}
+                  events={events}
+                  onClear={clearEvents}
+                  currentUserId={user?.user_id}
+                  selectedSessionId={effectiveSelectedSessionId}
+                  currentBoard={currentBoard}
+                  client={client}
+                  branchActions={eventStreamBranchActions}
+                />
+              )
+            }
+          />
         </Content>
         {/* Invisible mount of antd Upload so its CSS-in-JS styles stay
               registered even after the SessionPanel (which contains FileUpload)

--- a/apps/agor-ui/src/components/App/WorkspaceLayout.tsx
+++ b/apps/agor-ui/src/components/App/WorkspaceLayout.tsx
@@ -1,0 +1,147 @@
+import type React from 'react';
+import { type ImperativePanelHandle, Panel, PanelGroup } from 'react-resizable-panels';
+import { WorkspaceResizeHandle } from './WorkspaceResizeHandle';
+
+export interface WorkspaceLayoutProps {
+  /** Outer group layout callback (side-panel size persistence). */
+  onMainLayout: (sizes: number[]) => void;
+  /** Nested canvas/session group layout callback (session-panel size persistence). */
+  onContentLayout: (sizes: number[]) => void;
+  contentPanelWidthPercent: number;
+
+  canvasDefaultSize: number;
+  canvasMinSize: number;
+  canvasContent: React.ReactNode;
+
+  /** Session slot (session panel / tool choice / event stream / empty state). */
+  sessionSlotOpen: boolean;
+  sessionPanelRef: React.Ref<ImperativePanelHandle>;
+  sessionPanelDefaultSize: number;
+  sessionPanelMinSize: number;
+  sessionPanelMaxSize: number;
+  onSessionHandleDragging: (isDragging: boolean) => void;
+  sessionContent: React.ReactNode;
+
+  /** Which edge hosts the teammate panel. Classic = left, slim = right. */
+  sidePanelSide: 'left' | 'right';
+  /** Side panel (teammate/sessions/branches/comments, or collapsed rail). */
+  sidePanelRef: React.Ref<ImperativePanelHandle>;
+  sidePanelCollapsed: boolean;
+  sidePanelCollapsedSize: number;
+  sidePanelDefaultSize: number;
+  sidePanelMinSize: number;
+  sidePanelMaxSize: number;
+  sidePanelMinWidthPx: number;
+  onSideHandleDragging: (isDragging: boolean) => void;
+  sideContent: React.ReactNode;
+}
+
+/**
+ * The board workspace shell: canvas + session slot in a nested group, with the
+ * teammate side panel on either edge (left in classic, right in slim). Purely
+ * presentational — all sizing state, persistence, and slot contents are owned
+ * by App. Panel `order` follows visual order so react-resizable-panels keeps
+ * sizes consistent when the side flips.
+ */
+export function WorkspaceLayout({
+  onMainLayout,
+  onContentLayout,
+  contentPanelWidthPercent,
+  canvasDefaultSize,
+  canvasMinSize,
+  canvasContent,
+  sessionSlotOpen,
+  sessionPanelRef,
+  sessionPanelDefaultSize,
+  sessionPanelMinSize,
+  sessionPanelMaxSize,
+  onSessionHandleDragging,
+  sessionContent,
+  sidePanelSide,
+  sidePanelRef,
+  sidePanelCollapsed,
+  sidePanelCollapsedSize,
+  sidePanelDefaultSize,
+  sidePanelMinSize,
+  sidePanelMaxSize,
+  sidePanelMinWidthPx,
+  onSideHandleDragging,
+  sideContent,
+}: WorkspaceLayoutProps) {
+  const sideOnLeft = sidePanelSide === 'left';
+
+  const sidePanel = (
+    <Panel
+      id="teammate-panel"
+      order={sideOnLeft ? 1 : 2}
+      ref={sidePanelRef}
+      collapsible
+      defaultSize={sidePanelCollapsed ? sidePanelCollapsedSize : sidePanelDefaultSize}
+      collapsedSize={sidePanelCollapsedSize}
+      minSize={sidePanelCollapsed ? sidePanelCollapsedSize : sidePanelMinSize}
+      maxSize={sidePanelMaxSize}
+      style={{ minWidth: sidePanelMinWidthPx }}
+    >
+      {sideContent}
+    </Panel>
+  );
+
+  const sideHandle = (
+    <WorkspaceResizeHandle disabled={sidePanelCollapsed} onDragging={onSideHandleDragging} />
+  );
+
+  const contentPanel = (
+    <Panel
+      id="content-panel"
+      order={sideOnLeft ? 2 : 1}
+      defaultSize={contentPanelWidthPercent}
+      minSize={40}
+    >
+      <PanelGroup
+        id="canvas-session"
+        direction="horizontal"
+        style={{ flex: 1 }}
+        onLayout={onContentLayout}
+      >
+        <Panel id="canvas-panel" order={1} defaultSize={canvasDefaultSize} minSize={canvasMinSize}>
+          <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
+            {canvasContent}
+          </div>
+        </Panel>
+        {sessionSlotOpen && (
+          <>
+            <WorkspaceResizeHandle onDragging={onSessionHandleDragging} />
+            <Panel
+              id="session-panel"
+              order={2}
+              ref={sessionPanelRef}
+              defaultSize={sessionPanelDefaultSize}
+              minSize={sessionPanelMinSize}
+              maxSize={sessionPanelMaxSize}
+            >
+              {sessionContent}
+            </Panel>
+          </>
+        )}
+      </PanelGroup>
+    </Panel>
+  );
+
+  return (
+    <PanelGroup id="main-layout" direction="horizontal" style={{ flex: 1 }} onLayout={onMainLayout}>
+      {sideOnLeft ? (
+        <>
+          {sidePanel}
+          {sideHandle}
+          {contentPanel}
+        </>
+      ) : (
+        <>
+          {contentPanel}
+          {sideHandle}
+          {sidePanel}
+        </>
+      )}
+    </PanelGroup>
+  );
+}

--- a/apps/agor-ui/src/components/App/WorkspaceResizeHandle.tsx
+++ b/apps/agor-ui/src/components/App/WorkspaceResizeHandle.tsx
@@ -1,0 +1,42 @@
+import { theme } from 'antd';
+import { useState } from 'react';
+import { PanelResizeHandle } from 'react-resizable-panels';
+
+interface WorkspaceResizeHandleProps {
+  /** Render as an inert 0-width divider (used while the adjacent panel is collapsed). */
+  disabled?: boolean;
+  onDragging?: (isDragging: boolean) => void;
+}
+
+/** Vertical panel divider: 4px visible line, 12px grab target. */
+export function WorkspaceResizeHandle({
+  disabled = false,
+  onDragging,
+}: WorkspaceResizeHandleProps) {
+  const { token } = theme.useToken();
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <PanelResizeHandle
+      style={{
+        position: 'relative',
+        width: disabled ? '0px' : '4px',
+        background: !disabled && hovered ? token.colorPrimary : token.colorBorderSecondary,
+        cursor: disabled ? 'default' : 'col-resize',
+        transition: 'background 0.2s',
+        pointerEvents: disabled ? 'none' : 'auto',
+        overflow: 'visible',
+        zIndex: 10,
+      }}
+      onDragging={onDragging}
+    >
+      {!disabled && (
+        <div
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          style={{ position: 'absolute', top: 0, bottom: 0, left: -4, right: -4 }}
+        />
+      )}
+    </PanelResizeHandle>
+  );
+}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import type { ActiveUser, AgorClient, Board, BoardID, User } from '@agor-live/client';
-import { BulbOutlined } from '@ant-design/icons';
+import { BulbOutlined, CheckOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { memo, useMemo } from 'react';
@@ -7,6 +7,7 @@ import { useHref, useNavigate } from 'react-router-dom';
 import { mapToArray } from '@/utils/mapHelpers';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectBranchById, selectUserById } from '../../store/selectors';
@@ -94,6 +95,9 @@ const RecentBoardPills: React.FC<{
   );
 };
 
+const uiModeCheckIcon = <CheckOutlined />;
+const uiModeBlankIcon = <span style={{ width: 14, display: 'inline-block' }} />;
+
 const AppHeaderInner: React.FC<AppHeaderProps> = ({
   user,
   presenceClient = null,
@@ -121,6 +125,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
   const { themeMode, setThemeMode } = useTheme();
+  const { uiMode, setUIMode } = useUIMode();
 
   // Entity state via narrow store subscriptions rather than props. Each
   // whole-map selector is a stable module-level reference, so the header
@@ -167,6 +172,24 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
       key: 'theme',
       label: 'Theme',
       children: buildThemeMenuItems(themeMode, setThemeMode, onThemeEditorClick),
+    },
+    {
+      key: 'ui-mode',
+      label: 'Appearance',
+      children: [
+        {
+          key: 'ui-mode-classic',
+          label: 'Classic',
+          icon: uiMode === 'classic' ? uiModeCheckIcon : uiModeBlankIcon,
+          onClick: () => setUIMode('classic'),
+        },
+        {
+          key: 'ui-mode-slim',
+          label: 'Slim',
+          icon: uiMode === 'slim' ? uiModeCheckIcon : uiModeBlankIcon,
+          onClick: () => setUIMode('slim'),
+        },
+      ],
     },
     { type: 'divider' as const },
     {

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -125,7 +125,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
   const { themeMode, setThemeMode } = useTheme();
-  const { uiMode, setUIMode } = useUIMode();
+  const { uiMode, setUIMode, isSlim } = useUIMode();
 
   // Entity state via narrow store subscriptions rather than props. Each
   // whole-map selector is a stable module-level reference, so the header
@@ -271,7 +271,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             onUpdateBoard={onUpdateBoard}
           />
         </div>
-        {boards.length > 0 && (
+        {boards.length > 0 && !isSlim && (
           <RecentBoardPills
             recentBoards={recentBoards}
             onBoardChange={onBoardChange || (() => {})}

--- a/apps/agor-ui/src/components/ArchiveDeleteBranchModal/ArchiveDeleteBranchModal.tsx
+++ b/apps/agor-ui/src/components/ArchiveDeleteBranchModal/ArchiveDeleteBranchModal.tsx
@@ -1,6 +1,7 @@
 import type { Branch } from '@agor-live/client';
 import { Alert, Modal, Radio, Space, Typography } from 'antd';
 import { useEffect, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 
 const { Text } = Typography;
 
@@ -28,6 +29,7 @@ export const ArchiveDeleteBranchModal: React.FC<ArchiveDeleteBranchModalProps> =
   onCancel,
   afterClose,
 }) => {
+  const { isSlim } = useUIMode();
   const [filesystemAction, setFilesystemAction] = useState<'preserved' | 'cleaned' | 'deleted'>(
     'cleaned'
   );
@@ -157,7 +159,8 @@ export const ArchiveDeleteBranchModal: React.FC<ArchiveDeleteBranchModalProps> =
                 <Text>• Links to issues/PRs will be removed forever</Text>
                 <Text>• This action cannot be undone</Text>
                 <Text strong style={{ marginTop: 8, display: 'block' }}>
-                  💡 Consider archiving instead - keeps data for history but hides from board
+                  {isSlim ? '' : '💡 '}Consider archiving instead - keeps data for history but hides
+                  from board
                 </Text>
               </Space>
             }

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -193,7 +193,11 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
       }}
     >
       <Space size={8}>
-        <span style={{ fontSize: 18 }}>🏠</span>
+        {isSlim ? (
+          <HomeOutlined style={{ fontSize: 14, opacity: 0.65 }} />
+        ) : (
+          <span style={{ fontSize: 18 }}>🏠</span>
+        )}
         <Text strong={!currentBoardId}>Home</Text>
       </Space>
       <HomeOutlined style={{ color: token.colorTextTertiary }} />

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -1,5 +1,11 @@
 import type { AgorClient, Board, Branch, User } from '@agor-live/client';
-import { DownOutlined, EditOutlined, HomeOutlined, SearchOutlined } from '@ant-design/icons';
+import {
+  ApartmentOutlined,
+  DownOutlined,
+  EditOutlined,
+  HomeOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import {
   Badge,
@@ -15,6 +21,7 @@ import {
 } from 'antd';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useCanManageBoard } from '../../hooks/useCanManageBoard';
 import { BoardEditModal } from '../BoardEditModal';
 
@@ -62,6 +69,7 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
   onUpdateBoard,
 }) => {
   const { token } = useToken();
+  const { isSlim } = useUIMode();
   const [filterText, setFilterText] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -141,7 +149,11 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
             }}
           >
             <Space size={8}>
-              <span style={{ fontSize: 18 }}>{board.icon || '📋'}</span>
+              {isSlim ? (
+                <ApartmentOutlined style={{ fontSize: 14, opacity: 0.65 }} />
+              ) : (
+                <span style={{ fontSize: 18 }}>{board.icon || '📋'}</span>
+              )}
               <Text strong={isActive}>{board.name}</Text>
             </Space>
             <Badge
@@ -154,7 +166,16 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
         onClick: () => handleBoardClick(board.board_id),
       };
     });
-  }, [boards, currentBoardId, branchCountByBoard, handleBoardClick, token, filterText, showFilter]);
+  }, [
+    boards,
+    currentBoardId,
+    branchCountByBoard,
+    handleBoardClick,
+    token,
+    filterText,
+    showFilter,
+    isSlim,
+  ]);
 
   const homeRow = (
     <Button
@@ -273,9 +294,17 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
             }}
           >
             <Space size={8} style={{ minWidth: 0, overflow: 'hidden' }}>
-              <span style={{ fontSize: 18 }}>
-                {currentBoard ? currentBoard.icon || '📋' : '🏠'}
-              </span>
+              {isSlim ? (
+                currentBoard ? (
+                  <ApartmentOutlined style={{ fontSize: 14, opacity: 0.65 }} />
+                ) : (
+                  <HomeOutlined style={{ fontSize: 14, opacity: 0.65 }} />
+                )
+              ) : (
+                <span style={{ fontSize: 18 }}>
+                  {currentBoard ? currentBoard.icon || '📋' : '🏠'}
+                </span>
+              )}
               <Text strong ellipsis style={{ minWidth: 0 }}>
                 {currentBoard?.name || 'Home'}
               </Text>

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, Board, Branch, Repo, SpawnConfig, User } from '@agor-live/client';
 import { getTeammateConfig, isTeammate } from '@agor-live/client';
-import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
+import { LeftOutlined, RightOutlined, RobotOutlined } from '@ant-design/icons';
 import {
   Alert,
   App as AntApp,
@@ -517,6 +517,121 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
       </div>
     );
   })();
+
+  const sectionTitles: Record<BoardTeammatePanelTab, string> = {
+    teammate: 'Teammate',
+    'all-sessions': 'Sessions',
+    'all-branches': 'Branches',
+    comments: 'Comments',
+  };
+
+  const noBoard = <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No board selected" />;
+
+  const sectionContent = (() => {
+    switch (activeTab) {
+      case 'teammate':
+        return <div style={{ height: '100%', overflow: 'auto' }}>{teammateContent}</div>;
+      case 'all-sessions':
+        return board ? (
+          <div style={{ height: '100%', overflow: 'auto' }}>
+            {sessionDetailsHydrated ? (
+              <BoardSessionList
+                board={board}
+                currentBoardId={board.board_id}
+                branchById={branchById}
+                repoById={repoById}
+                sessionsByBranch={sessionsByBranch}
+                onSessionClick={onSessionClick}
+              />
+            ) : (
+              <div style={{ padding: 16 }}>
+                <Skeleton active paragraph={{ rows: 4 }} title={false} />
+              </div>
+            )}
+          </div>
+        ) : (
+          noBoard
+        );
+      case 'all-branches':
+        return board ? (
+          <div style={{ height: '100%', overflow: 'auto' }}>
+            {sessionDetailsHydrated ? (
+              <BoardBranchList board={board} repoById={repoById} client={client} />
+            ) : (
+              <div style={{ padding: 16 }}>
+                <Skeleton active paragraph={{ rows: 4 }} title={false} />
+              </div>
+            )}
+          </div>
+        ) : (
+          noBoard
+        );
+      case 'comments':
+        return board ? (
+          <div style={{ height: '100%' }}>
+            <CommentsPanel
+              client={client}
+              boardId={board.board_id}
+              comments={comments}
+              userById={userById}
+              currentUserId={currentUserId || 'unknown'}
+              boardObjects={boardObjects}
+              branchById={branchById}
+              onSendComment={(content) => onSendComment?.(content)}
+              onReplyComment={onReplyComment}
+              onResolveComment={onResolveComment}
+              onToggleReaction={onToggleReaction}
+              onDeleteComment={onDeleteComment}
+              hoveredCommentId={hoveredCommentId}
+              selectedCommentId={selectedCommentId}
+            />
+          </div>
+        ) : (
+          noBoard
+        );
+    }
+  })();
+
+  // No tab bar: the persistent icon rail (TeammatePanelRail, rendered by App
+  // beside this panel) owns section switching. The panel is content plus a
+  // slim title header.
+  if (isSlim) {
+    return (
+      <div
+        style={{
+          height: '100%',
+          background: token.colorBgContainer,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '8px 12px',
+            borderBottom: `1px solid ${token.colorBorderSecondary}`,
+            flexShrink: 0,
+          }}
+        >
+          <Typography.Text strong>{sectionTitles[activeTab]}</Typography.Text>
+          {onCollapse && (
+            <Tooltip title="Collapse panel" placement="bottom">
+              <Button
+                type="text"
+                size="small"
+                icon={<RightOutlined style={{ fontSize: 11 }} />}
+                onClick={onCollapse}
+              />
+            </Tooltip>
+          )}
+        </div>
+        <div style={{ flex: 1, minHeight: 0 }}>{sectionContent}</div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -18,6 +18,7 @@ import {
 } from 'antd';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectBranchById,
@@ -137,6 +138,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
   client,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const { message } = AntApp.useApp();
   // Subscribe to entity maps by slice from the store: each selector only wakes
   // this panel when its own slice changes.
@@ -379,7 +381,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               >
                 {isCreating ? (
                   <Spin />
-                ) : teammateConfig?.emoji ? (
+                ) : teammateConfig?.emoji && !isSlim ? (
                   <span style={{ fontSize: 30 }}>{teammateConfig.emoji}</span>
                 ) : (
                   <RobotOutlined style={{ fontSize: 30, color: token.colorInfo }} />

--- a/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { theme } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { TeammatePanelRail } from './TeammatePanelRail';
 
@@ -48,5 +49,13 @@ describe('TeammatePanelRail', () => {
     render(<TeammatePanelRail onSelectTab={vi.fn()} unreadCommentsCount={3} />);
 
     expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('uses mention emphasis for unread comments that mention the current user', () => {
+    render(<TeammatePanelRail onSelectTab={vi.fn()} unreadCommentsCount={1} hasUserMentions />);
+
+    expect(screen.getByText('1').closest('.ant-badge-count')).toHaveStyle({
+      backgroundColor: theme.getDesignToken().colorError,
+    });
   });
 });

--- a/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/TeammatePanelRail.tsx
@@ -6,7 +6,8 @@ import {
 } from '@ant-design/icons';
 import { Badge, theme } from 'antd';
 import type React from 'react';
-import { memo } from 'react';
+import { memo, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import type { BoardTeammatePanelTab } from './BoardTeammatePanel';
 
 interface RailItem {
@@ -24,6 +25,8 @@ const RAIL_ITEMS: RailItem[] = [
 
 export interface TeammatePanelRailProps {
   onSelectTab: (tab: BoardTeammatePanelTab) => void;
+  /** Section currently shown in the expanded panel; null when collapsed. */
+  activeTab?: BoardTeammatePanelTab | null;
   unreadCommentsCount?: number;
   hasUserMentions?: boolean;
 }
@@ -33,10 +36,13 @@ export interface TeammatePanelRailProps {
 // low-contrast circle floating at the panel edge.
 const TeammatePanelRailComponent: React.FC<TeammatePanelRailProps> = ({
   onSelectTab,
+  activeTab = null,
   unreadCommentsCount = 0,
   hasUserMentions = false,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
+  const [hoveredKey, setHoveredKey] = useState<BoardTeammatePanelTab | null>(null);
 
   return (
     <div
@@ -49,55 +55,101 @@ const TeammatePanelRailComponent: React.FC<TeammatePanelRailProps> = ({
         gap: 4,
         paddingTop: 12,
         background: token.colorBgContainer,
-        borderRight: `1px solid ${token.colorBorderSecondary}`,
+        // Border faces the canvas: rail sits on the right edge in slim
+        // (border on its left), left edge in classic (border on its right).
+        ...(isSlim
+          ? { borderLeft: `1px solid ${token.colorBorderSecondary}` }
+          : { borderRight: `1px solid ${token.colorBorderSecondary}` }),
       }}
     >
       {RAIL_ITEMS.map((item) => {
-        const button = (
+        const isActive = item.key === activeTab;
+        const isHovered = item.key === hoveredKey;
+        // Light-touch states: hover tints only a compact chip behind the
+        // icon; active swaps the icon to the accent color and lights a 2px
+        // bar on the rail's outer edge. No full-button fill.
+        const iconChip = (
+          <span
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              fontSize: 18,
+              lineHeight: 1,
+              background: isHovered ? token.colorFillTertiary : 'transparent',
+              color: isActive ? token.colorPrimary : 'inherit',
+              transition: 'background 0.15s',
+            }}
+          >
+            {item.icon}
+          </span>
+        );
+
+        return (
           <button
             key={item.key}
             type="button"
             aria-label={item.label}
             onClick={() => onSelectTab(item.key)}
+            onMouseEnter={() => setHoveredKey(item.key)}
+            onMouseLeave={() => setHoveredKey(null)}
             style={{
+              position: 'relative',
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
-              gap: 2,
-              width: 48,
-              padding: '8px 2px',
+              gap: 3,
+              width: '100%',
+              padding: '6px 0',
               border: 0,
-              borderRadius: token.borderRadius,
               background: 'transparent',
               color: token.colorText,
               cursor: 'pointer',
             }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLButtonElement).style.background = token.colorFillTertiary;
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
-            }}
           >
-            <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
-            <span style={{ fontSize: 10, lineHeight: 1.2 }}>{item.label}</span>
+            {/* Badge wraps only the icon chip so the button itself keeps the
+                full rail width — the edge indicator anchors to the rail edge,
+                not the badge wrapper's shrink-wrapped box. */}
+            {item.key === 'comments' ? (
+              <Badge
+                count={unreadCommentsCount}
+                offset={[-2, 4]}
+                style={{
+                  backgroundColor: hasUserMentions ? token.colorError : token.colorPrimaryBgHover,
+                }}
+              >
+                {iconChip}
+              </Badge>
+            ) : (
+              iconChip
+            )}
+            <span
+              style={{
+                fontSize: 10,
+                lineHeight: 1.2,
+                color: isActive || isHovered ? token.colorText : token.colorTextSecondary,
+              }}
+            >
+              {item.label}
+            </span>
+            {isActive && (
+              <span
+                style={{
+                  position: 'absolute',
+                  right: 0,
+                  top: 6,
+                  bottom: 6,
+                  width: 2,
+                  borderRadius: 1,
+                  background: token.colorPrimary,
+                }}
+              />
+            )}
           </button>
-        );
-
-        if (item.key !== 'comments') return button;
-
-        return (
-          <Badge
-            key={item.key}
-            count={unreadCommentsCount}
-            offset={[-10, 10]}
-            style={{
-              backgroundColor: hasUserMentions ? token.colorError : token.colorPrimaryBgHover,
-            }}
-          >
-            {button}
-          </Badge>
         );
       })}
     </div>

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -12,6 +12,7 @@ import { Button, Card, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useProgressiveMount } from '../../hooks/useProgressiveMount';
 import { readCollapsedBranchNode } from '../../utils/collapsedBranchNodes';
@@ -107,6 +108,7 @@ const BranchCardComponent = ({
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const connectionDisabled = useConnectionDisabled();
 
   const branchBoardId = (branch as { board_id?: string | null }).board_id;
@@ -384,7 +386,7 @@ const BranchCardComponent = ({
             >
               {isCreating || hasRunningSession ? (
                 <Spin size="large" />
-              ) : isAgent && teammateConfig?.emoji ? (
+              ) : isAgent && teammateConfig?.emoji && !isSlim ? (
                 <span style={{ fontSize: 32 }}>{teammateConfig.emoji}</span>
               ) : isAgent ? (
                 <RobotOutlined

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -35,6 +35,7 @@ import {
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import {
@@ -255,6 +256,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   client,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const { modal } = App.useApp();
   const { showSuccess, showError } = useThemedMessage();
   const connectionDisabled = useConnectionDisabled();
@@ -929,7 +931,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             }}
             title={isCreating ? 'Branch is being created...' : undefined}
           >
-            New Session
+            {isSlim ? 'Session' : 'New Session'}
           </Button>
         </div>
       )}

--- a/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
+++ b/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
@@ -27,6 +27,7 @@ import {
   resolveUiBranchStorageConfig,
 } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
+import { useUIMode } from '../../contexts/UIModeContext';
 
 /**
  * Default depth pre-filled into the "Depth" input when the user selects
@@ -76,6 +77,7 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
   onUseSameBranchNameChange,
   branchStorageConfig,
 }) => {
+  const { isSlim } = useUIMode();
   const [internalUseSameBranchName, setInternalUseSameBranchName] = useState(true);
   const [refType, setRefType] = useState<'branch' | 'tag'>('branch');
 
@@ -169,7 +171,7 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
               .sort((a: Board, b: Board) => a.name.localeCompare(b.name))
               .map((board: Board) => ({
                 value: board.board_id,
-                label: `${board.icon || '📋'} ${board.name}`,
+                label: isSlim ? board.name : `${board.icon || '📋'} ${board.name}`,
               }))}
             onChange={onFormChange}
           />

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.slim.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.slim.test.tsx
@@ -1,0 +1,114 @@
+import type { Branch, Repo } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UIModeProvider } from '../../contexts/UIModeContext';
+
+vi.mock('../../hooks/useConfirmNukeEnvironment', () => ({
+  useConfirmNukeEnvironment: () => vi.fn(),
+}));
+
+import { BranchHeaderPill } from './BranchHeaderPill';
+
+const repo = {
+  repo_id: 'repo-1',
+  slug: 'preset-io/agor',
+  environment_config: {
+    up_command: 'pnpm dev',
+    down_command: 'pnpm stop',
+    nuke_command: 'docker compose down -v',
+    logs_command: 'docker compose logs',
+  },
+} as Repo;
+
+const branch = {
+  branch_id: 'branch-1',
+  repo_id: repo.repo_id,
+  name: 'feature/remove-nuke',
+  nuke_command: 'docker compose down -v',
+  others_can: 'all',
+  environment_instance: { status: 'stopped' },
+} as Branch;
+
+const defaultProps = {
+  repo,
+  branch,
+  sessionCount: 3,
+  onOpenBranch: vi.fn(),
+  onStartEnvironment: vi.fn(),
+  onStopEnvironment: vi.fn(),
+  onViewLogs: vi.fn(),
+  onNukeEnvironment: vi.fn(),
+};
+
+const renderSlim = (ui: React.ReactElement) =>
+  render(
+    <MemoryRouter>
+      <UIModeProvider>{ui}</UIModeProvider>
+    </MemoryRouter>
+  );
+
+describe('BranchHeaderPill (slim mode)', () => {
+  beforeEach(() => {
+    localStorage.setItem('agor:uiMode', 'slim');
+  });
+
+  it('renders the identity as a menu trigger without a hover tooltip', () => {
+    renderSlim(<BranchHeaderPill {...defaultProps} />);
+
+    const identity = screen.getByRole('button', { name: 'preset-io/agor / feature/remove-nuke' });
+    expect(identity).toHaveAttribute('aria-haspopup', 'menu');
+    // No tooltip wiring on the identity — the classic hover tooltip is gone.
+    expect(identity).not.toHaveAttribute('aria-describedby');
+    expect(identity).not.toHaveAttribute('data-tooltip-trigger');
+    expect(
+      screen.queryByRole('button', {
+        name: 'preset-io/agor / feature/remove-nuke · Open branch settings',
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the inline action buttons but keeps the environment status chip', () => {
+    renderSlim(<BranchHeaderPill {...defaultProps} />);
+
+    expect(screen.queryByRole('button', { name: 'Start environment' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Stop environment' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View environment logs' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sessions' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Files' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Schedule' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit branch' })).not.toBeInTheDocument();
+
+    expect(screen.getByText('env')).toBeInTheDocument();
+  });
+
+  it('opens a menu with the branch modal tabs and environment actions on click', async () => {
+    renderSlim(<BranchHeaderPill {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'preset-io/agor / feature/remove-nuke' }));
+
+    expect(await screen.findByRole('menuitem', { name: /General/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Sessions \(3\)/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Environment/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Files/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Schedule/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Knowledge/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Start environment/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Stop environment/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /View logs/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Nuke environment/ })).toBeInTheDocument();
+    // Non-teammate branch: no Teammate tab.
+    expect(screen.queryByRole('menuitem', { name: /Teammate/ })).not.toBeInTheDocument();
+  });
+
+  it('opens the matching modal tab from the menu', async () => {
+    const onOpenBranch = vi.fn();
+    renderSlim(<BranchHeaderPill {...defaultProps} onOpenBranch={onOpenBranch} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'preset-io/agor / feature/remove-nuke' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Files/ }));
+
+    expect(onOpenBranch).toHaveBeenCalledWith('branch-1', 'files');
+  });
+});

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -1,19 +1,27 @@
 import type { Branch, Repo } from '@agor-live/client';
+import { isTeammate } from '@agor-live/client';
 import {
   ApartmentOutlined,
+  BookOutlined,
   BranchesOutlined,
   CalendarOutlined,
+  DownOutlined,
   EditOutlined,
   FileTextOutlined,
   FireOutlined,
   FolderOutlined,
   GlobalOutlined,
+  LinkOutlined,
   PlayCircleOutlined,
+  RobotOutlined,
   StopOutlined,
   TeamOutlined,
+  UnorderedListOutlined,
 } from '@ant-design/icons';
-import { Button, Tooltip, theme } from 'antd';
-import { Link } from 'react-router-dom';
+import type { MenuProps } from 'antd';
+import { Button, Dropdown, Tooltip, theme } from 'antd';
+import { Link, useNavigate } from 'react-router-dom';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
@@ -71,7 +79,12 @@ const NARROW_ACTION_BUTTON_STYLE: React.CSSProperties = {
   padding: 0,
 };
 
-export function BranchHeaderPill({
+export function BranchHeaderPill(props: BranchHeaderPillProps) {
+  const { isSlim } = useUIMode();
+  return isSlim ? <SlimBranchHeaderPill {...props} /> : <ClassicBranchHeaderPill {...props} />;
+}
+
+function ClassicBranchHeaderPill({
   repo,
   branch,
   sessionCount,
@@ -527,6 +540,387 @@ export function BranchHeaderPill({
           />
         </Tooltip>
       </div>
+    </Tag>
+  );
+}
+
+function SlimBranchHeaderPill({
+  repo,
+  branch,
+  sessionCount,
+  onOpenBranch,
+  onStartEnvironment,
+  onStopEnvironment,
+  onNukeEnvironment,
+  onViewLogs,
+  canControlEnvironment,
+  connectionDisabled = false,
+  showEnvButtons = true,
+  showNukeEnvironment = true,
+  identityLink,
+  truncateToFit = false,
+  compact = false,
+}: BranchHeaderPillProps) {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+  const confirmNuke = useConfirmNukeEnvironment();
+  const effectiveEnv = getEffectiveEnv(repo);
+  const hasConfig = effectiveEnv.hasConfig;
+  const env = branch.environment_instance;
+  const inferredState = getEnvironmentState(env);
+  const environmentUrl = branch.app_url;
+  // Surface the active environment variant name on the label instead of the
+  // generic "env" — only when the repo defines more than one variant to
+  // distinguish (single-variant / v1 repos stay quiet as "env"). Mirrors
+  // EnvironmentPill on the board card.
+  const variantCount = repo.environment ? Object.keys(repo.environment.variants ?? {}).length : 0;
+  const envLabel =
+    branch.environment_variant && variantCount > 1 ? branch.environment_variant : 'env';
+  const variantPrefix = envLabel !== 'env' ? `${envLabel} · ` : '';
+  // If a parent has loaded effective branch access (e.g. BranchModal), honor
+  // that explicit decision. Otherwise do not infer from direct ownership or
+  // `others_can`: group grants are not present on this branch payload, and the
+  // daemon is the source of truth for environment authorization.
+  const resolvedCanControlEnvironment = canControlEnvironment ?? true;
+
+  const status = env?.status || 'stopped';
+  const isRunning = status === 'running';
+  const isStarting = status === 'starting';
+  const isStopping = status === 'stopping';
+  const canStop = status === 'running' || status === 'starting';
+  const startDisabled =
+    connectionDisabled ||
+    !resolvedCanControlEnvironment ||
+    !hasConfig ||
+    !onStartEnvironment ||
+    isStarting ||
+    isStopping ||
+    isRunning;
+  const stopDisabled =
+    connectionDisabled ||
+    !resolvedCanControlEnvironment ||
+    !hasConfig ||
+    !onStopEnvironment ||
+    isStopping ||
+    !canStop;
+
+  const identityContent = (
+    <>
+      <BranchesOutlined style={{ fontSize: 12, flexShrink: 0 }} />
+      {!compact && (
+        <>
+          <span
+            style={{
+              fontFamily: token.fontFamilyCode,
+              fontSize: token.fontSizeSM,
+              ...(truncateToFit
+                ? {
+                    flex: '0 1 auto',
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }
+                : {}),
+            }}
+          >
+            {repo.slug}
+          </span>
+          <ApartmentOutlined style={{ fontSize: 10, opacity: 0.6, flexShrink: 0 }} />
+        </>
+      )}
+      <span
+        style={{
+          fontFamily: token.fontFamilyCode,
+          fontSize: token.fontSizeSM,
+          ...(truncateToFit
+            ? { flex: '1 1 auto', minWidth: 0 }
+            : { maxWidth: compact ? 220 : 180 }),
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {branch.name}
+      </span>
+      {/* Menu affordance — signals the identity is a dropdown trigger */}
+      <DownOutlined style={{ fontSize: 9, opacity: 0.65, flexShrink: 0 }} />
+    </>
+  );
+
+  // --- Environment status helpers ---
+
+  const getEnvTooltip = () => {
+    if (!hasConfig) return 'Click to configure environment';
+    const healthCheck = env?.last_health_check;
+    const healthMessage = healthCheck?.message ? ` - ${healthCheck.message}` : '';
+    switch (inferredState) {
+      case 'healthy':
+        return environmentUrl
+          ? `Healthy - ${environmentUrl}${healthMessage}`
+          : `Healthy${healthMessage}`;
+      case 'unhealthy':
+        return environmentUrl
+          ? `Unhealthy - ${environmentUrl}${healthMessage}`
+          : `Unhealthy${healthMessage}`;
+      case 'running':
+        return environmentUrl ? `Running - ${environmentUrl}` : 'Running (no health check)';
+      case 'starting':
+        return 'Starting...';
+      case 'stopping':
+        return 'Stopping...';
+      case 'error':
+        return 'Failed to start';
+      default:
+        return 'Stopped';
+    }
+  };
+
+  const openTab = (tab?: BranchModalTab) => onOpenBranch?.(branch.branch_id, tab);
+
+  // --- Branch menu ---
+
+  const tabItems: MenuProps['items'] = [
+    ...(identityLink
+      ? [
+          { key: 'open-link', label: 'Open session', icon: <LinkOutlined /> },
+          { type: 'divider' as const },
+        ]
+      : []),
+    { key: 'tab:general', label: 'General', icon: <EditOutlined /> },
+    ...(isTeammate(branch)
+      ? [{ key: 'tab:teammate', label: 'Teammate', icon: <RobotOutlined /> }]
+      : []),
+    {
+      key: 'tab:sessions',
+      label: `Sessions${sessionCount != null ? ` (${sessionCount})` : ''}`,
+      icon: <UnorderedListOutlined />,
+    },
+    { key: 'tab:environment', label: 'Environment', icon: <GlobalOutlined /> },
+    { key: 'tab:files', label: 'Files', icon: <FolderOutlined /> },
+    { key: 'tab:schedule', label: 'Schedule', icon: <CalendarOutlined /> },
+    { key: 'tab:knowledge', label: 'Knowledge', icon: <BookOutlined /> },
+  ];
+
+  const envActionItems: MenuProps['items'] =
+    showEnvButtons && hasConfig
+      ? [
+          { type: 'divider' as const },
+          ...(onStartEnvironment
+            ? [
+                {
+                  key: 'env:start',
+                  label: 'Start environment',
+                  icon: <PlayCircleOutlined />,
+                  disabled: startDisabled,
+                },
+              ]
+            : []),
+          ...(onStopEnvironment
+            ? [
+                {
+                  key: 'env:stop',
+                  label: isStarting ? 'Cancel startup' : 'Stop environment',
+                  icon: <StopOutlined />,
+                  disabled: stopDisabled,
+                },
+              ]
+            : []),
+          ...(onViewLogs && effectiveEnv.logs
+            ? [
+                {
+                  key: 'env:logs',
+                  label: 'View logs',
+                  icon: <FileTextOutlined />,
+                  disabled: !resolvedCanControlEnvironment,
+                },
+              ]
+            : []),
+          ...(showNukeEnvironment && !compact && onNukeEnvironment && branch.nuke_command
+            ? [
+                {
+                  key: 'env:nuke',
+                  label: 'Nuke environment',
+                  icon: <FireOutlined />,
+                  danger: true,
+                  disabled: connectionDisabled || !resolvedCanControlEnvironment,
+                },
+              ]
+            : []),
+        ]
+      : [];
+
+  const handleMenuClick: MenuProps['onClick'] = ({ key, domEvent }) => {
+    domEvent.stopPropagation();
+    if (key === 'open-link' && identityLink) {
+      if (identityLink.startsWith('/')) {
+        navigate(identityLink);
+      } else {
+        window.location.assign(identityLink);
+      }
+      return;
+    }
+    if (key.startsWith('tab:')) {
+      const tab = key.slice('tab:'.length) as BranchModalTab;
+      openTab(tab === 'general' ? undefined : tab);
+      return;
+    }
+    switch (key) {
+      case 'env:start':
+        onStartEnvironment?.(branch.branch_id);
+        break;
+      case 'env:stop':
+        onStopEnvironment?.(branch.branch_id);
+        break;
+      case 'env:logs':
+        onViewLogs?.(branch.branch_id);
+        break;
+      case 'env:nuke':
+        confirmNuke(() => onNukeEnvironment?.(branch.branch_id));
+        break;
+    }
+  };
+
+  const identityLabel = `${repo.slug} / ${branch.name}`;
+
+  // --- Render ---
+
+  return (
+    <Tag
+      color={ENTITY_PILL_COLORS.branch}
+      style={{
+        userSelect: 'none',
+        padding: 0,
+        overflow: 'hidden',
+        lineHeight: `${PILL_HEIGHT}px`,
+        display: 'inline-flex',
+        alignItems: 'stretch',
+        cursor: 'default',
+        // Content-sized, but never wider than the row: the identity section
+        // truncates before the action sections are pushed out of view.
+        ...(truncateToFit ? { maxWidth: '100%', minWidth: 0 } : {}),
+      }}
+    >
+      {/* Section 1: Repo + Branch — click opens the branch menu */}
+      <Dropdown
+        menu={{ items: [...tabItems, ...envActionItems], onClick: handleMenuClick }}
+        trigger={['click']}
+      >
+        <button
+          type="button"
+          aria-label={identityLabel}
+          aria-haspopup="menu"
+          onClick={(e) => e.stopPropagation()}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = token.colorFillSecondary;
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = 'none';
+          }}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: compact ? '0 6px' : '0 8px',
+            cursor: 'pointer',
+            height: PILL_HEIGHT,
+            background: 'none',
+            border: 'none',
+            color: 'inherit',
+            font: 'inherit',
+            transition: 'background 0.15s',
+            ...(truncateToFit ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
+          }}
+        >
+          {identityContent}
+        </button>
+      </Dropdown>
+
+      {/* Section 2: Environment status chip */}
+      {showEnvButtons && (
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 2,
+            padding: '0 4px',
+            height: PILL_HEIGHT,
+            borderLeft: `1px solid ${token.colorBorderSecondary}`,
+            flexShrink: 0,
+          }}
+        >
+          {hasConfig && isRunning && environmentUrl ? (
+            <Tooltip title={`${variantPrefix}Open ${environmentUrl}`}>
+              <a
+                href={environmentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  color: 'inherit',
+                  textDecoration: 'none',
+                  padding: '0 2px',
+                }}
+              >
+                <EnvironmentStatusIcon state={inferredState} size={11} />
+                <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>{envLabel}</span>
+              </a>
+            </Tooltip>
+          ) : hasConfig ? (
+            <Tooltip title={`${variantPrefix}${getEnvTooltip()}`}>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openTab('environment');
+                }}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  cursor: 'pointer',
+                  padding: '0 2px',
+                  background: 'none',
+                  border: 'none',
+                  color: 'inherit',
+                  font: 'inherit',
+                }}
+              >
+                <EnvironmentStatusIcon state={inferredState} size={11} />
+                <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>{envLabel}</span>
+              </button>
+            </Tooltip>
+          ) : (
+            <Tooltip title="Configure environment">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openTab('environment');
+                }}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  cursor: 'pointer',
+                  opacity: 0.5,
+                  padding: '0 2px',
+                  background: 'none',
+                  border: 'none',
+                  color: 'inherit',
+                  font: 'inherit',
+                }}
+              >
+                <GlobalOutlined style={{ fontSize: 11 }} />
+                <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      )}
     </Tag>
   );
 }

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -9,6 +9,7 @@
 import type { AgorClient, Branch, TeammateConfig, User } from '@agor-live/client';
 import { screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UIModeProvider } from '../../contexts/UIModeContext';
 import { EMPTY_MAPS } from '../../store/agorMaps';
 import { agorStore } from '../../store/agorStore';
 import { BranchModal } from './BranchModal';
@@ -192,5 +193,35 @@ describe('BranchModal — permissions tab visibility', () => {
         },
       },
     });
+  });
+});
+
+describe('BranchModal — slim mode', () => {
+  it('renders as a drawer instead of a modal', async () => {
+    localStorage.setItem('agor:uiMode', 'slim');
+    try {
+      const seb = makeUser({ user_id: 'seb', role: 'admin' });
+      renderWithApp(
+        <UIModeProvider>
+          <BranchModal
+            open={true}
+            onClose={() => {}}
+            branch={makeBranch()}
+            repo={makeRepo()}
+            sessions={[]}
+            client={makeStubClient({ owners: [seb], users: [seb] }).client}
+            currentUser={seb}
+          />
+        </UIModeProvider>
+      );
+
+      expect(await screen.findByRole('tab', { name: /general/i })).toBeInTheDocument();
+      expect(document.querySelector('.ant-drawer')).toBeInTheDocument();
+      expect(document.querySelector('.ant-modal')).toBeNull();
+      // Footer actions survive the drawer conversion.
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    } finally {
+      localStorage.removeItem('agor:uiMode');
+    }
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -1,11 +1,12 @@
 import type { AgorClient, BoardEntityObject, Branch, Repo, Session, User } from '@agor-live/client';
 import { getTeammateConfig, isTeammate } from '@agor-live/client';
-import { Badge, Button, Modal, Space, Tabs, theme } from 'antd';
+import { Badge, Button, Space, Tabs, theme } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectMcpServerById, selectUserById } from '../../store/selectors';
 import { useThemedMessage } from '../../utils/message';
+import { ModalOrDrawer } from '../ModalOrDrawer';
 import { EnvironmentTab } from './tabs/EnvironmentTab';
 import { FilesTab } from './tabs/FilesTab';
 import { GeneralTab } from './tabs/GeneralTab';
@@ -290,16 +291,31 @@ export const BranchModal: React.FC<BranchModalProps> = ({
     </Space>
   );
 
+  // Classic: centered modal. Slim: right-hand drawer with no mask so the
+  // board stays visible and interactive while branch settings are open.
   return (
-    <Modal
+    <ModalOrDrawer
       title={title}
       open={open}
-      onCancel={onClose}
-      footer={footer}
-      width={900}
-      mask={{ closable: false }}
-      styles={{
-        body: { padding: 0, maxHeight: '80vh', overflowY: 'auto' },
+      onClose={onClose}
+      modal={{
+        footer,
+        width: 900,
+        mask: { closable: false },
+        styles: {
+          body: { padding: 0, maxHeight: '80vh', overflowY: 'auto' },
+        },
+      }}
+      drawer={{
+        placement: 'right',
+        size: 760,
+        mask: false,
+        footer,
+        styles: {
+          body: { paddingTop: 0 },
+          footer: { textAlign: 'right' },
+          wrapper: { maxWidth: '100vw' },
+        },
       }}
     >
       <Tabs
@@ -307,6 +323,6 @@ export const BranchModal: React.FC<BranchModalProps> = ({
         onChange={(key) => setActiveTab(key as BranchModalTab)}
         items={tabItems}
       />
-    </Modal>
+    </ModalOrDrawer>
   );
 };

--- a/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
@@ -3,6 +3,7 @@ import { isTeammate } from '@agor-live/client';
 import { FolderOutlined, LinkOutlined } from '@ant-design/icons';
 import { Descriptions, Form, Input, Select, Space, Tooltip, Typography } from 'antd';
 import { useState } from 'react';
+import { useUIMode } from '../../../contexts/UIModeContext';
 import { ArchiveActionButton } from '../../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../../ArchiveDeleteBranchModal';
 import { MCPServerSelect } from '../../MCPServerSelect';
@@ -44,6 +45,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
   setField,
   onArchiveOrDelete,
 }) => {
+  const { isSlim } = useUIMode();
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
 
   const handleArchiveOrDelete = (options: {
@@ -126,7 +128,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
                   .sort((a, b) => a.name.localeCompare(b.name))
                   .map((board) => ({
                     value: board.board_id,
-                    label: `${board.icon || '📋'} ${board.name}`,
+                    label: isSlim ? board.name : `${board.icon || '📋'} ${board.name}`,
                   }))}
               />
             </Form.Item>

--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -33,12 +33,14 @@ import {
 } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMutationGate } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { AgorAvatar } from '../AgorAvatar';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { AgorEmojiPicker } from '../EmojiPickerInput';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { MetaRow } from '../MetaRow';
 import { ZONE_CONTENT_OPACITY } from '../SessionCanvas/canvas/BoardObjectNodes';
+import { UserIdentityAvatar } from '../UserIdentityAvatar';
 
 const { Text, Title } = Typography;
 
@@ -173,6 +175,7 @@ const ReplyItem: React.FC<{
   onDelete?: (commentId: string) => void;
 }> = ({ reply, userById, currentUserId, onToggleReaction, onDelete }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const [replyHovered, setReplyHovered] = useState(false);
   const replyUser = userById.get(reply.created_by);
   const isReplyCurrentUser = reply.created_by === currentUserId;
@@ -189,7 +192,13 @@ const ReplyItem: React.FC<{
         onMouseLeave={() => setReplyHovered(false)}
       >
         <MetaRow
-          avatar={<AgorAvatar>{replyUser?.emoji || '👤'}</AgorAvatar>}
+          avatar={
+            isSlim ? (
+              <UserIdentityAvatar user={replyUser} size={40} />
+            ) : (
+              <AgorAvatar>{replyUser?.emoji || '👤'}</AgorAvatar>
+            )
+          }
           title={
             <Space size={4}>
               <Text strong style={{ fontSize: token.fontSizeSM }}>
@@ -292,6 +301,7 @@ const CommentThread: React.FC<{
   client,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const [showReplyInput, setShowReplyInput] = useState(false);
   const [replyValue, setReplyValue] = useState('');
   const [isHovered, setIsHovered] = useState(false);
@@ -317,7 +327,13 @@ const CommentThread: React.FC<{
       >
         {/* Thread Root */}
         <MetaRow
-          avatar={<AgorAvatar>{user?.emoji || '👤'}</AgorAvatar>}
+          avatar={
+            isSlim ? (
+              <UserIdentityAvatar user={user} size={40} />
+            ) : (
+              <AgorAvatar>{user?.emoji || '👤'}</AgorAvatar>
+            )
+          }
           title={
             <Space size={4}>
               <Text strong style={{ fontSize: token.fontSizeSM }}>

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -23,11 +23,13 @@ import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons'
 import { Alert, Button, Spin, Typography, theme } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStickToBottom } from 'use-stick-to-bottom';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useStreamingMessagesByTask } from '../../hooks/useStreamingMessagesByTask';
 import { useCopyToClipboard } from '../../utils/clipboard';
 import { BrandMark } from '../BrandMark';
 import { TaskBlock } from '../TaskBlock';
+import { CallbackEventRow } from '../TaskBlock/CallbackEventRow';
 
 const { Text } = Typography;
 const EMPTY_STREAMING_MESSAGES = new Map();
@@ -157,6 +159,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     onOpenAgenticToolSettings,
   }) => {
     const { token } = theme.useToken();
+    const { isSlim } = useUIMode();
     const [copied, copy] = useCopyToClipboard();
 
     // use-stick-to-bottom owns the entire auto-scroll lifecycle. It keeps a
@@ -481,34 +484,60 @@ export const ConversationView = React.memo<ConversationViewProps>(
           <GenealogyBanner />
 
           {/* Task-organized conversation */}
-          {tasks.map((task, taskIndex) => (
-            <TaskBlock
-              key={task.task_id}
-              task={task}
-              agentic_tool={agentic_tool}
-              sessionModel={sessionModel}
-              userById={userById}
-              currentUserId={currentUserId}
-              isExpanded={forceExpandAll || expandedTaskIds.has(task.task_id)}
-              onExpandChange={handleTaskExpandChange}
-              sessionId={sessionId}
-              onPermissionDecision={onPermissionDecision}
-              branchName={branchName}
-              scheduledFromBranch={scheduledFromBranch}
-              scheduledRunAt={scheduledRunAt}
-              streamingMessages={streamingMessagesByTask.get(task.task_id)}
-              taskMessages={
-                currentReactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES
-              }
-              taskMessagesLoaded={!!currentReactiveState?.loadedTaskIds.has(task.task_id)}
-              onLoadTaskMessages={handleLoadTaskMessages}
-              onUnloadTaskMessages={handleUnloadTaskMessages}
-              teammateEmoji={teammateEmoji}
-              isLatestTask={taskIndex === tasks.length - 1}
-              client={client}
-              onOpenAgenticToolSettings={onOpenAgenticToolSettings}
-            />
-          ))}
+          {tasks.map((task, taskIndex) => {
+            // Daemon-synthesized callbacks (child session finished) render as
+            // one-line system events until expanded. The latest task keeps the
+            // full block: its agent reply may still be streaming.
+            const isTaskExpanded = forceExpandAll || expandedTaskIds.has(task.task_id);
+            const isTerminal =
+              task.status === TaskStatus.COMPLETED ||
+              task.status === TaskStatus.FAILED ||
+              task.status === TaskStatus.STOPPED;
+            if (
+              isSlim &&
+              task.metadata?.is_agor_callback &&
+              isTerminal &&
+              !isTaskExpanded &&
+              taskIndex !== tasks.length - 1
+            ) {
+              return (
+                <CallbackEventRow
+                  key={task.task_id}
+                  task={task}
+                  onExpandChange={handleTaskExpandChange}
+                />
+              );
+            }
+            return (
+              <TaskBlock
+                key={task.task_id}
+                task={task}
+                agentic_tool={agentic_tool}
+                sessionModel={sessionModel}
+                previousTaskModel={taskIndex > 0 ? tasks[taskIndex - 1].model : undefined}
+                userById={userById}
+                currentUserId={currentUserId}
+                isExpanded={forceExpandAll || expandedTaskIds.has(task.task_id)}
+                onExpandChange={handleTaskExpandChange}
+                sessionId={sessionId}
+                onPermissionDecision={onPermissionDecision}
+                branchName={branchName}
+                scheduledFromBranch={scheduledFromBranch}
+                scheduledRunAt={scheduledRunAt}
+                streamingMessages={streamingMessagesByTask.get(task.task_id)}
+                taskMessages={
+                  currentReactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES
+                }
+                taskMessagesLoaded={!!currentReactiveState?.loadedTaskIds.has(task.task_id)}
+                onLoadTaskMessages={handleLoadTaskMessages}
+                onUnloadTaskMessages={handleUnloadTaskMessages}
+                teammateEmoji={teammateEmoji}
+                isLatestTask={taskIndex === tasks.length - 1}
+                client={client}
+                onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+              />
+            );
+          })}
         </div>
       </div>
     );

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
@@ -15,6 +15,7 @@
 import type { AgorClient, Branch } from '@agor-live/client';
 import { render, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { UIModeProvider } from '../../contexts/UIModeContext';
 import { Ansi } from '../AnsiText';
 import { EnvironmentLogsModal } from './EnvironmentLogsModal';
 
@@ -110,5 +111,35 @@ describe('EnvironmentLogsModal', () => {
     const alert = await findByRole('alert');
     expect(within(alert).getByText('Error fetching logs')).toBeInTheDocument();
     expect(within(alert).getByText(/No logs command configured/)).toBeInTheDocument();
+  });
+});
+
+describe('EnvironmentLogsModal — slim mode', () => {
+  it('renders as a drawer instead of a modal', async () => {
+    localStorage.setItem('agor:uiMode', 'slim');
+    try {
+      const client = makeClient({
+        logs: 'Server started on port 3000',
+        timestamp: new Date('2026-05-10T12:00:00Z').toISOString(),
+        truncated: false,
+      });
+
+      const { findByText } = render(
+        <UIModeProvider>
+          <EnvironmentLogsModal
+            open
+            onClose={() => {}}
+            branch={mockBranch as Branch}
+            client={client}
+          />
+        </UIModeProvider>
+      );
+
+      expect(await findByText(/Server started on port 3000/)).toBeInTheDocument();
+      expect(document.querySelector('.ant-drawer')).toBeInTheDocument();
+      expect(document.querySelector('.ant-modal')).toBeNull();
+    } finally {
+      localStorage.removeItem('agor:uiMode');
+    }
   });
 });

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -1,10 +1,12 @@
 // biome-ignore-all lint/plugin/noHardcodedColorProperty: log output intentionally uses a fixed terminal-like surface
 import type { AgorClient, Branch } from '@agor-live/client';
 import { ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Checkbox, Modal, Space, Typography, theme } from 'antd';
+import { Alert, Button, Checkbox, Space, Typography, theme } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { Ansi } from '../AnsiText';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { ModalOrDrawer } from '../ModalOrDrawer';
 
 const { Text } = Typography;
 
@@ -31,6 +33,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
   client,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const [logs, setLogs] = useState<LogsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -129,33 +132,64 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
     return date.toLocaleString();
   };
 
+  // Slim drawer is fixed-height, so the log box fills the remainder instead
+  // of the classic modal's viewport-relative 60vh.
+  const logBoxSizing = isSlim
+    ? { height: 'calc(65vh - 230px)', minHeight: 200 }
+    : { height: '60vh' };
+
+  // Classic: near-fullscreen modal. Slim: bottom drawer (no mask) so logs
+  // read alongside the board/environment controls instead of covering them.
   return (
-    <Modal
+    <ModalOrDrawer
       title={`Environment Logs - ${branch.name}`}
       open={open}
-      onCancel={onClose}
-      width={900}
-      style={{ top: 20 }}
-      footer={[
-        <Checkbox
-          key="auto-refresh"
-          checked={autoRefresh}
-          onChange={(e) => setAutoRefresh(e.target.checked)}
-        >
-          Auto-refresh
-        </Checkbox>,
-        <Button
-          key="refresh"
-          icon={<ReloadOutlined />}
-          onClick={() => fetchLogs(false, true)}
-          loading={loading}
-        >
-          Refresh
-        </Button>,
-        <Button key="close" onClick={onClose}>
-          Close
-        </Button>,
-      ]}
+      onClose={onClose}
+      modal={{
+        width: 900,
+        style: { top: 20 },
+        footer: [
+          <Checkbox
+            key="auto-refresh"
+            checked={autoRefresh}
+            onChange={(e) => setAutoRefresh(e.target.checked)}
+          >
+            Auto-refresh
+          </Checkbox>,
+          <Button
+            key="refresh"
+            icon={<ReloadOutlined />}
+            onClick={() => fetchLogs(false, true)}
+            loading={loading}
+          >
+            Refresh
+          </Button>,
+          <Button key="close" onClick={onClose}>
+            Close
+          </Button>,
+        ],
+      }}
+      drawer={{
+        placement: 'bottom',
+        size: '65vh',
+        mask: false,
+        footer: (
+          <Space>
+            <Checkbox checked={autoRefresh} onChange={(e) => setAutoRefresh(e.target.checked)}>
+              Auto-refresh
+            </Checkbox>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchLogs(false, true)}
+              loading={loading}
+            >
+              Refresh
+            </Button>
+            <Button onClick={onClose}>Close</Button>
+          </Space>
+        ),
+        styles: { footer: { textAlign: 'right' } },
+      }}
     >
       <ErrorBoundary fallbackTitle="Couldn't render the logs viewer." resetKey={logs?.timestamp}>
         <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
@@ -205,7 +239,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
                 border: `1px solid ${token.colorBorder}`,
                 borderRadius: token.borderRadius,
                 padding: 16,
-                height: '60vh',
+                ...logBoxSizing,
                 overflowY: 'auto',
                 fontFamily: 'monospace',
                 fontSize: 12,
@@ -225,7 +259,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
                 textAlign: 'center',
                 padding: 40,
                 color: token.colorTextSecondary,
-                height: '60vh',
+                ...logBoxSizing,
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -236,6 +270,6 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
           )}
         </Space>
       </ErrorBoundary>
-    </Modal>
+    </ModalOrDrawer>
   );
 };

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -10,6 +10,7 @@
 import type { ActiveUser, Board, BoardID } from '@agor-live/client';
 import { Avatar, Flex, Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { slackAvatarRadius, UserIdentityAvatar } from '../UserIdentityAvatar';
 
 export interface FacepileProps {
@@ -38,6 +39,7 @@ export const Facepile: React.FC<FacepileProps> = ({
   style,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
 
   // Show first N users, with overflow count
   const visibleUsers = activeUsers.slice(0, maxVisible);
@@ -58,7 +60,7 @@ export const Facepile: React.FC<FacepileProps> = ({
       {visibleUsers.map(({ user, cursor, boardId }) => {
         const board = boardId && boardById ? boardById.get(boardId) : null;
         const boardName = board?.name || 'Unknown Board';
-        const boardIcon = board?.icon || '📋';
+        const boardIcon = isSlim ? '' : board?.icon || '📋';
         const canClick = onUserClick && boardId;
 
         return (

--- a/apps/agor-ui/src/components/GlobalUserMenu.tsx
+++ b/apps/agor-ui/src/components/GlobalUserMenu.tsx
@@ -4,6 +4,8 @@ import type { MenuProps } from 'antd';
 import { Button, Dropdown, Space, Tooltip, theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
+import { useUIMode } from '../contexts/UIModeContext';
+import { UserIdentityAvatar } from './UserIdentityAvatar';
 
 export interface GlobalUserMenuProps {
   user?: User | null;
@@ -27,6 +29,7 @@ export const GlobalUserMenu: React.FC<GlobalUserMenuProps> = ({
   onLogout,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const [open, setOpen] = useState(false);
   const userEmoji = user?.emoji || '👤';
   const audioEnabled = user?.preferences?.audio?.enabled ?? false;
@@ -36,7 +39,11 @@ export const GlobalUserMenu: React.FC<GlobalUserMenuProps> = ({
       key: 'user-info',
       label: (
         <div style={{ padding: '4px 0', display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontSize: 20 }}>{userEmoji}</span>
+          {isSlim ? (
+            <UserIdentityAvatar user={user} size={28} />
+          ) : (
+            <span style={{ fontSize: 20 }}>{userEmoji}</span>
+          )}
           <div>
             <div style={{ fontWeight: 500 }}>{user?.name || 'User'}</div>
             <div style={{ fontSize: 12, color: token.colorTextDescription }}>{user?.email}</div>

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -9,9 +9,11 @@ import {
 import { Button, Empty, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { memo, useMemo, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectBranchById, selectSessionsByBranch } from '../../store/selectors';
 import { getTimeMs } from '../../utils/entityTime';
+import { nameInitial } from '../../utils/nameInitial';
 import { formatRelativeTime } from '../../utils/time';
 import { glassSurfaceStyle, withAlpha } from './homeStyles';
 import type { HomePageProps } from './types';
@@ -92,6 +94,7 @@ const BoardHomeCard = memo(function BoardHomeCard({
   onBoardClick: (boardId: string) => void;
 }) {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
 
@@ -152,7 +155,7 @@ const BoardHomeCard = memo(function BoardHomeCard({
               flexShrink: 0,
             }}
           >
-            {board.icon || '📋'}
+            {isSlim ? nameInitial(board.name) : board.icon || '📋'}
           </div>
 
           {/* Name + meta — all aligned under each other, to the right of the icon */}

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -4,6 +4,7 @@ import { Button, Dropdown, Layout, Modal, Segmented, Select, Typography, theme }
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
+import { useUIMode } from '../../contexts/UIModeContext';
 import {
   type AgorState,
   agorStore,
@@ -152,6 +153,7 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
     props.currentUserId ? s.userById.get(props.currentUserId)?.name : undefined
   );
   const username = currentUserName || 'there';
+  const { isSlim } = useUIMode();
 
   // Resizable sidebar
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
@@ -283,24 +285,26 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
                 minHeight: 0,
               }}
             >
-              {/* Greeting */}
+              {/* Greeting (hidden in slim mode — boards and sessions are the page) */}
               <header
                 style={{
                   display: 'flex',
-                  alignItems: 'flex-start',
-                  justifyContent: 'space-between',
+                  alignItems: isSlim ? 'center' : 'flex-start',
+                  justifyContent: isSlim ? 'flex-end' : 'space-between',
                   gap: 16,
-                  marginBottom: 24,
+                  marginBottom: isSlim ? 16 : 24,
                 }}
               >
-                <div>
-                  <Title level={5} style={{ margin: 0, fontWeight: 700 }}>
-                    Hi, {username}! 👋
-                  </Title>
-                  <Text type="secondary" style={{ fontSize: 14 }}>
-                    Here's an overview of your workspace.
-                  </Text>
-                </div>
+                {!isSlim && (
+                  <div>
+                    <Title level={5} style={{ margin: 0, fontWeight: 700 }}>
+                      Hi, {username}! 👋
+                    </Title>
+                    <Text type="secondary" style={{ fontSize: 14 }}>
+                      Here's an overview of your workspace.
+                    </Text>
+                  </div>
+                )}
                 <Dropdown
                   menu={{
                     items: NEW_MENU_ITEMS,
@@ -341,7 +345,7 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
               />
 
               {/* Workspace stats */}
-              <HomeStatsBar currentUserId={props.currentUserId} />
+              {!isSlim && <HomeStatsBar currentUserId={props.currentUserId} />}
 
               {/* My Sessions — flex: 1 fills remaining viewport height */}
               <HomeSessionsSection
@@ -360,8 +364,8 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
             </div>
           </Content>
 
-          {/* Resizable right sidebar — hidden below 992px */}
-          {sidebarVisible && (
+          {/* Resizable right sidebar — hidden below 992px and in slim mode */}
+          {sidebarVisible && !isSlim && (
             <aside
               style={{
                 width: sidebarWidth,

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -243,8 +243,11 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
     () =>
       Array.from(boardById.values())
         .filter((b) => !b.archived)
-        .map((b) => ({ value: b.board_id, label: `${b.icon || '📋'} ${b.name}` })),
-    [boardById]
+        .map((b) => ({
+          value: b.board_id,
+          label: isSlim ? b.name : `${b.icon || '📋'} ${b.name}`,
+        })),
+    [boardById, isSlim]
   );
 
   const [createOpen, setCreateOpen] = useState(false);

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -28,6 +28,7 @@ import { Button, Tooltip, theme } from 'antd';
 
 import React, { useState } from 'react';
 import { BRAND, brandBadgeHref } from '../../branding/brand';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
 import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
@@ -211,11 +212,13 @@ function getAgentAvatar({
   teammateEmoji,
   agentic_tool,
   isCallback,
+  isSlim,
   token,
 }: {
   teammateEmoji?: string;
   agentic_tool?: string;
   isCallback?: boolean;
+  isSlim?: boolean;
   token: ReturnType<typeof theme.useToken>['token'];
 }): React.ReactNode {
   if (isCallback) {
@@ -230,6 +233,12 @@ function getAgentAvatar({
     );
   }
   if (teammateEmoji) {
+    // Slim mode replaces the teammate emoji with the neutral robot avatar.
+    if (isSlim) {
+      return (
+        <AgorAvatar icon={<RobotOutlined />} style={{ backgroundColor: token.colorBgContainer }} />
+      );
+    }
     return <AgorAvatar>{teammateEmoji}</AgorAvatar>;
   }
   if (agentic_tool) {
@@ -338,6 +347,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   onOpenAgenticToolSettings,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
 
   // Handle permission request messages specially
   if (message.type === 'permission_request') {
@@ -674,7 +684,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
           const avatar = isUser ? (
             <UserIdentityAvatar user={currentUser} />
           ) : (
-            getAgentAvatar({ teammateEmoji, agentic_tool, isCallback, token })
+            getAgentAvatar({ teammateEmoji, agentic_tool, isCallback, isSlim, token })
           );
 
           return (
@@ -819,7 +829,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       {/* Response text after tools */}
       {hasTextAfter &&
         (() => {
-          const avatar = getAgentAvatar({ teammateEmoji, agentic_tool, isCallback, token });
+          const avatar = getAgentAvatar({ teammateEmoji, agentic_tool, isCallback, isSlim, token });
 
           return (
             <div style={{ margin: `${token.sizeUnit}px 0` }}>

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -722,15 +722,18 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
                       }}
                     >
                       {textBeforeTools.map((text) => {
-                        // Use CollapsibleMarkdown for long text blocks (15+ lines)
-                        const shouldTruncate = text.split('\n').length > 15;
+                        // Callback prompt echoes (child-session notifications)
+                        // duplicate what the collapsed summary already says —
+                        // cap them hard. Regular text truncates at 15+ lines.
+                        const truncateAt = isSlim && isCallback ? 4 : 15;
+                        const shouldTruncate = text.split('\n').length > truncateAt;
 
                         return (
                           <div key={`text-${text.length}-${text.substring(0, 32)}`}>
                             {shouldTruncate ? (
                               <CollapsibleMarkdown
-                                maxLines={10}
-                                defaultExpanded={isLatestMessage}
+                                maxLines={isSlim && isCallback ? 3 : 10}
+                                defaultExpanded={isLatestMessage && !(isSlim && isCallback)}
                                 isStreaming={isStreaming}
                               >
                                 {text}
@@ -860,12 +863,13 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
                     <div style={{ wordWrap: 'break-word' }}>
                       {(() => {
                         const combinedText = textAfterTools.join('\n\n');
-                        const shouldTruncate = combinedText.split('\n').length > 15;
+                        const truncateAt = isSlim && isCallback ? 4 : 15;
+                        const shouldTruncate = combinedText.split('\n').length > truncateAt;
 
                         return shouldTruncate ? (
                           <CollapsibleMarkdown
-                            maxLines={10}
-                            defaultExpanded={isLatestMessage}
+                            maxLines={isSlim && isCallback ? 3 : 10}
+                            defaultExpanded={isLatestMessage && !(isSlim && isCallback)}
                             isStreaming={isStreaming}
                           >
                             {combinedText}

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -628,7 +628,9 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
           // Task tools: render as text message (spinner is shown in the tool chain)
           const subagentType = toolUse.input.subagent_type || 'Task';
           const description = toolUse.input.description || '';
-          const taskText = `🔧 **Task (${subagentType}):** ${description}`;
+          const taskText = isSlim
+            ? `**Task (${subagentType}):** ${description}`
+            : `🔧 **Task (${subagentType}):** ${description}`;
 
           textBeforeTools.push(taskText);
         } else {

--- a/apps/agor-ui/src/components/ModalOrDrawer/ModalOrDrawer.tsx
+++ b/apps/agor-ui/src/components/ModalOrDrawer/ModalOrDrawer.tsx
@@ -1,0 +1,60 @@
+import type { DrawerProps, ModalProps } from 'antd';
+import { Drawer, Modal } from 'antd';
+import type React from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
+
+export interface ModalOrDrawerProps {
+  open: boolean;
+  title?: React.ReactNode;
+  /** Maps to Modal `onCancel` in classic mode and Drawer `onClose` in slim. */
+  onClose?: () => void;
+  afterOpenChange?: (open: boolean) => void;
+  children?: React.ReactNode;
+  /** Classic-mode Modal props (width, footer, styles, …). */
+  modal?: Omit<ModalProps, 'open' | 'title' | 'onCancel' | 'afterOpenChange' | 'children'>;
+  /** Slim-mode Drawer props (placement, size, mask, footer, …). */
+  drawer?: Omit<DrawerProps, 'open' | 'title' | 'onClose' | 'afterOpenChange' | 'children'>;
+}
+
+/**
+ * Renders its content in an antd Modal (classic mode) or Drawer (slim mode).
+ * Shared props cover the common surface; mode-specific presentation lives in
+ * the `modal` / `drawer` prop bags.
+ */
+export const ModalOrDrawer: React.FC<ModalOrDrawerProps> = ({
+  open,
+  title,
+  onClose,
+  afterOpenChange,
+  children,
+  modal,
+  drawer,
+}) => {
+  const { isSlim } = useUIMode();
+
+  if (isSlim) {
+    return (
+      <Drawer
+        open={open}
+        title={title}
+        onClose={onClose}
+        afterOpenChange={afterOpenChange}
+        {...drawer}
+      >
+        {children}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Modal
+      open={open}
+      title={title}
+      onCancel={onClose}
+      afterOpenChange={afterOpenChange}
+      {...modal}
+    >
+      {children}
+    </Modal>
+  );
+};

--- a/apps/agor-ui/src/components/ModalOrDrawer/index.ts
+++ b/apps/agor-ui/src/components/ModalOrDrawer/index.ts
@@ -1,0 +1,1 @@
+export { ModalOrDrawer, type ModalOrDrawerProps } from './ModalOrDrawer';

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -13,6 +13,7 @@
 import type { AgenticToolName, AuthCheckResult, User } from '@agor-live/client';
 import { Alert, Button, Space } from 'antd';
 import { useEffect, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useAgorStore } from '../../store/agorStore';
 import {
   BannerDecision,
@@ -94,6 +95,7 @@ export function OnboardingBanners({
   onCheckAuth,
   credentialVersion,
 }: OnboardingBannersProps) {
+  const { isSlim } = useUIMode();
   const [probeState, setProbeState] = useState<ProbeState>(ProbeState.Unknown);
   const [integrationsBannerDismissed, setIntegrationsBannerDismissed] = useState(false);
   const agenticToolSettings = useAgorStore((state) => state.agenticToolSettingsByName);
@@ -176,7 +178,7 @@ export function OnboardingBanners({
     case BannerDecision.NoAi:
       return (
         <AmberBanner
-          message="⚡ No AI connected - sessions will open but nothing will run."
+          message={`${isSlim ? '' : '⚡ '}No AI connected - sessions will open but nothing will run.`}
           buttonLabel="Connect AI"
           onClick={() =>
             credentialOwner === 'tenant' && canManageWorkspaceCredentials

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -25,7 +25,7 @@ import {
   UnorderedListOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { Badge, Collapse, Popover, Tooltip, theme } from 'antd';
+import { Badge, Collapse, Popover, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useUIMode } from '../../contexts/UIModeContext';
 import { copyToClipboard } from '../../utils/clipboard';

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -515,7 +515,7 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
     </Tag>
   );
 
-  return (
+  const popover = (
     <Popover
       content={
         <ContextWindowPopoverContent
@@ -533,6 +533,21 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
       {trigger}
     </Popover>
   );
+
+  // Slim's click trigger sits inside the clickable task row — stop the click
+  // at this boundary so opening the popover doesn't also expand the card.
+  if (isSlim) {
+    return (
+      <span
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        style={{ display: 'inline-flex', lineHeight: 0 }}
+      >
+        {popover}
+      </span>
+    );
+  }
+  return popover;
 };
 
 interface ModelPillProps extends BasePillProps {

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -619,6 +619,8 @@ interface GitStatePillProps extends BasePillProps {
   sha: string;
   branchName?: string; // Hide branch name if it matches branch name
   showDirtyIndicator?: boolean;
+  /** Unboxed rendering for dense rows: plain text, no Tag chrome. */
+  bare?: boolean;
 }
 
 export const GitStatePill: React.FC<GitStatePillProps> = ({
@@ -626,6 +628,7 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
   sha,
   branchName,
   showDirtyIndicator = true,
+  bare = false,
   style,
 }) => {
   const { token } = theme.useToken();
@@ -644,6 +647,30 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
     e.stopPropagation();
     await copyToClipboard(cleanSha);
   };
+
+  if (bare) {
+    // Unboxed variant for dense chip rows: plain tertiary monospace text,
+    // same tooltip and click-to-copy.
+    return (
+      <Tooltip title={tooltip}>
+        <Typography.Text
+          onClick={handleClick}
+          style={{
+            fontFamily: token.fontFamilyCode,
+            fontSize: 11,
+            color: token.colorTextTertiary,
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+            ...style,
+          }}
+        >
+          {shouldShowBranch && `${branch} : `}
+          {displaySha}
+          {showDirty && <DirtyDot />}
+        </Typography.Text>
+      </Tooltip>
+    );
+  }
 
   return (
     <Tooltip title={tooltip}>

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -27,6 +27,7 @@ import {
 } from '@ant-design/icons';
 import { Badge, Collapse, Popover, Tooltip, theme } from 'antd';
 import type React from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { copyToClipboard } from '../../utils/clipboard';
 import { resolveContextWindowPercentage } from '../../utils/contextWindow';
 import { parseGitStateSha } from '../../utils/gitState';
@@ -854,6 +855,9 @@ export const EntityPill: React.FC<EntityPillProps> = ({
   style,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
+  // Slim mode ignores emoji overrides — entity pills always show their icon.
+  const effectiveEmoji = isSlim ? undefined : emoji;
   const hasLabel = label !== undefined && label !== null && label !== '';
   const interactive = Boolean(onClick);
   const resolvedAriaLabel = ariaLabelProp ?? ariaLabel;
@@ -866,7 +870,7 @@ export const EntityPill: React.FC<EntityPillProps> = ({
 
   return (
     <Tag
-      icon={emoji ? undefined : icon}
+      icon={effectiveEmoji ? undefined : icon}
       color={color}
       title={title}
       aria-label={resolvedAriaLabel}
@@ -886,7 +890,7 @@ export const EntityPill: React.FC<EntityPillProps> = ({
           style={{
             display: 'inline-flex',
             alignItems: 'center',
-            gap: emoji ? 4 : undefined,
+            gap: effectiveEmoji ? 4 : undefined,
             maxWidth: compact ? maxWidth : undefined,
             overflow: compact ? 'hidden' : undefined,
             textOverflow: compact ? 'ellipsis' : undefined,
@@ -895,7 +899,7 @@ export const EntityPill: React.FC<EntityPillProps> = ({
             fontFamily: code ? token.fontFamilyCode : token.fontFamily,
           }}
         >
-          {emoji && <span style={{ fontFamily: token.fontFamily }}>{emoji}</span>}
+          {effectiveEmoji && <span style={{ fontFamily: token.fontFamily }}>{effectiveEmoji}</span>}
           {label}
         </span>
       )}

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -427,6 +427,8 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
   taskMetadata,
   style,
 }) => {
+  const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   // Prefer the executor-supplied snapshot — its totalTokens/maxTokens are
   // authoritative (agent-reported), and its `percentage` matches the agent's
   // own "Context XX% used" display (e.g. Codex applies a baseline subtraction
@@ -448,7 +450,66 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
     return 'red';
   };
 
-  const pill = (
+  const ringColor = !hasLimit
+    ? token.colorInfo
+    : percentage < 50
+      ? token.colorSuccess
+      : percentage < 80
+        ? token.colorWarning
+        : token.colorError;
+
+  // Slim: a small progress ring, details on click. Classic: the % tag with
+  // details on hover.
+  const RING_SIZE = 16;
+  const RING_STROKE = 2.5;
+  const radius = (RING_SIZE - RING_STROKE) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const fillFraction = hasLimit ? Math.min(percentage, 100) / 100 : 0.25;
+
+  const trigger = isSlim ? (
+    <button
+      type="button"
+      aria-label={hasLimit ? `Context ${percentage}% used` : 'Context usage unknown'}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        cursor: 'pointer',
+        lineHeight: 0,
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        ...style,
+      }}
+    >
+      <svg
+        width={RING_SIZE}
+        height={RING_SIZE}
+        viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
+        style={{ transform: 'rotate(-90deg)' }}
+        aria-hidden="true"
+      >
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={radius}
+          fill="none"
+          stroke={token.colorFillSecondary}
+          strokeWidth={RING_STROKE}
+        />
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={radius}
+          fill="none"
+          stroke={ringColor}
+          strokeWidth={RING_STROKE}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - fillFraction)}
+        />
+      </svg>
+    </button>
+  ) : (
     <Tag icon={<PercentageOutlined />} color={getColor()} style={style}>
       {hasLimit ? `${percentage}%` : '?'}
     </Tag>
@@ -465,11 +526,11 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
         />
       }
       title={null}
-      trigger="hover"
+      trigger={isSlim ? 'click' : 'hover'}
       placement="top"
       mouseEnterDelay={0.3}
     >
-      {pill}
+      {trigger}
     </Popover>
   );
 };

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -147,7 +147,7 @@ function parseTimestamp(value?: string | number | Date): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function formatDuration(milliseconds: number): string {
+export function formatDuration(milliseconds: number): string {
   if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
     return '00:00';
   }

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -1,7 +1,10 @@
 /* biome-ignore-all lint/plugin/noFirstPartyCss: React Flow integration, tool cursors, and resize hit areas require third-party selectors */
-/* Adjust MiniMap panel to have more bottom spacing */
+/* Small lift so the minimap clears the React Flow attribution. (Was 75px,
+   compensating for the canvas overflowing the fold by the header height —
+   fixed at the source: SessionCanvas defaults to 100% of its panel and the
+   app shell pins Content to the viewport remainder.) */
 .react-flow__panel.react-flow__minimap.bottom.right {
-  margin-bottom: 75px;
+  margin-bottom: 20px;
 }
 
 /* Theme-aware React Flow controls */

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -113,3 +113,29 @@
 .react-flow__node-appNode .react-flow__resize-control.line.bottom {
   height: 12px;
 }
+
+/* ---- Slim mode: horizontal floating toolbar at the bottom of the board ---- */
+.canvas-slim .react-flow__controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 3px;
+  padding: 4px;
+  margin-bottom: 20px;
+  border-radius: 12px;
+}
+
+.canvas-slim .react-flow__controls-button {
+  border: none;
+  border-radius: 8px;
+  width: 33px;
+  height: 33px;
+  min-width: 33px;
+  min-height: 33px;
+}
+
+.canvas-slim .react-flow__controls-button svg {
+  max-width: none;
+  max-height: none;
+  transform: scale(1.35);
+}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -21,6 +21,7 @@ import type {
 import {
   BorderOutlined,
   CommentOutlined,
+  CompassOutlined,
   DeleteOutlined,
   FileMarkdownOutlined,
   MinusOutlined,
@@ -62,6 +63,7 @@ import {
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -532,6 +534,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const [activeTool, setActiveTool] = useState<
       'select' | 'zone' | 'comment' | 'eraser' | 'markdown'
     >('select');
+
+    const [miniMapVisible, setMiniMapVisible] = useLocalStorage<boolean>(
+      'agor:board-minimap-visible',
+      true
+    );
 
     // Zone drawing state (drag-to-draw)
     const [drawingZone, setDrawingZone] = useState<{
@@ -2825,20 +2832,42 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   </ControlButton>
                 </span>
               </Tooltip>
+              <Tooltip
+                title={miniMapVisible ? 'Hide Minimap' : 'Show Minimap'}
+                placement="right"
+                mouseEnterDelay={0.3}
+              >
+                <span>
+                  <ControlButton
+                    aria-label={miniMapVisible ? 'Hide Minimap' : 'Show Minimap'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMiniMapVisible(!miniMapVisible);
+                    }}
+                    style={{
+                      background: miniMapVisible ? token.colorFillSecondary : 'transparent',
+                    }}
+                  >
+                    <CompassOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
+              </Tooltip>
             </Controls>
-            <MiniMap
-              nodeColor={miniMapNodeColor}
-              onClick={handleMiniMapClick}
-              pannable
-              zoomable
-              style={{
-                backgroundColor: token.colorBgElevated,
-                border: `1px solid ${token.colorBorder}`,
-              }}
-              maskColor="rgba(0, 0, 0, 0.5)"
-              maskStrokeColor={token.colorPrimary}
-              maskStrokeWidth={2}
-            />
+            {miniMapVisible && (
+              <MiniMap
+                nodeColor={miniMapNodeColor}
+                onClick={handleMiniMapClick}
+                pannable
+                zoomable
+                style={{
+                  backgroundColor: token.colorBgElevated,
+                  border: `1px solid ${token.colorBorder}`,
+                }}
+                maskColor="rgba(0, 0, 0, 0.5)"
+                maskStrokeColor={token.colorPrimary}
+                maskStrokeWidth={2}
+              />
+            )}
             <RemoteCursorLayer
               client={client}
               boardId={(board?.board_id as BoardID | null) ?? null}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -460,7 +460,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onCommentSelect,
       staticCursors,
       staticCursorScale,
-      height = '100vh',
+      // Fill the hosting panel, not the viewport: inside the app shell the
+      // canvas sits below the 64px header, so a 100vh default overflowed the
+      // fold by exactly the header height (bottom toolbar/minimap clipped).
+      // Surfaces needing viewport sizing pass an explicit height.
+      height = '100%',
     }: SessionCanvasProps,
     ref
   ) => {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2720,10 +2720,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       setActiveTool('select');
                     }}
                     style={{
-                      borderLeft:
-                        activeTool === 'select'
-                          ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
-                          : 'none',
+                      ...(activeTool === 'select'
+                        ? isSlim
+                          ? { background: token.colorFillSecondary }
+                          : {
+                              borderLeft: `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`,
+                            }
+                        : {}),
                     }}
                   >
                     <SelectOutlined style={{ fontSize: '16px' }} />
@@ -2743,10 +2746,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       setActiveTool('zone');
                     }}
                     style={{
-                      borderLeft:
-                        activeTool === 'zone'
-                          ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
-                          : 'none',
+                      ...(activeTool === 'zone'
+                        ? isSlim
+                          ? { background: token.colorFillSecondary }
+                          : {
+                              borderLeft: `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`,
+                            }
+                        : {}),
                       opacity: mutationGate.canMutate ? 1 : 0.4,
                       cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
                     }}
@@ -2770,10 +2776,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       setActiveTool('comment');
                     }}
                     style={{
-                      borderLeft:
-                        activeTool === 'comment'
-                          ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
-                          : 'none',
+                      ...(activeTool === 'comment'
+                        ? isSlim
+                          ? { background: token.colorFillSecondary }
+                          : {
+                              borderLeft: `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`,
+                            }
+                        : {}),
                       opacity: mutationGate.canMutate ? 1 : 0.4,
                       cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
                     }}
@@ -2800,10 +2809,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       setActiveTool('markdown');
                     }}
                     style={{
-                      borderLeft:
-                        activeTool === 'markdown'
-                          ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
-                          : 'none',
+                      ...(activeTool === 'markdown'
+                        ? isSlim
+                          ? { background: token.colorFillSecondary }
+                          : {
+                              borderLeft: `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`,
+                            }
+                        : {}),
                       opacity: mutationGate.canMutate ? 1 : 0.4,
                       cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
                     }}
@@ -2829,8 +2841,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
                     }}
                     style={{
-                      borderLeft:
-                        activeTool === 'eraser' ? `3px solid ${token.colorError}` : 'none',
+                      ...(activeTool === 'eraser' && !isSlim
+                        ? { borderLeft: `3px solid ${token.colorError}` }
+                        : {}),
                       color: activeTool === 'eraser' ? token.colorError : 'inherit',
                       backgroundColor:
                         activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -61,6 +61,7 @@ import {
   useRegisterRecenter,
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { useAgorStore } from '../../store/agorStore';
@@ -527,6 +528,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Card modal state
     const [selectedCard, setSelectedCard] = useState<CardWithType | null>(null);
     const [cardModalOpen, setCardModalOpen] = useState(false);
+
+    const { isSlim } = useUIMode();
+    const controlTooltipPlacement = isSlim ? ('top' as const) : ('right' as const);
 
     // Tool state for canvas annotations
     const [activeTool, setActiveTool] = useState<
@@ -2599,7 +2603,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         {scopedCustomCss && <style>{scopedCustomCss}</style>}
         <div
           ref={reactFlowWrapperRef}
-          className={boardCssClass || undefined}
+          className={
+            [boardCssClass, isSlim ? 'canvas-slim' : ''].filter(Boolean).join(' ') || undefined
+          }
           style={{
             width: '100%',
             height: '100%',
@@ -2652,13 +2658,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           >
             {!canvasBackground && <Background />}
             <Controls
-              position="top-left"
+              position={isSlim ? 'bottom-center' : 'top-left'}
               showZoom={false}
               showFitView={false}
               showInteractive={false}
             >
               {/* Zoom controls */}
-              <Tooltip title="Zoom In" placement="right" mouseEnterDelay={0.3}>
+              <Tooltip title="Zoom In" placement={controlTooltipPlacement} mouseEnterDelay={0.3}>
                 <span>
                   <ControlButton
                     onClick={(e) => {
@@ -2670,7 +2676,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   </ControlButton>
                 </span>
               </Tooltip>
-              <Tooltip title="Zoom Out" placement="right" mouseEnterDelay={0.3}>
+              <Tooltip title="Zoom Out" placement={controlTooltipPlacement} mouseEnterDelay={0.3}>
                 <span>
                   <ControlButton
                     onClick={(e) => {
@@ -2682,7 +2688,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   </ControlButton>
                 </span>
               </Tooltip>
-              <Tooltip title="Fit View" placement="right" mouseEnterDelay={0.3}>
+              <Tooltip title="Fit View" placement={controlTooltipPlacement} mouseEnterDelay={0.3}>
                 <span>
                   <ControlButton
                     onClick={(e) => {
@@ -2695,7 +2701,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 </span>
               </Tooltip>
               {/* Custom toolbox buttons */}
-              <Tooltip title="Select" placement="right" mouseEnterDelay={0.3}>
+              <Tooltip title="Select" placement={controlTooltipPlacement} mouseEnterDelay={0.3}>
                 <span>
                   <ControlButton
                     onClick={(e) => {
@@ -2715,7 +2721,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               </Tooltip>
               <Tooltip
                 title={mutationGate.canMutate ? 'Add Zone' : (mutationGate.message ?? 'Add Zone')}
-                placement="right"
+                placement={controlTooltipPlacement}
                 mouseEnterDelay={0.3}
               >
                 <span>
@@ -2742,7 +2748,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 title={
                   mutationGate.canMutate ? 'Add Comment' : (mutationGate.message ?? 'Add Comment')
                 }
-                placement="right"
+                placement={controlTooltipPlacement}
                 mouseEnterDelay={0.3}
               >
                 <span>
@@ -2771,7 +2777,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     ? 'Add Markdown Note — click canvas to place'
                     : (mutationGate.message ?? 'Add Markdown Note — click canvas to place')
                 }
-                placement="right"
+                placement={controlTooltipPlacement}
                 mouseEnterDelay={0.3}
               >
                 <span>
@@ -2801,7 +2807,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     ? 'Eraser - Click to toggle'
                     : (mutationGate.message ?? 'Eraser')
                 }
-                placement="right"
+                placement={controlTooltipPlacement}
                 mouseEnterDelay={0.3}
               >
                 <span>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -393,199 +393,12 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           position: 'relative',
         }}
       >
-        {/* Toolbar - ALWAYS rendered, visibility controlled by CSS only */}
-        <div
-          className="nodrag nopan"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onPointerUp={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          style={{
-            position: 'absolute',
-            top: '-44px',
-            left: '50%',
-            transform: `translateX(-50%) scale(${scale})`,
-            transformOrigin: 'center bottom',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '6px',
-            background: token.colorBgElevated,
-            border: `1px solid ${token.colorBorder}`,
-            borderRadius: token.borderRadius,
-            boxShadow: token.boxShadowSecondary,
-            zIndex: 1000,
-            userSelect: 'none',
-            // CSS-only visibility control (no DOM changes). When the
-            // connection gate is closed we also dim and block clicks so the
-            // toolbar reads as read-only and never accidentally fires.
-            opacity: toolbarVisible ? (mutationDisabled ? 0.5 : 1) : 0,
-            pointerEvents: toolbarVisible && !mutationDisabled ? 'auto' : 'none',
-            transition: 'opacity 0.15s ease',
-          }}
-        >
-          {/* Border Color Picker */}
+        {/* Toolbar — mounted only while the zone is selected (toolbarVisible
+            keeps a 100ms grace so quick re-selects don't flicker). Keeps the
+            other ~11 controls out of the DOM/accessibility tree per zone. */}
+        {toolbarVisible && (
           <div
             className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Border
-            </span>
-            <ColorPicker
-              value={borderColor}
-              onChange={handleBorderColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors,
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: borderColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change border color"
-              />
-            </ColorPicker>
-          </div>
-          <div
-            style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Background Color Picker */}
-          <div
-            className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Fill
-            </span>
-            <ColorPicker
-              value={backgroundColor}
-              onChange={handleBackgroundColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors.map(
-                    (c) =>
-                      `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
-                        .toString(16)
-                        .padStart(2, '0')}`
-                  ),
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: backgroundColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change background color"
-              />
-            </ColorPicker>
-          </div>
-          <div
-            style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Lock/Unlock Button */}
-          <button
-            type="button"
             onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -593,40 +406,339 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
             onPointerUp={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              if (mutationDisabled) return;
-              handleToggleLock();
             }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
             style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
-              border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+              position: 'absolute',
+              top: '-44px',
+              left: '50%',
+              transform: `translateX(-50%) scale(${scale})`,
+              transformOrigin: 'center bottom',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center',
+              gap: '8px',
+              padding: '6px',
+              background: token.colorBgElevated,
+              border: `1px solid ${token.colorBorder}`,
+              borderRadius: token.borderRadius,
+              boxShadow: token.boxShadowSecondary,
+              zIndex: 1000,
               userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
+              // When the connection gate is closed, dim and block clicks so the
+              // toolbar reads as read-only and never accidentally fires.
+              opacity: mutationDisabled ? 0.5 : 1,
+              pointerEvents: mutationDisabled ? 'none' : 'auto',
             }}
-            title={data.locked ? 'Unlock zone' : 'Lock zone'}
           >
-            {data.locked ? (
-              <LockOutlined
+            {/* Border Color Picker */}
+            <div
+              className="nodrag nopan"
+              onPointerDown={(e) => {
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.stopPropagation();
+              }}
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <span
                 style={{
-                  fontSize: '12px',
-                  color: token.colorWarning,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontWeight: 500,
+                  userSelect: 'none',
+                  lineHeight: 1,
                 }}
+              >
+                Border
+              </span>
+              <ColorPicker
+                value={borderColor}
+                onChange={handleBorderColorChange}
+                trigger="click"
+                destroyTooltipOnHide
+                showText={false}
+                format="hex"
+                presets={[
+                  {
+                    label: 'Presets',
+                    colors: colors,
+                  },
+                  ...(recentColors.length > 0
+                    ? [
+                        {
+                          label: 'Recent',
+                          colors: recentColors,
+                        },
+                      ]
+                    : []),
+                ]}
+              >
+                <button
+                  type="button"
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '3px',
+                    backgroundColor: borderColor,
+                    border: `1px solid ${token.colorBorder}`,
+                    userSelect: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    boxShadow: token.boxShadowSecondary,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  title="Change border color"
+                />
+              </ColorPicker>
+            </div>
+            <div
+              style={{
+                width: '1px',
+                height: '24px',
+                backgroundColor: token.colorBorder,
+                margin: '0 2px',
+                alignSelf: 'center',
+              }}
+            />
+            {/* Background Color Picker */}
+            <div
+              className="nodrag nopan"
+              onPointerDown={(e) => {
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.stopPropagation();
+              }}
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontWeight: 500,
+                  userSelect: 'none',
+                  lineHeight: 1,
+                }}
+              >
+                Fill
+              </span>
+              <ColorPicker
+                value={backgroundColor}
+                onChange={handleBackgroundColorChange}
+                trigger="click"
+                destroyTooltipOnHide
+                showText={false}
+                format="hex"
+                presets={[
+                  {
+                    label: 'Presets',
+                    colors: colors.map(
+                      (c) =>
+                        `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
+                          .toString(16)
+                          .padStart(2, '0')}`
+                    ),
+                  },
+                  ...(recentColors.length > 0
+                    ? [
+                        {
+                          label: 'Recent',
+                          colors: recentColors,
+                        },
+                      ]
+                    : []),
+                ]}
+              >
+                <button
+                  type="button"
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '3px',
+                    backgroundColor: backgroundColor,
+                    border: `1px solid ${token.colorBorder}`,
+                    userSelect: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    boxShadow: token.boxShadowSecondary,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  title="Change background color"
+                />
+              </ColorPicker>
+            </div>
+            <div
+              style={{
+                width: '1px',
+                height: '24px',
+                backgroundColor: token.colorBorder,
+                margin: '0 2px',
+                alignSelf: 'center',
+              }}
+            />
+            {/* Lock/Unlock Button */}
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                handleToggleLock();
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              style={{
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
+                border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+              title={data.locked ? 'Unlock zone' : 'Lock zone'}
+            >
+              {data.locked ? (
+                <LockOutlined
+                  style={{
+                    fontSize: '12px',
+                    color: token.colorWarning,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                />
+              ) : (
+                <UnlockOutlined
+                  style={{
+                    fontSize: '12px',
+                    color: token.colorText,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                />
+              )}
+            </button>
+            {verticalDivider}
+            {/* Layer (z-order) controls */}
+            <div
+              className="nodrag nopan"
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              {renderActionButton(
+                'to-back',
+                'Send to back',
+                <VerticalAlignBottomOutlined style={layerIconStyle} />,
+                () => handleReorder('back')
+              )}
+              {renderActionButton(
+                'send-backward',
+                'Send backward',
+                <CaretDownOutlined style={layerIconStyle} />,
+                () => handleReorder('backward')
+              )}
+              {renderActionButton(
+                'bring-forward',
+                'Bring forward',
+                <CaretUpOutlined style={layerIconStyle} />,
+                () => handleReorder('forward')
+              )}
+              {renderActionButton(
+                'to-front',
+                'Bring to front',
+                <VerticalAlignTopOutlined style={layerIconStyle} />,
+                () => handleReorder('front')
+              )}
+            </div>
+            {verticalDivider}
+            {/* Label font-size stepper */}
+            <div
+              className="nodrag nopan"
+              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+            >
+              <FontSizeOutlined
+                style={{ fontSize: '12px', color: token.colorTextSecondary }}
+                title="Label font size"
               />
-            ) : (
-              <UnlockOutlined
+              {renderActionButton(
+                'font-smaller',
+                'Smaller label',
+                <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>−</span>,
+                () => handleFontSizeStep(-ZONE_FONT_SIZE_STEP),
+                atMinFontSize
+              )}
+              <span
+                style={{
+                  fontSize: '11px',
+                  color: token.colorTextSecondary,
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: '20px',
+                  textAlign: 'center',
+                  userSelect: 'none',
+                }}
+              >
+                {Math.round(labelFontSize)}
+              </span>
+              {renderActionButton(
+                'font-larger',
+                'Larger label',
+                <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>+</span>,
+                () => handleFontSizeStep(ZONE_FONT_SIZE_STEP),
+                atMaxFontSize
+              )}
+            </div>
+            {verticalDivider}
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                setConfigModalOpen(true);
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              style={{
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: token.colorBgContainer,
+                border: `1px solid ${token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
+              title="Configure zone"
+            >
+              <SettingOutlined
                 style={{
                   fontSize: '12px',
                   color: token.colorText,
@@ -635,168 +747,58 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
                   justifyContent: 'center',
                 }}
               />
-            )}
-          </button>
-          {verticalDivider}
-          {/* Layer (z-order) controls */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            {renderActionButton(
-              'to-back',
-              'Send to back',
-              <VerticalAlignBottomOutlined style={layerIconStyle} />,
-              () => handleReorder('back')
-            )}
-            {renderActionButton(
-              'send-backward',
-              'Send backward',
-              <CaretDownOutlined style={layerIconStyle} />,
-              () => handleReorder('backward')
-            )}
-            {renderActionButton(
-              'bring-forward',
-              'Bring forward',
-              <CaretUpOutlined style={layerIconStyle} />,
-              () => handleReorder('forward')
-            )}
-            {renderActionButton(
-              'to-front',
-              'Bring to front',
-              <VerticalAlignTopOutlined style={layerIconStyle} />,
-              () => handleReorder('front')
-            )}
-          </div>
-          {verticalDivider}
-          {/* Label font-size stepper */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <FontSizeOutlined
-              style={{ fontSize: '12px', color: token.colorTextSecondary }}
-              title="Label font size"
-            />
-            {renderActionButton(
-              'font-smaller',
-              'Smaller label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>−</span>,
-              () => handleFontSizeStep(-ZONE_FONT_SIZE_STEP),
-              atMinFontSize
-            )}
-            <span
+            </button>
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onPointerUp={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (mutationDisabled) return;
+                setDeleteModalOpen(true);
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = token.colorError;
+                e.currentTarget.style.borderColor = token.colorError;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = token.colorTextSecondary;
+                e.currentTarget.style.borderColor = token.colorBorder;
+              }}
               style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontVariantNumeric: 'tabular-nums',
-                minWidth: '20px',
-                textAlign: 'center',
+                width: '20px',
+                height: '20px',
+                borderRadius: '3px',
+                backgroundColor: token.colorBgContainer,
+                border: `1px solid ${token.colorBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
                 userSelect: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                color: token.colorTextSecondary,
               }}
+              title="Delete zone"
             >
-              {Math.round(labelFontSize)}
-            </span>
-            {renderActionButton(
-              'font-larger',
-              'Larger label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>+</span>,
-              () => handleFontSizeStep(ZONE_FONT_SIZE_STEP),
-              atMaxFontSize
-            )}
+              <DeleteOutlined
+                style={{
+                  fontSize: '12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              />
+            </button>
           </div>
-          {verticalDivider}
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setConfigModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
-              border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-            }}
-            title="Configure zone"
-          >
-            <SettingOutlined
-              style={{
-                fontSize: '12px',
-                color: token.colorText,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            />
-          </button>
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setDeleteModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = token.colorError;
-              e.currentTarget.style.borderColor = token.colorError;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = token.colorTextSecondary;
-              e.currentTarget.style.borderColor = token.colorBorder;
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
-              border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-              color: token.colorTextSecondary,
-            }}
-            title="Delete zone"
-          >
-            <DeleteOutlined
-              style={{
-                fontSize: '12px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            />
-          </button>
-        </div>
+        )}
         <div
           style={{
             pointerEvents: 'auto',

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -20,6 +20,8 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NodeResizer, useViewport } from 'reactflow';
 import { useMutationGate } from '../../../contexts/ConnectionContext';
+import { useUIMode } from '../../../contexts/UIModeContext';
+import { nameInitial } from '../../../utils/nameInitial';
 import { getContrastingTextColor } from '../../../utils/theme';
 import { DeleteZoneModal } from './DeleteZoneModal';
 import { ZoneConfigModal } from './ZoneConfigModal';
@@ -933,6 +935,7 @@ const PIN_OFFSET_Y = -PIN_HEIGHT; // Position tip at coordinate
 
 const CommentNodeComponent = ({ data }: { data: CommentNodeData }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const { zoom } = useViewport();
   const { comment, replyCount, user, parentLabel, parentColor, onClick, onHover, onLeave } = data;
   const [isHovered, setIsHovered] = useState(false);
@@ -1002,8 +1005,10 @@ const CommentNodeComponent = ({ data }: { data: CommentNodeData }) => {
             left: '0',
           }}
         >
-          {/* Emoji (counter-rotate to keep upright) */}
-          <div style={{ transform: 'rotate(45deg)' }}>{user?.emoji || '💬'}</div>
+          {/* Avatar glyph (counter-rotate to keep upright) */}
+          <div style={{ transform: 'rotate(45deg)', fontWeight: isSlim ? 600 : undefined }}>
+            {isSlim ? nameInitial(user?.name) : user?.emoji || '💬'}
+          </div>
         </div>
 
         {/* Reply count badge */}
@@ -1075,7 +1080,9 @@ const CommentNodeComponent = ({ data }: { data: CommentNodeData }) => {
         >
           {/* Who and when */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-            <div style={{ fontSize: 14 }}>{user?.emoji || '💬'}</div>
+            <div style={{ fontSize: 14, fontWeight: isSlim ? 600 : undefined }}>
+              {isSlim ? nameInitial(user?.name) : user?.emoji || '💬'}
+            </div>
             <div style={{ flex: 1, minWidth: 0 }}>
               <div
                 style={{

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ant-design/icons';
 import { App, Button, Card, Collapse, Space, Typography } from 'antd';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { parseGitStateSha } from '../../utils/gitState';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
@@ -57,6 +58,7 @@ const SessionCard = ({
   zoneColor,
   defaultExpanded = true,
 }: SessionCardProps) => {
+  const { isSlim } = useUIMode();
   const { modal } = App.useApp();
   const connectionDisabled = useConnectionDisabled();
 
@@ -279,7 +281,8 @@ const SessionCard = ({
           <div style={{ marginBottom: 8 }}>
             <Space size={4}>
               <Typography.Text type="secondary">
-                📍 {latestRef} @ {cleanSha.substring(0, 7)}
+                {isSlim ? '' : '📍 '}
+                {latestRef} @ {cleanSha.substring(0, 7)}
               </Typography.Text>
               {isDirty && (
                 <Tag icon={<EditOutlined />} color="orange" style={{ fontSize: 11 }}>
@@ -294,7 +297,7 @@ const SessionCard = ({
         {/* {session.contextFiles && session.contextFiles.length > 0 && (
           <div style={{ marginBottom: 12 }}>
             <Space size={4} wrap>
-              <Typography.Text type="secondary">📦</Typography.Text>
+              {!isSlim && <Typography.Text type="secondary">📦</Typography.Text>}
               {session.contextFiles.map((file) => (
                 <Tag key={file} color="geekblue">
                   {file}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -50,7 +50,6 @@ import {
   theme,
 } from 'antd';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
@@ -59,7 +58,7 @@ import { useUIMode } from '../../contexts/UIModeContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useSessionSearch } from '../../hooks/useSessionSearch';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
-import { agorStore, useAgorStore } from '../../store/agorStore';
+import { useAgorStore } from '../../store/agorStore';
 import {
   selectMcpServerById,
   selectUserAuthenticatedMcpServerIds,
@@ -299,73 +298,6 @@ export interface SessionPanelProps {
   open: boolean;
   onClose: () => void;
   uploadPolicy?: import('@agor/core/types').UploadIngressPolicy;
-}
-
-/** Slim-only header dropdown for jumping between this branch's sessions.
- * Menu items are built at open time from a non-reactive store read, so the
- * panel keeps its narrow-subscription contract (no re-render on session
- * churn). Lives in its own component so useNavigate() only runs when a
- * Router is guaranteed. */
-function SessionSwitcher({
-  currentSessionId,
-  branchId,
-}: {
-  currentSessionId: string;
-  branchId: string;
-}) {
-  const navigate = useNavigate();
-  const [items, setItems] = React.useState<NonNullable<MenuProps['items']>>([]);
-
-  const buildItems = React.useCallback(() => {
-    const sessions = agorStore.getState().sessionsByBranch.get(branchId) ?? [];
-    setItems(
-      sessions
-        .filter((s) => !s.archived)
-        .sort(
-          (a, b) =>
-            new Date(b.last_updated ?? 0).getTime() - new Date(a.last_updated ?? 0).getTime()
-        )
-        .slice(0, 15)
-        .map((s) => ({
-          key: s.session_id,
-          label: (
-            <Typography.Text
-              strong={s.session_id === currentSessionId}
-              ellipsis
-              style={{ maxWidth: 280, display: 'inline-block' }}
-            >
-              {getSessionDisplayTitle(s, { includeAgentFallback: false }) || 'Untitled session'}
-            </Typography.Text>
-          ),
-        }))
-    );
-  }, [branchId, currentSessionId]);
-
-  return (
-    <Dropdown
-      menu={{
-        items,
-        selectedKeys: [currentSessionId],
-        onClick: ({ key }) => {
-          if (key !== currentSessionId) navigate(`/s/${shortId(key)}/`);
-        },
-      }}
-      trigger={['click']}
-      placement="bottomLeft"
-      onOpenChange={(open) => {
-        if (open) buildItems();
-      }}
-    >
-      <Tooltip title="Switch session">
-        <Button
-          type="text"
-          size="small"
-          aria-label="Switch session"
-          icon={<DownOutlined style={{ fontSize: 10 }} />}
-        />
-      </Tooltip>
-    </Dropdown>
-  );
 }
 
 const SessionPanel: React.FC<SessionPanelProps> = ({
@@ -1548,12 +1480,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                     />
                   </button>
                 </Tooltip>
-              )}
-              {isSlim && branch && (
-                <SessionSwitcher
-                  currentSessionId={session.session_id}
-                  branchId={branch.branch_id}
-                />
               )}
               <Tooltip title={isSlim ? session.status.toUpperCase() : undefined}>
                 <Badge

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -54,6 +54,7 @@ import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useSessionSearch } from '../../hooks/useSessionSearch';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
@@ -310,6 +311,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   uploadPolicy,
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const { modal } = App.useApp();
   const { showSuccess, showInfo, showError } = useThemedMessage();
   const connectionDisabled = useConnectionDisabled();
@@ -1399,7 +1401,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       <div
         style={{
           flexShrink: 0,
-          padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
+          padding: isSlim
+            ? `${token.sizeUnit * 1.5}px ${token.sizeUnit * 3}px`
+            : `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
           borderBottom: `1px solid ${token.colorBorder}`,
           background: token.colorBgContainer,
         }}
@@ -1408,7 +1412,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div style={{ display: 'flex', gap: 12, alignItems: 'center', flex: 1, minWidth: 0 }}>
             <div style={{ flexShrink: 0 }}>
-              <ToolIcon tool={session.agentic_tool} size={40} />
+              <ToolIcon tool={session.agentic_tool} size={isSlim ? 24 : 40} />
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
               {editingTitle ? (
@@ -1428,7 +1432,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   }}
                   placeholder="Untitled session"
                   variant="borderless"
-                  style={{ fontSize: 18, fontWeight: 600, padding: 0 }}
+                  style={{ fontSize: isSlim ? 14 : 18, fontWeight: 600, padding: 0 }}
                 />
               ) : (
                 <Tooltip title="Click to rename">
@@ -1454,7 +1458,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                       textAlign: 'left',
                     }}
                   >
-                    <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
+                    <Typography.Text
+                      strong
+                      style={{
+                        fontSize: isSlim ? 14 : 18,
+                        ...getSessionTitleStyles(isSlim ? 1 : 2),
+                      }}
+                    >
                       {session.title || session.description
                         ? getSessionDisplayTitle(session, { includeAgentFallback: false })
                         : 'Untitled session'}
@@ -1471,8 +1481,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   </button>
                 </Tooltip>
               )}
-              <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
-              {session.created_by && (
+              <Tooltip title={isSlim ? session.status.toUpperCase() : undefined}>
+                <Badge
+                  status={getStatusColor()}
+                  text={isSlim ? undefined : session.status.toUpperCase()}
+                />
+              </Tooltip>
+              {session.created_by && (!isSlim || session.created_by !== currentUserId) && (
                 <div style={{ marginTop: token.sizeUnit }}>
                   <CreatedByTag
                     createdBy={session.created_by}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -50,6 +50,7 @@ import {
   theme,
 } from 'antd';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
@@ -58,7 +59,7 @@ import { useUIMode } from '../../contexts/UIModeContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useSessionSearch } from '../../hooks/useSessionSearch';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
-import { useAgorStore } from '../../store/agorStore';
+import { agorStore, useAgorStore } from '../../store/agorStore';
 import {
   selectMcpServerById,
   selectUserAuthenticatedMcpServerIds,
@@ -298,6 +299,73 @@ export interface SessionPanelProps {
   open: boolean;
   onClose: () => void;
   uploadPolicy?: import('@agor/core/types').UploadIngressPolicy;
+}
+
+/** Slim-only header dropdown for jumping between this branch's sessions.
+ * Menu items are built at open time from a non-reactive store read, so the
+ * panel keeps its narrow-subscription contract (no re-render on session
+ * churn). Lives in its own component so useNavigate() only runs when a
+ * Router is guaranteed. */
+function SessionSwitcher({
+  currentSessionId,
+  branchId,
+}: {
+  currentSessionId: string;
+  branchId: string;
+}) {
+  const navigate = useNavigate();
+  const [items, setItems] = React.useState<NonNullable<MenuProps['items']>>([]);
+
+  const buildItems = React.useCallback(() => {
+    const sessions = agorStore.getState().sessionsByBranch.get(branchId) ?? [];
+    setItems(
+      sessions
+        .filter((s) => !s.archived)
+        .sort(
+          (a, b) =>
+            new Date(b.last_updated ?? 0).getTime() - new Date(a.last_updated ?? 0).getTime()
+        )
+        .slice(0, 15)
+        .map((s) => ({
+          key: s.session_id,
+          label: (
+            <Typography.Text
+              strong={s.session_id === currentSessionId}
+              ellipsis
+              style={{ maxWidth: 280, display: 'inline-block' }}
+            >
+              {getSessionDisplayTitle(s, { includeAgentFallback: false }) || 'Untitled session'}
+            </Typography.Text>
+          ),
+        }))
+    );
+  }, [branchId, currentSessionId]);
+
+  return (
+    <Dropdown
+      menu={{
+        items,
+        selectedKeys: [currentSessionId],
+        onClick: ({ key }) => {
+          if (key !== currentSessionId) navigate(`/s/${shortId(key)}/`);
+        },
+      }}
+      trigger={['click']}
+      placement="bottomLeft"
+      onOpenChange={(open) => {
+        if (open) buildItems();
+      }}
+    >
+      <Tooltip title="Switch session">
+        <Button
+          type="text"
+          size="small"
+          aria-label="Switch session"
+          icon={<DownOutlined style={{ fontSize: 10 }} />}
+        />
+      </Tooltip>
+    </Dropdown>
+  );
 }
 
 const SessionPanel: React.FC<SessionPanelProps> = ({
@@ -1480,6 +1548,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                     />
                   </button>
                 </Tooltip>
+              )}
+              {isSlim && branch && (
+                <SessionSwitcher
+                  currentSessionId={session.session_id}
+                  branchId={branch.branch_id}
+                />
               )}
               <Tooltip title={isSlim ? session.status.toUpperCase() : undefined}>
                 <Badge

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.test.tsx
@@ -4,6 +4,7 @@ import type { AgorClient, Session, User } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
+import { UIModeProvider } from '../../contexts/UIModeContext';
 import { SessionSettingsModal } from './SessionSettingsModal';
 
 const persistUserDefaultFromForm = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -168,5 +169,32 @@ describe('SessionSettingsModal configuration', { timeout: 10_000 }, () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(2));
     expect(persistUserDefaultFromForm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionSettingsModal — slim mode', () => {
+  it('renders as a drawer instead of a modal', () => {
+    localStorage.setItem('agor:uiMode', 'slim');
+    try {
+      render(
+        <UIModeProvider>
+          <SessionSettingsModal
+            open
+            onClose={vi.fn()}
+            session={claudeSession}
+            client={null}
+            currentUser={null}
+          />
+        </UIModeProvider>
+      );
+
+      expect(document.querySelector('.ant-drawer')).toBeInTheDocument();
+      expect(document.querySelector('.ant-modal')).toBeNull();
+      // Drawer footer keeps the Save/Cancel actions.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    } finally {
+      localStorage.removeItem('agor:uiMode');
+    }
   });
 });

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -31,7 +31,7 @@ import {
 } from '@agor-live/client';
 import { DownOutlined, KeyOutlined, SettingOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import type { CollapseProps } from 'antd';
-import { Collapse, Divider, Form, Modal, Typography, theme } from 'antd';
+import { Button, Collapse, Divider, Form, Space, Typography, theme } from 'antd';
 import React from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById, selectSessionMcpServerIds } from '../../store/selectors';
@@ -48,6 +48,7 @@ import { CallbackConfigForm } from '../CallbackConfigForm';
 import { CallbackTargetDisplay } from '../CallbackToggleButton';
 import { CodexSettingsForm } from '../CodexSettingsForm';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { ModalOrDrawer } from '../ModalOrDrawer';
 import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
 import { SessionIdsList } from '../SessionIds';
 import { SessionMetadataForm } from '../SessionMetadataForm';
@@ -411,26 +412,45 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
 
   if (!activeAgenticTool) {
     return (
-      <Modal title="Historical Session" open={open} onCancel={onClose} footer={null} width={600}>
+      <ModalOrDrawer
+        title="Historical Session"
+        open={open}
+        onClose={onClose}
+        modal={{ footer: null, width: 600 }}
+        drawer={{ placement: 'right', size: 600, mask: false }}
+      >
         <Typography.Paragraph>
           This session used the removed experimental Claude Code CLI integration. Its stored
           metadata and conversation remain readable, but its runtime settings cannot be changed and
           the session cannot be resumed.
         </Typography.Paragraph>
         <SessionIdsList session={session} />
-      </Modal>
+      </ModalOrDrawer>
     );
   }
 
+  // Classic: centered modal with built-in Save/Cancel. Slim: right-hand
+  // drawer beside the session panel (no mask), with an explicit footer.
   return (
-    <Modal
+    <ModalOrDrawer
       title="Session Settings"
       open={open}
-      onOk={handleOk}
-      onCancel={handleCancel}
-      okText="Save"
-      cancelText="Cancel"
-      width={600}
+      onClose={handleCancel}
+      modal={{ onOk: handleOk, okText: 'Save', cancelText: 'Cancel', width: 600 }}
+      drawer={{
+        placement: 'right',
+        size: 600,
+        mask: false,
+        footer: (
+          <Space>
+            <Button onClick={handleCancel}>Cancel</Button>
+            <Button type="primary" onClick={handleOk}>
+              Save
+            </Button>
+          </Space>
+        ),
+        styles: { footer: { textAlign: 'right' } },
+      }}
     >
       <Form
         form={form}
@@ -473,6 +493,6 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
           items={secondaryItems}
         />
       </Form>
-    </Modal>
+    </ModalOrDrawer>
   );
 };

--- a/apps/agor-ui/src/components/TaskBlock/CallbackEventRow.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/CallbackEventRow.tsx
@@ -1,0 +1,66 @@
+import type { Task } from '@agor-live/client';
+import { CheckCircleOutlined, CloseCircleOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { Typography, theme } from 'antd';
+
+interface CallbackEventRowProps {
+  task: Task;
+  /** Same stable callback ConversationView hands every TaskBlock. */
+  onExpandChange: (taskId: string, expanded: boolean) => void;
+}
+
+/**
+ * One-line rendering of a daemon-synthesized callback task (child session
+ * completed/failed). These are system events, not conversation turns — the
+ * full TaskBlock (prompt echo, chips, agent reply) renders only after the
+ * user expands the row, so nothing is lost, it just stops shouting.
+ */
+export function CallbackEventRow({ task, onExpandChange }: CallbackEventRowProps) {
+  const { token } = theme.useToken();
+
+  const firstLine = (task.full_prompt || 'System event')
+    .split('\n')[0]
+    .replace(/^\[Agor\]\s*/, '')
+    .replace(/\.\s*$/, '');
+  const failed = /has failed/i.test(firstLine);
+  const completed = /has completed/i.test(firstLine);
+  const icon = failed ? (
+    <CloseCircleOutlined style={{ color: token.colorError, fontSize: 13 }} />
+  ) : completed ? (
+    <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 13 }} />
+  ) : (
+    <InfoCircleOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+  );
+
+  return (
+    <button
+      type="button"
+      data-conversation-block
+      onClick={() => onExpandChange(task.task_id, true)}
+      title="Show details"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: token.sizeUnit,
+        width: '100%',
+        padding: `${token.sizeUnit / 2}px ${token.sizeUnit}px`,
+        margin: `${token.sizeUnit / 2}px 0`,
+        background: 'transparent',
+        border: 0,
+        borderRadius: token.borderRadiusSM,
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = token.colorFillQuaternary;
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+      }}
+    >
+      {icon}
+      <Typography.Text type="secondary" style={{ fontSize: 12, flex: 1, minWidth: 0 }} ellipsis>
+        {firstLine}
+      </Typography.Text>
+    </button>
+  );
+}

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -39,6 +39,7 @@ import { AgentChain } from '../AgentChain';
 import { AgorAvatar } from '../AgorAvatar';
 import { CompactionBlock } from '../CompactionBlock';
 import { CopyableContent } from '../CopyableContent';
+import { MarkdownRenderer } from '../MarkdownRenderer';
 import { MessageBlock } from '../MessageBlock';
 import { CreatedByTag } from '../metadata/CreatedByTag';
 import {
@@ -428,6 +429,26 @@ export function groupMessagesIntoBlocks(messages: Message[]): Block[] {
   return blocks;
 }
 
+/** Pure-text assistant message with no widgets/tools — safe to render as a
+ * quiet log line in slim instead of a full bubble. */
+function isPlainTextAssistantMessage(message: Message): boolean {
+  if (message.role !== MessageRole.ASSISTANT) return false;
+  if (message.type === 'permission_request') return false;
+  if (typeof message.content === 'string') return message.content.trim().length > 0;
+  if (Array.isArray(message.content)) {
+    return message.content.length > 0 && message.content.every((block) => block.type === 'text');
+  }
+  return false;
+}
+
+function plainTextOf(message: Message): string {
+  if (typeof message.content === 'string') return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
+  }
+  return '';
+}
+
 /**
  * Identity key for reconciling a block across renders — mirrors the React
  * `key` each block type renders with.
@@ -791,7 +812,20 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 },
               },
               children: (
-                <div style={{ paddingTop: token.sizeUnit }}>
+                <div
+                  style={{
+                    paddingTop: token.sizeUnit,
+                    // Slim: one continuous timeline down the task instead of
+                    // per-bubble gutters.
+                    ...(isSlim
+                      ? {
+                          borderLeft: `2px solid ${token.colorBorderSecondary}`,
+                          paddingLeft: token.sizeUnit * 2,
+                          marginLeft: token.sizeUnit,
+                        }
+                      : {}),
+                  }}
+                >
                   {isVerifiedRuntimeInterruption(task, isLatestTask) && (
                     <RuntimeInterruptionNotice task={task} sessionId={sessionId} client={client} />
                   )}
@@ -851,6 +885,28 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         const isLatestMessage =
                           block.message.role === MessageRole.ASSISTANT &&
                           blockIndex === blocks.length - 1;
+
+                        // Slim: intermediate narration renders as a quiet log
+                        // line — only the task's final reply gets the bubble.
+                        if (
+                          isSlim &&
+                          !isLatestMessage &&
+                          isPlainTextAssistantMessage(block.message)
+                        ) {
+                          return (
+                            <div
+                              key={block.message.message_id}
+                              data-conversation-block={getBlockMarker(block)}
+                              style={{
+                                padding: `${token.sizeUnit / 2}px 0`,
+                                fontSize: token.fontSizeSM,
+                                color: token.colorTextSecondary,
+                              }}
+                            >
+                              <MarkdownRenderer content={plainTextOf(block.message)} />
+                            </div>
+                          );
+                        }
 
                         return (
                           <div

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -31,7 +31,7 @@ import {
   UpOutlined,
 } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
-import { Alert, Button, Collapse, Flex, Spin, Typography, theme } from 'antd';
+import { Alert, Button, Collapse, Flex, Spin, Tooltip, Typography, theme } from 'antd';
 import React, { useMemo, useRef, useState } from 'react';
 import { useUIMode } from '../../contexts/UIModeContext';
 import { getContextWindowGradient } from '../../utils/contextWindow';

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -32,6 +32,7 @@ import {
 import { Bubble } from '@ant-design/x';
 import { Alert, Button, Collapse, Flex, Spin, Typography, theme } from 'antd';
 import React, { useMemo, useRef, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { getContextWindowGradient } from '../../utils/contextWindow';
 import { AgentChain } from '../AgentChain';
 import { AgorAvatar } from '../AgorAvatar';
@@ -482,6 +483,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     client = null,
   }) => {
     const { token } = theme.useToken();
+    const { isSlim } = useUIMode();
 
     const [reactiveMessagesLoading, setReactiveMessagesLoading] = React.useState(false);
 
@@ -845,7 +847,14 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         placement="start"
                         avatar={
                           teammateEmoji ? (
-                            <AgorAvatar>{teammateEmoji}</AgorAvatar>
+                            isSlim ? (
+                              <AgorAvatar
+                                icon={<RobotOutlined />}
+                                style={{ backgroundColor: token.colorSuccess }}
+                              />
+                            ) : (
+                              <AgorAvatar>{teammateEmoji}</AgorAvatar>
+                            )
                           ) : agentic_tool ? (
                             <ToolIcon tool={agentic_tool} size={32} />
                           ) : (

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -23,6 +23,7 @@ import {
 } from '@agor-live/client';
 // TODO: Move normalization to DB or daemon API
 import {
+  CloseCircleOutlined,
   DownOutlined,
   FileTextOutlined,
   GithubOutlined,
@@ -48,6 +49,7 @@ import {
   TimerPill,
   TokenCountPill,
 } from '../Pill';
+import { formatDuration } from '../Pill/TimerPill';
 import { RateLimitBlock } from '../RateLimitBlock';
 import { StickyTodoRenderer } from '../StickyTodoRenderer';
 import { Tag } from '../Tag';
@@ -487,6 +489,17 @@ export const TaskBlock = React.memo<TaskBlockProps>(
   }) => {
     const { token } = theme.useToken();
     const { isSlim } = useUIMode();
+    // Callback tasks complete successfully even when they announce a child
+    // FAILURE — surface the child's outcome, not the courier's.
+    const callbackFailed =
+      !!task.metadata?.is_agor_callback && /has failed/i.test(task.full_prompt || '');
+    const isTaskActive =
+      task.status === TaskStatus.RUNNING ||
+      task.status === TaskStatus.STOPPING ||
+      task.status === TaskStatus.QUEUED;
+    const gutterTooltip = `${callbackFailed ? 'CHILD SESSION FAILED' : task.status.toUpperCase()}${
+      !isTaskActive && task.duration_ms ? ` · ${formatDuration(task.duration_ms)}` : ''
+    }`;
 
     const [reactiveMessagesLoading, setReactiveMessagesLoading] = React.useState(false);
 
@@ -584,7 +597,13 @@ export const TaskBlock = React.memo<TaskBlockProps>(
             {isExpanded ? (
               <UpOutlined style={{ color: token.colorPrimary, fontSize: 14 }} />
             ) : (
-              <TaskStatusIcon status={task.status} size={16} />
+              <Tooltip title={gutterTooltip} placement="left">
+                {callbackFailed ? (
+                  <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
+                ) : (
+                  <TaskStatusIcon status={task.status} size={16} />
+                )}
+              </Tooltip>
             )}
           </Flex>
         ) : (
@@ -630,19 +649,23 @@ export const TaskBlock = React.memo<TaskBlockProps>(
 
           {/* Task metadata */}
           <Flex wrap gap={token.sizeUnit}>
-            <TimerPill
-              status={task.status}
-              startedAt={task.started_at || task.message_range?.start_timestamp || task.created_at}
-              endedAt={
-                task.completed_at ||
-                (task.message_range?.end_timestamp !== task.message_range?.start_timestamp
-                  ? task.message_range?.end_timestamp
-                  : undefined)
-              }
-              durationMs={task.duration_ms}
-              lastExecutorHeartbeatAt={task.last_executor_heartbeat_at}
-              latestExecutorPulse={task.latest_executor_pulse}
-            />
+            {(!isSlim || isTaskActive) && (
+              <TimerPill
+                status={task.status}
+                startedAt={
+                  task.started_at || task.message_range?.start_timestamp || task.created_at
+                }
+                endedAt={
+                  task.completed_at ||
+                  (task.message_range?.end_timestamp !== task.message_range?.start_timestamp
+                    ? task.message_range?.end_timestamp
+                    : undefined)
+                }
+                durationMs={task.duration_ms}
+                lastExecutorHeartbeatAt={task.last_executor_heartbeat_at}
+                latestExecutorPulse={task.latest_executor_pulse}
+              />
+            )}
             {scheduledFromBranch && scheduledRunAt && (
               <ScheduledRunPill scheduledRunAt={scheduledRunAt} />
             )}

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -684,14 +684,19 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               task.model !== (isSlim ? (previousTaskModel ?? sessionModel) : sessionModel) && (
                 <ModelPill model={task.model} />
               )}
-            {!isSlim &&
-              task.git_state.sha_at_start &&
-              task.git_state.sha_at_start !== 'unknown' && (
+            {task.git_state.sha_at_start &&
+              task.git_state.sha_at_start !== 'unknown' &&
+              (!isSlim ||
+                isExpanded ||
+                (task.git_state.sha_at_end &&
+                  task.git_state.sha_at_end !== 'unknown' &&
+                  task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
                 <Flex gap={token.sizeUnit / 2} align="center">
                   <GitStatePill
                     branch={task.git_state.ref_at_start}
                     sha={task.git_state.sha_at_start}
                     branchName={branchName}
+                    bare={isSlim}
                     style={{ fontSize: 11 }}
                   />
                   {task.git_state.sha_at_end &&
@@ -706,6 +711,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           sha={task.git_state.sha_at_end}
                           branchName={branchName}
                           showDirtyIndicator={true}
+                          bare={isSlim}
                           style={{ fontSize: 11 }}
                         />
                       </>
@@ -718,41 +724,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               </Tag>
             )}
           </Flex>
-          {/* Slim: the sha lives on a quiet line under the timer chip instead
-              of occupying chip-row width. Shown when expanded or when the
-              task made commits. */}
-          {isSlim &&
-            task.git_state.sha_at_start &&
-            task.git_state.sha_at_start !== 'unknown' &&
-            (isExpanded ||
-              (task.git_state.sha_at_end &&
-                task.git_state.sha_at_end !== 'unknown' &&
-                task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
-              <Flex gap={token.sizeUnit / 2} align="center" style={{ marginTop: 2 }}>
-                <GitStatePill
-                  branch={task.git_state.ref_at_start}
-                  sha={task.git_state.sha_at_start}
-                  branchName={branchName}
-                  style={{ fontSize: 10 }}
-                />
-                {task.git_state.sha_at_end &&
-                  task.git_state.sha_at_end !== 'unknown' &&
-                  task.git_state.sha_at_end !== task.git_state.sha_at_start && (
-                    <>
-                      <Typography.Text type="secondary" style={{ fontSize: 10 }}>
-                        →
-                      </Typography.Text>
-                      <GitStatePill
-                        branch={task.git_state.ref_at_end}
-                        sha={task.git_state.sha_at_end}
-                        branchName={branchName}
-                        showDirtyIndicator={true}
-                        style={{ fontSize: 10 }}
-                      />
-                    </>
-                  )}
-              </Flex>
-            )}
         </Flex>
       </Flex>
     );

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -497,6 +497,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
       task.status === TaskStatus.RUNNING ||
       task.status === TaskStatus.STOPPING ||
       task.status === TaskStatus.QUEUED;
+    // Collapsed slim rows put meta inline with the prompt line — the chips
+    // no longer earn a second row.
+    const slimInlineMeta = isSlim && !isExpanded;
     const gutterTooltip = `${callbackFailed ? 'CHILD SESSION FAILED' : task.status.toUpperCase()}${
       !isTaskActive && task.duration_ms ? ` · ${formatDuration(task.duration_ms)}` : ''
     }`;
@@ -586,6 +589,111 @@ export const TaskBlock = React.memo<TaskBlockProps>(
         })
       : undefined;
 
+    const taskMetaChips = (
+      <Flex
+        wrap={!slimInlineMeta}
+        gap={token.sizeUnit}
+        align="center"
+        style={slimInlineMeta ? { flexShrink: 0 } : undefined}
+      >
+        {(!isSlim || isTaskActive) && (
+          <TimerPill
+            status={task.status}
+            startedAt={task.started_at || task.message_range?.start_timestamp || task.created_at}
+            endedAt={
+              task.completed_at ||
+              (task.message_range?.end_timestamp !== task.message_range?.start_timestamp
+                ? task.message_range?.end_timestamp
+                : undefined)
+            }
+            durationMs={task.duration_ms}
+            lastExecutorHeartbeatAt={task.last_executor_heartbeat_at}
+            latestExecutorPulse={task.latest_executor_pulse}
+          />
+        )}
+        {scheduledFromBranch && scheduledRunAt && (
+          <ScheduledRunPill scheduledRunAt={scheduledRunAt} />
+        )}
+        {/* Noise budget: collapsed rows show only chips that carry signal
+                for THIS task (who else ran it, how long, context pressure,
+                commits made). Steady-state facts (own user, token counts,
+                unchanged model/SHA) appear when expanded or when they change. */}
+        {task.created_by && (!isSlim || task.created_by !== currentUserId) && (
+          <CreatedByTag
+            createdBy={task.created_by}
+            currentUserId={currentUserId}
+            userById={userById}
+            prefix="By"
+          />
+        )}
+        {normalized && !isSlim && (
+          <TokenCountPill
+            count={normalized.tokenUsage.totalTokens}
+            inputTokens={normalized.tokenUsage.inputTokens}
+            outputTokens={normalized.tokenUsage.outputTokens}
+            cacheReadTokens={normalized.tokenUsage.cacheReadTokens}
+            cacheCreationTokens={normalized.tokenUsage.cacheCreationTokens}
+          />
+        )}
+        {hasContextWindowUsage && (
+          <ContextWindowPill
+            used={contextWindowUsed}
+            limit={contextWindowLimit || 0}
+            taskMetadata={{
+              model: task.model,
+              duration_ms: task.duration_ms,
+              agentic_tool,
+              raw_sdk_response: task.raw_sdk_response,
+              normalized_sdk_response: normalized ?? undefined,
+            }}
+          />
+        )}
+        {task.model &&
+          task.model !== (isSlim ? (previousTaskModel ?? sessionModel) : sessionModel) && (
+            <ModelPill model={task.model} />
+          )}
+        {task.git_state.sha_at_start &&
+          task.git_state.sha_at_start !== 'unknown' &&
+          (!isSlim ||
+            isExpanded ||
+            (task.git_state.sha_at_end &&
+              task.git_state.sha_at_end !== 'unknown' &&
+              task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
+            <Flex gap={token.sizeUnit / 2} align="center">
+              <GitStatePill
+                branch={task.git_state.ref_at_start}
+                sha={task.git_state.sha_at_start}
+                branchName={branchName}
+                bare={isSlim}
+                style={{ fontSize: 11 }}
+              />
+              {task.git_state.sha_at_end &&
+                task.git_state.sha_at_end !== 'unknown' &&
+                task.git_state.sha_at_end !== task.git_state.sha_at_start && (
+                  <>
+                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                      →
+                    </Typography.Text>
+                    <GitStatePill
+                      branch={task.git_state.ref_at_end}
+                      sha={task.git_state.sha_at_end}
+                      branchName={branchName}
+                      showDirtyIndicator={true}
+                      bare={isSlim}
+                      style={{ fontSize: 11 }}
+                    />
+                  </>
+                )}
+            </Flex>
+          )}
+        {task.report && (
+          <Tag icon={<FileTextOutlined />} color="green" style={{ fontSize: 11 }}>
+            Report
+          </Tag>
+        )}
+      </Flex>
+    );
+
     // Task header shows when collapsed
     const taskHeader = (
       <Flex gap={token.sizeUnit * 2} style={{ width: '100%' }}>
@@ -598,11 +706,13 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               <UpOutlined style={{ color: token.colorPrimary, fontSize: 14 }} />
             ) : (
               <Tooltip title={gutterTooltip} placement="left">
-                {callbackFailed ? (
-                  <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
-                ) : (
-                  <TaskStatusIcon status={task.status} size={16} />
-                )}
+                <span style={{ display: 'inline-flex', lineHeight: 0 }}>
+                  {callbackFailed ? (
+                    <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
+                  ) : (
+                    <TaskStatusIcon status={task.status} size={16} />
+                  )}
+                </span>
               </Tooltip>
             )}
           </Flex>
@@ -628,125 +738,31 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               text stays in the DOM so users can recover it via the
               copy-overlay (matches MessageBlock's pattern) — no tooltip,
               which got in the way of normal hover behavior. */}
-          <CopyableContent
-            textContent={task.full_prompt || ''}
-            // Default offsets place the icon outside the wrapper, but the
-            // task header has rounded corners with overflow:hidden which
-            // clips it. Pull the icon inside the prompt row instead.
-            copyButtonOffset={{ top: 0, right: 0 }}
-          >
-            <Typography.Text
-              ellipsis
-              style={{
-                marginBottom: token.sizeUnit,
-                display: 'block',
-                paddingRight: token.sizeUnit * 3,
-              }}
-            >
-              {task.full_prompt || 'User Prompt'}
-            </Typography.Text>
-          </CopyableContent>
-
-          {/* Task metadata */}
-          <Flex wrap gap={token.sizeUnit}>
-            {(!isSlim || isTaskActive) && (
-              <TimerPill
-                status={task.status}
-                startedAt={
-                  task.started_at || task.message_range?.start_timestamp || task.created_at
-                }
-                endedAt={
-                  task.completed_at ||
-                  (task.message_range?.end_timestamp !== task.message_range?.start_timestamp
-                    ? task.message_range?.end_timestamp
-                    : undefined)
-                }
-                durationMs={task.duration_ms}
-                lastExecutorHeartbeatAt={task.last_executor_heartbeat_at}
-                latestExecutorPulse={task.latest_executor_pulse}
-              />
-            )}
-            {scheduledFromBranch && scheduledRunAt && (
-              <ScheduledRunPill scheduledRunAt={scheduledRunAt} />
-            )}
-            {/* Noise budget: collapsed rows show only chips that carry signal
-                for THIS task (who else ran it, how long, context pressure,
-                commits made). Steady-state facts (own user, token counts,
-                unchanged model/SHA) appear when expanded or when they change. */}
-            {task.created_by && (!isSlim || task.created_by !== currentUserId) && (
-              <CreatedByTag
-                createdBy={task.created_by}
-                currentUserId={currentUserId}
-                userById={userById}
-                prefix="By"
-              />
-            )}
-            {normalized && !isSlim && (
-              <TokenCountPill
-                count={normalized.tokenUsage.totalTokens}
-                inputTokens={normalized.tokenUsage.inputTokens}
-                outputTokens={normalized.tokenUsage.outputTokens}
-                cacheReadTokens={normalized.tokenUsage.cacheReadTokens}
-                cacheCreationTokens={normalized.tokenUsage.cacheCreationTokens}
-              />
-            )}
-            {hasContextWindowUsage && (
-              <ContextWindowPill
-                used={contextWindowUsed}
-                limit={contextWindowLimit || 0}
-                taskMetadata={{
-                  model: task.model,
-                  duration_ms: task.duration_ms,
-                  agentic_tool,
-                  raw_sdk_response: task.raw_sdk_response,
-                  normalized_sdk_response: normalized ?? undefined,
-                }}
-              />
-            )}
-            {task.model &&
-              task.model !== (isSlim ? (previousTaskModel ?? sessionModel) : sessionModel) && (
-                <ModelPill model={task.model} />
-              )}
-            {task.git_state.sha_at_start &&
-              task.git_state.sha_at_start !== 'unknown' &&
-              (!isSlim ||
-                isExpanded ||
-                (task.git_state.sha_at_end &&
-                  task.git_state.sha_at_end !== 'unknown' &&
-                  task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
-                <Flex gap={token.sizeUnit / 2} align="center">
-                  <GitStatePill
-                    branch={task.git_state.ref_at_start}
-                    sha={task.git_state.sha_at_start}
-                    branchName={branchName}
-                    bare={isSlim}
-                    style={{ fontSize: 11 }}
-                  />
-                  {task.git_state.sha_at_end &&
-                    task.git_state.sha_at_end !== 'unknown' &&
-                    task.git_state.sha_at_end !== task.git_state.sha_at_start && (
-                      <>
-                        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                          →
-                        </Typography.Text>
-                        <GitStatePill
-                          branch={task.git_state.ref_at_end}
-                          sha={task.git_state.sha_at_end}
-                          branchName={branchName}
-                          showDirtyIndicator={true}
-                          bare={isSlim}
-                          style={{ fontSize: 11 }}
-                        />
-                      </>
-                    )}
-                </Flex>
-              )}
-            {task.report && (
-              <Tag icon={<FileTextOutlined />} color="green" style={{ fontSize: 11 }}>
-                Report
-              </Tag>
-            )}
+          <Flex align="center" gap={token.sizeUnit} style={{ minWidth: 0 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <CopyableContent
+                textContent={task.full_prompt || ''}
+                // Default offsets place the icon outside the wrapper, but the
+                // task header has rounded corners with overflow:hidden which
+                // clips it. Pull the icon inside the prompt row instead.
+                copyButtonOffset={{ top: 0, right: 0 }}
+              >
+                <Typography.Text
+                  ellipsis
+                  style={{
+                    marginBottom: slimInlineMeta ? 0 : token.sizeUnit,
+                    display: 'block',
+                    paddingRight: token.sizeUnit * 3,
+                  }}
+                >
+                  {task.full_prompt || 'User Prompt'}
+                </Typography.Text>
+              </CopyableContent>
+            </div>
+            {slimInlineMeta && taskMetaChips}
           </Flex>
+
+          {!slimInlineMeta && taskMetaChips}
         </Flex>
       </Flex>
     );

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -812,20 +812,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 },
               },
               children: (
-                <div
-                  style={{
-                    paddingTop: token.sizeUnit,
-                    // Slim: one continuous timeline down the task instead of
-                    // per-bubble gutters.
-                    ...(isSlim
-                      ? {
-                          borderLeft: `2px solid ${token.colorBorderSecondary}`,
-                          paddingLeft: token.sizeUnit * 2,
-                          marginLeft: token.sizeUnit,
-                        }
-                      : {}),
-                  }}
-                >
+                <div style={{ paddingTop: token.sizeUnit }}>
                   {isVerifiedRuntimeInterruption(task, isLatestTask) && (
                     <RuntimeInterruptionNotice task={task} sessionId={sessionId} client={client} />
                   )}

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -518,9 +518,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
       task.status === TaskStatus.RUNNING ||
       task.status === TaskStatus.STOPPING ||
       task.status === TaskStatus.QUEUED;
-    // Collapsed slim rows put meta inline with the prompt line — the chips
-    // no longer earn a second row.
-    const slimInlineMeta = isSlim && !isExpanded;
+    // Slim rows put meta inline at the right end of the prompt line —
+    // collapsed and expanded alike; the chips never earn a second row.
+    const slimInlineMeta = isSlim;
     const gutterTooltip = `${callbackFailed ? 'CHILD SESSION FAILED' : task.status.toUpperCase()}${
       !isTaskActive && task.duration_ms ? ` · ${formatDuration(task.duration_ms)}` : ''
     }`;

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -72,6 +72,8 @@ interface TaskBlockProps {
   task: Task;
   agentic_tool?: string;
   sessionModel?: string;
+  /** Model of the preceding task; suppresses the per-task model chip when unchanged. */
+  previousTaskModel?: string;
   userById?: Map<string, User>;
   currentUserId?: string;
   isExpanded: boolean;
@@ -463,6 +465,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     task,
     agentic_tool,
     sessionModel,
+    previousTaskModel,
     userById = EMPTY_USER_MAP,
     currentUserId,
     isExpanded,
@@ -573,20 +576,32 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     // Task header shows when collapsed
     const taskHeader = (
       <Flex gap={token.sizeUnit * 2} style={{ width: '100%' }}>
-        {/* Left column: Icons stacked vertically */}
-        <Flex
-          vertical
-          align="center"
-          gap={token.sizeUnit / 2}
-          style={{ width: 'auto', paddingTop: token.sizeUnit }}
-        >
-          {isExpanded ? (
-            <UpOutlined style={{ color: token.colorPrimary }} />
-          ) : (
-            <DownOutlined style={{ color: token.colorPrimary }} />
-          )}
-          <TaskStatusIcon status={task.status} size={16} />
-        </Flex>
+        {/* Left column. Slim: one gutter icon — status when collapsed (the
+            row itself is the expand affordance), collapse chevron when
+            expanded. Classic: chevron + status stacked. */}
+        {isSlim ? (
+          <Flex vertical align="center" style={{ width: 'auto', paddingTop: token.sizeUnit }}>
+            {isExpanded ? (
+              <UpOutlined style={{ color: token.colorPrimary, fontSize: 14 }} />
+            ) : (
+              <TaskStatusIcon status={task.status} size={16} />
+            )}
+          </Flex>
+        ) : (
+          <Flex
+            vertical
+            align="center"
+            gap={token.sizeUnit / 2}
+            style={{ width: 'auto', paddingTop: token.sizeUnit }}
+          >
+            {isExpanded ? (
+              <UpOutlined style={{ color: token.colorPrimary }} />
+            ) : (
+              <DownOutlined style={{ color: token.colorPrimary }} />
+            )}
+            <TaskStatusIcon status={task.status} size={16} />
+          </Flex>
+        )}
 
         {/* Right column: Content */}
         <Flex vertical flex={1} style={{ minWidth: 0 }}>
@@ -631,7 +646,11 @@ export const TaskBlock = React.memo<TaskBlockProps>(
             {scheduledFromBranch && scheduledRunAt && (
               <ScheduledRunPill scheduledRunAt={scheduledRunAt} />
             )}
-            {task.created_by && (
+            {/* Noise budget: collapsed rows show only chips that carry signal
+                for THIS task (who else ran it, how long, context pressure,
+                commits made). Steady-state facts (own user, token counts,
+                unchanged model/SHA) appear when expanded or when they change. */}
+            {task.created_by && (!isSlim || task.created_by !== currentUserId) && (
               <CreatedByTag
                 createdBy={task.created_by}
                 currentUserId={currentUserId}
@@ -639,7 +658,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 prefix="By"
               />
             )}
-            {normalized && (
+            {normalized && (!isSlim || isExpanded) && (
               <TokenCountPill
                 count={normalized.tokenUsage.totalTokens}
                 inputTokens={normalized.tokenUsage.inputTokens}
@@ -661,33 +680,42 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 }}
               />
             )}
-            {task.model && task.model !== sessionModel && <ModelPill model={task.model} />}
-            {task.git_state.sha_at_start && task.git_state.sha_at_start !== 'unknown' && (
-              <Flex gap={token.sizeUnit / 2} align="center">
-                <GitStatePill
-                  branch={task.git_state.ref_at_start}
-                  sha={task.git_state.sha_at_start}
-                  branchName={branchName}
-                  style={{ fontSize: 11 }}
-                />
-                {task.git_state.sha_at_end &&
+            {task.model &&
+              task.model !== (isSlim ? (previousTaskModel ?? sessionModel) : sessionModel) && (
+                <ModelPill model={task.model} />
+              )}
+            {task.git_state.sha_at_start &&
+              task.git_state.sha_at_start !== 'unknown' &&
+              (!isSlim ||
+                isExpanded ||
+                (task.git_state.sha_at_end &&
                   task.git_state.sha_at_end !== 'unknown' &&
-                  task.git_state.sha_at_end !== task.git_state.sha_at_start && (
-                    <>
-                      <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                        →
-                      </Typography.Text>
-                      <GitStatePill
-                        branch={task.git_state.ref_at_end}
-                        sha={task.git_state.sha_at_end}
-                        branchName={branchName}
-                        showDirtyIndicator={true}
-                        style={{ fontSize: 11 }}
-                      />
-                    </>
-                  )}
-              </Flex>
-            )}
+                  task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
+                <Flex gap={token.sizeUnit / 2} align="center">
+                  <GitStatePill
+                    branch={task.git_state.ref_at_start}
+                    sha={task.git_state.sha_at_start}
+                    branchName={branchName}
+                    style={{ fontSize: 11 }}
+                  />
+                  {task.git_state.sha_at_end &&
+                    task.git_state.sha_at_end !== 'unknown' &&
+                    task.git_state.sha_at_end !== task.git_state.sha_at_start && (
+                      <>
+                        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                          →
+                        </Typography.Text>
+                        <GitStatePill
+                          branch={task.git_state.ref_at_end}
+                          sha={task.git_state.sha_at_end}
+                          branchName={branchName}
+                          showDirtyIndicator={true}
+                          style={{ fontSize: 11 }}
+                        />
+                      </>
+                    )}
+                </Flex>
+              )}
             {task.report && (
               <Tag icon={<FileTextOutlined />} color="green" style={{ fontSize: 11 }}>
                 Report

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -658,7 +658,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 prefix="By"
               />
             )}
-            {normalized && (!isSlim || isExpanded) && (
+            {normalized && !isSlim && (
               <TokenCountPill
                 count={normalized.tokenUsage.totalTokens}
                 inputTokens={normalized.tokenUsage.inputTokens}
@@ -684,13 +684,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               task.model !== (isSlim ? (previousTaskModel ?? sessionModel) : sessionModel) && (
                 <ModelPill model={task.model} />
               )}
-            {task.git_state.sha_at_start &&
-              task.git_state.sha_at_start !== 'unknown' &&
-              (!isSlim ||
-                isExpanded ||
-                (task.git_state.sha_at_end &&
-                  task.git_state.sha_at_end !== 'unknown' &&
-                  task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
+            {!isSlim &&
+              task.git_state.sha_at_start &&
+              task.git_state.sha_at_start !== 'unknown' && (
                 <Flex gap={token.sizeUnit / 2} align="center">
                   <GitStatePill
                     branch={task.git_state.ref_at_start}
@@ -722,6 +718,41 @@ export const TaskBlock = React.memo<TaskBlockProps>(
               </Tag>
             )}
           </Flex>
+          {/* Slim: the sha lives on a quiet line under the timer chip instead
+              of occupying chip-row width. Shown when expanded or when the
+              task made commits. */}
+          {isSlim &&
+            task.git_state.sha_at_start &&
+            task.git_state.sha_at_start !== 'unknown' &&
+            (isExpanded ||
+              (task.git_state.sha_at_end &&
+                task.git_state.sha_at_end !== 'unknown' &&
+                task.git_state.sha_at_end !== task.git_state.sha_at_start)) && (
+              <Flex gap={token.sizeUnit / 2} align="center" style={{ marginTop: 2 }}>
+                <GitStatePill
+                  branch={task.git_state.ref_at_start}
+                  sha={task.git_state.sha_at_start}
+                  branchName={branchName}
+                  style={{ fontSize: 10 }}
+                />
+                {task.git_state.sha_at_end &&
+                  task.git_state.sha_at_end !== 'unknown' &&
+                  task.git_state.sha_at_end !== task.git_state.sha_at_start && (
+                    <>
+                      <Typography.Text type="secondary" style={{ fontSize: 10 }}>
+                        →
+                      </Typography.Text>
+                      <GitStatePill
+                        branch={task.git_state.ref_at_end}
+                        sha={task.git_state.sha_at_end}
+                        branchName={branchName}
+                        showDirtyIndicator={true}
+                        style={{ fontSize: 10 }}
+                      />
+                    </>
+                  )}
+              </Flex>
+            )}
         </Flex>
       </Flex>
     );

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.test.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: class {} }));
 vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }));
 vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 
+import { UIModeProvider } from '../../contexts/UIModeContext';
 import { TerminalModal } from './TerminalModal';
 
 const ALICE = '11111111-aaaa-aaaa-aaaa-111111111111';
@@ -149,5 +150,38 @@ describe('TerminalModal reconnect + readiness', () => {
     });
     await Promise.resolve();
     expect(screen.getByText(/Reconnecting/)).toBeInTheDocument();
+  });
+});
+
+describe('TerminalModal — slim mode', () => {
+  it('renders as a drawer instead of a modal', () => {
+    localStorage.setItem('agor:uiMode', 'slim');
+    try {
+      const socket = makeFakeSocket();
+      const create = vi.fn().mockResolvedValue({
+        userId: ALICE,
+        channel: `user/${ALICE}/terminal`,
+        sessionName: 'agor-x',
+        isNew: true,
+        ready: false,
+      });
+
+      render(
+        <UIModeProvider>
+          <TerminalModal
+            open
+            onClose={() => {}}
+            client={makeClient(socket, create)}
+            user={memberUser}
+            initialCommands={NO_COMMANDS}
+          />
+        </UIModeProvider>
+      );
+
+      expect(document.querySelector('.ant-drawer')).toBeInTheDocument();
+      expect(document.querySelector('.ant-modal')).toBeNull();
+    } finally {
+      localStorage.removeItem('agor:uiMode');
+    }
   });
 });

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -6,9 +6,11 @@ import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal } from '@xterm/xterm';
-import { App, Badge, Modal } from 'antd';
+import { App, Badge } from 'antd';
 import { useEffect, useRef, useState } from 'react';
+import { useUIMode } from '../../contexts/UIModeContext';
 import { loadWebglRenderer } from '../../utils/xtermWebgl';
+import { ModalOrDrawer } from '../ModalOrDrawer';
 import '@xterm/xterm/css/xterm.css';
 import { WEB_TERMINAL_MIN_ROLE } from './constants';
 
@@ -88,6 +90,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
   initialCommands = [],
 }) => {
   const { modal } = App.useApp();
+  const { isSlim } = useUIMode();
   const terminalDivRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -440,21 +443,38 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
     }
   };
 
+  // Classic: auto-sized centered modal. Slim: bottom drawer (no mask) so the
+  // terminal coexists with the board, like an IDE terminal panel.
   return (
-    <Modal
+    <ModalOrDrawer
       title={`Terminal${sessionInfo.branchName ? ` - ${sessionInfo.branchName}` : ''}`}
       open={open}
-      onCancel={handleClose}
+      onClose={handleClose}
       afterOpenChange={setModalReady}
-      footer={null}
-      width="auto"
-      styles={{
-        body: {
-          padding: '16px',
-          background: '#000',
+      modal={{
+        footer: null,
+        width: 'auto',
+        centered: true,
+        styles: {
+          body: {
+            padding: '16px',
+            background: '#000',
+          },
         },
       }}
-      centered
+      drawer={{
+        placement: 'bottom',
+        size: '65vh',
+        mask: false,
+        styles: {
+          body: {
+            padding: '16px',
+            background: '#000',
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        },
+      }}
     >
       {!canUseTerminal ? (
         <div style={{ padding: '24px', color: '#fff' }}>
@@ -495,17 +515,33 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           </p>
         </div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, color: '#fff' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+            color: '#fff',
+            ...(isSlim ? { flex: 1, minHeight: 0 } : {}),
+          }}
+        >
           {reconnecting ? (
             <Badge status="warning" text="Reconnecting…" />
           ) : !isConnected ? (
             <Badge status="processing" text="Connecting to terminal…" />
           ) : null}
-          {/* Concrete size gives @xterm/addon-fit a box to measure; the
-              width="auto" Modal then sizes itself to the terminal. */}
-          <div ref={terminalDivRef} style={{ width: '80vw', maxWidth: 1100, height: '70vh' }} />
+          {/* Classic: a concrete size gives @xterm/addon-fit a box to measure
+              and the width="auto" Modal sizes itself to the terminal. Slim:
+              the terminal fills the fixed-height drawer body instead. */}
+          <div
+            ref={terminalDivRef}
+            style={
+              isSlim
+                ? { width: '100%', flex: 1, minHeight: 0 }
+                : { width: '80vw', maxWidth: 1100, height: '70vh' }
+            }
+          />
         </div>
       )}
-    </Modal>
+    </ModalOrDrawer>
   );
 };

--- a/apps/agor-ui/src/components/UserIdentityAvatar.test.tsx
+++ b/apps/agor-ui/src/components/UserIdentityAvatar.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UIModeProvider } from '../contexts/UIModeContext';
+import { UserIdentityAvatar, type UserIdentityAvatarProps } from './UserIdentityAvatar';
+
+const user = {
+  name: 'Abhi',
+  email: 'abhi@example.com',
+  emoji: '🦖',
+} as NonNullable<UserIdentityAvatarProps['user']>;
+
+const renderSlim = (ui: React.ReactElement) => {
+  localStorage.setItem('agor:uiMode', 'slim');
+  return render(<UIModeProvider>{ui}</UIModeProvider>);
+};
+
+describe('UserIdentityAvatar', () => {
+  beforeEach(() => {
+    localStorage.removeItem('agor:uiMode');
+  });
+
+  it('renders the user emoji in classic mode (default, no provider)', () => {
+    render(<UserIdentityAvatar user={user} />);
+    expect(screen.getByText('🦖')).toBeInTheDocument();
+  });
+
+  it('falls back to the neutral emoji in classic mode without a user emoji', () => {
+    render(<UserIdentityAvatar user={{ ...user, emoji: undefined }} />);
+    expect(screen.getByText('👤')).toBeInTheDocument();
+  });
+
+  it('renders the name initial instead of the emoji in slim mode', () => {
+    renderSlim(<UserIdentityAvatar user={user} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.queryByText('🦖')).not.toBeInTheDocument();
+  });
+
+  it('uses the email initial in slim mode when the name is missing', () => {
+    renderSlim(
+      <UserIdentityAvatar user={{ ...user, name: undefined, email: 'zed@example.com' }} />
+    );
+    expect(screen.getByText('Z')).toBeInTheDocument();
+  });
+
+  it('shows ? in slim mode when no identity is available', () => {
+    renderSlim(<UserIdentityAvatar user={null} />);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/UserIdentityAvatar.tsx
+++ b/apps/agor-ui/src/components/UserIdentityAvatar.tsx
@@ -1,6 +1,8 @@
 import type { User } from '@agor-live/client';
 import { Avatar, type AvatarProps, theme } from 'antd';
 import type { CSSProperties } from 'react';
+import { useUIMode } from '../contexts/UIModeContext';
+import { nameInitial } from '../utils/nameInitial';
 
 export interface UserIdentityAvatarProps extends Omit<AvatarProps, 'src' | 'style'> {
   user?: Pick<
@@ -28,6 +30,7 @@ export const UserIdentityAvatar: React.FC<UserIdentityAvatarProps> = ({
   ...props
 }) => {
   const { token } = theme.useToken();
+  const { isSlim } = useUIMode();
   const prefersSlackAvatar = user?.preferences?.use_slack_avatar !== false;
   const rawAvatarUrl = getUserAvatarUrl(user);
   const avatarUrl =
@@ -43,13 +46,14 @@ export const UserIdentityAvatar: React.FC<UserIdentityAvatarProps> = ({
         borderRadius: slackAvatarRadius(size),
         backgroundColor: avatarUrl ? token.colorBgContainer : token.colorPrimaryBg,
         color: token.colorText,
-        fontSize: fontSize ?? `${Math.round(size * 0.6)}px`,
+        fontSize: fontSize ?? `${Math.round(size * (isSlim ? 0.45 : 0.6))}px`,
+        fontWeight: isSlim ? 600 : undefined,
         lineHeight: `${size}px`,
         overflow: 'hidden',
         ...style,
       }}
     >
-      {user?.emoji || '👤'}
+      {isSlim ? nameInitial(user?.name || user?.email) : user?.emoji || '👤'}
     </Avatar>
   );
 };

--- a/apps/agor-ui/src/contexts/UIModeContext.tsx
+++ b/apps/agor-ui/src/contexts/UIModeContext.tsx
@@ -30,6 +30,9 @@ const UI_MODE_KEY = 'agor:uiMode';
 
 export const UIModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [uiMode, setUIModeState] = useState<UIMode>(() => {
+    // Non-persisting URL override for demo pages and screenshot tooling.
+    const param = new URLSearchParams(window.location.search).get('uiMode');
+    if (param === 'slim' || param === 'classic') return param;
     const stored = localStorage.getItem(UI_MODE_KEY);
     return stored === 'slim' ? 'slim' : 'classic';
   });

--- a/apps/agor-ui/src/contexts/UIModeContext.tsx
+++ b/apps/agor-ui/src/contexts/UIModeContext.tsx
@@ -1,0 +1,52 @@
+import type React from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+/**
+ * UI density mode. `classic` is the default experience; `slim` is a
+ * progressive-disclosure variant: contextual controls over always-visible
+ * ones, drawers over modals, initials over emoji, and a minimal homepage.
+ * Stored per browser (like the theme), not on the user record.
+ */
+export type UIMode = 'classic' | 'slim';
+
+export interface UIModeContextValue {
+  uiMode: UIMode;
+  setUIMode: (mode: UIMode) => void;
+  /** Convenience flag — most call sites only ask "is slim on?". */
+  isSlim: boolean;
+}
+
+// Default to classic so consumers rendered without a provider (tests,
+// isolated portals) behave like the stock UI instead of throwing.
+const DEFAULT_UI_MODE: UIModeContextValue = {
+  uiMode: 'classic',
+  setUIMode: () => {},
+  isSlim: false,
+};
+
+const UIModeContext = createContext<UIModeContextValue>(DEFAULT_UI_MODE);
+
+const UI_MODE_KEY = 'agor:uiMode';
+
+export const UIModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [uiMode, setUIModeState] = useState<UIMode>(() => {
+    const stored = localStorage.getItem(UI_MODE_KEY);
+    return stored === 'slim' ? 'slim' : 'classic';
+  });
+
+  const setUIMode = useCallback((mode: UIMode) => {
+    setUIModeState(mode);
+    localStorage.setItem(UI_MODE_KEY, mode);
+  }, []);
+
+  const value = useMemo(
+    () => ({ uiMode, setUIMode, isSlim: uiMode === 'slim' }),
+    [uiMode, setUIMode]
+  );
+
+  return <UIModeContext.Provider value={value}>{children}</UIModeContext.Provider>;
+};
+
+export function useUIMode(): UIModeContextValue {
+  return useContext(UIModeContext);
+}

--- a/apps/agor-ui/src/utils/nameInitial.test.ts
+++ b/apps/agor-ui/src/utils/nameInitial.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { nameInitial } from './nameInitial';
+
+describe('nameInitial', () => {
+  it('returns the first letter uppercased', () => {
+    expect(nameInitial('abhi')).toBe('A');
+    expect(nameInitial('Max')).toBe('M');
+  });
+
+  it('trims leading whitespace before picking the initial', () => {
+    expect(nameInitial('  zoe')).toBe('Z');
+  });
+
+  it('falls back to ? for missing or empty names', () => {
+    expect(nameInitial(undefined)).toBe('?');
+    expect(nameInitial(null)).toBe('?');
+    expect(nameInitial('')).toBe('?');
+    expect(nameInitial('   ')).toBe('?');
+  });
+
+  it('keeps a full emoji grapheme intact', () => {
+    expect(nameInitial('🦄 unicorn')).toBe('🦄');
+  });
+
+  it('handles combining-character graphemes', () => {
+    expect(nameInitial('éric')).toBe('É');
+  });
+
+  it('works for email-style fallbacks', () => {
+    expect(nameInitial('abhi@svix.com')).toBe('A');
+  });
+});

--- a/apps/agor-ui/src/utils/nameInitial.ts
+++ b/apps/agor-ui/src/utils/nameInitial.ts
@@ -1,0 +1,16 @@
+/**
+ * First grapheme of a display name, uppercased — the emoji-free avatar glyph.
+ * Falls back to '?' for missing/empty names.
+ */
+export function nameInitial(name?: string | null): string {
+  const trimmed = name?.trim();
+  if (!trimmed) return '?';
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const first = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+      .segment(trimmed)
+      [Symbol.iterator]()
+      .next();
+    if (!first.done) return first.value.segment.toUpperCase();
+  }
+  return trimmed.charAt(0).toUpperCase();
+}


### PR DESCRIPTION
I find the UI to be overwhelming and quite verbose, making it difficult to get into the platform. I've made a "Slim" version of the UI that reduces visual noise and focuses on the main features of agor, which are quite powerful. The name isn't perfect, as it actually makes the function bar in the board bigger, but improves accessibility.

To activate slim mode, go to Settings -> Appearance -> Slim

I'm a human writing this PR description, I understand this is a very large suggested change; this is more or less a UI overhaul that's gated behind a setting just in case people prefer the original. I do believe that most of these changes should probably just be canonized, but this gives the option to bring in parts of it that are liked. Here's an overview of the main changes:

1. The most important view, to me, is the session view. This needs to be clean and readable and free of excess. I've pushed the context window into a claude-style circle, moved the completion time to a hover on the status (checked/x) and redundant runs are now deemphasized. This should make most sessions take up less than half of the space they used to, or more. When you click into a session, certain elements are auto-collapsed and there is a lot of visual cleanup that reduces overload.

Left is new, right is old.

<img width="1935" height="1244" alt="image" src="https://github.com/user-attachments/assets/3ad6c273-88cd-4cba-abfb-10ec26340ae8" />


2. The board palette is a lot bigger, is located at the bottom of the screen, and is more in line with what people would expect out of a tool like this. You can now hide the minimap, which seemed to get in the way more often than not.

<img width="721" height="474" alt="Screenshot 2026-08-11 at 9 52 51 PM" src="https://github.com/user-attachments/assets/daa268dc-bfb8-4e3b-9142-277dc4b4219a" />

3. Sidebar navigation is smoother now, and doesn't use tabs; instead we lock the rail so that we don't have elements jumping around. There's reduced clutter on the branch settings selection too.

<img width="386" height="413" alt="Screenshot 2026-08-11 at 9 54 30 PM" src="https://github.com/user-attachments/assets/e65c7dbc-d8b1-45da-a01c-adee8860d5cf" />

4. The home screen was also too much information. I just want the sessions and boards I've recently worked on.

Top is new, bottom is old.

<img width="2862" height="2868" alt="image (2)" src="https://github.com/user-attachments/assets/c5a41422-1b85-4d4f-bd2f-1553d34e04bc" />

5. Finally, we removed emojis completely, as they were very noisy, and turned branch settings, session settings, the terminal, and environment logs into drawers instead of modals.

This PR depends on #2276 and #2277 