### PR TITLE
fix(daemon): preserve tenant scope across hosted surfaces

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -478,6 +478,11 @@ export const TENANT_OWNED_SERVICE_PATHS = [
 // so they carry tenant identity for the full request and open short database
 // units of work at the call site instead of holding an HTTP-long transaction.
 export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
+  // File browsing crosses the executor/process boundary. Its short repository
+  // reads open tenant DB units at the call site rather than holding a DB
+  // transaction over executor I/O.
+  'file',
+  'files',
   'check-auth',
   // Global catalog: no tenant column to scope, no writes to stamp.
   'mcp-catalog',

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -13,6 +13,9 @@ describe('prompt and widget transaction scopes', () => {
     expect(promptStart).toBeGreaterThan(0);
     expect(prompt).toContain('registerLongAuthenticatedRoute(');
     expect(prompt).toContain('bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db))');
+    expect(prompt).toContain('const getPromptSession = (sessionId: string) =>');
+    expect(prompt).toContain('runWithTenantDatabaseScope(db, promptTenantId');
+    expect(prompt).not.toMatch(/await sessionsService\.get\(/);
     expect(prompt).toContain(
       'isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool)'
     );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1482,7 +1482,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
 
-        let session = await sessionsService.get(id, params);
+        const getPromptSession = (sessionId: string) =>
+          runWithTenantDatabaseScope(db, promptTenantId, () =>
+            sessionsService.get(sessionId, params)
+          );
+        let session = await getPromptSession(id);
         id = session.session_id;
         const taskRepo = bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db));
 
@@ -1565,7 +1569,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           sessionTurnLocks,
           id as SessionID,
           async () => {
-            let lockedSession = await sessionsService.get(id, params);
+            let lockedSession = await getPromptSession(id);
             if (lockedSession.status === SessionStatus.STOPPING) {
               // The earlier STOPPING check was against pre-lock state — re-check
               // here so a session that entered STOPPING while we waited for our
@@ -2314,29 +2318,34 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       if (DEBUG_UPLOAD) console.log('🔑 [Upload Auth] JWT token found, verifying...');
 
       const authService = app.service('authentication');
-      const result = await authService.create({
-        strategy: 'jwt',
-        accessToken: token,
-      });
+      // Pass one mutable params object through authentication. The JWT strategy
+      // propagates the verified tenant claim onto it before its Users lookup,
+      // allowing the authentication service's tenant hook to open the required
+      // database scope. Calling create(data) without params works locally but
+      // reaches the guarded daemon DB without scope in required_from_auth mode.
+      const authParams: AuthenticatedParams = { headers: req.headers };
+      const result = await authService.create({ strategy: 'jwt', accessToken: token }, authParams);
 
       if (DEBUG_UPLOAD) {
         console.log('✅ [Upload Auth] Authentication successful');
         console.log('   User:', result.user?.user_id ? shortId(result.user.user_id) : 'unknown');
       }
 
-      const authParams = {
+      const authenticatedParams = {
         user: result.user,
         provider: 'rest',
         authentication: result.authentication,
         headers: req.headers,
       };
       req.feathers = {
-        ...authParams,
-        tenant: resolveTenantContext(multiTenancy, {
-          params: authParams,
-          authPayload: result.authentication?.payload,
-          headers: req.headers,
-        }),
+        ...authenticatedParams,
+        tenant:
+          authParams.tenant ??
+          resolveTenantContext(multiTenancy, {
+            params: authenticatedParams,
+            authPayload: result.authentication?.payload,
+            headers: req.headers,
+          }),
       };
 
       next();

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -3,8 +3,9 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('browser upload route boundary ordering', () => {
+  const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
+
   it('authenticates and authorizes before the multipart parser can accept bytes', () => {
-    const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
     const route = source.slice(source.indexOf("'/sessions/:sessionId/upload'"));
     expect(route.indexOf('uploadAuthMiddleware')).toBeLessThan(
       route.indexOf("uploadMiddleware.array('files'")
@@ -15,7 +16,6 @@ describe('browser upload route boundary ordering', () => {
   });
 
   it('does not expose Multer buffers or physical file paths in the response contract', () => {
-    const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
     const handler = source.slice(
       source.indexOf('const uploadHandler'),
       source.indexOf('const uploadLogger')
@@ -23,5 +23,20 @@ describe('browser upload route boundary ordering', () => {
     expect(handler).not.toContain('f.buffer');
     expect(handler).not.toContain('f.path');
     expect(handler).toContain('ref: staged.ref');
+  });
+
+  it('carries authentication params so the JWT user lookup receives tenant scope', () => {
+    const start = source.indexOf('const uploadAuthMiddleware');
+    const middleware = source.slice(
+      start,
+      source.indexOf("(app as any).post(\n    '/sessions/:sessionId/upload'", start)
+    );
+
+    expect(start).toBeGreaterThan(0);
+    expect(middleware).toContain(
+      'const authParams: AuthenticatedParams = { headers: req.headers }'
+    );
+    expect(middleware).toMatch(/authService\.create\([\s\S]*authParams\s*\)/);
+    expect(middleware).toContain('authParams.tenant ??');
   });
 });

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -1,3 +1,4 @@
+import { createTenantScopedDatabaseProxy } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
 import { FileService } from './file.js';
@@ -29,7 +30,7 @@ describe('FileService executor failures', () => {
     });
     const service = new FileService(
       { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
-      null as never,
+      {} as never,
       { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
     );
 
@@ -78,7 +79,7 @@ describe('FileService executor failures', () => {
       vi.mocked(runExecutorCommand).mockResolvedValue({ success: true, data });
       const service = new FileService(
         { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
-        null as never,
+        {} as never,
         { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
       );
       const params = {
@@ -98,4 +99,28 @@ describe('FileService executor failures', () => {
       );
     }
   );
+
+  it('opens a short tenant scope before the teammate Files branch lookup', async () => {
+    const rawDb = { run: vi.fn(), select: vi.fn(() => 'scoped lookup') };
+    const guardedDb = createTenantScopedDatabaseProxy(rawDb as never, {
+      requireScope: true,
+      label: 'daemon database',
+    });
+    const findById = vi.fn(async () => guardedDb.select());
+    vi.mocked(runExecutorCommand).mockResolvedValue({ success: true, data: { files: [] } });
+    const service = new FileService({ findById } as never, guardedDb, {
+      get: () => ({}),
+      settings: { authentication: { secret: 'test' } },
+    } as never);
+
+    await expect(
+      service.find({
+        query: { branch_id: 'branch-1' },
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    ).resolves.toEqual([]);
+
+    expect(rawDb.select).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -1,7 +1,11 @@
 /**
  * Read-only branch file browser. Tenant filesystem access is delegated to the executor.
  */
-import type { BranchRepository, TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  type BranchRepository,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
@@ -47,7 +51,9 @@ export class FileService
     ensureMinimumRole(params, ROLES.MEMBER, 'list files');
     const branchId = params?.query?.branch_id;
     if (!branchId) throw new Error('branch_id query parameter is required');
-    const branch = await this.branchRepo.findById(branchId);
+    const branch = await runWithTenantDatabaseScope(this.db, params?.tenant?.tenant_id, () =>
+      this.branchRepo.findById(branchId)
+    );
     if (!branch) throw new Error(`Branch not found: ${branchId}`);
 
     const result = await this.runCommand('branch.files.browse', branch.branch_id, params);
@@ -63,7 +69,9 @@ export class FileService
     ensureMinimumRole(params, ROLES.MEMBER, 'read file');
     const branchId = params?.query?.branch_id;
     if (!branchId) throw new Error('branch_id query parameter is required');
-    const branch = await this.branchRepo.findById(branchId);
+    const branch = await runWithTenantDatabaseScope(this.db, params?.tenant?.tenant_id, () =>
+      this.branchRepo.findById(branchId)
+    );
     if (!branch) throw new Error(`Branch not found: ${branchId}`);
 
     const result = await this.runCommand('branch.files.read', branch.branch_id, params, {

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -8,6 +8,7 @@
 
 import {
   BranchRepository,
+  runWithTenantDatabaseScope,
   SessionRepository,
   type TenantScopeAwareDatabase,
   UsersRepository,
@@ -92,13 +93,20 @@ export class FilesService {
 
     try {
       // Fetch session to get branch_id
-      const session = await this.sessionRepo.findById(sessionId);
-      if (!session) {
-        return [];
-      }
-
-      // Fetch branch to validate it still exists before crossing the executor boundary.
-      const branch = await this.branchRepo.findById(session.branch_id);
+      const { session, branch } = await runWithTenantDatabaseScope(
+        this.db,
+        params.tenant?.tenant_id,
+        async () => {
+          const session = await this.sessionRepo.findById(sessionId);
+          if (!session) return { session: null, branch: null };
+          return {
+            session,
+            // Validate it still exists before crossing the executor boundary.
+            branch: await this.branchRepo.findById(session.branch_id),
+          };
+        }
+      );
+      if (!session) return [];
       if (!branch?.path) {
         return [];
       }
@@ -108,7 +116,11 @@ export class FilesService {
       );
 
       const currentUserId = params.user?.user_id as UserID | undefined;
-      const currentUser = currentUserId ? await this.usersRepo.findById(currentUserId) : null;
+      const currentUser = currentUserId
+        ? await runWithTenantDatabaseScope(this.db, params.tenant?.tenant_id, () =>
+            this.usersRepo.findById(currentUserId)
+          )
+        : null;
 
       const result = await runExecutorCommand(
         {

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -92,6 +92,16 @@ const checks = [
   },
 
   {
+    name: 'parameterless custom authentication calls',
+    roots: ['apps/agor-daemon/src'],
+    excludeTests: true,
+    patterns: [/\bauthService\.create\(\s*\{[^)]*\}\s*\)/gs],
+    // Custom HTTP middleware must pass a mutable params object. The JWT
+    // strategy places its verified tenant claim there before loading Users;
+    // omitting params only fails when the hosted DB scope guard is enabled.
+    baseline: {},
+  },
+  {
     name: 'raw tenant database scope imports',
     roots: ['apps/agor-daemon/src'],
     excludeTests: true,


### PR DESCRIPTION
## Summary

Fixes #2313 for the three hosted-only surfaces that reached the guarded daemon database without an active tenant scope:

- **Session resume:** the prompt route intentionally carries tenant identity rather than a route-long transaction, but its initial and post-lock `sessionsService.get()` calls were direct DB reads. Both now use short `runWithTenantDatabaseScope` units.
- **Teammate Files:** the `file`/`files` services crossed an executor boundary without being registered as identity-only services, and their repository reads were unscoped. They now retain tenant identity for the request and open short tenant DB units only around branch/session/user reads.
- **Uploads settings:** the custom bearer middleware called `authentication.create()` without a params object. In hosted mode that prevented the JWT strategy from propagating the verified tenant claim before its Users lookup. The middleware now passes and reuses one mutable authenticated params object.

## Regression guard

- Extends `check:multitenancy-boundaries` to reject parameterless custom `authService.create({...})` calls, the subtle pattern behind the Uploads failure.
- Adds focused source-boundary assertions for prompt admission and upload authentication.
- Adds a guarded-database test proving teammate Files branch lookup succeeds only because the service opens a short tenant scope.

## Tenant isolation

All affected records/files are tenant-owned or derived from tenant-owned sessions/branches. Tenant identity continues to come from authenticated request/JWT context; no caller-provided tenant identifier is trusted. The changes preserve short DB transactions across long executor/process boundaries and retain Postgres RLS enforcement.

This is unrelated to `agor-cloud#251`, which is a static Helm/Codex credential-storage configuration issue.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test --run src/services/file.test.ts src/register-routes.prompt-scope.test.ts src/register-routes.upload-boundary.test.ts`
