### PR TITLE
feat(environments): support launch.json worktree profiles

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -235,6 +235,11 @@ export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersP
     data: { branch_id: string },
     params?: FeathersParams
   ): Promise<Repo>;
+  importFromLaunchJson(
+    id: string,
+    data: { branch_id: string },
+    params?: FeathersParams
+  ): Promise<Repo>;
   exportToAgorYml(
     id: string,
     data: { branch_id: string },

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3252,6 +3252,23 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
+  registerAuthenticatedRoute(
+    app,
+    '/repos/:id/import-launch-json',
+    {
+      async create(data: { branch_id: string }, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Repo ID required');
+        if (!data?.branch_id) throw new Error('branch_id is required');
+        return reposService.importFromLaunchJson(id, data, params);
+      },
+    },
+    {
+      create: { role: ROLES.ADMIN, action: 'import environment config from launch.json' },
+    },
+    requireAuth
+  );
+
   // ============================================================================
   // User API Keys routes
   // ============================================================================

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -990,7 +990,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   private async runAgorYmlExecutorCommand(
     repo: Repo,
     branch: Branch,
-    command: 'branch.agor-yml.import' | 'branch.agor-yml.export',
+    command: 'branch.agor-yml.import' | 'branch.agor-yml.export' | 'branch.launch-json.import',
     params: Record<string, unknown>,
     serviceParams?: RepoParams
   ) {
@@ -1086,6 +1086,44 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       params,
       id,
     });
+    return updated;
+  }
+
+  /**
+   * Import editor-style launch profiles from `.agor/launch.json`, falling
+   * back to `.vscode/launch.json`, and compile them into normal Agor variants.
+   */
+  async importFromLaunchJson(
+    id: string,
+    data: { branch_id: string },
+    params?: RepoParams
+  ): Promise<Repo> {
+    if (!data?.branch_id) throw new Error('branch_id is required to import launch.json');
+    const repo = await this.get(id, params);
+    const branch = await this.getAuthorizedAgorYmlBranch(repo, data.branch_id, params);
+    const importResult = await this.runAgorYmlExecutorCommand(
+      repo,
+      branch,
+      'branch.launch-json.import',
+      {},
+      params
+    );
+    if (!importResult.success) {
+      throw new Error(
+        `Cannot import launch.json from ${branch.name}: ${importResult.error?.message ?? 'executor failed'}`
+      );
+    }
+    const payload = importResult.data as
+      | { environment?: RepoEnvironment | null; path?: string }
+      | undefined;
+    if (!payload?.environment) {
+      throw new Error('No .agor/launch.json or .vscode/launch.json found in this branch');
+    }
+    const replacement: RepoEnvironment = repo.environment?.template_overrides
+      ? { ...payload.environment, template_overrides: repo.environment.template_overrides }
+      : payload.environment;
+    const updated = await this.repoRepo.setEnvironment(id, replacement);
+    emitServiceEvent(this.app, { path: 'repos', event: 'patched', data: updated, params, id });
     return updated;
   }
 

--- a/apps/agor-docs/content/guide/environment-configuration.mdx
+++ b/apps/agor-docs/content/guide/environment-configuration.mdx
@@ -7,6 +7,10 @@ description: Define named environment variants per repo, layer deployment-local 
 
 Agor's managed environments let a repo ship a **library of named variants** (`lean`, `postgres`, `full`, …) that every branch can pick from. Variants are Handlebars-templated and get **rendered into a per-branch snapshot** that the Start/Stop/Nuke/Logs buttons execute against.
 
+They are not limited to containers. In addition to `.agor.yml` shell/webhook
+variants, Agor can import VS Code-shaped launch profiles for local worktree dev
+servers.
+
 This page documents the data model, the template vars, deployment-local overrides, and the permission rules.
 
 <img
@@ -75,28 +79,28 @@ Every field in a variant is a Handlebars template. The render context is built i
 
 ### Variables
 
-| Variable | Source | Example | Notes |
-|---|---|---|---|
-| `{{branch.unique_id}}` | Branch | `3` | Auto-incrementing integer. Use for deterministic port offsets. |
-| `{{branch.name}}` | Branch | `feat-new-filter` | Slugified branch name. Good for `docker compose -p`. |
-| `{{branch.path}}` | Branch | `/home/you/agor/feat-new-filter` | Absolute path on disk. |
-| `{{branch.gid}}` | Branch | `1042` | Unix GID of the branch's isolation group. |
-| `{{branch.base_ref}}` | Branch | `main` | Source branch/tag name the branch was created from (the "Base Branch"/"Base Tag" in the create dialog). The **name**, not a SHA. Empty string if unknown. |
-| `{{branch.ref_type}}` | Branch | `branch` | `branch` or `tag`, indicating whether `base_ref` names a branch or a tag. Defaults to `branch`. |
-| `{{repo.slug}}` | Repo | `preset-io/superset` | Repository slug. |
-| `{{host.ip_address}}` | Auto-detected | `10.0.1.42` | Fallback order: `template_overrides.host.ip_address` → `daemon.host_ip_address` in `~/.agor/config.yaml` → autodetect. |
-| `{{custom.<key>}}` | Branch custom context | `{{custom.compose_profile}}` | Anything you store in `branch.custom_context`. |
-| `{{custom.<key>}}` via overrides | `template_overrides.custom.*` | `{{custom.internal_registry}}` | Repo-wide fallback if the branch doesn't set a key. |
+| Variable                         | Source                        | Example                          | Notes                                                                                                                                                     |
+| -------------------------------- | ----------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{{branch.unique_id}}`           | Branch                        | `3`                              | Auto-incrementing integer. Use for deterministic port offsets.                                                                                            |
+| `{{branch.name}}`                | Branch                        | `feat-new-filter`                | Slugified branch name. Good for `docker compose -p`.                                                                                                      |
+| `{{branch.path}}`                | Branch                        | `/home/you/agor/feat-new-filter` | Absolute path on disk.                                                                                                                                    |
+| `{{branch.gid}}`                 | Branch                        | `1042`                           | Unix GID of the branch's isolation group.                                                                                                                 |
+| `{{branch.base_ref}}`            | Branch                        | `main`                           | Source branch/tag name the branch was created from (the "Base Branch"/"Base Tag" in the create dialog). The **name**, not a SHA. Empty string if unknown. |
+| `{{branch.ref_type}}`            | Branch                        | `branch`                         | `branch` or `tag`, indicating whether `base_ref` names a branch or a tag. Defaults to `branch`.                                                           |
+| `{{repo.slug}}`                  | Repo                          | `preset-io/superset`             | Repository slug.                                                                                                                                          |
+| `{{host.ip_address}}`            | Auto-detected                 | `10.0.1.42`                      | Fallback order: `template_overrides.host.ip_address` → `daemon.host_ip_address` in `~/.agor/config.yaml` → autodetect.                                    |
+| `{{custom.<key>}}`               | Branch custom context         | `{{custom.compose_profile}}`     | Anything you store in `branch.custom_context`.                                                                                                            |
+| `{{custom.<key>}}` via overrides | `template_overrides.custom.*` | `{{custom.internal_registry}}`   | Repo-wide fallback if the branch doesn't set a key.                                                                                                       |
 
 ### Math helpers
 
-| Helper | Example | Result (with `unique_id = 3`) |
-|---|---|---|
-| `add` | `{{add 9000 branch.unique_id}}` | `9003` |
-| `sub` | `{{sub 9000 branch.unique_id}}` | `8997` |
-| `mul` | `{{mul branch.unique_id 10}}` | `30` |
-| `div` | `{{div 60 branch.unique_id}}` | `20` |
-| `mod` | `{{mod branch.unique_id 4}}` | `3` |
+| Helper | Example                         | Result (with `unique_id = 3`) |
+| ------ | ------------------------------- | ----------------------------- |
+| `add`  | `{{add 9000 branch.unique_id}}` | `9003`                        |
+| `sub`  | `{{sub 9000 branch.unique_id}}` | `8997`                        |
+| `mul`  | `{{mul branch.unique_id 10}}`   | `30`                          |
+| `div`  | `{{div 60 branch.unique_id}}`   | `20`                          |
+| `mod`  | `{{mod branch.unique_id 4}}`    | `3`                           |
 
 Math helpers are deterministic. The same branch always renders the same ports, which is what keeps parallel branches from colliding.
 
@@ -110,23 +114,107 @@ Math helpers are deterministic. The same branch always renders the same ports, w
 
 `.agor.yml` lives at the **branch root** (`$BRANCH_PATH/.agor.yml`) and is the shared, committed description of a repo's environment variants. It's a regular repo file: you edit it on a branch, open a PR, and it rolls out when merged.
 
+## Launch JSON profiles {/* #launch-json */}
+
+For projects that run directly in a worktree, the Environment tab can import
+`.agor/launch.json`. If that file is absent, Agor falls back to the familiar
+`.vscode/launch.json`. `.agor/launch.json` is recommended when you need Agor's
+lifecycle metadata without changing the configuration developers use in VS
+Code.
+
+Launch files use JSONC, so comments and trailing commas are supported. Every
+configuration becomes a named Agor environment variant; the first is the
+default unless exactly one configuration sets `agor.default: true`.
+
+```jsonc
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Web dev",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "pnpm dev",
+      "cwd": "${workspaceFolder}/apps/web",
+      "env": {
+        "PORT": "{{add 5000 branch.unique_id}}",
+      },
+      "agor": {
+        "default": true,
+        "description": "Vite dev server in this worktree",
+        "health": "http://localhost:{{add 5000 branch.unique_id}}/health",
+        "app": "http://localhost:{{add 5000 branch.unique_id}}",
+      },
+    },
+    {
+      "name": "Node API",
+      "type": "pwa-node",
+      "request": "launch",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["--enable-source-maps"],
+      "program": "${workspaceFolder}/server.js",
+      "args": ["--port", "{{add 7000 branch.unique_id}}"],
+    },
+  ],
+}
+```
+
+### Supported launch fields
+
+| Field                                                 | Behavior                                                                                                  |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `name`                                                | Required; becomes the Agor variant name.                                                                  |
+| `request`                                             | Optional, but only `launch` is accepted. Attach/debug sessions are not managed environments.              |
+| `command`                                             | Shell command, matching VS Code's `node-terminal` style.                                                  |
+| `runtimeExecutable`, `runtimeArgs`, `program`, `args` | Safely shell-quoted into a command. Node profiles may omit `runtimeExecutable` when `program` is present. |
+| `cwd`                                                 | Working directory; defaults to `${workspaceFolder}`.                                                      |
+| `env`                                                 | Scalar environment variables for the launched process.                                                    |
+| `agor.default`                                        | Selects the default imported variant.                                                                     |
+| `agor.background`                                     | Defaults to `true`; Agor supervises the process and returns from Start immediately.                       |
+| `agor.stop`, `agor.nuke`, `agor.logs`                 | Optional lifecycle command overrides.                                                                     |
+| `agor.health`, `agor.app`                             | Health-check and browser URLs.                                                                            |
+
+`${workspaceFolder}` and the legacy `${workspaceRoot}` are translated to the
+branch checkout working directory. All normal Agor Handlebars variables are
+available for ports and other profile values.
+
+For a background profile, Agor writes private runtime PID and log files beneath
+the operating system's temporary directory, keyed by a SHA-256 digest of the
+worktree path. The checkout stays clean and different worktrees cannot share a
+runtime directory. Stop verifies the PID still belongs to the profile before
+signaling it, preventing a stale PID from stopping an unrelated process. When
+`pgrep` is available (standard on Linux and macOS), Stop walks and terminates
+the profile's descendant process tree as well. Nuke stops the profile and
+removes its runtime directory. For unusual launchers that re-parent processes
+outside that tree, set an explicit `agor.stop` command.
+
+Import is explicit and admin-only. It replaces repository variants just like
+`.agor.yml` import, preserves deployment-local `template_overrides`, and does
+not rewrite already-rendered branch snapshots. Select a profile and click
+**Render** to apply it to a branch.
+
+Current scope deliberately excludes VS Code `attach` requests, debug-adapter
+protocol behavior, `preLaunchTask`, variable commands/inputs, and compounds.
+Those editor orchestration features do not map safely to a long-lived Agor
+environment without additional lifecycle semantics.
+
 ### Schema
 
 ```yaml
 version: 2
 
 environment:
-  default: lean                    # which variant new branches get
+  default: lean # which variant new branches get
   variants:
     <variant-name>:
-      description: "Human-readable one-liner"
-      extends: <base-variant>      # optional, single-level only
-      start:  "<shell command template>"
-      stop:   "<shell command template>"
-      nuke:   "<shell command template>"   # optional
-      logs:   "<shell command template>"   # optional
-      health: "<url template>"             # optional
-      app:    "<url template>"             # optional
+      description: 'Human-readable one-liner'
+      extends: <base-variant> # optional, single-level only
+      start: '<shell command template>'
+      stop: '<shell command template>'
+      nuke: '<shell command template>' # optional
+      logs: '<shell command template>' # optional
+      health: '<url template>' # optional
+      app: '<url template>' # optional
 ```
 
 `start`, `stop`, `nuke`, and `logs` are rendered lifecycle fields. In the
@@ -162,29 +250,29 @@ environment:
   default: lean
   variants:
     lean:
-      description: "SQLite-backed, single-container, fast iteration"
-      start:  "docker compose -f docker-compose-light.yml -p agor-{{branch.name}} up -d"
-      stop:   "docker compose -f docker-compose-light.yml -p agor-{{branch.name}} down"
-      nuke:   "docker compose -f docker-compose-light.yml -p agor-{{branch.name}} down -v"
-      logs:   "docker compose -f docker-compose-light.yml -p agor-{{branch.name}} logs --tail=100"
-      health: "http://{{host.ip_address}}:{{add 9000 branch.unique_id}}/health"
-      app:    "http://{{host.ip_address}}:{{add 5000 branch.unique_id}}"
+      description: 'SQLite-backed, single-container, fast iteration'
+      start: 'docker compose -f docker-compose-light.yml -p agor-{{branch.name}} up -d'
+      stop: 'docker compose -f docker-compose-light.yml -p agor-{{branch.name}} down'
+      nuke: 'docker compose -f docker-compose-light.yml -p agor-{{branch.name}} down -v'
+      logs: 'docker compose -f docker-compose-light.yml -p agor-{{branch.name}} logs --tail=100'
+      health: 'http://{{host.ip_address}}:{{add 9000 branch.unique_id}}/health'
+      app: 'http://{{host.ip_address}}:{{add 5000 branch.unique_id}}'
 
     postgres:
-      description: "Postgres + Redis + Celery — closer to prod"
-      extends: lean                # inherits health + app from lean
-      start:  "docker compose -p agor-{{branch.name}} up -d --build"
-      stop:   "docker compose -p agor-{{branch.name}} down"
-      nuke:   "docker compose -p agor-{{branch.name}} down -v"
-      logs:   "docker compose -p agor-{{branch.name}} logs --tail=100"
+      description: 'Postgres + Redis + Celery — closer to prod'
+      extends: lean # inherits health + app from lean
+      start: 'docker compose -p agor-{{branch.name}} up -d --build'
+      stop: 'docker compose -p agor-{{branch.name}} down'
+      nuke: 'docker compose -p agor-{{branch.name}} down -v'
+      logs: 'docker compose -p agor-{{branch.name}} logs --tail=100'
 
     full:
-      description: "Postgres + Redis + Celery + worker + beat"
-      extends: lean                # NOT extends: postgres — chains are not allowed
-      start:  "COMPOSE_PROFILES=full docker compose -p agor-{{branch.name}} up -d --build"
-      stop:   "docker compose -p agor-{{branch.name}} down"
-      nuke:   "docker compose -p agor-{{branch.name}} down -v"
-      logs:   "docker compose -p agor-{{branch.name}} logs --tail=100"
+      description: 'Postgres + Redis + Celery + worker + beat'
+      extends: lean # NOT extends: postgres — chains are not allowed
+      start: 'COMPOSE_PROFILES=full docker compose -p agor-{{branch.name}} up -d --build'
+      stop: 'docker compose -p agor-{{branch.name}} down'
+      nuke: 'docker compose -p agor-{{branch.name}} down -v'
+      logs: 'docker compose -p agor-{{branch.name}} logs --tail=100'
 ```
 
 Notice that `postgres` and `full` both extend `lean` (not each other). That's the single-level rule. Both inherit `health` and `app` from `lean` and override the rest.
@@ -193,10 +281,10 @@ Notice that `postgres` and `full` both extend `lean` (not each other). That's th
 
 Two admin-only actions in the repo editor header:
 
-| Action | Effect |
-|---|---|
+| Action                 | Effect                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Import `.agor.yml`** | Parses `$BRANCH_PATH/.agor.yml` and **replaces** `environment.variants` + `environment.default` in the DB. `template_overrides` and branch snapshots are untouched. |
-| **Export `.agor.yml`** | Writes the current `environment.variants` + `environment.default` to `$BRANCH_PATH/.agor.yml`. `template_overrides` is **stripped** before writing. |
+| **Export `.agor.yml`** | Writes the current `environment.variants` + `environment.default` to `$BRANCH_PATH/.agor.yml`. `template_overrides` is **stripped** before writing.                 |
 
 Both paths go through a confirm dialog. Import is **replace, not merge**. A variant that exists in the DB but not in the file gets dropped.
 
@@ -224,11 +312,11 @@ Superset's upstream `.agor.yml` shouldn't hard-code `10.0.1.42` as the host IP. 
 ```yaml
 template_overrides:
   host:
-    ip_address: "10.0.1.42"        # overrides daemon config / autodetect
+    ip_address: '10.0.1.42' # overrides daemon config / autodetect
   custom:
-    internal_registry: "registry.preset.io"
-    aws_profile: "preset-dev"
-    compose_profile: "preset"
+    internal_registry: 'registry.preset.io'
+    aws_profile: 'preset-dev'
+    compose_profile: 'preset'
 ```
 
 The structure is a plain `{ host, custom }` map. `template_overrides` is root-level and applies to **all variants**. There are no per-variant overrides.
@@ -261,10 +349,10 @@ Each branch has:
 
 The Environment tab has two stacked editors:
 
-| Editor | Who edits | What it shows |
-|---|---|---|
-| **Repo editor** (top) | Admins only | `version`, `environment.variants`, `environment.default`, `template_overrides` as YAML |
-| **Branch editor** (bottom) | Admins only | The 6 rendered commands for this branch |
+| Editor                     | Who edits   | What it shows                                                                          |
+| -------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| **Repo editor** (top)      | Admins only | `version`, `environment.variants`, `environment.default`, `template_overrides` as YAML |
+| **Branch editor** (bottom) | Admins only | The 6 rendered commands for this branch                                                |
 
 Members see both editors **read-only**. Users with branch `all` permission and admins can use the **Variant picker** and the **Render** button in between them.
 
@@ -278,7 +366,7 @@ Members see both editors **read-only**. Users with branch `all` permission and a
 2. Click **Render**.
 3. Agor re-evaluates `variant + template_overrides` and overwrites the branch snapshot.
 
-If the snapshot has unsaved manual edits (admins only, since members can't make them), Render prompts a confirm: *"Rendering will discard your local edits. Continue?"*
+If the snapshot has unsaved manual edits (admins only, since members can't make them), Render prompts a confirm: _"Rendering will discard your local edits. Continue?"_
 
 ### No auto-tracking
 
@@ -288,7 +376,7 @@ If an admin edits a variant after a branch has rendered, **the branch snapshot d
 
 A repo with no variants configured shows a disabled picker and:
 
-> *No environment variants configured. Ask an admin to set up commands in the repo editor above.*
+> _No environment variants configured. Ask an admin to set up commands in the repo editor above._
 
 ---
 
@@ -298,14 +386,14 @@ Two orthogonal axes govern access: **who can edit what**, and **who can run Star
 
 ### Edit permissions
 
-| Action | Member | Admin |
-|---|:---:|:---:|
-| View repo config (top editor) | ✅ read-only | ✅ |
-| Edit `environment.variants` / `environment.default` | ❌ | ✅ |
-| Edit `template_overrides` | ❌ | ✅ |
-| Import / export `.agor.yml` | ❌ | ✅ |
-| Pick variant + Render to branch | Requires branch `all` | ✅ |
-| Hand-edit branch rendered commands | ❌ | ✅ |
+| Action                                              |        Member         | Admin |
+| --------------------------------------------------- | :-------------------: | :---: |
+| View repo config (top editor)                       |     ✅ read-only      |  ✅   |
+| Edit `environment.variants` / `environment.default` |          ❌           |  ✅   |
+| Edit `template_overrides`                           |          ❌           |  ✅   |
+| Import / export `.agor.yml`                         |          ❌           |  ✅   |
+| Pick variant + Render to branch                     | Requires branch `all` |  ✅   |
+| Hand-edit branch rendered commands                  |          ❌           |  ✅   |
 
 The reason members **cannot** hand-edit rendered commands: admins curate the set of commands that can run (the variants), and users with branch `all` permission pick from that list. This makes the variant library the effective allowlist and complements the execution-time deny-list guard.
 
@@ -319,12 +407,12 @@ Start, Stop, Restart, Nuke, Logs, and Render controls require branch `all` permi
 
 No forced user action. The upgrade is silent:
 
-| Before | After |
-|---|---|
-| `repos.environment_config: { up_command, down_command, … }` | `repos.environment: { version: 2, default: "default", variants: { default: <old value> }, template_overrides: {} }` |
-| Branch `start_command` / `stop_command` / … | Unchanged. They're already the rendered snapshot this design formalizes. |
-| `.agor.yml` v1 (flat `environment: { start, stop, … }`) | Still parses. Loaded as `variants.default`. Export writes v2 going forward. |
-| `daemon.host_ip_address` in `~/.agor/config.yaml` | Still works as the fallback for `{{host.ip_address}}`. For new setups, prefer per-repo `template_overrides.host.ip_address`. |
+| Before                                                      | After                                                                                                                        |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `repos.environment_config: { up_command, down_command, … }` | `repos.environment: { version: 2, default: "default", variants: { default: <old value> }, template_overrides: {} }`          |
+| Branch `start_command` / `stop_command` / …                 | Unchanged. They're already the rendered snapshot this design formalizes.                                                     |
+| `.agor.yml` v1 (flat `environment: { start, stop, … }`)     | Still parses. Loaded as `variants.default`. Export writes v2 going forward.                                                  |
+| `daemon.host_ip_address` in `~/.agor/config.yaml`           | Still works as the fallback for `{{host.ip_address}}`. For new setups, prefer per-repo `template_overrides.host.ip_address`. |
 
 Existing branches keep running against their existing rendered commands. Nothing re-renders until someone hits Render or creates a new branch.
 
@@ -383,11 +471,11 @@ environment:
   default: remote
   variants:
     remote:
-      start: "https://orchestrator.example.com/agor/start?branch={{branch.name}}"
-      stop:  "https://orchestrator.example.com/agor/stop?branch={{branch.name}}"
-      logs:  "https://orchestrator.example.com/agor/logs?branch={{branch.name}}"
-      health: "https://apps.example.com/{{branch.name}}/health"
-      app:    "https://apps.example.com/{{branch.name}}"
+      start: 'https://orchestrator.example.com/agor/start?branch={{branch.name}}'
+      stop: 'https://orchestrator.example.com/agor/stop?branch={{branch.name}}'
+      logs: 'https://orchestrator.example.com/agor/logs?branch={{branch.name}}'
+      health: 'https://apps.example.com/{{branch.name}}/health'
+      app: 'https://apps.example.com/{{branch.name}}'
 ```
 
 V1 webhooks are intentionally simple: GET only, no custom headers, no request

--- a/apps/agor-docs/public/openapi/agor.json
+++ b/apps/agor-docs/public/openapi/agor.json
@@ -10630,6 +10630,53 @@
         }
       }
     },
+    "/repos/{id}/import-launch-json": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "id parameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_id"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "not authenticated"
+          },
+          "500": {
+            "description": "general error"
+          }
+        },
+        "description": "Imports .agor/launch.json or .vscode/launch.json profiles from a branch.",
+        "summary": "Imports launch profiles",
+        "tags": ["repos"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_id"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/user/api-keys": {
       "get": {
         "parameters": [

--- a/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
@@ -40,6 +40,7 @@ import {
   PlayCircleOutlined,
   PoweroffOutlined,
   ReloadOutlined,
+  RocketOutlined,
   SaveOutlined,
   ThunderboltOutlined,
   UploadOutlined,
@@ -527,6 +528,41 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     });
   };
 
+  const handleImportLaunchJson = () => {
+    if (!client || !onUpdateRepo) return;
+    confirm({
+      title: 'Import launch profiles?',
+      icon: <RocketOutlined />,
+      content: (
+        <div>
+          <p>
+            This reads <code>.agor/launch.json</code>, or falls back to{' '}
+            <code>.vscode/launch.json</code>, from this branch and replaces the repository&apos;s
+            environment variants.
+          </p>
+          <p>
+            Launch profiles are compiled into supervised Start, Stop, Nuke, and Logs commands.
+            Existing <code>template_overrides</code> and branch snapshots are preserved.
+          </p>
+        </div>
+      ),
+      okText: 'Import profiles',
+      cancelText: 'Cancel',
+      onOk: async () => {
+        try {
+          const updated = (await client
+            .service(`repos/${repo.repo_id}/import-launch-json`)
+            .create({ branch_id: branch.branch_id })) as Repo;
+          if (updated.environment) setRepoYamlText(prettyYaml(updated.environment));
+          onUpdateRepo(repo.repo_id, { environment: updated.environment });
+          showSuccess('Imported launch profiles');
+        } catch (error) {
+          showError(error instanceof Error ? error.message : 'Failed to import launch profiles');
+        }
+      },
+    });
+  };
+
   // ----- Derived UI state -----
   const inferredState = getEnvironmentState(branch.environment_instance);
   const hasEnvironmentConfig = !!repo.environment;
@@ -739,9 +775,12 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                     : 'Ask an admin to set up environment commands in the repo editor below.'}
                 </p>
                 {isAdmin && (
-                  <Space>
+                  <Space wrap>
                     <Button size="small" icon={<DownloadOutlined />} onClick={handleImport}>
                       Import from .agor.yml
+                    </Button>
+                    <Button size="small" icon={<RocketOutlined />} onClick={handleImportLaunchJson}>
+                      Import launch.json
                     </Button>
                   </Space>
                 )}
@@ -784,6 +823,23 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   disabled={!isAdmin}
                 >
                   Import
+                </Button>
+              </Tooltip>
+              <Tooltip
+                title={
+                  isAdmin
+                    ? 'Import .agor/launch.json or .vscode/launch.json from this branch'
+                    : 'Only admins can import launch profiles'
+                }
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<RocketOutlined />}
+                  onClick={handleImportLaunchJson}
+                  disabled={!isAdmin}
+                >
+                  Launch JSON
                 </Button>
               </Tooltip>
               <Tooltip

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -42,11 +42,11 @@
     "url": "https://github.com/preset-io/agor/issues"
   },
   "dependencies": {
+    "@agor-live/client": "workspace:*",
     "@agor/agentic-tool-opencode": "workspace:*",
     "@agor/agentic-tools": "workspace:*",
     "@agor/core": "workspace:*",
     "@agor/git": "workspace:*",
-    "@agor-live/client": "workspace:*",
     "@anthropic-ai/sdk": "^0.109.0",
     "@feathersjs/authentication": "^5.0.46",
     "@feathersjs/authentication-client": "^5.0.46",
@@ -89,6 +89,7 @@
     "inquirer": "^12.10.0",
     "ioredis": "^5.11.1",
     "js-yaml": "^5.2.3",
+    "jsonc-parser": "^3.3.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.2.0",
     "postgres": "^3.4.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,6 +100,12 @@
       "import": "./dist/config/browser.js",
       "require": "./dist/config/browser.cjs"
     },
+    "./config/launch-json": {
+      "source": "./src/config/launch-json.ts",
+      "types": "./dist/config/launch-json.d.ts",
+      "import": "./dist/config/launch-json.js",
+      "require": "./dist/config/launch-json.cjs"
+    },
     "./permissions": {
       "source": "./src/permissions/index.ts",
       "types": "./dist/permissions/index.d.ts",
@@ -479,6 +485,7 @@
     "drizzle-orm": "^0.45.2",
     "emojibase-data": "^17.0.0",
     "js-yaml": "^5.2.3",
+    "jsonc-parser": "^3.3.1",
     "postgres": "^3.4.9",
     "simple-git": "^3.36.0",
     "slackify-markdown": "^5.0.0",

--- a/packages/core/src/config/agor-yml.test.ts
+++ b/packages/core/src/config/agor-yml.test.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { RepoEnvironment, RepoEnvironmentConfigV1 } from '../types/branch';
-import { parseAgorYml, resolveVariant, writeAgorYml } from './agor-yml';
+import { parseAgorYml, parseLaunchJson, resolveVariant, writeAgorYml } from './agor-yml';
 
 const REPO_ROOT_AGOR_YML = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -264,6 +264,32 @@ describe('parseAgorYml — misc', () => {
       fs.writeFileSync(file, `invalid: yaml: syntax:`);
       expect(() => parseAgorYml(file)).toThrow(/Invalid YAML/);
     });
+  });
+});
+
+describe('parseLaunchJson', () => {
+  it('prefers .agor/launch.json and accepts comments and trailing commas', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-launch-json-test-'));
+    try {
+      fs.mkdirSync(path.join(tmpDir, '.agor'));
+      fs.mkdirSync(path.join(tmpDir, '.vscode'));
+      fs.writeFileSync(
+        path.join(tmpDir, '.agor/launch.json'),
+        `{
+          // Agor-specific launch profile
+          "configurations": [{ "name": "Agor", "command": "pnpm dev", }],
+        }`
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, '.vscode/launch.json'),
+        JSON.stringify({ configurations: [{ name: 'VS Code', command: 'npm start' }] })
+      );
+      const result = parseLaunchJson(tmpDir);
+      expect(result?.path).toBe('.agor/launch.json');
+      expect(result?.environment.default).toBe('Agor');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/config/agor-yml.ts
+++ b/packages/core/src/config/agor-yml.ts
@@ -18,12 +18,20 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from 'jsonc-parser';
 import type {
   RepoEnvironment,
   RepoEnvironmentConfigV1,
   RepoEnvironmentVariant,
 } from '../types/branch';
 import * as yaml from '../yaml/index.js';
+import {
+  LAUNCH_JSON_PATHS,
+  type LaunchJsonDocument,
+  type LaunchJsonPath,
+  parseLaunchJsonDocument,
+} from './launch-json.js';
 import {
   type AgorYmlSchema,
   parseAgorYmlString,
@@ -63,6 +71,34 @@ export function parseAgorYml(filePath: string): RepoEnvironment | null {
   }
   const content = fs.readFileSync(filePath, 'utf-8');
   return parseAgorYmlString(content);
+}
+
+/**
+ * Find and parse an Agor/VS Code launch file from a branch root.
+ * `.agor/launch.json` wins so projects can add Agor lifecycle metadata without
+ * changing the editor configuration used by developers.
+ */
+export function parseLaunchJson(repoRoot: string): {
+  environment: RepoEnvironment;
+  path: LaunchJsonPath;
+} | null {
+  for (const relativePath of LAUNCH_JSON_PATHS) {
+    const filePath = path.join(repoRoot, relativePath);
+    if (!fs.existsSync(filePath)) continue;
+    const errors: ParseError[] = [];
+    const document = parseJsonc(fs.readFileSync(filePath, 'utf8'), errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    }) as LaunchJsonDocument;
+    if (errors.length > 0) {
+      const first = errors[0]!;
+      throw new Error(
+        `Invalid ${relativePath}: ${printParseErrorCode(first.error)} at offset ${first.offset}`
+      );
+    }
+    return { environment: parseLaunchJsonDocument(document, relativePath), path: relativePath };
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/config/launch-json.lifecycle.test.ts
+++ b/packages/core/src/config/launch-json.lifecycle.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderBranchSnapshot } from '../environment/render-snapshot';
+import { assertEnvCommandAllowed } from '../unix/environment-command-deny-list';
+import { parseLaunchJsonDocument } from './launch-json';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+async function eventually(assertion: () => void, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    }
+  }
+  assertion();
+}
+
+describe.skipIf(process.platform === 'win32')('launch profile lifecycle', () => {
+  it('starts in the background, captures logs, and stops only its supervised process', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-launch-lifecycle-'));
+    temporaryDirectories.push(directory);
+    const environment = parseLaunchJsonDocument(
+      {
+        configurations: [
+          {
+            name: 'test server',
+            request: 'launch',
+            runtimeExecutable: process.execPath,
+            args: ['-e', 'setInterval(() => console.log("ready"), 20)'],
+          },
+        ],
+      },
+      '.agor/launch.json'
+    );
+    const snapshot = renderBranchSnapshot(
+      { slug: 'fixture', environment },
+      { branch_unique_id: 42, name: 'fixture', path: directory }
+    )!;
+
+    assertEnvCommandAllowed(snapshot.start, 'start');
+    assertEnvCommandAllowed(snapshot.stop, 'stop');
+    assertEnvCommandAllowed(snapshot.nuke!, 'nuke');
+    assertEnvCommandAllowed(snapshot.logs!, 'logs');
+
+    execFileSync('/bin/sh', ['-c', snapshot.start], { cwd: directory });
+    const runtimeRoot = path.join(
+      process.env.TMPDIR || '/tmp',
+      'agor-launch',
+      await import('node:crypto').then(({ createHash }) =>
+        createHash('sha256').update(fs.realpathSync(directory)).digest('hex')
+      ),
+      'test-server-42'
+    );
+    temporaryDirectories.push(runtimeRoot);
+    const pidFile = path.join(runtimeRoot, 'pid');
+    const logFile = path.join(runtimeRoot, 'output.log');
+    await eventually(() => {
+      expect(fs.existsSync(pidFile)).toBe(true);
+      expect(fs.readFileSync(logFile, 'utf8')).toContain('ready');
+    });
+    expect(fs.statSync(runtimeRoot).mode & 0o777).toBe(0o700);
+
+    const pid = Number(fs.readFileSync(pidFile, 'utf8').trim());
+    expect(() => process.kill(pid, 0)).not.toThrow();
+    execFileSync('/bin/sh', ['-c', snapshot.stop], { cwd: directory });
+    await eventually(() => expect(() => process.kill(pid, 0)).toThrow());
+    expect(fs.existsSync(pidFile)).toBe(false);
+    expect(fs.existsSync(path.join(directory, '.agor'))).toBe(false);
+    execFileSync('/bin/sh', ['-c', snapshot.nuke!], { cwd: directory });
+    expect(fs.existsSync(runtimeRoot)).toBe(false);
+  });
+});

--- a/packages/core/src/config/launch-json.test.ts
+++ b/packages/core/src/config/launch-json.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { parseLaunchJsonDocument } from './launch-json';
+
+describe('parseLaunchJsonDocument', () => {
+  it('compiles VS Code-shaped profiles into supervised environment variants', () => {
+    const environment = parseLaunchJsonDocument(
+      {
+        version: '0.2.0',
+        configurations: [
+          {
+            name: 'Web dev',
+            type: 'node-terminal',
+            request: 'launch',
+            command: 'pnpm dev',
+            cwd: `$${'{workspaceFolder}'}/apps/web`,
+            env: { PORT: '{{add 5000 branch.unique_id}}' },
+            agor: {
+              default: true,
+              health: 'http://localhost:{{add 5000 branch.unique_id}}/health',
+              app: 'http://localhost:{{add 5000 branch.unique_id}}',
+            },
+          },
+        ],
+      },
+      '.agor/launch.json'
+    );
+
+    expect(environment.default).toBe('Web dev');
+    expect(environment.variants['Web dev']).toMatchObject({
+      health: 'http://localhost:{{add 5000 branch.unique_id}}/health',
+      app: 'http://localhost:{{add 5000 branch.unique_id}}',
+    });
+    expect(environment.variants['Web dev']!.start).toContain('nohup sh -c');
+    expect(environment.variants['Web dev']!.start).toContain('PORT=');
+    expect(environment.variants['Web dev']!.start).toContain('{{add 5000 branch.unique_id}}');
+    expect(environment.variants['Web dev']!.start).toContain('./apps/web');
+    expect(environment.variants['Web dev']!.stop).toContain('kill');
+    expect(environment.variants['Web dev']!.logs).toContain('tail -n 100');
+  });
+
+  it('supports runtimeExecutable, runtimeArgs, program, and args', () => {
+    const environment = parseLaunchJsonDocument(
+      {
+        configurations: [
+          {
+            name: 'API',
+            type: 'pwa-node',
+            request: 'launch',
+            runtimeExecutable: 'node',
+            runtimeArgs: ['--enable-source-maps'],
+            program: `$${'{workspaceFolder}'}/server.js`,
+            args: ['--port', '3000'],
+          },
+        ],
+      },
+      '.vscode/launch.json'
+    );
+    expect(environment.variants.API!.start).toContain('node');
+    expect(environment.variants.API!.start).toContain('--enable-source-maps');
+    expect(environment.variants.API!.start).toContain('./server.js');
+  });
+
+  it('rejects attach profiles, duplicate names, and multiple defaults', () => {
+    expect(() =>
+      parseLaunchJsonDocument(
+        { configurations: [{ name: 'Attach', request: 'attach', command: 'node server.js' }] },
+        '.vscode/launch.json'
+      )
+    ).toThrow(/only "launch" is supported/);
+
+    expect(() =>
+      parseLaunchJsonDocument(
+        {
+          configurations: [
+            { name: 'Dev', command: 'a' },
+            { name: 'Dev', command: 'b' },
+          ],
+        },
+        '.agor/launch.json'
+      )
+    ).toThrow(/Duplicate/);
+
+    expect(() =>
+      parseLaunchJsonDocument(
+        {
+          configurations: [
+            { name: 'A', command: 'a', agor: { default: true } },
+            { name: 'B', command: 'b', agor: { default: true } },
+          ],
+        },
+        '.agor/launch.json'
+      )
+    ).toThrow(/Only one/);
+  });
+
+  it('fails clearly for editor orchestration that would otherwise be ignored', () => {
+    expect(() =>
+      parseLaunchJsonDocument(
+        {
+          configurations: [{ name: 'Dev', command: 'npm start', preLaunchTask: 'build' }],
+        },
+        '.vscode/launch.json'
+      )
+    ).toThrow(/preLaunchTask/);
+    expect(() =>
+      parseLaunchJsonDocument(
+        {
+          configurations: [{ name: 'Dev', runtimeExecutable: `$${'{command:pickProcess}'}` }],
+        },
+        '.vscode/launch.json'
+      )
+    ).toThrow(/Unsupported launch variable/);
+  });
+});

--- a/packages/core/src/config/launch-json.ts
+++ b/packages/core/src/config/launch-json.ts
@@ -1,0 +1,236 @@
+import type { RepoEnvironment, RepoEnvironmentVariant } from '../types/branch';
+
+export const LAUNCH_JSON_PATHS = ['.agor/launch.json', '.vscode/launch.json'] as const;
+export type LaunchJsonPath = (typeof LAUNCH_JSON_PATHS)[number];
+const WORKSPACE_FOLDER_VARIABLE = `$${'{workspaceFolder}'}`;
+const WORKSPACE_ROOT_VARIABLE = `$${'{workspaceRoot}'}`;
+
+interface LaunchConfiguration {
+  name?: unknown;
+  request?: unknown;
+  type?: unknown;
+  runtimeExecutable?: unknown;
+  runtimeArgs?: unknown;
+  program?: unknown;
+  args?: unknown;
+  command?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+  agor?: unknown;
+  preLaunchTask?: unknown;
+  postDebugTask?: unknown;
+  envFile?: unknown;
+}
+
+interface AgorLaunchExtension {
+  description?: unknown;
+  default?: unknown;
+  background?: unknown;
+  stop?: unknown;
+  nuke?: unknown;
+  logs?: unknown;
+  health?: unknown;
+  app?: unknown;
+}
+
+export interface LaunchJsonDocument {
+  version?: unknown;
+  configurations?: unknown;
+  compounds?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function expectStringArray(value: unknown, field: string, name: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Launch configuration "${name}" field "${field}" must be an array of strings`);
+  }
+  return value;
+}
+
+function translateVariable(value: string): string {
+  const translated = value
+    .replaceAll(WORKSPACE_FOLDER_VARIABLE, '.')
+    .replaceAll(WORKSPACE_ROOT_VARIABLE, '.');
+  const unsupported = translated.match(/\$\{(?:env|config|command|input):[^}]+\}/)?.[0];
+  if (unsupported) {
+    throw new Error(
+      `Unsupported launch variable "${unsupported}"; use an Agor template or profile env value`
+    );
+  }
+  return translated;
+}
+
+function safeProfileSlug(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'launch';
+}
+
+function compileCommand(config: LaunchConfiguration, name: string): string {
+  if (typeof config.command === 'string' && config.command.trim()) {
+    return translateVariable(config.command.trim());
+  }
+
+  const executable =
+    typeof config.runtimeExecutable === 'string'
+      ? config.runtimeExecutable
+      : typeof config.program === 'string' && ['node', 'pwa-node'].includes(String(config.type))
+        ? 'node'
+        : undefined;
+  if (!executable) {
+    throw new Error(
+      `Launch configuration "${name}" needs "command" or "runtimeExecutable" (Node profiles may use "program")`
+    );
+  }
+
+  const values = [
+    translateVariable(executable),
+    ...expectStringArray(config.runtimeArgs, 'runtimeArgs', name).map(translateVariable),
+    ...(typeof config.program === 'string' ? [translateVariable(config.program)] : []),
+    ...expectStringArray(config.args, 'args', name).map(translateVariable),
+  ];
+  return values.map(shellQuote).join(' ');
+}
+
+function compileEnvironment(value: unknown, name: string): string {
+  if (value === undefined) return '';
+  if (!isRecord(value)) {
+    throw new Error(`Launch configuration "${name}" field "env" must be an object`);
+  }
+  return Object.entries(value)
+    .map(([key, raw]) => {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+        throw new Error(`Launch configuration "${name}" has invalid environment key "${key}"`);
+      }
+      if (typeof raw !== 'string' && typeof raw !== 'number' && typeof raw !== 'boolean') {
+        throw new Error(`Launch configuration "${name}" environment value "${key}" must be scalar`);
+      }
+      return `${key}=${shellQuote(translateVariable(String(raw)))}`;
+    })
+    .join(' ');
+}
+
+function optionalString(
+  extension: AgorLaunchExtension,
+  key: keyof AgorLaunchExtension
+): string | undefined {
+  const value = extension[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') throw new Error(`Launch field "agor.${key}" must be a string`);
+  return translateVariable(value);
+}
+
+function compileConfiguration(
+  config: LaunchConfiguration,
+  sourcePath: LaunchJsonPath
+): { name: string; variant: RepoEnvironmentVariant; isDefault: boolean } {
+  if (typeof config.name !== 'string' || !config.name.trim()) {
+    throw new Error('Every launch configuration must have a non-empty string "name"');
+  }
+  const name = config.name.trim();
+  if (config.request !== undefined && config.request !== 'launch') {
+    throw new Error(
+      `Launch configuration "${name}" uses request "${String(config.request)}"; only "launch" is supported`
+    );
+  }
+  for (const unsupportedField of ['preLaunchTask', 'postDebugTask', 'envFile']) {
+    if (unsupportedField in config) {
+      throw new Error(
+        `Launch configuration "${name}" uses unsupported field "${unsupportedField}"`
+      );
+    }
+  }
+  const extension: AgorLaunchExtension = isRecord(config.agor) ? config.agor : {};
+  const command = compileCommand(config, name);
+  const env = compileEnvironment(config.env, name);
+  const cwd = typeof config.cwd === 'string' ? translateVariable(config.cwd) : '.';
+  const foreground = [env, command].filter(Boolean).join(' ');
+  const slug = safeProfileSlug(name);
+  const marker = `agor-launch-${slug}-{{branch.unique_id}}`;
+  const runtimeSetup = [
+    `agor_runtime_root="$${'{TMPDIR:-/tmp}'}/agor-launch"`,
+    `agor_runtime_key="$(node -e ${shellQuote("process.stdout.write(require('node:crypto').createHash('sha256').update(process.cwd()).digest('hex'))")})"`,
+    `run_dir="$agor_runtime_root/$agor_runtime_key/${slug}-{{branch.unique_id}}"`,
+  ].join('; ');
+  const background = extension.background !== false;
+  const stopOverride = optionalString(extension, 'stop');
+  if (!background && !stopOverride) {
+    throw new Error(
+      `Launch configuration "${name}" sets "agor.background" to false and must provide "agor.stop"`
+    );
+  }
+
+  const supervisor = [
+    'run_dir=$1',
+    'child=',
+    'cleanup() { test -z "$child" || kill "$child" 2>/dev/null || true; rm -f "$run_dir/pid"; }',
+    'trap cleanup TERM INT',
+    `cd ${shellQuote(cwd)} || exit 1`,
+    `${foreground} & child=$!`,
+    'wait "$child"',
+    'status=$?',
+    'rm -f "$run_dir/pid"',
+    'exit "$status"',
+  ].join('; ');
+  const generatedStart = background
+    ? `${runtimeSetup}; mkdir -p "$run_dir"; chmod 700 "$run_dir"; nohup sh -c ${shellQuote(supervisor)} ${shellQuote(marker)} "$run_dir" > "$run_dir/output.log" 2>&1 < /dev/null & echo $! > "$run_dir/pid"`
+    : `cd ${shellQuote(cwd)} && ${foreground}`;
+  const stopTree = `stop_tree() { if command -v pgrep >/dev/null 2>&1; then for child_pid in $(pgrep -P "$1" 2>/dev/null); do stop_tree "$child_pid"; done; fi; kill "$1" 2>/dev/null || true; }`;
+  const generatedStop = `${runtimeSetup}; ${stopTree}; if test -f "$run_dir/pid"; then pid="$(cat "$run_dir/pid")"; if ps -p "$pid" -o command= 2>/dev/null | grep -F -- ${shellQuote(marker)} >/dev/null; then stop_tree "$pid"; else echo "Refusing to stop stale launch PID $pid" >&2; fi; rm -f "$run_dir/pid"; fi`;
+  const stop = stopOverride ?? generatedStop;
+
+  return {
+    name,
+    isDefault: extension.default === true,
+    variant: {
+      description:
+        typeof extension.description === 'string'
+          ? extension.description
+          : `Launch profile imported from ${sourcePath}`,
+      start: generatedStart,
+      stop,
+      nuke: optionalString(extension, 'nuke') ?? `${stop}; ${runtimeSetup}; rm -rf "$run_dir"`,
+      logs:
+        optionalString(extension, 'logs') ??
+        (background ? `${runtimeSetup}; tail -n 100 "$run_dir/output.log"` : undefined),
+      health: optionalString(extension, 'health'),
+      app: optionalString(extension, 'app'),
+    },
+  };
+}
+
+/** Compile VS Code-shaped launch configurations into Agor environment variants. */
+export function parseLaunchJsonDocument(
+  document: LaunchJsonDocument,
+  sourcePath: LaunchJsonPath
+): RepoEnvironment {
+  if (!isRecord(document) || !Array.isArray(document.configurations)) {
+    throw new Error(`${sourcePath} must contain a "configurations" array`);
+  }
+  if (document.configurations.length === 0) {
+    throw new Error(`${sourcePath} has no launch configurations`);
+  }
+  const compiled = document.configurations.map((item) => {
+    if (!isRecord(item)) throw new Error('Every launch configuration must be an object');
+    return compileConfiguration(item, sourcePath);
+  });
+  const defaults = compiled.filter((item) => item.isDefault);
+  if (defaults.length > 1)
+    throw new Error('Only one launch configuration may set "agor.default": true');
+  const variants: Record<string, RepoEnvironmentVariant> = {};
+  for (const item of compiled) {
+    if (variants[item.name]) throw new Error(`Duplicate launch configuration name "${item.name}"`);
+    variants[item.name] = item.variant;
+  }
+  return { version: 2, default: defaults[0]?.name ?? compiled[0]!.name, variants };
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     'codex/auth-file': 'src/codex/auth-file.ts', // Pure Codex auth.json schema inspection
     'config/index': 'src/config/index.ts',
     'config/agor-yml': 'src/config/agor-yml.ts', // Node-only .agor.yml file I/O
+    'config/launch-json': 'src/config/launch-json.ts', // Browser-safe launch profile compiler
     'config/browser': 'src/config/browser.ts', // Browser-safe config utilities
     'permissions/index': 'src/permissions/index.ts',
     'feathers/index': 'src/feathers/index.ts', // FeathersJS runtime re-exports

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   createExecutorClient: vi.fn(),
   diagnoseGit: vi.fn(),
   parseAgorYml: vi.fn(),
+  parseLaunchJson: vi.fn(),
   writeAgorYml: vi.fn(),
   deleteBranchDirectory: vi.fn(),
   deleteRepoDirectory: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock('@agor/core/config', async () => {
 
 vi.mock('@agor/core/config/node', () => ({
   parseAgorYml: mocks.parseAgorYml,
+  parseLaunchJson: mocks.parseLaunchJson,
   writeAgorYml: mocks.writeAgorYml,
 }));
 
@@ -81,6 +83,7 @@ vi.mock('./unix.js', async () => {
 import {
   handleBranchAgorYmlExport,
   handleBranchAgorYmlImport,
+  handleBranchLaunchJsonImport,
   handleGitBranchAdd,
   handleGitBranchRemove,
   handleGitClone,
@@ -696,5 +699,29 @@ describe('managed executor git/fs commands', () => {
       '/safe/worktrees/repo/feature/.agor.yml',
       environment
     );
+  });
+
+  it('imports launch profiles only from the executor-owned branch path', async () => {
+    const imported = {
+      path: '.agor/launch.json',
+      environment: {
+        version: 2,
+        default: 'Web',
+        variants: { Web: { start: 'pnpm dev', stop: 'kill 1' } },
+      },
+    };
+    mocks.parseLaunchJson.mockReturnValue(imported);
+    createClient({
+      branch: { branch_id: branchId, repo_id: repoId, path: '/safe/worktrees/repo/feature' },
+    });
+
+    const result = await handleBranchLaunchJsonImport(
+      { command: 'branch.launch-json.import', sessionToken: 'jwt', params: { repoId, branchId } },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.parseLaunchJson).toHaveBeenCalledWith('/safe/worktrees/repo/feature');
+    expect(result.data).toMatchObject(imported);
   });
 });

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -22,7 +22,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { userInfo } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
 import { getReposDir } from '@agor/core/config';
-import { parseAgorYml, writeAgorYml } from '@agor/core/config/node';
+import { parseAgorYml, parseLaunchJson, writeAgorYml } from '@agor/core/config/node';
 import { shortId } from '@agor/core/db';
 import type { BranchID } from '@agor/core/types';
 import { diagnoseGit } from '@agor/git';
@@ -52,6 +52,7 @@ import type {
   BranchAgorYmlExportPayload,
   BranchAgorYmlImportPayload,
   BranchFilesListPayload,
+  BranchLaunchJsonImportPayload,
   ExecutorResult,
   GitBranchAddPayload,
   GitBranchCleanPayload,
@@ -418,6 +419,34 @@ export async function handleBranchAgorYmlImport(
         // Ignore disconnect errors
       }
     }
+  }
+}
+
+/** Read and compile a branch-scoped editor-style launch file. */
+export async function handleBranchLaunchJsonImport(
+  payload: BranchLaunchJsonImportPayload,
+  options: CommandOptions
+): Promise<ExecutorResult> {
+  const { repoId, branchId } = payload.params;
+  if (options.dryRun) {
+    return { success: true, data: { dryRun: true, command: payload.command, repoId, branchId } };
+  }
+  let client: AgorClient | null = null;
+  try {
+    const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
+    client = await createExecutorClient(daemonUrl, payload.sessionToken);
+    const branch = await fetchBranchForRepo(client, repoId, branchId);
+    const result = parseLaunchJson(branch.path);
+    return { success: true, data: { repoId, branchId, ...result } };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[branch.launch-json.import] Failed:', message);
+    return {
+      success: false,
+      error: { code: 'BRANCH_LAUNCH_JSON_IMPORT_FAILED', message, details: { repoId, branchId } },
+    };
+  } finally {
+    client?.io.disconnect();
   }
 }
 

--- a/packages/executor/src/commands/index.test.ts
+++ b/packages/executor/src/commands/index.test.ts
@@ -54,6 +54,7 @@ describe('Command Registry', () => {
     expect(commands).toContain('branch.gateway.slack-file-upload');
     expect(commands).toContain('branch.upload.materialize');
     expect(commands).toContain('branch.agor-yml.import');
+    expect(commands).toContain('branch.launch-json.import');
     expect(commands).toContain('branch.agor-yml.export');
     expect(commands).toContain('environment.lifecycle');
     expect(commands).toContain('environment.logs');
@@ -79,6 +80,7 @@ describe('Command Registry', () => {
     expect(hasCommand('branch.gateway.slack-file-upload')).toBe(true);
     expect(hasCommand('branch.upload.materialize')).toBe(true);
     expect(hasCommand('branch.agor-yml.import')).toBe(true);
+    expect(hasCommand('branch.launch-json.import')).toBe(true);
     expect(hasCommand('branch.agor-yml.export')).toBe(true);
     expect(hasCommand('environment.lifecycle')).toBe(true);
     expect(hasCommand('environment.logs')).toBe(true);

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -31,6 +31,7 @@ import {
   handleBranchAgorYmlExport,
   handleBranchAgorYmlImport,
   handleBranchFilesList,
+  handleBranchLaunchJsonImport,
   handleGitBranchAdd,
   handleGitBranchClean,
   handleGitBranchRemove,
@@ -261,6 +262,7 @@ registerCommand('branch.knowledge.read', handleBranchKnowledgeRead);
 registerCommand('branch.gateway.slack-file-upload', handleBranchSlackFileUpload);
 registerCommand('branch.upload.materialize', handleBranchUploadMaterialize);
 registerCommand('branch.agor-yml.import', handleBranchAgorYmlImport);
+registerCommand('branch.launch-json.import', handleBranchLaunchJsonImport);
 registerCommand('branch.agor-yml.export', handleBranchAgorYmlExport);
 registerCommand('environment.lifecycle', handleEnvironmentLifecycle);
 registerCommand('environment.logs', handleEnvironmentLogs);

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -603,6 +603,7 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('branch.gateway.slack-file-upload');
     expect(commands).toContain('branch.upload.materialize');
     expect(commands).toContain('branch.agor-yml.import');
+    expect(commands).toContain('branch.launch-json.import');
     expect(commands).toContain('branch.agor-yml.export');
     expect(commands).toContain('environment.lifecycle');
     expect(commands).toContain('environment.logs');
@@ -616,6 +617,6 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('zellij.tab');
     expect(commands).toContain('agentic-tool.invoke');
     expect(commands).toContain('codex.auth-file');
-    expect(commands.length).toBe(32);
+    expect(commands.length).toBe(33);
   });
 });

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -561,6 +561,17 @@ export const BranchAgorYmlImportPayloadSchema = BasePayloadSchema.extend({
 
 export type BranchAgorYmlImportPayload = z.infer<typeof BranchAgorYmlImportPayloadSchema>;
 
+/** Import branch-scoped .agor/launch.json or .vscode/launch.json. */
+export const BranchLaunchJsonImportPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('branch.launch-json.import'),
+  sessionToken: z.string(),
+  params: z.object({
+    repoId: z.string().uuid(),
+    branchId: z.string().uuid(),
+  }),
+});
+export type BranchLaunchJsonImportPayload = z.infer<typeof BranchLaunchJsonImportPayloadSchema>;
+
 /**
  * Export environment config into branch-scoped .agor.yml in a managed checkout.
  */
@@ -979,6 +990,7 @@ export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   BranchSlackFileUploadPayloadSchema,
   BranchUploadMaterializePayloadSchema,
   BranchAgorYmlImportPayloadSchema,
+  BranchLaunchJsonImportPayloadSchema,
   BranchAgorYmlExportPayloadSchema,
   EnvironmentLifecyclePayloadSchema,
   EnvironmentLogsPayloadSchema,
@@ -1059,6 +1071,7 @@ export function getSupportedCommands(): string[] {
     'branch.gateway.slack-file-upload',
     'branch.upload.materialize',
     'branch.agor-yml.import',
+    'branch.launch-json.import',
     'branch.agor-yml.export',
     'environment.lifecycle',
     'environment.logs',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,9 @@ importers:
       js-yaml:
         specifier: '>=4.3.1 <5'
         version: 4.3.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -5305,6 +5308,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-clipboard@0.2.0':
     resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,9 @@ importers:
       js-yaml:
         specifier: '>=4.3.1 <5'
         version: 4.3.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3


### PR DESCRIPTION
## Summary

Adds a VS Code-shaped way to run projects directly in Agor worktrees while preserving the existing Docker, shell-command, and webhook environment paths.

Repositories can define `.agor/launch.json` or reuse `.vscode/launch.json`. An admin imports the profiles from a branch's Environment tab, each configuration becomes an Agor environment variant, and the existing Render/Start/Stop/Restart/Nuke/Logs controls continue to own authorization and runtime state.

## Launch profile support

- prefer `.agor/launch.json`, falling back to `.vscode/launch.json`
- parse JSONC comments and trailing commas
- support `command`, `runtimeExecutable`, `runtimeArgs`, `program`, `args`, `cwd`, and scalar `env`
- translate `${workspaceFolder}` and `${workspaceRoot}` to the branch checkout
- support `agor.default`, `description`, `background`, `stop`, `nuke`, `logs`, `health`, and `app`
- fail clearly on attach profiles, duplicate names/defaults, `preLaunchTask`, `postDebugTask`, `envFile`, and editor command/input variables instead of silently ignoring them

## Process lifecycle

- background profiles return from Start immediately and capture output for View Logs
- runtime metadata lives outside the checkout in a mode-0700 temporary directory keyed by a SHA-256 digest of the worktree path
- Stop validates the saved PID's launch marker before signaling it, rejects stale PID reuse, and recursively terminates descendants when `pgrep` is available
- Nuke performs Stop and removes the profile runtime directory
- foreground/one-shot profiles remain available with `agor.background: false` and require an explicit stop command

## Security and tenancy

- import is admin-only and uses the existing authenticated, branch-scoped repo/branch relationship check
- filesystem discovery occurs in the executor using the authorized branch path; callers cannot supply an arbitrary path
- compiled profiles flow through the existing environment snapshot, RBAC, execution identity, command deny-list, and tenant-scoped repo update paths
- runtime directories are worktree-derived and private, preventing collisions and log/PID sharing across worktrees
- deployment-local `template_overrides` are preserved and existing branch snapshots are not silently rewritten

## Validation

- core launch compiler and JSONC discovery tests: 26 passing
- real lifecycle test launches a Node server, captures logs, verifies private runtime permissions and a clean checkout, stops it, and verifies Nuke cleanup
- executor payload, routing, and authorized branch-path tests: 77 passing
- Biome passes on all touched TypeScript/TSX files
- Prettier passes on docs, OpenAPI, package metadata, and lockfile
- `git diff --check` passes

## Documentation

The environment guide now includes the supported schema, examples, lifecycle behavior, import precedence, security model, and explicitly unsupported VS Code features.
