### PR TITLE
fix(security): decouple session Unix identity checks from branch RBAC

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -140,6 +140,38 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/missing task scope/);
   });
 
+  /**
+   * The custom prompt/run routes admit their Task through the repository, so
+   * neither `protectExternalTaskCreate` nor the `tasks.create` chain ever sees
+   * them, and their own gate is role-only. What keeps a live executor token off
+   * them is this guard: `registerAuthenticatedRoute` splices it into every
+   * method named in a route's authConfig (`utils/authorization.ts`), and an
+   * endpoint the allowlist does not name fails closed.
+   *
+   * That containment is what the executor exemption in
+   * `validateSessionUnixUsername` rests on, and nothing else pinned it.
+   */
+  it.each(['sessions/:id/prompt', 'sessions/:id/spawn-prompt', 'tasks/:id/run'])(
+    'refuses an executor-session token on the custom route %s',
+    async (path) => {
+      const context = ctx({
+        path,
+        method: 'create',
+        data: { prompt: 'queue me' },
+        params: {
+          authentication: { payload },
+          query: {},
+          provider: 'rest',
+          route: { id: 'session-1' },
+        },
+      });
+
+      await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+        /not valid for this endpoint/
+      );
+    }
+  );
+
   it('narrows branch find queries to branch scope', async () => {
     const context = ctx({ path: 'branches', method: 'find' });
 

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -53,6 +53,20 @@ export function hasExecutorRuntimeScope(context: HookContext): boolean {
   return scopedPayload(context) !== null;
 }
 
+/**
+ * The session an executor-session token is scoped to, or undefined when the
+ * request carries no executor scope.
+ *
+ * Callers that exempt executors from a per-session rule should compare against
+ * this rather than {@link hasExecutorRuntimeScope}, so the exemption is bound to
+ * the session it was minted for instead of depending on
+ * {@link executorRuntimeScopeGuard} having pinned the claims upstream.
+ */
+export function executorRuntimeScopeSessionId(context: HookContext): string | undefined {
+  const payload = scopedPayload(context);
+  return payload ? getExecutorSessionTokenSessionId(payload) : undefined;
+}
+
 function expectClaim(claim: string | undefined, label: string): string {
   if (!claim) {
     throw new Forbidden(`Executor token is missing ${label} scope`);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -731,7 +731,6 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     app,
     config: effectiveConfig,
     jwtSecret,
-    branchRbacEnabled,
     requireAuth,
     superadminOpts,
     sessionsService: services.sessionsService,

--- a/apps/agor-daemon/src/register-hooks.knowledge-realtime.test.ts
+++ b/apps/agor-daemon/src/register-hooks.knowledge-realtime.test.ts
@@ -37,7 +37,6 @@ describe('Knowledge command realtime suppression', () => {
         multi_tenancy: { mode: 'static', static_tenant_id: 'registration-test' },
       } as RegisterHooksContext['config'],
       jwtSecret: 'registration-test-secret',
-      branchRbacEnabled: false,
       requireAuth: async (context) => context,
       superadminOpts: { allowSuperadmin: true },
       sessionsService: {} as RegisterHooksContext['sessionsService'],

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -794,9 +794,9 @@ describe('registered file service RBAC database preload', () => {
         config: {
           database: { dialect: 'postgresql' },
           multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-a' },
+          execution: { branch_rbac: true },
         } as RegisterHooksContext['config'],
         jwtSecret: 'registration-test-secret',
-        branchRbacEnabled: true,
         requireAuth: async (context) => context,
         superadminOpts: { allowSuperadmin: true },
         sessionsService: sessionsService as RegisterHooksContext['sessionsService'],

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -325,9 +325,9 @@ describe('tenant-owned service registration', () => {
       config: {
         database: { dialect: 'postgresql' },
         multi_tenancy: { mode: 'static', static_tenant_id: 'registration-test' },
+        execution: { branch_rbac: false },
       } as RegisterHooksContext['config'],
       jwtSecret: 'registration-test-secret',
-      branchRbacEnabled: false,
       requireAuth: async (context) => context,
       superadminOpts: { allowSuperadmin: true },
       sessionsService: {} as RegisterHooksContext['sessionsService'],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1115,6 +1115,41 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Helper to get usersService from app
   const usersService = app.service('users');
 
+  /**
+   * Authorization chain shared by the two externally-initiated prompt writes,
+   * `messages.create` and `tasks.create`.
+   *
+   * Two independently configured properties put hooks in here:
+   *
+   *  - `branch_rbac` decides whether the caller may prompt in this branch.
+   *  - `unix_user_mode` decides whether the session may execute at all. A
+   *    session is stamped with its creator's `unix_username` at creation and
+   *    `delegated`/`strict` execute under that value (register-services.ts
+   *    feeds it to `resolveUnixUserForImpersonation`). Once the creator's
+   *    username changes, the stamp names an identity the user no longer has
+   *    and the SDK state lives in a home directory this instance cannot
+   *    reach, so the prompt must be refused — branch permissions have no
+   *    bearing on that, and an open-access instance can still run strict.
+   *
+   * The session load is the precondition of both halves and is memoised per
+   * request, so whichever combination is configured pays for it once.
+   */
+  const promptWriteGuards = [
+    ...(executionMode.appRbacEnabled || executionMode.requiresUserUnixUsername
+      ? [
+          resolveSessionContext(),
+          loadSession(sessionsService),
+          validateSessionUnixUsername(usersRepository),
+        ]
+      : []),
+    ...(executionMode.appRbacEnabled
+      ? [
+          loadBranchFromSession(branchRepository),
+          ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
+        ]
+      : []),
+  ];
+
   // ============================================================================
   // Messages hooks
   // ============================================================================
@@ -1149,15 +1184,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireMinimumRole(ROLES.MEMBER, 'create messages'),
         protectWidgetMessageWrites,
         protectPermissionMessageWrites,
-        ...(executionMode.appRbacEnabled
-          ? [
-              resolveSessionContext(),
-              loadSession(sessionsService),
-              validateSessionUnixUsername(usersRepository), // Defensive check: session.unix_username must match creator's current unix_username
-              loadBranchFromSession(branchRepository),
-              ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
-            ]
-          : []),
+        ...promptWriteGuards,
         // Detect "no credential resolved for this session's provider"
         // structurally, never by matching raw provider error text. Drives the
         // Connect-AI empty state instead of a raw "/login" message.
@@ -3136,15 +3163,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create tasks'),
-        ...(executionMode.appRbacEnabled
-          ? [
-              resolveSessionContext(),
-              loadSession(sessionsService),
-              validateSessionUnixUsername(usersRepository), // Defensive check: session.unix_username must match creator's current unix_username
-              loadBranchFromSession(branchRepository),
-              ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
-            ]
-          : []),
+        ...promptWriteGuards,
         protectExternalTaskCreate,
         injectCreatedBy(),
       ],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1279,7 +1279,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       // rows. The service composes this marker into an object-specific SQL
       // predicate: branch-bound rows require branch access; loose rows require
       // board visibility.
-      find: [...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : [])],
+      find: [
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
+      ],
     },
   });
 
@@ -3092,7 +3094,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       find: [
-        ...(executionMode.appRbacEnabled ? [scopeScheduleQuery(scheduleRepository, superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled
+          ? [scopeScheduleQuery(scheduleRepository, superadminOpts)]
+          : []),
       ],
       get: [
         ...(executionMode.appRbacEnabled

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1126,9 +1126,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
    *  - `branch_rbac` decides whether the caller may prompt in this branch.
    *  - `unix_user_mode` decides whether the session may execute as the
    *    identity it was stamped with. Only `delegated`/`strict` consume the
-   *    stamp — `register-services.ts` feeds `session.unix_username` to
-   *    `resolveUnixUserForImpersonation`, which ignores it in `simple` and
-   *    `insulated`. Once the creator's username changes, the stamp names an
+   *    stamp *as an execution identity* — `register-services.ts` feeds
+   *    `session.unix_username` to `resolveUnixUserForImpersonation`, which
+   *    ignores it in `simple` and `insulated`. (`insulated` reads the stamp
+   *    too, but for Unix group membership in `unix.sync-branch`, which no
+   *    prompt write triggers.) Once the creator's username changes, the
+   *    stamp names an
    *    identity the user no longer has and the SDK state lives in a home
    *    directory this instance cannot reach, so the prompt is refused. Branch
    *    permissions have no bearing on that: an open-access instance can be

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -418,7 +418,6 @@ export interface RegisterHooksContext {
   app: Application & { io?: import('socket.io').Server };
   config: AgorConfig;
   jwtSecret: string;
-  branchRbacEnabled: boolean;
   requireAuth: (context: HookContext) => Promise<HookContext>;
   superadminOpts: { allowSuperadmin: boolean };
   realtimeRelay?: Pick<RedisRealtimeRuntime, 'relay' | 'setRelayHandler'>;
@@ -714,7 +713,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     app,
     config,
     jwtSecret,
-    branchRbacEnabled,
     requireAuth,
     superadminOpts,
     sessionsService,
@@ -1135,10 +1133,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // RBAC: Scope messages.find() to sessions the caller can access.
         // Without this backstop, any authenticated member could list messages
         // across every session/branch by omitting the session_id filter.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -1151,7 +1149,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireMinimumRole(ROLES.MEMBER, 'create messages'),
         protectWidgetMessageWrites,
         protectPermissionMessageWrites,
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -1173,7 +1171,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       update: [protectWidgetMessageWrites, protectPermissionMessageWrites],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -1186,7 +1184,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       remove: [
         requireMinimumRole(ROLES.MEMBER, 'delete messages'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -1249,7 +1247,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       // rows. The service composes this marker into an object-specific SQL
       // predicate: branch-bound rows require branch access; loose rows require
       // board visibility.
-      find: [...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : [])],
+      find: [...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : [])],
     },
   });
 
@@ -1271,7 +1269,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       find: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [scopeFindToAccessibleBoards(new BoardRepository(db), superadminOpts)]
           : []),
       ],
@@ -1319,7 +1317,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // Scope find() to the branches the caller can access. The service pushes
         // this into SQL as a correlated visibility predicate rather than
         // preloading ids and injecting `branch_id IN (...)`.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts'), injectCreatedBy()],
       publishFromExecutor: [requireMinimumRole(ROLES.MEMBER, 'publish artifacts')],
@@ -1557,7 +1555,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // Board comments inherit board visibility for pure board/spatial
         // comments and branch/session/task/message visibility for attached
         // comments. The service pushes the marker into SQL.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create board comments'), injectCreatedBy()],
       update: [requireMinimumRole(ROLES.MEMBER, 'update board comments')],
@@ -1600,10 +1598,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       find: [
         // RBAC: mark external regular-user finds for BranchesService to compose
         // the shared branch visibility predicate directly into its SQL read.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
       ],
       get: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               loadBranch(branchRepository),
               ensureCanView(superadminOpts), // Require 'view' permission to read branch
@@ -1628,7 +1626,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         protectServerManagedUnixGroupWrites('branch'),
         requireAdminForEnvConfig(),
         validateBranchEnvPolicyHook(config),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               loadBranch(branchRepository),
               ensureBranchPermission('all', 'update branches', superadminOpts), // Require 'all' permission to update
@@ -1656,7 +1654,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [
         requireMinimumRole(ROLES.MEMBER, 'delete branches'),
         loadBranch(branchRepository),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               ensureBranchPermission('all', 'delete branches', superadminOpts), // Require 'all' permission to delete
             ]
@@ -1666,7 +1664,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
     after: {
       create: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               async (context: HookContext) => {
                 // RBAC: Add the creator as the initial branch owner
@@ -2049,7 +2047,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       find: [
         // RBAC: Scope to sessions the caller can access.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
     },
     after: {
@@ -2306,7 +2304,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // that branch before running git ls-files. If sessionId is missing
         // the service itself returns []; we skip the permission check in that
         // case rather than throwing.
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               createTenantScopedBeforeHookChain(db, async (context: HookContext) => {
                 if (!context.params.provider) return context;
@@ -2334,7 +2332,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [
         requireAuth,
         requireMinimumRole(ROLES.MEMBER, 'read files'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               createTenantScopedBeforeHookChain(
                 db,
@@ -2766,7 +2764,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   configureRealtimePublish({
     app,
     db,
-    branchRbacEnabled,
+    branchRbacEnabled: executionMode.appRbacEnabled,
     branchRepository,
     sessionsRepository,
     accessCache: realtimeAccessCache,
@@ -2787,7 +2785,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     // independently of branch_rbac, so their immutability cannot be conditional
     // on it — an open-access instance can still be running delegated or strict.
     ensureSessionImmutability(),
-    ...(branchRbacEnabled
+    ...(executionMode.appRbacEnabled
       ? [
           resolveSessionContext(),
           loadSession(sessionsService),
@@ -2840,10 +2838,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       find: [
         // RBAC: mark external regular-user finds for SessionsService to compose
         // the shared branch visibility predicate directly into its SQL read.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               // Load session's branch and check permissions
               loadSessionBranch(sessionsService, branchRepository),
@@ -2857,10 +2855,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // registered without RBAC when the Unix mode (strict/delegated) makes
         // unix_username load-bearing — otherwise sessions would be stamped
         // null and fail only at prompt time.
-        ...(branchRbacEnabled || executionMode.requiresUserUnixUsername
+        ...(executionMode.appRbacEnabled || executionMode.requiresUserUnixUsername
           ? [setSessionUnixUsername(usersRepository, executionMode.unixUserMode)]
           : []),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               // Check branch permission BEFORE injecting created_by (need branch_id)
               async (context: HookContext) => {
@@ -2931,7 +2929,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       update: sessionWriteGuards,
       patch: sessionWriteGuards,
       remove: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -3062,10 +3060,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       find: [
-        ...(branchRbacEnabled ? [scopeScheduleQuery(scheduleRepository, superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeScheduleQuery(scheduleRepository, superadminOpts)] : []),
       ],
       get: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               loadScheduleAndBranch(scheduleRepository, branchRepository),
               ensureCanView(superadminOpts),
@@ -3074,7 +3072,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create schedules'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [loadBranch(branchRepository, 'branch_id'), ensureCanCreateSession(superadminOpts)]
           : []),
         enforcePublicWriteFields('Schedule', SCHEDULE_CREATE_WRITE_FIELDS),
@@ -3085,7 +3083,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update schedules'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               loadScheduleAndBranch(scheduleRepository, branchRepository),
               ensureCanModifySchedule(superadminOpts),
@@ -3104,7 +3102,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       remove: [
         requireMinimumRole(ROLES.MEMBER, 'delete schedules'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               loadScheduleAndBranch(scheduleRepository, branchRepository),
               ensureBranchPermission('all', 'delete schedule', superadminOpts),
@@ -3124,10 +3122,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [typedValidateQuery(taskQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: Scope tasks.find() to sessions the caller can access.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -3138,7 +3136,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create tasks'),
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -3152,7 +3150,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         protectServerManagedTaskWrites,
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -3170,7 +3168,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // RBAC: deleting a task requires 'all' permission on the branch
         // (mirrors sessions.remove). Without this, any member with 'session'
         // access could delete tasks owned by other users on shared branches.
-        ...(branchRbacEnabled
+        ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
               loadSession(sessionsService),
@@ -3191,7 +3189,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const boardRepository = new BoardRepository(db);
   const ensureBoardAccess = (mode: 'view' | 'mutate', action: string) => {
     return async (context: HookContext) => {
-      if (!branchRbacEnabled || !context.params.provider) return context;
+      if (!executionMode.appRbacEnabled || !context.params.provider) return context;
       const user = context.params.user;
       if (!user) throw new NotAuthenticated('Authentication required');
       if (user._isServiceAccount) return context;
@@ -3255,7 +3253,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // RBAC: restrict boards.find to boards the caller created or has a
         // branch on. The service pushes this into the repository query as one
         // SQL predicate, avoiding a preloaded `board_id IN (...)` list.
-        ...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
+        ...(executionMode.appRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
       ],
       get: [ensureCanViewBoard('view this board')],
       findBySlug: [ensureCanViewBoard('view this board')],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1126,18 +1126,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
    *  - `branch_rbac` decides whether the caller may prompt in this branch.
    *  - `unix_user_mode` decides whether the session may execute as the
    *    identity it was stamped with. Only `delegated`/`strict` consume the
-   *    stamp *as an execution identity* — `register-services.ts` feeds
+   *    stamp *as the executor's OS identity* — `register-services.ts` feeds
    *    `session.unix_username` to `resolveUnixUserForImpersonation`, which
-   *    ignores it in `simple` and `insulated`. (`insulated` reads the stamp
-   *    too, but for Unix group membership in `unix.sync-branch`, which no
-   *    prompt write triggers.) Once the creator's username changes, the
-   *    stamp names an
-   *    identity the user no longer has and the SDK state lives in a home
-   *    directory this instance cannot reach, so the prompt is refused. Branch
-   *    permissions have no bearing on that: an open-access instance can be
-   *    running strict, and an RBAC instance can be running simple, where
-   *    refusing would only lock a user out of their own sessions over an
-   *    identity nothing executes as.
+   *    never reads it in the `simple` or `insulated` arms. (`insulated` does
+   *    read the stamp, but for Unix group membership in `unix.sync-branch`,
+   *    which no prompt write triggers.) Once the creator's username changes,
+   *    the stamp names an identity the user no longer has and the SDK state
+   *    lives in a home directory this instance cannot reach, so the prompt is
+   *    refused. Branch permissions have no bearing on that: an open-access
+   *    instance can be running strict, and an RBAC instance can be running
+   *    simple, where refusing would only lock a user out of their own sessions
+   *    over an identity nothing executes as.
    *
    * The session load is the precondition of both, and is memoised per request.
    */

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1119,28 +1119,31 @@ export function registerHooks(ctx: RegisterHooksContext): void {
    * Authorization chain shared by the two externally-initiated prompt writes,
    * `messages.create` and `tasks.create`.
    *
-   * Two independently configured properties put hooks in here:
+   * Two independently configured properties put hooks in here, and each hook
+   * is gated on the one that makes it load-bearing rather than on whichever
+   * flag happens to be nearby:
    *
    *  - `branch_rbac` decides whether the caller may prompt in this branch.
-   *  - `unix_user_mode` decides whether the session may execute at all. A
-   *    session is stamped with its creator's `unix_username` at creation and
-   *    `delegated`/`strict` execute under that value (register-services.ts
-   *    feeds it to `resolveUnixUserForImpersonation`). Once the creator's
-   *    username changes, the stamp names an identity the user no longer has
-   *    and the SDK state lives in a home directory this instance cannot
-   *    reach, so the prompt must be refused — branch permissions have no
-   *    bearing on that, and an open-access instance can still run strict.
+   *  - `unix_user_mode` decides whether the session may execute as the
+   *    identity it was stamped with. Only `delegated`/`strict` consume the
+   *    stamp — `register-services.ts` feeds `session.unix_username` to
+   *    `resolveUnixUserForImpersonation`, which ignores it in `simple` and
+   *    `insulated`. Once the creator's username changes, the stamp names an
+   *    identity the user no longer has and the SDK state lives in a home
+   *    directory this instance cannot reach, so the prompt is refused. Branch
+   *    permissions have no bearing on that: an open-access instance can be
+   *    running strict, and an RBAC instance can be running simple, where
+   *    refusing would only lock a user out of their own sessions over an
+   *    identity nothing executes as.
    *
-   * The session load is the precondition of both halves and is memoised per
-   * request, so whichever combination is configured pays for it once.
+   * The session load is the precondition of both, and is memoised per request.
    */
   const promptWriteGuards = [
     ...(executionMode.appRbacEnabled || executionMode.requiresUserUnixUsername
-      ? [
-          resolveSessionContext(),
-          loadSession(sessionsService),
-          validateSessionUnixUsername(usersRepository),
-        ]
+      ? [resolveSessionContext(), loadSession(sessionsService)]
+      : []),
+    ...(executionMode.requiresUserUnixUsername
+      ? [validateSessionUnixUsername(usersRepository)]
       : []),
     ...(executionMode.appRbacEnabled
       ? [

--- a/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
+++ b/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
@@ -109,17 +109,17 @@ const buildHarness = (options: {
  * session token minted for the prompting user, so it is an ordinary user
  * identity on the wire and only the token payload marks it as executor-scoped.
  */
-const EXECUTOR_AUTHENTICATION = {
+const executorAuthentication = (sessionId: string) => ({
   payload: {
     type: 'executor-session',
     purpose: 'executor-task',
-    session_id: SESSION_ID,
+    session_id: sessionId,
     task_id: '00000000-0000-7000-8000-000000000004',
   },
-};
+});
 
 /** An external prompt write, as the REST/socket transports deliver it. */
-const makeContext = (path: 'messages' | 'tasks', asExecutor = false): HookContext =>
+const makeContext = (path: 'messages' | 'tasks', asExecutor: false | string = false): HookContext =>
   ({
     path,
     method: 'create',
@@ -131,14 +131,14 @@ const makeContext = (path: 'messages' | 'tasks', asExecutor = false): HookContex
       provider: 'rest',
       user: { user_id: CREATOR_ID, role: 'member' },
       query: {},
-      ...(asExecutor ? { authentication: EXECUTOR_AUTHENTICATION } : {}),
+      ...(asExecutor ? { authentication: executorAuthentication(asExecutor) } : {}),
     },
   }) as unknown as HookContext;
 
 const runCreateChain = async (
   harness: Harness,
   path: 'messages' | 'tasks',
-  asExecutor = false
+  asExecutor: false | string = false
 ): Promise<void> => {
   const chain = harness.chains.get(`${path}.create`);
   if (!chain?.length) throw new Error(`no before.create hooks captured for ${path}`);
@@ -192,8 +192,25 @@ describe.each(PROMPT_WRITES)('%s.create — session unix identity drift', (path)
         creatorUnixUsername: 'alice-renamed',
       });
 
-      await expect(runCreateChain(harness, path, true)).resolves.toBeUndefined();
+      await expect(runCreateChain(harness, path, SESSION_ID)).resolves.toBeUndefined();
       expect(harness.userReads).toBe(0);
+    });
+
+    /**
+     * The exemption is bound to the token's own session claim rather than to
+     * "an executor token is present", so it cannot be widened by registering
+     * this hook where `executorRuntimeScopeGuard` has not pinned the claims.
+     */
+    it('does not exempt an executor token scoped to another session', async () => {
+      const harness = buildHarness({
+        branchRbac: false,
+        unixUserMode,
+        creatorUnixUsername: 'alice-renamed',
+      });
+
+      await expect(
+        runCreateChain(harness, path, '00000000-0000-7000-8000-00000000000f')
+      ).rejects.toThrow(/Session security context has changed/);
     });
   });
 
@@ -212,9 +229,12 @@ describe.each(PROMPT_WRITES)('%s.create — session unix identity drift', (path)
     });
 
     // The branch-permission half of the chain is deliberately not stubbed: this
-    // asserts which hooks are registered, not what they decide.
+    // asserts which hooks are registered, not what they decide. Pin the failure
+    // it does produce, so stubbing `branchRepository` later cannot turn the
+    // negative assertion below into a no-op against `undefined`.
     const failure = await runCreateChain(harness, path).catch((error: Error) => error);
 
+    expect(String(failure)).toMatch(/is not a function/);
     expect(String(failure)).not.toMatch(/Session security context has changed/);
     expect(harness.userReads).toBe(0);
     expect(harness.sessionReads).toBe(1);

--- a/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
+++ b/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
@@ -104,8 +104,22 @@ const buildHarness = (options: {
   return harness;
 };
 
+/**
+ * A running executor writing its own transcript. It authenticates with a
+ * session token minted for the prompting user, so it is an ordinary user
+ * identity on the wire and only the token payload marks it as executor-scoped.
+ */
+const EXECUTOR_AUTHENTICATION = {
+  payload: {
+    type: 'executor-session',
+    purpose: 'executor-task',
+    session_id: SESSION_ID,
+    task_id: '00000000-0000-7000-8000-000000000004',
+  },
+};
+
 /** An external prompt write, as the REST/socket transports deliver it. */
-const makeContext = (path: 'messages' | 'tasks'): HookContext =>
+const makeContext = (path: 'messages' | 'tasks', asExecutor = false): HookContext =>
   ({
     path,
     method: 'create',
@@ -117,13 +131,18 @@ const makeContext = (path: 'messages' | 'tasks'): HookContext =>
       provider: 'rest',
       user: { user_id: CREATOR_ID, role: 'member' },
       query: {},
+      ...(asExecutor ? { authentication: EXECUTOR_AUTHENTICATION } : {}),
     },
   }) as unknown as HookContext;
 
-const runCreateChain = async (harness: Harness, path: 'messages' | 'tasks'): Promise<void> => {
+const runCreateChain = async (
+  harness: Harness,
+  path: 'messages' | 'tasks',
+  asExecutor = false
+): Promise<void> => {
   const chain = harness.chains.get(`${path}.create`);
   if (!chain?.length) throw new Error(`no before.create hooks captured for ${path}`);
-  let context = makeContext(path);
+  let context = makeContext(path, asExecutor);
   for (const hook of chain) {
     context = ((await hook(context)) as HookContext) ?? context;
   }
@@ -158,18 +177,47 @@ describe.each(PROMPT_WRITES)('%s.create — session unix identity drift', (path)
       expect(harness.sessionReads).toBe(1);
       expect(harness.userReads).toBe(1);
     });
+
+    /**
+     * A running executor writes its transcript over its own authenticated
+     * transport, so it reaches this chain as a normal user. Holding it to the
+     * check would cost two reads per transcript row and, once a rename landed
+     * mid-task, would drop the rows of a process that is already running as the
+     * stamped user — the launch it could have prevented is long past.
+     */
+    it('exempts the executor writing its own transcript', async () => {
+      const harness = buildHarness({
+        branchRbac: false,
+        unixUserMode,
+        creatorUnixUsername: 'alice-renamed',
+      });
+
+      await expect(runCreateChain(harness, path, true)).resolves.toBeUndefined();
+      expect(harness.userReads).toBe(0);
+    });
   });
 
-  it('still refuses under branch_rbac with a Unix mode that stamps nothing', async () => {
+  /**
+   * `simple` and `insulated` never execute as the stamped identity —
+   * `resolveUnixUserForImpersonation` ignores `session.unix_username` in both —
+   * so refusing on drift there would lock a user out of their own sessions over
+   * an identity nothing runs as. RBAC still stamps sessions in those modes,
+   * which is what used to make the check fire.
+   */
+  it('does not consult the creator under branch_rbac when the mode ignores the stamp', async () => {
     const harness = buildHarness({
       branchRbac: true,
       unixUserMode: 'simple',
       creatorUnixUsername: 'alice-renamed',
     });
 
-    await expect(runCreateChain(harness, path)).rejects.toThrow(
-      /Session security context has changed/
-    );
+    // The branch-permission half of the chain is deliberately not stubbed: this
+    // asserts which hooks are registered, not what they decide.
+    const failure = await runCreateChain(harness, path).catch((error: Error) => error);
+
+    expect(String(failure)).not.toMatch(/Session security context has changed/);
+    expect(harness.userReads).toBe(0);
+    expect(harness.sessionReads).toBe(1);
   });
 
   /**

--- a/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
+++ b/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
@@ -1,0 +1,190 @@
+/**
+ * A session is stamped with its creator's `unix_username` at creation, and in
+ * `delegated`/`strict` that stamp is the OS identity the executor runs as. If
+ * an admin later changes the user's `unix_username`, the stamp names an
+ * identity the user no longer owns and the SDK state sits in a home directory
+ * the instance cannot read, so the prompt has to be refused.
+ *
+ * That property comes from `unix_user_mode` alone, but `validateSessionUnixUsername`
+ * used to be registered only inside the `branch_rbac` spread — so an
+ * open-access instance running `strict` kept executing prompts as the stale
+ * user, while the same request was refused once RBAC was on.
+ *
+ * These tests run the before-create chains that `registerHooks` actually
+ * installs, rather than calling the validator directly: the bug was never in
+ * the validator, it was in whether the validator was reached.
+ */
+
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks';
+
+type RegisteredHook = (context: HookContext) => unknown;
+
+const SESSION_ID = '00000000-0000-7000-8000-000000000001';
+const BRANCH_ID = '00000000-0000-7000-8000-000000000002';
+const CREATOR_ID = '00000000-0000-7000-8000-000000000003';
+
+interface Harness {
+  chains: Map<string, RegisteredHook[]>;
+  sessionReads: number;
+  userReads: number;
+}
+
+/**
+ * Register the real hooks against a recording stand-in for the Feathers app,
+ * with session/user stubs wired in so the captured chain can be executed.
+ */
+const buildHarness = (options: {
+  branchRbac: boolean;
+  unixUserMode: 'simple' | 'delegated' | 'insulated' | 'strict';
+  /** Creator's `unix_username` today; the session is always stamped 'alice'. */
+  creatorUnixUsername: string | null;
+}): Harness => {
+  const harness: Harness = { chains: new Map(), sessionReads: 0, userReads: 0 };
+
+  const app = {
+    service(path: string) {
+      return {
+        // `strict` also subscribes to service events to materialize Unix
+        // groups; nothing here exercises that path.
+        on() {},
+        hooks(hooks: { before?: Record<string, RegisteredHook[]> }) {
+          const key = path.replace(/^\//, '');
+          for (const [method, chain] of Object.entries(hooks?.before ?? {})) {
+            const mapKey = `${key}.${method}`;
+            harness.chains.set(mapKey, [...(harness.chains.get(mapKey) ?? []), ...(chain ?? [])]);
+          }
+        },
+      };
+    },
+    use() {},
+    publish() {},
+  };
+
+  const sessionsService = {
+    async get(sessionId: string) {
+      harness.sessionReads += 1;
+      return {
+        session_id: sessionId,
+        branch_id: BRANCH_ID,
+        created_by: CREATOR_ID,
+        unix_username: 'alice',
+      };
+    },
+  };
+
+  const usersRepository = {
+    async findById(userId: string) {
+      harness.userReads += 1;
+      return { user_id: userId, unix_username: options.creatorUnixUsername };
+    },
+  };
+
+  registerHooks({
+    db: {} as RegisterHooksContext['db'],
+    app: app as unknown as RegisterHooksContext['app'],
+    config: {
+      database: { dialect: 'postgresql' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'unix-identity-drift-test' },
+      execution: { branch_rbac: options.branchRbac, unix_user_mode: options.unixUserMode },
+    } as RegisterHooksContext['config'],
+    jwtSecret: 'unix-identity-drift-test-secret',
+    deployment: { mode: 'standalone' },
+    requireAuth: async (context) => context,
+    superadminOpts: { allowSuperadmin: true },
+    sessionsService: sessionsService as unknown as RegisterHooksContext['sessionsService'],
+    messagesService: {} as RegisterHooksContext['messagesService'],
+    boardsService: undefined,
+    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    usersRepository: usersRepository as unknown as RegisterHooksContext['usersRepository'],
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+  });
+
+  return harness;
+};
+
+/** An external prompt write, as the REST/socket transports deliver it. */
+const makeContext = (path: 'messages' | 'tasks'): HookContext =>
+  ({
+    path,
+    method: 'create',
+    data:
+      path === 'messages'
+        ? { session_id: SESSION_ID, role: 'user', content: 'ship it' }
+        : { session_id: SESSION_ID, full_prompt: 'ship it' },
+    params: {
+      provider: 'rest',
+      user: { user_id: CREATOR_ID, role: 'member' },
+      query: {},
+    },
+  }) as unknown as HookContext;
+
+const runCreateChain = async (harness: Harness, path: 'messages' | 'tasks'): Promise<void> => {
+  const chain = harness.chains.get(`${path}.create`);
+  if (!chain?.length) throw new Error(`no before.create hooks captured for ${path}`);
+  let context = makeContext(path);
+  for (const hook of chain) {
+    context = ((await hook(context)) as HookContext) ?? context;
+  }
+};
+
+const PROMPT_WRITES = ['messages', 'tasks'] as const;
+const IDENTITY_MODES = ['delegated', 'strict'] as const;
+
+describe.each(PROMPT_WRITES)('%s.create — session unix identity drift', (path) => {
+  describe.each(IDENTITY_MODES)('unix_user_mode: %s, branch_rbac: false', (unixUserMode) => {
+    it('refuses a prompt whose creator has been renamed since session creation', async () => {
+      const harness = buildHarness({
+        branchRbac: false,
+        unixUserMode,
+        creatorUnixUsername: 'alice-renamed',
+      });
+
+      await expect(runCreateChain(harness, path)).rejects.toThrow(
+        /Session security context has changed/
+      );
+      expect(harness.userReads).toBe(1);
+    });
+
+    it('allows a prompt while the creator still owns the stamped identity', async () => {
+      const harness = buildHarness({
+        branchRbac: false,
+        unixUserMode,
+        creatorUnixUsername: 'alice',
+      });
+
+      await expect(runCreateChain(harness, path)).resolves.toBeUndefined();
+      expect(harness.sessionReads).toBe(1);
+      expect(harness.userReads).toBe(1);
+    });
+  });
+
+  it('still refuses under branch_rbac with a Unix mode that stamps nothing', async () => {
+    const harness = buildHarness({
+      branchRbac: true,
+      unixUserMode: 'simple',
+      creatorUnixUsername: 'alice-renamed',
+    });
+
+    await expect(runCreateChain(harness, path)).rejects.toThrow(
+      /Session security context has changed/
+    );
+  });
+
+  /**
+   * The inverse pin. Widening the guard costs one session read plus one user
+   * read per prompt, and the default deployment must not pay either.
+   */
+  it('reads neither session nor creator when RBAC and per-user identity are both off', async () => {
+    const harness = buildHarness({
+      branchRbac: false,
+      unixUserMode: 'simple',
+      creatorUnixUsername: 'alice-renamed',
+    });
+
+    await expect(runCreateChain(harness, path)).resolves.toBeUndefined();
+    expect(harness.sessionReads).toBe(0);
+    expect(harness.userReads).toBe(0);
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.update-gating.test.ts
+++ b/apps/agor-daemon/src/register-hooks.update-gating.test.ts
@@ -65,12 +65,12 @@ const captureRegisteredHooks = (
     config: {
       database: { dialect: 'postgresql' },
       multi_tenancy: { mode: 'static', static_tenant_id: 'update-gating-test' },
+      execution: { branch_rbac: branchRbacEnabled },
     } as RegisterHooksContext['config'],
     jwtSecret: 'update-gating-test-secret',
     // The HA gates are `before.all` entries, so they cannot satisfy or defeat a
     // per-verb invariant; standalone keeps the captured map to the real hooks.
     deployment: { mode: 'standalone' },
-    branchRbacEnabled,
     requireAuth: async (context) => context,
     superadminOpts: { allowSuperadmin: true },
     sessionsService: {} as RegisterHooksContext['sessionsService'],

--- a/apps/agor-daemon/src/register-hooks.viewer-mcp-floor.test.ts
+++ b/apps/agor-daemon/src/register-hooks.viewer-mcp-floor.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The MCP configuration write floor, driven through the chain `registerHooks`
+ * actually installs.
+ *
+ * `authorizeMcpServerWrite` has refused below-member roles since #2240, but that
+ * could only ever be asserted against the authorizer in isolation: a viewer
+ * could not authenticate at all, because the local strategy read the user back
+ * through a `users.get` gated at member. #2322 fixed that, and in doing so also
+ * removed the blanket `requireMinimumRole(ROLES.MEMBER)` from several `all`
+ * chains — `mcp-servers` now carries only `[typedValidateQuery, requireAuth]`.
+ *
+ * So the floor's enforcement rests entirely on the write hook being registered
+ * on every write verb. That is what this asserts, by running the registered
+ * chain with a viewer identity rather than by calling the authorizer.
+ */
+
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks';
+
+type RegisteredHook = (context: HookContext) => unknown;
+
+const captureChains = (): Map<string, RegisteredHook[]> => {
+  const chains = new Map<string, RegisteredHook[]>();
+  const app = {
+    service(path: string) {
+      return {
+        on() {},
+        hooks(hooks: { before?: Record<string, RegisteredHook[]> }) {
+          const key = path.replace(/^\//, '');
+          for (const [method, chain] of Object.entries(hooks?.before ?? {})) {
+            const mapKey = `${key}.${method}`;
+            chains.set(mapKey, [...(chains.get(mapKey) ?? []), ...(chain ?? [])]);
+          }
+        },
+      };
+    },
+    use() {},
+    publish() {},
+  };
+
+  registerHooks({
+    db: {} as RegisterHooksContext['db'],
+    app: app as unknown as RegisterHooksContext['app'],
+    config: {
+      database: { dialect: 'postgresql' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'viewer-mcp-floor-test' },
+    } as RegisterHooksContext['config'],
+    jwtSecret: 'viewer-mcp-floor-test-secret',
+    deployment: { mode: 'standalone' },
+    requireAuth: async (context) => context,
+    superadminOpts: { allowSuperadmin: true },
+    sessionsService: {} as RegisterHooksContext['sessionsService'],
+    messagesService: {} as RegisterHooksContext['messagesService'],
+    boardsService: undefined,
+    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    usersRepository: {} as RegisterHooksContext['usersRepository'],
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+  });
+
+  return chains;
+};
+
+/** A logged-in viewer creating an MCP server — impossible to express before #2322. */
+const viewerCreate = (): HookContext =>
+  ({
+    path: 'mcp-servers',
+    method: 'create',
+    data: {
+      name: 'exfil',
+      transport: 'http',
+      url: 'https://example.invalid/mcp',
+    },
+    params: {
+      provider: 'rest',
+      user: { user_id: 'viewer-1', role: 'viewer' },
+      query: {},
+    },
+  }) as unknown as HookContext;
+
+describe('MCP write floor for a logged-in viewer', () => {
+  it('registers the write authorizer on every mcp-servers write verb', () => {
+    const chains = captureChains();
+
+    for (const verb of ['create', 'update', 'patch', 'remove']) {
+      expect(chains.get(`mcp-servers.${verb}`)?.length, `mcp-servers.${verb}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('refuses a viewer through the registered create chain', async () => {
+    const chains = captureChains();
+    const chain = chains.get('mcp-servers.create');
+    if (!chain?.length) throw new Error('no before.create hooks captured for mcp-servers');
+
+    let context = viewerCreate();
+    const run = async () => {
+      for (const hook of chain) {
+        context = ((await hook(context)) as HookContext) ?? context;
+      }
+    };
+
+    // The role floor is checked before any policy or database work, so this
+    // refuses without the stub db being touched.
+    await expect(run()).rejects.toThrow(/member access/i);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -40,6 +40,7 @@ import {
   sessions,
   shortId,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   UserMCPOAuthTokenRepository,
   UsersRepository,
   visibleSessionReferenceAccessExists,
@@ -875,7 +876,10 @@ function createExecuteHandler(
   // Only the modes that impersonate per user read the creator back; the others
   // never stamped a `unix_username` for it to have drifted from.
   const unixIdentityGuard = resolveExecutionSecurityMode(config).requiresUserUnixUsername
-    ? { loadCreator: (userId: string) => new UsersRepository(db).findById(userId) }
+    ? {
+        loadCreator: (tenantDb: TenantScopedDatabase) => (userId: string) =>
+          new UsersRepository(tenantDb).findById(userId),
+      }
     : undefined;
 
   return async (

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -872,6 +872,11 @@ function createExecuteHandler(
 ) {
   const { db, app, config, daemonUrl } = ctx;
   const deploymentAgenticToolPolicy = resolveDeploymentAgenticToolPolicy(config);
+  // Only the modes that impersonate per user read the creator back; the others
+  // never stamped a `unix_username` for it to have drifted from.
+  const unixIdentityGuard = resolveExecutionSecurityMode(config).requiresUserUnixUsername
+    ? { loadCreator: (userId: string) => new UsersRepository(db).findById(userId) }
+    : undefined;
 
   return async (
     sessionId: string,
@@ -891,7 +896,8 @@ function createExecuteHandler(
       sessionsService,
       sessionId,
       params,
-      deploymentAgenticToolPolicy
+      deploymentAgenticToolPolicy,
+      unixIdentityGuard
     );
     assertHaTaskPermissionSupported(ctx.deployment, {
       session,

--- a/apps/agor-daemon/src/services/executor-startup.test.ts
+++ b/apps/agor-daemon/src/services/executor-startup.test.ts
@@ -118,6 +118,73 @@ describe('prepareSessionForExecutorStart tenant scope', () => {
     );
   });
 
+  /**
+   * `/sessions/:id/prompt` admits its Task through the repository and treats
+   * the `messages.create` write — where the transport guard lives — as
+   * best-effort, so the launch itself has to refuse a session whose creator no
+   * longer owns the stamped `unix_username`.
+   */
+  describe('stale unix identity', () => {
+    const stampedSession = { ...session, created_by: 'user-1', unix_username: 'alice' } as Session;
+
+    const prepareWithCreator = (creator: { unix_username: string | null } | null) => {
+      const loadCreator = vi.fn(async () => creator);
+      const sessionsService = {
+        get: vi.fn(async () => stampedSession),
+        materializeAgenticToolPreset: vi.fn(async (loaded: Session) => loaded),
+      };
+      const run = runWithTenantContext('tenant-x', () =>
+        prepareSessionForExecutorStart(
+          { run: vi.fn() } as never,
+          sessionsService as never,
+          stampedSession.session_id,
+          {} as never,
+          undefined,
+          { loadCreator }
+        )
+      );
+      return { run, sessionsService, loadCreator };
+    };
+
+    it('refuses the launch when the creator has been renamed', async () => {
+      const { run, sessionsService } = prepareWithCreator({ unix_username: 'alice-renamed' });
+
+      await expect(run).rejects.toThrow(/Session security context has changed/);
+      expect(sessionsService.materializeAgenticToolPreset).not.toHaveBeenCalled();
+    });
+
+    it('refuses the launch when the creator no longer exists', async () => {
+      const { run } = prepareWithCreator(null);
+
+      await expect(run).rejects.toThrow(/Session creator not found/);
+    });
+
+    it('launches while the creator still owns the stamped identity', async () => {
+      const { run, loadCreator } = prepareWithCreator({ unix_username: 'alice' });
+
+      await expect(run).resolves.toBe(stampedSession);
+      expect(loadCreator).toHaveBeenCalledOnce();
+    });
+
+    // `register-services.ts` builds the guard only when the resolved execution
+    // mode requires a per-user `unix_username`; every other mode launches
+    // through this same call with no guard and therefore no creator read.
+    it('launches with no guard at all when the caller supplies none', async () => {
+      const sessionsService = createSessionsService();
+
+      await expect(
+        runWithTenantContext('tenant-x', () =>
+          prepareSessionForExecutorStart(
+            { run: vi.fn() } as never,
+            sessionsService as never,
+            session.session_id,
+            {} as never
+          )
+        )
+      ).resolves.toBe(session);
+    });
+  });
+
   it('fails fast for missing, mismatched, and system tenant identity', async () => {
     const db = { run: vi.fn() } as never;
     const sessionsService = createSessionsService();

--- a/apps/agor-daemon/src/services/executor-startup.test.ts
+++ b/apps/agor-daemon/src/services/executor-startup.test.ts
@@ -129,6 +129,16 @@ describe('prepareSessionForExecutorStart tenant scope', () => {
 
     const prepareWithCreator = (creator: { unix_username: string | null } | null) => {
       const loadCreator = vi.fn(async () => creator);
+      // The loader is handed the tenant-scoped handle this startup opened.
+      const guard = {
+        loadCreator: vi.fn(() => {
+          expect(getCurrentTenantDatabaseScope()).toMatchObject({
+            kind: 'tenant',
+            tenantId: 'tenant-x',
+          });
+          return loadCreator;
+        }),
+      };
       const sessionsService = {
         get: vi.fn(async () => stampedSession),
         materializeAgenticToolPreset: vi.fn(async (loaded: Session) => loaded),
@@ -140,10 +150,10 @@ describe('prepareSessionForExecutorStart tenant scope', () => {
           stampedSession.session_id,
           {} as never,
           undefined,
-          { loadCreator }
+          guard
         )
       );
-      return { run, sessionsService, loadCreator };
+      return { run, sessionsService, loadCreator, guard };
     };
 
     it('refuses the launch when the creator has been renamed', async () => {
@@ -160,10 +170,11 @@ describe('prepareSessionForExecutorStart tenant scope', () => {
     });
 
     it('launches while the creator still owns the stamped identity', async () => {
-      const { run, loadCreator } = prepareWithCreator({ unix_username: 'alice' });
+      const { run, loadCreator, guard } = prepareWithCreator({ unix_username: 'alice' });
 
       await expect(run).resolves.toBe(stampedSession);
-      expect(loadCreator).toHaveBeenCalledOnce();
+      expect(guard.loadCreator).toHaveBeenCalledOnce();
+      expect(loadCreator).toHaveBeenCalledWith(stampedSession.created_by);
     });
 
     // `register-services.ts` builds the guard only when the resolved execution

--- a/apps/agor-daemon/src/services/executor-startup.test.ts
+++ b/apps/agor-daemon/src/services/executor-startup.test.ts
@@ -129,13 +129,12 @@ describe('prepareSessionForExecutorStart tenant scope', () => {
 
     const prepareWithCreator = (creator: { unix_username: string | null } | null) => {
       const loadCreator = vi.fn(async () => creator);
-      // The loader is handed the tenant-scoped handle this startup opened.
+      // The loader is handed the tenant-scoped handle this startup opened —
+      // asserted on the argument, not on the ambient scope, which was already
+      // active before that handle was threaded through.
       const guard = {
-        loadCreator: vi.fn(() => {
-          expect(getCurrentTenantDatabaseScope()).toMatchObject({
-            kind: 'tenant',
-            tenantId: 'tenant-x',
-          });
+        loadCreator: vi.fn((tenantDb: unknown) => {
+          expect(tenantDb).toBe(getCurrentTenantDatabaseScope()?.db);
           return loadCreator;
         }),
       };

--- a/apps/agor-daemon/src/services/executor-startup.ts
+++ b/apps/agor-daemon/src/services/executor-startup.ts
@@ -11,6 +11,10 @@ import {
 import type { AgenticToolName, AuthenticatedParams, Session } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
+import {
+  assertSessionUnixIdentityUnchanged,
+  type SessionCreatorLoader,
+} from '../utils/branch-authorization.js';
 
 type ExecutorStartupSessionsService = Pick<
   SessionsServiceImpl,
@@ -19,13 +23,34 @@ type ExecutorStartupSessionsService = Pick<
 
 export type ActiveExecutorSession = Session & { agentic_tool: AgenticToolName };
 
-/** Load and validate the session state needed before any executor/process work begins. */
+/**
+ * Supplied only by the Unix modes that make `session.unix_username` the OS
+ * identity of the executor (`delegated`/`strict`). Omitted otherwise, so a
+ * deployment that never impersonates per user pays no lookup.
+ */
+export interface ExecutorStartupUnixIdentityGuard {
+  loadCreator: SessionCreatorLoader;
+}
+
+/**
+ * Load and validate the session state needed before any executor/process work begins.
+ *
+ * This is the funnel every executor launch passes through: `/sessions/:id/prompt`,
+ * the queue drainer, `/tasks/:id/run`, gateway and scheduled prompts all arrive
+ * here via `SessionsService.executeTask`. The transport guards on
+ * `messages.create` / `tasks.create` refuse a drifted `unix_username` earlier
+ * and with a better error, but they do not cover every launch — the prompt
+ * route admits its Task through the repository and treats the initial-message
+ * write as best-effort — so the identity the executor is about to assume is
+ * re-checked here, where it is about to be used.
+ */
 export async function prepareSessionForExecutorStart(
   db: TenantScopeAwareDatabase,
   sessionsService: ExecutorStartupSessionsService,
   sessionId: string,
   params: AuthenticatedParams,
-  deploymentPolicy: DeploymentAgenticToolPolicy = { managed: false, installed: new Set() }
+  deploymentPolicy: DeploymentAgenticToolPolicy = { managed: false, installed: new Set() },
+  unixIdentityGuard?: ExecutorStartupUnixIdentityGuard
 ): Promise<ActiveExecutorSession> {
   const tenantId = getCurrentTenantId();
   if (!tenantId) throw new Error('Missing active tenant context for executor startup');
@@ -33,6 +58,9 @@ export async function prepareSessionForExecutorStart(
   return runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
     const session = await sessionsService.get(sessionId, params);
     if (!session) throw new Error(`Session ${sessionId} not found`);
+    if (unixIdentityGuard) {
+      await assertSessionUnixIdentityUnchanged(session, unixIdentityGuard.loadCreator);
+    }
     const agenticTool = requireActiveAgenticTool(session.agentic_tool);
     if (!isDeploymentAgenticToolAvailable(agenticTool, deploymentPolicy)) {
       throw new Error(`${agenticTool} is not installed for this deployment`);

--- a/apps/agor-daemon/src/services/executor-startup.ts
+++ b/apps/agor-daemon/src/services/executor-startup.ts
@@ -7,6 +7,7 @@ import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
 } from '@agor/core/db';
 import type { AgenticToolName, AuthenticatedParams, Session } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
@@ -27,9 +28,12 @@ export type ActiveExecutorSession = Session & { agentic_tool: AgenticToolName };
  * Supplied only by the Unix modes that make `session.unix_username` the OS
  * identity of the executor (`delegated`/`strict`). Omitted otherwise, so a
  * deployment that never impersonates per user pays no lookup.
+ *
+ * `loadCreator` receives the tenant-scoped handle this startup opened, so the
+ * creator read cannot escape the session's tenant.
  */
 export interface ExecutorStartupUnixIdentityGuard {
-  loadCreator: SessionCreatorLoader;
+  loadCreator: (tenantDb: TenantScopedDatabase) => SessionCreatorLoader;
 }
 
 /**
@@ -59,7 +63,7 @@ export async function prepareSessionForExecutorStart(
     const session = await sessionsService.get(sessionId, params);
     if (!session) throw new Error(`Session ${sessionId} not found`);
     if (unixIdentityGuard) {
-      await assertSessionUnixIdentityUnchanged(session, unixIdentityGuard.loadCreator);
+      await assertSessionUnixIdentityUnchanged(session, unixIdentityGuard.loadCreator(tenantDb));
     }
     const agenticTool = requireActiveAgenticTool(session.agentic_tool);
     if (!isDeploymentAgenticToolAvailable(agenticTool, deploymentPolicy)) {

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -265,7 +265,6 @@ function captureRegisteredMcpServerCreateHooks(
     app: app as unknown as RegisterHooksContext['app'],
     config: { database: { dialect: 'sqlite' } } as RegisterHooksContext['config'],
     jwtSecret: 'mcp-server-wiring-test-secret',
-    branchRbacEnabled: false,
     requireAuth: async (context) => context,
     superadminOpts: { allowSuperadmin: true },
     sessionsService: {} as RegisterHooksContext['sessionsService'],

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1202,6 +1202,51 @@ export function setSessionUnixUsername(
   };
 }
 
+/** Loads a user by id for an identity-consistency comparison. */
+export type SessionCreatorLoader = (
+  userId: string
+) => Promise<{ unix_username?: string | null } | null | undefined>;
+
+/**
+ * Refuse a session whose creator no longer owns the `unix_username` the
+ * session was stamped with.
+ *
+ * The stamp is the OS identity the executor runs as under `delegated`/`strict`
+ * (`register-services.ts` feeds `session.unix_username` to
+ * `resolveUnixUserForImpersonation`). Once it drifts, that identity is no
+ * longer the caller's, and the SDK state the session resumes from lives in a
+ * home directory this instance cannot read.
+ *
+ * Shared by the transport guard ({@link validateSessionUnixUsername}) and the
+ * executor-startup guard, so both refuse on the same terms with the same
+ * message.
+ *
+ * A session with no stamp is not covered: `simple`/`insulated` never stamp
+ * one, and there is no identity to have drifted.
+ */
+export async function assertSessionUnixIdentityUnchanged(
+  session: { created_by: string; unix_username?: string | null },
+  loadCreator: SessionCreatorLoader
+): Promise<void> {
+  if (!session.unix_username) return;
+
+  const creator = await loadCreator(session.created_by);
+
+  if (!creator) {
+    throw new Forbidden(`Session creator not found: ${session.created_by}`);
+  }
+
+  if (creator.unix_username !== session.unix_username) {
+    throw new Forbidden(
+      `Session security context has changed. ` +
+        `Session was created with unix_username="${session.unix_username}" ` +
+        `but creator's current unix_username="${creator.unix_username || 'null'}". ` +
+        `Cannot execute this session with a different unix user. ` +
+        `SDK session data is stored in the original user's home directory and cannot be accessed.`
+    );
+  }
+}
+
 /**
  * Validate session unix_username before prompting
  *
@@ -1237,28 +1282,7 @@ export function validateSessionUnixUsername(
       throw new Error('loadSession hook must run before validateSessionUnixUsername');
     }
 
-    // If session has no unix_username, allow (backward compatibility)
-    if (!session.unix_username) {
-      return context;
-    }
-
-    // Load session creator to check current unix_username
-    const creator = await userRepo.findById(session.created_by);
-
-    if (!creator) {
-      throw new Forbidden(`Session creator not found: ${session.created_by}`);
-    }
-
-    // DEFENSIVE CHECK: Creator's current unix_username must match session's
-    if (creator.unix_username !== session.unix_username) {
-      throw new Forbidden(
-        `Session security context has changed. ` +
-          `Session was created with unix_username="${session.unix_username}" ` +
-          `but creator's current unix_username="${creator.unix_username || 'null'}". ` +
-          `Cannot execute this session with a different unix user. ` +
-          `SDK session data is stored in the original user's home directory and cannot be accessed.`
-      );
-    }
+    await assertSessionUnixIdentityUnchanged(session, (userId) => userRepo.findById(userId));
 
     return context;
   };

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -29,6 +29,7 @@ import type {
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
 import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
+import { hasExecutorRuntimeScope } from '../auth/executor-runtime-scope.js';
 
 /**
  * Check if a user has the superadmin role (or deprecated 'owner' alias).
@@ -1260,6 +1261,13 @@ export async function assertSessionUnixIdentityUnchanged(
  * - SDK session data would be inaccessible (stored in old home directory)
  * - Execution would happen as wrong Unix user
  *
+ * Executor-scoped requests are exempt. An executor authenticates with a
+ * session token minted for the prompting user, so it is not a service account
+ * and would otherwise be held to this check on every transcript row it writes.
+ * By then the process is already running as the stamped user: refusing its
+ * writes only loses the transcript, and the launch that mattered was already
+ * gated by `prepareSessionForExecutorStart`.
+ *
  * @param userRepo - UserRepository instance
  */
 export function validateSessionUnixUsername(
@@ -1273,6 +1281,10 @@ export function validateSessionUnixUsername(
 
     // Skip for internal calls
     if (!context.params.provider) {
+      return context;
+    }
+
+    if (hasExecutorRuntimeScope(context)) {
       return context;
     }
 

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -29,7 +29,7 @@ import type {
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
 import { assertUnixUsernameSatisfiesMode } from '@agor/core/unix';
-import { hasExecutorRuntimeScope } from '../auth/executor-runtime-scope.js';
+import { executorRuntimeScopeSessionId } from '../auth/executor-runtime-scope.js';
 
 /**
  * Check if a user has the superadmin role (or deprecated 'owner' alias).
@@ -1222,8 +1222,9 @@ export type SessionCreatorLoader = (
  * executor-startup guard, so both refuse on the same terms with the same
  * message.
  *
- * A session with no stamp is not covered: `simple`/`insulated` never stamp
- * one, and there is no identity to have drifted.
+ * A session with no stamp is not covered: there is no identity to have drifted,
+ * and `resolveUnixUserForImpersonation` already refuses a missing username in
+ * the modes that need one.
  */
 export async function assertSessionUnixIdentityUnchanged(
   session: { created_by: string; unix_username?: string | null },
@@ -1261,12 +1262,15 @@ export async function assertSessionUnixIdentityUnchanged(
  * - SDK session data would be inaccessible (stored in old home directory)
  * - Execution would happen as wrong Unix user
  *
- * Executor-scoped requests are exempt. An executor authenticates with a
- * session token minted for the prompting user, so it is not a service account
- * and would otherwise be held to this check on every transcript row it writes.
- * By then the process is already running as the stamped user: refusing its
- * writes only loses the transcript, and the launch that mattered was already
- * gated by `prepareSessionForExecutorStart`.
+ * The executor of this very session is exempt. It authenticates with a session
+ * token minted for the prompting user, so it is not a service account and would
+ * otherwise be held to this check on every transcript row it writes. By then the
+ * process is already running as the stamped user: refusing its writes only loses
+ * the transcript, and the launch that mattered was already gated by
+ * `prepareSessionForExecutorStart`. The exemption compares the token's own
+ * session claim rather than merely asking whether an executor token is present,
+ * so it cannot be widened by a caller registering this hook somewhere
+ * `executorRuntimeScopeGuard` has not already pinned the claims.
  *
  * @param userRepo - UserRepository instance
  */
@@ -1284,14 +1288,14 @@ export function validateSessionUnixUsername(
       return context;
     }
 
-    if (hasExecutorRuntimeScope(context)) {
-      return context;
-    }
-
     const session = context.params.session;
 
     if (!session) {
       throw new Error('loadSession hook must run before validateSessionUnixUsername');
+    }
+
+    if (executorRuntimeScopeSessionId(context) === session.session_id) {
+      return context;
     }
 
     await assertSessionUnixIdentityUnchanged(session, (userId) => userRepo.findById(userId));

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1218,6 +1218,11 @@ export type SessionCreatorLoader = (
  * longer the caller's, and the SDK state the session resumes from lives in a
  * home directory this instance cannot read.
  *
+ * That is the stamp's role as an *execution* identity, and the only one this
+ * refusal covers. `unix.sync-branch` also reads it, to grant Unix group
+ * membership under `insulated`/`strict`, on a path no caller of this function
+ * sits on — see the `agor_wt_*` reconciliation gap noted in #2287.
+ *
  * Shared by the transport guard ({@link validateSessionUnixUsername}) and the
  * executor-startup guard, so both refuse on the same terms with the same
  * message.

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.test.ts
@@ -422,12 +422,17 @@ describe('authorizeMcpServerWrite', () => {
  * a read-only account could configure a server, and under `allow_crud` an
  * unowned one that every session in the tenant can then reach.
  *
- * This is currently unreachable over HTTP for an unrelated reason — a viewer
- * cannot authenticate at all, because the local strategy reads the user back
- * through a `users.get` gated at member. That is a separate bug, and one that
- * will be fixed; it is not a gate this rule may lean on. So the check lives
- * here, where the decision is actually made, and the tests synthesize the
- * identity rather than logging in.
+ * This was unreachable over HTTP when the rule was written, for an unrelated
+ * reason: a viewer could not authenticate at all, because the local strategy
+ * read the user back through a `users.get` gated at member. #2322 fixed that,
+ * and removed the blanket member floor from several `all` chains in the same
+ * change — `mcp-servers` now carries only `[typedValidateQuery, requireAuth]`.
+ * So this rule became load-bearing over HTTP, which is exactly why it was
+ * written not to lean on the login gate.
+ *
+ * The tests here still synthesize the identity, because this is where the
+ * decision is made. That the decision is actually *reached* from a registered
+ * chain is covered by `register-hooks.viewer-mcp-floor.test.ts`.
  */
 describe('authorizeMcpServerWrite refuses below-member roles', () => {
   beforeEach(() => {


### PR DESCRIPTION
Closes #2244.

## The property being protected

A session is stamped with its creator's `unix_username` at creation, and under
`delegated`/`strict` that stamp is the OS identity the executor assumes —
`register-services.ts:930` feeds it to `resolveUnixUserForImpersonation`. That is
the **only** place the stamp is consumed as an execution identity: every other
identity resolution in the daemon (terminals, branch environments, Codex auth,
OpenCode credentials, executor reads) resolves from the live `users.unix_username`,
where nothing can have drifted.

Once the creator's username changes, the stamp names an identity the user no
longer has, and the SDK state the session resumes from lives in a home directory
this instance cannot read. The session must not run.

## The bug

`validateSessionUnixUsername` enforces exactly that, but was registered only
inside the `branch_rbac` spread on `messages.create` and `tasks.create`. An
open-access instance running `strict` kept accepting prompts on a stale identity,
while the identical request was refused the moment RBAC was turned on.

Pre-existing on `main`. It takes an admin renaming a user after session creation,
so this is a failure to fail closed on identity drift, not a privilege
escalation.

## What actually closes it: the launch guard, not the transport guard

The two hook sites named in the issue do not cover the path users prompt on.
`/sessions/:id/prompt` admits its Task through `TaskRepository.createPending`,
bypassing `tasks.create` entirely, and writes the initial user message through
`messages.create` inside `ensureInitialUserMessage` — which deliberately swallows
the failure so a message write cannot break a spawn (`register-routes.ts:1057-1072`,
logged as `write_failed`). A `Forbidden` from the widened transport guard was
therefore logged and discarded while the executor launched under the stale
identity.

`prepareSessionForExecutorStart` is the funnel every launch passes through — the
prompt route, the queue drainer, `/tasks/:id/run`, gateway and scheduled prompts
all reach it through the single `SessionsService.executeTask` call site in
`spawnTaskExecutor` — and it already loads the session before any process work.
It now refuses there, immediately before the stamp becomes an OS user. A refusal
at that point marks the task FAILED and writes the reason into the transcript
(`register-routes.ts:1358-1400`) instead of being discarded.

The comparison lives in one place, `assertSessionUnixIdentityUnchanged`, so both
guards refuse on the same terms with the same message.

## ⚠️ What this PR *relaxes*, and why that is safe

This is a security fix that also removes two checks. Both were reviewed
specifically as relaxations and verified from the code; please review them as
such.

### 1. The transport guard no longer fires under `branch_rbac` + `simple`/`insulated`

It is gated on `requiresUserUnixUsername` alone (`strict`/`delegated`), where it
was previously `appRbacEnabled || requiresUserUnixUsername`.

**Why it is safe:** `resolveUnixUserForImpersonation`
(`packages/core/src/unix/user-manager.ts:441-490`) never reads `userUnixUsername`
in the `simple` arm (returns `{unixUser: null, reportedUnixUser: null}`) or the
`insulated` arm (returns the *config* `executor_unix_user`). Execution in those
modes is the daemon user or the shared executor user regardless of the stamp.

**Why the old condition was wrong, not merely broad:** RBAC stamps sessions in
those modes too (`setSessionUnixUsername` registers when `appRbacEnabled`), so a
rename made `POST /tasks` and `POST /messages` return 403 over an identity
nothing executes as — while `/sessions/:id/prompt` kept working, because it
admits internally. Two routes, two answers, one session. This removes a
false-positive lockout and makes both guards share one predicate, so they cannot
drift apart.

**Upgrade/downgrade safety:** `strict` → `simple` makes the stamp inert, nothing
else changes. `simple` → `strict` flips `requiresUserUnixUsername` true, the hook
re-registers and drifted sessions are refused again — no window. External
fork/spawn resolves the caller's *current* username, so drift does not propagate
to children.

**One caveat worth knowing:** `insulated` *does* read the stamp — `unix.sync-branch`
collects session stamps to grant Unix group membership. That sync is triggered by
`sessions.created` / `branches.patch` / group grants, never by a prompt write, so
the transport guard never stood between a rename and a group. (It has its own
stale-identity bug, noted in follow-ups.)

### 2. A running executor is exempt from the transport guard

**Why it was needed:** an executor authenticates with a session token minted for
the prompting user (`service-jwt-strategy.ts:187-206` returns the real user for
`executor-session` payloads — it is *not* a service account), so it was held to
the check on every transcript row it wrote. A rename mid-task would have started
dropping the assistant and tool rows of a process that carries on running as the
stamped user, and every row in `delegated`/`strict` would have paid a creator
lookup.

**Why it is safe:**
- The exemption is bound to the token's **own session claim**, not merely to "an
  executor token is present", so it cannot be widened by registering the hook
  where `executorRuntimeScopeGuard` has not pinned the claims. A token scoped to
  another session is still refused — pinned by a test.
- On the service paths the exemption actually covers, `executorRuntimeScopeGuard`
  pins the write to the **claimed task**: `messages.create` runs
  `expectMatch(taskId, record.task_id ?? query.task_id, 'task')`
  (`auth/executor-runtime-scope.ts:315-321`), and `protectExternalTaskCreate`
  independently rejects a client-supplied `task_id` on `tasks.create`
  (`register-hooks.ts:542-565`, registered only there, at `:2963`).
- Endpoints outside that allowlist **fail closed** —
  `throw new Forbidden('Executor token is not valid for this endpoint')`
  (`executor-runtime-scope.ts:387-388`). That is what keeps a live executor token
  off the custom prompt/run routes, which admit their Task through
  `taskRepo.createPending` and are otherwise gated on role alone:
  `registerAuthenticatedRoute` splices the guard into every method named in a
  route's authConfig (`utils/authorization.ts:155-160`), and
  `sessions/:id/prompt`, `sessions/:id/spawn-prompt` and `tasks/:id/run` are not
  in the guard's dispatch chain. **Now pinned by a test** in
  `auth/executor-runtime-scope.test.ts` — previously this invariant rested on
  reading two files together.
- Exempting it cannot admit a launch in any case: reaching an executor requires
  `spawnTaskExecutor` → `executeTask` → `prepareSessionForExecutorStart`, which is
  where the launch guard sits.

Net exposure: transcript rows written into the executor's own already-running
task.

## Performance

The original concern was that making `loadSession` unconditional adds a DB read
to every prompt in the default configuration. It does not — the guards register
only under the Unix modes that consume the stamp, so the default (`simple`, RBAC
off) and RBAC + `simple`/`insulated` both register nothing and read nothing.

Where the mode does make the stamp load-bearing:

| Path | Added reads | Measured (local SQLite, 2000 iterations) |
|---|---|---|
| `messages.create` / `tasks.create` | 1 session + 1 user PK | ~1.0 ms |
| Executor launch | 1 user PK | ~0.24 ms |
| Executor transcript rows | 1 session (no creator read) | ~0.76 ms |

`session.created_by` is a full UUID, so `resolveByShortIdPrefix` short-circuits to
a single indexed primary-key lookup rather than a `LIKE` scan. The session read is
memoised per request via `getRequestRbacCache`; the creator read is not, which is
why the executor exemption matters — it keeps the per-transcript-row cost to the
session read alone. For scale: the prompt route already performs a dozen-odd
session/task reads before it spawns a process and calls a model.

## Commits

1. **`refactor(daemon)` — retire the raw boolean.** `registerHooks` received two
   representations of the same truth: a `branchRbacEnabled` boolean and the
   `ResolvedExecutionSecurityMode` whose `appRbacEnabled` is the identical
   expression. Thirty-eight conditionals reached for the boolean and only eight
   consulted the capability object, which is how a guard whose real dependency
   was the Unix mode ended up nested under branch RBAC. Behaviour-preserving by
   construction: substituting the new expression back to the old name leaves a
   diff of exactly the two removed declarations, one shorthand property that had
   to become explicit, and two formatter reflows. Typechecks standalone, so
   bisect stays clean.
2. **`fix(security)` — the transport guard.** Could not be hoisted the way
   `ensureSessionImmutability` was in #2239: the validator requires
   `resolveSessionContext()` + `loadSession()` to have run.
3. **`fix(security)` — the launch guard.** The commit that closes the issue on the
   prompt path.
4. **`fix(security)` — corrections from an architectural review.** Relaxations 1
   and 2 above.
5. **`fix(security)` — corrections from a second review, of commit 4.** Binds the
   executor exemption to its own session claim, so its safety no longer depends
   on `executorRuntimeScopeGuard` in another file; makes two test assertions
   positive that could otherwise pass vacuously (one mock discarded the argument
   it existed to check, one asserted only that a string did *not* match, which
   passes against `undefined`).
6. **`docs(security)` — say what the stamp is load-bearing for.** The gating
   rationale claimed `delegated`/`strict` are the only modes that consume
   `session.unix_username`. They are not — `unix.sync-branch` reads it under
   `insulated` for group membership. The gating is unaffected (no prompt write
   triggers that sync) but the stated reason was wrong, which is how the next
   person reasons their way into a real bug.
7. **`test(security)` — pin that executor tokens are refused on the custom prompt
   routes.** The containment the exemption relies on was only visible by reading
   `utils/authorization.ts` and `auth/executor-runtime-scope.ts` together, which
   is how a correctness review reached the opposite conclusion from correct
   premises. Now executed rather than argued.

## Tests

`register-hooks.unix-identity-drift.test.ts` drives the before-create chains
`registerHooks` actually installs rather than calling the validator directly —
the validator was never wrong, only unreachable, so a test that calls it proves
nothing about whether it runs.

Against `6f87913d` the drifted prompt **resolves instead of rejecting** for both
`messages.create` and `tasks.create` under both `delegated` and `strict` (8
failures, `AssertionError: promise resolved "undefined" instead of rejecting`).
It also pins the inverses: nothing is read when RBAC and per-user identity are
both off; the creator is not consulted under RBAC when the mode ignores the
stamp; the executor is exempt for its own session but not for another's.

`executor-startup.test.ts` covers the launch guard: refuses on rename, refuses on
a deleted creator, launches when the stamp still matches, and asserts the creator
read happens inside the session's tenant scope.

Full `pnpm -w typecheck` (21/21), biome on every changed file, `@agor/core`
(3621 passed) and daemon (2534 passed). The one failure,
`cursor-models.test.ts`, is a stale `@cursor/sdk` mock specific to the dev host —
it passes in CI.

## Reviews

Three: two architectural passes, then a correctness pass by a different model
(Codex). The second architectural pass reviewed the commit the first produced.

The first inverted the framing this PR started with — the transport guard is a
better error on a path almost nobody takes; the launch guard is what closes the
issue — and produced commit 4.

> **Note for reviewers: `_isServiceAccount` is the wrong exemption here, please
> don't re-propose it.** The first review recommended exempting the executor with
> `if (context.params.user?._isServiceAccount) return context`, mirroring
> `loadBranchFromSession`. That would have been a silent no-op. An executor
> writing its transcript authenticates with an **`executor-session`** token, and
> `service-jwt-strategy.ts:187-206` resolves that branch to the *real user* —
> `{...result, session_id, task_id, branch_id}`, where `result.user` comes from
> the parent JWT strategy. `_isServiceAccount: true` is set only on the
> `type: 'service'` / `sub: 'executor-service'` branch (`:178-186`), which is used
> for `unix.sync-*` and git spawns and never reaches `messages.create`. Hence the
> exemption keys on the executor-session scope instead.

The second review verified both relaxations from the code rather than the commit
message, and produced commits 5 and 6. One of its findings was **not applied**:
it proposed binding the transport guard's creator read with
`bindRepositoryToTenantUnitOfWork`, on the premise that "there is no
request-level `runWithTenantDatabaseScope` in the daemon". That premise is false
for these two services — `messages` and `tasks` are in
`TENANT_OWNED_SERVICE_PATHS` and get `around: { all: [tenantDatabaseScopeAround] }`
(`register-hooks.ts:738`, gated at `:3431`), which wraps the whole chain,
before-hooks included, in `runWithTenantDatabaseScope` under Postgres. The
scope-aware proxy therefore already resolves inside an active tenant scope, by
the same call-time mechanism that review accepted for the launch guard. Binding
this one read would leave it inconsistent with the neighbouring RBAC reads
(`branchRepository` is unbound in exactly the same way) for no behavioural gain,
so it is deliberately left alone rather than half-converted.

The Codex correctness pass independently confirmed three claims a reviewer would
otherwise have to take on faith: commit 1 is behaviour-preserving
(`config-manager.ts:1511-1513`), the default path adds no DB read
(`register-hooks.ts:999-1011`, `register-services.ts:829-836`), and a missing
creator row fails closed (`branch-authorization.ts:1228-1230`). It found **no**
path that launches a drifted session under a stale identity.

Its one High finding — that executor-session tokens could enqueue cross-task work
through `/sessions/:id/prompt` and `/tasks/:id/run`, since those admit via
`taskRepo.createPending` and gate on role alone — **does not hold**, and the
containment bullet above now carries the evidence. `registerAuthenticatedRoute`
splices `executorRuntimeScopeGuard()` into every method named in a route's
authConfig (`utils/authorization.ts:155-160`), both routes declare `create`, and
the guard's dispatch chain has no case for either path, so they hit the
fail-closed `else` at `executor-runtime-scope.ts:387-388`. Verified by executing
the guard against all three custom routes; that is now a permanent test rather
than an argument.

## Follow-ups (not in this PR)

- A rename is a single deterministic event and should be decided at `users.patch`
  — count the user's stamped sessions, refuse by default, mark them terminal on
  acknowledgement — rather than deferred into per-request 403s discovered at
  prompt time. Nothing warns the admin today.
- **#2287 — found while here, not fixed here.** `unix.sync-branch` has the same
  defect by a different mechanism, on the filesystem path this PR does not touch:
  branch-group membership is both granted from and *protected by* the immutable
  session stamp, so a renamed user's old Unix name is never reconciled out of
  `agor_wt_*` and is re-added on every sync. If that OS account name is later
  reassigned, the new holder inherits `rwx` on the branch worktree. Verified
  against the code before filing; pre-existing on `main`.
- `setSessionUnixUsername` still stamps in modes that ignore the stamp, which is
  what manufactures the drifted identity in the first place.
- `ensureInitialUserMessage` swallows authorization refusals identically to
  transient DB errors; it should rethrow 401/403.
- **#2290 — found while here, not fixed here.** `unix_username` uniqueness is
  enforced only in app code, by a query with no tenant predicate
  (`repositories/users.ts:171-190`), and no unique index exists on either dialect
  — so under RLS the check structurally cannot see the conflicting tenant. Two
  tenants can both own `alice` and, under `strict`/`delegated`, resolve to one
  host account, one home directory, one credential store. Needs a multi-tenant
  deployment *and* `strict`/`delegated`, so it is inert on the default
  configuration — but it is the one finding here that crosses a tenant boundary.
- `register-routes.ts` still takes the raw `branchRbacEnabled` for seven
  authorization branches, including `/tasks/:id/run` — the same shape that
  produced this issue.



