### PR TITLE
fix(executor): bound Claude getContextUsage so Tasks always settle

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/bounded-await.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/bounded-await.test.ts
@@ -18,6 +18,22 @@ describe('awaitWithTimeout', () => {
     }
   });
 
+  it('propagates an ordinary rejection unchanged when it settles before the deadline', async () => {
+    const boom = new Error('boom');
+    await expect(awaitWithTimeout(Promise.reject(boom), 1_000)).rejects.toBe(boom);
+  });
+
+  it('clears the safety timer once the promise settles first', async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(awaitWithTimeout(Promise.resolve('ok'), 15_000)).resolves.toBe('ok');
+      // The timer must be cleared in `finally`, not left pending to fire later.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not raise an unhandled rejection when the losing promise rejects late', async () => {
     vi.useFakeTimers();
     const rejection = vi.fn();

--- a/packages/executor/src/sdk-handlers/claude/bounded-await.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/bounded-await.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AWAIT_TIMEOUT, awaitWithTimeout } from './bounded-await.js';
+
+describe('awaitWithTimeout', () => {
+  it('resolves with the value when the promise settles in time', async () => {
+    await expect(awaitWithTimeout(Promise.resolve('ok'), 1_000)).resolves.toBe('ok');
+  });
+
+  it('resolves to the timeout sentinel when the promise never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = new Promise<string>(() => {}); // never settles
+      const raced = awaitWithTimeout(pending, 15_000);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(raced).resolves.toBe(AWAIT_TIMEOUT);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not raise an unhandled rejection when the losing promise rejects late', async () => {
+    vi.useFakeTimers();
+    const rejection = vi.fn();
+    process.on('unhandledRejection', rejection);
+    try {
+      let reject!: (error: Error) => void;
+      const pending = new Promise<string>((_, r) => {
+        reject = r;
+      });
+      const raced = awaitWithTimeout(pending, 10);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await raced).toBe(AWAIT_TIMEOUT);
+      // Transport closes after we already timed out and rejects the orphan.
+      reject(new Error('transport closed'));
+      await Promise.resolve();
+    } finally {
+      process.off('unhandledRejection', rejection);
+      vi.useRealTimers();
+    }
+    expect(rejection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/bounded-await.ts
+++ b/packages/executor/src/sdk-handlers/claude/bounded-await.ts
@@ -1,0 +1,42 @@
+/**
+ * Bounded await for Claude Agent SDK control requests.
+ *
+ * Control requests (e.g. `getContextUsage()`) are answered by the CLI
+ * subprocess over stdin/stdout and the SDK resolves them ONLY when a matching
+ * `control_response` arrives — there is no built-in timeout. On the terminal
+ * result path we deliberately hold the input stream open so the control request
+ * can use stdin, which means a subprocess that never answers leaves the await
+ * pending forever, the query generator never closes, and the Task never settles.
+ *
+ * `awaitWithTimeout` races the control request against a bounded timer so the
+ * lifecycle can always converge: the caller gets the real value when the
+ * subprocess answers in time, or the `AWAIT_TIMEOUT` sentinel so it can degrade
+ * gracefully and finish settling the turn.
+ */
+
+/** Sentinel resolved when the awaited promise does not settle within the budget. */
+export const AWAIT_TIMEOUT = Symbol('await-timeout');
+
+export async function awaitWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T | typeof AWAIT_TIMEOUT> {
+  // The losing promise stays pending (or rejects later when the transport
+  // closes). Attach a no-op catch so a late rejection can't surface as an
+  // unhandledRejection after we've already moved on.
+  promise.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof AWAIT_TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(AWAIT_TIMEOUT), timeoutMs);
+        // Never let the safety timer keep the process alive on its own.
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -179,6 +179,41 @@ describe('ClaudePromptService background task query lifetime', () => {
     expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
   });
 
+  it('settles the terminal turn even when getContextUsage never responds', async () => {
+    vi.useFakeTimers();
+    try {
+      const query = fakeQuery([sdkResult('terminal-result')]);
+      // Reproduce the production hang: the control request is issued (stdin is
+      // held open for it) but the subprocess never answers it.
+      query.getContextUsage.mockReturnValue(new Promise(() => {}));
+      vi.mocked(setupQuery).mockResolvedValue({
+        query: query as never,
+        resolvedModel: 'claude-sonnet-4-6',
+        getStderr: () => '',
+      });
+
+      const events: Array<{ type: string }> = [];
+      const drained = (async () => {
+        for await (const event of service().promptSessionStreaming(sessionId, 'prompt')) {
+          events.push(event);
+        }
+      })();
+
+      // Advance past the bounded getContextUsage budget; without the timeout the
+      // generator would never break out of its for-await loop.
+      await vi.advanceTimersByTimeAsync(ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS + 10);
+      await drained;
+
+      expect(events.filter((event) => event.type === 'result')).toHaveLength(1);
+      // No context snapshot is yielded when the request times out.
+      expect(events.filter((event) => event.type === 'context_usage')).toHaveLength(0);
+      // Input is still released so the subprocess can close stdin and exit.
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('releases input and balances watchdog activity when cancellation interrupts a task', async () => {
     const query = fakeQuery(async function* () {
       yield {

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -22,6 +22,7 @@ import type { SessionID, TaskID } from '../../types.js';
 import { MessageRole } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
 import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
+import { AWAIT_TIMEOUT, awaitWithTimeout } from './bounded-await.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
 import { aggregateClaudeResults } from './result-aggregation.js';
@@ -51,6 +52,18 @@ export interface PromptResult {
 export class ClaudePromptService {
   /** Enable token-level streaming from Claude Agent SDK */
   private static readonly ENABLE_TOKEN_STREAMING = true;
+
+  /**
+   * Upper bound on the terminal-result `getContextUsage()` control request.
+   *
+   * This is a fast local round-trip to the CLI subprocess (normally answered in
+   * milliseconds). The SDK gives it no timeout of its own, so when a subprocess
+   * fails to answer after the final `result` — while we are holding stdin open
+   * for exactly this request — the await would otherwise never settle and the
+   * Task would stay `running` forever. 15s is far beyond any healthy response
+   * yet still bounds the hang; on timeout we settle the turn without a context
+   * snapshot rather than wedge the query. */
+  static readonly CONTEXT_USAGE_TIMEOUT_MS = 15_000;
 
   /** Serialize permission checks per session to prevent duplicate prompts for concurrent tool calls */
   private permissionLocks = new Map<SessionID, Promise<void>>();
@@ -282,8 +295,19 @@ If you continue to see authentication errors, please contact your Agor administr
             } else {
               event.raw_sdk_message = aggregateClaudeResults(sdkResults);
               try {
-                const contextUsage = await result.getContextUsage();
-                yield { type: 'context_usage', contextUsage } as ProcessedEvent;
+                // Bounded: a subprocess that never answers this control request
+                // must not wedge the query generator open (Task stuck running).
+                const contextUsage = await awaitWithTimeout(
+                  result.getContextUsage(),
+                  ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS
+                );
+                if (contextUsage === AWAIT_TIMEOUT) {
+                  console.warn(
+                    `⚠️  getContextUsage() did not respond within ${ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS}ms; settling turn without a context snapshot`
+                  );
+                } else {
+                  yield { type: 'context_usage', contextUsage } as ProcessedEvent;
+                }
               } catch (error) {
                 console.warn(
                   `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`


### PR DESCRIPTION
## Summary

A Claude Task could deliver its **final assistant message and then stay `running` forever**. This fixes that hang at its root.

On the terminal-result path, `promptSessionStreaming` awaits `result.getContextUsage()` — a **control request** answered by the Claude CLI subprocess — *before* releasing stdin, yielding the result, or breaking its `for await` loop:

- The Agent SDK gives that control request **no timeout**: its internal `request()` resolves only when a matching `control_response` arrives and rejects only when the transport closes (verified against `@anthropic-ai/claude-agent-sdk@0.3.197`).
- Agor **deliberately holds stdin open** for exactly this request (defers `releaseInput()`).

So when the subprocess never answers, the `await` stays pending forever → the query generator never closes → the base executor's `for await` never returns → **the Task is never settled**. The executor keeps heartbeating while idle, so the UI shows it "running" indefinitely.

This is Claude-specific: only the Claude handler issues `getContextUsage()`.

## Production evidence

Session `019ffd92` (**Dev-Env Watchtower**, 2026-08-14):

| Signal | Value |
|---|---|
| Final assistant message | index 158, "Run complete. Summary…" @ **00:24:30** |
| Last executor pulse | `progress` / **`result`** @ **00:24:39**, then silence |
| `last_executor_heartbeat_at` | **07:03:12** (process alive 6.5h later) |
| Task status | still `running` |
| Background tasks / subagents | **none in the run** → rules out the `await-background-tasks` lifecycle |

## Regression window

The unbounded `await result.getContextUsage()` on the terminal path was introduced in **#1966** and survived the **#2057** background-task-lifecycle restructure (which added the `await-background-tasks` branch but kept the unbounded await in the `else`).

## Fix

New `bounded-await.ts` (`awaitWithTimeout`) races the control request against an `unref`'d timer (`CONTEXT_USAGE_TIMEOUT_MS = 15_000`), clears it on the winner, and swallows any late rejection. The terminal-result branch now uses it:

- **Answers in time** → yield `context_usage` as before.
- **Times out** → log once, settle the turn **without** a context snapshot.

`releaseInput()` still runs in `finally`, so the query always converges and the Task settles. No arbitrary success on timeout, and legitimate background agents are untouched.

## Before / after

```
BEFORE:  result(success) → await getContextUsage() ──✗ never answers──▶ ∞
         (releaseInput NOT called, no `end`, Task never settles, executor idle-but-alive)

AFTER:   result(success) → awaitWithTimeout(getContextUsage(), 15s)
              ├─ answers → yield context_usage
              └─ 15s     → warn, skip snapshot
         → releaseInput() → yield result → end → break → Task settles
```

## Tests

- `bounded-await.test.ts` — resolves-in-time, timeout sentinel, no unhandled-rejection on late reject.
- `prompt-service.background-tasks.test.ts` — regression: a never-responding `getContextUsage()` still yields exactly one `result`, **zero** `context_usage`, and calls `releaseInput()` once (fake timers advance past the budget).

## Validation

- `pnpm check` — ✅ typecheck, lint, boundary checks, all 15 build tasks
- `pnpm --filter @agor/executor` Claude lifecycle tests — ✅ **23 passed** (4 files)

## Residual (follow-up, not in this PR)

The `await-background-tasks` path can also hang if a background task never emits a terminal `task_notification`/`task_updated`, because the SDK watchdog is fully disabled while `activeToolCount > 0` (`sdk-watchdog.ts`). Not touched here — a bounded recovery there must avoid killing legitimate long-running background agents, and no production case matched it. `TERMINAL_TASK_STATUSES` also omits `'killed'` (valid for `task_updated.patch.status`); harmless today, worth reconciling with that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
