### PR TITLE
fix: improve provider credit and OAuth recovery

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -50,11 +50,13 @@ import type {
   OAuthFlowContext,
   OAuthTokenResponse,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import { OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import type {
   AuthenticatedParams,
   HookContext,
   MCPAuth,
   MCPOAuthAttemptID,
+  MCPOAuthDCRDiagnostic,
   MCPOAuthDCRMode,
   MCPOAuthPendingFlowStatus,
   MCPServerID,
@@ -1447,6 +1449,10 @@ async function registerMCPServices(
     '(3) /.well-known/oauth-authorization-server at MCP origin (RFC 8414), ' +
     '(4) /.well-known/openid-configuration at MCP origin (OIDC).';
 
+  function oauthDcrDiagnostic(error: unknown): MCPOAuthDCRDiagnostic | undefined {
+    return error instanceof OAuthDCRFailure ? error.diagnostic : undefined;
+  }
+
   type StartTwoPhaseOAuthOptions = {
     mcpUrl: string;
     wwwAuthenticate: string;
@@ -2400,10 +2406,12 @@ async function registerMCPServices(
                   flowError instanceof Error ? flowError.name : 'unknown'
                 }`
               );
+              const diagnostic = oauthDcrDiagnostic(flowError);
               return {
                 success: false,
                 error: `OAuth 2.1 browser flow failed: ${flowError instanceof Error ? flowError.message : String(flowError)}`,
                 oauthType: 'oauth2.1',
+                ...(diagnostic ? { diagnostic } : {}),
               };
             }
           }
@@ -2783,7 +2791,12 @@ async function registerMCPServices(
         console.error(
           `[OAuth Start] Failed category=${error instanceof Error ? error.name : 'unknown'}`
         );
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        const diagnostic = oauthDcrDiagnostic(error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          ...(diagnostic ? { diagnostic } : {}),
+        };
       }
     },
   });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const showSuccess = vi.fn();
 const showError = vi.fn();
 
+type FormFieldsMockProps = {
+  onSaveBeforeOAuthRetry?: () => Promise<boolean>;
+};
+
 vi.mock('@/utils/message', () => ({
   useThemedMessage: () => ({
     showSuccess,
@@ -15,12 +19,23 @@ vi.mock('@/utils/message', () => ({
 }));
 
 vi.mock('./MCPServerFormFields', async () => {
-  const { Form, Input } = await import('antd');
+  const { Button, Form, Input } = await import('antd');
   return {
-    MCPServerFormFields: () => (
-      <Form.Item label="Description" name="description">
-        <Input />
-      </Form.Item>
+    MCPServerFormFields: ({ onSaveBeforeOAuthRetry }: FormFieldsMockProps) => (
+      <>
+        <Form.Item label="Description" name="description">
+          <Input />
+        </Form.Item>
+        <Form.Item label="Client ID" name="oauth_client_id">
+          <Input />
+        </Form.Item>
+        <Form.Item label="Client Secret" name="oauth_client_secret">
+          <Input />
+        </Form.Item>
+        <Button onClick={() => void onSaveBeforeOAuthRetry?.()}>
+          Save OAuth settings &amp; retry
+        </Button>
+      </>
     ),
   };
 });
@@ -59,6 +74,50 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     const updates = patch.mock.calls[0]?.[1] as { auth?: Record<string, unknown> };
     expect(updates.auth).not.toHaveProperty('oauth_dcr_mode');
     expect(showSuccess).toHaveBeenCalled();
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('persists edited OAuth client credentials without closing before a retry', async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const onClose = vi.fn();
+    const client = {
+      service: vi.fn().mockReturnValue({ patch }),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000002',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      description: 'server',
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+      scope: 'global',
+      enabled: true,
+      auth: {
+        type: 'oauth',
+        oauth_client_id: 'stale-client-id',
+        oauth_client_secret: 'stale-client-secret',
+      },
+    } as MCPServer;
+
+    render(<MCPServerEditModal server={server} open client={client} onClose={onClose} />);
+
+    fireEvent.change(await screen.findByLabelText('Client ID'), {
+      target: { value: 'fresh-client-id' },
+    });
+    fireEvent.change(screen.getByLabelText('Client Secret'), {
+      target: { value: 'fresh-client-secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save OAuth settings & retry' }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+    const updates = patch.mock.calls[0]?.[1] as { auth?: Record<string, unknown> };
+    expect(updates.auth).toMatchObject({
+      type: 'oauth',
+      oauth_client_id: 'fresh-client-id',
+      oauth_client_secret: 'fresh-client-secret',
+    });
+    expect(onClose).not.toHaveBeenCalled();
     expect(showError).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -187,8 +187,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     }
   };
 
-  const handleSave = async () => {
-    if (!server || !client) return;
+  const saveFormValues = async (): Promise<boolean> => {
+    if (!server || !client) return false;
 
     try {
       await form.validateFields();
@@ -216,12 +216,18 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       updates.auth = buildAuthFromValues(values, { preserveAbsentDcrMode });
 
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
-
-      showSuccess('MCP server updated successfully');
-      closeAndReset();
+      return true;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to update server';
       showError(errorMessage);
+      return false;
+    }
+  };
+
+  const handleSave = async () => {
+    if (await saveFormValues()) {
+      showSuccess('MCP server updated successfully');
+      closeAndReset();
     }
   };
 
@@ -255,6 +261,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
           onTestConnection={handleTestConnection}
           testing={testing}
           testResult={testResult}
+          onSaveBeforeOAuthRetry={saveFormValues}
         />
       </Form>
     </Modal>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -1,0 +1,97 @@
+import type { AgorClient } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPServerFormFields } from './MCPServerFormFields';
+
+const showError = vi.fn();
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({
+    showError,
+    showInfo: vi.fn(),
+    showSuccess: vi.fn(),
+    showWarning: vi.fn(),
+  }),
+}));
+
+describe('MCPServerFormFields OAuth recovery', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders safe DCR diagnostics and opens the existing manual client fields', async () => {
+    const testOAuth = vi.fn().mockResolvedValue({
+      success: true,
+      requiresBrowserFlow: true,
+      message: 'OAuth 2.1 metadata discovered.',
+    });
+    const startOAuth = vi.fn().mockResolvedValue({
+      success: false,
+      error:
+        'Dynamic Client Registration failed (HTTP 400) at stage dcr_registration. Provider response: invalid_client_metadata — redirect URI is not approved. The provider rejected the configured OAuth redirect URI. Enter the Client ID and Client Secret for a pre-registered OAuth app in Advanced — OAuth settings, then retry.',
+      diagnostic: {
+        stage: 'dcr_registration',
+        http_status: 400,
+        error: 'invalid_client_metadata',
+        error_description: 'redirect URI is not approved',
+      },
+    });
+    const client = {
+      service: vi.fn((path: string) => {
+        if (path === 'mcp-servers/test-oauth') return { create: testOAuth };
+        if (path === 'mcp-servers/oauth-start') return { create: startOAuth };
+        throw new Error(`unexpected service ${path}`);
+      }),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const saveBeforeOAuthRetry = vi.fn().mockResolvedValue(true);
+
+    const TestForm = () => {
+      const [form] = Form.useForm();
+      useEffect(() => {
+        form.setFieldsValue({ url: 'https://mcp.example.com', auth_type: 'oauth' });
+      }, [form]);
+      return (
+        <Form
+          form={form}
+          initialValues={{
+            url: 'https://mcp.example.com',
+          }}
+        >
+          <MCPServerFormFields
+            mode="edit"
+            transport="http"
+            authType="oauth"
+            form={form}
+            client={client}
+            serverId="server-1"
+            onSaveBeforeOAuthRetry={saveBeforeOAuthRetry}
+          />
+        </Form>
+      );
+    };
+
+    render(<TestForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test Authentication' }));
+    await waitFor(() => expect(testOAuth).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Start OAuth Flow' })).toBeVisible()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start OAuth Flow' }));
+    expect(await screen.findByText('OAuth setup needs attention')).toBeInTheDocument();
+    expect(screen.getAllByText(/HTTP 400/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/redirect URI is not approved/)).toBeInTheDocument();
+    expect(screen.queryByText(/figma/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open OAuth settings' }));
+    await waitFor(() => expect(screen.getByLabelText('Client ID')).toBeVisible());
+    expect(screen.getByLabelText('Client Secret')).toBeVisible();
+    expect(startOAuth).toHaveBeenCalledWith(expect.objectContaining({ mcp_server_id: 'server-1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save OAuth settings & retry' }));
+    await waitFor(() => expect(saveBeforeOAuthRetry).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(2));
+    expect(showError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -1,3 +1,4 @@
+import type { MCPOAuthDCRDiagnostic } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { ApiOutlined, DownOutlined } from '@ant-design/icons';
 import type { FormInstance } from 'antd';
@@ -56,6 +57,8 @@ export interface MCPServerFormFieldsProps {
   } | null;
   /** Callback to save server first before OAuth flow (for new servers) */
   onSaveFirst?: () => Promise<string | null>;
+  /** Persist edited OAuth settings before retrying an existing server's flow. */
+  onSaveBeforeOAuthRetry?: () => Promise<boolean>;
 }
 
 /**
@@ -83,11 +86,17 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   testing = false,
   testResult,
   onSaveFirst,
+  onSaveBeforeOAuthRetry,
 }) => {
   const { showSuccess, showError, showWarning, showInfo } = useThemedMessage();
   const [testingAuth, setTestingAuth] = useState(false);
   const [oauthBrowserFlowAvailable, setOauthBrowserFlowAvailable] = useState(false);
   const [startingOAuthFlow, setStartingOAuthFlow] = useState(false);
+  const [oauthFailure, setOauthFailure] = useState<{
+    message: string;
+    diagnostic?: MCPOAuthDCRDiagnostic;
+  } | null>(null);
+  const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
 
   // OAuth flow state
   const [oauthCallbackModalVisible, setOauthCallbackModalVisible] = useState(false);
@@ -168,6 +177,13 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       setEffectiveServerId(newServerId);
     }
 
+    const isOAuthRetry = oauthFailure !== null;
+    if (isOAuthRetry && targetServerId && onSaveBeforeOAuthRetry) {
+      showInfo('Saving OAuth settings before retrying...');
+      const saved = await onSaveBeforeOAuthRetry();
+      if (!saved) return;
+    }
+
     const values = form.getFieldsValue(true);
     const requestData = extractOAuthConfigForTesting(values);
     if (!requestData) {
@@ -176,6 +192,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     }
 
     setStartingOAuthFlow(true);
+    setOauthFailure(null);
 
     try {
       showInfo('Starting OAuth authentication flow...');
@@ -191,6 +208,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         authorizationUrl?: string;
         attempt_id?: string;
         state?: string;
+        diagnostic?: MCPOAuthDCRDiagnostic;
       };
 
       if (data.success && data.authorizationUrl && data.attempt_id) {
@@ -218,6 +236,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
               showSuccess('OAuth authentication successful!');
               setOauthCallbackModalVisible(false);
               setOauthBrowserFlowAvailable(false);
+              setOauthFailure(null);
             } else {
               showError(oauthAttemptFailureMessage(attempt.status));
               setOauthCallbackModalVisible(false);
@@ -231,10 +250,15 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             if (!controller.signal.aborted) cleanup();
           });
       } else {
-        showError(data.error || 'Failed to start OAuth flow');
+        setOauthFailure({
+          message: data.error || 'Failed to start OAuth flow',
+          diagnostic: data.diagnostic,
+        });
       }
     } catch (error) {
-      showError(`OAuth flow error: ${error instanceof Error ? error.message : String(error)}`);
+      setOauthFailure({
+        message: `OAuth flow error: ${error instanceof Error ? error.message : String(error)}`,
+      });
     } finally {
       setStartingOAuthFlow(false);
     }
@@ -277,6 +301,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
 
     const values = form.getFieldsValue(true);
     const currentAuthType = values.auth_type || authType;
+    if (currentAuthType === 'oauth') setOauthFailure(null);
 
     setTestingAuth(true);
     try {
@@ -528,6 +553,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     oauth_scope: undefined,
                   });
                 }
+                setOauthFailure(null);
                 onAuthTypeChange?.(value as 'none' | 'bearer' | 'jwt' | 'oauth');
               }}
             >
@@ -592,7 +618,9 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             )}
             {authType === 'oauth' && oauthBrowserFlowAvailable && (
               <Button type="primary" loading={startingOAuthFlow} onClick={handleStartOAuthFlow}>
-                Start OAuth Flow
+                {oauthFailure && mode === 'edit'
+                  ? 'Save OAuth settings & retry'
+                  : 'Start OAuth Flow'}
               </Button>
             )}
             {authType === 'oauth' && effectiveServerId && !oauthBrowserFlowAvailable && (
@@ -717,12 +745,47 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         />
       )}
 
+      {oauthFailure && (
+        <Alert
+          type="error"
+          title="OAuth setup needs attention"
+          description={
+            <Space orientation="vertical" size={4}>
+              <Typography.Text>{oauthFailure.message}</Typography.Text>
+              {oauthFailure.diagnostic && (
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Stage: {oauthFailure.diagnostic.stage.replaceAll('_', ' ')}
+                  {oauthFailure.diagnostic.http_status !== undefined
+                    ? ` · HTTP ${oauthFailure.diagnostic.http_status}`
+                    : ''}
+                </Typography.Text>
+              )}
+            </Space>
+          }
+          action={
+            <Button size="small" onClick={() => setOauthAdvancedOpen(true)}>
+              Open OAuth settings
+            </Button>
+          }
+          showIcon
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
       {/* Advanced — long tail of OAuth endpoints that are normally
           auto-discovered. Collapsed by default; a dot on the header
           signals that one or more values have been customized. */}
       {showAdvancedSection && (
         <Collapse
           ghost
+          activeKey={oauthAdvancedOpen ? ['advanced-oauth'] : []}
+          onChange={(activeKey) => {
+            setOauthAdvancedOpen(
+              Array.isArray(activeKey)
+                ? activeKey.includes('advanced-oauth')
+                : activeKey === 'advanced-oauth'
+            );
+          }}
           // Keep panel children mounted when collapsed so Form.Items inside
           // don't lose their values (and Form.useWatch keeps reporting them).
           destroyOnHidden={false}
@@ -759,7 +822,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                         </li>
                         <li>
                           Set Client ID / Client Secret only for servers that require a
-                          pre-registered OAuth app (e.g. Figma, GitHub).
+                          pre-registered OAuth app.
                         </li>
                         <li>
                           Override the URLs only if the server doesn't expose a discovery document
@@ -811,7 +874,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                   <Form.Item
                     label="Client Secret"
                     name="oauth_client_secret"
-                    tooltip="Required for servers that use confidential clients (e.g. Figma). The secret is sent via HTTP Basic Auth during token exchange."
+                    tooltip="Required for servers that use confidential clients. The secret is sent via HTTP Basic Auth during token exchange."
                   >
                     <Input.Password
                       placeholder="Enter client secret or {{ user.env.OAUTH_CLIENT_SECRET }}"

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
@@ -1,5 +1,6 @@
+import { PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND } from '@agor/core/types';
 import type { Message } from '@agor-live/client';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { MessageBlock } from './MessageBlock';
 
@@ -22,5 +23,29 @@ describe('MessageBlock layout', () => {
 
     expect(bubble).toHaveStyle({ maxWidth: '100%' });
     expect(body).toHaveStyle({ minWidth: '0' });
+  });
+
+  it('renders provider credit exhaustion as recovery state instead of raw provider text', () => {
+    const unsafeProviderBody = 'Credit balance is too low; provider-secret-body-marker';
+    const message = {
+      message_id: 'message-2',
+      session_id: 'session-1',
+      type: 'system',
+      role: 'system',
+      index: 1,
+      timestamp: '2026-07-23T00:00:00.000Z',
+      content: unsafeProviderBody,
+      content_preview: unsafeProviderBody,
+      metadata: {
+        error_kind: PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+        error_code: 'PROVIDER_CREDIT_EXHAUSTED',
+        tool: 'claude-code',
+      },
+    } as unknown as Message;
+
+    render(<MessageBlock message={message} />);
+
+    expect(screen.getByText(/no available balance or usage quota/i)).toBeInTheDocument();
+    expect(screen.queryByText(/provider-secret-body-marker/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -9,6 +9,7 @@
  * - User emoji avatars
  */
 
+import { PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND } from '@agor/core/types';
 import {
   type AgenticToolName,
   type AgorClient,
@@ -37,6 +38,7 @@ import { CopyableContent } from '../CopyableContent';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { MissingCredentialPanel } from '../MissingCredentialPanel';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
+import { ProviderCreditExhaustedPanel } from '../ProviderCreditExhaustedPanel';
 import { SystemMessage } from '../SystemMessage';
 import { ThinkingBlock } from '../ThinkingBlock';
 import {
@@ -508,6 +510,21 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       <MissingCredentialPanel
         tool={message.metadata.tool}
         client={client}
+        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+      />
+    );
+  }
+
+  // Provider credit/quota failure — keep the workspace and teammate intact,
+  // and replace the provider's raw error body with recovery guidance.
+  if (
+    isSystem &&
+    message.metadata?.error_kind === PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND &&
+    isAgenticToolName(message.metadata?.tool)
+  ) {
+    return (
+      <ProviderCreditExhaustedPanel
+        tool={message.metadata.tool}
         onOpenAgenticToolSettings={onOpenAgenticToolSettings}
       />
     );

--- a/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/ProviderCreditExhaustedPanel.test.tsx
+++ b/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/ProviderCreditExhaustedPanel.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { ProviderCreditExhaustedPanel } from './ProviderCreditExhaustedPanel';
+
+describe('ProviderCreditExhaustedPanel', () => {
+  it('explains the provider recovery path and keeps the existing setup intact', () => {
+    const onOpenSettings = vi.fn();
+
+    render(
+      <AntApp>
+        <ProviderCreditExhaustedPanel
+          tool="claude-code"
+          onOpenAgenticToolSettings={onOpenSettings}
+        />
+      </AntApp>
+    );
+
+    expect(screen.getByText(/no available balance or usage quota/i)).toBeInTheDocument();
+    expect(screen.getByText(/AI teammate and workspace are still set up/i)).toBeInTheDocument();
+    expect(screen.getByText(/send a new message/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open Claude Code settings/i }));
+    expect(onOpenSettings).toHaveBeenCalledWith('claude-code');
+    expect(screen.getByRole('link', { name: /open Claude Code account/i })).toHaveAttribute(
+      'href',
+      'https://platform.claude.com/settings/keys'
+    );
+  });
+});

--- a/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/ProviderCreditExhaustedPanel.tsx
+++ b/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/ProviderCreditExhaustedPanel.tsx
@@ -1,0 +1,71 @@
+/**
+ * Recovery state for a provider that accepted the connection but rejected the
+ * request because its balance or usage quota is unavailable.
+ */
+
+import { AGENTIC_TOOL_DISPLAY_NAMES, AGENTIC_TOOL_KEY_CREATION_URL } from '@agor/agentic-tools';
+import type { AgenticToolName } from '@agor-live/client';
+import { Button, Space, Typography, theme } from 'antd';
+import { SystemMessage } from '../SystemMessage';
+
+const { Text, Link } = Typography;
+
+export interface ProviderCreditExhaustedPanelProps {
+  tool: AgenticToolName;
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+}
+
+export const ProviderCreditExhaustedPanel: React.FC<ProviderCreditExhaustedPanelProps> = ({
+  tool,
+  onOpenAgenticToolSettings,
+}) => {
+  const { token } = theme.useToken();
+  const displayName = AGENTIC_TOOL_DISPLAY_NAMES[tool] ?? tool;
+  const providerAccountUrl = AGENTIC_TOOL_KEY_CREATION_URL[tool];
+
+  return (
+    <SystemMessage
+      agenticTool={tool}
+      content={
+        <div style={{ maxWidth: 520 }}>
+          <Text style={{ fontSize: 13 }}>
+            Your {displayName} connection is present, but the model provider has no available
+            balance or usage quota for this request.
+          </Text>
+
+          <Text
+            type="secondary"
+            style={{ display: 'block', fontSize: 13, marginTop: token.marginSM }}
+          >
+            Add credits or increase the provider quota, or switch to another connected provider or
+            account. Your AI teammate and workspace are still set up. After fixing the provider,
+            send a new message.
+          </Text>
+
+          <Space orientation="vertical" size={4} style={{ marginTop: token.marginSM }}>
+            <Button
+              type="primary"
+              onClick={() => onOpenAgenticToolSettings?.(tool)}
+              disabled={!onOpenAgenticToolSettings}
+            >
+              Open {displayName} settings
+            </Button>
+            {providerAccountUrl && (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                Review your provider balance or quota:{' '}
+                <Link
+                  href={providerAccountUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ fontSize: 12 }}
+                >
+                  Open {displayName} account →
+                </Link>
+              </Text>
+            )}
+          </Space>
+        </div>
+      }
+    />
+  );
+};

--- a/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/index.ts
+++ b/apps/agor-ui/src/components/ProviderCreditExhaustedPanel/index.ts
@@ -1,0 +1,2 @@
+export type { ProviderCreditExhaustedPanelProps } from './ProviderCreditExhaustedPanel';
+export { ProviderCreditExhaustedPanel } from './ProviderCreditExhaustedPanel';

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -48,6 +48,16 @@ import {
   startMCPOAuthFlow,
 } from './oauth-mcp-transport';
 
+async function rejectedError<T extends Error>(promise: Promise<unknown>): Promise<T> {
+  try {
+    await promise;
+  } catch (failure) {
+    if (failure instanceof Error) return failure as T;
+    throw failure;
+  }
+  throw new Error('Expected OAuth flow to reject');
+}
+
 // ---------------------------------------------------------------------------
 // completeMCPOAuthFlow — token exchange request contract
 // ---------------------------------------------------------------------------
@@ -1168,6 +1178,137 @@ describe('strict current MCP OAuth profile', () => {
       `${issuer}/register`,
       expect.objectContaining({ method: 'POST' })
     );
+  });
+
+  it('preserves a missing advertised registration endpoint as an actionable diagnostic', async () => {
+    globalThis.fetch = strictFetch();
+
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri }
+      )
+    ).rejects.toMatchObject({
+      diagnostic: { stage: 'dcr_endpoint_discovery' },
+    });
+
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUri}"`,
+        undefined,
+        'https://agor.example.com/mcp-servers/oauth-callback',
+        { resourceUri }
+      )
+    ).rejects.toThrow(/pre-registered OAuth app|Client ID and Client Secret/i);
+  });
+
+  it('preserves a provider registration 404 without the old provider-specific copy', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'not_found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+
+    const result = startMCPOAuthFlow('', undefined, 'http://127.0.0.1:9999/oauth/callback', {
+      prefetchedAuthServerMetadata: {
+        issuer: 'https://auth.reo.dev',
+        authorization_endpoint: 'https://auth.reo.dev/oauth/authorize',
+        token_endpoint: 'https://auth.reo.dev/oauth/token',
+        registration_endpoint: 'https://auth.reo.dev/oauth/register',
+      },
+      cacheKey: 'https://mcp.reo.dev/mcp',
+      resourceUri: 'https://mcp.reo.dev/mcp',
+      compatibilityMode: 'legacy',
+      dcrMode: 'fallback',
+      allowLocalhostHttp: true,
+    });
+
+    await expect(result).rejects.toMatchObject({
+      diagnostic: { stage: 'dcr_registration', http_status: 404, error: 'not_found' },
+    });
+    await expect(result).rejects.toThrow(/advertised registration endpoint.*HTTP 404/i);
+    await expect(result).rejects.not.toThrow(/figma/i);
+  });
+
+  it('turns approved-redirect-URI rejection details into manual-client guidance', async () => {
+    const clientSecret = 'CLIENT_SECRET_SHOULD_NOT_APPEAR';
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'invalid_client_metadata',
+          error_description: `The redirect URI is not in the approved redirect URI list; client_secret=${clientSecret}`,
+        }),
+        { status: 400, headers: { 'content-type': 'application/json' } }
+      )
+    ) as unknown as typeof fetch;
+
+    const result = startMCPOAuthFlow('', undefined, 'http://127.0.0.1:9999/oauth/callback', {
+      prefetchedAuthServerMetadata: {
+        issuer: 'https://auth.reo.dev',
+        authorization_endpoint: 'https://auth.reo.dev/oauth/authorize',
+        token_endpoint: 'https://auth.reo.dev/oauth/token',
+        registration_endpoint: 'https://auth.reo.dev/oauth/register',
+      },
+      cacheKey: 'https://mcp.reo.dev/mcp',
+      resourceUri: 'https://mcp.reo.dev/mcp',
+      compatibilityMode: 'legacy',
+      dcrMode: 'fallback',
+      allowLocalhostHttp: true,
+    });
+
+    const error = await rejectedError<
+      Error & {
+        diagnostic: { error?: string; error_description?: string; http_status?: number };
+      }
+    >(result);
+    expect(error).toMatchObject({
+      diagnostic: {
+        stage: 'dcr_registration',
+        http_status: 400,
+        error: 'invalid_client_metadata',
+      },
+    });
+    expect(error.diagnostic.error_description).toMatch(/redirect URI/i);
+    expect(error.message).toMatch(/rejected the configured OAuth redirect URI/i);
+    expect(error.message).toMatch(/Client ID and Client Secret/i);
+    expect(error.message).not.toContain(clientSecret);
+  });
+
+  it('bounds and sanitizes provider error descriptions', async () => {
+    const accessToken = 'ACCESS_TOKEN_SHOULD_NOT_APPEAR';
+    const longDescription = `Provider detail access_token=${accessToken} ${'x'.repeat(2_000)}`;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: longDescription }),
+          { status: 400, headers: { 'content-type': 'application/json' } }
+        )
+      ) as unknown as typeof fetch;
+
+    const error = await rejectedError<Error & { diagnostic: { error_description?: string } }>(
+      startMCPOAuthFlow('', undefined, 'http://127.0.0.1:9999/oauth/callback', {
+        prefetchedAuthServerMetadata: {
+          issuer: 'https://auth.reo.dev',
+          authorization_endpoint: 'https://auth.reo.dev/oauth/authorize',
+          token_endpoint: 'https://auth.reo.dev/oauth/token',
+          registration_endpoint: 'https://auth.reo.dev/oauth/register',
+        },
+        cacheKey: 'https://mcp.reo.dev/mcp',
+        resourceUri: 'https://mcp.reo.dev/mcp',
+        compatibilityMode: 'legacy',
+        dcrMode: 'fallback',
+        allowLocalhostHttp: true,
+      })
+    );
+
+    expect(error.diagnostic.error_description).toMatch(/access_token=\[redacted\]/i);
+    expect(error.diagnostic.error_description?.length).toBeLessThanOrEqual(280);
+    expect(error.message).not.toContain(accessToken);
+    expect(error.message.length).toBeLessThan(1_200);
   });
 
   it('guesses issuer-relative /register only for explicit legacy fallback', async () => {

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -8,7 +8,7 @@
 
 import crypto from 'node:crypto';
 import http from 'node:http';
-import type { MCPOAuthDCRMode } from '../../types/mcp.js';
+import type { MCPOAuthDCRDiagnostic, MCPOAuthDCRMode } from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import type { OAuthTokenResponse } from './oauth-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
@@ -107,6 +107,23 @@ export class OAuthCallbackValidationError extends Error {
   ) {
     super(`OAuth callback validation failed (${failureCode})`);
     this.name = 'OAuthCallbackValidationError';
+  }
+}
+
+/**
+ * A safe, actionable Dynamic Client Registration failure.
+ *
+ * The diagnostic is intentionally structured so daemon/UI callers do not need
+ * to parse provider response text. Only sanitized `error` fields are carried;
+ * response bodies and registration credentials are never retained.
+ */
+export class OAuthDCRFailure extends Error {
+  constructor(
+    message: string,
+    readonly diagnostic: MCPOAuthDCRDiagnostic
+  ) {
+    super(message);
+    this.name = 'OAuthDCRFailure';
   }
 }
 
@@ -411,6 +428,152 @@ const dynamicClientCache = new Map<
   { client_id: string; client_secret?: string; redirect_uri: string }
 >();
 
+const MAX_DCR_RESPONSE_BODY_CHARS = 16 * 1024;
+const MAX_DCR_PROVIDER_DETAIL_CHARS = 280;
+
+const SECRET_VALUE_PATTERN =
+  /(["']?(?:client[_ -]?secret|access[_ -]?token|refresh[_ -]?token|authorization[_ -]?code|code[_ -]?verifier|api[_ -]?key|password|secret|token)["']?)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi;
+const SECRET_QUERY_PARAMETER_PATTERN =
+  /([?&](?:client_secret|access_token|refresh_token|code|code_verifier|api_key|password|secret|token)=)[^&\s]+/gi;
+
+function sanitizeProviderDetail(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+
+  const sanitized = normalized
+    .replace(SECRET_VALUE_PATTERN, '$1=[redacted]')
+    .replace(SECRET_QUERY_PARAMETER_PATTERN, '$1[redacted]')
+    .replace(/\b(Bearer|Basic)\s+[^\s,;]+/gi, '$1 [redacted]');
+
+  return sanitized.length > MAX_DCR_PROVIDER_DETAIL_CHARS
+    ? `${sanitized.slice(0, MAX_DCR_PROVIDER_DETAIL_CHARS - 1)}…`
+    : sanitized;
+}
+
+async function readDcrResponseJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    // `safeOutboundFetch` bounds the response in production. Slice again here
+    // so test doubles and future transports cannot turn provider text into an
+    // unbounded diagnostic.
+    let body: string;
+    if (typeof response.text === 'function') {
+      body = (await response.text()).slice(0, MAX_DCR_RESPONSE_BODY_CHARS);
+    } else {
+      body = JSON.stringify(await response.json()).slice(0, MAX_DCR_RESPONSE_BODY_CHARS);
+    }
+    const parsed: unknown = JSON.parse(body);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function registrationDiagnostic(
+  httpStatus: number,
+  providerResponse: Record<string, unknown> | null
+): MCPOAuthDCRDiagnostic {
+  const diagnostic: MCPOAuthDCRDiagnostic = {
+    stage: 'dcr_registration',
+    http_status: httpStatus,
+  };
+  const error = sanitizeProviderDetail(providerResponse?.error);
+  const errorDescription = sanitizeProviderDetail(providerResponse?.error_description);
+  if (error) diagnostic.error = error;
+  if (errorDescription) diagnostic.error_description = errorDescription;
+  return diagnostic;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+/** Parse only the fields the OAuth flow understands from an untrusted body. */
+function parseDynamicClientRegistrationResponse(
+  body: Record<string, unknown>
+): DynamicClientRegistrationResponse | null {
+  if (typeof body.client_id !== 'string') return null;
+
+  const result: DynamicClientRegistrationResponse = { client_id: body.client_id };
+  const stringFields = ['client_secret', 'token_endpoint_auth_method', 'client_name'] as const;
+  for (const field of stringFields) {
+    const value = body[field];
+    if (value !== undefined && typeof value !== 'string') return null;
+    if (typeof value === 'string') result[field] = value;
+  }
+
+  const numberFields = ['client_id_issued_at', 'client_secret_expires_at'] as const;
+  for (const field of numberFields) {
+    const value = body[field];
+    if (value !== undefined && typeof value !== 'number') return null;
+    if (typeof value === 'number') result[field] = value;
+  }
+
+  const arrayFields = ['redirect_uris', 'grant_types', 'response_types'] as const;
+  for (const field of arrayFields) {
+    const value = body[field];
+    if (value !== undefined && !isStringArray(value)) return null;
+    if (isStringArray(value)) result[field] = value;
+  }
+
+  return result;
+}
+
+function diagnosticStatus(diagnostic: MCPOAuthDCRDiagnostic): string {
+  return diagnostic.http_status === undefined ? '' : ` (HTTP ${diagnostic.http_status})`;
+}
+
+function diagnosticDetails(diagnostic: MCPOAuthDCRDiagnostic): string {
+  const details = [diagnostic.error, diagnostic.error_description].filter(Boolean);
+  return details.length > 0 ? ` Provider response: ${details.join(' — ')}.` : '';
+}
+
+function isRedirectUriRejection(diagnostic: MCPOAuthDCRDiagnostic): boolean {
+  return (
+    `${diagnostic.error ?? ''} ${diagnostic.error_description ?? ''}`.match(
+      /redirect[ _-]?uri|redirect[ _-]?url|approved redirect/i
+    ) !== null
+  );
+}
+
+function dcrRecoveryGuidance(diagnostic: MCPOAuthDCRDiagnostic): string {
+  const manualClient =
+    'enter the Client ID and Client Secret for a pre-registered OAuth app in Advanced — OAuth settings, then retry.';
+
+  if (isRedirectUriRejection(diagnostic)) {
+    return `The provider rejected the configured OAuth redirect URI. Approve that callback URL in the provider application, or ${manualClient}`;
+  }
+  if (diagnostic.http_status === 404) {
+    return `The advertised registration endpoint returned HTTP 404 and is unavailable or stale. Verify the provider OAuth metadata, or ${manualClient}`;
+  }
+  return `The provider rejected Dynamic Client Registration. Review its client-registration requirements, or ${manualClient}`;
+}
+
+function registrationFailure(
+  diagnostic: MCPOAuthDCRDiagnostic,
+  lead = 'Dynamic Client Registration failed'
+): OAuthDCRFailure {
+  const failureLead = lead.startsWith('Dynamic Client Registration failed')
+    ? lead
+    : `Dynamic Client Registration failed: ${lead}`;
+  return new OAuthDCRFailure(
+    `${failureLead}${diagnosticStatus(diagnostic)} at stage ${diagnostic.stage}.${diagnosticDetails(diagnostic)} ${dcrRecoveryGuidance(diagnostic)}`,
+    diagnostic
+  );
+}
+
+function missingRegistrationEndpointFailure(): OAuthDCRFailure {
+  const diagnostic: MCPOAuthDCRDiagnostic = { stage: 'dcr_endpoint_discovery' };
+  return new OAuthDCRFailure(
+    'OAuth client_id is required because the authorization server does not advertise a Dynamic Client Registration endpoint (stage: dcr_endpoint_discovery). The provider may require a pre-registered OAuth app. Enter the Client ID and Client Secret in Advanced — OAuth settings, then retry.',
+    diagnostic
+  );
+}
+
 /**
  * Test-only hook: snapshot the DCR client cache size. Used to verify that
  * `clearAuthCodeTokenCache` clears DCR registrations on blanket clears.
@@ -479,42 +642,77 @@ async function registerDynamicClient(
     body: JSON.stringify(registrationRequest),
     redirect: 'error',
     timeoutMs: 15_000,
+    maxResponseBytes: MAX_DCR_RESPONSE_BODY_CHARS,
     allowLocalhostHttp,
   });
 
   if (!response.ok) {
-    throw new Error(
-      `Dynamic Client Registration failed (${response.status}).\n\n` +
-        'This MCP server does not support Dynamic Client Registration (RFC 7591). ' +
-        "You need to register an OAuth app in the provider's developer portal " +
-        '(e.g. figma.com/developers/apps for Figma) and enter the Client ID and ' +
-        'Client Secret in the MCP server configuration.'
+    throw registrationFailure(
+      registrationDiagnostic(response.status, await readDcrResponseJson(response))
     );
   }
 
-  const result = (await response.json()) as DynamicClientRegistrationResponse;
+  const responseBody = await readDcrResponseJson(response);
+  if (!responseBody) {
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration returned an invalid response'
+    );
+  }
+  const result = parseDynamicClientRegistrationResponse(responseBody);
+
+  if (!result) {
+    const invalidClientId = responseBody.client_id;
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      typeof invalidClientId !== 'string' || !invalidClientId.trim()
+        ? 'Dynamic Client Registration returned an invalid client ID'
+        : 'Dynamic Client Registration returned an invalid response'
+    );
+  }
 
   if (typeof result.client_id !== 'string' || !result.client_id.trim()) {
-    throw new Error('Dynamic Client Registration returned an invalid client ID');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration returned an invalid client ID'
+    );
   }
   if (!result.redirect_uris?.includes(redirectUri)) {
-    throw new Error('Dynamic Client Registration did not bind the required redirect URI');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration did not bind the required redirect URI'
+    );
   }
   const authMethod = result.token_endpoint_auth_method ?? 'none';
   if (!['none', 'client_secret_basic'].includes(authMethod)) {
-    throw new Error('Dynamic Client Registration returned an unsupported token auth method');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration returned an unsupported token auth method'
+    );
   }
   if (authMethod === 'client_secret_basic' && !result.client_secret) {
-    throw new Error('Dynamic Client Registration omitted the required client secret');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration omitted the required client secret'
+    );
   }
   if (authMethod === 'none' && result.client_secret) {
-    throw new Error('Dynamic Client Registration returned incompatible public-client credentials');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration returned incompatible public-client credentials'
+    );
   }
   if (result.grant_types && !result.grant_types.includes('authorization_code')) {
-    throw new Error('Dynamic Client Registration did not enable the authorization-code grant');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration did not enable the authorization-code grant'
+    );
   }
   if (result.response_types && !result.response_types.includes('code')) {
-    throw new Error('Dynamic Client Registration did not enable the code response type');
+    throw registrationFailure(
+      { stage: 'dcr_registration', http_status: response.status },
+      'Dynamic Client Registration did not enable the code response type'
+    );
   }
 
   if (reuseLocalCache) {
@@ -1353,12 +1551,9 @@ async function startMCPOAuthFlowWithAS(opts: {
         );
         actualClientId = registration.client_id;
         resolvedClientSecret = registration.client_secret;
-      } catch {
-        throw new Error(
-          'Dynamic Client Registration failed.\n\n' +
-            "Register an OAuth app in the provider's developer portal and enter " +
-            'the Client ID (and Client Secret if required) in the MCP server configuration.'
-        );
+      } catch (error) {
+        if (error instanceof OAuthDCRFailure) throw error;
+        throw registrationFailure({ stage: 'dcr_registration' });
       }
     } else if (hasFullOverrides) {
       throw new Error(
@@ -1366,12 +1561,7 @@ async function startMCPOAuthFlowWithAS(opts: {
           'Please provide a client_id in the MCP server configuration.'
       );
     } else {
-      throw new Error(
-        'OAuth client_id is required but the authorization server does not advertise ' +
-          'a Dynamic Client Registration endpoint (RFC 7591).\n\n' +
-          "Register an OAuth app in the provider's developer portal and enter " +
-          'the Client ID (and Client Secret if required) in the MCP server configuration.'
-      );
+      throw missingRegistrationEndpointFailure();
     }
   } else if (!actualClientId) {
     throw new Error(

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -22,6 +22,7 @@ export * from './message';
 export * from './opencode-auth';
 export * from './opencode-models';
 export * from './presence';
+export * from './provider-error';
 export * from './repo';
 export * from './report';
 export * from './schedule';

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -54,6 +54,22 @@ export interface MCPOAuthRefreshResult {
 /** Credential subject selected for the resulting MCP OAuth grant. */
 export type MCPOAuthMode = 'per_user' | 'shared';
 export type MCPOAuthDCRMode = 'disabled' | 'advertised' | 'fallback';
+
+/**
+ * Safe diagnostics for a failed OAuth Dynamic Client Registration attempt.
+ *
+ * These fields are deliberately limited to provider error identifiers and
+ * descriptions. They must never contain the response body, credentials, or
+ * OAuth protocol secrets.
+ */
+export type MCPOAuthDCRDiagnosticStage = 'dcr_endpoint_discovery' | 'dcr_registration';
+export interface MCPOAuthDCRDiagnostic {
+  stage: MCPOAuthDCRDiagnosticStage;
+  http_status?: number;
+  error?: string;
+  error_description?: string;
+}
+
 export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2] as const;
 export type MCPOAuthGrantBindingVersion = (typeof MCP_OAUTH_GRANT_BINDING_VERSIONS)[number];
 

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -7,6 +7,7 @@
 
 import type { PersistedAgenticToolName } from './agentic-tool';
 import type { MessageID, SessionID, TaskID } from './id';
+import type { ProviderErrorCode, ProviderErrorKind } from './provider-error';
 import type { WidgetMessageMetadata } from './widget';
 
 /**
@@ -301,7 +302,8 @@ export interface Message {
      * session's provider". Drives the Connect-AI empty state instead of the
      * raw error; `tool` names the provider that needs a credential.
      */
-    error_kind?: 'missing_credential';
+    error_kind?: 'missing_credential' | ProviderErrorKind;
+    error_code?: ProviderErrorCode;
     tool?: PersistedAgenticToolName;
 
     /** Additional agent-specific fields */

--- a/packages/core/src/types/provider-error.test.ts
+++ b/packages/core/src/types/provider-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyProviderError,
+  PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE,
+  PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+} from './provider-error';
+
+describe('classifyProviderError', () => {
+  it.each([
+    'Credit balance is too low',
+    'Your credit balance is too low to access this API',
+    'You exceeded your current quota, please check your plan and billing details',
+    'insufficient_quota',
+    'No available credits remain for this request',
+  ])('classifies provider credit exhaustion: %s', (message) => {
+    expect(classifyProviderError(message)).toEqual({
+      kind: PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+      code: PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE,
+    });
+  });
+
+  it('classifies nested provider error objects without returning their body', () => {
+    const unsafeBody = 'provider-secret-body-marker';
+    const classification = classifyProviderError({
+      error: { message: `Credit balance is too low (${unsafeBody})` },
+    });
+
+    expect(classification).toEqual({
+      kind: PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+      code: PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE,
+    });
+    expect(JSON.stringify(classification)).not.toContain(unsafeBody);
+  });
+
+  it('classifies provider responses that expose errors as an array', () => {
+    expect(classifyProviderError({ errors: ['Credit balance is too low'] })).toEqual({
+      kind: PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+      code: PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE,
+    });
+  });
+
+  it.each([
+    'No scoped claude-code credential is configured',
+    'Key rejected by provider',
+    'The provider is temporarily unavailable',
+  ])('keeps non-quota failures unclassified: %s', (message) => {
+    expect(classifyProviderError(message)).toBeUndefined();
+  });
+});

--- a/packages/core/src/types/provider-error.ts
+++ b/packages/core/src/types/provider-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Stable, provider-agnostic classifications for errors that are safe to show
+ * in durable conversation state. The provider response itself must never be
+ * persisted when one of these classifications matches.
+ */
+
+export const PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND = 'provider_credit_exhausted' as const;
+export const PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE = 'PROVIDER_CREDIT_EXHAUSTED' as const;
+export const PROVIDER_CREDIT_EXHAUSTED_MESSAGE =
+  'The model provider has no available credit or quota for this request.';
+
+export type ProviderErrorKind = typeof PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND;
+export type ProviderErrorCode = typeof PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE;
+
+export interface ProviderErrorClassification {
+  kind: ProviderErrorKind;
+  code: ProviderErrorCode;
+}
+
+const CREDIT_EXHAUSTION_PATTERNS = [
+  /\bcredit\s+balance\b[\s\S]{0,48}\btoo\s+low\b/i,
+  /\binsufficient[\s_-]+(?:credit|credits|funds|quota)\b/i,
+  /\b(?:credit|credits|funds|quota|balance)\b[\s\S]{0,32}\b(?:exhausted|depleted|used\s+up)\b/i,
+  /\b(?:credit|credits|quota)\s+(?:limit\s+)?exceeded\b/i,
+  /\b(?:exceeded|reached)\s+(?:your\s+)?(?:current\s+)?(?:credit|credits|quota)\b/i,
+  /\b(?:out\s+of|no)\s+(?:available\s+)?(?:credit|credits|quota)\b/i,
+];
+
+function collectErrorText(value: unknown, seen = new Set<unknown>(), depth = 0): string[] {
+  if (depth > 3 || value == null || seen.has(value)) return [];
+  if (typeof value === 'string') return [value];
+  if (typeof value !== 'object') return [];
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectErrorText(entry, seen, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  const text: string[] = [];
+  for (const key of ['message', 'error', 'errors', 'error_description', 'detail', 'code', 'type']) {
+    const field = record[key];
+    if (typeof field === 'string') text.push(field);
+    else if (key === 'error' || key === 'errors' || key === 'detail') {
+      text.push(...collectErrorText(field, seen, depth + 1));
+    }
+  }
+  return text;
+}
+
+/**
+ * Classify a provider failure without returning or persisting provider text.
+ * This intentionally recognizes only quota/credit exhaustion; missing
+ * credentials and ordinary authentication errors remain separate states.
+ */
+export function classifyProviderError(value: unknown): ProviderErrorClassification | undefined {
+  const matches = collectErrorText(value).some((text) =>
+    CREDIT_EXHAUSTION_PATTERNS.some((pattern) => pattern.test(text))
+  );
+
+  return matches
+    ? {
+        kind: PROVIDER_CREDIT_EXHAUSTED_ERROR_KIND,
+        code: PROVIDER_CREDIT_EXHAUSTED_ERROR_CODE,
+      }
+    : undefined;
+}

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -91,6 +91,50 @@ describe('resolveApiKeyForTask', () => {
 });
 
 describe('settleTaskFailure', () => {
+  it('persists provider credit exhaustion as safe classified state', async () => {
+    const unsafeBody = 'Credit balance is too low; provider-secret-body-marker';
+    const taskPatch = vi.fn().mockResolvedValue(undefined);
+    const messageCreate = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') return { patch: taskPatch };
+        if (name === 'messages') {
+          return {
+            find: vi.fn().mockResolvedValue({ total: 0, data: [] }),
+            create: messageCreate,
+          };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await settleTaskFailure(
+      client,
+      'session-1' as never,
+      'task-1' as never,
+      new Error(unsafeBody),
+      { status: 'failed', error_message: unsafeBody },
+      'claude-code'
+    );
+
+    expect(messageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'The model provider has no available credit or quota for this request.',
+        metadata: {
+          is_task_failure: true,
+          error_kind: 'provider_credit_exhausted',
+          error_code: 'PROVIDER_CREDIT_EXHAUSTED',
+          tool: 'claude-code',
+        },
+      })
+    );
+    expect(taskPatch).toHaveBeenCalledWith('task-1', {
+      status: 'failed',
+      error_message: 'The model provider has no available credit or quota for this request.',
+    });
+    expect(JSON.stringify(messageCreate.mock.calls)).not.toContain('provider-secret-body-marker');
+  });
+
   it('does not persist Drizzle query parameters in task or transcript diagnostics', async () => {
     const secret = 'secret-binary-tool-result';
     const taskPatch = vi.fn().mockResolvedValue(undefined);

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -25,6 +25,7 @@ import type {
 import { MessageRole, PROVIDER_CREDENTIAL_FIELDS } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import { getCurrentBranch, getGitState } from '../../git/index.js';
+import { buildSafeProviderFailureMessage } from '../../provider-error.js';
 import { formatExecutorFailure } from '../../safe-executor-error.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
@@ -49,9 +50,13 @@ async function appendTaskFailureMessage(
   client: AgorClient,
   sessionId: SessionID,
   taskId: TaskID,
-  failure: Error
+  failure: Error,
+  tool?: AgenticToolName
 ): Promise<void> {
-  const safeFailure = formatExecutorFailure(failure);
+  const fallbackContent = formatExecutorFailure(failure);
+  const safeFailure = tool
+    ? buildSafeProviderFailureMessage(failure, fallbackContent, tool)
+    : { content: fallbackContent };
   try {
     const existingMessages = await client.service('messages').find({
       query: { session_id: sessionId, $limit: 0 },
@@ -71,13 +76,14 @@ async function appendTaskFailureMessage(
       role: MessageRole.SYSTEM,
       index: messageCount,
       timestamp: new Date().toISOString(),
-      content: safeFailure,
-      content_preview: safeFailure.substring(0, 200),
+      content: safeFailure.content,
+      content_preview: safeFailure.content.substring(0, 200),
       metadata: {
         is_task_failure: true,
         ...(failure instanceof MissingCredentialError
           ? { is_missing_credential_failure: true }
           : {}),
+        ...safeFailure.metadata,
       },
     });
   } catch (error) {
@@ -90,14 +96,19 @@ export async function settleTaskFailure(
   sessionId: SessionID,
   taskId: TaskID,
   failure: Error,
-  patch: Partial<Task>
+  patch: Partial<Task>,
+  tool?: AgenticToolName
 ): Promise<void> {
   // Terminal task hooks may drain the next queued turn, so reserve the current
   // transcript index before publishing terminality. Message failure stays best-effort.
-  await appendTaskFailureMessage(client, sessionId, taskId, failure);
+  const fallbackContent = formatExecutorFailure(failure);
+  const safeFailure = tool
+    ? buildSafeProviderFailureMessage(failure, fallbackContent, tool)
+    : { content: fallbackContent };
+  await appendTaskFailureMessage(client, sessionId, taskId, failure, tool);
   await client.service('tasks').patch(taskId, {
     ...patch,
-    ...(patch.error_message ? { error_message: formatExecutorFailure(failure) } : {}),
+    ...(patch.error_message ? { error_message: safeFailure.content } : {}),
   });
 }
 
@@ -580,10 +591,17 @@ export async function executeToolTask(params: {
     // - wasStopped: user explicitly stopped the task
     // - hadError: SDK returned an error subtype (e.g., error_during_execution)
     const taskStatus = result.wasStopped ? 'stopped' : result.hadError ? 'failed' : 'completed';
+    const providerFailure = result.hadError
+      ? buildSafeProviderFailureMessage(
+          result.errorDetails ?? result.rawSdkResponse,
+          result.errorDetails?.join('; ') ?? 'The provider returned an error result.',
+          toolName
+        )
+      : undefined;
 
     if (result.hadError) {
       console.error(
-        `[${toolName}] SDK returned error result for session ${shortId(sessionId)}, marking task as failed${result.errorDetails?.length ? `: ${result.errorDetails.join('; ')}` : ''}`
+        `[${toolName}] SDK returned error result for session ${shortId(sessionId)}, marking task as failed${providerFailure?.metadata?.error_code ? ` (code=${providerFailure.metadata.error_code})` : ''}`
       );
     }
 
@@ -605,15 +623,23 @@ export async function executeToolTask(params: {
 
     // Add SDK response data for token accounting
     // Store both raw (for debugging) and normalized (for UI/analytics)
+    if (providerFailure?.metadata?.error_code) {
+      patchData.error_message = providerFailure.content;
+    }
     if (result.rawSdkResponse) {
-      patchData.raw_sdk_response = result.rawSdkResponse;
-      // `modelHint` refines context-window lookup for tools whose SDK
-      // event omits the model; never used as primaryModel.
-      const normalized = normalizeRawSdkResponse(toolName, result.rawSdkResponse, {
-        modelHint: result.model,
-      });
-      if (normalized) {
-        patchData.normalized_sdk_response = normalized;
+      if (providerFailure?.metadata?.error_code) {
+        // Do not retain a provider response body once it has been classified.
+        patchData.raw_sdk_response = providerFailure.metadata;
+      } else {
+        patchData.raw_sdk_response = result.rawSdkResponse;
+        // `modelHint` refines context-window lookup for tools whose SDK
+        // event omits the model; never used as primaryModel.
+        const normalized = normalizeRawSdkResponse(toolName, result.rawSdkResponse, {
+          modelHint: result.model,
+        });
+        if (normalized) {
+          patchData.normalized_sdk_response = normalized;
+        }
       }
     }
 
@@ -697,7 +723,7 @@ export async function executeToolTask(params: {
       };
     }
 
-    await settleTaskFailure(client, sessionId, taskId, err, patchData);
+    await settleTaskFailure(client, sessionId, taskId, err, patchData, toolName);
 
     throw err;
   } finally {

--- a/packages/executor/src/handlers/sdk/cursor.test.ts
+++ b/packages/executor/src/handlers/sdk/cursor.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCursorAssistantContent,
+  buildCursorTaskResultPersistence,
+  getCursorReturnedFailure,
   normalizeCursorToolInput,
   normalizeCursorToolName,
 } from './cursor.js';
@@ -59,5 +61,45 @@ describe('Cursor SDK handler helpers', () => {
       cursor_tool_name: 'edit',
       status: 'completed',
     });
+  });
+
+  it('sanitizes returned provider credit failures before task persistence', () => {
+    const unsafeBody = 'Credit balance is too low; provider-secret-body-marker';
+    const result = buildCursorTaskResultPersistence({
+      runResult: {
+        id: 'run-1',
+        status: 'error',
+        error: { message: unsafeBody, code: 'provider-secret-code' },
+      },
+      rawMessages: [],
+      agentId: 'agent-1',
+      toolCallMessageIds: [],
+    });
+
+    expect(result).toMatchObject({
+      errorMessage: 'The model provider has no available credit or quota for this request.',
+      rawSdkResponse: {
+        error_kind: 'provider_credit_exhausted',
+        error_code: 'PROVIDER_CREDIT_EXHAUSTED',
+        tool: 'cursor',
+      },
+      isClassifiedProviderFailure: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('provider-secret-body-marker');
+    expect(JSON.stringify(result)).not.toContain('provider-secret-code');
+  });
+
+  it('preserves structured provider codes through task failure settlement', () => {
+    const failure = getCursorReturnedFailure({
+      id: 'run-2',
+      status: 'error',
+      error: { message: 'request failed', code: 'insufficient_quota' },
+    });
+
+    expect(failure?.safeMessage.metadata).toMatchObject({
+      error_code: 'PROVIDER_CREDIT_EXHAUSTED',
+    });
+    expect(failure).toBeDefined();
+    expect((failure as { error: Error & { code?: string } }).error.code).toBe('insufficient_quota');
   });
 });

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -25,10 +25,11 @@ import type {
   TaskID,
 } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
-import type { McpServerConfig, Run, SDKMessage } from '@cursor/sdk';
+import type { McpServerConfig, Run, RunResult, SDKMessage } from '@cursor/sdk';
 import { getDaemonUrl } from '../../config.js';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { ResolvedConfigSlice } from '../../payload-types.js';
+import { buildSafeProviderFailureMessage } from '../../provider-error.js';
 import { resolveContextUserId } from '../../sdk-handlers/base/context-user.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import {
@@ -67,6 +68,109 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+interface CursorReturnedFailure {
+  error: Error;
+  safeMessage: ReturnType<typeof buildSafeProviderFailureMessage>;
+}
+
+export function getCursorReturnedFailure(runResult: RunResult): CursorReturnedFailure | undefined {
+  if (runResult.status !== 'error') return undefined;
+
+  // Keep structured provider fields (notably `code`) on the internal Error so
+  // the later settleTaskFailure call makes the same classification decision as
+  // this helper. Those fields are never persisted; only safeMessage is.
+  const error = Object.assign(
+    new Error(runResult.error?.message || 'Cursor returned an error result.'),
+    asRecord(runResult.error)
+  );
+  return {
+    error,
+    safeMessage: buildSafeProviderFailureMessage(
+      runResult.error ?? runResult,
+      error.message,
+      'cursor'
+    ),
+  };
+}
+
+async function redactCursorMessages(args: {
+  client: AgorClient;
+  messageIds: ReadonlyArray<MessageID>;
+  safeMessage: ReturnType<typeof buildSafeProviderFailureMessage>;
+}): Promise<boolean> {
+  const messageIds = [...new Set(args.messageIds)];
+  const results = await Promise.allSettled(
+    messageIds.map(async (messageId) => {
+      try {
+        await args.client.service('messages').patch(messageId, {
+          content: args.safeMessage.content,
+          content_preview: args.safeMessage.content.substring(0, 200),
+          metadata: {
+            is_task_failure: true,
+            ...args.safeMessage.metadata,
+          },
+        });
+      } catch (patchError) {
+        // If the message cannot be rewritten, prefer removing it over leaving
+        // a provider response durable. The caller logs any final cleanup gap.
+        try {
+          await args.client.service('messages').remove(messageId);
+        } catch (removeError) {
+          throw new Error(`Could not redact Cursor message ${messageId}: ${String(removeError)}`, {
+            cause: patchError,
+          });
+        }
+      }
+    })
+  );
+  const failedMessageIds = results.flatMap((result, index) =>
+    result.status === 'rejected' ? [messageIds[index]] : []
+  );
+  if (failedMessageIds.length > 0) {
+    console.error(
+      `[cursor] failed to redact ${failedMessageIds.length} streamed message(s) after provider failure`,
+      failedMessageIds
+    );
+    return false;
+  }
+  return true;
+}
+
+export function buildCursorTaskResultPersistence(args: {
+  runResult: RunResult;
+  rawMessages: ReadonlyArray<SDKMessage>;
+  agentId: string;
+  toolCallMessageIds: ReadonlyArray<MessageID>;
+}): {
+  errorMessage?: string;
+  rawSdkResponse: unknown;
+  isClassifiedProviderFailure: boolean;
+} {
+  const returnedFailure = getCursorReturnedFailure(args.runResult);
+  const providerFailure = returnedFailure?.safeMessage;
+  const isClassifiedProviderFailure = Boolean(providerFailure?.metadata?.error_code);
+
+  if (isClassifiedProviderFailure && providerFailure) {
+    // A classified provider failure must not retain the provider response or
+    // streamed messages, which may contain the same sensitive response body.
+    return {
+      errorMessage: providerFailure.content,
+      rawSdkResponse: providerFailure.metadata,
+      isClassifiedProviderFailure: true,
+    };
+  }
+
+  return {
+    rawSdkResponse: {
+      run: args.runResult,
+      messages: args.rawMessages,
+      agentId: args.agentId,
+      toolCallMessageIds: args.toolCallMessageIds,
+    },
+    isClassifiedProviderFailure: false,
+  };
 }
 
 export function normalizeCursorToolName(name: string): string {
@@ -350,7 +454,10 @@ async function createAssistantMessage(args: {
   });
 }
 
-function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>): {
+function getToolMessageContent(
+  event: Extract<SDKMessage, { type: 'tool_call' }>,
+  includeResult = true
+): {
   content: ContentBlock[];
   preview: string;
 } {
@@ -369,7 +476,7 @@ function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>
     },
   ];
 
-  if (event.status !== 'running') {
+  if (includeResult && event.status !== 'running') {
     content.push({
       type: 'tool_result',
       tool_use_id: event.call_id,
@@ -381,7 +488,7 @@ function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>
 
   return {
     content,
-    preview: `${toolName}: ${input.command ? String(input.command) : resultText}`,
+    preview: `${toolName}: ${includeResult ? (input.command ? String(input.command) : resultText) : `[${event.status}]`}`,
   };
 }
 
@@ -392,9 +499,10 @@ async function createToolMessage(args: {
   index: number;
   event: Extract<SDKMessage, { type: 'tool_call' }>;
   model?: string;
+  includeResult?: boolean;
 }): Promise<MessageID> {
   const messageId = generateId() as MessageID;
-  const { content, preview } = getToolMessageContent(args.event);
+  const { content, preview } = getToolMessageContent(args.event, args.includeResult);
 
   await createAssistantMessage({
     client: args.client,
@@ -413,8 +521,9 @@ async function updateToolMessage(args: {
   client: AgorClient;
   messageId: MessageID;
   event: Extract<SDKMessage, { type: 'tool_call' }>;
+  includeResult?: boolean;
 }): Promise<void> {
-  const { content, preview } = getToolMessageContent(args.event);
+  const { content, preview } = getToolMessageContent(args.event, args.includeResult);
   await args.client.service('messages').patch(args.messageId, {
     content,
     content_preview: preview.substring(0, 200),
@@ -532,6 +641,7 @@ export async function executeCursorTask(params: {
       let thinkingText = '';
       const toolCallMessageIds: MessageID[] = [];
       const toolCallMessageIdsByCallId = new Map<string, MessageID>();
+      const toolCallEventsByCallId = new Map<string, Extract<SDKMessage, { type: 'tool_call' }>>();
       const rawMessages: SDKMessage[] = [];
 
       currentRun = await agent.send(prompt, {
@@ -569,6 +679,7 @@ export async function executeCursorTask(params: {
           setThinkingText: (value) => {
             thinkingText = value;
           },
+          toolCallEventsByCallId,
           isAssistantStreamStarted: () => assistantStreamStarted,
           setAssistantStreamStarted: (value) => {
             assistantStreamStarted = value;
@@ -589,12 +700,37 @@ export async function executeCursorTask(params: {
       }
 
       const runResult = await currentRun.wait();
+      const failed = runResult.status === 'error';
+      const stopped = runResult.status === 'cancelled' || params.abortController.signal.aborted;
+      const returnedFailure = failed ? getCursorReturnedFailure(runResult) : undefined;
+      const taskResultPersistence = buildCursorTaskResultPersistence({
+        runResult,
+        rawMessages,
+        agentId: agent.agentId,
+        toolCallMessageIds,
+      });
+      const classifiedProviderFailure = taskResultPersistence?.isClassifiedProviderFailure === true;
+      if (!classifiedProviderFailure) {
+        await Promise.all(
+          [...toolCallEventsByCallId.entries()].map(([callId, event]) => {
+            const messageId = toolCallMessageIdsByCallId.get(callId);
+            return messageId
+              ? updateToolMessage({
+                  client,
+                  messageId,
+                  event,
+                  includeResult: true,
+                })
+              : undefined;
+          })
+        );
+      }
       const resultText = typeof runResult.result === 'string' ? runResult.result : '';
       const finalText = resultText.length > assistantText.length ? resultText : assistantText;
       const finalContent = buildCursorAssistantContent({ text: finalText, thinkingText });
       // SDK echo > configured selection; undefined if neither.
       const recordedModel = runResult.model?.id ?? configuredModel;
-      if (finalContent.length > 0) {
+      if (finalContent.length > 0 && !classifiedProviderFailure) {
         await createAssistantMessage({
           client,
           sessionId,
@@ -607,19 +743,26 @@ export async function executeCursorTask(params: {
         });
       }
 
-      const failed = runResult.status === 'error';
-      const stopped = runResult.status === 'cancelled' || params.abortController.signal.aborted;
       const gitStateAtEnd = await captureGitStateAtTaskEnd(client, sessionId);
       const taskPatch: Partial<Task> = {
         status: stopped ? 'stopped' : failed ? 'failed' : 'completed',
         completed_at: new Date().toISOString(),
         ...(recordedModel ? { model: recordedModel } : {}),
-        raw_sdk_response: {
-          run: runResult,
-          messages: rawMessages,
-          agentId: agent.agentId,
-          toolCallMessageIds,
-        },
+        ...(taskResultPersistence
+          ? {
+              ...(taskResultPersistence.errorMessage
+                ? { error_message: taskResultPersistence.errorMessage }
+                : {}),
+              raw_sdk_response: taskResultPersistence.rawSdkResponse,
+            }
+          : {
+              raw_sdk_response: {
+                run: runResult,
+                messages: rawMessages,
+                agentId: agent.agentId,
+                toolCallMessageIds,
+              },
+            }),
       };
       if (gitStateAtEnd) {
         // @ts-expect-error - Partial update of nested git_state object is handled by repository deep merge
@@ -628,7 +771,26 @@ export async function executeCursorTask(params: {
           sha_at_end: gitStateAtEnd.sha,
         };
       }
-      await client.service('tasks').patch(taskId, taskPatch);
+      if (classifiedProviderFailure && returnedFailure) {
+        const redacted = await redactCursorMessages({
+          client,
+          messageIds: [assistantMessageId, ...toolCallMessageIds],
+          safeMessage: returnedFailure.safeMessage,
+        });
+        if (!redacted) {
+          console.error('[cursor] provider failure settlement completed with redaction gaps');
+        }
+        await settleTaskFailure(
+          client,
+          sessionId,
+          taskId,
+          returnedFailure.error,
+          taskPatch,
+          'cursor'
+        );
+      } else {
+        await client.service('tasks').patch(taskId, taskPatch);
+      }
     } finally {
       agent.close();
     }
@@ -648,7 +810,7 @@ export async function executeCursorTask(params: {
         sha_at_end: gitStateAtEnd.sha,
       };
     }
-    await settleTaskFailure(client, sessionId, taskId, err, taskPatch);
+    await settleTaskFailure(client, sessionId, taskId, err, taskPatch, 'cursor');
     throw err;
   } finally {
     params.abortController.signal.removeEventListener('abort', abortHandler);
@@ -674,6 +836,7 @@ async function handleCursorEvent(args: {
   setAssistantText: (value: string) => void;
   getThinkingText: () => string;
   setThinkingText: (value: string) => void;
+  toolCallEventsByCallId: Map<string, Extract<SDKMessage, { type: 'tool_call' }>>;
   isAssistantStreamStarted: () => boolean;
   setAssistantStreamStarted: (value: boolean) => void;
   ensureAssistantMessageIndex: () => number;
@@ -726,12 +889,14 @@ async function handleCursorEvent(args: {
     }
 
     case 'tool_call': {
+      args.toolCallEventsByCallId.set(args.event.call_id, args.event);
       const existingMessageId = args.toolCallMessageIdsByCallId.get(args.event.call_id);
       if (existingMessageId) {
         await updateToolMessage({
           client: args.client,
           messageId: existingMessageId,
           event: args.event,
+          includeResult: false,
         });
         return;
       }
@@ -743,6 +908,7 @@ async function handleCursorEvent(args: {
         index: args.getNextIndex(),
         event: args.event,
         model: args.model,
+        includeResult: false,
       });
       args.toolCallMessageIdsByCallId.set(args.event.call_id, messageId);
       args.toolCallMessageIds.push(messageId);

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -190,11 +190,18 @@ export async function executeOpenCodeTask(params: {
       return;
     }
     if (!params.abortController.signal.aborted) {
-      await settleTaskFailure(client, sessionId, taskId, failure, {
-        status: 'failed',
-        completed_at: new Date().toISOString(),
-        error_message: failure.message,
-      });
+      await settleTaskFailure(
+        client,
+        sessionId,
+        taskId,
+        failure,
+        {
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          error_message: failure.message,
+        },
+        'opencode'
+      );
     }
     throw failure;
   } finally {

--- a/packages/executor/src/provider-error.test.ts
+++ b/packages/executor/src/provider-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildSafeProviderFailureMessage } from './provider-error';
+
+describe('buildSafeProviderFailureMessage', () => {
+  it('replaces a quota provider body with safe classified state', () => {
+    const unsafeBody = 'Credit balance is too low; account=provider-secret-body-marker';
+    const result = buildSafeProviderFailureMessage(
+      new Error(unsafeBody),
+      `Agent SDK error: ${unsafeBody}`,
+      'claude-code'
+    );
+
+    expect(result).toEqual({
+      content: 'The model provider has no available credit or quota for this request.',
+      metadata: {
+        error_kind: 'provider_credit_exhausted',
+        error_code: 'PROVIDER_CREDIT_EXHAUSTED',
+        tool: 'claude-code',
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('provider-secret-body-marker');
+  });
+
+  it('preserves a non-quota fallback and leaves missing credentials unclassified', () => {
+    expect(
+      buildSafeProviderFailureMessage(
+        new Error('No scoped claude-code credential is configured'),
+        'missing credential',
+        'claude-code'
+      )
+    ).toEqual({ content: 'missing credential' });
+  });
+});

--- a/packages/executor/src/provider-error.ts
+++ b/packages/executor/src/provider-error.ts
@@ -1,0 +1,34 @@
+import {
+  type AgenticToolName,
+  classifyProviderError,
+  type Message,
+  PROVIDER_CREDIT_EXHAUSTED_MESSAGE,
+} from '@agor/core/types';
+
+export interface SafeProviderFailureMessage {
+  content: string;
+  metadata?: Message['metadata'];
+}
+
+/**
+ * Convert a provider failure into durable user-facing state. Recognized quota
+ * failures deliberately discard the raw provider body and retain only stable
+ * classification metadata.
+ */
+export function buildSafeProviderFailureMessage(
+  failure: unknown,
+  fallbackContent: string,
+  tool: AgenticToolName
+): SafeProviderFailureMessage {
+  const classification = classifyProviderError(failure);
+  if (!classification) return { content: fallbackContent };
+
+  return {
+    content: PROVIDER_CREDIT_EXHAUSTED_MESSAGE,
+    metadata: {
+      error_kind: classification.kind,
+      error_code: classification.code,
+      tool,
+    },
+  };
+}

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -23,6 +23,7 @@ import type {
   SessionRepository,
 } from '../../db/feathers-repositories.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
+import { buildSafeProviderFailureMessage } from '../../provider-error.js';
 import { truncateContentIfNeeded } from '../../services/tool-result-truncator.js';
 import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-response.js';
 // Removed import of calculateModelContextWindowUsage - inlined instead
@@ -673,13 +674,17 @@ export class ClaudeTool implements ITool {
           if (sdkResult.subtype && sdkResult.subtype !== 'success') {
             hadError = true;
             errorDetails = sdkResult.errors;
+            const failureMessage = buildSafeProviderFailureMessage(
+              sdkResult.errors ?? [],
+              `Agent SDK error (${sdkResult.subtype}): ${sdkResult.errors?.join('\n') ?? ''}`,
+              this.toolType
+            );
             console.error(
-              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
+              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, code=${failureMessage.metadata?.error_code ?? 'UNCLASSIFIED'}`
             );
 
             // Create a system message with the error details so it's visible in the conversation UI
             if (this.messagesService && sdkResult.errors?.length) {
-              const errorText = sdkResult.errors.join('\n');
               const errorMessageId = generateId() as MessageID;
               await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
                 await createSystemMessage(
@@ -688,13 +693,14 @@ export class ClaudeTool implements ITool {
                   [
                     {
                       type: 'text',
-                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
+                      text: failureMessage.content,
                     },
                   ],
                   taskId,
                   nextIndex++,
                   resolvedModel,
-                  this.messagesService!
+                  this.messagesService!,
+                  failureMessage.metadata
                 );
                 return true;
               });
@@ -1101,13 +1107,17 @@ export class ClaudeTool implements ITool {
           if (sdkResult.subtype && sdkResult.subtype !== 'success') {
             hadError = true;
             errorDetails = sdkResult.errors;
+            const failureMessage = buildSafeProviderFailureMessage(
+              sdkResult.errors ?? [],
+              `Agent SDK error (${sdkResult.subtype}): ${sdkResult.errors?.join('\n') ?? ''}`,
+              this.toolType
+            );
             console.error(
-              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
+              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, code=${failureMessage.metadata?.error_code ?? 'UNCLASSIFIED'}`
             );
 
             // Create a system message with the error details so it's visible in the conversation UI
             if (this.messagesService && sdkResult.errors?.length) {
-              const errorText = sdkResult.errors.join('\n');
               const errorMessageId = generateId() as MessageID;
               await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
                 await createSystemMessage(
@@ -1116,13 +1126,14 @@ export class ClaudeTool implements ITool {
                   [
                     {
                       type: 'text',
-                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
+                      text: failureMessage.content,
                     },
                   ],
                   taskId,
                   nextIndex++,
                   resolvedModel,
-                  this.messagesService!
+                  this.messagesService!,
+                  failureMessage.metadata
                 );
                 return true;
               });

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -247,7 +247,8 @@ export async function createSystemMessage(
   taskId: TaskID | undefined,
   nextIndex: number,
   resolvedModel: string | undefined,
-  messagesService: MessagesService
+  messagesService: MessagesService,
+  metadata?: Message['metadata']
 ): Promise<Message> {
   const message: Message = {
     message_id: messageId,
@@ -262,6 +263,7 @@ export async function createSystemMessage(
     metadata: {
       ...(resolvedModel ? { model: resolvedModel } : {}),
       is_meta: true, // Mark as synthetic system message
+      ...metadata,
     },
   };
 


### PR DESCRIPTION
## Linked issue

Refs #2288
Refs #1957

## Summary

- Classify provider credit/quota failures into stable safe metadata and a recovery panel.
- Sanitize executor persistence for provider failures, including Cursor returned, stopped, and streamed-tool paths.
- Improve MCP OAuth/DCR diagnostics and preserve bounded provider error details.
- Save edited OAuth client settings before retrying an existing server's flow.

## Why / context

Bootstrap could surface a raw provider balance error as a dead end even though provisioning succeeded. MCP OAuth failures were also being reported as generic “DCR unsupported” errors, which hid actionable provider details and made manual client recovery unreliable.

## Implementation notes

- Provider failures are classified only on failure paths; missing credentials remain a separate case.
- Classified provider details are sanitized before task/message persistence, including tool-result and cancellation paths.
- DCR discovery remains strict by default; relative endpoint fallback is still explicit.
- Registration responses are parsed through a typed allowlist and bounded before surfacing to users.
- Existing-server OAuth retries persist the current client settings before starting the flow.
- No database migration is required.

## Validation / test plan

- `pnpm check` — passed (typechecks, lint, boundary checks, and repository build).
- Focused core, executor, daemon, and UI Vitest suites — passed.
- `git diff --check` — passed.
- The repository-wide `pnpm test` run reached two unrelated `@agor/cli` interactive-init test timeouts; affected-package focused suites passed.

## Screenshots / demos

Not applicable; behavior is covered by automated tests.

## Risks / rollout / rollback

The classifier is intentionally narrow and leaves unrelated provider failures on the existing path. Rollback is a standard revert of this change. No live provider calls were made during validation.

## Out of scope / follow-ups

- Sandbox/runtime QA was intentionally skipped per approval.
- Deployment and production verification remain follow-ups after review and merge.
