### PR TITLE
Use collision-safe Unix group IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 ### Fixes
 
-- **Collision-safe Unix group names** — new branch/repo groups use canonical 24-character short IDs while persisted legacy names remain authoritative. Existing `strict`/`insulated` installations should run `sudo agor local fix-group-uuids --only-dups` (preview with `--dry-run`); an optional run without `--only-dups` migrates every legacy group.
+- **Collision-safe Unix group names** — new branch/repo groups use canonical 24-character short IDs while persisted legacy names remain authoritative. Existing `strict`/`insulated` installations should run `sudo agor local fix-group-uuids --only-dups` (preview with `--dry-run`); an optional run without `--only-dups` migrates every legacy group and safely cleans verified legacy orphans.
 - **Reliable fresh and destructive init** — interactive init requires an intentional nonempty agentic-tool selection, persists the immutable deployment policy, and finishes package reconciliation before success. Destructive re-init now refuses a live daemon, closes SQLite inspection handles, and removes WAL/SHM sidecars before replacing the database.
 - **Reliable cold-cache global installs** — removes deprecated transitive trees and bundled agent runtimes from `agor-live`, bundles selected high-fanout pure-JS dependencies, and adds package-content and low-file-descriptor installation checks. ([#2201](https://github.com/preset-io/agor/pull/2201))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 ### Fixes
 
+- **Collision-safe Unix group names** — new branch/repo groups use canonical 24-character short IDs while persisted legacy names remain authoritative. Existing `strict`/`insulated` installations should run `sudo agor local fix-group-uuids --only-dups` (preview with `--dry-run`); an optional run without `--only-dups` migrates every legacy group.
 - **Reliable fresh and destructive init** — interactive init requires an intentional nonempty agentic-tool selection, persists the immutable deployment policy, and finishes package reconciliation before success. Destructive re-init now refuses a live daemon, closes SQLite inspection handles, and removes WAL/SHM sidecars before replacing the database.
 - **Reliable cold-cache global installs** — removes deprecated transitive trees and bundled agent runtimes from `agor-live`, bundles selected high-fanout pure-JS dependencies, and adds package-content and low-file-descriptor installation checks. ([#2201](https://github.com/preset-io/agor/pull/2201))
 

--- a/apps/agor-cli/src/commands/local/create-branch-group.ts
+++ b/apps/agor-cli/src/commands/local/create-branch-group.ts
@@ -1,4 +1,3 @@
-import { createBranchGroupAction } from '@agor/core/local-actions';
 import { Command, Flags } from '@oclif/core';
 
 export default class CreateBranchGroup extends Command {
@@ -25,11 +24,11 @@ export default class CreateBranchGroup extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(CreateBranchGroup);
-    await createBranchGroupAction({
-      branchId: flags['branch-id'],
-      dryRun: flags['dry-run'],
-      verbose: flags.verbose,
-      reporter: { log: (message) => this.log(message) },
-    });
+    // The DB-aware sync command owns absent-field stamping. Delegating avoids
+    // deriving a group from the UUID in this offline host-only command.
+    const args = ['--branch-id', flags['branch-id']];
+    if (flags['dry-run']) args.push('--dry-run');
+    if (flags.verbose) args.push('--verbose');
+    await this.config.runCommand('local:sync-unix', args);
   }
 }

--- a/apps/agor-cli/src/commands/local/fix-group-uuids.ts
+++ b/apps/agor-cli/src/commands/local/fix-group-uuids.ts
@@ -10,6 +10,7 @@ import {
   createDatabase,
   eq,
   repos,
+  resolveDatabaseUrl,
   select,
   sessions,
   shortId,
@@ -77,10 +78,6 @@ function invokingAgorHome(): string {
   return join(homedir(), '.agor');
 }
 
-function defaultLocalDatabaseUrl(agorHome: string): string {
-  return `file:${join(agorHome, 'agor.db')}`;
-}
-
 export default class FixGroupUuids extends Command {
   static override description =
     'Explicitly migrate legacy 8-character branch/repo Unix groups to collision-safe names';
@@ -120,7 +117,20 @@ export default class FixGroupUuids extends Command {
     }
 
     const agorHome = invokingAgorHome();
-    const databaseUrl = process.env.DATABASE_URL || defaultLocalDatabaseUrl(agorHome);
+    const configPath = join(agorHome, 'config.yaml');
+    if (!existsSync(configPath)) {
+      this.error(`Config not found: ${configPath}`);
+    }
+    const config = await loadConfigFromFile(configPath);
+    const resolvedDatabaseUrl = resolveDatabaseUrl({
+      config,
+      env: process.env,
+      homeDir: join(agorHome, '..'),
+    });
+    const databaseUrl =
+      resolvedDatabaseUrl.startsWith('file:') || /^[a-z][a-z0-9+.-]*:/i.test(resolvedDatabaseUrl)
+        ? resolvedDatabaseUrl
+        : `file:${resolvedDatabaseUrl}`;
     if (
       process.env.AGOR_DB_DIALECT === 'postgresql' ||
       /^(?:postgres(?:ql)?|pg):\/\//.test(databaseUrl) ||
@@ -141,11 +151,6 @@ export default class FixGroupUuids extends Command {
     }
 
     const db = createDatabase({ dialect: 'sqlite', url: `file:${databasePath}` });
-    const configPath = join(agorHome, 'config.yaml');
-    if (!existsSync(configPath)) {
-      this.error(`Config not found: ${configPath}`);
-    }
-    const config = await loadConfigFromFile(configPath);
     const daemonUser = config.daemon?.unix_user;
     if (!daemonUser || !isValidUnixUsername(daemonUser)) {
       this.error(

--- a/apps/agor-cli/src/commands/local/fix-group-uuids.ts
+++ b/apps/agor-cli/src/commands/local/fix-group-uuids.ts
@@ -1,0 +1,531 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfigFromFile } from '@agor/core/config';
+import {
+  and,
+  BranchRepository,
+  branches,
+  createDatabase,
+  eq,
+  repos,
+  select,
+  sessions,
+  shortId,
+  update,
+  users,
+} from '@agor/core/db';
+import type { BranchID } from '@agor/core/types';
+import {
+  createAdminExecutor,
+  getBranchPermissionMode,
+  isValidUnixUsername,
+  listBranchGroups,
+  listRepoGroups,
+  type PlannedUnixGroupResource,
+  planUnixGroupUuidMigration,
+  REPO_GIT_PERMISSION_MODE,
+  runUnixGroupUuidMigration,
+  UnixGroupCommands,
+  type UnixGroupCompareAndSetResult,
+  type UnixGroupMigrationResource,
+} from '@agor/core/unix';
+import { Command, Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+interface RawBranch {
+  branch_id: string;
+  repo_id: string;
+  name: string;
+  unix_group: string | null;
+  others_fs_access: 'none' | 'read' | 'write' | null;
+  data: { path?: string } | null;
+}
+
+interface RawRepo {
+  repo_id: string;
+  slug: string;
+  unix_group: string | null;
+  data: { local_path?: string } | null;
+}
+
+interface RawSession {
+  branch_id: string;
+  unix_username: string | null;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function invokingAgorHome(): string {
+  const sudoUser = process.env.SUDO_USER;
+
+  if (sudoUser) {
+    try {
+      const passwdEntry = execSync(`getent passwd ${shellQuote(sudoUser)}`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).trim();
+      return join(passwdEntry.split(':')[5], '.agor');
+    } catch {
+      return join('/home', sudoUser, '.agor');
+    }
+  }
+
+  return join(homedir(), '.agor');
+}
+
+function defaultLocalDatabaseUrl(agorHome: string): string {
+  return `file:${join(agorHome, 'agor.db')}`;
+}
+
+export default class FixGroupUuids extends Command {
+  static override description =
+    'Explicitly migrate legacy 8-character branch/repo Unix groups to collision-safe names';
+
+  static override examples = [
+    'sudo <%= config.bin %> <%= command.id %> --only-dups --dry-run',
+    'sudo <%= config.bin %> <%= command.id %> --only-dups',
+    'sudo <%= config.bin %> <%= command.id %> --dry-run  # Preview full legacy migration',
+    'sudo <%= config.bin %> <%= command.id %>            # Migrate every legacy group',
+  ];
+
+  static override flags = {
+    'only-dups': Flags.boolean({
+      description: 'Migrate only real legacy collision cohorts (recommended)',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      char: 'n',
+      description: 'Show the plan without changing groups, paths, or database rows',
+      default: false,
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'Show privileged commands and detailed progress',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(FixGroupUuids);
+    const dryRun = flags['dry-run'];
+
+    if (!dryRun && typeof process.getuid === 'function' && process.getuid() !== 0) {
+      this.error(
+        'fix-group-uuids must run as root so it can verify every managed path. Re-run with sudo, or use --dry-run.'
+      );
+    }
+
+    const agorHome = invokingAgorHome();
+    const databaseUrl = process.env.DATABASE_URL || defaultLocalDatabaseUrl(agorHome);
+    if (
+      process.env.AGOR_DB_DIALECT === 'postgresql' ||
+      /^(?:postgres(?:ql)?|pg):\/\//.test(databaseUrl) ||
+      !databaseUrl.startsWith('file:')
+    ) {
+      this.error(
+        'fix-group-uuids supports only the host-local single-tenant SQLite database. ' +
+          'Unix groups are system-global, so a PostgreSQL/RLS or remote database view cannot prove that another tenant or host is not still using a legacy group.'
+      );
+    }
+
+    const rawDatabasePath = databaseUrl.slice('file:'.length);
+    const databasePath = rawDatabasePath.startsWith('~/')
+      ? join(join(agorHome, '..'), rawDatabasePath.slice(2))
+      : rawDatabasePath;
+    if (!existsSync(databasePath)) {
+      this.error(`Database not found: ${databasePath}`);
+    }
+
+    const db = createDatabase({ dialect: 'sqlite', url: `file:${databasePath}` });
+    const configPath = join(agorHome, 'config.yaml');
+    if (!existsSync(configPath)) {
+      this.error(`Config not found: ${configPath}`);
+    }
+    const config = await loadConfigFromFile(configPath);
+    const daemonUser = config.daemon?.unix_user;
+    if (!daemonUser || !isValidUnixUsername(daemonUser)) {
+      this.error(
+        'daemon.unix_user must be configured to a valid Unix username before reconstructing group memberships.'
+      );
+    }
+
+    const branchRows = (await select(db).from(branches).all()) as RawBranch[];
+    const repoRows = (await select(db).from(repos).all()) as RawRepo[];
+    const sessionRows = (await select(db, {
+      branch_id: sessions.branch_id,
+      unix_username: sessions.unix_username,
+    })
+      .from(sessions)
+      .all()) as RawSession[];
+    const userRows = (await select(db, {
+      user_id: users.user_id,
+      unix_username: users.unix_username,
+    })
+      .from(users)
+      .all()) as Array<{ user_id: string; unix_username: string | null }>;
+
+    const branchById = new Map(branchRows.map((branch) => [branch.branch_id, branch]));
+    const repoById = new Map(repoRows.map((repo) => [repo.repo_id, repo]));
+    const branchesByRepo = new Map<string, RawBranch[]>();
+    for (const branch of branchRows) {
+      const repoBranches = branchesByRepo.get(branch.repo_id) ?? [];
+      repoBranches.push(branch);
+      branchesByRepo.set(branch.repo_id, repoBranches);
+    }
+    const sessionsByBranch = new Map<string, Set<string>>();
+    for (const session of sessionRows) {
+      if (!session.unix_username) continue;
+      if (!isValidUnixUsername(session.unix_username)) {
+        this.error(
+          `Session on branch ${shortId(session.branch_id)} has invalid unix_username ${session.unix_username}; refusing partial authorization reconstruction.`
+        );
+      }
+      const usernames = sessionsByBranch.get(session.branch_id) ?? new Set<string>();
+      usernames.add(session.unix_username);
+      sessionsByBranch.set(session.branch_id, usernames);
+    }
+    const usernameByUserId = new Map<string, string>();
+    for (const user of userRows) {
+      if (!user.unix_username) continue;
+      if (!isValidUnixUsername(user.unix_username)) {
+        this.error(
+          `User ${shortId(user.user_id)} has invalid unix_username ${user.unix_username}; refusing partial authorization reconstruction.`
+        );
+      }
+      usernameByUserId.set(user.user_id, user.unix_username);
+    }
+
+    const resources: UnixGroupMigrationResource[] = [
+      ...branchRows.map((branch) => ({
+        kind: 'branch' as const,
+        id: branch.branch_id,
+        unixGroup: branch.unix_group,
+        label: branch.name,
+      })),
+      ...repoRows.map((repo) => ({
+        kind: 'repo' as const,
+        id: repo.repo_id,
+        unixGroup: repo.unix_group,
+        label: repo.slug,
+      })),
+    ];
+    const systemGroups = [...listBranchGroups(), ...listRepoGroups()];
+    const plan = planUnixGroupUuidMigration(resources, {
+      onlyDuplicates: flags['only-dups'],
+      existingSystemGroups: systemGroups,
+    });
+
+    const pendingRows = plan.reduce((total, cohort) => total + cohort.resources.length, 0);
+    this.log(chalk.cyan.bold('Unix group UUID migration'));
+    this.log(`Mode: ${flags['only-dups'] ? 'duplicate cohorts only' : 'all legacy groups'}`);
+    this.log(`Cohorts: ${plan.length}; pending rows: ${pendingRows}`);
+
+    if (plan.length === 0) {
+      this.log(chalk.green('\nNo matching legacy groups need migration.'));
+      return;
+    }
+
+    for (const cohort of plan) {
+      this.log(
+        `  ${cohort.legacyGroup}: ${cohort.resources.length} pending, ` +
+          `${cohort.collisionResourceIds.length} collision-cohort row(s)`
+      );
+      for (const resource of cohort.resources) {
+        this.log(
+          chalk.gray(
+            `    ${resource.kind} ${resource.label} (${shortId(resource.id)}): ${resource.unixGroup} → ${resource.newGroup}`
+          )
+        );
+      }
+    }
+
+    if (dryRun) {
+      this.log(chalk.yellow('\nDry run: no Unix, filesystem, or database changes were made.'));
+      return;
+    }
+
+    const executor = createAdminExecutor({ 'dry-run': false, verbose: flags.verbose });
+    const branchRepository = new BranchRepository(db);
+
+    const expectedBranchMembers = async (branch: RawBranch): Promise<Set<string>> => {
+      const expected = new Set<string>([daemonUser]);
+      const explicitUserIds = await branchRepository.findExplicitFsAccessUserIds(
+        branch.branch_id as BranchID
+      );
+      for (const userId of explicitUserIds) {
+        const username = usernameByUserId.get(userId);
+        if (username) expected.add(username);
+      }
+      if ((branch.others_fs_access ?? 'read') === 'write') {
+        for (const username of sessionsByBranch.get(branch.branch_id) ?? []) {
+          expected.add(username);
+        }
+      }
+      return expected;
+    };
+
+    const expectedRepoMembers = async (repo: RawRepo): Promise<Set<string>> => {
+      const expected = new Set<string>([daemonUser]);
+      for (const branch of branchesByRepo.get(repo.repo_id) ?? []) {
+        const explicitUserIds = await branchRepository.findExplicitFsAccessUserIds(
+          branch.branch_id as BranchID
+        );
+        for (const userId of explicitUserIds) {
+          const username = usernameByUserId.get(userId);
+          if (username) expected.add(username);
+        }
+        if ((branch.others_fs_access ?? 'read') !== 'none') {
+          for (const username of sessionsByBranch.get(branch.branch_id) ?? []) {
+            expected.add(username);
+          }
+        }
+      }
+      return expected;
+    };
+
+    const getMembers = async (groupName: string): Promise<Set<string>> => {
+      const output = await executor.exec(UnixGroupCommands.listGroupMembers(groupName));
+      return new Set(output.stdout.trim().split(',').filter(Boolean));
+    };
+
+    const inspectPath = async (path: string): Promise<{ group: string; acl: string[] }> => {
+      const quotedPath = shellQuote(path);
+      const [statResult, aclResult] = await Promise.all([
+        executor.exec(`stat -c %G -- ${quotedPath}`),
+        executor.exec(`getfacl -cp -- ${quotedPath}`),
+      ]);
+      return {
+        group: statResult.stdout.trim(),
+        acl: aclResult.stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean),
+      };
+    };
+
+    const managedPathsFor = (resource: PlannedUnixGroupResource): string[] => {
+      if (resource.kind === 'branch') {
+        const path = branchById.get(resource.id)?.data?.path;
+        return path && existsSync(path) ? [path] : [];
+      }
+      const path = repoById.get(resource.id)?.data?.local_path;
+      if (!path || !existsSync(path)) return [];
+      const gitPath = join(path, '.git');
+      return existsSync(gitPath) ? [path, gitPath] : [path];
+    };
+
+    const result = await runUnixGroupUuidMigration(plan, {
+      log: (message) => this.log(message),
+      ensureGroup: async (groupName) => {
+        if (!(await executor.check(UnixGroupCommands.groupExists(groupName)))) {
+          await executor.exec(UnixGroupCommands.createGroup(groupName));
+        }
+      },
+      expectedMembers: async (resource) => {
+        if (resource.kind === 'branch') {
+          const branch = branchById.get(resource.id);
+          if (!branch) throw new Error('branch disappeared while migration was running');
+          return expectedBranchMembers(branch);
+        }
+        const repo = repoById.get(resource.id);
+        if (!repo) throw new Error('repo disappeared while migration was running');
+        return expectedRepoMembers(repo);
+      },
+      reconcileMembers: async (groupName, expectedMembers) => {
+        const current = await getMembers(groupName);
+        for (const username of expectedMembers) {
+          if (!current.has(username)) {
+            await executor.exec(UnixGroupCommands.addUserToGroup(username, groupName));
+          }
+        }
+        for (const username of current) {
+          if (!expectedMembers.has(username)) {
+            await executor.exec(UnixGroupCommands.removeUserFromGroup(username, groupName));
+          }
+        }
+      },
+      verifyMembers: async (groupName, expectedMembers) => {
+        const actual = await getMembers(groupName);
+        const missing = [...expectedMembers].filter((username) => !actual.has(username));
+        const extra = [...actual].filter((username) => !expectedMembers.has(username));
+        if (missing.length || extra.length) {
+          throw new Error(
+            `membership verification failed (missing: ${missing.join(', ') || 'none'}; extra: ${extra.join(', ') || 'none'})`
+          );
+        }
+      },
+      applyFilesystem: async (resource) => {
+        if (resource.kind === 'branch') {
+          const branch = branchById.get(resource.id);
+          const path = branch?.data?.path;
+          if (!branch || !path || !existsSync(path)) return;
+          await executor.execAll([
+            ...UnixGroupCommands.setDirectoryGroup(
+              path,
+              resource.newGroup,
+              getBranchPermissionMode(branch.others_fs_access ?? 'read')
+            ),
+            ...UnixGroupCommands.removeDirectoryGroupAcl(path, resource.unixGroup),
+          ]);
+          return;
+        }
+
+        const repo = repoById.get(resource.id);
+        const path = repo?.data?.local_path;
+        if (!path || !existsSync(path)) return;
+        const commands = [
+          ...UnixGroupCommands.setDirectoryGroupShallow(
+            path,
+            resource.newGroup,
+            REPO_GIT_PERMISSION_MODE
+          ),
+          ...UnixGroupCommands.removeDirectoryGroupAclShallow(path, resource.unixGroup),
+        ];
+        const gitPath = join(path, '.git');
+        if (existsSync(gitPath)) {
+          commands.push(
+            ...UnixGroupCommands.setDirectoryGroup(
+              gitPath,
+              resource.newGroup,
+              REPO_GIT_PERMISSION_MODE
+            ),
+            ...UnixGroupCommands.removeDirectoryGroupAcl(gitPath, resource.unixGroup)
+          );
+        }
+        await executor.execAll(commands);
+      },
+      verifyFilesystem: async (resource) => {
+        for (const path of managedPathsFor(resource)) {
+          const state = await inspectPath(path);
+          const hasNewAcl = state.acl.some((line) =>
+            line.startsWith(`group:${resource.newGroup}:`)
+          );
+          const hasOldAcl = state.acl.some(
+            (line) =>
+              line.startsWith(`group:${resource.unixGroup}:`) ||
+              line.startsWith(`default:group:${resource.unixGroup}:`)
+          );
+          if (state.group !== resource.newGroup || !hasNewAcl || hasOldAcl) {
+            throw new Error(
+              `filesystem verification failed for ${path} (group=${state.group}, new_acl=${hasNewAcl}, old_acl=${hasOldAcl})`
+            );
+          }
+        }
+      },
+      compareAndSetGroup: async (resource): Promise<UnixGroupCompareAndSetResult> => {
+        if (resource.kind === 'branch') {
+          const row = await select(db, { unix_group: branches.unix_group })
+            .from(branches)
+            .where(eq(branches.branch_id, resource.id))
+            .one();
+          if (!row) return 'conflict';
+          if (row.unix_group === resource.newGroup) return 'already-updated';
+          if (row.unix_group !== resource.unixGroup) return 'conflict';
+
+          await update(db, branches)
+            .set({ unix_group: resource.newGroup })
+            .where(
+              and(eq(branches.branch_id, resource.id), eq(branches.unix_group, resource.unixGroup))
+            )
+            .run();
+          const verified = await select(db, { unix_group: branches.unix_group })
+            .from(branches)
+            .where(eq(branches.branch_id, resource.id))
+            .one();
+          return verified?.unix_group === resource.newGroup ? 'updated' : 'conflict';
+        }
+
+        const row = await select(db, { unix_group: repos.unix_group })
+          .from(repos)
+          .where(eq(repos.repo_id, resource.id))
+          .one();
+        if (!row) return 'conflict';
+        if (row.unix_group === resource.newGroup) return 'already-updated';
+        if (row.unix_group !== resource.unixGroup) return 'conflict';
+
+        await update(db, repos)
+          .set({ unix_group: resource.newGroup })
+          .where(and(eq(repos.repo_id, resource.id), eq(repos.unix_group, resource.unixGroup)))
+          .run();
+        const verified = await select(db, { unix_group: repos.unix_group })
+          .from(repos)
+          .where(eq(repos.repo_id, resource.id))
+          .one();
+        return verified?.unix_group === resource.newGroup ? 'updated' : 'conflict';
+      },
+      findDatabaseReferences: async (groupName) => {
+        const [branchRefs, repoRefs] = await Promise.all([
+          select(db, { id: branches.branch_id })
+            .from(branches)
+            .where(eq(branches.unix_group, groupName))
+            .all(),
+          select(db, { id: repos.repo_id })
+            .from(repos)
+            .where(eq(repos.unix_group, groupName))
+            .all(),
+        ]);
+        return [
+          ...branchRefs.map((row: { id: string }) => `branch:${row.id}`),
+          ...repoRefs.map((row: { id: string }) => `repo:${row.id}`),
+        ];
+      },
+      findManagedRootsUsingGroup: async (groupName) => {
+        const paths = new Set<string>();
+        for (const branch of branchRows) {
+          if (branch.data?.path && existsSync(branch.data.path)) paths.add(branch.data.path);
+        }
+        for (const repo of repoRows) {
+          const path = repo.data?.local_path;
+          if (!path || !existsSync(path)) continue;
+          paths.add(path);
+          const gitPath = join(path, '.git');
+          if (existsSync(gitPath)) paths.add(gitPath);
+        }
+
+        const references: string[] = [];
+        for (const path of paths) {
+          const state = await inspectPath(path);
+          if (
+            state.group === groupName ||
+            state.acl.some(
+              (line) =>
+                line.startsWith(`group:${groupName}:`) ||
+                line.startsWith(`default:group:${groupName}:`)
+            )
+          ) {
+            references.push(path);
+          }
+        }
+        return references;
+      },
+      groupExists: (groupName) => executor.check(UnixGroupCommands.groupExists(groupName)),
+      deleteGroup: async (groupName) => {
+        await executor.exec(UnixGroupCommands.deleteGroup(groupName));
+      },
+    });
+
+    this.log(chalk.bold('\nSummary'));
+    this.log(`Rows migrated: ${result.migrated}`);
+    this.log(`Legacy groups deleted: ${result.groupsDeleted}`);
+    this.log(`Legacy groups retained: ${result.retained.length}`);
+    this.log(`Errors: ${result.errors.length}`);
+
+    if (result.retained.length > 0) {
+      for (const retained of result.retained) {
+        this.log(chalk.yellow(`  ${retained.group}: ${retained.reason}`));
+      }
+    }
+    if (result.errors.length > 0) {
+      for (const error of result.errors) {
+        this.log(chalk.red(`  ${error.resource}: ${error.message}`));
+      }
+      this.error(
+        'Migration completed with errors. Fix the reported issue and rerun the same command; completed steps are idempotent.'
+      );
+    }
+  }
+}

--- a/apps/agor-cli/src/commands/local/sync-unix.test.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { canVerifyGlobalUnixState } from './sync-unix.js';
+import {
+  buildBranchGroupAuthorizationIndex,
+  buildExplicitFsAuthorizationIndex,
+  canVerifyGlobalUnixState,
+} from './sync-unix.js';
 
 describe('canVerifyGlobalUnixState', () => {
   it('accepts a host-local SQLite file', () => {
@@ -13,5 +17,67 @@ describe('canVerifyGlobalUnixState', () => {
     'https://db.example/agor',
   ])('rejects a remote or tenant-scoped DB view: %s', (databaseUrl) => {
     expect(canVerifyGlobalUnixState(databaseUrl)).toBe(false);
+  });
+});
+
+describe('buildExplicitFsAuthorizationIndex', () => {
+  it('indexes every user returned by the canonical branch authorization expansion', async () => {
+    const directBranch = {
+      branch_id: 'branch-direct',
+      name: 'direct',
+      unix_group: 'agor_wt_019ffd3d2cef79d1a1c64073',
+      repo_id: 'repo-a',
+    };
+    const boardAlignedBranch = {
+      branch_id: 'branch-board',
+      name: 'board-aligned',
+      unix_group: 'agor_wt_019ffd3d2cef79d1a1c64074',
+      repo_id: 'repo-a',
+    };
+    const authorizationByBranch = new Map([
+      [directBranch.branch_id, ['direct-owner', 'branch-group-member']],
+      [boardAlignedBranch.branch_id, ['board-owner', 'board-group-member']],
+    ]);
+
+    const index = await buildExplicitFsAuthorizationIndex([directBranch, boardAlignedBranch], {
+      findExplicitFsAccessUserIds: async (branchId) => authorizationByBranch.get(branchId) ?? [],
+    });
+
+    expect(index.userIdsByBranchId.get(directBranch.branch_id)).toEqual(
+      new Set(['direct-owner', 'branch-group-member'])
+    );
+    expect(index.userIdsByBranchId.get(boardAlignedBranch.branch_id)).toEqual(
+      new Set(['board-owner', 'board-group-member'])
+    );
+    expect(index.branchesByUserId.get('branch-group-member')).toEqual([directBranch]);
+    expect(index.branchesByUserId.get('board-owner')).toEqual([boardAlignedBranch]);
+  });
+});
+
+describe('buildBranchGroupAuthorizationIndex', () => {
+  it('unions authorization across a shared legacy collision cohort', () => {
+    const legacyGroup = 'agor_wt_019ffd3d';
+    const first = {
+      branch_id: '019ffd3d-0000-7000-8000-000000000001',
+      name: 'first',
+      unix_group: legacyGroup,
+      repo_id: 'repo-a',
+    };
+    const second = {
+      branch_id: '019ffd3d-0000-7000-8000-000000000002',
+      name: 'second',
+      unix_group: legacyGroup,
+      repo_id: 'repo-b',
+    };
+
+    const index = buildBranchGroupAuthorizationIndex(
+      [first, second],
+      new Map([
+        [first.branch_id, new Set(['first-user'])],
+        [second.branch_id, new Set(['second-user'])],
+      ])
+    );
+
+    expect(index.userIdsByGroup.get(legacyGroup)).toEqual(new Set(['first-user', 'second-user']));
   });
 });

--- a/apps/agor-cli/src/commands/local/sync-unix.test.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { canVerifyGlobalUnixState } from './sync-unix.js';
+
+describe('canVerifyGlobalUnixState', () => {
+  it('accepts a host-local SQLite file', () => {
+    expect(canVerifyGlobalUnixState('file:/home/operator/.agor/agor.db')).toBe(true);
+  });
+
+  it.each([
+    'postgresql://db.example/agor',
+    'postgres://db.example/agor',
+    'libsql://db.example/agor',
+    'https://db.example/agor',
+  ])('rejects a remote or tenant-scoped DB view: %s', (databaseUrl) => {
+    expect(canVerifyGlobalUnixState(databaseUrl)).toBe(false);
+  });
+});

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -22,11 +22,11 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { loadConfig } from '@agor/core/config';
+import { loadConfigFromFile } from '@agor/core/config';
 import {
   and,
   branches,
@@ -36,6 +36,7 @@ import {
   inArray,
   isNull,
   repos,
+  resolveDatabaseUrl,
   select,
   shortId,
   update,
@@ -228,62 +229,52 @@ export default class SyncUnix extends Command {
     let syncErrors = 0;
 
     try {
-      // Connect to database
-      // When running via sudo, os.homedir() returns /root, but we need the original user's DB.
-      // Use SUDO_USER env var to resolve the correct home directory.
-      let databaseUrl = process.env.DATABASE_URL;
-      if (!databaseUrl) {
-        const sudoUser = process.env.SUDO_USER;
-        let agorHome: string;
-
-        if (sudoUser) {
-          // Running under sudo - use the invoking user's home directory
-          // Try to get home directory from passwd entry
-          try {
-            const passwdEntry = execSync(`getent passwd ${sudoUser}`, {
-              encoding: 'utf-8',
-              stdio: ['pipe', 'pipe', 'ignore'],
-            }).trim();
-            const homeDir = passwdEntry.split(':')[5]; // 6th field is home directory
-            agorHome = join(homeDir, '.agor');
-          } catch {
-            // Fallback to /home/<user>/.agor if getent fails
-            agorHome = join('/home', sudoUser, '.agor');
-          }
-        } else {
-          // Not running under sudo - use current user's home
-          agorHome = join(homedir(), '.agor');
+      // Resolve both config and database relative to the invoking user. When
+      // running via sudo, os.homedir() points at /root rather than the Agor
+      // installation being administered.
+      const sudoUser = process.env.SUDO_USER;
+      let operatorHome = homedir();
+      if (sudoUser) {
+        try {
+          const passwdEntry = execFileSync('getent', ['passwd', sudoUser], {
+            encoding: 'utf-8',
+            stdio: ['pipe', 'pipe', 'ignore'],
+          }).trim();
+          operatorHome = passwdEntry.split(':')[5] || join('/home', sudoUser);
+        } catch {
+          operatorHome = join('/home', sudoUser);
         }
+      }
 
-        const dbPath = join(agorHome, 'agor.db');
+      const agorHome = join(operatorHome, '.agor');
+      const configPath = join(agorHome, 'config.yaml');
+      if (!existsSync(configPath)) {
+        this.error(`Config not found: ${configPath}`);
+      }
+      const config = await loadConfigFromFile(configPath);
+      const resolvedDatabaseUrl = resolveDatabaseUrl({
+        config,
+        env: process.env,
+        homeDir: operatorHome,
+      });
+      const databaseUrl =
+        resolvedDatabaseUrl.startsWith('file:') || /^[a-z][a-z0-9+.-]*:/i.test(resolvedDatabaseUrl)
+          ? resolvedDatabaseUrl
+          : `file:${resolvedDatabaseUrl}`;
 
-        // Verify the database exists
+      if (databaseUrl.startsWith('file:')) {
+        const dbPath = databaseUrl.slice('file:'.length);
         if (!existsSync(dbPath)) {
-          this.log(chalk.red(`Database not found: ${dbPath}`));
-          if (sudoUser) {
-            this.log(
-              chalk.yellow(
-                `\nHint: Running as root via sudo. Expected database at ~${sudoUser}/.agor/agor.db`
-              )
-            );
-            this.log(
-              chalk.yellow('If your database is elsewhere, set DATABASE_URL environment variable:')
-            );
-            this.log(chalk.gray('  sudo DATABASE_URL=file:/path/to/agor.db agor local sync-unix'));
-          }
-          process.exit(1);
+          this.error(`Database not found: ${dbPath}`);
         }
-
-        databaseUrl = `file:${dbPath}`;
       }
 
       const db = createDatabase({ url: databaseUrl });
 
-      // Load config and get daemon user
+      // Get daemon user from the same operator config used for DB resolution.
       // The daemon user must be added to all Unix groups so it can access files
       // Since this command runs under sudo, we MUST require explicit config
       // (process.env.USER would return 'root' which is wrong)
-      const config = await loadConfig();
       const daemonUser = config.daemon?.unix_user;
 
       if (!daemonUser) {

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -47,6 +47,8 @@ import {
   AGOR_USERS_GROUP,
   CommandError,
   createAdminExecutor,
+  generateBranchGroupName,
+  generateRepoGroupName,
   getBranchDirectoryAction,
   getBranchPermissionMode,
   getBranchSymlinkPath,
@@ -393,11 +395,50 @@ export default class SyncUnix extends Command {
             data: { local_path?: string } | null;
           };
 
-          const expectedGroup = resolveRepoGroupName(rawRepo.repo_id as RepoID, rawRepo.unix_group);
           const dbNeedsBackfill = rawRepo.unix_group === null;
-          const groupMissingOnSystem = !groupExists(expectedGroup);
+          let expectedGroup =
+            rawRepo.unix_group == null
+              ? generateRepoGroupName(rawRepo.repo_id as RepoID)
+              : resolveRepoGroupName(rawRepo.repo_id as RepoID, rawRepo.unix_group);
           const repoPath = rawRepo.data?.local_path;
           const pathUsable = repoPath ? existsSync(repoPath) : false;
+          let hadError = false;
+
+          // Persist before any system-global group or filesystem operation.
+          if (dbNeedsBackfill) {
+            if (dryRun) {
+              this.log(
+                chalk.gray(
+                  `   [dry-run] Would update database: SET unix_group = '${expectedGroup}' WHERE repo_id = '${rawRepo.repo_id}'`
+                )
+              );
+              reposBackfilled++;
+            } else {
+              try {
+                await update(db, repos)
+                  .set({ unix_group: expectedGroup })
+                  .where(and(eq(repos.repo_id, rawRepo.repo_id), isNull(repos.unix_group)))
+                  .run();
+                const stampedRepo = await select(db, { unix_group: repos.unix_group })
+                  .from(repos)
+                  .where(eq(repos.repo_id, rawRepo.repo_id))
+                  .one();
+                if (!stampedRepo?.unix_group) {
+                  throw new Error('unix_group remained absent after stamping');
+                }
+                expectedGroup = resolveRepoGroupName(
+                  rawRepo.repo_id as RepoID,
+                  stampedRepo.unix_group
+                );
+                reposBackfilled++;
+                this.log(chalk.green(`   ✓ Backfilled unix_group in database`));
+              } catch (error) {
+                syncErrors++;
+                hadError = true;
+                this.log(chalk.red(`   ✗ Failed to update database: ${error}`));
+              }
+            }
+          }
 
           this.log(chalk.bold(`📁 ${rawRepo.slug}`));
           this.log(chalk.gray(`   repo_id: ${shortId(rawRepo.repo_id)}`));
@@ -410,7 +451,12 @@ export default class SyncUnix extends Command {
             this.log(chalk.gray(`   repo path: <none in data.local_path>`));
           }
 
-          let hadError = false;
+          if (hadError) {
+            this.log('');
+            continue;
+          }
+
+          const groupMissingOnSystem = !groupExists(expectedGroup);
 
           // 1. Ensure Unix group exists on the system
           if (groupMissingOnSystem) {
@@ -446,41 +492,7 @@ export default class SyncUnix extends Command {
             }
           }
 
-          // 3. Backfill DB if unix_group was NULL
-          if (!hadError && dbNeedsBackfill) {
-            if (dryRun) {
-              this.log(
-                chalk.gray(
-                  `   [dry-run] Would update database: SET unix_group = '${expectedGroup}' WHERE repo_id = '${rawRepo.repo_id}'`
-                )
-              );
-              reposBackfilled++;
-            } else {
-              try {
-                await update(db, repos)
-                  .set({ unix_group: expectedGroup })
-                  .where(and(eq(repos.repo_id, rawRepo.repo_id), isNull(repos.unix_group)))
-                  .run();
-                const stampedRepo = await select(db, { unix_group: repos.unix_group })
-                  .from(repos)
-                  .where(eq(repos.repo_id, rawRepo.repo_id))
-                  .one();
-                if (stampedRepo?.unix_group !== expectedGroup) {
-                  throw new Error(
-                    `unix_group was stamped concurrently as ${stampedRepo?.unix_group ?? '<missing>'}; preserved authoritative value`
-                  );
-                }
-                reposBackfilled++;
-                this.log(chalk.green(`   ✓ Backfilled unix_group in database`));
-              } catch (error) {
-                syncErrors++;
-                hadError = true;
-                this.log(chalk.red(`   ✗ Failed to update database: ${error}`));
-              }
-            }
-          }
-
-          // 4. Apply permissions (idempotent; always run unless error)
+          // 3. Apply permissions (idempotent; always run unless error)
           if (!hadError) {
             if (!repoPath) {
               this.log(chalk.yellow(`   ⚠ No local_path in repo data, skipping permissions`));
@@ -530,6 +542,52 @@ export default class SyncUnix extends Command {
           this.log('');
         }
       }
+
+      // Stamp every active branch before any membership or filesystem phase
+      // can use its group. This is intentionally DB-first: if a later host
+      // operation fails, rerunning converges on the same persisted name.
+      const branchesForStamp = targetBranchId
+        ? await select(db).from(branches).where(eq(branches.branch_id, targetBranchId)).all()
+        : await select(db).from(branches).all();
+      const unstampedBranches = branchesForStamp.filter(
+        (row: { archived: boolean; filesystem_status: string | null; unix_group: string | null }) =>
+          row.unix_group == null && !(row.archived && row.filesystem_status === 'deleted')
+      ) as Array<{ branch_id: string; name: string; unix_group: null }>;
+
+      if (unstampedBranches.length > 0) {
+        this.log(chalk.cyan.bold('\n━━━ Stamp Branch Unix Groups ━━━\n'));
+      }
+      for (const branch of unstampedBranches) {
+        const candidate = generateBranchGroupName(branch.branch_id as BranchID);
+        if (dryRun) {
+          branchesBackfilled++;
+          this.log(
+            chalk.gray(`   [dry-run] ${branch.name}: would persist unix_group ${candidate}`)
+          );
+          continue;
+        }
+
+        try {
+          await update(db, branches)
+            .set({ unix_group: candidate })
+            .where(and(eq(branches.branch_id, branch.branch_id), isNull(branches.unix_group)))
+            .run();
+          const stampedBranch = await select(db, { unix_group: branches.unix_group })
+            .from(branches)
+            .where(eq(branches.branch_id, branch.branch_id))
+            .one();
+          if (!stampedBranch?.unix_group) {
+            throw new Error('unix_group remained absent after stamping');
+          }
+          resolveBranchGroupName(branch.branch_id as BranchID, stampedBranch.unix_group);
+          branchesBackfilled++;
+          this.log(chalk.green(`   ✓ ${branch.name}: persisted ${stampedBranch.unix_group}`));
+        } catch (error) {
+          syncErrors++;
+          this.log(chalk.red(`   ✗ ${branch.name}: failed to persist unix_group: ${error}`));
+        }
+      }
+      if (unstampedBranches.length > 0) this.log('');
 
       if (targetBranchId) {
         this.log(chalk.gray('   ⊘ Skipping user sync phase (--branch-id mode)\n'));
@@ -655,8 +713,18 @@ export default class SyncUnix extends Command {
 
             // Build expected groups from owned branches
             for (const wt of ownedBranches) {
-              // Use existing unix_group or generate from branch_id
-              const expectedGroup = resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group);
+              if (wt.unix_group == null && !dryRun) {
+                const message = `Branch ${wt.name} has no persisted unix_group; skipping host group access`;
+                result.errors.push(message);
+                this.log(chalk.red(`   ✗ ${message}`));
+                continue;
+              }
+              // A dry-run may plan an absent stamp, but every mutating run
+              // reaches this phase only after the DB-first stamping pass.
+              const expectedGroup =
+                wt.unix_group == null
+                  ? generateBranchGroupName(wt.branch_id as BranchID)
+                  : resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group);
               result.groups.expected.push(expectedGroup);
 
               const isInGroup = result.groups.actual.includes(expectedGroup);
@@ -725,11 +793,17 @@ export default class SyncUnix extends Command {
               if (repoIdsSeen.has(wt.repo_id)) continue;
               repoIdsSeen.add(wt.repo_id);
 
-              // Get repo group (from prefetched map or generate)
-              const repoGroup = resolveRepoGroupName(
-                wt.repo_id as RepoID,
-                repoGroupMap.get(wt.repo_id)
-              );
+              const persistedRepoGroup = repoGroupMap.get(wt.repo_id);
+              if (persistedRepoGroup == null && !dryRun) {
+                const message = `Repo ${shortId(wt.repo_id)} has no persisted unix_group; skipping host group access`;
+                result.errors.push(message);
+                this.log(chalk.red(`   ✗ ${message}`));
+                continue;
+              }
+              const repoGroup =
+                persistedRepoGroup == null
+                  ? generateRepoGroupName(wt.repo_id as RepoID)
+                  : resolveRepoGroupName(wt.repo_id as RepoID, persistedRepoGroup);
               result.groups.expected.push(repoGroup);
 
               const isInRepoGroup = result.groups.actual.includes(repoGroup);
@@ -806,7 +880,7 @@ export default class SyncUnix extends Command {
       //   1. Unix group exists on the system (creates if missing — covers
       //      fresh branches and DB-migration cruft).
       //   2. Daemon user is a member of the group.
-      //   3. unix_group is backfilled in the DB if NULL.
+      // Group names were persisted by the DB-first stamping phase above.
       //
       // Archived+deleted branches are left alone here; the Sync Branch
       // Permissions phase below handles their group cleanup.
@@ -839,11 +913,19 @@ export default class SyncUnix extends Command {
             data: { path?: string } | null;
           };
 
-          const expectedGroup = resolveBranchGroupName(
-            rawWt.branch_id as BranchID,
-            rawWt.unix_group
-          );
           const dbNeedsBackfill = rawWt.unix_group === null;
+          if (dbNeedsBackfill && !dryRun) {
+            this.log(
+              chalk.red(
+                `   ✗ ${rawWt.name}: unix_group is still absent; skipping host group access`
+              )
+            );
+            continue;
+          }
+          const expectedGroup =
+            rawWt.unix_group == null
+              ? generateBranchGroupName(rawWt.branch_id as BranchID)
+              : resolveBranchGroupName(rawWt.branch_id as BranchID, rawWt.unix_group);
           const groupMissingOnSystem = !groupExists(expectedGroup);
 
           // Skip logging for branches already in canonical state (quiet mode)
@@ -907,39 +989,6 @@ export default class SyncUnix extends Command {
             }
           }
 
-          // 3. Backfill DB if unix_group was NULL
-          if (!hadError && dbNeedsBackfill) {
-            if (dryRun) {
-              this.log(
-                chalk.gray(
-                  `   [dry-run] Would update database: SET unix_group = '${expectedGroup}' WHERE branch_id = '${rawWt.branch_id}'`
-                )
-              );
-              branchesBackfilled++;
-            } else {
-              try {
-                await update(db, branches)
-                  .set({ unix_group: expectedGroup })
-                  .where(and(eq(branches.branch_id, rawWt.branch_id), isNull(branches.unix_group)))
-                  .run();
-                const stampedBranch = await select(db, { unix_group: branches.unix_group })
-                  .from(branches)
-                  .where(eq(branches.branch_id, rawWt.branch_id))
-                  .one();
-                if (stampedBranch?.unix_group !== expectedGroup) {
-                  throw new Error(
-                    `unix_group was stamped concurrently as ${stampedBranch?.unix_group ?? '<missing>'}; preserved authoritative value`
-                  );
-                }
-                branchesBackfilled++;
-                this.log(chalk.green(`   ✓ Backfilled unix_group in database`));
-              } catch (error) {
-                syncErrors++;
-                this.log(chalk.red(`   ✗ Failed to update database: ${error}`));
-              }
-            }
-          }
-
           this.log('');
         }
 
@@ -957,7 +1006,7 @@ export default class SyncUnix extends Command {
 
       this.log(chalk.cyan.bold('\n━━━ Sync Branch Permissions ━━━\n'));
 
-      // Refresh from DB to pick up unix_group values backfilled in the phase above.
+      // Refresh from DB to use only persisted unix_group values.
       const allBranchesForSync = targetBranchId
         ? await select(db).from(branches).where(eq(branches.branch_id, targetBranchId)).all()
         : await select(db).from(branches).all();
@@ -1547,8 +1596,8 @@ export default class SyncUnix extends Command {
         // Get all branch groups that should exist (from DB)
         const allBranches = await select(db).from(branches).all();
         const expectedGroups = new Set(
-          allBranches.map((wt: { branch_id: string; unix_group: string | null }) =>
-            resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group)
+          allBranches.flatMap((wt: { branch_id: string; unix_group: string | null }) =>
+            wt.unix_group ? [resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group)] : []
           )
         );
 
@@ -1595,8 +1644,8 @@ export default class SyncUnix extends Command {
         // Get all repo groups that should exist (from DB)
         const allReposForCleanup = await select(db).from(repos).all();
         const expectedRepoGroups = new Set(
-          allReposForCleanup.map((r: { repo_id: string; unix_group: string | null }) =>
-            resolveRepoGroupName(r.repo_id as RepoID, r.unix_group)
+          allReposForCleanup.flatMap((r: { repo_id: string; unix_group: string | null }) =>
+            r.unix_group ? [resolveRepoGroupName(r.repo_id as RepoID, r.unix_group)] : []
           )
         );
 

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -996,6 +996,10 @@ export default class SyncUnix extends Command {
           };
 
           const branchPath = rawBranch.data?.path;
+          const branchGroup = resolveBranchGroupName(
+            rawBranch.branch_id as BranchID,
+            rawBranch.unix_group
+          );
 
           // Skip branches without a path in the data blob
           if (!branchPath) {
@@ -1015,7 +1019,7 @@ export default class SyncUnix extends Command {
 
           if (action === 'cleanup') {
             // Archived+deleted: remove Unix group cruft
-            const wtGroup = rawBranch.unix_group;
+            const wtGroup = branchGroup;
             if (isLegacyManagedGroupName(wtGroup)) {
               this.log(
                 chalk.yellow(
@@ -1120,7 +1124,7 @@ export default class SyncUnix extends Command {
 
           this.log(chalk.bold(`📁 ${rawBranch.name}`));
           this.log(chalk.gray(`   branch_id: ${shortId(rawBranch.branch_id)}`));
-          this.log(chalk.gray(`   unix_group: ${rawBranch.unix_group}`));
+          this.log(chalk.gray(`   unix_group: ${branchGroup}`));
           this.log(chalk.gray(`   path: ${branchPath}`));
           if (rawBranch.archived) {
             this.log(
@@ -1239,7 +1243,7 @@ export default class SyncUnix extends Command {
 
           const permCmds = UnixGroupCommands.setDirectoryGroup(
             branchPath,
-            rawBranch.unix_group,
+            branchGroup,
             permissionMode
           );
           if (await execAllCmds(permCmds)) {
@@ -1302,7 +1306,10 @@ export default class SyncUnix extends Command {
           for (const wt of allWtForPrune) {
             const raw = wt as { branch_id: string; unix_group: string | null };
             if (raw.unix_group) {
-              wtGroupMap.set(raw.branch_id, raw.unix_group);
+              wtGroupMap.set(
+                raw.branch_id,
+                resolveBranchGroupName(raw.branch_id as BranchID, raw.unix_group)
+              );
             }
           }
 

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -98,6 +98,11 @@ interface SyncResult {
   errors: string[];
 }
 
+/** Whether this DB view can prove facts about the host-global Unix namespace. */
+export function canVerifyGlobalUnixState(databaseUrl: string): boolean {
+  return databaseUrl.startsWith('file:');
+}
+
 export default class SyncUnix extends Command {
   static override description =
     'Sync Unix users and groups with database (admin only). Creates missing users and fixes group memberships. NOTE: This command does NOT sync passwords - password hashes are one-way and cannot be converted to Unix passwords. Passwords are only synced in real-time during user creation or password updates via the web API.';
@@ -261,8 +266,16 @@ export default class SyncUnix extends Command {
         resolvedDatabaseUrl.startsWith('file:') || /^[a-z][a-z0-9+.-]*:/i.test(resolvedDatabaseUrl)
           ? resolvedDatabaseUrl
           : `file:${resolvedDatabaseUrl}`;
+      const hasGlobalUnixStateView = canVerifyGlobalUnixState(databaseUrl);
 
-      if (databaseUrl.startsWith('file:')) {
+      if ((cleanupGroups || cleanupUsers) && !hasGlobalUnixStateView) {
+        this.error(
+          'sync-unix cleanup supports only the host-local SQLite database. ' +
+            'Unix users and groups are system-global, so a PostgreSQL/RLS or remote database view cannot prove that another tenant or host is not still using them.'
+        );
+      }
+
+      if (hasGlobalUnixStateView) {
         const dbPath = databaseUrl.slice('file:'.length);
         if (!existsSync(dbPath)) {
           this.error(`Database not found: ${dbPath}`);
@@ -1284,6 +1297,12 @@ export default class SyncUnix extends Command {
 
       if (targetBranchId) {
         this.log(chalk.gray('   ⊘ Skipping membership pruning phase (--branch-id mode)\n'));
+      } else if (!hasGlobalUnixStateView) {
+        this.log(
+          chalk.yellow(
+            '   ⊘ Skipping membership pruning: a PostgreSQL/RLS or remote database view cannot prove global Unix group membership\n'
+          )
+        );
       } else {
         this.log(chalk.cyan.bold('\n━━━ Prune Stale Group Memberships ━━━\n'));
 

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -28,11 +28,13 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { loadConfig } from '@agor/core/config';
 import {
+  and,
   branches,
   branchOwners,
   createDatabase,
   eq,
   inArray,
+  isNull,
   repos,
   select,
   shortId,
@@ -44,8 +46,6 @@ import {
   AGOR_USERS_GROUP,
   CommandError,
   createAdminExecutor,
-  generateBranchGroupName,
-  generateRepoGroupName,
   getBranchDirectoryAction,
   getBranchPermissionMode,
   getBranchSymlinkPath,
@@ -53,11 +53,14 @@ import {
   getUserBranchesDir,
   getUserGroups,
   groupExists,
+  isLegacyManagedGroupName,
   isUserInGroup,
   listAgorUsers,
   listBranchGroups,
   listRepoGroups,
   REPO_GIT_PERMISSION_MODE,
+  resolveBranchGroupName,
+  resolveRepoGroupName,
   SymlinkCommands,
   UnixGroupCommands,
   UnixUserCommands,
@@ -386,8 +389,7 @@ export default class SyncUnix extends Command {
             data: { local_path?: string } | null;
           };
 
-          const expectedGroup =
-            rawRepo.unix_group || generateRepoGroupName(rawRepo.repo_id as RepoID);
+          const expectedGroup = resolveRepoGroupName(rawRepo.repo_id as RepoID, rawRepo.unix_group);
           const dbNeedsBackfill = rawRepo.unix_group === null;
           const groupMissingOnSystem = !groupExists(expectedGroup);
           const repoPath = rawRepo.data?.local_path;
@@ -453,8 +455,17 @@ export default class SyncUnix extends Command {
               try {
                 await update(db, repos)
                   .set({ unix_group: expectedGroup })
-                  .where(eq(repos.repo_id, rawRepo.repo_id))
+                  .where(and(eq(repos.repo_id, rawRepo.repo_id), isNull(repos.unix_group)))
                   .run();
+                const stampedRepo = await select(db, { unix_group: repos.unix_group })
+                  .from(repos)
+                  .where(eq(repos.repo_id, rawRepo.repo_id))
+                  .one();
+                if (stampedRepo?.unix_group !== expectedGroup) {
+                  throw new Error(
+                    `unix_group was stamped concurrently as ${stampedRepo?.unix_group ?? '<missing>'}; preserved authoritative value`
+                  );
+                }
                 reposBackfilled++;
                 this.log(chalk.green(`   ✓ Backfilled unix_group in database`));
               } catch (error) {
@@ -641,8 +652,7 @@ export default class SyncUnix extends Command {
             // Build expected groups from owned branches
             for (const wt of ownedBranches) {
               // Use existing unix_group or generate from branch_id
-              const expectedGroup =
-                wt.unix_group || generateBranchGroupName(wt.branch_id as BranchID);
+              const expectedGroup = resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group);
               result.groups.expected.push(expectedGroup);
 
               const isInGroup = result.groups.actual.includes(expectedGroup);
@@ -712,8 +722,10 @@ export default class SyncUnix extends Command {
               repoIdsSeen.add(wt.repo_id);
 
               // Get repo group (from prefetched map or generate)
-              const repoGroup =
-                repoGroupMap.get(wt.repo_id) || generateRepoGroupName(wt.repo_id as RepoID);
+              const repoGroup = resolveRepoGroupName(
+                wt.repo_id as RepoID,
+                repoGroupMap.get(wt.repo_id)
+              );
               result.groups.expected.push(repoGroup);
 
               const isInRepoGroup = result.groups.actual.includes(repoGroup);
@@ -823,8 +835,10 @@ export default class SyncUnix extends Command {
             data: { path?: string } | null;
           };
 
-          const expectedGroup =
-            rawWt.unix_group || generateBranchGroupName(rawWt.branch_id as BranchID);
+          const expectedGroup = resolveBranchGroupName(
+            rawWt.branch_id as BranchID,
+            rawWt.unix_group
+          );
           const dbNeedsBackfill = rawWt.unix_group === null;
           const groupMissingOnSystem = !groupExists(expectedGroup);
 
@@ -902,8 +916,17 @@ export default class SyncUnix extends Command {
               try {
                 await update(db, branches)
                   .set({ unix_group: expectedGroup })
-                  .where(eq(branches.branch_id, rawWt.branch_id))
+                  .where(and(eq(branches.branch_id, rawWt.branch_id), isNull(branches.unix_group)))
                   .run();
+                const stampedBranch = await select(db, { unix_group: branches.unix_group })
+                  .from(branches)
+                  .where(eq(branches.branch_id, rawWt.branch_id))
+                  .one();
+                if (stampedBranch?.unix_group !== expectedGroup) {
+                  throw new Error(
+                    `unix_group was stamped concurrently as ${stampedBranch?.unix_group ?? '<missing>'}; preserved authoritative value`
+                  );
+                }
                 branchesBackfilled++;
                 this.log(chalk.green(`   ✓ Backfilled unix_group in database`));
               } catch (error) {
@@ -993,6 +1016,14 @@ export default class SyncUnix extends Command {
           if (action === 'cleanup') {
             // Archived+deleted: remove Unix group cruft
             const wtGroup = rawBranch.unix_group;
+            if (isLegacyManagedGroupName(wtGroup)) {
+              this.log(
+                chalk.yellow(
+                  `   ⊘ ${rawBranch.name}: retaining shared-capable legacy group ${wtGroup}; use agor local fix-group-uuids`
+                )
+              );
+              continue;
+            }
             if (groupExists(wtGroup)) {
               this.log(
                 chalk.yellow(
@@ -1499,9 +1530,8 @@ export default class SyncUnix extends Command {
         // Get all branch groups that should exist (from DB)
         const allBranches = await select(db).from(branches).all();
         const expectedGroups = new Set(
-          allBranches.map(
-            (wt: { branch_id: string; unix_group: string | null }) =>
-              wt.unix_group || generateBranchGroupName(wt.branch_id as BranchID)
+          allBranches.map((wt: { branch_id: string; unix_group: string | null }) =>
+            resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group)
           )
         );
 
@@ -1522,6 +1552,14 @@ export default class SyncUnix extends Command {
           this.log(chalk.yellow(`   Found ${staleGroups.length} stale group(s) to remove:\n`));
 
           for (const groupName of staleGroups) {
+            if (isLegacyManagedGroupName(groupName)) {
+              this.log(
+                chalk.yellow(
+                  `   ⊘ Retaining legacy group ${groupName}; use agor local fix-group-uuids for globally verified cleanup`
+                )
+              );
+              continue;
+            }
             this.log(chalk.yellow(`   → Deleting group ${groupName}...`));
             if (await execCmd(UnixGroupCommands.deleteGroup(groupName))) {
               groupsDeleted++;
@@ -1540,9 +1578,8 @@ export default class SyncUnix extends Command {
         // Get all repo groups that should exist (from DB)
         const allReposForCleanup = await select(db).from(repos).all();
         const expectedRepoGroups = new Set(
-          allReposForCleanup.map(
-            (r: { repo_id: string; unix_group: string | null }) =>
-              r.unix_group || generateRepoGroupName(r.repo_id as RepoID)
+          allReposForCleanup.map((r: { repo_id: string; unix_group: string | null }) =>
+            resolveRepoGroupName(r.repo_id as RepoID, r.unix_group)
           )
         );
 
@@ -1565,6 +1602,14 @@ export default class SyncUnix extends Command {
           );
 
           for (const groupName of staleRepoGroups) {
+            if (isLegacyManagedGroupName(groupName)) {
+              this.log(
+                chalk.yellow(
+                  `   ⊘ Retaining legacy group ${groupName}; use agor local fix-group-uuids for globally verified cleanup`
+                )
+              );
+              continue;
+            }
             this.log(chalk.yellow(`   → Deleting group ${groupName}...`));
             if (await execCmd(UnixGroupCommands.deleteGroup(groupName))) {
               groupsDeleted++;

--- a/apps/agor-cli/src/commands/local/sync-unix.ts
+++ b/apps/agor-cli/src/commands/local/sync-unix.ts
@@ -29,11 +29,11 @@ import { join } from 'node:path';
 import { loadConfigFromFile } from '@agor/core/config';
 import {
   and,
+  BranchRepository,
   branches,
   branchOwners,
   createDatabase,
   eq,
-  inArray,
   isNull,
   repos,
   resolveDatabaseUrl,
@@ -80,11 +80,79 @@ interface UserWithUnix {
   unix_username: string;
 }
 
-interface BranchOwnership {
+interface BranchAuthorization {
   branch_id: string;
   name: string;
   unix_group: string | null;
   repo_id: string;
+}
+
+interface ExplicitFsAuthorizationSource {
+  findExplicitFsAccessUserIds(branchId: BranchID): Promise<readonly string[]>;
+}
+
+interface ExplicitFsAuthorizationIndex {
+  branchesByUserId: Map<string, BranchAuthorization[]>;
+  userIdsByBranchId: Map<string, Set<string>>;
+}
+
+interface BranchGroupAuthorizationIndex {
+  groupByBranchId: Map<string, string>;
+  userIdsByGroup: Map<string, Set<string>>;
+}
+
+/**
+ * Index the repository's canonical explicit filesystem authorization expansion
+ * for Unix membership reconciliation. Keep policy in BranchRepository rather
+ * than reimplementing owners/group/board grant rules in this privileged CLI.
+ */
+export async function buildExplicitFsAuthorizationIndex(
+  branchRows: readonly BranchAuthorization[],
+  authorizationSource: ExplicitFsAuthorizationSource
+): Promise<ExplicitFsAuthorizationIndex> {
+  const branchesByUserId = new Map<string, BranchAuthorization[]>();
+  const userIdsByBranchId = new Map<string, Set<string>>();
+
+  for (const branch of branchRows) {
+    const userIds = new Set(
+      await authorizationSource.findExplicitFsAccessUserIds(branch.branch_id as BranchID)
+    );
+    userIdsByBranchId.set(branch.branch_id, userIds);
+
+    for (const userId of userIds) {
+      const authorizedBranches = branchesByUserId.get(userId) ?? [];
+      authorizedBranches.push(branch);
+      branchesByUserId.set(userId, authorizedBranches);
+    }
+  }
+
+  return { branchesByUserId, userIdsByBranchId };
+}
+
+/**
+ * Collapse branch authorization by persisted Unix group. Legacy UUID-prefix
+ * collisions can make several rows share one group, so expected membership is
+ * deliberately unioned across the whole cohort before any pruning decision.
+ */
+export function buildBranchGroupAuthorizationIndex(
+  branchRows: readonly BranchAuthorization[],
+  userIdsByBranchId: ReadonlyMap<string, ReadonlySet<string>>
+): BranchGroupAuthorizationIndex {
+  const groupByBranchId = new Map<string, string>();
+  const userIdsByGroup = new Map<string, Set<string>>();
+
+  for (const branch of branchRows) {
+    if (!branch.unix_group) continue;
+    const group = resolveBranchGroupName(branch.branch_id as BranchID, branch.unix_group);
+    groupByBranchId.set(branch.branch_id, group);
+    const expectedUserIds = userIdsByGroup.get(group) ?? new Set<string>();
+    for (const userId of userIdsByBranchId.get(branch.branch_id) ?? []) {
+      expectedUserIds.add(userId);
+    }
+    userIdsByGroup.set(group, expectedUserIds);
+  }
+
+  return { groupByBranchId, userIdsByGroup };
 }
 
 interface SyncResult {
@@ -557,8 +625,10 @@ export default class SyncUnix extends Command {
       if (unstampedBranches.length > 0) {
         this.log(chalk.cyan.bold('\n━━━ Stamp Branch Unix Groups ━━━\n'));
       }
+      const plannedBranchGroups = new Map<string, string>();
       for (const branch of unstampedBranches) {
         const candidate = generateBranchGroupName(branch.branch_id as BranchID);
+        plannedBranchGroups.set(branch.branch_id, candidate);
         if (dryRun) {
           branchesBackfilled++;
           this.log(
@@ -589,6 +659,23 @@ export default class SyncUnix extends Command {
       }
       if (unstampedBranches.length > 0) this.log('');
 
+      // Build one authorization snapshot for both additions and pruning. The
+      // repository owns the policy expansion (direct owners, branch groups,
+      // board owners, and board groups); consuming the same snapshot in both
+      // directions prevents a later phase from undoing an earlier one.
+      const branchesForAuthorization = targetBranchId
+        ? []
+        : ((await select(db).from(branches).all()) as BranchAuthorization[]);
+      const explicitFsAuthorization = targetBranchId
+        ? {
+            branchesByUserId: new Map<string, BranchAuthorization[]>(),
+            userIdsByBranchId: new Map<string, Set<string>>(),
+          }
+        : await buildExplicitFsAuthorizationIndex(
+            branchesForAuthorization,
+            new BranchRepository(db)
+          );
+
       if (targetBranchId) {
         this.log(chalk.gray('   ⊘ Skipping user sync phase (--branch-id mode)\n'));
       } else if (validUsers.length === 0) {
@@ -598,40 +685,6 @@ export default class SyncUnix extends Command {
         // Don't return early - still need to run cleanup if requested
       } else {
         this.log(chalk.cyan(`Found ${validUsers.length} user(s) with unix_username\n`));
-
-        // Prefetch all branch ownerships in a single query to avoid N+1
-        const userIds = validUsers.map((u) => u.user_id);
-        // biome-ignore lint/suspicious/noExplicitAny: Join query requires type assertion
-        const allOwnerships = await (db as any)
-          .select()
-          .from(branchOwners)
-          .innerJoin(branches, eq(branchOwners.branch_id, branches.branch_id))
-          .where(inArray(branchOwners.user_id, userIds));
-
-        // Group ownerships by user_id for O(1) lookup
-        const ownershipsByUser = new Map<string, BranchOwnership[]>();
-        for (const row of allOwnerships) {
-          const userId = (
-            row as {
-              branch_owners: { user_id: string };
-              branches: {
-                branch_id: string;
-                name: string;
-                unix_group: string | null;
-                repo_id: string;
-              };
-            }
-          ).branch_owners.user_id;
-          const ownership: BranchOwnership = {
-            branch_id: (row as { branches: { branch_id: string } }).branches.branch_id,
-            name: (row as { branches: { name: string } }).branches.name,
-            unix_group: (row as { branches: { unix_group: string | null } }).branches.unix_group,
-            repo_id: (row as { branches: { repo_id: string } }).branches.repo_id,
-          };
-          const existing = ownershipsByUser.get(userId) || [];
-          existing.push(ownership);
-          ownershipsByUser.set(userId, existing);
-        }
 
         // Build a map of repo_id -> unix_group for quick lookup in the
         // per-user loop. The Sync Repos phase above already ensured every
@@ -704,15 +757,21 @@ export default class SyncUnix extends Command {
               }
             }
 
-            // Get branches owned by this user (from prefetched data)
-            const ownedBranches: BranchOwnership[] = ownershipsByUser.get(user.user_id) || [];
+            // Get every branch for which the user has explicit filesystem
+            // authorization, not only branches they directly own.
+            const authorizedBranches =
+              explicitFsAuthorization.branchesByUserId.get(user.user_id) ?? [];
 
             if (verbose) {
-              this.log(chalk.gray(`   Owns ${ownedBranches.length} branch(s)`));
+              this.log(
+                chalk.gray(
+                  `   Has explicit filesystem access to ${authorizedBranches.length} branch(s)`
+                )
+              );
             }
 
-            // Build expected groups from owned branches
-            for (const wt of ownedBranches) {
+            // Build expected groups from authorized branches
+            for (const wt of authorizedBranches) {
               if (wt.unix_group == null && !dryRun) {
                 const message = `Branch ${wt.name} has no persisted unix_group; skipping host group access`;
                 result.errors.push(message);
@@ -723,8 +782,14 @@ export default class SyncUnix extends Command {
               // reaches this phase only after the DB-first stamping pass.
               const expectedGroup =
                 wt.unix_group == null
-                  ? generateBranchGroupName(wt.branch_id as BranchID)
+                  ? plannedBranchGroups.get(wt.branch_id)
                   : resolveBranchGroupName(wt.branch_id as BranchID, wt.unix_group);
+              if (!expectedGroup) {
+                const message = `Branch ${wt.name} has no persisted or planned unix_group; skipping host group access`;
+                result.errors.push(message);
+                this.log(chalk.red(`   ✗ ${message}`));
+                continue;
+              }
               result.groups.expected.push(expectedGroup);
 
               const isInGroup = result.groups.actual.includes(expectedGroup);
@@ -787,9 +852,10 @@ export default class SyncUnix extends Command {
               }
             }
 
-            // Sync repo groups - user should be in repo group for each unique repo they own branches in
+            // Sync repo groups - a user needs the repo group for every repo in
+            // which they have explicit filesystem access to a branch.
             const repoIdsSeen = new Set<string>();
-            for (const wt of ownedBranches) {
+            for (const wt of authorizedBranches) {
               if (repoIdsSeen.has(wt.repo_id)) continue;
               repoIdsSeen.add(wt.repo_id);
 
@@ -924,8 +990,16 @@ export default class SyncUnix extends Command {
           }
           const expectedGroup =
             rawWt.unix_group == null
-              ? generateBranchGroupName(rawWt.branch_id as BranchID)
+              ? plannedBranchGroups.get(rawWt.branch_id)
               : resolveBranchGroupName(rawWt.branch_id as BranchID, rawWt.unix_group);
+          if (!expectedGroup) {
+            this.log(
+              chalk.red(
+                `   ✗ ${rawWt.name}: unix_group is absent and no dry-run stamp was planned; skipping`
+              )
+            );
+            continue;
+          }
           const groupMissingOnSystem = !groupExists(expectedGroup);
 
           // Skip logging for branches already in canonical state (quiet mode)
@@ -1006,12 +1080,15 @@ export default class SyncUnix extends Command {
 
       this.log(chalk.cyan.bold('\n━━━ Sync Branch Permissions ━━━\n'));
 
-      // Refresh from DB to use only persisted unix_group values.
+      // Refresh from DB to use persisted unix_group values. In dry-run mode,
+      // include the in-memory proposed stamp so the preview also reports the
+      // downstream filesystem permission work.
       const allBranchesForSync = targetBranchId
         ? await select(db).from(branches).where(eq(branches.branch_id, targetBranchId)).all()
         : await select(db).from(branches).all();
       const branchesWithGroup = allBranchesForSync.filter(
-        (wt: { unix_group: string | null }) => wt.unix_group !== null
+        (wt: { branch_id: string; unix_group: string | null }) =>
+          wt.unix_group !== null || (dryRun && plannedBranchGroups.has(wt.branch_id))
       );
 
       // Build repo path lookup map for git branch operations
@@ -1041,7 +1118,7 @@ export default class SyncUnix extends Command {
             name: string;
             ref: string;
             repo_id: string;
-            unix_group: string;
+            unix_group: string | null;
             archived: boolean;
             filesystem_status: string | null;
             others_fs_access: 'none' | 'read' | 'write' | null;
@@ -1049,10 +1126,16 @@ export default class SyncUnix extends Command {
           };
 
           const branchPath = rawBranch.data?.path;
-          const branchGroup = resolveBranchGroupName(
-            rawBranch.branch_id as BranchID,
-            rawBranch.unix_group
-          );
+          const branchGroup = rawBranch.unix_group
+            ? resolveBranchGroupName(rawBranch.branch_id as BranchID, rawBranch.unix_group)
+            : plannedBranchGroups.get(rawBranch.branch_id);
+          if (!branchGroup) {
+            this.log(
+              chalk.red(`   ✗ ${rawBranch.name}: no persisted or planned unix_group; skipping`)
+            );
+            branchesSkipped++;
+            continue;
+          }
 
           // Skip branches without a path in the data blob
           if (!branchPath) {
@@ -1341,7 +1424,7 @@ export default class SyncUnix extends Command {
 
       // ========================================
       // Membership Pruning Phase
-      // Removes users from branch groups they no longer own
+      // Removes users from branch groups they are no longer authorized to use
       // ========================================
 
       if (targetBranchId) {
@@ -1356,33 +1439,15 @@ export default class SyncUnix extends Command {
         this.log(chalk.cyan.bold('\n━━━ Prune Stale Group Memberships ━━━\n'));
 
         {
-          // Build a map of branch group → expected members (owners + daemon)
-          const allWtForPrune = await select(db).from(branches).all();
-          const allOwnerRows = await select(db).from(branchOwners).all();
+          // Build a map of branch group → expected members (explicit
+          // filesystem authorization + daemon) from the same repository-owned
+          // policy snapshot used by the addition phase.
+          const allWtForPrune = branchesForAuthorization;
 
-          // Map branch_id → unix_group
-          const wtGroupMap = new Map<string, string>();
-          for (const wt of allWtForPrune) {
-            const raw = wt as { branch_id: string; unix_group: string | null };
-            if (raw.unix_group) {
-              wtGroupMap.set(
-                raw.branch_id,
-                resolveBranchGroupName(raw.branch_id as BranchID, raw.unix_group)
-              );
-            }
-          }
-
-          // Map unix_group → set of expected user_ids
-          const groupToOwnerIds = new Map<string, Set<string>>();
-          for (const row of allOwnerRows) {
-            const raw = row as { branch_id: string; user_id: string };
-            const group = wtGroupMap.get(raw.branch_id);
-            if (group) {
-              const owners = groupToOwnerIds.get(group) || new Set();
-              owners.add(raw.user_id);
-              groupToOwnerIds.set(group, owners);
-            }
-          }
+          const branchGroupAuthorization = buildBranchGroupAuthorizationIndex(
+            allWtForPrune,
+            explicitFsAuthorization.userIdsByBranchId
+          );
 
           // Map user_id → unix_username for all users with unix_username
           const allUsersForPrune = (await select(db).from(users).all()) as UserWithUnix[];
@@ -1397,15 +1462,17 @@ export default class SyncUnix extends Command {
 
           // Iterate ALL branch groups (including those with zero owners)
           let pruneChecked = 0;
-          for (const [, group] of wtGroupMap.entries()) {
+          for (const group of new Set(branchGroupAuthorization.groupByBranchId.values())) {
             if (!groupExists(group)) continue;
             pruneChecked++;
 
-            // Get expected unix_usernames for this group (may be empty if no owners)
-            const ownerIds = groupToOwnerIds.get(group) || new Set<string>();
+            // Get expected Unix usernames for this group (may be empty when no
+            // user has explicit filesystem authorization).
+            const authorizedUserIds =
+              branchGroupAuthorization.userIdsByGroup.get(group) ?? new Set<string>();
             const expectedUsernames = new Set<string>();
-            for (const ownerId of ownerIds) {
-              const uname = userIdToUnixName.get(ownerId);
+            for (const userId of authorizedUserIds) {
+              const uname = userIdToUnixName.get(userId);
               if (uname) expectedUsernames.add(uname);
             }
             // Daemon user is always expected
@@ -1421,7 +1488,11 @@ export default class SyncUnix extends Command {
               // Only prune DB-managed users (skip manually-added system users)
               if (!unixNameToUserId.has(member)) continue;
 
-              this.log(chalk.yellow(`   → Removing ${member} from ${group} (no longer owner)`));
+              this.log(
+                chalk.yellow(
+                  `   → Removing ${member} from ${group} (no explicit filesystem access)`
+                )
+              );
               if (await execCmd(UnixGroupCommands.removeUserFromGroup(member, group))) {
                 membershipsRemoved++;
                 this.log(chalk.green(`   ✓ Removed ${member} from ${group}`));

--- a/apps/agor-daemon/src/host/operations.ts
+++ b/apps/agor-daemon/src/host/operations.ts
@@ -7,7 +7,7 @@ export interface DaemonHostOperationResult {
 }
 export interface DaemonHostIdentityOperations {
   createBranchGroup(
-    input: HostOperationOptions & { branchId: string }
+    input: HostOperationOptions & { group: string }
   ): Promise<DaemonHostOperationResult>;
   deleteBranchGroup(
     input: HostOperationOptions & { group: string }

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -35,6 +35,7 @@ import {
   PROMPT_FLOW_PATCH_FIELDS,
   protectExternalTaskCreate,
   protectServerManagedTaskWrites,
+  protectServerManagedUnixGroupWrites,
   type RegisterHooksContext,
   registerHooks,
   shouldDrainQueueAfterSessionPostTurnPatch,
@@ -219,6 +220,82 @@ describe('protectServerManagedTaskWrites', () => {
     context.params.provider = undefined;
 
     await expect(protectServerManagedTaskWrites(context)).resolves.toBe(context);
+  });
+});
+
+describe('protectServerManagedUnixGroupWrites', () => {
+  const branchId = '019ffd3d-2cef-79d1-a1c6-407300000001';
+  const canonicalGroup = 'agor_wt_019ffd3d2cef79d1a1c64073';
+  const legacyGroup = 'agor_wt_019ffd3d';
+  const context = (
+    unixGroup: unknown,
+    options: {
+      provider?: string;
+      serviceAccount?: boolean;
+      existingGroup?: string | null;
+    } = {}
+  ) =>
+    ({
+      path: 'branches',
+      method: 'patch',
+      id: branchId,
+      data: { unix_group: unixGroup },
+      params: {
+        provider: options.provider,
+        user: options.serviceAccount
+          ? {
+              user_id: 'executor',
+              email: 'executor@local',
+              role: 'service',
+              _isServiceAccount: true,
+            }
+          : { user_id: 'member', email: 'member@example.com', role: 'member' },
+      },
+      service: {
+        get: vi.fn(async () => ({ unix_group: options.existingGroup ?? null })),
+      },
+    }) as unknown as HookContext;
+
+  it('rejects unix_group writes from normal transport users', async () => {
+    await expect(
+      protectServerManagedUnixGroupWrites('branch')(context(canonicalGroup, { provider: 'rest' }))
+    ).rejects.toThrow('server-managed');
+  });
+
+  it('allows an executor service account to stamp the canonical name once', async () => {
+    const hook = context(canonicalGroup, { provider: 'rest', serviceAccount: true });
+    await expect(protectServerManagedUnixGroupWrites('branch')(hook)).resolves.toBe(hook);
+  });
+
+  it('rejects executor attempts to migrate an authoritative legacy stamp', async () => {
+    await expect(
+      protectServerManagedUnixGroupWrites('branch')(
+        context(canonicalGroup, {
+          provider: 'rest',
+          serviceAccount: true,
+          existingGroup: legacyGroup,
+        })
+      )
+    ).rejects.toThrow('authoritative');
+  });
+
+  it('rejects valid-looking names that belong to another row', async () => {
+    await expect(
+      protectServerManagedUnixGroupWrites('branch')(
+        context('agor_wt_019ffd3d2cef79d1a1c64074', {
+          provider: 'rest',
+          serviceAccount: true,
+        })
+      )
+    ).rejects.toThrow('Invalid persisted Unix group');
+  });
+
+  it('validates trusted internal legacy writes', async () => {
+    const hook = context(legacyGroup);
+    await expect(protectServerManagedUnixGroupWrites('branch')(hook)).resolves.toBe(hook);
+    await expect(
+      protectServerManagedUnixGroupWrites('branch')(context('developers; groupdel root'))
+    ).rejects.toThrow('Invalid persisted Unix group');
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -80,6 +80,7 @@ import type {
   MessageID,
   Paginated,
   Params,
+  RepoID,
   Session,
   Task,
   User,
@@ -95,6 +96,12 @@ import {
   SCHEDULE_PATCH_WRITE_FIELDS,
   TaskStatus,
 } from '@agor/core/types';
+import {
+  generateBranchGroupName,
+  generateRepoGroupName,
+  resolveBranchGroupName,
+  resolveRepoGroupName,
+} from '@agor/core/unix';
 import {
   executorRuntimeScopeGuard,
   isTaskScopedExecutorRequest,
@@ -602,6 +609,72 @@ export async function protectServerManagedTaskWrites(context: HookContext): Prom
   }
 
   return context;
+}
+
+type ManagedUnixGroupKind = 'branch' | 'repo';
+
+/**
+ * Keep `unix_group` server-owned and validate every trusted write.
+ *
+ * Executor service accounts may perform the one normal transport write: stamp
+ * the canonical group on a row whose field is still absent. Explicit legacy
+ * migration writes directly through the local database after global checks.
+ */
+export function protectServerManagedUnixGroupWrites(kind: ManagedUnixGroupKind) {
+  return async (context: HookContext): Promise<HookContext> => {
+    const data =
+      context.data && typeof context.data === 'object' && !Array.isArray(context.data)
+        ? (context.data as Record<string, unknown>)
+        : undefined;
+    if (!data || !Object.hasOwn(data, 'unix_group')) return context;
+
+    const value = data.unix_group;
+    const id =
+      typeof context.id === 'string'
+        ? context.id
+        : typeof data[`${kind}_id`] === 'string'
+          ? (data[`${kind}_id`] as string)
+          : undefined;
+
+    if (value !== null && value !== undefined) {
+      if (typeof value !== 'string' || !id) {
+        throw new BadRequest(`A valid ${kind} id is required to validate unix_group`);
+      }
+      if (kind === 'branch') {
+        resolveBranchGroupName(id as BranchID, value);
+      } else {
+        resolveRepoGroupName(id as RepoID, value);
+      }
+    }
+
+    if (!context.params.provider) return context;
+    if (!context.params.user?._isServiceAccount) {
+      throw new Forbidden('unix_group is server-managed');
+    }
+
+    // A transported executor may only stamp an absent field with the row's
+    // canonical name. It cannot clear, rename, or migrate an existing stamp.
+    if (context.method !== 'patch' || !id || typeof value !== 'string') {
+      throw new Forbidden('Executor unix_group writes must stamp one existing row');
+    }
+    const canonical =
+      kind === 'branch'
+        ? generateBranchGroupName(id as BranchID)
+        : generateRepoGroupName(id as RepoID);
+    if (value !== canonical) {
+      throw new Forbidden('Executor unix_group writes must use the canonical group name');
+    }
+
+    const existing = (await context.service.get(id, {
+      ...context.params,
+      provider: undefined,
+    })) as { unix_group?: string | null };
+    if (existing.unix_group != null && existing.unix_group !== value) {
+      throw new Forbidden('Persisted unix_group is authoritative and cannot be changed');
+    }
+
+    return context;
+  };
 }
 
 /** Run an identity-only service's database-reading before hooks in one short unit of work. */
@@ -1475,16 +1548,19 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [typedValidateQuery(repoQueryValidator), requireAuth],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create repositories'),
+        protectServerManagedUnixGroupWrites('repo'),
         requireAdminForEnvConfig(),
         validateRepoEnvPolicyHook(config),
       ],
       update: [
         requireMinimumRole(ROLES.MEMBER, 'update repositories'),
+        protectServerManagedUnixGroupWrites('repo'),
         requireAdminForEnvConfig(),
         validateRepoEnvPolicyHook(config),
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update repositories'),
+        protectServerManagedUnixGroupWrites('repo'),
         requireAdminForEnvConfig(),
         validateRepoEnvPolicyHook(config),
       ],
@@ -1513,17 +1589,20 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create branches'),
+        protectServerManagedUnixGroupWrites('branch'),
         requireAdminForEnvConfig(),
         validateBranchEnvPolicyHook(config),
         injectCreatedBy(),
       ],
       update: [
         requireMinimumRole(ROLES.MEMBER, 'update branches'),
+        protectServerManagedUnixGroupWrites('branch'),
         requireAdminForEnvConfig(),
         validateBranchEnvPolicyHook(config),
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update branches'),
+        protectServerManagedUnixGroupWrites('branch'),
         requireAdminForEnvConfig(),
         validateBranchEnvPolicyHook(config),
         ...(branchRbacEnabled

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -45,13 +45,14 @@ import {
   visibleSessionReferenceAccessExists,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   OAuthFlowContext,
   OAuthTokenResponse,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import type {
   AuthenticatedParams,
+  BranchID,
   HookContext,
   MCPAuth,
   MCPOAuthAttemptID,
@@ -66,7 +67,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { hasMinimumRole, isMCPOAuthGrantBindingVersion, ROLES, TaskStatus } from '@agor/core/types';
-import type { UnixUserMode } from '@agor/core/unix';
+import { resolveBranchGroupName, type UnixUserMode } from '@agor/core/unix';
 import { safeOutboundFetch } from '@agor/core/utils/safe-outbound-fetch';
 import type express from 'express';
 import type {
@@ -611,7 +612,18 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // registration is intentionally absent rather than forwarding privileged
   // work through an impersonated executor.
   if (shouldRegisterLocalHostOperations(config)) {
-    app.use('/admin/local-actions', createLocalActionsService(createLocalDaemonHostOperations()));
+    app.use(
+      '/admin/local-actions',
+      createLocalActionsService(createLocalDaemonHostOperations(), async (branchId, params) => {
+        const branch = await app.service('branches').get(branchId, params);
+        if (!branch.unix_group) {
+          throw new BadRequest(
+            `Branch ${branchId} has no persisted unix_group; run agor local sync-unix --branch-id ${branchId}`
+          );
+        }
+        return resolveBranchGroupName(branchId as BranchID, branch.unix_group);
+      })
+    );
   }
 
   app.use(

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -60,6 +60,7 @@ import {
 } from '@agor/core/types';
 import {
   getGidFromGroupName,
+  resolveBranchGroupName,
   resolveUnixUserForImpersonation,
   validateResolvedUnixUser,
 } from '@agor/core/unix';
@@ -2557,7 +2558,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // Resolve host IP + unix GID (matches executor's renderEnvironmentTemplates).
     const config = this.app.get('config');
     const hostIpAddress = resolveHostIpAddress(config.daemon?.host_ip_address);
-    const unixGid = branch.unix_group ? getGidFromGroupName(branch.unix_group) : undefined;
+    const unixGid = branch.unix_group
+      ? getGidFromGroupName(resolveBranchGroupName(branch.branch_id as BranchID, branch.unix_group))
+      : undefined;
 
     const snapshot = renderBranchSnapshot(
       { slug: repo.slug, environment: env },

--- a/apps/agor-daemon/src/services/local-actions.test.ts
+++ b/apps/agor-daemon/src/services/local-actions.test.ts
@@ -20,7 +20,10 @@ function host(): DaemonHostOperations {
 describe('local daemon host operations service', () => {
   it('validates and delegates identity operations with dry-run options', async () => {
     const operations = host();
-    const service = createLocalActionsService(operations);
+    const service = createLocalActionsService(
+      operations,
+      vi.fn(async () => 'agor_wt_019ffd3d')
+    );
     await expect(
       service.create({
         action: 'unix.group.addUser',
@@ -43,7 +46,10 @@ describe('local daemon host operations service', () => {
     'git.remoteCredentials.scrubManaged',
   ])('rejects removed maintenance action %s', async (action) => {
     const operations = host();
-    const service = createLocalActionsService(operations);
+    const service = createLocalActionsService(
+      operations,
+      vi.fn(async () => 'agor_wt_019ffd3d')
+    );
     await expect(
       service.create({
         action: action as never,
@@ -55,6 +61,29 @@ describe('local daemon host operations service', () => {
         },
       })
     ).rejects.toThrow(/Unsupported local action/);
+  });
+
+  it('resolves a persisted branch group before crossing the host boundary', async () => {
+    const operations = host();
+    const resolvePersistedGroup = vi.fn(async () => 'agor_wt_019ffd3d');
+    const service = createLocalActionsService(operations, resolvePersistedGroup);
+
+    await service.create(
+      {
+        action: 'unix.group.createBranch',
+        params: { branchId: '019ffd3d-2cef-79d1-a1c6-407300000001' },
+      },
+      { provider: 'rest' }
+    );
+
+    expect(resolvePersistedGroup).toHaveBeenCalledWith('019ffd3d-2cef-79d1-a1c6-407300000001', {
+      provider: 'rest',
+    });
+    expect(operations.identity.createBranchGroup).toHaveBeenCalledWith({
+      group: 'agor_wt_019ffd3d',
+      dryRun: false,
+      verbose: false,
+    });
   });
 
   it('does not register local host operations in hosted mode', () => {

--- a/apps/agor-daemon/src/services/local-actions.ts
+++ b/apps/agor-daemon/src/services/local-actions.ts
@@ -16,6 +16,7 @@ export interface LocalActionRequest {
   dryRun?: boolean;
   verbose?: boolean;
 }
+export type ResolvePersistedBranchGroup = (branchId: string, params?: Params) => Promise<string>;
 function stringParam(params: Record<string, unknown>, key: string): string {
   const value = params[key];
   if (typeof value !== 'string' || !value.trim())
@@ -28,16 +29,22 @@ function homeBase(params: Record<string, unknown>): string | undefined {
     throw new BadRequest(`homeBase must be the managed Agor home base: ${AGOR_HOME_BASE}`);
   return AGOR_HOME_BASE;
 }
-export function createLocalActionsService(host: DaemonHostOperations) {
+export function createLocalActionsService(
+  host: DaemonHostOperations,
+  resolvePersistedBranchGroup: ResolvePersistedBranchGroup
+) {
   return {
     async create(data: LocalActionRequest, _params?: Params): Promise<DaemonHostOperationResult> {
       const p = data.params ?? {};
       const options = { dryRun: data.dryRun === true, verbose: data.verbose === true };
       switch (data.action) {
         case 'unix.group.createBranch':
+          // Resolve through the tenant-scoped DB row before crossing the host
+          // capability boundary. The host action must never derive a group
+          // name from a UUID.
           return host.identity.createBranchGroup({
             ...options,
-            branchId: stringParam(p, 'branchId'),
+            group: await resolvePersistedBranchGroup(stringParam(p, 'branchId'), _params),
           });
         case 'unix.group.deleteBranch':
           return host.identity.deleteBranchGroup({ ...options, group: stringParam(p, 'group') });

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -350,7 +350,7 @@ When RBAC is enabled (`branch_rbac: true`):
 
 Each branch gets OS-level protection:
 
-1. **Unix Group** - Dedicated group `agor_wt_<short-id>`
+1. **Unix Group** - Dedicated group `agor_wt_<24-character-short-id>`
 2. **Filesystem Permissions** - Directory owned by group with proper mode
 3. **Group Membership** - Branch owners added to group
 4. **Home Symlinks** - Owners get `~/agor/worktrees/<name>` → branch path
@@ -359,16 +359,16 @@ Each branch gets OS-level protection:
 
 ```bash
 # Branch created
-$ ls -la /var/agor/worktrees/wt-abc123/
-drwxrwx--- alice agor_wt_abc123 my-project/
+$ ls -la /var/agor/worktrees/wt-019ffd3d2cef79d1a1c64073/
+drwxrwx--- alice agor_wt_019ffd3d2cef79d1a1c64073 my-project/
 
 # Alice's home
 $ ls -la ~/agor/worktrees/
-lrwxrwxrwx alice alice my-project-abc123 -> /var/agor/worktrees/wt-abc123/my-project
+lrwxrwxrwx alice alice my-project-019ffd3d -> /var/agor/worktrees/wt-019ffd3d2cef79d1a1c64073/my-project
 
 # Bob added as owner
-$ getent group agor_wt_abc123
-agor_wt_abc123:x:1050:alice,bob
+$ getent group agor_wt_019ffd3d2cef79d1a1c64073
+agor_wt_019ffd3d2cef79d1a1c64073:x:1050:alice,bob
 ```
 
 ### Permission Levels
@@ -414,6 +414,33 @@ Agor defines three permission levels per branch:
 ---
 
 ## Troubleshooting
+
+### Migrating legacy 8-character groups
+
+New branch and repo groups use collision-safe 24-character short IDs. Existing
+8-character names remain supported and normal sync never renames a persisted
+group automatically.
+
+For an existing `strict` or `insulated` installation, first preview and then
+migrate only real legacy collision cohorts (recommended):
+
+```bash
+sudo agor local fix-group-uuids --only-dups --dry-run
+sudo agor local fix-group-uuids --only-dups
+```
+
+An optional full migration handles every legacy branch and repo group:
+
+```bash
+sudo agor local fix-group-uuids --dry-run
+sudo agor local fix-group-uuids
+```
+
+The command reconstructs membership from current database authorization,
+verifies managed paths before switching each row, and is safe to rerun after an
+interruption. It intentionally supports only the host-local single-tenant
+SQLite database: system-global Unix groups cannot be safely reconciled from a
+tenant-limited PostgreSQL/RLS view.
 
 ### Daemon Can't Create Users
 

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -429,7 +429,9 @@ sudo agor local fix-group-uuids --only-dups --dry-run
 sudo agor local fix-group-uuids --only-dups
 ```
 
-An optional full migration handles every legacy branch and repo group:
+An optional full migration handles every legacy branch and repo group and
+removes system-only legacy groups after proving that no database row or managed
+filesystem root still uses them:
 
 ```bash
 sudo agor local fix-group-uuids --dry-run

--- a/context/concepts/id-management.md
+++ b/context/concepts/id-management.md
@@ -34,7 +34,7 @@ shortId('01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f')
 
 Repositories (`cards`, `users`, `mcp-servers`, `board-comments`, `card-types`, `branches`, `tasks`, `sessions`, `boards`, `repos`) all delegate to it — never write a new resolver inline.
 
-**Don't roll your own truncation.** `scripts/check-no-ad-hoc-shortid.mjs` greps for `xxxId.substring(0, N)` / `.slice(0, N)` / `.replace(/-/g, '').slice(0, N)` patterns and fails CI. Use `shortId(id)` for display, `toShortId(id, length)` for the rare documented non-canonical case (e.g. Unix-name 8-char carve-out in `unix/short-id-naming.ts`). Pragma escape hatch: `// shortid-guard:ignore <reason>` on the offending line or the line above.
+**Don't roll your own truncation.** `scripts/check-no-ad-hoc-shortid.mjs` greps for `xxxId.substring(0, N)` / `.slice(0, N)` / `.replace(/-/g, '').slice(0, N)` patterns and fails CI. Use `shortId(id)` for display and for new branch/repo Unix group names. `toShortId(id, length)` is reserved for documented compatibility cases such as Unix usernames and legacy group detection in `unix/short-id-naming.ts`. Pragma escape hatch: `// shortid-guard:ignore <reason>` on the offending line or the line above.
 
 ## Branded types
 

--- a/docker/sudoers/agor-daemon.sudoers
+++ b/docker/sudoers/agor-daemon.sudoers
@@ -66,7 +66,7 @@ agor ALL=(ALL) NOPASSWD: /usr/sbin/chpasswd
 # ============================================================================
 # GROUP MANAGEMENT - Worktree Isolation
 # ============================================================================
-# Each worktree gets a Unix group (agor_wt_<short-id>).
+# Each worktree gets a Unix group (agor_wt_<24-character-short-id>).
 # Users with 'all' permission are added to the group.
 # Filesystem permissions on the worktree directory enforce access.
 

--- a/packages/core/src/db/client.test.ts
+++ b/packages/core/src/db/client.test.ts
@@ -14,6 +14,7 @@ import {
   DatabaseConnectionError,
   type DbConfig,
   DEFAULT_DB_PATH,
+  resolveDatabaseUrl,
 } from './client';
 
 // Mock @libsql/client to avoid actual database connections
@@ -360,6 +361,48 @@ describe('createLocalDatabase', () => {
         syncInterval: expect.anything(),
       })
     );
+  });
+});
+
+describe('resolveDatabaseUrl', () => {
+  it('honors a PostgreSQL URL selected in config', () => {
+    expect(
+      resolveDatabaseUrl({
+        env: {},
+        config: {
+          database: {
+            dialect: 'postgresql',
+            postgresql: { url: 'postgresql://db.example/agor' },
+          },
+        },
+      })
+    ).toBe('postgresql://db.example/agor');
+  });
+
+  it('does not fall back to SQLite when config selects PostgreSQL without a URL', () => {
+    expect(resolveDatabaseUrl({ env: {}, config: { database: { dialect: 'postgresql' } } })).toBe(
+      'postgresql://localhost:5432/agor'
+    );
+  });
+
+  it('honors and expands the configured SQLite path using the explicit operator home', () => {
+    expect(
+      resolveDatabaseUrl({
+        env: {},
+        homeDir: '/home/operator',
+        config: { database: { dialect: 'sqlite', sqlite: { path: '~/.agor/custom.db' } } },
+      })
+    ).toBe('file:/home/operator/.agor/custom.db');
+  });
+
+  it('keeps environment database overrides ahead of config', () => {
+    expect(
+      resolveDatabaseUrl({
+        env: { AGOR_DB_PATH: 'file:~/.agor/override.db' },
+        homeDir: '/home/operator',
+        config: { database: { dialect: 'postgresql' } },
+      })
+    ).toBe('file:/home/operator/.agor/override.db');
   });
 });
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -5,6 +5,8 @@
  * Supports both SQLite (LibSQL) and PostgreSQL.
  */
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { Client, Config } from '@libsql/client';
 import { createClient } from '@libsql/client';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
@@ -13,6 +15,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { loadConfigSync } from '../config/config-manager';
+import type { AgorConfig } from '../config/types';
 import { sanitizeDbError } from './sanitize-error';
 import * as postgresSchema from './schema.postgres';
 
@@ -342,6 +345,66 @@ export type SystemDatabase = Database & { readonly [systemDatabaseBrand]: 'syste
  */
 export const DEFAULT_DB_PATH = 'file:~/.agor/agor.db';
 
+export interface DatabaseUrlResolutionOptions {
+  /** Already-loaded config, allowing sudo/local callers to choose the correct home. */
+  config?: Pick<AgorConfig, 'database'>;
+  /** Environment override source (defaults to process.env). */
+  env?: NodeJS.ProcessEnv;
+  /** Home used to expand `~` in local database paths. */
+  homeDir?: string;
+}
+
+function expandDatabasePathForHome(value: string, homeDir: string): string {
+  if (value.startsWith('file:~/')) return `file:${join(homeDir, value.slice(7))}`;
+  if (value.startsWith('~/')) return join(homeDir, value.slice(2));
+  return value;
+}
+
+/** Resolve the effective database URL from an explicit config/environment view. */
+export function resolveDatabaseUrl(options: DatabaseUrlResolutionOptions = {}): string {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? homedir();
+
+  if (env.AGOR_DB_DIALECT === 'postgresql') {
+    return env.DATABASE_URL || 'postgresql://localhost:5432/agor';
+  }
+  if (env.AGOR_DB_PATH) {
+    return expandDatabasePathForHome(env.AGOR_DB_PATH, homeDir);
+  }
+  if (env.DATABASE_URL) {
+    return expandDatabasePathForHome(env.DATABASE_URL, homeDir);
+  }
+
+  const dbConfig = options.config?.database;
+  if (dbConfig) {
+    const inferredDialect = dbConfig.postgresql?.url
+      ? detectDialectFromUrl(dbConfig.postgresql.url)
+      : null;
+    const dialect = dbConfig.dialect ?? inferredDialect ?? 'sqlite';
+
+    if (dialect === 'postgresql') {
+      if (dbConfig.postgresql?.url) return dbConfig.postgresql.url;
+      if (dbConfig.postgresql?.host) {
+        const pg = dbConfig.postgresql;
+        const user = encodeURIComponent(pg.user || 'postgres');
+        const password = pg.password ? `:${encodeURIComponent(pg.password)}` : '';
+        const port = pg.port || 5432;
+        const database = pg.database || 'agor';
+        return `postgresql://${user}${password}@${pg.host}:${port}/${database}`;
+      }
+      return 'postgresql://localhost:5432/agor';
+    }
+
+    if (dbConfig.sqlite?.path) {
+      const sqlitePath = dbConfig.sqlite.path;
+      const prefixed = sqlitePath.startsWith('file:') ? sqlitePath : `file:${sqlitePath}`;
+      return expandDatabasePathForHome(prefixed, homeDir);
+    }
+  }
+
+  return expandDatabasePathForHome(DEFAULT_DB_PATH, homeDir);
+}
+
 /**
  * Resolve database URL from environment and config
  *
@@ -355,53 +418,13 @@ export const DEFAULT_DB_PATH = 'file:~/.agor/agor.db';
  * @returns Database URL string
  */
 export function getDatabaseUrl(): string {
-  // Environment variables take highest priority
-  if (process.env.AGOR_DB_DIALECT === 'postgresql') {
-    return process.env.DATABASE_URL || 'postgresql://localhost:5432/agor';
-  }
-  if (process.env.AGOR_DB_PATH) {
-    return expandPath(process.env.AGOR_DB_PATH);
-  }
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL;
-  }
-
-  // Fall back to config.yaml
+  let config: AgorConfig | undefined;
   try {
-    const config = loadConfigSync();
-    const dbConfig = config.database;
-
-    if (dbConfig) {
-      const dialect = dbConfig.dialect || getDatabaseDialect();
-
-      if (dialect === 'postgresql') {
-        // Build URL from individual params or use url directly
-        if (dbConfig.postgresql?.url) {
-          return dbConfig.postgresql.url;
-        }
-        if (dbConfig.postgresql?.host) {
-          const pg = dbConfig.postgresql;
-          const user = encodeURIComponent(pg.user || 'postgres');
-          const password = pg.password ? `:${encodeURIComponent(pg.password)}` : '';
-          const host = pg.host;
-          const port = pg.port || 5432;
-          const database = pg.database || 'agor';
-          return `postgresql://${user}${password}@${host}:${port}/${database}`;
-        }
-      }
-
-      if (dialect === 'sqlite' && dbConfig.sqlite?.path) {
-        const sqlitePath = dbConfig.sqlite.path;
-        // Ensure file: prefix for consistency
-        const prefixed = sqlitePath.startsWith('file:') ? sqlitePath : `file:${sqlitePath}`;
-        return expandPath(prefixed);
-      }
-    }
+    config = loadConfigSync();
   } catch {
-    // Config not available — fall through to default
+    // Config not available — resolve from environment/defaults.
   }
-
-  return expandPath(DEFAULT_DB_PATH);
+  return resolveDatabaseUrl({ config });
 }
 
 /**

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -11,6 +11,7 @@ export {
   gt,
   gte,
   inArray,
+  isNull,
   like,
   lt,
   lte,

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -1238,6 +1238,46 @@ describe('BranchRepository resolveUserAccess', () => {
 });
 
 describe('BranchRepository findExplicitFsAccessUserIds', () => {
+  dbTest('expands direct owners and branch group filesystem grants', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const groupRepo = new GroupRepository(db);
+    const usersRepo = new UsersRepository(db);
+    const repo = await repoRepo.create(createRepoData({ slug: 'direct-fs-users-repo' }));
+    const creatorId = generateId() as UUID;
+    const ownerId = generateId() as UUID;
+    const groupMemberId = generateId() as UUID;
+
+    await usersRepo.create({ user_id: creatorId, email: 'creator-direct-fs@example.com' });
+    await usersRepo.create({ user_id: ownerId, email: 'owner-direct-fs@example.com' });
+    await usersRepo.create({
+      user_id: groupMemberId,
+      email: 'member-direct-fs@example.com',
+    });
+    const branch = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        name: 'direct-fs-users',
+        branch_unique_id: 9300,
+        created_by: creatorId,
+      })
+    );
+    await branchRepo.addOwner(branch.branch_id, ownerId);
+    const group = await groupRepo.create({ name: 'Direct FS Group', created_by: creatorId });
+    await groupRepo.addMember(group.group_id, groupMemberId, creatorId);
+    await groupRepo.upsertBranchGrant({
+      branch_id: branch.branch_id,
+      group_id: group.group_id,
+      can: 'session',
+      fs_access: 'write',
+      created_by: creatorId,
+    });
+
+    expect(await branchRepo.findExplicitFsAccessUserIds(branch.branch_id)).toEqual(
+      expect.arrayContaining([ownerId, groupMemberId])
+    );
+  });
+
   dbTest(
     'expands board owners and board groups only for board-aligned branches',
     async ({ db }) => {

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -19,6 +19,7 @@ import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, desc, eq, exists, getTableColumns, inArray, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
+import { resolveBranchGroupName, resolveBranchGroupUpdate } from '../../unix/group-manager';
 import { getBranchUrl } from '../../utils/url';
 import type { Database } from '../client';
 import {
@@ -208,7 +209,8 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
       permission_source: branch.permission_source ?? 'override',
       others_can: branch.others_can ?? 'session',
       others_fs_access: branch.others_fs_access ?? null,
-      unix_group: branch.unix_group ?? null,
+      unix_group:
+        branch.unix_group == null ? null : resolveBranchGroupName(branchId, branch.unix_group),
       // Branch storage mode (default 'worktree' matches schema default)
       storage_mode: branch.storage_mode ?? 'worktree',
       clone_depth: branch.clone_depth ?? null,
@@ -569,6 +571,11 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
         created_at: current.created_at, // Never change created timestamp
         updated_at: options?.preserveUpdatedAt ? current.updated_at : new Date().toISOString(),
       });
+      merged.unix_group = resolveBranchGroupUpdate(
+        current.branch_id,
+        current.unix_group,
+        Object.hasOwn(updates, 'unix_group') ? updates.unix_group : undefined
+      );
       // A materialization error describes only the failed filesystem state.
       // Clear it atomically with every explicit transition away from failed
       // so a successful retry/unarchive cannot remain visually poisoned by

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -4,10 +4,17 @@
  * Type-safe CRUD operations for git repositories with short ID support.
  */
 
-import type { Repo, RepoEnvironment, RepoEnvironmentConfigV1, UUID } from '@agor/core/types';
+import type {
+  Repo,
+  RepoEnvironment,
+  RepoEnvironmentConfigV1,
+  RepoID,
+  UUID,
+} from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { resolveVariant, wrapV1AsV2 } from '../../config/variant-resolver.js';
 import { generateId } from '../../lib/ids';
+import { resolveRepoGroupName, resolveRepoGroupUpdate } from '../../unix/group-manager';
 import { httpUrlHasUserinfo, stripHttpUrlUserinfo } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
@@ -138,7 +145,8 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       created_at: new Date(repo.created_at ?? now),
       updated_at: repo.last_updated ? new Date(repo.last_updated) : new Date(now),
       repo_type: repo.repo_type,
-      unix_group: repo.unix_group ?? null,
+      unix_group:
+        repo.unix_group == null ? null : resolveRepoGroupName(repoId as RepoID, repo.unix_group),
       data: {
         name: repo.name ?? repo.slug,
         remote_url: repo.remote_url ? stripHttpUrlUserinfo(repo.remote_url) : undefined,
@@ -363,6 +371,11 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         // STEP 2: Deep merge updates into current repo (in memory)
         // Preserves nested objects like permission_config when doing partial updates
         const merged = deepMerge(current, updates);
+        merged.unix_group = resolveRepoGroupUpdate(
+          current.repo_id as RepoID,
+          current.unix_group,
+          Object.hasOwn(updates, 'unix_group') ? updates.unix_group : undefined
+        );
         const insertData = this.repoToInsert(merged);
 
         // STEP 3: Write merged repo (within same transaction)
@@ -373,7 +386,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
             slug: insertData.slug,
             updated_at: newUpdatedAt,
             repo_type: insertData.repo_type,
-            unix_group: merged.unix_group ?? null,
+            unix_group: insertData.unix_group,
             data: insertData.data,
           })
           .where(eq(repos.repo_id, fullId))
@@ -432,6 +445,11 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
 
         const current = this.rowToRepo(currentRow);
         const next: Repo = { ...current, ...patch };
+        next.unix_group = resolveRepoGroupUpdate(
+          current.repo_id as RepoID,
+          current.unix_group,
+          Object.hasOwn(patch, 'unix_group') ? patch.unix_group : undefined
+        );
 
         const insertData = this.repoToInsert(next);
         const newUpdatedAt = new Date();
@@ -440,7 +458,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
             slug: insertData.slug,
             updated_at: newUpdatedAt,
             repo_type: insertData.repo_type,
-            unix_group: next.unix_group ?? null,
+            unix_group: insertData.unix_group,
             data: insertData.data,
           })
           .where(eq(repos.repo_id, fullId))

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -631,7 +631,7 @@ export const repos = pgTable(
       .notNull()
       .default('remote'),
 
-    // Unix group for repo-level git access (agor_rp_<short-id>)
+    // Unix group for repo-level git access (canonical 24-char suffix; legacy 8-char valid)
     // Users who have access to ANY branch in this repo get added to this group.
     // Applied to repo Unix-group-managed paths:
     // - repo root (non-recursive) for traversal into .git/worktrees/<name>
@@ -779,7 +779,7 @@ export const branches = pgTable(
     }).default('view'),
 
     // RBAC: OS-layer permissions (unix-user-modes.md)
-    unix_group: text('unix_group'), // e.g., 'agor_wt_abc123'
+    unix_group: text('unix_group'), // canonical 24-char suffix; legacy 8-char stamps remain valid
     others_fs_access: text('others_fs_access', {
       enum: ['none', 'read', 'write'],
     })

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -598,7 +598,7 @@ export const repos = sqliteTable(
       .notNull()
       .default('remote'),
 
-    // Unix group for repo-level git access (agor_rp_<short-id>)
+    // Unix group for repo-level git access (canonical 24-char suffix; legacy 8-char valid)
     // Users who have access to ANY branch in this repo get added to this group.
     // Applied to repo Unix-group-managed paths:
     // - repo root (non-recursive) for traversal into .git/worktrees/<name>
@@ -742,7 +742,7 @@ export const branches = sqliteTable(
     }).default('view'),
 
     // RBAC: OS-layer permissions (unix-user-modes.md)
-    unix_group: text('unix_group'), // e.g., 'agor_wt_abc123'
+    unix_group: text('unix_group'), // canonical 24-char suffix; legacy 8-char stamps remain valid
     others_fs_access: text('others_fs_access', {
       enum: ['none', 'read', 'write'],
     })

--- a/packages/core/src/lib/ids.ts
+++ b/packages/core/src/lib/ids.ts
@@ -6,7 +6,7 @@
  *
  * Key concepts:
  * - Full UUIDs stored in database (36 chars)
- * - Short IDs displayed to users — always 20 hex chars via `shortId(id)`.
+ * - Short IDs displayed to users — always 24 hex chars via `shortId(id)`.
  *   See `SHORT_ID_LENGTH` in `../types/id` for the collision math.
  * - Git-style collision resolution on user input (expand prefix when
  *   ambiguous) — handled centrally by `resolveByShortIdPrefix` in

--- a/packages/core/src/local-actions/unix-groups.ts
+++ b/packages/core/src/local-actions/unix-groups.ts
@@ -1,7 +1,5 @@
-import type { BranchID } from '../types/index.js';
 import { createAdminExecutor } from '../unix/command-executor.js';
 import {
-  generateBranchGroupName,
   isLegacyManagedGroupName,
   isValidBranchGroupName,
   UnixGroupCommands,
@@ -9,7 +7,8 @@ import {
 import { getReporter, type LocalActionOptions } from './types.js';
 
 export interface CreateBranchGroupParams extends LocalActionOptions {
-  branchId: string;
+  /** Persisted, caller-resolved branch group. Never derive this from an ID here. */
+  group: string;
 }
 
 export async function createBranchGroupAction(params: CreateBranchGroupParams): Promise<void> {
@@ -18,7 +17,7 @@ export async function createBranchGroupAction(params: CreateBranchGroupParams): 
 
   if (params.dryRun) reporter.log('🔍 Dry run mode - no changes will be made\n');
 
-  const groupName = generateBranchGroupName(params.branchId as BranchID);
+  const groupName = params.group;
   if (!isValidBranchGroupName(groupName)) {
     throw new Error(`Invalid group name format: ${groupName}`);
   }

--- a/packages/core/src/local-actions/unix-groups.ts
+++ b/packages/core/src/local-actions/unix-groups.ts
@@ -2,6 +2,7 @@ import type { BranchID } from '../types/index.js';
 import { createAdminExecutor } from '../unix/command-executor.js';
 import {
   generateBranchGroupName,
+  isLegacyManagedGroupName,
   isValidBranchGroupName,
   UnixGroupCommands,
 } from '../unix/group-manager.js';
@@ -40,6 +41,13 @@ export async function deleteBranchGroupAction(params: DeleteBranchGroupParams): 
   const reporter = getReporter(params);
   const executor = createAdminExecutor({ 'dry-run': !!params.dryRun, verbose: !!params.verbose });
   if (params.dryRun) reporter.log('🔍 Dry run mode - no changes will be made\n');
+
+  if (isLegacyManagedGroupName(params.group)) {
+    throw new Error(
+      `Refusing to delete legacy group ${params.group} without global database and filesystem verification. ` +
+        'Run agor local fix-group-uuids instead.'
+    );
+  }
 
   const groupExists = await executor.check(UnixGroupCommands.groupExists(params.group));
   if (!groupExists) {

--- a/packages/core/src/types/branch.ts
+++ b/packages/core/src/types/branch.ts
@@ -340,7 +340,8 @@ export interface Branch {
   /**
    * Unix group for this branch (if Unix modes enabled)
    *
-   * Format: 'agor_wt_<short-id>'
+   * Format: 'agor_wt_<canonical-24-char-short-id>'; legacy persisted rows may
+   * retain the older 8-character form until explicitly migrated.
    * Owners are added to this group for filesystem access.
    */
   unix_group?: string;

--- a/packages/core/src/types/id.ts
+++ b/packages/core/src/types/id.ts
@@ -143,7 +143,7 @@ export function toShortId(id: AnyShortId, length: number = SHORT_ID_LENGTH): Sho
  * browser-safe `@agor/core/client` surface for the React UI.
  *
  * @example
- * shortId("01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f") // => "01933e4a7b897c35a8f3"
+ * shortId("01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f") // => "01933e4a7b897c35a8f39d2e"
  */
 export function shortId(id: AnyShortId): ShortID {
   return toShortId(id, SHORT_ID_LENGTH);

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -120,7 +120,8 @@ export interface Repo {
   /**
    * Unix group for .git/ directory access
    *
-   * Format: agor_rp_<short-id> (e.g., 'agor_rp_03b62447')
+   * Format: `agor_rp_<canonical-24-char-short-id>`; legacy persisted rows may
+   * retain the older 8-character form until explicitly migrated.
    *
    * This group is created when branch RBAC is enabled and controls access
    * to the shared .git/ directory. Users who have access to ANY branch

--- a/packages/core/src/unix/group-manager.test.ts
+++ b/packages/core/src/unix/group-manager.test.ts
@@ -9,14 +9,20 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { BranchID } from '../types/index.js';
+import type { BranchID, RepoID } from '../types/index.js';
 import {
   AGOR_USERS_GROUP,
   BranchPermissionModes,
   generateBranchGroupName,
+  generateLegacyBranchGroupName,
+  generateRepoGroupName,
   getBranchPermissionMode,
   isValidBranchGroupName,
+  isValidRepoGroupName,
   parseBranchGroupName,
+  parseRepoGroupName,
+  resolveBranchGroupName,
+  resolveRepoGroupName,
   UnixGroupCommands,
 } from './group-manager.js';
 
@@ -29,19 +35,47 @@ describe('group-manager', () => {
     it('generates group name from UUID with agor_wt_ prefix', () => {
       const branchId = '01234567-89ab-cdef-0123-456789abcdef' as BranchID;
       const groupName = generateBranchGroupName(branchId);
-      expect(groupName).toBe('agor_wt_01234567');
+      expect(groupName).toBe('agor_wt_0123456789abcdef01234567');
     });
 
-    it('uses first 8 chars of UUID as short ID', () => {
+    it('uses the canonical 24-character short ID', () => {
       const branchId = 'abcdef01-2345-6789-abcd-ef0123456789' as BranchID;
       const groupName = generateBranchGroupName(branchId);
-      expect(groupName).toBe('agor_wt_abcdef01');
+      expect(groupName).toBe('agor_wt_abcdef0123456789abcdef01');
     });
 
     it('handles UUIDv7 format correctly', () => {
       const branchId = '019377a4-5c3b-7def-8abc-123456789abc' as BranchID;
       const groupName = generateBranchGroupName(branchId);
-      expect(groupName).toBe('agor_wt_019377a4');
+      expect(groupName).toBe('agor_wt_019377a45c3b7def8abc1234');
+    });
+
+    it('does not collide for UUIDv7 IDs with the same timestamp prefix', () => {
+      const first = '019ffd3d-2cef-79d1-a1c6-407300000001' as BranchID;
+      const second = '019ffd3d-2cef-7abc-b2d7-518400000002' as BranchID;
+
+      expect(generateLegacyBranchGroupName(first)).toBe(generateLegacyBranchGroupName(second));
+      expect(generateBranchGroupName(first)).not.toBe(generateBranchGroupName(second));
+      expect(generateBranchGroupName(first)).toBe('agor_wt_019ffd3d2cef79d1a1c64073');
+      expect(generateRepoGroupName(first as unknown as RepoID)).not.toBe(
+        generateRepoGroupName(second as unknown as RepoID)
+      );
+    });
+  });
+
+  describe('persisted group names', () => {
+    const branchId = '019ffd3d-2cef-79d1-a1c6-407300000001' as BranchID;
+    const repoId = '019ffd3d-2cef-79d1-a1c6-407300000002' as RepoID;
+
+    it('keeps legacy and custom stamped values authoritative', () => {
+      expect(resolveBranchGroupName(branchId, 'agor_wt_019ffd3d')).toBe('agor_wt_019ffd3d');
+      expect(resolveRepoGroupName(repoId, 'operator_managed')).toBe('operator_managed');
+    });
+
+    it('generates only when the field is absent', () => {
+      expect(resolveBranchGroupName(branchId, null)).toBe(generateBranchGroupName(branchId));
+      expect(resolveRepoGroupName(repoId, undefined)).toBe(generateRepoGroupName(repoId));
+      expect(resolveBranchGroupName(branchId, '')).toBe('');
     });
   });
 
@@ -53,6 +87,9 @@ describe('group-manager', () => {
     it('extracts short ID from valid branch group name', () => {
       expect(parseBranchGroupName('agor_wt_01234567')).toBe('01234567');
       expect(parseBranchGroupName('agor_wt_abcdef01')).toBe('abcdef01');
+      expect(parseBranchGroupName('agor_wt_019ffd3d2cef79d1a1c64073')).toBe(
+        '019ffd3d2cef79d1a1c64073'
+      );
     });
 
     it('returns null for non-branch group names', () => {
@@ -64,7 +101,7 @@ describe('group-manager', () => {
     it('returns null for invalid branch group formats', () => {
       expect(parseBranchGroupName('agor_wt_')).toBeNull(); // too short
       expect(parseBranchGroupName('agor_wt_1234567')).toBeNull(); // 7 chars
-      expect(parseBranchGroupName('agor_wt_123456789')).toBeNull(); // 9 chars
+      expect(parseBranchGroupName('agor_wt_123456789')).toBeNull(); // unsupported length
       expect(parseBranchGroupName('agor_wt_ABCDEF01')).toBeNull(); // uppercase
       expect(parseBranchGroupName('agor_wt_1234567g')).toBeNull(); // invalid hex
     });
@@ -84,6 +121,7 @@ describe('group-manager', () => {
       expect(isValidBranchGroupName('agor_wt_abcdef01')).toBe(true);
       expect(isValidBranchGroupName('agor_wt_00000000')).toBe(true);
       expect(isValidBranchGroupName('agor_wt_ffffffff')).toBe(true);
+      expect(isValidBranchGroupName('agor_wt_019ffd3d2cef79d1a1c64073')).toBe(true);
     });
 
     it('returns false for invalid formats', () => {
@@ -92,6 +130,17 @@ describe('group-manager', () => {
       expect(isValidBranchGroupName('agor_wt_123456789')).toBe(false); // 9 chars
       expect(isValidBranchGroupName('agor_01234567')).toBe(false); // missing wt_
       expect(isValidBranchGroupName('wt_01234567')).toBe(false); // missing agor_
+    });
+  });
+
+  describe('repo group compatibility', () => {
+    it('accepts and parses legacy and canonical repo group names', () => {
+      expect(isValidRepoGroupName('agor_rp_019ffd3d')).toBe(true);
+      expect(isValidRepoGroupName('agor_rp_019ffd3d2cef79d1a1c64073')).toBe(true);
+      expect(parseRepoGroupName('agor_rp_019ffd3d')).toBe('019ffd3d');
+      expect(parseRepoGroupName('agor_rp_019ffd3d2cef79d1a1c64073')).toBe(
+        '019ffd3d2cef79d1a1c64073'
+      );
     });
   });
 

--- a/packages/core/src/unix/group-manager.test.ts
+++ b/packages/core/src/unix/group-manager.test.ts
@@ -22,7 +22,9 @@ import {
   parseBranchGroupName,
   parseRepoGroupName,
   resolveBranchGroupName,
+  resolveBranchGroupUpdate,
   resolveRepoGroupName,
+  resolveRepoGroupUpdate,
   UnixGroupCommands,
 } from './group-manager.js';
 
@@ -67,15 +69,38 @@ describe('group-manager', () => {
     const branchId = '019ffd3d-2cef-79d1-a1c6-407300000001' as BranchID;
     const repoId = '019ffd3d-2cef-79d1-a1c6-407300000002' as RepoID;
 
-    it('keeps legacy and custom stamped values authoritative', () => {
+    it('keeps matching legacy and canonical stamped values authoritative', () => {
       expect(resolveBranchGroupName(branchId, 'agor_wt_019ffd3d')).toBe('agor_wt_019ffd3d');
-      expect(resolveRepoGroupName(repoId, 'operator_managed')).toBe('operator_managed');
+      expect(resolveRepoGroupName(repoId, generateRepoGroupName(repoId))).toBe(
+        generateRepoGroupName(repoId)
+      );
     });
 
     it('generates only when the field is absent', () => {
       expect(resolveBranchGroupName(branchId, null)).toBe(generateBranchGroupName(branchId));
       expect(resolveRepoGroupName(repoId, undefined)).toBe(generateRepoGroupName(repoId));
-      expect(resolveBranchGroupName(branchId, '')).toBe('');
+    });
+
+    it('fails closed for empty, custom, or wrong-row persisted values', () => {
+      expect(() => resolveBranchGroupName(branchId, '')).toThrow('Invalid persisted Unix group');
+      expect(() => resolveRepoGroupName(repoId, 'operator_managed')).toThrow(
+        'Invalid persisted Unix group'
+      );
+      expect(() => resolveBranchGroupName(branchId, 'agor_wt_019ffd3d2cef79d1a1c64074')).toThrow(
+        'Invalid persisted Unix group'
+      );
+    });
+
+    it('never clears or changes an existing repository stamp', () => {
+      expect(resolveBranchGroupUpdate(branchId, 'agor_wt_019ffd3d', undefined)).toBe(
+        'agor_wt_019ffd3d'
+      );
+      expect(() => resolveBranchGroupUpdate(branchId, 'agor_wt_019ffd3d', null)).toThrow(
+        'authoritative'
+      );
+      expect(() =>
+        resolveRepoGroupUpdate(repoId, generateRepoGroupName(repoId), 'agor_rp_019ffd3d')
+      ).toThrow('authoritative');
     });
   });
 
@@ -201,6 +226,15 @@ describe('group-manager', () => {
   // =========================================================================
 
   describe('UnixGroupCommands', () => {
+    it('rejects shell metacharacters in group names', () => {
+      expect(() => UnixGroupCommands.deleteGroup('agor_wt_safe; groupdel wheel')).toThrow(
+        'Unsafe Unix group name'
+      );
+      expect(() =>
+        UnixGroupCommands.setDirectoryGroup('/data/project', '$(touch pwned)', '2775')
+      ).toThrow('Unsafe Unix group name');
+    });
+
     describe('createGroup', () => {
       it('generates groupadd command', () => {
         expect(UnixGroupCommands.createGroup('agor_wt_01234567')).toBe(

--- a/packages/core/src/unix/group-manager.test.ts
+++ b/packages/core/src/unix/group-manager.test.ts
@@ -76,9 +76,13 @@ describe('group-manager', () => {
       );
     });
 
-    it('generates only when the field is absent', () => {
-      expect(resolveBranchGroupName(branchId, null)).toBe(generateBranchGroupName(branchId));
-      expect(resolveRepoGroupName(repoId, undefined)).toBe(generateRepoGroupName(repoId));
+    it('requires callers to persist a generated value before resolving it', () => {
+      expect(() => resolveBranchGroupName(branchId, null as unknown as string)).toThrow(
+        'Invalid persisted Unix group'
+      );
+      expect(() => resolveRepoGroupName(repoId, undefined as unknown as string)).toThrow(
+        'Invalid persisted Unix group'
+      );
     });
 
     it('fails closed for empty, custom, or wrong-row persisted values', () => {

--- a/packages/core/src/unix/group-manager.ts
+++ b/packages/core/src/unix/group-manager.ts
@@ -26,6 +26,15 @@ const repoGroupPattern = new RegExp(
 );
 const legacyBranchGroupPattern = new RegExp(`^agor_wt_[0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}$`);
 const legacyRepoGroupPattern = new RegExp(`^agor_rp_[0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}$`);
+const safeUnixGroupPattern = /^[a-z_][a-z0-9_-]{0,31}$/;
+
+/** Reject shell-unsafe Unix group names before constructing privileged commands. */
+export function assertSafeUnixGroupName(groupName: string): string {
+  if (!safeUnixGroupPattern.test(groupName)) {
+    throw new Error(`Unsafe Unix group name: ${JSON.stringify(groupName)}`);
+  }
+  return groupName;
+}
 
 /**
  * Generate Unix group name for a branch
@@ -45,6 +54,17 @@ export function generateLegacyBranchGroupName(branchId: BranchID): string {
   return `agor_wt_${toShortId(branchId as UUID, LEGACY_GROUP_SHORT_ID_LENGTH)}`;
 }
 
+/** Require a persisted branch group to belong to the row that stamped it. */
+export function assertBranchGroupNameMatchesId(branchId: BranchID, groupName: string): string {
+  if (
+    groupName !== generateBranchGroupName(branchId) &&
+    groupName !== generateLegacyBranchGroupName(branchId)
+  ) {
+    throw new Error(`Invalid persisted Unix group for branch ${branchId}: ${groupName}`);
+  }
+  return groupName;
+}
+
 /**
  * Resolve the group a normal sync must use.
  *
@@ -55,7 +75,27 @@ export function resolveBranchGroupName(
   branchId: BranchID,
   persistedGroup: string | null | undefined
 ): string {
-  return persistedGroup ?? generateBranchGroupName(branchId);
+  return persistedGroup == null
+    ? generateBranchGroupName(branchId)
+    : assertBranchGroupNameMatchesId(branchId, persistedGroup);
+}
+
+/** Preserve an existing branch stamp while validating a requested repository update. */
+export function resolveBranchGroupUpdate(
+  branchId: BranchID,
+  currentGroup: string | null | undefined,
+  requestedGroup: string | null | undefined
+): string | undefined {
+  if (currentGroup != null) {
+    const validatedCurrent = assertBranchGroupNameMatchesId(branchId, currentGroup);
+    if (requestedGroup !== undefined && requestedGroup !== validatedCurrent) {
+      throw new Error(`Persisted Unix group for branch ${branchId} is authoritative`);
+    }
+    return validatedCurrent;
+  }
+  return requestedGroup == null
+    ? undefined
+    : assertBranchGroupNameMatchesId(branchId, requestedGroup);
 }
 
 /**
@@ -111,12 +151,41 @@ export function generateLegacyRepoGroupName(repoId: RepoID): string {
   return `agor_rp_${toShortId(repoId as UUID, LEGACY_GROUP_SHORT_ID_LENGTH)}`;
 }
 
+/** Require a persisted repo group to belong to the row that stamped it. */
+export function assertRepoGroupNameMatchesId(repoId: RepoID, groupName: string): string {
+  if (
+    groupName !== generateRepoGroupName(repoId) &&
+    groupName !== generateLegacyRepoGroupName(repoId)
+  ) {
+    throw new Error(`Invalid persisted Unix group for repo ${repoId}: ${groupName}`);
+  }
+  return groupName;
+}
+
 /** See {@link resolveBranchGroupName}; repo sync follows the same persistence rule. */
 export function resolveRepoGroupName(
   repoId: RepoID,
   persistedGroup: string | null | undefined
 ): string {
-  return persistedGroup ?? generateRepoGroupName(repoId);
+  return persistedGroup == null
+    ? generateRepoGroupName(repoId)
+    : assertRepoGroupNameMatchesId(repoId, persistedGroup);
+}
+
+/** Preserve an existing repo stamp while validating a requested repository update. */
+export function resolveRepoGroupUpdate(
+  repoId: RepoID,
+  currentGroup: string | null | undefined,
+  requestedGroup: string | null | undefined
+): string | undefined {
+  if (currentGroup != null) {
+    const validatedCurrent = assertRepoGroupNameMatchesId(repoId, currentGroup);
+    if (requestedGroup !== undefined && requestedGroup !== validatedCurrent) {
+      throw new Error(`Persisted Unix group for repo ${repoId} is authoritative`);
+    }
+    return validatedCurrent;
+  }
+  return requestedGroup == null ? undefined : assertRepoGroupNameMatchesId(repoId, requestedGroup);
 }
 
 /**
@@ -177,7 +246,7 @@ export const UnixGroupCommands = {
    * @param groupName - Name of the group to create
    * @returns Command string with sudo
    */
-  createGroup: (groupName: string) => `sudo -n groupadd ${groupName}`,
+  createGroup: (groupName: string) => `sudo -n groupadd ${assertSafeUnixGroupName(groupName)}`,
 
   /**
    * Delete a Unix group
@@ -185,7 +254,7 @@ export const UnixGroupCommands = {
    * @param groupName - Name of the group to delete
    * @returns Command string with sudo
    */
-  deleteGroup: (groupName: string) => `sudo -n groupdel ${groupName}`,
+  deleteGroup: (groupName: string) => `sudo -n groupdel ${assertSafeUnixGroupName(groupName)}`,
 
   /**
    * Add user to a Unix group
@@ -195,7 +264,7 @@ export const UnixGroupCommands = {
    * @returns Command string with sudo
    */
   addUserToGroup: (username: string, groupName: string) =>
-    `sudo -n usermod -aG ${groupName} ${username}`,
+    `sudo -n usermod -aG ${assertSafeUnixGroupName(groupName)} ${username}`,
 
   /**
    * Remove user from a Unix group
@@ -205,7 +274,7 @@ export const UnixGroupCommands = {
    * @returns Command string with sudo
    */
   removeUserFromGroup: (username: string, groupName: string) =>
-    `sudo -n gpasswd -d ${username} ${groupName}`,
+    `sudo -n gpasswd -d ${username} ${assertSafeUnixGroupName(groupName)}`,
 
   /**
    * Check if a group exists (read-only, no sudo needed)
@@ -213,7 +282,8 @@ export const UnixGroupCommands = {
    * @param groupName - Group name to check
    * @returns Command string (exits 0 if exists, 1 if not)
    */
-  groupExists: (groupName: string) => `getent group ${groupName} > /dev/null`,
+  groupExists: (groupName: string) =>
+    `getent group ${assertSafeUnixGroupName(groupName)} > /dev/null`,
 
   /**
    * Check if a user is in a group (read-only, no sudo needed)
@@ -223,7 +293,7 @@ export const UnixGroupCommands = {
    * @returns Command string (exits 0 if member, 1 if not)
    */
   isUserInGroup: (username: string, groupName: string) =>
-    `id -nG ${username} | grep -qw ${groupName}`,
+    `id -nG ${username} | grep -qw ${assertSafeUnixGroupName(groupName)}`,
 
   /**
    * List all members of a group (read-only, no sudo needed)
@@ -231,7 +301,8 @@ export const UnixGroupCommands = {
    * @param groupName - Group name
    * @returns Command string (outputs comma-separated usernames)
    */
-  listGroupMembers: (groupName: string) => `getent group ${groupName} | cut -d: -f4`,
+  listGroupMembers: (groupName: string) =>
+    `getent group ${assertSafeUnixGroupName(groupName)} | cut -d: -f4`,
 
   /**
    * Set directory group ownership and permissions
@@ -255,6 +326,7 @@ export const UnixGroupCommands = {
    * @returns Array of command strings with sudo to execute sequentially
    */
   setDirectoryGroup: (path: string, groupName: string, permissions: string): string[] => {
+    assertSafeUnixGroupName(groupName);
     // Determine "others" ACL based on permissions mode
     // 2770 = no others, 2775 = others r-X, 2777 = others rwX
     // Using capital X means: execute only on directories, not files
@@ -308,6 +380,7 @@ export const UnixGroupCommands = {
    * @returns Array of command strings with sudo to execute sequentially
    */
   setDirectoryGroupShallow: (path: string, groupName: string, permissions: string): string[] => {
+    assertSafeUnixGroupName(groupName);
     const othersDigit = permissions.charAt(3);
     let othersAcl: string;
     switch (othersDigit) {
@@ -338,16 +411,22 @@ export const UnixGroupCommands = {
    * ACL has been installed. `setfacl -x` is idempotent when the entry is
    * already absent, so interrupted reruns converge.
    */
-  removeDirectoryGroupAcl: (path: string, groupName: string): string[] => [
-    `sudo -n setfacl -R -x g:${groupName} "${path}"`,
-    `sudo -n setfacl -R -d -x g:${groupName} "${path}"`,
-  ],
+  removeDirectoryGroupAcl: (path: string, groupName: string): string[] => {
+    assertSafeUnixGroupName(groupName);
+    return [
+      `sudo -n setfacl -R -x g:${groupName} "${path}"`,
+      `sudo -n setfacl -R -d -x g:${groupName} "${path}"`,
+    ];
+  },
 
   /** Non-recursive counterpart used for the managed repo root. */
-  removeDirectoryGroupAclShallow: (path: string, groupName: string): string[] => [
-    `sudo -n setfacl -x g:${groupName} "${path}"`,
-    `sudo -n setfacl -d -x g:${groupName} "${path}"`,
-  ],
+  removeDirectoryGroupAclShallow: (path: string, groupName: string): string[] => {
+    assertSafeUnixGroupName(groupName);
+    return [
+      `sudo -n setfacl -x g:${groupName} "${path}"`,
+      `sudo -n setfacl -d -x g:${groupName} "${path}"`,
+    ];
+  },
 
   /**
    * Set explicit user ACL on a directory (recursive with defaults)

--- a/packages/core/src/unix/group-manager.ts
+++ b/packages/core/src/unix/group-manager.ts
@@ -11,21 +11,51 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { toShortId } from '../lib/ids.js';
+import { SHORT_ID_LENGTH, shortId, toShortId } from '../lib/ids.js';
 import type { BranchID, RepoID, UUID } from '../types/index.js';
 import { UNIX_NAME_SHORT_ID_LENGTH } from './short-id-naming.js';
+
+const CANONICAL_GROUP_SHORT_ID_LENGTH = SHORT_ID_LENGTH;
+const LEGACY_GROUP_SHORT_ID_LENGTH = UNIX_NAME_SHORT_ID_LENGTH;
+
+const branchGroupPattern = new RegExp(
+  `^agor_wt_([0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}|[0-9a-f]{${CANONICAL_GROUP_SHORT_ID_LENGTH}})$`
+);
+const repoGroupPattern = new RegExp(
+  `^agor_rp_([0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}|[0-9a-f]{${CANONICAL_GROUP_SHORT_ID_LENGTH}})$`
+);
+const legacyBranchGroupPattern = new RegExp(`^agor_wt_[0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}$`);
+const legacyRepoGroupPattern = new RegExp(`^agor_rp_[0-9a-f]{${LEGACY_GROUP_SHORT_ID_LENGTH}}$`);
 
 /**
  * Generate Unix group name for a branch
  *
  * Format: agor_wt_<short-id>
- * Example: agor_wt_03b62447
+ * Example: agor_wt_019ffd3d2cef79d1a1c64073
  *
  * @param branchId - Full branch UUID
- * @returns Unix group name (e.g., 'agor_wt_03b62447')
+ * @returns Unix group name containing Agor's canonical collision-safe short ID
  */
 export function generateBranchGroupName(branchId: BranchID): string {
-  return `agor_wt_${toShortId(branchId as UUID, UNIX_NAME_SHORT_ID_LENGTH)}`;
+  return `agor_wt_${shortId(branchId as UUID)}`;
+}
+
+/** Return the group name used by Agor versions that truncated UUIDs to 8 chars. */
+export function generateLegacyBranchGroupName(branchId: BranchID): string {
+  return `agor_wt_${toShortId(branchId as UUID, LEGACY_GROUP_SHORT_ID_LENGTH)}`;
+}
+
+/**
+ * Resolve the group a normal sync must use.
+ *
+ * A stamped value is authoritative, including a legacy 8-character name.
+ * Generation is reserved exclusively for rows where `unix_group` is absent.
+ */
+export function resolveBranchGroupName(
+  branchId: BranchID,
+  persistedGroup: string | null | undefined
+): string {
+  return persistedGroup ?? generateBranchGroupName(branchId);
 }
 
 /**
@@ -34,10 +64,10 @@ export function generateBranchGroupName(branchId: BranchID): string {
  * Extracts the short ID from a group name like 'agor_wt_03b62447'
  *
  * @param groupName - Unix group name
- * @returns Short branch ID (8 chars) or null if invalid format
+ * @returns Legacy or canonical short branch ID, or null if invalid
  */
 export function parseBranchGroupName(groupName: string): string | null {
-  const match = groupName.match(/^agor_wt_([0-9a-f]{8})$/);
+  const match = groupName.match(branchGroupPattern);
   return match ? match[1] : null;
 }
 
@@ -48,7 +78,12 @@ export function parseBranchGroupName(groupName: string): string | null {
  * @returns true if valid branch group name
  */
 export function isValidBranchGroupName(groupName: string): boolean {
-  return /^agor_wt_[0-9a-f]{8}$/.test(groupName);
+  return branchGroupPattern.test(groupName);
+}
+
+/** Whether a branch group uses the legacy collision-prone 8-character form. */
+export function isLegacyBranchGroupName(groupName: string): boolean {
+  return legacyBranchGroupPattern.test(groupName);
 }
 
 // ============================================================
@@ -59,16 +94,29 @@ export function isValidBranchGroupName(groupName: string): boolean {
  * Generate Unix group name for a repo
  *
  * Format: agor_rp_<short-id>
- * Example: agor_rp_03b62447
+ * Example: agor_rp_019ffd3d2cef79d1a1c64073
  *
  * This group controls access to repo Unix-group-managed paths:
  * repo-root traversal and the shared .git/ directory.
  *
  * @param repoId - Full repo UUID
- * @returns Unix group name (e.g., 'agor_rp_03b62447')
+ * @returns Unix group name containing Agor's canonical collision-safe short ID
  */
 export function generateRepoGroupName(repoId: RepoID): string {
-  return `agor_rp_${toShortId(repoId as UUID, UNIX_NAME_SHORT_ID_LENGTH)}`;
+  return `agor_rp_${shortId(repoId as UUID)}`;
+}
+
+/** Return the group name used by Agor versions that truncated UUIDs to 8 chars. */
+export function generateLegacyRepoGroupName(repoId: RepoID): string {
+  return `agor_rp_${toShortId(repoId as UUID, LEGACY_GROUP_SHORT_ID_LENGTH)}`;
+}
+
+/** See {@link resolveBranchGroupName}; repo sync follows the same persistence rule. */
+export function resolveRepoGroupName(
+  repoId: RepoID,
+  persistedGroup: string | null | undefined
+): string {
+  return persistedGroup ?? generateRepoGroupName(repoId);
 }
 
 /**
@@ -77,10 +125,10 @@ export function generateRepoGroupName(repoId: RepoID): string {
  * Extracts the short ID from a group name like 'agor_rp_03b62447'
  *
  * @param groupName - Unix group name
- * @returns Short repo ID (8 chars) or null if invalid format
+ * @returns Legacy or canonical short repo ID, or null if invalid
  */
 export function parseRepoGroupName(groupName: string): string | null {
-  const match = groupName.match(/^agor_rp_([0-9a-f]{8})$/);
+  const match = groupName.match(repoGroupPattern);
   return match ? match[1] : null;
 }
 
@@ -91,7 +139,17 @@ export function parseRepoGroupName(groupName: string): string | null {
  * @returns true if valid repo group name
  */
 export function isValidRepoGroupName(groupName: string): boolean {
-  return /^agor_rp_[0-9a-f]{8}$/.test(groupName);
+  return repoGroupPattern.test(groupName);
+}
+
+/** Whether a repo group uses the legacy collision-prone 8-character form. */
+export function isLegacyRepoGroupName(groupName: string): boolean {
+  return legacyRepoGroupPattern.test(groupName);
+}
+
+/** Legacy branch/repo groups are never safe for context-limited automatic cleanup. */
+export function isLegacyManagedGroupName(groupName: string): boolean {
+  return isLegacyBranchGroupName(groupName) || isLegacyRepoGroupName(groupName);
 }
 
 /**
@@ -272,6 +330,24 @@ export const UnixGroupCommands = {
       `sudo -n chmod g+s "${path}"`,
     ];
   },
+
+  /**
+   * Remove access and default ACL entries for a superseded group.
+   *
+   * Used only by the explicit legacy group migration after the replacement
+   * ACL has been installed. `setfacl -x` is idempotent when the entry is
+   * already absent, so interrupted reruns converge.
+   */
+  removeDirectoryGroupAcl: (path: string, groupName: string): string[] => [
+    `sudo -n setfacl -R -x g:${groupName} "${path}"`,
+    `sudo -n setfacl -R -d -x g:${groupName} "${path}"`,
+  ],
+
+  /** Non-recursive counterpart used for the managed repo root. */
+  removeDirectoryGroupAclShallow: (path: string, groupName: string): string[] => [
+    `sudo -n setfacl -x g:${groupName} "${path}"`,
+    `sudo -n setfacl -d -x g:${groupName} "${path}"`,
+  ],
 
   /**
    * Set explicit user ACL on a directory (recursive with defaults)

--- a/packages/core/src/unix/group-manager.ts
+++ b/packages/core/src/unix/group-manager.ts
@@ -66,18 +66,14 @@ export function assertBranchGroupNameMatchesId(branchId: BranchID, groupName: st
 }
 
 /**
- * Resolve the group a normal sync must use.
+ * Validate and return a branch's persisted Unix group.
  *
- * A stamped value is authoritative, including a legacy 8-character name.
- * Generation is reserved exclusively for rows where `unix_group` is absent.
+ * This deliberately does not accept an absent value. Callers that initialize
+ * a row must generate and persist the canonical name first, then re-read it
+ * through this function before touching system-global Unix state.
  */
-export function resolveBranchGroupName(
-  branchId: BranchID,
-  persistedGroup: string | null | undefined
-): string {
-  return persistedGroup == null
-    ? generateBranchGroupName(branchId)
-    : assertBranchGroupNameMatchesId(branchId, persistedGroup);
+export function resolveBranchGroupName(branchId: BranchID, persistedGroup: string): string {
+  return assertBranchGroupNameMatchesId(branchId, persistedGroup);
 }
 
 /** Preserve an existing branch stamp while validating a requested repository update. */
@@ -162,14 +158,9 @@ export function assertRepoGroupNameMatchesId(repoId: RepoID, groupName: string):
   return groupName;
 }
 
-/** See {@link resolveBranchGroupName}; repo sync follows the same persistence rule. */
-export function resolveRepoGroupName(
-  repoId: RepoID,
-  persistedGroup: string | null | undefined
-): string {
-  return persistedGroup == null
-    ? generateRepoGroupName(repoId)
-    : assertRepoGroupNameMatchesId(repoId, persistedGroup);
+/** See {@link resolveBranchGroupName}; repo access follows the same persistence rule. */
+export function resolveRepoGroupName(repoId: RepoID, persistedGroup: string): string {
+  return assertRepoGroupNameMatchesId(repoId, persistedGroup);
 }
 
 /** Preserve an existing repo stamp while validating a requested repository update. */

--- a/packages/core/src/unix/group-uuid-migration.test.ts
+++ b/packages/core/src/unix/group-uuid-migration.test.ts
@@ -33,13 +33,28 @@ describe('planUnixGroupUuidMigration', () => {
   });
 
   it('plans every legacy group in full mode', () => {
-    const plan = planUnixGroupUuidMigration(resources, { onlyDuplicates: false });
+    const orphanGroup = 'agor_rp_deadbeef';
+    const plan = planUnixGroupUuidMigration(resources, {
+      onlyDuplicates: false,
+      existingSystemGroups: [orphanGroup],
+    });
 
     expect(plan.map((cohort) => cohort.legacyGroup)).toEqual([
+      orphanGroup,
       singletonGroup,
       legacyCollisionGroup,
     ]);
     expect(plan.reduce((count, cohort) => count + cohort.resources.length, 0)).toBe(3);
+    expect(plan[0].resources).toEqual([]);
+  });
+
+  it('does not treat a system-only legacy group as a duplicate cohort', () => {
+    const plan = planUnixGroupUuidMigration(resources, {
+      onlyDuplicates: true,
+      existingSystemGroups: ['agor_rp_deadbeef'],
+    });
+
+    expect(plan.map((cohort) => cohort.legacyGroup)).toEqual([legacyCollisionGroup]);
   });
 
   it('retains a partially migrated collision cohort for resumed planning', () => {
@@ -176,5 +191,25 @@ describe('runUnixGroupUuidMigration', () => {
       },
     ]);
     expect(state.systemGroups.has(legacyGroup)).toBe(true);
+  });
+
+  it('deletes a system-only legacy group only after global verification', async () => {
+    const orphanGroup = 'agor_rp_deadbeef';
+    const state: FakeState = {
+      rows: new Map(),
+      systemGroups: new Set([orphanGroup]),
+      pathGroups: new Map(),
+      members: new Map([[orphanGroup, new Set(['stale-user'])]]),
+    };
+    const plan = planUnixGroupUuidMigration([], {
+      onlyDuplicates: false,
+      existingSystemGroups: state.systemGroups,
+    });
+
+    const result = await runUnixGroupUuidMigration(plan, adapterFor(state));
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.groupsDeleted).toBe(1);
+    expect(state.systemGroups.has(orphanGroup)).toBe(false);
   });
 });

--- a/packages/core/src/unix/group-uuid-migration.test.ts
+++ b/packages/core/src/unix/group-uuid-migration.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planUnixGroupUuidMigration,
+  runUnixGroupUuidMigration,
+  type UnixGroupMigrationAdapter,
+  type UnixGroupMigrationResource,
+} from './group-uuid-migration.js';
+
+const firstId = '019ffd3d-2cef-79d1-a1c6-407300000001';
+const secondId = '019ffd3d-2cef-7abc-b2d7-518400000002';
+const singletonId = '019aaaaa-1111-7aaa-8aaa-111111111111';
+
+function branch(id: string, group: string): UnixGroupMigrationResource {
+  return { kind: 'branch', id, unixGroup: group, label: id };
+}
+
+describe('planUnixGroupUuidMigration', () => {
+  const legacyCollisionGroup = 'agor_wt_019ffd3d';
+  const singletonGroup = 'agor_wt_019aaaaa';
+  const resources = [
+    branch(firstId, legacyCollisionGroup),
+    branch(secondId, legacyCollisionGroup),
+    branch(singletonId, singletonGroup),
+  ];
+
+  it('limits --only-dups to actual legacy collision cohorts', () => {
+    const plan = planUnixGroupUuidMigration(resources, { onlyDuplicates: true });
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0].legacyGroup).toBe(legacyCollisionGroup);
+    expect(plan[0].resources.map((resource) => resource.id)).toEqual([firstId, secondId]);
+    expect(new Set(plan[0].resources.map((resource) => resource.newGroup)).size).toBe(2);
+  });
+
+  it('plans every legacy group in full mode', () => {
+    const plan = planUnixGroupUuidMigration(resources, { onlyDuplicates: false });
+
+    expect(plan.map((cohort) => cohort.legacyGroup)).toEqual([
+      singletonGroup,
+      legacyCollisionGroup,
+    ]);
+    expect(plan.reduce((count, cohort) => count + cohort.resources.length, 0)).toBe(3);
+  });
+
+  it('retains a partially migrated collision cohort for resumed planning', () => {
+    const canonicalFirst = 'agor_wt_019ffd3d2cef79d1a1c64073';
+    const plan = planUnixGroupUuidMigration(
+      [branch(firstId, canonicalFirst), branch(secondId, legacyCollisionGroup)],
+      { onlyDuplicates: true, existingSystemGroups: [legacyCollisionGroup] }
+    );
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0].resources.map((resource) => resource.id)).toEqual([secondId]);
+    expect(plan[0].collisionResourceIds).toEqual([firstId, secondId]);
+  });
+});
+
+interface FakeState {
+  rows: Map<string, string>;
+  systemGroups: Set<string>;
+  pathGroups: Map<string, string>;
+  members: Map<string, Set<string>>;
+  failCasFor?: string;
+  extraOldRoot?: string;
+}
+
+function adapterFor(state: FakeState): UnixGroupMigrationAdapter {
+  return {
+    log: () => undefined,
+    ensureGroup: async (groupName) => {
+      state.systemGroups.add(groupName);
+      if (!state.members.has(groupName)) state.members.set(groupName, new Set());
+    },
+    expectedMembers: async (resource) => new Set([`user-${resource.id.slice(-1)}`, 'daemon']),
+    reconcileMembers: async (groupName, expected) => {
+      state.members.set(groupName, new Set(expected));
+    },
+    verifyMembers: async (groupName, expected) => {
+      expect(state.members.get(groupName)).toEqual(expected);
+    },
+    applyFilesystem: async (resource) => {
+      state.pathGroups.set(`/managed/${resource.id}`, resource.newGroup);
+    },
+    verifyFilesystem: async (resource) => {
+      expect(state.pathGroups.get(`/managed/${resource.id}`)).toBe(resource.newGroup);
+    },
+    compareAndSetGroup: async (resource) => {
+      if (state.failCasFor === resource.id) throw new Error('simulated interruption');
+      const current = state.rows.get(resource.id);
+      if (current === resource.newGroup) return 'already-updated';
+      if (current !== resource.unixGroup) return 'conflict';
+      state.rows.set(resource.id, resource.newGroup);
+      return 'updated';
+    },
+    findDatabaseReferences: async (groupName) =>
+      [...state.rows].filter(([, current]) => current === groupName).map(([id]) => `branch:${id}`),
+    findManagedRootsUsingGroup: async (groupName) => {
+      const roots = [...state.pathGroups]
+        .filter(([, current]) => current === groupName)
+        .map(([path]) => path);
+      if (state.extraOldRoot && groupName === 'agor_wt_019ffd3d') {
+        roots.push(state.extraOldRoot);
+      }
+      return roots;
+    },
+    groupExists: async (groupName) => state.systemGroups.has(groupName),
+    deleteGroup: async (groupName) => {
+      state.systemGroups.delete(groupName);
+      state.members.delete(groupName);
+    },
+  };
+}
+
+describe('runUnixGroupUuidMigration', () => {
+  const legacyGroup = 'agor_wt_019ffd3d';
+
+  it('converges after an interrupted cohort is resumed', async () => {
+    const state: FakeState = {
+      rows: new Map([
+        [firstId, legacyGroup],
+        [secondId, legacyGroup],
+      ]),
+      systemGroups: new Set([legacyGroup]),
+      pathGroups: new Map([
+        [`/managed/${firstId}`, legacyGroup],
+        [`/managed/${secondId}`, legacyGroup],
+      ]),
+      members: new Map([[legacyGroup, new Set(['contaminated-user'])]]),
+      failCasFor: secondId,
+    };
+
+    const firstPlan = planUnixGroupUuidMigration(
+      [branch(firstId, state.rows.get(firstId)!), branch(secondId, state.rows.get(secondId)!)],
+      { onlyDuplicates: true, existingSystemGroups: state.systemGroups }
+    );
+    const interrupted = await runUnixGroupUuidMigration(firstPlan, adapterFor(state));
+
+    expect(interrupted.migrated).toBe(1);
+    expect(interrupted.errors).toHaveLength(1);
+    expect(state.systemGroups.has(legacyGroup)).toBe(true);
+    expect(state.rows.get(secondId)).toBe(legacyGroup);
+
+    state.failCasFor = undefined;
+    const resumedPlan = planUnixGroupUuidMigration(
+      [branch(firstId, state.rows.get(firstId)!), branch(secondId, state.rows.get(secondId)!)],
+      { onlyDuplicates: true, existingSystemGroups: state.systemGroups }
+    );
+    const resumed = await runUnixGroupUuidMigration(resumedPlan, adapterFor(state));
+
+    expect(resumed.errors).toHaveLength(0);
+    expect(resumed.migrated).toBe(1);
+    expect(state.systemGroups.has(legacyGroup)).toBe(false);
+    expect([...state.rows.values()]).not.toContain(legacyGroup);
+  });
+
+  it('never deletes a legacy group while a managed root still uses it', async () => {
+    const state: FakeState = {
+      rows: new Map([[firstId, legacyGroup]]),
+      systemGroups: new Set([legacyGroup]),
+      pathGroups: new Map([[`/managed/${firstId}`, legacyGroup]]),
+      members: new Map([[legacyGroup, new Set(['contaminated-user'])]]),
+      extraOldRoot: '/managed/unrelated-but-still-using-old-group',
+    };
+    const plan = planUnixGroupUuidMigration([branch(firstId, legacyGroup)], {
+      onlyDuplicates: false,
+      existingSystemGroups: state.systemGroups,
+    });
+
+    const result = await runUnixGroupUuidMigration(plan, adapterFor(state));
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.retained).toEqual([
+      {
+        group: legacyGroup,
+        reason: 'still used by managed root(s): /managed/unrelated-but-still-using-old-group',
+      },
+    ]);
+    expect(state.systemGroups.has(legacyGroup)).toBe(true);
+  });
+});

--- a/packages/core/src/unix/group-uuid-migration.ts
+++ b/packages/core/src/unix/group-uuid-migration.ts
@@ -110,6 +110,15 @@ export function planUnixGroupUuidMigration(
 
   const candidateGroups = new Set<string>(currentLegacyRefs.keys());
 
+  // Full mode also owns cleanup of system-only legacy groups left behind by
+  // deleted rows or an interrupted migration. The runner still performs the
+  // same global DB and managed-root verification before deleting one.
+  if (!options.onlyDuplicates) {
+    for (const groupName of systemGroups) {
+      if (kindForLegacyGroup(groupName)) candidateGroups.add(groupName);
+    }
+  }
+
   // A predecessor that is still on the OS but whose rows already contain the
   // canonical name represents an interrupted run after CAS and before cleanup.
   for (const [legacyGroup, cohort] of derivedCohorts) {

--- a/packages/core/src/unix/group-uuid-migration.ts
+++ b/packages/core/src/unix/group-uuid-migration.ts
@@ -1,0 +1,289 @@
+/**
+ * Explicit migration support for legacy 8-character branch/repo Unix groups.
+ *
+ * Normal sync must never call this module: persisted `unix_group` values are
+ * authoritative there. This compatibility layer exists solely for the local
+ * administrative migration command and can be removed with Unix isolation.
+ */
+
+import type { BranchID, RepoID } from '../types/index.js';
+import {
+  generateBranchGroupName,
+  generateLegacyBranchGroupName,
+  generateLegacyRepoGroupName,
+  generateRepoGroupName,
+  isLegacyBranchGroupName,
+  isLegacyRepoGroupName,
+} from './group-manager.js';
+
+export type UnixGroupResourceKind = 'branch' | 'repo';
+
+export interface UnixGroupMigrationResource {
+  kind: UnixGroupResourceKind;
+  id: string;
+  unixGroup: string | null | undefined;
+  /** Human-readable label for progress output. */
+  label: string;
+}
+
+export interface PlannedUnixGroupResource extends UnixGroupMigrationResource {
+  unixGroup: string;
+  newGroup: string;
+}
+
+export interface UnixGroupMigrationCohort {
+  legacyGroup: string;
+  kind: UnixGroupResourceKind;
+  /** Rows that still require a compare-and-set from legacyGroup to newGroup. */
+  resources: PlannedUnixGroupResource[];
+  /** IDs that establish a real same-prefix legacy collision cohort. */
+  collisionResourceIds: string[];
+}
+
+export interface PlanUnixGroupMigrationOptions {
+  onlyDuplicates: boolean;
+  /** Legacy groups currently present in the system-global Unix namespace. */
+  existingSystemGroups?: Iterable<string>;
+}
+
+function namesForResource(resource: UnixGroupMigrationResource): {
+  legacy: string;
+  canonical: string;
+} {
+  return resource.kind === 'branch'
+    ? {
+        legacy: generateLegacyBranchGroupName(resource.id as BranchID),
+        canonical: generateBranchGroupName(resource.id as BranchID),
+      }
+    : {
+        legacy: generateLegacyRepoGroupName(resource.id as RepoID),
+        canonical: generateRepoGroupName(resource.id as RepoID),
+      };
+}
+
+function isLegacyGroupForKind(kind: UnixGroupResourceKind, groupName: string): boolean {
+  return kind === 'branch' ? isLegacyBranchGroupName(groupName) : isLegacyRepoGroupName(groupName);
+}
+
+function kindForLegacyGroup(groupName: string): UnixGroupResourceKind | null {
+  if (isLegacyBranchGroupName(groupName)) return 'branch';
+  if (isLegacyRepoGroupName(groupName)) return 'repo';
+  return null;
+}
+
+function migrationErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const command = (error as { command?: unknown } | null)?.command;
+  return typeof command === 'string' && command ? `${message} (command: ${command})` : message;
+}
+
+/**
+ * Build the migration plan without inspecting or mutating the OS.
+ *
+ * Duplicate-only mode selects actual cohorts: either two or more rows still
+ * stamp the same legacy group, or two or more UUIDs map to that legacy prefix
+ * and are already partially migrated. The latter makes interrupted reruns
+ * converge, including cleanup-only reruns after every CAS already succeeded.
+ */
+export function planUnixGroupUuidMigration(
+  resources: UnixGroupMigrationResource[],
+  options: PlanUnixGroupMigrationOptions
+): UnixGroupMigrationCohort[] {
+  const systemGroups = new Set(options.existingSystemGroups ?? []);
+  const currentLegacyRefs = new Map<string, UnixGroupMigrationResource[]>();
+  const derivedCohorts = new Map<string, UnixGroupMigrationResource[]>();
+
+  for (const resource of resources) {
+    const { legacy, canonical } = namesForResource(resource);
+    if (resource.unixGroup === legacy || resource.unixGroup === canonical) {
+      const cohort = derivedCohorts.get(legacy) ?? [];
+      cohort.push(resource);
+      derivedCohorts.set(legacy, cohort);
+    }
+
+    if (resource.unixGroup && isLegacyGroupForKind(resource.kind, resource.unixGroup)) {
+      const refs = currentLegacyRefs.get(resource.unixGroup) ?? [];
+      refs.push(resource);
+      currentLegacyRefs.set(resource.unixGroup, refs);
+    }
+  }
+
+  const candidateGroups = new Set<string>(currentLegacyRefs.keys());
+
+  // A predecessor that is still on the OS but whose rows already contain the
+  // canonical name represents an interrupted run after CAS and before cleanup.
+  for (const [legacyGroup, cohort] of derivedCohorts) {
+    if (
+      systemGroups.has(legacyGroup) &&
+      cohort.some((resource) => resource.unixGroup === namesForResource(resource).canonical)
+    ) {
+      candidateGroups.add(legacyGroup);
+    }
+  }
+
+  const plan: UnixGroupMigrationCohort[] = [];
+  for (const legacyGroup of candidateGroups) {
+    const kind = kindForLegacyGroup(legacyGroup);
+    if (!kind) continue;
+
+    const currentRefs = currentLegacyRefs.get(legacyGroup) ?? [];
+    const derived = derivedCohorts.get(legacyGroup) ?? [];
+    const collisionResourceIds = Array.from(new Set(derived.map((resource) => resource.id)));
+    const isActualDuplicate =
+      currentRefs.length >= 2 ||
+      (collisionResourceIds.length >= 2 &&
+        (currentRefs.length > 0 || systemGroups.has(legacyGroup)));
+
+    if (options.onlyDuplicates && !isActualDuplicate) continue;
+
+    plan.push({
+      legacyGroup,
+      kind,
+      collisionResourceIds,
+      resources: currentRefs.map((resource) => ({
+        ...resource,
+        unixGroup: legacyGroup,
+        newGroup: namesForResource(resource).canonical,
+      })),
+    });
+  }
+
+  return plan.sort((a, b) => a.legacyGroup.localeCompare(b.legacyGroup));
+}
+
+export type UnixGroupCompareAndSetResult = 'updated' | 'already-updated' | 'conflict';
+
+export interface UnixGroupMigrationAdapter {
+  ensureGroup(groupName: string): Promise<void>;
+  expectedMembers(resource: PlannedUnixGroupResource): Promise<Set<string>>;
+  reconcileMembers(groupName: string, expectedMembers: Set<string>): Promise<void>;
+  verifyMembers(groupName: string, expectedMembers: Set<string>): Promise<void>;
+  applyFilesystem(resource: PlannedUnixGroupResource): Promise<void>;
+  verifyFilesystem(resource: PlannedUnixGroupResource): Promise<void>;
+  compareAndSetGroup(resource: PlannedUnixGroupResource): Promise<UnixGroupCompareAndSetResult>;
+  findDatabaseReferences(groupName: string): Promise<string[]>;
+  findManagedRootsUsingGroup(groupName: string): Promise<string[]>;
+  groupExists(groupName: string): Promise<boolean>;
+  deleteGroup(groupName: string): Promise<void>;
+  log(message: string): void;
+}
+
+export interface UnixGroupMigrationRunResult {
+  migrated: number;
+  groupsDeleted: number;
+  errors: Array<{ resource: string; message: string }>;
+  retained: Array<{ group: string; reason: string }>;
+}
+
+/**
+ * Execute a plan in a forward-recoverable order:
+ *
+ * 1. create and reconstruct the new group;
+ * 2. apply and verify every managed path;
+ * 3. compare-and-set the DB row;
+ * 4. delete the predecessor only after global DB and filesystem verification.
+ */
+export async function runUnixGroupUuidMigration(
+  plan: UnixGroupMigrationCohort[],
+  adapter: UnixGroupMigrationAdapter
+): Promise<UnixGroupMigrationRunResult> {
+  const result: UnixGroupMigrationRunResult = {
+    migrated: 0,
+    groupsDeleted: 0,
+    errors: [],
+    retained: [],
+  };
+
+  for (const cohort of plan) {
+    adapter.log(`Migrating ${cohort.legacyGroup} (${cohort.resources.length} pending row(s))`);
+    let cohortFailed = false;
+
+    for (const resource of cohort.resources) {
+      const resourceLabel = `${resource.kind} ${resource.label} (${resource.id})`;
+      try {
+        adapter.log(`  ${resourceLabel}: preparing ${resource.newGroup}`);
+        await adapter.ensureGroup(resource.newGroup);
+
+        // Membership is intentionally derived from current DB authorization;
+        // the possibly contaminated predecessor is never read or copied.
+        const expectedMembers = await adapter.expectedMembers(resource);
+        await adapter.reconcileMembers(resource.newGroup, expectedMembers);
+        await adapter.verifyMembers(resource.newGroup, expectedMembers);
+
+        await adapter.applyFilesystem(resource);
+        await adapter.verifyFilesystem(resource);
+
+        const cas = await adapter.compareAndSetGroup(resource);
+        if (cas === 'conflict') {
+          throw new Error(
+            `unix_group changed concurrently; expected ${resource.unixGroup} or ${resource.newGroup}`
+          );
+        }
+        if (cas === 'updated') result.migrated += 1;
+        adapter.log(`  ${resourceLabel}: ${cas === 'updated' ? 'migrated' : 'already migrated'}`);
+      } catch (error) {
+        cohortFailed = true;
+        const message = migrationErrorMessage(error);
+        result.errors.push({ resource: resourceLabel, message });
+        adapter.log(`  ERROR ${resourceLabel}: ${message}`);
+      }
+    }
+
+    if (cohortFailed) {
+      result.retained.push({ group: cohort.legacyGroup, reason: 'one or more rows failed' });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: one or more rows failed`);
+      continue;
+    }
+
+    let databaseReferences: string[];
+    try {
+      databaseReferences = await adapter.findDatabaseReferences(cohort.legacyGroup);
+    } catch (error) {
+      const message = migrationErrorMessage(error);
+      result.errors.push({ resource: `cleanup ${cohort.legacyGroup}`, message });
+      result.retained.push({ group: cohort.legacyGroup, reason: 'database verification failed' });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: database verification failed: ${message}`);
+      continue;
+    }
+    if (databaseReferences.length > 0) {
+      const reason = `still referenced by ${databaseReferences.length} database row(s)`;
+      result.retained.push({ group: cohort.legacyGroup, reason });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: ${reason}`);
+      continue;
+    }
+
+    let filesystemReferences: string[];
+    try {
+      filesystemReferences = await adapter.findManagedRootsUsingGroup(cohort.legacyGroup);
+    } catch (error) {
+      const message = migrationErrorMessage(error);
+      result.errors.push({ resource: `cleanup ${cohort.legacyGroup}`, message });
+      result.retained.push({ group: cohort.legacyGroup, reason: 'filesystem verification failed' });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: filesystem verification failed: ${message}`);
+      continue;
+    }
+    if (filesystemReferences.length > 0) {
+      const reason = `still used by managed root(s): ${filesystemReferences.join(', ')}`;
+      result.retained.push({ group: cohort.legacyGroup, reason });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: ${reason}`);
+      continue;
+    }
+
+    try {
+      if (await adapter.groupExists(cohort.legacyGroup)) {
+        await adapter.deleteGroup(cohort.legacyGroup);
+        result.groupsDeleted += 1;
+        adapter.log(`  Deleted verified-unused legacy group ${cohort.legacyGroup}`);
+      } else {
+        adapter.log(`  Legacy group ${cohort.legacyGroup} is already absent`);
+      }
+    } catch (error) {
+      const message = migrationErrorMessage(error);
+      result.errors.push({ resource: `cleanup ${cohort.legacyGroup}`, message });
+      result.retained.push({ group: cohort.legacyGroup, reason: 'group deletion failed' });
+      adapter.log(`  Retaining ${cohort.legacyGroup}: group deletion failed: ${message}`);
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/unix/id-lookups.ts
+++ b/packages/core/src/unix/id-lookups.ts
@@ -6,6 +6,7 @@
 
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
+import { assertSafeUnixGroupName } from './group-manager.js';
 
 /**
  * Get GID (group ID) from Unix group name
@@ -22,6 +23,8 @@ export function getGidFromGroupName(groupName: string | undefined | null): numbe
   if (!groupName) {
     return undefined;
   }
+
+  assertSafeUnixGroupName(groupName);
 
   try {
     // Try getent first (Linux, some BSD)

--- a/packages/core/src/unix/index.ts
+++ b/packages/core/src/unix/index.ts
@@ -12,6 +12,8 @@ export * from './command-executor.js';
 export * from './environment-command-deny-list.js';
 // Branch group management
 export * from './group-manager.js';
+// Explicit legacy group-name migration (never used by normal sync)
+export * from './group-uuid-migration.js';
 // ID lookup utilities
 export * from './id-lookups.js';
 // Central command execution as another user (preferred API)

--- a/packages/core/src/unix/short-id-naming.ts
+++ b/packages/core/src/unix/short-id-naming.ts
@@ -1,21 +1,19 @@
 /**
- * Carve-out: short-ID length used inside Unix group/user names.
+ * Carve-out: legacy short-ID length used in Unix user names and old Unix
+ * group names.
  *
  * Everywhere else in the codebase, "short ID" means `SHORT_ID_LENGTH`
  * (24 chars) — the collision-safe display form for IDs users see.
  *
- * Unix names are different: they're persisted system-wide in `/etc/group`
- * and `/etc/passwd`, parsed by fixed-length regexes in this module, and
- * referenced by the `unix_group` / `unix_username` columns on every
- * branch/repo/user row. Bumping this length would require migrating
- * every existing installation (old groups wouldn't match the new regex)
- * for no real win — Unix-name creation is rare and failure-loud
- * (`groupadd` errors if the name exists), so the collision risk that
- * motivates a longer display short-ID just doesn't apply.
+ * Unix usernames remain at eight characters for compatibility. Branch and
+ * repo groups created before the collision-safe group-name change also used
+ * this length; their persisted names remain valid and authoritative until an
+ * administrator explicitly migrates them. New branch/repo groups use the
+ * canonical 24-character `shortId()` instead.
  *
- * Lives next to `group-manager.ts` and `user-manager.ts` so the carve-out
- * is grep-able and self-documenting; deliberately NOT in `types/id.ts`
- * (the canonical short-ID home) to avoid suggesting it's a public
- * length people should reach for.
+ * Lives next to `group-manager.ts` and `user-manager.ts` so the compatibility
+ * carve-out is grep-able and self-documenting; deliberately NOT in
+ * `types/id.ts` (the canonical short-ID home) to avoid suggesting it is a
+ * public length people should reach for.
  */
 export const UNIX_NAME_SHORT_ID_LENGTH = 8;

--- a/packages/core/src/unix/system-queries.ts
+++ b/packages/core/src/unix/system-queries.ts
@@ -10,7 +10,11 @@
  */
 
 import { execSync } from 'node:child_process';
-import { UnixGroupCommands } from './group-manager.js';
+import {
+  isValidBranchGroupName,
+  isValidRepoGroupName,
+  UnixGroupCommands,
+} from './group-manager.js';
 import { UnixUserCommands } from './user-manager.js';
 
 // ============================================================
@@ -124,7 +128,7 @@ export function listBranchGroups(): string[] {
     return output
       .trim()
       .split('\n')
-      .filter((g) => g && /^agor_wt_[0-9a-f]{8}$/.test(g));
+      .filter((g) => g && isValidBranchGroupName(g));
   } catch {
     return [];
   }
@@ -144,7 +148,7 @@ export function listRepoGroups(): string[] {
     return output
       .trim()
       .split('\n')
-      .filter((g) => g && /^agor_rp_[0-9a-f]{8}$/.test(g));
+      .filter((g) => g && isValidRepoGroupName(g));
   } catch {
     return [];
   }

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -21,10 +21,12 @@ import type { CommandExecutor } from './command-executor.js';
 import { NoOpExecutor } from './command-executor.js';
 import {
   AGOR_USERS_GROUP,
-  generateBranchGroupName,
-  generateRepoGroupName,
   getBranchPermissionMode,
+  isLegacyBranchGroupName,
+  isLegacyRepoGroupName,
   REPO_GIT_PERMISSION_MODE,
+  resolveBranchGroupName,
+  resolveRepoGroupName,
   UnixGroupCommands,
 } from './group-manager.js';
 import { getBranchSymlinkPath, SymlinkCommands } from './symlink-manager.js';
@@ -243,7 +245,13 @@ export class UnixIntegrationService {
    * @returns Group name created
    */
   async createBranchGroup(branchId: BranchID): Promise<string> {
-    const groupName = generateBranchGroupName(branchId);
+    // A persisted name is authoritative. In particular, do not silently move
+    // legacy 8-character groups during normal lifecycle reconciliation.
+    const branch = await this.branchRepo.findById(branchId);
+    if (!branch) {
+      throw new Error(`Branch not found: ${branchId}`);
+    }
+    let groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     console.log(`[UnixIntegration] Creating group ${groupName} for branch ${shortId(branchId)}`);
 
@@ -255,13 +263,21 @@ export class UnixIntegrationService {
       await this.executor.exec(UnixGroupCommands.createGroup(groupName));
     }
 
-    // Fetch current branch to get existing data and path
-    const branch = await this.branchRepo.findById(branchId);
-
-    // Update branch record with group name (using repository)
-    await this.branchRepo.update(branchId, {
-      unix_group: groupName,
-    });
+    // Stamp only an absent field. Existing values, including legacy names,
+    // are never regenerated or implicitly migrated by normal sync.
+    if (branch.unix_group == null) {
+      const latestBranch = await this.branchRepo.findById(branchId);
+      if (latestBranch?.unix_group != null) {
+        groupName = latestBranch.unix_group;
+        if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
+          await this.executor.exec(UnixGroupCommands.createGroup(groupName));
+        }
+      } else {
+        await this.branchRepo.update(branchId, {
+          unix_group: groupName,
+        });
+      }
+    }
 
     // Apply group ownership and permissions to branch directory
     if (branch?.path) {
@@ -307,6 +323,16 @@ export class UnixIntegrationService {
     const branch = await this.branchRepo.findById(branchId);
     if (!branch?.unix_group) {
       console.log(`[UnixIntegration] No Unix group for branch ${shortId(branchId)}`);
+      return;
+    }
+
+    // Legacy short names may be shared by multiple UUIDv7 rows (and even by
+    // rows hidden behind another tenant's RLS scope). Only the global,
+    // verification-heavy local migration command may remove them.
+    if (isLegacyBranchGroupName(branch.unix_group)) {
+      console.log(
+        `[UnixIntegration] Retaining legacy group ${branch.unix_group}; run agor local fix-group-uuids for verified cleanup`
+      );
       return;
     }
 
@@ -485,7 +511,13 @@ export class UnixIntegrationService {
    * @returns Group name created
    */
   async createRepoGroup(repoId: RepoID): Promise<string> {
-    const groupName = generateRepoGroupName(repoId);
+    // A persisted name is authoritative. In particular, do not silently move
+    // legacy 8-character groups during normal lifecycle reconciliation.
+    const repo = await this.repoRepo.findById(repoId);
+    if (!repo) {
+      throw new Error(`Repo not found: ${repoId}`);
+    }
+    let groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     console.log(`[UnixIntegration] Creating repo group ${groupName} for repo ${shortId(repoId)}`);
 
@@ -497,15 +529,25 @@ export class UnixIntegrationService {
       await this.executor.exec(UnixGroupCommands.createGroup(groupName));
     }
 
-    // Update repo record with group name
-    await this.repoRepo.update(repoId, {
-      unix_group: groupName,
-    });
+    // Stamp only an absent field. Existing values, including legacy names,
+    // are never regenerated or implicitly migrated by normal sync.
+    if (repo.unix_group == null) {
+      const latestRepo = await this.repoRepo.findById(repoId);
+      if (latestRepo?.unix_group != null) {
+        groupName = latestRepo.unix_group;
+        if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
+          await this.executor.exec(UnixGroupCommands.createGroup(groupName));
+        }
+      } else {
+        await this.repoRepo.update(repoId, {
+          unix_group: groupName,
+        });
+      }
+    }
 
     // Apply group ownership and permissions to repo Unix-group-managed paths:
     // - repo root (non-recursive, traversal)
     // - `.git` (recursive, shared git objects/refs + branch metadata)
-    const repo = await this.repoRepo.findById(repoId);
     if (repo?.local_path) {
       await this.setRepoPermissions(repoId, repo.local_path);
     }
@@ -550,6 +592,15 @@ export class UnixIntegrationService {
     const repo = await this.repoRepo.findById(repoId);
     if (!repo?.unix_group) {
       console.log(`[UnixIntegration] No Unix group for repo ${shortId(repoId)}`);
+      return;
+    }
+
+    // See deleteBranchGroup(): tenant-scoped lifecycle work cannot prove a
+    // system-global legacy group is unshared.
+    if (isLegacyRepoGroupName(repo.unix_group)) {
+      console.log(
+        `[UnixIntegration] Retaining legacy repo group ${repo.unix_group}; run agor local fix-group-uuids for verified cleanup`
+      );
       return;
     }
 

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -21,6 +21,8 @@ import type { CommandExecutor } from './command-executor.js';
 import { NoOpExecutor } from './command-executor.js';
 import {
   AGOR_USERS_GROUP,
+  generateBranchGroupName,
+  generateRepoGroupName,
   getBranchPermissionMode,
   isLegacyBranchGroupName,
   isLegacyRepoGroupName,
@@ -247,11 +249,24 @@ export class UnixIntegrationService {
   async createBranchGroup(branchId: BranchID): Promise<string> {
     // A persisted name is authoritative. In particular, do not silently move
     // legacy 8-character groups during normal lifecycle reconciliation.
-    const branch = await this.branchRepo.findById(branchId);
+    let branch = await this.branchRepo.findById(branchId);
     if (!branch) {
       throw new Error(`Branch not found: ${branchId}`);
     }
-    let groupName = resolveBranchGroupName(branchId, branch.unix_group);
+
+    // Persist the canonical candidate before any system-global group or
+    // filesystem operation. A failed OS step is forward-recoverable because a
+    // rerun reads this same authoritative stamp.
+    if (branch.unix_group == null) {
+      await this.branchRepo.update(branchId, {
+        unix_group: generateBranchGroupName(branchId),
+      });
+      branch = await this.branchRepo.findById(branchId);
+    }
+    if (!branch?.unix_group) {
+      throw new Error(`Branch ${branchId} has no persisted Unix group after stamping`);
+    }
+    const groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     console.log(`[UnixIntegration] Creating group ${groupName} for branch ${shortId(branchId)}`);
 
@@ -261,22 +276,6 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] Group ${groupName} already exists`);
     } else {
       await this.executor.exec(UnixGroupCommands.createGroup(groupName));
-    }
-
-    // Stamp only an absent field. Existing values, including legacy names,
-    // are never regenerated or implicitly migrated by normal sync.
-    if (branch.unix_group == null) {
-      const latestBranch = await this.branchRepo.findById(branchId);
-      if (latestBranch?.unix_group != null) {
-        groupName = resolveBranchGroupName(branchId, latestBranch.unix_group);
-        if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
-          await this.executor.exec(UnixGroupCommands.createGroup(groupName));
-        }
-      } else {
-        await this.branchRepo.update(branchId, {
-          unix_group: groupName,
-        });
-      }
     }
 
     // Apply group ownership and permissions to branch directory
@@ -509,11 +508,23 @@ export class UnixIntegrationService {
   async createRepoGroup(repoId: RepoID): Promise<string> {
     // A persisted name is authoritative. In particular, do not silently move
     // legacy 8-character groups during normal lifecycle reconciliation.
-    const repo = await this.repoRepo.findById(repoId);
+    let repo = await this.repoRepo.findById(repoId);
     if (!repo) {
       throw new Error(`Repo not found: ${repoId}`);
     }
-    let groupName = resolveRepoGroupName(repoId, repo.unix_group);
+
+    // See createBranchGroup(): persist first, then use only the re-read value
+    // for privileged operations.
+    if (repo.unix_group == null) {
+      await this.repoRepo.update(repoId, {
+        unix_group: generateRepoGroupName(repoId),
+      });
+      repo = await this.repoRepo.findById(repoId);
+    }
+    if (!repo?.unix_group) {
+      throw new Error(`Repo ${repoId} has no persisted Unix group after stamping`);
+    }
+    const groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     console.log(`[UnixIntegration] Creating repo group ${groupName} for repo ${shortId(repoId)}`);
 
@@ -523,22 +534,6 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] Repo group ${groupName} already exists`);
     } else {
       await this.executor.exec(UnixGroupCommands.createGroup(groupName));
-    }
-
-    // Stamp only an absent field. Existing values, including legacy names,
-    // are never regenerated or implicitly migrated by normal sync.
-    if (repo.unix_group == null) {
-      const latestRepo = await this.repoRepo.findById(repoId);
-      if (latestRepo?.unix_group != null) {
-        groupName = resolveRepoGroupName(repoId, latestRepo.unix_group);
-        if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
-          await this.executor.exec(UnixGroupCommands.createGroup(groupName));
-        }
-      } else {
-        await this.repoRepo.update(repoId, {
-          unix_group: groupName,
-        });
-      }
     }
 
     // Apply group ownership and permissions to repo Unix-group-managed paths:

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -268,7 +268,7 @@ export class UnixIntegrationService {
     if (branch.unix_group == null) {
       const latestBranch = await this.branchRepo.findById(branchId);
       if (latestBranch?.unix_group != null) {
-        groupName = latestBranch.unix_group;
+        groupName = resolveBranchGroupName(branchId, latestBranch.unix_group);
         if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
           await this.executor.exec(UnixGroupCommands.createGroup(groupName));
         }
@@ -325,25 +325,24 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] No Unix group for branch ${shortId(branchId)}`);
       return;
     }
+    const groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     // Legacy short names may be shared by multiple UUIDv7 rows (and even by
     // rows hidden behind another tenant's RLS scope). Only the global,
     // verification-heavy local migration command may remove them.
-    if (isLegacyBranchGroupName(branch.unix_group)) {
+    if (isLegacyBranchGroupName(groupName)) {
       console.log(
-        `[UnixIntegration] Retaining legacy group ${branch.unix_group}; run agor local fix-group-uuids for verified cleanup`
+        `[UnixIntegration] Retaining legacy group ${groupName}; run agor local fix-group-uuids for verified cleanup`
       );
       return;
     }
 
-    console.log(
-      `[UnixIntegration] Deleting group ${branch.unix_group} for branch ${shortId(branchId)}`
-    );
+    console.log(`[UnixIntegration] Deleting group ${groupName} for branch ${shortId(branchId)}`);
 
     // Check if group exists before deleting
-    const exists = await this.executor.check(UnixGroupCommands.groupExists(branch.unix_group));
+    const exists = await this.executor.check(UnixGroupCommands.groupExists(groupName));
     if (exists) {
-      await this.executor.exec(UnixGroupCommands.deleteGroup(branch.unix_group));
+      await this.executor.exec(UnixGroupCommands.deleteGroup(groupName));
     }
   }
 
@@ -361,6 +360,7 @@ export class UnixIntegrationService {
       );
       return;
     }
+    const groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     const user = await this.usersRepo.findById(userId as UserID);
     if (!user?.unix_username) {
@@ -370,20 +370,16 @@ export class UnixIntegrationService {
       return;
     }
 
-    console.log(
-      `[UnixIntegration] Adding user ${user.unix_username} to group ${branch.unix_group}`
-    );
+    console.log(`[UnixIntegration] Adding user ${user.unix_username} to group ${groupName}`);
 
     // Check if already in group
     const inGroup = await this.executor.check(
-      UnixGroupCommands.isUserInGroup(user.unix_username, branch.unix_group)
+      UnixGroupCommands.isUserInGroup(user.unix_username, groupName)
     );
     if (inGroup) {
       console.log(`[UnixIntegration] User ${user.unix_username} already in group`);
     } else {
-      await this.executor.exec(
-        UnixGroupCommands.addUserToGroup(user.unix_username, branch.unix_group)
-      );
+      await this.executor.exec(UnixGroupCommands.addUserToGroup(user.unix_username, groupName));
     }
 
     // Also create symlink if auto-manage is enabled
@@ -406,6 +402,7 @@ export class UnixIntegrationService {
       );
       return;
     }
+    const groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     const user = await this.usersRepo.findById(userId as UserID);
     if (!user?.unix_username) {
@@ -415,17 +412,15 @@ export class UnixIntegrationService {
       return;
     }
 
-    console.log(
-      `[UnixIntegration] Removing user ${user.unix_username} from group ${branch.unix_group}`
-    );
+    console.log(`[UnixIntegration] Removing user ${user.unix_username} from group ${groupName}`);
 
     // Check if in group before removing
     const inGroup = await this.executor.check(
-      UnixGroupCommands.isUserInGroup(user.unix_username, branch.unix_group)
+      UnixGroupCommands.isUserInGroup(user.unix_username, groupName)
     );
     if (inGroup) {
       await this.executor.exec(
-        UnixGroupCommands.removeUserFromGroup(user.unix_username, branch.unix_group)
+        UnixGroupCommands.removeUserFromGroup(user.unix_username, groupName)
       );
     }
 
@@ -449,15 +444,16 @@ export class UnixIntegrationService {
       );
       return;
     }
+    const groupName = resolveBranchGroupName(branchId, branch.unix_group);
 
     const permissionMode = getBranchPermissionMode(branch.others_fs_access || 'read');
 
     console.log(
-      `[UnixIntegration] Setting permissions ${permissionMode} for ${branchPath} (group: ${branch.unix_group})`
+      `[UnixIntegration] Setting permissions ${permissionMode} for ${branchPath} (group: ${groupName})`
     );
 
     await this.executor.execAll(
-      UnixGroupCommands.setDirectoryGroup(branchPath, branch.unix_group, permissionMode)
+      UnixGroupCommands.setDirectoryGroup(branchPath, groupName, permissionMode)
     );
 
     // Set explicit user ACL for the daemon user so it can access branch files
@@ -534,7 +530,7 @@ export class UnixIntegrationService {
     if (repo.unix_group == null) {
       const latestRepo = await this.repoRepo.findById(repoId);
       if (latestRepo?.unix_group != null) {
-        groupName = latestRepo.unix_group;
+        groupName = resolveRepoGroupName(repoId, latestRepo.unix_group);
         if (!(await this.executor.check(UnixGroupCommands.groupExists(groupName)))) {
           await this.executor.exec(UnixGroupCommands.createGroup(groupName));
         }
@@ -594,24 +590,23 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] No Unix group for repo ${shortId(repoId)}`);
       return;
     }
+    const groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     // See deleteBranchGroup(): tenant-scoped lifecycle work cannot prove a
     // system-global legacy group is unshared.
-    if (isLegacyRepoGroupName(repo.unix_group)) {
+    if (isLegacyRepoGroupName(groupName)) {
       console.log(
-        `[UnixIntegration] Retaining legacy repo group ${repo.unix_group}; run agor local fix-group-uuids for verified cleanup`
+        `[UnixIntegration] Retaining legacy repo group ${groupName}; run agor local fix-group-uuids for verified cleanup`
       );
       return;
     }
 
-    console.log(
-      `[UnixIntegration] Deleting repo group ${repo.unix_group} for repo ${shortId(repoId)}`
-    );
+    console.log(`[UnixIntegration] Deleting repo group ${groupName} for repo ${shortId(repoId)}`);
 
     // Check if group exists before deleting
-    const exists = await this.executor.check(UnixGroupCommands.groupExists(repo.unix_group));
+    const exists = await this.executor.check(UnixGroupCommands.groupExists(groupName));
     if (exists) {
-      await this.executor.exec(UnixGroupCommands.deleteGroup(repo.unix_group));
+      await this.executor.exec(UnixGroupCommands.deleteGroup(groupName));
     }
   }
 
@@ -633,25 +628,22 @@ export class UnixIntegrationService {
       );
       return;
     }
+    const groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     const gitPath = `${repoPath}/.git`;
     const gitExists = await this.executor.check(`[ -d "${gitPath}" ]`);
 
     console.log(
-      `[UnixIntegration] Setting repo permissions ${REPO_GIT_PERMISSION_MODE} for ${repoPath}${gitExists ? ' and .git' : ''} (group: ${repo.unix_group})`
+      `[UnixIntegration] Setting repo permissions ${REPO_GIT_PERMISSION_MODE} for ${repoPath}${gitExists ? ' and .git' : ''} (group: ${groupName})`
     );
 
     await this.executor.execAll(
-      UnixGroupCommands.setDirectoryGroupShallow(
-        repoPath,
-        repo.unix_group,
-        REPO_GIT_PERMISSION_MODE
-      )
+      UnixGroupCommands.setDirectoryGroupShallow(repoPath, groupName, REPO_GIT_PERMISSION_MODE)
     );
 
     if (gitExists) {
       await this.executor.execAll(
-        UnixGroupCommands.setDirectoryGroup(gitPath, repo.unix_group, REPO_GIT_PERMISSION_MODE)
+        UnixGroupCommands.setDirectoryGroup(gitPath, groupName, REPO_GIT_PERMISSION_MODE)
       );
     }
 
@@ -691,6 +683,7 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] Repo has no Unix group or path, skipping .git/worktrees fix`);
       return;
     }
+    const groupName = resolveRepoGroupName(branch.repo_id as RepoID, repo.unix_group);
 
     // The branch's git dir is at .git/worktrees/<branch-name>/
     // Extract branch name from path (last component)
@@ -703,11 +696,11 @@ export class UnixIntegrationService {
     const branchGitDir = `${repo.local_path}/.git/worktrees/${branchName}`;
 
     console.log(
-      `[UnixIntegration] Setting .git/worktrees/${branchName} permissions ${REPO_GIT_PERMISSION_MODE} (group: ${repo.unix_group})`
+      `[UnixIntegration] Setting .git/worktrees/${branchName} permissions ${REPO_GIT_PERMISSION_MODE} (group: ${groupName})`
     );
 
     await this.executor.execAll(
-      UnixGroupCommands.setDirectoryGroup(branchGitDir, repo.unix_group, REPO_GIT_PERMISSION_MODE)
+      UnixGroupCommands.setDirectoryGroup(branchGitDir, groupName, REPO_GIT_PERMISSION_MODE)
     );
 
     // Set explicit user ACL for the daemon user on .git/worktrees/<name>
@@ -732,6 +725,7 @@ export class UnixIntegrationService {
       console.log(`[UnixIntegration] No Unix group for repo ${shortId(repoId)}, skipping user add`);
       return;
     }
+    const groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     const user = await this.usersRepo.findById(userId as UserID);
     if (!user?.unix_username) {
@@ -741,20 +735,16 @@ export class UnixIntegrationService {
       return;
     }
 
-    console.log(
-      `[UnixIntegration] Adding user ${user.unix_username} to repo group ${repo.unix_group}`
-    );
+    console.log(`[UnixIntegration] Adding user ${user.unix_username} to repo group ${groupName}`);
 
     // Check if already in group
     const inGroup = await this.executor.check(
-      UnixGroupCommands.isUserInGroup(user.unix_username, repo.unix_group)
+      UnixGroupCommands.isUserInGroup(user.unix_username, groupName)
     );
     if (inGroup) {
       console.log(`[UnixIntegration] User ${user.unix_username} already in repo group`);
     } else {
-      await this.executor.exec(
-        UnixGroupCommands.addUserToGroup(user.unix_username, repo.unix_group)
-      );
+      await this.executor.exec(UnixGroupCommands.addUserToGroup(user.unix_username, groupName));
     }
   }
 
@@ -775,6 +765,7 @@ export class UnixIntegrationService {
       );
       return;
     }
+    const groupName = resolveRepoGroupName(repoId, repo.unix_group);
 
     const user = await this.usersRepo.findById(userId as UserID);
     if (!user?.unix_username) {
@@ -785,16 +776,16 @@ export class UnixIntegrationService {
     }
 
     console.log(
-      `[UnixIntegration] Removing user ${user.unix_username} from repo group ${repo.unix_group}`
+      `[UnixIntegration] Removing user ${user.unix_username} from repo group ${groupName}`
     );
 
     // Check if in group before removing
     const inGroup = await this.executor.check(
-      UnixGroupCommands.isUserInGroup(user.unix_username, repo.unix_group)
+      UnixGroupCommands.isUserInGroup(user.unix_username, groupName)
     );
     if (inGroup) {
       await this.executor.exec(
-        UnixGroupCommands.removeUserFromGroup(user.unix_username, repo.unix_group)
+        UnixGroupCommands.removeUserFromGroup(user.unix_username, groupName)
       );
     }
   }
@@ -888,7 +879,7 @@ export class UnixIntegrationService {
     const repo = await this.repoRepo.findById(repoId);
     if (repo?.unix_group) {
       await this.reconcileUnixGroupMembers(
-        repo.unix_group,
+        resolveRepoGroupName(repoId, repo.unix_group),
         await this.getUnixUsernamesForUsers(userIds),
         { label: 'repo' }
       );
@@ -1267,7 +1258,7 @@ export class UnixIntegrationService {
     const branch = await this.branchRepo.findById(branchId);
     if (branch?.unix_group) {
       await this.reconcileUnixGroupMembers(
-        branch.unix_group,
+        resolveBranchGroupName(branchId, branch.unix_group),
         await this.getUnixUsernamesForUsers(userIds),
         { label: 'branch' }
       );

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -24,6 +24,7 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { getReposDir } from '@agor/core/config';
 import { parseAgorYml, writeAgorYml } from '@agor/core/config/node';
 import { shortId } from '@agor/core/db';
+import type { BranchID } from '@agor/core/types';
 import { diagnoseGit } from '@agor/git';
 import { appendGitConfigParameterPairs } from '../git/config-parameters.js';
 import {
@@ -934,7 +935,7 @@ async function renderEnvironmentTemplates(
 }> {
   // Import dependencies dynamically
   const { renderBranchSnapshot } = await import('@agor/core/environment/render-snapshot');
-  const { getGidFromGroupName } = await import('@agor/core/unix');
+  const { getGidFromGroupName, resolveBranchGroupName } = await import('@agor/core/unix');
   const { resolveHostIpAddress } = await import('@agor/core/utils/host-ip');
 
   // Fetch branch and repo from database
@@ -948,7 +949,9 @@ async function renderEnvironmentTemplates(
   }
 
   // Look up GID from Unix group (only if group was created)
-  const unixGid = unixGroup ? getGidFromGroupName(unixGroup) : undefined;
+  const unixGid = unixGroup
+    ? getGidFromGroupName(resolveBranchGroupName(branchId as BranchID, unixGroup))
+    : undefined;
 
   // Resolve host IP for {{host.ip_address}} (frozen into rendered commands).
   // Override comes from daemon-resolved config slice; autodetected fallback

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -914,7 +914,6 @@ export async function handleGitClone(
  * @param client - Feathers client
  * @param branchId - Branch ID
  * @param repoId - Repo ID
- * @param unixGroup - Unix group name (to look up GID), undefined if RBAC disabled
  * @param configuredHostIp - Host IP override from daemon-resolved config (config.daemon.host_ip_address)
  * @returns Rendered template fields
  */
@@ -922,7 +921,6 @@ async function renderEnvironmentTemplates(
   client: AgorClient,
   branchId: string,
   repoId: string,
-  unixGroup: string | undefined,
   configuredHostIp: string | undefined
 ): Promise<{
   start_command?: string;
@@ -949,8 +947,8 @@ async function renderEnvironmentTemplates(
   }
 
   // Look up GID from Unix group (only if group was created)
-  const unixGid = unixGroup
-    ? getGidFromGroupName(resolveBranchGroupName(branchId as BranchID, unixGroup))
+  const unixGid = branch.unix_group
+    ? getGidFromGroupName(resolveBranchGroupName(branchId as BranchID, branch.unix_group))
     : undefined;
 
   // Resolve host IP for {{host.ip_address}} (frozen into rendered commands).
@@ -1205,7 +1203,6 @@ export async function handleGitBranchAdd(
           client,
           branchId,
           repoId,
-          unixGroup,
           payload.resolvedConfig?.daemon?.host_ip_address
         );
         console.log(`[git.branch.add] Templates rendered successfully`);

--- a/packages/executor/src/commands/unix.lifecycle.test.ts
+++ b/packages/executor/src/commands/unix.lifecycle.test.ts
@@ -21,7 +21,7 @@ const repoId = '019fc9dc-2a17-7384-bfa7-d8b327614088';
 
 function makeClient(
   storageMode: 'worktree' | 'clone' = 'worktree',
-  branchGroup = 'agor_wt_existing'
+  branchGroup = 'agor_wt_019fc9dc'
 ) {
   const branch = {
     branch_id: branchId,
@@ -34,7 +34,7 @@ function makeClient(
   const repo = {
     repo_id: repoId,
     local_path: '/tenant/repos/repo',
-    unix_group: 'agor_repo_existing',
+    unix_group: 'agor_rp_019fc9dc',
   };
 
   return {
@@ -113,9 +113,9 @@ describe('handleUnixSyncBranch lifecycle permissions', () => {
       {}
     );
 
-    expect(result).toMatchObject({ success: true, data: { groupName: 'agor_wt_existing' } });
+    expect(result).toMatchObject({ success: true, data: { groupName: 'agor_wt_019fc9dc' } });
     expect(mocks.exec).toHaveBeenCalledWith(
-      expect.stringContaining('chgrp -R agor_wt_existing "/tenant/worktrees/repo/feature"'),
+      expect.stringContaining('chgrp -R agor_wt_019fc9dc "/tenant/worktrees/repo/feature"'),
       expect.any(Function)
     );
     expect(mocks.exec).not.toHaveBeenCalledWith(

--- a/packages/executor/src/commands/unix.lifecycle.test.ts
+++ b/packages/executor/src/commands/unix.lifecycle.test.ts
@@ -21,7 +21,7 @@ const repoId = '019fc9dc-2a17-7384-bfa7-d8b327614088';
 
 function makeClient(
   storageMode: 'worktree' | 'clone' = 'worktree',
-  branchGroup = 'agor_wt_019fc9dc'
+  branchGroup: string | null = 'agor_wt_019fc9dc'
 ) {
   const branch = {
     branch_id: branchId,
@@ -37,13 +37,18 @@ function makeClient(
     unix_group: 'agor_rp_019fc9dc',
   };
 
+  const branchPatch = vi.fn(async (_id: string, data: Record<string, unknown>) => {
+    Object.assign(branch, data);
+    return branch;
+  });
   return {
     io: { disconnect: vi.fn() },
     service: vi.fn((name: string) => ({
       get: vi.fn(async () => (name === 'branches' ? branch : repo)),
-      patch: vi.fn(async () => branch),
+      patch: name === 'branches' ? branchPatch : vi.fn(async () => repo),
       find: vi.fn(async () => []),
     })),
+    branchPatch,
   };
 }
 
@@ -121,6 +126,32 @@ describe('handleUnixSyncBranch lifecycle permissions', () => {
     expect(mocks.exec).not.toHaveBeenCalledWith(
       expect.stringContaining('agor_wt_019fc9dc1dc57e69b0607855'),
       expect.any(Function)
+    );
+  });
+
+  it('persists an absent group before any host group access', async () => {
+    const client = makeClient('clone', null);
+    mocks.createExecutorClient.mockResolvedValue(client);
+
+    const result = await handleUnixSyncBranch(
+      {
+        command: 'unix.sync-branch',
+        daemonUrl: 'http://daemon.test',
+        sessionToken: 'tenant-scoped-token',
+        params: { branchId, daemonUser: 'agor-daemon' },
+      },
+      {}
+    );
+
+    expect(client.branchPatch).toHaveBeenCalledWith(branchId, {
+      unix_group: 'agor_wt_019fc9dc1dc57e69b0607855',
+    });
+    expect(result).toMatchObject({
+      success: true,
+      data: { groupName: 'agor_wt_019fc9dc1dc57e69b0607855' },
+    });
+    expect(client.branchPatch.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.exec.mock.invocationCallOrder[0]
     );
   });
 

--- a/packages/executor/src/commands/unix.lifecycle.test.ts
+++ b/packages/executor/src/commands/unix.lifecycle.test.ts
@@ -19,14 +19,17 @@ import { handleUnixSyncBranch } from './unix.js';
 const branchId = '019fc9dc-1dc5-7e69-b060-785569277230';
 const repoId = '019fc9dc-2a17-7384-bfa7-d8b327614088';
 
-function makeClient(storageMode: 'worktree' | 'clone' = 'worktree') {
+function makeClient(
+  storageMode: 'worktree' | 'clone' = 'worktree',
+  branchGroup = 'agor_wt_existing'
+) {
   const branch = {
     branch_id: branchId,
     repo_id: repoId,
     path: '/tenant/worktrees/repo/feature',
     storage_mode: storageMode,
     others_fs_access: 'none',
-    unix_group: 'agor_wt_existing',
+    unix_group: branchGroup,
   };
   const repo = {
     repo_id: repoId,
@@ -93,6 +96,53 @@ describe('handleUnixSyncBranch lifecycle permissions', () => {
     expect(result.success).toBe(true);
     expect(mocks.exec).not.toHaveBeenCalledWith(
       expect.stringContaining('/.git/worktrees/feature'),
+      expect.any(Function)
+    );
+  });
+
+  it('uses persisted group names without regenerating or silently migrating them', async () => {
+    mocks.createExecutorClient.mockResolvedValue(makeClient('clone'));
+
+    const result = await handleUnixSyncBranch(
+      {
+        command: 'unix.sync-branch',
+        daemonUrl: 'http://daemon.test',
+        sessionToken: 'tenant-scoped-token',
+        params: { branchId, daemonUser: 'agor-daemon' },
+      },
+      {}
+    );
+
+    expect(result).toMatchObject({ success: true, data: { groupName: 'agor_wt_existing' } });
+    expect(mocks.exec).toHaveBeenCalledWith(
+      expect.stringContaining('chgrp -R agor_wt_existing "/tenant/worktrees/repo/feature"'),
+      expect.any(Function)
+    );
+    expect(mocks.exec).not.toHaveBeenCalledWith(
+      expect.stringContaining('agor_wt_019fc9dc1dc57e69b0607855'),
+      expect.any(Function)
+    );
+  });
+
+  it('retains legacy groups during tenant-scoped lifecycle cleanup', async () => {
+    mocks.createExecutorClient.mockResolvedValue(makeClient('clone', 'agor_wt_019fc9dc'));
+
+    const result = await handleUnixSyncBranch(
+      {
+        command: 'unix.sync-branch',
+        daemonUrl: 'http://daemon.test',
+        sessionToken: 'tenant-scoped-token',
+        params: { branchId, daemonUser: 'agor-daemon', delete: true },
+      },
+      {}
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { deleted: false, retainedLegacyGroup: true },
+    });
+    expect(mocks.exec).not.toHaveBeenCalledWith(
+      expect.stringContaining('groupdel agor_wt_019fc9dc'),
       expect.any(Function)
     );
   });

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -24,11 +24,13 @@ import type { BranchID, RepoID } from '@agor/core/types';
 import {
   AGOR_USERS_GROUP,
   assertChpasswdInputSafe,
-  generateBranchGroupName,
-  generateRepoGroupName,
   getBranchPermissionMode,
+  isLegacyBranchGroupName,
+  isLegacyRepoGroupName,
   isValidUnixUsername,
   REPO_GIT_PERMISSION_MODE,
+  resolveBranchGroupName,
+  resolveRepoGroupName,
   UnixGroupCommands,
   UnixUserCommands,
 } from '@agor/core/unix';
@@ -194,6 +196,12 @@ export async function handleUnixSyncRepo(
       // Fetch repo to get group name
       const repo = await client.service('repos').get(repoId);
       if (repo.unix_group) {
+        if (isLegacyRepoGroupName(repo.unix_group)) {
+          console.log(
+            `[unix.sync-repo] Retaining legacy group ${repo.unix_group}; verified cleanup requires agor local fix-group-uuids`
+          );
+          return { success: true, data: { repoId, deleted: false, retainedLegacyGroup: true } };
+        }
         const exists = await checkCommand(UnixGroupCommands.groupExists(repo.unix_group));
         if (exists) {
           await runCommand(UnixGroupCommands.deleteGroup(repo.unix_group));
@@ -212,7 +220,7 @@ export async function handleUnixSyncRepo(
       };
     }
 
-    const groupName = generateRepoGroupName(repoId as RepoID);
+    let groupName = resolveRepoGroupName(repoId as RepoID, repo.unix_group);
     console.log(`[unix.sync-repo] Syncing repo ${shortId(repoId)} with group ${groupName}`);
 
     // Ensure group exists
@@ -220,6 +228,22 @@ export async function handleUnixSyncRepo(
     if (!groupExists) {
       await runCommand(UnixGroupCommands.createGroup(groupName));
       console.log(`[unix.sync-repo] Created group ${groupName}`);
+    }
+
+    // Stamp only when absent. Re-read immediately before patching so a value
+    // persisted by another sync/admin wins and is adopted for all work below.
+    if (repo.unix_group == null) {
+      const latestRepo = await client.service('repos').get(repoId);
+      if (latestRepo.unix_group != null) {
+        groupName = latestRepo.unix_group;
+        if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
+          await runCommand(UnixGroupCommands.createGroup(groupName));
+        }
+        console.log(`[unix.sync-repo] Adopted concurrently stamped group ${groupName}`);
+      } else {
+        await client.service('repos').patch(repoId, { unix_group: groupName });
+        console.log(`[unix.sync-repo] Stamped repo record with unix_group`);
+      }
     }
 
     // Initial clone setup owns the complete managed repo directory. Later
@@ -247,12 +271,6 @@ export async function handleUnixSyncRepo(
         await runCommand(UnixGroupCommands.addUserToGroup(payload.params.daemonUser, groupName));
         console.log(`[unix.sync-repo] Added daemon user ${payload.params.daemonUser} to group`);
       }
-    }
-
-    // Update repo record with group name
-    if (repo.unix_group !== groupName) {
-      await client.service('repos').patch(repoId, { unix_group: groupName });
-      console.log(`[unix.sync-repo] Updated repo record with unix_group`);
     }
 
     // Fetch all branches for this repo and add their owners to repo group
@@ -370,6 +388,15 @@ export async function handleUnixSyncBranch(
       try {
         const branch = await client.service('branches').get(branchId);
         if (branch.unix_group) {
+          if (isLegacyBranchGroupName(branch.unix_group)) {
+            console.log(
+              `[unix.sync-branch] Retaining legacy group ${branch.unix_group}; verified cleanup requires agor local fix-group-uuids`
+            );
+            return {
+              success: true,
+              data: { branchId, deleted: false, retainedLegacyGroup: true },
+            };
+          }
           const exists = await checkCommand(UnixGroupCommands.groupExists(branch.unix_group));
           if (exists) {
             await runCommand(UnixGroupCommands.deleteGroup(branch.unix_group));
@@ -392,7 +419,7 @@ export async function handleUnixSyncBranch(
       };
     }
 
-    const groupName = generateBranchGroupName(branchId as BranchID);
+    let groupName = resolveBranchGroupName(branchId as BranchID, branch.unix_group);
     console.log(`[unix.sync-branch] Syncing branch ${shortId(branchId)} with group ${groupName}`);
 
     // Ensure group exists
@@ -400,6 +427,22 @@ export async function handleUnixSyncBranch(
     if (!groupExists) {
       await runCommand(UnixGroupCommands.createGroup(groupName));
       console.log(`[unix.sync-branch] Created group ${groupName}`);
+    }
+
+    // Stamp only when absent. Re-read immediately before patching so a value
+    // persisted by another sync/admin wins and is adopted for all work below.
+    if (branch.unix_group == null) {
+      const latestBranch = await client.service('branches').get(branchId);
+      if (latestBranch.unix_group != null) {
+        groupName = latestBranch.unix_group;
+        if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
+          await runCommand(UnixGroupCommands.createGroup(groupName));
+        }
+        console.log(`[unix.sync-branch] Adopted concurrently stamped group ${groupName}`);
+      } else {
+        await client.service('branches').patch(branchId, { unix_group: groupName });
+        console.log(`[unix.sync-branch] Stamped branch record with unix_group`);
+      }
     }
 
     // Set permissions on branch directory
@@ -426,12 +469,6 @@ export async function handleUnixSyncBranch(
         await runCommand(UnixGroupCommands.addUserToGroup(payload.params.daemonUser, groupName));
         console.log(`[unix.sync-branch] Added daemon user to branch group`);
       }
-    }
-
-    // Update branch record with group name
-    if (branch.unix_group !== groupName) {
-      await client.service('branches').patch(branchId, { unix_group: groupName });
-      console.log(`[unix.sync-branch] Updated branch record with unix_group`);
     }
 
     // Fetch and add all owners to branch group

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -24,6 +24,8 @@ import type { BranchID, RepoID } from '@agor/core/types';
 import {
   AGOR_USERS_GROUP,
   assertChpasswdInputSafe,
+  generateBranchGroupName,
+  generateRepoGroupName,
   getBranchPermissionMode,
   isLegacyBranchGroupName,
   isLegacyRepoGroupName,
@@ -213,7 +215,7 @@ export async function handleUnixSyncRepo(
     }
 
     // Fetch repo details
-    const repo = await client.service('repos').get(repoId);
+    let repo = await client.service('repos').get(repoId);
     if (!repo.local_path) {
       return {
         success: false,
@@ -221,30 +223,31 @@ export async function handleUnixSyncRepo(
       };
     }
 
-    let groupName = resolveRepoGroupName(repoId as RepoID, repo.unix_group);
+    // Stamp before touching system-global Unix state. Re-read immediately
+    // before and after patching so a concurrently persisted value wins.
+    if (repo.unix_group == null) {
+      const latestRepo = await client.service('repos').get(repoId);
+      if (latestRepo.unix_group != null) {
+        repo = latestRepo;
+      } else {
+        await client.service('repos').patch(repoId, {
+          unix_group: generateRepoGroupName(repoId as RepoID),
+        });
+        repo = await client.service('repos').get(repoId);
+        console.log(`[unix.sync-repo] Stamped repo record with unix_group`);
+      }
+    }
+    if (!repo.unix_group) {
+      throw new Error(`Repo ${repoId} has no persisted Unix group after stamping`);
+    }
+    const groupName = resolveRepoGroupName(repoId as RepoID, repo.unix_group);
     console.log(`[unix.sync-repo] Syncing repo ${shortId(repoId)} with group ${groupName}`);
 
-    // Ensure group exists
+    // Ensure the persisted group exists
     const groupExists = await checkCommand(UnixGroupCommands.groupExists(groupName));
     if (!groupExists) {
       await runCommand(UnixGroupCommands.createGroup(groupName));
       console.log(`[unix.sync-repo] Created group ${groupName}`);
-    }
-
-    // Stamp only when absent. Re-read immediately before patching so a value
-    // persisted by another sync/admin wins and is adopted for all work below.
-    if (repo.unix_group == null) {
-      const latestRepo = await client.service('repos').get(repoId);
-      if (latestRepo.unix_group != null) {
-        groupName = resolveRepoGroupName(repoId as RepoID, latestRepo.unix_group);
-        if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
-          await runCommand(UnixGroupCommands.createGroup(groupName));
-        }
-        console.log(`[unix.sync-repo] Adopted concurrently stamped group ${groupName}`);
-      } else {
-        await client.service('repos').patch(repoId, { unix_group: groupName });
-        console.log(`[unix.sync-repo] Stamped repo record with unix_group`);
-      }
     }
 
     // Initial clone setup owns the complete managed repo directory. Later
@@ -413,7 +416,7 @@ export async function handleUnixSyncBranch(
     }
 
     // Fetch branch details
-    const branch = await client.service('branches').get(branchId);
+    let branch = await client.service('branches').get(branchId);
     if (!branch.path) {
       return {
         success: false,
@@ -421,30 +424,31 @@ export async function handleUnixSyncBranch(
       };
     }
 
-    let groupName = resolveBranchGroupName(branchId as BranchID, branch.unix_group);
+    // Stamp before touching system-global Unix state. Re-read immediately
+    // before and after patching so a concurrently persisted value wins.
+    if (branch.unix_group == null) {
+      const latestBranch = await client.service('branches').get(branchId);
+      if (latestBranch.unix_group != null) {
+        branch = latestBranch;
+      } else {
+        await client.service('branches').patch(branchId, {
+          unix_group: generateBranchGroupName(branchId as BranchID),
+        });
+        branch = await client.service('branches').get(branchId);
+        console.log(`[unix.sync-branch] Stamped branch record with unix_group`);
+      }
+    }
+    if (!branch.unix_group) {
+      throw new Error(`Branch ${branchId} has no persisted Unix group after stamping`);
+    }
+    const groupName = resolveBranchGroupName(branchId as BranchID, branch.unix_group);
     console.log(`[unix.sync-branch] Syncing branch ${shortId(branchId)} with group ${groupName}`);
 
-    // Ensure group exists
+    // Ensure the persisted group exists
     const groupExists = await checkCommand(UnixGroupCommands.groupExists(groupName));
     if (!groupExists) {
       await runCommand(UnixGroupCommands.createGroup(groupName));
       console.log(`[unix.sync-branch] Created group ${groupName}`);
-    }
-
-    // Stamp only when absent. Re-read immediately before patching so a value
-    // persisted by another sync/admin wins and is adopted for all work below.
-    if (branch.unix_group == null) {
-      const latestBranch = await client.service('branches').get(branchId);
-      if (latestBranch.unix_group != null) {
-        groupName = resolveBranchGroupName(branchId as BranchID, latestBranch.unix_group);
-        if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
-          await runCommand(UnixGroupCommands.createGroup(groupName));
-        }
-        console.log(`[unix.sync-branch] Adopted concurrently stamped group ${groupName}`);
-      } else {
-        await client.service('branches').patch(branchId, { unix_group: groupName });
-        console.log(`[unix.sync-branch] Stamped branch record with unix_group`);
-      }
     }
 
     // Set permissions on branch directory

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -196,16 +196,17 @@ export async function handleUnixSyncRepo(
       // Fetch repo to get group name
       const repo = await client.service('repos').get(repoId);
       if (repo.unix_group) {
-        if (isLegacyRepoGroupName(repo.unix_group)) {
+        const persistedGroup = resolveRepoGroupName(repoId as RepoID, repo.unix_group);
+        if (isLegacyRepoGroupName(persistedGroup)) {
           console.log(
-            `[unix.sync-repo] Retaining legacy group ${repo.unix_group}; verified cleanup requires agor local fix-group-uuids`
+            `[unix.sync-repo] Retaining legacy group ${persistedGroup}; verified cleanup requires agor local fix-group-uuids`
           );
           return { success: true, data: { repoId, deleted: false, retainedLegacyGroup: true } };
         }
-        const exists = await checkCommand(UnixGroupCommands.groupExists(repo.unix_group));
+        const exists = await checkCommand(UnixGroupCommands.groupExists(persistedGroup));
         if (exists) {
-          await runCommand(UnixGroupCommands.deleteGroup(repo.unix_group));
-          console.log(`[unix.sync-repo] Deleted group ${repo.unix_group}`);
+          await runCommand(UnixGroupCommands.deleteGroup(persistedGroup));
+          console.log(`[unix.sync-repo] Deleted group ${persistedGroup}`);
         }
       }
       return { success: true, data: { repoId, deleted: true } };
@@ -235,7 +236,7 @@ export async function handleUnixSyncRepo(
     if (repo.unix_group == null) {
       const latestRepo = await client.service('repos').get(repoId);
       if (latestRepo.unix_group != null) {
-        groupName = latestRepo.unix_group;
+        groupName = resolveRepoGroupName(repoId as RepoID, latestRepo.unix_group);
         if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
           await runCommand(UnixGroupCommands.createGroup(groupName));
         }
@@ -388,19 +389,20 @@ export async function handleUnixSyncBranch(
       try {
         const branch = await client.service('branches').get(branchId);
         if (branch.unix_group) {
-          if (isLegacyBranchGroupName(branch.unix_group)) {
+          const persistedGroup = resolveBranchGroupName(branchId as BranchID, branch.unix_group);
+          if (isLegacyBranchGroupName(persistedGroup)) {
             console.log(
-              `[unix.sync-branch] Retaining legacy group ${branch.unix_group}; verified cleanup requires agor local fix-group-uuids`
+              `[unix.sync-branch] Retaining legacy group ${persistedGroup}; verified cleanup requires agor local fix-group-uuids`
             );
             return {
               success: true,
               data: { branchId, deleted: false, retainedLegacyGroup: true },
             };
           }
-          const exists = await checkCommand(UnixGroupCommands.groupExists(branch.unix_group));
+          const exists = await checkCommand(UnixGroupCommands.groupExists(persistedGroup));
           if (exists) {
-            await runCommand(UnixGroupCommands.deleteGroup(branch.unix_group));
-            console.log(`[unix.sync-branch] Deleted group ${branch.unix_group}`);
+            await runCommand(UnixGroupCommands.deleteGroup(persistedGroup));
+            console.log(`[unix.sync-branch] Deleted group ${persistedGroup}`);
           }
         }
       } catch {
@@ -434,7 +436,7 @@ export async function handleUnixSyncBranch(
     if (branch.unix_group == null) {
       const latestBranch = await client.service('branches').get(branchId);
       if (latestBranch.unix_group != null) {
-        groupName = latestBranch.unix_group;
+        groupName = resolveBranchGroupName(branchId as BranchID, latestBranch.unix_group);
         if (!(await checkCommand(UnixGroupCommands.groupExists(groupName)))) {
           await runCommand(UnixGroupCommands.createGroup(groupName));
         }
@@ -600,21 +602,22 @@ export async function handleUnixSyncBranch(
           );
         }
         if (repo.unix_group) {
+          const repoGroup = resolveRepoGroupName(branch.repo_id as RepoID, repo.unix_group);
           // Add daemon user to repo group if provided
           if (payload.params.daemonUser) {
             const inRepoGroup = await checkCommand(
-              UnixGroupCommands.isUserInGroup(payload.params.daemonUser, repo.unix_group)
+              UnixGroupCommands.isUserInGroup(payload.params.daemonUser, repoGroup)
             );
             if (!inRepoGroup) {
               await runCommand(
-                UnixGroupCommands.addUserToGroup(payload.params.daemonUser, repo.unix_group)
+                UnixGroupCommands.addUserToGroup(payload.params.daemonUser, repoGroup)
               );
-              console.log(`[unix.sync-branch] Added daemon user to repo group ${repo.unix_group}`);
+              console.log(`[unix.sync-branch] Added daemon user to repo group ${repoGroup}`);
             }
           }
 
           // Add all explicit filesystem access users to repo group (for .git/ access)
-          await addUsersToGroup(explicitFsUsernames, repo.unix_group);
+          await addUsersToGroup(explicitFsUsernames, repoGroup);
 
           // Add all branch owners to repo group (for .git/ access)
           // This ensures owners can run git commands which need .git/ access
@@ -625,14 +628,14 @@ export async function handleUnixSyncBranch(
             for (const owner of owners as Array<{ unix_username?: string }>) {
               if (owner.unix_username) {
                 const inRepoGroup = await checkCommand(
-                  UnixGroupCommands.isUserInGroup(owner.unix_username, repo.unix_group)
+                  UnixGroupCommands.isUserInGroup(owner.unix_username, repoGroup)
                 );
                 if (!inRepoGroup) {
                   await runCommand(
-                    UnixGroupCommands.addUserToGroup(owner.unix_username, repo.unix_group)
+                    UnixGroupCommands.addUserToGroup(owner.unix_username, repoGroup)
                   );
                   console.log(
-                    `[unix.sync-branch] Added owner ${owner.unix_username} to repo group ${repo.unix_group}`
+                    `[unix.sync-branch] Added owner ${owner.unix_username} to repo group ${repoGroup}`
                   );
                 }
               }
@@ -666,12 +669,12 @@ export async function handleUnixSyncBranch(
 
               for (const username of sessionUsernames) {
                 const inRepoGroup = await checkCommand(
-                  UnixGroupCommands.isUserInGroup(username, repo.unix_group)
+                  UnixGroupCommands.isUserInGroup(username, repoGroup)
                 );
                 if (!inRepoGroup) {
-                  await runCommand(UnixGroupCommands.addUserToGroup(username, repo.unix_group));
+                  await runCommand(UnixGroupCommands.addUserToGroup(username, repoGroup));
                   console.log(
-                    `[unix.sync-branch] Added session user ${username} to repo group ${repo.unix_group} (others_fs_access: ${othersAccess})`
+                    `[unix.sync-branch] Added session user ${username} to repo group ${repoGroup} (others_fs_access: ${othersAccess})`
                   );
                 }
               }
@@ -686,7 +689,7 @@ export async function handleUnixSyncBranch(
             const branchGitDir = `${repo.local_path}/.git/worktrees/${branchName}`;
             const fixCommands = UnixGroupCommands.setDirectoryGroup(
               branchGitDir,
-              repo.unix_group,
+              repoGroup,
               REPO_GIT_PERMISSION_MODE
             );
             await runCommands(fixCommands);

--- a/scripts/check-no-ad-hoc-shortid.mjs
+++ b/scripts/check-no-ad-hoc-shortid.mjs
@@ -48,6 +48,30 @@ const ALLOWLIST = new Set([
   'packages/core/src/db/scripts/test-integration.test.ts',
 ]);
 
+// Unix group generation is a persistence-boundary operation, not a general
+// formatting helper. Every other caller must read unix_group from the row and
+// validate it with resolveBranchGroupName/resolveRepoGroupName.
+const UNIX_GROUP_GENERATION_ALLOWLIST = new Set([
+  'apps/agor-cli/src/commands/local/sync-unix.ts',
+  'apps/agor-daemon/src/register-hooks.ts',
+  'packages/core/src/unix/group-manager.ts',
+  'packages/core/src/unix/group-manager.test.ts',
+  'packages/core/src/unix/group-uuid-migration.ts',
+  'packages/core/src/unix/unix-integration-service.ts',
+  'packages/executor/src/commands/unix.ts',
+]);
+const LEGACY_UNIX_GROUP_GENERATION_ALLOWLIST = new Set([
+  'packages/core/src/unix/group-manager.ts',
+  'packages/core/src/unix/group-manager.test.ts',
+  'packages/core/src/unix/group-uuid-migration.ts',
+]);
+
+const UNIX_GROUP_GENERATION_PATTERNS = [
+  /\bgenerate(?:Branch|Repo)GroupName\b/,
+  /agor_(?:wt|rp)_\$\{/,
+  /['"]agor_(?:wt|rp)_['"]\s*\+/,
+];
+
 // `reportId` and `displayId` are intentionally OMITTED — reports are
 // addressed by file path (`<session-id>/<task-id>.md`), not UUIDv7, and
 // `displayId` is a generic alias that may not be a UUID.
@@ -134,20 +158,36 @@ async function dirExists(abs) {
 
 async function main() {
   let violations = 0;
+  let unixGroupViolations = 0;
   for (const dir of TARGETS) {
     const abs = path.join(ROOT, dir);
     if (!(await dirExists(abs))) continue;
     for await (const file of walk(abs)) {
       const rel = path.relative(ROOT, file);
-      if (ALLOWLIST.has(rel)) continue;
       const text = await fs.readFile(file, 'utf8');
       const lines = text.split('\n');
       for (let i = 0; i < lines.length; i++) {
-        if (!lineMatches(lines[i])) continue;
         const prev = lines[i - 1] ?? '';
-        if (PRAGMA_RE.test(prev) || PRAGMA_RE.test(lines[i])) continue;
-        console.error(`${rel}:${i + 1}: ${lines[i].trim()}`);
-        violations++;
+        if (!ALLOWLIST.has(rel) && lineMatches(lines[i])) {
+          if (!PRAGMA_RE.test(prev) && !PRAGMA_RE.test(lines[i])) {
+            console.error(`${rel}:${i + 1}: ${lines[i].trim()}`);
+            violations++;
+          }
+        }
+        if (
+          !UNIX_GROUP_GENERATION_ALLOWLIST.has(rel) &&
+          UNIX_GROUP_GENERATION_PATTERNS.some((pattern) => pattern.test(lines[i]))
+        ) {
+          console.error(`${rel}:${i + 1}: ${lines[i].trim()}`);
+          unixGroupViolations++;
+        }
+        if (
+          !LEGACY_UNIX_GROUP_GENERATION_ALLOWLIST.has(rel) &&
+          /\bgenerateLegacy(?:Branch|Repo)GroupName\b/.test(lines[i])
+        ) {
+          console.error(`${rel}:${i + 1}: ${lines[i].trim()}`);
+          unixGroupViolations++;
+        }
       }
     }
   }
@@ -170,7 +210,18 @@ async function main() {
     process.exit(1);
   }
 
-  console.log('✅ No ad-hoc UUID truncation found.');
+  if (unixGroupViolations > 0) {
+    console.error(
+      `\n❌ ${unixGroupViolations} Unix group name generation boundary violation${unixGroupViolations === 1 ? '' : 's'} found.\n` +
+        `\nUnix group names are persisted identity. Generate a canonical name only in\n` +
+        `an allowlisted absent-field stamping or explicit migration boundary. Every\n` +
+        `host/filesystem/GID consumer must read unix_group from the branch/repo row\n` +
+        `and validate it with resolveBranchGroupName/resolveRepoGroupName.\n`
+    );
+    process.exit(1);
+  }
+
+  console.log('✅ No ad-hoc UUID truncation or Unix group generation bypass found.');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- generate new branch and repo Unix groups with Agor's canonical collision-safe 24-character `shortId()`
- keep a persisted `unix_group` authoritative during normal daemon, executor, and CLI synchronization while preserving legacy 8-character names
- add the idempotent local administrative command `agor local fix-group-uuids`, with duplicate-only/full planning and `--dry-run`
- prevent ordinary lifecycle cleanup from deleting shared-capable legacy groups without global verification

## Migration safety

- reconstructs replacement memberships from current database authorization instead of copying a potentially contaminated legacy group
- creates and populates replacement groups, updates and verifies managed paths, then compare-and-sets the persisted group name
- retains predecessor groups until database and filesystem checks prove they are unused, allowing interrupted runs to converge safely
- fails closed for PostgreSQL/RLS and remote databases because the Unix group namespace is system-global

## Documentation

- documents the migration workflow and recommends `--only-dups` for existing strict/insulated installations
- adds a concise release note describing the optional full legacy migration

## Testing

- `pnpm check`
- `pnpm --filter @agor/core exec vitest run src/unix/group-manager.test.ts src/unix/group-uuid-migration.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/commands/unix.lifecycle.test.ts`
