### PR TITLE
fix(mcp): delete the origin-matching OAuth token cache reader

### DIFF
--- a/context/explorations/mcp-oauth-token-lifecycle.md
+++ b/context/explorations/mcp-oauth-token-lifecycle.md
@@ -214,11 +214,11 @@ Two follow-ups suggested (out of scope here):
   `oauth-refresh.ts` header as known follow-up. Combined with the 1-hour
   default bug above, the failure mode for Notion is silent stale-token use
   until the provider rejects.
-- ⚠️ **In-memory `authCodeTokenCache`** in `oauth-mcp-transport.ts` is
-  vestigial in daemon mode (the DB-backed path is authoritative). Worth
-  pruning to one cache to avoid drift. `getCachedOAuth21Token` is referenced
-  from `apps/agor-daemon/src/oauth-cache.ts` and `services/gateway.ts`, and
-  this in-memory map is what backs it.
+- **In-memory `authCodeTokenCache`** in `oauth-mcp-transport.ts` is vestigial
+  in daemon mode: daemon callers pass `cacheToken:false`, so only the
+  standalone CLI flow reads and writes it, keyed on the exact metadata URL.
+  Its origin-matching reader is gone, and the daemon resolves tokens from
+  `user_mcp_oauth_tokens` only.
 - ⚠️ **Token endpoint inference on refresh.** `refreshAndPersistToken` falls
   back to `inferOAuthTokenUrl(server.url)` when `oauth_token_url` isn't
   persisted on the server config. We should persist the _discovered_ token
@@ -720,9 +720,8 @@ Don't build it speculatively — the maintenance cost is double.
   know when to refresh) but creates the Notion silent-break failure mode
   when paired with no retry-on-401. Document the contract.
 - `authCodeTokenCache` (in-memory, in `oauth-mcp-transport.ts`) is vestigial
-  in daemon mode. Worth auditing whether `getCachedOAuth21Token` callsites
-  in `apps/agor-daemon/src/oauth-cache.ts` and `services/gateway.ts` can
-  read directly from `user_mcp_oauth_tokens` instead.
+  in daemon mode; the daemon reads `user_mcp_oauth_tokens` directly. Any new
+  reader must key on tenant + user + server, not on a URL.
 - DCR scope auto-population strips scopes when `client_id` is pre-registered
   (intentional). When DCR is used, we should **add** `offline_access` if
   advertised by the AS — currently we just join `scopes_supported`.

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -1083,45 +1083,6 @@ export function isOAuthRequired(status: number, headers: Headers): boolean {
 }
 
 /**
- * Get a cached OAuth 2.1 token for an MCP URL
- *
- * This checks all cached tokens and returns a valid one if the metadata URL
- * matches or contains the MCP URL's origin.
- *
- * @param mcpUrl - The MCP server URL to find a cached token for
- * @returns The cached token if valid, undefined otherwise
- */
-export function getCachedOAuth21Token(mcpUrl: string): string | undefined {
-  const now = Date.now();
-
-  let mcpOrigin: string;
-  try {
-    mcpOrigin = new URL(mcpUrl).origin;
-  } catch {
-    return undefined;
-  }
-
-  // Check all cached tokens for a match
-  for (const [metadataUrl, cached] of authCodeTokenCache.entries()) {
-    // Check if token is still valid
-    if (cached.expiresAt <= now) {
-      continue;
-    }
-
-    // Check if the metadata URL is from the same origin as the MCP URL
-    try {
-      const metadataOrigin = new URL(metadataUrl).origin;
-
-      if (metadataOrigin === mcpOrigin || metadataUrl.includes(mcpOrigin)) {
-        return cached.token;
-      }
-    } catch {}
-  }
-
-  return undefined;
-}
-
-/**
  * Clear cached OAuth tokens from Authorization Code flow
  *
  * Useful when switching accounts or forcing re-authentication.
@@ -1223,8 +1184,9 @@ export interface OAuthFlowContext {
  *
  * Inputs:
  *   - `authServerMetadata`: required when no full URL overrides are supplied
- *   - `cacheKey`: token cache key (must share origin with the MCP URL so
- *     `getCachedOAuth21Token` can find it on later requests)
+ *   - `cacheKey`: becomes `context.metadataUrl` — the exact key
+ *     `completeMCPOAuthFlow` writes its legacy CLI cache entry under, and the
+ *     metadata URI the daemon persists as the grant's binding
  */
 async function startMCPOAuthFlowWithAS(opts: {
   authServerMetadata: AuthorizationServerMetadata | null;
@@ -1434,10 +1396,11 @@ export async function startMCPOAuthFlow(
      */
     prefetchedAuthServerMetadata?: AuthorizationServerMetadata;
     /**
-     * Token cache key. When `prefetchedAuthServerMetadata` is provided there's
-     * no real RFC 9728 metadata URL to use as the key, so the caller passes a
-     * stable string (typically the MCP URL itself). `getCachedOAuth21Token`
-     * matches by URL origin, so any value sharing the MCP URL's origin works.
+     * Metadata URL stand-in. When `prefetchedAuthServerMetadata` is provided
+     * there's no real RFC 9728 metadata URL, so the caller passes a stable
+     * string (typically the MCP URL itself). It lands on
+     * `OAuthFlowContext.metadataUrl` and must be the same value on every flow
+     * for the server: lookups against it are exact-match, never by origin.
      */
     cacheKey?: string;
     /** Disable process-global DCR credential reuse in multi-user daemons. */
@@ -1466,9 +1429,9 @@ export async function startMCPOAuthFlow(
       throw new Error('Authorization-server-direct discovery requires explicit legacy mode');
     }
     if (!options.cacheKey) {
-      // Without a cache key, `getCachedOAuth21Token` can't find the token on
-      // future requests — every MCP call would re-trigger the browser flow.
-      // The daemon callsites have the MCP URL handy and should pass it.
+      // Without it there is no `context.metadataUrl` to carry through the
+      // flow — the daemon persists that as the grant's metadata URI. The
+      // daemon callsites have the MCP URL handy and should pass it.
       throw new Error(
         'startMCPOAuthFlow: cacheKey is required when prefetchedAuthServerMetadata is provided ' +
           '(typically pass the MCP server URL).'


### PR DESCRIPTION
Deletes `getCachedOAuth21Token` from `packages/core/src/tools/mcp/oauth-mcp-transport.ts`.

## What it was

```ts
export function getCachedOAuth21Token(mcpUrl: string): string | undefined
```

A bearer token looked up by **a URL alone** — no tenant, no user, no protected resource, no issuer, no client, no scopes. The match was an origin comparison **or a substring test**:

```ts
if (metadataOrigin === mcpOrigin || metadataUrl.includes(mcpOrigin)) {
  return cached.token;
}
```

A cached metadata URL that merely *contains* another origin as a substring hands back that origin's token.

## Why remove it

**This is dead code today — the reason to remove it is not that it is currently exploitable.** It has zero production callers (see below), so nothing reaches the bad match at runtime.

The reason is that it is a ready-made credential-leak primitive sitting in the exact module Phase 2C is about to extend. Our credential rules require identity to bind tenant + user + protected resource + issuer + client + scopes, and forbid reusing a bearer because two issuer origins match; that rule exists because an earlier review caught this same shape as a token-exfiltration path. A loaded, correctly-typed, exported helper is the thing a future callsite reaches for. Removing it means the next author has to write the lookup deliberately rather than find one.

## What stays

The cache itself, `authCodeTokenCache`, is live and is **not** removed:

- **Read** by `performMCPOAuthFlow` via exact key — `authCodeTokenCache.get(metadataUrl)`.
- **Written** by `performMCPOAuthFlow` and by `completeMCPOAuthFlow` (under `context.metadataUrl`).
- Daemon callers pass `cacheToken: false` and resolve against `user_mcp_oauth_tokens` instead, so only the standalone CLI flow populates the map.

So only the unbound reader goes. The exact-key path is untouched; `clearAuthCodeTokenCache` and `getAuthCodeTokenCacheStats` are untouched.

## Breaking-change note

`@agor/core` is published, and `./tools/mcp/oauth-mcp-transport` is a declared export subpath in `packages/core/package.json`. `getCachedOAuth21Token` was therefore **publicly reachable to consumers outside this repo**, and removing it is technically a breaking change to that subpath. No in-repo consumer imports it. This doesn't change the decision — a token-handout function shouldn't be part of the public surface either — but a reviewer should see it stated rather than discover it.

## Comments

Three comments in the transport described the origin-matching lookup and are corrected to the exact-key behaviour that remains; two bullets in `context/explorations/mcp-oauth-token-lifecycle.md` claimed callsites in `apps/agor-daemon/src/oauth-cache.ts` and `services/gateway.ts` that no longer exist (that daemon cache was already removed) and now state the DB-backed reality.

## Verification

- `grep -rn getCachedOAuth21Token` across the repo: **0 production callers**, 0 test callers. Before this change the only hits were the definition and 5 comments (3 in the transport, 2 in the exploration doc); after it, zero hits repo-wide.
- Codex correctness review, asked specifically whether anything reaches the cache by another route: no findings. Verdict — keep the cache, remove only the unbound reader. It confirmed the remaining reader is exact-key, its writers use the same key, no namespace/dynamic/string-keyed access remains, and the daemon completion sites pass `cacheToken: false`.
- Typecheck: 21/21 tasks pass. Lint: biome clean across 2245 files.
- `packages/core`: 3630 passed, 86 skipped (146 files passed, 15 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)