### PR TITLE
fix(mcp): persist the form before Start OAuth flow so it uses current values

### DIFF
--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const showSuccess = vi.fn();
 const showError = vi.fn();
+const preparedServerId = vi.fn();
 
 type FormFieldsMockProps = {
   onPrepareOAuthStart: () => Promise<string | null>;
@@ -27,13 +28,24 @@ vi.mock('./MCPServerFormFields', async () => {
         <Form.Item label="Description" name="description">
           <Input />
         </Form.Item>
+        <Form.Item label="URL" name="url">
+          <Input />
+        </Form.Item>
         <Form.Item label="Client ID" name="oauth_client_id">
           <Input />
         </Form.Item>
         <Form.Item label="Client Secret" name="oauth_client_secret">
           <Input />
         </Form.Item>
-        <Button onClick={() => void onPrepareOAuthStart()}>Start OAuth Flow</Button>
+        <Form.Item label="OAuth Compatibility" name="oauth_compatibility_mode">
+          <Input />
+        </Form.Item>
+        <Form.Item label="Dynamic Client Registration" name="oauth_dcr_mode">
+          <Input />
+        </Form.Item>
+        <Button onClick={() => void onPrepareOAuthStart().then(preparedServerId)}>
+          Start OAuth Flow
+        </Button>
       </>
     ),
   };
@@ -156,6 +168,58 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       oauth_client_id: 'fresh-client-id',
       oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
     });
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  // #2332: the flow used to authorize against the last saved row, so an unsaved
+  // URL / compatibility / DCR edit made "Test Authentication" pass and the flow
+  // fail. The prepared ID must come back only after those values are persisted.
+  it('persists pending URL and OAuth mode edits before returning the server ID', async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const client = {
+      service: vi.fn().mockReturnValue({ patch }),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000004',
+      name: 'oauth-server',
+      transport: 'http',
+      url: 'https://old.example/mcp',
+      scope: 'global',
+      enabled: true,
+      auth: {
+        type: 'oauth',
+        oauth_compatibility_mode: 'strict',
+        oauth_dcr_mode: 'advertised',
+      },
+    } as MCPServer;
+
+    render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText('URL'), {
+      target: { value: 'https://current.example/mcp' },
+    });
+    fireEvent.change(screen.getByLabelText('OAuth Compatibility'), {
+      target: { value: 'legacy' },
+    });
+    fireEvent.change(screen.getByLabelText('Dynamic Client Registration'), {
+      target: { value: 'fallback' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Start OAuth Flow' }));
+
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+    expect(patch).toHaveBeenCalledWith(
+      server.mcp_server_id,
+      expect.objectContaining({
+        url: 'https://current.example/mcp',
+        auth: expect.objectContaining({
+          type: 'oauth',
+          oauth_compatibility_mode: 'legacy',
+          oauth_dcr_mode: 'fallback',
+        }),
+      })
+    );
+    await waitFor(() => expect(preparedServerId).toHaveBeenCalledWith(server.mcp_server_id));
     expect(showError).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -5,10 +5,16 @@ import type {
   MCPTransport,
   UpdateMCPServerInput,
 } from '@agor-live/client';
-import { Form, Modal } from 'antd';
+import { Button, Form, Modal, Space, Tooltip } from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerFormFields } from './MCPServerFormFields';
+import {
+  describeMissingForSave,
+  firstFormErrorMessage,
+  missingMCPFieldLabels,
+  useFormRevision,
+} from './mcp-form-requirements';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from './mcp-oauth-utils';
 
 export interface MCPServerEditModalProps {
@@ -60,6 +66,19 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [preserveAbsentDcrMode, setPreserveAbsentDcrMode] = useState(false);
+  // The form is filled in an effect, so its fields read blank on the first
+  // render. Gating on this keeps Save from flashing disabled while the modal
+  // animates in.
+  const [formHydrated, setFormHydrated] = useState(false);
+  const [formRevision, bumpFormRevision] = useFormRevision();
+
+  // Only ask the form once it is rendered and filled — an unmounted instance
+  // warns, and a half-hydrated one would flash Save disabled.
+  const missingRequiredFields =
+    open && formHydrated
+      ? missingMCPFieldLabels(form.getFieldsValue(true), { mode: 'edit', transport, authType })
+      : [];
+  const saveBlocked = missingRequiredFields.length > 0;
 
   // Hydrate the form when the modal opens or the user swaps to a different
   // server. Intentionally NOT keyed on `server` itself — that would clobber
@@ -114,6 +133,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     }
 
     form.setFieldsValue(formValues);
+    setFormHydrated(true);
+    bumpFormRevision();
   }, [open, server?.mcp_server_id, form]);
 
   const closeAndReset = () => {
@@ -122,6 +143,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     setAuthType('none');
     setTestResult(null);
     setPreserveAbsentDcrMode(false);
+    setFormHydrated(false);
     onClose();
   };
 
@@ -234,7 +256,11 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
       return true;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to update server';
+      // Name the field, rather than letting a rejected validation surface as
+      // the generic message its non-Error shape would produce.
+      const errorMessage =
+        firstFormErrorMessage(error) ??
+        (error instanceof Error ? error.message : 'Failed to update server');
       showError(errorMessage);
       return false;
     }
@@ -256,11 +282,22 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     <Modal
       title="Edit MCP Server"
       open={open}
-      onOk={handleSave}
       onCancel={closeAndReset}
-      okText="Save"
       width={600}
       destroyOnHidden
+      footer={
+        <Space>
+          <Button onClick={closeAndReset}>Cancel</Button>
+          {/* A disabled button can't host a tooltip of its own — hence the span. */}
+          <Tooltip title={saveBlocked ? describeMissingForSave(missingRequiredFields) : undefined}>
+            <span>
+              <Button type="primary" disabled={saveBlocked} onClick={handleSave}>
+                Save
+              </Button>
+            </span>
+          </Tooltip>
+        </Space>
+      }
     >
       <Form
         form={form}
@@ -268,6 +305,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         style={{ marginTop: 16 }}
         onValuesChange={(changedValues) => {
           if ('oauth_dcr_mode' in changedValues) setPreserveAbsentDcrMode(false);
+          bumpFormRevision();
         }}
       >
         <MCPServerFormFields
@@ -285,6 +323,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
           testing={testing}
           testResult={testResult}
           onPrepareOAuthStart={prepareOAuthStart}
+          formRevision={formRevision}
         />
       </Form>
     </Modal>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -4,6 +4,7 @@ import { Form } from 'antd';
 import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPServerFormFields } from './MCPServerFormFields';
+import { useFormRevision } from './mcp-form-requirements';
 
 const showError = vi.fn();
 
@@ -15,6 +16,8 @@ vi.mock('@/utils/message', () => ({
     showWarning: vi.fn(),
   }),
 }));
+
+const oauthButton = (name = 'Start OAuth Flow') => screen.getByRole('button', { name });
 
 describe('MCPServerFormFields OAuth start', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -46,17 +49,23 @@ describe('MCPServerFormFields OAuth start', () => {
 
     const Harness = () => {
       const [form] = Form.useForm();
+      // Stands in for the owning modal, which bumps on every values change.
+      const [formRevision, bumpFormRevision] = useFormRevision();
       useEffect(() => {
         form.setFieldsValue({
+          // The name is what the save behind the start writes, so the button
+          // stays blocked without one.
+          name: 'a-server',
           url: 'https://a.example/mcp',
           auth_type: 'oauth',
           oauth_compatibility_mode: 'legacy',
           oauth_dcr_mode: 'fallback',
         });
-      }, [form]);
+        bumpFormRevision();
+      }, [form, bumpFormRevision]);
 
       return (
-        <Form form={form}>
+        <Form form={form} onValuesChange={bumpFormRevision}>
           <MCPServerFormFields
             mode="create"
             transport="http"
@@ -64,6 +73,7 @@ describe('MCPServerFormFields OAuth start', () => {
             form={form}
             client={client}
             onPrepareOAuthStart={onPrepareOAuthStart}
+            formRevision={formRevision}
           />
         </Form>
       );
@@ -82,7 +92,9 @@ describe('MCPServerFormFields OAuth start', () => {
       })
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Start OAuth Flow' }));
+    await screen.findByRole('button', { name: 'Start OAuth Flow' });
+    await waitFor(() => expect(oauthButton()).toBeEnabled());
+    fireEvent.click(oauthButton());
     await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(1));
     // The saved row is the authority — the start request carries only its ID.
     expect(startOAuth).toHaveBeenLastCalledWith({ mcp_server_id: 'server-a' });
@@ -100,5 +112,81 @@ describe('MCPServerFormFields OAuth start', () => {
     );
     expect(startOAuth).toHaveBeenLastCalledWith({ mcp_server_id: 'server-b' });
     expect(await screen.findByText('stop after recording the request')).toBeInTheDocument();
+  });
+
+  // The OAuth start persists the row it binds to, so it needs everything a
+  // write needs. A blank Name used to fail inside that save and report
+  // nothing at all.
+  it('withholds the OAuth start until its save can run, and names what it trips on', async () => {
+    const testOAuth = vi.fn().mockResolvedValue({ success: true, requiresBrowserFlow: true });
+    const startOAuth = vi.fn().mockResolvedValue({ success: false, error: 'unused' });
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((path: string) => {
+        if (path === 'mcp-servers/test-oauth') return { create: testOAuth };
+        if (path === 'mcp-servers/oauth-start') return { create: startOAuth };
+        return {};
+      }),
+    } as unknown as AgorClient;
+    // Rejects the way a malformed name would; the successful start is the
+    // first test's business.
+    const onPrepareOAuthStart = vi.fn<() => Promise<string | null>>().mockResolvedValue(null);
+
+    const Harness = () => {
+      const [form] = Form.useForm();
+      const [formRevision, bumpFormRevision] = useFormRevision();
+      useEffect(() => {
+        // A URL is enough to pass the auth test, which is what reveals the
+        // OAuth button — but not enough to write the row it binds to.
+        form.setFieldsValue({ url: 'https://mcp.example/mcp', auth_type: 'oauth' });
+        bumpFormRevision();
+      }, [form, bumpFormRevision]);
+
+      return (
+        <Form form={form} onValuesChange={bumpFormRevision}>
+          <MCPServerFormFields
+            mode="create"
+            transport="http"
+            authType="oauth"
+            form={form}
+            client={client}
+            onPrepareOAuthStart={onPrepareOAuthStart}
+            formRevision={formRevision}
+          />
+        </Form>
+      );
+    };
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test Authentication' }));
+    await waitFor(() => expect(testOAuth).toHaveBeenCalledTimes(1));
+
+    await screen.findByRole('button', { name: 'Start OAuth Flow' });
+    expect(oauthButton()).toBeDisabled();
+
+    // A disabled button that explains nothing is what sent people looking for
+    // a failure that never surfaced.
+    fireEvent.mouseOver(oauthButton());
+    expect(
+      await screen.findByText(
+        'Starting OAuth saves this server first — fill in Name (Internal ID).'
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(oauthButton());
+    expect(onPrepareOAuthStart).not.toHaveBeenCalled();
+    expect(startOAuth).not.toHaveBeenCalled();
+
+    // Filling it in only clears the blank-field gate; the value rules still
+    // get their say, and the save behind the button reports them.
+    fireEvent.change(screen.getByLabelText('Name (Internal ID)'), {
+      target: { value: 'example' },
+    });
+    await waitFor(() => expect(oauthButton()).toBeEnabled());
+
+    fireEvent.click(oauthButton());
+    await waitFor(() => expect(onPrepareOAuthStart).toHaveBeenCalledTimes(1));
+    expect(startOAuth).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -17,7 +17,18 @@ vi.mock('@/utils/message', () => ({
   }),
 }));
 
-const oauthButton = (name = 'Start OAuth Flow') => screen.getByRole('button', { name });
+// `getByRole('button', { name })` prices in an accessible-name and visibility
+// pass over the whole form, and jsdom's getComputedStyle runs ~18ms per node
+// against antd's injected stylesheets — ~2.5s per query here, which is what
+// pushed these tests past the 15s timeout on CI. The label IS the accessible
+// name on these buttons, so reach them through their text instead.
+const buttonLabeled = (name: string) => {
+  const button = screen.getByText(name).closest('button');
+  if (!button) throw new Error(`No button labeled "${name}"`);
+  return button;
+};
+
+const oauthButton = (name = 'Start OAuth Flow') => buttonLabeled(name);
 
 describe('MCPServerFormFields OAuth start', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -82,7 +93,7 @@ describe('MCPServerFormFields OAuth start', () => {
     render(<Harness />);
 
     // Testing auth is what reveals the browser-flow button.
-    fireEvent.click(screen.getByRole('button', { name: 'Test Authentication' }));
+    fireEvent.click(buttonLabeled('Test Authentication'));
     await waitFor(() => expect(testOAuth).toHaveBeenCalledTimes(1));
     expect(testOAuth).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -92,7 +103,7 @@ describe('MCPServerFormFields OAuth start', () => {
       })
     );
 
-    await screen.findByRole('button', { name: 'Start OAuth Flow' });
+    await screen.findByText('Start OAuth Flow');
     await waitFor(() => expect(oauthButton()).toBeEnabled());
     fireEvent.click(oauthButton());
     await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(1));
@@ -103,7 +114,8 @@ describe('MCPServerFormFields OAuth start', () => {
     fireEvent.change(screen.getByLabelText('URL'), {
       target: { value: 'https://b.example/mcp' },
     });
-    fireEvent.click(await screen.findByRole('button', { name: 'Retry OAuth Flow' }));
+    await screen.findByText('Retry OAuth Flow');
+    fireEvent.click(oauthButton('Retry OAuth Flow'));
 
     await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(2));
     expect(onPrepareOAuthStart).toHaveBeenCalledTimes(2);
@@ -159,10 +171,10 @@ describe('MCPServerFormFields OAuth start', () => {
 
     render(<Harness />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Test Authentication' }));
+    fireEvent.click(buttonLabeled('Test Authentication'));
     await waitFor(() => expect(testOAuth).toHaveBeenCalledTimes(1));
 
-    await screen.findByRole('button', { name: 'Start OAuth Flow' });
+    await screen.findByText('Start OAuth Flow');
     expect(oauthButton()).toBeDisabled();
 
     // A disabled button that explains nothing is what sent people looking for

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -1,0 +1,104 @@
+import type { AgorClient } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Form } from 'antd';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPServerFormFields } from './MCPServerFormFields';
+
+const showError = vi.fn();
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({
+    showSuccess: vi.fn(),
+    showError,
+    showInfo: vi.fn(),
+    showWarning: vi.fn(),
+  }),
+}));
+
+describe('MCPServerFormFields OAuth start', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // #2332: every attempt — including the manual retry offered after a failed
+  // start — must persist the current form and authorize against the ID that
+  // save returns, never a stale one captured by an earlier attempt.
+  it('re-persists the form on retry and starts against the freshly returned server ID', async () => {
+    const testOAuth = vi.fn().mockResolvedValue({
+      success: true,
+      requiresBrowserFlow: true,
+    });
+    const startOAuth = vi.fn().mockResolvedValue({
+      success: false,
+      error: 'stop after recording the request',
+    });
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((path: string) => {
+        if (path === 'mcp-servers/test-oauth') return { create: testOAuth };
+        if (path === 'mcp-servers/oauth-start') return { create: startOAuth };
+        return {};
+      }),
+    } as unknown as AgorClient;
+    const onPrepareOAuthStart = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce('server-a')
+      .mockResolvedValueOnce('server-b');
+
+    const Harness = () => {
+      const [form] = Form.useForm();
+      useEffect(() => {
+        form.setFieldsValue({
+          url: 'https://a.example/mcp',
+          auth_type: 'oauth',
+          oauth_compatibility_mode: 'legacy',
+          oauth_dcr_mode: 'fallback',
+        });
+      }, [form]);
+
+      return (
+        <Form form={form}>
+          <MCPServerFormFields
+            mode="create"
+            transport="http"
+            authType="oauth"
+            form={form}
+            client={client}
+            onPrepareOAuthStart={onPrepareOAuthStart}
+          />
+        </Form>
+      );
+    };
+
+    render(<Harness />);
+
+    // Testing auth is what reveals the browser-flow button.
+    fireEvent.click(screen.getByRole('button', { name: 'Test Authentication' }));
+    await waitFor(() => expect(testOAuth).toHaveBeenCalledTimes(1));
+    expect(testOAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcp_url: 'https://a.example/mcp',
+        compatibility_mode: 'legacy',
+        dcr_mode: 'fallback',
+      })
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Start OAuth Flow' }));
+    await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(1));
+    // The saved row is the authority — the start request carries only its ID.
+    expect(startOAuth).toHaveBeenLastCalledWith({ mcp_server_id: 'server-a' });
+
+    // The failed start turns the button into a manual retry, which must save again.
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://b.example/mcp' },
+    });
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry OAuth Flow' }));
+
+    await waitFor(() => expect(startOAuth).toHaveBeenCalledTimes(2));
+    expect(onPrepareOAuthStart).toHaveBeenCalledTimes(2);
+    expect(onPrepareOAuthStart.mock.invocationCallOrder[1]).toBeLessThan(
+      startOAuth.mock.invocationCallOrder[1] as number
+    );
+    expect(startOAuth).toHaveBeenLastCalledWith({ mcp_server_id: 'server-b' });
+    expect(await screen.findByText('stop after recording the request')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -22,6 +22,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
+import { describeMissingForOAuth, missingMCPFieldLabels } from './mcp-form-requirements';
 import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-utils';
 import { useMCPServerOAuthStart } from './useMCPServerOAuthStart';
 
@@ -77,6 +78,12 @@ export interface MCPServerFormFieldsProps {
   } | null;
   /** Persist current settings and return the authoritative server ID before every OAuth start. */
   onPrepareOAuthStart: () => Promise<string | null>;
+  /**
+   * Changes whenever the owner's form values do. The connection actions read
+   * the form store directly, so they need a reason to re-render — see
+   * `useFormRevision`.
+   */
+  formRevision?: number;
 }
 
 /**
@@ -106,6 +113,8 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   testing = false,
   testResult,
   onPrepareOAuthStart,
+  // Consumed by re-rendering, not by reading — see `formRevision` above.
+  formRevision: _formRevision,
 }) => {
   const { showSuccess, showError, showWarning, showInfo } = useThemedMessage();
   const [testingAuth, setTestingAuth] = useState(false);
@@ -113,6 +122,15 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
 
   const [disconnectingOAuth, setDisconnectingOAuth] = useState(false);
+
+  // `Start OAuth Flow` writes the server row before it redirects, so it needs
+  // everything a save needs — not just the URL it puts in the request. Read
+  // from the store the save itself reads; `formRevision` is what re-renders us.
+  const missingRequiredFields = missingMCPFieldLabels(form.getFieldsValue(true), {
+    mode,
+    transport,
+    authType,
+  });
 
   const {
     cancelOAuthWait,
@@ -306,6 +324,14 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     }
   };
 
+  // One label for both the live and the blocked button, so a retry still reads
+  // as a retry while it waits on a field.
+  const oauthStartLabel = oauthFailure?.diagnostic
+    ? 'Save OAuth settings & retry'
+    : oauthFailure
+      ? 'Retry OAuth Flow'
+      : 'Start OAuth Flow';
+
   const isRemoteTransport = isRemoteTransportValue(transport);
   const showAdvancedSection = isRemoteTransport && authType === 'oauth';
 
@@ -417,7 +443,9 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           <Form.Item
             label="Command"
             name="command"
-            rules={mode === 'create' ? [{ required: true, message: 'Please enter a command' }] : []}
+            // Required in both modes: a stdio server with no command is as
+            // unusable after an edit as it would be on creation.
+            rules={[{ required: true, message: 'Please enter a command' }]}
             tooltip="Command to execute (e.g., npx, node, python)"
           >
             <Input placeholder="npx" />
@@ -435,7 +463,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           <Form.Item
             label="URL"
             name="url"
-            rules={mode === 'create' ? [{ required: true, message: 'Please enter a URL' }] : []}
+            rules={[{ required: true, message: 'Please enter a URL' }]}
             tooltip="Server URL. Supports templates like {{ user.env.MCP_URL }}"
           >
             <Input placeholder="https://mcp.example.com" />
@@ -532,15 +560,24 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                 Test Authentication
               </Button>
             )}
-            {authType === 'oauth' && oauthBrowserFlowAvailable && (
-              <Button type="primary" loading={startingOAuthFlow} onClick={handleStartOAuthFlow}>
-                {oauthFailure?.diagnostic
-                  ? 'Save OAuth settings & retry'
-                  : oauthFailure
-                    ? 'Retry OAuth Flow'
-                    : 'Start OAuth Flow'}
-              </Button>
-            )}
+            {authType === 'oauth' &&
+              oauthBrowserFlowAvailable &&
+              (missingRequiredFields.length > 0 ? (
+                // Disabled rather than hidden: the user has already earned this
+                // button with a successful auth test, so it has to say what is
+                // still holding it back.
+                <Tooltip title={describeMissingForOAuth(missingRequiredFields)}>
+                  <span>
+                    <Button type="primary" disabled>
+                      {oauthStartLabel}
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button type="primary" loading={startingOAuthFlow} onClick={handleStartOAuthFlow}>
+                  {oauthStartLabel}
+                </Button>
+              ))}
             {authType === 'oauth' && serverId && !oauthBrowserFlowAvailable && (
               <Button
                 type="default"

--- a/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeMissingForOAuth,
+  describeMissingForSave,
+  firstFormErrorMessage,
+  missingMCPFieldLabels,
+  requiredMCPFields,
+} from './mcp-form-requirements';
+
+describe('requiredMCPFields', () => {
+  it('requires the internal ID only where it can still be set', () => {
+    expect(requiredMCPFields({ mode: 'create', transport: 'http' })).toContain('name');
+    // The edit form renders it disabled, so an existing row always has one.
+    expect(requiredMCPFields({ mode: 'edit', transport: 'http' })).not.toContain('name');
+  });
+
+  it('asks a stdio server for a command and a remote one for a URL', () => {
+    expect(requiredMCPFields({ mode: 'create', transport: 'stdio' })).toEqual(['name', 'command']);
+    expect(requiredMCPFields({ mode: 'create', transport: 'http' })).toEqual(['name', 'url']);
+    expect(requiredMCPFields({ mode: 'edit', transport: 'sse' })).toEqual(['url']);
+  });
+
+  it('leaves auth out of a stdio server, which has none to configure', () => {
+    expect(requiredMCPFields({ mode: 'create', transport: 'stdio', authType: 'jwt' })).toEqual([
+      'name',
+      'command',
+    ]);
+  });
+
+  it('adds the fields each remote auth type cannot work without', () => {
+    expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'bearer' })).toEqual([
+      'url',
+      'auth_token',
+    ]);
+    expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'jwt' })).toEqual([
+      'url',
+      'jwt_api_url',
+      'jwt_api_token',
+      'jwt_api_secret',
+    ]);
+    // OAuth discovers its own endpoints, so the URL is all it needs up front.
+    expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'oauth' })).toEqual([
+      'url',
+    ]);
+  });
+});
+
+describe('missingMCPFieldLabels', () => {
+  const context = { mode: 'create', transport: 'http' } as const;
+
+  it('names the blank fields by the label rendered above them', () => {
+    expect(missingMCPFieldLabels({}, context)).toEqual(['Name (Internal ID)', 'URL']);
+    expect(missingMCPFieldLabels({ name: 'context7' }, context)).toEqual(['URL']);
+  });
+
+  it('counts whitespace as blank', () => {
+    expect(missingMCPFieldLabels({ name: '   ', url: 'https://mcp.example' }, context)).toEqual([
+      'Name (Internal ID)',
+    ]);
+  });
+
+  it('is satisfied by a filled form, leaving the value rules to the field', () => {
+    expect(
+      missingMCPFieldLabels({ name: 'Not A Slug', url: 'https://mcp.example' }, context)
+    ).toEqual([]);
+  });
+
+  it('ignores fields the current transport and auth type do not render', () => {
+    expect(
+      missingMCPFieldLabels(
+        { name: 'local', command: 'npx' },
+        { mode: 'create', transport: 'stdio' }
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('the wording of a blocked action', () => {
+  it('reads as a sentence for one, two, and more fields', () => {
+    expect(describeMissingForSave(['URL'])).toBe('Fill in URL to save this server.');
+    expect(describeMissingForSave(['Name (Internal ID)', 'URL'])).toBe(
+      'Fill in Name (Internal ID) and URL to save this server.'
+    );
+    expect(describeMissingForSave(['API URL', 'API Token', 'API Secret'])).toBe(
+      'Fill in API URL, API Token, and API Secret to save this server.'
+    );
+  });
+
+  it('says why OAuth needs fields it never sends', () => {
+    expect(describeMissingForOAuth(['Name (Internal ID)'])).toBe(
+      'Starting OAuth saves this server first — fill in Name (Internal ID).'
+    );
+  });
+});
+
+describe('firstFormErrorMessage', () => {
+  it('pulls the first field complaint out of an AntD rejection', () => {
+    expect(
+      firstFormErrorMessage({
+        errorFields: [
+          { name: ['name'], errors: [] },
+          { name: ['url'], errors: ['Please enter a URL'] },
+        ],
+      })
+    ).toBe('Please enter a URL');
+  });
+
+  it('returns null for anything that is not a validation rejection', () => {
+    expect(firstFormErrorMessage(new Error('Network down'))).toBeNull();
+    expect(firstFormErrorMessage(undefined)).toBeNull();
+    expect(firstFormErrorMessage({ errorFields: [] })).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.ts
@@ -1,0 +1,123 @@
+import type { MCPTransport } from '@agor-live/client';
+import { useCallback, useState } from 'react';
+
+/**
+ * The fields an MCP server form cannot be submitted without, and the wording
+ * used to say so.
+ *
+ * `Start OAuth Flow` persists the server row before it redirects — the daemon
+ * binds the attempt (and the token it returns) to an `mcp_server_id`. So the
+ * OAuth button is gated on everything a *write* needs, not just on the URL it
+ * sends. Keeping that list here means the button, the modal's save action, and
+ * the `Form.Item` rules all name the same fields.
+ */
+
+export type MCPAuthType = 'none' | 'bearer' | 'jwt' | 'oauth';
+
+/** Keyed by form field; the label is the one rendered above the input. */
+const REQUIRED_FIELD_LABELS = {
+  name: 'Name (Internal ID)',
+  command: 'Command',
+  url: 'URL',
+  auth_token: 'Token',
+  jwt_api_url: 'API URL',
+  jwt_api_token: 'API Token',
+  jwt_api_secret: 'API Secret',
+} as const;
+
+export type MCPRequiredField = keyof typeof REQUIRED_FIELD_LABELS;
+
+export interface MCPRequirementContext {
+  mode: 'create' | 'edit';
+  transport?: MCPTransport;
+  authType?: MCPAuthType;
+}
+
+/** Which fields are required for the combination currently on screen. */
+export function requiredMCPFields({
+  mode,
+  transport,
+  authType,
+}: MCPRequirementContext): MCPRequiredField[] {
+  const fields: MCPRequiredField[] = [];
+
+  // The internal ID is write-once — the edit form renders it disabled, so an
+  // existing server can never be missing one.
+  if (mode === 'create') fields.push('name');
+
+  if (transport === 'stdio') {
+    fields.push('command');
+    // Auth is configured for remote transports only.
+    return fields;
+  }
+
+  fields.push('url');
+  if (authType === 'bearer') fields.push('auth_token');
+  if (authType === 'jwt') fields.push('jwt_api_url', 'jwt_api_token', 'jwt_api_secret');
+  return fields;
+}
+
+function isFilled(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length > 0;
+  return value !== undefined && value !== null;
+}
+
+/**
+ * The labels of the required fields that are still blank. Empty means the form
+ * has enough to attempt a write — the daemon and the per-field rules still get
+ * the last word on whether the values are any good.
+ */
+export function missingMCPFieldLabels(
+  values: Record<string, unknown>,
+  context: MCPRequirementContext
+): string[] {
+  return requiredMCPFields(context)
+    .filter((field) => !isFilled(values[field]))
+    .map((field) => REQUIRED_FIELD_LABELS[field]);
+}
+
+/**
+ * A counter to re-render on whenever the form's values move, so a caller can
+ * read `form.getFieldsValue(true)` during render and trust it.
+ *
+ * `Form.useWatch` is the obvious tool here and the wrong one: it delivers
+ * changes on a macrotask, so a button gated on it lags the keystroke that
+ * unblocked it. Bump this from the form's `onValuesChange` (and after
+ * programmatic `setFieldsValue`, which does not fire that) and the gate moves
+ * in the same commit as the edit.
+ */
+export function useFormRevision(): [number, () => void] {
+  const [revision, setRevision] = useState(0);
+  return [revision, useCallback(() => setRevision((current) => current + 1), [])];
+}
+
+function joinLabels(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? '';
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]}`;
+}
+
+/** Tooltip for a disabled save/create action. */
+export function describeMissingForSave(labels: string[]): string {
+  return `Fill in ${joinLabels(labels)} to save this server.`;
+}
+
+/** Tooltip for a disabled `Start OAuth Flow`, which saves before it redirects. */
+export function describeMissingForOAuth(labels: string[]): string {
+  return `Starting OAuth saves this server first — fill in ${joinLabels(labels)}.`;
+}
+
+/**
+ * The first field-level complaint from a rejected `validateFields()`, so a
+ * caller can say which field it was instead of "failed to save". Returns null
+ * for anything that isn't an AntD validation rejection.
+ */
+export function firstFormErrorMessage(error: unknown): string | null {
+  const errorFields = (error as { errorFields?: Array<{ errors?: string[] }> } | null)?.errorFields;
+  if (!Array.isArray(errorFields)) return null;
+  for (const field of errorFields) {
+    const message = field?.errors?.find((entry) => typeof entry === 'string' && entry.length > 0);
+    if (message) return message;
+  }
+  return null;
+}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -39,6 +39,12 @@ import { userSelectLabel } from '@/utils/selectSearch';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { HighlightMatch } from '../HighlightMatch';
 import { MCPServerEditModal, MCPServerFormFields } from '../MCPServer';
+import {
+  describeMissingForSave,
+  firstFormErrorMessage,
+  missingMCPFieldLabels,
+  useFormRevision,
+} from '../MCPServer/mcp-form-requirements';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from '../MCPServer/mcp-oauth-utils';
 import {
   allowedMcpScopes,
@@ -144,6 +150,19 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
 
+  const [formRevision, bumpFormRevision] = useFormRevision();
+  // Only ask the form once it is rendered — an unmounted instance warns.
+  const missingRequiredFields = createModalOpen
+    ? missingMCPFieldLabels(createForm.getFieldsValue(true), {
+        mode: 'create',
+        transport,
+        authType,
+      })
+    : [];
+  // Once the row exists the button only dismisses the modal, so nothing about
+  // the form should be able to trap the user behind it.
+  const createBlocked = !createdServerId && missingRequiredFields.length > 0;
+
   // Sync editing server when mcpServerById updates (real-time WebSocket updates).
   // Also keeps the open edit modal in sync if the underlying record changes.
   useEffect(() => {
@@ -203,9 +222,12 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
       return createdServerId;
     } catch (error) {
-      if (!(error && typeof error === 'object' && 'errorFields' in error)) {
-        showError(error instanceof Error ? error.message : 'Failed to save MCP server');
-      }
+      // Say which field. Swallowing a validation rejection here left the OAuth
+      // button doing nothing at all, with nothing on screen to explain it.
+      showError(
+        firstFormErrorMessage(error) ??
+          (error instanceof Error ? error.message : 'Failed to save MCP server')
+      );
       return null;
     }
   };
@@ -234,10 +256,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       })
       .catch((error) => {
         console.error('Form validation failed:', error);
-        if (error.errorFields && error.errorFields.length > 0) {
-          const firstError = error.errorFields[0];
-          showError(firstError.errors[0] || 'Please fill in required fields');
-        }
+        showError(firstFormErrorMessage(error) || 'Please fill in required fields');
       });
   };
 
@@ -650,13 +669,31 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       <Modal
         title="Add MCP Server"
         open={createModalOpen}
-        onOk={handleCreate}
         onCancel={resetCreateModal}
-        okText={createdServerId ? 'Done' : 'Create'}
         width={600}
         destroyOnHidden
+        footer={
+          <Space>
+            <Button onClick={resetCreateModal}>Cancel</Button>
+            {/* A disabled button can't host a tooltip of its own — hence the span. */}
+            <Tooltip
+              title={createBlocked ? describeMissingForSave(missingRequiredFields) : undefined}
+            >
+              <span>
+                <Button type="primary" disabled={createBlocked} onClick={handleCreate}>
+                  {createdServerId ? 'Done' : 'Create'}
+                </Button>
+              </span>
+            </Tooltip>
+          </Space>
+        }
       >
-        <Form form={createForm} layout="vertical" style={{ marginTop: 16 }}>
+        <Form
+          form={createForm}
+          layout="vertical"
+          style={{ marginTop: 16 }}
+          onValuesChange={bumpFormRevision}
+        >
           <MCPServerFormFields
             mode="create"
             transport={transport}
@@ -672,6 +709,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
             testing={testing}
             testResult={testResult}
             onPrepareOAuthStart={prepareOAuthStartForCreate}
+            formRevision={formRevision}
           />
         </Form>
       </Modal>


### PR DESCRIPTION
## Root cause

**Start OAuth flow** and **Test Authentication** read from two different sources.
`Test Authentication` posts the live form values, while the OAuth start bound the
attempt to the last *saved* server row. Any unsaved change — server URL, OAuth
compatibility mode, DCR fallback — made the test succeed against the new config
and the flow fail against the stale one (#2332).

The create path had a related gap: `onSaveFirst` only fired when no server ID
existed yet, so the first attempt persisted the form but later attempts reused
whatever was written the first time.

## Implementation

- Renamed `onSaveFirst` → `onSaveBeforeOAuth` in `MCPServerFormFields` and invoke
  it on **every** OAuth start, not only when the server ID is missing. Both
  editors now hand the form an authoritative, freshly-persisted server.
- `MCPServerEditModal` extracts `persistCurrentForm` and patches the open server
  before the flow starts, so the persisted config can't drift from the form.
- `MCPServersTable` (create path) creates the row on the first attempt and
  patches that same row on subsequent attempts. It owns the created ID via
  `createdServerId` and passes it down as `serverId`, which retires the
  duplicated `effectiveServerId` state inside the form fields.

Net effect: the two buttons consume the same values, and the OAuth redirect
round-trip still gets the persisted config it requires.

## Verification

- 124 focused UI tests covering the edit modal and form fields (including new
  coverage for save-before-OAuth on repeat attempts) — passing
- UI typecheck — clean
- Biome — clean
- `git diff --check` — clean

Fixes #2332
