### PR TITLE
feat(ui): add Agor signal-field screensaver

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -37,6 +37,7 @@ import type { BranchUpdate } from './components/BranchModal/tabs/GeneralTab';
 import { ErrorBoundary, setCrashContext } from './components/ErrorBoundary';
 import { uploadFilesToSession } from './components/FileUpload/upload';
 import { ForcePasswordChangeModal } from './components/ForcePasswordChangeModal';
+import { IdleGlyphScreensaver } from './components/IdleGlyphScreensaver';
 import { InitialLoadingScreen } from './components/InitialLoadingScreen';
 import { LoginPage } from './components/LoginPage';
 import { OnboardingBanners } from './components/OnboardingBanners';
@@ -1907,6 +1908,7 @@ function AppContent() {
   // Render main app
   return (
     <ConnectionProvider value={connectionContextValue}>
+      <IdleGlyphScreensaver />
       {/* Force Password Change Modal - shown when user.must_change_password is true */}
       <ForcePasswordChangeModal
         open={!!currentUser?.must_change_password}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,5 +1,5 @@
 import type { ActiveUser, AgorClient, Board, BoardID, Branch, User } from '@agor-live/client';
-import { BulbOutlined } from '@ant-design/icons';
+import { BulbOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { memo, useMemo } from 'react';
@@ -16,6 +16,7 @@ import { BrandLogo } from '../BrandLogo';
 import { BrandMark } from '../BrandMark';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { GlobalUserMenu } from '../GlobalUserMenu';
+import { startIdleGlyphScreensaver } from '../IdleGlyphScreensaver';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { buildThemeMenuItems } from '../ThemeSwitcher';
 import { AppHeaderGlobalSearch } from './AppHeaderGlobalSearch';
@@ -182,6 +183,12 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
       key: 'theme',
       label: 'Theme',
       children: buildThemeMenuItems(themeMode, setThemeMode, onThemeEditorClick),
+    },
+    {
+      key: 'screensaver',
+      label: 'Start screensaver',
+      icon: <PlayCircleOutlined />,
+      onClick: startIdleGlyphScreensaver,
     },
     { type: 'divider' as const },
     {

--- a/apps/agor-ui/src/components/IdleGlyphScreensaver/IdleGlyphScreensaver.test.tsx
+++ b/apps/agor-ui/src/components/IdleGlyphScreensaver/IdleGlyphScreensaver.test.tsx
@@ -1,0 +1,66 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_SCREENSAVER_IDLE_MS,
+  IdleGlyphScreensaver,
+  startIdleGlyphScreensaver,
+} from './IdleGlyphScreensaver';
+
+const motionPreference = { matches: false };
+
+describe('IdleGlyphScreensaver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    motionPreference.matches = false;
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: motionPreference.matches,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('appears after the idle deadline and wakes on activity', () => {
+    render(<IdleGlyphScreensaver />);
+    expect(screen.queryByRole('dialog', { name: /idle screensaver/i })).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(DEFAULT_SCREENSAVER_IDLE_MS));
+    expect(screen.getByRole('dialog', { name: /idle screensaver/i })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: /idle screensaver/i })).not.toBeInTheDocument();
+  });
+
+  it('resets the idle deadline when the user is active', () => {
+    render(<IdleGlyphScreensaver idleMs={1_000} />);
+    act(() => vi.advanceTimersByTime(800));
+    fireEvent.wheel(window);
+    act(() => vi.advanceTimersByTime(800));
+    expect(screen.queryByRole('dialog', { name: /idle screensaver/i })).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByRole('dialog', { name: /idle screensaver/i })).toBeInTheDocument();
+  });
+
+  it('does not activate when reduced motion is requested', () => {
+    motionPreference.matches = true;
+    render(<IdleGlyphScreensaver idleMs={1_000} />);
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByRole('dialog', { name: /idle screensaver/i })).not.toBeInTheDocument();
+  });
+
+  it('can be previewed immediately', () => {
+    render(<IdleGlyphScreensaver />);
+    act(() => startIdleGlyphScreensaver());
+    expect(screen.getByRole('dialog', { name: /idle screensaver/i })).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/IdleGlyphScreensaver/IdleGlyphScreensaver.tsx
+++ b/apps/agor-ui/src/components/IdleGlyphScreensaver/IdleGlyphScreensaver.tsx
@@ -1,0 +1,266 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: canvas artwork uses a fixed phosphor palette outside Ant Design's DOM styling boundary
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const DEFAULT_SCREENSAVER_IDLE_MS = 5 * 60 * 1000;
+
+const ACTIVITY_EVENTS = ['pointerdown', 'pointermove', 'keydown', 'touchstart', 'wheel'] as const;
+const GLYPHS = 'AGOR<>/{}[]01:+*·◇△○⌁⌘';
+const MAX_DEVICE_PIXEL_RATIO = 2;
+const POINTER_MOVE_THROTTLE_MS = 750;
+const START_SCREENSAVER_EVENT = 'agor:start-idle-screensaver';
+
+export function startIdleGlyphScreensaver(): void {
+  window.dispatchEvent(new Event(START_SCREENSAVER_EVENT));
+}
+
+interface SignalStream {
+  x: number;
+  y: number;
+  speed: number;
+  spacing: number;
+  length: number;
+  phase: number;
+  rotation: number;
+  rotationSpeed: number;
+  scale: number;
+}
+
+export interface IdleGlyphScreensaverProps {
+  idleMs?: number;
+}
+
+function createStreams(width: number, height: number): SignalStream[] {
+  const count = Math.max(18, Math.ceil(width / 34));
+  return Array.from({ length: count }, (_, index) => {
+    const scale = 0.65 + Math.random() * 0.8;
+    return {
+      x: ((index + Math.random() * 0.8) / count) * width,
+      y: Math.random() * height * -1.2,
+      speed: (28 + Math.random() * 72) * scale,
+      spacing: 17 + Math.random() * 11,
+      length: 7 + Math.floor(Math.random() * 15),
+      phase: Math.floor(Math.random() * GLYPHS.length),
+      rotation: (Math.random() - 0.5) * 0.42,
+      rotationSpeed: (Math.random() - 0.5) * 0.18,
+      scale,
+    };
+  });
+}
+
+function drawFrame(
+  context: CanvasRenderingContext2D,
+  streams: SignalStream[],
+  width: number,
+  height: number,
+  elapsedSeconds: number,
+  deltaSeconds: number
+) {
+  const wash = context.createLinearGradient(0, 0, 0, height);
+  wash.addColorStop(0, 'rgba(2, 10, 9, 0.20)');
+  wash.addColorStop(0.55, 'rgba(0, 6, 5, 0.12)');
+  wash.addColorStop(1, 'rgba(0, 2, 2, 0.28)');
+  context.fillStyle = wash;
+  context.fillRect(0, 0, width, height);
+
+  context.lineWidth = 0.6;
+  context.strokeStyle = 'rgba(74, 246, 190, 0.07)';
+  context.beginPath();
+  for (let y = 48; y < height; y += 96) {
+    const drift = Math.sin(elapsedSeconds * 0.18 + y * 0.01) * 22;
+    context.moveTo(0, y + drift);
+    context.bezierCurveTo(width * 0.3, y - 24, width * 0.72, y + 34, width, y - drift);
+  }
+  context.stroke();
+
+  for (const stream of streams) {
+    stream.y += stream.speed * deltaSeconds;
+    stream.rotation += stream.rotationSpeed * deltaSeconds;
+    const tailHeight = stream.length * stream.spacing;
+    if (stream.y - tailHeight > height) {
+      stream.y = -Math.random() * height * 0.7;
+      stream.x = Math.random() * width;
+    }
+
+    context.save();
+    context.translate(stream.x, stream.y);
+    context.rotate(stream.rotation);
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.font = `${Math.round(13 * stream.scale)}px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace`;
+
+    for (let index = 0; index < stream.length; index += 1) {
+      const progress = index / stream.length;
+      const pulse = 0.72 + Math.sin(elapsedSeconds * 2.4 + stream.phase + index) * 0.16;
+      const alpha = Math.max(0.04, (1 - progress) ** 1.65 * pulse);
+      const glyphIndex =
+        (stream.phase + index + Math.floor(elapsedSeconds * (1.5 + stream.scale))) % GLYPHS.length;
+      const glyph = GLYPHS[glyphIndex];
+      const y = -index * stream.spacing;
+
+      if (index === 0) {
+        context.shadowColor = 'rgba(156, 255, 220, 0.85)';
+        context.shadowBlur = 13;
+        context.fillStyle = 'rgba(215, 255, 239, 0.96)';
+      } else {
+        context.shadowBlur = index < 4 ? 7 : 0;
+        context.shadowColor = 'rgba(42, 245, 176, 0.55)';
+        context.fillStyle = `rgba(${index % 3 === 0 ? '37, 222, 182' : '63, 244, 153'}, ${alpha})`;
+      }
+      context.fillText(glyph, Math.sin(elapsedSeconds + index * 0.7) * 2.2, y);
+    }
+    context.restore();
+  }
+}
+
+export function IdleGlyphScreensaver({
+  idleMs = DEFAULT_SCREENSAVER_IDLE_MS,
+}: IdleGlyphScreensaverProps) {
+  const [active, setActive] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const activeRef = useRef(false);
+
+  const dismiss = useCallback(() => {
+    activeRef.current = false;
+    setActive(false);
+  }, []);
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let lastPointerMove = 0;
+
+    const arm = () => {
+      if (timer) clearTimeout(timer);
+      if (document.visibilityState === 'hidden' || reducedMotion.matches) return;
+      timer = setTimeout(() => {
+        activeRef.current = true;
+        setActive(true);
+      }, idleMs);
+    };
+
+    const onActivity = (event: Event) => {
+      if (event.type === 'pointermove' && !activeRef.current) {
+        const now = performance.now();
+        if (now - lastPointerMove < POINTER_MOVE_THROTTLE_MS) return;
+        lastPointerMove = now;
+      }
+      dismiss();
+      arm();
+    };
+
+    const onVisibilityChange = () => {
+      dismiss();
+      arm();
+    };
+
+    const onMotionPreferenceChange = () => {
+      dismiss();
+      arm();
+    };
+
+    const onManualStart = () => {
+      if (reducedMotion.matches || document.visibilityState === 'hidden') return;
+      if (timer) clearTimeout(timer);
+      activeRef.current = true;
+      setActive(true);
+    };
+
+    for (const eventName of ACTIVITY_EVENTS) {
+      window.addEventListener(eventName, onActivity, { passive: true, capture: true });
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    reducedMotion.addEventListener('change', onMotionPreferenceChange);
+    window.addEventListener(START_SCREENSAVER_EVENT, onManualStart);
+    arm();
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      for (const eventName of ACTIVITY_EVENTS) {
+        window.removeEventListener(eventName, onActivity, { capture: true });
+      }
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      reducedMotion.removeEventListener('change', onMotionPreferenceChange);
+      window.removeEventListener(START_SCREENSAVER_EVENT, onManualStart);
+    };
+  }, [dismiss, idleMs]);
+
+  useEffect(() => {
+    if (!active) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    let animationFrame = 0;
+    let streams: SignalStream[] = [];
+    let width = 0;
+    let height = 0;
+    let previousTime = performance.now();
+
+    const resize = () => {
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, MAX_DEVICE_PIXEL_RATIO);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.round(width * pixelRatio);
+      canvas.height = Math.round(height * pixelRatio);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+      context.fillStyle = '#010706';
+      context.fillRect(0, 0, width, height);
+      streams = createStreams(width, height);
+    };
+
+    const animate = (time: number) => {
+      const deltaSeconds = Math.min((time - previousTime) / 1000, 0.05);
+      previousTime = time;
+      drawFrame(context, streams, width, height, time / 1000, deltaSeconds);
+      animationFrame = requestAnimationFrame(animate);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    animationFrame = requestAnimationFrame(animate);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.removeEventListener('resize', resize);
+    };
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Agor idle screensaver"
+      aria-modal="true"
+      onPointerDown={dismiss}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 10000,
+        overflow: 'hidden',
+        cursor: 'none',
+        background: '#010706',
+      }}
+    >
+      <canvas ref={canvasRef} style={{ display: 'block' }} />
+      <div
+        style={{
+          position: 'absolute',
+          insetInline: 0,
+          bottom: 28,
+          textAlign: 'center',
+          color: 'rgba(185, 255, 224, 0.64)',
+          font: '12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          textShadow: '0 0 12px rgba(56, 245, 173, 0.45)',
+          pointerEvents: 'none',
+        }}
+      >
+        Agor signal field · move or press any key to return
+      </div>
+    </div>
+  );
+}

--- a/apps/agor-ui/src/components/IdleGlyphScreensaver/index.ts
+++ b/apps/agor-ui/src/components/IdleGlyphScreensaver/index.ts
@@ -1,0 +1,6 @@
+export {
+  DEFAULT_SCREENSAVER_IDLE_MS,
+  IdleGlyphScreensaver,
+  type IdleGlyphScreensaverProps,
+  startIdleGlyphScreensaver,
+} from './IdleGlyphScreensaver';


### PR DESCRIPTION
## Summary

Adds an original, Agor-themed idle screensaver to authenticated application surfaces.

After five minutes without pointer, keyboard, touch, or wheel activity, Agor fades into a full-screen “signal field”: layered teal/green glyph packets descend at different depths, rotate independently, leave phosphor-like trails, and pass over faint network curves. The visual language uses Agor text and orchestration symbols rather than reproducing the characters or composition of any existing film effect.

## Behavior

- can be previewed immediately from **Settings → Start screensaver**\n- activates automatically after five minutes of genuine inactivity
- wakes immediately on pointer, keyboard, touch, or wheel input
- resets its deadline whenever activity resumes
- dismisses and rearms across tab visibility changes
- never activates while the tab is hidden
- remains scoped to authenticated product surfaces, not login/loading/error or marketing routes
- does not activate when `prefers-reduced-motion: reduce` is enabled

## Rendering and performance

- uses a single Canvas 2D overlay rather than a large animated DOM tree
- caps device-pixel-ratio rendering at 2×
- rebuilds the stream field on viewport resize
- clamps frame deltas after suspended or delayed frames
- tears down animation frames, timers, resize handlers, media-query handlers, and activity listeners on dismissal/unmount

## Accessibility

- exposes the active overlay as a named modal dialog
- includes a visible wake instruction
- honors the operating system's reduced-motion preference by disabling automatic activation entirely

## Validation

- Biome passes on all touched files
- focused screensaver tests pass for activation, wake/reset behavior, and reduced-motion suppression
- full workspace build/typecheck/test runs in CI

https://github.com/user-attachments/assets/1a30bdfd-df03-4eb3-aceb-04f1551a8884


