### PR TITLE
fix(mcp-oauth): accept confidential clients from Dynamic Client Registration

### DIFF
--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -899,6 +899,57 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     expect(authUrl.searchParams.get('redirect_uri')).toBe('http://127.0.0.1:9999/oauth/callback');
   });
 
+  it('accepts a confidential client when DCR returns a secret with auth method none/omitted, then uses HTTP Basic on token exchange', async () => {
+    // Reproduces Atlassian's remote MCP: we request a public client
+    // (token_endpoint_auth_method: 'none'), but the provider registers a *confidential* client —
+    // HTTP 201 with a client_secret and no auth method echoed back. This previously failed DCR
+    // validation ("incompatible public-client credentials"); it must now be accepted.
+    const clientSecret = 'atlassian-dcr-secret';
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === 'https://auth.reo.dev/oauth/register' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            client_id: 'dcr-confidential-client',
+            client_secret: clientSecret,
+            redirect_uris: ['http://127.0.0.1:9999/oauth/callback'],
+          }),
+        };
+      }
+      if (url === 'https://auth.reo.dev/oauth/token' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ access_token: 'confidential-token' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    // DCR no longer rejects the returned secret — the flow starts and carries the secret.
+    const ctx = await startMCPOAuthFlow('', undefined, redirectUri, prefetchedOptions);
+    expect(ctx.clientSecret).toBe(clientSecret);
+    expect(new URL(ctx.authorizationUrl).searchParams.get('client_id')).toBe(
+      'dcr-confidential-client'
+    );
+
+    // The secret must flow into the token exchange as HTTP Basic auth (RFC 6749 §2.3.1),
+    // and client_id must NOT be duplicated in the request body.
+    const tokenResponse = await completeMCPOAuthFlow(ctx, 'auth-code', ctx.state, {
+      cacheToken: false,
+    });
+    expect(tokenResponse.access_token).toBe('confidential-token');
+
+    const tokenCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find(([url]) => String(url) === 'https://auth.reo.dev/oauth/token');
+    expect(tokenCall).toBeTruthy();
+    const headers = (tokenCall?.[1]?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe(
+      `Basic ${Buffer.from(`dcr-confidential-client:${clientSecret}`).toString('base64')}`
+    );
+    expect(String(tokenCall?.[1]?.body)).not.toContain('client_id=');
+  });
+
   it('throws when cacheKey is missing (would silently break token reuse)', async () => {
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
 

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -578,7 +578,16 @@ async function registerDynamicClient(
       'Dynamic Client Registration did not bind the required redirect URI'
     );
   }
-  const authMethod = result.token_endpoint_auth_method ?? 'none';
+  // We request a public client (`token_endpoint_auth_method: 'none'`), but some providers
+  // (e.g. Atlassian) ignore that and register a *confidential* client — returning HTTP 201
+  // with a `client_secret` while either omitting the auth method or echoing 'none'. A returned
+  // secret is the authoritative signal that the client is confidential, so treat it as
+  // client_secret_basic regardless of the advertised method. The token exchange already routes
+  // any present secret through HTTP Basic auth (RFC 6749 §2.3.1), so these credentials are
+  // usable as-is.
+  const authMethod = result.client_secret
+    ? 'client_secret_basic'
+    : (result.token_endpoint_auth_method ?? 'none');
   if (!['none', 'client_secret_basic'].includes(authMethod)) {
     throw registrationFailure(
       diagnostic,
@@ -589,12 +598,6 @@ async function registerDynamicClient(
     throw registrationFailure(
       diagnostic,
       'Dynamic Client Registration omitted the required client secret'
-    );
-  }
-  if (authMethod === 'none' && result.client_secret) {
-    throw registrationFailure(
-      diagnostic,
-      'Dynamic Client Registration returned incompatible public-client credentials'
     );
   }
   if (result.grant_types && !result.grant_types.includes('authorization_code')) {


### PR DESCRIPTION
## Problem

Adding the **Atlassian remote MCP server** (`https://mcp.atlassian.com/v1/mcp/authv2`, OAuth 2.1, Legacy compatibility + Legacy `/register` fallback DCR) fails during Dynamic Client Registration with:

> Dynamic Client Registration returned incompatible public-client credentials (HTTP 201) at stage `dcr_registration`.

### Root cause

In `packages/core/src/tools/mcp/oauth-mcp-transport.ts`, `registerDynamicClient` sends `token_endpoint_auth_method: 'none'` (requests a **public** client). Atlassian ignores that and registers a **confidential** client — returning HTTP 201 with a `client_secret` while omitting the auth method (or echoing `'none'`). The validator then rejected the mismatch:

```js
if (authMethod === 'none' && result.client_secret) {
  throw ... 'Dynamic Client Registration returned incompatible public-client credentials'
}
```

But those credentials are already usable: `exchangeCodeForToken` sends any present `client_secret` via HTTP Basic auth (RFC 6749 §2.3.1). Only the DCR validator refused them.

## Fix

Treat a returned `client_secret` as the authoritative signal that the client is **confidential**, inferring `client_secret_basic` regardless of the advertised auth method:

```js
const authMethod = result.client_secret
  ? 'client_secret_basic'
  : (result.token_endpoint_auth_method ?? 'none');
```

The secret then flows into the existing Basic-auth token exchange. The now-unreachable `none` + secret rejection branch is removed; the `client_secret_basic`-without-a-secret guard is preserved, as are the unsupported-auth-method / grant-type / response-type checks.

## Tests

`packages/core/src/tools/mcp/oauth-mcp-transport.test.ts` — added positive coverage in the legacy + fallback DCR block (mirroring Atlassian's config): DCR returns a secret with auth method none/omitted → the flow starts, the secret is carried on the OAuth context, and the token exchange authenticates with HTTP Basic (with no duplicated `client_id` in the body). Verified the test fails against the pre-fix validator (same "incompatible public-client credentials" error) and passes with the fix. Full file: 72 tests passing; Biome clean.

## Manual verification (cannot be automated)

End-to-end proof requires a real browser round-trip to Atlassian. To verify: configure the Atlassian server (HTTP, OAuth 2.1, **Legacy** OAuth compatibility, **Legacy `/register` fallback** DCR, empty client id/secret, token URL `https://auth.atlassian.com/oauth/token`, per-user), then click **Start OAuth Flow** — DCR should now complete and hand off to Atlassian's consent screen instead of failing at `dcr_registration`.

## Note on the secondary UI finding (deferred — already fixed on `main`)

A companion report described the OAuth-start flow building its request with `strict` compatibility even when the saved server is `legacy` (the `oauth_compatibility_mode` field lives in a collapsed Advanced panel with `initialValue="strict"`). On current `main` this no longer reproduces:

- The Advanced panel renders with `forceRender: true` + `destroyOnHidden={false}`, so the field is always registered and the modal's init `setFieldsValue({ oauth_compatibility_mode: 'legacy' })` wins over the `initialValue`.
- **#2339** (`fix(mcp): persist the form before Start OAuth flow so it uses current values`) makes the start persist the form first, then authorize against the saved row.
- Existing tests already lock this in: `MCPServerFormFields.test.tsx` renders the real collapsed-panel component, hydrates `legacy`, and asserts the extracted config stays `legacy`; `MCPServerEditModal.test.tsx` (#2332) asserts Start OAuth persists `oauth_compatibility_mode: 'legacy'`.

No code change was needed for the secondary finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)