### PR TITLE
fix(ui): make onboarding credit failures non-blocking

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -783,7 +783,21 @@ function AppContent() {
       onUpdateBranch: (branchId, updates) =>
         handleUpdateBranch(branchId, updates as BranchUpdate, { silent: true }),
       onCreateSession: handleCreateSession,
-      onWarn: (message) => showWarning(message, { key: 'onboarding-teammate', duration: 8 }),
+      onWarn: (warning) =>
+        showWarning(
+          <>
+            {warning.message}
+            {warning.action ? (
+              <>
+                {' '}
+                <a href={warning.action.href} target="_blank" rel="noreferrer">
+                  {warning.action.label}
+                </a>
+              </>
+            ) : null}
+          </>,
+          { key: 'onboarding-teammate', duration: warning.action ? 12 : 8 }
+        ),
     });
     if (seeded.sessionId) sessionId = seeded.sessionId;
 

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -1,7 +1,11 @@
 import type { Branch, Repo } from '@agor-live/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FRAMEWORK_REPO_SLUG, findFrameworkRepo } from '../hooks/useFrameworkRepo';
-import { type SeedOnboardingTeammateInput, seedOnboardingTeammate } from './seedOnboardingTeammate';
+import {
+  onboardingTeammateWarning,
+  type SeedOnboardingTeammateInput,
+  seedOnboardingTeammate,
+} from './seedOnboardingTeammate';
 import { startTeammateBootstrapSession } from './startTeammateBootstrapSession';
 import { createTeammateBranch } from './teammateCreation';
 
@@ -110,7 +114,7 @@ describe('seedOnboardingTeammate', () => {
       expect(createTeammateBranchMock).not.toHaveBeenCalled();
       expect(startTeammateBootstrapSessionMock).not.toHaveBeenCalled();
       expect(onWarn).toHaveBeenCalledTimes(1);
-      expect(onWarn.mock.calls[0][0]).toMatch(/still finishing setup/i);
+      expect(onWarn.mock.calls[0][0].message).toMatch(/still finishing setup/i);
       expect(result).toEqual({});
     });
   }
@@ -146,7 +150,8 @@ describe('seedOnboardingTeammate', () => {
 
     expect(startTeammateBootstrapSessionMock).not.toHaveBeenCalled();
     expect(onWarn).toHaveBeenCalledTimes(1);
-    expect(onWarn.mock.calls[0][0]).toMatch(/couldn't start your AI teammate/i);
+    expect(onWarn.mock.calls[0][0].message).toMatch(/couldn't start your AI teammate/i);
+    expect(onWarn.mock.calls[0][0].message).not.toContain('boom');
     expect(result).toEqual({});
   });
 
@@ -157,5 +162,34 @@ describe('seedOnboardingTeammate', () => {
     expect(createTeammateBranchMock).not.toHaveBeenCalled();
     expect(onWarn).not.toHaveBeenCalled();
     expect(result).toEqual({});
+  });
+});
+
+describe('onboardingTeammateWarning', () => {
+  it('turns a raw low-credit provider error into actionable, non-blocking copy', () => {
+    const warning = onboardingTeammateWarning(
+      new Error('400: credit balance too low; request_id=req_secret'),
+      'claude-code'
+    );
+
+    expect(warning.message).toMatch(/board is ready/i);
+    expect(warning.message).toMatch(/needs more credit/i);
+    expect(warning.message).not.toContain('credit balance too low');
+    expect(warning.message).not.toContain('req_secret');
+    expect(warning.action).toEqual({
+      label: 'Open Anthropic billing',
+      href: 'https://console.anthropic.com/settings/billing',
+    });
+  });
+
+  it('does not expose an unknown provider error in onboarding copy', () => {
+    const warning = onboardingTeammateWarning(
+      new Error('SDK exploded with internal request metadata'),
+      'codex'
+    );
+
+    expect(warning.message).toMatch(/try again from the board/i);
+    expect(warning.message).not.toContain('SDK exploded');
+    expect(warning.action).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -24,7 +24,51 @@ export interface SeedOnboardingTeammateInput {
   onUpdateBranch: TeammateCreationDeps['onUpdateBranch'];
   onCreateSession: (config: unknown, boardId: string) => Promise<string | null>;
   /** Non-fatal warning surface — teammate creation must never block completion. */
-  onWarn: (message: string) => void;
+  onWarn: (warning: OnboardingTeammateWarning) => void;
+}
+
+export interface OnboardingTeammateWarning {
+  message: string;
+  action?: { label: string; href: string };
+}
+
+const BILLING_LINKS: Partial<Record<AgenticToolName, { provider: string; href: string }>> = {
+  'claude-code': {
+    provider: 'Anthropic',
+    href: 'https://console.anthropic.com/settings/billing',
+  },
+  codex: {
+    provider: 'OpenAI',
+    href: 'https://platform.openai.com/settings/organization/billing/overview',
+  },
+  gemini: {
+    provider: 'Google AI Studio',
+    href: 'https://aistudio.google.com/app/billing',
+  },
+};
+
+const LOW_CREDIT_ERROR =
+  /credit balance.{0,20}(?:too low|depleted|exhausted)|insufficient[_\s-]*quota|billing.{0,30}(?:limit|credit)|payment required|purchase (?:more )?credits?/i;
+
+export function onboardingTeammateWarning(
+  error: unknown,
+  agent: AgenticToolName | null | undefined
+): OnboardingTeammateWarning {
+  const detail = error instanceof Error ? error.message : String(error);
+  const billing = agent ? BILLING_LINKS[agent] : undefined;
+  if (billing && LOW_CREDIT_ERROR.test(detail)) {
+    return {
+      message: `Your board is ready, but your ${billing.provider} account needs more credit before your AI teammate can start. Add credit, then start the teammate from your board.`,
+      action: { label: `Open ${billing.provider} billing`, href: billing.href },
+    };
+  }
+
+  // Provider/SDK errors can be terse, technical, or contain request metadata.
+  // Keep the raw value in the console for diagnostics, never in first-run copy.
+  return {
+    message:
+      "Your board is ready, but we couldn't start your AI teammate. You can try again from the board anytime.",
+  };
 }
 
 /**
@@ -45,9 +89,10 @@ export async function seedOnboardingTeammate(
   if (!teammateName || !input.boardId) return {};
 
   if (!input.frameworkRepo) {
-    input.onWarn(
-      "Your board is ready, but your AI teammate's workspace is still finishing setup. You can add a teammate from the board in a moment."
-    );
+    input.onWarn({
+      message:
+        "Your board is ready, but your AI teammate's workspace is still finishing setup. You can add a teammate from the board in a moment.",
+    });
     return {};
   }
 
@@ -69,9 +114,10 @@ export async function seedOnboardingTeammate(
     );
 
     if (!branch) {
-      input.onWarn(
-        "Your board is ready, but we couldn't set up your AI teammate's workspace. You can add a teammate from the board anytime."
-      );
+      input.onWarn({
+        message:
+          "Your board is ready, but we couldn't set up your AI teammate's workspace. You can add a teammate from the board anytime.",
+      });
       return {};
     }
 
@@ -100,11 +146,8 @@ export async function seedOnboardingTeammate(
 
     return { sessionId };
   } catch (error) {
-    input.onWarn(
-      `Your board is ready, but we couldn't start your AI teammate: ${
-        error instanceof Error ? error.message : String(error)
-      }. You can create one from the board anytime.`
-    );
+    console.error('Onboarding AI teammate bootstrap failed:', error);
+    input.onWarn(onboardingTeammateWarning(error, input.agent));
     return {};
   }
 }


### PR DESCRIPTION
## Summary

- keep onboarding completion non-blocking when the first teammate session fails
- replace raw provider/SDK errors with friendly copy that never exposes request IDs or internal details
- recognize low-credit and billing failures and offer the selected provider's billing page as a clear next step
- retain the raw error only in the browser console for diagnostics

## Root-cause finding: **(b) test-account credit state, not API-key propagation**

The wizard correctly propagates the key entered in the LLM step:

1. `OnboardingWizard.handlePrimary` awaits `onUpdateUser(...)` with the key in the selected tool's `agentic_tools` bucket before it advances to the workspace step.
2. Teammate bootstrap happens only later, from the done step, and `startTeammateBootstrapSession` creates the initial session through the normal authenticated session-create path.
3. The executor resolves credentials for the resulting task through `config/resolve-api-key`; the daemon reads `task.created_by` and resolves that user's encrypted, tool-scoped credential before falling back to tenant/native auth.

There is therefore no race or missing handoff from wizard state to bootstrap. A provider response saying the credit balance is too low came from the newly persisted user credential/account (or its provider-side project/org), so the observed report is consistent with the tester's account genuinely lacking usable credit. No credential-propagation code change is needed.

## Validation

- `pnpm --filter agor-ui exec vitest run src/utils/seedOnboardingTeammate.test.ts` (8 tests)
- `pnpm --filter agor-ui exec vitest run src/utils/seedOnboardingTeammate.test.ts src/components/OnboardingWizard/OnboardingWizard.test.tsx` (40 tests)
- `pnpm i && pnpm check`

Closes #2288
