### PR TITLE
test(marketplace): wait for catalog cards by label, not by role

### DIFF
--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -94,6 +94,33 @@ function renderTab({ connected = true }: { connected?: boolean } = {}) {
   );
 }
 
+/**
+ * A card, found by the label its accessible name is computed from.
+ *
+ * `*ByRole` resolves a role for every element in the tree and calls
+ * `getComputedStyle` on each to decide whether it is exposed. Against the
+ * ~340KB of CSS antd injects into jsdom that is 300-700ms over a freshly
+ * mounted subtree, and `findBy` allows 1000ms in total — so two polls exhaust
+ * the wait even though the card has been in the DOM since ~60ms, and the
+ * assertion turns on how loaded the runner is rather than on the component.
+ * `aria-label` is the attribute that name is computed from, and costs ~3ms.
+ *
+ * The role itself is asserted in `renders a card per entry`, once, off the
+ * polling path.
+ */
+const findCard = (title: string) => screen.findByLabelText(`Open ${title}`);
+const queryCard = (title: string) => screen.queryByLabelText(`Open ${title}`);
+
+/**
+ * The open drawer. The disclosure is the one block it always renders, so it is
+ * the cheap thing to wait on; the `dialog` role is then resolved once rather
+ * than on every poll.
+ */
+async function findDrawer() {
+  await screen.findByText('What this can access');
+  return within(screen.getByRole('dialog'));
+}
+
 beforeEach(() => {
   catalogQueries = [];
   catalogRows = [DEEPWIKI, LINEAR];
@@ -112,7 +139,11 @@ beforeEach(() => {
 describe('catalog browsing', () => {
   it('renders a card per entry', async () => {
     renderTab();
-    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    await findCard('DeepWiki');
+    // The one place the role itself is the claim, so the one place that pays
+    // for resolving it — and off the polling path, where the cost is a single
+    // query rather than one per attempt.
+    expect(screen.getByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Open Linear' })).toBeInTheDocument();
   });
 
@@ -163,7 +194,7 @@ describe('catalog browsing', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(await findCard('DeepWiki')).toBeInTheDocument();
   });
 
   it('renders a failed read as a failure, not as an empty catalog', async () => {
@@ -183,7 +214,7 @@ describe('catalog browsing', () => {
     catalogFindError = null;
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
-    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(await findCard('DeepWiki')).toBeInTheDocument();
     expect(screen.queryByText('Could not load the catalog')).not.toBeInTheDocument();
   });
 
@@ -202,7 +233,7 @@ describe('catalog browsing', () => {
 
   it('still blames the filters when the filters are to blame', async () => {
     renderTab();
-    await screen.findByRole('button', { name: 'Open DeepWiki' });
+    await findCard('DeepWiki');
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search MCP servers' }), {
       target: { value: 'nothing-matches-this' },
@@ -220,12 +251,12 @@ describe('catalog browsing', () => {
     catalogRows = [DEEPWIKI, LINEAR];
     fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
 
-    expect(await screen.findByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(await findCard('DeepWiki')).toBeInTheDocument();
   });
 
   it('pushes filters and page bounds to the server rather than filtering in the browser', async () => {
     renderTab();
-    await screen.findByRole('button', { name: 'Open DeepWiki' });
+    await findCard('DeepWiki');
 
     const listQuery = catalogQueries.find((query) => query.$limit === 24);
     expect(listQuery).toMatchObject({ sort: 'popularity', $limit: 24, $skip: 0 });
@@ -233,7 +264,7 @@ describe('catalog browsing', () => {
 
   it('hides the match count until something is actually filtering (REQ-CAT-3)', async () => {
     renderTab();
-    await screen.findByRole('button', { name: 'Open DeepWiki' });
+    await findCard('DeepWiki');
     expect(screen.queryByText(/servers match/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('switch', { name: /Reviewed by Preset/i }));
@@ -250,12 +281,12 @@ describe('catalog browsing', () => {
       { ...LINEAR, probed_auth_type: 'unknown' },
     ];
     renderTab();
-    await screen.findByRole('button', { name: 'Open DeepWiki' });
+    await findCard('DeepWiki');
 
     fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
 
     expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    expect(queryCard('DeepWiki')).toBeInTheDocument();
     expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
   });
 
@@ -265,14 +296,12 @@ describe('catalog browsing', () => {
       { ...LINEAR, probed_auth_type: 'oauth' },
     ];
     renderTab();
-    await screen.findByRole('button', { name: 'Open Linear' });
+    await findCard('Linear');
 
     fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
 
-    await waitFor(() =>
-      expect(screen.queryByRole('button', { name: 'Open Linear' })).not.toBeInTheDocument()
-    );
-    expect(screen.getByRole('button', { name: 'Open DeepWiki' })).toBeInTheDocument();
+    await waitFor(() => expect(queryCard('Linear')).not.toBeInTheDocument());
+    expect(queryCard('DeepWiki')).toBeInTheDocument();
     expect(catalogQueries.at(-1)?.probed_auth_types).toEqual(['none', 'unknown']);
   });
 
@@ -280,7 +309,7 @@ describe('catalog browsing', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       renderTab();
-      await screen.findByRole('button', { name: 'Open DeepWiki' });
+      await findCard('DeepWiki');
       const before = catalogQueries.length;
 
       const input = screen.getByRole('textbox', { name: 'Search MCP servers' });
@@ -301,8 +330,8 @@ describe('catalog browsing', () => {
 describe('connect', () => {
   async function openDrawer() {
     renderTab();
-    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
-    return within(await screen.findByRole('dialog'));
+    fireEvent.click(await findCard('DeepWiki'));
+    return findDrawer();
   }
 
   it('shows the access disclosure expanded and blocks connect until it is acknowledged', async () => {
@@ -327,8 +356,8 @@ describe('connect', () => {
   it('offers no connect control for an entry that discloses nothing', async () => {
     catalogRows = [{ ...DEEPWIKI, permission_disclosure: '' }];
     renderTab();
-    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
-    const drawer = within(await screen.findByRole('dialog'));
+    fireEvent.click(await findCard('DeepWiki'));
+    const drawer = await findDrawer();
 
     expect(drawer.getByText(/has not stated what it can access/)).toBeVisible();
     expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
@@ -336,10 +365,11 @@ describe('connect', () => {
 
   it('connects by catalog key alone and lands in the new session with the prompt loaded', async () => {
     const drawer = await openDrawer();
+    const connect = drawer.getByRole('button', { name: /Connect/ });
     fireEvent.click(drawer.getByRole('checkbox'));
-    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
+    await waitFor(() => expect(connect).toBeEnabled());
 
-    fireEvent.click(drawer.getByRole('button', { name: /Connect/ }));
+    fireEvent.click(connect);
 
     await waitFor(() => expect(connectCalls).toHaveLength(1));
     expect(connectCalls[0]).toEqual({
@@ -362,10 +392,11 @@ describe('connect', () => {
       throw new Error('DeepWiki requires authentication, which is not supported yet');
     };
     const drawer = await openDrawer();
+    const connect = drawer.getByRole('button', { name: /Connect/ });
     fireEvent.click(drawer.getByRole('checkbox'));
-    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
+    await waitFor(() => expect(connect).toBeEnabled());
 
-    fireEvent.click(drawer.getByRole('button', { name: /Connect/ }));
+    fireEvent.click(connect);
 
     expect(await drawer.findByText(/requires authentication/)).toBeVisible();
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -374,8 +405,8 @@ describe('connect', () => {
   it('offers no connect control for an entry that has not been reviewed', async () => {
     catalogRows = [{ ...DEEPWIKI, curated: false }];
     renderTab();
-    fireEvent.click(await screen.findByRole('button', { name: 'Open DeepWiki' }));
-    const drawer = within(await screen.findByRole('dialog'));
+    fireEvent.click(await findCard('DeepWiki'));
+    const drawer = await findDrawer();
 
     expect(drawer.getByText(/Only servers reviewed by Preset/)).toBeVisible();
     expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();


### PR DESCRIPTION
## Linked issue

Refs the intermittent `main` failures in `CatalogTab.test.tsx`, e.g. https://github.com/preset-io/agor/actions/runs/31777039113

## Summary

- Wait for catalog cards by `aria-label` (`findByLabelText('Open DeepWiki')`) instead of `findByRole('button', { name })`.
- Keep the role assertion in `renders a card per entry` — once, off the polling path — so nothing is lost.
- Give the sibling waits the same treatment: the drawer's `findByRole('dialog')`, the `waitFor` asserting a card's absence, and the two `waitFor`s that re-queried the Connect button on every attempt.
- No component change.

## Why / context

**This is category 2: the assertion was waiting on work the test doesn't care about.** Not category 1 — the component does no avoidable async work before first paint (measured below). Not category 3 — the wait isn't too short for the *component's* work; it's too short for the *query's*.

`*ByRole` resolves a role for every element in the tree and calls `getComputedStyle` on each to decide whether it is exposed. Ant Design injects ~340KB of CSS into jsdom, which makes that walk cost **300–700ms over a freshly mounted subtree** — and `findBy` allows 1000ms in total. Two polls exhaust the wait, so the assertion turns on how loaded the runner is rather than on the component. That is why a re-run of the same SHA passes.

Measured in an instrumented copy of the test (4 cores, otherwise idle), per test:

| step | cost |
| --- | --- |
| `render()` returns → card present in the DOM | **49–84ms** |
| first `getByRole('button', { name: 'Open DeepWiki' })` | **327–721ms** |
| second, identical `getByRole` (jsdom style cache warm) | 13–29ms |
| `getByLabelText('Open DeepWiki')` | **2–8ms** |
| `getByText('DeepWiki')` | 2–7ms |

So the card is on screen after ~60ms and the wait spends the remaining ~940ms re-running an accessibility computation. On an idle 16-core box the whole `findByRole` measured 655ms, 961ms and **1020ms** across three runs of the same assertion — already at and over the budget before CI load enters the picture.

The stated hypothesis — that `CatalogToolbar`'s 250ms search debounce sits in front of the first fetch — **is not the cause**, and the instrumentation kills it: the first `mcp-catalog` read is issued *during* mount (`firstQueryAt` ≈ end of `render()`), because `filters.search` starts as `''` and `useCatalogSearch`'s effect keys on the destructured primitive. The debounce's mount-time publish of `''` re-renders `CatalogTab` and re-fetches nothing. The two effects don't race either: only the entry query touches `requestSeq`, and no dep changes between mount and first response.

## Implementation notes

`aria-label` is the attribute `findByRole`'s `name` was computed from, so the label query targets the same element by the same string; the role is still asserted, in the one test whose subject it is. The two `waitFor`s around the Connect button now hold the element in a `const` (as the third already did) rather than re-querying by role on every attempt — React keeps that DOM node across the enable/disable re-render they're waiting on.

The drawer wait uses `findByText('What this can access')`, the one block `CatalogDetailDrawer` renders unconditionally, and then resolves `getByRole('dialog')` once.

## Validation / test plan

**Reproduction, before the fix.** The named test file, pinned to one core with three competing CPU burners on that same core:

```
for i in 1 2 3; do timeout 400 taskset -c 12 bash -c 'while :; do :; done' & done
taskset -c 12 npx vitest run src/components/Marketplace/CatalogTab.test.tsx
```

2 of 4 runs failed with the exact CI error:

```
× catalog browsing > loads once the socket connects, without a remount 1765ms
  → Unable to find role="button" and name "Open DeepWiki"
```

**After the fix**, the same command: 3 of 3 runs green (19/19 each). The file also got faster — `loads once the socket connects` 816ms → 171ms, `drops servers known to need an account` 1767ms → 649ms, whole file 23.4s → 8.9s of test time.

- [x] `pnpm turbo run typecheck` — 22 tasks, all pass
- [x] `npx biome check .` — 2296 files, 0 errors (5 pre-existing infos)
- [x] `npx vitest run` in `apps/agor-ui` — **203 files, 1440 tests, all pass**
- [x] Codex correctness review of the diff — no defects

## Risks / rollout / rollback

Test-only. No runtime code changed.

## Out of scope / follow-ups

The same `findByRole`-in-a-polling-loop pattern is likely to be marginal in other antd-heavy component tests; this PR only fixes the file that is failing. A repo-wide sweep, or a shared `findByLabel`-style helper, would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
