### PR TITLE
fix(daemon): preserve tenant database scope for long operations

### DIFF
--- a/apps/agor-daemon/src/knowledge/pgvector.test.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.test.ts
@@ -1,4 +1,4 @@
-import type { Database } from '@agor/core/db';
+import { createTenantScopedDatabaseProxy, type Database } from '@agor/core/db';
 import { describe, expect, it, vi } from 'vitest';
 import { ensureKnowledgePgvectorStorage, getKnowledgePgvectorCapability } from './pgvector';
 
@@ -9,6 +9,21 @@ function fakePostgresDb(execute: (query: unknown) => unknown | Promise<unknown>)
 }
 
 describe('Knowledge pgvector capability detection', () => {
+  it('can identify a guarded PostgreSQL handle before a tenant unit is active', async () => {
+    const db = createTenantScopedDatabaseProxy(
+      fakePostgresDb(() => []),
+      {
+        requireScope: true,
+        label: 'guarded pgvector database',
+      }
+    );
+
+    await expect(getKnowledgePgvectorCapability(db)).resolves.toMatchObject({
+      available: false,
+      reason: expect.stringContaining('unable to inspect pgvector capability'),
+    });
+  });
+
   it('treats postgres-js array results as available when extension and storage exist', async () => {
     const db = fakePostgresDb(() => [
       {

--- a/apps/agor-daemon/src/knowledge/pgvector.test.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.test.ts
@@ -1,4 +1,8 @@
-import { createTenantScopedDatabaseProxy, type Database } from '@agor/core/db';
+import {
+  createTenantScopedDatabaseProxy,
+  type Database,
+  MissingTenantDatabaseScopeError,
+} from '@agor/core/db';
 import { describe, expect, it, vi } from 'vitest';
 import { ensureKnowledgePgvectorStorage, getKnowledgePgvectorCapability } from './pgvector';
 
@@ -18,10 +22,9 @@ describe('Knowledge pgvector capability detection', () => {
       }
     );
 
-    await expect(getKnowledgePgvectorCapability(db)).resolves.toMatchObject({
-      available: false,
-      reason: expect.stringContaining('unable to inspect pgvector capability'),
-    });
+    await expect(getKnowledgePgvectorCapability(db)).rejects.toBeInstanceOf(
+      MissingTenantDatabaseScopeError
+    );
   });
 
   it('treats postgres-js array results as available when extension and storage exist', async () => {

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -1,6 +1,7 @@
 import {
   executeRaw,
   isPostgresDatabaseHandle,
+  MissingTenantDatabaseScopeError,
   sql,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
@@ -114,6 +115,7 @@ async function readCapability(db: KnowledgeTenantDatabase): Promise<KnowledgePgv
       setupHint: reason ? SETUP_HINT : null,
     };
   } catch (error) {
+    if (error instanceof MissingTenantDatabaseScopeError) throw error;
     return {
       available: false,
       extensionInstalled: false,

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -1,6 +1,6 @@
 import {
   executeRaw,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   sql,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
@@ -64,7 +64,7 @@ async function ensureEmbeddingTenantIsolation(db: KnowledgeTenantDatabase): Prom
 }
 
 async function readCapability(db: KnowledgeTenantDatabase): Promise<KnowledgePgvectorStorageState> {
-  if (!isPostgresDatabase(db)) {
+  if (!isPostgresDatabaseHandle(db)) {
     return {
       available: false,
       extensionInstalled: false,
@@ -137,7 +137,7 @@ export async function getKnowledgePgvectorCapability(
 export async function ensureKnowledgePgvectorStorage(
   db: KnowledgeTenantDatabase
 ): Promise<KnowledgePgvectorCapability> {
-  if (!isPostgresDatabase(db)) return readCapability(db);
+  if (!isPostgresDatabaseHandle(db)) return readCapability(db);
 
   let capability = await readCapability(db);
   if (!capability.extensionInstalled) {

--- a/apps/agor-daemon/src/knowledge/policy-transaction.ts
+++ b/apps/agor-daemon/src/knowledge/policy-transaction.ts
@@ -1,6 +1,6 @@
 import {
   getCurrentTenantDatabase,
-  isPostgresDatabaseHandle,
+  isPostgresDatabase,
   isSQLiteDatabase,
   runDatabaseTransaction,
   type TenantScopeAwareDatabase,
@@ -18,7 +18,7 @@ export async function runKnowledgePolicyTransaction<T>(
   work: (tx: TenantScopedDatabase) => Promise<T>
 ): Promise<T> {
   const ambientDb = getCurrentTenantDatabase();
-  if (ambientDb && isPostgresDatabaseHandle(ambientDb)) {
+  if (ambientDb && isPostgresDatabase(ambientDb)) {
     return work(ambientDb as TenantScopedDatabase);
   }
 

--- a/apps/agor-daemon/src/knowledge/policy-transaction.ts
+++ b/apps/agor-daemon/src/knowledge/policy-transaction.ts
@@ -1,6 +1,6 @@
 import {
   getCurrentTenantDatabase,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   isSQLiteDatabase,
   runDatabaseTransaction,
   type TenantScopeAwareDatabase,
@@ -18,7 +18,7 @@ export async function runKnowledgePolicyTransaction<T>(
   work: (tx: TenantScopedDatabase) => Promise<T>
 ): Promise<T> {
   const ambientDb = getCurrentTenantDatabase();
-  if (ambientDb && isPostgresDatabase(ambientDb)) {
+  if (ambientDb && isPostgresDatabaseHandle(ambientDb)) {
     return work(ambientDb as TenantScopedDatabase);
   }
 

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -667,6 +667,95 @@ describe('TENANT_IDENTITY_ONLY_SERVICE_PATHS', () => {
   });
 });
 
+describe('registered file service RBAC database preload', () => {
+  type RegisteredHook = (context: HookContext) => HookContext | Promise<HookContext>;
+
+  it.each(['file', 'files'])(
+    'runs the actual %s RBAC preload registration inside tenant database scope',
+    async (path) => {
+      const captured = new Map<string, RegisteredHook[]>();
+      const assertTenantScope = () => {
+        expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+      };
+      const branch = { branch_id: 'branch-1', path: '/branch-1', others_can: 'view' };
+      const branchRepository = {
+        findById: vi.fn(async () => {
+          assertTenantScope();
+          return branch;
+        }),
+        isOwner: vi.fn(async () => {
+          assertTenantScope();
+          return true;
+        }),
+        resolveUserPermission: vi.fn(async () => {
+          assertTenantScope();
+          return 'all';
+        }),
+      };
+      const sessionsService = {
+        get: vi.fn(async () => {
+          assertTenantScope();
+          return { session_id: 'session-1', branch_id: 'branch-1' };
+        }),
+      };
+      const app = {
+        service(servicePath: string) {
+          return {
+            hooks(hooks: { before?: { all?: RegisteredHook[] } }) {
+              const normalizedPath = servicePath.replace(/^\//, '');
+              if (hooks.before?.all) captured.set(normalizedPath, hooks.before.all);
+            },
+          };
+        },
+        use() {},
+        publish() {},
+      };
+
+      registerHooks({
+        db: { run: vi.fn() } as RegisterHooksContext['db'],
+        app: app as RegisterHooksContext['app'],
+        config: {
+          database: { dialect: 'postgresql' },
+          multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-a' },
+        } as RegisterHooksContext['config'],
+        jwtSecret: 'registration-test-secret',
+        branchRbacEnabled: true,
+        requireAuth: async (context) => context,
+        superadminOpts: { allowSuperadmin: true },
+        sessionsService: sessionsService as RegisterHooksContext['sessionsService'],
+        messagesService: {} as RegisterHooksContext['messagesService'],
+        boardsService: undefined,
+        branchRepository: branchRepository as RegisterHooksContext['branchRepository'],
+        usersRepository: {} as RegisterHooksContext['usersRepository'],
+        sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+        deployment: { mode: 'standalone' },
+      });
+
+      const context = {
+        path,
+        method: 'find',
+        params: {
+          provider: 'rest',
+          query:
+            path === 'file'
+              ? { branch_id: 'branch-1' }
+              : { sessionId: 'session-1', search: 'readme' },
+          user: { user_id: 'user-1', role: 'superadmin' },
+        },
+      } as HookContext;
+
+      await runWithTenantContext('tenant-a', async () => {
+        for (const hook of captured.get(path) ?? []) await hook(context);
+      });
+
+      expect(context.params.branch?.branch_id).toBe('branch-1');
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+      if (path === 'files') expect(sessionsService.get).toHaveBeenCalledOnce();
+      else expect(branchRepository.findById).toHaveBeenCalledOnce();
+    }
+  );
+});
+
 describe('file service RBAC database preload', () => {
   it.each(['file', 'files'])(
     'scopes guarded reads for %s and closes scope afterward',

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -18,11 +18,17 @@
  * branch-authorization.test.ts), so here we only verify the classifier.
  */
 
+import {
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantDatabaseScope,
+  runWithTenantContext,
+} from '@agor/core/db';
 import { type HookContext, TaskStatus } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   CONSTRAINED_HA_PROCESS_AFFINE_SERVICE_GATES,
+  createTenantScopedBeforeHookChain,
   enrichSessionFindResultWithRemoteRelationships,
   getTrustedSessionTenantId,
   isPromptFlowPatchOnly,
@@ -625,6 +631,11 @@ describe('canReceiveMcpTokenForSession', () => {
 });
 
 describe('TENANT_IDENTITY_ONLY_SERVICE_PATHS', () => {
+  it.each(['file', 'files'])('%s is identity-only and never request-transaction owned', (path) => {
+    expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain(path);
+    expect(TENANT_OWNED_SERVICE_PATHS).not.toContain(path);
+  });
+
   // Regression: the codex-auth endpoints do network/process work after a short
   // tenant DB read, then call getCurrentTenantId() to open their own units of
   // work — so they must carry ambient tenant identity via the identity-only
@@ -654,4 +665,45 @@ describe('TENANT_IDENTITY_ONLY_SERVICE_PATHS', () => {
     expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain(path);
     expect(TENANT_OWNED_SERVICE_PATHS).not.toContain(path);
   });
+});
+
+describe('file service RBAC database preload', () => {
+  it.each(['file', 'files'])(
+    'scopes guarded reads for %s and closes scope afterward',
+    async (path) => {
+      const guarded = createTenantScopedDatabaseProxy({ run: () => 'ok' } as never, {
+        requireScope: true,
+        label: `${path} hook test`,
+      });
+      const read = async (context: HookContext) => {
+        expect(guarded.run).toBeTypeOf('function');
+        expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+        context.params.branch = { branch_id: 'branch-1' } as never;
+        return context;
+      };
+      const hook = createTenantScopedBeforeHookChain(guarded, read);
+      const context = { path, params: {} } as HookContext;
+
+      await runWithTenantContext('tenant-a', () => hook(context));
+
+      expect(context.params.branch?.branch_id).toBe('branch-1');
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+      expect(() => guarded.run).toThrow(
+        `Missing tenant database scope for ${path} hook test access`
+      );
+    }
+  );
+
+  it.each(['file', 'files'])(
+    'fails before opening %s RBAC work without tenant identity',
+    async (path) => {
+      const read = vi.fn();
+      const hook = createTenantScopedBeforeHookChain({ run: vi.fn() } as never, read);
+
+      await expect(hook({ path, params: {} } as HookContext)).rejects.toThrow(
+        `Missing active tenant context for ${path} authorization`
+      );
+      expect(read).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -479,6 +479,11 @@ export const TENANT_OWNED_SERVICE_PATHS = [
 // units of work at the call site instead of holding an HTTP-long transaction.
 export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'check-auth',
+  // File browsing delegates to the executor after bounded repository reads.
+  // Keep request-wide tenant identity while each service opens only a short
+  // database unit of work before crossing the executor boundary.
+  'file',
+  'files',
   // Global catalog: no tenant column to scope, no writes to stamp.
   'mcp-catalog',
   'codex-auth/device',

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -28,6 +28,7 @@ import {
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   isPostgresDatabaseHandle,
+  requireCurrentTenantId,
   runWithTenantDatabaseScope,
   ScheduleRepository,
   type SessionRepository,
@@ -600,6 +601,23 @@ export async function protectServerManagedTaskWrites(context: HookContext): Prom
   }
 
   return context;
+}
+
+/** Run an identity-only service's database-reading before hooks in one short unit of work. */
+export function createTenantScopedBeforeHookChain(
+  db: TenantScopeAwareDatabase,
+  ...hooks: Array<(context: HookContext) => HookContext | Promise<HookContext>>
+) {
+  return async (context: HookContext): Promise<HookContext> => {
+    const tenantId = requireCurrentTenantId(
+      `Missing active tenant context for ${context.path} authorization`
+    );
+    return runWithTenantDatabaseScope(db, tenantId, async () => {
+      let current = context;
+      for (const hook of hooks) current = await hook(current);
+      return current;
+    });
+  };
 }
 
 export function registerHooks(ctx: RegisterHooksContext): void {
@@ -2159,7 +2177,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // case rather than throwing.
         ...(branchRbacEnabled
           ? [
-              async (context: HookContext) => {
+              createTenantScopedBeforeHookChain(db, async (context: HookContext) => {
                 if (!context.params.provider) return context;
                 if (context.params.user?._isServiceAccount) return context;
                 const query = context.params.query as { sessionId?: string } | undefined;
@@ -2171,7 +2189,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 await loadBranchFromSession(branchRepository)(context);
                 await ensureCanView(superadminOpts)(context);
                 return context;
-              },
+              }),
             ]
           : []),
       ],
@@ -2186,7 +2204,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireAuth,
         requireMinimumRole(ROLES.MEMBER, 'read files'),
         ...(branchRbacEnabled
-          ? [loadBranch(branchRepository, 'branch_id'), ensureCanView(superadminOpts)]
+          ? [
+              createTenantScopedBeforeHookChain(
+                db,
+                loadBranch(branchRepository, 'branch_id'),
+                ensureCanView(superadminOpts)
+              ),
+            ]
           : []),
       ],
     },

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -4,9 +4,29 @@ import {
   runWithTenantContext,
 } from '@agor/core/db';
 import { describe, expect, it } from 'vitest';
+import { createRequiredTenantDatabaseRunner } from './register-routes.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 
 describe('Stop route transaction scope', () => {
+  it('production-injected long-route runner activates the guarded tenant unit', async () => {
+    const rawDb = {
+      transaction: async (work: (tx: unknown) => Promise<unknown>) =>
+        work({ execute: async () => [], marker: () => 'scoped' }),
+      marker: () => 'unscoped',
+    };
+    const guardedDb = createTenantScopedDatabaseProxy(rawDb as never, {
+      requireScope: true,
+      label: 'route dependency test DB',
+    });
+    const runDatabaseUnit = createRequiredTenantDatabaseRunner(guardedDb);
+
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(
+        runDatabaseUnit(async () => (guardedDb as unknown as { marker(): string }).marker())
+      ).resolves.toBe('scoped');
+    });
+  });
+
   it('gives normal Stop and force-unverified ownership checks short guarded DB scopes', async () => {
     const transaction = async (work: (tx: unknown) => Promise<unknown>) =>
       work({

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -325,6 +325,56 @@ export function createRequiredTenantDatabaseRunner(db: TenantScopeAwareDatabase)
   };
 }
 
+export function createUploadAuthMiddleware(input: {
+  authentication: {
+    create(
+      data: { strategy: 'jwt'; accessToken: string },
+      params: AuthenticatedParams
+    ): Promise<{ user?: User; authentication?: { payload?: unknown } }>;
+  };
+  multiTenancy: ReturnType<typeof resolveMultiTenancyConfig>;
+}) {
+  // biome-ignore lint/suspicious/noExplicitAny: Express 5 middleware request augmentation
+  return async (req: any, res: any, next: NextFunction) => {
+    try {
+      const authHeader = req.headers.authorization;
+      const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
+      if (!token) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const authParams: AuthenticatedParams = { headers: req.headers };
+      const result = await input.authentication.create(
+        { strategy: 'jwt', accessToken: token },
+        authParams
+      );
+      const authenticatedParams = {
+        user: result.user,
+        provider: 'rest',
+        authentication: result.authentication,
+        headers: req.headers,
+      };
+      req.feathers = {
+        ...authenticatedParams,
+        tenant:
+          authParams.tenant ??
+          resolveTenantContext(input.multiTenancy, {
+            params: {
+              authentication: result.authentication,
+              headers: req.headers,
+            },
+            authPayload: result.authentication?.payload,
+            headers: req.headers,
+          }),
+      };
+      next();
+    } catch (error) {
+      console.error('❌ [Upload Auth] Authentication failed:', error);
+      res.status(401).json({ error: 'Authentication required' });
+    }
+  };
+}
+
 /**
  * Register authentication configuration and custom REST routes.
  */
@@ -2311,64 +2361,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     next();
   };
 
-  // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
-  const uploadAuthMiddleware: any = async (req: any, res: any, next: any) => {
-    try {
-      if (DEBUG_UPLOAD) console.log('🔐 [Upload Auth] Attempting authentication');
-
-      let token = null;
-
-      // Bearer-only. We previously fell back to feathers-jwt / agor-access-token
-      // / jwt cookies, which made the upload endpoint vulnerable to CSRF (a
-      // forged form-post would inherit the user's cookie). All in-tree callers
-      // (UI FileUpload component) already send `Authorization: Bearer …`.
-      const authHeader = req.headers.authorization;
-      if (authHeader?.startsWith('Bearer ')) {
-        token = authHeader.substring(7);
-        if (DEBUG_UPLOAD) console.log('   Found token in Authorization header');
-      }
-
-      if (!token) {
-        if (DEBUG_UPLOAD) console.log('⚠️  [Upload Auth] No JWT token found, rejecting');
-        return res.status(401).json({ error: 'Authentication required' });
-      }
-
-      if (DEBUG_UPLOAD) console.log('🔑 [Upload Auth] JWT token found, verifying...');
-
-      const authService = app.service('authentication');
-      // Reuse one mutable params object so authentication can propagate the
-      // verified tenant context before loading the authenticated user.
-      const authParams: AuthenticatedParams = { headers: req.headers };
-      const result = await authService.create({ strategy: 'jwt', accessToken: token }, authParams);
-
-      if (DEBUG_UPLOAD) {
-        console.log('✅ [Upload Auth] Authentication successful');
-        console.log('   User:', result.user?.user_id ? shortId(result.user.user_id) : 'unknown');
-      }
-
-      const authenticatedParams = {
-        user: result.user,
-        provider: 'rest',
-        authentication: result.authentication,
-        headers: req.headers,
-      };
-      req.feathers = {
-        ...authenticatedParams,
-        tenant:
-          authParams.tenant ??
-          resolveTenantContext(multiTenancy, {
-            params: authenticatedParams,
-            authPayload: result.authentication?.payload,
-            headers: req.headers,
-          }),
-      };
-
-      next();
-    } catch (error) {
-      console.error('❌ [Upload Auth] Authentication failed:', error);
-      res.status(401).json({ error: 'Authentication required' });
-    }
-  };
+  const uploadAuthMiddleware = createUploadAuthMiddleware({
+    authentication: app.service('authentication'),
+    multiTenancy,
+  });
 
   // biome-ignore lint/suspicious/noExplicitAny: Express route method not on FeathersJS Application type
   (app as any).post(

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -54,6 +54,7 @@ import {
 } from '@agor/core/mcp';
 import type {
   AuthenticatedParams,
+  Branch,
   HookContext,
   Message,
   MessageID,
@@ -365,6 +366,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         hook(context)
       ) as Promise<Awaited<T>>;
     };
+  const inCurrentTenantDatabaseScope = <T>(work: () => Promise<T>): Promise<T> => {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for database operation');
+    return runWithTenantDatabaseScope(db, tenantId, work);
+  };
 
   /** Schedule orchestration after commit with tenant identity but no open transaction. */
   function deferInFreshTenantScope(params: RouteParams, fn: () => Promise<void>): void {
@@ -1000,14 +1006,17 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       `🧹 [PromptState] Repairing stuck session ${shortId(session.session_id)} ` +
         `(status=${session.status}, ready_for_prompt=${session.ready_for_prompt})`
     );
-    return (await app.service('sessions').patch(
-      session.session_id,
-      {
-        status: SessionStatus.IDLE,
-        ready_for_prompt: true,
-      },
-      params
-    )) as Session;
+    return inCurrentTenantDatabaseScope(
+      async () =>
+        (await app.service('sessions').patch(
+          session.session_id,
+          {
+            status: SessionStatus.IDLE,
+            ready_for_prompt: true,
+          },
+          params
+        )) as Session
+    );
   }
 
   /**
@@ -1200,7 +1209,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     if (!agenticToolEnabled) {
       throw new Forbidden(`${loadedSession.agentic_tool} is disabled for this workspace`);
     }
-    const session = await sessionsService.materializeAgenticToolPreset(loadedSession, params);
+    const session = await runWithTenantDatabaseScope(db, tenantId, () =>
+      sessionsService.materializeAgenticToolPreset(loadedSession, params)
+    );
     const startTimestamp = new Date().toISOString();
 
     // The daemon persists launch intent and writes required sentinel git fields
@@ -1305,14 +1316,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // explicit patch, `session.status` stays IDLE while a task is RUNNING,
     // causing the queue gate in the prompt route to wave subsequent prompts
     // through instead of queuing them.
-    await app.service('sessions').patch(
-      task.session_id,
-      {
-        status: SessionStatus.RUNNING,
-        ready_for_prompt: false,
-        tasks: [...session.tasks, task.task_id],
-      },
-      params
+    await runWithTenantDatabaseScope(db, tenantId, () =>
+      app.service('sessions').patch(
+        task.session_id,
+        {
+          status: SessionStatus.RUNNING,
+          ready_for_prompt: false,
+          tasks: [...session.tasks, task.task_id],
+        },
+        params
+      )
     );
 
     // Tag the bytes shipped to the executor with `[Prompted by: ...]` when a
@@ -1482,7 +1495,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
 
-        let session = await sessionsService.get(id, params);
+        const requestedSessionId = id;
+        let session = await runWithTenantDatabaseScope(db, promptTenantId, () =>
+          sessionsService.get(requestedSessionId, params)
+        );
         id = session.session_id;
         const taskRepo = bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db));
 
@@ -1518,7 +1534,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           if (!(await isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool))) {
             throw new Forbidden(`${activeAgenticTool} is disabled for this workspace`);
           }
-          session = await sessionsService.materializeAgenticToolPreset(session, params);
+          session = await runWithTenantDatabaseScope(db, promptTenantId, () =>
+            sessionsService.materializeAgenticToolPreset(session, params)
+          );
           if (
             session.agentic_tool_preset_id &&
             data.permissionMode !== undefined &&
@@ -1540,10 +1558,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           console.log(
             `📦 [Prompt] Auto-unarchiving session ${shortId(id)} (was archived: ${session.archived_reason || 'unknown reason'})`
           );
-          session = (await sessionsService.patch(
-            id,
-            { archived: false, archived_reason: undefined },
-            params
+          session = (await runWithTenantDatabaseScope(db, promptTenantId, () =>
+            sessionsService.patch(id, { archived: false, archived_reason: undefined }, params)
           )) as typeof session;
         }
 
@@ -1565,7 +1581,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           sessionTurnLocks,
           id as SessionID,
           async () => {
-            let lockedSession = await sessionsService.get(id, params);
+            let lockedSession = await runWithTenantDatabaseScope(db, promptTenantId, () =>
+              sessionsService.get(id, params)
+            );
             if (lockedSession.status === SessionStatus.STOPPING) {
               // The earlier STOPPING check was against pre-lock state — re-check
               // here so a session that entered STOPPING while we waited for our
@@ -1602,7 +1620,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               status: TaskStatus.QUEUED,
               metadata: Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined,
             });
-            await tasksService.autoTitleSession(task, params);
+            await runWithTenantDatabaseScope(db, promptTenantId, () =>
+              tasksService.autoTitleSession(task, params)
+            );
 
             if (!prior) {
               // Repository admission bypasses TasksService.create. Publish the
@@ -2612,10 +2632,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         };
         if (body.force_unverified === true) {
           const result = await withSessionTurnLock(sessionTurnLocks, id as SessionID, async () => {
-            const session = await app.service('sessions').get(id, params);
-            const task = findUnverifiedTerminationTask(
-              await findActiveTasksForSession(app, session.session_id, params)
-            );
+            const { session, activeTasks } = await inCurrentTenantDatabaseScope(async () => {
+              const session = await app.service('sessions').get(id, params);
+              const activeTasks = await findActiveTasksForSession(app, session.session_id, params);
+              return { session, activeTasks };
+            });
+            const task = findUnverifiedTerminationTask(activeTasks);
             if (!task) throw new BadRequest('Session has no unverified Task to force-fail.');
             const taskId = task.task_id;
             const userId = params.user?.user_id;
@@ -2651,7 +2673,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             {
               app,
               taskRepo: stopRouteRepositories.taskRepo,
-              sessionsService: sessionsServiceWithHooks,
+              sessionsService: {
+                get: (...args) =>
+                  inCurrentTenantDatabaseScope(() => sessionsServiceWithHooks.get(...args)),
+                patch: (...args) =>
+                  inCurrentTenantDatabaseScope(() => sessionsServiceWithHooks.patch(...args)),
+              },
+              findActiveTasks: (stopApp, sessionId, stopParams) =>
+                inCurrentTenantDatabaseScope(() =>
+                  findActiveTasksForSession(stopApp, sessionId, stopParams)
+                ),
             },
             id as SessionID,
             params,
@@ -2951,6 +2982,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const widgetResolverDeps = {
     // biome-ignore lint/suspicious/noExplicitAny: Feathers Application shape
     app: app as any,
+    loadWidgetContext: (widgetId: string) =>
+      inCurrentTenantDatabaseScope(async () => {
+        const message = (await app.service('messages').get(widgetId)) as Message;
+        const session = (await app.service('sessions').get(message.session_id)) as Session;
+        const branch = (await app.service('branches').get(session.branch_id)) as Branch;
+        return { message, session, branch };
+      }),
     resolutionStore: new WidgetResolutionStore(widgetResolutionMessages, (message) =>
       emitServiceEvent(app, {
         path: 'messages',

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2336,29 +2336,31 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       if (DEBUG_UPLOAD) console.log('🔑 [Upload Auth] JWT token found, verifying...');
 
       const authService = app.service('authentication');
-      const result = await authService.create({
-        strategy: 'jwt',
-        accessToken: token,
-      });
+      // Reuse one mutable params object so authentication can propagate the
+      // verified tenant context before loading the authenticated user.
+      const authParams: AuthenticatedParams = { headers: req.headers };
+      const result = await authService.create({ strategy: 'jwt', accessToken: token }, authParams);
 
       if (DEBUG_UPLOAD) {
         console.log('✅ [Upload Auth] Authentication successful');
         console.log('   User:', result.user?.user_id ? shortId(result.user.user_id) : 'unknown');
       }
 
-      const authParams = {
+      const authenticatedParams = {
         user: result.user,
         provider: 'rest',
         authentication: result.authentication,
         headers: req.headers,
       };
       req.feathers = {
-        ...authParams,
-        tenant: resolveTenantContext(multiTenancy, {
-          params: authParams,
-          authPayload: result.authentication?.payload,
-          headers: req.headers,
-        }),
+        ...authenticatedParams,
+        tenant:
+          authParams.tenant ??
+          resolveTenantContext(multiTenancy, {
+            params: authenticatedParams,
+            authPayload: result.authentication?.payload,
+            headers: req.headers,
+          }),
       };
 
       next();

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -54,7 +54,6 @@ import {
 } from '@agor/core/mcp';
 import type {
   AuthenticatedParams,
-  Branch,
   HookContext,
   Message,
   MessageID,
@@ -317,6 +316,15 @@ export function findUnverifiedTerminationTask(tasks: readonly Task[]): Task | un
   );
 }
 
+/** Build the required short database unit used by authenticated long-route dependencies. */
+export function createRequiredTenantDatabaseRunner(db: TenantScopeAwareDatabase) {
+  return <T>(work: () => Promise<T>): Promise<T> => {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for database operation');
+    return runWithTenantDatabaseScope(db, tenantId, work);
+  };
+}
+
 /**
  * Register authentication configuration and custom REST routes.
  */
@@ -366,11 +374,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         hook(context)
       ) as Promise<Awaited<T>>;
     };
-  const inCurrentTenantDatabaseScope = <T>(work: () => Promise<T>): Promise<T> => {
-    const tenantId = getCurrentTenantId();
-    if (!tenantId) throw new Error('Missing active tenant context for database operation');
-    return runWithTenantDatabaseScope(db, tenantId, work);
-  };
+  const inCurrentTenantDatabaseScope = createRequiredTenantDatabaseRunner(db);
 
   /** Schedule orchestration after commit with tenant identity but no open transaction. */
   function deferInFreshTenantScope(params: RouteParams, fn: () => Promise<void>): void {
@@ -1620,9 +1624,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               status: TaskStatus.QUEUED,
               metadata: Object.keys(taskMetadata).length > 0 ? taskMetadata : undefined,
             });
-            await runWithTenantDatabaseScope(db, promptTenantId, () =>
-              tasksService.autoTitleSession(task, params)
-            );
+            await tasksService.autoTitleSession(task, params);
 
             if (!prior) {
               // Repository admission bypasses TasksService.create. Publish the
@@ -2673,12 +2675,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             {
               app,
               taskRepo: stopRouteRepositories.taskRepo,
-              sessionsService: {
-                get: (...args) =>
-                  inCurrentTenantDatabaseScope(() => sessionsServiceWithHooks.get(...args)),
-                patch: (...args) =>
-                  inCurrentTenantDatabaseScope(() => sessionsServiceWithHooks.patch(...args)),
-              },
+              sessionsService: sessionsServiceWithHooks,
               findActiveTasks: (stopApp, sessionId, stopParams) =>
                 inCurrentTenantDatabaseScope(() =>
                   findActiveTasksForSession(stopApp, sessionId, stopParams)
@@ -2982,13 +2979,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const widgetResolverDeps = {
     // biome-ignore lint/suspicious/noExplicitAny: Feathers Application shape
     app: app as any,
-    loadWidgetContext: (widgetId: string) =>
-      inCurrentTenantDatabaseScope(async () => {
-        const message = (await app.service('messages').get(widgetId)) as Message;
-        const session = (await app.service('sessions').get(message.session_id)) as Session;
-        const branch = (await app.service('branches').get(session.branch_id)) as Branch;
-        return { message, session, branch };
-      }),
+    runInTenantDatabaseScope: inCurrentTenantDatabaseScope,
     resolutionStore: new WidgetResolutionStore(widgetResolutionMessages, (message) =>
       emitServiceEvent(app, {
         path: 'messages',

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import type { TenantContext } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { createUploadAuthMiddleware } from './register-routes.js';
 
 describe('browser upload route boundary ordering', () => {
   const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
@@ -25,18 +27,55 @@ describe('browser upload route boundary ordering', () => {
     expect(handler).toContain('ref: staged.ref');
   });
 
+  it('propagates the tenant verified by authentication on the same params object', async () => {
+    const verifiedTenant = { tenant_id: 'verified-tenant', source: 'explicit' } as TenantContext;
+    let suppliedParams: unknown;
+    const authentication = {
+      create: vi.fn(async (_data, params) => {
+        suppliedParams = params;
+        params.tenant = verifiedTenant;
+        return {
+          user: { user_id: 'user-1' },
+          authentication: { payload: { tenant_id: 'payload-tenant' } },
+        };
+      }),
+    };
+    const middleware = createUploadAuthMiddleware({
+      authentication,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'static-tenant',
+        auth_claim: 'tenant_id',
+        trusted_header: 'x-tenant-id',
+      },
+    });
+    const req = {
+      headers: { authorization: 'Bearer token', 'x-tenant-id': 'header-tenant' },
+      feathers: undefined as { tenant?: TenantContext } | undefined,
+    };
+    const res = {};
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    const passedParams = authentication.create.mock.calls[0]?.[1];
+    expect(suppliedParams).toBe(passedParams);
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.feathers.tenant).toBe(verifiedTenant);
+  });
+
   it('carries authentication params so the JWT user lookup receives tenant scope', () => {
-    const start = source.indexOf('const uploadAuthMiddleware');
+    const start = source.indexOf('export function createUploadAuthMiddleware');
     const middleware = source.slice(
       start,
-      source.indexOf("(app as any).post(\n    '/sessions/:sessionId/upload'", start)
+      source.indexOf('/**\n * Register authentication', start)
     );
 
     expect(start).toBeGreaterThan(0);
     expect(middleware).toContain(
       'const authParams: AuthenticatedParams = { headers: req.headers }'
     );
-    expect(middleware).toMatch(/authService\.create\([\s\S]*authParams\s*\)/);
+    expect(middleware).toMatch(/authentication\.create\([\s\S]*authParams\s*\)/);
     expect(middleware).toContain('authParams.tenant ??');
   });
 });

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -3,8 +3,9 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('browser upload route boundary ordering', () => {
+  const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
+
   it('authenticates and authorizes before the multipart parser can accept bytes', () => {
-    const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
     const route = source.slice(source.indexOf("'/sessions/:sessionId/upload'"));
     expect(route.indexOf('uploadAuthMiddleware')).toBeLessThan(
       route.indexOf("uploadMiddleware.array('files'")
@@ -15,7 +16,6 @@ describe('browser upload route boundary ordering', () => {
   });
 
   it('does not expose Multer buffers or physical file paths in the response contract', () => {
-    const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
     const handler = source.slice(
       source.indexOf('const uploadHandler'),
       source.indexOf('const uploadLogger')
@@ -23,5 +23,20 @@ describe('browser upload route boundary ordering', () => {
     expect(handler).not.toContain('f.buffer');
     expect(handler).not.toContain('f.path');
     expect(handler).toContain('ref: staged.ref');
+  });
+
+  it('carries authentication params so the JWT user lookup receives tenant scope', () => {
+    const start = source.indexOf('const uploadAuthMiddleware');
+    const middleware = source.slice(
+      start,
+      source.indexOf("(app as any).post(\n    '/sessions/:sessionId/upload'", start)
+    );
+
+    expect(start).toBeGreaterThan(0);
+    expect(middleware).toContain(
+      'const authParams: AuthenticatedParams = { headers: req.headers }'
+    );
+    expect(middleware).toMatch(/authService\.create\([\s\S]*authParams\s*\)/);
+    expect(middleware).toContain('authParams.tenant ??');
   });
 });

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { createTenantScopedDatabaseProxy, runWithTenantDatabaseScope } from '@agor/core/db';
 import type { TenantContext } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { createUploadAuthMiddleware } from './register-routes.js';
@@ -29,13 +30,21 @@ describe('browser upload route boundary ordering', () => {
 
   it('propagates the tenant verified by authentication on the same params object', async () => {
     const verifiedTenant = { tenant_id: 'verified-tenant', source: 'explicit' } as TenantContext;
+    const rawDb = { run: vi.fn(), select: vi.fn(() => ({ user_id: 'user-1' })) };
+    const guardedDb = createTenantScopedDatabaseProxy(rawDb as never, {
+      requireScope: true,
+      label: 'upload authentication test database',
+    });
     let suppliedParams: unknown;
     const authentication = {
       create: vi.fn(async (_data, params) => {
         suppliedParams = params;
         params.tenant = verifiedTenant;
+        const user = await runWithTenantDatabaseScope(guardedDb, params.tenant.tenant_id, () =>
+          guardedDb.select()
+        );
         return {
-          user: { user_id: 'user-1' },
+          user,
           authentication: { payload: { tenant_id: 'payload-tenant' } },
         };
       }),
@@ -62,6 +71,38 @@ describe('browser upload route boundary ordering', () => {
     expect(suppliedParams).toBe(passedParams);
     expect(next).toHaveBeenCalledOnce();
     expect(req.feathers.tenant).toBe(verifiedTenant);
+    expect(rawDb.select).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when hosted authentication establishes no tenant identity', async () => {
+    const authentication = {
+      create: vi.fn(async () => ({
+        user: { user_id: 'user-1' },
+        authentication: { payload: {} },
+      })),
+    };
+    const middleware = createUploadAuthMiddleware({
+      authentication,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'static-tenant',
+        auth_claim: 'tenant_id',
+      },
+    });
+    const req = {
+      headers: { authorization: 'Bearer token' },
+      feathers: undefined,
+    };
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+    const next = vi.fn();
+
+    await middleware(req, { status }, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(req.feathers).toBeUndefined();
   });
 
   it('carries authentication params so the JWT user lookup receives tenant scope', () => {

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -1,3 +1,4 @@
+import { getCurrentTenantDatabaseScope, runWithTenantContext } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
 import { FileService } from './file.js';
@@ -29,7 +30,7 @@ describe('FileService executor failures', () => {
     });
     const service = new FileService(
       { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
-      null as never,
+      { run: vi.fn() } as never,
       { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
     );
 
@@ -78,7 +79,7 @@ describe('FileService executor failures', () => {
       vi.mocked(runExecutorCommand).mockResolvedValue({ success: true, data });
       const service = new FileService(
         { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
-        null as never,
+        { run: vi.fn() } as never,
         { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
       );
       const params = {
@@ -98,4 +99,34 @@ describe('FileService executor failures', () => {
       );
     }
   );
+
+  it('scopes database reads but leaves executor work outside the transaction', async () => {
+    const db = { run: vi.fn() } as never;
+    const findById = vi.fn(async () => {
+      expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+      return { branch_id: 'branch-1' };
+    });
+    impersonationMocks.resolveExecutorReadAsUser.mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+      return 'alice';
+    });
+    vi.mocked(runExecutorCommand).mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+      return { success: true, data: { files: [] } };
+    });
+    const service = new FileService({ findById } as never, db, {
+      get: () => ({}),
+      settings: { authentication: { secret: 'test' } },
+    } as never);
+
+    await runWithTenantContext('tenant-a', () =>
+      service.find({
+        query: { branch_id: 'branch-1' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    );
+
+    expect(findById).toHaveBeenCalledOnce();
+    expect(runExecutorCommand).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -35,14 +35,16 @@ describe('FileService executor failures', () => {
     );
 
     await expect(
-      service.find({
-        query: { branch_id: 'branch-1' },
-        user: {
-          user_id: 'user-1',
-          email: 'member@example.com',
-          role: 'member',
-        },
-      })
+      runWithTenantContext('tenant-a', () =>
+        service.find({
+          query: { branch_id: 'branch-1' },
+          user: {
+            user_id: 'user-1',
+            email: 'member@example.com',
+            role: 'member',
+          },
+        })
+      )
     ).rejects.toThrow('Failed to browse files: executor unavailable');
   });
 
@@ -91,7 +93,7 @@ describe('FileService executor failures', () => {
         },
       };
 
-      await invoke(service, params);
+      await runWithTenantContext('tenant-a', () => invoke(service, params));
 
       expect(runExecutorCommand).toHaveBeenCalledWith(
         expect.objectContaining({ command }),
@@ -127,6 +129,50 @@ describe('FileService executor failures', () => {
     );
 
     expect(findById).toHaveBeenCalledOnce();
+    expect(runExecutorCommand).toHaveBeenCalledOnce();
+  });
+
+  it('fails before repository access when tenant identity is missing', async () => {
+    const findById = vi.fn();
+    const service = new FileService(
+      { findById } as never,
+      { run: vi.fn() } as never,
+      {
+        get: () => ({}),
+        settings: { authentication: { secret: 'test' } },
+      } as never
+    );
+
+    await expect(
+      service.find({
+        query: { branch_id: 'branch-1' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    ).rejects.toThrow('Missing active tenant context for file database access');
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('reuses the branch authorized by the registered RBAC preload', async () => {
+    const findById = vi.fn();
+    vi.mocked(runExecutorCommand).mockResolvedValue({ success: true, data: { files: [] } });
+    const service = new FileService(
+      { findById } as never,
+      { run: vi.fn() } as never,
+      {
+        get: () => ({}),
+        settings: { authentication: { secret: 'test' } },
+      } as never
+    );
+
+    await runWithTenantContext('tenant-a', () =>
+      service.find({
+        query: { branch_id: 'branch-1' },
+        branch: { branch_id: 'branch-1', path: '/tenant-a/branch-1' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      } as never)
+    );
+
+    expect(findById).not.toHaveBeenCalled();
     expect(runExecutorCommand).toHaveBeenCalledOnce();
   });
 });

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -3,7 +3,7 @@
  */
 import {
   type BranchRepository,
-  getCurrentTenantId,
+  requireCurrentTenantId,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
@@ -14,6 +14,7 @@ import type {
   FileListItem,
   Id,
   QueryParams,
+  RBACParams,
   ServiceMethods,
 } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
@@ -104,8 +105,15 @@ export class FileService
   }
 
   private async resolveBranchRead(branchId: string, params?: FileParams) {
-    return runWithTenantDatabaseScope(this.db, getCurrentTenantId(), async () => {
-      const branch = await this.branchRepo.findById(branchId);
+    const tenantId = requireCurrentTenantId(
+      'Missing active tenant context for file database access'
+    );
+    return runWithTenantDatabaseScope(this.db, tenantId, async () => {
+      const cachedBranch = (params as Partial<RBACParams> | undefined)?.branch;
+      const branch =
+        cachedBranch?.branch_id === branchId
+          ? cachedBranch
+          : await this.branchRepo.findById(branchId);
       if (!branch) throw new Error(`Branch not found: ${branchId}`);
       const asUser = await resolveExecutorReadAsUser(
         this.db,

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -1,7 +1,12 @@
 /**
  * Read-only branch file browser. Tenant filesystem access is delegated to the executor.
  */
-import type { BranchRepository, TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  type BranchRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
@@ -47,10 +52,9 @@ export class FileService
     ensureMinimumRole(params, ROLES.MEMBER, 'list files');
     const branchId = params?.query?.branch_id;
     if (!branchId) throw new Error('branch_id query parameter is required');
-    const branch = await this.branchRepo.findById(branchId);
-    if (!branch) throw new Error(`Branch not found: ${branchId}`);
+    const resolved = await this.resolveBranchRead(branchId, params);
 
-    const result = await this.runCommand('branch.files.browse', branch.branch_id, params);
+    const result = await this.runCommand('branch.files.browse', resolved.branchId, resolved.asUser);
     if (!result.success) {
       throw new Error(
         `Failed to browse files: ${result.error?.message ?? 'unknown executor error'}`
@@ -63,10 +67,9 @@ export class FileService
     ensureMinimumRole(params, ROLES.MEMBER, 'read file');
     const branchId = params?.query?.branch_id;
     if (!branchId) throw new Error('branch_id query parameter is required');
-    const branch = await this.branchRepo.findById(branchId);
-    if (!branch) throw new Error(`Branch not found: ${branchId}`);
+    const resolved = await this.resolveBranchRead(branchId, params);
 
-    const result = await this.runCommand('branch.files.read', branch.branch_id, params, {
+    const result = await this.runCommand('branch.files.read', resolved.branchId, resolved.asUser, {
       filePath: id.toString(),
     });
     if (!result.success) {
@@ -80,7 +83,7 @@ export class FileService
   private async runCommand(
     command: 'branch.files.browse' | 'branch.files.read',
     branchId: string,
-    params?: FileParams,
+    asUser?: string,
     extraParams: Record<string, unknown> = {}
   ) {
     const sessionToken = generateScopedServiceToken(
@@ -95,13 +98,22 @@ export class FileService
       },
       {
         logPrefix: `[FileService ${branchId}]`,
-        asUser: await resolveExecutorReadAsUser(
-          this.db,
-          params?.user?.user_id,
-          this.app.get('config')
-        ),
+        asUser,
       }
     );
+  }
+
+  private async resolveBranchRead(branchId: string, params?: FileParams) {
+    return runWithTenantDatabaseScope(this.db, getCurrentTenantId(), async () => {
+      const branch = await this.branchRepo.findById(branchId);
+      if (!branch) throw new Error(`Branch not found: ${branchId}`);
+      const asUser = await resolveExecutorReadAsUser(
+        this.db,
+        params?.user?.user_id,
+        this.app.get('config')
+      );
+      return { branchId: branch.branch_id, asUser };
+    });
   }
 
   async setup(): Promise<void> {}

--- a/apps/agor-daemon/src/services/files.test.ts
+++ b/apps/agor-daemon/src/services/files.test.ts
@@ -1,0 +1,68 @@
+import { getCurrentTenantDatabaseScope, runWithTenantContext } from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runExecutorCommand } from '../utils/spawn-executor.js';
+import { FilesService } from './files.js';
+
+vi.mock('../utils/executor-read-impersonation.js', () => ({
+  resolveExecutorReadAsUser: vi.fn(async () => undefined),
+}));
+
+vi.mock('../utils/spawn-executor.js', () => ({
+  generateScopedServiceToken: vi.fn(() => 'service-token'),
+  getDaemonUrl: vi.fn(() => 'http://daemon.test'),
+  runExecutorCommand: vi.fn(),
+}));
+
+const app = {
+  get: () => ({}),
+  settings: { authentication: { secret: 'test' } },
+} as never;
+
+describe('FilesService tenant scope', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fails before repository access when tenant identity is missing', async () => {
+    const service = new FilesService({ run: vi.fn() } as never, app);
+
+    await expect(
+      service.find({
+        query: { sessionId: 'session-1' as never, search: 'readme' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    ).rejects.toThrow('Missing active tenant context for files database access');
+    expect(runExecutorCommand).not.toHaveBeenCalled();
+  });
+
+  it('uses RBAC-preloaded records in a short database scope and executes afterward', async () => {
+    vi.mocked(runExecutorCommand).mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+      return { success: true, data: { results: [] } };
+    });
+    const service = new FilesService({ run: vi.fn() } as never, app);
+
+    await runWithTenantContext('tenant-a', () =>
+      service.find({
+        query: { sessionId: 'session-1' as never, search: 'readme' },
+        session: { session_id: 'session-1', branch_id: 'branch-1' },
+        branch: { branch_id: 'branch-1', path: '/tenant-a/branch-1' },
+      } as never)
+    );
+
+    expect(runExecutorCommand).toHaveBeenCalledOnce();
+  });
+
+  it('does not swallow a conflicting tenant scope as empty autocomplete', async () => {
+    const service = new FilesService({ run: vi.fn() } as never, app);
+
+    await runWithTenantContext('tenant-a', async () => {
+      expect(() =>
+        runWithTenantContext('tenant-b', () =>
+          service.find({
+            query: { sessionId: 'session-1' as never, search: 'readme' },
+          })
+        )
+      ).toThrow('Cannot enter tenant context tenant-b');
+    });
+    expect(runExecutorCommand).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -8,6 +8,8 @@
 
 import {
   BranchRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
   SessionRepository,
   type TenantScopeAwareDatabase,
   UsersRepository,
@@ -91,24 +93,29 @@ export class FilesService {
     }
 
     try {
-      // Fetch session to get branch_id
-      const session = await this.sessionRepo.findById(sessionId);
-      if (!session) {
-        return [];
-      }
+      // Keep repository and identity reads inside a short tenant transaction.
+      // The executor call below is deliberately outside this scope.
+      const resolved = await runWithTenantDatabaseScope(this.db, getCurrentTenantId(), async () => {
+        const session = await this.sessionRepo.findById(sessionId);
+        if (!session) return null;
 
-      // Fetch branch to validate it still exists before crossing the executor boundary.
-      const branch = await this.branchRepo.findById(session.branch_id);
-      if (!branch?.path) {
-        return [];
-      }
+        const branch = await this.branchRepo.findById(session.branch_id);
+        if (!branch?.path) return null;
+
+        const currentUserId = params.user?.user_id as UserID | undefined;
+        const currentUser = currentUserId ? await this.usersRepo.findById(currentUserId) : null;
+        const asUser = await resolveExecutorReadAsUser(
+          this.db,
+          currentUser ?? currentUserId,
+          this.app.get('config')
+        );
+        return { branchId: branch.branch_id, asUser };
+      });
+      if (!resolved) return [];
 
       const sessionToken = generateScopedServiceToken(
         this.app as unknown as { settings: { authentication?: { secret?: string } } }
       );
-
-      const currentUserId = params.user?.user_id as UserID | undefined;
-      const currentUser = currentUserId ? await this.usersRepo.findById(currentUserId) : null;
 
       const result = await runExecutorCommand(
         {
@@ -116,7 +123,7 @@ export class FilesService {
           sessionToken,
           daemonUrl: getDaemonUrl(),
           params: {
-            branchId: branch.branch_id,
+            branchId: resolved.branchId,
             search,
             limit: MAX_FILE_RESULTS,
           },
@@ -126,11 +133,7 @@ export class FilesService {
           // In strict mode, autocomplete runs as the requesting Unix user.
           // In simple/insulated mode this stays undefined so default installs
           // do not require sudo and configured executor defaults can apply.
-          asUser: await resolveExecutorReadAsUser(
-            this.db,
-            currentUser ?? currentUserId,
-            this.app.get('config')
-          ),
+          asUser: resolved.asUser,
         }
       );
 

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -8,14 +8,14 @@
 
 import {
   BranchRepository,
-  getCurrentTenantId,
+  requireCurrentTenantId,
   runWithTenantDatabaseScope,
   SessionRepository,
   type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { AuthenticatedParams, SessionID, UserID } from '@agor/core/types';
+import type { AuthenticatedParams, RBACParams, SessionID, UserID } from '@agor/core/types';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 import {
   generateScopedServiceToken,
@@ -92,27 +92,39 @@ export class FilesService {
       return [];
     }
 
+    // Keep repository and identity reads inside a short tenant transaction.
+    // The executor call below is deliberately outside this scope. Resolve the
+    // identity before opening the unit of work and never turn boundary failures
+    // into an empty autocomplete response.
+    const tenantId = requireCurrentTenantId(
+      'Missing active tenant context for files database access'
+    );
+    const resolved = await runWithTenantDatabaseScope(this.db, tenantId, async () => {
+      const cached = params as Partial<RBACParams>;
+      const session =
+        cached.session?.session_id === sessionId
+          ? cached.session
+          : await this.sessionRepo.findById(sessionId);
+      if (!session) return null;
+
+      const branch =
+        cached.branch?.branch_id === session.branch_id
+          ? cached.branch
+          : await this.branchRepo.findById(session.branch_id);
+      if (!branch?.path) return null;
+
+      const currentUserId = params.user?.user_id as UserID | undefined;
+      const currentUser = currentUserId ? await this.usersRepo.findById(currentUserId) : null;
+      const asUser = await resolveExecutorReadAsUser(
+        this.db,
+        currentUser ?? currentUserId,
+        this.app.get('config')
+      );
+      return { branchId: branch.branch_id, asUser };
+    });
+    if (!resolved) return [];
+
     try {
-      // Keep repository and identity reads inside a short tenant transaction.
-      // The executor call below is deliberately outside this scope.
-      const resolved = await runWithTenantDatabaseScope(this.db, getCurrentTenantId(), async () => {
-        const session = await this.sessionRepo.findById(sessionId);
-        if (!session) return null;
-
-        const branch = await this.branchRepo.findById(session.branch_id);
-        if (!branch?.path) return null;
-
-        const currentUserId = params.user?.user_id as UserID | undefined;
-        const currentUser = currentUserId ? await this.usersRepo.findById(currentUserId) : null;
-        const asUser = await resolveExecutorReadAsUser(
-          this.db,
-          currentUser ?? currentUserId,
-          this.app.get('config')
-        );
-        return { branchId: branch.branch_id, asUser };
-      });
-      if (!resolved) return [];
-
       const sessionToken = generateScopedServiceToken(
         this.app as unknown as { settings: { authentication?: { secret?: string } } }
       );

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -8,7 +8,7 @@
 import { PAGINATION } from '@agor/core/config';
 import {
   type CreateKnowledgeDocumentInput,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   type KnowledgeDocumentFilters,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
@@ -281,7 +281,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
    */
 
   private async isEmbeddingConfigured(): Promise<boolean> {
-    if (!isPostgresDatabase(this.db)) return false;
+    if (!isPostgresDatabaseHandle(this.db)) return false;
     const settings = await this.semanticSettings.find();
     return (
       isUsableOpenAIEmbeddingConfig(settings, settings.api_key_configured) &&

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.test.ts
@@ -1,4 +1,5 @@
 import {
+  createTenantScopedDatabaseProxy,
   getCurrentTenantDatabase,
   getCurrentTenantId,
   type KnowledgeEmbeddingRoutingCursor,
@@ -34,6 +35,24 @@ describe('Knowledge embedding topology defaults', () => {
 });
 
 describe('Knowledge embedding routing traversal', () => {
+  it('inspects a guarded PostgreSQL handle without opening a tenant unit', async () => {
+    const db = createTenantScopedDatabaseProxy({ transaction: vi.fn() } as never, {
+      requireScope: true,
+      label: 'guarded Knowledge indexer database',
+    });
+    const indexer = new KnowledgeEmbeddingIndexer(db, {
+      distributedMode: true,
+      discoverHighWater: async () => ({
+        createdAt: '2030-01-01T00:00:00.000Z',
+        tenantId: 'tenant-a',
+        unitId: 'unit-a' as never,
+      }),
+      discover: async () => ({ refs: [], nextCursor: null }),
+    });
+
+    await expect(indexer.checkOnce()).resolves.toMatchObject({ candidates: 0, failures: 0 });
+  });
+
   it('holds one high-water through every page and snapshots a new one only after wrap', async () => {
     const highWaterA: KnowledgeEmbeddingRoutingCursor = {
       createdAt: '2030-01-01T00:00:00.000Z',

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -8,7 +8,7 @@ import {
   enqueueAfterTenantDatabaseCommit,
   generateId,
   getCurrentTenantId,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   type KnowledgeEmbeddingRoutingCursor,
   type KnowledgeEmbeddingRoutingPage,
   type KnowledgeEmbeddingRoutingRef,
@@ -389,7 +389,7 @@ export class KnowledgeEmbeddingIndexer {
   /** One bounded, tenant-fair scan exposed for deterministic HA tests. */
   async checkOnce(): Promise<KnowledgeEmbeddingIndexerStats> {
     if (this.shutdownRequested) return emptyStats();
-    if (!isPostgresDatabase(this.db)) return emptyStats();
+    if (!isPostgresDatabaseHandle(this.db)) return emptyStats();
     const page = await this.discoverRoutingPage();
     if (page.nextCursor) {
       this.routingCursor = page.nextCursor;
@@ -449,7 +449,7 @@ export class KnowledgeEmbeddingIndexer {
 
   /** Static/ambient-tenant compatibility seam used by focused probes. */
   async indexBatch(): Promise<number> {
-    if (!isPostgresDatabase(this.db)) return 0;
+    if (!isPostgresDatabaseHandle(this.db)) return 0;
     const tenantId = this.options.tenantId ?? getCurrentTenantId();
     if (!tenantId) throw new Error('Knowledge embedding indexBatch requires a tenant context');
     return runWithTenantContext(tenantId, async () => {

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -1,5 +1,5 @@
 import {
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
   select,
@@ -87,7 +87,8 @@ export class KnowledgeIndexingStatusService {
       semantic,
       semantic.api_key_configured
     );
-    const configured = isPostgresDatabase(this.db) && pgvector.available && embeddingConfigUsable;
+    const configured =
+      isPostgresDatabaseHandle(this.db) && pgvector.available && embeddingConfigUsable;
 
     const lastError = semanticEnabled
       ? ((configured ? durableLastError : null) ?? (!pgvector.available ? pgvector.reason : null))
@@ -96,7 +97,7 @@ export class KnowledgeIndexingStatusService {
     return {
       enabled: semanticEnabled,
       configured,
-      dialect: isPostgresDatabase(this.db) ? 'postgresql' : 'sqlite',
+      dialect: isPostgresDatabaseHandle(this.db) ? 'postgresql' : 'sqlite',
       pgvector_available: pgvector.available,
       pgvector_extension_installed: pgvector.extensionInstalled,
       pgvector_storage_ready: pgvector.storageReady,

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -1,5 +1,5 @@
 import {
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   KnowledgeSemanticSettingsRepository,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
@@ -27,7 +27,7 @@ export class KnowledgeReindexService {
   private async reindexInTransaction(db: TenantScopedDatabase): Promise<KnowledgeReindexResult> {
     const semantic = await new KnowledgeSemanticSettingsRepository(db).lockAggregateForUpdate(db);
     const embeddingConfigured =
-      isPostgresDatabase(db) &&
+      isPostgresDatabaseHandle(db) &&
       isUsableOpenAIEmbeddingConfig(semantic, semantic.api_key_configured) &&
       (await ensureKnowledgePgvectorStorage(db)).available;
     const status: KnowledgeEmbeddingStatus = embeddingConfigured ? 'pending' : 'not_configured';

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -5,7 +5,7 @@
 import { getBaseUrl } from '@agor/core/config';
 import {
   executeRaw,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   KnowledgeDocumentRepository,
   KnowledgeNamespaceRepository,
   type KnowledgeSearchQuery,
@@ -72,7 +72,7 @@ export class KnowledgeSearchService {
 
   private assertSupportedMode(query?: KnowledgeSearchQuery): void {
     const mode = query?.mode ?? 'text';
-    if (mode !== 'text' && !isPostgresDatabase(this.db)) {
+    if (mode !== 'text' && !isPostgresDatabaseHandle(this.db)) {
       throw new BadRequest(
         semanticUnavailableMessage('the configured database is not PostgreSQL'),
         { code: 'semantic_unavailable' }
@@ -138,7 +138,7 @@ export class KnowledgeSearchService {
     rawQuery: KnowledgeSearchQuery,
     user?: User
   ): Promise<KnowledgeSearchResult[]> {
-    if (!isPostgresDatabase(this.db)) {
+    if (!isPostgresDatabaseHandle(this.db)) {
       throw new BadRequest(
         semanticUnavailableMessage('the configured database is not PostgreSQL'),
         { code: 'semantic_unavailable' }

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -1,6 +1,6 @@
 import {
   executeRaw,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   KnowledgeSemanticSettingsRepository,
   kbDocumentUnits,
   sql,
@@ -154,7 +154,7 @@ export class KnowledgeSettingsService {
       .returning({ unit_id: kbDocumentUnits.unit_id })
       .all();
 
-    if (isPostgresDatabase(db) && rows.length > 0) {
+    if (isPostgresDatabaseHandle(db) && rows.length > 0) {
       const pgvector = await getKnowledgePgvectorCapability(db);
       if (pgvector.storageReady) {
         await executeRaw(
@@ -225,7 +225,7 @@ export class KnowledgeSettingsService {
 
       if (identityChanged || chunkingChanged) {
         const configured =
-          isPostgresDatabase(db) &&
+          isPostgresDatabaseHandle(db) &&
           isUsableOpenAIEmbeddingConfig(saved, saved.api_key_configured) &&
           (await ensureKnowledgePgvectorStorage(db)).available;
         const queued = chunkingChanged

--- a/apps/agor-daemon/src/uploads-maintenance.test.ts
+++ b/apps/agor-daemon/src/uploads-maintenance.test.ts
@@ -19,6 +19,7 @@ vi.mock('@agor/core/db', () => ({
     if (!value || value.includes('/')) throw new Error('Invalid tenant id');
   },
   isPostgresDatabase: (db: any) => db.postgres === true,
+  isPostgresDatabaseHandle: (db: any) => db.postgres === true,
   runWithSystemDatabaseScope: async (
     _db: unknown,
     _reason: string,

--- a/apps/agor-daemon/src/uploads-maintenance.ts
+++ b/apps/agor-daemon/src/uploads-maintenance.ts
@@ -1,7 +1,7 @@
 import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
 import {
   assertValidTenantId,
-  isPostgresDatabase,
+  isPostgresDatabaseHandle,
   type RawDatabase,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
@@ -52,7 +52,7 @@ async function resolveMaintenanceTenants(options: UploadCleanupOptions): Promise
   if (!options.allTenants) {
     throw new Error('Multi-tenant upload cleanup requires --tenant-id or --all-tenants');
   }
-  if (!isPostgresDatabase(options.db)) {
+  if (!isPostgresDatabaseHandle(options.db)) {
     throw new Error('Cross-tenant upload cleanup requires PostgreSQL');
   }
 

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -3,6 +3,13 @@ import type { SessionsServiceImpl } from '../declarations.js';
 
 import { markStoppedSessionPromptableNoDrain, stopSessionPreserveQueue } from './session-stop.js';
 
+const findActiveTasks = async (app: any, sessionId: string, params: unknown) => {
+  const result = await app
+    .service('tasks')
+    .find({ ...((params as object) ?? {}), query: { session_id: sessionId } });
+  return Array.isArray(result) ? result : result.data;
+};
+
 describe('markStoppedSessionPromptableNoDrain', () => {
   it('marks the session promptable without triggering queue processing', async () => {
     const calls: string[] = [];
@@ -66,6 +73,7 @@ describe('stopSessionPreserveQueue', () => {
             service: () => ({ find: vi.fn().mockResolvedValue({ data: [task] }) }),
           } as never,
           taskRepo: { findQueued: vi.fn().mockResolvedValue([]) } as never,
+          findActiveTasks: findActiveTasks as never,
           sessionsService: { get: vi.fn().mockResolvedValue(session), patch: vi.fn() } as never,
           requestTermination: requestTermination as never,
         } as never,
@@ -122,6 +130,7 @@ describe('stopSessionPreserveQueue', () => {
       {
         app: app as never,
         taskRepo: taskRepo as never,
+        findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
       },
@@ -182,6 +191,7 @@ describe('stopSessionPreserveQueue', () => {
       {
         app: app as never,
         taskRepo: taskRepo as never,
+        findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
       },
@@ -244,6 +254,7 @@ describe('stopSessionPreserveQueue', () => {
         {
           app: app as never,
           taskRepo: taskRepo as never,
+          findActiveTasks: findActiveTasks as never,
           sessionsService: sessionsService as never,
           requestTermination: requestTermination as never,
         },

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -19,6 +19,7 @@ export interface StopSessionDeps {
   app: Application;
   taskRepo: Pick<TaskRepository, 'findQueued'>;
   sessionsService: Pick<SessionsServiceImpl, 'get' | 'patch'>;
+  findActiveTasks?: typeof findActiveTasksForSession;
   requestTermination?: typeof requestExecutorTermination;
 }
 
@@ -74,7 +75,11 @@ export async function stopSessionPreserveQueue(
     };
   }
 
-  const targetTasksArray = await findActiveTasksForSession(deps.app, sessionId, params);
+  const targetTasksArray = await (deps.findActiveTasks ?? findActiveTasksForSession)(
+    deps.app,
+    sessionId,
+    params
+  );
   const queuedTasks = await deps.taskRepo.findQueued(sessionId);
 
   if (targetTasksArray.length === 0) {

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -5,7 +5,7 @@ import { isSessionExecuting, SessionStatus } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
 import { requestExecutorTermination, type TerminationResult } from '../termination-coordinator.js';
 import { requireActiveAgenticTool } from './agentic-tool-runtime.js';
-import { findActiveTasksForSession } from './session-tasks.js';
+import type { findActiveTasksForSession } from './session-tasks.js';
 
 export interface StopSessionResult {
   success: boolean;
@@ -19,7 +19,7 @@ export interface StopSessionDeps {
   app: Application;
   taskRepo: Pick<TaskRepository, 'findQueued'>;
   sessionsService: Pick<SessionsServiceImpl, 'get' | 'patch'>;
-  findActiveTasks?: typeof findActiveTasksForSession;
+  findActiveTasks: typeof findActiveTasksForSession;
   requestTermination?: typeof requestExecutorTermination;
 }
 
@@ -75,11 +75,7 @@ export async function stopSessionPreserveQueue(
     };
   }
 
-  const targetTasksArray = await (deps.findActiveTasks ?? findActiveTasksForSession)(
-    deps.app,
-    sessionId,
-    params
-  );
+  const targetTasksArray = await deps.findActiveTasks(deps.app, sessionId, params);
   const queuedTasks = await deps.taskRepo.findQueued(sessionId);
 
   if (targetTasksArray.length === 0) {

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -15,7 +15,7 @@
  * mock, so we exercise the full state machine with a hand-rolled stub.
  */
 
-import { BadRequest } from '@agor/core/feathers';
+import { BadRequest, NotFound } from '@agor/core/feathers';
 import type { Branch, Message, MessageID, Session, UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -37,6 +37,8 @@ interface MockEvent {
   event: string;
   payload: unknown;
 }
+
+const runInTenantDatabaseScope = <T>(work: () => Promise<T>) => work();
 
 function makeApp(
   records: { message: Message; session: Session; branch: Branch },
@@ -272,6 +274,70 @@ describe('resolveWidget', () => {
     _resetWidgetRegistryForTests();
   });
 
+  it('does not read authorization context for a non-widget message', async () => {
+    const fixtures = makeFixtures();
+    fixtures.message.type = 'user';
+    const { app, calls, resolutionStore } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'dismiss' },
+        { user_id: 'creator-user-id' as UserID },
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
+      )
+    ).rejects.toThrow('is not a widget request');
+    expect(calls.map((call) => call.service)).toEqual(['messages']);
+  });
+
+  it('propagates message infrastructure errors instead of translating them to not found', async () => {
+    const infrastructureError = new Error('database unavailable');
+    const app = {
+      service: () => ({ get: async () => Promise.reject(infrastructureError) }),
+    };
+    const resolutionStore = {} as WidgetResolutionStore;
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'dismiss' },
+        { user_id: 'creator-user-id' as UserID },
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
+      )
+    ).rejects.toBe(infrastructureError);
+  });
+
+  it('narrows message not-found errors to the widget lookup', async () => {
+    const app = {
+      service: () => ({ get: async () => Promise.reject(new NotFound('missing message')) }),
+    };
+    const resolutionStore = {} as WidgetResolutionStore;
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'dismiss' },
+        { user_id: 'creator-user-id' as UserID },
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
+      )
+    ).rejects.toThrow('Widget widget-msg-1 not found');
+  });
+
   it('submits a pending widget: dispatches to applySubmit, patches status, queues auto-resume, broadcasts', async () => {
     const { applySubmit } = registerTestWidget();
     const fixtures = makeFixtures();
@@ -281,7 +347,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
 
     expect(result).toEqual({
@@ -355,7 +426,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
         { user_id: 'someone-else' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/session creator|prompt/);
   });
@@ -369,7 +445,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
       { user_id: 'someone-else' as UserID },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
     expect(result.status).toBe('submitted');
     const promptCall = calls.find(
@@ -391,7 +472,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'k', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/already submitted/);
   });
@@ -405,7 +491,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: {} },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/not registered/);
   });
@@ -419,7 +510,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'submit', body: { value: 'k', scope: 'global' } },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
 
     expect(result.auto_resume_queued).toBe(false);
@@ -436,7 +532,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
 
     expect(result.status).toBe('dismissed');
@@ -458,7 +559,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
 
     expect(result.status).toBe('dismissed');
@@ -485,7 +591,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'dismiss' },
         { user_id: 'creator-user-id' as UserID, role: 'member' },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/admin/i);
 
@@ -508,7 +619,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'dismiss' },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/admin/i);
 
@@ -528,7 +644,12 @@ describe('resolveWidget', () => {
       'widget-msg-1',
       { kind: 'dismiss' },
       { user_id: 'creator-user-id' as UserID, role: 'admin' },
-      { app: app as never, resolutionStore, isBranchOwner: async () => false }
+      {
+        app: app as never,
+        resolutionStore,
+        runInTenantDatabaseScope,
+        isBranchOwner: async () => false,
+      }
     );
 
     expect(result.status).toBe('dismissed');
@@ -544,7 +665,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'k', scope: 'global' } },
         undefined,
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/Authentication/);
   });
@@ -559,7 +685,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { scope: 'invalid-scope' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toThrow(/Invalid submit/);
   });
@@ -580,7 +711,12 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       )
     ).rejects.toMatchObject({
       data: { field_errors: { HUBSPOT_API_KEY: 'Invalid saved value selection' } },
@@ -617,6 +753,7 @@ describe('resolveWidget', () => {
         {
           app: state.app as never,
           resolutionStore: state.resolutionStore,
+          runInTenantDatabaseScope,
           isBranchOwner: async () => false,
         }
       );
@@ -650,6 +787,7 @@ describe('resolveWidget', () => {
         {
           app: state.app as never,
           resolutionStore: state.resolutionStore,
+          runInTenantDatabaseScope,
           isBranchOwner: async () => false,
         }
       );
@@ -680,13 +818,23 @@ describe('resolveWidget', () => {
         'widget-msg-1',
         { kind: 'submit', body: { value: 'one', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       ),
       resolveWidget(
         'widget-msg-1',
         { kind: 'submit', body: { value: 'two', scope: 'global' } },
         { user_id: 'creator-user-id' as UserID },
-        { app: app as never, resolutionStore, isBranchOwner: async () => false }
+        {
+          app: app as never,
+          resolutionStore,
+          runInTenantDatabaseScope,
+          isBranchOwner: async () => false,
+        }
       ),
     ]);
 

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -56,12 +56,8 @@ export interface WidgetResolverApp {
 
 export interface WidgetResolverDeps {
   app: WidgetResolverApp;
-  /** Short database unit used by long-running route adapters for initial reads. */
-  loadWidgetContext?(widgetId: string): Promise<{
-    message: Message;
-    session: Session;
-    branch: Branch;
-  }>;
+  /** Required short database unit for the initial, consistent authorization snapshot. */
+  runInTenantDatabaseScope<T>(work: () => Promise<T>): Promise<T>;
   /** Durable, short-transaction state machine shared by every daemon. */
   resolutionStore: WidgetResolutionStore;
   /** Tenant-scoped custom-event publisher; production must not emit globally. */
@@ -160,29 +156,25 @@ async function doResolveWidget(
   deps: WidgetResolverDeps
 ): Promise<WidgetResolutionResult> {
   // 1. Load the widget and authorization context in one short database unit.
-  let message: Message;
-  let session: Session;
-  let branch: Branch;
-  try {
-    if (deps.loadWidgetContext) {
-      ({ message, session, branch } = await deps.loadWidgetContext(widgetId));
-    } else {
+  const { message, session, branch, widget } = await deps.runInTenantDatabaseScope(async () => {
+    let message: Message;
+    try {
       message = (await deps.app.service('messages').get(widgetId)) as Message;
-      session = (await deps.app.service('sessions').get(message.session_id)) as Session;
-      branch = (await deps.app.service('branches').get(session.branch_id)) as Branch;
+    } catch (error) {
+      if (error instanceof NotFound) throw new NotFound(`Widget ${widgetId} not found`);
+      throw error;
     }
-  } catch {
-    throw new NotFound(`Widget ${widgetId} not found`);
-  }
 
-  if (message.type !== 'widget_request') {
-    throw new NotFound(`Message ${widgetId} is not a widget request`);
-  }
+    if (message.type !== 'widget_request') {
+      throw new NotFound(`Message ${widgetId} is not a widget request`);
+    }
+    const widget = message.metadata?.widget;
+    if (!widget) throw new NotFound(`Widget ${widgetId} has no widget metadata`);
 
-  const widget = message.metadata?.widget;
-  if (!widget) {
-    throw new NotFound(`Widget ${widgetId} has no widget metadata`);
-  }
+    const session = (await deps.app.service('sessions').get(message.session_id)) as Session;
+    const branch = (await deps.app.service('branches').get(session.branch_id)) as Branch;
+    return { message, session, branch, widget };
+  });
 
   // 2. Authorize using the context loaded above.
   const isOwner = await deps.isBranchOwner(branch.branch_id, caller.user_id);

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -56,6 +56,12 @@ export interface WidgetResolverApp {
 
 export interface WidgetResolverDeps {
   app: WidgetResolverApp;
+  /** Short database unit used by long-running route adapters for initial reads. */
+  loadWidgetContext?(widgetId: string): Promise<{
+    message: Message;
+    session: Session;
+    branch: Branch;
+  }>;
   /** Durable, short-transaction state machine shared by every daemon. */
   resolutionStore: WidgetResolutionStore;
   /** Tenant-scoped custom-event publisher; production must not emit globally. */
@@ -153,10 +159,18 @@ async function doResolveWidget(
   caller: AuthenticatedCaller,
   deps: WidgetResolverDeps
 ): Promise<WidgetResolutionResult> {
-  // 1. Load the widget message.
+  // 1. Load the widget and authorization context in one short database unit.
   let message: Message;
+  let session: Session;
+  let branch: Branch;
   try {
-    message = (await deps.app.service('messages').get(widgetId)) as Message;
+    if (deps.loadWidgetContext) {
+      ({ message, session, branch } = await deps.loadWidgetContext(widgetId));
+    } else {
+      message = (await deps.app.service('messages').get(widgetId)) as Message;
+      session = (await deps.app.service('sessions').get(message.session_id)) as Session;
+      branch = (await deps.app.service('branches').get(session.branch_id)) as Branch;
+    }
   } catch {
     throw new NotFound(`Widget ${widgetId} not found`);
   }
@@ -170,9 +184,7 @@ async function doResolveWidget(
     throw new NotFound(`Widget ${widgetId} has no widget metadata`);
   }
 
-  // 2. Load the session + branch for authz.
-  const session = (await deps.app.service('sessions').get(message.session_id)) as Session;
-  const branch = (await deps.app.service('branches').get(session.branch_id)) as Branch;
+  // 2. Authorize using the context loaded above.
   const isOwner = await deps.isBranchOwner(branch.branch_id, caller.user_id);
   const effectivePermission = await deps.resolveBranchPermission?.(branch, caller.user_id);
 

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -92,6 +92,15 @@ const checks = [
   },
 
   {
+    name: 'parameterless custom authentication calls',
+    roots: ['apps/agor-daemon/src'],
+    excludeTests: true,
+    patterns: [/\bauthService\.create\(\s*\{[^)]*\}\s*\)/gs],
+    // Custom HTTP middleware must pass a mutable params object so verified
+    // tenant context is available to authentication hooks and user loading.
+    baseline: {},
+  },
+  {
     name: 'raw tenant database scope imports',
     roots: ['apps/agor-daemon/src'],
     excludeTests: true,

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -92,13 +92,20 @@ const checks = [
   },
 
   {
-    name: 'parameterless custom authentication calls',
+    name: 'parameterless authentication service calls',
     roots: ['apps/agor-daemon/src'],
     excludeTests: true,
-    patterns: [/\bauthService\.create\(\s*\{[^)]*\}\s*\)/gs],
+    patterns: [
+      /\bauthService\.create\(\s*\{[^)]*\}\s*\)/gs,
+      /\bapp\.service\(\s*['"]authentication['"]\s*\)\.create\(\s*\{[\s\S]*?\}\s*\);/g,
+    ],
     // Custom HTTP middleware must pass a mutable params object so verified
     // tenant context is available to authentication hooks and user loading.
-    baseline: {},
+    baseline: {
+      // These executor-facing routes authenticate narrow service tokens and
+      // consume claims directly; they do not perform an authenticated user lookup.
+      'apps/agor-daemon/src/register-routes.ts': 2,
+    },
   },
   {
     name: 'raw tenant database scope imports',


### PR DESCRIPTION
## Linked issue

Closes #2313.

## Summary

- preserve authenticated tenant identity for file browsing and long-running authenticated routes
- place direct database access in short tenant units without holding transactions across non-database work
- make guarded database-handle inspection safe for knowledge and upload-maintenance paths
- add behavioral regression coverage for file, prompt, stop, widget, and guarded-handle paths

## Why / context

In `multi_tenancy.mode: required_from_auth`, guarded database handles reject access without an active tenant database scope. Identity-only routes intentionally avoid route-wide transactions, so their direct database work must establish bounded tenant units explicitly. Dialect probes also need to inspect guarded handles without triggering the access guard.

## Implementation notes

File browsing retains authenticated tenant identity while repository reads and RBAC preloads run in short database units. Prompt admission scopes direct Session implementation calls, and Stop/widget routes require scoped dependencies rather than falling back to unscoped behavior.

Widget validation occurs before authorization-context reads. Only a missing widget message is translated to `NotFound`; scope, isolation, and infrastructure errors propagate. Executor, provider, termination, widget-handler, and environment work remains outside route-wide database transactions.

Knowledge and upload-maintenance paths use guarded-handle-aware PostgreSQL detection where the supplied database may be proxied. Pgvector capability inspection rethrows missing-scope errors instead of returning misleading setup guidance.

## Validation / test plan

- [x] focused daemon suites for pgvector, route scope registration, file services, knowledge embedding, upload maintenance, session stopping, widgets, and hook registration — 151 tests passed
- [x] `pnpm typecheck` — 21 tasks passed
- [x] `pnpm check:multitenancy-boundaries`
- [x] `pnpm check:daemon-filesystem-boundaries`
- [x] `pnpm check:realtime-boundaries`
- [x] `pnpm lint`
- [x] Biome checks on changed files
- [x] `git diff --check`

## Risks / rollout / rollback

The changes are limited to required-from-auth database scoping, error propagation, and guarded-handle inspection. Static-mode behavior is unchanged. Roll back by reverting the commits in this PR.

## Out of scope / follow-ups

- unrelated transport behavior
- pre-existing transaction-lifetime work outside the routes changed here

