### PR TITLE
feat(db): Add machine-readable migration status introspection

### DIFF
--- a/apps/agor-cli/src/commands/db/migrate.ts
+++ b/apps/agor-cli/src/commands/db/migrate.ts
@@ -5,7 +5,7 @@
 import {
   checkMigrationStatus,
   createDatabase,
-  isSQLiteDatabase,
+  getDatabaseInstanceDialect,
   pendingOfflineCutoverMigrations,
 } from '@agor/core/db';
 import { expandPath } from '@agor/core/utils/path';
@@ -13,6 +13,7 @@ import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import {
   databaseBackupGuidance,
+  MigrationVerificationError,
   migrationFailureMessage,
   migrationVerificationDiagnostics,
 } from '../../lib/db-migrate-presentation.js';
@@ -51,7 +52,7 @@ export default class DbMigrate extends Command {
       this.log('');
 
       const db = createDatabase({ url: dbUrl });
-      const dialect = isSQLiteDatabase(db) ? 'sqlite' : 'postgresql';
+      const dialect = getDatabaseInstanceDialect(db);
       const status = await checkMigrationStatus(db);
 
       if (!status.hasPending) {
@@ -154,7 +155,7 @@ export default class DbMigrate extends Command {
           this.log(chalk.cyan(line));
         });
         this.log('');
-        this.error(`Migration verification failed`);
+        throw new MigrationVerificationError();
       }
 
       this.log('');

--- a/apps/agor-cli/src/commands/db/migrate.ts
+++ b/apps/agor-cli/src/commands/db/migrate.ts
@@ -5,6 +5,8 @@
 import {
   checkMigrationStatus,
   createDatabase,
+  formatSanitizedDbError,
+  isSQLiteDatabase,
   pendingOfflineCutoverMigrations,
   sanitizeDbError,
 } from '@agor/core/db';
@@ -68,12 +70,15 @@ export default class DbMigrate extends Command {
       });
       this.log('');
 
-      const offlineCutovers = pendingOfflineCutoverMigrations(status);
+      const offlineCutovers = pendingOfflineCutoverMigrations(
+        isSQLiteDatabase(db) ? 'sqlite' : 'postgresql',
+        status
+      );
       if (offlineCutovers.length > 0) {
         this.log(chalk.red.bold('⛔ OFFLINE CUTOVER REQUIRED'));
         this.log('');
         this.log(
-          `${offlineCutovers.join(', ')} changes a distributed state/ownership protocol and is not rolling-compatible.`
+          `${offlineCutovers.join(', ')} includes migration work that is not safe while existing daemons are writing.`
         );
         this.log('Old and new daemons must not index this database concurrently.');
         this.log('');
@@ -84,7 +89,7 @@ export default class DbMigrate extends Command {
         );
         this.log('  3. Start only daemons running the new release.');
         this.log('');
-        requireOfflineCutoverAcknowledgement(status, flags['offline-cutover']);
+        requireOfflineCutoverAcknowledgement(db, status, flags['offline-cutover']);
       }
 
       // Warn about backup
@@ -165,7 +170,7 @@ export default class DbMigrate extends Command {
       process.exit(0);
     } catch (error) {
       const safeError = sanitizeDbError(error);
-      this.error(`Failed to run migrations: ${safeError.message}`);
+      this.error(`Failed to run migrations: ${formatSanitizedDbError(safeError)}`);
     }
   }
 }

--- a/apps/agor-cli/src/commands/db/migrate.ts
+++ b/apps/agor-cli/src/commands/db/migrate.ts
@@ -5,14 +5,17 @@
 import {
   checkMigrationStatus,
   createDatabase,
-  formatSanitizedDbError,
   isSQLiteDatabase,
   pendingOfflineCutoverMigrations,
-  sanitizeDbError,
 } from '@agor/core/db';
-import { expandPath, extractDbFilePath } from '@agor/core/utils/path';
+import { expandPath } from '@agor/core/utils/path';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
+import {
+  databaseBackupGuidance,
+  migrationFailureMessage,
+  migrationVerificationDiagnostics,
+} from '../../lib/db-migrate-presentation.js';
 import {
   requireOfflineCutoverAcknowledgement,
   runConfirmedMigrations,
@@ -44,12 +47,11 @@ export default class DbMigrate extends Command {
       // Priority: DATABASE_URL > AGOR_DB_PATH > default SQLite path
       const dbUrl =
         process.env.DATABASE_URL || expandPath(process.env.AGOR_DB_PATH || 'file:~/.agor/agor.db');
-      const dbFilePath = extractDbFilePath(dbUrl);
-
       this.log(chalk.bold('🔍 Checking database migration status...'));
       this.log('');
 
       const db = createDatabase({ url: dbUrl });
+      const dialect = isSQLiteDatabase(db) ? 'sqlite' : 'postgresql';
       const status = await checkMigrationStatus(db);
 
       if (!status.hasPending) {
@@ -70,10 +72,7 @@ export default class DbMigrate extends Command {
       });
       this.log('');
 
-      const offlineCutovers = pendingOfflineCutoverMigrations(
-        isSQLiteDatabase(db) ? 'sqlite' : 'postgresql',
-        status
-      );
+      const offlineCutovers = pendingOfflineCutoverMigrations(dialect, status);
       if (offlineCutovers.length > 0) {
         this.log(chalk.red.bold('⛔ OFFLINE CUTOVER REQUIRED'));
         this.log('');
@@ -95,8 +94,9 @@ export default class DbMigrate extends Command {
       // Warn about backup
       this.log(chalk.bold('⚠️  IMPORTANT: Backup your database before proceeding!'));
       this.log('');
-      this.log(`Run this command to create a backup:`);
-      this.log(chalk.cyan(`  cp ${dbFilePath} ${dbFilePath}.backup-$(date +%s)`));
+      databaseBackupGuidance(dialect, dbUrl).forEach((line) => {
+        this.log(chalk.cyan(line));
+      });
       this.log('');
 
       // Skip confirmation if --yes flag is set
@@ -150,12 +150,9 @@ export default class DbMigrate extends Command {
         this.log('  3. Schema changes were made manually outside migrations');
         this.log('');
         this.log(chalk.bold('Diagnostic steps:'));
-        this.log('  1. Check if columns already exist:');
-        this.log(chalk.cyan(`     sqlite3 ${dbFilePath} "PRAGMA table_info(branches)"`));
-        this.log('  2. Rebuild core package:');
-        this.log(chalk.cyan('     cd packages/core && pnpm build'));
-        this.log('  3. Check migration hashes:');
-        this.log(chalk.cyan(`     sqlite3 ${dbFilePath} "SELECT hash FROM __drizzle_migrations"`));
+        migrationVerificationDiagnostics(dialect, dbUrl).forEach((line) => {
+          this.log(chalk.cyan(line));
+        });
         this.log('');
         this.error(`Migration verification failed`);
       }
@@ -169,8 +166,7 @@ export default class DbMigrate extends Command {
       // Force exit to close database connections (postgres-js keeps connections open)
       process.exit(0);
     } catch (error) {
-      const safeError = sanitizeDbError(error);
-      this.error(`Failed to run migrations: ${formatSanitizedDbError(safeError)}`);
+      this.error(migrationFailureMessage(error));
     }
   }
 }

--- a/apps/agor-cli/src/commands/db/status.test.ts
+++ b/apps/agor-cli/src/commands/db/status.test.ts
@@ -88,7 +88,7 @@ describe('db status command', () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   it('does not expose credentials when status fails', async () => {
     const secret = 'status-secret-value';
@@ -99,7 +99,7 @@ describe('db status command', () => {
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain('postgresql://user:');
-  });
+  }, 30_000);
 
   it('does not expose credentials when migration fails', async () => {
     const secret = 'migration-secret-value';
@@ -110,5 +110,5 @@ describe('db status command', () => {
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain('postgresql://user:');
-  });
+  }, 30_000);
 });

--- a/apps/agor-cli/src/commands/db/status.test.ts
+++ b/apps/agor-cli/src/commands/db/status.test.ts
@@ -1,0 +1,90 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cliRoot = resolve(import.meta.dirname, '../../..');
+
+function runDb(
+  command: 'status' | 'migrate',
+  args: string[],
+  env: Record<string, string>
+): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', 'bin/dev.ts', 'db', command, ...args],
+      {
+        cwd: cliRoot,
+        env: {
+          ...process.env,
+          ...env,
+          NO_COLOR: '1',
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --conditions=source`.trim(),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+    child.once('error', reject);
+    child.once('close', (code) => resolveRun({ code, stdout, stderr }));
+  });
+}
+
+describe('db status command', () => {
+  it('emits only the strict JSON contract for a fresh database', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'agor-db-status-'));
+    try {
+      const result = await runDb('status', ['--json'], {
+        AGOR_DB_DIALECT: 'sqlite',
+        AGOR_DB_PATH: `file:${join(directory, 'fresh.db')}`,
+      });
+      expect(result.code).toBe(0);
+      const output = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(Object.keys(output).sort()).toEqual([
+        'appliedMigrations',
+        'databaseAheadOfBinary',
+        'pendingMigrations',
+        'requiresOfflineCutover',
+        'schemaVersion',
+      ]);
+      expect(output.schemaVersion).toBe(1);
+      expect(output.appliedMigrations).toEqual([]);
+      expect(Array.isArray(output.pendingMigrations)).toBe(true);
+      expect((output.pendingMigrations as unknown[]).length).toBeGreaterThan(0);
+      expect(output.requiresOfflineCutover).toBe(false);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not expose credentials when status fails', async () => {
+    const secret = 'status-secret-value';
+    const result = await runDb('status', ['--json'], {
+      AGOR_DB_DIALECT: 'postgresql',
+      DATABASE_URL: `postgresql://user:${secret}@[invalid/database`,
+    });
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain('postgresql://user:');
+  });
+
+  it('does not expose credentials when migration fails', async () => {
+    const secret = 'migration-secret-value';
+    const result = await runDb('migrate', ['--yes'], {
+      AGOR_DB_DIALECT: 'postgresql',
+      DATABASE_URL: `postgresql://user:${secret}@[invalid/database`,
+    });
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain('postgresql://user:');
+  });
+});

--- a/apps/agor-cli/src/commands/db/status.test.ts
+++ b/apps/agor-cli/src/commands/db/status.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const cliRoot = resolve(import.meta.dirname, '../../..');
+const COMMAND_TIMEOUT_MS = 15_000;
 
 function runDb(
   command: 'status' | 'migrate',
@@ -32,10 +33,31 @@ function runDb(
     );
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    let forceKill: ReturnType<typeof setTimeout> | undefined;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      forceKill = setTimeout(() => child.kill('SIGKILL'), 2_000);
+    }, COMMAND_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      if (forceKill) clearTimeout(forceKill);
+    };
     child.stdout.on('data', (chunk) => (stdout += String(chunk)));
     child.stderr.on('data', (chunk) => (stderr += String(chunk)));
-    child.once('error', reject);
-    child.once('close', (code) => resolveRun({ code, stdout, stderr }));
+    child.once('error', (error) => {
+      cleanup();
+      reject(error);
+    });
+    child.once('close', (code) => {
+      cleanup();
+      if (timedOut) {
+        reject(new Error(`db ${command} subprocess exceeded ${COMMAND_TIMEOUT_MS}ms`));
+      } else {
+        resolveRun({ code, stdout, stderr });
+      }
+    });
   });
 }
 
@@ -52,11 +74,13 @@ describe('db status command', () => {
       expect(Object.keys(output).sort()).toEqual([
         'appliedMigrations',
         'databaseAheadOfBinary',
+        'dialect',
         'pendingMigrations',
         'requiresOfflineCutover',
         'schemaVersion',
       ]);
       expect(output.schemaVersion).toBe(1);
+      expect(output.dialect).toBe('sqlite');
       expect(output.appliedMigrations).toEqual([]);
       expect(Array.isArray(output.pendingMigrations)).toBe(true);
       expect((output.pendingMigrations as unknown[]).length).toBeGreaterThan(0);
@@ -70,7 +94,7 @@ describe('db status command', () => {
     const secret = 'status-secret-value';
     const result = await runDb('status', ['--json'], {
       AGOR_DB_DIALECT: 'postgresql',
-      DATABASE_URL: `postgresql://user:${secret}@[invalid/database`,
+      DATABASE_URL: `postgresql://user:${secret}@127.0.0.1:1/database?connect_timeout=1`,
     });
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);
@@ -81,7 +105,7 @@ describe('db status command', () => {
     const secret = 'migration-secret-value';
     const result = await runDb('migrate', ['--yes'], {
       AGOR_DB_DIALECT: 'postgresql',
-      DATABASE_URL: `postgresql://user:${secret}@[invalid/database`,
+      DATABASE_URL: `postgresql://user:${secret}@127.0.0.1:1/database?connect_timeout=1`,
     });
     expect(result.code).not.toBe(0);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain(secret);

--- a/apps/agor-cli/src/commands/db/status.ts
+++ b/apps/agor-cli/src/commands/db/status.ts
@@ -6,6 +6,7 @@ import {
   checkMigrationStatus,
   createDatabase,
   formatSanitizedDbError,
+  getDatabaseInstanceDialect,
   getDatabaseUrl,
   introspectMigrationStatus,
   isSQLiteDatabase,
@@ -70,10 +71,7 @@ export default class DbStatus extends Command {
         });
         this.log(
           JSON.stringify(
-            introspectMigrationStatus(
-              isSQLiteDatabase(status.db) ? 'sqlite' : 'postgresql',
-              status.status
-            )
+            introspectMigrationStatus(getDatabaseInstanceDialect(status.db), status.status)
           )
         );
         process.exit(0);
@@ -81,6 +79,7 @@ export default class DbStatus extends Command {
 
       const dbUrl = getDatabaseUrl();
       const db = createDatabase({ url: dbUrl });
+      const sqlite = isSQLiteDatabase(db);
 
       // Use comprehensive migration status check
       const status = await checkMigrationStatus(db);
@@ -121,13 +120,13 @@ export default class DbStatus extends Command {
         this.log('');
 
         // Query Drizzle's tracking table for hash details
-        const result = isSQLiteDatabase(db)
+        const result = sqlite
           ? await db.run(sql`SELECT id, hash, created_at FROM __drizzle_migrations ORDER BY id ASC`)
           : await db.execute(
               sql`SELECT id, hash, created_at FROM drizzle.__drizzle_migrations ORDER BY id ASC`
             );
 
-        const rows = isSQLiteDatabase(db) ? (result as QueryResult).rows : (result as unknown[]);
+        const rows = sqlite ? (result as QueryResult).rows : (result as unknown[]);
 
         this.log(
           `${chalk.dim('Database contains')} ${rows.length} ${chalk.dim('migration record(s)')}`

--- a/apps/agor-cli/src/commands/db/status.ts
+++ b/apps/agor-cli/src/commands/db/status.ts
@@ -6,7 +6,9 @@ import {
   checkMigrationStatus,
   createDatabase,
   getDatabaseUrl,
+  introspectMigrationStatus,
   isSQLiteDatabase,
+  sanitizeDbError,
   sql,
 } from '@agor/core/db';
 import { Command, Flags } from '@oclif/core';
@@ -20,6 +22,19 @@ interface QueryResult {
   rowCount?: number;
 }
 
+async function withoutConsoleOutput<T>(operation: () => Promise<T>): Promise<T> {
+  const methods = ['log', 'info', 'warn', 'error'] as const;
+  const originals = methods.map((method) => console[method]);
+  for (const method of methods) console[method] = () => undefined;
+  try {
+    return await operation();
+  } finally {
+    methods.forEach((method, index) => {
+      console[method] = originals[index];
+    });
+  }
+}
+
 export default class DbStatus extends Command {
   static description = 'Show applied database migrations';
 
@@ -31,6 +46,11 @@ export default class DbStatus extends Command {
       description: 'Show detailed migration information including hashes and pending migrations',
       default: false,
     }),
+    json: Flags.boolean({
+      description: 'Output the versioned machine-readable migration status as JSON',
+      default: false,
+      exclusive: ['verbose'],
+    }),
   };
 
   async run(): Promise<void> {
@@ -39,6 +59,18 @@ export default class DbStatus extends Command {
     try {
       // Determine database URL using centralized logic
       // Priority: If AGOR_DB_DIALECT=postgresql, use DATABASE_URL; otherwise AGOR_DB_PATH
+      if (flags.json) {
+        // Database clients and probes may emit setup diagnostics. JSON mode is
+        // deliberately a single-document stdout contract, so contain those
+        // implementation details while the runtime builds the report.
+        const status = await withoutConsoleOutput(async () => {
+          const db = createDatabase({ url: getDatabaseUrl() });
+          return checkMigrationStatus(db);
+        });
+        this.log(JSON.stringify(introspectMigrationStatus(status)));
+        process.exit(0);
+      }
+
       const dbUrl = getDatabaseUrl();
       const db = createDatabase({ url: dbUrl });
 
@@ -113,9 +145,8 @@ export default class DbStatus extends Command {
       // Force exit to close database connections (postgres-js keeps connections open)
       process.exit(0);
     } catch (error) {
-      this.error(
-        `Failed to get migration status: ${error instanceof Error ? error.message : String(error)}`
-      );
+      const safeError = sanitizeDbError(error);
+      this.error(`Failed to get migration status: ${safeError.message}`);
     }
   }
 }

--- a/apps/agor-cli/src/commands/db/status.ts
+++ b/apps/agor-cli/src/commands/db/status.ts
@@ -5,6 +5,7 @@
 import {
   checkMigrationStatus,
   createDatabase,
+  formatSanitizedDbError,
   getDatabaseUrl,
   introspectMigrationStatus,
   isSQLiteDatabase,
@@ -65,9 +66,16 @@ export default class DbStatus extends Command {
         // implementation details while the runtime builds the report.
         const status = await withoutConsoleOutput(async () => {
           const db = createDatabase({ url: getDatabaseUrl() });
-          return checkMigrationStatus(db);
+          return { db, status: await checkMigrationStatus(db) };
         });
-        this.log(JSON.stringify(introspectMigrationStatus(status)));
+        this.log(
+          JSON.stringify(
+            introspectMigrationStatus(
+              isSQLiteDatabase(status.db) ? 'sqlite' : 'postgresql',
+              status.status
+            )
+          )
+        );
         process.exit(0);
       }
 
@@ -146,7 +154,7 @@ export default class DbStatus extends Command {
       process.exit(0);
     } catch (error) {
       const safeError = sanitizeDbError(error);
-      this.error(`Failed to get migration status: ${safeError.message}`);
+      this.error(`Failed to get migration status: ${formatSanitizedDbError(safeError)}`);
     }
   }
 }

--- a/apps/agor-cli/src/lib/db-migrate-presentation.test.ts
+++ b/apps/agor-cli/src/lib/db-migrate-presentation.test.ts
@@ -1,6 +1,8 @@
+import { MigrationError, OfflineMigrationCutoverRequiredError } from '@agor/core/db';
 import { describe, expect, it } from 'vitest';
 import {
   databaseBackupGuidance,
+  MigrationVerificationError,
   migrationFailureMessage,
   migrationVerificationDiagnostics,
 } from './db-migrate-presentation.js';
@@ -65,5 +67,57 @@ describe('db migrate presentation', () => {
     expect(backup).toContain(`cp -- '/tmp/agor db'"'"'s/runtime.db'`);
     expect(diagnostics).toContain(`sqlite3 '/tmp/agor db'"'"'s/runtime.db'`);
     expect(diagnostics).toContain('PRAGMA table_info(branches)');
+  });
+
+  it.each([
+    'libsql://remote_user:raw-secret@db.example/remote?authToken=token%2Fencoded&mode=rw',
+    'https://db.example/remote?username=remote_user&password=raw-secret&token=token%2Fencoded',
+  ])('never prints remote SQLite connection details for %s', (remoteUrl) => {
+    const output = [
+      ...databaseBackupGuidance('sqlite', remoteUrl),
+      ...migrationVerificationDiagnostics('sqlite', remoteUrl),
+    ].join('\n');
+
+    expect(output).toContain('database provider procedure');
+    expect(output).toContain('database administration tools');
+    expect(output).not.toContain('cp ');
+    expect(output).not.toContain('sqlite3');
+    for (const sensitive of [
+      remoteUrl,
+      'db.example',
+      'remote',
+      'remote_user',
+      'raw-secret',
+      'authToken',
+      'password',
+      'token/encoded',
+      'token%2Fencoded',
+    ]) {
+      expect(output).not.toContain(sensitive);
+      expect(output).not.toContain(encodeURIComponent(sensitive));
+    }
+  });
+
+  it('retains only explicitly recognized actionable migration failures', () => {
+    expect(
+      migrationFailureMessage(new OfflineMigrationCutoverRequiredError(['0074_safe']))
+    ).toContain('Offline migration cutover required for: 0074_safe');
+    expect(migrationFailureMessage(new MigrationVerificationError())).toBe(
+      'Failed to run migrations: Migration verification failed'
+    );
+  });
+
+  it('sanitizes arbitrary MigrationError messages and wrapped driver failures', () => {
+    const secret = 'libsql://user:secret@private.example/db?authToken=encoded%2Ftoken';
+    for (const error of [
+      new MigrationError(`Driver rejected ${secret}`),
+      new MigrationError('Migration failed', new Error(`connection failed: ${secret}`)),
+    ]) {
+      const message = migrationFailureMessage(error);
+      expect(message).toBe('Failed to run migrations: Database operation failed');
+      expect(message).not.toContain(secret);
+      expect(message).not.toContain('private.example');
+      expect(message).not.toContain('encoded%2Ftoken');
+    }
   });
 });

--- a/apps/agor-cli/src/lib/db-migrate-presentation.test.ts
+++ b/apps/agor-cli/src/lib/db-migrate-presentation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  databaseBackupGuidance,
+  migrationFailureMessage,
+  migrationVerificationDiagnostics,
+} from './db-migrate-presentation.js';
+
+const databaseUrl =
+  'postgresql://migration_user:super-secret-password@db.internal/runtime?sslmode=require';
+
+const sensitiveValues = [
+  databaseUrl,
+  'migration_user',
+  'super-secret-password',
+  'db.internal',
+  'runtime',
+  'sslmode',
+  'require',
+];
+
+function expectSecretSafe(stdout: string, stderr = ''): void {
+  for (const value of sensitiveValues) {
+    expect(stdout).not.toContain(value);
+    expect(stderr).not.toContain(value);
+    expect(stdout).not.toContain(encodeURIComponent(value));
+    expect(stderr).not.toContain(encodeURIComponent(value));
+  }
+}
+
+describe('db migrate presentation', () => {
+  it('presents successful PostgreSQL migration backup guidance without connection details', () => {
+    const stdout = databaseBackupGuidance('postgresql', databaseUrl).join('\n');
+    const stderr = '';
+
+    expect(stdout).toContain('PostgreSQL backup procedure');
+    expect(stdout).not.toContain('cp ');
+    expectSecretSafe(stdout, stderr);
+  });
+
+  it('presents a PostgreSQL migration failure without connection details', () => {
+    const stdout = '';
+    const stderr = migrationFailureMessage(
+      new Error(`connection to ${databaseUrl} (${encodeURIComponent(databaseUrl)}) failed`)
+    );
+
+    expect(stderr).toBe('Failed to run migrations: Database operation failed');
+    expectSecretSafe(stdout, stderr);
+  });
+
+  it('presents PostgreSQL verification failure diagnostics without SQLite commands or details', () => {
+    const stdout = migrationVerificationDiagnostics('postgresql', databaseUrl).join('\n');
+    const stderr = '';
+
+    expect(stdout).toContain('PostgreSQL administration tools');
+    expect(stdout).not.toContain('sqlite3');
+    expect(stdout).not.toContain('PRAGMA');
+    expectSecretSafe(stdout, stderr);
+  });
+
+  it('keeps SQLite backup and verification guidance safely path-based', () => {
+    const sqliteUrl = "file:/tmp/agor db's/runtime.db";
+    const backup = databaseBackupGuidance('sqlite', sqliteUrl).join('\n');
+    const diagnostics = migrationVerificationDiagnostics('sqlite', sqliteUrl).join('\n');
+
+    expect(backup).toContain(`cp -- '/tmp/agor db'"'"'s/runtime.db'`);
+    expect(diagnostics).toContain(`sqlite3 '/tmp/agor db'"'"'s/runtime.db'`);
+    expect(diagnostics).toContain('PRAGMA table_info(branches)');
+  });
+});

--- a/apps/agor-cli/src/lib/db-migrate-presentation.ts
+++ b/apps/agor-cli/src/lib/db-migrate-presentation.ts
@@ -1,18 +1,50 @@
-import { formatSanitizedDbError, type getDatabaseDialect, sanitizeDbError } from '@agor/core/db';
+import {
+  type DatabaseDialect,
+  formatSanitizedDbError,
+  OfflineMigrationCutoverRequiredError,
+  sanitizeDbError,
+} from '@agor/core/db';
 import { extractDbFilePath } from '@agor/core/utils/path';
-
-type DatabaseDialect = ReturnType<typeof getDatabaseDialect>;
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
+
+function localSQLitePath(dbUrl: string): string | undefined {
+  if (dbUrl.startsWith('file:')) {
+    if (dbUrl.includes('?') || dbUrl.includes('#')) return undefined;
+    const remainder = dbUrl.slice('file:'.length);
+    // A file URL with a non-local authority names a remote resource.
+    if (remainder.startsWith('//')) {
+      try {
+        const parsed = new URL(dbUrl);
+        if (parsed.hostname) return undefined;
+      } catch {
+        return undefined;
+      }
+    }
+    return extractDbFilePath(dbUrl);
+  }
+
+  // Scheme-less values are filesystem paths. Refuse URL-like and
+  // protocol-relative values rather than ever printing a remote endpoint.
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(dbUrl) || dbUrl.startsWith('//')) return undefined;
+  return extractDbFilePath(dbUrl);
+}
+
+const REMOTE_SQLITE_BACKUP =
+  'Create a database backup or storage snapshot using your database provider procedure.';
+const REMOTE_SQLITE_VERIFICATION =
+  '  1. Inspect the schema and migration ledger using your database administration tools.';
 
 export function databaseBackupGuidance(dialect: DatabaseDialect, dbUrl: string): string[] {
   if (dialect === 'postgresql') {
     return ['Create a database backup or storage snapshot using your PostgreSQL backup procedure.'];
   }
 
-  const path = shellQuote(extractDbFilePath(dbUrl));
+  const localPath = localSQLitePath(dbUrl);
+  if (!localPath) return [REMOTE_SQLITE_BACKUP];
+  const path = shellQuote(localPath);
   return ['Run this command to create a backup:', `  cp -- ${path} ${path}.backup-$(date +%s)`];
 }
 
@@ -29,7 +61,16 @@ export function migrationVerificationDiagnostics(
     ];
   }
 
-  const path = shellQuote(extractDbFilePath(dbUrl));
+  const localPath = localSQLitePath(dbUrl);
+  if (!localPath) {
+    return [
+      REMOTE_SQLITE_VERIFICATION,
+      '  2. Rebuild core package:',
+      '     cd packages/core && pnpm build',
+      '  3. Compare the applied migration ledger with the migrations in this release.',
+    ];
+  }
+  const path = shellQuote(localPath);
   return [
     '  1. Check if columns already exist:',
     `     sqlite3 ${path} "PRAGMA table_info(branches)"`,
@@ -40,6 +81,19 @@ export function migrationVerificationDiagnostics(
   ];
 }
 
+export class MigrationVerificationError extends Error {
+  constructor() {
+    super('Migration verification failed');
+    this.name = 'MigrationVerificationError';
+  }
+}
+
 export function migrationFailureMessage(error: unknown): string {
+  if (
+    error instanceof OfflineMigrationCutoverRequiredError ||
+    error instanceof MigrationVerificationError
+  ) {
+    return `Failed to run migrations: ${error.message}`;
+  }
   return `Failed to run migrations: ${formatSanitizedDbError(sanitizeDbError(error))}`;
 }

--- a/apps/agor-cli/src/lib/db-migrate-presentation.ts
+++ b/apps/agor-cli/src/lib/db-migrate-presentation.ts
@@ -1,0 +1,45 @@
+import { formatSanitizedDbError, type getDatabaseDialect, sanitizeDbError } from '@agor/core/db';
+import { extractDbFilePath } from '@agor/core/utils/path';
+
+type DatabaseDialect = ReturnType<typeof getDatabaseDialect>;
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function databaseBackupGuidance(dialect: DatabaseDialect, dbUrl: string): string[] {
+  if (dialect === 'postgresql') {
+    return ['Create a database backup or storage snapshot using your PostgreSQL backup procedure.'];
+  }
+
+  const path = shellQuote(extractDbFilePath(dbUrl));
+  return ['Run this command to create a backup:', `  cp -- ${path} ${path}.backup-$(date +%s)`];
+}
+
+export function migrationVerificationDiagnostics(
+  dialect: DatabaseDialect,
+  dbUrl: string
+): string[] {
+  if (dialect === 'postgresql') {
+    return [
+      '  1. Inspect the schema and migration ledger using your PostgreSQL administration tools.',
+      '  2. Rebuild core package:',
+      '     cd packages/core && pnpm build',
+      '  3. Compare the applied migration ledger with the migrations in this release.',
+    ];
+  }
+
+  const path = shellQuote(extractDbFilePath(dbUrl));
+  return [
+    '  1. Check if columns already exist:',
+    `     sqlite3 ${path} "PRAGMA table_info(branches)"`,
+    '  2. Rebuild core package:',
+    '     cd packages/core && pnpm build',
+    '  3. Check migration hashes:',
+    `     sqlite3 ${path} "SELECT hash FROM __drizzle_migrations"`,
+  ];
+}
+
+export function migrationFailureMessage(error: unknown): string {
+  return `Failed to run migrations: ${formatSanitizedDbError(sanitizeDbError(error))}`;
+}

--- a/apps/agor-cli/src/lib/offline-migration-cutover.test.ts
+++ b/apps/agor-cli/src/lib/offline-migration-cutover.test.ts
@@ -8,16 +8,17 @@ const existingDatabaseStatus = {
   applied: ['0073_task_runtime_reconciliation'],
   pending: ['0074_knowledge_embedding_claims'],
 };
+const postgresDb = {} as never;
 
 describe('offline migration cutover CLI boundary', () => {
   it('refuses an existing-database cutover without the dedicated acknowledgement', () => {
-    expect(() => requireOfflineCutoverAcknowledgement(existingDatabaseStatus, false)).toThrow(
-      'Offline migration cutover required'
-    );
+    expect(() =>
+      requireOfflineCutoverAcknowledgement(postgresDb, existingDatabaseStatus, false)
+    ).toThrow('Offline migration cutover required');
   });
 
   it('accepts the dedicated acknowledgement and propagates it to the migration runner', async () => {
-    requireOfflineCutoverAcknowledgement(existingDatabaseStatus, true);
+    requireOfflineCutoverAcknowledgement(postgresDb, existingDatabaseStatus, true);
     const migrate = vi.fn(async () => undefined);
     const db = { dialect: 'postgresql' } as never;
 

--- a/apps/agor-cli/src/lib/offline-migration-cutover.ts
+++ b/apps/agor-cli/src/lib/offline-migration-cutover.ts
@@ -1,6 +1,6 @@
 import {
   type Database,
-  isSQLiteDatabase,
+  getDatabaseInstanceDialect,
   OfflineMigrationCutoverRequiredError,
   pendingOfflineCutoverMigrations,
   runMigrations,
@@ -16,10 +16,7 @@ export function requireOfflineCutoverAcknowledgement(
   status: MigrationStatus,
   acknowledged: boolean
 ): void {
-  const offlineMigrations = pendingOfflineCutoverMigrations(
-    isSQLiteDatabase(db) ? 'sqlite' : 'postgresql',
-    status
-  );
+  const offlineMigrations = pendingOfflineCutoverMigrations(getDatabaseInstanceDialect(db), status);
   if (offlineMigrations.length > 0 && !acknowledged) {
     throw new OfflineMigrationCutoverRequiredError(offlineMigrations);
   }

--- a/apps/agor-cli/src/lib/offline-migration-cutover.ts
+++ b/apps/agor-cli/src/lib/offline-migration-cutover.ts
@@ -1,5 +1,6 @@
 import {
   type Database,
+  isSQLiteDatabase,
   OfflineMigrationCutoverRequiredError,
   pendingOfflineCutoverMigrations,
   runMigrations,
@@ -11,10 +12,14 @@ interface MigrationStatus {
 }
 
 export function requireOfflineCutoverAcknowledgement(
+  db: Database,
   status: MigrationStatus,
   acknowledged: boolean
 ): void {
-  const offlineMigrations = pendingOfflineCutoverMigrations(status);
+  const offlineMigrations = pendingOfflineCutoverMigrations(
+    isSQLiteDatabase(db) ? 'sqlite' : 'postgresql',
+    status
+  );
   if (offlineMigrations.length > 0 && !acknowledged) {
     throw new OfflineMigrationCutoverRequiredError(offlineMigrations);
   }

--- a/context/guides/creating-database-migrations.md
+++ b/context/guides/creating-database-migrations.md
@@ -184,7 +184,8 @@ pnpm agor db migrate         # apply pending migrations to local DB
 ```
 
 `db status --json` writes exactly one JSON document to stdout. Version 1 reports
-`appliedMigrations`, structured `pendingMigrations`, the aggregate
+the database `dialect` (`sqlite` or `postgresql`), `appliedMigrations`, structured
+`pendingMigrations`, the aggregate
 `requiresOfflineCutover` decision, and `databaseAheadOfBinary`. Each pending
 migration includes the runtime-owned `requiresOfflineCutover` decision and a
 bounded `impact` object (`classification`, `userAction`,

--- a/context/guides/creating-database-migrations.md
+++ b/context/guides/creating-database-migrations.md
@@ -179,8 +179,18 @@ pnpm db:studio               # open Drizzle Studio
 
 # From repo root:
 pnpm agor db status          # show pending migrations
+pnpm agor db status --json   # emit the versioned automation contract
 pnpm agor db migrate         # apply pending migrations to local DB
 ```
+
+`db status --json` writes exactly one JSON document to stdout. Version 1 reports
+`appliedMigrations`, structured `pendingMigrations`, the aggregate
+`requiresOfflineCutover` decision, and `databaseAheadOfBinary`. Each pending
+migration includes the runtime-owned `requiresOfflineCutover` decision and a
+bounded `impact` object (`classification`, `userAction`,
+`rollbackCompatibility`, and `summary`). Missing impact metadata is represented
+conservatively with explicit `unknown` values; callers must not infer impact by
+parsing migration names, SQL, or human-readable command output.
 
 **File locations:**
 

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -22,6 +22,7 @@ import type { SQLiteTable } from 'drizzle-orm/sqlite-core';
 import type { Database } from './client';
 import type * as postgresSchema from './schema.postgres';
 import type * as sqliteSchema from './schema.sqlite';
+import type { DatabaseDialect } from './schema-factory';
 import { getCurrentTenantId } from './tenant-context';
 
 /**
@@ -101,6 +102,11 @@ export function isSQLiteDatabase(db: Database): db is LibSQLDatabase<typeof sqli
 export function isPostgresDatabase(db: Database): db is PostgresJsDatabase<typeof postgresSchema> {
   // PostgreSQL doesn't have .run() method
   return !('run' in db);
+}
+
+/** Return the canonical dialect for an already-created database instance. */
+export function getDatabaseInstanceDialect(db: Database): DatabaseDialect {
+  return isSQLiteDatabase(db) ? 'sqlite' : 'postgresql';
 }
 
 /**

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -51,7 +51,11 @@ export * from './pending-migrations';
 export * from './repositories';
 export * from './sanitize-error';
 export * from './schema';
-export { detectDialectFromUrl, getDatabaseDialect } from './schema-factory';
+export {
+  type DatabaseDialect,
+  detectDialectFromUrl,
+  getDatabaseDialect,
+} from './schema-factory';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';
 // Tenant database lifecycle primitives. Filesystem-backed portability operations

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -61,6 +61,19 @@ describe('migration status introspection', () => {
     expect(fresh?.impact.summary).not.toMatch(/requires? .*offline cutover/i);
   });
 
+  it('preserves non-cutover user action for a registered online migration', () => {
+    const migration = introspectMigrationStatus('postgresql', {
+      applied: ['0000_init'],
+      pending: ['0030_migrate_queued_messages'],
+      dbAheadOfBinary: false,
+    }).pendingMigrations[0];
+
+    expect(migration).toMatchObject({
+      requiresOfflineCutover: false,
+      impact: { userAction: 'required' },
+    });
+  });
+
   it('never requires offline acknowledgement for an existing SQLite database', () => {
     const report = introspectMigrationStatus('sqlite', {
       applied: ['0000_init'],

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMigrationImpact,
+  introspectMigrationStatus,
+  MIGRATION_IMPACT_SUMMARY_MAX_LENGTH,
+} from './migrate';
+
+describe('migration status introspection', () => {
+  it('reports an offline pending migration and aggregate cutover requirement', () => {
+    const report = introspectMigrationStatus({
+      applied: ['0000_init'],
+      pending: ['0074_knowledge_embedding_claims'],
+      dbAheadOfBinary: false,
+    });
+
+    expect(report).toEqual({
+      schemaVersion: 1,
+      appliedMigrations: ['0000_init'],
+      pendingMigrations: [
+        {
+          name: '0074_knowledge_embedding_claims',
+          requiresOfflineCutover: true,
+          impact: {
+            classification: 'protocol',
+            userAction: 'required',
+            rollbackCompatibility: 'incompatible',
+            summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
+          },
+        },
+      ],
+      requiresOfflineCutover: true,
+      databaseAheadOfBinary: false,
+    });
+  });
+
+  it('keeps ordinary and fresh-database migrations online', () => {
+    expect(
+      introspectMigrationStatus({
+        applied: ['0000_init'],
+        pending: ['0001_ordinary'],
+        dbAheadOfBinary: false,
+      }).pendingMigrations[0]?.requiresOfflineCutover
+    ).toBe(false);
+    expect(
+      introspectMigrationStatus({
+        applied: [],
+        pending: ['0074_knowledge_embedding_claims'],
+        dbAheadOfBinary: false,
+      }).requiresOfflineCutover
+    ).toBe(false);
+  });
+
+  it('uses an explicit conservative representation for absent impact metadata', () => {
+    expect(getMigrationImpact('9999_unregistered')).toEqual({
+      classification: 'unknown',
+      userAction: 'unknown',
+      rollbackCompatibility: 'unknown',
+      summary: 'Migration impact metadata is unavailable.',
+    });
+  });
+
+  it('keeps impact summaries within the public bound', () => {
+    for (const name of [
+      '0074_knowledge_embedding_claims',
+      '0078_mcp_oauth_pending_flows',
+      '0082_github_install_state',
+      '0083_transcript_hydration_keysets',
+      'unregistered',
+    ]) {
+      expect(getMigrationImpact(name).summary.length).toBeLessThanOrEqual(
+        MIGRATION_IMPACT_SUMMARY_MAX_LENGTH
+      );
+    }
+  });
+});

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -3,6 +3,7 @@ import {
   getMigrationImpact,
   introspectMigrationStatus,
   MIGRATION_IMPACT_SUMMARY_MAX_LENGTH,
+  pendingOfflineCutoverMigrations,
 } from './migrate';
 
 describe('migration status introspection', () => {
@@ -87,6 +88,23 @@ describe('migration status introspection', () => {
       rollbackCompatibility: 'unknown',
       summary: 'Migration impact metadata is unavailable.',
     });
+  });
+
+  it('registers impact metadata for every offline cutover migration', () => {
+    const offlineMigrations = pendingOfflineCutoverMigrations('postgresql', {
+      applied: ['0000_init'],
+      pending: [
+        '0074_knowledge_embedding_claims',
+        '0078_mcp_oauth_pending_flows',
+        '0082_github_install_state',
+        '0083_transcript_hydration_keysets',
+      ],
+    });
+
+    expect(offlineMigrations).toHaveLength(4);
+    for (const name of offlineMigrations) {
+      expect(getMigrationImpact(name).classification).not.toBe('unknown');
+    }
   });
 
   it('keeps impact summaries within the public bound', () => {

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createMigrationImpactRegistry,
   getMigrationImpact,
   introspectMigrationStatus,
   MIGRATION_IMPACT_SUMMARY_MAX_LENGTH,
+  type MigrationImpactPolicy,
   pendingOfflineCutoverMigrations,
 } from './migrate';
 
@@ -105,6 +107,23 @@ describe('migration status introspection', () => {
     for (const name of offlineMigrations) {
       expect(getMigrationImpact(name).classification).not.toBe('unknown');
     }
+  });
+
+  it('does not derive offline cutover policy from impact metadata presence', () => {
+    const onlinePolicy: MigrationImpactPolicy = {
+      requiresOfflineCutover: false,
+      impact: {
+        classification: 'schema',
+        userAction: 'none',
+        rollbackCompatibility: 'compatible',
+        summary: 'Adds an ordinary online schema change.',
+      },
+    };
+
+    const registry = createMigrationImpactRegistry([['9998_ordinary_online', onlinePolicy]]);
+
+    expect(registry.impacts.get('9998_ordinary_online')).toBe(onlinePolicy);
+    expect(registry.offlineCutoverMigrations.has('9998_ordinary_online')).toBe(false);
   });
 
   it('keeps impact summaries within the public bound', () => {

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('migration status introspection', () => {
   it('reports an offline pending migration and aggregate cutover requirement', () => {
-    const report = introspectMigrationStatus({
+    const report = introspectMigrationStatus('postgresql', {
       applied: ['0000_init'],
       pending: ['0074_knowledge_embedding_claims'],
       dbAheadOfBinary: false,
@@ -15,6 +15,7 @@ describe('migration status introspection', () => {
 
     expect(report).toEqual({
       schemaVersion: 1,
+      dialect: 'postgresql',
       appliedMigrations: ['0000_init'],
       pendingMigrations: [
         {
@@ -35,19 +36,48 @@ describe('migration status introspection', () => {
 
   it('keeps ordinary and fresh-database migrations online', () => {
     expect(
-      introspectMigrationStatus({
+      introspectMigrationStatus('postgresql', {
         applied: ['0000_init'],
         pending: ['0001_ordinary'],
         dbAheadOfBinary: false,
       }).pendingMigrations[0]?.requiresOfflineCutover
     ).toBe(false);
     expect(
-      introspectMigrationStatus({
+      introspectMigrationStatus('postgresql', {
         applied: [],
         pending: ['0074_knowledge_embedding_claims'],
         dbAheadOfBinary: false,
       }).requiresOfflineCutover
     ).toBe(false);
+    const fresh = introspectMigrationStatus('postgresql', {
+      applied: [],
+      pending: ['0074_knowledge_embedding_claims'],
+      dbAheadOfBinary: false,
+    }).pendingMigrations[0];
+    expect(fresh?.impact.userAction).toBe('none');
+    expect(fresh?.impact.summary).not.toMatch(/requires? .*offline cutover/i);
+  });
+
+  it('never requires offline acknowledgement for an existing SQLite database', () => {
+    const report = introspectMigrationStatus('sqlite', {
+      applied: ['0000_init'],
+      pending: ['0074_knowledge_embedding_claims'],
+      dbAheadOfBinary: false,
+    });
+    expect(report.dialect).toBe('sqlite');
+    expect(report.requiresOfflineCutover).toBe(false);
+    expect(report.pendingMigrations[0]).toMatchObject({
+      requiresOfflineCutover: false,
+      impact: { userAction: 'none' },
+    });
+  });
+
+  it('describes the index migration as rollback-compatible performance work', () => {
+    expect(getMigrationImpact('0083_transcript_hydration_keysets')).toMatchObject({
+      classification: 'performance',
+      userAction: 'required',
+      rollbackCompatibility: 'compatible',
+    });
   });
 
   it('uses an explicit conservative representation for absent impact metadata', () => {

--- a/packages/core/src/db/migrate.test.ts
+++ b/packages/core/src/db/migrate.test.ts
@@ -61,17 +61,27 @@ describe('migration status introspection', () => {
     expect(fresh?.impact.summary).not.toMatch(/requires? .*offline cutover/i);
   });
 
-  it('preserves non-cutover user action for a registered online migration', () => {
-    const migration = introspectMigrationStatus('postgresql', {
+  it('shares queued-message impact metadata across the actual journal tags', () => {
+    const postgresqlMigration = introspectMigrationStatus('postgresql', {
       applied: ['0000_init'],
       pending: ['0030_migrate_queued_messages'],
       dbAheadOfBinary: false,
     }).pendingMigrations[0];
+    const sqliteMigration = introspectMigrationStatus('sqlite', {
+      applied: ['0000_init'],
+      pending: ['0040_migrate_queued_messages'],
+      dbAheadOfBinary: false,
+    }).pendingMigrations[0];
 
-    expect(migration).toMatchObject({
+    expect(postgresqlMigration).toMatchObject({
       requiresOfflineCutover: false,
-      impact: { userAction: 'required' },
+      impact: { classification: 'data', userAction: 'required' },
     });
+    expect(sqliteMigration).toMatchObject({
+      requiresOfflineCutover: false,
+      impact: { classification: 'data', userAction: 'required' },
+    });
+    expect(sqliteMigration?.impact).toBe(postgresqlMigration?.impact);
   });
 
   it('never requires offline acknowledgement for an existing SQLite database', () => {

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -45,16 +45,6 @@ export class MigrationError extends Error {
   }
 }
 
-const OFFLINE_CUTOVER_MIGRATIONS = new Set([
-  '0074_knowledge_embedding_claims',
-  '0078_mcp_oauth_pending_flows',
-  '0082_github_install_state',
-  // This index migration uses regular CREATE INDEX. Existing multi-daemon
-  // PostgreSQL installations must stop writers while it is built; embedded
-  // SQLite remains a single-daemon migration.
-  '0083_transcript_hydration_keysets',
-]);
-
 /** Maximum length of an automation-facing migration impact summary. */
 export const MIGRATION_IMPACT_SUMMARY_MAX_LENGTH = 200;
 
@@ -134,6 +124,12 @@ const MIGRATION_IMPACTS = new Map<string, Readonly<MigrationImpact>>([
     }),
   ],
 ]);
+
+// Every migration with registered impact currently requires an offline cutover
+// on an existing PostgreSQL database. Deriving the classification from the
+// impact registry prevents an offline migration from silently receiving the
+// unknown fallback impact.
+const OFFLINE_CUTOVER_MIGRATIONS = new Set(MIGRATION_IMPACTS.keys());
 
 const NO_OFFLINE_ACTION_SUMMARY =
   'No offline cutover is required for this database and migration state.';

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -65,6 +65,11 @@ export interface MigrationImpact {
   summary: string;
 }
 
+export interface MigrationImpactPolicy {
+  requiresOfflineCutover: boolean;
+  impact: Readonly<MigrationImpact>;
+}
+
 export interface PendingMigrationIntrospection {
   name: string;
   requiresOfflineCutover: boolean;
@@ -97,7 +102,20 @@ const UNKNOWN_MIGRATION_IMPACT = defineMigrationImpact({
   summary: 'Migration impact metadata is unavailable.',
 });
 
-const MIGRATION_IMPACTS = new Map<string, Readonly<MigrationImpact>>([
+export function createMigrationImpactRegistry(
+  entries: ReadonlyArray<readonly [string, MigrationImpactPolicy]>
+): {
+  impacts: ReadonlyMap<string, MigrationImpactPolicy>;
+  offlineCutoverMigrations: ReadonlySet<string>;
+} {
+  const impacts = new Map(entries);
+  const offlineCutoverMigrations = new Set(
+    entries.filter(([, policy]) => policy.requiresOfflineCutover).map(([name]) => name)
+  );
+  return { impacts, offlineCutoverMigrations };
+}
+
+const MIGRATION_IMPACT_REGISTRY = createMigrationImpactRegistry([
   ...[
     '0074_knowledge_embedding_claims',
     '0078_mcp_oauth_pending_flows',
@@ -106,36 +124,36 @@ const MIGRATION_IMPACTS = new Map<string, Readonly<MigrationImpact>>([
     (name) =>
       [
         name,
-        defineMigrationImpact({
-          classification: 'protocol',
-          userAction: 'required',
-          rollbackCompatibility: 'incompatible',
-          summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
-        }),
+        {
+          requiresOfflineCutover: true,
+          impact: defineMigrationImpact({
+            classification: 'protocol',
+            userAction: 'required',
+            rollbackCompatibility: 'incompatible',
+            summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
+          }),
+        },
       ] as const
   ),
   [
     '0083_transcript_hydration_keysets',
-    defineMigrationImpact({
-      classification: 'performance',
-      userAction: 'required',
-      rollbackCompatibility: 'compatible',
-      summary: 'Requires a coordinated offline cutover to build indexes; rollback is compatible.',
-    }),
+    {
+      requiresOfflineCutover: true,
+      impact: defineMigrationImpact({
+        classification: 'performance',
+        userAction: 'required',
+        rollbackCompatibility: 'compatible',
+        summary: 'Requires a coordinated offline cutover to build indexes; rollback is compatible.',
+      }),
+    },
   ],
 ]);
-
-// Every migration with registered impact currently requires an offline cutover
-// on an existing PostgreSQL database. Deriving the classification from the
-// impact registry prevents an offline migration from silently receiving the
-// unknown fallback impact.
-const OFFLINE_CUTOVER_MIGRATIONS = new Set(MIGRATION_IMPACTS.keys());
 
 const NO_OFFLINE_ACTION_SUMMARY =
   'No offline cutover is required for this database and migration state.';
 
 export function getMigrationImpact(name: string): MigrationImpact {
-  return MIGRATION_IMPACTS.get(name) ?? UNKNOWN_MIGRATION_IMPACT;
+  return MIGRATION_IMPACT_REGISTRY.impacts.get(name)?.impact ?? UNKNOWN_MIGRATION_IMPACT;
 }
 
 export function introspectMigrationStatus(
@@ -200,7 +218,9 @@ export function pendingOfflineCutoverMigrations(
   // A genuinely fresh database cannot have an old worker using the pre-claim
   // protocol, so first installation remains automatic.
   if (dialect !== 'postgresql' || status.applied.length === 0) return [];
-  return status.pending.filter((tag) => OFFLINE_CUTOVER_MIGRATIONS.has(tag));
+  return status.pending.filter((tag) =>
+    MIGRATION_IMPACT_REGISTRY.offlineCutoverMigrations.has(tag)
+  );
 }
 
 function getRootCause(error: unknown): unknown {

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -26,7 +26,12 @@ import { sql } from 'drizzle-orm';
 import { migrate as migrateSQLite } from 'drizzle-orm/libsql/migrator';
 import { migrate as migratePostgres } from 'drizzle-orm/postgres-js/migrator';
 import type { Database } from './client';
-import { insert, isPostgresDatabase, isSQLiteDatabase } from './database-wrapper';
+import {
+  getDatabaseInstanceDialect,
+  insert,
+  isPostgresDatabase,
+  isSQLiteDatabase,
+} from './database-wrapper';
 import { sanitizeDbError } from './sanitize-error';
 import { boards } from './schema';
 import type { DatabaseDialect } from './schema-factory';
@@ -116,6 +121,18 @@ export function createMigrationImpactRegistry(
 }
 
 const MIGRATION_IMPACT_REGISTRY = createMigrationImpactRegistry([
+  [
+    '0030_migrate_queued_messages',
+    {
+      requiresOfflineCutover: false,
+      impact: defineMigrationImpact({
+        classification: 'data',
+        userAction: 'required',
+        rollbackCompatibility: 'compatible',
+        summary: 'Queued work interrupted by the migration may need to be submitted again.',
+      }),
+    },
+  ],
   ...[
     '0074_knowledge_embedding_claims',
     '0078_mcp_oauth_pending_flows',
@@ -167,9 +184,10 @@ export function introspectMigrationStatus(
   const offline = new Set(pendingOfflineCutoverMigrations(dialect, status));
   const pendingMigrations = status.pending.map((name) => {
     const requiresOfflineCutover = offline.has(name);
-    const registeredImpact = getMigrationImpact(name);
+    const registeredPolicy = MIGRATION_IMPACT_REGISTRY.impacts.get(name);
+    const registeredImpact = registeredPolicy?.impact ?? UNKNOWN_MIGRATION_IMPACT;
     const impact =
-      !requiresOfflineCutover && registeredImpact.userAction === 'required'
+      registeredPolicy?.requiresOfflineCutover === true && !requiresOfflineCutover
         ? defineMigrationImpact({
             ...registeredImpact,
             userAction: 'none',
@@ -449,11 +467,12 @@ export async function runMigrations(
   try {
     console.log('Running database migrations...');
 
+    const dialect = getDatabaseInstanceDialect(db);
     const migrationsFolder = getMigrationsFolder(db);
     console.log(`Using migrations folder: ${migrationsFolder}`);
-    console.log(`Database dialect: ${isSQLiteDatabase(db) ? 'sqlite' : 'postgres'}`);
+    console.log(`Database dialect: ${dialect === 'sqlite' ? 'sqlite' : 'postgres'}`);
 
-    if (isPostgresDatabase(db) && options.allowOfflineCutover !== true) {
+    if (dialect === 'postgresql' && options.allowOfflineCutover !== true) {
       const status = await checkMigrationStatus(db);
       const offlineMigrations = pendingOfflineCutoverMigrations('postgresql', status);
       if (offlineMigrations.length > 0) {

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -29,6 +29,7 @@ import type { Database } from './client';
 import { insert, isPostgresDatabase, isSQLiteDatabase } from './database-wrapper';
 import { sanitizeDbError } from './sanitize-error';
 import { boards } from './schema';
+import type { DatabaseDialect } from './schema-factory';
 import { getCurrentTenantId } from './tenant-scope';
 
 /**
@@ -83,43 +84,89 @@ export interface PendingMigrationIntrospection {
 /** Stable, versioned contract returned by migration status tooling. */
 export interface MigrationStatusIntrospection {
   schemaVersion: 1;
+  dialect: DatabaseDialect;
   appliedMigrations: string[];
   pendingMigrations: PendingMigrationIntrospection[];
   requiresOfflineCutover: boolean;
   databaseAheadOfBinary: boolean;
 }
 
-const UNKNOWN_MIGRATION_IMPACT: MigrationImpact = Object.freeze({
+function defineMigrationImpact(impact: MigrationImpact): Readonly<MigrationImpact> {
+  if (impact.summary.length > MIGRATION_IMPACT_SUMMARY_MAX_LENGTH) {
+    throw new Error(
+      `Migration impact summary exceeds ${MIGRATION_IMPACT_SUMMARY_MAX_LENGTH} characters`
+    );
+  }
+  return Object.freeze(impact);
+}
+
+const UNKNOWN_MIGRATION_IMPACT = defineMigrationImpact({
   classification: 'unknown',
   userAction: 'unknown',
   rollbackCompatibility: 'unknown',
   summary: 'Migration impact metadata is unavailable.',
 });
 
-const OFFLINE_CUTOVER_IMPACT: MigrationImpact = Object.freeze({
-  classification: 'protocol',
-  userAction: 'required',
-  rollbackCompatibility: 'incompatible',
-  summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
-});
+const MIGRATION_IMPACTS = new Map<string, Readonly<MigrationImpact>>([
+  ...[
+    '0074_knowledge_embedding_claims',
+    '0078_mcp_oauth_pending_flows',
+    '0082_github_install_state',
+  ].map(
+    (name) =>
+      [
+        name,
+        defineMigrationImpact({
+          classification: 'protocol',
+          userAction: 'required',
+          rollbackCompatibility: 'incompatible',
+          summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
+        }),
+      ] as const
+  ),
+  [
+    '0083_transcript_hydration_keysets',
+    defineMigrationImpact({
+      classification: 'performance',
+      userAction: 'required',
+      rollbackCompatibility: 'compatible',
+      summary: 'Requires a coordinated offline cutover to build indexes; rollback is compatible.',
+    }),
+  ],
+]);
+
+const NO_OFFLINE_ACTION_SUMMARY =
+  'No offline cutover is required for this database and migration state.';
 
 export function getMigrationImpact(name: string): MigrationImpact {
-  return OFFLINE_CUTOVER_MIGRATIONS.has(name) ? OFFLINE_CUTOVER_IMPACT : UNKNOWN_MIGRATION_IMPACT;
+  return MIGRATION_IMPACTS.get(name) ?? UNKNOWN_MIGRATION_IMPACT;
 }
 
-export function introspectMigrationStatus(status: {
-  pending: readonly string[];
-  applied: readonly string[];
-  dbAheadOfBinary: boolean;
-}): MigrationStatusIntrospection {
-  const offline = new Set(pendingOfflineCutoverMigrations(status));
-  const pendingMigrations = status.pending.map((name) => ({
-    name,
-    requiresOfflineCutover: offline.has(name),
-    impact: getMigrationImpact(name),
-  }));
+export function introspectMigrationStatus(
+  dialect: DatabaseDialect,
+  status: {
+    pending: readonly string[];
+    applied: readonly string[];
+    dbAheadOfBinary: boolean;
+  }
+): MigrationStatusIntrospection {
+  const offline = new Set(pendingOfflineCutoverMigrations(dialect, status));
+  const pendingMigrations = status.pending.map((name) => {
+    const requiresOfflineCutover = offline.has(name);
+    const registeredImpact = getMigrationImpact(name);
+    const impact =
+      !requiresOfflineCutover && registeredImpact.userAction === 'required'
+        ? defineMigrationImpact({
+            ...registeredImpact,
+            userAction: 'none',
+            summary: NO_OFFLINE_ACTION_SUMMARY,
+          })
+        : registeredImpact;
+    return { name, requiresOfflineCutover, impact };
+  });
   return {
     schemaVersion: 1,
+    dialect,
     appliedMigrations: [...status.applied],
     pendingMigrations,
     requiresOfflineCutover: pendingMigrations.some((migration) => migration.requiresOfflineCutover),
@@ -147,13 +194,16 @@ export class OfflineMigrationCutoverRequiredError extends MigrationError {
   }
 }
 
-export function pendingOfflineCutoverMigrations(status: {
-  pending: readonly string[];
-  applied: readonly string[];
-}): string[] {
+export function pendingOfflineCutoverMigrations(
+  dialect: DatabaseDialect,
+  status: {
+    pending: readonly string[];
+    applied: readonly string[];
+  }
+): string[] {
   // A genuinely fresh database cannot have an old worker using the pre-claim
   // protocol, so first installation remains automatic.
-  if (status.applied.length === 0) return [];
+  if (dialect !== 'postgresql' || status.applied.length === 0) return [];
   return status.pending.filter((tag) => OFFLINE_CUTOVER_MIGRATIONS.has(tag));
 }
 
@@ -389,7 +439,7 @@ export async function runMigrations(
 
     if (isPostgresDatabase(db) && options.allowOfflineCutover !== true) {
       const status = await checkMigrationStatus(db);
-      const offlineMigrations = pendingOfflineCutoverMigrations(status);
+      const offlineMigrations = pendingOfflineCutoverMigrations('postgresql', status);
       if (offlineMigrations.length > 0) {
         throw new OfflineMigrationCutoverRequiredError(offlineMigrations);
       }

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -107,6 +107,16 @@ const UNKNOWN_MIGRATION_IMPACT = defineMigrationImpact({
   summary: 'Migration impact metadata is unavailable.',
 });
 
+const QUEUED_MESSAGES_MIGRATION_POLICY: MigrationImpactPolicy = {
+  requiresOfflineCutover: false,
+  impact: defineMigrationImpact({
+    classification: 'data',
+    userAction: 'required',
+    rollbackCompatibility: 'compatible',
+    summary: 'Queued work interrupted by the migration may need to be submitted again.',
+  }),
+};
+
 export function createMigrationImpactRegistry(
   entries: ReadonlyArray<readonly [string, MigrationImpactPolicy]>
 ): {
@@ -121,18 +131,8 @@ export function createMigrationImpactRegistry(
 }
 
 const MIGRATION_IMPACT_REGISTRY = createMigrationImpactRegistry([
-  [
-    '0030_migrate_queued_messages',
-    {
-      requiresOfflineCutover: false,
-      impact: defineMigrationImpact({
-        classification: 'data',
-        userAction: 'required',
-        rollbackCompatibility: 'compatible',
-        summary: 'Queued work interrupted by the migration may need to be submitted again.',
-      }),
-    },
-  ],
+  ['0030_migrate_queued_messages', QUEUED_MESSAGES_MIGRATION_POLICY],
+  ['0040_migrate_queued_messages', QUEUED_MESSAGES_MIGRATION_POLICY],
   ...[
     '0074_knowledge_embedding_claims',
     '0078_mcp_oauth_pending_flows',

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -54,6 +54,79 @@ const OFFLINE_CUTOVER_MIGRATIONS = new Set([
   '0083_transcript_hydration_keysets',
 ]);
 
+/** Maximum length of an automation-facing migration impact summary. */
+export const MIGRATION_IMPACT_SUMMARY_MAX_LENGTH = 200;
+
+export type MigrationImpactClassification =
+  | 'schema'
+  | 'data'
+  | 'protocol'
+  | 'performance'
+  | 'unknown';
+export type MigrationUserAction = 'none' | 'required' | 'unknown';
+export type MigrationRollbackCompatibility = 'compatible' | 'incompatible' | 'unknown';
+
+/** Bounded metadata maintained by the migration runtime, never inferred from SQL or CLI text. */
+export interface MigrationImpact {
+  classification: MigrationImpactClassification;
+  userAction: MigrationUserAction;
+  rollbackCompatibility: MigrationRollbackCompatibility;
+  summary: string;
+}
+
+export interface PendingMigrationIntrospection {
+  name: string;
+  requiresOfflineCutover: boolean;
+  impact: MigrationImpact;
+}
+
+/** Stable, versioned contract returned by migration status tooling. */
+export interface MigrationStatusIntrospection {
+  schemaVersion: 1;
+  appliedMigrations: string[];
+  pendingMigrations: PendingMigrationIntrospection[];
+  requiresOfflineCutover: boolean;
+  databaseAheadOfBinary: boolean;
+}
+
+const UNKNOWN_MIGRATION_IMPACT: MigrationImpact = Object.freeze({
+  classification: 'unknown',
+  userAction: 'unknown',
+  rollbackCompatibility: 'unknown',
+  summary: 'Migration impact metadata is unavailable.',
+});
+
+const OFFLINE_CUTOVER_IMPACT: MigrationImpact = Object.freeze({
+  classification: 'protocol',
+  userAction: 'required',
+  rollbackCompatibility: 'incompatible',
+  summary: 'Requires a coordinated offline cutover and is not rollback compatible.',
+});
+
+export function getMigrationImpact(name: string): MigrationImpact {
+  return OFFLINE_CUTOVER_MIGRATIONS.has(name) ? OFFLINE_CUTOVER_IMPACT : UNKNOWN_MIGRATION_IMPACT;
+}
+
+export function introspectMigrationStatus(status: {
+  pending: readonly string[];
+  applied: readonly string[];
+  dbAheadOfBinary: boolean;
+}): MigrationStatusIntrospection {
+  const offline = new Set(pendingOfflineCutoverMigrations(status));
+  const pendingMigrations = status.pending.map((name) => ({
+    name,
+    requiresOfflineCutover: offline.has(name),
+    impact: getMigrationImpact(name),
+  }));
+  return {
+    schemaVersion: 1,
+    appliedMigrations: [...status.applied],
+    pendingMigrations,
+    requiresOfflineCutover: pendingMigrations.some((migration) => migration.requiresOfflineCutover),
+    databaseAheadOfBinary: status.dbAheadOfBinary,
+  };
+}
+
 export interface RunMigrationsOptions {
   /**
    * Acknowledge that every daemon using this existing database is stopped.

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -14,13 +14,13 @@ interface JournalEntry {
 describe('Postgres migrations', () => {
   it('requires the Knowledge claim protocol migration to be an offline existing-db cutover', () => {
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: ['0073_task_runtime_reconciliation'],
         pending: ['0074_knowledge_embedding_claims'],
       })
     ).toEqual(['0074_knowledge_embedding_claims']);
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: [],
         pending: ['0000_pretty_mac_gargan', '0074_knowledge_embedding_claims'],
       })
@@ -29,13 +29,13 @@ describe('Postgres migrations', () => {
 
   it('enforces the structurally incompatible MCP OAuth migration as an offline cutover', () => {
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: ['0076_executor_session_token_session_binding'],
         pending: ['0078_mcp_oauth_pending_flows'],
       })
     ).toEqual(['0078_mcp_oauth_pending_flows']);
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: [],
         pending: ['0000_pretty_mac_gargan', '0078_mcp_oauth_pending_flows'],
       })
@@ -44,13 +44,13 @@ describe('Postgres migrations', () => {
 
   it('enforces the GitHub callback authority migration as an offline cutover', () => {
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: ['0078_mcp_oauth_pending_flows'],
         pending: ['0082_github_install_state'],
       })
     ).toEqual(['0082_github_install_state']);
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: [],
         pending: ['0000_pretty_mac_gargan', '0082_github_install_state'],
       })
@@ -59,19 +59,19 @@ describe('Postgres migrations', () => {
 
   it('enforces PostgreSQL transcript indexes as an offline existing-db cutover', () => {
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: ['0082_github_install_state'],
         pending: ['0083_transcript_hydration_keysets'],
       })
     ).toEqual(['0083_transcript_hydration_keysets']);
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: ['0085_github_install_state'],
         pending: ['0086_transcript_hydration_keysets'],
       })
     ).toEqual([]);
     expect(
-      pendingOfflineCutoverMigrations({
+      pendingOfflineCutoverMigrations('postgresql', {
         applied: [],
         pending: ['0000_pretty_mac_gargan', '0083_transcript_hydration_keysets'],
       })

--- a/packages/core/src/db/sanitize-error.test.ts
+++ b/packages/core/src/db/sanitize-error.test.ts
@@ -2,7 +2,11 @@ import { inspect } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
 import { RepositoryError } from './repositories/base';
-import { isDatabaseUniqueConstraintError, sanitizeDbError } from './sanitize-error';
+import {
+  formatSanitizedDbError,
+  isDatabaseUniqueConstraintError,
+  sanitizeDbError,
+} from './sanitize-error';
 
 describe('sanitizeDbError', () => {
   function drizzleFailure(): Error {
@@ -37,6 +41,14 @@ describe('sanitizeDbError', () => {
     expect(output).toContain('23505');
     expect(output).toContain('json_errsave_error');
     expect(output.length).toBeLessThan(1024);
+  });
+
+  it('formats only allowlisted metadata for command diagnostics', () => {
+    const diagnostic = formatSanitizedDbError(sanitizeDbError(drizzleFailure()));
+    expect(diagnostic).toBe(
+      'Database constraint violation (code=23505 constraint=sessions_schedule_run_unique routine=json_errsave_error)'
+    );
+    expect(diagnostic).not.toContain('SECRET_SENTINEL');
   });
 
   it('sanitizes RepositoryError output without changing its cause semantics', () => {

--- a/packages/core/src/db/sanitize-error.ts
+++ b/packages/core/src/db/sanitize-error.ts
@@ -110,3 +110,11 @@ export function sanitizeDbError(error: unknown): SanitizedDbError {
     ...(routine ? { routine } : {}),
   };
 }
+
+/** Format only the allowlisted scalar fields of a sanitized database diagnostic. */
+export function formatSanitizedDbError(error: SanitizedDbError): string {
+  const metadata = (['code', 'constraint', 'routine'] as const)
+    .flatMap((key) => (error[key] ? [`${key}=${error[key]}`] : []))
+    .join(' ');
+  return metadata ? `${error.message} (${metadata})` : error.message;
+}


### PR DESCRIPTION
## Linked issue

None.

## Summary

- add a versioned `db status --json` contract with dialect-aware offline-cutover and bounded migration-impact metadata
- make `db migrate` backup and verification guidance dialect-correct and credential-safe for local and remote database configurations
- preserve existing human output, migration execution, ledger semantics, offline-cutover policy, and exit behavior
- add focused coverage for fresh and existing databases, ordinary and offline migrations, remote connection strings, and secret-safe success and failure diagnostics

## Why / context

Automation needs stable migration status without parsing human output, while operators need migration guidance that never exposes database credentials. Remote database configurations must receive generic guidance; only validated local SQLite paths may appear in path-based commands.

## Implementation notes

Final reviewed head: `a03c0c6e9782ddac44da90bcbf8ecef46f2ce300`.

The core migration registry remains the single source of truth for impact metadata and explicit offline-cutover policy, including dialect-specific aliases for the same logical migration where journal tags differ. `db status --json` emits one versioned document. `db migrate` remains human-only and uses dialect-aware presentation helpers: validated local SQLite paths receive safely quoted commands, while PostgreSQL and remote SQLite-compatible URLs receive generic backup and verification guidance without connection details. Known policy and verification errors retain reviewed actionable messages; unknown database failures remain strictly sanitized.

Connection selection, migration SQL, offline-cutover enforcement, migration ledger behavior, and exit semantics are unchanged.

## Validation / test plan

- [x] targeted CLI migration-presentation and offline-cutover tests — 13 passed on the main repair pass
- [x] targeted core migration tests — 9 passed on each focused repair pass
- [x] targeted core migration and sanitization regression suite — 44 passed on the initial secret-safe delta
- [x] core TypeScript check — passed
- [x] core runtime and declaration build — passed
- [x] CLI JavaScript build — passed
- [x] Biome formatting/lint on changed files — passed
- [x] `git diff --check` — passed
- [x] Claude Fable 5 skeptic and GPT-5.6 Sol advocate reviewed exact final head and reported zero substantive issues after three rounds
- [ ] workspace `pnpm` commands were blocked by the validation environment's read-only package-store database; package-level checks ran through installed binaries
- [ ] full CLI declaration/typecheck was blocked by unrelated unavailable workspace declarations in the installed dependency state
- [ ] final CI rerun is in progress

## Risks / rollout / rollback

`db status --json` remains opt-in and versioned with `schemaVersion: 1`; `db migrate` does not gain JSON output. Existing PostgreSQL databases require acknowledgement only for migrations explicitly marked for offline cutover, while fresh databases and SQLite do not. Rolling back removes the new status contract and presentation helpers without changing migration SQL or ledger state.

## Out of scope / follow-ups

- No database-independent migration manifest or catalog command is included.
- No `db migrate --json` mode is included; successful termination followed by `db status --json` is the verification model.
