### PR TITLE
fix(onboarding): simplify Claude CLI setup

### DIFF
--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -284,6 +284,14 @@ claude setup-token
 
 Copy the printed token.
 
+The browser authorization is owned by Anthropic and currently does not redirect back into Agor.
+After selecting **Authorize**, return to the terminal where you ran the command; the token is
+printed there. Keep the Agor setup modal open, then paste the token into it.
+
+If the command or browser flow appears stuck, return to the terminal, press **Ctrl+C**, and run
+`claude setup-token` again. You should not need to restart the terminal. Because the CLI and
+authorization page run outside Agor, Agor cannot detect or reset a stalled attempt itself.
+
 **3. Paste it into Agor:** open **User Settings → Agentic Tools → Claude Code** and paste the token into **Claude Subscription Token**. Agor stores it as `CLAUDE_CODE_OAUTH_TOKEN` for your user.
 
 ### Per-user API keys (recommended for teams)

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -260,6 +260,13 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
                 placeholder={placeholder}
                 value={inputValues[field] || ''}
                 onChange={(e) => setInputValues((prev) => ({ ...prev, [field]: e.target.value }))}
+                onPaste={(e) => {
+                  e.preventDefault();
+                  setInputValues((prev) => ({
+                    ...prev,
+                    [field]: e.clipboardData.getData('text').trim(),
+                  }));
+                }}
                 onPressEnter={() => handleSave(field)}
                 style={{ flex: 1 }}
                 disabled={disabled}

--- a/apps/agor-ui/src/components/ClaudeSubscriptionTokenInstructions.tsx
+++ b/apps/agor-ui/src/components/ClaudeSubscriptionTokenInstructions.tsx
@@ -3,9 +3,11 @@ import { Typography } from 'antd';
 /** Shared guidance for obtaining the explicit Claude subscription token Agor stores. */
 export const ClaudeSubscriptionTokenInstructions: React.FC = () => (
   <span>
-    In any terminal with Claude Code installed, run{' '}
-    <Typography.Text code>claude setup-token</Typography.Text>, then paste the printed token here.
-    Need Claude Code?{' '}
+    Run <Typography.Text code>claude setup-token</Typography.Text> in a terminal with Claude Code,
+    authorize in the browser, then return to the terminal and paste the token printed there. The
+    Anthropic page does not redirect back into Agor. If the command gets stuck, press{' '}
+    <Typography.Text code>Ctrl+C</Typography.Text> and run it again; restarting the terminal should
+    not be necessary. Need Claude Code?{' '}
     <Typography.Link href="https://docs.claude.com/en/docs/claude-code/setup" target="_blank">
       Install docs
     </Typography.Link>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -209,6 +209,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ initialStep: 'llm' });
 
     clickButton('Claude');
+    clickButton(/Advanced Setup · API key/);
     const input = screen.getByLabelText('Anthropic API key');
     fireEvent.change(input, { target: { value: 'not-a-real-key' } });
 
@@ -224,6 +225,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ initialStep: 'llm', onUpdateUser, onCheckAuth });
 
     clickButton('Claude');
+    clickButton(/Advanced Setup · API key/);
     const validKey = `sk-ant-api03-${'x'.repeat(40)}`;
     fireEvent.change(screen.getByLabelText('Anthropic API key'), {
       target: { value: validKey },
@@ -248,6 +250,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ initialStep: 'llm', onUpdateUser, onCheckAuth });
 
     clickButton('Claude');
+    clickButton(/Advanced Setup · API key/);
     const validKey = `sk-ant-api03-${'x'.repeat(40)}`;
     fireEvent.change(screen.getByLabelText('Anthropic API key'), { target: { value: validKey } });
     clickButton(/^connect →/i);
@@ -274,6 +277,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ initialStep: 'llm', onUpdateUser, onCheckAuth });
 
     clickButton('Claude');
+    clickButton(/Advanced Setup · API key/);
     fireEvent.change(screen.getByLabelText('Anthropic API key'), {
       target: { value: `sk-ant-api03-${'x'.repeat(40)}` },
     });
@@ -283,17 +287,20 @@ describe('OnboardingWizard', () => {
     expect(onUpdateUser).not.toHaveBeenCalled();
   });
 
-  it('can save a Claude subscription token instead of an API key', async () => {
+  it('defaults Claude to Quick Start, explains the return path, and trims a pasted token', async () => {
     const onUpdateUser = vi.fn(async () => undefined);
     renderWizard({ initialStep: 'llm', onUpdateUser });
 
     clickButton('Claude');
-    clickButton('Subscription token');
-    expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
+    expect(screen.getByText(/Quick Start · Claude subscription/)).toBeInTheDocument();
+    expect(screen.getAllByText(/claude setup-token/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/return to the terminal/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/you do not need to restart the terminal/i)).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Claude subscription token'), {
-      target: { value: 'token-from-cli' },
+    fireEvent.paste(screen.getByLabelText('Claude subscription token'), {
+      clipboardData: { getData: () => '  token-from-cli\n' },
     });
+    expect(screen.getByLabelText('Claude subscription token')).toHaveValue('token-from-cli');
     clickButton(/^connect →/i);
 
     await waitFor(() => {
@@ -462,6 +469,7 @@ describe('OnboardingWizard', () => {
 
     // llm
     await findAndClickButton('Claude');
+    clickButton(/Advanced Setup · API key/);
     const validKey = `sk-ant-api03-${'x'.repeat(40)}`;
     fireEvent.change(screen.getByLabelText('Anthropic API key'), {
       target: { value: validKey },

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -67,8 +67,8 @@ const AUTH_METHOD_OPTIONS: Partial<
   Record<AgenticToolName, { label: string; value: AuthMethod }[]>
 > = {
   'claude-code': [
-    { label: 'API key', value: 'api-key' },
-    { label: 'Subscription token', value: 'claude-subscription-token' },
+    { label: 'Quick Start · Claude subscription', value: 'claude-subscription-token' },
+    { label: 'Advanced Setup · API key', value: 'api-key' },
   ],
   codex: [
     { label: 'API key', value: 'api-key' },
@@ -532,7 +532,7 @@ export function OnboardingWizard({
   // ── Step 2: LLM ─────────────────────────────────────────────────────────
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName | null>(null);
   const [apiKey, setApiKey] = useState('');
-  const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('claude-subscription-token');
   const [llmSaving, setLlmSaving] = useState(false);
   const [llmError, setLlmError] = useState<string | null>(null);
   const [llmAuthChecking, setLlmAuthChecking] = useState<AgenticToolName | null>(null);
@@ -569,7 +569,7 @@ export function OnboardingWizard({
     setSelectedPersona(null);
     setSelectedAgent(null);
     setApiKey('');
-    setAuthMethod('api-key');
+    setAuthMethod('claude-subscription-token');
     setLlmError(null);
     setLlmSaving(false);
     setLlmAuthChecking(null);
@@ -1271,7 +1271,9 @@ export function OnboardingWizard({
                   onClick={() => {
                     setSelectedAgent(option.agent);
                     setApiKey('');
-                    setAuthMethod('api-key');
+                    setAuthMethod(
+                      option.agent === 'claude-code' ? 'claude-subscription-token' : 'api-key'
+                    );
                     setLlmError(null);
                   }}
                   style={{
@@ -1508,12 +1510,23 @@ export function OnboardingWizard({
                         <Alert
                           type="info"
                           showIcon
-                          style={{ marginBottom: 10, fontSize: 12 }}
+                          style={{ marginBottom: 12, fontSize: 12 }}
                           message={
-                            <span>
-                              For claude.ai Pro or Max subscribers. In any terminal with Claude Code
-                              installed, run <code>claude setup-token</code>, then paste the printed
-                              token below. Need Claude Code?{' '}
+                            <div>
+                              <Text strong>Connect your Claude subscription in three steps</Text>
+                              <ol style={{ margin: '8px 0 6px', paddingLeft: 20 }}>
+                                <li>
+                                  In a terminal with Claude Code installed, run{' '}
+                                  <code>claude setup-token</code>.
+                                </li>
+                                <li>
+                                  Authorize in the browser. When Anthropic finishes, return to the
+                                  terminal—the token is printed there, not on the web page.
+                                </li>
+                                <li>Copy the entire token and paste it below.</li>
+                              </ol>
+                              Agor stores this token so it can start Claude Code for you. Need
+                              Claude Code?{' '}
                               <Typography.Link
                                 href="https://docs.claude.com/en/docs/claude-code/setup"
                                 target="_blank"
@@ -1522,24 +1535,45 @@ export function OnboardingWizard({
                                 Install docs
                               </Typography.Link>
                               .
-                            </span>
+                            </div>
                           }
                         />
                         <Input.Password
                           aria-label="Claude subscription token"
-                          placeholder="Paste token from claude setup-token…"
+                          size="large"
+                          placeholder="Paste the token printed in your terminal"
                           value={apiKey}
                           onChange={(e) => {
                             setApiKey(e.target.value);
                             setLlmError(null);
                           }}
+                          onPaste={(e) => {
+                            e.preventDefault();
+                            setApiKey(e.clipboardData.getData('text').trim());
+                            setLlmError(null);
+                          }}
                           style={{
+                            width: '100%',
                             background: 'rgba(0,0,0,0.3)',
                             borderColor: 'rgba(255,255,255,0.12)',
                             fontFamily: 'monospace',
                             fontSize: 13,
                           }}
                         />
+                        <Text
+                          style={{
+                            fontSize: 11,
+                            color: TEXT_MUTED,
+                            marginTop: 8,
+                            display: 'block',
+                          }}
+                        >
+                          Browser or terminal stuck? Return to the terminal, press{' '}
+                          <code>Ctrl+C</code>, then run <code>claude setup-token</code> again. You
+                          do not need to restart the terminal. Agor cannot detect the external CLI
+                          or Anthropic browser redirect, so keep this modal open while you
+                          authorize.
+                        </Text>
                       </>
                     ) : (
                       <Input.Password
@@ -1550,6 +1584,13 @@ export function OnboardingWizard({
                           setApiKey(e.target.value);
                           if (selectedAgent)
                             setLlmError(validateLlmKeyPattern(selectedAgent, e.target.value));
+                        }}
+                        onPaste={(e) => {
+                          e.preventDefault();
+                          const value = e.clipboardData.getData('text').trim();
+                          setApiKey(value);
+                          if (selectedAgent)
+                            setLlmError(validateLlmKeyPattern(selectedAgent, value));
                         }}
                         style={{
                           background: 'rgba(0,0,0,0.3)',
@@ -1973,7 +2014,7 @@ export function OnboardingWizard({
         mask={true}
         keyboard={false}
         footer={null}
-        width={600}
+        width={720}
         style={{
           background: MODAL_BG,
           borderRadius: 20,


### PR DESCRIPTION
## Summary

Fixes #2289 by making the existing Claude Code CLI onboarding path easier to follow for non-technical users.

### Our fix

- makes **Quick Start · Claude subscription** the default Claude connection path and keeps **Advanced Setup · API key** opt-in
- widens the onboarding modal and token input area
- turns `claude setup-token` into a clear three-step flow that tells users where the token appears and why Agor needs it
- adds an inline recovery path (`Ctrl+C`, then rerun the command) instead of suggesting a terminal restart
- trims surrounding whitespace when credentials are pasted in onboarding and shared credential settings
- adds focused onboarding coverage and updates the installation guide

### Documented upstream boundary

The browser authorization page and OAuth redirect are controlled by the Anthropic CLI/authorization flow. Agor cannot change that redirect, observe whether the external CLI is stuck, or automatically return focus to the setup modal.

On our side, the modal now stays open and explicitly tells users that after **Authorize** they must return to the terminal, where the token is printed, and then return to the still-open Agor modal to paste it. The same boundary and recovery instructions are documented in the guide.

## Testing

- `pnpm i`
- `pnpm exec vitest run src/components/OnboardingWizard/OnboardingWizard.test.tsx --reporter=dot` (32 passed)
- `pnpm check`
