### PR TITLE
fix init agentic tool onboarding

### DIFF
--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -83,23 +83,27 @@ jobs:
       # this smoke test is to validate before publishing). Installing both
       # tarballs in a single `npm install` lets npm satisfy the sibling
       # dep locally — zero registry hits.
-      - name: Pack tarballs (agor-live + @agor-live/client)
+      - name: Pack tarballs (agor-live + client + Codex integration)
         id: pack
         run: |
           set -euo pipefail
           pnpm pack -C packages/client    --pack-destination "$RUNNER_TEMP"
+          pnpm pack -C packages/agor-codex --pack-destination "$RUNNER_TEMP"
           pnpm pack -C packages/agor-live --pack-destination "$RUNNER_TEMP"
           CLIENT=$(ls "$RUNNER_TEMP"/agor-live-client-*.tgz | head -1)
+          CODEX=$(ls "$RUNNER_TEMP"/agor-live-codex-*.tgz | head -1)
           LIVE=$(ls "$RUNNER_TEMP"/agor-live-[0-9]*.tgz | head -1)
-          if [ -z "$CLIENT" ] || [ -z "$LIVE" ]; then
+          if [ -z "$CLIENT" ] || [ -z "$CODEX" ] || [ -z "$LIVE" ]; then
             echo "::error::pnpm pack produced incomplete tarballs"
             ls "$RUNNER_TEMP"
             exit 1
           fi
           echo "client=$CLIENT" >> "$GITHUB_OUTPUT"
+          echo "codex=$CODEX" >> "$GITHUB_OUTPUT"
           echo "live=$LIVE" >> "$GITHUB_OUTPUT"
           echo "Packed:"
           echo "  client: $CLIENT"
+          echo "  codex:  $CODEX"
           echo "  live:   $LIVE"
 
       # The single grep that would have caught agor-live@0.17.1.
@@ -147,6 +151,51 @@ jobs:
               --no-fund --no-audit "$ROOT/$LOCAL_LIVE"
           )
           "$ROOT/prefix/bin/agor" doctor --json >/dev/null
+
+          # Exercise fresh global-style init from the packed artifact, not only
+          # command discovery. Rewrite the allowlisted exact Codex spec to the
+          # locally packed integration so this remains a pre-publish smoke test.
+          REAL_NPM=$(command -v npm)
+          mkdir -p "$ROOT/npm-shim"
+          cat > "$ROOT/npm-shim/npm" <<'SH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          args=()
+          for arg in "$@"; do
+            if [[ "$arg" == @agor-live/codex@* ]]; then
+              args+=("$AGOR_SMOKE_CODEX_TARBALL")
+            else
+              args+=("$arg")
+            fi
+          done
+          exec "$AGOR_SMOKE_REAL_NPM" "${args[@]}"
+          SH
+          chmod +x "$ROOT/npm-shim/npm"
+          export HOME="$ROOT/init-home"
+          export PATH="$ROOT/npm-shim:$PATH"
+          export AGOR_SMOKE_REAL_NPM="$REAL_NPM"
+          export AGOR_SMOKE_CODEX_TARBALL="${{ steps.pack.outputs.codex }}"
+          unset AGOR_AGENTIC_TOOLS_DIR AGOR_VERSION
+          AGOR_TELEMETRY=0 "$ROOT/prefix/bin/agor" init \
+            --non-interactive --agentic-tools codex >"$ROOT/init.stdout" 2>"$ROOT/init.stderr"
+          test -f "$HOME/.agor/config.yaml"
+          grep -q '^agentic_tools:' "$HOME/.agor/config.yaml"
+          grep -q '^    - codex$' "$HOME/.agor/config.yaml"
+          AGOR_TELEMETRY=0 "$ROOT/prefix/bin/agor" doctor --json >"$ROOT/doctor.json"
+          node - "$ROOT/doctor.json" "$ROOT/prefix/lib/node_modules/agor-live/package.json" <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const expectedVersion = JSON.parse(fs.readFileSync(process.argv[3], 'utf8')).version;
+          const codex = report.agenticTools?.find((tool) => tool.id === 'codex');
+          if (
+            report.policy?.mode !== 'declarative' ||
+            JSON.stringify(report.policy?.selected) !== JSON.stringify(['codex']) ||
+            codex?.status !== 'ready' ||
+            codex?.version !== expectedVersion
+          ) {
+            throw new Error(`Unexpected init policy: ${JSON.stringify(report.policy)}`);
+          }
+          NODE
 
       # Install BOTH tarballs together. List the client first so npm registers
       # it before resolving agor-live's "@agor-live/client" dep — guarantees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 ### Breaking
 
 - **`config.yaml` is immutable after initialization** — daemon startup, telemetry, Docker entrypoints, upgrades, APIs, MCP, and UI flows no longer rewrite the deployment-owned YAML file. Configure stable JWT/master secrets with environment variables or YAML before startup. The mutating `agor config set/get/unset` commands are removed; `agor config --yaml` materializes the effective read-only configuration. Existing Docker environment overrides are resolved in memory instead of being written to YAML.
-- **Agentic tool installs now support declarative and local-managed policy** — explicit `agentic_tools.installed` remains immutable YAML authority; otherwise interactive `agor install` owns a private host-local manifest and `agor install --sync` reconciles it noninteractively. `agor doctor` is the sole read-only inspection surface. Empty selections start with a warning, while selected missing or misaligned packages fail with an exact repair command.
+- **Agentic tool installs now support declarative and legacy local-managed policy** — fresh interactive init selects from every allowlisted integration, writes `agentic_tools.installed` once, and reconciles before success; fresh headless init requires an explicit list, `all`, or `none`. Older configs that omit the YAML key retain interactive `agor install` through a private host-local manifest. `agor install --sync` repairs declarative state and `agor doctor` remains read-only.
 
 ### Features
 
@@ -42,6 +42,7 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 ### Fixes
 
+- **Reliable fresh and destructive init** — interactive init requires an intentional nonempty agentic-tool selection, persists the immutable deployment policy, and finishes package reconciliation before success. Destructive re-init now refuses a live daemon, closes SQLite inspection handles, and removes WAL/SHM sidecars before replacing the database.
 - **Reliable cold-cache global installs** — removes deprecated transitive trees and bundled agent runtimes from `agor-live`, bundles selected high-fanout pure-JS dependencies, and adds package-content and low-file-descriptor installation checks. ([#2201](https://github.com/preset-io/agor/pull/2201))
 
 ### Chores

--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -15,10 +15,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@agor-live/client": "workspace:*",
+    "@agor/agentic-tool-opencode": "workspace:*",
     "@agor/core": "workspace:*",
     "@agor/daemon": "workspace:*",
-    "@agor/agentic-tool-opencode": "workspace:*",
-    "@agor-live/client": "workspace:*",
     "@oclif/core": "^4.13.3",
     "@oclif/plugin-help": "^6.2.56",
     "chalk": "^5.6.2",
@@ -28,13 +28,14 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
+    "@types/proper-lockfile": "4.1.4",
     "glob": "^11.1.0",
+    "node-pty": "1.2.0-beta.12",
     "oclif": "^4.23.29",
+    "tsup": "^8.5.1",
     "tsx": "4.23.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.10",
-    "tsup": "^8.5.1",
-    "@types/proper-lockfile": "4.1.4"
+    "vitest": "^4.1.10"
   },
   "oclif": {
     "bin": "agor",

--- a/apps/agor-cli/src/commands/init.test.ts
+++ b/apps/agor-cli/src/commands/init.test.ts
@@ -1,5 +1,220 @@
-import { describe, expect, it } from 'vitest';
-import { createInstallTelemetryConfig, isFreshInitState, shouldDeferAdminSetup } from './init.js';
+import { spawn } from 'node:child_process';
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getAgenticToolSelectionManifestPath,
+  inspectManagedAgenticToolAlignment,
+} from '@agor/core/agentic-integrations';
+import { load as loadYaml } from '@agor/core/yaml';
+import { spawn as spawnPty } from 'node-pty';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createInstallTelemetryConfig,
+  isFreshInitState,
+  parseInitialAgenticTools,
+  shouldDeferAdminSetup,
+} from './init.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true }))
+  );
+});
+
+function stripTerminalControl(value: string): string {
+  const controlSequence = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+  return value.replaceAll(controlSequence, '');
+}
+
+async function writeFixtureNpm(binDirectory: string, fail = false): Promise<void> {
+  await mkdir(binDirectory, { recursive: true });
+  const fixture = fail
+    ? '#!/usr/bin/env node\nprocess.exit(42);\n'
+    : `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+const prefix = args[args.indexOf('--prefix') + 1];
+const spec = args.at(-1);
+const match = /^(@agor-live\\/[^@]+)@(.+)$/.exec(spec);
+if (!prefix || !match) process.exit(64);
+const packageName = match[1];
+const version = match[2];
+const slug = packageName.slice('@agor-live/'.length);
+const vendors = {
+  claude: '@anthropic-ai/claude-agent-sdk',
+  codex: '@openai/codex-sdk',
+  copilot: '@github/copilot-sdk',
+  gemini: '@google/gemini-cli-core',
+  opencode: '@opencode-ai/sdk',
+  cursor: '@cursor/sdk',
+};
+const writePackage = (name, source) => {
+  const directory = path.join(prefix, 'node_modules', ...name.split('/'));
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, 'package.json'), JSON.stringify({ name, version, type: 'module', main: 'index.js' }));
+  fs.writeFileSync(path.join(directory, 'index.js'), source);
+};
+writePackage(packageName, \`export const AGOR_INTEGRATION_VERSION = \${JSON.stringify(version)}; export const sdk = { fixture: true };\`);
+writePackage(vendors[slug], 'export const fixture = true;');
+console.log('fixture npm installed ' + packageName + '@' + version);
+`;
+  const npmPath = join(binDirectory, 'npm');
+  await writeFile(npmPath, fixture, 'utf8');
+  await chmod(npmPath, 0o755);
+}
+
+async function runInteractiveInit(
+  home: string,
+  fixtureBin: string
+): Promise<{
+  exitCode: number;
+  output: string;
+}> {
+  const cliRoot = join(import.meta.dirname, '..', '..');
+  const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'));
+  const terminal = spawnPty(process.execPath, [tsxCli, join(cliRoot, 'bin', 'dev.ts'), 'init'], {
+    cwd: cliRoot,
+    cols: 100,
+    rows: 40,
+    env: {
+      ...process.env,
+      HOME: home,
+      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
+      AGOR_MANAGED_AGENTIC_TOOLS: '1',
+      AGOR_TELEMETRY: '0',
+      AGOR_VERSION: '9.8.7-test',
+      PATH: `${fixtureBin}${delimiter}${process.env.PATH ?? ''}`,
+    },
+  });
+
+  let output = '';
+  let skippedAdmin = false;
+  let rejectedEmptySelection = false;
+  let selectedTools = false;
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      terminal.kill();
+      reject(new Error(`Timed out waiting for interactive init:\n${stripTerminalControl(output)}`));
+    }, 30_000);
+    terminal.onData((data) => {
+      output += data;
+      const plain = stripTerminalControl(output);
+      if (!skippedAdmin && plain.includes('Set up your admin account now?')) {
+        skippedAdmin = true;
+        terminal.write('n\r');
+      }
+      if (
+        !rejectedEmptySelection &&
+        plain.includes('Which agentic tools should this deployment support?') &&
+        plain.includes('@agor-live/codex@9.8.7-test')
+      ) {
+        rejectedEmptySelection = true;
+        terminal.write('\r');
+      }
+      if (
+        !selectedTools &&
+        plain.includes('Select at least one agentic tool, or press Ctrl+C to exit.')
+      ) {
+        selectedTools = true;
+        // Move from Claude Code to Codex, select it, then submit.
+        terminal.write('\u001B[B \r');
+      }
+    });
+    terminal.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+      resolve({ exitCode, output: stripTerminalControl(output) });
+    });
+  });
+}
+
+async function runInitWithoutPty(
+  home: string,
+  args: string[]
+): Promise<{
+  exitCode: number | null;
+  output: string;
+}> {
+  const cliRoot = join(import.meta.dirname, '..', '..');
+  const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'));
+  const child = spawn(process.execPath, [tsxCli, join(cliRoot, 'bin', 'dev.ts'), 'init', ...args], {
+    cwd: cliRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      HOME: home,
+      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
+      AGOR_MANAGED_AGENTIC_TOOLS: '1',
+      AGOR_TELEMETRY: '0',
+      AGOR_VERSION: '9.8.7-test',
+    },
+  });
+  let output = '';
+  child.stdout.on('data', (data) => {
+    output += data;
+  });
+  child.stderr.on('data', (data) => {
+    output += data;
+  });
+  return await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (exitCode) => resolve({ exitCode, output: stripTerminalControl(output) }));
+  });
+}
+
+async function runInteractiveReinit(home: string): Promise<{
+  exitCode: number;
+  output: string;
+}> {
+  const cliRoot = join(import.meta.dirname, '..', '..');
+  const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'));
+  const terminal = spawnPty(process.execPath, [tsxCli, join(cliRoot, 'bin', 'dev.ts'), 'init'], {
+    cwd: cliRoot,
+    cols: 100,
+    rows: 40,
+    env: {
+      ...process.env,
+      HOME: home,
+      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
+      AGOR_MANAGED_AGENTIC_TOOLS: '1',
+      AGOR_TELEMETRY: '0',
+      AGOR_VERSION: '9.8.7-test',
+    },
+  });
+
+  let output = '';
+  let confirmedDeletion = false;
+  let skippedAdmin = false;
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      terminal.kill();
+      reject(
+        new Error(`Timed out waiting for interactive re-init:\n${stripTerminalControl(output)}`)
+      );
+    }, 30_000);
+    terminal.onData((data) => {
+      output += data;
+      const plain = stripTerminalControl(output);
+      if (!confirmedDeletion && plain.includes('Delete all existing data and re-initialize?')) {
+        confirmedDeletion = true;
+        terminal.write('y\r');
+      }
+      if (!skippedAdmin && plain.includes('Set up your admin account now?')) {
+        skippedAdmin = true;
+        terminal.write('n\r');
+      }
+    });
+    terminal.onExit(({ exitCode }) => {
+      clearTimeout(timeout);
+      resolve({ exitCode, output: stripTerminalControl(output) });
+    });
+  });
+}
 
 describe('safe init state detection', () => {
   it('treats a pre-created empty .agor mount as fresh', () => {
@@ -48,4 +263,144 @@ describe('headless admin bootstrap', () => {
     expect(shouldDeferAdminSetup(false, '')).toBe(true);
     expect(shouldDeferAdminSetup(false, 'production')).toBe(true);
   });
+});
+
+describe('initial agentic tool selection', () => {
+  it('supports allowlisted lists and explicit all/none shorthands', () => {
+    expect(parseInitialAgenticTools('claude,codex,codex')).toEqual(['claude-code', 'codex']);
+    expect(parseInitialAgenticTools('none')).toEqual([]);
+    expect(parseInitialAgenticTools('all')).toHaveLength(6);
+    expect(() => parseInitialAgenticTools('codex,arbitrary-package')).toThrow(
+      /Unknown agentic tool/
+    );
+    expect(() => parseInitialAgenticTools('all,codex')).toThrow(/Use `all` or `none` by itself/);
+  });
+
+  it('rejects a non-TTY interactive invocation before creating partial state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-init-nontty-'));
+    temporaryDirectories.push(root);
+    const home = join(root, 'home');
+    await mkdir(home);
+
+    const result = await runInitWithoutPty(home, []);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toContain('Interactive `agor init` requires a TTY');
+    await expect(access(join(home, '.agor'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('requires an explicit fresh headless policy before creating partial state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-init-headless-'));
+    temporaryDirectories.push(root);
+    const home = join(root, 'home');
+    await mkdir(home);
+
+    const result = await runInitWithoutPty(home, ['--non-interactive']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toContain('requires an explicit agentic-tool policy');
+    await expect(access(join(home, '.agor'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('refuses to unlink a live daemon database, then safely re-initializes after it stops', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-reinit-pty-'));
+    temporaryDirectories.push(root);
+    const home = join(root, 'home');
+    await mkdir(home, { recursive: true });
+
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"status":"ok"}');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Test server has no TCP port');
+
+    const firstInit = await runInitWithoutPty(home, [
+      '--non-interactive',
+      '--agentic-tools',
+      'none',
+      '--daemon-host',
+      '127.0.0.1',
+      '--daemon-port',
+      String(address.port),
+    ]);
+    expect(firstInit.exitCode, firstInit.output).toBe(0);
+
+    const refused = await runInteractiveReinit(home);
+    expect(refused.exitCode, refused.output).toBe(2);
+    expect(refused.output).toContain('The Agor daemon is running');
+    expect(refused.output).toContain('agor daemon stop');
+    await expect(access(join(home, '.agor', 'agor.db'))).resolves.toBeUndefined();
+
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+    await writeFile(join(home, '.agor', 'agor.db-wal'), 'stale WAL fixture');
+    await writeFile(join(home, '.agor', 'agor.db-shm'), 'stale SHM fixture');
+
+    const reinitialized = await runInteractiveReinit(home);
+    expect(reinitialized.exitCode, reinitialized.output).toBe(0);
+    expect(reinitialized.output).toContain('Migrations complete');
+    expect(reinitialized.output).toContain('Agor initialized successfully');
+    const config = loadYaml(await readFile(join(home, '.agor', 'config.yaml'), 'utf8')) as {
+      agentic_tools?: { installed?: string[] };
+    };
+    expect(config.agentic_tools?.installed).toEqual([]);
+  }, 40_000);
+
+  it('drives the real CLI through a pseudo-TTY, persists declarative policy, and proves managed readiness', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-init-pty-'));
+    temporaryDirectories.push(root);
+    const home = join(root, 'home');
+    const fixtureBin = join(root, 'bin');
+    await mkdir(home, { recursive: true });
+    await writeFixtureNpm(fixtureBin);
+
+    const result = await runInteractiveInit(home, fixtureBin);
+
+    expect(result.exitCode, result.output).toBe(0);
+    expect(result.output).toContain('Agentic tool packages');
+    expect(result.output).toContain('Provider credentials are configured after the daemon starts.');
+    expect(result.output).toContain('Select at least one agentic tool, or press Ctrl+C to exit.');
+    expect(result.output).toContain('Configured: codex');
+    expect(result.output).toContain('Codex installed');
+    const config = loadYaml(await readFile(join(home, '.agor', 'config.yaml'), 'utf8')) as {
+      agentic_tools?: { installed?: string[] };
+    };
+    expect(config.agentic_tools?.installed).toEqual(['codex']);
+
+    const previousToolsDirectory = process.env.AGOR_AGENTIC_TOOLS_DIR;
+    process.env.AGOR_AGENTIC_TOOLS_DIR = join(home, '.agor', 'agentic-tools');
+    try {
+      await expect(readFile(getAgenticToolSelectionManifestPath(), 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      await expect(inspectManagedAgenticToolAlignment(['codex'], '9.8.7-test')).resolves.toEqual([
+        expect.objectContaining({ tool: 'codex', status: 'ready' }),
+      ]);
+    } finally {
+      if (previousToolsDirectory === undefined) delete process.env.AGOR_AGENTIC_TOOLS_DIR;
+      else process.env.AGOR_AGENTIC_TOOLS_DIR = previousToolsDirectory;
+    }
+  }, 35_000);
+
+  it('preserves the declarative choice and prints one recovery command when install fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-init-pty-failure-'));
+    temporaryDirectories.push(root);
+    const home = join(root, 'home');
+    const fixtureBin = join(root, 'bin');
+    await mkdir(home, { recursive: true });
+    await writeFixtureNpm(fixtureBin, true);
+
+    const result = await runInteractiveInit(home, fixtureBin);
+
+    expect(result.exitCode, result.output).toBe(2);
+    const config = loadYaml(await readFile(join(home, '.agor', 'config.yaml'), 'utf8')) as {
+      agentic_tools?: { installed?: string[] };
+    };
+    expect(config.agentic_tools?.installed).toEqual(['codex']);
+    expect(result.output.match(/agor install --sync/g)).toHaveLength(1);
+    expect(result.output).toContain('The new config was preserved.');
+  }, 35_000);
 });

--- a/apps/agor-cli/src/commands/init.test.ts
+++ b/apps/agor-cli/src/commands/init.test.ts
@@ -69,6 +69,28 @@ console.log('fixture npm installed ' + packageName + '@' + version);
   await chmod(npmPath, 0o755);
 }
 
+function createInitEnvironment(
+  home: string,
+  overrides: Record<string, string> = {}
+): Record<string, string> {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: home,
+    AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
+    AGOR_MANAGED_AGENTIC_TOOLS: '1',
+    AGOR_TELEMETRY: '0',
+    AGOR_VERSION: '9.8.7-test',
+    ...overrides,
+  };
+  // The parent Agor session points at its own daemon. A clean-install fixture
+  // must resolve daemon status only from the fixture's HOME/config, exactly as
+  // a fresh shell would.
+  delete env.DAEMON_URL;
+  delete env.PORT;
+  delete env.AGOR_CONFIG_PATH;
+  return env as Record<string, string>;
+}
+
 async function runInteractiveInit(
   home: string,
   fixtureBin: string
@@ -82,15 +104,9 @@ async function runInteractiveInit(
     cwd: cliRoot,
     cols: 100,
     rows: 40,
-    env: {
-      ...process.env,
-      HOME: home,
-      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
-      AGOR_MANAGED_AGENTIC_TOOLS: '1',
-      AGOR_TELEMETRY: '0',
-      AGOR_VERSION: '9.8.7-test',
+    env: createInitEnvironment(home, {
       PATH: `${fixtureBin}${delimiter}${process.env.PATH ?? ''}`,
-    },
+    }),
   });
 
   let output = '';
@@ -145,14 +161,7 @@ async function runInitWithoutPty(
   const child = spawn(process.execPath, [tsxCli, join(cliRoot, 'bin', 'dev.ts'), 'init', ...args], {
     cwd: cliRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: {
-      ...process.env,
-      HOME: home,
-      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
-      AGOR_MANAGED_AGENTIC_TOOLS: '1',
-      AGOR_TELEMETRY: '0',
-      AGOR_VERSION: '9.8.7-test',
-    },
+    env: createInitEnvironment(home),
   });
   let output = '';
   child.stdout.on('data', (data) => {
@@ -177,14 +186,7 @@ async function runInteractiveReinit(home: string): Promise<{
     cwd: cliRoot,
     cols: 100,
     rows: 40,
-    env: {
-      ...process.env,
-      HOME: home,
-      AGOR_AGENTIC_TOOLS_DIR: join(home, '.agor', 'agentic-tools'),
-      AGOR_MANAGED_AGENTIC_TOOLS: '1',
-      AGOR_TELEMETRY: '0',
-      AGOR_VERSION: '9.8.7-test',
-    },
+    env: createInitEnvironment(home),
   });
 
   let output = '';

--- a/apps/agor-cli/src/commands/init.test.ts
+++ b/apps/agor-cli/src/commands/init.test.ts
@@ -278,6 +278,15 @@ describe('initial agentic tool selection', () => {
     expect(() => parseInitialAgenticTools('all,codex')).toThrow(/Use `all` or `none` by itself/);
   });
 
+  it.each(['', '   ', ',,,', ' , , '])(
+    'rejects blank policy %j instead of treating it as none',
+    (policy) => {
+      expect(() => parseInitialAgenticTools(policy)).toThrow(
+        'Use `none` for an intentionally empty deployment'
+      );
+    }
+  );
+
   it('rejects a non-TTY interactive invocation before creating partial state', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agor-init-nontty-'));
     temporaryDirectories.push(root);

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -33,6 +33,7 @@ import {
   pruneDefaultOpenSourceTelemetryDestination,
 } from '@agor/core/telemetry';
 import { isDaemonRunning } from '@agor-live/client';
+import { getDaemonUrl } from '@agor-live/client/config';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
@@ -208,12 +209,13 @@ export default class Init extends Command {
   }
 
   private async assertDaemonStoppedBeforeReinit(): Promise<void> {
-    const config = await loadConfig();
-    const host = config.daemon?.host || 'localhost';
-    const port = config.daemon?.port || 3030;
-    if (await isDaemonRunning(`http://${host}:${port}`)) {
+    // Use the same environment/config resolution and health probe as
+    // `agor daemon status` so re-init cannot drift from the CLI's canonical
+    // answer about which daemon endpoint is active.
+    const daemonUrl = await getDaemonUrl();
+    if (await isDaemonRunning(daemonUrl)) {
       throw new Error(
-        `The Agor daemon is running at http://${host}:${port}. Stop it with \`agor daemon stop\` (or Ctrl+C for a development daemon) before re-initializing.`
+        `The Agor daemon is running at ${daemonUrl}. Stop it with \`agor daemon stop\` (or Ctrl+C for a development daemon) before re-initializing.`
       );
     }
   }
@@ -609,10 +611,8 @@ export default class Init extends Command {
     this.log('');
 
     // Check if daemon is running
-    const config = await loadConfig();
-    const host = config.daemon?.host || 'localhost';
-    const port = config.daemon?.port || 3030;
-    const daemonRunning = await isDaemonRunning(`http://${host}:${port}`);
+    const daemonUrl = await getDaemonUrl();
+    const daemonRunning = await isDaemonRunning(daemonUrl);
     const isDevMode = await this.isDevMode();
 
     this.log(chalk.bold('Next steps:'));

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -71,7 +71,12 @@ export function parseInitialAgenticTools(value: string): InstallableAgenticTool[
     .split(',')
     .map((name) => name.trim().toLowerCase())
     .filter(Boolean);
-  if (names.length === 0 || (names.length === 1 && names[0] === 'none')) return [];
+  if (names.length === 0) {
+    throw new Error(
+      'Agentic-tool policy cannot be empty. Use `none` for an intentionally empty deployment.'
+    );
+  }
+  if (names.length === 1 && names[0] === 'none') return [];
   if (names.length === 1 && names[0] === 'all') {
     return Object.keys(AGENTIC_TOOL_INTEGRATIONS) as InstallableAgenticTool[];
   }

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -18,7 +18,7 @@ import {
   loadConfig,
 } from '@agor/core/config';
 import {
-  createDatabase,
+  createDatabaseAsync,
   createUser,
   DEVELOPMENT_DEFAULT_ADMIN_USER,
   runMigrations,
@@ -64,6 +64,29 @@ export function shouldDeferAdminSetup(nonInteractive: boolean, nodeEnv = process
   return nonInteractive || (nodeEnv !== 'development' && nodeEnv !== 'test');
 }
 
+/** Parse only the fixed integration allowlist; `all` and `none` are explicit headless shorthands. */
+export function parseInitialAgenticTools(value: string): InstallableAgenticTool[] {
+  const names = value
+    .split(',')
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean);
+  if (names.length === 0 || (names.length === 1 && names[0] === 'none')) return [];
+  if (names.length === 1 && names[0] === 'all') {
+    return Object.keys(AGENTIC_TOOL_INTEGRATIONS) as InstallableAgenticTool[];
+  }
+  if (names.includes('all') || names.includes('none')) {
+    throw new Error('Use `all` or `none` by itself, or provide a comma-separated tool list.');
+  }
+  const normalized = names.map(normalizeAgenticToolName);
+  const unknown = names.filter((_, index) => !normalized[index]);
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown agentic tool: ${unknown.join(', ')}. Choose from ${Object.keys(AGENTIC_TOOL_INTEGRATIONS).join(', ')}, all, or none.`
+    );
+  }
+  return [...new Set(normalized as InstallableAgenticTool[])];
+}
+
 export default class Init extends Command {
   private initialDaemonConfig: NonNullable<AgorConfig['daemon']> = {};
   private initialConfig: AgorConfig = getDefaultConfig();
@@ -106,8 +129,7 @@ export default class Init extends Command {
       required: false,
     }),
     'agentic-tools': Flags.string({
-      description:
-        'Comma-separated agentic tools to configure and install during noninteractive initialization',
+      description: 'Comma-separated agentic tools to configure and install (or "all" / "none")',
       required: false,
     }),
     'non-interactive': Flags.boolean({
@@ -153,11 +175,14 @@ export default class Init extends Command {
     messages: number;
     repos: number;
   } | null> {
+    let closeDatabase: (() => void) | undefined;
     try {
-      const { createDatabase, select, sessions, tasks, messages, repos } = await import(
+      const { createDatabaseAsync, select, sessions, tasks, messages, repos } = await import(
         '@agor/core/db'
       );
-      const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
+      const db = await createDatabaseAsync({ url: `file:${dbPath}`, dialect: 'sqlite' });
+      const client = (db as unknown as { $client?: { close?: () => void } }).$client;
+      closeDatabase = () => client?.close?.();
 
       // Count rows by selecting all and measuring length
       const sessionRows = await select(db).from(sessions).all();
@@ -173,6 +198,23 @@ export default class Init extends Command {
       };
     } catch {
       return null;
+    } finally {
+      closeDatabase?.();
+    }
+  }
+
+  private closeSQLiteDatabase(db: unknown): void {
+    (db as { $client?: { close?: () => void } }).$client?.close?.();
+  }
+
+  private async assertDaemonStoppedBeforeReinit(): Promise<void> {
+    const config = await loadConfig();
+    const host = config.daemon?.host || 'localhost';
+    const port = config.daemon?.port || 3030;
+    if (await isDaemonRunning(`http://${host}:${port}`)) {
+      throw new Error(
+        `The Agor daemon is running at http://${host}:${port}. Stop it with \`agor daemon stop\` (or Ctrl+C for a development daemon) before re-initializing.`
+      );
     }
   }
 
@@ -223,18 +265,11 @@ export default class Init extends Command {
     this.nonInteractive = flags['non-interactive'];
     const requestedTools = flags['agentic-tools'] ?? process.env.AGOR_AGENTIC_TOOLS;
     if (requestedTools !== undefined) {
-      const names = requestedTools
-        .split(',')
-        .map((name) => name.trim())
-        .filter(Boolean);
-      const normalized = names.map(normalizeAgenticToolName);
-      const unknown = names.filter((_, index) => !normalized[index]);
-      if (unknown.length > 0) {
-        this.error(
-          `Unknown agentic tool: ${unknown.join(', ')}. Choose from ${Object.keys(AGENTIC_TOOL_INTEGRATIONS).join(', ')}.`
-        );
+      try {
+        this.requestedAgenticTools = parseInitialAgenticTools(requestedTools);
+      } catch (error) {
+        this.error(error instanceof Error ? error.message : String(error));
       }
-      this.requestedAgenticTools = [...new Set(normalized as InstallableAgenticTool[])];
     }
     this.initialDaemonConfig = {
       host: flags['daemon-host'] ?? process.env.DAEMON_HOST ?? 'localhost',
@@ -265,6 +300,12 @@ export default class Init extends Command {
       return;
     }
 
+    if (!flags.force && !this.nonInteractive && (!process.stdin.isTTY || !process.stdout.isTTY)) {
+      this.error(
+        'Interactive `agor init` requires a TTY. For headless setup, use `agor init --non-interactive --agentic-tools <comma-separated-list|all|none>`.'
+      );
+    }
+
     try {
       const dbPath = join(baseDir, 'agor.db');
       const reposDir = join(baseDir, 'repos');
@@ -275,15 +316,24 @@ export default class Init extends Command {
       const dbExists = await this.pathExists(dbPath);
       const reposExist = await this.pathExists(reposDir);
       const branchesExist = await this.pathExists(branchesDir);
+      const freshState = isFreshInitState({
+        baseExists: alreadyExists,
+        databaseExists: dbExists,
+        reposExist,
+        branchesExist,
+      });
 
-      if (
-        isFreshInitState({
-          baseExists: alreadyExists,
-          databaseExists: dbExists,
-          reposExist,
-          branchesExist,
-        })
-      ) {
+      if (freshState) {
+        if (
+          (flags.force || this.nonInteractive) &&
+          process.env.AGOR_MANAGED_AGENTIC_TOOLS === '1' &&
+          this.requestedAgenticTools === undefined &&
+          !(await this.pathExists(getConfigPath()))
+        ) {
+          this.error(
+            'Fresh noninteractive initialization requires an explicit agentic-tool policy. Pass `--agentic-tools <comma-separated-list|all|none>` (or set AGOR_AGENTIC_TOOLS).'
+          );
+        }
         // Fresh initialization
         await this.performInit(baseDir, dbPath, flags.force || this.nonInteractive);
         return;
@@ -299,6 +349,11 @@ export default class Init extends Command {
           'Refusing noninteractive re-initialization because existing data was found. Use --skip-if-exists for idempotent startup or run interactively to confirm destructive re-initialization.'
         );
       }
+
+      // A live daemon owns the SQLite database and its WAL/SHM sidecars. Unlinking
+      // those files underneath it can make the replacement migration fail with
+      // SQLITE_IOERR (and can strand writes in the old unlinked database).
+      await this.assertDaemonStoppedBeforeReinit();
 
       // Gather information about what exists
       const dbStats = dbExists ? await this.getDbStats(dbPath) : null;
@@ -389,8 +444,9 @@ export default class Init extends Command {
     this.log('🗑️  Cleaning up existing installation...');
 
     // Delete database
-    if (await this.pathExists(dbPath)) {
-      await rm(dbPath, { force: true });
+    const databaseArtifacts = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
+    if ((await Promise.all(databaseArtifacts.map((path) => this.pathExists(path)))).some(Boolean)) {
+      await Promise.all(databaseArtifacts.map((path) => rm(path, { force: true })));
       this.log(`${chalk.green('   ✓')} Deleted database`);
     }
 
@@ -415,6 +471,11 @@ export default class Init extends Command {
     dbPath: string,
     skipPrompts: boolean = false
   ): Promise<void> {
+    // Make the deployment choice before creating any state so rejecting the
+    // empty selection (or cancelling the prompt) does not strand a partial DB.
+    const configAlreadyExists = await this.pathExists(getConfigPath());
+    const selectedTools = await this.selectInitialAgenticTools(skipPrompts);
+
     // Create directory structure
     this.log('');
     this.log('📁 Creating directory structure...');
@@ -435,16 +496,19 @@ export default class Init extends Command {
     // Initialize database
     this.log('');
     this.log('💾 Setting up database...');
-    const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
+    const db = await createDatabaseAsync({ url: `file:${dbPath}`, dialect: 'sqlite' });
+    try {
+      await runMigrations(db);
+      this.log(`${chalk.green('   ✓')} Created ${dbPath}`);
 
-    await runMigrations(db);
-    this.log(`${chalk.green('   ✓')} Created ${dbPath}`);
-
-    // Seed initial data
-    this.log('');
-    this.log('🌱 Seeding initial data...');
-    await seedInitialData(db);
-    this.log(`${chalk.green('   ✓')} Created Main Board`);
+      // Seed initial data
+      this.log('');
+      this.log('🌱 Seeding initial data...');
+      await seedInitialData(db);
+      this.log(`${chalk.green('   ✓')} Created Main Board`);
+    } finally {
+      this.closeSQLiteDatabase(db);
+    }
 
     // Create the admin user (auth is always required — anonymous mode was removed).
     if (!skipPrompts) {
@@ -463,14 +527,17 @@ export default class Init extends Command {
         );
       } else {
         try {
-          const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
-
-          await createUser(db, {
-            email: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
-            password: DEVELOPMENT_DEFAULT_ADMIN_USER.password,
-            name: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
-            role: 'admin',
-          });
+          const db = await createDatabaseAsync({ url: `file:${dbPath}`, dialect: 'sqlite' });
+          try {
+            await createUser(db, {
+              email: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
+              password: DEVELOPMENT_DEFAULT_ADMIN_USER.password,
+              name: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
+              role: 'admin',
+            });
+          } finally {
+            this.closeSQLiteDatabase(db);
+          }
 
           this.log(`${chalk.green('   ✓')} Development admin user created`);
           this.log(chalk.dim(`     Email: ${DEVELOPMENT_DEFAULT_ADMIN_USER.email}`));
@@ -492,23 +559,18 @@ export default class Init extends Command {
       // Explicit hard opt-out intentionally omits it.
       await this.saveTelemetryPreference(false, true);
     }
-    const configAlreadyExists = await this.pathExists(getConfigPath());
-    const useLocalManagedSelection =
-      !configAlreadyExists &&
-      !skipPrompts &&
-      process.env.AGOR_MANAGED_AGENTIC_TOOLS === '1' &&
-      this.requestedAgenticTools === undefined;
-    if (!useLocalManagedSelection) {
-      const selectedTools = await this.selectInitialAgenticTools(skipPrompts);
-      this.initialConfig.agentic_tools = { installed: selectedTools };
-    } else {
-      delete this.initialConfig.agentic_tools;
-    }
+    this.initialConfig.agentic_tools = { installed: selectedTools };
     if (!configAlreadyExists) {
       await this.persistDuringInitialCreation(this.initialConfig);
     }
     if (process.env.AGOR_MANAGED_AGENTIC_TOOLS === '1') {
-      await this.config.runCommand('install', useLocalManagedSelection ? [] : ['--sync']);
+      try {
+        await this.config.runCommand('install', ['--sync']);
+      } catch (error) {
+        throw new Error(
+          `Agentic tool installation did not complete: ${error instanceof Error ? error.message : String(error)}. The new config was preserved. Recovery: agor install --sync`
+        );
+      }
     }
 
     // Success summary
@@ -523,17 +585,21 @@ export default class Init extends Command {
     this.log('');
 
     this.log(chalk.bold('Agentic tools:'));
+    const configured = new Set(this.initialConfig.agentic_tools?.installed ?? []);
     const tools = await diagnoseAgenticTools(
       resolveManagedAgenticToolVersion(this.config.version) as string
     );
     for (const tool of tools) {
       const marker = tool.status === 'ready' ? chalk.green('✓') : chalk.yellow('○');
       const detail =
-        tool.status === 'ready' ? (tool.version ?? tool.path ?? 'ready') : 'not available';
+        tool.status === 'ready'
+          ? (tool.version ?? tool.path ?? 'ready')
+          : configured.has(tool.id)
+            ? 'installation incomplete'
+            : 'not selected by this deployment';
       this.log(`   ${marker} ${tool.name}: ${detail}`);
     }
     let missingTools = tools.filter((tool) => tool.status !== 'ready');
-    const configured = new Set(this.initialConfig.agentic_tools?.installed ?? []);
     missingTools = missingTools.filter((tool) => configured.has(tool.id));
     if (missingTools.length > 0) {
       this.log(chalk.dim(`   ${missingTools.length} optional agentic tool(s) are not installed.`));
@@ -595,16 +661,27 @@ export default class Init extends Command {
       return existing.agentic_tools?.installed ?? [];
     }
     if (this.requestedAgenticTools) return this.requestedAgenticTools;
-    if (skipPrompts || process.env.AGOR_MANAGED_AGENTIC_TOOLS !== '1') return [];
+    if (process.env.AGOR_MANAGED_AGENTIC_TOOLS !== '1') return [];
+    if (skipPrompts) {
+      throw new Error(
+        'Fresh noninteractive initialization requires an explicit agentic-tool policy. Pass `--agentic-tools <comma-separated-list|all|none>` (or set AGOR_AGENTIC_TOOLS).'
+      );
+    }
 
     const agorVersion = resolveManagedAgenticToolVersion(this.config.version) as string;
     this.log('');
     this.log(chalk.bold('Agentic tool packages'));
     this.log(
       chalk.dim(
-        `Selected packages will be installed at ${agorVersion} and recorded in config.yaml.`
+        `Selected packages will be downloaded with npm, installed at ${agorVersion}, and recorded once in config.yaml.`
       )
     );
+    this.log(
+      chalk.dim(
+        'Each selection uses additional disk and setup time. Provider credentials are configured after the daemon starts.'
+      )
+    );
+    this.log(chalk.dim('Unchecked tools will not be available to workspaces on this deployment.'));
     const { selectedTools } = await inquirer.prompt<{ selectedTools: InstallableAgenticTool[] }>([
       {
         type: 'checkbox',
@@ -614,6 +691,8 @@ export default class Init extends Command {
           name: `${definition.displayName} (${definition.packageName}@${agorVersion})`,
           value: tool,
         })),
+        validate: (selection) =>
+          selection.length > 0 || 'Select at least one agentic tool, or press Ctrl+C to exit.',
       },
     ]);
     return selectedTools;
@@ -818,14 +897,17 @@ export default class Init extends Command {
     ]);
 
     // Create admin user directly in database (no daemon required)
-    const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
-
-    const _user = await createUser(db, {
-      email,
-      password,
-      name: username,
-      role: 'admin',
-    });
+    const db = await createDatabaseAsync({ url: `file:${dbPath}`, dialect: 'sqlite' });
+    try {
+      await createUser(db, {
+        email,
+        password,
+        name: username,
+        role: 'admin',
+      });
+    } finally {
+      this.closeSQLiteDatabase(db);
+    }
 
     this.log(`${chalk.green('   ✓')} Admin user created (${chalk.gray(email)})`);
   }

--- a/apps/agor-cli/src/lib/agentic-tool-integrations.test.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-integrations.test.ts
@@ -1,10 +1,22 @@
-import { access, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   acquireAgenticToolInstallLock,
   findRestorableAgenticTools,
+  installManagedIntegration,
   listInstalledAgenticTools,
   listManagedAgorVersions,
   listManagedToolDirectories,
@@ -15,11 +27,13 @@ import {
 } from './agentic-tool-integrations.js';
 
 const originalRoot = process.env.AGOR_AGENTIC_TOOLS_DIR;
+const originalPath = process.env.PATH;
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   if (originalRoot === undefined) delete process.env.AGOR_AGENTIC_TOOLS_DIR;
   else process.env.AGOR_AGENTIC_TOOLS_DIR = originalRoot;
+  process.env.PATH = originalPath;
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -128,6 +142,32 @@ describe('listInstalledAgenticTools', () => {
 });
 
 describe('managed integration cleanup', () => {
+  it.runIf(process.platform !== 'win32')(
+    'preserves the previous package and cleans staging when npm fails',
+    async () => {
+      const root = await createRoot();
+      const destination = await installFixture(root, '0.24.0', 'codex', '@agor-live/codex');
+      await writeFile(join(destination, 'previous-marker'), 'preserve me');
+      const bin = join(root, 'fixture-bin');
+      await mkdir(bin);
+      const npm = join(bin, 'npm');
+      await writeFile(npm, '#!/bin/sh\nexit 42\n');
+      await chmod(npm, 0o755);
+      process.env.PATH = `${bin}${delimiter}${originalPath ?? ''}`;
+
+      await expect(installManagedIntegration('codex', '0.24.0')).rejects.toThrow(
+        'npm install failed with exit code 42'
+      );
+
+      await expect(readFile(join(destination, 'previous-marker'), 'utf8')).resolves.toBe(
+        'preserve me'
+      );
+      expect((await readdir(join(root, '0.24.0'))).filter((name) => name.startsWith('.'))).toEqual(
+        []
+      );
+    }
+  );
+
   it('lists and removes broken current-version tool directories', async () => {
     const root = await createRoot();
     await mkdir(join(root, '0.24.0', 'codex'), { recursive: true });

--- a/apps/agor-daemon/src/services/agentic-tool-deployment.ts
+++ b/apps/agor-daemon/src/services/agentic-tool-deployment.ts
@@ -1,0 +1,5 @@
+import type { AgenticToolName } from '@agor/core/types';
+
+export function deploymentAgenticToolUnavailableMessage(tool: AgenticToolName): string {
+  return `${tool} is unavailable under this deployment's agentic-tool policy. A deployment operator must add it to agentic_tools.installed in config.yaml, run agor install --sync, and restart the daemon.`;
+}

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -76,6 +76,7 @@ import {
 } from '../utils/branch-authorization.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
+import { deploymentAgenticToolUnavailableMessage } from './agentic-tool-deployment.js';
 
 type MaterializedAgenticToolConfiguration = Awaited<
   ReturnType<typeof materializeAgenticToolConfiguration>
@@ -243,9 +244,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
 
   private assertDeploymentToolConfigured(tool: AgenticToolName): void {
     if (this.deploymentAvailable(tool)) return;
-    throw new BadRequest(
-      `${tool} is unavailable under this deployment's agentic-tool policy. A local operator must select it with agor install, or declare it in config.yaml and run agor install --sync.`
-    );
+    throw new BadRequest(deploymentAgenticToolUnavailableMessage(tool));
   }
 
   private assertSupportedModelConfig(

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
@@ -1,8 +1,29 @@
-import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { describe, expect, it } from 'vitest';
+import { TenantAgenticToolSettingsRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TenantAgenticToolSettingsService } from './tenant-agentic-tools.js';
 
+afterEach(() => vi.restoreAllMocks());
+
 describe('tenant agentic tool deployment boundary', () => {
+  it('reports deployment availability separately from workspace enablement', async () => {
+    vi.spyOn(TenantAgenticToolSettingsRepository.prototype, 'find').mockResolvedValue({});
+    const service = new TenantAgenticToolSettingsService(
+      {} as TenantScopeAwareDatabase,
+      (tool) => tool === 'claude-code'
+    );
+
+    await expect(service.get('codex')).resolves.toMatchObject({
+      tool: 'codex',
+      deployment_available: false,
+      enabled: false,
+    });
+    await expect(service.get('claude-code')).resolves.toMatchObject({
+      tool: 'claude-code',
+      deployment_available: true,
+      enabled: true,
+    });
+  });
+
   it('rejects enabling a package the deployment operator did not configure', async () => {
     const service = new TenantAgenticToolSettingsService(
       {} as TenantScopeAwareDatabase,

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.ts
@@ -19,6 +19,7 @@ import {
   TENANT_AGENTIC_TOOL_NAMES,
   TENANT_PROVIDER_CONNECTION_FIELDS,
 } from '@agor/core/types';
+import { deploymentAgenticToolUnavailableMessage } from './agentic-tool-deployment.js';
 
 function parseTool(id: string): TenantAgenticToolName {
   if ((TENANT_AGENTIC_TOOL_NAMES as readonly string[]).includes(id)) {
@@ -73,9 +74,7 @@ export class TenantAgenticToolSettingsService {
   ): Promise<TenantAgenticToolSettings> {
     const tool = parseTool(id);
     if (data.enabled === true && !this.deploymentAvailable(tool)) {
-      throw new BadRequest(
-        `${tool} is unavailable under this deployment's agentic-tool policy. A deployment operator must add it to agentic_tools.installed in config.yaml, run agor install --sync, and restart the daemon.`
-      );
+      throw new BadRequest(deploymentAgenticToolUnavailableMessage(tool));
     }
     if (data.enabled !== undefined && typeof data.enabled !== 'boolean') {
       throw new BadRequest('enabled must be a boolean');

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.ts
@@ -50,6 +50,7 @@ export class TenantAgenticToolSettingsService {
     }
     return {
       tool,
+      deployment_available: deploymentEnabled,
       enabled: deploymentEnabled && stored.enabled !== false,
       resolution_policy: stored.resolution_policy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY,
       inline_configuration_allowed: stored.inline_configuration_allowed !== false,
@@ -73,7 +74,7 @@ export class TenantAgenticToolSettingsService {
     const tool = parseTool(id);
     if (data.enabled === true && !this.deploymentAvailable(tool)) {
       throw new BadRequest(
-        `${tool} is unavailable under this deployment's agentic-tool policy. A local operator must select it with agor install, or declare it in config.yaml and run agor install --sync.`
+        `${tool} is unavailable under this deployment's agentic-tool policy. A deployment operator must add it to agentic_tools.installed in config.yaml, run agor install --sync, and restart the daemon.`
       );
     }
     if (data.enabled !== undefined && typeof data.enabled !== 'boolean') {

--- a/apps/agor-docs/components/InstallTabs.mdx
+++ b/apps/agor-docs/components/InstallTabs.mdx
@@ -63,7 +63,8 @@ import { Tabs } from 'nextra/components';
 
     # Set an admin password before first boot.
     # Start from docker/.env.prod.example for the full list of options.
-    echo "AGOR_ADMIN_PASSWORD=replace-with-a-long-random-password" > .env.prod
+    cp docker/.env.prod.example .env.prod
+    # Edit AGOR_ADMIN_PASSWORD and choose AGOR_AGENTIC_TOOLS before first boot.
 
     docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
     ```
@@ -71,6 +72,8 @@ import { Tabs } from 'nextra/components';
     Open [http://localhost:3030](http://localhost:3030) and log in as `admin@agor.live` (health check: `curl http://localhost:3030/health`).
 
     > **Skipped the password?** Agor generates one on first boot and writes it to `/home/agor/.agor/admin-credentials` inside the container — retrieve it with `docker compose -f docker-compose.prod.yml exec agor-prod cat /home/agor/.agor/admin-credentials`. Either way, this bootstrap only runs once, against an empty database; setting `AGOR_ADMIN_PASSWORD` later won't reset an existing user's password.
+
+    > `AGOR_AGENTIC_TOOLS` is the immutable fresh-install package policy. Set a comma-separated list, `all`, or `none`; the container defaults to the explicit safe value `none` when it is omitted. Changing the environment variable later does not rewrite existing config — edit `agentic_tools.installed` deliberately and run `agor install --sync` inside the container.
 
     > For hot-reload dev environments, multi-branch setups, and PostgreSQL, see `docker/README.md` and the [Development Guide](/guide/development). For Kubernetes-style executor isolation, see [Containerized Execution](/guide/containerized-execution).
 

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -24,9 +24,14 @@ packaged daemon fails before listening if any configured integration is missing 
 Tenant administrators may disable an installed tool but cannot install packages or enable a tool
 absent from this deployment list.
 
-If `agentic_tools.installed` is absent, local CLI installs instead use a host-local managed manifest.
-Run interactive `agor install` to create or change it. The manifest is never exposed for mutation
-through API, UI, or MCP. Headless deployments should use an explicit YAML list, including `[]`.
+Fresh interactive init always writes `agentic_tools.installed` once, then installs the selected
+packages before returning. Fresh headless init requires `--agentic-tools` (or
+`AGOR_AGENTIC_TOOLS`); `all` and `none` are explicit shorthands.
+
+If `agentic_tools.installed` is absent in an older config, local CLI installs use a backward-compatible
+host-local managed manifest. Run interactive `agor install` to create or change it. The manifest is
+never exposed for mutation through API, UI, or MCP. Headless deployments should use an explicit
+YAML list, including `[]`.
 
 ## Environment precedence
 

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -40,11 +40,12 @@ npm install -g agor-live@latest
 agor init
 ```
 
-The original npm installation never downloads optional runtimes. On a local installation, run
-`agor install` and choose tools interactively. Agor records the choice in a private, host-local
-manifest beside the packages; it never rewrites `config.yaml`.
+The original npm installation never downloads optional runtimes. Interactive `agor init` shows all
+six supported tools in a multi-select and requires you to select at least one. Press Ctrl+C to cancel
+instead of creating a deployment accidentally. Init records the final selection in the newly created
+immutable `config.yaml` and reconciles the packages before it reports success.
 
-For a declarative or headless deployment, explicitly configure the selection:
+The generated deployment policy has this shape:
 
 ```yaml filename="~/.agor/config.yaml"
 agentic_tools:
@@ -53,8 +54,18 @@ agentic_tools:
     - codex
 ```
 
-Then run `agor install --sync` to reconcile disk state noninteractively. An explicit `installed: []`
-is valid and removes all managed tools. Merely omitting the key selects local-managed mode.
+After initialization, edit this list explicitly and run `agor install --sync` to change or repair the
+package set. It installs missing packages and removes unselected or stale versions without rewriting
+the file. If an init-time npm operation fails, the config and any completed atomic package installs
+remain in place; fix npm registry/proxy/permission issues and run exactly `agor install --sync`.
+
+Stop the daemon before accepting destructive re-initialization. `agor init` refuses to remove a live
+daemon's SQLite database; after shutdown it closes its own inspection handle and removes the database
+plus WAL/SHM sidecars before migrating the replacement.
+
+Configurations created before this onboarding contract may omit `agentic_tools.installed`. Those
+installations retain the backward-compatible host-local manifest mode: run `agor install` once to
+choose tools interactively. New init flows always create a declarative list.
 
 `agor install` uses your configured npm registry, proxy, authentication, and integrity verification,
 but installs into Agor's private runtime directory rather than changing global npm state. Installation
@@ -68,8 +79,12 @@ agor doctor
 ```
 
 The packaged daemon refuses to start when a selected integration is absent, corrupt, or from a
-different Agor version. An empty selection does not block startup; a missing local manifest produces
-an actionable warning. Unselected tools are unavailable to tenants.
+different Agor version. An explicitly empty headless selection does not block startup; a missing
+legacy local manifest produces an actionable warning. Unselected tools are unavailable to tenants.
+In the UI, workspace admins see **Not installed by this deployment** separately from **Disabled in
+this workspace**; users configure credentials only for installed, enabled tools, and transient
+provider probes use a separate status-unavailable state. Workspace and tenant admins cannot install
+deployment packages.
 
 | Agentic tool   | Configuration value | Managed package       |
 | -------------- | ------------------- | --------------------- |
@@ -85,8 +100,12 @@ For automated images and CI, run the same noninteractive commands after installi
 ```bash
 npm install -g agor-live@latest
 agor init --non-interactive --agentic-tools claude,codex
-agor install --sync
 ```
+
+Headless fresh init requires the flag (or `AGOR_AGENTIC_TOOLS`). Use `--agentic-tools all` for every
+allowlisted tool or `--agentic-tools none` for an intentionally empty deployment. Init performs the
+initial reconciliation synchronously; a later `agor install --sync` is the idempotent repair/upgrade
+command.
 
 Set `AGOR_AGENTIC_TOOLS_DIR` when integrations must live in an administrator-provisioned shared
 read-only location. Executors receive the resolved absolute directory across Agor's supported Unix
@@ -96,6 +115,11 @@ Run `agor install` as the user the daemon runs as. Integrations install under th
 directory, so installing them with `sudo` places them in root's home where the daemon cannot see
 them — `agor doctor` then reports them as missing. Set `AGOR_AGENTIC_TOOLS_DIR` explicitly when the
 daemon and its executors run as different users.
+
+Tool selection and exact-version validation are identical in `simple`, `delegated`, `insulated`, and
+`strict` execution modes. The difference is filesystem identity: every daemon/executor Unix identity
+that loads the shared packages must be able to traverse and read `AGOR_AGENTIC_TOOLS_DIR`; only the
+deployment installer should be able to write it.
 
 ### Upgrading
 
@@ -113,9 +137,10 @@ removes current-version packages absent from `agentic_tools.installed`, deletes 
 directory, and cleans interrupted staging/backup directories. There is currently no compatibility
 range or keep-old mode: every managed wrapper must exactly match `agor-live`.
 
-On local upgrades where the YAML key and local manifest are both absent, `agor install --sync`
-fails without changing packages and directs the operator to interactive `agor install`. Docker and
-Kubernetes deployments should always declare `agentic_tools.installed` and use `--sync`.
+On upgrades from a legacy configuration where the YAML key and local manifest are both absent,
+`agor install --sync` fails without changing packages and directs the operator to interactive
+`agor install`. Docker and Kubernetes deployments should always declare
+`agentic_tools.installed` and use `--sync`.
 
 Microsoft Teams gateway support remains optional and separate from agentic tools:
 

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -105,7 +105,8 @@ agor init --non-interactive --agentic-tools claude,codex
 Headless fresh init requires the flag (or `AGOR_AGENTIC_TOOLS`). Use `--agentic-tools all` for every
 allowlisted tool or `--agentic-tools none` for an intentionally empty deployment. Init performs the
 initial reconciliation synchronously; a later `agor install --sync` is the idempotent repair/upgrade
-command.
+command. Empty, whitespace-only, and comma-only values are rejected; use the literal `none` to make
+an empty policy intentional.
 
 Set `AGOR_AGENTIC_TOOLS_DIR` when integrations must live in an administrator-provisioned shared
 read-only location. Executors receive the resolved absolute directory across Agor's supported Unix

--- a/apps/agor-docs/content/guide/getting-started.mdx
+++ b/apps/agor-docs/content/guide/getting-started.mdx
@@ -13,9 +13,15 @@ Install Agor, open the UI, and follow the onboarding wizard. Your **first AI tea
 
 <InstallTabs />
 
-Run `agor init` after installation. It lets you choose the agentic tools you plan to use and shows
-exactly what will be installed before running npm. Skip the selection if you are not ready—you can add
-a version-aligned tool later by editing `agentic_tools.installed` in config.yaml and running `agor install`.
+Run `agor init` after installation. It shows a multi-select for every supported agentic tool and
+requires an intentional selection of at least one. The prompt explains that each selection adds
+download time and disk use; credentials are configured later in the UI. Init writes the selection
+once to `agentic_tools.installed` and installs the exact version-aligned packages before reporting
+success. Press Ctrl+C to cancel. An intentionally tool-free headless deployment must use
+`--agentic-tools none`.
+
+To change the deployment policy later, edit `agentic_tools.installed` in `config.yaml`, run
+`agor install --sync`, and restart the daemon. Agor does not silently rewrite existing config.
 Repeat the readiness check with `agor doctor`; see
 [Agentic tools](/guide/extended-install#agentic-tools) for the complete model.
 

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.test.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.test.tsx
@@ -10,11 +10,17 @@ import type { AgenticToolOption } from '../../types';
 import { AgentSelectionGrid } from './AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from './availableAgents';
 
-const store = vi.hoisted(() => ({ agenticToolSettingsByName: new Map() }));
+const store = vi.hoisted(() => ({
+  agenticToolSettingsByName: new Map(),
+  agenticToolSettingsHydrated: true,
+}));
 
 vi.mock('../../store/agorStore', () => ({
   useAgorStore: (selector: (state: unknown) => unknown) =>
-    selector({ agenticToolSettingsByName: store.agenticToolSettingsByName }),
+    selector({
+      agenticToolSettingsByName: store.agenticToolSettingsByName,
+      agenticToolSettingsHydrated: store.agenticToolSettingsHydrated,
+    }),
 }));
 
 const agents: AgenticToolOption[] = [
@@ -24,6 +30,7 @@ const agents: AgenticToolOption[] = [
 
 afterEach(() => {
   store.agenticToolSettingsByName = new Map();
+  store.agenticToolSettingsHydrated = true;
 });
 
 function gridEl(container: HTMLElement): HTMLElement {
@@ -31,6 +38,23 @@ function gridEl(container: HTMLElement): HTMLElement {
 }
 
 describe('AgentSelectionGrid tile layout', () => {
+  it('does not expose or select tools before deployment settings hydrate', () => {
+    store.agenticToolSettingsHydrated = false;
+    const onSelect = vi.fn();
+    render(
+      <AgentSelectionGrid
+        agents={agents}
+        selectedAgentId="claude-code-cli"
+        onSelect={onSelect}
+        fallbackToFirstVisibleAgent
+      />
+    );
+
+    expect(screen.getByLabelText('Loading agentic tool availability')).toBeInTheDocument();
+    expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
   it('shows a non-operator action when no deployment/workspace tool is available', () => {
     store.agenticToolSettingsByName = new Map(
       agents.map((agent) => [agent.id, { tool: agent.id, enabled: false }])

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.test.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.test.tsx
@@ -5,14 +5,16 @@
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgenticToolOption } from '../../types';
 import { AgentSelectionGrid } from './AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from './availableAgents';
 
+const store = vi.hoisted(() => ({ agenticToolSettingsByName: new Map() }));
+
 vi.mock('../../store/agorStore', () => ({
   useAgorStore: (selector: (state: unknown) => unknown) =>
-    selector({ agenticToolSettingsByName: new Map() }),
+    selector({ agenticToolSettingsByName: store.agenticToolSettingsByName }),
 }));
 
 const agents: AgenticToolOption[] = [
@@ -20,11 +22,26 @@ const agents: AgenticToolOption[] = [
   { id: 'opencode', name: 'OpenCode', icon: '🌐', description: 'y' },
 ];
 
+afterEach(() => {
+  store.agenticToolSettingsByName = new Map();
+});
+
 function gridEl(container: HTMLElement): HTMLElement {
   return container.querySelector('[style*="grid"]') as HTMLElement;
 }
 
 describe('AgentSelectionGrid tile layout', () => {
+  it('shows a non-operator action when no deployment/workspace tool is available', () => {
+    store.agenticToolSettingsByName = new Map(
+      agents.map((agent) => [agent.id, { tool: agent.id, enabled: false }])
+    );
+    render(<AgentSelectionGrid agents={agents} selectedAgentId={null} onSelect={vi.fn()} />);
+    expect(screen.getByText('No agentic tools are enabled for this workspace')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Deployment package changes require a separate deployment operator/)
+    ).toBeInTheDocument();
+  });
+
   it('does not replace an unavailable persisted selection unless fallback is opted in', () => {
     const onSelect = vi.fn();
     render(

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { TenantAgenticToolName } from '@agor-live/client';
-import { Alert, Select, Space, Typography, theme } from 'antd';
+import { Alert, Select, Space, Spin, Typography, theme } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import type { AgenticToolOption } from '../../types';
@@ -71,10 +71,15 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
 }) => {
   const { token } = theme.useToken();
   const settings = useAgorStore((state) => state.agenticToolSettingsByName);
+  const settingsHydrated = useAgorStore((state) => state.agenticToolSettingsHydrated);
   const visibleAgents = useMemo(
     () =>
-      agents.filter((agent) => settings.get(agent.id as TenantAgenticToolName)?.enabled !== false),
-    [agents, settings]
+      settingsHydrated
+        ? agents.filter(
+            (agent) => settings.get(agent.id as TenantAgenticToolName)?.enabled !== false
+          )
+        : [],
+    [agents, settings, settingsHydrated]
   );
   useEffect(() => {
     if (
@@ -86,6 +91,17 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
       onSelect(visibleAgents[0].id);
     }
   }, [fallbackToFirstVisibleAgent, onSelect, selectedAgentId, visibleAgents]);
+  if (!settingsHydrated) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading agentic tool availability"
+        style={{ display: 'flex', justifyContent: 'center', padding: token.paddingLG }}
+      >
+        <Spin size="small" />
+      </div>
+    );
+  }
   if (variant === 'select') {
     return (
       <>

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { TenantAgenticToolName } from '@agor-live/client';
-import { Select, Space, Typography, theme } from 'antd';
+import { Alert, Select, Space, Typography, theme } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import type { AgenticToolOption } from '../../types';
@@ -89,6 +89,15 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
   if (variant === 'select') {
     return (
       <>
+        {visibleAgents.length === 0 && (
+          <Alert
+            type="warning"
+            showIcon
+            title="No agentic tools are enabled for this workspace"
+            description="Contact a workspace administrator. Deployment package changes require a separate deployment operator."
+            style={{ marginBottom: token.marginSM }}
+          />
+        )}
         <Select
           value={selectedAgentId ?? undefined}
           onChange={(id) => onSelect(id)}
@@ -111,6 +120,14 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
 
   return (
     <>
+      {visibleAgents.length === 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          title="No agentic tools are enabled for this workspace"
+          description="Contact a workspace administrator. Deployment package changes require a separate deployment operator."
+        />
+      )}
       {showHelperText && !selectedAgentId && (
         <Text type="secondary" style={{ fontSize: 12, marginBottom: 8, display: 'block' }}>
           {helperText}

--- a/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { App, ConfigProvider } from 'antd';
 import type React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agorStore } from '../../store/agorStore';
 import type { AgenticToolOption } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { PendingToolChoicePanel } from './PendingToolChoicePanel';
 
@@ -15,6 +16,14 @@ const agents: AgenticToolOption[] = [
   { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Anthropic' },
   { id: 'codex', name: 'Codex', icon: '💻', description: 'OpenAI' },
 ];
+
+beforeEach(() => {
+  agorStore.getState().setAgenticToolSettings([]);
+});
+
+afterEach(() => {
+  agorStore.getState().reset();
+});
 
 describe('PendingToolChoicePanel', () => {
   it('renders one tile per available agent and the inert composer bar', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.quickstart.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.quickstart.test.tsx
@@ -2,9 +2,10 @@
 import type { Branch, Session } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { agorStore } from '../../store/agorStore';
 import type { AgenticToolOption } from '../../types';
 import SessionPanel from './SessionPanel';
 
@@ -85,6 +86,14 @@ const availableAgents: AgenticToolOption[] = [
   { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Anthropic' },
   { id: 'codex', name: 'Codex', icon: '💻', description: 'OpenAI' },
 ];
+
+beforeEach(() => {
+  agorStore.getState().setAgenticToolSettings([]);
+});
+
+afterEach(() => {
+  agorStore.getState().reset();
+});
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
@@ -40,5 +40,7 @@ describe('AgenticToolsSection deployment availability', () => {
       screen.getByText(/Workspace settings cannot install deployment packages/)
     ).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Credential resolution')).not.toBeInTheDocument();
+    expect(screen.queryByText('Allow inline configuration')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
@@ -1,0 +1,44 @@
+import type {
+  AgorClient,
+  TenantAgenticToolName,
+  TenantAgenticToolSettings,
+} from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AgenticToolsSection } from './AgenticToolsSection';
+
+const tools: TenantAgenticToolName[] = [
+  'claude-code',
+  'codex',
+  'gemini',
+  'copilot',
+  'cursor',
+  'opencode',
+];
+
+describe('AgenticToolsSection deployment availability', () => {
+  it('distinguishes an uninstalled deployment package without offering a mutation action', async () => {
+    const settings: TenantAgenticToolSettings[] = tools.map((tool) => ({
+      tool,
+      deployment_available: tool !== 'claude-code',
+      enabled: false,
+      resolution_policy: 'user_preferred',
+      inline_configuration_allowed: true,
+      connection: {},
+    }));
+    const client = {
+      service: vi.fn(() => ({ find: vi.fn().mockResolvedValue(settings) })),
+    } as unknown as AgorClient;
+
+    render(<AgenticToolsSection client={client} />);
+
+    expect(await screen.findByText('Not installed by this deployment')).toBeInTheDocument();
+    expect(
+      screen.getByText('This deployment did not install this agentic tool')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Workspace settings cannot install deployment packages/)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -205,102 +205,104 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                     }
                   />
                 )}
-                <Tabs
-                  defaultActiveKey="authentication"
-                  items={[
-                    {
-                      key: 'authentication',
-                      label: 'Authentication',
-                      children:
-                        TENANT_TOOL_FIELDS[tool].length > 0 ? (
-                          <Space direction="vertical" size="large" style={{ width: '100%' }}>
-                            <Space direction="vertical" size="small" style={{ width: '100%' }}>
-                              <Typography.Text strong>Credential resolution</Typography.Text>
-                              <Select
-                                value={current.resolution_policy}
-                                style={{ width: '100%', maxWidth: 420 }}
-                                options={RESOLUTION_POLICIES.map((policy) => ({
-                                  value: policy.value,
-                                  label: policy.label,
-                                  title: policy.description,
-                                }))}
-                                onChange={(resolution_policy) =>
-                                  void patch(tool, { resolution_policy })
-                                }
+                {current.deployment_available && (
+                  <Tabs
+                    defaultActiveKey="authentication"
+                    items={[
+                      {
+                        key: 'authentication',
+                        label: 'Authentication',
+                        children:
+                          TENANT_TOOL_FIELDS[tool].length > 0 ? (
+                            <Space direction="vertical" size="large" style={{ width: '100%' }}>
+                              <Space direction="vertical" size="small" style={{ width: '100%' }}>
+                                <Typography.Text strong>Credential resolution</Typography.Text>
+                                <Select
+                                  value={current.resolution_policy}
+                                  style={{ width: '100%', maxWidth: 420 }}
+                                  options={RESOLUTION_POLICIES.map((policy) => ({
+                                    value: policy.value,
+                                    label: policy.label,
+                                    title: policy.description,
+                                  }))}
+                                  onChange={(resolution_policy) =>
+                                    void patch(tool, { resolution_policy })
+                                  }
+                                />
+                                <Typography.Text type="secondary">
+                                  {
+                                    RESOLUTION_POLICIES.find(
+                                      (policy) => policy.value === current.resolution_policy
+                                    )?.description
+                                  }
+                                </Typography.Text>
+                              </Space>
+                              <ApiKeyFields
+                                tool={tool as AgenticToolName}
+                                fields={TENANT_TOOL_FIELDS[tool]}
+                                fieldStatus={fieldStatus}
+                                onSave={async (field, value) => {
+                                  setSaving((state) => ({ ...state, [field]: true }));
+                                  try {
+                                    await patch(tool, { connection: { [field]: value } });
+                                  } finally {
+                                    setSaving((state) => ({ ...state, [field]: false }));
+                                  }
+                                }}
+                                onClear={async (field) => {
+                                  setSaving((state) => ({ ...state, [field]: true }));
+                                  try {
+                                    await patch(tool, { connection: { [field]: null } });
+                                  } finally {
+                                    setSaving((state) => ({ ...state, [field]: false }));
+                                  }
+                                }}
+                                saving={saving}
                               />
+                            </Space>
+                          ) : (
+                            <Alert
+                              type="info"
+                              showIcon
+                              title="No workspace authentication settings"
+                              description={`${TOOL_LABELS[tool]} does not currently expose a centrally managed connection.`}
+                            />
+                          ),
+                      },
+                      {
+                        key: 'presets',
+                        label: 'Presets',
+                        children: (
+                          <Space direction="vertical" size="large" style={{ width: '100%' }}>
+                            <Space direction="vertical" size="small">
+                              <Space>
+                                <Switch
+                                  checked={current.inline_configuration_allowed}
+                                  onChange={(inline_configuration_allowed) =>
+                                    void patch(tool, { inline_configuration_allowed })
+                                  }
+                                />
+                                <Typography.Text strong>Allow inline configuration</Typography.Text>
+                              </Space>
                               <Typography.Text type="secondary">
-                                {
-                                  RESOLUTION_POLICIES.find(
-                                    (policy) => policy.value === current.resolution_policy
-                                  )?.description
-                                }
+                                {current.inline_configuration_allowed
+                                  ? 'Members may choose a preset or define configuration directly.'
+                                  : 'Members must choose an administrator-managed preset.'}
                               </Typography.Text>
                             </Space>
-                            <ApiKeyFields
-                              tool={tool as AgenticToolName}
-                              fields={TENANT_TOOL_FIELDS[tool]}
-                              fieldStatus={fieldStatus}
-                              onSave={async (field, value) => {
-                                setSaving((state) => ({ ...state, [field]: true }));
-                                try {
-                                  await patch(tool, { connection: { [field]: value } });
-                                } finally {
-                                  setSaving((state) => ({ ...state, [field]: false }));
-                                }
-                              }}
-                              onClear={async (field) => {
-                                setSaving((state) => ({ ...state, [field]: true }));
-                                try {
-                                  await patch(tool, { connection: { [field]: null } });
-                                } finally {
-                                  setSaving((state) => ({ ...state, [field]: false }));
-                                }
-                              }}
-                              saving={saving}
-                            />
-                          </Space>
-                        ) : (
-                          <Alert
-                            type="info"
-                            showIcon
-                            title="No workspace authentication settings"
-                            description={`${TOOL_LABELS[tool]} does not currently expose a centrally managed connection.`}
-                          />
-                        ),
-                    },
-                    {
-                      key: 'presets',
-                      label: 'Presets',
-                      children: (
-                        <Space direction="vertical" size="large" style={{ width: '100%' }}>
-                          <Space direction="vertical" size="small">
-                            <Space>
-                              <Switch
-                                checked={current.inline_configuration_allowed}
-                                onChange={(inline_configuration_allowed) =>
-                                  void patch(tool, { inline_configuration_allowed })
-                                }
+                            {client && (
+                              <AgenticToolPresetsManager
+                                client={client}
+                                tool={tool}
+                                onError={setError}
                               />
-                              <Typography.Text strong>Allow inline configuration</Typography.Text>
-                            </Space>
-                            <Typography.Text type="secondary">
-                              {current.inline_configuration_allowed
-                                ? 'Members may choose a preset or define configuration directly.'
-                                : 'Members must choose an administrator-managed preset.'}
-                            </Typography.Text>
+                            )}
                           </Space>
-                          {client && (
-                            <AgenticToolPresetsManager
-                              client={client}
-                              tool={tool}
-                              onError={setError}
-                            />
-                          )}
-                        </Space>
-                      ),
-                    },
-                  ]}
-                />
+                        ),
+                      },
+                    ]}
+                  />
+                )}
               </Space>
             ),
           };

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -157,6 +157,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
         items={(Object.keys(TOOL_LABELS) as TenantAgenticToolName[]).map((tool) => {
           const current = settings[tool] ?? {
             tool,
+            deployment_available: true,
             enabled: true,
             resolution_policy: 'user_preferred' as const,
             inline_configuration_allowed: true,
@@ -178,12 +179,32 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                 <Space>
                   <Switch
                     checked={current.enabled}
+                    disabled={!current.deployment_available}
                     onChange={(enabled) => void patch(tool, { enabled })}
                   />
                   <Typography.Text>
-                    {current.enabled ? 'Available in this workspace' : 'Disabled in this workspace'}
+                    {!current.deployment_available
+                      ? 'Not installed by this deployment'
+                      : current.enabled
+                        ? 'Installed and available in this workspace'
+                        : 'Installed, but disabled in this workspace'}
                   </Typography.Text>
                 </Space>
+                {!current.deployment_available && (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    title="This deployment did not install this agentic tool"
+                    description={
+                      <>
+                        Workspace settings cannot install deployment packages. A deployment operator
+                        must add the tool to <code>agentic_tools.installed</code> in{' '}
+                        <code>config.yaml</code>, run <code>agor install --sync</code>, and restart
+                        the daemon.
+                      </>
+                    }
+                  />
+                )}
                 <Tabs
                   defaultActiveKey="authentication"
                   items={[

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,9 @@ services:
       - DAEMON_PORT=${DAEMON_PORT:-3030}
       - DAEMON_HOST=0.0.0.0
       - CORS_ORIGIN=${CORS_ORIGIN:-*}
+      # Explicit fresh-install package policy. The entrypoint defaults to the
+      # intentionally tool-free "none" policy when this is omitted.
+      - AGOR_AGENTIC_TOOLS=${AGOR_AGENTIC_TOOLS:-none}
       # Optional first-run bootstrap password. If unset on an empty database,
       # Agor writes a random password to /home/agor/.agor/admin-credentials
       # (mode 0600) and logs only that file path.

--- a/docker/.env.prod.example
+++ b/docker/.env.prod.example
@@ -6,6 +6,10 @@ DAEMON_PORT=3030
 DAEMON_HOST=0.0.0.0
 CORS_ORIGIN=*
 
+# Fresh-install agentic-tool package policy. Choose a comma-separated allowlisted
+# list, "all", or "none". Existing config is never rewritten on restart.
+AGOR_AGENTIC_TOOLS=claude-code,codex
+
 # First-run admin bootstrap (optional)
 # If set on an empty database, this password creates admin@agor.live and is
 # never printed by Agor. If unset, Agor creates a random password in

--- a/docker/docker-entrypoint-prod.sh
+++ b/docker/docker-entrypoint-prod.sh
@@ -14,6 +14,7 @@ echo "📦 Initializing Agor environment..."
 agor init \
   --skip-if-exists \
   --non-interactive \
+  --agentic-tools "${AGOR_AGENTIC_TOOLS:-none}" \
   --daemon-port "${DAEMON_PORT:-3030}" \
   --daemon-host "${DAEMON_HOST:-0.0.0.0}"
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -243,7 +243,7 @@ echo "✅ Watch modes started (git, core, agentic tools, executor, and client wi
 # Initialize database and configure daemon settings for Docker
 # (idempotent: creates database on first run, preserves JWT secrets on subsequent runs)
 echo "📦 Initializing Agor environment..."
-pnpm agor init --skip-if-exists --non-interactive --daemon-port "${DAEMON_PORT:-3030}" --daemon-host "${DAEMON_HOST:-0.0.0.0}"
+pnpm agor init --skip-if-exists --non-interactive --agentic-tools "${AGOR_AGENTIC_TOOLS:-none}" --daemon-port "${DAEMON_PORT:-3030}" --daemon-host "${DAEMON_HOST:-0.0.0.0}"
 
 # Run database migrations (idempotent: safe to run on every start)
 # This ensures schema is up-to-date even when using existing database volumes

--- a/packages/agor-live/README.md
+++ b/packages/agor-live/README.md
@@ -17,7 +17,7 @@ Prefer Homebrew on macOS or Linux? See the main docs for the brew install path.
 ## Quick Start
 
 ```bash
-# 1. Initialize Agor (creates ~/.agor/ and database)
+# 1. Initialize Agor, choose agentic tools, and install their aligned packages
 agor init
 
 # 2. Start the daemon

--- a/packages/core/src/types/tenant-agentic-tool.ts
+++ b/packages/core/src/types/tenant-agentic-tool.ts
@@ -72,6 +72,9 @@ export interface TenantAgenticToolFieldStatus {
 
 export interface TenantAgenticToolSettings {
   tool: TenantAgenticToolName;
+  /** Whether the deployment operator selected and installed this tool package. */
+  deployment_available: boolean;
+  /** Effective workspace availability: deployment_available and not tenant-disabled. */
   enabled: boolean;
   resolution_policy: ProviderResolutionPolicy;
   inline_configuration_allowed: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       glob:
         specifier: ^11.1.0
         version: 11.1.0
+      node-pty:
+        specifier: 1.2.0-beta.12
+        version: 1.2.0-beta.12
       oclif:
         specifier: ^4.23.29
         version: 4.23.29(@types/node@24.13.3)(supports-color@8.1.1)


### PR DESCRIPTION
## Summary

- restore fresh interactive `agor init` as the owner of deployment agentic-tool selection
- require at least one interactive selection, persist it once in immutable `config.yaml`, and reconcile exact-version packages before success
- fail headless/TTY-invalid setup before creating partial state and preserve one-command recovery on install failure
- harden destructive re-init by refusing a live daemon, closing SQLite inspection handles, and removing WAL/SHM sidecars
- distinguish deployment package availability from workspace enablement and user credential/health states in the UI
- add pseudo-TTY, package-readiness, partial-install, UI boundary, and packed global-install regression coverage

## Root cause

PR #2224 introduced the declarative `agentic_tools.installed` contract, but the subsequent local-managed install flow redirected fresh interactive init through nested `agor install`. All choices were unchecked, so pressing Enter silently selected no tools, wrote only a host-local selection manifest, and allowed init to report success without deployment packages.

Destructive re-init also inspected SQLite without closing its client, removed only `agor.db`, and did not prevent deleting a database still owned by a running daemon. That could surface as `SQLITE_IOERR` during replacement migrations, especially with WAL/SHM sidecars.

## UX contract

### Interactive fresh init

- displays all six allowlisted integrations before creating database state
- rejects an empty submission with `Select at least one agentic tool, or press Ctrl+C to exit.`
- explains download, disk, and credential implications
- writes the chosen list once to `agentic_tools.installed`
- runs `agor install --sync` before reporting success
- preserves config and completed atomic installs on failure, with exactly one recovery command

### Headless init

Requires an explicit allowlisted policy via `--agentic-tools` or `AGOR_AGENTIC_TOOLS`:

```bash
agor init --non-interactive --agentic-tools claude,codex
agor init --non-interactive --agentic-tools all
agor init --non-interactive --agentic-tools none
```

### Existing installations

Existing config is not silently rewritten. Operators change declarative policy by editing `config.yaml`, running `agor install --sync`, and restarting the daemon. Older configurations without the key retain the legacy host-local manifest flow.

## UI behavior

Workspace settings now expose deployment availability separately from workspace enablement:

- **Not installed by this deployment**
- **Installed, but disabled in this workspace**
- **Installed and available in this workspace**

Personal credentials and transient provider health remain separate states. Workspace members are not offered deployment-global mutation actions.

## Validation

- `pnpm install`
- `pnpm check`
- CLI init/install focused tests: 30 passed
- core agentic/config focused tests: 125 passed
- daemon deployment-boundary tests: 2 passed
- UI availability-state tests: 7 passed
- packed `agor-live` global-style install smoke with actual managed Codex readiness
- `git diff --check`
