### PR TITLE
fix(executor): disable Codex goal continuations

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -533,6 +533,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expect(mockInstanceCount).toBe(1);
       expect(mockInstanceConfigs).toEqual([
         {
+          features: { goals: false },
           model_instructions_file: '/tmp/agor-codex-instructions-flow.md',
           mcp_servers: {
             agor: {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1121,6 +1121,9 @@ export class CodexPromptService {
     );
 
     const codexConfigPayload: CodexConfigObject = {
+      // Agor owns durable task continuation. Codex goals can automatically
+      // continue after an internal answer without completing the SDK turn.
+      features: { goals: false },
       model_instructions_file: instructionsFile,
       ...(Object.keys(mcpServersConfig).length > 0 ? { mcp_servers: mcpServersConfig } : {}),
       // Codex Apps (for example the GitHub connector supplied by a plugin)


### PR DESCRIPTION
## Summary

- disable Codex persisted goals and automatic continuation in Agor-managed SDK sessions
- assert the effective Codex SDK config in the prompt-flow test

## Why

Agor owns durable execution through Sessions, Tasks, queues, heartbeats, watchdogs, and explicit prompt admission. Codex goals add a second continuation lifecycle inside one `codex exec` invocation.

During a hosted sandbox investigation, a Codex thread with an active goal reproduced this sequence:

1. The user requested a one-word `pong` response and explicitly asked Codex not to work.
2. Codex's private rollout recorded the `pong` assistant message and an internal `task_complete` event.
3. 27 ms later, Codex automatically started another internal task for the persisted goal.
4. The public TypeScript SDK stream exposed only `thread.started`; it did not expose the internal answer, tool activity, or continuation events while the outer invocation remained active.
5. The executor heartbeat remained healthy and Stop containment worked, but Agor correctly had no provider events to persist. Its SDK watchdog therefore diagnosed `no_first_progress` despite ongoing work in the private rollout.

This also reproduced on a second goal-bearing thread. Ordinary non-goal Codex turns under the same executor sandbox completed and streamed normally. The managed CLI and `@openai/codex-sdk` were version-aligned at `0.144.0`, and the CLI-to-SDK stdout socket was connected without backpressure.

Codex documents `features.goals` as enabling persisted goals and automatic continuation, stable and on by default. The SDK's public event surface does not currently provide goal-continuation lifecycle events that Agor can map onto its Task model.

## Decision

Set `features.goals=false` in the per-session `CodexOptions.config` payload.

This is intentionally an Agor lifecycle decision, not a claim that Codex goals are generally broken. Agor already provides the durable orchestration layer, and allowing an inner automatic-continuation loop makes one Agor prompt non-terminal and can hide completed answers until the entire goal finishes.

## Scope and follow-up

- affects Codex sessions only
- leaves ordinary Codex thread resume behavior unchanged
- does not change Claude, Gemini, Copilot, Cursor, or OpenCode execution
- does not attempt to parse Codex's private rollout format
- can be revisited if the SDK exposes goal lifecycle/progress events that can be represented safely as Agor Tasks

## Verification

- `pnpm --filter @agor/executor exec vitest run src/sdk-handlers/codex/prompt-service.test.ts` (65 passed)
- `pnpm --filter @agor/executor typecheck`