### PR TITLE
fix(onboarding): recover from provider credit failures

### DIFF
--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -259,7 +259,7 @@ describe('classifyMissingCredentialFailure', () => {
     ]);
   });
 
-  it('checks each joined SDK error within its own bounded search window', async () => {
+  it('does not classify a signal beyond the bound of one multiline error block', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
@@ -273,8 +273,31 @@ describe('classifyMissingCredentialFailure', () => {
         content: [
           {
             type: 'text',
-            text: `${'x'.repeat(600)}\ncredit balance is too low`,
+            text: `${'x'.repeat(500)}\ncredit balance is too low`,
           },
+        ],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+  });
+
+  it('classifies an early signal in a distinct error block after a long multiline error', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...sdkErrorBillingResult,
+        content: [
+          { type: 'text', text: 'Agent SDK error (error_during_execution): ' },
+          { type: 'text', text: `${'x'.repeat(600)}\nordinary tail` },
+          { type: 'text', text: '\n' },
+          { type: 'text', text: 'payment_required' },
         ],
       })
     );

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -496,7 +496,7 @@ describe('protectExternalProviderFailureMetadata', () => {
   });
 
   it('allows external content patches to ordinary messages', async () => {
-    const context = makeContext({ content: 'edited' });
+    const context = makeContext({ content: 'edited', content_preview: 'edited preview' });
     context.method = 'patch';
     context.id = 'message-1';
 
@@ -504,7 +504,7 @@ describe('protectExternalProviderFailureMetadata', () => {
     const patchProtect = protectExternalProviderFailureMetadata(loadMessage);
 
     await expect(patchProtect(context)).resolves.toBe(context);
-    expect(loadMessage).not.toHaveBeenCalled();
+    expect(loadMessage).toHaveBeenCalledWith('message-1');
   });
 
   it('rejects forged recovery metadata in bulk payloads', () => {

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -4,6 +4,7 @@ import type { HookContext, Message, Session, Task } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  assertExternalProviderFailureMetadataAllowed,
   classifyMissingCredentialFailure,
   protectExternalProviderFailureMetadata,
 } from './classify-missing-credential';
@@ -75,6 +76,19 @@ describe('classifyMissingCredentialFailure', () => {
   const zeroTurnBillingResult: Partial<Message> = {
     ...zeroTurnResult,
     content: [{ type: 'text', text: 'Credit balance is too low' }],
+  };
+
+  const sdkErrorBillingResult: Partial<Message> = {
+    ...zeroTurnResult,
+    type: 'system',
+    role: MessageRole.SYSTEM,
+    content: [
+      {
+        type: 'text',
+        text: 'Agent SDK error (error_during_execution): Credit balance is too low',
+      },
+    ],
+    metadata: { is_meta: true, is_provider_failure_result: true },
   };
 
   it('normalizes an explicit executor credential-preflight failure', async () => {
@@ -170,6 +184,24 @@ describe('classifyMissingCredentialFailure', () => {
     expect(result.content_preview).not.toContain('Credit balance is too low');
   });
 
+  it('classifies the verified Anthropic credit failure from an SDK error result', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(makeContext({ ...sdkErrorBillingResult }));
+    const result = ctx.data as Message;
+
+    expect(result.metadata).toMatchObject({
+      error_kind: 'provider_credit_exhausted',
+      tool: 'claude-code',
+    });
+    expect(result.content).not.toContain('Credit balance is too low');
+  });
+
   it('classifies a stable billing signal in a short zero-turn result', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
@@ -203,6 +235,24 @@ describe('classifyMissingCredentialFailure', () => {
       expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
       expect((ctx.data as Message).content).toEqual([{ type: 'text', text: content }]);
     }
+  });
+
+  it('lets an explicit billing code win when a provider also reports HTTP 429', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...zeroTurnResult,
+        content: [{ type: 'text', text: '429 Too Many Requests: insufficient_quota' }],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
   });
 
   it('preserves legitimate zero-turn output when an API key resolved', async () => {
@@ -357,5 +407,23 @@ describe('protectExternalProviderFailureMetadata', () => {
     });
     internalContext.params.provider = undefined;
     expect(protectExternalProviderFailureMetadata(internalContext)).toBe(internalContext);
+  });
+
+  it('rejects forged recovery metadata in bulk payloads', () => {
+    expect(() =>
+      assertExternalProviderFailureMetadataAllowed([
+        { type: 'user', content: 'safe' },
+        { metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' } },
+      ])
+    ).toThrow('Provider failure metadata can only be classified by the daemon');
+  });
+
+  it('allows ordinary executor bulk messages and their classification markers', () => {
+    expect(() =>
+      assertExternalProviderFailureMetadataAllowed([
+        { metadata: { is_zero_turn_result: true } },
+        { metadata: { is_provider_failure_result: true } },
+      ])
+    ).not.toThrow();
   });
 });

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -3,7 +3,10 @@ import type { SessionRepository, TaskRepository } from '@agor/core/db';
 import type { HookContext, Message, Session, Task } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { classifyMissingCredentialFailure } from './classify-missing-credential';
+import {
+  classifyMissingCredentialFailure,
+  protectExternalProviderFailureMetadata,
+} from './classify-missing-credential';
 
 vi.mock('@agor/core/config', () => ({ resolveApiKey: vi.fn() }));
 
@@ -69,6 +72,11 @@ describe('classifyMissingCredentialFailure', () => {
     metadata: { is_zero_turn_result: true },
   };
 
+  const zeroTurnBillingResult: Partial<Message> = {
+    ...zeroTurnResult,
+    content: [{ type: 'text', text: 'Credit balance is too low' }],
+  };
+
   it('normalizes an explicit executor credential-preflight failure', async () => {
     const ctx = await runHook()(makeContext({ ...explicitCredentialFailure }));
     const result = ctx.data as Message;
@@ -118,6 +126,85 @@ describe('classifyMissingCredentialFailure', () => {
     expect((ctx.data as Message).type).toBe('system');
   });
 
+  it('lets missing credential classification win over billing-like provider text', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: undefined,
+      connection: {},
+      source: 'none',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(makeContext({ ...zeroTurnBillingResult }));
+    const result = ctx.data as Message;
+
+    expect(result.metadata).toMatchObject({
+      error_kind: 'missing_credential',
+      tool: 'claude-code',
+    });
+    expect(result.content).toBe(
+      'This session needs to be connected to Claude Code before it can run.'
+    );
+    expect(result.content).not.toContain('Credit balance is too low');
+  });
+
+  it('classifies the verified Anthropic credit failure when a credential resolved', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(makeContext({ ...zeroTurnBillingResult }));
+    const result = ctx.data as Message;
+
+    expect(result.metadata).toMatchObject({
+      error_kind: 'provider_credit_exhausted',
+      tool: 'claude-code',
+    });
+    expect(result.type).toBe('system');
+    expect(result.content).toBe(
+      "This session's Claude Code account needs available credit or quota before it can respond."
+    );
+    expect(result.content).not.toContain('Credit balance is too low');
+    expect(result.content_preview).not.toContain('Credit balance is too low');
+  });
+
+  it('classifies a stable billing signal in a short zero-turn result', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...zeroTurnResult,
+        content: [{ type: 'text', text: 'provider error: payment_required' }],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
+  });
+
+  it('does not classify ordinary rate-limit text or arbitrary quota prose', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    for (const content of ['429 Too Many Requests', 'Your quota may be limited']) {
+      const ctx = await runHook()(
+        makeContext({ ...zeroTurnResult, content: [{ type: 'text', text: content }] })
+      );
+      expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+      expect((ctx.data as Message).content).toEqual([{ type: 'text', text: content }]);
+    }
+  });
+
   it('preserves legitimate zero-turn output when an API key resolved', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
@@ -130,6 +217,40 @@ describe('classifyMissingCredentialFailure', () => {
 
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
     expect((ctx.data as Message).type).toBe('assistant');
+  });
+
+  it('does not classify a normal assistant message without the zero-turn marker', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...zeroTurnBillingResult,
+        metadata: {},
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toEqual(zeroTurnBillingResult.content);
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('does not classify a client-forged zero-turn marker outside executor scope', async () => {
+    const context = makeContext({ ...zeroTurnBillingResult });
+    context.params = {
+      provider: 'socketio',
+      authentication: { strategy: 'jwt', payload: { sub: 'user-1' } },
+    } as never;
+
+    const ctx = await runHook()(context);
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toEqual(zeroTurnBillingResult.content);
+    expect(taskRepository.findById).not.toHaveBeenCalled();
   });
 
   it('preserves legitimate zero-turn output with a Claude subscription token', async () => {
@@ -213,5 +334,28 @@ describe('classifyMissingCredentialFailure', () => {
     );
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
     expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+});
+
+describe('protectExternalProviderFailureMetadata', () => {
+  it('rejects externally supplied recovery-panel metadata', () => {
+    const context = makeContext({
+      metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' },
+    });
+
+    expect(() => protectExternalProviderFailureMetadata(context)).toThrow(
+      'Provider failure metadata can only be classified by the daemon'
+    );
+  });
+
+  it('allows executor markers before daemon classification and internal projections', () => {
+    const externalContext = makeContext({ metadata: { is_zero_turn_result: true } });
+    expect(protectExternalProviderFailureMetadata(externalContext)).toBe(externalContext);
+
+    const internalContext = makeContext({
+      metadata: { error_kind: 'missing_credential', tool: 'claude-code' },
+    });
+    internalContext.params.provider = undefined;
+    expect(protectExternalProviderFailureMetadata(internalContext)).toBe(internalContext);
   });
 });

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -220,6 +220,68 @@ describe('classifyMissingCredentialFailure', () => {
     expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
   });
 
+  it('classifies a billing signal within the bounded search window of a long error', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...zeroTurnResult,
+        content: [{ type: 'text', text: `${'x'.repeat(480)} payment_required ${'x'.repeat(40)}` }],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
+  });
+
+  it('does not classify a billing signal beyond the bounded search window', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...zeroTurnResult,
+        content: [{ type: 'text', text: `${'x'.repeat(500)} payment_required` }],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toEqual([
+      { type: 'text', text: `${'x'.repeat(500)} payment_required` },
+    ]);
+  });
+
+  it('checks each joined SDK error within its own bounded search window', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(
+      makeContext({
+        ...sdkErrorBillingResult,
+        content: [
+          {
+            type: 'text',
+            text: `${'x'.repeat(600)}\ncredit balance is too low`,
+          },
+        ],
+      })
+    );
+
+    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
+  });
+
   it('does not classify ordinary rate-limit text or arbitrary quota prose', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
@@ -388,25 +450,61 @@ describe('classifyMissingCredentialFailure', () => {
 });
 
 describe('protectExternalProviderFailureMetadata', () => {
-  it('rejects externally supplied recovery-panel metadata', () => {
+  const protect = protectExternalProviderFailureMetadata(async () => null);
+
+  it('rejects externally supplied recovery-panel metadata', async () => {
     const context = makeContext({
       metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' },
     });
 
-    expect(() => protectExternalProviderFailureMetadata(context)).toThrow(
+    await expect(protect(context)).rejects.toThrow(
       'Provider failure metadata can only be classified by the daemon'
     );
   });
 
-  it('allows executor markers before daemon classification and internal projections', () => {
+  it('allows executor markers before daemon classification and internal projections', async () => {
     const externalContext = makeContext({ metadata: { is_zero_turn_result: true } });
-    expect(protectExternalProviderFailureMetadata(externalContext)).toBe(externalContext);
+    await expect(protect(externalContext)).resolves.toBe(externalContext);
 
     const internalContext = makeContext({
       metadata: { error_kind: 'missing_credential', tool: 'claude-code' },
     });
     internalContext.params.provider = undefined;
-    expect(protectExternalProviderFailureMetadata(internalContext)).toBe(internalContext);
+    await expect(protect(internalContext)).resolves.toBe(internalContext);
+  });
+
+  it.each([
+    ['clearing metadata', { metadata: {} }],
+    ['changing the classified tool', { metadata: { tool: 'codex' } }],
+    ['changing the message type', { type: 'assistant' }],
+    ['changing the message role', { role: MessageRole.ASSISTANT }],
+  ])('rejects external patch attempts at %s', async (_label, data) => {
+    const context = makeContext(data);
+    context.method = 'patch';
+    context.id = 'message-1';
+
+    const patchProtect = protectExternalProviderFailureMetadata(
+      async () =>
+        ({
+          metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' },
+        }) as Message
+    );
+
+    await expect(patchProtect(context)).rejects.toThrow(
+      'Provider failure classification is daemon-owned'
+    );
+  });
+
+  it('allows external content patches to ordinary messages', async () => {
+    const context = makeContext({ content: 'edited' });
+    context.method = 'patch';
+    context.id = 'message-1';
+
+    const loadMessage = vi.fn().mockResolvedValue({ metadata: {} } as Message);
+    const patchProtect = protectExternalProviderFailureMetadata(loadMessage);
+
+    await expect(patchProtect(context)).resolves.toBe(context);
+    expect(loadMessage).not.toHaveBeenCalled();
   });
 
   it('rejects forged recovery metadata in bulk payloads', () => {

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -60,7 +60,13 @@ export function assertExternalProviderFailureMetadataAllowed(data: unknown): voi
 function changesProviderFailureOwnedFields(data: unknown): boolean {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const record = data as Record<string, unknown>;
-  return 'metadata' in record || 'type' in record || 'role' in record;
+  return (
+    'metadata' in record ||
+    'type' in record ||
+    'role' in record ||
+    'content' in record ||
+    'content_preview' in record
+  );
 }
 
 /**

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -1,13 +1,13 @@
 /**
- * Before-create hook that reclassifies a task failure as "missing credential"
- * without matching the provider's raw stderr. Fires on two failure shapes —
- * an explicit executor credential-preflight failure and a zero-turn "success"
- * whose current scoped connection resolves no credential.
+ * Before-create hook that reclassifies executor-scoped provider failures
+ * without matching arbitrary provider stderr. It handles explicit credential
+ * preflight failures and narrowly recognized zero-turn billing failures.
  */
 
 import { TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository, TenantScopeAwareDatabase } from '@agor/core/db';
+import { Forbidden } from '@agor/core/feathers';
 import type { AgenticToolName, HookContext, Message, TaskID, UserID } from '@agor/core/types';
 import {
   canonicalTenantAgenticTool,
@@ -21,6 +21,91 @@ import { hasExecutorRuntimeScope } from '../auth/executor-runtime-scope.js';
  * The web UI renders its own copy from MissingCredentialPanel instead. */
 function fallbackContent(toolDisplayName: string): string {
   return `This session needs to be connected to ${toolDisplayName} before it can run.`;
+}
+
+function providerCreditContent(toolDisplayName: string): string {
+  return `This session's ${toolDisplayName} account needs available credit or quota before it can respond.`;
+}
+
+type ProviderFailureKind = 'missing_credential' | 'provider_credit_exhausted';
+
+function declaresProviderFailure(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const metadata = (data as { metadata?: unknown }).metadata;
+  return (
+    !!metadata &&
+    typeof metadata === 'object' &&
+    !Array.isArray(metadata) &&
+    'error_kind' in metadata
+  );
+}
+
+/** Keep the recovery-panel discriminator owned by daemon classification. */
+export function protectExternalProviderFailureMetadata(context: HookContext): HookContext {
+  if (!context.params.provider) return context;
+  const writes = Array.isArray(context.data) ? context.data : [context.data];
+  if (writes.some(declaresProviderFailure)) {
+    throw new Forbidden('Provider failure metadata can only be classified by the daemon');
+  }
+  return context;
+}
+
+function classifyProviderFailure(
+  data: Partial<Message>,
+  tool: AgenticToolName,
+  toolDisplayName: string,
+  errorKind: ProviderFailureKind
+): Partial<Message> {
+  const content =
+    errorKind === 'missing_credential'
+      ? fallbackContent(toolDisplayName)
+      : providerCreditContent(toolDisplayName);
+
+  return {
+    ...data,
+    type: 'system',
+    role: MessageRole.SYSTEM,
+    content,
+    content_preview: content.substring(0, 200),
+    metadata: {
+      ...data.metadata,
+      error_kind: errorKind,
+      tool,
+    },
+  };
+}
+
+const PROVIDER_CREDIT_SIGNALS = [
+  'insufficient_quota',
+  'quota_exhausted',
+  'billing_hard_limit_reached',
+  'payment_required',
+] as const;
+
+function textContent(content: Message['content'] | undefined): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  return content
+    .filter((block) => block.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text as string)
+    .join('\n');
+}
+
+function isProviderCreditFailure(
+  tool: AgenticToolName,
+  content: Message['content'] | undefined
+): boolean {
+  const text = textContent(content).trim().toLowerCase();
+  if (!text || text.length > 500) return false;
+
+  const isAnthropicCreditFailure =
+    tool === 'claude-code' && /\bcredit balance is too low\b/.test(text);
+  const hasStableCreditSignal = new RegExp(`\\b(?:${PROVIDER_CREDIT_SIGNALS.join('|')})\\b`).test(
+    text
+  );
+
+  return isAnthropicCreditFailure || hasStableCreditSignal;
 }
 
 function hasResolvedCredential(
@@ -72,28 +157,41 @@ export function classifyMissingCredentialFailure(
           db,
           tool,
         });
-        if (
+
+        const hasCredential =
           resolution.apiKey ||
           resolution.useNativeAuth ||
-          hasResolvedCredential(tool, resolution.connection)
-        ) {
+          hasResolvedCredential(tool, resolution.connection);
+        if (!hasCredential) {
+          // Missing credential wins over any provider text in the synthesized
+          // result: the scoped resolver is the source of truth here.
+          context.data = classifyProviderFailure(
+            data,
+            tool,
+            toolDisplayNames[tool] ?? tool,
+            'missing_credential'
+          );
           return context;
         }
+
+        if (!isProviderCreditFailure(tool, data.content)) return context;
+
+        context.data = classifyProviderFailure(
+          data,
+          tool,
+          toolDisplayNames[tool] ?? tool,
+          'provider_credit_exhausted'
+        );
+        return context;
       }
 
-      context.data = {
-        ...data,
-        // Normalize both pathways onto system/SYSTEM so the UI has one render branch.
-        type: 'system',
-        role: MessageRole.SYSTEM,
-        content: fallbackContent(toolDisplayNames[tool] ?? tool),
-        content_preview: fallbackContent(toolDisplayNames[tool] ?? tool).substring(0, 200),
-        metadata: {
-          ...data.metadata,
-          error_kind: 'missing_credential',
-          tool,
-        },
-      };
+      // Normalize both pathways onto system/SYSTEM so the UI has one render branch.
+      context.data = classifyProviderFailure(
+        data,
+        tool,
+        toolDisplayNames[tool] ?? tool,
+        'missing_credential'
+      );
     } catch (err) {
       console.error('[classifyMissingCredentialFailure] classification failed:', err);
     }

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -40,13 +40,18 @@ function declaresProviderFailure(data: unknown): boolean {
   );
 }
 
-/** Keep the recovery-panel discriminator owned by daemon classification. */
-export function protectExternalProviderFailureMetadata(context: HookContext): HookContext {
-  if (!context.params.provider) return context;
-  const writes = Array.isArray(context.data) ? context.data : [context.data];
+/** Reject public single/bulk DTOs that attempt to mint daemon-owned recovery states. */
+export function assertExternalProviderFailureMetadataAllowed(data: unknown): void {
+  const writes = Array.isArray(data) ? data : [data];
   if (writes.some(declaresProviderFailure)) {
     throw new Forbidden('Provider failure metadata can only be classified by the daemon');
   }
+}
+
+/** Keep the recovery-panel discriminator owned by daemon classification. */
+export function protectExternalProviderFailureMetadata(context: HookContext): HookContext {
+  if (!context.params.provider) return context;
+  assertExternalProviderFailureMetadataAllowed(context.data);
   return context;
 }
 
@@ -132,8 +137,11 @@ export function classifyMissingCredentialFailure(
 
     const isMissingCredentialFailure = data.metadata?.is_missing_credential_failure === true;
     const isZeroTurnResult = data.metadata?.is_zero_turn_result === true;
+    const isProviderFailureResult = data.metadata?.is_provider_failure_result === true;
 
-    if (!isMissingCredentialFailure && !isZeroTurnResult) return context;
+    if (!isMissingCredentialFailure && !isZeroTurnResult && !isProviderFailureResult) {
+      return context;
+    }
 
     try {
       const [task, session] = await Promise.all([
@@ -151,7 +159,7 @@ export function classifyMissingCredentialFailure(
       // Tools with no mapped key (e.g. opencode) aren't credential-gated.
       if (!keyName) return context;
 
-      if (isZeroTurnResult && !isMissingCredentialFailure) {
+      if ((isZeroTurnResult || isProviderFailureResult) && !isMissingCredentialFailure) {
         const resolution = await resolveApiKey(keyName, {
           userId: task.created_by as UserID,
           db,

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -8,7 +8,14 @@ import { TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository, TenantScopeAwareDatabase } from '@agor/core/db';
 import { Forbidden } from '@agor/core/feathers';
-import type { AgenticToolName, HookContext, Message, TaskID, UserID } from '@agor/core/types';
+import type {
+  AgenticToolName,
+  HookContext,
+  Message,
+  MessageID,
+  TaskID,
+  UserID,
+} from '@agor/core/types';
 import {
   canonicalTenantAgenticTool,
   isAgenticToolName,
@@ -29,6 +36,8 @@ function providerCreditContent(toolDisplayName: string): string {
 
 type ProviderFailureKind = 'missing_credential' | 'provider_credit_exhausted';
 
+export type ProviderFailureMessageLoader = (messageId: MessageID) => Promise<Message | null>;
+
 function declaresProviderFailure(data: unknown): boolean {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const metadata = (data as { metadata?: unknown }).metadata;
@@ -48,11 +57,34 @@ export function assertExternalProviderFailureMetadataAllowed(data: unknown): voi
   }
 }
 
-/** Keep the recovery-panel discriminator owned by daemon classification. */
-export function protectExternalProviderFailureMetadata(context: HookContext): HookContext {
-  if (!context.params.provider) return context;
-  assertExternalProviderFailureMetadataAllowed(context.data);
-  return context;
+function changesProviderFailureOwnedFields(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const record = data as Record<string, unknown>;
+  return 'metadata' in record || 'type' in record || 'role' in record;
+}
+
+/**
+ * Keep the recovery-panel discriminator and its render gate owned by daemon
+ * classification. Public patching uses a shallow repository merge, so an
+ * otherwise harmless-looking metadata/type/role patch could erase or hide a
+ * trusted classification unless the existing record is checked first.
+ */
+export function protectExternalProviderFailureMetadata(loadMessage: ProviderFailureMessageLoader) {
+  return async (context: HookContext): Promise<HookContext> => {
+    if (!context.params.provider) return context;
+    assertExternalProviderFailureMetadataAllowed(context.data);
+
+    if (context.method !== 'patch' || context.id === null || context.id === undefined) {
+      return context;
+    }
+    if (!changesProviderFailureOwnedFields(context.data)) return context;
+
+    const existing = await loadMessage(String(context.id) as MessageID);
+    if (existing && declaresProviderFailure(existing)) {
+      throw new Forbidden('Provider failure classification is daemon-owned');
+    }
+    return context;
+  };
 }
 
 function classifyProviderFailure(
@@ -86,6 +118,8 @@ const PROVIDER_CREDIT_SIGNALS = [
   'billing_hard_limit_reached',
   'payment_required',
 ] as const;
+const PROVIDER_CREDIT_SIGNAL_PATTERN = new RegExp(`\\b(?:${PROVIDER_CREDIT_SIGNALS.join('|')})\\b`);
+const PROVIDER_ERROR_SEARCH_WINDOW = 500;
 
 function textContent(content: Message['content'] | undefined): string {
   if (typeof content === 'string') return content;
@@ -101,16 +135,19 @@ function isProviderCreditFailure(
   tool: AgenticToolName,
   content: Message['content'] | undefined
 ): boolean {
-  const text = textContent(content).trim().toLowerCase();
-  if (!text || text.length > 500) return false;
+  const text = textContent(content).toLowerCase();
+  if (!text) return false;
 
-  const isAnthropicCreditFailure =
-    tool === 'claude-code' && /\bcredit balance is too low\b/.test(text);
-  const hasStableCreditSignal = new RegExp(`\\b(?:${PROVIDER_CREDIT_SIGNALS.join('|')})\\b`).test(
-    text
-  );
-
-  return isAnthropicCreditFailure || hasStableCreditSignal;
+  // Claude's SDK joins its error array with newlines. Bound each error's
+  // search window instead of rejecting the whole joined response when one
+  // error is long; this still avoids classifying arbitrary distant prose.
+  return text.split(/\r?\n/).some((error) => {
+    const searchWindow = error.slice(0, PROVIDER_ERROR_SEARCH_WINDOW);
+    const isAnthropicCreditFailure =
+      tool === 'claude-code' && /\bcredit balance is too low\b/.test(searchWindow);
+    const hasStableCreditSignal = PROVIDER_CREDIT_SIGNAL_PATTERN.test(searchWindow);
+    return isAnthropicCreditFailure || hasStableCreditSignal;
+  });
 }
 
 function hasResolvedCredential(

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -127,28 +127,27 @@ const PROVIDER_CREDIT_SIGNALS = [
 const PROVIDER_CREDIT_SIGNAL_PATTERN = new RegExp(`\\b(?:${PROVIDER_CREDIT_SIGNALS.join('|')})\\b`);
 const PROVIDER_ERROR_SEARCH_WINDOW = 500;
 
-function textContent(content: Message['content'] | undefined): string {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
+function textBlocks(content: Message['content'] | undefined): string[] {
+  if (typeof content === 'string') return [content];
+  if (!Array.isArray(content)) return [];
 
   return content
     .filter((block) => block.type === 'text' && typeof block.text === 'string')
-    .map((block) => block.text as string)
-    .join('\n');
+    .map((block) => block.text as string);
 }
 
 function isProviderCreditFailure(
   tool: AgenticToolName,
   content: Message['content'] | undefined
 ): boolean {
-  const text = textContent(content).toLowerCase();
-  if (!text) return false;
+  const blocks = textBlocks(content);
+  if (blocks.length === 0) return false;
 
-  // Claude's SDK joins its error array with newlines. Bound each error's
-  // search window instead of rejecting the whole joined response when one
-  // error is long; this still avoids classifying arbitrary distant prose.
-  return text.split(/\r?\n/).some((error) => {
-    const searchWindow = error.slice(0, PROVIDER_ERROR_SEARCH_WINDOW);
+  // Claude's executor preserves each sdkResult.errors[] entry as its own text
+  // block. Bound each actual block without splitting internal newlines; a
+  // zero-turn string remains one bounded entry.
+  return blocks.some((block) => {
+    const searchWindow = block.slice(0, PROVIDER_ERROR_SEARCH_WINDOW).toLowerCase();
     const isAnthropicCreditFailure =
       tool === 'claude-code' && /\bcredit balance is too low\b/.test(searchWindow);
     const hasStableCreditSignal = PROVIDER_CREDIT_SIGNAL_PATTERN.test(searchWindow);

--- a/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
+++ b/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
@@ -1,0 +1,120 @@
+import type { HookContext, Message, MessageID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks';
+
+type RegisteredHook = (context: HookContext) => HookContext | Promise<HookContext>;
+
+function classifiedMessage(): Message {
+  return {
+    message_id: 'message-1' as MessageID,
+    session_id: 'session-1' as never,
+    type: 'system',
+    role: MessageRole.SYSTEM,
+    metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' },
+  } as Message;
+}
+
+function captureMessageHooks(existing: Message) {
+  const captured: Partial<Record<'all' | 'patch' | 'update', RegisteredHook[]>> = {};
+  const findByIdForScopeCheck = vi.fn().mockResolvedValue(existing);
+  const app = {
+    service(path: string) {
+      return {
+        hooks(hooks: { before?: Record<string, RegisteredHook[]> }) {
+          if (path !== 'messages') return;
+          for (const [method, chain] of Object.entries(hooks.before ?? {})) {
+            if (method === 'all' || method === 'patch' || method === 'update') {
+              captured[method] = [...(captured[method] ?? []), ...(chain ?? [])];
+            }
+          }
+        },
+      };
+    },
+    use() {},
+    publish() {},
+  };
+
+  registerHooks({
+    db: {} as RegisterHooksContext['db'],
+    app: app as unknown as RegisterHooksContext['app'],
+    config: {
+      database: { dialect: 'postgresql' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'provider-failure-test' },
+    } as RegisterHooksContext['config'],
+    jwtSecret: 'provider-failure-test-secret',
+    branchRbacEnabled: false,
+    requireAuth: async (context) => context,
+    superadminOpts: { allowSuperadmin: true },
+    messagesService: {
+      findByIdForScopeCheck,
+    } as unknown as RegisterHooksContext['messagesService'],
+    sessionsService: {} as RegisterHooksContext['sessionsService'],
+    boardsService: undefined,
+    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    usersRepository: {} as RegisterHooksContext['usersRepository'],
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+    deployment: { mode: 'standalone' },
+  });
+
+  return { captured, findByIdForScopeCheck };
+}
+
+async function runRegisteredMessageHooks(
+  hooks: RegisteredHook[],
+  method: 'patch' | 'update',
+  data: Record<string, unknown>
+): Promise<HookContext> {
+  const context = {
+    path: 'messages',
+    method,
+    id: 'message-1',
+    data,
+    params: {
+      provider: 'rest',
+      query: {},
+      user: { user_id: 'user-1', role: 'member' },
+    },
+  } as unknown as HookContext;
+
+  for (const hook of hooks) await hook(context);
+  return context;
+}
+
+describe('registered provider failure message boundary', () => {
+  it.each([
+    ['clearing metadata', { metadata: {} }],
+    ['changing the classified tool', { metadata: { tool: 'codex' } }],
+    ['changing the message type', { type: 'assistant' }],
+    ['changing the message role', { role: 'assistant' }],
+  ])('rejects an external patch that attempts %s', async (_label, data) => {
+    const { captured, findByIdForScopeCheck } = captureMessageHooks(classifiedMessage());
+
+    await expect(
+      runRegisteredMessageHooks([...(captured.all ?? []), ...(captured.patch ?? [])], 'patch', data)
+    ).rejects.toMatchObject({ name: 'Forbidden' });
+    expect(findByIdForScopeCheck).toHaveBeenCalledWith('message-1');
+  });
+
+  it('keeps ordinary external message patches available', async () => {
+    const { captured } = captureMessageHooks(classifiedMessage());
+
+    await expect(
+      runRegisteredMessageHooks([...(captured.all ?? []), ...(captured.patch ?? [])], 'patch', {
+        content: 'edited',
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it('keeps external whole-row replacement blocked by the registered message boundary', async () => {
+    const { captured } = captureMessageHooks(classifiedMessage());
+
+    await expect(
+      runRegisteredMessageHooks([...(captured.all ?? []), ...(captured.update ?? [])], 'update', {
+        type: 'assistant',
+        role: 'assistant',
+        metadata: {},
+      })
+    ).rejects.toMatchObject({ name: 'Forbidden' });
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
+++ b/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
@@ -16,7 +16,7 @@ function classifiedMessage(): Message {
 }
 
 function captureMessageHooks(existing: Message) {
-  const captured: Partial<Record<'all' | 'patch' | 'update', RegisteredHook[]>> = {};
+  const captured: Partial<Record<'all' | 'create' | 'patch' | 'update', RegisteredHook[]>> = {};
   const findByIdForScopeCheck = vi.fn().mockResolvedValue(existing);
   const app = {
     service(path: string) {
@@ -24,7 +24,12 @@ function captureMessageHooks(existing: Message) {
         hooks(hooks: { before?: Record<string, RegisteredHook[]> }) {
           if (path !== 'messages') return;
           for (const [method, chain] of Object.entries(hooks.before ?? {})) {
-            if (method === 'all' || method === 'patch' || method === 'update') {
+            if (
+              method === 'all' ||
+              method === 'create' ||
+              method === 'patch' ||
+              method === 'update'
+            ) {
               captured[method] = [...(captured[method] ?? []), ...(chain ?? [])];
             }
           }
@@ -62,7 +67,7 @@ function captureMessageHooks(existing: Message) {
 
 async function runRegisteredMessageHooks(
   hooks: RegisteredHook[],
-  method: 'patch' | 'update',
+  method: 'create' | 'patch' | 'update',
   data: Record<string, unknown>
 ): Promise<HookContext> {
   const context = {
@@ -82,6 +87,16 @@ async function runRegisteredMessageHooks(
 }
 
 describe('registered provider failure message boundary', () => {
+  it('rejects forged recovery metadata through the registered create hooks', async () => {
+    const { captured } = captureMessageHooks(classifiedMessage());
+
+    await expect(
+      runRegisteredMessageHooks([...(captured.all ?? []), ...(captured.create ?? [])], 'create', {
+        metadata: { error_kind: 'provider_credit_exhausted', tool: 'claude-code' },
+      })
+    ).rejects.toMatchObject({ name: 'Forbidden' });
+  });
+
   it.each([
     ['clearing metadata', { metadata: {} }],
     ['changing the classified tool', { metadata: { tool: 'codex' } }],

--- a/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
+++ b/apps/agor-daemon/src/register-hooks.provider-failure.test.ts
@@ -15,6 +15,17 @@ function classifiedMessage(): Message {
   } as Message;
 }
 
+function ordinaryMessage(): Message {
+  return {
+    ...classifiedMessage(),
+    type: 'assistant',
+    role: MessageRole.ASSISTANT,
+    content: 'existing content',
+    content_preview: 'existing preview',
+    metadata: {},
+  };
+}
+
 function captureMessageHooks(existing: Message) {
   const captured: Partial<Record<'all' | 'create' | 'patch' | 'update', RegisteredHook[]>> = {};
   const findByIdForScopeCheck = vi.fn().mockResolvedValue(existing);
@@ -102,6 +113,8 @@ describe('registered provider failure message boundary', () => {
     ['changing the classified tool', { metadata: { tool: 'codex' } }],
     ['changing the message type', { type: 'assistant' }],
     ['changing the message role', { role: 'assistant' }],
+    ['clearing content', { content: '' }],
+    ['clearing content preview', { content_preview: '' }],
   ])('rejects an external patch that attempts %s', async (_label, data) => {
     const { captured, findByIdForScopeCheck } = captureMessageHooks(classifiedMessage());
 
@@ -112,13 +125,15 @@ describe('registered provider failure message boundary', () => {
   });
 
   it('keeps ordinary external message patches available', async () => {
-    const { captured } = captureMessageHooks(classifiedMessage());
+    const { captured, findByIdForScopeCheck } = captureMessageHooks(ordinaryMessage());
 
     await expect(
       runRegisteredMessageHooks([...(captured.all ?? []), ...(captured.patch ?? [])], 'patch', {
         content: 'edited',
+        content_preview: 'edited preview',
       })
     ).resolves.toBeDefined();
+    expect(findByIdForScopeCheck).toHaveBeenCalledWith('message-1');
   });
 
   it('keeps external whole-row replacement blocked by the registered message boundary', async () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -996,6 +996,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const protectWidgetMessageWrites = protectExternalWidgetMessageWrites((messageId) =>
     messagesService.findByIdForScopeCheck(messageId as MessageID)
   );
+  const protectProviderFailureMetadata = protectExternalProviderFailureMetadata((messageId) =>
+    messagesService.findByIdForScopeCheck(messageId as MessageID)
+  );
   const protectPermissionMessageWrites = protectExternalPermissionMessageWrites((messageId) =>
     messagesService.findByIdForScopeCheck(messageId as MessageID)
   );
@@ -1021,7 +1024,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create messages'),
-        protectExternalProviderFailureMetadata,
+        protectProviderFailureMetadata,
         protectWidgetMessageWrites,
         protectPermissionMessageWrites,
         ...(branchRbacEnabled
@@ -1043,13 +1046,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ),
       ],
       update: [
-        protectExternalProviderFailureMetadata,
+        protectProviderFailureMetadata,
         protectWidgetMessageWrites,
         protectPermissionMessageWrites,
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),
-        protectExternalProviderFailureMetadata,
+        protectProviderFailureMetadata,
         ...(branchRbacEnabled
           ? [
               resolveSessionContext(),

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -106,7 +106,10 @@ import type {
   TasksServiceImpl,
 } from './declarations.js';
 import { rejectInConstrainedHa } from './ha-support.js';
-import { classifyMissingCredentialFailure } from './hooks/classify-missing-credential.js';
+import {
+  classifyMissingCredentialFailure,
+  protectExternalProviderFailureMetadata,
+} from './hooks/classify-missing-credential.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
 import { protectExternalPermissionMessageWrites } from './permissions/permission-message-boundary.js';
@@ -1018,6 +1021,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create messages'),
+        protectExternalProviderFailureMetadata,
         protectWidgetMessageWrites,
         protectPermissionMessageWrites,
         ...(branchRbacEnabled
@@ -1029,9 +1033,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
             ]
           : []),
-        // Detect "no credential resolved for this session's provider"
-        // structurally, never by matching raw provider error text. Drives the
-        // Connect-AI empty state instead of a raw "/login" message.
+        // Reclassify executor-scoped credential and narrow provider-credit
+        // failures structurally, never by matching arbitrary provider text.
         classifyMissingCredentialFailure(
           db,
           taskRepository,
@@ -1039,9 +1042,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           AGENTIC_TOOL_DISPLAY_NAMES
         ),
       ],
-      update: [protectWidgetMessageWrites, protectPermissionMessageWrites],
+      update: [
+        protectExternalProviderFailureMetadata,
+        protectWidgetMessageWrites,
+        protectPermissionMessageWrites,
+      ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),
+        protectExternalProviderFailureMetadata,
         ...(branchRbacEnabled
           ? [
               resolveSessionContext(),

--- a/apps/agor-daemon/src/register-routes.messages-bulk.test.ts
+++ b/apps/agor-daemon/src/register-routes.messages-bulk.test.ts
@@ -1,14 +1,30 @@
+import { feathers } from '@agor/core/feathers';
 import type { Message } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { createMessagesBulkRouteService } from './register-routes.js';
+import { registerAuthenticatedRoute } from './utils/authorization.js';
+
+function createAuthenticatedBulkService(createMany: (messages: Message[]) => Promise<Message[]>) {
+  const app = feathers();
+  registerAuthenticatedRoute(
+    app,
+    '/messages/bulk',
+    createMessagesBulkRouteService({ createMany }),
+    { create: { role: 'member', action: 'create messages' } },
+    async (context) => context
+  );
+  return app.service('/messages/bulk') as unknown as {
+    create(data: unknown, params: { provider: string; user: { role: 'member' } }): Promise<unknown>;
+  };
+}
 
 describe('/messages/bulk provider failure boundary', () => {
   it('rejects forged daemon-owned recovery metadata before persistence', async () => {
     const createMany = vi.fn();
-    const route = createMessagesBulkRouteService({ createMany } as never);
+    const service = createAuthenticatedBulkService(createMany);
 
     await expect(
-      route.create(
+      service.create(
         [
           {
             type: 'system',
@@ -19,7 +35,7 @@ describe('/messages/bulk provider failure boundary', () => {
             },
           },
         ],
-        {} as never
+        { provider: 'rest', user: { role: 'member' } }
       )
     ).rejects.toThrow('Provider failure metadata can only be classified by the daemon');
     expect(createMany).not.toHaveBeenCalled();
@@ -34,9 +50,11 @@ describe('/messages/bulk provider failure boundary', () => {
       },
     ] as unknown as Message[];
     const createMany = vi.fn().mockResolvedValue(messages);
-    const route = createMessagesBulkRouteService({ createMany } as never);
+    const service = createAuthenticatedBulkService(createMany);
 
-    await expect(route.create(messages, {} as never)).resolves.toBe(messages);
+    await expect(
+      service.create(messages, { provider: 'rest', user: { role: 'member' } })
+    ).resolves.toBe(messages);
     expect(createMany).toHaveBeenCalledWith(messages);
   });
 });

--- a/apps/agor-daemon/src/register-routes.messages-bulk.test.ts
+++ b/apps/agor-daemon/src/register-routes.messages-bulk.test.ts
@@ -1,0 +1,42 @@
+import type { Message } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { createMessagesBulkRouteService } from './register-routes.js';
+
+describe('/messages/bulk provider failure boundary', () => {
+  it('rejects forged daemon-owned recovery metadata before persistence', async () => {
+    const createMany = vi.fn();
+    const route = createMessagesBulkRouteService({ createMany } as never);
+
+    await expect(
+      route.create(
+        [
+          {
+            type: 'system',
+            role: 'system',
+            metadata: {
+              error_kind: 'provider_credit_exhausted',
+              tool: 'claude-code',
+            },
+          },
+        ],
+        {} as never
+      )
+    ).rejects.toThrow('Provider failure metadata can only be classified by the daemon');
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it('passes ordinary executor-scoped messages to the scoped service dependency', async () => {
+    const messages = [
+      {
+        task_id: 'task-1',
+        session_id: 'session-1',
+        metadata: { is_provider_failure_result: true },
+      },
+    ] as unknown as Message[];
+    const createMany = vi.fn().mockResolvedValue(messages);
+    const route = createMessagesBulkRouteService({ createMany } as never);
+
+    await expect(route.create(messages, {} as never)).resolves.toBe(messages);
+    expect(createMany).toHaveBeenCalledWith(messages);
+  });
+});

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -105,6 +105,7 @@ import {
   publicHealthDb,
 } from './health/payload.js';
 import { registerHealthProbeRoutes } from './health/routes.js';
+import { assertExternalProviderFailureMetadataAllowed } from './hooks/classify-missing-credential.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
 import {
   deliverPermissionDecision,
@@ -232,6 +233,19 @@ export interface RouteParams extends Params {
   user?: User;
   /** Trusted internal callback request, populated by MCP tooling only. */
   _taskCompletionCallback?: NonNullable<TaskMetadata['completion_callback']>;
+}
+
+export function createMessagesBulkRouteService(
+  messagesService: Pick<MessagesServiceImpl, 'createMany'>
+) {
+  return {
+    async create(data: unknown, _params: RouteParams) {
+      assertExternalProviderFailureMetadataAllowed(data);
+      assertExternalWidgetMessageCreateAllowed(data);
+      assertExternalPermissionMessageCreateAllowed(data);
+      return messagesService.createMany(data as Message[]);
+    },
+  };
 }
 
 /** Compatibility tombstone retained for stale Claude CLI restart clients. */
@@ -728,13 +742,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   registerAuthenticatedRoute(
     app,
     '/messages/bulk',
-    {
-      async create(data: unknown, params: RouteParams) {
-        assertExternalWidgetMessageCreateAllowed(data);
-        assertExternalPermissionMessageCreateAllowed(data);
-        return messagesService.createMany(data as Message[]);
-      },
-    },
+    createMessagesBulkRouteService(messagesService),
     {
       create: { role: ROLES.MEMBER, action: 'create messages' },
     },

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
@@ -1,6 +1,6 @@
 import type { Message } from '@agor-live/client';
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { MessageBlock } from './MessageBlock';
 
 describe('MessageBlock layout', () => {
@@ -22,5 +22,32 @@ describe('MessageBlock layout', () => {
 
     expect(bubble).toHaveStyle({ maxWidth: '100%' });
     expect(body).toHaveStyle({ minWidth: '0' });
+  });
+
+  it('renders provider billing recovery instead of raw zero-turn text', () => {
+    const onOpenSettings = vi.fn();
+    const message = {
+      message_id: 'message-2',
+      session_id: 'session-1',
+      type: 'system',
+      role: 'system',
+      index: 1,
+      timestamp: '2026-07-23T00:00:00.000Z',
+      content: 'Credit balance is too low',
+      content_preview: 'Credit balance is too low',
+      metadata: {
+        error_kind: 'provider_credit_exhausted',
+        tool: 'claude-code',
+      },
+    } as unknown as Message;
+
+    render(<MessageBlock message={message} onOpenAgenticToolSettings={onOpenSettings} />);
+
+    expect(screen.getByText(/needs available credit or quota/i)).toBeVisible();
+    expect(screen.getByText(/workspace and teammate are still set up/i)).toBeVisible();
+    expect(screen.getByRole('link', { name: /Open Claude Code's console/i })).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: /Open Claude Code settings/i }));
+    expect(onOpenSettings).toHaveBeenCalledWith('claude-code');
+    expect(screen.queryByText(/credit balance is too low/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
@@ -50,4 +50,28 @@ describe('MessageBlock layout', () => {
     expect(onOpenSettings).toHaveBeenCalledWith('claude-code');
     expect(screen.queryByText(/credit balance is too low/i)).not.toBeInTheDocument();
   });
+
+  it.each([
+    ['missing_credential', /couldn't verify your Claude Code connection/i],
+    ['provider_credit_exhausted', /needs available credit or quota/i],
+  ] as const)('renders %s recovery for empty content', async (errorKind, recoveryText) => {
+    const message = {
+      message_id: `empty-${errorKind}`,
+      session_id: 'session-1',
+      type: 'system',
+      role: 'system',
+      index: 2,
+      timestamp: '2026-07-23T00:00:00.000Z',
+      content: '',
+      content_preview: '',
+      metadata: {
+        error_kind: errorKind,
+        tool: 'claude-code',
+      },
+    } as unknown as Message;
+
+    render(<MessageBlock message={message} />);
+
+    expect(await screen.findByText(recoveryText)).toBeVisible();
+  });
 });

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -37,6 +37,7 @@ import { CopyableContent } from '../CopyableContent';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { MissingCredentialPanel } from '../MissingCredentialPanel';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
+import { ProviderBillingRecoveryPanel } from '../ProviderBillingRecoveryPanel';
 import { SystemMessage } from '../SystemMessage';
 import { ThinkingBlock } from '../ThinkingBlock';
 import {
@@ -508,6 +509,20 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       <MissingCredentialPanel
         tool={message.metadata.tool}
         client={client}
+        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+      />
+    );
+  }
+
+  // Provider credit/quota failure — show recovery actions, not the raw result.
+  if (
+    isSystem &&
+    message.metadata?.error_kind === 'provider_credit_exhausted' &&
+    isAgenticToolName(message.metadata?.tool)
+  ) {
+    return (
+      <ProviderBillingRecoveryPanel
+        tool={message.metadata.tool}
         onOpenAgenticToolSettings={onOpenAgenticToolSettings}
       />
     );

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -426,6 +426,35 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   // Get current user's emoji
   const currentUser = currentUserId ? userById.get(currentUserId) : undefined;
 
+  // Missing-credential failure — show the Connect-AI panel, not the raw error.
+  if (
+    isSystem &&
+    message.metadata?.error_kind === 'missing_credential' &&
+    isAgenticToolName(message.metadata?.tool)
+  ) {
+    return (
+      <MissingCredentialPanel
+        tool={message.metadata.tool}
+        client={client}
+        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+      />
+    );
+  }
+
+  // Provider credit/quota failure — show recovery actions, not the raw result.
+  if (
+    isSystem &&
+    message.metadata?.error_kind === 'provider_credit_exhausted' &&
+    isAgenticToolName(message.metadata?.tool)
+  ) {
+    return (
+      <ProviderBillingRecoveryPanel
+        tool={message.metadata.tool}
+        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+      />
+    );
+  }
+
   // Skip rendering if message has no content
   if (!message.content || (typeof message.content === 'string' && message.content.trim() === '')) {
     return null;
@@ -496,35 +525,6 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
         </div>
         <MarkdownRenderer content={markdownContent} />
       </div>
-    );
-  }
-
-  // Missing-credential failure — show the Connect-AI panel, not the raw error.
-  if (
-    isSystem &&
-    message.metadata?.error_kind === 'missing_credential' &&
-    isAgenticToolName(message.metadata?.tool)
-  ) {
-    return (
-      <MissingCredentialPanel
-        tool={message.metadata.tool}
-        client={client}
-        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
-      />
-    );
-  }
-
-  // Provider credit/quota failure — show recovery actions, not the raw result.
-  if (
-    isSystem &&
-    message.metadata?.error_kind === 'provider_credit_exhausted' &&
-    isAgenticToolName(message.metadata?.tool)
-  ) {
-    return (
-      <ProviderBillingRecoveryPanel
-        tool={message.metadata.tool}
-        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
-      />
     );
   }
 

--- a/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.test.tsx
+++ b/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProviderBillingRecoveryPanel } from './ProviderBillingRecoveryPanel';
+
+describe('ProviderBillingRecoveryPanel', () => {
+  it('renders recovery actions without exposing provider text', () => {
+    const onOpenSettings = vi.fn();
+
+    render(
+      <ProviderBillingRecoveryPanel tool="claude-code" onOpenAgenticToolSettings={onOpenSettings} />
+    );
+
+    expect(screen.getByText(/needs available credit or quota/i)).toBeVisible();
+    expect(screen.getByText(/workspace and teammate are still set up/i)).toBeVisible();
+    expect(screen.getByText(/send a new message/i)).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Claude Code settings/i }));
+    expect(onOpenSettings).toHaveBeenCalledWith('claude-code');
+
+    const consoleLink = screen.getByRole('link', { name: /Open Claude Code's console/i });
+    expect(consoleLink).toHaveAttribute('href', 'https://platform.claude.com/settings/keys');
+    expect(screen.queryByText(/credit balance is too low/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.test.tsx
+++ b/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.test.tsx
@@ -18,7 +18,7 @@ describe('ProviderBillingRecoveryPanel', () => {
     expect(onOpenSettings).toHaveBeenCalledWith('claude-code');
 
     const consoleLink = screen.getByRole('link', { name: /Open Claude Code's console/i });
-    expect(consoleLink).toHaveAttribute('href', 'https://platform.claude.com/settings/keys');
+    expect(consoleLink).toHaveAttribute('href', 'https://platform.claude.com/settings/billing');
     expect(screen.queryByText(/credit balance is too low/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.tsx
+++ b/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.tsx
@@ -1,4 +1,4 @@
-import { AGENTIC_TOOL_DISPLAY_NAMES, AGENTIC_TOOL_KEY_CREATION_URL } from '@agor/agentic-tools';
+import { AGENTIC_TOOL_BILLING_URL, AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
 import type { AgenticToolName } from '@agor-live/client';
 import { Button, Space, Typography, theme } from 'antd';
 import type React from 'react';
@@ -18,7 +18,7 @@ export const ProviderBillingRecoveryPanel: React.FC<ProviderBillingRecoveryPanel
 }) => {
   const { token } = theme.useToken();
   const displayName = AGENTIC_TOOL_DISPLAY_NAMES[tool] ?? tool;
-  const accountUrl = AGENTIC_TOOL_KEY_CREATION_URL[tool];
+  const accountUrl = AGENTIC_TOOL_BILLING_URL[tool];
 
   return (
     <SystemMessage

--- a/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.tsx
+++ b/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/ProviderBillingRecoveryPanel.tsx
@@ -1,0 +1,62 @@
+import { AGENTIC_TOOL_DISPLAY_NAMES, AGENTIC_TOOL_KEY_CREATION_URL } from '@agor/agentic-tools';
+import type { AgenticToolName } from '@agor-live/client';
+import { Button, Space, Typography, theme } from 'antd';
+import type React from 'react';
+import { SystemMessage } from '../SystemMessage';
+
+const { Text, Link } = Typography;
+
+export interface ProviderBillingRecoveryPanelProps {
+  tool: AgenticToolName;
+  /** Opens Settings deep-linked to this tool's Agentic Tools tab. */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+}
+
+export const ProviderBillingRecoveryPanel: React.FC<ProviderBillingRecoveryPanelProps> = ({
+  tool,
+  onOpenAgenticToolSettings,
+}) => {
+  const { token } = theme.useToken();
+  const displayName = AGENTIC_TOOL_DISPLAY_NAMES[tool] ?? tool;
+  const accountUrl = AGENTIC_TOOL_KEY_CREATION_URL[tool];
+
+  return (
+    <SystemMessage
+      content={
+        <div style={{ maxWidth: 480 }}>
+          <Text style={{ fontSize: 13 }}>
+            The {displayName} account used for this run needs available credit or quota. Your
+            workspace and teammate are still set up. Check your settings or provider console, then
+            send a new message.
+          </Text>
+
+          <div style={{ marginTop: token.marginSM }}>
+            <Button
+              type="primary"
+              onClick={() => onOpenAgenticToolSettings?.(tool)}
+              disabled={!onOpenAgenticToolSettings}
+            >
+              Open {displayName} settings
+            </Button>
+          </div>
+
+          {accountUrl && (
+            <Space orientation="vertical" size={4} style={{ marginTop: token.marginSM }}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                Need to update your account?{' '}
+                <Link
+                  href={accountUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ fontSize: 12 }}
+                >
+                  Open {displayName}'s console →
+                </Link>
+              </Text>
+            </Space>
+          )}
+        </div>
+      }
+    />
+  );
+};

--- a/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/index.ts
+++ b/apps/agor-ui/src/components/ProviderBillingRecoveryPanel/index.ts
@@ -1,0 +1,2 @@
+export type { ProviderBillingRecoveryPanelProps } from './ProviderBillingRecoveryPanel';
+export { ProviderBillingRecoveryPanel } from './ProviderBillingRecoveryPanel';

--- a/packages/agentic-tools/src/index.ts
+++ b/packages/agentic-tools/src/index.ts
@@ -23,6 +23,7 @@ export const AGENTIC_TOOL_INTEGRATIONS = Object.freeze({
     apiKeyName: 'ANTHROPIC_API_KEY',
     authentication: 'api-key',
     keyCreationUrl: 'https://platform.claude.com/settings/keys',
+    billingUrl: 'https://platform.claude.com/settings/billing',
     capabilities: {
       supportsSessionFork: true,
       supportsChildSpawn: true,
@@ -126,6 +127,14 @@ export const AGENTIC_TOOL_KEY_CREATION_URL = Object.freeze(
   Object.fromEntries(
     Object.values(AGENTIC_TOOL_INTEGRATIONS).flatMap((integration) =>
       integration.keyCreationUrl ? [[integration.name, integration.keyCreationUrl]] : []
+    )
+  ) as Partial<Record<AgenticToolName, string>>
+);
+
+export const AGENTIC_TOOL_BILLING_URL = Object.freeze(
+  Object.fromEntries(
+    Object.values(AGENTIC_TOOL_INTEGRATIONS).flatMap((integration) =>
+      integration.billingUrl ? [[integration.name, integration.billingUrl]] : []
     )
   ) as Partial<Record<AgenticToolName, string>>
 );

--- a/packages/agentic-tools/src/types.ts
+++ b/packages/agentic-tools/src/types.ts
@@ -13,6 +13,7 @@ export interface AgenticToolIntegration {
   authentication: 'api-key' | 'runtime-managed';
   apiKeyName?: ApiKeyName;
   keyCreationUrl?: string;
+  billingUrl?: string;
   sdkVersion?: string;
   unverifiedTerminationReason?: string;
   /** Integration-owned model resolution and persisted-shape policy. */

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -296,6 +296,9 @@ export interface Message {
     /** Marks the synthesized message from a zero-turn success (no real model call). */
     is_zero_turn_result?: boolean;
 
+    /** Marks an executor-owned terminal SDK error result for bounded classification. */
+    is_provider_failure_result?: boolean;
+
     /**
      * Set server-side when a task failure resolves to a missing credential or
      * provider credit/quota exhaustion. Drives a recovery state instead of the

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -297,11 +297,11 @@ export interface Message {
     is_zero_turn_result?: boolean;
 
     /**
-     * Set server-side when a task failure resolves to "no credential for this
-     * session's provider". Drives the Connect-AI empty state instead of the
-     * raw error; `tool` names the provider that needs a credential.
+     * Set server-side when a task failure resolves to a missing credential or
+     * provider credit/quota exhaustion. Drives a recovery state instead of the
+     * raw error; `tool` names the provider that needs attention.
      */
-    error_kind?: 'missing_credential';
+    error_kind?: 'missing_credential' | 'provider_credit_exhausted';
     tool?: PersistedAgenticToolName;
 
     /** Additional agent-specific fields */

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -238,6 +238,87 @@ describe('executeToolTask credential preflight', () => {
   });
 });
 
+describe('executeToolTask provider-failure settlement', () => {
+  it('patches a classified Claude result with sanitized raw response and accounting', async () => {
+    const secret = 'provider-secret-body';
+    const taskPatch = vi.fn().mockResolvedValue(undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const safeRawResponse = {
+      type: 'result',
+      subtype: 'error_during_execution',
+      duration_ms: 42,
+      duration_api_ms: 31,
+      is_error: true,
+      num_turns: 1,
+      stop_reason: null,
+      total_cost_usd: 0.12,
+      usage: { input_tokens: 10, output_tokens: 4 },
+      modelUsage: {
+        'claude-sonnet-4-6': {
+          inputTokens: 10,
+          outputTokens: 4,
+          contextWindow: 200_000,
+        },
+      },
+      permission_denials: [],
+    };
+    const client = {
+      service(name: string) {
+        if (name === 'config/resolve-api-key') {
+          return {
+            create: vi.fn().mockResolvedValue({
+              apiKey: 'daemon-key',
+              source: 'user',
+              useNativeAuth: false,
+            }),
+          };
+        }
+        if (name === 'sessions') return { get: vi.fn().mockResolvedValue({}) };
+        if (name === 'tasks') return { patch: taskPatch };
+        if (name === 'messages') return { create: vi.fn(), patch: vi.fn() };
+        if (name === '/tasks/streaming') return { create: vi.fn() };
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+    const createTool = vi.fn(() => ({
+      executePromptWithStreaming: vi.fn().mockResolvedValue({
+        userMessageId: 'user-1',
+        assistantMessageIds: [],
+        hadError: true,
+        errorDetails: undefined,
+        rawSdkResponse: safeRawResponse,
+      }),
+    }));
+
+    try {
+      await executeToolTask({
+        client,
+        sessionId: 'session-1' as never,
+        taskId: 'task-1' as never,
+        prompt: 'hello',
+        abortController: new AbortController(),
+        apiKeyEnvVar: 'ANTHROPIC_API_KEY',
+        toolName: 'claude-code',
+        createTool,
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    const patch = taskPatch.mock.calls[0]?.[1];
+    expect(patch).toMatchObject({
+      status: 'failed',
+      raw_sdk_response: safeRawResponse,
+      normalized_sdk_response: {
+        tokenUsage: { inputTokens: 10, outputTokens: 4 },
+        durationMs: 42,
+        costUsd: 0.12,
+      },
+    });
+    expect(JSON.stringify(patch)).not.toContain(secret);
+  });
+});
+
 describe('installProviderConnection', () => {
   // Regression tests for the 2026-07-13 incident: the pre-install strip was
   // tool-agnostic and deleted user-configured env vars (GITHUB_TOKEN in

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.test.ts
@@ -1,0 +1,247 @@
+import { generateId } from '@agor/core';
+import type { Message, SessionID, TaskID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessagesService } from '../base/index.js';
+import type { ProcessedEvent } from './message-processor.js';
+
+const promptState = vi.hoisted(() => ({ events: [] as unknown[] }));
+
+vi.mock('./prompt-service.js', () => ({
+  ClaudePromptService: class {
+    async *promptSessionStreaming(): AsyncGenerator<ProcessedEvent> {
+      for (const event of promptState.events) {
+        yield event as ProcessedEvent;
+      }
+    }
+  },
+}));
+
+import { ClaudeTool } from './claude-tool.js';
+
+const RAW_PROVIDER_BODY = 'provider-secret-body';
+
+type Harness = {
+  tool: ClaudeTool;
+  outgoing: Partial<Message>[];
+  persisted: Message[];
+};
+
+function createHarness(
+  classifiedKind?: 'missing_credential' | 'provider_credit_exhausted'
+): Harness {
+  const sessionId = generateId() as SessionID;
+  const outgoing: Partial<Message>[] = [];
+  const persisted: Message[] = [];
+  const messagesService = {
+    create: vi.fn(async (data: Partial<Message>) => {
+      outgoing.push(data);
+      const daemonMessage = {
+        ...data,
+        ...(classifiedKind && data.metadata?.is_zero_turn_result
+          ? {
+              type: 'system' as const,
+              role: MessageRole.SYSTEM,
+              content: 'This session needs to be connected before it can run.',
+              content_preview: 'This session needs to be connected before it can run.',
+              metadata: { ...data.metadata, error_kind: classifiedKind },
+            }
+          : {}),
+        ...(classifiedKind && data.metadata?.is_provider_failure_result
+          ? {
+              content: 'This session needs available provider credit before it can respond.',
+              content_preview:
+                'This session needs available provider credit before it can respond.',
+              metadata: { ...data.metadata, error_kind: classifiedKind },
+            }
+          : {}),
+      } as Message;
+      persisted.push(daemonMessage);
+      return daemonMessage;
+    }),
+  } as unknown as MessagesService;
+
+  const messagesRepo = {
+    findBySessionId: vi.fn().mockResolvedValue([]),
+  };
+  const sessionsRepo = {
+    findById: vi.fn().mockResolvedValue({ session_id: sessionId }),
+    update: vi.fn().mockResolvedValue({ session_id: sessionId }),
+  };
+  const tasksService = {
+    patch: vi.fn().mockResolvedValue(undefined),
+    emit: vi.fn(),
+  };
+
+  return {
+    tool: new ClaudeTool(
+      messagesRepo as never,
+      sessionsRepo as never,
+      '',
+      messagesService,
+      undefined,
+      undefined,
+      undefined,
+      tasksService as never
+    ),
+    outgoing,
+    persisted,
+  };
+}
+
+function rawResult(subtype: 'success' | 'error_during_execution') {
+  return {
+    type: 'result' as const,
+    subtype,
+    duration_ms: 42,
+    duration_api_ms: 31,
+    is_error: subtype !== 'success',
+    num_turns: 1,
+    stop_reason: null,
+    total_cost_usd: 0.12,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 4,
+      cache_creation_input_tokens: 2,
+      cache_read_input_tokens: 3,
+    },
+    modelUsage: {
+      'claude-sonnet-4-6': {
+        inputTokens: 10,
+        outputTokens: 4,
+        cacheCreationInputTokens: 2,
+        cacheReadInputTokens: 3,
+        contextWindow: 200_000,
+      },
+    },
+    permission_denials: [],
+    uuid: generateId(),
+    session_id: generateId(),
+    ...(subtype === 'success'
+      ? { result: RAW_PROVIDER_BODY }
+      : { errors: [RAW_PROVIDER_BODY, 'Credit balance is too low'] }),
+  };
+}
+
+function resultEvent(raw: ReturnType<typeof rawResult>): ProcessedEvent {
+  return { type: 'result', raw_sdk_message: raw } as ProcessedEvent;
+}
+
+function synthesizedAssistantEvent(): ProcessedEvent {
+  return {
+    type: 'complete',
+    role: MessageRole.ASSISTANT,
+    content: [{ type: 'text', text: RAW_PROVIDER_BODY }],
+    isSynthesizedResult: true,
+  };
+}
+
+async function execute(tool: ClaudeTool, mode: 'streaming' | 'non-streaming', taskId: TaskID) {
+  const sessionId = generateId() as SessionID;
+  if (mode === 'streaming') {
+    return tool.executePromptWithStreaming(sessionId, 'prompt', taskId);
+  }
+  return tool.executePrompt(sessionId, 'prompt', taskId);
+}
+
+describe('ClaudeTool provider-failure settlement', () => {
+  beforeEach(() => {
+    promptState.events = [];
+  });
+
+  it.each(['streaming', 'non-streaming'] as const)(
+    'uses the daemon-confirmed assistant message for classified zero-turn %s turns',
+    async (mode) => {
+      const harness = createHarness('missing_credential');
+      const raw = rawResult('success');
+      const contextUsage = {
+        totalTokens: 123,
+        maxTokens: 200_000,
+      } as unknown as import('@agor/core/sdk').SDKControlGetContextUsageResponse;
+      promptState.events = [
+        synthesizedAssistantEvent(),
+        { type: 'context_usage', contextUsage },
+        resultEvent(raw),
+      ];
+
+      const result = await execute(harness.tool, mode, generateId() as TaskID);
+
+      expect(harness.persisted.at(-1)).toMatchObject({
+        type: 'system',
+        role: MessageRole.SYSTEM,
+        content: 'This session needs to be connected before it can run.',
+        metadata: { error_kind: 'missing_credential' },
+      });
+      expect(result.rawSdkResponse).not.toHaveProperty('result');
+      expect(result.rawSdkResponse).toMatchObject({
+        subtype: 'success',
+        usage: raw.usage,
+        modelUsage: raw.modelUsage,
+        duration_ms: raw.duration_ms,
+        total_cost_usd: raw.total_cost_usd,
+      });
+      expect(result.errorDetails).toBeUndefined();
+      expect(result.rawContextUsage).toEqual(contextUsage);
+    }
+  );
+
+  it.each(['streaming', 'non-streaming'] as const)(
+    'keeps classified non-success %s results safe while preserving accounting',
+    async (mode) => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const harness = createHarness('provider_credit_exhausted');
+        const raw = rawResult('error_during_execution');
+        promptState.events = [resultEvent(raw)];
+
+        const result = await execute(harness.tool, mode, generateId() as TaskID);
+
+        const persistedFailure = harness.persisted.at(-1);
+        expect(persistedFailure).toMatchObject({
+          content: 'This session needs available provider credit before it can respond.',
+          metadata: { error_kind: 'provider_credit_exhausted' },
+        });
+        expect(harness.outgoing.at(-1)?.content).toEqual([
+          { type: 'text', text: 'Agent SDK error (error_during_execution): ' },
+          { type: 'text', text: RAW_PROVIDER_BODY },
+          { type: 'text', text: '\n' },
+          { type: 'text', text: 'Credit balance is too low' },
+        ]);
+        expect(result.rawSdkResponse).not.toHaveProperty('errors');
+        expect(result.rawSdkResponse).toMatchObject({
+          subtype: 'error_during_execution',
+          usage: raw.usage,
+          modelUsage: raw.modelUsage,
+          duration_ms: raw.duration_ms,
+          num_turns: raw.num_turns,
+          total_cost_usd: raw.total_cost_usd,
+        });
+        expect(result.errorDetails).toBeUndefined();
+        expect(errorSpy.mock.calls.flat().join(' ')).not.toContain(RAW_PROVIDER_BODY);
+        expect(errorSpy.mock.calls.flat().join(' ')).toContain('provider_credit_exhausted');
+      } finally {
+        errorSpy.mockRestore();
+      }
+    }
+  );
+
+  it.each(['streaming', 'non-streaming'] as const)(
+    'keeps raw diagnostics when the daemon does not classify an executor marker in %s turns',
+    async (mode) => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const harness = createHarness();
+        const raw = rawResult('error_during_execution');
+        promptState.events = [resultEvent(raw)];
+
+        const result = await execute(harness.tool, mode, generateId() as TaskID);
+
+        expect(result.rawSdkResponse).toEqual(raw);
+        expect(result.errorDetails).toEqual(raw.errors);
+        expect(errorSpy.mock.calls.flat().join(' ')).toContain(RAW_PROVIDER_BODY);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    }
+  );
+});

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -694,7 +694,8 @@ export class ClaudeTool implements ITool {
                   taskId,
                   nextIndex++,
                   resolvedModel,
-                  this.messagesService!
+                  this.messagesService!,
+                  { is_provider_failure_result: true }
                 );
                 return true;
               });
@@ -1122,7 +1123,8 @@ export class ClaudeTool implements ITool {
                   taskId,
                   nextIndex++,
                   resolvedModel,
-                  this.messagesService!
+                  this.messagesService!,
+                  { is_provider_failure_result: true }
                 );
                 return true;
               });

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -28,6 +28,7 @@ import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-resp
 // Removed import of calculateModelContextWindowUsage - inlined instead
 import type { TokenUsage } from '../../types/token-usage.js';
 import {
+  type Message,
   type MessageID,
   MessageRole,
   type MessageSource,
@@ -107,6 +108,45 @@ function buildRateLimitContentBlock(
       isUsingOverage: event.isUsingOverage,
     },
   ];
+}
+
+type ClassifiedProviderFailureKind = Extract<
+  NonNullable<Message['metadata']>['error_kind'],
+  'missing_credential' | 'provider_credit_exhausted'
+>;
+
+function getClassifiedProviderFailureKind(
+  message: Message | null | undefined
+): ClassifiedProviderFailureKind | undefined {
+  const kind = message?.metadata?.error_kind;
+  return kind === 'missing_credential' || kind === 'provider_credit_exhausted' ? kind : undefined;
+}
+
+function buildProviderFailureContent(
+  subtype: string,
+  errors: string[]
+): Array<{ type: string; text?: string }> {
+  return [
+    { type: 'text', text: `Agent SDK error (${subtype}): ` },
+    ...errors.flatMap((error, index) => [
+      { type: 'text', text: error },
+      ...(index < errors.length - 1 ? [{ type: 'text', text: '\n' }] : []),
+    ]),
+  ];
+}
+
+function sanitizeClassifiedClaudeResponse(
+  response: import('@agor/core/sdk').SDKResultMessage | undefined,
+  kind: ClassifiedProviderFailureKind | undefined
+): unknown {
+  if (!response || !kind) return response;
+
+  // Provider result/error bodies can contain secrets. Accounting fields remain
+  // useful after removing only the body-bearing result fields.
+  const sanitized = { ...response } as Record<string, unknown>;
+  delete sanitized.result;
+  delete sanitized.errors;
+  return sanitized;
 }
 
 /**
@@ -270,7 +310,7 @@ export class ClaudeTool implements ITool {
     contextWindowLimit?: number;
     model?: string;
     modelUsage?: unknown;
-    rawSdkResponse?: import('@agor/core/sdk').SDKResultMessage;
+    rawSdkResponse?: unknown;
     /** Raw SDK context usage snapshot from getContextUsage() — authoritative source */
     rawContextUsage?: import('@agor/core/sdk').SDKControlGetContextUsageResponse;
     wasStopped?: boolean;
@@ -349,6 +389,8 @@ export class ClaudeTool implements ITool {
     let wasStopped = false;
     let hadError = false;
     let errorDetails: string[] | undefined;
+    let errorSubtype: string | undefined;
+    let classifiedProviderFailureKind: ClassifiedProviderFailureKind | undefined;
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -672,33 +714,28 @@ export class ClaudeTool implements ITool {
           };
           if (sdkResult.subtype && sdkResult.subtype !== 'success') {
             hadError = true;
+            errorSubtype = sdkResult.subtype;
             errorDetails = sdkResult.errors;
-            console.error(
-              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
-            );
 
             // Create a system message with the error details so it's visible in the conversation UI
             if (this.messagesService && sdkResult.errors?.length) {
-              const errorText = sdkResult.errors.join('\n');
               const errorMessageId = generateId() as MessageID;
-              await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
-                await createSystemMessage(
-                  sessionId,
-                  errorMessageId,
-                  [
-                    {
-                      type: 'text',
-                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
-                    },
-                  ],
-                  taskId,
-                  nextIndex++,
-                  resolvedModel,
-                  this.messagesService!,
-                  { is_provider_failure_result: true }
-                );
-                return true;
-              });
+              const persisted = await withFeathersSessionGuard(
+                sessionId,
+                this.sessionsRepo,
+                async () =>
+                  createSystemMessage(
+                    sessionId,
+                    errorMessageId,
+                    buildProviderFailureContent(sdkResult.subtype!, sdkResult.errors!),
+                    taskId,
+                    nextIndex++,
+                    resolvedModel,
+                    this.messagesService!,
+                    { is_provider_failure_result: true }
+                  )
+              );
+              classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
             }
           }
         }
@@ -795,7 +832,7 @@ export class ClaudeTool implements ITool {
 
           // Create assistant message with session guard (handles deleted sessions gracefully)
           const created = await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
-            await createAssistantMessage(
+            const persisted = await createAssistantMessage(
               sessionId,
               assistantMessageId,
               safeAssistantContent,
@@ -809,7 +846,8 @@ export class ClaudeTool implements ITool {
               tokenUsage,
               completeEvent.isSynthesizedResult
             );
-            return true;
+            classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
+            return persisted;
           });
 
           if (created) {
@@ -879,6 +917,18 @@ export class ClaudeTool implements ITool {
       }
     }
 
+    if (hadError) {
+      if (classifiedProviderFailureKind) {
+        console.error(
+          `[claude-code] SDK result classified: subtype=${errorSubtype ?? 'unknown'} kind=${classifiedProviderFailureKind}`
+        );
+      } else {
+        console.error(
+          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}, errors=${JSON.stringify(errorDetails)}`
+        );
+      }
+    }
+
     return {
       userMessageId: userMessage.message_id,
       assistantMessageIds,
@@ -889,11 +939,14 @@ export class ClaudeTool implements ITool {
       contextWindowLimit,
       model: resolvedModel,
       modelUsage,
-      rawSdkResponse,
+      rawSdkResponse: sanitizeClassifiedClaudeResponse(
+        rawSdkResponse,
+        classifiedProviderFailureKind
+      ),
       rawContextUsage,
       wasStopped,
       hadError,
-      errorDetails,
+      errorDetails: classifiedProviderFailureKind ? undefined : errorDetails,
     };
   }
 
@@ -966,7 +1019,7 @@ export class ClaudeTool implements ITool {
     contextWindowLimit?: number;
     model?: string;
     modelUsage?: unknown;
-    rawSdkResponse?: import('@agor/core/sdk').SDKResultMessage;
+    rawSdkResponse?: unknown;
     /** Raw SDK context usage snapshot from getContextUsage() — authoritative source */
     rawContextUsage?: import('@agor/core/sdk').SDKControlGetContextUsageResponse;
     wasStopped?: boolean;
@@ -1012,6 +1065,8 @@ export class ClaudeTool implements ITool {
     let wasStopped = false;
     let hadError = false;
     let errorDetails: string[] | undefined;
+    let errorSubtype: string | undefined;
+    let classifiedProviderFailureKind: ClassifiedProviderFailureKind | undefined;
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -1101,33 +1156,28 @@ export class ClaudeTool implements ITool {
           };
           if (sdkResult.subtype && sdkResult.subtype !== 'success') {
             hadError = true;
+            errorSubtype = sdkResult.subtype;
             errorDetails = sdkResult.errors;
-            console.error(
-              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
-            );
 
             // Create a system message with the error details so it's visible in the conversation UI
             if (this.messagesService && sdkResult.errors?.length) {
-              const errorText = sdkResult.errors.join('\n');
               const errorMessageId = generateId() as MessageID;
-              await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
-                await createSystemMessage(
-                  sessionId,
-                  errorMessageId,
-                  [
-                    {
-                      type: 'text',
-                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
-                    },
-                  ],
-                  taskId,
-                  nextIndex++,
-                  resolvedModel,
-                  this.messagesService!,
-                  { is_provider_failure_result: true }
-                );
-                return true;
-              });
+              const persisted = await withFeathersSessionGuard(
+                sessionId,
+                this.sessionsRepo,
+                async () =>
+                  createSystemMessage(
+                    sessionId,
+                    errorMessageId,
+                    buildProviderFailureContent(sdkResult.subtype!, sdkResult.errors!),
+                    taskId,
+                    nextIndex++,
+                    resolvedModel,
+                    this.messagesService!,
+                    { is_provider_failure_result: true }
+                  )
+              );
+              classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
             }
           }
         }
@@ -1165,7 +1215,7 @@ export class ClaudeTool implements ITool {
         // Create message with session guard (handles deleted sessions gracefully)
         const created = await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
           if (completeEvent.role === MessageRole.ASSISTANT) {
-            await createAssistantMessage(
+            const persisted = await createAssistantMessage(
               sessionId,
               messageId,
               completeEvent.content,
@@ -1179,6 +1229,7 @@ export class ClaudeTool implements ITool {
               tokenUsage,
               completeEvent.isSynthesizedResult
             );
+            classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
             return true;
           } else if (completeEvent.role === MessageRole.SYSTEM) {
             // Handle system messages (compaction, etc.)
@@ -1212,6 +1263,18 @@ export class ClaudeTool implements ITool {
       }
     }
 
+    if (hadError) {
+      if (classifiedProviderFailureKind) {
+        console.error(
+          `[claude-code] SDK result classified: subtype=${errorSubtype ?? 'unknown'} kind=${classifiedProviderFailureKind}`
+        );
+      } else {
+        console.error(
+          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}, errors=${JSON.stringify(errorDetails)}`
+        );
+      }
+    }
+
     return {
       userMessageId: userMessage.message_id,
       assistantMessageIds,
@@ -1222,11 +1285,14 @@ export class ClaudeTool implements ITool {
       contextWindowLimit,
       model: resolvedModel,
       modelUsage,
-      rawSdkResponse,
+      rawSdkResponse: sanitizeClassifiedClaudeResponse(
+        rawSdkResponse,
+        classifiedProviderFailureKind
+      ),
       rawContextUsage,
       wasStopped,
       hadError,
-      errorDetails,
+      errorDetails: classifiedProviderFailureKind ? undefined : errorDetails,
     };
   }
 

--- a/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
@@ -181,7 +181,7 @@ describe('extractTokenUsage', () => {
 });
 
 describe('createSystemMessage', () => {
-  it('preserves the executor-owned provider failure marker for daemon classification', async () => {
+  it('preserves the provider failure marker without allowing reserved metadata overrides', async () => {
     const messagesService = {
       create: vi.fn().mockResolvedValue(undefined),
     } as unknown as MessagesService;
@@ -201,7 +201,11 @@ describe('createSystemMessage', () => {
       0,
       'claude-sonnet-4-6',
       messagesService,
-      { is_provider_failure_result: true }
+      {
+        is_provider_failure_result: true,
+        is_meta: false,
+        model: 'spoofed-model',
+      } as NonNullable<import('@agor/core/types').Message['metadata']>
     );
 
     expect(result.metadata).toMatchObject({

--- a/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MessagesService, TasksService } from '../base/index.js';
 import {
   createAssistantMessage,
+  createSystemMessage,
   createUserMessage,
   createUserMessageFromContent,
   extractTokenUsage,
@@ -175,6 +176,38 @@ describe('extractTokenUsage', () => {
         cache_read_tokens: undefined,
         cache_creation_tokens: undefined,
       });
+    });
+  });
+});
+
+describe('createSystemMessage', () => {
+  it('preserves the executor-owned provider failure marker for daemon classification', async () => {
+    const messagesService = {
+      create: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MessagesService;
+    const sessionId = generateId() as SessionID;
+    const messageId = generateId() as MessageID;
+
+    const result = await createSystemMessage(
+      sessionId,
+      messageId,
+      [
+        {
+          type: 'text',
+          text: 'Agent SDK error (error_during_execution): Credit balance is too low',
+        },
+      ],
+      undefined,
+      0,
+      'claude-sonnet-4-6',
+      messagesService,
+      { is_provider_failure_result: true }
+    );
+
+    expect(result.metadata).toMatchObject({
+      is_meta: true,
+      is_provider_failure_result: true,
+      model: 'claude-sonnet-4-6',
     });
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
@@ -1,5 +1,5 @@
 import { generateId } from '@agor/core';
-import type { MessageID, SessionID, TaskID } from '@agor/core/types';
+import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import type { MessagesService, TasksService } from '../base/index.js';
@@ -183,7 +183,7 @@ describe('extractTokenUsage', () => {
 describe('createSystemMessage', () => {
   it('preserves the provider failure marker without allowing reserved metadata overrides', async () => {
     const messagesService = {
-      create: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (data: Partial<Message>) => data as Message),
     } as unknown as MessagesService;
     const sessionId = generateId() as SessionID;
     const messageId = generateId() as MessageID;
@@ -213,6 +213,33 @@ describe('createSystemMessage', () => {
       is_provider_failure_result: true,
       model: 'claude-sonnet-4-6',
     });
+  });
+
+  it('returns the daemon-confirmed system message after message hooks transform it', async () => {
+    const messagesService = {
+      create: vi.fn(
+        async (data: Partial<Message>) =>
+          ({
+            ...data,
+            content: 'safe provider recovery message',
+            content_preview: 'safe provider recovery message',
+            metadata: { ...data.metadata, error_kind: 'provider_credit_exhausted' },
+          }) as Message
+      ),
+    } as unknown as MessagesService;
+
+    const result = await createSystemMessage(
+      generateId() as SessionID,
+      generateId() as MessageID,
+      [{ type: 'text', text: 'raw provider body' }],
+      undefined,
+      0,
+      'claude-sonnet-4-6',
+      messagesService
+    );
+
+    expect(result.content).toBe('safe provider recovery message');
+    expect(result.metadata?.error_kind).toBe('provider_credit_exhausted');
   });
 });
 
@@ -707,7 +734,7 @@ describe('createUserMessageFromContent', () => {
 describe('createAssistantMessage', () => {
   function createMockMessagesService(): MessagesService {
     return {
-      create: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (data: Partial<Message>) => data as Message),
     } as unknown as MessagesService;
   }
 
@@ -741,6 +768,38 @@ describe('createAssistantMessage', () => {
     expect(result.content).toEqual(content);
     expect(result.content_preview).toBe('Hello, I am Claude!');
     expect(result.metadata?.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('returns the daemon-confirmed assistant message after message hooks transform it', async () => {
+    const messagesService = {
+      create: vi.fn(
+        async (data: Partial<Message>) =>
+          ({
+            ...data,
+            type: 'system',
+            role: MessageRole.SYSTEM,
+            content: 'safe provider recovery message',
+            content_preview: 'safe provider recovery message',
+            metadata: { ...data.metadata, error_kind: 'missing_credential' },
+          }) as Message
+      ),
+    } as unknown as MessagesService;
+
+    const result = await createAssistantMessage(
+      generateId() as SessionID,
+      generateId() as MessageID,
+      [{ type: 'text', text: 'raw provider body' }],
+      undefined,
+      undefined,
+      0,
+      'claude-sonnet-4-6',
+      messagesService
+    );
+
+    expect(result.type).toBe('system');
+    expect(result.role).toBe(MessageRole.SYSTEM);
+    expect(result.content).toBe('safe provider recovery message');
+    expect(result.metadata?.error_kind).toBe('missing_credential');
   });
 
   it('should extract text from multiple text blocks', async () => {

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -248,7 +248,7 @@ export async function createSystemMessage(
   nextIndex: number,
   resolvedModel: string | undefined,
   messagesService: MessagesService,
-  metadata?: Message['metadata']
+  metadata?: Pick<NonNullable<Message['metadata']>, 'is_provider_failure_result'>
 ): Promise<Message> {
   const message: Message = {
     message_id: messageId,

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -202,10 +202,10 @@ export async function createAssistantMessage(
     },
   };
 
-  await messagesService.create(message);
+  const persisted = await messagesService.create(message);
   await patchTaskModelIfKnown(tasksService, taskId, resolvedModel);
 
-  return message;
+  return persisted;
 }
 
 /**
@@ -267,6 +267,5 @@ export async function createSystemMessage(
     },
   };
 
-  await messagesService.create(message);
-  return message;
+  return await messagesService.create(message);
 }

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -247,7 +247,8 @@ export async function createSystemMessage(
   taskId: TaskID | undefined,
   nextIndex: number,
   resolvedModel: string | undefined,
-  messagesService: MessagesService
+  messagesService: MessagesService,
+  metadata?: Message['metadata']
 ): Promise<Message> {
   const message: Message = {
     message_id: messageId,
@@ -260,6 +261,7 @@ export async function createSystemMessage(
     content: content as Message['content'],
     task_id: taskId,
     metadata: {
+      ...metadata,
       ...(resolvedModel ? { model: resolvedModel } : {}),
       is_meta: true, // Mark as synthetic system message
     },

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -1,5 +1,8 @@
-import type { SessionID } from '@agor/core/types';
+import { generateId } from '@agor/core';
+import type { MessageID, SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import type { MessagesService } from '../base/index.js';
+import { createAssistantMessage } from './message-builder.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 
 function createProcessor() {
@@ -70,6 +73,50 @@ describe('SDKMessageProcessor result logging', () => {
     } finally {
       logSpy.mockRestore();
     }
+  });
+
+  it('carries the exact #2288 zero-turn result into executor-owned message metadata', async () => {
+    const processor = createProcessor();
+    const events = await processor.process({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 0,
+      duration_api_ms: 0,
+      is_error: false,
+      num_turns: 0,
+      result: 'Credit balance is too low',
+      total_cost_usd: 0,
+      usage: { input_tokens: 0, output_tokens: 0 },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: 'result-uuid',
+      session_id: 'sdk-session',
+    } as never);
+    const complete = events.find(
+      (event): event is Extract<ProcessedEvent, { type: 'complete' }> => event.type === 'complete'
+    );
+    expect(complete?.isSynthesizedResult).toBe(true);
+
+    const messagesService = {
+      create: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MessagesService;
+    const message = await createAssistantMessage(
+      'test-session-id' as SessionID,
+      generateId() as MessageID,
+      complete?.content ?? [],
+      complete?.toolUses,
+      undefined,
+      0,
+      complete?.resolvedModel,
+      messagesService,
+      undefined,
+      complete?.parent_tool_use_id,
+      undefined,
+      complete?.isSynthesizedResult
+    );
+
+    expect(message.content).toEqual([{ type: 'text', text: 'Credit balance is too low' }]);
+    expect(message.metadata?.is_zero_turn_result).toBe(true);
   });
 });
 

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -1,5 +1,5 @@
 import { generateId } from '@agor/core';
-import type { MessageID, SessionID } from '@agor/core/types';
+import type { Message, MessageID, SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import type { MessagesService } from '../base/index.js';
 import { createAssistantMessage } from './message-builder.js';
@@ -98,7 +98,7 @@ describe('SDKMessageProcessor result logging', () => {
     expect(complete?.isSynthesizedResult).toBe(true);
 
     const messagesService = {
-      create: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn(async (data: Partial<Message>) => data as Message),
     } as unknown as MessagesService;
     const message = await createAssistantMessage(
       'test-session-id' as SessionID,


### PR DESCRIPTION
## Linked issue

Fixes #2288

## Summary

- Recognize narrow credit/billing failures in executor-scoped zero-turn responses.
- Replace the raw provider response before persistence with a stable recovery state.
- Show clear settings and provider-console actions without undoing the completed workspace setup.

## Why / context

Bootstrap provisioning was succeeding, but the provider rejected the first model request because the configured account had no available credit. Agor treated that zero-turn provider response like a normal assistant message, leaving the user with a raw error and no recovery path.

This fixes the product boundary where that response enters durable message state; it does not add a second provider-error framework or change onboarding completion semantics.

## Implementation notes

- Reuses the existing message before-create hook that already owns missing-credential recovery.
- Classification requires an executor-scoped zero-turn result, a matching task/session, a resolved credential, and a short known billing signal.
- Missing credentials retain precedence. Ordinary `429` responses and arbitrary quota prose are intentionally not reclassified.
- The provider response is replaced before persistence with safe system copy plus `error_kind` and `tool` metadata.
- The recovery discriminator is daemon-owned; external message writes cannot forge it.
- Reuses the existing agentic-tool display names, settings deep link, provider-console URL, and `SystemMessage` presentation.
- No database migration or executor/runtime changes are required.

## Validation / test plan

- [x] Full daemon suite: 215 files / 2,563 tests passed; 8 files / 72 tests skipped.
- [x] Full UI suite: 201 files / 1,366 tests passed.
- [x] Focused daemon regression: 19 tests passed.
- [x] Focused recovery-panel and `MessageBlock` regression: 3 tests passed.
- [x] Daemon source-condition typecheck passed.
- [x] UI application source-condition typecheck passed.
- [x] Biome passed on all 9 changed files.
- [x] Multi-tenancy boundary check passed (existing baseline-improvement notice only).
- [x] `git diff --check` passed.
- [ ] CI on the rewritten PR head.

Standard package typechecks require generated workspace declarations that are not present in this clean clone; no build was run in accordance with repository instructions. No live provider request was made.

## Screenshots / demos

Not included. The change is covered at the pre-persistence hook and rendered component seams; no safe live billing failure was triggered.

## Risks / rollout / rollback

The classifier is deliberately narrow and leaves unknown failures unchanged. Rollback is a standard revert; there is no migration or configuration change.

## Out of scope / follow-ups

- Generic rate-limit or provider-error normalization.
- OAuth/DCR diagnostics, tracked separately in #2307.
