### PR TITLE
fix: preflight npm trusted publishers

### DIFF
--- a/.github/workflows/release-agor-live.yml
+++ b/.github/workflows/release-agor-live.yml
@@ -136,14 +136,25 @@ jobs:
           for artifact in "${expected[@]}"; do test -f "$RELEASE/$artifact"; done
           (cd "$RELEASE" && sha256sum "${expected[@]}")
 
-      - name: Publish integrations, client, then agor-live
+      - name: Preflight trusted publishers and publish exact artifacts
         env:
           VERSION: ${{ needs.metadata.outputs.version }}
         run: |
           set -euo pipefail
           RELEASE="$RUNNER_TEMP/release"
+          artifacts=(
+            "$RELEASE/agor-live-claude-$VERSION.tgz"
+            "$RELEASE/agor-live-codex-$VERSION.tgz"
+            "$RELEASE/agor-live-copilot-$VERSION.tgz"
+            "$RELEASE/agor-live-gemini-$VERSION.tgz"
+            "$RELEASE/agor-live-opencode-$VERSION.tgz"
+            "$RELEASE/agor-live-cursor-$VERSION.tgz"
+            "$RELEASE/agor-live-client-$VERSION.tgz"
+            "$RELEASE/agor-live-$VERSION.tgz"
+          )
+          to_publish=()
 
-          publish_exact() {
+          inspect_exact() {
             local artifact=$1
             local manifest name version spec local_sha remote_sha lookup_error
             manifest=$(tar -xOf "$artifact" package/package.json)
@@ -181,17 +192,49 @@ jobs:
               echo "✓ $spec already contains the validated artifact; skipping"
               return
             fi
-            npm publish "$artifact" --access public
+
+            to_publish+=("$artifact")
           }
 
-          # agor-live is the user-visible release marker and is always last, so
-          # a partial failure cannot expose a base package whose selected tool
-          # wrappers are not yet available.
-          for id in claude codex copilot gemini opencode cursor; do
-            publish_exact "$RELEASE/agor-live-$id-$VERSION.tgz"
+          verify_trusted_publisher() {
+            local artifact=$1
+            local manifest name probe_log
+            manifest=$(tar -xOf "$artifact" package/package.json)
+            name=$(node -e 'const p=JSON.parse(process.argv[1]); process.stdout.write(p.name)' "$manifest")
+            probe_log=$(mktemp)
+
+            # npm's dry-run still performs the real package-scoped OIDC token
+            # exchange. npm returns success when that exchange is unavailable,
+            # so require its pinned client's explicit success diagnostic.
+            if ! npm publish "$artifact" --access public --dry-run --loglevel verbose >"$probe_log" 2>&1 || \
+              ! grep -Fq 'oidc Successfully retrieved and set token' "$probe_log"; then
+              echo "::error::npm trusted publishing is not authorized for $name"
+              echo "::error::Configure preset-io/agor, release-agor-live.yml, environment npm, and allow npm publish in this package's npmjs.com settings"
+              grep -E 'npm (verbose oidc|warn publish|error)' "$probe_log" >&2 || true
+              rm -f "$probe_log"
+              return 1
+            fi
+
+            rm -f "$probe_log"
+            echo "✓ npm trusted publisher accepted $name"
+          }
+
+          # Determine the complete missing set before authenticating or
+          # publishing. This keeps exact-byte partial-release recovery intact.
+          for artifact in "${artifacts[@]}"; do
+            inspect_exact "$artifact"
           done
-          publish_exact "$RELEASE/agor-live-client-$VERSION.tgz"
-          publish_exact "$RELEASE/agor-live-$VERSION.tgz"
+
+          # Prove every missing package's npm-side trust relationship before
+          # publishing any package, avoiding preventable partial releases.
+          for artifact in "${to_publish[@]}"; do
+            verify_trusted_publisher "$artifact"
+          done
+
+          # agor-live is the user-visible release marker and remains last.
+          for artifact in "${to_publish[@]}"; do
+            npm publish "$artifact" --access public
+          done
 
       - name: Verify registry release
         env:


### PR DESCRIPTION
## Linked issue

Follow-up to #2310, #2354, and #2355. The `v0.24.6` release's OIDC environment preflight passed, but npm rejected the first package (`@agor-live/claude`) with `ENEEDAUTH` in [run 31854812670](https://github.com/preset-io/agor/actions/runs/31854812670/job/94938308146).

## Summary

- inventory every missing release artifact before publishing
- perform a real npm package-scoped OIDC exchange for every missing package
- require all eight trusted-publisher relationships to succeed before publishing anything
- retain exact-byte partial-release recovery and `agor-live`-last ordering

## Why / context

npm trusted publishers are package-specific settings stored on npmjs.com. Presence of GitHub's OIDC request variables proves the workflow can request an identity, but it does not prove npm trusts that identity for each package.

Pinned npm `11.16.0` performs its OIDC exchange during `npm publish --dry-run`, but returns success when the exchange is unavailable. This change runs the real dry-run exchange with verbose diagnostics and explicitly requires npm's successful-token diagnostic. On failure, it prints only npm's OIDC/error messages and actionable package settings; it does not print the GitHub identity token or npm credential.

## Implementation notes

The release step now has three phases:

1. compare every registry version with the validated local tarball and collect only missing artifacts;
2. authenticate every missing artifact via package-scoped OIDC dry-runs;
3. publish the already-validated missing artifacts in dependency order, with `agor-live` last.

Previously published identical artifacts remain skipped; different bytes under the same version still fail closed.

## Validation / test plan

- `prettier --check .github/workflows/release-agor-live.yml`
- `git diff --check`
- extracted the exact workflow shell block and ran it against all eight tarballs from failed release run `31854812670`
- positive fake-npm boundary: all eight OIDC probes succeeded and all eight publish calls occurred in order
- negative fake-npm boundary: Codex trust failed after Claude passed; the step failed and made zero publish calls
- inspected pinned npm `11.16.0` source to confirm dry-run executes the package-scoped OIDC exchange before its dry-run authentication warning

After merge, configure all eight npmjs.com package settings and move the still-unpublished `v0.24.6` tag to the merge commit. The release itself will then prove all eight trust relationships before its first publish.

## Risks / rollout / rollback

This changes only the deployment-global npm release boundary; it does not affect tenant resources. It adds eight short-lived OIDC exchanges in a fully missing release, then publishes as before. If npm changes its verbose success diagnostic, the pinned-client preflight fails closed before publication. Rollback is reverting this commit, but doing so restores the possibility of discovering a package-specific trust error after a partial release.
