### PR TITLE
fix(ui): hide archived sessions from global search and schedule runs

### DIFF
--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.test.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Global search must not surface archived sessions.
+ *
+ * Artifacts and boards are already filtered in this hook; sessions were not,
+ * so an archived branch's sessions kept showing up in search results.
+ */
+
+import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useGlobalSearch } from './useGlobalSearch';
+
+const USER_ID = 'user-1';
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'session-1',
+    branch_id: 'branch-1',
+    created_by: USER_ID,
+    archived: false,
+    title: 'deploy pipeline',
+    agentic_tool: 'claude-code',
+    last_updated: '2026-08-12T10:00:00.000Z',
+    ...overrides,
+  } as unknown as Session;
+}
+
+function renderSearch(sessions: Session[], query: string) {
+  return renderHook(() =>
+    useGlobalSearch({
+      query,
+      ownedByMe: false,
+      activeTypeChip: 'all',
+      currentUserId: USER_ID,
+      sessionById: new Map(sessions.map((s) => [s.session_id, s])),
+      branchById: new Map<string, Branch>(),
+      artifactById: new Map<string, Artifact>(),
+      boardById: new Map<string, Board>(),
+      mcpServerById: new Map<string, MCPServer>(),
+    })
+  );
+}
+
+describe('useGlobalSearch', () => {
+  it('omits archived sessions from results', async () => {
+    const { result } = renderSearch(
+      [
+        makeSession({ session_id: 'active', title: 'deploy pipeline' }),
+        makeSession({ session_id: 'gone', title: 'deploy pipeline', archived: true }),
+      ],
+      'deploy'
+    );
+
+    await waitFor(() => {
+      expect(result.current.debouncedQuery).toBe('deploy');
+    });
+
+    const ids = result.current.results.session.map((r) => (r.item as Session).session_id);
+
+    expect(ids).toEqual(['active']);
+  });
+
+  it('does not count archived sessions in the chip badge', async () => {
+    const { result } = renderSearch(
+      [
+        makeSession({ session_id: 'active', title: 'deploy pipeline' }),
+        makeSession({ session_id: 'gone', title: 'deploy pipeline', archived: true }),
+      ],
+      'deploy'
+    );
+
+    await waitFor(() => {
+      expect(result.current.debouncedQuery).toBe('deploy');
+    });
+
+    expect(result.current.counts.session).toBe(1);
+  });
+});

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -88,6 +88,7 @@ export function useGlobalSearch({
 
     // Sessions (timestamp field is `last_updated`, not `updated_at`)
     const sessions = Array.from(sessionById.values())
+      .filter((s) => !s.archived)
       .filter((s) => !ownedByMe || s.created_by === currentUserId)
       .filter((s) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(s)))
       .sort(byTimestamp((s) => s.last_updated));

--- a/apps/agor-ui/src/components/GlobalSearch/useRecents.test.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useRecents.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Recents must not surface archived sessions.
+ *
+ * `useAgorData` deliberately keeps archived sessions in `sessionById` so a
+ * direct `/s/<id>` link can still open an archived session's drawer, which
+ * makes filtering each consumer's responsibility. Artifacts and boards already
+ * filter here; sessions did not.
+ */
+
+import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useRecents } from './useRecents';
+
+const USER_ID = 'user-1';
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'session-1',
+    branch_id: 'branch-1',
+    created_by: USER_ID,
+    archived: false,
+    title: 'Active session',
+    last_updated: '2026-08-12T10:00:00.000Z',
+    ...overrides,
+  } as unknown as Session;
+}
+
+function renderRecents(sessions: Session[]) {
+  return renderHook(() =>
+    useRecents({
+      currentUserId: USER_ID,
+      sessionById: new Map(sessions.map((s) => [s.session_id, s])),
+      branchById: new Map<string, Branch>(),
+      artifactById: new Map<string, Artifact>(),
+      boardById: new Map<string, Board>(),
+      mcpServerById: new Map<string, MCPServer>(),
+    })
+  );
+}
+
+describe('useRecents', () => {
+  it('omits archived sessions', () => {
+    const { result } = renderRecents([
+      makeSession({ session_id: 'active', title: 'Active session' }),
+      makeSession({ session_id: 'gone', title: 'Archived session', archived: true }),
+    ]);
+
+    const ids = result.current.session.map((r) => (r.item as Session).session_id);
+
+    expect(ids).toEqual(['active']);
+  });
+
+  it('does not let archived sessions consume a recents slot', () => {
+    // RECENTS_SECTION_LIMIT is 3. Four archived sessions sort ahead of the one
+    // active session, so filtering after the slice would return nothing.
+    const sessions = [
+      ...Array.from({ length: 4 }, (_, i) =>
+        makeSession({
+          session_id: `archived-${i}`,
+          archived: true,
+          last_updated: `2026-08-12T12:0${i}:00.000Z`,
+        })
+      ),
+      makeSession({ session_id: 'active', last_updated: '2026-08-12T09:00:00.000Z' }),
+    ];
+
+    const { result } = renderRecents(sessions);
+
+    expect(result.current.session.map((r) => (r.item as Session).session_id)).toEqual(['active']);
+  });
+});

--- a/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
@@ -36,6 +36,7 @@ export function useRecents({
     if (!currentUserId) return EMPTY_RESULTS;
 
     const sessions = Array.from(sessionById.values())
+      .filter((s) => !s.archived)
       .filter((s) => s.created_by === currentUserId)
       .sort(byTimestamp((s) => s.last_updated))
       .slice(0, RECENTS_SECTION_LIMIT);

--- a/apps/agor-ui/src/components/ScheduleRunsPanel/ScheduleRunsPanel.tsx
+++ b/apps/agor-ui/src/components/ScheduleRunsPanel/ScheduleRunsPanel.tsx
@@ -67,6 +67,7 @@ export const ScheduleRunsPanel: React.FC<ScheduleRunsPanelProps> = ({
       const result = await client.service('sessions').find({
         query: {
           schedule_id: schedule.schedule_id,
+          archived: false,
           $sort: { scheduled_run_at: -1 },
           $limit: RUNS_LIMIT,
         },


### PR DESCRIPTION
## What

Filters archived sessions out of the three surfaces that were still showing them: global search
results, the search "Recents" dropdown, and the schedule Runs panel.

## Why

After archiving a branch, its sessions are correctly cascade-archived — but they kept appearing in
global search and schedule runs, so archived work stayed visible with no branch behind it.

## How

`useAgorData` **deliberately** keeps archived sessions in the `sessionById` map so a direct
`/s/<id>` link can still open an archived session's drawer. Filtering is therefore each consumer's
responsibility. Artifacts and boards already did this in these very functions; sessions were missed.

| Surface | File | Change |
|---|---|---|
| Search results | `GlobalSearch/useGlobalSearch.ts` | `.filter((s) => !s.archived)` |
| Recents dropdown | `GlobalSearch/useRecents.ts` | `.filter((s) => !s.archived)` |
| Schedule Runs panel | `ScheduleRunsPanel/ScheduleRunsPanel.tsx` | `archived: false` in the `sessions.find()` query |

In `useRecents` the filter goes **before** the `.slice(0, RECENTS_SECTION_LIMIT)`, not after —
otherwise archived rows consume the section's limited slots and legitimately-active sessions get
pushed out entirely. There is a regression test for exactly that case.

### Scope — why not the backend default

The issue suggests defaulting `archived: false` on the sessions `find` hook as the more robust fix.
I deliberately went with the three-surface fix it lists as the alternative, because the hook version:

- changes default behaviour of a public API **and the MCP surface** (`agor_sessions_*`), not just
  the UI — any caller relying on today's unfiltered default would silently change;
- works against `useAgorData`, which *intentionally* fetches archived sessions for direct links, so
  it would need a new opt-out threaded through callers.

Happy to switch to the hook approach if you'd prefer it — glad to follow up.

## Testing

- **New:** `useGlobalSearch.test.ts` and `useRecents.test.ts` — 4 tests covering archived sessions
  excluded from results, excluded from Recents, not counted in the chip badge, and not consuming
  recents slots. All four **fail on `main` and pass with this change.**
- Full `agor-ui` suite: **1342 passed** across 198 files.
- `pnpm typecheck` (21/21) and `pnpm lint` both clean.
- Manually verified on a local instance: archive a session, then Cmd+K — it no longer appears.

**Not covered by an automated test:** the `ScheduleRunsPanel` query change. That component has no
existing test file and testing a one-line query change would mean standing up a Feathers client
mock; I verified it manually instead rather than writing an assertion that just restates the query
object. Happy to add one if you'd like it covered.

## Video demo


https://github.com/user-attachments/assets/dd3ba26a-6bcc-4fef-96c5-56affed31f36




Closes #1771
