### PR TITLE
fix: simplify agor-live release retries

### DIFF
--- a/.github/workflows/release-agor-live.yml
+++ b/.github/workflows/release-agor-live.yml
@@ -243,12 +243,13 @@ jobs:
           remaining=("${packages[@]}")
 
           # npm publish can return before a new version is visible through
-          # every registry read path. Retry the complete missing set rather
-          # than reporting a successful publish as failed immediately.
+          # every registry read path. Force npm to revalidate its metadata
+          # cache and retry the complete missing set rather than reporting a
+          # successful publish as failed immediately.
           for attempt in {1..13}; do
             next=()
             for package in "${remaining[@]}"; do
-              actual=$(npm view "$package@$VERSION" version 2>/dev/null || true)
+              actual=$(npm view --prefer-online "$package@$VERSION" version 2>/dev/null || true)
               if [[ "$actual" == "$VERSION" ]]; then
                 echo "✓ $package@$VERSION is visible"
               else

--- a/.github/workflows/release-agor-live.yml
+++ b/.github/workflows/release-agor-live.yml
@@ -4,19 +4,15 @@
 #   3. This workflow builds once, runs the full packaged-install matrix, and
 #      publishes those exact tarballs with npm trusted publishing (OIDC).
 #
-# workflow_dispatch is useful for a non-publishing preflight on any ref and for
-# retrying a failed publish from an existing v* tag. It may not publish a branch.
+# workflow_dispatch is a non-publishing preflight on the selected ref. Retry a
+# failed tag release with GitHub's "Re-run failed jobs" so it reuses the same
+# validated artifacts and cannot accidentally publish from a branch.
 name: Release agor-live
 
 on:
   push:
     tags: ['v*']
-  workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish after validation (requires selecting an existing v* tag)
-        type: boolean
-        default: false
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -35,13 +31,11 @@ jobs:
 
       - id: release
         name: Validate tag and package alignment
-        env:
-          REQUESTED_PUBLISH: ${{ inputs.publish || false }}
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./packages/agor-live/package.json').version")
           SHOULD_PUBLISH=false
-          if [[ "$GITHUB_EVENT_NAME" == push || "$REQUESTED_PUBLISH" == true ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == push ]]; then
             if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
               echo "::error::Publishing is allowed only from an existing v* tag"
               exit 1
@@ -241,9 +235,36 @@ jobs:
           VERSION: ${{ needs.metadata.outputs.version }}
         run: |
           set -euo pipefail
-          for package in \
+          packages=(
             @agor-live/claude @agor-live/codex @agor-live/copilot \
             @agor-live/gemini @agor-live/opencode @agor-live/cursor \
-            @agor-live/client agor-live; do
-            test "$(npm view "$package@$VERSION" version)" = "$VERSION"
+            @agor-live/client agor-live
+          )
+          remaining=("${packages[@]}")
+
+          # npm publish can return before a new version is visible through
+          # every registry read path. Retry the complete missing set rather
+          # than reporting a successful publish as failed immediately.
+          for attempt in {1..13}; do
+            next=()
+            for package in "${remaining[@]}"; do
+              actual=$(npm view "$package@$VERSION" version 2>/dev/null || true)
+              if [[ "$actual" == "$VERSION" ]]; then
+                echo "✓ $package@$VERSION is visible"
+              else
+                next+=("$package")
+              fi
+            done
+
+            if [[ "${#next[@]}" -eq 0 ]]; then
+              exit 0
+            fi
+            if [[ "$attempt" -eq 13 ]]; then
+              echo "::error::npm versions were not visible after 60 seconds: ${next[*]}"
+              exit 1
+            fi
+
+            echo "Waiting for npm registry propagation: ${next[*]}"
+            remaining=("${next[@]}")
+            sleep 5
           done


### PR DESCRIPTION
## Summary

- make `workflow_dispatch` an explicitly non-publishing release preflight
- reserve npm publication for protected `v*` tag pushes
- direct failed tag releases to GitHub's **Re-run failed jobs**, which reuses the validated artifact job
- retry exact-version registry verification for 60 seconds to tolerate npm read-path propagation

## Context

The `v0.24.6` release successfully published all eight packages, but the workflow turned red when the immediate final `npm view agor-live@0.24.6` raced registry propagation. A manual dispatch from `main` also cannot satisfy the npm environment's tag protection and should not pretend to be a publish-retry path.

This keeps one unambiguous contract:

- **new release:** push a protected, version-aligned tag
- **same-release retry:** re-run failed jobs on that tag-triggered run
- **manual dispatch:** build/install preflight only; never publish

## Validation

- `pnpm exec prettier --check .github/workflows/release-agor-live.yml`
- extracted metadata shell simulation:
  - dispatch from `main` => `should_publish=false`
  - `v0.24.6` tag push => `should_publish=true`
- extracted registry verification shell simulation:
  - transient E404 resolves on retry
  - persistent absence fails closed after the bounded window
- `scripts/check-agentic-tool-packages.mjs` via both metadata simulations
- `git diff --check`

## Boundary assessment

Deployment-global release automation only. No tenant-owned data or runtime application boundary changes.

The published release run incident and recovery are documented in the [release runbook](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/engineering/releasing-agor-packages.md).
