### PR TITLE
feat(onboarding): wizard improvements from onboarding review feedback

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -797,20 +797,22 @@ function AppContent() {
     });
     if (seeded.sessionId) sessionId = seeded.sessionId;
 
-    // Navigate to the user's board + session, or to the boards list if they
-    // skipped. Use the centralized path builders — the old
-    // `/b/<board>/<session>/` shape was removed when we flattened entity URLs.
+    // Always land the user on a board — never the homepage. Prefer the seeded
+    // session, then the board the wizard created, then the user's main board,
+    // then any existing board. With the workspace step now required a board
+    // always exists, so the later fallbacks are belt-and-suspenders. Use the
+    // centralized path builders — the old `/b/<board>/<session>/` shape was
+    // removed when we flattened entity URLs.
+    const boardById = agorStore.getState().boardById;
+    const mainBoardId = currentUser.preferences?.mainBoardId;
+    const targetBoardId =
+      result.boardId ||
+      (mainBoardId && boardById.has(mainBoardId) ? mainBoardId : undefined) ||
+      boardById.keys().next().value;
     if (sessionId) {
       navigate(sessionPath(sessionId as SessionID));
-    } else if (result.boardId) {
-      navigate(
-        boardPath(
-          result.boardId as BoardID,
-          agorStore.getState().boardById.get(result.boardId)?.slug
-        )
-      );
-    } else {
-      navigate('/');
+    } else if (targetBoardId) {
+      navigate(boardPath(targetBoardId as BoardID, boardById.get(targetBoardId)?.slug));
     }
 
     // Close the wizard only now that creation + navigation are done, so the

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -353,7 +353,7 @@ describe('OnboardingWizard', () => {
         })
       );
     });
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
   });
 
   it('workspace step renders the concept tags below the teammate-name field', () => {
@@ -391,7 +391,7 @@ describe('OnboardingWizard', () => {
 
     expect(boardsService.create).not.toHaveBeenCalled();
     expect(boardsService.patch).not.toHaveBeenCalled();
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
   });
 
   it('reuses existing board via server fetch when boardById store is empty (restart onboarding)', async () => {
@@ -422,7 +422,7 @@ describe('OnboardingWizard', () => {
     clickButton(/^continue →/i);
     expect(boardsService.create).not.toHaveBeenCalled();
     expect(boardsService.patch).not.toHaveBeenCalled();
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
   });
 
   it('creates a new board when mainBoardId points to a deleted board', async () => {
@@ -465,7 +465,7 @@ describe('OnboardingWizard', () => {
     await waitFor(() =>
       expect(boardsService.create).toHaveBeenCalledWith({ name: 'Rusty', icon: '🤖' })
     );
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
 
     // Back to the workspace step — the name field is still editable (not replaced
     // by a read-only card).
@@ -480,7 +480,7 @@ describe('OnboardingWizard', () => {
       expect(boardsService.patch).toHaveBeenCalledWith('board-1', { name: 'Ada', icon: '🤖' })
     );
     expect(boardsService.create).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
   });
 
   it('integrations step shows persona-tailored MCP recommendations', async () => {
@@ -512,7 +512,7 @@ describe('OnboardingWizard', () => {
     // workspace — name the teammate, which creates their board
     fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Rusty' } });
     clickButton(/^continue →/i);
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
 
     // integrations
     clickButton(/^continue →/i);
@@ -543,7 +543,7 @@ describe('OnboardingWizard', () => {
     expect(onCreateSession).not.toHaveBeenCalled();
   });
 
-  it('requires the workspace step but lets the other steps skip, always yielding a board', async () => {
+  it('requires the workspace + tools steps but lets persona/llm skip, always yielding a board', async () => {
     const onComplete = vi.fn();
     const { boardsService } = renderWizard({ onComplete });
 
@@ -566,8 +566,11 @@ describe('OnboardingWizard', () => {
       expect(boardsService.create).toHaveBeenCalledWith({ name: 'Scout', icon: '🤖' })
     );
 
-    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
-    clickButton(/skip for now/i);
+    // Tools is purely informational recommendations — also non-skippable; the
+    // enabled "Continue →" is the only way forward.
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
+    expect(screen.queryByText(/skip for now/i)).not.toBeInTheDocument();
+    clickButton(/^continue →/i);
 
     expect(await screen.findByText("You're ready to build.")).toBeInTheDocument();
     // Final step is not skippable.

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -77,6 +77,7 @@ function renderWizard(
 
   const boardsService = {
     create: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
+    patch: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
   };
   const client = {
     io: { on: vi.fn(), off: vi.fn() },
@@ -156,7 +157,7 @@ describe('OnboardingWizard', () => {
     expect(screen.queryByText('Back')).not.toBeInTheDocument();
 
     clickButton('I write code');
-    clickButton(/this is me/i);
+    clickButton(/^continue →/i);
 
     expect(await screen.findByText('Connect your AI')).toBeInTheDocument();
     await waitFor(() => {
@@ -334,7 +335,7 @@ describe('OnboardingWizard', () => {
     const { boardsService } = renderWizard({ initialStep: 'workspace', onUpdateUser });
 
     expect(screen.getByText('Name your AI teammate')).toBeInTheDocument();
-    // The teammate name is empty by default — the user names their teammate.
+    // The name is prefilled with a sensible default; the user renames it here.
     fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Rusty' } });
 
     clickButton(/^continue →/i);
@@ -369,7 +370,7 @@ describe('OnboardingWizard', () => {
     ).toBeTruthy();
   });
 
-  it('workspace step skips board creation when the user already has one', async () => {
+  it('keeps the teammate name editable and never renames a pre-existing board', async () => {
     const boardById = new Map<string, Board>([['board-existing', makeBoard()]]);
     const { boardsService } = renderWizard({
       initialStep: 'workspace',
@@ -377,14 +378,18 @@ describe('OnboardingWizard', () => {
       user: makeUser({ preferences: { mainBoardId: 'board-existing' } } as Partial<User>),
     });
 
-    // Teammate-first: the name UI always renders; the existing board is only a
-    // muted caption, not a replacement for the name field.
-    expect(screen.getByLabelText('Teammate name')).toBeInTheDocument();
+    // The name editor is always shown — even when the user already has a board —
+    // so the teammate can be (re)named; the existing board is only a muted
+    // caption and is never touched.
+    const nameInput = screen.getByLabelText('Teammate name');
+    expect(nameInput).toBeInTheDocument();
     expect(screen.getByText(/join your existing board/i)).toHaveTextContent('Existing board');
+    fireEvent.change(nameInput, { target: { value: 'Ada' } });
 
-    clickButton(/keep going/i);
+    clickButton(/^continue →/i);
 
     expect(boardsService.create).not.toHaveBeenCalled();
+    expect(boardsService.patch).not.toHaveBeenCalled();
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
   });
 
@@ -392,6 +397,7 @@ describe('OnboardingWizard', () => {
     const serverBoard = makeBoard({ board_id: 'board-existing', name: 'My board' });
     const boardsService = {
       create: vi.fn(async () => ({ board_id: 'board-new', created_by: 'user-1' })),
+      patch: vi.fn(async () => serverBoard),
       get: vi.fn(async () => serverBoard),
     };
     const client = {
@@ -406,12 +412,15 @@ describe('OnboardingWizard', () => {
       // No boardById — store is empty (the bug scenario)
     });
 
+    // The pre-existing board is verified server-side but never renamed; the name
+    // editor stays available so the teammate can still be named.
     await waitFor(() => expect(boardsService.get).toHaveBeenCalledWith('board-existing'));
     expect(await screen.findByLabelText('Teammate name')).toBeInTheDocument();
     expect(screen.getByText(/join your existing board/i)).toHaveTextContent('My board');
 
-    clickButton(/keep going/i);
+    clickButton(/^continue →/i);
     expect(boardsService.create).not.toHaveBeenCalled();
+    expect(boardsService.patch).not.toHaveBeenCalled();
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
   });
 
@@ -445,12 +454,42 @@ describe('OnboardingWizard', () => {
     });
   });
 
+  it('going Back to the workspace step keeps the teammate name editable and renames the same board', async () => {
+    const onUpdateUser = vi.fn(async () => undefined);
+    const { boardsService } = renderWizard({ initialStep: 'workspace', onUpdateUser });
+
+    // Name the teammate and create the board.
+    fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Rusty' } });
+    clickButton(/^continue →/i);
+    await waitFor(() =>
+      expect(boardsService.create).toHaveBeenCalledWith({ name: 'Rusty', icon: '🤖' })
+    );
+    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+
+    // Back to the workspace step — the name field is still editable (not replaced
+    // by a read-only card).
+    clickButton('Back');
+    const nameInput = await screen.findByLabelText('Teammate name');
+    expect(nameInput).toHaveValue('Rusty');
+    fireEvent.change(nameInput, { target: { value: 'Ada' } });
+    clickButton(/^continue →/i);
+
+    // Editing after a board was created patches the SAME board — no duplicate.
+    await waitFor(() =>
+      expect(boardsService.patch).toHaveBeenCalledWith('board-1', { name: 'Ada', icon: '🤖' })
+    );
+    expect(boardsService.create).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
+  });
+
   it('integrations step shows persona-tailored MCP recommendations', async () => {
     renderWizard({ initialStep: 'integrations' });
 
     // No persona chosen — falls back to the default rec set.
     expect(screen.getByText('Slack')).toBeInTheDocument();
     expect(screen.getByText('Notion')).toBeInTheDocument();
+    // Recommendations only: nothing is connected here; the AI teammate does it later.
+    expect(screen.getByText(/ask your AI teammate to connect/i)).toBeInTheDocument();
   });
 
   it('completes the full flow and calls onComplete with the created board', async () => {
@@ -475,7 +514,7 @@ describe('OnboardingWizard', () => {
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
 
     // integrations
-    clickButton(/connect when done/i);
+    clickButton(/^continue →/i);
 
     // done
     expect(await screen.findByText("You're ready to build.")).toBeInTheDocument();
@@ -503,18 +542,28 @@ describe('OnboardingWizard', () => {
     expect(onCreateSession).not.toHaveBeenCalled();
   });
 
-  it('lets the user skip every step without any confirmation dialog', async () => {
+  it('requires the workspace step but lets the other steps skip, always yielding a board', async () => {
     const onComplete = vi.fn();
-    renderWizard({ onComplete });
+    const { boardsService } = renderWizard({ onComplete });
 
+    // persona and llm stay optional.
     expect(screen.getByText(/let's make this yours/i)).toBeInTheDocument();
     clickButton(/skip for now/i);
 
     expect(await screen.findByText('Connect your AI')).toBeInTheDocument();
     clickButton(/skip for now/i);
 
+    // Workspace is the step that creates the board + teammate, so it is required:
+    // no "Skip for now" affordance, and the name is prefilled so the user isn't
+    // blocked on an empty field.
     expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
-    clickButton(/skip for now/i);
+    expect(screen.queryByText(/skip for now/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Teammate name')).toHaveValue('Scout');
+    clickButton(/^continue →/i);
+
+    await waitFor(() =>
+      expect(boardsService.create).toHaveBeenCalledWith({ name: 'Scout', icon: '🤖' })
+    );
 
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
     clickButton(/skip for now/i);
@@ -524,19 +573,13 @@ describe('OnboardingWizard', () => {
     expect(screen.queryByText(/skip for now/i)).not.toBeInTheDocument();
 
     clickButton(/open my board/i);
-    // Skipping the workspace step leaves the teammate unnamed — no teammateName
-    // is emitted, so the app shell skips teammate creation and just opens the board.
-    expect(onComplete).toHaveBeenCalledWith({
-      branchId: '',
-      sessionId: '',
-      boardId: '',
-      path: 'teammate',
-      teammateName: undefined,
-      teammateEmoji: '🤖',
-      agent: null,
-      suggestedIntegrations: ['Slack', 'GitHub', 'Linear', 'Notion'],
-      persona: null,
-    });
+    // A board was created from the (required) workspace step, so completion
+    // always carries a board destination — the app shell never falls back to the
+    // homepage.
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    const result = onComplete.mock.calls[0][0] as { boardId: string; teammateName?: string };
+    expect(result.boardId).toBe('board-1');
+    expect(result.teammateName).toBe('Scout');
   });
 
   it('shows a loading state on the final step while onComplete is in flight', async () => {
@@ -567,7 +610,7 @@ describe('OnboardingWizard', () => {
     renderWizard();
 
     clickButton('I write code');
-    clickButton(/this is me/i);
+    clickButton(/^continue →/i);
     expect(await screen.findByText('Connect your AI')).toBeInTheDocument();
 
     clickButton('Back');

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -356,17 +356,18 @@ describe('OnboardingWizard', () => {
     expect(await screen.findByText('Connect your tools via MCP')).toBeInTheDocument();
   });
 
-  it("workspace step renders the concept tags at the bottom, below the Board's AI tool helper", () => {
+  it('workspace step renders the concept tags below the teammate-name field', () => {
     renderWizard({ initialStep: 'workspace' });
 
-    const aiTool = screen.getByText("Board's AI tool");
+    const nameLabel = screen.getByText('Teammate name');
     const branchTag = screen.getByText('Branch');
     const sessionTag = screen.getByText('Session');
     expect(branchTag).toBeInTheDocument();
     expect(sessionTag).toBeInTheDocument();
-    // Tags moved below the name field + AI-tool helper (Fix 2).
+    // The "Board's AI tool" helper was removed — the tool is chosen in the prior step.
+    expect(screen.queryByText("Board's AI tool")).not.toBeInTheDocument();
     expect(
-      aiTool.compareDocumentPosition(branchTag) & Node.DOCUMENT_POSITION_FOLLOWING
+      nameLabel.compareDocumentPosition(branchTag) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });
 
@@ -489,7 +490,7 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('Slack')).toBeInTheDocument();
     expect(screen.getByText('Notion')).toBeInTheDocument();
     // Recommendations only: nothing is connected here; the AI teammate does it later.
-    expect(screen.getByText(/ask your AI teammate to connect/i)).toBeInTheDocument();
+    expect(screen.getByText(/ask your AI teammate to help set them up/i)).toBeInTheDocument();
   });
 
   it('completes the full flow and calls onComplete with the created board', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -586,6 +586,72 @@ describe('OnboardingWizard', () => {
     expect(result.teammateName).toBe('Scout');
   });
 
+  it('skipping the LLM step finishes onto the board with no agent to bootstrap a session', async () => {
+    const onComplete = vi.fn();
+    const { boardsService } = renderWizard({ onComplete });
+
+    // persona — skipped.
+    clickButton(/skip for now/i);
+
+    // llm — highlight a provider but never connect it, then skip. Selecting a
+    // card alone must not survive as "there is a model to run on".
+    expect(await screen.findByText('Connect your AI')).toBeInTheDocument();
+    clickButton('Claude');
+    expect(screen.getByLabelText('Anthropic API key')).toBeInTheDocument();
+    clickButton(/skip for now/i);
+
+    // workspace is still required, so a board is created either way.
+    expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
+    clickButton(/^continue →/i);
+    await waitFor(() => expect(boardsService.create).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('Recommended tools')).toBeInTheDocument();
+    clickButton(/^continue →/i);
+
+    // The summary must not claim a connected AI, and must not promise a first
+    // session that will never be started.
+    expect(await screen.findByText("You're ready to build.")).toBeInTheDocument();
+    expect(screen.getByText(/connect an ai model in settings whenever/i)).toBeInTheDocument();
+    expect(screen.getByText('Add in Settings - AI & Agents')).toBeInTheDocument();
+
+    clickButton(/open my board/i);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    const result = onComplete.mock.calls[0][0] as {
+      agent: string | null;
+      boardId: string;
+      sessionId: string;
+    };
+    // A null agent is what tells the completion handler to seed the workspace
+    // and land on the board rather than open a credential-less claude-code
+    // session (see seedOnboardingTeammate).
+    expect(result.agent).toBeNull();
+    expect(result.boardId).toBe('board-1');
+    expect(result.sessionId).toBe('');
+  });
+
+  it('final checklist reports the board it created, not a teammate it has not seeded yet', () => {
+    renderWizard({ initialStep: 'done' });
+
+    expect(screen.getByText('Board created')).toBeInTheDocument();
+    // The teammate is seeded by the app shell *after* this step resolves, so
+    // the wizard has nothing to tick off here.
+    expect(screen.queryByText('Teammate ready')).not.toBeInTheDocument();
+  });
+
+  it('explains the failure instead of no-oping when the required workspace step has no client', async () => {
+    renderWizard({ initialStep: 'workspace', client: null });
+
+    fireEvent.change(screen.getByLabelText('Teammate name'), { target: { value: 'Rusty' } });
+    clickButton(/^continue →/i);
+
+    // The workspace step is required and has no Skip, so a silent early return
+    // would leave the user on a dead button with no explanation.
+    expect(await screen.findByText(/can't reach the server right now/i)).toBeInTheDocument();
+    expect(screen.getByText('Name your AI teammate')).toBeInTheDocument();
+    expect(screen.queryByText('Recommended tools')).not.toBeInTheDocument();
+  });
+
   it('shows a loading state on the final step while onComplete is in flight', async () => {
     // onComplete stays pending until we resolve it — mirrors the app shell
     // creating the teammate + navigating before the modal closes.

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -517,8 +517,12 @@ describe('OnboardingWizard', () => {
     // integrations
     clickButton(/^continue →/i);
 
-    // done
+    // done — with a model connected the app shell *does* seed a first session,
+    // so the summary is allowed to promise one. The skipped-LLM flow asserts
+    // the other half of this below.
     expect(await screen.findByText("You're ready to build.")).toBeInTheDocument();
+    expect(screen.getByText(/start your first AI session/i)).toBeInTheDocument();
+    expect(screen.queryByText(/connect an ai model in settings whenever/i)).not.toBeInTheDocument();
     clickButton(/open my board/i);
 
     // The wizard emits the teammate naming details + selected agent so the app
@@ -630,10 +634,10 @@ describe('OnboardingWizard', () => {
     expect(result.sessionId).toBe('');
   });
 
-  it('final checklist reports the board it created, not a teammate it has not seeded yet', () => {
+  it('final checklist reports the workspace it created, not a teammate it has not seeded yet', () => {
     renderWizard({ initialStep: 'done' });
 
-    expect(screen.getByText('Board created')).toBeInTheDocument();
+    expect(screen.getByText('Workspace ready')).toBeInTheDocument();
     // The teammate is seeded by the app shell *after* this step resolves, so
     // the wizard has nothing to tick off here.
     expect(screen.queryByText('Teammate ready')).not.toBeInTheDocument();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -634,13 +634,14 @@ describe('OnboardingWizard', () => {
     expect(result.sessionId).toBe('');
   });
 
-  it('final checklist reports the workspace it created, not a teammate it has not seeded yet', () => {
+  it('final checklist names the teammate, gated on the board that was created', () => {
     renderWizard({ initialStep: 'done' });
 
-    expect(screen.getByText('Workspace ready')).toBeInTheDocument();
-    // The teammate is seeded by the app shell *after* this step resolves, so
-    // the wizard has nothing to tick off here.
-    expect(screen.queryByText('Teammate ready')).not.toBeInTheDocument();
+    // Deliberate copy call: the app shell seeds the teammate immediately after
+    // this step resolves, so the checklist says "Teammate ready" rather than
+    // the drier claim the wizard could strictly back on its own.
+    expect(screen.getByText('Teammate ready')).toBeInTheDocument();
+    expect(screen.queryByText('Workspace ready')).not.toBeInTheDocument();
   });
 
   it('explains the failure instead of no-oping when the required workspace step has no client', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1759,8 +1759,11 @@ export function OnboardingWizard({
     // What the wizard has actually done by this point is create/confirm the
     // board. The teammate itself is seeded by the app shell *after* the user
     // clicks through, so claiming "Teammate ready" here would be a lie the
-    // checklist can't back up.
-    const boardReady = hasExistingBoard;
+    // checklist can't back up. "Workspace ready" is the warm version of the
+    // same true claim — the place to work exists, whoever ends up in it —
+    // and matches the word the skip path already uses ("<name>'s workspace
+    // is ready", seedOnboardingTeammate).
+    const workspaceReady = hasExistingBoard;
 
     return (
       <div style={{ textAlign: 'center', padding: '8px 0' }}>
@@ -1866,9 +1869,9 @@ export function OnboardingWizard({
               hint: 'Add in Settings - AI & Agents',
             },
             {
-              label: 'Board created',
-              done: boardReady,
-              hint: 'Create one anytime from the sidebar',
+              label: 'Workspace ready',
+              done: workspaceReady,
+              hint: 'Create a board anytime from the sidebar',
             },
             {
               label: 'MCP tools',

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1756,14 +1756,13 @@ export function OnboardingWizard({
 
   const renderDone = () => {
     const aiConnected = hasAnyLlmKey(user) || (selectedAgent !== null && apiKey.trim().length > 0);
-    // What the wizard has actually done by this point is create/confirm the
-    // board. The teammate itself is seeded by the app shell *after* the user
-    // clicks through, so claiming "Teammate ready" here would be a lie the
-    // checklist can't back up. "Workspace ready" is the warm version of the
-    // same true claim — the place to work exists, whoever ends up in it —
-    // and matches the word the skip path already uses ("<name>'s workspace
-    // is ready", seedOnboardingTeammate).
-    const workspaceReady = hasExistingBoard;
+    // The checklist sits under "You're ready to build.", the one place in the
+    // wizard that should sound like a welcome, so it names the teammate. The
+    // wizard itself has only created/confirmed the board here — the teammate is
+    // seeded by the app shell right after this step resolves, best-effort — but
+    // the friendlier word is the deliberate call. The board still gates it:
+    // without one there is nowhere to seed a teammate into.
+    const teammateReady = hasExistingBoard;
 
     return (
       <div style={{ textAlign: 'center', padding: '8px 0' }}>
@@ -1869,8 +1868,8 @@ export function OnboardingWizard({
               hint: 'Add in Settings - AI & Agents',
             },
             {
-              label: 'Workspace ready',
-              done: workspaceReady,
+              label: 'Teammate ready',
+              done: teammateReady,
               hint: 'Create a board anytime from the sidebar',
             },
             {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -27,7 +27,7 @@ import {
   TeamOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import { Alert, Button, Input, List, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
@@ -1609,8 +1609,8 @@ export function OnboardingWizard({
     <div>
       {renderStepBadge('Name your AI teammate')}
       <Paragraph style={{ color: TEXT_SECONDARY, marginBottom: 20 }}>
-        Give your AI teammate a name and an avatar. They get their own board to work on - you can
-        change everything anytime.
+        An AI teammate is your assistant for getting work done. Each board is recommended to have
+        one primary teammate — give yours a name and an avatar. You can change everything anytime.
       </Paragraph>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -1641,22 +1641,6 @@ export function OnboardingWizard({
             </Text>
           )}
         </div>
-        {(() => {
-          const chosenOption = LLM_OPTIONS.find((o) => o.agent === selectedAgent);
-          return (
-            <div>
-              <Text style={{ color: TEXT_PRIMARY, fontWeight: 500, fontSize: 13 }}>
-                Board's AI tool
-              </Text>
-              <div style={{ color: TEXT_SECONDARY, fontSize: 12, marginTop: 2 }}>
-                Each board runs on one AI tool for every session created here.
-                {chosenOption
-                  ? ` Currently: ${chosenOption.title}. Change anytime in Settings.`
-                  : ' Connect your AI in the previous step.'}
-              </div>
-            </div>
-          );
-        })()}
       </div>
 
       {/* Concept pills */}
@@ -1705,8 +1689,8 @@ export function OnboardingWizard({
             lineHeight: 1.6,
           }}
         >
-          These are the tools we recommend for your work — nothing to connect on this screen. Once
-          you're in, just ask your AI teammate to connect any of them for you.{' '}
+          These are the tools we recommend for your work. You can connect any of them via MCP — just
+          ask your AI teammate to help set them up.{' '}
           <Typography.Link
             href={MCP_DOCS_URL}
             target="_blank"
@@ -1717,53 +1701,33 @@ export function OnboardingWizard({
           </Typography.Link>
         </div>
 
-        {/* Persona-curated MCP recommendations — informational, no selection */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {recs.map((rec) => (
-            <div
-              key={rec.id}
-              style={{
-                background: GLASS_CARD_BG,
-                border: GLASS_CARD_BORDER,
-                backdropFilter: 'blur(20px)',
-                WebkitBackdropFilter: 'blur(20px)',
-                borderRadius: 10,
-                boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.09)',
-                cursor: 'default',
-                overflow: 'hidden',
-              }}
-            >
-              <div
-                style={{
-                  padding: '12px 16px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 12,
-                }}
-              >
-                <McpLogo id={rec.id} name={rec.name} size={20} color={TEXT_PRIMARY} />
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                    <span style={{ color: TEXT_PRIMARY, fontWeight: 600, fontSize: 13 }}>
-                      {rec.name}
-                    </span>
-                    {rec.featured && (
-                      <Tag
-                        color="processing"
-                        style={{ fontSize: 10, lineHeight: '16px', padding: '0 5px', margin: 0 }}
-                      >
-                        Recommended
-                      </Tag>
-                    )}
-                  </div>
-                  <div style={{ color: TEXT_SECONDARY, fontSize: 12, marginTop: 1 }}>
-                    {rec.description}
-                  </div>
+        {/* Persona-curated MCP recommendations — informational list, no selection */}
+        <List
+          dataSource={recs}
+          renderItem={(rec) => (
+            <List.Item style={{ padding: '10px 4px', gap: 12 }}>
+              <McpLogo id={rec.id} name={rec.name} size={20} color={TEXT_PRIMARY} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <span style={{ color: TEXT_PRIMARY, fontWeight: 600, fontSize: 13 }}>
+                    {rec.name}
+                  </span>
+                  {rec.featured && (
+                    <Tag
+                      color="processing"
+                      style={{ fontSize: 10, lineHeight: '16px', padding: '0 5px', margin: 0 }}
+                    >
+                      Recommended
+                    </Tag>
+                  )}
+                </div>
+                <div style={{ color: TEXT_SECONDARY, fontSize: 12, marginTop: 1 }}>
+                  {rec.description}
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            </List.Item>
+          )}
+        />
       </div>
     );
   };

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -97,6 +97,12 @@ const STEPS: WizardStep[] = ['persona', 'llm', 'workspace', 'integrations', 'don
 // user can rename it. Named the teammate and the board the wizard creates.
 const DEFAULT_TEAMMATE_NAME = 'Scout';
 
+// Surfaced when the workspace step needs the API but the socket client isn't
+// available. That step is required and has no Skip, so a bare early return
+// would leave its only button doing nothing at all.
+const NO_CLIENT_BOARD_ERROR =
+  "Can't reach the server right now - check your connection and try again.";
+
 // The workspace step creates the user's board + first teammate, so it is NOT
 // skippable — completing the wizard must always yield a board to land on.
 const STEP_META: Record<WizardStep, { number: number; label: string; skippable: boolean }> = {
@@ -936,8 +942,18 @@ export function OnboardingWizard({
 
   const handleSkip = useCallback(() => {
     if (currentStep === 'done') return;
+    // Skipping the LLM step must not leave a merely *highlighted* provider
+    // behind. Selecting a card sets `selectedAgent` before any key is entered,
+    // and completion reads a non-null agent as "there is a model to run on" —
+    // which would bootstrap the teammate's first session with no credentials.
+    // Clear it unless the provider is genuinely configured.
+    if (currentStep === 'llm' && selectedAgent && !agentHasKey(selectedAgent)) {
+      setSelectedAgent(null);
+      setApiKey('');
+      setLlmError(null);
+    }
     goToStep(STEPS[stepIndex + 1]);
-  }, [currentStep, stepIndex, goToStep]);
+  }, [currentStep, stepIndex, goToStep, selectedAgent, agentHasKey]);
 
   const handlePrimary = useCallback(async () => {
     switch (currentStep) {
@@ -1020,7 +1036,10 @@ export function OnboardingWizard({
         // Board created earlier this pass (Back → edit → forward): rename the
         // same board instead of creating a duplicate.
         if (createdBoardId) {
-          if (!client) return;
+          if (!client) {
+            setBoardError(NO_CLIENT_BOARD_ERROR);
+            return;
+          }
           setBoardCreating(true);
           setBoardError(null);
           try {
@@ -1042,7 +1061,10 @@ export function OnboardingWizard({
           goToStep('integrations');
           return;
         }
-        if (!client) return;
+        if (!client) {
+          setBoardError(NO_CLIENT_BOARD_ERROR);
+          return;
+        }
         setBoardCreating(true);
         setBoardError(null);
         try {
@@ -1734,7 +1756,11 @@ export function OnboardingWizard({
 
   const renderDone = () => {
     const aiConnected = hasAnyLlmKey(user) || (selectedAgent !== null && apiKey.trim().length > 0);
-    const teammateReady = hasExistingBoard;
+    // What the wizard has actually done by this point is create/confirm the
+    // board. The teammate itself is seeded by the app shell *after* the user
+    // clicks through, so claiming "Teammate ready" here would be a lie the
+    // checklist can't back up.
+    const boardReady = hasExistingBoard;
 
     return (
       <div style={{ textAlign: 'center', padding: '8px 0' }}>
@@ -1812,7 +1838,11 @@ export function OnboardingWizard({
         <Paragraph
           style={{ color: TEXT_SECONDARY, marginBottom: 28, maxWidth: 380, margin: '0 auto 28px' }}
         >
-          Open your board to start your first AI session.
+          {/* Without a model there is no first session to open — the completion
+              handler deliberately stops at the board. Don't promise one. */}
+          {aiConnected
+            ? 'Open your board to start your first AI session.'
+            : 'Open your board to get started. Connect an AI model in Settings whenever you are ready.'}
         </Paragraph>
 
         {/* Summary checklist */}
@@ -1836,9 +1866,9 @@ export function OnboardingWizard({
               hint: 'Add in Settings - AI & Agents',
             },
             {
-              label: 'Teammate ready',
-              done: teammateReady,
-              hint: 'Add more teammates anytime in Settings',
+              label: 'Board created',
+              done: boardReady,
+              hint: 'Create one anytime from the sidebar',
             },
             {
               label: 'MCP tools',

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -27,7 +27,19 @@ import {
   TeamOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Input, List, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import {
+  Alert,
+  Button,
+  Divider,
+  Input,
+  List,
+  Modal,
+  Spin,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
@@ -1643,30 +1655,28 @@ export function OnboardingWizard({
         </div>
       </div>
 
-      {/* Concept pills */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 24 }}>
+      {/* Glossary — reference text, not interactive */}
+      <Divider titlePlacement="start" plain style={{ margin: '24px 0 12px' }}>
+        <Text
+          style={{
+            color: TEXT_MUTED,
+            fontSize: 11,
+            letterSpacing: 0.4,
+            textTransform: 'uppercase',
+          }}
+        >
+          Quick reference
+        </Text>
+      </Divider>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         {[
           { term: 'Branch', def: 'isolated workspace per task' },
           { term: 'Session', def: 'conversation with your AI' },
           { term: 'Board', def: 'kanban view of all branches' },
         ].map(({ term, def }) => (
-          <div
-            key={term}
-            style={{
-              background:
-                'linear-gradient(135deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.03) 100%)',
-              border: '1px solid rgba(255,255,255,0.13)',
-              backdropFilter: 'blur(12px)',
-              WebkitBackdropFilter: 'blur(12px)',
-              borderRadius: 20,
-              padding: '4px 12px',
-              fontSize: 12,
-              color: TEXT_SECONDARY,
-              boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.09)',
-            }}
-          >
-            <span style={{ color: TEXT_PRIMARY, fontWeight: 500 }}>{term}</span> - {def}
-          </div>
+          <Text key={term} style={{ color: TEXT_SECONDARY, fontSize: 12 }}>
+            <span style={{ color: TEXT_PRIMARY, fontWeight: 500 }}>{term}</span> — {def}
+          </Text>
         ))}
       </div>
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -103,7 +103,7 @@ const STEP_META: Record<WizardStep, { number: number; label: string; skippable: 
   persona: { number: 1, label: 'You', skippable: true },
   llm: { number: 2, label: 'AI', skippable: true },
   workspace: { number: 3, label: 'Workspace', skippable: false },
-  integrations: { number: 4, label: 'Tools', skippable: true },
+  integrations: { number: 4, label: 'Tools', skippable: false },
   done: { number: 5, label: "You're ready", skippable: false },
 };
 
@@ -1688,7 +1688,7 @@ export function OnboardingWizard({
     const recs = PERSONA_MCP_RECS[selectedPersona ?? '_default'] ?? PERSONA_MCP_RECS._default;
     return (
       <div>
-        {renderStepBadge('Connect your tools via MCP')}
+        {renderStepBadge('Recommended tools')}
 
         {/* General MCP intro — plain helper text, not a card */}
         <div

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -173,8 +173,6 @@ interface McpRecommendation {
   featured?: boolean;
 }
 
-const MCP_DOCS_URL = 'https://agor.live/docs/mcp';
-
 const PERSONA_MCP_RECS: Record<string, McpRecommendation[]> = {
   developer: [
     {
@@ -1700,15 +1698,7 @@ export function OnboardingWizard({
           }}
         >
           These are the tools we recommend for your work. You can connect any of them via MCP — just
-          ask your AI teammate to help set them up.{' '}
-          <Typography.Link
-            href={MCP_DOCS_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: 12 }}
-          >
-            What's MCP?
-          </Typography.Link>
+          ask your AI teammate to help set them up.
         </div>
 
         {/* Persona-curated MCP recommendations — informational list, no selection */}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -81,10 +81,16 @@ const AUTH_METHOD_OPTIONS: Partial<
 
 const STEPS: WizardStep[] = ['persona', 'llm', 'workspace', 'integrations', 'done'];
 
+// Prefilled so the required workspace step never blocks on an empty field; the
+// user can rename it. Named the teammate and the board the wizard creates.
+const DEFAULT_TEAMMATE_NAME = 'Scout';
+
+// The workspace step creates the user's board + first teammate, so it is NOT
+// skippable — completing the wizard must always yield a board to land on.
 const STEP_META: Record<WizardStep, { number: number; label: string; skippable: boolean }> = {
   persona: { number: 1, label: 'You', skippable: true },
   llm: { number: 2, label: 'AI', skippable: true },
-  workspace: { number: 3, label: 'Workspace', skippable: true },
+  workspace: { number: 3, label: 'Workspace', skippable: false },
   integrations: { number: 4, label: 'Tools', skippable: true },
   done: { number: 5, label: "You're ready", skippable: false },
 };
@@ -543,7 +549,7 @@ export function OnboardingWizard({
   // ── Step 3: workspace — name the user's first AI teammate ─────────────────
   // The teammate's name/emoji also names the board the wizard creates for them,
   // which the teammate is later seeded onto (see App.handleOnboardingComplete).
-  const [teammateName, setTeammateName] = useState('');
+  const [teammateName, setTeammateName] = useState(DEFAULT_TEAMMATE_NAME);
   const [teammateEmoji, setTeammateEmoji] = useState('🤖');
   const [createdBoardId, setCreatedBoardId] = useState<string | null>(null);
   const [boardCreating, setBoardCreating] = useState(false);
@@ -574,7 +580,7 @@ export function OnboardingWizard({
     setLlmSaving(false);
     setLlmAuthChecking(null);
     setLlmAuthVerified({});
-    setTeammateName('');
+    setTeammateName(DEFAULT_TEAMMATE_NAME);
     setTeammateEmoji('🤖');
     setCreatedBoardId(null);
     setBoardError(null);
@@ -624,7 +630,7 @@ export function OnboardingWizard({
     } else {
       setSelectedAgent(null);
     }
-    setTeammateName('');
+    setTeammateName(DEFAULT_TEAMMATE_NAME);
     setCreatedBoardId(null);
   }, [open, user]);
 
@@ -778,7 +784,7 @@ export function OnboardingWizard({
       }
       case 'workspace':
         if (boardVerifying) return false;
-        return hasExistingBoard || teammateName.trim().length > 0;
+        return teammateName.trim().length > 0;
       case 'integrations':
         return true;
       case 'done':
@@ -794,7 +800,6 @@ export function OnboardingWizard({
     apiKey,
     authMethod,
     boardVerifying,
-    hasExistingBoard,
     teammateName,
   ]);
 
@@ -823,7 +828,6 @@ export function OnboardingWizard({
       }
       case 'workspace':
         if (boardVerifying) return null;
-        if (hasExistingBoard) return null;
         return teammateName.trim().length === 0 ? 'Name your AI teammate to continue' : null;
       default:
         return null;
@@ -838,7 +842,6 @@ export function OnboardingWizard({
     apiKey,
     authMethod,
     boardVerifying,
-    hasExistingBoard,
     teammateName,
     llmSaving,
     boardCreating,
@@ -847,7 +850,7 @@ export function OnboardingWizard({
   const primaryLabel = useMemo(() => {
     switch (currentStep) {
       case 'persona':
-        return selectedPersona ? 'This is me →' : 'Continue →';
+        return 'Continue →';
       case 'llm': {
         if (
           selectedAgent &&
@@ -859,17 +862,15 @@ export function OnboardingWizard({
         return 'Connect →';
       }
       case 'workspace':
-        return hasExistingBoard ? 'Keep going →' : 'Continue →';
+        return 'Continue →';
       case 'integrations':
-        return 'Connect when done →';
+        return 'Continue →';
       case 'done':
         return completing ? 'Setting up your AI teammate…' : 'Open my board →';
     }
   }, [
     currentStep,
     completing,
-    hasExistingBoard,
-    selectedPersona,
     selectedAgent,
     agentHasKey,
     llmAuthVerified,
@@ -1005,11 +1006,33 @@ export function OnboardingWizard({
         break;
       }
       case 'workspace': {
-        if (hasExistingBoard) {
+        if (!teammateName.trim()) return;
+        // Board created earlier this pass (Back → edit → forward): rename the
+        // same board instead of creating a duplicate.
+        if (createdBoardId) {
+          if (!client) return;
+          setBoardCreating(true);
+          setBoardError(null);
+          try {
+            await client
+              .service('boards')
+              .patch(createdBoardId, { name: teammateName.trim(), icon: teammateEmoji });
+            if (user) saveOnboardingProgress({ boardId: createdBoardId });
+            goToStep('integrations');
+          } catch (err) {
+            setBoardError(err instanceof Error ? err.message : 'Failed to rename board');
+          } finally {
+            setBoardCreating(false);
+          }
+          return;
+        }
+        // A board the user already had before onboarding is theirs — carry the
+        // teammate name forward without renaming their board.
+        if (verifiedBoard) {
           goToStep('integrations');
           return;
         }
-        if (!client || !teammateName.trim()) return;
+        if (!client) return;
         setBoardCreating(true);
         setBoardError(null);
         try {
@@ -1076,7 +1099,6 @@ export function OnboardingWizard({
     authMethod,
     onCheckAuth,
     onUpdateUser,
-    hasExistingBoard,
     client,
     teammateName,
     teammateEmoji,
@@ -1683,18 +1705,16 @@ export function OnboardingWizard({
             lineHeight: 1.6,
           }}
         >
-          Agor connects your AI to external tools using{' '}
+          These are the tools we recommend for your work — nothing to connect on this screen. Once
+          you're in, just ask your AI teammate to connect any of them for you.{' '}
           <Typography.Link
             href={MCP_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
             style={{ fontSize: 12 }}
           >
-            MCP (Model Context Protocol)
+            What's MCP?
           </Typography.Link>
-          . You set each one up yourself in{' '}
-          <span style={{ color: TEXT_PRIMARY, fontWeight: 500 }}>Settings - MCP</span>. Here are the
-          ones that work well for you.
         </div>
 
         {/* Persona-curated MCP recommendations — informational, no selection */}
@@ -1707,8 +1727,9 @@ export function OnboardingWizard({
                 border: GLASS_CARD_BORDER,
                 backdropFilter: 'blur(20px)',
                 WebkitBackdropFilter: 'blur(20px)',
-                borderRadius: 12,
-                boxShadow: GLASS_CARD_SHADOW,
+                borderRadius: 10,
+                boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.09)',
+                cursor: 'default',
                 overflow: 'hidden',
               }}
             >
@@ -1749,7 +1770,7 @@ export function OnboardingWizard({
 
   const renderDone = () => {
     const aiConnected = hasAnyLlmKey(user) || (selectedAgent !== null && apiKey.trim().length > 0);
-    const workspaceReady = hasExistingBoard;
+    const teammateReady = hasExistingBoard;
 
     return (
       <div style={{ textAlign: 'center', padding: '8px 0' }}>
@@ -1851,9 +1872,9 @@ export function OnboardingWizard({
               hint: 'Add in Settings - AI & Agents',
             },
             {
-              label: 'Workspace ready',
-              done: workspaceReady,
-              hint: 'Create a board in Settings',
+              label: 'Teammate ready',
+              done: teammateReady,
+              hint: 'Add more teammates anytime in Settings',
             },
             {
               label: 'MCP tools',

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -150,6 +150,33 @@ describe('seedOnboardingTeammate', () => {
     expect(result).toEqual({});
   });
 
+  // The LLM step is skippable, so `agent` can legitimately be null at completion.
+  // Bootstrapping a claude-code session anyway would fail on the first turn with
+  // no credentials — the workspace is still created, but the caller gets no
+  // session id and therefore lands the user on their board.
+  for (const agent of [null, undefined] as const) {
+    it(`creates the workspace but no session when the LLM step was skipped (agent: ${agent})`, async () => {
+      createTeammateBranchMock.mockResolvedValue({
+        branch_id: 'branch-1',
+        board_id: 'board-1',
+      } as Branch);
+
+      const { input, onWarn, onCreateSession } = setup({ agent });
+      const result = await seedOnboardingTeammate(input);
+
+      // The teammate's branch still lands on the board...
+      expect(createTeammateBranchMock).toHaveBeenCalledTimes(1);
+      // ...but nothing is prompted, and no claude-code default sneaks in.
+      expect(startTeammateBootstrapSessionMock).not.toHaveBeenCalled();
+      expect(onCreateSession).not.toHaveBeenCalled();
+      expect(result).toEqual({});
+
+      // The user is told why there's no session waiting for them.
+      expect(onWarn).toHaveBeenCalledTimes(1);
+      expect(onWarn.mock.calls[0][0]).toMatch(/connect an ai model/i);
+    });
+  }
+
   it('does nothing when no teammate was named (the workspace step was skipped)', async () => {
     const { input, onWarn } = setup({ teammateName: '   ' });
     const result = await seedOnboardingTeammate(input);

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -13,7 +13,11 @@ export interface SeedOnboardingTeammateInput {
   boardId: string;
   teammateName?: string;
   teammateEmoji?: string;
-  /** Agent chosen in the LLM step; defaults to claude-code. */
+  /**
+   * Agent chosen in the LLM step. `null`/`undefined` means the user skipped that
+   * step and has no credentials, so no bootstrap session is started — see the
+   * skip handling in `seedOnboardingTeammate`.
+   */
   agent?: AgenticToolName | null;
   /** Persona-tailored MCP integration names to suggest in the onboarding prompt. */
   suggestedIntegrations?: string[];
@@ -36,6 +40,10 @@ export interface SeedOnboardingTeammateInput {
  * session creation throws, it surfaces a non-fatal warning and resolves without
  * a session so the caller can still finish onboarding on the board. Returns the
  * onboarding session id when one was created.
+ *
+ * Skipping the LLM step is a supported outcome, not a failure: the teammate's
+ * workspace is still created, but no session is started, so the caller lands the
+ * user on their board rather than in a conversation that cannot run.
  */
 export async function seedOnboardingTeammate(
   input: SeedOnboardingTeammateInput
@@ -75,13 +83,24 @@ export async function seedOnboardingTeammate(
       return {};
     }
 
+    // No agent means the LLM step was skipped: there is no configured model to
+    // run on. Silently defaulting to claude-code here would open a session whose
+    // very first turn fails on missing credentials, so stop at the workspace and
+    // tell the user what to do instead.
+    if (!input.agent) {
+      input.onWarn(
+        `${teammateName}'s workspace is ready. Connect an AI model in Settings - AI & Agents to start your first session.`
+      );
+      return {};
+    }
+
     const sessionId = await startTeammateBootstrapSession({
       client: input.client,
       branchId: branch.branch_id,
       boardId: branch.board_id || input.boardId,
       sessionConfig: {
         branch_id: branch.branch_id,
-        agent: input.agent ?? 'claude-code',
+        agent: input.agent,
         title: buildTeammateOnboardingSessionTitle({
           displayName: teammateName,
           emoji: input.teammateEmoji,


### PR DESCRIPTION
> ✅ **Rebased onto `main` (post-#2294).** #2294 ("too many icons") has merged and this branch is rebased on top of it — both sets of changes are preserved: the MCP recommendation cards keep #2294's real logos (`McpLogo`) and now carry this PR's non-interactive "recommendations, connect later" treatment, and the workspace step keeps #2294's "join your existing board" affordance alongside this PR's always-editable teammate name. **Merge order: land after #2293** (personal/goals — "persona → goal cards redesign + first-session fixes", which also edits the onboarding wizard, incl. the persona step this PR touches). Per Kasia/Kamil, #2293 merges first; this branch will then be **rebased onto `main`** before merging.

## Context / Problem

The first-run onboarding wizard review (testers: Juliann, Anna, Seb, Sophie, Vitor) surfaced a cluster of usability bugs and confusing copy on the wizard's later steps. This PR bundles the fixes that came out of that feedback into a single pass over the wizard.

## Goal

Finishing the wizard should always leave the user set up and on their board, and every step's copy/affordance should match what it actually does.

## Changes

1. **Always land on a board after the wizard — never the homepage.** `handleOnboardingComplete` (`App.tsx`) resolves a board destination (seeded session → wizard-created board → the user's main board → any existing board) via the centralized path builders; the bare `navigate('/')` is gone.
2. **The board / AI-teammate step is required.** The workspace step is the only one that creates the board + first teammate, so it's now `skippable: false` (with a prefilled default name so "required" never blocks on an empty field). Completion therefore always yields a board + teammate to open. Other steps stay skippable — no flow or field dropped.
3. **Step 3 keeps the teammate name editable.** Previously, once a board existed (go forward → Back, or a pre-existing workspace board), the name/avatar editor was replaced by a read-only "Board already set up" card, so you couldn't (re)name the teammate. The editor now always renders, prefilled; editing after a board was created **patches that same board** (no duplicate); a **pre-existing** board is never renamed. Copy is teammate-centric.
4. **Finish-screen checklist:** "Workspace ready" → **"Teammate ready"** (the required step always sets up the teammate now).
5. **Primary CTA copy is consistent and matches the action.** `persona` is always "Continue →" (was morphing to "This is me →" once selected, though the action is identical); `integrations` is "Continue →" (was "Connect when done →", which read like a button but only advances). The `llm` step keeps "Connect →"/"Continue →" because there the label genuinely reflects a different action.
6. **Integrations / MCP step reframed as recommendations.** The connector cards no longer look clickable, and the copy makes clear nothing is set up on this screen — the AI teammate helps connect tools later. Removes the "you set each one up yourself in Settings" framing that read like an action.

## Onboarding-review items addressed

- **"Skipping All Onboarding Questions"** (P1) — dropped-on-homepage-after-skip → fixed by #1 + #2. https://app.notion.com/p/3b98718b646580318817c5de132b3c7c
- **OB-04 · MCP connector cards look clickable but do nothing** (P1) — → #6 (cards non-interactive, rationale kept via the Recommended tag + descriptions). https://app.notion.com/p/3ba8718b646581228c88d366c25ec555
- **OB-05 · "why can't I connect them here?"** (P1) — → #5 + #6. Resolved per Sophie's suggestion (the teammate prompts/handles connection later), **not** by adding inline connect during onboarding. https://app.notion.com/p/3ba8718b646581afb027fa83ec3e6e54

## How verified

- Onboarding wizard vitest suite passing; `tsc -b` + biome clean on touched files. CI was 3/3 green on the land-on-board + editable-name + done-label commits; re-runs as the copy commits land.
- The RBAC-for-members concern that rode in on the "Skipping All Onboarding Questions" report was split out to its own P1 (Member User Permissions - MCP Servers) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**From Notion (Skipping All Onboarding Questions - Still shows actions as checked off):**

**Problem.** If a user chooses to skip through the entire onboarding flow, they get dropped onto the home page, and tasks are still checked off (screenshot on file in Notion). Member-permission concern (member prompted to add MCPs they can't save) moved to its own P1: "Member User Permissions - MCP Servers".

**From Notion (OB-04 · MCP connector cards look clickable but do nothing (x3)):**

**Problem.** On the Integrations step the connector cards **look clickable but do nothing** — "I would expect this to be 'connect'!" (Juliann); Anna: buttons "looked clickable but didn't respond." Seb adds the **recommendation logic is invisible** — no rationale for *why* these tools are suggested. The single action the screen invites fails silently, at the exact step it's offered. Third tester to hit it.

**Where in Agor:** Step 4 — Integrations / connect tools.
**Source:** Juliann, Anna, Seb (x3).