### PR TITLE
fix(auth): allow viewer role to log in

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -119,7 +119,7 @@ import {
   isRemoteRelationshipsEnrichedResult,
   markRemoteRelationshipsEnrichedResult,
 } from './services/sessions.js';
-import { isLocalAuthenticationLookup } from './services/users.js';
+import { isAuthenticationUserLookup, isLocalAuthenticationLookup } from './services/users.js';
 import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import {
   ensureMinimumRole,
@@ -594,6 +594,17 @@ export async function protectServerManagedTaskWrites(context: HookContext): Prom
     throw new Forbidden('Task patch contains fields that are not executor-managed');
   }
 
+  return context;
+}
+
+export function authorizeUsersGet(context: HookContext): HookContext {
+  const params = context.params as AuthenticatedParams;
+
+  if (isAuthenticationUserLookup(params)) {
+    return context;
+  }
+
+  ensureMinimumRole(params, ROLES.MEMBER, 'view users');
   return context;
 }
 
@@ -2344,12 +2355,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           throw new NotAuthenticated('Authentication required');
         },
       ],
-      get: [
-        (context) => {
-          ensureMinimumRole(context.params as AuthenticatedParams, ROLES.MEMBER, 'view users');
-          return context;
-        },
-      ],
+      get: [authorizeUsersGet],
       create: [
         async (context: HookContext<Board>) => {
           const params = context.params as AuthenticatedParams;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1448,11 +1448,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   app.service('repos').hooks({
     before: {
-      all: [
-        typedValidateQuery(repoQueryValidator),
-        requireAuth,
-        requireMinimumRole(ROLES.MEMBER, 'access repositories'),
-      ],
+      all: [typedValidateQuery(repoQueryValidator), requireAuth],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create repositories'),
         requireAdminForEnvConfig(),
@@ -1477,12 +1473,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   app.service('branches').hooks({
     before: {
-      all: [
-        typedValidateQuery(branchQueryValidator),
-        requireAuth,
-        executorRuntimeScopeGuard(),
-        requireMinimumRole(ROLES.MEMBER, 'access branches'),
-      ],
+      all: [typedValidateQuery(branchQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: mark external regular-user finds for BranchesService to compose
         // the shared branch visibility predicate directly into its SQL read.
@@ -1508,6 +1499,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         validateBranchEnvPolicyHook(config),
       ],
       patch: [
+        requireMinimumRole(ROLES.MEMBER, 'update branches'),
         requireAdminForEnvConfig(),
         validateBranchEnvPolicyHook(config),
         ...(branchRbacEnabled
@@ -1536,12 +1528,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       remove: [
+        requireMinimumRole(ROLES.MEMBER, 'delete branches'),
         ...(branchRbacEnabled
           ? [
               loadBranch(branchRepository),
               ensureBranchPermission('all', 'delete branches', superadminOpts), // Require 'all' permission to delete
             ]
           : []),
+      ],
+      updateEnvironment: [requireMinimumRole(ROLES.MEMBER, 'update branch environments')],
+      ensureTeammateKnowledgeNamespace: [
+        requireMinimumRole(ROLES.MEMBER, 'create teammate knowledge namespaces'),
       ],
     },
     after: {
@@ -1642,7 +1639,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
     },
-  });
+    // biome-ignore lint/suspicious/noExplicitAny: custom branch service methods are transport-exposed
+  } as any);
 
   // ============================================================================
   // Knowledge hooks
@@ -1903,7 +1901,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       find: [
-        requireMinimumRole(ROLES.MEMBER, 'list session MCP servers'),
         // RBAC: Scope to sessions the caller can access.
         ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
@@ -1916,14 +1913,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Top-level `/session-env-selections` exists mainly to surface WebSocket
   // events emitted by the `/sessions/:id/env-selections` route handlers. Its
   // `find()` must still be gated — without these hooks any authenticated
-  // member could read selection metadata for sessions they can't access,
+  // user could read selection metadata for sessions they can't access,
   // bypassing the creator/admin gate on the nested route. Mirror the
   // `/session-mcp-servers` pattern exactly so the two stay consistent.
   safeService('session-env-selections')?.hooks({
     before: {
       all: [requireAuth],
       find: [
-        requireMinimumRole(ROLES.MEMBER, 'list session env selections'),
         // This top-level service is event-only and always returns []; do not
         // run RBAC preloads for an intentionally empty result set.
       ],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1536,10 +1536,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             ]
           : []),
       ],
-      updateEnvironment: [requireMinimumRole(ROLES.MEMBER, 'update branch environments')],
-      ensureTeammateKnowledgeNamespace: [
-        requireMinimumRole(ROLES.MEMBER, 'create teammate knowledge namespaces'),
-      ],
     },
     after: {
       create: [
@@ -1639,8 +1635,24 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
     },
-    // biome-ignore lint/suspicious/noExplicitAny: custom branch service methods are transport-exposed
-  } as any);
+  });
+
+  type BranchCustomHookRegistrar = {
+    hooks(options: {
+      before: Record<
+        'updateEnvironment' | 'ensureTeammateKnowledgeNamespace',
+        Array<(context: HookContext) => HookContext>
+      >;
+    }): void;
+  };
+  (app.service('branches') as unknown as BranchCustomHookRegistrar).hooks({
+    before: {
+      updateEnvironment: [requireMinimumRole(ROLES.MEMBER, 'update branch environments')],
+      ensureTeammateKnowledgeNamespace: [
+        requireMinimumRole(ROLES.MEMBER, 'create teammate knowledge namespaces'),
+      ],
+    },
+  });
 
   // ============================================================================
   // Knowledge hooks

--- a/apps/agor-daemon/src/register-hooks.update-gating.test.ts
+++ b/apps/agor-daemon/src/register-hooks.update-gating.test.ts
@@ -34,6 +34,10 @@ type CapturedHooks = { before: Record<string, RegisteredHook[]> };
  */
 const captureRegisteredHooks = (branchRbacEnabled: boolean): Map<string, CapturedHooks> => {
   const captured = new Map<string, CapturedHooks>();
+  const visibleBranch = {
+    branch_id: '00000000-0000-7000-8000-000000000001',
+    others_can: 'view',
+  };
   const app = {
     service(path: string) {
       return {
@@ -68,7 +72,11 @@ const captureRegisteredHooks = (branchRbacEnabled: boolean): Map<string, Capture
     sessionsService: {} as RegisterHooksContext['sessionsService'],
     messagesService: {} as RegisterHooksContext['messagesService'],
     boardsService: undefined,
-    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    branchRepository: {
+      findById: async () => visibleBranch,
+      isOwner: async () => false,
+      resolveUserPermission: async () => 'view',
+    } as unknown as RegisterHooksContext['branchRepository'],
     usersRepository: {} as RegisterHooksContext['usersRepository'],
     sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
   });
@@ -95,7 +103,7 @@ const runCapturedHooks = async (
   path: string,
   method: string,
   role: string
-): Promise<void> => {
+): Promise<HookContext> => {
   const hooks = captured.get(path)?.before;
   if (!hooks) throw new Error(`${path} registers no before hooks`);
   const context = {
@@ -112,10 +120,11 @@ const runCapturedHooks = async (
   for (const hook of [...(hooks.all ?? []), ...(hooks[method] ?? [])]) {
     await hook(context);
   }
+  return context;
 };
 
-describe('viewer read access', () => {
-  const captured = captureRegisteredHooks(false);
+describe.each(RBAC_MODES)('viewer read access ($name)', ({ branchRbacEnabled }) => {
+  const captured = captureRegisteredHooks(branchRbacEnabled);
 
   it.each([
     ['repos', 'find'],
@@ -125,8 +134,24 @@ describe('viewer read access', () => {
     ['session-mcp-servers', 'find'],
     ['session-env-selections', 'find'],
   ])('allows viewers to use %s.%s', async (path, method) => {
-    await expect(runCapturedHooks(captured, path, method, 'viewer')).resolves.toBeUndefined();
+    await expect(runCapturedHooks(captured, path, method, 'viewer')).resolves.toBeDefined();
   });
+
+  if (branchRbacEnabled) {
+    it('retains SQL branch visibility scoping for viewer branch finds', async () => {
+      const context = await runCapturedHooks(captured, 'branches', 'find', 'viewer');
+      expect(context.params).toMatchObject({
+        _agorSqlBranchAccessUserId: '00000000-0000-7000-8000-0000000000ff',
+      });
+    });
+
+    it('retains SQL session visibility scoping for viewer MCP assignment finds', async () => {
+      const context = await runCapturedHooks(captured, 'session-mcp-servers', 'find', 'viewer');
+      expect(context.params).toMatchObject({
+        _agorSqlSessionAccessUserId: '00000000-0000-7000-8000-0000000000ff',
+      });
+    });
+  }
 
   it.each([
     ['repos', 'create'],

--- a/apps/agor-daemon/src/register-hooks.update-gating.test.ts
+++ b/apps/agor-daemon/src/register-hooks.update-gating.test.ts
@@ -90,6 +90,60 @@ const RBAC_MODES = [
 
 const WRITE_METHODS = ['create', 'patch', 'remove'] as const;
 
+const runCapturedHooks = async (
+  captured: Map<string, CapturedHooks>,
+  path: string,
+  method: string,
+  role: string
+): Promise<void> => {
+  const hooks = captured.get(path)?.before;
+  if (!hooks) throw new Error(`${path} registers no before hooks`);
+  const context = {
+    path,
+    method,
+    id: method === 'get' ? '00000000-0000-7000-8000-000000000001' : undefined,
+    params: {
+      provider: 'rest',
+      query: {},
+      user: { user_id: '00000000-0000-7000-8000-0000000000ff', role },
+    },
+  } as unknown as HookContext;
+
+  for (const hook of [...(hooks.all ?? []), ...(hooks[method] ?? [])]) {
+    await hook(context);
+  }
+};
+
+describe('viewer read access', () => {
+  const captured = captureRegisteredHooks(false);
+
+  it.each([
+    ['repos', 'find'],
+    ['repos', 'get'],
+    ['branches', 'find'],
+    ['branches', 'get'],
+    ['session-mcp-servers', 'find'],
+    ['session-env-selections', 'find'],
+  ])('allows viewers to use %s.%s', async (path, method) => {
+    await expect(runCapturedHooks(captured, path, method, 'viewer')).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['repos', 'create'],
+    ['repos', 'patch'],
+    ['repos', 'remove'],
+    ['branches', 'create'],
+    ['branches', 'patch'],
+    ['branches', 'remove'],
+    ['branches', 'updateEnvironment'],
+    ['branches', 'ensureTeammateKnowledgeNamespace'],
+  ])('keeps %s.%s restricted to members', async (path, method) => {
+    await expect(runCapturedHooks(captured, path, method, 'viewer')).rejects.toMatchObject({
+      name: 'Forbidden',
+    });
+  });
+});
+
 /**
  * Services that gate a write verb but deliberately leave `update` ungated,
  * because `update` is not reachable from any transport.

--- a/apps/agor-daemon/src/services/users.find.test.ts
+++ b/apps/agor-daemon/src/services/users.find.test.ts
@@ -1,6 +1,7 @@
 import { AuthenticationService, feathers } from '@agor/core/feathers';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { authorizeUsersGet } from '../register-hooks';
 import { AgorLocalStrategy } from '../register-routes';
 import { createUsersService, LOCAL_AUTH_LOOKUP_PARAM, UsersService } from './users';
 
@@ -190,6 +191,7 @@ describe('UsersService.find exact-email hardening', () => {
     });
 
     app.use('users', createUsersService(db));
+    app.service('users').hooks({ before: { get: [authorizeUsersGet] } });
 
     const authentication = new AuthenticationService(app);
     authentication.register('local', new AgorLocalStrategy());
@@ -198,6 +200,7 @@ describe('UsersService.find exact-email hardening', () => {
     await app.service('users').create({
       email: 'strategy-login@example.com',
       password: 'password-123',
+      role: 'viewer',
     });
 
     const result = await app.service('authentication').create(
@@ -210,6 +213,7 @@ describe('UsersService.find exact-email hardening', () => {
     );
 
     expect(result.user.email).toBe('strategy-login@example.com');
+    expect(result.user.role).toBe('viewer');
     expect(result.user).not.toHaveProperty('password');
   });
 });


### PR DESCRIPTION
## Summary

- exempt trusted authentication entity hydration from the member-only `users.get` role gate
- restore viewer access to core read-only UI data: repositories, branches, session MCP assignments, and the session environment-selection event feed
- keep every repository/branch write and exposed custom mutation restricted to members
- add regression coverage for viewer login and the audited read/write authorization matrix

## Security / tenancy

- the login exemption is keyed by the existing symbol-backed internal authentication marker, so transport callers cannot forge it through request data
- viewer reads retain existing tenant scoping and branch RBAC visibility filtering
- repository and branch creates, updates, patches, deletes, environment updates, and teammate knowledge namespace creation remain member-only
- user/group directory reads, filesystem browsing, templates, terminals, and other intentionally member-only surfaces remain unchanged

## Testing

- `pnpm i`
- `pnpm --filter @agor/daemon exec vitest run src/register-hooks.update-gating.test.ts src/services/users.find.test.ts` (60 passed)
- `pnpm check`

Closes #2295
