### PR TITLE
fix(mcp): open a tenant unit of work for discovery's DB touches

### DIFF
--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -46,25 +46,18 @@ describe('register-services /mcp-servers/discover wiring', () => {
     expect(discoverBlock).toContain('loadMcpServerForCaller');
   });
 
-  it('opens a tenant unit of work around every database touch', () => {
+  it('persists capabilities through the helper that opens a tenant unit of work', () => {
     // Discover is a tenant-identity-only service (see
     // TENANT_IDENTITY_ONLY_SERVICE_PATHS): it performs network I/O, so it
     // never inherits a request-long tenant transaction and each database
     // touch must open its own short scope. An unscoped one throws against a
     // scope-requiring handle, which this endpoint's try/catch would report as
     // a discovery failure — after the outbound probe already ran.
-    const loads = discoverBlock.match(/\bloadMcpServerForCaller\s*\(/g) ?? [];
-    const scopedLoads =
-      discoverBlock.match(
-        /runInOAuthTenantScope\(\s*db,\s*tenantId,\s*\(\)\s*=>\s*loadMcpServerForCaller\s*\(/g
-      ) ?? [];
-    expect(loads.length).toBeGreaterThan(0);
-    expect(scopedLoads).toHaveLength(loads.length);
-
-    // The capability write is scoped by `persistDiscoveredMCPCapabilities`,
-    // which is also where the reason it bypasses `mcp-servers` configuration
-    // CRUD is documented. Reaching the repository from here would skip both.
-    expect(discoverBlock).toContain('persistDiscoveredMCPCapabilities(db, tenantId,');
+    //
+    // `persistDiscoveredMCPCapabilities` opens that scope and is where the
+    // reason this write bypasses `mcp-servers` configuration CRUD is
+    // documented. Reaching a repository directly from here would skip both.
+    expect(discoverBlock).toContain('persistDiscoveredMCPCapabilities(');
     expect(discoverBlock).not.toMatch(/\bMCPServerRepository\s*\(/);
   });
 

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -46,6 +46,28 @@ describe('register-services /mcp-servers/discover wiring', () => {
     expect(discoverBlock).toContain('loadMcpServerForCaller');
   });
 
+  it('opens a tenant unit of work around every database touch', () => {
+    // Discover is a tenant-identity-only service (see
+    // TENANT_IDENTITY_ONLY_SERVICE_PATHS): it performs network I/O, so it
+    // never inherits a request-long tenant transaction and each database
+    // touch must open its own short scope. An unscoped one throws against a
+    // scope-requiring handle, which this endpoint's try/catch would report as
+    // a discovery failure — after the outbound probe already ran.
+    const loads = discoverBlock.match(/\bloadMcpServerForCaller\s*\(/g) ?? [];
+    const scopedLoads =
+      discoverBlock.match(
+        /runInOAuthTenantScope\(\s*db,\s*tenantId,\s*\(\)\s*=>\s*loadMcpServerForCaller\s*\(/g
+      ) ?? [];
+    expect(loads.length).toBeGreaterThan(0);
+    expect(scopedLoads).toHaveLength(loads.length);
+
+    // The capability write is scoped by `persistDiscoveredMCPCapabilities`,
+    // which is also where the reason it bypasses `mcp-servers` configuration
+    // CRUD is documented. Reaching the repository from here would skip both.
+    expect(discoverBlock).toContain('persistDiscoveredMCPCapabilities(db, tenantId,');
+    expect(discoverBlock).not.toMatch(/\bMCPServerRepository\s*\(/);
+  });
+
   it('calls resolveProbeServerTemplates before resolveMCPAuthHeaders', () => {
     const probeIdx = discoverBlock.search(/\bresolveProbeServerTemplates\s*\(/);
     const headersIdx = discoverBlock.search(/\bresolveMCPAuthHeaders\s*\(/);

--- a/apps/agor-daemon/src/register-services.mcp-tenant-scope.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-tenant-scope.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TENANT_IDENTITY_ONLY_SERVICE_PATHS } from './register-hooks.js';
+
+/**
+ * The `/mcp-servers/*` endpoints that perform provider network I/O carry tenant
+ * identity only — they must not hold an HTTP-long tenant transaction — so each
+ * of their database touches opens its own short tenant unit of work. Against a
+ * scope-requiring handle an unscoped touch throws `MissingTenantDatabaseScope`,
+ * which these handlers' try/catch reports as an endpoint failure, so the
+ * symptom points at the provider rather than at the missing scope.
+ *
+ * `loadMcpServerForCaller` is the shared authorization read across those
+ * endpoints and the easiest one to add unscoped, because nothing in its
+ * signature says a scope is required. Assert the invariant over the whole file
+ * rather than per endpoint, so a new caller is covered on the day it lands.
+ */
+describe('register-services MCP tenant unit of work', () => {
+  const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
+  const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  it('keeps the MCP discovery and OAuth endpoints on the identity-only list', () => {
+    // The invariant below only matters while these endpoints are denied an
+    // automatic request transaction.
+    expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain('mcp-servers/discover');
+    expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain('mcp-servers/test-oauth');
+    expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain('mcp-servers/oauth-start');
+  });
+
+  /** The service path of the `app.use()` registration a source offset falls in. */
+  const owningServicePath = (offset: number): string | undefined => {
+    let path: string | undefined;
+    for (const registration of codeOnly.matchAll(/app\.use\(\s*'\/([^']+)'/g)) {
+      if (registration.index > offset) break;
+      path = registration[1];
+    }
+    return path;
+  };
+
+  it('opens a tenant scope around every identity-only loadMcpServerForCaller call', () => {
+    const callSites = [...codeOnly.matchAll(/\bloadMcpServerForCaller\s*\(/g)];
+    expect(callSites.length).toBeGreaterThan(0);
+
+    const identityOnly = callSites.filter((match) => {
+      const path = owningServicePath(match.index);
+      return !!path && (TENANT_IDENTITY_ONLY_SERVICE_PATHS as readonly string[]).includes(path);
+    });
+    // Endpoints that are tenant-owned instead inherit the request transaction
+    // and need no scope of their own, so they are not the subject here.
+    expect(identityOnly.length).toBeGreaterThan(0);
+
+    // A scope opened for this read is the innermost thing wrapping it, so the
+    // opener sits within a short window before the call. Matching on the
+    // opener rather than on its arguments keeps this from breaking when a
+    // local is renamed.
+    const unscoped = identityOnly.filter((match) => {
+      const preceding = codeOnly.slice(Math.max(0, match.index - 160), match.index);
+      return !/runInOAuthTenantScope\s*\([^;]*$/.test(preceding);
+    });
+
+    expect(
+      unscoped.map((match) => `${owningServicePath(match.index)}: unscoped authorization read`)
+    ).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -3867,7 +3867,7 @@ async function registerMCPServices(
           ])) as PromptsResult;
 
           if (serverId) {
-            await persistDiscoveredMCPCapabilities(db, tenantId, serverId, {
+            await persistDiscoveredMCPCapabilities(db, tenantId, serverId as MCPServerID, {
               tools: toolsResult.tools.map((t) => ({
                 name: t.name,
                 description: t.description || '',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -189,6 +189,7 @@ import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
 import { escapeHtml } from './utils/html.js';
+import { persistDiscoveredMCPCapabilities } from './utils/mcp-discovered-capabilities.js';
 import {
   shouldExposeMCPServerSecrets,
   shouldExposeMCPServerSecretsForSessionToken,
@@ -3485,7 +3486,6 @@ async function registerMCPServices(
           '@agor/core/tools/mcp/http-headers'
         );
         const tenantId = tenantIdFromParams(params);
-        const mcpServerRepo = new MCPServerRepository(db);
 
         const validateUrl = (url: string): { valid: boolean; error?: string } => {
           try {
@@ -3867,7 +3867,7 @@ async function registerMCPServices(
           ])) as PromptsResult;
 
           if (serverId) {
-            await mcpServerRepo.update(serverId, {
+            await persistDiscoveredMCPCapabilities(db, tenantId, serverId, {
               tools: toolsResult.tools.map((t) => ({
                 name: t.name,
                 description: t.description || '',

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   type TenantScopeAwareDatabase,
   TenantWriteGateActiveError,
 } from '@agor/core/db';
+import type { MCPServerID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -54,6 +55,8 @@ vi.mock('@agor/core/db', async (importOriginal) => {
 
 const { persistDiscoveredMCPCapabilities } = await import('./mcp-discovered-capabilities.js');
 
+const SERVER_ID = 'server-1' as MCPServerID;
+
 /**
  * `isPostgresDatabase` keys off the absence of `run`, so the `run` stub is what
  * makes this handle SQLite-shaped and keeps the scope in-process rather than
@@ -83,7 +86,7 @@ describe('persistDiscoveredMCPCapabilities', () => {
       MissingTenantDatabaseScopeError
     );
 
-    await persistDiscoveredMCPCapabilities(db, 'tenant-a', 'server-1', {
+    await persistDiscoveredMCPCapabilities(db, 'tenant-a', SERVER_ID, {
       tools: [{ name: 'search', description: 'Search' }],
       resources: [],
       prompts: [],
@@ -94,7 +97,7 @@ describe('persistDiscoveredMCPCapabilities', () => {
   });
 
   it('clears the per-tenant write gate before writing', async () => {
-    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', SERVER_ID, {
       tools: [],
       resources: [],
       prompts: [],
@@ -107,7 +110,7 @@ describe('persistDiscoveredMCPCapabilities', () => {
     assertTenantWritable.mockRejectedValue(new TenantWriteGateActiveError('tenant-a', 'gen-1'));
 
     await expect(
-      persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+      persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', SERVER_ID, {
         tools: [{ name: 'search', description: 'Search' }],
         resources: [],
         prompts: [],
@@ -117,21 +120,23 @@ describe('persistDiscoveredMCPCapabilities', () => {
     expect(updateCalls).toHaveLength(0);
   });
 
-  it('writes each capability list, defaulting a list the probe did not return to empty', async () => {
-    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+  it('writes every capability list the probe reported', async () => {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', SERVER_ID, {
       tools: [{ name: 'search', description: 'Search' }],
+      resources: [{ uri: 'file:///a', name: 'a' }],
+      prompts: [{ name: 'greet', description: 'Greet' }],
     });
 
-    expect(updateCalls[0].serverId).toBe('server-1');
+    expect(updateCalls[0].serverId).toBe(SERVER_ID);
     expect(updateCalls[0].updates).toEqual({
       tools: [{ name: 'search', description: 'Search' }],
-      resources: [],
-      prompts: [],
+      resources: [{ uri: 'file:///a', name: 'a' }],
+      prompts: [{ name: 'greet', description: 'Greet' }],
     });
   });
 
   it('carries no ownership field, so a refresh cannot move the row between owners', async () => {
-    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', SERVER_ID, {
       tools: [],
       resources: [],
       prompts: [],
@@ -144,7 +149,7 @@ describe('persistDiscoveredMCPCapabilities', () => {
     await persistDiscoveredMCPCapabilities(
       guardedDatabase({ requireScope: false }),
       undefined,
-      'server-1',
+      SERVER_ID,
       { tools: [], resources: [], prompts: [] }
     );
 

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
@@ -1,0 +1,154 @@
+import {
+  createTenantScopedDatabaseProxy,
+  MissingTenantDatabaseScopeError,
+  type TenantScopeAwareDatabase,
+  TenantWriteGateActiveError,
+} from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `/mcp-servers/discover` is registered as a tenant-identity-only service: it
+ * makes outbound MCP requests, so it never inherits the request-long tenant
+ * transaction that tenant-owned services get. Every database touch inside it
+ * has to open its own short unit of work instead.
+ *
+ * Nothing in the type system says so. Against a scope-requiring handle the
+ * only signal is that the guarded proxy throws on first property access, which
+ * the endpoint's own try/catch turns into `{ success: false }` — a discovery
+ * that reports failure after it already probed the server. So the property is
+ * asserted here directly: the helper is called from no scope at all, and the
+ * repository underneath it must still find one.
+ */
+
+const updateCalls: Array<{
+  serverId: string;
+  updates: Record<string, unknown>;
+  scopeAtCall: { kind?: string; tenantId?: string } | undefined;
+}> = [];
+
+const assertTenantWritable = vi.fn<(db: unknown, tenantId: string) => Promise<void>>();
+
+vi.mock('@agor/core/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/db')>();
+  return {
+    ...actual,
+    assertTenantWritable: (db: unknown, tenantId: string) => assertTenantWritable(db, tenantId),
+    MCPServerRepository: class {
+      constructor(private db: TenantScopeAwareDatabase) {}
+      async update(serverId: string, updates: Record<string, unknown>) {
+        // Touch the guarded handle the way the real repository does, so a
+        // missing scope fails here rather than passing silently.
+        (this.db as unknown as { probe(): string }).probe();
+        updateCalls.push({
+          serverId,
+          updates,
+          scopeAtCall: actual.getCurrentTenantDatabaseScope() as
+            | { kind?: string; tenantId?: string }
+            | undefined,
+        });
+        return undefined;
+      }
+    },
+  };
+});
+
+const { persistDiscoveredMCPCapabilities } = await import('./mcp-discovered-capabilities.js');
+
+/**
+ * `isPostgresDatabase` keys off the absence of `run`, so the `run` stub is what
+ * makes this handle SQLite-shaped and keeps the scope in-process rather than
+ * opening a transaction against a fake.
+ */
+function guardedDatabase(options: { requireScope?: boolean } = {}): TenantScopeAwareDatabase {
+  const rawDb = { probe: () => 'reached', run: () => undefined };
+  return createTenantScopedDatabaseProxy(rawDb as never, {
+    requireScope: options.requireScope ?? true,
+    label: 'discover capability test DB',
+  });
+}
+
+describe('persistDiscoveredMCPCapabilities', () => {
+  beforeEach(() => {
+    updateCalls.length = 0;
+    assertTenantWritable.mockReset();
+    assertTenantWritable.mockResolvedValue(undefined);
+  });
+
+  it('opens a tenant unit of work around the capability write', async () => {
+    const db = guardedDatabase();
+
+    // The guard is real: the same access from the endpoint's own call frame,
+    // which is where the write used to happen, is refused.
+    expect(() => (db as unknown as { probe(): string }).probe()).toThrow(
+      MissingTenantDatabaseScopeError
+    );
+
+    await persistDiscoveredMCPCapabilities(db, 'tenant-a', 'server-1', {
+      tools: [{ name: 'search', description: 'Search' }],
+      resources: [],
+      prompts: [],
+    });
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].scopeAtCall).toMatchObject({ kind: 'tenant', tenantId: 'tenant-a' });
+  });
+
+  it('clears the per-tenant write gate before writing', async () => {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+      tools: [],
+      resources: [],
+      prompts: [],
+    });
+
+    expect(assertTenantWritable).toHaveBeenCalledWith(expect.anything(), 'tenant-a');
+  });
+
+  it('writes nothing while the tenant is frozen', async () => {
+    assertTenantWritable.mockRejectedValue(new TenantWriteGateActiveError('tenant-a', 'gen-1'));
+
+    await expect(
+      persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+        tools: [{ name: 'search', description: 'Search' }],
+        resources: [],
+        prompts: [],
+      })
+    ).rejects.toBeInstanceOf(TenantWriteGateActiveError);
+
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('writes each capability list, defaulting a list the probe did not return to empty', async () => {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+      tools: [{ name: 'search', description: 'Search' }],
+    });
+
+    expect(updateCalls[0].serverId).toBe('server-1');
+    expect(updateCalls[0].updates).toEqual({
+      tools: [{ name: 'search', description: 'Search' }],
+      resources: [],
+      prompts: [],
+    });
+  });
+
+  it('carries no ownership field, so a refresh cannot move the row between owners', async () => {
+    await persistDiscoveredMCPCapabilities(guardedDatabase(), 'tenant-a', 'server-1', {
+      tools: [],
+      resources: [],
+      prompts: [],
+    });
+
+    expect(Object.keys(updateCalls[0].updates).sort()).toEqual(['prompts', 'resources', 'tools']);
+  });
+
+  it('still writes when there is no tenant to scope to, as on single-tenant SQLite', async () => {
+    await persistDiscoveredMCPCapabilities(
+      guardedDatabase({ requireScope: false }),
+      undefined,
+      'server-1',
+      { tools: [], resources: [], prompts: [] }
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(assertTenantWritable).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
@@ -78,7 +78,7 @@ describe('persistDiscoveredMCPCapabilities', () => {
     const db = guardedDatabase();
 
     // The guard is real: the same access from the endpoint's own call frame,
-    // which is where the write used to happen, is refused.
+    // outside any scope of its own, is refused.
     expect(() => (db as unknown as { probe(): string }).probe()).toThrow(
       MissingTenantDatabaseScopeError
     );

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
@@ -13,16 +13,21 @@ export interface DiscoveredMCPCapabilities {
  * Persist the capability lists a discovery probe read off an MCP server.
  *
  * This does not go through `app.service('mcp-servers')`, the entry point for
- * configuration CRUD that the tenant's write authorization is wired to. There
- * is no version of that route which both works and enforces something:
+ * configuration CRUD that `authorizeMcpServerWrite` is wired to. That is the
+ * decision #2240 documents at `denyDiscoverOfAnotherUsersServer`, and the
+ * reason it holds is that the authorizer gates *who* may configure a server,
+ * while a refresh configures nothing: the payload is the server's own report
+ * of itself, not anything the caller submitted.
  *
- * - Called with the caller's params, the service's role gate rejects the
- *   request. Discovery deliberately admits the server's owner and not just an
- *   admin, so every owner's refresh would fail at the persist step, after the
- *   outbound probe already ran.
- * - Called internally, `ensureMinimumRole` returns early on a missing
- *   `provider` and no authorization runs at all — a boundary that reads like
- *   one in review and enforces nothing.
+ * Routing through it would not be inert, which is the part worth being precise
+ * about. Called internally it still enforces nothing — `decidePolicyAndOwnership`
+ * returns early on a missing `provider`. Called with the caller's params it
+ * would work, and would add two refusals: a `viewer` who still owns a server
+ * from before a demotion, and any member under `use_existing_only`. The second
+ * is why this stays out. A private server keeps resolving into its owner's
+ * sessions no matter what the policy later says (`isMCPServerUsableBy`), so
+ * revoking refresh does not stop it being used — it freezes the tool list the
+ * agent actually sees. Tightening the policy would make live servers rot.
  *
  * The endpoint's own owner/admin rule is therefore the authorization, and it
  * has already run by the time this is reached. Two structural facts keep that

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
@@ -1,0 +1,43 @@
+import { MCPServerRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import type { MCPCapabilities } from '@agor/core/types';
+import { runInOAuthTenantWriteScope } from '../oauth-auth-helpers.js';
+
+/**
+ * Persist the capability lists a discovery probe read off an MCP server.
+ *
+ * This deliberately does not go through `app.service('mcp-servers').patch`,
+ * which is the entry point for configuration CRUD and the one the tenant's
+ * write authorization is wired to. Two reasons, both structural:
+ *
+ * - The payload is not the caller's. `tools` / `resources` / `prompts` are
+ *   whatever the remote server answered; discovery's own owner/admin rule
+ *   decides who may ask, and there is no caller-supplied field left for a
+ *   configuration authorizer to judge. `UpdateMCPServerInput` cannot carry
+ *   `owner_user_id`, so this write cannot move a row between owners.
+ * - The service's write pipe exists to react to configuration changes. Its
+ *   around-hook takes an OAuth grant configuration lock and re-reads the row
+ *   twice to decide whether to invalidate every grant on the server. A
+ *   capability refresh changes none of the fields that decision looks at, so
+ *   routing through it would pay for an answer that is always "no change".
+ *
+ * What discovery does still owe the tenant is the database boundary every
+ * other write in this endpoint honors. `/mcp-servers/discover` carries tenant
+ * identity only — it performs network I/O, so it must not hold an HTTP-long
+ * transaction — which means each database touch opens its own short tenant
+ * unit of work. Without one, the guarded database handle has no scope to
+ * route to and the per-tenant write gate never gets consulted.
+ */
+export async function persistDiscoveredMCPCapabilities(
+  db: TenantScopeAwareDatabase,
+  tenantId: string | undefined,
+  serverId: string,
+  capabilities: MCPCapabilities
+): Promise<void> {
+  await runInOAuthTenantWriteScope(db, tenantId, async () => {
+    await new MCPServerRepository(db).update(serverId, {
+      tools: capabilities.tools ?? [],
+      resources: capabilities.resources ?? [],
+      prompts: capabilities.prompts ?? [],
+    });
+  });
+}

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
@@ -1,43 +1,58 @@
 import { MCPServerRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
-import type { MCPCapabilities } from '@agor/core/types';
+import type { MCPPrompt, MCPResource, MCPServerID, MCPTool } from '@agor/core/types';
 import { runInOAuthTenantWriteScope } from '../oauth-auth-helpers.js';
+
+/** Every list a probe reports, so a missing one cannot be read as an empty one. */
+export interface DiscoveredMCPCapabilities {
+  tools: MCPTool[];
+  resources: MCPResource[];
+  prompts: MCPPrompt[];
+}
 
 /**
  * Persist the capability lists a discovery probe read off an MCP server.
  *
- * This deliberately does not go through `app.service('mcp-servers').patch`,
- * which is the entry point for configuration CRUD and the one the tenant's
- * write authorization is wired to. Two reasons, both structural:
+ * This does not go through `app.service('mcp-servers')`, the entry point for
+ * configuration CRUD that the tenant's write authorization is wired to. There
+ * is no version of that route which both works and enforces something:
  *
- * - The payload is not the caller's. `tools` / `resources` / `prompts` are
- *   whatever the remote server answered; discovery's own owner/admin rule
- *   decides who may ask, and there is no caller-supplied field left for a
- *   configuration authorizer to judge. `UpdateMCPServerInput` cannot carry
- *   `owner_user_id`, so this write cannot move a row between owners.
- * - The service's write pipe exists to react to configuration changes. Its
- *   around-hook takes an OAuth grant configuration lock and re-reads the row
- *   twice to decide whether to invalidate every grant on the server. A
- *   capability refresh changes none of the fields that decision looks at, so
- *   routing through it would pay for an answer that is always "no change".
+ * - Called with the caller's params, the service's role gate rejects the
+ *   request. Discovery deliberately admits the server's owner and not just an
+ *   admin, so every owner's refresh would fail at the persist step, after the
+ *   outbound probe already ran.
+ * - Called internally, `ensureMinimumRole` returns early on a missing
+ *   `provider` and no authorization runs at all — a boundary that reads like
+ *   one in review and enforces nothing.
+ *
+ * The endpoint's own owner/admin rule is therefore the authorization, and it
+ * has already run by the time this is reached. Two structural facts keep that
+ * narrow: the update input carries no `owner_user_id`, `url` or `auth`, so a
+ * refresh cannot move a row between owners or repoint the server; and those
+ * are exactly the fields the OAuth grant-invalidation hook inspects, so
+ * routing through the service would take an OAuth grant configuration lock and
+ * re-read the row twice to reach an answer that is always "no change".
+ *
+ * The cost of the bypass is that no `mcp-servers` service event is emitted, so
+ * other clients keep a stale capability list until they refetch.
  *
  * What discovery does still owe the tenant is the database boundary every
  * other write in this endpoint honors. `/mcp-servers/discover` carries tenant
  * identity only — it performs network I/O, so it must not hold an HTTP-long
  * transaction — which means each database touch opens its own short tenant
- * unit of work. Without one, the guarded database handle has no scope to
- * route to and the per-tenant write gate never gets consulted.
+ * unit of work. Without one, the guarded database handle has no scope to route
+ * to and the per-tenant write gate never gets consulted.
  */
 export async function persistDiscoveredMCPCapabilities(
   db: TenantScopeAwareDatabase,
   tenantId: string | undefined,
-  serverId: string,
-  capabilities: MCPCapabilities
+  serverId: MCPServerID,
+  capabilities: DiscoveredMCPCapabilities
 ): Promise<void> {
   await runInOAuthTenantWriteScope(db, tenantId, async () => {
     await new MCPServerRepository(db).update(serverId, {
-      tools: capabilities.tools ?? [],
-      resources: capabilities.resources ?? [],
-      prompts: capabilities.prompts ?? [],
+      tools: capabilities.tools,
+      resources: capabilities.resources,
+      prompts: capabilities.prompts,
     });
   });
 }

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -99,6 +99,16 @@ export interface MCPOAuthPendingFlowSealedMaterial {
 /**
  * What a non-admin member may do with MCP server configuration, tenant-wide.
  *
+ * "Configuration" is the caller-supplied surface — the fields somebody submits
+ * to create, update, or delete a server. Capability refresh is not on it:
+ * `mcp-servers/discover` opens the server's own transport and writes back the
+ * `tools` / `resources` / `prompts` that endpoint reported, which is nobody's
+ * submission. It answers to its own owner-or-admin rule
+ * (`denyDiscoverOfAnotherUsersServer`) instead, so that a member who may no
+ * longer configure servers can still refresh one that is already running in
+ * their sessions — revoking refresh would leave the stale tool list the agent
+ * actually sees, not stop the server being used.
+ *
  * - `use_existing_only` — members attach servers an admin already configured;
  *   they create nothing. The default, and the only behaviour that existed
  *   before private servers.


### PR DESCRIPTION
Closes #2300.

> **Rebased onto `main` after #2240 merged, and the argument re-derived against it.** The original version of this PR argued from the fact that neither `mcp_member_policy` nor `authorizeMcpServerWrite` existed on `main` yet. Both do now, so that reasoning is gone and one of its legs turned out to be wrong on the merits, not just stale. What changed is recorded under "What #2240 settled and what it broke in this argument" below.

## Decision: option (2), and #2240 had already made it

#2300 offers two closes: (1) route discovery's capability write through `authorizeMcpServerWrite`, or (2) narrow the policy's doc comment to the surface it actually governs. This PR does (2) — and supplies the tenant boundary the write was missing regardless of which one won.

Option (2) is not a preference here. #2240 merged the decision into the tree at `denyDiscoverOfAnotherUsersServer` (`register-services.ts:3413-3439`), which states outright that capability refresh "is a narrow mutation of its own, not ordinary configuration CRUD, so it does not run through `authorizeMcpServerWrite`". The comment #2300 objects to is the one place that hadn't been told. #2240 merged the rule without narrowing the comment that contradicts it; this closes that gap.

**The deciding argument:** the authorizer gates *who* may configure a server. A refresh configures nothing — the payload is the server's own report of itself, not anything the caller submitted. The invariant #2300 names ("the policy which claims authority over MCP server configuration does not reach one of the writes to that configuration") is real, and the correct repair is to stop the policy claiming a write that isn't configuration, rather than to route a non-submission through a submission gate.

## What #2240 settled and what it broke in this argument

The earlier version of this PR claimed there is *no* version of routing through the authorizer that both works and enforces something. **Half of that is now false and should not be relied on.**

- **"It wouldn't work" — dead.** That rested on `requireMinimumRole(ADMIN)` sitting in front of the four write verbs. #2240 *replaced* that gate with the authorizer, which admits `existing.owner_user_id === userId` (`utils/mcp-server-authorization.ts:328-331`). The owner discovery deliberately admits would pass. Routing through works.
- **"It wouldn't enforce anything" — half dead.** Called internally it still enforces nothing: `decidePolicyAndOwnership` returns early on a missing `provider` (`:251`). But called with the caller's params it *would* add two refusals — a `viewer` who still owns a server (`assertAtLeastMember`, `:277`), and any member under `use_existing_only` (`assertPolicyAllowsWrite`, `:284`).

So the choice is a real one with a real delta, and it is declined on the merits:

1. **Revoking refresh makes live servers rot; it does not stop them being used.** A private server keeps resolving into its owner's sessions regardless of the tenant's member policy (`packages/core/src/mcp/ownership.ts:20-26`). A tenant tightening `allow_private_only` → `use_existing_only` would leave members with servers still running in their sessions whose tool lists can never be refreshed again. The stale list is what the agent sees. That is a worse outcome than the one it prevents.
2. **The write pipe is built to react to configuration changes and would misfire.** `app.service('mcp-servers')` carries `invalidateOAuthGrantsAfterServerChange` on patch/update (`register-services.ts:2130,2160-2161`), which takes `lockMCPOAuthGrantConfiguration` and re-reads the row twice to decide whether to invalidate every grant on the server. A capability refresh changes none of the fields that decision inspects, so routing through means taking an OAuth grant lock to write a tool list, for an answer that is always "no change".
3. **The escalation field is structurally unwritable on this path.** `UpdateMCPServerInput` cannot carry `owner_user_id` (`packages/core/src/types/mcp.ts:368-384`), and `MCPServerRepository.update`'s SET clause writes only `enabled` / `scope` / `transport` / `updated_at` / `data` (`db/repositories/mcp-servers.ts:289-298`) — while `owner_user_id` is its own column (`schema.sqlite.ts:1334`). A refresh cannot move a row between owners or repoint the server.

**Left open, reported not fixed:** the `viewer` refusal is a genuine behavioral difference this PR declines to adopt. A viewer cannot create a server under the merged authorizer, so it is reachable only by demoting a member who already owns one; that viewer can still refresh it. It is narrow and arguably wants closing inside `denyDiscoverOfAnotherUsersServer` (where discovery's own rule lives) rather than by routing the write through configuration CRUD. Flagging for @richardfogaca along with the rest, per #2300.

## The bug this actually fixes

Independent of which close won, discovery was missing the *other* boundary, and that one is live.

`mcp-servers/discover` is registered in `TENANT_IDENTITY_ONLY_SERVICE_PATHS` (`register-hooks.ts:497`): it performs outbound network I/O, so it deliberately does not inherit a request-long tenant transaction, and each database touch must open its own short tenant unit of work. #2240 wrapped discovery's two `loadMcpServerForCaller` reads and the `test-oauth` read — **but not the capability write**, which is what this supplies.

When `multi_tenancy.mode === 'required_from_auth'`, the daemon builds its database handle with `requireScope: true` (`index.ts:631`), and an unscoped access throws `MissingTenantDatabaseScopeError` (`packages/core/src/db/tenant-scope.ts:51-58`). The endpoint's own try/catch converts that into `{ success: false }` — a discovery that reports failure *after* it already probed the server. The write additionally never reached `assertTenantWritable`, the per-tenant write gate every other write in this endpoint clears.

The write moves into `persistDiscoveredMCPCapabilities`, which opens its own write scope and is where the reason it bypasses configuration CRUD now lives.

Capability lists are required rather than `?? []` defaulted: "the probe did not report resources" and "this server has no resources" are different claims, and only the second belongs in the row.

## Absorbed by the rebase

The original PR also fixed `/mcp-servers/test-oauth`, which reached `loadMcpServerForCaller` with no scope of its own. **#2240 landed the same fix independently**, so it is no longer in this diff. The invariant test that found it is kept and now guards `main`'s version: `register-services.mcp-tenant-scope.test.ts` asserts over the whole file that every `loadMcpServerForCaller` call in an identity-only endpoint opens a tenant scope, mapping call sites to their owning `app.use()` registration so tenant-owned endpoints are correctly exempt.

Likewise, the earlier sweep's conclusion holds on merged `main`: `check-auth`, `mcp-catalog`, the three `codex-auth/*`, `opencode-*`, the three `*-models`, `terminals`, and the remaining `mcp-servers/oauth-*` endpoints all open scopes correctly. `oauth-disconnect` and `oauth-status` look unscoped but are tenant-owned (`register-hooks.ts:451-452`) and inherit the request transaction.

## `mcp-servers/oauth-start`

Checked, and it does **not** need discovery's floor — reported here rather than fixed. It is `requireAuth`-only but writes nothing to `mcp_servers`: DCR results are cached in process, and the only persistence is a token row in `user_mcp_oauth_tokens` keyed to the calling user for `per_user` grants. `shared` grants — the ones that mint a credential everyone uses — already require admin, and it correctly opens a tenant scope around its own server load.

Two things worth a second opinion, neither fixed here:

- It applies no scope-based check where discovery does. A member who can *use* a shared server can start a `per_user` flow against it. That looks like the intended per-user UX rather than a hole — the token binds to them — but the asymmetry with discovery is unexplained in code.
- When `mcp_server_id` is omitted and durable OAuth flows are off (SQLite / self-hosted), `data.mcp_url` is a caller-supplied outbound destination the daemon probes. Under Postgres this is already refused.

## Testing

- `apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts` — 6 behavioral tests: the write lands inside a tenant scope, clears the write gate, writes nothing while the tenant is frozen, carries no ownership field. Mutation-checked: removing the scope fails 5 of 6.
- `apps/agor-daemon/src/register-services.mcp-tenant-scope.test.ts` — the file-wide invariant above. Mutation-checked against the `test-oauth` regression it originally caught.
- `register-services.mcp-discover.test.ts` — extended to pin the wiring, so a correct helper that stops being called still fails.

Full typecheck and lint green. Daemon 2657 passed / 72 skipped; core 3644 passed / 86 skipped, 0 failures. The one daemon failure on the dev host is `cursor-models.test.ts`, which needs a live Cursor API key and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
