### PR TITLE
fix(codex): route MCP custom headers through env_http_headers

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -2185,6 +2185,52 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
     });
   });
 
+  it('passes custom HTTP headers through Codex env_http_headers without inlining secrets', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'userguiding',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          auth: { type: 'none' },
+          headers: {
+            'X-API-Key': 'secret-api-key',
+            'X-Workspace': 'workspace-123',
+          },
+        },
+      },
+    ]);
+
+    const service = makeService();
+    try {
+      const { servers, total } = await (service as any).buildMcpServersConfig(
+        '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+        undefined,
+        { sessionOwnerId }
+      );
+
+      expect(total).toBe(1);
+      expect(servers.userguiding).toMatchObject({
+        url: 'https://example.com/mcp',
+        env_http_headers: {
+          'X-API-Key': 'AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_1',
+          'X-Workspace': 'AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_2',
+        },
+      });
+      expect(servers.userguiding).not.toHaveProperty('headers');
+      expect(servers.userguiding).not.toHaveProperty('http_headers');
+      expect(process.env.AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_1).toBe(
+        'secret-api-key'
+      );
+      expect(process.env.AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_2).toBe(
+        'workspace-123'
+      );
+    } finally {
+      delete process.env.AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_1;
+      delete process.env.AGOR_MCP_019e3700aaaabbbbccccdddd_USERGUIDING_HEADER_2;
+    }
+  });
+
   it('applies default_tools_approval_mode=approve to ALL servers in a mixed config', async () => {
     mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
       {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -755,9 +755,9 @@ export class CodexPromptService {
       // Resolve the Authorization header via the shared MCP auth helper —
       // covers bearer / JWT (with token-mint) / OAuth (with cached & DB
       // tokens). Codex passes the bearer through `bearer_token_env_var`,
-      // not a header map, so we extract the bearer token and route it via
-      // an env var. Non-bearer schemes log a warning since Codex's CLI
-      // only supports bearer auth.
+      // while custom headers use `env_http_headers`, so secret values stay
+      // out of the SDK's generated `--config` arguments. Non-bearer schemes
+      // log a warning since Codex's CLI only supports bearer auth.
       try {
         const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
         const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
@@ -766,7 +766,15 @@ export class CodexPromptService {
         const customHeaders = headers ? { ...headers } : undefined;
         if (customHeaders) delete customHeaders.Authorization;
         if (customHeaders && Object.keys(customHeaders).length > 0) {
-          serverConfig.headers = customHeaders;
+          const envHttpHeaders: Record<string, string> = {};
+          for (const [index, [headerName, headerValue]] of Object.entries(
+            customHeaders
+          ).entries()) {
+            const envVarName = `AGOR_MCP_${shortId(sessionId)}_${serverName.toUpperCase()}_HEADER_${index + 1}`;
+            process.env[envVarName] = headerValue;
+            envHttpHeaders[headerName] = envVarName;
+          }
+          serverConfig.env_http_headers = envHttpHeaders;
           codexDebug(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
         }
         if (authHeader) {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -766,6 +766,17 @@ export class CodexPromptService {
         const customHeaders = headers ? { ...headers } : undefined;
         if (customHeaders) delete customHeaders.Authorization;
         if (customHeaders && Object.keys(customHeaders).length > 0) {
+          // Codex's streamable-HTTP MCP config takes `env_http_headers`: a map
+          // of header NAME -> the NAME of an env var whose value Codex reads at
+          // runtime. (It will not accept literal header values here the way
+          // Claude's `.mcp.json` `headers` object does — that indirection is
+          // also what keeps secrets out of the SDK-generated `--config` argv.)
+          // The env var name itself is arbitrary to Codex; we synthesize a
+          // unique one per session + server + position so concurrent sessions
+          // and multi-header servers don't clobber each other in the shared
+          // process.env. The index (not the header name) keys the suffix
+          // because header names like `X-API-Key` aren't valid env-var
+          // identifiers.
           const envHttpHeaders: Record<string, string> = {};
           for (const [index, [headerName, headerValue]] of Object.entries(
             customHeaders

--- a/packages/executor/src/sdk-handlers/mcp-custom-headers-wiring.test.ts
+++ b/packages/executor/src/sdk-handlers/mcp-custom-headers-wiring.test.ts
@@ -17,4 +17,13 @@ describe('executor MCP custom headers wiring', () => {
     );
     expect(source).toContain('...(headers ? { headers } : {})');
   });
+
+  it('routes Codex custom headers through environment-backed HTTP headers', () => {
+    const source = readFileSync(new URL('./codex/prompt-service.ts', import.meta.url), 'utf8');
+    expect(source).toContain(
+      'mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders })'
+    );
+    expect(source).toContain('serverConfig.env_http_headers = envHttpHeaders');
+    expect(source).not.toContain('serverConfig.headers = customHeaders');
+  });
 });


### PR DESCRIPTION
## Problem

Codex runner sessions could not see HTTP MCP servers configured with **custom headers** (`transport=http`, `auth_type=none`, `has_custom_headers=true`), while Claude Code sessions with the *identical* attachment saw them fine.

**Repro (2026-08-13):** Two sessions with the same `userguiding` MCP server attached (id `019ffa18-3e88-7672-826c-fa06ea083d7e`):
- Codex session (`gpt-5.6-sol`) → could **not** see it ("only Slack is registered").
- Claude Code session (`opus`) → saw it fine, tools available as deferred.

## Root cause

The Codex MCP config writer emitted custom headers as `serverConfig.headers`, which the Codex CLI does not honor for streamable-http servers. Those servers were silently dropped. Claude Code's `.mcp.json` path was unaffected.

## Fix

Route custom headers through Codex's `env_http_headers` map instead of a literal `headers` object:

- Each header value is exported to a per-session env var (`AGOR_MCP_<shortId>_<SERVER>_HEADER_<n>`).
- The config maps each header **name** to its env var name.

This mirrors how the bearer token is already handled (`bearer_token_env_var`) and keeps secret header values out of the SDK-generated `--config` arguments.

## Tests

- New `buildMcpServersConfig` unit test: custom HTTP headers flow through `env_http_headers` with secrets in env vars, not inlined; no `headers`/`http_headers` keys leak.
- New source-wiring assertion in `mcp-custom-headers-wiring.test.ts`.

Both targeted suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)