### PR TITLE
chore(release): prepare agor-live 0.24.7

### DIFF
--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -226,6 +226,9 @@ jobs:
           export PATH="$ROOT/npm-shim:$PATH"
           export AGOR_SMOKE_REAL_NPM="$REAL_NPM"
           export AGOR_SMOKE_CODEX="$CODEX"
+          # Model an upgrade initiated from an executor spawned by the prior
+          # Agor version. The newly installed launcher must own AGOR_VERSION.
+          export AGOR_VERSION=0.0.0-stale
           AGOR_TELEMETRY=0 "$RUNNER_TEMP/plain-install/prefix/bin/agor" init \
             --non-interactive --agentic-tools codex
           AGOR_TELEMETRY=0 "$RUNNER_TEMP/plain-install/prefix/bin/agor" doctor --json \

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/bin/agor-daemon.js
+++ b/packages/agor-live/bin/agor-daemon.js
@@ -18,7 +18,9 @@ const { dirname: pathDirname, join: pathJoin } = await import('node:path');
 const { fileURLToPath: toFilePath } = await import('node:url');
 const packageRoot = pathJoin(pathDirname(toFilePath(import.meta.url)), '..');
 const packageMetadata = JSON.parse(readFileSync(pathJoin(packageRoot, 'package.json'), 'utf8'));
-process.env.AGOR_VERSION ??= packageMetadata.version;
+// The installed package is the authority for its managed-integration version.
+// Do not inherit a stale value when an older Agor executor upgrades the host.
+process.env.AGOR_VERSION = packageMetadata.version;
 process.env.AGOR_AGENTIC_TOOLS_DIR ??= pathJoin(homedir(), '.agor', 'agentic-tools');
 process.env.AGOR_MANAGED_AGENTIC_TOOLS ??= '1';
 

--- a/packages/agor-live/bin/agor.js
+++ b/packages/agor-live/bin/agor.js
@@ -18,7 +18,9 @@ const { dirname: pathDirname, join: pathJoin } = await import('node:path');
 const { fileURLToPath: toFilePath } = await import('node:url');
 const packageRoot = pathJoin(pathDirname(toFilePath(import.meta.url)), '..');
 const packageMetadata = JSON.parse(readFileSync(pathJoin(packageRoot, 'package.json'), 'utf8'));
-process.env.AGOR_VERSION ??= packageMetadata.version;
+// The installed package is the authority for its managed-integration version.
+// Do not inherit a stale value when an older Agor executor upgrades the host.
+process.env.AGOR_VERSION = packageMetadata.version;
 process.env.AGOR_AGENTIC_TOOLS_DIR ??= pathJoin(homedir(), '.agor', 'agentic-tools');
 process.env.AGOR_MANAGED_AGENTIC_TOOLS ??= '1';
 

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.24.6';
+export const AGOR_INTEGRATION_VERSION = '0.24.7';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- align `agor-live`, `@agor-live/client`, and all six managed integration wrappers at `0.24.7`
- make the installed launcher/package manifest authoritative for `AGOR_VERSION`
- cover upgrades initiated inside an executor inherited from an older Agor version

## Why the launcher change is included

During packaged validation from this Agor session, the new `0.24.7` CLI inherited
`AGOR_VERSION=0.24.6` from its parent executor. The launchers previously used
`??=`, so `agor install --sync` could reconcile the old version and a restarted
daemon could continue advertising/using the stale managed-package version.

Packaged launchers now always stamp the version from their own immutable
`package.json`. User-configurable package location remains overridable through
`AGOR_AGENTIC_TOOLS_DIR`.

## Validation

- `packages/agor-live/build.sh --bump patch`
- all 8 release tarballs produced and aligned at `0.24.7`
- full workspace build/typecheck performed by the packer
- `pnpm check:agentic-tool-packages`
- `node scripts/sync-agor-live-deps.mjs --check`
- `pnpm --dir packages/agor-live test` - 4/4
- package-content budget - 2,456 files; 21.95 MiB packed
- clean isolated global install with npm 10 / Node 22
- clean `--ignore-scripts` global install
- packaged `agor --version`, headless init, and doctor
- bundled internal-package containment
- real optional PTY spawn
- packaged init with inherited stale `AGOR_VERSION` resolves `0.24.7`
- workflow Prettier and `git diff --check`

The PR packaged smoke is the representative Node 24.19 gate. After merge, the
`v0.24.7` tag runs the full Node 22.12/24.19/26, macOS, npm 12, daemon/UI/Git,
and all-integration release matrix before protected npm publication.

## Runbook

Verified current:

- [Releasing Agor packages](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/engineering/releasing-agor-packages.md)
- [Production runbook](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/operations/production-runbook.md)

They already describe the bump-PR -> merge -> immutable tag flow, publishing all
eight packages with `agor-live` last, exact-version reconciliation, RCs under
`next`, and the production deployment checklist. No runbook change is required
for this patch.
