### PR TITLE
feat(markdown): download authenticated branch files

### DIFF
--- a/apps/agor-daemon/src/services/file.integration.test.ts
+++ b/apps/agor-daemon/src/services/file.integration.test.ts
@@ -13,7 +13,7 @@
  * Express + Feathers app and issues a genuine HTTP GET to prove the fix
  * (`resolveRestFilePath` in ./file.ts) actually closes the gap.
  */
-import { feathers, feathersExpress, rest } from '@agor/core/feathers';
+import { errorHandler, feathers, feathersExpress, rest } from '@agor/core/feathers';
 import type { HookContext } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
@@ -33,6 +33,56 @@ vi.mock('../utils/spawn-executor.js', () => ({
   getDaemonUrl: vi.fn(() => 'http://daemon.test'),
   runExecutorCommand: vi.fn(),
 }));
+
+/**
+ * Boots a real Express + Feathers app with the real FileService, mirroring
+ * the daemon's actual 'file' registration: RBAC/tenant identity via the
+ * TENANT_IDENTITY_ONLY_SERVICE_PATHS around hook, a stand-in for the
+ * requireAuth hook that normally populates params.user, and the daemon's
+ * real errorHandler() (see register-routes.ts) — without it, every thrown
+ * error (including a deliberate BadRequest) falls through to Express's
+ * generic 500 handler instead of the status code the error actually carries.
+ */
+async function startFileServiceApp() {
+  const service = new FileService(
+    { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
+    { run: vi.fn() } as never,
+    { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
+  );
+
+  const app = feathersExpress(feathers());
+  app.configure(rest());
+  app.use('/file', service);
+  app.service('file').hooks({
+    around: {
+      all: [
+        createTenantDatabaseScopeAroundHook({
+          db: {} as never,
+          config: {} as never,
+          jwtSecret: 'test-secret',
+          transaction: false,
+        }),
+      ],
+    },
+    before: {
+      all: [
+        (context: HookContext) => {
+          context.params.user = {
+            user_id: 'user-1',
+            email: 'member@example.com',
+            role: 'member',
+          };
+          return context;
+        },
+      ],
+    },
+  });
+  (app as any).use(errorHandler());
+
+  const server = await app.listen(0);
+  const { port } = server.address() as { port: number };
+  return { server, port };
+}
 
 describe('GET /file/:path over the real REST transport', () => {
   beforeEach(() => {
@@ -58,45 +108,7 @@ describe('GET /file/:path over the real REST transport', () => {
       },
     });
 
-    const service = new FileService(
-      { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
-      { run: vi.fn() } as never,
-      { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
-    );
-
-    // Mirrors the daemon's real registration for 'file': RBAC/tenant identity
-    // via an around hook (see register-hooks.ts TENANT_IDENTITY_ONLY_SERVICE_PATHS),
-    // plus a stand-in for the requireAuth hook that normally populates params.user.
-    const app = feathersExpress(feathers());
-    app.configure(rest());
-    app.use('/file', service);
-    app.service('file').hooks({
-      around: {
-        all: [
-          createTenantDatabaseScopeAroundHook({
-            db: {} as never,
-            config: {} as never,
-            jwtSecret: 'test-secret',
-            transaction: false,
-          }),
-        ],
-      },
-      before: {
-        all: [
-          (context: HookContext) => {
-            context.params.user = {
-              user_id: 'user-1',
-              email: 'member@example.com',
-              role: 'member',
-            };
-            return context;
-          },
-        ],
-      },
-    });
-
-    const server = await app.listen(0);
-    const { port } = server.address() as { port: number };
+    const { server, port } = await startFileServiceApp();
 
     try {
       const response = await fetch(
@@ -114,6 +126,21 @@ describe('GET /file/:path over the real REST transport', () => {
         expect.objectContaining({ params: expect.objectContaining({ filePath: nestedPath }) }),
         expect.anything()
       );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('returns a clean 400 for malformed percent-encoding instead of an uncaught 500, and never calls the executor', async () => {
+    const { server, port } = await startFileServiceApp();
+
+    try {
+      // '%c3%28' is not a valid UTF-8 percent-encoded sequence; decodeURIComponent
+      // throws a URIError on it. This must not surface as an unhandled 500.
+      const response = await fetch(`http://127.0.0.1:${port}/file/%c3%28?branch_id=branch-1`);
+
+      expect(response.status).toBe(400);
+      expect(runExecutorCommand).not.toHaveBeenCalled();
     } finally {
       await new Promise((resolve) => server.close(resolve));
     }

--- a/apps/agor-daemon/src/services/file.integration.test.ts
+++ b/apps/agor-daemon/src/services/file.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Actual-layer regression for a real HTTP 500 observed on nested branch-file
+ * paths (e.g. `qa-evidence/pr-ready/screenshot.png`).
+ *
+ * Root cause: `@feathersjs/rest-client` percent-encodes the id
+ * (`encodeURIComponent(id)`), but `@feathersjs/transport-commons`'s Router
+ * splits the request path on literal `/` *before* any decoding — so a
+ * nested id's encoded slash reaches `FileService.get()` completely
+ * undecoded (`qa-evidence%2Fpr-ready%2Fscreenshot.png`), and the executor
+ * then fails to find a file literally named with percent-encoded slashes.
+ * Unit tests that call `service.get(id, params)` directly bypass this
+ * transport layer entirely and cannot catch it — this test boots a real
+ * Express + Feathers app and issues a genuine HTTP GET to prove the fix
+ * (`resolveRestFilePath` in ./file.ts) actually closes the gap.
+ */
+import { feathers, feathersExpress, rest } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runExecutorCommand } from '../utils/spawn-executor.js';
+import { createTenantDatabaseScopeAroundHook } from '../utils/tenant-db-scope.js';
+import { FileService } from './file.js';
+
+const impersonationMocks = vi.hoisted(() => ({
+  resolveExecutorReadAsUser: vi.fn(),
+}));
+
+vi.mock('../utils/executor-read-impersonation.js', () => ({
+  resolveExecutorReadAsUser: impersonationMocks.resolveExecutorReadAsUser,
+}));
+
+vi.mock('../utils/spawn-executor.js', () => ({
+  generateScopedServiceToken: vi.fn(() => 'service-token'),
+  getDaemonUrl: vi.fn(() => 'http://daemon.test'),
+  runExecutorCommand: vi.fn(),
+}));
+
+describe('GET /file/:path over the real REST transport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    impersonationMocks.resolveExecutorReadAsUser.mockResolvedValue(undefined);
+  });
+
+  it('retrieves a nested evidence path instead of 500ing on its percent-encoded slash', async () => {
+    const nestedPath = 'qa-evidence/pr-ready/screenshot.png';
+    vi.mocked(runExecutorCommand).mockResolvedValue({
+      success: true,
+      data: {
+        file: {
+          path: nestedPath,
+          title: 'screenshot.png',
+          size: 3,
+          lastModified: '2026-07-30T00:00:00.000Z',
+          isText: false,
+          mimeType: 'image/png',
+          content: 'AAEC',
+          encoding: 'base64',
+        },
+      },
+    });
+
+    const service = new FileService(
+      { findById: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) } as never,
+      { run: vi.fn() } as never,
+      { get: () => ({}), settings: { authentication: { secret: 'test' } } } as never
+    );
+
+    // Mirrors the daemon's real registration for 'file': RBAC/tenant identity
+    // via an around hook (see register-hooks.ts TENANT_IDENTITY_ONLY_SERVICE_PATHS),
+    // plus a stand-in for the requireAuth hook that normally populates params.user.
+    const app = feathersExpress(feathers());
+    app.configure(rest());
+    app.use('/file', service);
+    app.service('file').hooks({
+      around: {
+        all: [
+          createTenantDatabaseScopeAroundHook({
+            db: {} as never,
+            config: {} as never,
+            jwtSecret: 'test-secret',
+            transaction: false,
+          }),
+        ],
+      },
+      before: {
+        all: [
+          (context: HookContext) => {
+            context.params.user = {
+              user_id: 'user-1',
+              email: 'member@example.com',
+              role: 'member',
+            };
+            return context;
+          },
+        ],
+      },
+    });
+
+    const server = await app.listen(0);
+    const { port } = server.address() as { port: number };
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/file/${encodeURIComponent(nestedPath)}?branch_id=branch-1`
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        path: nestedPath,
+        encoding: 'base64',
+      });
+      // Proves the executor received the real nested path, not the raw
+      // percent-encoded id the transport handed the service.
+      expect(runExecutorCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ params: expect.objectContaining({ filePath: nestedPath }) }),
+        expect.anything()
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -1,4 +1,5 @@
 import { getCurrentTenantDatabaseScope, runWithTenantContext } from '@agor/core/db';
+import { BadRequest } from '@agor/core/feathers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
 import { FileService, resolveRestFilePath } from './file.js';
@@ -20,6 +21,17 @@ describe('resolveRestFilePath', () => {
 
   it('round-trips a root-level filename with no path separators', () => {
     expect(resolveRestFilePath('README.md', { provider: 'rest' } as never)).toBe('README.md');
+  });
+
+  it('raises a clean BadRequest instead of an uncaught URIError on malformed REST percent-encoding', () => {
+    expect(() => resolveRestFilePath('%c3%28', { provider: 'rest' } as never)).toThrow(BadRequest);
+    expect(() => resolveRestFilePath('%', { provider: 'rest' } as never)).toThrow(BadRequest);
+  });
+
+  it('never throws for malformed percent-sequences arriving over a non-REST provider', () => {
+    // Socket.IO/internal callers never percent-encode, so a literal '%c3%28'
+    // filename is passed through untouched rather than rejected.
+    expect(resolveRestFilePath('%c3%28', { provider: 'socketio' } as never)).toBe('%c3%28');
   });
 });
 

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -1,7 +1,27 @@
 import { getCurrentTenantDatabaseScope, runWithTenantContext } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { runExecutorCommand } from '../utils/spawn-executor.js';
-import { FileService } from './file.js';
+import { FileService, resolveRestFilePath } from './file.js';
+
+describe('resolveRestFilePath', () => {
+  it('decodes a REST-provided id, recovering a nested path from its encoded slash', () => {
+    const encoded = encodeURIComponent('qa-evidence/pr-ready/screenshot.png');
+    expect(resolveRestFilePath(encoded, { provider: 'rest' } as never)).toBe(
+      'qa-evidence/pr-ready/screenshot.png'
+    );
+  });
+
+  it('leaves a non-REST id untouched, since only REST clients percent-encode it', () => {
+    // Socket.IO (and internal/no-provider) calls pass the plain path directly —
+    // decoding here would wrongly mangle a real "%" in a filename.
+    expect(resolveRestFilePath('100%.txt', { provider: 'socketio' } as never)).toBe('100%.txt');
+    expect(resolveRestFilePath('100%.txt', undefined)).toBe('100%.txt');
+  });
+
+  it('round-trips a root-level filename with no path separators', () => {
+    expect(resolveRestFilePath('README.md', { provider: 'rest' } as never)).toBe('README.md');
+  });
+});
 
 const impersonationMocks = vi.hoisted(() => ({
   resolveExecutorReadAsUser: vi.fn(),

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -7,7 +7,7 @@ import {
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import type { Application } from '@agor/core/feathers';
+import { type Application, BadRequest } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   FileDetail,
@@ -49,10 +49,20 @@ function extractFile(data: unknown): FileDetail | null {
  * executor then 404s on a file literally named with a percent-encoded
  * slash. Socket.IO calls pass `id` as a plain value with no such encoding,
  * so only decode when the request actually came in over REST.
+ *
+ * `decodeURIComponent` throws a `URIError` on malformed percent-encoding
+ * (e.g. a lone `%` or an invalid escape like `%c3%28`) — an attacker- or
+ * client-controlled input reaching an authenticated request, not a server
+ * bug, so it's translated into a clean 400 instead of an uncaught 500.
  */
 export function resolveRestFilePath(id: Id, params?: FileParams): string {
   const raw = id.toString();
-  return params?.provider === 'rest' ? decodeURIComponent(raw) : raw;
+  if (params?.provider !== 'rest') return raw;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw new BadRequest('Invalid file path encoding');
+  }
 }
 
 export class FileService

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -40,6 +40,21 @@ function extractFile(data: unknown): FileDetail | null {
   return file && typeof file === 'object' ? (file as FileDetail) : null;
 }
 
+/**
+ * REST clients percent-encode the id (`@feathersjs/rest-client`:
+ * `encodeURIComponent(id)`), but the REST transport's route matcher
+ * (`@feathersjs/transport-commons` Router) splits the request path on
+ * literal `/` before any decoding happens — so a nested id's encoded slash
+ * (`evidence%2Fscreenshot.png`) reaches the service unchanged, and the
+ * executor then 404s on a file literally named with a percent-encoded
+ * slash. Socket.IO calls pass `id` as a plain value with no such encoding,
+ * so only decode when the request actually came in over REST.
+ */
+export function resolveRestFilePath(id: Id, params?: FileParams): string {
+  const raw = id.toString();
+  return params?.provider === 'rest' ? decodeURIComponent(raw) : raw;
+}
+
 export class FileService
   implements Pick<ServiceMethods<FileListItem | FileDetail>, 'find' | 'get' | 'setup' | 'teardown'>
 {
@@ -71,7 +86,7 @@ export class FileService
     const resolved = await this.resolveBranchRead(branchId, params);
 
     const result = await this.runCommand('branch.files.read', resolved.branchId, resolved.asUser, {
-      filePath: id.toString(),
+      filePath: resolveRestFilePath(id, params),
     });
     if (!result.success) {
       throw new Error(`Failed to read file: ${result.error?.message ?? 'unknown executor error'}`);

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/plugin/noHardcodedColorLiteral: distinctive ConfigProvider tokens verify fullscreen portal theme inheritance
 import { readFileSync } from 'node:fs';
+import { buildBranchFileMarkdownLink } from '@agor/core/types';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -188,6 +189,113 @@ describe('MarkdownRenderer', () => {
     expect(anchorClick).toHaveBeenCalledOnce();
     expect(clickedAnchor?.download).toBe('screenshot.png');
     expect(screen.getByRole('button', { name: 'Download screenshot.png' })).toBeInTheDocument();
+
+    anchorClick.mockRestore();
+  });
+
+  it('renders a parenthesized, Unicode evidence filename from buildBranchFileMarkdownLink as an authenticated download control', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          path: 'qa-evidence/before (final) résumé.webm',
+          title: 'before (final) résumé.webm',
+          size: 3,
+          lastModified: new Date(0).toISOString(),
+          isText: false,
+          mimeType: 'video/webm',
+          content: 'AAEC',
+          encoding: 'base64',
+        }),
+        { status: 200 }
+      )
+    );
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      clickedAnchor = this;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal(
+      'URL',
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => 'blob:branch-file-preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    );
+
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+      typeof buildBranchFileMarkdownLink
+    >[0];
+    const filename = 'before (final) résumé.webm';
+    // Uses the real builder, not a hand-typed link — proving the renderer's
+    // grammar actually agrees with what buildBranchFileMarkdownLink emits.
+    const markdownLink = buildBranchFileMarkdownLink(branchId, `qa-evidence/${filename}`);
+
+    render(<MarkdownRenderer content={markdownLink} />);
+
+    // Must become the authenticated control (a button), not a dead ordinary
+    // link — the original bug this regression covers.
+    expect(screen.queryByRole('link', { name: filename })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: filename }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(anchorClick).toHaveBeenCalledOnce();
+    expect(clickedAnchor?.download).toBe(filename);
+
+    anchorClick.mockRestore();
+  });
+
+  it('escapes an adversarial label instead of injecting attributes or elements into generated markup', async () => {
+    const adversarialFilename = 'img" onmouseover="alert(1)<b>x</b>&';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          path: 'evidence/shot.png',
+          title: 'shot.png',
+          size: 3,
+          lastModified: new Date(0).toISOString(),
+          isText: false,
+          mimeType: 'image/png',
+          content: 'AAEC',
+          encoding: 'base64',
+        }),
+        { status: 200 }
+      )
+    );
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      clickedAnchor = this;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal(
+      'URL',
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => 'blob:branch-file-preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    );
+
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f';
+    const { container } = render(
+      <MarkdownRenderer
+        content={`[${adversarialFilename}](https://agor.live/_branch-files/${branchId}/evidence%2Fshot.png)`}
+      />
+    );
+
+    // The label's quote/angle-bracket/ampersand characters must not break
+    // out of the generated `filename="..."` attribute: no injected
+    // attribute or real <b> element should reach the DOM.
+    expect(container.querySelector('[onmouseover]')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('b')).toHaveLength(0);
+
+    // The HTML parser still decodes the escaped entities back to the
+    // literal label, so the control renders with the real filename.
+    fireEvent.click(await screen.findByRole('button', { name: adversarialFilename }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(anchorClick).toHaveBeenCalledOnce();
+    expect(clickedAnchor?.download).toBe(adversarialFilename);
 
     anchorClick.mockRestore();
   });

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -140,7 +140,7 @@ describe('MarkdownRenderer', () => {
     anchorClick.mockRestore();
   });
 
-  it('renders internal branch-file links as authenticated preview and download actions', async () => {
+  it('downloads on the primary branch-file link click (one-click download, not preview)', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -156,7 +156,12 @@ describe('MarkdownRenderer', () => {
         { status: 200 }
       )
     );
-    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      clickedAnchor = this;
+    });
     vi.stubGlobal('fetch', fetchMock);
     vi.stubGlobal(
       'URL',
@@ -173,12 +178,15 @@ describe('MarkdownRenderer', () => {
       />
     );
 
+    // The primary labeled link — not the adjacent "Download" icon — must
+    // download directly, matching the one-click acceptance for QA evidence.
     fireEvent.click(await screen.findByRole('button', { name: 'screenshot.png' }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
     expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
       new RegExp(`/file/evidence%2Fscreenshot\\.png\\?branch_id=${branchId}$`)
     );
     expect(anchorClick).toHaveBeenCalledOnce();
+    expect(clickedAnchor?.download).toBe('screenshot.png');
     expect(screen.getByRole('button', { name: 'Download screenshot.png' })).toBeInTheDocument();
 
     anchorClick.mockRestore();

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -140,6 +140,71 @@ describe('MarkdownRenderer', () => {
     anchorClick.mockRestore();
   });
 
+  it('renders internal branch-file links as authenticated preview and download actions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          path: 'evidence/screenshot.png',
+          title: 'screenshot.png',
+          size: 3,
+          lastModified: new Date(0).toISOString(),
+          isText: false,
+          mimeType: 'image/png',
+          content: 'AAEC',
+          encoding: 'base64',
+        }),
+        { status: 200 }
+      )
+    );
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal(
+      'URL',
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => 'blob:branch-file-preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    );
+
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f';
+    render(
+      <MarkdownRenderer
+        content={`[screenshot.png](https://agor.live/_branch-files/${branchId}/evidence%2Fscreenshot.png)`}
+      />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'screenshot.png' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(String(fetchMock.mock.calls[0]?.[0])).toMatch(
+      new RegExp(`/file/evidence%2Fscreenshot\\.png\\?branch_id=${branchId}$`)
+    );
+    expect(anchorClick).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Download screenshot.png' })).toBeInTheDocument();
+
+    anchorClick.mockRestore();
+  });
+
+  it('falls back to an ordinary link for a malformed branch-file URL instead of a privileged download', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MarkdownRenderer
+        content={'[evil](https://agor.live/_branch-files/not-a-branch-id/etc%2Fpasswd)'}
+      />
+    );
+
+    // The branch id fails BRANCH_ID_PATTERN, so the rewrite never fires and
+    // Streamdown parses it as an ordinary external link — never a fetch.
+    const link = await screen.findByRole('link', { name: 'evil' });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://agor.live/_branch-files/not-a-branch-id/etc%2Fpasswd'
+    );
+    expect(screen.queryByRole('button', { name: 'evil' })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('adds stable ids and self-links when heading anchors are enabled', async () => {
     const { container } = render(<MarkdownRenderer content={'## Foo\n\n## Foo!'} headingAnchors />);
 

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -300,6 +300,61 @@ describe('MarkdownRenderer', () => {
     anchorClick.mockRestore();
   });
 
+  it('renders a bracketed evidence filename from buildBranchFileMarkdownLink as an authenticated download control', async () => {
+    const filename = 'screenshot [draft].png';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          path: `qa-evidence/${filename}`,
+          title: filename,
+          size: 3,
+          lastModified: new Date(0).toISOString(),
+          isText: false,
+          mimeType: 'image/png',
+          content: 'AAEC',
+          encoding: 'base64',
+        }),
+        { status: 200 }
+      )
+    );
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement
+    ) {
+      clickedAnchor = this;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal(
+      'URL',
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => 'blob:branch-file-preview'),
+        revokeObjectURL: vi.fn(),
+      })
+    );
+
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+      typeof buildBranchFileMarkdownLink
+    >[0];
+    // Uses the real builder, not a hand-typed link — proves the label's '['
+    // and ']' survive buildBranchFileMarkdownLink's backslash-escaping and
+    // MarkdownRenderer's matching label grammar, instead of the label's own
+    // ']' prematurely closing the Markdown link boundary.
+    const markdownLink = buildBranchFileMarkdownLink(branchId, `qa-evidence/${filename}`);
+
+    render(<MarkdownRenderer content={markdownLink} />);
+
+    // Must become the authenticated control (a button) with the literal,
+    // unescaped filename — not a dead ordinary link, and not the raw
+    // backslash-escaped label text.
+    expect(screen.queryByRole('link', { name: filename })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: filename }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(anchorClick).toHaveBeenCalledOnce();
+    expect(clickedAnchor?.download).toBe(filename);
+
+    anchorClick.mockRestore();
+  });
+
   it('falls back to an ordinary link for a malformed branch-file URL instead of a privileged download', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -314,14 +314,22 @@ const INTERNAL_BRANCH_FILE_MARKDOWN_LINK = new RegExp(
   'g'
 );
 
-/** Shared preview/download controls for authenticated virtual-link attachments. */
+/**
+ * Shared preview/download controls for authenticated virtual-link
+ * attachments. `primaryAction` controls what clicking the labeled link
+ * itself does — uploads preview first (existing behavior); branch files
+ * download first, matching the one-click "click the link to download"
+ * acceptance for QA evidence. The adjacent icon button always downloads.
+ */
 function AttachmentControls({
   filename,
   fetchBlob,
+  primaryAction,
   children,
 }: {
   filename: string;
   fetchBlob: () => Promise<Blob>;
+  primaryAction: 'preview' | 'download';
   children: React.ReactNode;
 }) {
   const { showError } = useThemedMessage();
@@ -349,7 +357,7 @@ function AttachmentControls({
         size="small"
         icon={<PaperClipOutlined />}
         aria-label={filename}
-        onClick={() => void openAttachment(false)}
+        onClick={() => void openAttachment(primaryAction === 'download')}
         style={{ height: 'auto', paddingInline: 0 }}
       >
         {children}
@@ -386,7 +394,7 @@ function UploadAttachmentLink({
   };
 
   return (
-    <AttachmentControls filename={filename} fetchBlob={fetchBlob}>
+    <AttachmentControls filename={filename} fetchBlob={fetchBlob} primaryAction="preview">
       {children}
     </AttachmentControls>
   );
@@ -431,7 +439,7 @@ function BranchFileAttachmentLink({
   };
 
   return (
-    <AttachmentControls filename={filename} fetchBlob={fetchBlob}>
+    <AttachmentControls filename={filename} fetchBlob={fetchBlob} primaryAction="download">
       {children}
     </AttachmentControls>
   );

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -115,15 +115,20 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   text = highlightMentionsInMarkdown(text);
   // Convert Agor's authenticated virtual upload and branch-file links into
   // closed custom elements before Streamdown's external-link hardener runs.
+  // Every captured group is HTML-escaped before interpolation: these are
+  // hand-built HTML strings (not JSX), so an unescaped `"` in a filename
+  // could otherwise break out of the attribute and inject new attributes
+  // or elements. The HTML parser decodes the entities back to the original
+  // text, so components still receive the real filename via props.
   text = text.replace(
     INTERNAL_UPLOAD_MARKDOWN_LINK,
     (_, filename: string, uploadRef: string) =>
-      `<agor-upload upload_ref="${uploadRef}" filename="${filename}"></agor-upload>`
+      `<agor-upload upload_ref="${escapeHtmlAttribute(uploadRef)}" filename="${escapeHtmlAttribute(filename)}"></agor-upload>`
   );
   text = text.replace(
     INTERNAL_BRANCH_FILE_MARKDOWN_LINK,
     (_, filename: string, branchId: string, encodedPath: string) =>
-      `<agor-branch-file branch_id="${branchId}" path="${encodedPath}" filename="${filename}"></agor-branch-file>`
+      `<agor-branch-file branch_id="${escapeHtmlAttribute(branchId)}" path="${escapeHtmlAttribute(encodedPath)}" filename="${escapeHtmlAttribute(filename)}"></agor-branch-file>`
   );
 
   // Detect dark mode from Ant Design token system
@@ -288,6 +293,22 @@ function reactText(value: React.ReactNode): string {
     .join('');
 }
 
+/**
+ * Escapes a value for safe interpolation into a double-quoted HTML
+ * attribute inside a hand-built markup string (not JSX, so React's
+ * auto-escaping doesn't apply). The HTML parser decodes these entities
+ * back to the original text, so the receiving component still sees the
+ * real, unescaped value via props.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const UPLOAD_REF_PATTERN =
   'upl_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}';
 const ESCAPED_UPLOAD_VIRTUAL_URL_PREFIX = UPLOAD_VIRTUAL_URL_PREFIX.replace(
@@ -305,12 +326,20 @@ const BRANCH_ID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3
 // extra-escaped parens, so it never contains a literal ')' that could close
 // the Markdown link early.
 const BRANCH_FILE_PATH_PATTERN = "[A-Za-z0-9%._~!*'-]{1,2000}";
+// buildBranchFileMarkdownLink() emits the real filename as the link label —
+// unlike uploads' fixed ASCII-only charset, evidence filenames routinely
+// include parens and Unicode (e.g. "before (final).png", "résumé.webm"), so
+// this only excludes what would break Markdown's own `[...]` bracket syntax
+// (a literal `]`) or span lines. Every capture is HTML-escaped before this
+// is interpolated into generated markup (see escapeHtmlAttribute above), so
+// widening the charset here does not reopen attribute injection.
+const BRANCH_FILE_LABEL_PATTERN = '[^\\]\\n]{1,200}';
 const ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX = BRANCH_FILE_VIRTUAL_URL_PREFIX.replace(
   /[.*+?^${}()|[\]\\]/g,
   '\\$&'
 );
 const INTERNAL_BRANCH_FILE_MARKDOWN_LINK = new RegExp(
-  `\\[([A-Za-z0-9._ -]{1,200})\\]\\(${ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX}(${BRANCH_ID_PATTERN})\\/(${BRANCH_FILE_PATH_PATTERN})\\)`,
+  `\\[(${BRANCH_FILE_LABEL_PATTERN})\\]\\(${ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX}(${BRANCH_ID_PATTERN})\\/(${BRANCH_FILE_PATH_PATTERN})\\)`,
   'g'
 );
 

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -11,7 +11,12 @@
  * Typography wrapper provides consistent Ant Design styling.
  */
 
-import { UPLOAD_VIRTUAL_URL_PREFIX } from '@agor/core/types';
+import {
+  BRANCH_FILE_VIRTUAL_URL_PREFIX,
+  decodeBranchFilePath,
+  type FileDetail,
+  UPLOAD_VIRTUAL_URL_PREFIX,
+} from '@agor/core/types';
 import { DownloadOutlined, PaperClipOutlined } from '@ant-design/icons';
 import { Button, Tooltip, Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
@@ -108,12 +113,17 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
 
   // Pre-process text to highlight @ mentions
   text = highlightMentionsInMarkdown(text);
-  // Convert Agor's authenticated virtual upload links into a closed custom
-  // element before Streamdown's external-link hardener runs.
+  // Convert Agor's authenticated virtual upload and branch-file links into
+  // closed custom elements before Streamdown's external-link hardener runs.
   text = text.replace(
     INTERNAL_UPLOAD_MARKDOWN_LINK,
     (_, filename: string, uploadRef: string) =>
       `<agor-upload upload_ref="${uploadRef}" filename="${filename}"></agor-upload>`
+  );
+  text = text.replace(
+    INTERNAL_BRANCH_FILE_MARKDOWN_LINK,
+    (_, filename: string, branchId: string, encodedPath: string) =>
+      `<agor-branch-file branch_id="${branchId}" path="${encodedPath}" filename="${filename}"></agor-branch-file>`
   );
 
   // Detect dark mode from Ant Design token system
@@ -155,6 +165,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
       blockquote: MarkdownBlockquote,
       a: MarkdownAnchor,
       'agor-upload': UploadAttachmentTag,
+      'agor-branch-file': BranchFileAttachmentTag,
     }),
     []
   );
@@ -177,7 +188,10 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
           mermaid={{ config: mermaidConfig }} // Set Mermaid theme based on current theme mode
           plugins={plugins}
           components={components}
-          allowedTags={{ 'agor-upload': ['upload_ref', 'filename'] }}
+          allowedTags={{
+            'agor-upload': ['upload_ref', 'filename'],
+            'agor-branch-file': ['branch_id', 'path', 'filename'],
+          }}
           linkSafety={LINK_SAFETY}
           rehypePlugins={rehypePlugins}
           remarkPlugins={streamdownRemarkPlugins}
@@ -285,24 +299,37 @@ const INTERNAL_UPLOAD_MARKDOWN_LINK = new RegExp(
   'g'
 );
 
-function UploadAttachmentLink({
-  uploadRef,
+// UUIDv7 (matches BranchID's format — see packages/core/src/types/id.ts).
+const BRANCH_ID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}';
+// encodeBranchFilePath() output: encodeURIComponent charset plus its own
+// extra-escaped parens, so it never contains a literal ')' that could close
+// the Markdown link early.
+const BRANCH_FILE_PATH_PATTERN = "[A-Za-z0-9%._~!*'-]{1,2000}";
+const ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX = BRANCH_FILE_VIRTUAL_URL_PREFIX.replace(
+  /[.*+?^${}()|[\]\\]/g,
+  '\\$&'
+);
+const INTERNAL_BRANCH_FILE_MARKDOWN_LINK = new RegExp(
+  `\\[([A-Za-z0-9._ -]{1,200})\\]\\(${ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX}(${BRANCH_ID_PATTERN})\\/(${BRANCH_FILE_PATH_PATTERN})\\)`,
+  'g'
+);
+
+/** Shared preview/download controls for authenticated virtual-link attachments. */
+function AttachmentControls({
+  filename,
+  fetchBlob,
   children,
 }: {
-  uploadRef: string;
+  filename: string;
+  fetchBlob: () => Promise<Blob>;
   children: React.ReactNode;
 }) {
   const { showError } = useThemedMessage();
-  const filename = reactText(children).trim() || 'upload';
 
-  const openUpload = async (download: boolean) => {
+  const openAttachment = async (download: boolean) => {
     try {
-      const response = await fetch(
-        `${getDaemonUrl().replace(/\/$/, '')}/uploads/${encodeURIComponent(uploadRef)}/content`,
-        { headers: getAuthHeaders() }
-      );
-      if (!response.ok) throw new Error('Upload is unavailable');
-      const objectUrl = URL.createObjectURL(await response.blob());
+      const blob = await fetchBlob();
+      const objectUrl = URL.createObjectURL(blob);
       const anchor = document.createElement('a');
       anchor.href = objectUrl;
       if (download) anchor.download = filename;
@@ -311,7 +338,7 @@ function UploadAttachmentLink({
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
     } catch (error) {
-      showError(error instanceof Error ? error.message : 'Upload is unavailable');
+      showError(error instanceof Error ? error.message : 'File is unavailable');
     }
   };
 
@@ -322,7 +349,7 @@ function UploadAttachmentLink({
         size="small"
         icon={<PaperClipOutlined />}
         aria-label={filename}
-        onClick={() => void openUpload(false)}
+        onClick={() => void openAttachment(false)}
         style={{ height: 'auto', paddingInline: 0 }}
       >
         {children}
@@ -333,10 +360,35 @@ function UploadAttachmentLink({
           size="small"
           aria-label={`Download ${filename}`}
           icon={<DownloadOutlined />}
-          onClick={() => void openUpload(true)}
+          onClick={() => void openAttachment(true)}
         />
       </Tooltip>
     </span>
+  );
+}
+
+function UploadAttachmentLink({
+  uploadRef,
+  children,
+}: {
+  uploadRef: string;
+  children: React.ReactNode;
+}) {
+  const filename = reactText(children).trim() || 'upload';
+
+  const fetchBlob = async () => {
+    const response = await fetch(
+      `${getDaemonUrl().replace(/\/$/, '')}/uploads/${encodeURIComponent(uploadRef)}/content`,
+      { headers: getAuthHeaders() }
+    );
+    if (!response.ok) throw new Error('Upload is unavailable');
+    return response.blob();
+  };
+
+  return (
+    <AttachmentControls filename={filename} fetchBlob={fetchBlob}>
+      {children}
+    </AttachmentControls>
   );
 }
 
@@ -345,6 +397,67 @@ function UploadAttachmentTag(props: Record<string, unknown>) {
   const filename = typeof props.filename === 'string' ? props.filename : 'upload';
   if (!new RegExp(`^${UPLOAD_REF_PATTERN}$`).test(uploadRef)) return null;
   return <UploadAttachmentLink uploadRef={uploadRef}>{filename}</UploadAttachmentLink>;
+}
+
+/** Decodes a `FileDetail` response body into a typed Blob (utf-8 or base64 encoded content). */
+function fileDetailToBlob(detail: FileDetail): Blob {
+  if (detail.encoding === 'base64') {
+    const binaryString = atob(detail.content);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) bytes[i] = binaryString.charCodeAt(i);
+    return new Blob([bytes], { type: detail.mimeType || 'application/octet-stream' });
+  }
+  return new Blob([detail.content], { type: detail.mimeType || 'text/plain' });
+}
+
+function BranchFileAttachmentLink({
+  branchId,
+  relativePath,
+  children,
+}: {
+  branchId: string;
+  relativePath: string;
+  children: React.ReactNode;
+}) {
+  const filename = reactText(children).trim() || relativePath.split('/').pop() || 'file';
+
+  const fetchBlob = async () => {
+    const response = await fetch(
+      `${getDaemonUrl().replace(/\/$/, '')}/file/${encodeURIComponent(relativePath)}?branch_id=${encodeURIComponent(branchId)}`,
+      { headers: getAuthHeaders() }
+    );
+    if (!response.ok) throw new Error('File is unavailable');
+    return fileDetailToBlob((await response.json()) as FileDetail);
+  };
+
+  return (
+    <AttachmentControls filename={filename} fetchBlob={fetchBlob}>
+      {children}
+    </AttachmentControls>
+  );
+}
+
+function BranchFileAttachmentTag(props: Record<string, unknown>) {
+  const branchId = typeof props.branch_id === 'string' ? props.branch_id : '';
+  const encodedPath = typeof props.path === 'string' ? props.path : '';
+  const filename = typeof props.filename === 'string' ? props.filename : 'file';
+  // Defense in depth: agent output can embed this tag's raw HTML directly
+  // (Streamdown's allowedTags permits it), bypassing INTERNAL_BRANCH_FILE_MARKDOWN_LINK.
+  // Re-validate here so a malformed or hand-crafted tag never reaches fetch().
+  if (!new RegExp(`^${BRANCH_ID_PATTERN}$`).test(branchId)) return null;
+  if (!new RegExp(`^${BRANCH_FILE_PATH_PATTERN}$`).test(encodedPath)) return null;
+  let relativePath: string;
+  try {
+    relativePath = decodeBranchFilePath(encodedPath);
+  } catch {
+    return null;
+  }
+  if (!relativePath) return null;
+  return (
+    <BranchFileAttachmentLink branchId={branchId} relativePath={relativePath}>
+      {filename}
+    </BranchFileAttachmentLink>
+  );
 }
 
 function MarkdownAnchor({ children, className, href, node: _node, ...props }: MarkdownAnchorProps) {

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -16,6 +16,7 @@ import {
   decodeBranchFilePath,
   type FileDetail,
   UPLOAD_VIRTUAL_URL_PREFIX,
+  unescapeMarkdownLinkLabel,
 } from '@agor/core/types';
 import { DownloadOutlined, PaperClipOutlined } from '@ant-design/icons';
 import { Button, Tooltip, Typography, theme } from 'antd';
@@ -128,7 +129,10 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   text = text.replace(
     INTERNAL_BRANCH_FILE_MARKDOWN_LINK,
     (_, filename: string, branchId: string, encodedPath: string) =>
-      `<agor-branch-file branch_id="${escapeHtmlAttribute(branchId)}" path="${escapeHtmlAttribute(encodedPath)}" filename="${escapeHtmlAttribute(filename)}"></agor-branch-file>`
+      // buildBranchFileMarkdownLink() backslash-escapes `\`, `[`, `]` in the
+      // label so filenames containing them survive Markdown's own `[...]`
+      // boundary; recover the literal filename before HTML-escaping it.
+      `<agor-branch-file branch_id="${escapeHtmlAttribute(branchId)}" path="${escapeHtmlAttribute(encodedPath)}" filename="${escapeHtmlAttribute(unescapeMarkdownLinkLabel(filename))}"></agor-branch-file>`
   );
 
   // Detect dark mode from Ant Design token system
@@ -328,12 +332,16 @@ const BRANCH_ID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3
 const BRANCH_FILE_PATH_PATTERN = "[A-Za-z0-9%._~!*'-]{1,2000}";
 // buildBranchFileMarkdownLink() emits the real filename as the link label —
 // unlike uploads' fixed ASCII-only charset, evidence filenames routinely
-// include parens and Unicode (e.g. "before (final).png", "résumé.webm"), so
-// this only excludes what would break Markdown's own `[...]` bracket syntax
-// (a literal `]`) or span lines. Every capture is HTML-escaped before this
-// is interpolated into generated markup (see escapeHtmlAttribute above), so
+// include parens, Unicode, and even Markdown metacharacters like `[`/`]`
+// (e.g. "before (final).png", "résumé.webm", "screenshot [draft].png").
+// buildBranchFileMarkdownLink() backslash-escapes `\`, `[`, and `]` in the
+// label, so this pattern accepts either an escaped pair (`\\.` — backslash
+// plus the character it protects) or any other character that isn't the
+// unescaped `]` that would close the label or a newline. Every capture is
+// HTML-escaped (after unescapeMarkdownLinkLabel — see below) before this is
+// interpolated into generated markup (see escapeHtmlAttribute above), so
 // widening the charset here does not reopen attribute injection.
-const BRANCH_FILE_LABEL_PATTERN = '[^\\]\\n]{1,200}';
+const BRANCH_FILE_LABEL_PATTERN = /(?:\\.|[^\]\n\\]){1,200}/.source;
 const ESCAPED_BRANCH_FILE_VIRTUAL_URL_PREFIX = BRANCH_FILE_VIRTUAL_URL_PREFIX.replace(
   /[.*+?^${}()|[\]\\]/g,
   '\\$&'

--- a/packages/core/src/types/file.test.ts
+++ b/packages/core/src/types/file.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BRANCH_FILE_VIRTUAL_URL_PREFIX,
+  buildBranchFileMarkdownLink,
+  decodeBranchFilePath,
+  encodeBranchFilePath,
+} from './file';
+
+describe('branch file virtual Markdown links', () => {
+  it('round-trips branch-relative paths, including parens and unicode', () => {
+    const paths = [
+      'README.md',
+      'src/screenshots/before (final).png',
+      'docs/résumé notes.webm',
+      'a/b/c.d.e',
+    ];
+    for (const path of paths) {
+      expect(decodeBranchFilePath(encodeBranchFilePath(path))).toBe(path);
+    }
+  });
+
+  it('never leaves an unescaped paren that could close a Markdown link early', () => {
+    expect(encodeBranchFilePath('shots/before (final).png')).not.toMatch(/[()]/);
+  });
+
+  it('builds a closed virtual link naming the branch and encoded path', () => {
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+      typeof buildBranchFileMarkdownLink
+    >[0];
+    const link = buildBranchFileMarkdownLink(branchId, 'evidence/screenshot (1).png');
+
+    expect(link).toBe(
+      `[screenshot (1).png](${BRANCH_FILE_VIRTUAL_URL_PREFIX}${branchId}/${encodeBranchFilePath('evidence/screenshot (1).png')})`
+    );
+    const [, encodedPath] = link.match(/\/([^/]+)\)$/) ?? [];
+    expect(decodeBranchFilePath(encodedPath)).toBe('evidence/screenshot (1).png');
+  });
+
+  it('falls back to the last path segment as filename when no display name is given', () => {
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+      typeof buildBranchFileMarkdownLink
+    >[0];
+    expect(buildBranchFileMarkdownLink(branchId, 'a/b/report.txt')).toContain('[report.txt]');
+  });
+});

--- a/packages/core/src/types/file.test.ts
+++ b/packages/core/src/types/file.test.ts
@@ -4,6 +4,7 @@ import {
   buildBranchFileMarkdownLink,
   decodeBranchFilePath,
   encodeBranchFilePath,
+  unescapeMarkdownLinkLabel,
 } from './file';
 
 describe('branch file virtual Markdown links', () => {
@@ -41,5 +42,48 @@ describe('branch file virtual Markdown links', () => {
       typeof buildBranchFileMarkdownLink
     >[0];
     expect(buildBranchFileMarkdownLink(branchId, 'a/b/report.txt')).toContain('[report.txt]');
+  });
+
+  it('backslash-escapes a bracketed filename so the label survives its own Markdown boundary', () => {
+    const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+      typeof buildBranchFileMarkdownLink
+    >[0];
+    const filename = 'screenshot [draft].png';
+    const link = buildBranchFileMarkdownLink(branchId, `evidence/${filename}`);
+
+    // Asserted against the exact expected string (not re-parsed out of the
+    // link), so this pins the escaping behavior unambiguously: '[' and ']'
+    // inside the label become '\[' and '\]'.
+    expect(link).toBe(
+      `[screenshot \\[draft\\].png](${BRANCH_FILE_VIRTUAL_URL_PREFIX}${branchId}/${encodeBranchFilePath(`evidence/${filename}`)})`
+    );
+    expect(unescapeMarkdownLinkLabel('screenshot \\[draft\\].png')).toBe(filename);
+  });
+
+  it('round-trips filenames containing backslash, [, and ] through the label grammar', () => {
+    // Mirrors MarkdownRenderer's BRANCH_FILE_LABEL_PATTERN: a label token is
+    // either an escaped pair ('\\.') or any character that isn't the
+    // unescaped ']' that closes the label. A naive `.*?` extraction would
+    // wrongly stop at an escaped ']', so the test uses the same
+    // escape-aware grammar the renderer actually parses with.
+    const LABEL = /^\[((?:\\.|[^\]\n\\])*)\]\(/;
+    const filenames = [
+      'screenshot [draft].png',
+      'a[[nested]].png',
+      String.raw`report\notes.txt`,
+      String.raw`weird\[literal\].png`,
+      // An escaped ']' immediately followed by a literal '(' in the
+      // filename — the case a naive '.*?\]\(' extractor gets wrong.
+      'draft](fake.png',
+    ];
+    for (const filename of filenames) {
+      const branchId = '0193f1a2-3b4c-7d5e-a8f3-9d2e1c4b5a6f' as Parameters<
+        typeof buildBranchFileMarkdownLink
+      >[0];
+      const link = buildBranchFileMarkdownLink(branchId, `evidence/${filename}`);
+      const [, label] = link.match(LABEL) ?? [];
+      expect(label, `label for ${filename}`).toBeDefined();
+      expect(unescapeMarkdownLinkLabel(label)).toBe(filename);
+    }
   });
 });

--- a/packages/core/src/types/file.ts
+++ b/packages/core/src/types/file.ts
@@ -40,6 +40,25 @@ export function decodeBranchFilePath(encoded: string): FilePath {
   return decodeURIComponent(encoded);
 }
 
+/**
+ * Escapes Markdown link-label metacharacters (`\`, `[`, `]`) so a filename
+ * containing them survives as literal text through the label's `[...]`
+ * boundary instead of prematurely closing it. Mirror of
+ * `unescapeMarkdownLinkLabel` below — keep both in sync.
+ */
+function escapeMarkdownLinkLabel(label: string): string {
+  return label.replace(/[\\[\]]/g, (char) => `\\${char}`);
+}
+
+/**
+ * Reverses `escapeMarkdownLinkLabel`: recovers the literal filename from a
+ * Markdown link label that may contain `\\`, `\[`, or `\]` escape
+ * sequences. Any other backslash sequence is left untouched.
+ */
+export function unescapeMarkdownLinkLabel(label: string): string {
+  return label.replace(/\\([\\[\]])/g, '$1');
+}
+
 /** Builds a closed virtual Markdown link naming an authenticated branch-file download. */
 export function buildBranchFileMarkdownLink(
   branchId: BranchID,
@@ -47,7 +66,7 @@ export function buildBranchFileMarkdownLink(
   displayName?: string
 ): string {
   const filename = displayName ?? path.split('/').pop() ?? path;
-  return `[${filename}](${BRANCH_FILE_VIRTUAL_URL_PREFIX}${branchId}/${encodeBranchFilePath(path)})`;
+  return `[${escapeMarkdownLinkLabel(filename)}](${BRANCH_FILE_VIRTUAL_URL_PREFIX}${branchId}/${encodeBranchFilePath(path)})`;
 }
 
 /**

--- a/packages/core/src/types/file.ts
+++ b/packages/core/src/types/file.ts
@@ -1,5 +1,7 @@
 // src/types/file.ts
 
+import type { BranchID } from './id';
+
 /**
  * Path to a file relative to branch root
  *
@@ -9,6 +11,44 @@
  * - "packages/core/src/types/file.ts"
  */
 export type FilePath = string;
+
+/**
+ * Provider-owned virtual Markdown link prefix naming an authenticated,
+ * closed branch-file download. Mirrors `UPLOAD_VIRTUAL_URL_PREFIX`: never
+ * dereferenced as a real host, only pattern-matched client-side and
+ * rewritten into an authenticated fetch through the `file` service.
+ */
+export const BRANCH_FILE_VIRTUAL_URL_PREFIX = 'https://agor.live/_branch-files/';
+
+/**
+ * Encodes a branch-relative file path for embedding in a virtual Markdown
+ * URL. Escapes parentheses in addition to the usual reserved characters so
+ * the result can never prematurely close a Markdown link's `(...)` target.
+ */
+export function encodeBranchFilePath(path: FilePath): string {
+  return encodeURIComponent(path).replace(
+    /[()]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+/**
+ * Decodes a percent-encoded branch file path segment back to its
+ * branch-relative path. Throws on malformed percent-encoding.
+ */
+export function decodeBranchFilePath(encoded: string): FilePath {
+  return decodeURIComponent(encoded);
+}
+
+/** Builds a closed virtual Markdown link naming an authenticated branch-file download. */
+export function buildBranchFileMarkdownLink(
+  branchId: BranchID,
+  path: FilePath,
+  displayName?: string
+): string {
+  const filename = displayName ?? path.split('/').pop() ?? path;
+  return `[${filename}](${BRANCH_FILE_VIRTUAL_URL_PREFIX}${branchId}/${encodeBranchFilePath(path)})`;
+}
 
 /**
  * File list response (lightweight, for browsing)

--- a/packages/executor/src/commands/files.test.ts
+++ b/packages/executor/src/commands/files.test.ts
@@ -33,9 +33,22 @@ describe('branch file commands', () => {
     });
     expect(await readBranchFile(root, 'image.png')).toMatchObject({
       isText: false,
+      mimeType: 'image/png',
       content: 'AAEC',
       encoding: 'base64',
     });
+  });
+
+  it.each([
+    ['screenshot.jpg', 'image/jpeg'],
+    ['screenshot.jpeg', 'image/jpeg'],
+    ['evidence.gif', 'image/gif'],
+    ['recording.webm', 'video/webm'],
+  ])('detects the %s MIME type as %s', async (filename, mimeType) => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-files-'));
+    await writeFile(join(root, filename), Buffer.from([0, 1, 2]));
+
+    expect(await readBranchFile(root, filename)).toMatchObject({ isText: false, mimeType });
   });
 
   it('rejects traversal and symlink escapes', async () => {

--- a/packages/executor/src/commands/files.ts
+++ b/packages/executor/src/commands/files.ts
@@ -108,6 +108,11 @@ function getMimeType(filePath: string): string | undefined {
     '.svg': 'image/svg+xml',
     '.yaml': 'text/yaml',
     '.yml': 'text/yaml',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webm': 'video/webm',
   }[extname(filePath).toLowerCase()];
 }
 


### PR DESCRIPTION
## Summary

- add a closed Markdown URL for authenticated files stored in an Agor branch
- make the primary attachment label download the file with its useful filename while preserving existing upload-preview behavior
- support nested branch-relative paths through the REST transport and preserve PNG/JPEG/GIF/WebM MIME types

## Security

- branch lookup and tenant context remain owned by the existing file service
- traversal and symlink protection remain owned by the executor's branch-path resolver
- malformed virtual links fall back without triggering a privileged file read

## Verification

- core branch-link tests: 6 passed
- executor file/MIME tests: 7 passed
- Markdown renderer tests: 24 passed
- daemon file unit and real REST integration tests: 13 passed
- independent code-quality and security-boundary review performed at the final HEAD