### PR TITLE
fix(mcp): show callback-linked remote sessions in the parent SessionTree

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1154,6 +1154,60 @@ describe('agor_sessions_create', () => {
     expect(parsed.remoteRelationship).toBeUndefined();
   });
 
+  // Genealogy and provenance are orthogonal and can coexist: a cross-branch
+  // caller assigns a valid same-target-branch genealogy parent. The child gets
+  // BOTH the local genealogy parent AND a remote_create edge sourced from the
+  // cross-branch caller.
+  it('records both genealogy parent and remote_create edge for a cross-branch caller with an explicit parent', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: Array<{ id: unknown; data: unknown }> = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        // The explicit parent lives in the target branch; the caller (sess-A)
+        // lives in a different branch.
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: id === 'sess-A' ? 'wt-caller' : 'wt-target',
+          genealogy: { children: [] },
+        }),
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-A' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-target',
+      agenticTool: 'claude-code',
+      parentSessionId: 'sess-parent',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Local genealogy parent is honored...
+    expect(created.genealogy.parent_session_id).toBe('sess-parent');
+    expect(patchCalls[0].id).toBe('sess-parent');
+    // ...AND the cross-branch caller is recorded as the remote creator.
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toMatchObject({
+      source_session_id: 'sess-A',
+      target_session_id: 'sess-new',
+      relationship_type: 'remote_create',
+    });
+  });
+
   it('does not auto-link to the calling session when creating in a different branch', async () => {
     const sessionCreates: unknown[] = [];
     const patchCalls: unknown[] = [];

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -885,6 +885,13 @@ describe('agor_sessions_create', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
+        // null inspects the calling session to decide cross-branch provenance;
+        // here the caller shares the target branch, so it stays fully unlinked.
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async (...args: unknown[]) => {
           patchCalls.push(args);
           return {};
@@ -967,6 +974,184 @@ describe('agor_sessions_create', () => {
       callback_enabled: true,
       callback_session_id: 'sess-caller',
     });
+  });
+
+  // Provenance (who created the child) is the CALLING session, not the callback
+  // target (where completion is routed). Caller A creates the child and routes
+  // callbacks to a different session B: the remote_create source must be A,
+  // while the callback endpoint records B.
+  it('attributes remote_create provenance to the caller, not the callback target', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        // The caller (sess-A) lives in a different branch than the target.
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-caller',
+          genealogy: { children: [] },
+        }),
+        patch: async () => ({}),
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-A' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-target',
+      agenticTool: 'claude-code',
+      parentSessionId: null,
+      callbackSessionId: 'sess-B',
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toMatchObject({
+      source_session_id: 'sess-A', // the creator, NOT sess-B
+      target_session_id: 'sess-new',
+      relationship_type: 'remote_create',
+      callback_session_id: 'sess-B', // routing endpoint
+    });
+  });
+
+  // With no calling-session context there is no creator to attribute, so no
+  // provenance edge is written even when an explicit cross-branch callback
+  // target is supplied. Completion routing (callback_config) is still recorded.
+  it('records no remote_create relationship when there is no calling session', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        patch: async () => ({}),
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1' }, // no sessionId
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-target',
+      agenticTool: 'claude-code',
+      callbackSessionId: 'sess-B',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Routing is still set up so completion is delivered...
+    expect(created.callback_config).toMatchObject({
+      enabled: true,
+      callback_session_id: 'sess-B',
+    });
+    // ...but there is no creator, so no provenance edge.
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toBeUndefined();
+  });
+
+  // parentSessionId: null with a same-branch callback target is an intentional
+  // unlinked root: no genealogy parent AND no cross-branch provenance edge.
+  it('records no remote_create relationship for a same-branch callback target', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch }, // branch_id 'wt-1'
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1', // caller shares the target branch
+          genealogy: { children: [] },
+        }),
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      parentSessionId: null,
+      enableCallback: true,
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(patchCalls).toHaveLength(0);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toBeUndefined();
+  });
+
+  // A same-branch genealogy parent with an explicit cross-branch callback
+  // target: the creator is local (genealogy handles it), so no remote_create
+  // edge is written — the callback target is routing only.
+  it('records no remote_create relationship when the caller shares the branch but routes callbacks cross-branch', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch }, // branch_id 'wt-1'
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1', // caller shares the target branch → genealogy parent
+          genealogy: { children: [] },
+        }),
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      callbackSessionId: 'sess-B', // cross-branch routing target
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Same-branch genealogy parent is established (omitted parentSessionId).
+    expect(created.genealogy.parent_session_id).toBe('sess-caller');
+    expect(patchCalls).toHaveLength(1);
+    // No remote provenance edge — the creator is local.
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toBeUndefined();
   });
 
   it('does not auto-link to the calling session when creating in a different branch', async () => {

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -910,6 +910,65 @@ describe('agor_sessions_create', () => {
     expect(patchCalls).toHaveLength(0);
   });
 
+  // Regression: an orchestrator that opts out of same-branch genealogy with
+  // `parentSessionId: null` while still requesting a callback to itself created
+  // a session that carried `callback_config` but NO durable `remote_create`
+  // relationship. The remote branch's link/unlink toggle (which reads
+  // callback_config / as_target) rendered, but the parent SessionTree — which
+  // projects surrogates from the source session's `remote_relationships` — had
+  // no edge to show, so the child was invisible upstream.
+  it('records a remote_create relationship for parentSessionId: null cross-branch with a callback', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-caller',
+          genealogy: { children: [] },
+        }),
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-target',
+      agenticTool: 'claude-code',
+      parentSessionId: null,
+      enableCallback: true,
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Genealogy opt-out is preserved: no same-branch parent, no parent patch.
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(patchCalls).toHaveLength(0);
+    // But the durable cross-branch provenance edge IS recorded so the
+    // orchestrator's SessionTree can surface the child.
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.remoteRelationship).toMatchObject({
+      source_session_id: 'sess-caller',
+      target_session_id: 'sess-new',
+      relationship_type: 'remote_create',
+      callback_enabled: true,
+      callback_session_id: 'sess-caller',
+    });
+  });
+
   it('does not auto-link to the calling session when creating in a different branch', async () => {
     const sessionCreates: unknown[] = [];
     const patchCalls: unknown[] = [];

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1147,7 +1147,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // different target branch is remote provenance/callback state, not a
       // tree child of the caller. Keep the implicit convenience branch-local:
       // - explicit string: resolve (supports short IDs), require same branch, and use
-      // - explicit null: opt out — create a root session with no parent
+      // - explicit null: opt out of genealogy — create a session with no
+      //   same-branch parent (cross-branch remote provenance is still recorded
+      //   below when a callback endpoint is configured)
       // - undefined (omitted): auto-link to the calling session only when the
       //   calling session lives in the same branch as the new session
       let resolvedParentSessionId: string | undefined;
@@ -1182,6 +1184,43 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           skippedAutoParentDueToBranchMismatch = true;
           remoteRelationshipSourceSessionId = callingSession.session_id;
           remoteRelationshipSourceBranchId = callingSession.branch_id;
+        }
+      }
+
+      // Durable remote-provenance backstop.
+      //
+      // The auto-parent detection above only records a `remote_create`
+      // relationship on the implicit convenience path: `parentSessionId`
+      // omitted AND a same-user session context present AND cross-branch. Two
+      // legitimate callback-configured paths fall through it and would produce
+      // a session that carries `callback_config` but no durable relationship —
+      // making the child invisible in the orchestrator's SessionTree even
+      // though the remote branch still renders the link/unlink toggle:
+      //   - `parentSessionId: null` — the caller opts out of *genealogy* (a
+      //     same-branch tree link), which is orthogonal to cross-branch remote
+      //     provenance. An "unlinked root session" that still reports back to a
+      //     remote parent must keep that edge.
+      //   - an explicit `callbackSessionId` targeting a session in another
+      //     branch (source of the callback ≠ the calling session, or no calling
+      //     session at all).
+      // A cross-branch callback endpoint IS the remote parent, so back it with
+      // the relationship whenever one isn't already established. The callback
+      // target's branch prompt permission was validated above, so this adds no
+      // new authorization surface.
+      if (
+        wantsCallback &&
+        effectiveCallbackSessionId &&
+        !resolvedParentSessionId &&
+        !remoteRelationshipSourceSessionId
+      ) {
+        const callbackTargetSession = (await ctx.app
+          .service('sessions')
+          .get(effectiveCallbackSessionId, ctx.baseServiceParams)) as Session;
+
+        if (callbackTargetSession.branch_id !== branch.branch_id) {
+          skippedAutoParentDueToBranchMismatch = true;
+          remoteRelationshipSourceSessionId = callbackTargetSession.session_id;
+          remoteRelationshipSourceBranchId = callbackTargetSession.branch_id;
         }
       }
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1169,6 +1169,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       let remoteRelationshipSourceSessionId: string | undefined;
       let remoteRelationshipSourceBranchId: string | undefined;
 
+      // Decision 1 — genealogy: resolve an EXPLICIT parent (same-branch only).
+      // Implicit same-branch genealogy is handled in decision 2.
       if (args.parentSessionId !== undefined && args.parentSessionId !== null) {
         resolvedParentSessionId = await resolveSessionId(ctx, args.parentSessionId);
         parentSessionForPatch = (await ctx.app
@@ -1181,17 +1183,21 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
               'For cross-branch completion routing, use enableCallback/callbackSessionId instead of genealogy.'
           );
         }
-      } else if (ctx.sessionId && !resolvedParentSessionId) {
-        // No explicit genealogy parent. Inspect the calling session: same
-        // branch is an implicit genealogy parent (omitted only); a different
-        // branch makes the caller the remote creator regardless of the
-        // genealogy opt-out.
+      }
+
+      // Decision 2 — inspect the calling session, independently of genealogy.
+      // A cross-branch caller is the remote creator and ALWAYS gets a
+      // `remote_create` edge (it can coexist with an explicit same-branch
+      // genealogy parent). A same-branch caller becomes the implicit genealogy
+      // parent only when `parentSessionId` was omitted (an explicit parent
+      // wins; `null` opts out).
+      if (ctx.sessionId) {
         const callingSession = (await ctx.app
           .service('sessions')
           .get(ctx.sessionId, ctx.baseServiceParams)) as Session;
 
         if (callingSession.branch_id === branch.branch_id) {
-          if (args.parentSessionId === undefined) {
+          if (args.parentSessionId === undefined && !resolvedParentSessionId) {
             resolvedParentSessionId = callingSession.session_id;
             parentSessionForPatch = callingSession;
           }

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1140,87 +1140,67 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackConfig.callback_mode = args.callbackMode ?? 'persistent';
       }
 
-      // Determine the parent session to link to in the genealogy.
+      // Determine the parent session to link to in the genealogy, and — for a
+      // cross-branch create — the source of the durable `remote_create`
+      // provenance edge.
       //
       // `parent_session_id` is the canonical branch-local session tree used by
-      // fork/spawn UI and recursive delete semantics. A session created in a
-      // different target branch is remote provenance/callback state, not a
-      // tree child of the caller. Keep the implicit convenience branch-local:
-      // - explicit string: resolve (supports short IDs), require same branch, and use
-      // - explicit null: opt out of genealogy — create a session with no
-      //   same-branch parent (cross-branch remote provenance is still recorded
-      //   below when a callback endpoint is configured)
-      // - undefined (omitted): auto-link to the calling session only when the
-      //   calling session lives in the same branch as the new session
+      // fork/spawn UI and recursive delete semantics. `remote_create` is a
+      // separate, cross-branch *provenance* edge (rendered as a surrogate under
+      // the creator in the SessionTree). Provenance answers "which session
+      // created this child" — it is ALWAYS the calling session, never the
+      // callback target (that only answers "where should completion be
+      // delivered", i.e. routing). Keep the two concerns distinct:
+      // - explicit string: resolve (supports short IDs), require same branch,
+      //   use as the genealogy parent.
+      // - explicit null: opt out of *genealogy* only. This is orthogonal to
+      //   provenance: a cross-branch calling session is still recorded as the
+      //   remote creator below, so an "unlinked root session" that a remote
+      //   orchestrator spun up still surfaces under that orchestrator.
+      // - undefined (omitted): auto-link to the calling session as the
+      //   genealogy parent only when it shares the new session's branch.
+      // In every case, a calling session in a *different* branch is the remote
+      // creator and gets a `remote_create` edge. With no calling session there
+      // is no creator to attribute, so no provenance edge is written (the child
+      // still carries callback_config, so completion is still delivered).
       let resolvedParentSessionId: string | undefined;
       let parentSessionForPatch: Session | undefined;
       let skippedAutoParentDueToBranchMismatch = false;
       let remoteRelationshipSourceSessionId: string | undefined;
       let remoteRelationshipSourceBranchId: string | undefined;
 
-      if (args.parentSessionId !== undefined) {
-        if (args.parentSessionId !== null) {
-          resolvedParentSessionId = await resolveSessionId(ctx, args.parentSessionId);
-          parentSessionForPatch = (await ctx.app
-            .service('sessions')
-            .get(resolvedParentSessionId, ctx.baseServiceParams)) as Session;
+      if (args.parentSessionId !== undefined && args.parentSessionId !== null) {
+        resolvedParentSessionId = await resolveSessionId(ctx, args.parentSessionId);
+        parentSessionForPatch = (await ctx.app
+          .service('sessions')
+          .get(resolvedParentSessionId, ctx.baseServiceParams)) as Session;
 
-          if (parentSessionForPatch.branch_id !== branch.branch_id) {
-            throw new Error(
-              `parentSessionId must reference a session in the target branch (${shortId(branch.branch_id)}). ` +
-                'For cross-branch completion routing, use enableCallback/callbackSessionId instead of genealogy.'
-            );
-          }
+        if (parentSessionForPatch.branch_id !== branch.branch_id) {
+          throw new Error(
+            `parentSessionId must reference a session in the target branch (${shortId(branch.branch_id)}). ` +
+              'For cross-branch completion routing, use enableCallback/callbackSessionId instead of genealogy.'
+          );
         }
-      } else if (ctx.sessionId) {
+      } else if (ctx.sessionId && !resolvedParentSessionId) {
+        // No explicit genealogy parent. Inspect the calling session: same
+        // branch is an implicit genealogy parent (omitted only); a different
+        // branch makes the caller the remote creator regardless of the
+        // genealogy opt-out.
         const callingSession = (await ctx.app
           .service('sessions')
           .get(ctx.sessionId, ctx.baseServiceParams)) as Session;
 
         if (callingSession.branch_id === branch.branch_id) {
-          resolvedParentSessionId = callingSession.session_id;
-          parentSessionForPatch = callingSession;
+          if (args.parentSessionId === undefined) {
+            resolvedParentSessionId = callingSession.session_id;
+            parentSessionForPatch = callingSession;
+          }
+          // parentSessionId: null in the same branch → intentionally unlinked;
+          // no genealogy parent and no cross-branch provenance.
         } else {
           skippedAutoParentDueToBranchMismatch = true;
           remoteRelationshipSourceSessionId = callingSession.session_id;
           remoteRelationshipSourceBranchId = callingSession.branch_id;
-        }
-      }
-
-      // Durable remote-provenance backstop.
-      //
-      // The auto-parent detection above only records a `remote_create`
-      // relationship on the implicit convenience path: `parentSessionId`
-      // omitted AND a same-user session context present AND cross-branch. Two
-      // legitimate callback-configured paths fall through it and would produce
-      // a session that carries `callback_config` but no durable relationship —
-      // making the child invisible in the orchestrator's SessionTree even
-      // though the remote branch still renders the link/unlink toggle:
-      //   - `parentSessionId: null` — the caller opts out of *genealogy* (a
-      //     same-branch tree link), which is orthogonal to cross-branch remote
-      //     provenance. An "unlinked root session" that still reports back to a
-      //     remote parent must keep that edge.
-      //   - an explicit `callbackSessionId` targeting a session in another
-      //     branch (source of the callback ≠ the calling session, or no calling
-      //     session at all).
-      // A cross-branch callback endpoint IS the remote parent, so back it with
-      // the relationship whenever one isn't already established. The callback
-      // target's branch prompt permission was validated above, so this adds no
-      // new authorization surface.
-      if (
-        wantsCallback &&
-        effectiveCallbackSessionId &&
-        !resolvedParentSessionId &&
-        !remoteRelationshipSourceSessionId
-      ) {
-        const callbackTargetSession = (await ctx.app
-          .service('sessions')
-          .get(effectiveCallbackSessionId, ctx.baseServiceParams)) as Session;
-
-        if (callbackTargetSession.branch_id !== branch.branch_id) {
-          skippedAutoParentDueToBranchMismatch = true;
-          remoteRelationshipSourceSessionId = callbackTargetSession.session_id;
-          remoteRelationshipSourceBranchId = callbackTargetSession.branch_id;
         }
       }
 


### PR DESCRIPTION
## Problem

Sessions created by an orchestrator in a **remote branch** with a callback back to the orchestrator did **not** appear under the root in the BranchCard / AssistantPanel / SessionTree — even though the remote branch's session UI correctly showed the **link/unlink** toggle.

Observed in production: root/orchestrator `019f907c…` created dozens of remote review sessions (e.g. `019ffe63…` "Review PR 2151"), each with `callback_config.callback_session_id → 019f907c…`, yet none rendered under the root.

## Root cause

`agor_sessions_create` writes a session's **`callback_config`** (notification routing) and its **durable `remote_create` relationship** (cross-branch provenance) via two *different* code paths. The parent SessionTree projects remote surrogates from the source session's `remote_relationships.as_source` — so the relationship row, not `callback_config`, is what makes a child visible upstream. The link/unlink toggle reads `callback_config` / `as_target`, which is why it kept rendering.

The relationship was only recorded on the implicit auto-parent path: `parentSessionId` **omitted** AND a live calling-session context AND cross-branch. A caller that opted out of genealogy with **`parentSessionId: null`** (advertised by the tool as "create an unlinked root session") fell through it — producing a child with `callback_config` but no `session_relationships` row, invisible in the orchestrator's tree.

This is a latent gap in the original feature (relationship-write + surrogate-projection both shipped in #1907, 2026-07-16); it surfaced once orchestrator calls began passing `parentSessionId: null`. It was **not** introduced by the task-level-callbacks PR (#2175), which never touched the relationship-write block.

## Fix

Key the `remote_create` **provenance** edge to the **calling session** (the creator), decoupled from genealogy and from callback routing:

- A **cross-branch calling session** is recorded as the remote creator whether `parentSessionId` is **omitted** or explicitly **`null`** — `null` opts out of *branch-local genealogy*, not provenance.
- A **same-branch calling session** is an implicit genealogy parent only when `parentSessionId` was omitted (unchanged).
- An explicit cross-branch **`callbackSessionId`** is **routing only** — it is recorded on the row's `callback_session_id`, and does **not** by itself create a relationship. (Provenance = who created the child, not where completion is delivered.)
- With **no calling session** there is no creator to attribute, so no provenance edge is written; the child still carries `callback_config`, so completion is still delivered.

Uses the authoritative durable-relationship API (no copying IDs into genealogy). Reuses the callback target's already-validated branch prompt permission → **no new authorization surface, no cross-tenant enumeration**. Same-branch and omitted-path behavior are unchanged. The UI's existing surrogate projection (`agorMaps.ts`) then surfaces the child with no UI change.

> **Review note (Codex, #2336):** the first cut derived the provenance source from the callback *target*, which conflated routing with provenance (caller A routing callbacks to B would record B as the creator). Corrected to key provenance to the calling session; behavior above reflects the fix.

## Relationship model (for reviewers)

| Relationship | Storage | Meaning |
|---|---|---|
| `genealogy.parent_session_id` / `forked_from_session_id` | `sessions.genealogy` | **Hierarchy/ownership**, branch-local |
| `remote_create` row | `session_relationships` table | **Cross-branch provenance** — the edge the tree renders (source = creator) |
| `callback_config` | `sessions.callback_config` | **Notification routing** |
| `completion_callback` | `tasks.metadata` (≤1/task) | One-shot task callback, not part of the tree |

## Tests

- `records a remote_create relationship for parentSessionId: null cross-branch with a callback` — **proven to fail before the fix** (`remoteRelationship` was `undefined`).
- Provenance-vs-routing coverage: caller ≠ callback-target attribution; no-calling-session (no edge); same-branch callback target (no edge); same-branch genealogy parent + cross-branch callback target (no edge).
- `pnpm check` (typecheck, lint, shortid/multitenancy/filesystem/realtime boundary checks, build): green. Daemon session/callback/archive suites pass.

## Not included / follow-ups

- **Backfill** of pre-fix remote children is intentionally out of scope (confirmed with operator).
- **Archived-branch filtering** is unchanged: completed remote children whose branches were archived remain filtered from the tree by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
