### PR TITLE
fix: handle unpublished npm release versions

### DIFF
--- a/.github/workflows/release-agor-live.yml
+++ b/.github/workflows/release-agor-live.yml
@@ -121,13 +121,34 @@ jobs:
 
           publish_exact() {
             local artifact=$1
-            local manifest name version spec local_sha remote_sha
+            local manifest name version spec local_sha remote_sha lookup_error
             manifest=$(tar -xOf "$artifact" package/package.json)
             name=$(node -e 'const p=JSON.parse(process.argv[1]); process.stdout.write(p.name)' "$manifest")
             version=$(node -e 'const p=JSON.parse(process.argv[1]); process.stdout.write(p.version)' "$manifest")
             spec="$name@$version"
             local_sha=$(sha1sum "$artifact" | awk '{print $1}')
-            remote_sha=$(npm view "$spec" dist.shasum --json 2>/dev/null | tr -d '"[:space:]' || true)
+
+            # npm emits a JSON error object on stdout for a missing version when
+            # --json is used. Preserve the command status instead of mistaking
+            # that object for a published tarball shasum.
+            lookup_error=$(mktemp)
+            if remote_sha=$(npm view "$spec" dist.shasum 2>"$lookup_error"); then
+              remote_sha=$(printf '%s' "$remote_sha" | tr -d '"[:space:]')
+              if [[ -z "$remote_sha" ]]; then
+                echo "::error::npm returned no shasum for existing package $spec"
+                rm -f "$lookup_error"
+                return 1
+              fi
+            elif grep -Eq '(^|[[:space:]])E404([[:space:]]|$)' "$lookup_error"; then
+              remote_sha=""
+            else
+              echo "::error::Failed to query npm for $spec"
+              cat "$lookup_error" >&2
+              rm -f "$lookup_error"
+              return 1
+            fi
+            rm -f "$lookup_error"
+
             if [[ -n "$remote_sha" ]]; then
               if [[ "$remote_sha" != "$local_sha" ]]; then
                 echo "::error::$spec already exists with different tarball bytes"


### PR DESCRIPTION
## Linked issue

Related: #2310

## Summary

- Preserve the exit status from `npm view` when checking whether a release version already exists.
- Treat only npm `E404` as an unpublished version that is safe to publish.
- Continue comparing shasums for existing versions, while surfacing network, authentication, and other lookup failures.

## Why / context

The first `v0.24.6` release attempt reached the new idempotent publisher after the complete package matrix passed. npm prints a JSON error object to stdout when `npm view --json` cannot find a version. The workflow suppressed the nonzero exit status and mistook that object for a remote tarball shasum:

> `@agor-live/claude@0.24.6 already exists with different tarball bytes`

No `0.24.6` package was published. Failed runs:

- https://github.com/preset-io/agor/actions/runs/31849731197
- https://github.com/preset-io/agor/actions/runs/31850625019

## Implementation notes

The release remains fail-closed:

- successful lookup: require and compare the published shasum;
- `E404`: proceed to `npm publish`;
- any other lookup failure: print npm's diagnostic and stop.

This changes only the deployment-global npm release workflow; it does not touch tenant-owned data or runtime boundaries.

## Validation / test plan

- [x] Reproduced npm's JSON-on-stdout behavior for an unpublished version.
- [x] Verified pinned `npm@11.16.0` returns `E404` with no shasum for `@agor-live/claude@0.24.6`.
- [x] Verified pinned `npm@11.16.0` returns the published shasum for `@agor-live/claude@0.24.5`.
- [x] `pnpm exec prettier --check .github/workflows/release-agor-live.yml`
- [x] `git diff --check`

## Risks / rollout / rollback

After merge, recreate the unpublished `v0.24.6` tag at the merge commit and run the protected release workflow again. The npm environment and trusted-publisher configuration are already in place.
