### PR TITLE
Fix production Stop to Stopping convergence

### DIFF
--- a/apps/agor-daemon/src/executor-tracking.test.ts
+++ b/apps/agor-daemon/src/executor-tracking.test.ts
@@ -43,6 +43,42 @@ describe.runIf(process.platform === 'linux' || process.platform === 'darwin')(
       }
     });
 
+    it('waits through transient strict-mode EPERM after cooperative quiescence', async () => {
+      const owner = {};
+      const inspectGroupForTest = vi
+        .fn<
+          (
+            pgid: number,
+            signal?: 0 | NodeJS.Signals,
+            asUser?: string
+          ) => 'present' | 'absent' | 'unverified'
+        >()
+        .mockReturnValueOnce('unverified')
+        .mockReturnValue('absent');
+      trackExecutorProcess(
+        {
+          sessionId: 'session-strict-wrapper',
+          taskId: 'task-strict-wrapper',
+          pid: process.pid,
+          asUser: 'alice',
+        },
+        owner
+      );
+      try {
+        await expect(
+          containExecutorProcess(
+            'session-strict-wrapper',
+            'task-strict-wrapper',
+            { preSignalGraceMs: 25, pollMs: 1, inspectGroupForTest },
+            owner
+          )
+        ).resolves.toEqual({ status: 'verified_absent' });
+        expect(inspectGroupForTest).toHaveBeenCalledTimes(2);
+      } finally {
+        untrackExecutorProcess('session-strict-wrapper', 'task-strict-wrapper', owner);
+      }
+    });
+
     it('kills a process group whose leader and descendant ignore SIGTERM', async () => {
       const script = `
         const { spawn } = require('node:child_process');

--- a/apps/agor-daemon/src/executor-tracking.ts
+++ b/apps/agor-daemon/src/executor-tracking.ts
@@ -204,14 +204,15 @@ async function waitForAbsence(
   pgid: number,
   timeoutMs: number,
   pollMs: number,
-  asUser?: string
+  asUser?: string,
+  inspect: typeof inspectGroup = inspectGroup
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (inspectGroup(pgid, 0, asUser) === 'absent') return true;
+    if (inspect(pgid, 0, asUser) === 'absent') return true;
     await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
   }
-  return inspectGroup(pgid, 0, asUser) === 'absent';
+  return inspect(pgid, 0, asUser) === 'absent';
 }
 
 export function trackExecutorProcess(
@@ -260,6 +261,12 @@ async function containExecutorIdentity(
     pollMs?: number;
     /** A recovered identity cannot safely signal a group after its leader exited. */
     recovered?: boolean;
+    /** Deterministic test seam for transient cross-UID inspection results. */
+    inspectGroupForTest?: (
+      pgid: number,
+      signal?: 0 | NodeJS.Signals,
+      asUser?: string
+    ) => 'present' | 'absent' | 'unverified';
   } = {}
 ): Promise<ContainmentResult> {
   if (process.platform !== 'linux' && process.platform !== 'darwin') {
@@ -276,9 +283,31 @@ async function containExecutorIdentity(
   ) {
     return { status: 'verified_absent' };
   }
-  const initial = inspectGroup(tracked.pgid, 0, tracked.asUser);
-  if (initial === 'absent') return { status: 'verified_absent' };
-  if (initial === 'unverified') {
+  const inspect = options.inspectGroupForTest ?? inspectGroup;
+  let inspection = inspect(tracked.pgid, 0, tracked.asUser);
+  if (inspection === 'absent') return { status: 'verified_absent' };
+
+  // A strict-mode executor runs below a root-owned sudo wrapper in the same
+  // process group. After the scoped executor acknowledges quiescence, its
+  // user may temporarily get EPERM while that wrapper unwinds. Honor the
+  // cooperative grace before treating this transient inspection as durable
+  // uncertainty; absence must still be observed explicitly.
+  if (options.preSignalGraceMs) {
+    if (
+      await waitForAbsence(
+        tracked.pgid,
+        options.preSignalGraceMs,
+        options.pollMs ?? 50,
+        tracked.asUser,
+        inspect
+      )
+    ) {
+      return { status: 'verified_absent' };
+    }
+    inspection = inspect(tracked.pgid, 0, tracked.asUser);
+  }
+
+  if (inspection === 'unverified') {
     return {
       status: 'unverified',
       reason: tracked.asUser
@@ -308,20 +337,8 @@ async function containExecutorIdentity(
     }
   }
 
-  if (
-    options.preSignalGraceMs &&
-    (await waitForAbsence(
-      tracked.pgid,
-      options.preSignalGraceMs,
-      options.pollMs ?? 50,
-      tracked.asUser
-    ))
-  ) {
-    return { status: 'verified_absent' };
-  }
-
   const signal = (value: NodeJS.Signals): ContainmentResult | undefined => {
-    const result = inspectGroup(tracked.pgid, value, tracked.asUser);
+    const result = inspect(tracked.pgid, value, tracked.asUser);
     if (result === 'present') return undefined;
     if (result === 'absent') return { status: 'verified_absent' };
     return { status: 'unverified', reason: `${value} process-group signal was not authorized.` };
@@ -337,7 +354,8 @@ async function containExecutorIdentity(
       tracked.pgid,
       options.termGraceMs ?? DEFAULT_EXECUTOR_TERM_GRACE_MS,
       options.pollMs ?? 50,
-      tracked.asUser
+      tracked.asUser,
+      inspect
     )
   ) {
     return { status: 'verified_absent' };
@@ -351,7 +369,8 @@ async function containExecutorIdentity(
       tracked.pgid,
       options.killGraceMs ?? DEFAULT_EXECUTOR_KILL_GRACE_MS,
       options.pollMs ?? 50,
-      tracked.asUser
+      tracked.asUser,
+      inspect
     )
   ) {
     return { status: 'verified_absent' };
@@ -368,6 +387,12 @@ export async function containExecutorProcess(
     termGraceMs?: number;
     killGraceMs?: number;
     pollMs?: number;
+    /** Deterministic test seam for transient cross-UID inspection results. */
+    inspectGroupForTest?: (
+      pgid: number,
+      signal?: 0 | NodeJS.Signals,
+      asUser?: string
+    ) => 'present' | 'absent' | 'unverified';
   } = {},
   owner?: object
 ): Promise<ContainmentResult> {

--- a/apps/agor-daemon/src/executor-tracking.ts
+++ b/apps/agor-daemon/src/executor-tracking.ts
@@ -176,6 +176,11 @@ function readBootIdentity(): string | undefined {
 }
 
 type GroupInspection = 'present' | 'absent' | 'unverified';
+type GroupInspector = (
+  pgid: number,
+  signal?: 0 | NodeJS.Signals,
+  asUser?: string
+) => GroupInspection;
 
 function inspectGroup(
   pgid: number,
@@ -205,7 +210,7 @@ async function waitForAbsence(
   timeoutMs: number,
   pollMs: number,
   asUser?: string,
-  inspect: typeof inspectGroup = inspectGroup
+  inspect: GroupInspector = inspectGroup
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -262,11 +267,7 @@ async function containExecutorIdentity(
     /** A recovered identity cannot safely signal a group after its leader exited. */
     recovered?: boolean;
     /** Deterministic test seam for transient cross-UID inspection results. */
-    inspectGroupForTest?: (
-      pgid: number,
-      signal?: 0 | NodeJS.Signals,
-      asUser?: string
-    ) => 'present' | 'absent' | 'unverified';
+    inspectGroupForTest?: GroupInspector;
   } = {}
 ): Promise<ContainmentResult> {
   if (process.platform !== 'linux' && process.platform !== 'darwin') {
@@ -388,11 +389,7 @@ export async function containExecutorProcess(
     killGraceMs?: number;
     pollMs?: number;
     /** Deterministic test seam for transient cross-UID inspection results. */
-    inspectGroupForTest?: (
-      pgid: number,
-      signal?: 0 | NodeJS.Signals,
-      asUser?: string
-    ) => 'present' | 'absent' | 'unverified';
+    inspectGroupForTest?: GroupInspector;
   } = {},
   owner?: object
 ): Promise<ContainmentResult> {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1612,7 +1612,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_stop',
     {
       description:
-        'Stop a running session. Kills the executor process and sets the session to idle. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, stopping, awaiting_permission, awaiting_input).',
+        'Request that a running session stop. The session becomes idle only after Agor verifies executor quiescence or process absence; otherwise it remains guarded in stopping. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, stopping, awaiting_permission, awaiting_input).',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
         sessionId: mcpRequiredId('sessionId', 'Session', 'Session ID to stop (UUIDv7 or short ID)'),

--- a/apps/agor-daemon/src/register-routes.task-terminal.test.ts
+++ b/apps/agor-daemon/src/register-routes.task-terminal.test.ts
@@ -2,8 +2,9 @@ import { BadRequest, Forbidden } from '@agor/core/feathers';
 import { type Task, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  authorizeForceFailRoute,
   authorizeTaskTerminalRoute,
-  findUnverifiedTerminationTask,
+  findMatchingUnverifiedTerminationTask,
   rejectRemovedClaudeCliRestart,
 } from './register-routes.js';
 import { REMOVED_AGENTIC_TOOL_RUNTIME_MESSAGE } from './utils/agentic-tool-runtime.js';
@@ -44,15 +45,92 @@ describe('task complete/fail route authorization', () => {
   });
 });
 
-it('selects the unverified active task even when newer queued work exists', () => {
-  const stopping = {
-    task_id: 'task-stopping',
+it('does not apply a stale force-fail target to a later unverified Task', () => {
+  const taskA = {
+    task_id: 'task-a',
+    status: TaskStatus.FAILED,
+    termination_request: { requested_at: '2026-01-01T00:00:00.000Z' },
+  } as Task;
+  const taskB = {
+    task_id: 'task-b',
     status: TaskStatus.STOPPING,
     sdk_failure: { termination: 'unverified' },
+    termination_request: { requested_at: '2026-01-01T00:01:00.000Z' },
   } as Task;
-  const queued = { task_id: 'task-queued', status: TaskStatus.QUEUED } as Task;
 
-  expect(findUnverifiedTerminationTask([queued, stopping])).toBe(stopping);
+  expect(
+    findMatchingUnverifiedTerminationTask([taskA, taskB], {
+      taskId: taskA.task_id,
+      terminationRequestedAt: taskA.termination_request!.requested_at,
+    })
+  ).toBeUndefined();
+  expect(
+    findMatchingUnverifiedTerminationTask([taskB], {
+      taskId: taskB.task_id,
+      terminationRequestedAt: '2026-01-01T00:00:59.000Z',
+    })
+  ).toBeUndefined();
+});
+
+describe('force-fail route authorization and request fencing', () => {
+  const stopping = {
+    task_id: 'task-a',
+    status: TaskStatus.STOPPING,
+    sdk_failure: { termination: 'unverified' },
+    termination_request: { requested_at: '2026-01-01T00:00:00.000Z' },
+  } as Task;
+  const body = {
+    confirmation: 'STOP',
+    task_id: stopping.task_id,
+    termination_requested_at: stopping.termination_request!.requested_at,
+  };
+
+  it('authorizes a branch owner and returns the exact Task epoch', async () => {
+    await expect(
+      authorizeForceFailRoute({
+        session: { branch_id: 'branch-a' as never },
+        params: { user: { user_id: 'user-a', role: 'member' } } as never,
+        body,
+        findActiveTasks: async () => [stopping],
+        isBranchOwner: async () => true,
+      })
+    ).resolves.toMatchObject({
+      task: stopping,
+      confirmation: 'STOP',
+      terminationRequestedAt: stopping.termination_request!.requested_at,
+    });
+  });
+
+  it('rejects non-owners before loading active Task state', async () => {
+    const findActiveTasks = vi.fn().mockResolvedValue([stopping]);
+    await expect(
+      authorizeForceFailRoute({
+        session: { branch_id: 'branch-a' as never },
+        params: { user: { user_id: 'user-b', role: 'member' } } as never,
+        body,
+        findActiveTasks,
+        isBranchOwner: async () => false,
+      })
+    ).rejects.toBeInstanceOf(Forbidden);
+    expect(findActiveTasks).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale Task epoch instead of selecting a later unverified Task', async () => {
+    const later = {
+      ...stopping,
+      task_id: 'task-b',
+      termination_request: { requested_at: '2026-01-01T00:01:00.000Z' },
+    } as Task;
+    await expect(
+      authorizeForceFailRoute({
+        session: { branch_id: 'branch-a' as never },
+        params: { user: { user_id: 'admin-a', role: 'admin' } } as never,
+        body,
+        findActiveTasks: async () => [later],
+        isBranchOwner: async () => false,
+      })
+    ).rejects.toThrow('termination state changed');
+  });
 });
 
 it('keeps the stale restart endpoint as an explicit removed-runtime tombstone', () => {

--- a/apps/agor-daemon/src/register-routes.task-terminal.test.ts
+++ b/apps/agor-daemon/src/register-routes.task-terminal.test.ts
@@ -121,15 +121,17 @@ describe('force-fail route authorization and request fencing', () => {
       task_id: 'task-b',
       termination_request: { requested_at: '2026-01-01T00:01:00.000Z' },
     } as Task;
+    const isBranchOwner = vi.fn().mockResolvedValue(false);
     await expect(
       authorizeForceFailRoute({
         session: { branch_id: 'branch-a' as never },
         params: { user: { user_id: 'admin-a', role: 'admin' } } as never,
         body,
         findActiveTasks: async () => [later],
-        isBranchOwner: async () => false,
+        isBranchOwner,
       })
     ).rejects.toThrow('termination state changed');
+    expect(isBranchOwner).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2655,7 +2655,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               throw new Forbidden('Only a branch owner or administrator may force-fail a Task.');
             }
             if (typeof body.confirmation !== 'string') {
-              throw new BadRequest(`Type ${shortId(taskId)} to confirm force-fail.`);
+              throw new BadRequest('Type STOP to confirm force-fail.');
             }
             const failedTask = await forceFailUnverifiedTask({
               app,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -397,7 +397,8 @@ export async function authorizeForceFailRoute(input: {
 }): Promise<{ task: Task; confirmation: string; terminationRequestedAt: string }> {
   const userId = input.params.user?.user_id;
   const isAdmin = hasMinimumRole(input.params.user?.role, ROLES.ADMIN);
-  const isOwner = !!userId && (await input.isBranchOwner(input.session.branch_id, userId as UUID));
+  const isOwner =
+    !isAdmin && !!userId && (await input.isBranchOwner(input.session.branch_id, userId as UUID));
   if (!isAdmin && !isOwner) {
     throw new Forbidden('Only a branch owner or administrator may force-fail a Task.');
   }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -316,9 +316,16 @@ export async function authorizeTaskTerminalRoute(input: {
   return internalParams;
 }
 
-export function findUnverifiedTerminationTask(tasks: readonly Task[]): Task | undefined {
+export function findMatchingUnverifiedTerminationTask(
+  tasks: readonly Task[],
+  expected: { taskId: string; terminationRequestedAt: string }
+): Task | undefined {
   return tasks.find(
-    (task) => task.status === TaskStatus.STOPPING && task.sdk_failure?.termination === 'unverified'
+    (task) =>
+      task.task_id === expected.taskId &&
+      task.status === TaskStatus.STOPPING &&
+      task.sdk_failure?.termination === 'unverified' &&
+      task.termination_request?.requested_at === expected.terminationRequestedAt
   );
 }
 
@@ -378,6 +385,44 @@ export function createUploadAuthMiddleware(input: {
       console.error('❌ [Upload Auth] Authentication failed:', error);
       res.status(401).json({ error: 'Authentication required' });
     }
+  };
+}
+
+export async function authorizeForceFailRoute(input: {
+  session: Pick<Session, 'branch_id'>;
+  params: RouteParams;
+  body: Record<string, unknown>;
+  findActiveTasks: () => Promise<readonly Task[]>;
+  isBranchOwner: (branchId: Session['branch_id'], userId: UUID) => Promise<boolean>;
+}): Promise<{ task: Task; confirmation: string; terminationRequestedAt: string }> {
+  const userId = input.params.user?.user_id;
+  const isAdmin = hasMinimumRole(input.params.user?.role, ROLES.ADMIN);
+  const isOwner = !!userId && (await input.isBranchOwner(input.session.branch_id, userId as UUID));
+  if (!isAdmin && !isOwner) {
+    throw new Forbidden('Only a branch owner or administrator may force-fail a Task.');
+  }
+  if (typeof input.body.confirmation !== 'string') {
+    throw new BadRequest('Type STOP to confirm force-fail.');
+  }
+  if (
+    typeof input.body.task_id !== 'string' ||
+    typeof input.body.termination_requested_at !== 'string'
+  ) {
+    throw new BadRequest('Force-fail requires the exact Task termination request.');
+  }
+  const task = findMatchingUnverifiedTerminationTask(await input.findActiveTasks(), {
+    taskId: input.body.task_id,
+    terminationRequestedAt: input.body.termination_requested_at,
+  });
+  if (!task) {
+    throw new Conflict(
+      'The Task termination state changed. Review the current Task before force-failing.'
+    );
+  }
+  return {
+    task,
+    confirmation: input.body.confirmation,
+    terminationRequestedAt: input.body.termination_requested_at,
   };
 }
 
@@ -2638,29 +2683,22 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         };
         if (body.force_unverified === true) {
           const result = await withSessionTurnLock(sessionTurnLocks, id as SessionID, async () => {
-            const { session, activeTasks } = await inCurrentTenantDatabaseScope(async () => {
+            const target = await inCurrentTenantDatabaseScope(async () => {
               const session = await app.service('sessions').get(id, params);
-              const activeTasks = await findActiveTasksForSession(app, session.session_id, params);
-              return { session, activeTasks };
+              return authorizeForceFailRoute({
+                session,
+                params,
+                body,
+                findActiveTasks: () => findActiveTasksForSession(app, session.session_id, params),
+                isBranchOwner: (branchId, userId) =>
+                  stopRouteRepositories.branchRepo.isOwner(branchId, userId),
+              });
             });
-            const task = findUnverifiedTerminationTask(activeTasks);
-            if (!task) throw new BadRequest('Session has no unverified Task to force-fail.');
-            const taskId = task.task_id;
-            const userId = params.user?.user_id;
-            const isAdmin = hasMinimumRole(params.user?.role, ROLES.ADMIN);
-            const isOwner =
-              !!userId &&
-              (await stopRouteRepositories.branchRepo.isOwner(session.branch_id, userId as UUID));
-            if (!isAdmin && !isOwner) {
-              throw new Forbidden('Only a branch owner or administrator may force-fail a Task.');
-            }
-            if (typeof body.confirmation !== 'string') {
-              throw new BadRequest('Type STOP to confirm force-fail.');
-            }
             const failedTask = await forceFailUnverifiedTask({
               app,
-              taskId,
-              confirmation: body.confirmation,
+              taskId: target.task.task_id,
+              terminationRequestedAt: target.terminationRequestedAt,
+              confirmation: target.confirmation,
               params,
             });
             return {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -411,6 +411,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
     await this.runAfterTenantDatabaseCommit('publish termination claim', async () => {
       if (claimed) {
+        console.log(
+          `[task.termination] event=request_committed task_id=${shortId(result.task.task_id)} ` +
+            `cause=${result.task.termination_request?.cause ?? 'unknown'} ` +
+            `mode=${result.task.executor_mode ?? 'local'}`
+        );
         emitServiceEvent(this.app, {
           path: 'tasks',
           event: 'patched',
@@ -474,6 +479,17 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     if (result.outcome !== 'transitioned' && result.outcome !== 'unverified') return result;
 
     await this.runAfterTenantDatabaseCommit('publish termination settlement', async () => {
+      if (result.outcome === 'unverified') {
+        console.warn(
+          `[task.termination] event=settled task_id=${shortId(result.task.task_id)} ` +
+            `outcome=unverified mode=${result.task.executor_mode ?? 'local'}`
+        );
+      } else {
+        console.log(
+          `[task.termination] event=settled task_id=${shortId(result.task.task_id)} ` +
+            `outcome=${result.task.status} mode=${result.task.executor_mode ?? 'local'}`
+        );
+      }
       emitServiceEvent(this.app, {
         path: 'tasks',
         event: 'patched',
@@ -1347,14 +1363,19 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     const coordinatorParams = { ...(params ?? {}), provider: undefined };
     deferWithTenantContext(
       params,
-      () =>
-        requestExecutorTermination({
+      () => {
+        console.log(
+          `[task.termination] event=executor_quiescence_committed ` +
+            `task_id=${shortId(task.task_id)} mode=${task.executor_mode ?? 'local'}`
+        );
+        return requestExecutorTermination({
           app: this.app,
           taskId: task.task_id,
           cause: terminationRequest.cause,
           errorMessage: terminationRequest.error_message ?? 'Executor stopped cooperatively.',
           params: coordinatorParams,
-        }).then(() => undefined),
+        }).then(() => undefined);
+      },
       (error) =>
         console.error(
           `[termination] Failed to settle executor report for Task ${shortId(task.task_id)}:`,

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -541,5 +541,12 @@ describe('termination coordinator', () => {
       confirmation: 'STOP',
     });
     expect(state.settleTermination).toHaveBeenCalledTimes(2);
+    expect(state.settleTermination).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        outcome: 'forced_unverified',
+        expectedTerminationRequestedAt: '2026-01-01T00:00:01.000Z',
+      }),
+      expect.objectContaining({ suppressTerminalQueueProcessing: true })
+    );
   });
 });

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -185,6 +185,31 @@ describe('termination coordinator', () => {
     expect(containExecutorProcess).not.toHaveBeenCalled();
   });
 
+  it('does not expose remote force-fail after only the local one-second signal grace', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = appDouble();
+      const remoteStopping = {
+        ...stopping('user_stop'),
+        executor_mode: 'templated',
+        executor_connected_at: '2026-01-01T00:00:00.000Z',
+      };
+      state.claim(remoteStopping);
+      state.settle(task(TaskStatus.STOPPED));
+
+      const result = request(state.app, 'user_stop');
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(state.settleTermination).not.toHaveBeenCalled();
+
+      state.markExecutorQuiesced();
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(result).resolves.toMatchObject({ status: 'terminal' });
+      expect(containExecutorProcess).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('still verifies local process absence after executor quiescence', async () => {
     containExecutorProcess.mockResolvedValue({ status: 'verified_absent' });
     const state = appDouble();
@@ -441,7 +466,7 @@ describe('termination coordinator', () => {
     expect(containExecutorProcess).toHaveBeenCalledWith(sessionId, taskId, {}, state.app);
   });
 
-  it('requires the short Task ID before force-failing unverified work', async () => {
+  it('requires the stable STOP phrase before force-failing unverified work', async () => {
     containExecutorProcess.mockResolvedValue({ status: 'unverified', reason: 'EPERM' });
     const state = appDouble();
     state.claim(stopping('heartbeat_lost'));
@@ -456,12 +481,12 @@ describe('termination coordinator', () => {
 
     await expect(
       forceFailUnverifiedTask({ app: state.app, taskId, confirmation: 'bad' })
-    ).rejects.toThrow('Type 018f0000');
+    ).rejects.toThrow('Type STOP');
     state.settle(task(TaskStatus.FAILED));
     await forceFailUnverifiedTask({
       app: state.app,
       taskId,
-      confirmation: '018f00000000700080000000',
+      confirmation: 'STOP',
     });
     expect(state.settleTermination).toHaveBeenCalledTimes(2);
   });

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -210,6 +210,44 @@ describe('termination coordinator', () => {
     }
   });
 
+  it('reports the remote acknowledgement timeout without claiming local PID containment', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = appDouble();
+      const remoteStopping = {
+        ...stopping('user_stop'),
+        executor_mode: 'templated',
+        executor_connected_at: '2026-01-01T00:00:00.000Z',
+      };
+      state.claim(remoteStopping);
+      state.settle(
+        task(TaskStatus.STOPPING, {
+          ...remoteStopping,
+          sdk_failure: { termination: 'unverified' },
+        }),
+        'unverified'
+      );
+
+      const result = request(state.app, 'user_stop');
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(result).resolves.toMatchObject({
+        status: 'unverified',
+        reason: expect.stringContaining('did not acknowledge quiescence'),
+      });
+      expect(containExecutorProcess).not.toHaveBeenCalled();
+      expect(state.settleTermination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'unverified',
+          errorMessage: expect.stringContaining('did not acknowledge quiescence'),
+        }),
+        expect.anything()
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('still verifies local process absence after executor quiescence', async () => {
     containExecutorProcess.mockResolvedValue({ status: 'verified_absent' });
     const state = appDouble();
@@ -480,12 +518,26 @@ describe('termination coordinator', () => {
     await request(state.app, 'heartbeat_lost');
 
     await expect(
-      forceFailUnverifiedTask({ app: state.app, taskId, confirmation: 'bad' })
+      forceFailUnverifiedTask({
+        app: state.app,
+        taskId,
+        terminationRequestedAt: '2026-01-01T00:00:01.000Z',
+        confirmation: 'bad',
+      })
     ).rejects.toThrow('Type STOP');
+    await expect(
+      forceFailUnverifiedTask({
+        app: state.app,
+        taskId,
+        terminationRequestedAt: '2026-01-01T00:00:00.000Z',
+        confirmation: 'STOP',
+      })
+    ).rejects.toThrow('termination state changed');
     state.settle(task(TaskStatus.FAILED));
     await forceFailUnverifiedTask({
       app: state.app,
       taskId,
+      terminationRequestedAt: '2026-01-01T00:00:01.000Z',
       confirmation: 'STOP',
     });
     expect(state.settleTermination).toHaveBeenCalledTimes(2);

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -61,19 +61,32 @@ interface LocalTerminationOperation {
 }
 
 const operationsByApp = new WeakMap<object, Map<string, LocalTerminationOperation>>();
-const DEFAULT_COOPERATIVE_GRACE_MS = 1000;
+const DEFAULT_LOCAL_COOPERATIVE_GRACE_MS = 1_000;
+// A remote/templated executor has no daemon-side PGID fallback. Give normal
+// provider cleanup enough time to acknowledge before exposing force-fail;
+// late fenced acknowledgements remain recoverable after this bounded window.
+const DEFAULT_REMOTE_COOPERATIVE_GRACE_MS = 15_000;
 const COOPERATIVE_POLL_MS = 25;
 const LOCAL_WRAPPER_EXIT_GRACE_MS = 250;
 const COORDINATION_LEASE_MARGIN_MS = 5_000;
 const DEFAULT_COORDINATION_LEASE_MS = 30_000;
 
-function coordinationLeaseMs(input: TerminationInput): number {
+function cooperativeGraceMs(input: TerminationInput, task: Task): number {
+  return (
+    input.signalDelayMs ??
+    input.cooperativeGraceMs ??
+    (task.executor_mode === 'templated'
+      ? DEFAULT_REMOTE_COOPERATIVE_GRACE_MS
+      : DEFAULT_LOCAL_COOPERATIVE_GRACE_MS)
+  );
+}
+
+function coordinationLeaseMs(input: TerminationInput, task: Task): number {
   if (input.coordinationLeaseMs !== undefined) return input.coordinationLeaseMs;
-  const cooperativeGraceMs =
-    input.signalDelayMs ?? input.cooperativeGraceMs ?? DEFAULT_COOPERATIVE_GRACE_MS;
+  const graceMs = cooperativeGraceMs(input, task);
   return Math.max(
     DEFAULT_COORDINATION_LEASE_MS,
-    cooperativeGraceMs +
+    graceMs +
       LOCAL_WRAPPER_EXIT_GRACE_MS +
       DEFAULT_EXECUTOR_TERM_GRACE_MS +
       DEFAULT_EXECUTOR_KILL_GRACE_MS +
@@ -144,7 +157,7 @@ async function waitForExecutorQuiescence(input: TerminationInput, requested: Tas
     return requested;
   }
 
-  const graceMs = input.signalDelayMs ?? input.cooperativeGraceMs ?? DEFAULT_COOPERATIVE_GRACE_MS;
+  const graceMs = cooperativeGraceMs(input, requested);
   if (graceMs <= 0) return requested;
 
   const tasks = input.app.service('tasks');
@@ -308,7 +321,7 @@ async function claimContainmentCoordination(
       {
         taskId: task.task_id,
         claimToken: token,
-        leaseDurationMs: coordinationLeaseMs(input),
+        leaseDurationMs: coordinationLeaseMs(input, task),
         instanceId: identity.instanceId,
         bootId: identity.bootId,
         ...(localMode && !ownsLocalHandle && input.unownedLocalOwnerGraceMs !== undefined
@@ -412,8 +425,8 @@ export async function forceFailUnverifiedTask(input: {
   ) {
     throw new Conflict('Only a Task with unverified termination may be force-failed.');
   }
-  if (input.confirmation !== shortId(current.task_id)) {
-    throw new BadRequest(`Type ${shortId(current.task_id)} to confirm force-fail.`);
+  if (input.confirmation !== 'STOP') {
+    throw new BadRequest('Type STOP to confirm force-fail.');
   }
   console.warn(
     `[SECURITY] Force-failing Task ${shortId(current.task_id)} without verified executor termination`

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -212,11 +212,18 @@ async function runContainment(
   const executorQuiesced = !!current.termination_request?.executor_quiesced_at;
   // A scoped remote executor is the only component able to authoritatively
   // quiesce its SDK runtime. Local mode additionally verifies PGID absence.
-  const remoteCooperativeContainment = current.executor_mode === 'templated' && executorQuiesced;
+  const remoteMode = current.executor_mode === 'templated';
   const containment = input.absenceVerified
     ? ({ status: 'verified_absent' } as const)
-    : remoteCooperativeContainment
-      ? ({ status: 'verified_absent' } as const)
+    : remoteMode
+      ? executorQuiesced
+        ? ({ status: 'verified_absent' } as const)
+        : ({
+            status: 'unverified',
+            reason:
+              `Remote executor did not acknowledge quiescence for this termination request ` +
+              `within ${cooperativeGraceMs(input, current)}ms.`,
+          } as const)
       : executorQuiesced
         ? await containExecutorProcess(
             current.session_id,
@@ -413,20 +420,24 @@ export async function beginExecutorTermination(input: TerminationInput): Promise
 export async function forceFailUnverifiedTask(input: {
   app: Application;
   taskId: TaskID | string;
+  terminationRequestedAt: string;
   confirmation: string;
   params?: Params;
 }): Promise<Task> {
   const tasks = input.app.service('tasks') as unknown as TasksServiceImpl;
   const current = await tasks.get(input.taskId, input.params);
+  if (input.confirmation !== 'STOP') {
+    throw new BadRequest('Type STOP to confirm force-fail.');
+  }
   if (
     current.status !== TaskStatus.STOPPING ||
     !current.termination_request ||
+    current.termination_request.requested_at !== input.terminationRequestedAt ||
     current.sdk_failure?.termination !== 'unverified'
   ) {
-    throw new Conflict('Only a Task with unverified termination may be force-failed.');
-  }
-  if (input.confirmation !== 'STOP') {
-    throw new BadRequest('Type STOP to confirm force-fail.');
+    throw new Conflict(
+      'The Task termination state changed. Review the current Task before force-failing.'
+    );
   }
   console.warn(
     `[SECURITY] Force-failing Task ${shortId(current.task_id)} without verified executor termination`

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -446,6 +446,7 @@ export async function forceFailUnverifiedTask(input: {
     {
       taskId: current.task_id,
       outcome: 'forced_unverified',
+      expectedTerminationRequestedAt: input.terminationRequestedAt,
       errorMessage: 'Force-failed by an authorized user; executor termination remains unverified.',
     },
     { ...internalParams(input.params), suppressTerminalQueueProcessing: true } as Params

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -51,6 +51,32 @@ describe('markStoppedSessionPromptableNoDrain', () => {
 });
 
 describe('stopSessionPreserveQueue', () => {
+  it('treats an already-idle session as an idempotent successful Stop', async () => {
+    const findQueued = vi.fn().mockResolvedValue([{ task_id: 'queued-task' }]);
+    const requestTermination = vi.fn();
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued } as never,
+          sessionsService: {
+            get: vi.fn().mockResolvedValue({ status: 'idle' }),
+            patch: vi.fn(),
+          } as never,
+          requestTermination: requestTermination as never,
+        },
+        'session-idle' as never
+      )
+    ).resolves.toEqual({
+      success: true,
+      status: 'idle',
+      reason: 'Session is already idle',
+      queuedTasksPreserved: 1,
+    });
+    expect(findQueued).toHaveBeenCalledWith('session-idle');
+    expect(requestTermination).not.toHaveBeenCalled();
+  });
+
   it('rejects process control for a historical removed-runtime session', async () => {
     const task = {
       task_id: 'task-cli',

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -68,6 +68,19 @@ export async function stopSessionPreserveQueue(
 ): Promise<StopSessionResult> {
   const session = await deps.sessionsService.get(sessionId, params);
 
+  // Stop is idempotent across retries and the per-session turn lock. A
+  // concurrent caller can observe the first caller's already-committed idle
+  // projection; report the requested postcondition instead of a false failure.
+  if (session.status === SessionStatus.IDLE) {
+    const queuedTasks = await deps.taskRepo.findQueued(sessionId);
+    return {
+      success: true,
+      status: SessionStatus.IDLE,
+      reason: 'Session is already idle',
+      queuedTasksPreserved: queuedTasks.length,
+    };
+  }
+
   if (!isSessionExecuting(session)) {
     return {
       success: false,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -156,7 +156,7 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
       } as Task,
     ];
     const create = vi.fn().mockRejectedValue(new Error('denied'));
-    vi.spyOn(window, 'prompt').mockReturnValue('018f00000000700080000000');
+    const nativePrompt = vi.spyOn(window, 'prompt');
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     renderPanel({
       client: {
@@ -167,7 +167,33 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
 
     fireEvent.click(await screen.findByRole('button', { name: 'Stop' }));
 
+    expect(await screen.findByRole('dialog', { name: 'Force-fail task?' })).toBeInTheDocument();
+    expect(screen.getByText('Executor termination is unverified')).toBeInTheDocument();
+    expect(screen.getByText(/cannot prove or guarantee process termination/i)).toBeInTheDocument();
+    const forceFail = screen.getByRole('button', { name: 'Force fail' });
+    expect(forceFail).toBeDisabled();
+    const confirmation = screen.getByRole('textbox', {
+      name: 'Type STOP to confirm force-fail',
+    });
+    await waitFor(() => expect(confirmation).toHaveFocus());
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Force-fail task?' })).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    const reopenedConfirmation = await screen.findByRole('textbox', {
+      name: 'Type STOP to confirm force-fail',
+    });
+    const reopenedForceFail = screen.getByRole('button', { name: 'Force fail' });
+    expect(reopenedForceFail).toBeDisabled();
+    fireEvent.change(reopenedConfirmation, { target: { value: 'STOP' } });
+    expect(reopenedForceFail).toBeEnabled();
+    fireEvent.keyDown(reopenedConfirmation, { key: 'Enter', code: 'Enter' });
+
     await waitFor(() => expect(create).toHaveBeenCalledOnce());
+    expect(create).toHaveBeenCalledWith({ force_unverified: true, confirmation: 'STOP' });
+    expect(nativePrompt).not.toHaveBeenCalled();
     expect(
       await screen.findByText('Failed to force-fail execution. You can try again.')
     ).toBeVisible();

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -153,6 +153,10 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
         task_id: '018f0000-0000-7000-8000-000000000001',
         status: 'stopping',
         sdk_failure: { termination: 'unverified' },
+        termination_request: {
+          cause: 'user_stop',
+          requested_at: '2026-06-24T00:00:01.000Z',
+        },
       } as Task,
     ];
     const create = vi.fn().mockRejectedValue(new Error('denied'));
@@ -192,7 +196,12 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
     fireEvent.keyDown(reopenedConfirmation, { key: 'Enter', code: 'Enter' });
 
     await waitFor(() => expect(create).toHaveBeenCalledOnce());
-    expect(create).toHaveBeenCalledWith({ force_unverified: true, confirmation: 'STOP' });
+    expect(create).toHaveBeenCalledWith({
+      force_unverified: true,
+      confirmation: 'STOP',
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      termination_requested_at: '2026-06-24T00:00:01.000Z',
+    });
     expect(nativePrompt).not.toHaveBeenCalled();
     expect(
       await screen.findByText('Failed to force-fail execution. You can try again.')

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -18,7 +18,6 @@ import {
   isAgenticToolName,
   mapToCodexPermissionConfig,
   SessionStatus,
-  shortId,
   TaskStatus,
 } from '@agor-live/client';
 import {
@@ -473,6 +472,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [advancedUploadInitialFiles, setAdvancedUploadInitialFiles] = React.useState<File[]>([]);
   const [composerDropActive, setComposerDropActive] = React.useState(false);
   const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
+  const [forceFailTaskId, setForceFailTaskId] = React.useState<string | null>(null);
+  const [forceFailConfirmation, setForceFailConfirmation] = React.useState('');
+  const forceFailInputRef = React.useRef<InputRef | null>(null);
   const reactiveSessionId = session?.session_id ?? null;
   const { state: reactiveSessionState } = useSharedReactiveSession(client, reactiveSessionId, {
     enabled: open,
@@ -480,6 +482,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   });
 
   const tasks = reactiveSessionState?.tasks || EMPTY_TASKS;
+  React.useEffect(() => {
+    if (
+      forceFailTaskId &&
+      !tasks.some(
+        (task) =>
+          task.task_id === forceFailTaskId &&
+          task.status === TaskStatus.STOPPING &&
+          task.sdk_failure?.termination === 'unverified'
+      )
+    ) {
+      setForceFailTaskId(null);
+      setForceFailConfirmation('');
+    }
+  }, [forceFailTaskId, tasks]);
   const attachmentInputRef = React.useRef<HTMLInputElement>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
   // Search observes only the conversation region, not the whole body: the
@@ -1100,27 +1116,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           task.status === TaskStatus.STOPPING && task.sdk_failure?.termination === 'unverified'
       );
     if (unverifiedTask) {
-      const expected = shortId(unverifiedTask.task_id);
-      const confirmation = window.prompt(
-        `Agor could not verify that this executor stopped. It may still be running and writing to the branch. Type ${expected} to force-fail the Task anyway.`
-      );
-      if (confirmation === null) return;
-      if (confirmation !== expected) {
-        showError(`Type ${expected} to confirm force-fail.`);
-        return;
-      }
-      setStopRequestInFlight(true);
-      try {
-        await client.service(`sessions/${session.session_id}/stop`).create({
-          force_unverified: true,
-          confirmation,
-        });
-      } catch (error) {
-        console.error('Failed to force-fail execution:', error);
-        showError('Failed to force-fail execution. You can try again.');
-      } finally {
-        setStopRequestInFlight(false);
-      }
+      setForceFailConfirmation('');
+      setForceFailTaskId(unverifiedTask.task_id);
       return;
     }
 
@@ -1135,6 +1132,32 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     } catch (error) {
       console.error('Failed to stop execution:', error);
       showError('Failed to stop execution. You can try again.');
+    } finally {
+      setStopRequestInFlight(false);
+    }
+  };
+
+  const handleForceFail = async () => {
+    if (
+      !session ||
+      !client ||
+      !forceFailTaskId ||
+      forceFailConfirmation !== 'STOP' ||
+      stopRequestInFlight
+    ) {
+      return;
+    }
+    setStopRequestInFlight(true);
+    try {
+      await client.service(`sessions/${session.session_id}/stop`).create({
+        force_unverified: true,
+        confirmation: 'STOP',
+      });
+      setForceFailTaskId(null);
+      setForceFailConfirmation('');
+    } catch (error) {
+      console.error('Failed to force-fail execution:', error);
+      showError('Failed to force-fail execution. You can try again.');
     } finally {
       setStopRequestInFlight(false);
     }
@@ -1671,6 +1694,52 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
         {/* Footer is unavailable for historical sessions whose runtime was removed. */}
         {sessionFooter}
+
+        <Modal
+          title="Force-fail task?"
+          open={forceFailTaskId !== null}
+          okText="Force fail"
+          cancelText="Cancel"
+          keyboard
+          mask={{ closable: false }}
+          confirmLoading={stopRequestInFlight}
+          okButtonProps={{
+            danger: true,
+            disabled: forceFailConfirmation !== 'STOP',
+          }}
+          cancelButtonProps={{ disabled: stopRequestInFlight }}
+          onOk={handleForceFail}
+          onCancel={() => {
+            if (stopRequestInFlight) return;
+            setForceFailTaskId(null);
+            setForceFailConfirmation('');
+          }}
+          afterOpenChange={(modalOpen) => {
+            if (modalOpen) forceFailInputRef.current?.focus();
+          }}
+        >
+          <Alert
+            type="warning"
+            showIcon
+            title="Executor termination is unverified"
+            description="The executor may still be running and writing to this branch. Force-fail changes Agor's durable Task status to failed and makes the Session available again. It cannot prove or guarantee process termination."
+            style={{ marginBottom: token.marginMD }}
+          />
+          <Typography.Paragraph>
+            Type <Typography.Text code>STOP</Typography.Text> to continue.
+          </Typography.Paragraph>
+          <Input
+            ref={forceFailInputRef}
+            aria-label="Type STOP to confirm force-fail"
+            value={forceFailConfirmation}
+            onChange={(event) => setForceFailConfirmation(event.target.value)}
+            onPressEnter={() => {
+              if (forceFailConfirmation === 'STOP') void handleForceFail();
+            }}
+            disabled={stopRequestInFlight}
+            autoComplete="off"
+          />
+        </Modal>
 
         {/* Advanced upload modal preserves the existing file upload flow for
             non-image files and notify-agent options. */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -472,7 +472,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [advancedUploadInitialFiles, setAdvancedUploadInitialFiles] = React.useState<File[]>([]);
   const [composerDropActive, setComposerDropActive] = React.useState(false);
   const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
-  const [forceFailTaskId, setForceFailTaskId] = React.useState<string | null>(null);
+  const [forceFailTarget, setForceFailTarget] = React.useState<{
+    taskId: string;
+    terminationRequestedAt: string;
+  } | null>(null);
   const [forceFailConfirmation, setForceFailConfirmation] = React.useState('');
   const forceFailInputRef = React.useRef<InputRef | null>(null);
   const reactiveSessionId = session?.session_id ?? null;
@@ -484,18 +487,19 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const tasks = reactiveSessionState?.tasks || EMPTY_TASKS;
   React.useEffect(() => {
     if (
-      forceFailTaskId &&
+      forceFailTarget &&
       !tasks.some(
         (task) =>
-          task.task_id === forceFailTaskId &&
+          task.task_id === forceFailTarget.taskId &&
           task.status === TaskStatus.STOPPING &&
-          task.sdk_failure?.termination === 'unverified'
+          task.sdk_failure?.termination === 'unverified' &&
+          task.termination_request?.requested_at === forceFailTarget.terminationRequestedAt
       )
     ) {
-      setForceFailTaskId(null);
+      setForceFailTarget(null);
       setForceFailConfirmation('');
     }
-  }, [forceFailTaskId, tasks]);
+  }, [forceFailTarget, tasks]);
   const attachmentInputRef = React.useRef<HTMLInputElement>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
   // Search observes only the conversation region, not the whole body: the
@@ -1115,9 +1119,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         (task) =>
           task.status === TaskStatus.STOPPING && task.sdk_failure?.termination === 'unverified'
       );
-    if (unverifiedTask) {
+    if (unverifiedTask?.termination_request) {
       setForceFailConfirmation('');
-      setForceFailTaskId(unverifiedTask.task_id);
+      setForceFailTarget({
+        taskId: unverifiedTask.task_id,
+        terminationRequestedAt: unverifiedTask.termination_request.requested_at,
+      });
       return;
     }
 
@@ -1141,7 +1148,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     if (
       !session ||
       !client ||
-      !forceFailTaskId ||
+      !forceFailTarget ||
       forceFailConfirmation !== 'STOP' ||
       stopRequestInFlight
     ) {
@@ -1152,8 +1159,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       await client.service(`sessions/${session.session_id}/stop`).create({
         force_unverified: true,
         confirmation: 'STOP',
+        task_id: forceFailTarget.taskId,
+        termination_requested_at: forceFailTarget.terminationRequestedAt,
       });
-      setForceFailTaskId(null);
+      setForceFailTarget(null);
       setForceFailConfirmation('');
     } catch (error) {
       console.error('Failed to force-fail execution:', error);
@@ -1697,7 +1706,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
         <Modal
           title="Force-fail task?"
-          open={forceFailTaskId !== null}
+          open={forceFailTarget !== null}
           okText="Force fail"
           cancelText="Cancel"
           keyboard
@@ -1711,7 +1720,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           onOk={handleForceFail}
           onCancel={() => {
             if (stopRequestInFlight) return;
-            setForceFailTaskId(null);
+            setForceFailTarget(null);
             setForceFailConfirmation('');
           }}
           afterOpenChange={(modalOpen) => {

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
@@ -11,7 +11,12 @@
 import type { Message, Task } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
 
-import { type Block, groupMessagesIntoBlocks, isVerifiedRuntimeInterruption } from './TaskBlock';
+import {
+  type Block,
+  groupMessagesIntoBlocks,
+  isTaskRuntimeLive,
+  isVerifiedRuntimeInterruption,
+} from './TaskBlock';
 
 function userMessage(index: number, id: string): Message {
   return {
@@ -178,5 +183,15 @@ describe('verified runtime interruption projection', () => {
         true
       )
     ).toBe(false);
+  });
+});
+
+describe('live runtime projection', () => {
+  it.each(['running', 'stopping'])('keeps progress visible while the Task is %s', (status) => {
+    expect(isTaskRuntimeLive({ status } as Task)).toBe(true);
+  });
+
+  it.each(['stopped', 'completed', 'failed'])('settles progress after the Task is %s', (status) => {
+    expect(isTaskRuntimeLive({ status } as Task)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
@@ -14,8 +14,8 @@ import { describe, expect, it } from 'vitest';
 import {
   type Block,
   groupMessagesIntoBlocks,
-  isTaskRuntimeLive,
   isVerifiedRuntimeInterruption,
+  shouldRenderLiveTaskProgress,
 } from './TaskBlock';
 
 function userMessage(index: number, id: string): Message {
@@ -188,10 +188,10 @@ describe('verified runtime interruption projection', () => {
 
 describe('live runtime projection', () => {
   it.each(['running', 'stopping'])('keeps progress visible while the Task is %s', (status) => {
-    expect(isTaskRuntimeLive({ status } as Task)).toBe(true);
+    expect(shouldRenderLiveTaskProgress({ status } as Task)).toBe(true);
   });
 
   it.each(['stopped', 'completed', 'failed'])('settles progress after the Task is %s', (status) => {
-    expect(isTaskRuntimeLive({ status } as Task)).toBe(false);
+    expect(shouldRenderLiveTaskProgress({ status } as Task)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -125,6 +125,11 @@ export function isVerifiedRuntimeInterruption(task: Task, isLatestTask = false):
   );
 }
 
+/** STOPPING is still live until executor quiescence/containment is authoritative. */
+export function isTaskRuntimeLive(task: Task): boolean {
+  return task.status === TaskStatus.RUNNING || task.status === TaskStatus.STOPPING;
+}
+
 function RuntimeInterruptionNotice({
   task,
   sessionId,
@@ -482,6 +487,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     client = null,
   }) => {
     const { token } = theme.useToken();
+    const runtimeLive = isTaskRuntimeLive(task);
 
     const [reactiveMessagesLoading, setReactiveMessagesLoading] = React.useState(false);
 
@@ -791,7 +797,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                               agentic_tool={agentic_tool}
                               userById={userById}
                               currentUserId={task.created_by}
-                              isTaskRunning={task.status === TaskStatus.RUNNING}
+                              isTaskRunning={runtimeLive}
                               sessionId={sessionId}
                               onPermissionDecision={onPermissionDecision}
                               isFirstPendingPermission={isFirstPending}
@@ -811,7 +817,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           <div key={blockKey} data-conversation-block={getBlockMarker(block)}>
                             <AgentChain
                               messages={block.messages}
-                              isTaskRunning={task.status === TaskStatus.RUNNING}
+                              isTaskRunning={runtimeLive}
                               isLatest={isLatestTask && blockIndex === lastAgentChainIndex}
                             />
                           </div>
@@ -835,11 +841,11 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   {/* Keep latest TODO visible even after completion (Claude parity). */}
                   <StickyTodoRenderer messages={messages} taskStatus={task.status} />
 
-                  {/* Show typing indicator whenever task is actively running.
+                  {/* Show typing indicator whenever the executor may still be live.
                       Marked as a conversation block so its unmount at stream
                       end gives search one final structural re-scan that picks
                       up the finished message text. */}
-                  {task.status === TaskStatus.RUNNING && (
+                  {runtimeLive && (
                     <div data-conversation-block style={{ margin: `${token.sizeUnit}px 0` }}>
                       <Bubble
                         placement="start"

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -125,8 +125,8 @@ export function isVerifiedRuntimeInterruption(task: Task, isLatestTask = false):
   );
 }
 
-/** STOPPING is still live until executor quiescence/containment is authoritative. */
-export function isTaskRuntimeLive(task: Task): boolean {
+/** Presentation policy: keep STOPPING output visible until a durable terminal projection arrives. */
+export function shouldRenderLiveTaskProgress(task: Task): boolean {
   return task.status === TaskStatus.RUNNING || task.status === TaskStatus.STOPPING;
 }
 
@@ -487,7 +487,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     client = null,
   }) => {
     const { token } = theme.useToken();
-    const runtimeLive = isTaskRuntimeLive(task);
+    const runtimeLive = shouldRenderLiveTaskProgress(task);
 
     const [reactiveMessagesLoading, setReactiveMessagesLoading] = React.useState(false);
 

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -151,7 +151,9 @@ an explicit mapping-review point.
   launcher exit or delay may not prove that remote work was not created. A
   durable observation marker removes that ambiguous dispatch from subsequent
   deadline scans so it cannot hot-loop or starve other candidates.
-- Connected active tasks heartbeat every 10 seconds by default.
+- Connected active tasks heartbeat every 10 seconds by default. A scoped
+  executor continues heartbeat and pulse telemetry while `stopping` until its
+  provider cleanup returns and it reports quiescence.
 - The default stale threshold is at least 30 seconds and at least three
   heartbeat intervals.
 - A stale heartbeat requests containment using the expected status and
@@ -169,7 +171,11 @@ an explicit mapping-review point.
   rejects any later stale-coordinator settlement.
 - A replacement daemon resumes an existing durable `stopping` request after
   the prior claim expires. Durable unverified containment is excluded from
-  rediscovery and remains owner/admin-guarded.
+  rediscovery and remains owner/admin-guarded unless a first, correctly
+  task/request-fenced executor quiescence report arrives later. That new
+  evidence clears the old guard exactly once and makes the same termination
+  epoch reconcilable; a repeated failed containment writes a fresh guard that a
+  duplicate acknowledgement cannot clear.
 
 ### Executor SDK watchdog
 
@@ -222,13 +228,23 @@ Containment then depends on execution mode:
 | Templated/remote executor | The scoped executor's fenced quiescence report, because the daemon cannot inspect a process group on another host.                                                                          |
 | OpenCode provider work    | Local process absence is insufficient to prove server-side work stopped, so termination can remain unverified.                                                                              |
 
+Local cooperative shutdown gives the wrapper 250 ms to disappear before
+signaling. In strict mode the target-user process may exit just before its
+root-owned `sudo` wrapper, so a target-user PGID probe can transiently return
+`EPERM`. The grace applies to both `present` and `unverified` probes; only an
+explicit later `absent` result verifies termination. Persistent uncertainty
+still fails closed. Templated/remote executors get a 15 second cooperative
+window because the daemon has no local signal fallback.
+
 Verified user Stop settles as `stopped`; verified health/startup/heartbeat
 containment settles as `failed`. If absence cannot be verified, the task stays
 `stopping`, the session stays non-promptable, and an authorized owner/admin must
-explicitly force-fail it. A daemon restart can logically release orphaned work
-as `stopped`, but records that termination was not verified. This last release
-exists only in explicit `standalone` compatibility mode; shared PostgreSQL
-startup never treats another replica's work as orphaned.
+explicitly force-fail it by typing `STOP`. Force-fail changes durable status to
+`failed`; it does not prove or guarantee process termination. A daemon restart
+can logically release orphaned work as `stopped`, but records that termination
+was not verified. This last release exists only in explicit `standalone`
+compatibility mode; shared PostgreSQL startup never treats another replica's
+work as orphaned.
 
 An abrupt local-launcher-daemon loss is not absence proof. If its execution
 substrate survives the launcher and callbacks route to the fleet, the detached

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -236,6 +236,14 @@ explicit later `absent` result verifies termination. Persistent uncertainty
 still fails closed. Templated/remote executors get a 15 second cooperative
 window because the daemon has no local signal fallback.
 
+After provider cleanup returns, the executor makes bounded, idempotent retries
+to report its exact Task/request-fenced quiescence fact. A failed write is
+followed by a bounded durable Task read so a lost response after commit does
+not strand an already-quiesced runtime. The executor logs the first outage and
+one final exhaustion event rather than every retry. Provider cleanup that is
+still running after 15 seconds emits one warning but is not falsely reported as
+quiescent.
+
 Verified user Stop settles as `stopped`; verified health/startup/heartbeat
 containment settles as `failed`. If absence cannot be verified, the task stays
 `stopping`, the session stays non-promptable, and an authorized owner/admin must

--- a/docs/internal/task-runtime-ha-reconciliation-2026-08-06.md
+++ b/docs/internal/task-runtime-ha-reconciliation-2026-08-06.md
@@ -106,8 +106,9 @@ Initial HA support for process tracking is intentionally narrow:
 - Local process handles are scoped to one daemon application via a `WeakMap`; tests can construct two applications in one process without sharing ownership accidentally.
 - Only the daemon with the matching tracked PID/PGID may claim local verified absence.
 - Missing local tracking is **not** absence proof.
+- After cooperative quiescence, local containment gives the process wrapper a brief exit grace. This includes transient `EPERM` inspection in strict mode while a root-owned `sudo` wrapper unwinds; only a subsequent explicit absence result is authoritative.
 - A non-owner waits a short grace period for the owner, then may reclaim the durable request, but containment remains `unverified` without an authoritative handle. The Task stays `stopping`.
-- A branch owner/admin may force-fail an unverified Task by typing its short ID. This does not convert the evidence to verified.
+- A branch owner/admin may force-fail an unverified Task by typing the stable literal `STOP`. This changes durable status only; it does not convert the evidence to verified or guarantee process termination.
 - Local executors are detached from the daemon process, but survival still depends on the execution substrate. If the substrate survives launcher loss, they may reconnect and heartbeat through another replica. The checked-in shared-local Compose smoke stack does not guarantee survival when the whole daemon container is lost.
 - Standalone graceful shutdown retains local PGID containment. A shared
   replica does not intentionally kill its detached executors, allowing a

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1248,6 +1248,40 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
     });
   });
 
+  dbTest(
+    'retains heartbeat and progress evidence while cancellation is stopping',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await taskRepo.create(
+        createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+      );
+      await taskRepo.connectExecutor(task.task_id);
+      await taskRepo.claimTermination({
+        taskId: task.task_id,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        now: new Date('2026-01-01T00:00:02.000Z'),
+      });
+
+      await expect(
+        taskRepo.reportRuntimeTelemetry(
+          task.task_id,
+          { sequence: 3, kind: 'progress', detail: 'provider.cancel.pending' },
+          new Date('2026-01-01T00:00:03.000Z')
+        )
+      ).resolves.toMatchObject({
+        status: TaskStatus.STOPPING,
+        last_executor_heartbeat_at: '2026-01-01T00:00:03.000Z',
+        latest_executor_pulse: {
+          sequence: 3,
+          kind: 'progress',
+          detail: 'provider.cancel.pending',
+        },
+      });
+    }
+  );
+
   dbTest('rejects telemetry before connect and after terminality', async ({ db }) => {
     const taskRepo = new TaskRepository(db);
     const sessionId = await createSessionWithDeps(db);
@@ -1718,6 +1752,224 @@ describe('TaskRepository.update', () => {
       )
     ).toEqual(reported);
   });
+
+  dbTest(
+    'reconciles a late fenced quiescence report after containment was unverified',
+    async ({ db }) => {
+      const tasks = new TaskRepository(db);
+      const sessions = new SessionRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.RUNNING,
+          executor_mode: 'templated',
+          executor_connected_at: '2026-07-10T20:00:00.000Z',
+        })
+      );
+      const requested = await tasks.claimTermination({
+        taskId: task.task_id,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        now: new Date('2026-07-10T20:01:00.000Z'),
+      });
+      const requestedAt = requested.task.termination_request!.requested_at;
+      await tasks.claimTerminationCoordination({
+        taskId: task.task_id,
+        claimToken: 'initial-claim',
+        leaseDurationMs: 30_000,
+        instanceId: 'daemon-a',
+        bootId: 'boot-a',
+        now: new Date('2026-07-10T20:01:00.010Z'),
+      });
+      await tasks.settleTermination({
+        taskId: task.task_id,
+        outcome: 'unverified',
+        coordinationToken: 'initial-claim',
+        errorMessage: 'Executor acknowledgement did not arrive in time.',
+        sdkFailure: {
+          reason: 'termination_unverified',
+          detected_at: '2026-07-10T20:01:01.500Z',
+          tool: 'codex',
+          termination: 'unverified',
+        },
+        now: new Date('2026-07-10T20:01:01.500Z'),
+      });
+
+      const reported = await tasks.recordExecutorQuiescence(
+        { task_id: task.task_id, requested_at: requestedAt },
+        new Date('2026-07-10T20:01:02.000Z')
+      );
+
+      expect(reported).toMatchObject({
+        status: TaskStatus.STOPPING,
+        termination_request: { executor_quiesced_at: '2026-07-10T20:01:02.000Z' },
+      });
+      expect(reported?.sdk_failure).toBeUndefined();
+      expect(reported?.error_message).toBeUndefined();
+      expect(
+        (
+          await tasks.findStrandedTerminationRefs({
+            now: new Date('2026-07-10T20:01:02.001Z'),
+          })
+        ).map((ref) => ref.task_id)
+      ).toContain(task.task_id);
+
+      await expect(
+        tasks.claimTerminationCoordination({
+          taskId: task.task_id,
+          claimToken: 'late-quiescence-claim',
+          leaseDurationMs: 30_000,
+          instanceId: 'daemon-b',
+          bootId: 'boot-b',
+          now: new Date('2026-07-10T20:01:02.010Z'),
+        })
+      ).resolves.toMatchObject({ outcome: 'claimed' });
+      const settled = await tasks.settleTermination({
+        taskId: task.task_id,
+        outcome: 'verified_absent',
+        coordinationToken: 'late-quiescence-claim',
+        now: new Date('2026-07-10T20:01:02.020Z'),
+      });
+      expect(settled).toMatchObject({
+        outcome: 'transitioned',
+        task: { status: TaskStatus.STOPPED },
+      });
+      expect(settled.task.sdk_failure).toBeUndefined();
+      expect(settled.task.error_message).toBeUndefined();
+      await expect(sessions.findById(sessionId)).resolves.toMatchObject({
+        status: SessionStatus.IDLE,
+        ready_for_prompt: true,
+      });
+    }
+  );
+
+  dbTest(
+    'does not let a duplicate quiescence report reopen renewed unverified containment',
+    async ({ db }) => {
+      const tasks = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.RUNNING,
+          executor_mode: 'templated',
+          executor_connected_at: '2026-07-10T20:00:00.000Z',
+        })
+      );
+      const requested = await tasks.claimTermination({
+        taskId: task.task_id,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        now: new Date('2026-07-10T20:01:00.000Z'),
+      });
+      const requestedAt = requested.task.termination_request!.requested_at;
+      const markUnverified = async (claimToken: string, at: string) => {
+        await tasks.claimTerminationCoordination({
+          taskId: task.task_id,
+          claimToken,
+          leaseDurationMs: 30_000,
+          instanceId: 'daemon-a',
+          bootId: 'boot-a',
+          now: new Date(at),
+        });
+        return tasks.settleTermination({
+          taskId: task.task_id,
+          outcome: 'unverified',
+          coordinationToken: claimToken,
+          errorMessage: 'Executor containment remains unverified.',
+          sdkFailure: {
+            reason: 'termination_unverified',
+            detected_at: at,
+            tool: 'codex',
+            termination: 'unverified',
+          },
+          now: new Date(at),
+        });
+      };
+
+      await markUnverified('initial-claim', '2026-07-10T20:01:01.000Z');
+      await tasks.recordExecutorQuiescence(
+        { task_id: task.task_id, requested_at: requestedAt },
+        new Date('2026-07-10T20:01:02.000Z')
+      );
+      await markUnverified('renewed-claim', '2026-07-10T20:01:03.000Z');
+
+      const duplicate = await tasks.recordExecutorQuiescence(
+        { task_id: task.task_id, requested_at: requestedAt },
+        new Date('2026-07-10T20:01:04.000Z')
+      );
+      expect(duplicate).toMatchObject({
+        status: TaskStatus.STOPPING,
+        sdk_failure: { termination: 'unverified' },
+        termination_request: { executor_quiesced_at: '2026-07-10T20:01:02.000Z' },
+      });
+      expect(
+        (
+          await tasks.findStrandedTerminationRefs({
+            now: new Date('2026-07-10T20:01:04.001Z'),
+          })
+        ).map((ref) => ref.task_id)
+      ).not.toContain(task.task_id);
+    }
+  );
+
+  dbTest(
+    'preserves a real SDK diagnosis when late quiescence reopens containment',
+    async ({ db }) => {
+      const tasks = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.RUNNING,
+          executor_mode: 'templated',
+          executor_connected_at: '2026-07-10T20:00:00.000Z',
+        })
+      );
+      const failure = {
+        reason: 'heartbeat_lost' as const,
+        detected_at: '2026-07-10T20:01:00.000Z',
+        tool: 'codex' as const,
+        termination: 'requested' as const,
+      };
+      const request = await tasks.claimTermination({
+        taskId: task.task_id,
+        cause: 'heartbeat_lost',
+        errorMessage: 'Heartbeat lost',
+        sdkFailure: failure,
+        now: new Date('2026-07-10T20:01:00.000Z'),
+      });
+      await tasks.claimTerminationCoordination({
+        taskId: task.task_id,
+        claimToken: 'health-claim',
+        leaseDurationMs: 30_000,
+        instanceId: 'daemon-a',
+        bootId: 'boot-a',
+        now: new Date('2026-07-10T20:01:00.010Z'),
+      });
+      await tasks.settleTermination({
+        taskId: task.task_id,
+        outcome: 'unverified',
+        coordinationToken: 'health-claim',
+        errorMessage: 'Heartbeat lost; containment remains unverified.',
+        sdkFailure: { ...failure, termination: 'unverified' },
+        now: new Date('2026-07-10T20:01:01.000Z'),
+      });
+
+      const reported = await tasks.recordExecutorQuiescence(
+        {
+          task_id: task.task_id,
+          requested_at: request.task.termination_request!.requested_at,
+        },
+        new Date('2026-07-10T20:01:02.000Z')
+      );
+      expect(reported).toMatchObject({
+        sdk_failure: { reason: 'heartbeat_lost', termination: 'requested' },
+      });
+      expect(reported?.error_message).toBeUndefined();
+    }
+  );
 
   dbTest(
     'releases a stopping task after restart without claiming verified absence',

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1733,7 +1733,7 @@ describe('TaskRepository.update', () => {
     const task = await tasks.create(
       createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING })
     );
-    await tasks.claimTermination({
+    const termination = await tasks.claimTermination({
       taskId: task.task_id,
       cause: 'heartbeat_lost',
       errorMessage: 'Heartbeat lost',
@@ -1767,9 +1767,20 @@ describe('TaskRepository.update', () => {
       ready_for_prompt: false,
     });
 
+    const staleForce = await tasks.settleTermination({
+      taskId: task.task_id,
+      outcome: 'forced_unverified',
+      expectedTerminationRequestedAt: '2026-08-06T11:59:59.000Z',
+      errorMessage: 'Force-failed by an authorized user',
+    });
+    expect(staleForce).toMatchObject({
+      outcome: 'condition_changed',
+      task: { status: TaskStatus.STOPPING },
+    });
     const forced = await tasks.settleTermination({
       taskId: task.task_id,
       outcome: 'forced_unverified',
+      expectedTerminationRequestedAt: termination.task.termination_request!.requested_at,
       errorMessage: 'Force-failed by an authorized user',
     });
     expect(forced).toMatchObject({

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -1282,6 +1282,79 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
     }
   );
 
+  dbTest('rejects late telemetry after executor quiescence', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const task = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+    );
+    await taskRepo.connectExecutor(task.task_id);
+    const claim = await taskRepo.claimTermination({
+      taskId: task.task_id,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user',
+      now: new Date('2026-01-01T00:00:02.000Z'),
+    });
+    await taskRepo.recordExecutorQuiescence(
+      {
+        task_id: task.task_id,
+        requested_at: claim.task.termination_request!.requested_at,
+      },
+      new Date('2026-01-01T00:00:03.000Z')
+    );
+
+    await expect(taskRepo.reportRuntimeTelemetry(task.task_id)).resolves.toBeNull();
+  });
+
+  dbTest(
+    'retains late telemetry when containment is unverified but the executor is live',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await taskRepo.create(
+        createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+      );
+      await taskRepo.connectExecutor(task.task_id);
+      await taskRepo.claimTermination({
+        taskId: task.task_id,
+        cause: 'heartbeat_lost',
+        errorMessage: 'Heartbeat lost',
+      });
+      await taskRepo.claimTerminationCoordination({
+        taskId: task.task_id,
+        claimToken: 'telemetry-claim',
+        leaseDurationMs: 30_000,
+        instanceId: 'daemon-a',
+        bootId: 'boot-a',
+      });
+      await taskRepo.settleTermination({
+        taskId: task.task_id,
+        outcome: 'unverified',
+        coordinationToken: 'telemetry-claim',
+        errorMessage: 'Containment remains unverified.',
+        sdkFailure: {
+          reason: 'termination_unverified',
+          detected_at: '2026-01-01T00:00:03.000Z',
+          tool: 'codex',
+          termination: 'unverified',
+        },
+      });
+
+      await expect(
+        taskRepo.reportRuntimeTelemetry(
+          task.task_id,
+          { sequence: 4, kind: 'progress', detail: 'provider.cancel.still_pending' },
+          new Date('2026-01-01T00:00:04.000Z')
+        )
+      ).resolves.toMatchObject({
+        status: TaskStatus.STOPPING,
+        sdk_failure: { termination: 'unverified' },
+        last_executor_heartbeat_at: '2026-01-01T00:00:04.000Z',
+        latest_executor_pulse: { sequence: 4, detail: 'provider.cancel.still_pending' },
+      });
+    }
+  );
+
   dbTest('rejects telemetry before connect and after terminality', async ({ db }) => {
     const taskRepo = new TaskRepository(db);
     const sessionId = await createSessionWithDeps(db);

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -58,6 +58,14 @@ function executorOwnsTask(row: Pick<TaskRow, 'status' | 'executor_connected_at'>
   );
 }
 
+function executorMayReportTelemetry(
+  row: Pick<TaskRow, 'status' | 'executor_connected_at'>
+): boolean {
+  return (
+    executorOwnsTask(row) || (!!row.executor_connected_at && row.status === TaskStatus.STOPPING)
+  );
+}
+
 function isExecutorResultStatus(status: Task['status']): boolean {
   return (
     status === TaskStatus.RUNNING ||
@@ -940,7 +948,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     observedAt?: Date
   ): Promise<Task | null> {
     return this.mutateLockedTask(id, async (txDb, row, fullId) => {
-      if (!executorOwnsTask(row)) return null;
+      // STOPPING remains executor-owned until the scoped executor reports
+      // quiescence (or containment proves absence). Retain its heartbeat and
+      // pulse evidence while cancellation is still in progress.
+      if (!executorMayReportTelemetry(row)) return null;
 
       const heartbeatAt = await this.mutationNow(txDb, fullId, observedAt);
 
@@ -983,15 +994,48 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const quiescedAt = await this.mutationNow(txDb, fullId, observedAt);
 
       const { coordination: _coordination, ...storedRequest } = request;
+      // An unverified marker guards against an old coordinator terminalizing
+      // without proof. A new, correctly task/request-fenced executor report is
+      // new evidence, so make the same request recoverable again. If renewed
+      // containment is still unverified it writes a fresh guard after this
+      // quiescence timestamp; duplicate reports cannot clear that newer guard.
+      const recoveringUnverified =
+        !!row.termination_unverified_at || current.sdk_failure?.termination === 'unverified';
+      const sdkFailure = recoveringUnverified
+        ? current.sdk_failure?.reason === 'termination_unverified'
+          ? undefined
+          : current.sdk_failure
+            ? { ...current.sdk_failure, termination: 'requested' as const }
+            : undefined
+        : current.sdk_failure;
       const data = {
         ...row.data,
+        ...(sdkFailure ? { sdk_failure: sdkFailure } : {}),
         termination_request: {
           ...storedRequest,
           executor_quiesced_at: quiescedAt.toISOString(),
         },
       };
-      await update(txDb, tasks).set({ data }).where(eq(tasks.task_id, fullId)).run();
-      return this.rowToTask({ ...row, data });
+      if (recoveringUnverified) {
+        // The guard wrote this diagnostic while absence was unknown. New
+        // evidence supersedes it; do not leave a successfully stopped Task
+        // carrying the obsolete "may still be running" error. Preserve only
+        // a real preceding SDK-health diagnosis, not the synthetic guard.
+        delete data.error_message;
+        if (!sdkFailure) delete data.sdk_failure;
+      }
+      await update(txDb, tasks)
+        .set({
+          data,
+          ...(recoveringUnverified ? { termination_unverified_at: null } : {}),
+        })
+        .where(eq(tasks.task_id, fullId))
+        .run();
+      return this.rowToTask({
+        ...row,
+        data,
+        ...(recoveringUnverified ? { termination_unverified_at: null } : {}),
+      });
     });
   }
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -59,11 +59,13 @@ function executorOwnsTask(row: Pick<TaskRow, 'status' | 'executor_connected_at'>
 }
 
 function executorMayReportTelemetry(
-  row: Pick<TaskRow, 'status' | 'executor_connected_at'>
+  row: Pick<TaskRow, 'status' | 'executor_connected_at' | 'data'>
 ): boolean {
-  return (
-    executorOwnsTask(row) || (!!row.executor_connected_at && row.status === TaskStatus.STOPPING)
-  );
+  if (executorOwnsTask(row)) return true;
+  if (!row.executor_connected_at || row.status !== TaskStatus.STOPPING) {
+    return false;
+  }
+  return !!row.data.termination_request && !row.data.termination_request.executor_quiesced_at;
 }
 
 function isExecutorResultStatus(status: Task['status']): boolean {
@@ -949,8 +951,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   ): Promise<Task | null> {
     return this.mutateLockedTask(id, async (txDb, row, fullId) => {
       // STOPPING remains executor-owned until the scoped executor reports
-      // quiescence (or containment proves absence). Retain its heartbeat and
-      // pulse evidence while cancellation is still in progress.
+      // quiescence. An unverified containment guard is not proof of absence,
+      // so a still-live executor may continue publishing useful evidence and
+      // eventually recover the request with a late task/request-fenced ack.
       if (!executorMayReportTelemetry(row)) return null;
 
       const heartbeatAt = await this.mutationNow(txDb, fullId, observedAt);

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -144,7 +144,13 @@ export type TerminationSettlementInput =
       coordinationToken: string;
     })
   | (TerminationSettlementInputBase & {
-      outcome: 'forced_unverified' | 'restart_unverified';
+      outcome: 'forced_unverified';
+      /** Exact termination request confirmed by the authorized operator. */
+      expectedTerminationRequestedAt: string;
+      coordinationToken?: never;
+    })
+  | (TerminationSettlementInputBase & {
+      outcome: 'restart_unverified';
       coordinationToken?: never;
     });
 
@@ -1264,7 +1270,8 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
 
       if (
         input.outcome === 'forced_unverified' &&
-        current.sdk_failure?.termination !== 'unverified'
+        (current.sdk_failure?.termination !== 'unverified' ||
+          current.termination_request?.requested_at !== input.expectedTerminationRequestedAt)
       ) {
         return { outcome: 'condition_changed', task: current };
       }

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -282,6 +282,117 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
     });
   });
 
+  it('reconciles late executor quiescence through RLS without exposing it cross-tenant', async () => {
+    const owner = await seedTenant(db, 'late-quiescence-owner');
+    const other = await seedTenant(db, 'late-quiescence-other');
+    const { task, requestedAt } = await runWithTenantDatabaseScope(
+      db,
+      owner.tenantId,
+      async (scoped) => {
+        const tasks = new TaskRepository(scoped);
+        const task = await tasks.create(
+          taskInput(owner, TaskStatus.RUNNING, {
+            executor_mode: 'templated',
+            executor_connected_at: '2026-08-06T12:00:00.000Z',
+          })
+        );
+        const request = await tasks.claimTermination({
+          taskId: task.task_id,
+          cause: 'user_stop',
+          errorMessage: 'Stopped by user',
+          now: new Date('2026-08-06T12:01:00.000Z'),
+        });
+        await tasks.claimTerminationCoordination({
+          taskId: task.task_id,
+          claimToken: 'initial-unverified',
+          leaseDurationMs: 30_000,
+          instanceId: 'daemon-a',
+          bootId: 'boot-a',
+          now: new Date('2026-08-06T12:01:00.010Z'),
+        });
+        await tasks.settleTermination({
+          taskId: task.task_id,
+          outcome: 'unverified',
+          coordinationToken: 'initial-unverified',
+          errorMessage: 'Executor acknowledgement did not arrive in time.',
+          sdkFailure: {
+            reason: 'termination_unverified',
+            detected_at: '2026-08-06T12:01:01.500Z',
+            tool: 'codex',
+            termination: 'unverified',
+          },
+          now: new Date('2026-08-06T12:01:01.500Z'),
+        });
+        return {
+          task,
+          requestedAt: request.task.termination_request!.requested_at,
+        };
+      }
+    );
+
+    await runWithTenantDatabaseScope(db, other.tenantId, async (scoped) => {
+      await expect(
+        new TaskRepository(scoped).recordExecutorQuiescence({
+          task_id: task.task_id,
+          requested_at: requestedAt,
+        })
+      ).rejects.toThrow();
+    });
+
+    await runWithTenantDatabaseScope(db, owner.tenantId, async (scoped) => {
+      const reported = await new TaskRepository(scoped).recordExecutorQuiescence(
+        { task_id: task.task_id, requested_at: requestedAt },
+        new Date('2026-08-06T12:01:02.000Z')
+      );
+      expect(reported).toMatchObject({ status: TaskStatus.STOPPING });
+      expect(reported?.sdk_failure).toBeUndefined();
+      expect(reported?.error_message).toBeUndefined();
+    });
+
+    const stranded = await runWithSystemDatabaseScope(
+      db,
+      'late quiescence discovery',
+      (systemDb) =>
+        new TaskRepository(systemDb).findStrandedTerminationRefs({
+          now: new Date('2026-08-06T12:01:02.001Z'),
+          limit: 1_000,
+        }),
+      { capability: 'task_runtime_discovery' }
+    );
+    expect(stranded).toContainEqual(
+      expect.objectContaining({ task_id: task.task_id, tenant_id: owner.tenantId })
+    );
+
+    await runWithTenantDatabaseScope(db, owner.tenantId, async (scoped) => {
+      const tasks = new TaskRepository(scoped);
+      await expect(
+        tasks.claimTerminationCoordination({
+          taskId: task.task_id,
+          claimToken: 'late-quiescence',
+          leaseDurationMs: 30_000,
+          instanceId: 'daemon-b',
+          bootId: 'boot-b',
+          now: new Date('2026-08-06T12:01:02.010Z'),
+        })
+      ).resolves.toMatchObject({ outcome: 'claimed' });
+      await expect(
+        tasks.settleTermination({
+          taskId: task.task_id,
+          outcome: 'verified_absent',
+          coordinationToken: 'late-quiescence',
+          now: new Date('2026-08-06T12:01:02.020Z'),
+        })
+      ).resolves.toMatchObject({
+        outcome: 'transitioned',
+        task: { status: TaskStatus.STOPPED },
+      });
+      await expect(new SessionRepository(scoped).findById(owner.sessionId)).resolves.toMatchObject({
+        status: SessionStatus.IDLE,
+        ready_for_prompt: true,
+      });
+    });
+  });
+
   it('discovers routing refs globally but rejects cross-tenant reload and mutation', async () => {
     const a = await seedTenant(db, 'tenant-a');
     const b = await seedTenant(db, 'tenant-b');

--- a/packages/executor/src/executor-heartbeat.test.ts
+++ b/packages/executor/src/executor-heartbeat.test.ts
@@ -66,6 +66,37 @@ describe('startExecutorHeartbeat', () => {
     }
   });
 
+  it('logs only the first consecutive write failure and one recovery summary', async () => {
+    vi.useFakeTimers();
+    try {
+      const reportRuntimeTelemetry = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('offline'))
+        .mockRejectedValueOnce(new Error('still offline'))
+        .mockResolvedValue({});
+      const warn = vi.fn();
+      const log = vi.fn();
+      const client = { service: () => ({ reportRuntimeTelemetry }) } as never;
+      const handle = startExecutorHeartbeat({
+        client,
+        taskId: 'task-1',
+        intervalMs: 1000,
+        warn,
+        log,
+      });
+
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('event=write_failed'));
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('missed_writes=2'));
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('coalesces many pulses into the latest fact at heartbeat cadence', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/executor/src/executor-heartbeat.ts
+++ b/packages/executor/src/executor-heartbeat.ts
@@ -1,3 +1,4 @@
+import { shortId } from '@agor/core/db';
 import type { ExecutorPulseKind, Task, TaskID } from '@agor/core/types';
 import type { AgorClient } from './services/feathers-client.js';
 
@@ -7,6 +8,7 @@ export interface ExecutorHeartbeatOptions {
   enabled?: boolean;
   intervalMs?: number;
   warn?: (...args: unknown[]) => void;
+  log?: (...args: unknown[]) => void;
   /** Observe the durable Task returned by any daemon handling this heartbeat. */
   onTask?: (task: Task) => void;
 }
@@ -31,10 +33,12 @@ export function startExecutorHeartbeat(options: ExecutorHeartbeatOptions): Execu
       ? Math.floor(options.intervalMs)
       : DEFAULT_INTERVAL_MS;
   const warn = options.warn ?? console.warn;
+  const log = options.log ?? console.log;
   let stopped = false;
   let inFlight = false;
   let timer: ReturnType<typeof setInterval> | undefined;
   let sequence = 0;
+  let consecutiveFailures = 0;
   let latestPulse: { sequence: number; kind: ExecutorPulseKind; detail?: string } | undefined;
 
   const emit = async () => {
@@ -45,12 +49,22 @@ export function startExecutorHeartbeat(options: ExecutorHeartbeatOptions): Execu
         task_id: options.taskId,
         ...(latestPulse ? { pulse: latestPulse } : {}),
       });
+      if (consecutiveFailures > 0) {
+        log(
+          `[executor.heartbeat] event=recovered task_id=${shortId(String(options.taskId))} ` +
+            `missed_writes=${consecutiveFailures}`
+        );
+        consecutiveFailures = 0;
+      }
       options.onTask?.(task as Task);
-    } catch (error) {
-      warn(
-        '[executor-heartbeat] Failed to write heartbeat:',
-        error instanceof Error ? error.message : String(error)
-      );
+    } catch {
+      consecutiveFailures += 1;
+      if (consecutiveFailures === 1) {
+        warn(
+          `[executor.heartbeat] event=write_failed task_id=${shortId(String(options.taskId))} ` +
+            'retrying=true'
+        );
+      }
     } finally {
       inFlight = false;
     }

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -151,6 +151,39 @@ describe('AgorExecutor watchdog handoff', () => {
     });
   });
 
+  it('acknowledges Stop when an aborted provider rejects', async () => {
+    const reportTerminationComplete = vi.fn().mockResolvedValue({});
+    const executor = new AgorExecutor({
+      sessionToken: 'token',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      prompt: 'prompt',
+      tool: 'codex',
+      daemonUrl: 'http://daemon',
+    }) as unknown as {
+      client: {
+        service: () => { reportTerminationComplete: typeof reportTerminationComplete };
+      };
+      handleTaskLifecycleUpdate(task: unknown): void;
+      recoverTerminationAfterExecutionError(): Promise<boolean>;
+    };
+    executor.client = { service: () => ({ reportTerminationComplete }) };
+    executor.handleTaskLifecycleUpdate({
+      task_id: 'task-1',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
+
+    await expect(executor.recoverTerminationAfterExecutionError()).resolves.toBe(true);
+    expect(reportTerminationComplete).toHaveBeenCalledWith({
+      task_id: 'task-1',
+      requested_at: '2026-07-23T12:00:00.000Z',
+    });
+  });
+
   it('warns once when provider cleanup remains active after Stop', async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -60,6 +60,7 @@ describe('AgorExecutor watchdog handoff', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    runtime.execute.mockResolvedValue(undefined);
   });
 
   it('starts SDK observation before invoking the tool', async () => {
@@ -148,6 +149,51 @@ describe('AgorExecutor watchdog handoff', () => {
       task_id: 'task-1',
       requested_at: '2026-07-23T12:00:00.000Z',
     });
+  });
+
+  it('warns once when provider cleanup remains active after Stop', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let settleProvider!: () => void;
+    runtime.execute.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (settleProvider = resolve))
+    );
+    const executor = new AgorExecutor({
+      sessionToken: 'token',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      prompt: 'prompt',
+      tool: 'codex',
+      daemonUrl: 'http://daemon',
+    }) as unknown as {
+      client: object;
+      executeTask(): Promise<void>;
+      handleTaskLifecycleUpdate(task: unknown): void;
+    };
+    executor.client = {};
+    const execution = executor.executeTask();
+    await vi.advanceTimersByTimeAsync(0);
+    executor.handleTaskLifecycleUpdate({
+      task_id: 'task-1',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(
+      warn.mock.calls.filter(([message]) => String(message).includes('provider_cleanup_slow'))
+    ).toHaveLength(1);
+
+    settleProvider();
+    await execution;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(
+      warn.mock.calls.filter(([message]) => String(message).includes('provider_cleanup_slow'))
+    ).toHaveLength(1);
   });
 
   it('handles the private task-scoped termination socket event', () => {

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -110,7 +110,7 @@ describe('AgorExecutor watchdog handoff', () => {
     expect(exit).toHaveBeenCalledWith(70);
   });
 
-  it('aborts immediately on the durable stopping patch and reports quiescence', async () => {
+  it('aborts immediately but retains liveness until it can report quiescence', async () => {
     const reportTerminationComplete = vi.fn().mockResolvedValue({});
     const heartbeatStop = vi.fn();
     const executor = new AgorExecutor({
@@ -142,7 +142,7 @@ describe('AgorExecutor watchdog handoff', () => {
     });
 
     expect(executor.abortController.signal.aborted).toBe(true);
-    expect(heartbeatStop).toHaveBeenCalledOnce();
+    expect(heartbeatStop).not.toHaveBeenCalled();
     await executor.reportTerminationComplete();
     expect(reportTerminationComplete).toHaveBeenCalledWith({
       task_id: 'task-1',
@@ -200,7 +200,7 @@ describe('AgorExecutor watchdog handoff', () => {
     });
 
     expect(executor.abortController.signal.aborted).toBe(true);
-    expect(heartbeatStop).toHaveBeenCalledOnce();
+    expect(heartbeatStop).not.toHaveBeenCalled();
   });
 
   it('forwards only this Task permission decision to the live permission waiter', () => {

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -144,7 +144,8 @@ export class AgorExecutor {
       );
       process.exit(0);
     } catch (error) {
-      if (!this.terminationRequest && (await this.recoverTerminationBeforeStart())) {
+      const terminationRecovered = await this.recoverTerminationAfterExecutionError();
+      if (terminationRecovered) {
         console.log(
           `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
             'code=0 reason=termination_recovered'
@@ -152,7 +153,9 @@ export class AgorExecutor {
         process.exit(0);
         return;
       }
-      console.error('[executor] fatal error category=task_startup');
+      console.error(
+        `[executor] fatal error category=${this.terminationRequest ? 'termination_report' : 'task_startup'}`
+      );
       await this.tryMarkTaskTerminal(TaskStatus.FAILED, formatExecutorFailure(error));
       process.exit(1);
     }
@@ -275,11 +278,24 @@ export class AgorExecutor {
         readTask: () => client.service('tasks').get(this.config.taskId) as Promise<Task>,
       });
       this.terminationReport = report;
-      void report.catch(() => {
-        if (this.terminationReport === report) this.terminationReport = null;
-      });
     }
     await this.terminationReport;
+  }
+
+  /**
+   * A provider commonly rejects when its AbortSignal fires. Treat that as a
+   * successful cooperative Stop only after the exact request is durably
+   * acknowledged. The startup refresh covers the connect/Stop race where the
+   * socket event arrived before this process claimed the Task.
+   */
+  private async recoverTerminationAfterExecutionError(): Promise<boolean> {
+    if (!this.terminationRequest) return this.recoverTerminationBeforeStart();
+    try {
+      await this.reportTerminationComplete();
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /** Handle Stop that atomically beat connectExecutor() without starting SDK work. */

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -200,8 +200,11 @@ export class AgorExecutor {
       `[executor] Received ${task.termination_request.cause} termination request; stopping SDK`
     );
     markCoordinatorTerminationAbort(this.abortController);
-    this.heartbeat?.stop();
-    this.heartbeat = null;
+    // Keep task-scoped heartbeat/pulse reporting alive until ToolRegistry.execute
+    // and provider cleanup actually return. STOPPING is still live work; hiding
+    // its liveness here makes a slow or ignored cancellation indistinguishable
+    // from a dead executor. executeTask's finally stops telemetry immediately
+    // before the quiescence acknowledgement.
     this.watchdog?.stop();
     this.watchdog = null;
     this.abortController.abort();

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -46,6 +46,15 @@ function executorDebug(...args: unknown[]): void {
   }
 }
 
+type TerminationObservationSource =
+  | 'connect_claim'
+  | 'heartbeat'
+  | 'reconnect'
+  | 'startup_recovery'
+  | 'task_patch'
+  | 'task_stop_event'
+  | 'unknown';
+
 export interface ExecutorConfig {
   sessionToken: string;
   sessionId: string;
@@ -69,6 +78,7 @@ export class AgorExecutor {
   private watchdog: SdkWatchdog | null = null;
   private terminationRequest: Task['termination_request'];
   private terminationReport: Promise<void> | null = null;
+  private terminationObservedAtMs: number | null = null;
 
   constructor(private config: ExecutorConfig) {
     this.abortController = new AbortController();
@@ -101,7 +111,7 @@ export class AgorExecutor {
       // Connect to daemon via Feathers/WebSocket
       executorDebug('[executor] Connecting to daemon via Feathers...');
       this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken, {
-        onReauthenticated: () => this.refreshTerminationState(),
+        onReauthenticated: () => this.refreshTerminationState('reconnect'),
       });
       executorDebug('[executor] Connected to daemon');
 
@@ -117,17 +127,24 @@ export class AgorExecutor {
       const connectedTask = await this.client
         .service('tasks')
         .connectExecutor({ task_id: this.config.taskId });
-      this.handleTaskLifecycleUpdate(connectedTask);
+      this.handleTaskLifecycleUpdate(connectedTask, 'connect_claim');
 
       // Execute the task
       if (!this.terminationRequest) await this.executeTask();
       await this.reportTerminationComplete();
 
       // Exit successfully
-      console.log('[executor] Task completed, exiting');
+      console.log(
+        `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
+          `code=0 reason=${this.terminationRequest ? 'termination_complete' : 'task_complete'}`
+      );
       process.exit(0);
     } catch (error) {
       if (await this.recoverTerminationBeforeStart()) {
+        console.log(
+          `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
+            'code=0 reason=termination_recovered'
+        );
         process.exit(0);
         return;
       }
@@ -147,10 +164,10 @@ export class AgorExecutor {
     if (!this.client) return;
 
     this.client.service('tasks').on('patched', (data: unknown) => {
-      this.handleTaskLifecycleUpdate(data as Task);
+      this.handleTaskLifecycleUpdate(data as Task, 'task_patch');
     });
     this.client.service('tasks').on('termination_requested', (data: unknown) => {
-      this.handleTaskLifecycleUpdate(data as Task);
+      this.handleTaskLifecycleUpdate(data as Task, 'task_stop_event');
     });
 
     // Listen for permission_resolved events
@@ -185,7 +202,10 @@ export class AgorExecutor {
     executorDebug('[executor] Event listeners registered');
   }
 
-  private handleTaskLifecycleUpdate(task: Task): void {
+  private handleTaskLifecycleUpdate(
+    task: Task,
+    source: TerminationObservationSource = 'unknown'
+  ): void {
     if (
       task.task_id !== this.config.taskId ||
       task.status !== TaskStatus.STOPPING ||
@@ -196,8 +216,10 @@ export class AgorExecutor {
     if (this.terminationRequest?.requested_at === task.termination_request.requested_at) return;
 
     this.terminationRequest = task.termination_request;
+    this.terminationObservedAtMs = Date.now();
     console.log(
-      `[executor] Received ${task.termination_request.cause} termination request; stopping SDK`
+      `[executor.stop] event=request_observed task_id=${shortId(this.config.taskId)} ` +
+        `cause=${task.termination_request.cause} source=${source}`
     );
     markCoordinatorTerminationAbort(this.abortController);
     // Keep task-scoped heartbeat/pulse reporting alive until ToolRegistry.execute
@@ -205,20 +227,29 @@ export class AgorExecutor {
     // its liveness here makes a slow or ignored cancellation indistinguishable
     // from a dead executor. executeTask's finally stops telemetry immediately
     // before the quiescence acknowledgement.
-    this.watchdog?.stop();
+    if (this.watchdog) {
+      this.watchdog.stop();
+      console.log(`[executor.stop] event=watchdog_stopped task_id=${shortId(this.config.taskId)}`);
+    }
     this.watchdog = null;
     this.abortController.abort();
+    console.log(
+      `[executor.stop] event=provider_abort_requested task_id=${shortId(this.config.taskId)}`
+    );
   }
 
-  private async refreshTerminationState(): Promise<void> {
+  private async refreshTerminationState(source: TerminationObservationSource): Promise<void> {
     if (!this.client) return;
     const task = (await this.client.service('tasks').get(this.config.taskId)) as Task;
-    this.handleTaskLifecycleUpdate(task);
+    this.handleTaskLifecycleUpdate(task, source);
   }
 
   private async reportTerminationComplete(): Promise<void> {
     if (!this.client || !this.terminationRequest) return;
     if (!this.terminationReport) {
+      console.log(
+        `[executor.stop] event=quiescence_report_started task_id=${shortId(this.config.taskId)}`
+      );
       const report = this.client
         .service('tasks')
         .reportTerminationComplete({
@@ -226,7 +257,16 @@ export class AgorExecutor {
           requested_at: this.terminationRequest.requested_at,
         })
         .then(() => {
-          console.log('[executor] Cooperative termination complete');
+          console.log(
+            `[executor.stop] event=quiescence_report_accepted task_id=${shortId(this.config.taskId)}`
+          );
+        })
+        .catch((error) => {
+          console.warn(
+            `[executor.stop] event=quiescence_report_failed task_id=${shortId(this.config.taskId)} ` +
+              `error_type=${error instanceof Error ? 'error' : 'non_error'} retryable=true`
+          );
+          throw error;
         });
       this.terminationReport = report;
       void report.catch(() => {
@@ -240,7 +280,7 @@ export class AgorExecutor {
   private async recoverTerminationBeforeStart(): Promise<boolean> {
     if (!this.client) return false;
     try {
-      await this.refreshTerminationState();
+      await this.refreshTerminationState('startup_recovery');
       if (!this.terminationRequest) return false;
       await this.reportTerminationComplete();
       return true;
@@ -266,7 +306,7 @@ export class AgorExecutor {
       taskId: this.config.taskId,
       enabled: heartbeatConfig?.enabled ?? true,
       intervalMs: heartbeatConfig?.interval_ms,
-      onTask: (task) => this.handleTaskLifecycleUpdate(task),
+      onTask: (task) => this.handleTaskLifecycleUpdate(task, 'heartbeat'),
     });
     const watchdogConfig =
       this.config.resolvedConfig?.execution?.sdk_watchdog ?? resolveSdkWatchdogConfig();
@@ -305,9 +345,23 @@ export class AgorExecutor {
         onPulse: (kind, detail) => this.recordPulse(kind, detail),
       });
     } finally {
+      if (this.terminationRequest) {
+        const elapsedMs = Math.max(0, Date.now() - (this.terminationObservedAtMs ?? Date.now()));
+        console.log(
+          `[executor.stop] event=provider_cleanup_settled task_id=${shortId(this.config.taskId)} ` +
+            `elapsed_ms=${elapsedMs}`
+        );
+      }
       this.watchdog?.stop();
       this.watchdog = null;
-      this.heartbeat?.stop();
+      if (this.heartbeat) {
+        this.heartbeat.stop();
+        if (this.terminationRequest) {
+          console.log(
+            `[executor.stop] event=runtime_telemetry_stopped task_id=${shortId(this.config.taskId)}`
+          );
+        }
+      }
       this.heartbeat = null;
       this.isRunning = false;
     }
@@ -370,6 +424,12 @@ export class AgorExecutor {
    * Setup graceful shutdown handlers
    */
   private setupShutdownHandlers(): void {
+    process.once('exit', (code) => {
+      console.log(
+        `[executor.lifecycle] event=process_exit task_id=${shortId(this.config.taskId)} code=${code}`
+      );
+    });
+
     const shutdown = async (signal: string) => {
       console.log(`[executor] Received ${signal}, shutting down...`);
 
@@ -386,6 +446,10 @@ export class AgorExecutor {
       // fallback only fires for an out-of-band signal while the task is active.
       await this.tryMarkTaskTerminal(TaskStatus.STOPPED);
 
+      console.log(
+        `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
+          `code=0 reason=signal_${signal.toLowerCase()}`
+      );
       process.exit(0);
     };
 

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -33,12 +33,15 @@ import { formatExecutorFailure } from './safe-executor-error.js';
 import { getSdkActivityVersion, markSdkHealthAbort, SdkWatchdog } from './sdk-watchdog.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
+import { reportExecutorQuiescence } from './termination-report.js';
 import { isDaemonOwnedAbort, markCoordinatorTerminationAbort } from './termination-state.js';
 
 patchConsole();
 
 const DEBUG_EXECUTOR =
   process.env.AGOR_DEBUG_EXECUTOR === '1' || process.env.DEBUG?.includes('executor');
+
+const PROVIDER_CLEANUP_SLOW_MS = 15_000;
 
 function executorDebug(...args: unknown[]): void {
   if (DEBUG_EXECUTOR) {
@@ -79,6 +82,7 @@ export class AgorExecutor {
   private terminationRequest: Task['termination_request'];
   private terminationReport: Promise<void> | null = null;
   private terminationObservedAtMs: number | null = null;
+  private providerCleanupSlowTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private config: ExecutorConfig) {
     this.abortController = new AbortController();
@@ -140,7 +144,7 @@ export class AgorExecutor {
       );
       process.exit(0);
     } catch (error) {
-      if (await this.recoverTerminationBeforeStart()) {
+      if (!this.terminationRequest && (await this.recoverTerminationBeforeStart())) {
         console.log(
           `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
             'code=0 reason=termination_recovered'
@@ -236,6 +240,17 @@ export class AgorExecutor {
     console.log(
       `[executor.stop] event=provider_abort_requested task_id=${shortId(this.config.taskId)}`
     );
+    if (this.isRunning && !this.providerCleanupSlowTimer) {
+      this.providerCleanupSlowTimer = setTimeout(() => {
+        this.providerCleanupSlowTimer = null;
+        if (!this.isRunning || !this.terminationRequest) return;
+        console.warn(
+          `[executor.stop] event=provider_cleanup_slow task_id=${shortId(this.config.taskId)} ` +
+            `elapsed_ms=${PROVIDER_CLEANUP_SLOW_MS}`
+        );
+      }, PROVIDER_CLEANUP_SLOW_MS);
+      this.providerCleanupSlowTimer.unref?.();
+    }
   }
 
   private async refreshTerminationState(source: TerminationObservationSource): Promise<void> {
@@ -247,27 +262,18 @@ export class AgorExecutor {
   private async reportTerminationComplete(): Promise<void> {
     if (!this.client || !this.terminationRequest) return;
     if (!this.terminationReport) {
-      console.log(
-        `[executor.stop] event=quiescence_report_started task_id=${shortId(this.config.taskId)}`
-      );
-      const report = this.client
-        .service('tasks')
-        .reportTerminationComplete({
-          task_id: this.config.taskId,
-          requested_at: this.terminationRequest.requested_at,
-        })
-        .then(() => {
-          console.log(
-            `[executor.stop] event=quiescence_report_accepted task_id=${shortId(this.config.taskId)}`
-          );
-        })
-        .catch((error) => {
-          console.warn(
-            `[executor.stop] event=quiescence_report_failed task_id=${shortId(this.config.taskId)} ` +
-              `error_type=${error instanceof Error ? 'error' : 'non_error'} retryable=true`
-          );
-          throw error;
-        });
+      const client = this.client;
+      const requestedAt = this.terminationRequest.requested_at;
+      const report = reportExecutorQuiescence({
+        taskId: this.config.taskId,
+        requestedAt,
+        report: () =>
+          client.service('tasks').reportTerminationComplete({
+            task_id: this.config.taskId,
+            requested_at: requestedAt,
+          }),
+        readTask: () => client.service('tasks').get(this.config.taskId) as Promise<Task>,
+      });
       this.terminationReport = report;
       void report.catch(() => {
         if (this.terminationReport === report) this.terminationReport = null;
@@ -345,6 +351,10 @@ export class AgorExecutor {
         onPulse: (kind, detail) => this.recordPulse(kind, detail),
       });
     } finally {
+      if (this.providerCleanupSlowTimer) {
+        clearTimeout(this.providerCleanupSlowTimer);
+        this.providerCleanupSlowTimer = null;
+      }
       if (this.terminationRequest) {
         const elapsedMs = Math.max(0, Date.now() - (this.terminationObservedAtMs ?? Date.now()));
         console.log(

--- a/packages/executor/src/termination-report.test.ts
+++ b/packages/executor/src/termination-report.test.ts
@@ -1,0 +1,105 @@
+import type { Task } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { reportExecutorQuiescence } from './termination-report.js';
+
+const requestedAt = '2026-07-23T12:00:00.000Z';
+const stopping = (executorQuiescedAt?: string) =>
+  ({
+    task_id: 'task-1',
+    status: 'stopping',
+    termination_request: {
+      cause: 'user_stop',
+      requested_at: requestedAt,
+      ...(executorQuiescedAt ? { executor_quiesced_at: executorQuiescedAt } : {}),
+    },
+  }) as Task;
+
+describe('reportExecutorQuiescence', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries transient failure and logs only the first outage', async () => {
+    vi.useFakeTimers();
+    const report = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockRejectedValueOnce(new Error('still offline'))
+      .mockResolvedValue({});
+    const warn = vi.fn();
+    const result = reportExecutorQuiescence({
+      taskId: 'task-1',
+      requestedAt,
+      report,
+      readTask: async () => stopping(),
+      log: vi.fn(),
+      warn,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(report).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('quiescence_report_failed'));
+  });
+
+  it('accepts durable quiescence when the write response was lost', async () => {
+    const report = vi.fn().mockRejectedValue(new Error('response lost'));
+    const warn = vi.fn();
+
+    await expect(
+      reportExecutorQuiescence({
+        taskId: 'task-1',
+        requestedAt,
+        report,
+        readTask: async () => stopping('2026-07-23T12:00:00.100Z'),
+        log: vi.fn(),
+        warn,
+      })
+    ).resolves.toBeUndefined();
+    expect(report).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not accept quiescence from a different termination request', async () => {
+    vi.useFakeTimers();
+    const report = vi.fn().mockRejectedValueOnce(new Error('response lost')).mockResolvedValue({});
+    const warn = vi.fn();
+    const stale = stopping('2026-07-23T12:00:00.100Z');
+    stale.termination_request!.requested_at = '2026-07-23T11:59:59.000Z';
+    const result = reportExecutorQuiescence({
+      taskId: 'task-1',
+      requestedAt,
+      report,
+      readTask: async () => stale,
+      log: vi.fn(),
+      warn,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('bounds a hung report and logs only first failure plus exhaustion', async () => {
+    vi.useFakeTimers();
+    const report = vi.fn(() => new Promise(() => undefined));
+    const warn = vi.fn();
+    const result = reportExecutorQuiescence({
+      taskId: 'task-1',
+      requestedAt,
+      report,
+      readTask: async () => stopping(),
+      log: vi.fn(),
+      warn,
+    }).catch((error) => error as Error);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(result).resolves.toBeInstanceOf(Error);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(1, expect.stringContaining('quiescence_report_failed'));
+    expect(warn).toHaveBeenNthCalledWith(2, expect.stringContaining('quiescence_report_exhausted'));
+  });
+});

--- a/packages/executor/src/termination-report.ts
+++ b/packages/executor/src/termination-report.ts
@@ -1,0 +1,111 @@
+import { shortId } from '@agor/core/db';
+import type { Task } from '@agor/core/types';
+import { isTerminalTaskStatus, TaskStatus } from '@agor/core/types';
+
+const RETRY_WINDOW_MS = 15_000;
+const ATTEMPT_TIMEOUT_MS = 2_000;
+const RETRY_BASE_MS = 250;
+const RETRY_MAX_MS = 1_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function within<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('executor lifecycle operation timed out')),
+      timeoutMs
+    );
+    operation.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+export interface ExecutorQuiescenceReportOptions {
+  taskId: string;
+  requestedAt: string;
+  report: () => Promise<unknown>;
+  readTask: () => Promise<Task>;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Bounded retry for the executor's final, task/request-fenced quiescence fact.
+ * A read after failure distinguishes an unavailable daemon from a response
+ * lost after commit. Replays are safe because the daemon validates both IDs.
+ */
+export async function reportExecutorQuiescence(
+  options: ExecutorQuiescenceReportOptions
+): Promise<void> {
+  const log = options.log ?? console.log;
+  const warn = options.warn ?? console.warn;
+  const deadline = Date.now() + RETRY_WINDOW_MS;
+  const operationTimeoutMs = () => Math.max(1, Math.min(ATTEMPT_TIMEOUT_MS, deadline - Date.now()));
+  let attempts = 0;
+  let loggedFailure = false;
+  log(`[executor.stop] event=quiescence_report_started task_id=${shortId(options.taskId)}`);
+
+  while (true) {
+    attempts += 1;
+    try {
+      await within(options.report(), operationTimeoutMs());
+      log(
+        `[executor.stop] event=quiescence_report_accepted task_id=${shortId(options.taskId)} ` +
+          `attempts=${attempts}`
+      );
+      return;
+    } catch {
+      try {
+        if (Date.now() >= deadline) throw new Error('retry window elapsed');
+        const task = await within(options.readTask(), operationTimeoutMs());
+        const matchingQuiescence =
+          task.status === TaskStatus.STOPPING &&
+          task.termination_request?.requested_at === options.requestedAt &&
+          !!task.termination_request.executor_quiesced_at;
+        if (isTerminalTaskStatus(task.status) || matchingQuiescence) {
+          log(
+            `[executor.stop] event=quiescence_report_observed_committed ` +
+              `task_id=${shortId(options.taskId)} attempts=${attempts}`
+          );
+          return;
+        }
+      } catch {
+        // The same bounded retry covers both a lost write response and an
+        // unavailable durable read. Exact Task/request fencing makes replay
+        // idempotent.
+      }
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        warn(
+          `[executor.stop] event=quiescence_report_exhausted ` +
+            `task_id=${shortId(options.taskId)} attempts=${attempts}`
+        );
+        throw new Error('executor quiescence report retry window exhausted');
+      }
+      if (!loggedFailure) {
+        loggedFailure = true;
+        warn(
+          `[executor.stop] event=quiescence_report_failed task_id=${shortId(options.taskId)} ` +
+            'retrying=true'
+        );
+      }
+      const retryDelayMs = Math.min(
+        RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 2),
+        RETRY_MAX_MS,
+        remainingMs
+      );
+      await delay(retryDelayMs);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix the production Task/Session Stop flow so a cooperatively terminated executor reliably converges from `stopping` to a terminal Task and promptable Session.

This also keeps runtime evidence visible while cancellation is still in progress and replaces the browser-native force-fail prompt with an accessible Ant Design modal.

## Root cause

In strict/insulated local execution, the target-user executor runs under a root-owned `sudo` wrapper in the same process group. After the executor acknowledged quiescence, the first target-user PGID inspection could transiently return `EPERM` while the wrapper unwound.

`containExecutorIdentity()` classified that result as unverified before honoring its intended 250 ms cooperative grace. The process could therefore already be gone while the durable Task and Session remained guarded in `stopping`.

A second recovery gap made this permanent: after an unverified guard was written, a late exact task/request-fenced quiescence acknowledgement could not make the same termination request eligible for reconciliation again.

## Changes

- honor the local wrapper-exit grace before classifying transient cross-UID inspection uncertainty, while still requiring explicit process-group absence
- make the first late, exact quiescence acknowledgement clear an obsolete unverified guard and retry fenced reconciliation
- prevent duplicate/stale acknowledgements from clearing a newer guard or mutating a terminal/newer Task generation
- give remote/templated executors a bounded 15-second cooperative window because no local signal fallback exists, with an explicit remote-acknowledgement timeout diagnosis
- make repeated Stop idempotent after the first caller has already projected the Session to idle
- continue task heartbeats/pulses until provider cleanup returns—including after an unverified guard—and render `stopping` Tasks as live in the UI; stop accepting telemetry after executor quiescence
- replace `window.prompt()` force-fail confirmation with a danger Ant Design modal requiring literal `STOP`
- fence force-fail to the exact Task ID and termination-request timestamp captured by that modal, at both REST and coordinator boundaries
- clarify that force-fail changes durable Agor state but cannot prove or guarantee process termination
- add bounded, safe executor/daemon lifecycle logs for Stop observation, provider cleanup, telemetry shutdown, quiescence acknowledgement, durable settlement, heartbeat outage/recovery, and process exit
- retry the final executor quiescence acknowledgement for a bounded 15-second window, using durable Task state to recognize a response lost after commit and logging only first failure/final exhaustion
- acknowledge the exact Stop request even when provider cancellation returns by rejecting, without starting a second retry window after bounded acknowledgement exhaustion
- warn once when provider cleanup remains active for 15 seconds without falsely claiming quiescence
- document the local, remote, HA, recovery, and force-fail contracts

## Validation

- `pnpm i`
- `pnpm check`
- core Task lifecycle repository: 115 tests
- daemon termination, process tracking, Socket/realtime, session Stop, and startup: 230 tests; follow-up focused lifecycle suite: 41 tests
- executor cancellation/heartbeat/output/watchdog: 38 tests; follow-up focused suite: 16 tests
- reactive session reconnect/subscription: 28 tests
- SessionPanel and TaskBlock UI: 17 tests
- PostgreSQL Task runtime/RLS integration: 5 tests
- two-daemon PostgreSQL reconciler integration: 2 tests

Live `full` PostgreSQL/strict validation confirmed that:

- before the fix, the executor acknowledged and exited and its PID/PGID disappeared, but the Task and Session remained `stopping` with an unverified marker
- after the fix, cooperative Stop completed in 604 ms, the Task became `stopped`, the Session became `idle`, and the PID/PGID was explicitly absent
- immediate Stop during dispatch, repeated Stop, SIGTERM fallback, and an executor process group ignoring SIGTERM also converged correctly
- the environment remains healthy with no active Task rows or executor runtime processes left behind after validation

## Security and tenancy

- preserves owner/admin enforcement for force-fail and existing branch RBAC
- authorizes before loading force-fail target state, avoiding unauthorized Task-state disclosure
- retains tenant + Task-scoped executor rooms and credentials
- fences reports and force-fail escalation by exact Task ID and termination request timestamp, including at the locked repository writer
- requires the current coordination lease token for settlement
- keeps terminal Tasks immutable
- includes a PostgreSQL/RLS negative test proving a different tenant cannot report quiescence for a known Task ID
- system reconciliation remains capability-gated discovery followed by exact tenant scope

Force-fail remains intentionally non-authoritative: it marks the durable Task failed and makes the Session available, but does not claim the executor process stopped.


