### PR TITLE
fix: allow npm trusted publishing OIDC

### DIFF
--- a/.github/workflows/release-agor-live.yml
+++ b/.github/workflows/release-agor-live.yml
@@ -76,16 +76,40 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
     steps:
       - uses: actions/setup-node@v7
         with:
           node-version: '24.19.0'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
       # Trusted publishing requires npm >=11.5.1. Pin the release client rather
       # than inheriting whichever npm happens to ship with the runner image.
       - run: npm install -g --ignore-scripts npm@11.16.0
+
+      # Do not pass setup-node's registry-url here. It writes an _authToken
+      # placeholder that makes npm attempt token auth instead of trusted
+      # publishing: https://github.com/actions/setup-node/issues/1551
+      - name: Verify npm trusted publishing environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${ACTIONS_ID_TOKEN_REQUEST_URL:?GitHub OIDC request URL is unavailable}"
+          : "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?GitHub OIDC request token is unavailable}"
+          if [[ -n "${NODE_AUTH_TOKEN:-}" || -n "${NPM_TOKEN:-}" ]]; then
+            echo "::error::Static npm credentials are configured; this release requires trusted publishing"
+            exit 1
+          fi
+          if [[ "$(npm config get registry)" != "https://registry.npmjs.org/" ]]; then
+            echo "::error::npm is not configured for the public registry"
+            exit 1
+          fi
+          npmrc=$(npm config get userconfig)
+          if [[ -f "$npmrc" ]] && grep -Eq '_auth(Token)?[[:space:]]*=' "$npmrc"; then
+            echo "::error::npm user config contains static registry credentials"
+            exit 1
+          fi
 
       - uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## Linked issue

Follow-up to #2310 and #2354. The `v0.24.6` release failed at the first publish in [run 31852902897](https://github.com/preset-io/agor/actions/runs/31852902897).

## Summary

- stop asking `actions/setup-node` to write an npm auth placeholder
- configure the public npm registry without generating credentials
- fail early unless GitHub OIDC is available and static npm credentials are absent

## Why / context

`actions/setup-node` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` whenever `registry-url` is set. With no `NODE_AUTH_TOKEN`—the intended trusted-publishing setup—npm sees configured token auth and does not perform the OIDC exchange. The observed first-package `E404` matches [actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551).

The failed run published none of the eight `0.24.6` artifacts, so the existing retry-safe publish order remains valid.

## Implementation notes

The publish job retains `id-token: write` and npm `11.16.0`, but now sets `NPM_CONFIG_REGISTRY` directly. A preflight confirms:

- GitHub exposes the OIDC request URL and request token
- neither `NODE_AUTH_TOKEN` nor `NPM_TOKEN` is present
- npm targets the public registry
- npm's user config does not contain `_auth` / `_authToken`

The check never prints token values or npmrc contents.

## Validation / test plan

- `prettier --check .github/workflows/release-agor-live.yml`
- `git diff --check`
- after merge, move the unpublished `v0.24.6` tag to the merge commit and rerun the release
- confirm npm trusted publishing is configured for all eight packages with workflow `release-agor-live.yml`, environment `npm`, and `npm publish` allowed

## Risks / rollout / rollback

This changes only the deployment-global npm publish authentication boundary; it does not affect tenant data or runtime installs. If OIDC or registry configuration is missing, the job now fails before attempting any publish. Rollback is reverting this commit and restoring token authentication, which is intentionally not preferred.
