### PR TITLE
feat(docs): fire a GTM event on HubSpot contact-form submission

### DIFF
--- a/apps/agor-docs/app/layout.tsx
+++ b/apps/agor-docs/app/layout.tsx
@@ -5,7 +5,12 @@ import Script from 'next/script';
 import { type ReactNode, Suspense } from 'react';
 import { DocsAuroraBackground } from '../components/DocsAuroraBackground';
 import { GoogleAnalytics } from '../components/GoogleAnalytics';
-import { DISCORD_INVITE_URL, GITHUB_REPO_URL, HUBSPOT_FORM_ID } from '../lib/links';
+import {
+  AGOR_CLOUD_DEMO_URL,
+  DISCORD_INVITE_URL,
+  GITHUB_REPO_URL,
+  HUBSPOT_FORM_ID,
+} from '../lib/links';
 import {
   BRAND_NAME,
   DEFAULT_DESCRIPTION,
@@ -19,6 +24,7 @@ import './styles.css';
 
 const basePath = getBasePath();
 const siteUrl = getSiteUrl();
+const hubspotMeetingOrigin = new URL(AGOR_CLOUD_DEMO_URL).origin;
 const googleAnalyticsId = process.env.NEXT_PUBLIC_GA_ID;
 const analyticsEnabled =
   Boolean(googleAnalyticsId) &&
@@ -198,6 +204,42 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 form_name: 'agor_cloud_beta',
                 source_page: sourcePage || 'unknown',
               });
+            });
+          })();`}
+        </Script>
+        {/* GTM events for the "Book a demo" HubSpot meeting scheduler.
+            Unlike the contact form, this is a genuinely cross-origin iframe
+            (meetings-na2.hubspot.com), so its postMessage contract is much
+            narrower — confirmed by reading its shipped JS bundle
+            (MeetingsPublic .../bundles/project.js): it only ever posts a
+            consent-readiness handshake, an iframe-resize notice, and a
+            final `{meetingBookSucceeded}`/`{meetingBookFailed}` on booking
+            completion. There's no "opened" or "in progress" signal — the
+            scheduler never tells the embedder someone's picking a date.
+            "Opened" is tracked separately, client-side, in MeetingEmbed
+            (HubSpotMeetingModal.tsx), since we already know that moment
+            ourselves without needing HubSpot's cooperation. Origin-checked
+            here (unlike the form listener above) because this really is a
+            different origin posting to us, not our own same-window script. */}
+        <Script id="hs-meeting-book-tracking" strategy="afterInteractive">
+          {`(function () {
+            window.addEventListener('message', function (event) {
+              if (event.origin !== '${hubspotMeetingOrigin}') {
+                return;
+              }
+              var payload = event.data;
+              if (!payload || typeof payload !== 'object') {
+                return;
+              }
+              window.dataLayer = window.dataLayer || [];
+              if (payload.meetingBookSucceeded) {
+                window.dataLayer.push({
+                  event: 'hubspot_meeting_booked',
+                  form_name: 'agor_cloud_demo',
+                });
+              } else if (payload.meetingBookFailed) {
+                window.dataLayer.push({ event: 'hubspot_meeting_book_failed' });
+              }
             });
           })();`}
         </Script>

--- a/apps/agor-docs/app/layout.tsx
+++ b/apps/agor-docs/app/layout.tsx
@@ -5,7 +5,7 @@ import Script from 'next/script';
 import { type ReactNode, Suspense } from 'react';
 import { DocsAuroraBackground } from '../components/DocsAuroraBackground';
 import { GoogleAnalytics } from '../components/GoogleAnalytics';
-import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL, HUBSPOT_FORM_ID } from '../lib/links';
 import {
   BRAND_NAME,
   DEFAULT_DESCRIPTION,
@@ -159,6 +159,48 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           strategy="afterInteractive"
           src="https://js-na2.hs-scripts.com/246818610.js"
         />
+        {/* GTM event on contact-form submission. HubSpot's forms-embed
+            runtime calls window.postMessage({type:'hsFormCallback', ...})
+            unconditionally on every form event — confirmed by reading its
+            shipped JS (js.hsforms.net/forms/embed/v2.js): the dispatch isn't
+            gated on iframe/cross-origin embedding, so this fires the same
+            way whether the form's rendered inline (as ours is, via
+            HubSpotForm) or in a HubSpot-hosted iframe. `id` is the form
+            GUID; `source_page` (when present in submissionValues) carries
+            the per-CTA attribution already stamped by HubSpotForm, so this
+            single site-wide listener covers every "Sign up for Agor Cloud"
+            entry point without needing one tag per placement. */}
+        <Script id="hs-form-submit-tracking" strategy="afterInteractive">
+          {`(function () {
+            window.addEventListener('message', function (event) {
+              var payload = event.data;
+              if (
+                !payload ||
+                payload.type !== 'hsFormCallback' ||
+                payload.eventName !== 'onFormSubmitted' ||
+                payload.id !== '${HUBSPOT_FORM_ID}'
+              ) {
+                return;
+              }
+              var submissionValues = (payload.data && payload.data.submissionValues) || {};
+              var sourcePage;
+              if (Array.isArray(submissionValues)) {
+                var match = submissionValues.filter(function (field) {
+                  return field.name === 'source_page';
+                })[0];
+                sourcePage = match && match.value;
+              } else {
+                sourcePage = submissionValues.source_page;
+              }
+              window.dataLayer = window.dataLayer || [];
+              window.dataLayer.push({
+                event: 'hubspot_interest_form_success',
+                form_name: 'agor_cloud_beta',
+                source_page: sourcePage || 'unknown',
+              });
+            });
+          })();`}
+        </Script>
         {/* Microsoft Clarity analytics (project xroxavynkf). */}
         <Script id="ms-clarity" strategy="afterInteractive">
           {`(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","xroxavynkf");`}

--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -2,7 +2,7 @@
 
 import Script from 'next/script';
 import { useEffect, useId, useState } from 'react';
-import { AGOR_CLOUD_DEMO_URL } from '../lib/links';
+import { AGOR_CLOUD_DEMO_URL, HUBSPOT_FORM_ID } from '../lib/links';
 import styles from './HubSpotForm.module.css';
 
 declare global {
@@ -25,7 +25,6 @@ declare global {
 // Source form (edit submit button copy, fields, etc. in HubSpot):
 // https://app-na2.hubspot.com/forms/246818610/editor/56f5b614-72f0-4412-9247-33b53715fda4/edit
 const HUBSPOT_PORTAL_ID = '246818610';
-const HUBSPOT_FORM_ID = '56f5b614-72f0-4412-9247-33b53715fda4';
 const HUBSPOT_REGION = 'na2';
 const HUBSPOT_SCRIPT_SRC = 'https://js.hsforms.net/forms/embed/v2.js';
 

--- a/apps/agor-docs/components/HubSpotMeetingModal.tsx
+++ b/apps/agor-docs/components/HubSpotMeetingModal.tsx
@@ -18,10 +18,32 @@ interface HubSpotMeetingModalProps {
  * repeat opens deterministic (no loader-script re-scan). The calendar's
  * internals are HubSpot-rendered; we own everything around it.
  */
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+  }
+}
+
 /** Spinner-gated scheduler iframe — shared by the standalone meeting modal
  * and the beta-form modal's "book a demo instead" view. */
 export function MeetingEmbed() {
   const [frameReady, setFrameReady] = useState(false);
+
+  // "Opened" isn't something HubSpot's meeting embed reports back to us —
+  // unlike the contact form's hsFormCallback postMessage contract, the
+  // meetings scheduler bundle only ever posts a consent-readiness handshake,
+  // an iframe-resize notice, and a final booking success/failure (confirmed
+  // by reading its shipped JS — see app/layout.tsx's booking-tracking
+  // script). There's no "in progress" signal to latch onto either. So the
+  // "opened the scheduler" moment is something we already know ourselves —
+  // this component mounting IS that moment, in every context it's used
+  // (the standalone meeting modal and the contact-form modal's "book a demo
+  // instead" view alike).
+  useEffect(() => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: 'hubspot_meeting_open' });
+  }, []);
+
   return (
     <>
       {!frameReady && (

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -30,6 +30,13 @@ export const AGOR_CLOUD_INVITE_URL = `https://preset.io/contact-us-about-agor/${
 // Agor Cloud demo / contact link (HubSpot meetings scheduler).
 export const AGOR_CLOUD_DEMO_URL = 'https://meetings-na2.hubspot.com/zane-aitken/agor-demo';
 
+// HubSpot contact form GUID (portal 246818610, region na2). Shared between
+// HubSpotForm (which renders it) and the GTM form-submission tracking script
+// in app/layout.tsx (which matches on it), so there's one source of truth
+// for the ID both sides need to agree on. Edit the form itself at
+// https://app-na2.hubspot.com/forms/246818610/editor/56f5b614-72f0-4412-9247-33b53715fda4/edit
+export const HUBSPOT_FORM_ID = '56f5b614-72f0-4412-9247-33b53715fda4';
+
 // Preset blog post defining the AI Enablement Engineer — Agor's target
 // persona. Linked from landing-page copy.
 export const AI_ENABLEMENT_POST_URL = `https://preset.io/blog/ai-enablement-engineer/${presetUtm('ai-enablement-post')}`;


### PR DESCRIPTION
## Summary

Adds a site-wide `dataLayer.push('hubspot_interest_form_success')` so GTM/Google Ads can see every "Sign up for Agor Cloud" conversion, across all CTA placements (homepage, hero A/B variants, `/cloud`) at once — no per-page/per-placement wiring needed.

Prompted by: `@evan_1`'s proposed listener snippet (`window.addEventListener('message', ...)` matching HubSpot's `hsFormCallback` postMessage). I verified the mechanism before shipping it rather than taking it on faith:

- Read HubSpot's actual shipped `js.hsforms.net/forms/embed/v2.js` bundle. Confirmed `window.postMessage({type:'hsFormCallback', eventName, id, data}, "*")` fires **unconditionally** on every form event — the dispatch isn't gated on iframe/cross-origin embedding, so it fires the same way for our inline-rendered form (via `HubSpotForm`) as it would for a HubSpot-hosted iframe. Also confirmed `id` is the form GUID (traced through `gr = e => mr(e).formId`).
- Enriched the event with `source_page`, read out of `submissionValues` when present, so the GTM event carries the same per-CTA attribution already stamped into the form's hidden field — one differentiated signal per landing page/CTA instead of one undifferentiated bucket for the whole site. Handles both plausible shapes for `submissionValues` (plain object or `{name,value}[]` array) defensively, since pinning down the exact minified shape further wasn't worth it when the guard costs nothing.
- Centralized the form GUID into `lib/links.ts` (`HUBSPOT_FORM_ID`) instead of duplicating the literal string in both `HubSpotForm.tsx` and the new tracking script.

### Update: "Book a demo" meeting scheduler too

Extended to cover the other conversion path — the "Book a demo" HubSpot meeting scheduler. This one's a genuinely cross-origin iframe (`meetings-na2.hubspot.com`), unlike the contact form, so its postMessage contract is much narrower. Confirmed by reading its shipped JS bundle (`MeetingsPublic/.../bundles/project.js`): the only messages it ever posts to the parent are a consent-readiness handshake, an iframe-resize notice, and a final `{meetingBookSucceeded}` / `{meetingBookFailed}` on booking completion. **There's no "opened" or "in progress" signal exposed** — the scheduler never tells the embedder someone opened it or is mid-way through picking a date, so "fills" genuinely isn't observable through this mechanism.

Given that:
- **Opened** is tracked ourselves, client-side, in `MeetingEmbed` (fires `hubspot_meeting_open` on mount) — we already know that moment without needing HubSpot's cooperation, and `MeetingEmbed` is the actual shared mount point for both the standalone meeting modal and the contact-form modal's "book a demo instead" view, so this one spot covers every placement.
- **Submitted** is tracked via the postMessage listener in `app/layout.tsx`, firing `hubspot_meeting_booked` / `hubspot_meeting_book_failed` on the confirmed real payload shape. This listener is origin-checked against `AGOR_CLOUD_DEMO_URL`'s own origin (unlike the form listener, which doesn't need this since that postMessage is same-window) — this really is a different origin posting to us.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Live browser check via Chrome DevTools Protocol: dispatched a synthetic `postMessage` matching HubSpot's confirmed real payload shape and watched `window.dataLayer` receive the expected event with the correct `source_page` value.
- [x] Confirmed a `postMessage` with a *different* form id is correctly ignored — no false positives from unrelated HubSpot widgets that might exist on a page.
- [x] Opening the meeting modal correctly fires `hubspot_meeting_open` (fired twice in dev only — React StrictMode's expected double-invoke of effects, not a bug, doesn't happen in production builds).
- [x] A same-origin spoofed `{meetingBookSucceeded}` message sent from the top frame is correctly ignored by the origin guard. The origin string used for the check (`https://meetings-na2.hubspot.com`) was independently confirmed against a real message actually observed coming from the live iframe during investigation.
- Deliberately did **not** submit a real test lead or a real test meeting booking through HubSpot's live endpoints for this verification, since that would create a real CRM record / reserve an actual calendar slot and notify a real person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)