### PR TITLE
fix(config): explain sandbox-masked config instead of failing opaquely

### DIFF
--- a/apps/agor-daemon/test/isolate-host-env.ts
+++ b/apps/agor-daemon/test/isolate-host-env.ts
@@ -1,0 +1,17 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Point HOME at an empty per-worker directory before any test runs.
+ *
+ * Mirrors `packages/core/test/isolate-host-env.ts` — kept local rather than
+ * imported across the package boundary so neither test suite depends on the
+ * other's layout. See that file for the full rationale: config resolution goes
+ * through `os.homedir()`, so without this every suite that loads config reads
+ * the machine's own `~/.agor/config.yaml`.
+ */
+process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'agor-daemon-test-home-'));
+
+delete process.env.AGOR_DATA_HOME;
+delete process.env.AGOR_OUTER_SANDBOX;

--- a/apps/agor-daemon/test/isolate-host-env.ts
+++ b/apps/agor-daemon/test/isolate-host-env.ts
@@ -11,7 +11,12 @@ import path from 'node:path';
  * through `os.homedir()`, so without this every suite that loads config reads
  * the machine's own `~/.agor/config.yaml`.
  */
-process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'agor-daemon-test-home-'));
+const testHome = mkdtempSync(path.join(os.tmpdir(), 'agor-daemon-test-home-'));
+
+// `os.homedir()` reads HOME on POSIX and USERPROFILE on Windows; set both so
+// the isolation doesn't quietly become a no-op on one platform.
+process.env.HOME = testHome;
+process.env.USERPROFILE = testHome;
 
 delete process.env.AGOR_DATA_HOME;
 delete process.env.AGOR_OUTER_SANDBOX;

--- a/apps/agor-daemon/vitest.config.ts
+++ b/apps/agor-daemon/vitest.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
     testTimeout: 10000,
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: [...configDefaults.exclude, 'test/**'],
+    setupFiles: ['./test/isolate-host-env.ts'],
   },
 });

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultConfig, loadConfigSync } from './config';
+
+describe('loadConfigSync', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-client-test-'));
+    // homedir() reads $HOME on POSIX, so this keeps the suite off the host's
+    // real ~/.agor/config.yaml.
+    vi.stubEnv('HOME', tempDir);
+    vi.stubEnv('AGOR_OUTER_SANDBOX', '');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns defaults when no config file exists', () => {
+    expect(loadConfigSync()).toEqual(getDefaultConfig());
+  });
+
+  it('fails loudly when the config file is unreadable', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(configPath);
+
+    expect(() => loadConfigSync()).toThrow(/Failed to load config.*EISDIR/s);
+  });
+
+  // This loader backs getDaemonUrl() for every BaseCommand-derived CLI
+  // command. Inside the executor sandbox the daemon config is masked, and
+  // DAEMON_URL is injected precisely so this path is never reached — so
+  // arriving here means the injection is what broke. Say that instead of
+  // reporting a bare EACCES against a file the caller was never meant to read.
+  it('explains the sandbox when the config is masked and DAEMON_URL is unset', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.mkdir(path.join(agorDir, 'config.yaml'));
+    vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
+
+    expect(() => loadConfigSync()).toThrow(
+      /DAEMON_URL is unset.*masked by Agor's executor sandbox/s
+    );
+  });
+});

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -38,14 +38,23 @@ describe('loadConfigSync', () => {
   // DAEMON_URL is injected precisely so this path is never reached — so
   // arriving here means the injection is what broke. Say that instead of
   // reporting a bare EACCES against a file the caller was never meant to read.
-  it('explains the sandbox when the config is masked and DAEMON_URL is unset', async () => {
+  it('explains the sandbox when the config is unreadable', async () => {
     const agorDir = path.join(tempDir, '.agor');
     await fs.mkdir(agorDir, { recursive: true });
     await fs.mkdir(path.join(agorDir, 'config.yaml'));
     vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
 
-    expect(() => loadConfigSync()).toThrow(
-      /DAEMON_URL is unset.*masked by Agor's executor sandbox/s
-    );
+    expect(() => loadConfigSync()).toThrow(/masked by Agor's executor sandbox/s);
+  });
+
+  // A file we read successfully is not a masked file, whatever it contains.
+  it('reports malformed YAML as a parse failure even inside the sandbox', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(path.join(agorDir, 'config.yaml'), 'daemon: [unclosed\n', 'utf-8');
+    vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
+
+    expect(() => loadConfigSync()).toThrow(/Failed to load config/);
+    expect(() => loadConfigSync()).not.toThrow(/executor sandbox/);
   });
 });

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -28,28 +28,39 @@ export function getDefaultConfig(): AgorConfig {
 
 export function loadConfigSync(): AgorConfig {
   const configPath = path.join(homedir(), '.agor', 'config.yaml');
+  let content: string;
+  // Read and parse are caught separately: only a read failure can be the
+  // sandbox mask, and blaming it for malformed YAML in a file we just read
+  // successfully would send the reader after the wrong thing.
   try {
-    const content = readFileSync(configPath, 'utf-8');
-    const config = yaml.load(content) as AgorConfig;
-    return config || {};
+    content = readFileSync(configPath, 'utf-8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return getDefaultConfig();
     }
     const detail = error instanceof Error ? error.message : String(error);
     // Agor's executor sandbox masks the daemon config with a `/dev/null` bind
-    // mount, so reads from inside fail with EACCES rather than ENOENT. The
-    // sandbox supplies DAEMON_URL precisely so this loader is never reached;
-    // arriving here inside the sandbox means that injection is the thing that
-    // broke. Explain that rather than fabricating a daemon address.
+    // mount, so reads from inside fail with EACCES rather than ENOENT.
+    // `getDaemonUrl()` only consults this loader when DAEMON_URL is unset, and
+    // the sandbox is meant to supply it — so reaching here inside the sandbox
+    // points at that injection, not at the config file.
     if (process.env.AGOR_OUTER_SANDBOX === '1') {
       throw new Error(
-        `DAEMON_URL is unset and ${configPath} is masked by Agor's executor sandbox. ` +
-          'The sandbox provides DAEMON_URL — if it is missing, that is the bug. ' +
-          `See context/explorations/executor-sandboxing.md. (underlying error: ${detail})`
+        `${configPath} is masked by Agor's executor sandbox and is intentionally out of reach. ` +
+          'Inside the sandbox the daemon address comes from DAEMON_URL; if that is unset, ' +
+          `that is the bug. See context/explorations/executor-sandboxing.md. (underlying error: ${detail})`
       );
     }
     throw new Error(`Failed to load config: ${detail}`);
+  }
+
+  try {
+    const config = yaml.load(content) as AgorConfig;
+    return config || {};
+  } catch (error) {
+    throw new Error(
+      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -36,9 +36,20 @@ export function loadConfigSync(): AgorConfig {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return getDefaultConfig();
     }
-    throw new Error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    const detail = error instanceof Error ? error.message : String(error);
+    // Agor's executor sandbox masks the daemon config with a `/dev/null` bind
+    // mount, so reads from inside fail with EACCES rather than ENOENT. The
+    // sandbox supplies DAEMON_URL precisely so this loader is never reached;
+    // arriving here inside the sandbox means that injection is the thing that
+    // broke. Explain that rather than fabricating a daemon address.
+    if (process.env.AGOR_OUTER_SANDBOX === '1') {
+      throw new Error(
+        `DAEMON_URL is unset and ${configPath} is masked by Agor's executor sandbox. ` +
+          'The sandbox provides DAEMON_URL — if it is missing, that is the bug. ' +
+          `See context/explorations/executor-sandboxing.md. (underlying error: ${detail})`
+      );
+    }
+    throw new Error(`Failed to load config: ${detail}`);
   }
 }
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -448,6 +448,77 @@ describe('loadConfig', () => {
     expect(loaded).toEqual(defaults);
   });
 
+  it('should explain the sandbox rather than fabricate a config when masked', async () => {
+    // The executor sandbox masks the daemon's config.yaml with a `--ro-bind
+    // /dev/null` mount, so reads from inside fail with EACCES rather than
+    // ENOENT. Falling back to defaults here would be worse than failing: the
+    // defaults carry no `paths` key and disable filesystem isolation, so a
+    // fabricated config resolves tenant data roots to the wrong directory.
+    // Mounting needs privileges tests don't have; an unreadable file produces
+    // the same EACCES the mask does.
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(configPath, yaml.dump(createConfigData()), 'utf-8');
+    await fs.chmod(configPath, 0o000);
+    vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
+
+    try {
+      await expect(loadConfig()).rejects.toThrow(
+        /masked by Agor's executor sandbox.*payload\.resolvedConfig and DAEMON_URL/s
+      );
+
+      __resetConfigCacheForTests();
+      expect(() => loadConfigSync()).toThrow(/masked by Agor's executor sandbox/s);
+    } finally {
+      // restoreAllMocks() does not undo stubEnv, and the marker leaking into
+      // later tests would silently rewrite their expected errors.
+      vi.unstubAllEnvs();
+      await fs.chmod(configPath, 0o600);
+    }
+  });
+
+  // The masked-config diagnostic is a better message, never a different
+  // outcome: outside the sandbox the same failures stay loud and unchanged.
+  it('should fail loudly when the config path is a directory', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.mkdir(configPath);
+
+    await expect(loadConfig()).rejects.toThrow(/Failed to load config.*EISDIR/s);
+
+    __resetConfigCacheForTests();
+    expect(() => loadConfigSync()).toThrow(/Failed to load config.*EISDIR/s);
+  });
+
+  // Permission bits don't constrain root, and non-POSIX hosts don't honor
+  // mode 000 at all, so this can only assert anything as an unprivileged
+  // POSIX user.
+  it.skipIf(process.getuid === undefined || process.getuid() === 0)(
+    'should fail loudly when a regular config file is unreadable',
+    async () => {
+      const agorDir = path.join(tempDir, '.agor');
+      const configPath = path.join(agorDir, 'config.yaml');
+
+      await fs.mkdir(agorDir, { recursive: true });
+      await fs.writeFile(configPath, yaml.dump(createConfigData()), 'utf-8');
+      await fs.chmod(configPath, 0o000);
+
+      try {
+        await expect(loadConfig()).rejects.toThrow(/Failed to load config.*EACCES/s);
+
+        __resetConfigCacheForTests();
+        expect(() => loadConfigSync()).toThrow(/Failed to load config.*EACCES/s);
+      } finally {
+        // Restore so the afterEach cleanup can remove it.
+        await fs.chmod(configPath, 0o600);
+      }
+    }
+  );
+
   it('should return empty config for empty YAML file', async () => {
     const agorDir = path.join(tempDir, '.agor');
     const configPath = path.join(agorDir, 'config.yaml');

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -448,36 +448,42 @@ describe('loadConfig', () => {
     expect(loaded).toEqual(defaults);
   });
 
-  it('should explain the sandbox rather than fabricate a config when masked', async () => {
-    // The executor sandbox masks the daemon's config.yaml with a `--ro-bind
-    // /dev/null` mount, so reads from inside fail with EACCES rather than
-    // ENOENT. Falling back to defaults here would be worse than failing: the
-    // defaults carry no `paths` key and disable filesystem isolation, so a
-    // fabricated config resolves tenant data roots to the wrong directory.
-    // Mounting needs privileges tests don't have; an unreadable file produces
-    // the same EACCES the mask does.
-    const agorDir = path.join(tempDir, '.agor');
-    const configPath = path.join(agorDir, 'config.yaml');
+  // Manufacturing the mask's EACCES needs mode bits, which don't constrain
+  // root and aren't honored off POSIX — same reason as the unreadable-file
+  // test below.
+  it.skipIf(process.getuid === undefined || process.getuid() === 0)(
+    'should explain the sandbox rather than fabricate a config when masked',
+    async () => {
+      // The executor sandbox masks the daemon's config.yaml with a `--ro-bind
+      // /dev/null` mount, so reads from inside fail with EACCES rather than
+      // ENOENT. Falling back to defaults here would be worse than failing: the
+      // defaults carry no `paths` key and disable filesystem isolation, so a
+      // fabricated config resolves tenant data roots to the wrong directory.
+      // Mounting needs privileges tests don't have; an unreadable file
+      // produces the same EACCES the mask does.
+      const agorDir = path.join(tempDir, '.agor');
+      const configPath = path.join(agorDir, 'config.yaml');
 
-    await fs.mkdir(agorDir, { recursive: true });
-    await fs.writeFile(configPath, yaml.dump(createConfigData()), 'utf-8');
-    await fs.chmod(configPath, 0o000);
-    vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
+      await fs.mkdir(agorDir, { recursive: true });
+      await fs.writeFile(configPath, yaml.dump(createConfigData()), 'utf-8');
+      await fs.chmod(configPath, 0o000);
+      vi.stubEnv('AGOR_OUTER_SANDBOX', '1');
 
-    try {
-      await expect(loadConfig()).rejects.toThrow(
-        /masked by Agor's executor sandbox.*payload\.resolvedConfig and DAEMON_URL/s
-      );
+      try {
+        await expect(loadConfig()).rejects.toThrow(
+          /masked by Agor's executor sandbox.*payload\.resolvedConfig and DAEMON_URL/s
+        );
 
-      __resetConfigCacheForTests();
-      expect(() => loadConfigSync()).toThrow(/masked by Agor's executor sandbox/s);
-    } finally {
-      // restoreAllMocks() does not undo stubEnv, and the marker leaking into
-      // later tests would silently rewrite their expected errors.
-      vi.unstubAllEnvs();
-      await fs.chmod(configPath, 0o600);
+        __resetConfigCacheForTests();
+        expect(() => loadConfigSync()).toThrow(/masked by Agor's executor sandbox/s);
+      } finally {
+        // restoreAllMocks() does not undo stubEnv, and the marker leaking into
+        // later tests would silently rewrite their expected errors.
+        vi.unstubAllEnvs();
+        await fs.chmod(configPath, 0o600);
+      }
     }
-  });
+  );
 
   // The masked-config diagnostic is a better message, never a different
   // outcome: outside the sandbox the same failures stay loud and unchanged.

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -115,6 +115,34 @@ function cacheKeyMatches(a: CacheKey, b: CacheKey): boolean {
   return a.mtimeMs === b.mtimeMs && a.size === b.size;
 }
 
+/**
+ * Wrap a config read/stat failure, explaining the sandbox when we're inside it.
+ *
+ * The executor sandbox masks the daemon config with a `/dev/null` bind mount,
+ * so reads from inside fail with EACCES rather than ENOENT. That is the mask
+ * working as designed. Code running in the sandbox is contractually forbidden
+ * from reading the daemon config (see `packages/executor/src/contract.test.ts`)
+ * and receives what it needs via `payload.resolvedConfig` and `DAEMON_URL`.
+ *
+ * Deliberately an error and not a fall back to `getDefaultConfig()`: the
+ * defaults carry no `paths` key and disable filesystem isolation, so
+ * fabricating them would silently resolve tenant data roots to the wrong
+ * directory instead of failing. A wrong answer here crosses a tenant boundary;
+ * a loud one does not.
+ */
+function configLoadError(configPath: string, error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (process.env.AGOR_OUTER_SANDBOX === '1') {
+    return new Error(
+      `${configPath} is masked by Agor's executor sandbox and is intentionally out of reach. ` +
+        'Code inside the sandbox must not read the daemon config — it receives configuration ' +
+        'via payload.resolvedConfig and DAEMON_URL. Run this on the daemon host instead. ' +
+        `See context/explorations/executor-sandboxing.md. (underlying error: ${detail})`
+    );
+  }
+  return new Error(`Failed to load config: ${detail}`);
+}
+
 function statCacheKey(configPath: string): CacheKey | null {
   try {
     const stat = statSync(configPath);
@@ -863,9 +891,7 @@ export async function loadConfig(): Promise<AgorConfig> {
       writeCachedConfig(configPath, defaults, NO_FILE_KEY);
       return defaults;
     }
-    throw new Error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    throw configLoadError(configPath, error);
   }
 
   let finalConfig: AgorConfig;
@@ -1485,9 +1511,7 @@ export function loadConfigSync(): AgorConfig {
       writeCachedConfig(configPath, defaults, NO_FILE_KEY);
       return defaults;
     }
-    throw new Error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    throw configLoadError(configPath, error);
   }
 
   let finalConfig: AgorConfig;

--- a/packages/core/test/isolate-host-env.ts
+++ b/packages/core/test/isolate-host-env.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Point HOME at an empty per-worker directory before any test runs.
+ *
+ * `getConfigPath()` resolves through `os.homedir()`, which reads `$HOME` on
+ * POSIX. Without this, every suite that loads config reads whatever
+ * `~/.agor/config.yaml` the machine happens to have — so results depend on the
+ * developer's own settings, and a host whose config is unreadable (an executor
+ * sandbox masks it with a `/dev/null` bind mount) fails hundreds of tests that
+ * have nothing to do with config.
+ *
+ * The directory is left empty: absent config is the documented path to
+ * `getDefaultConfig()`, so suites get deterministic defaults and any test
+ * wanting real config writes one under its own temp HOME.
+ *
+ * Host env vars that feed the same resolution are cleared for the same reason.
+ * Tests that care about them set them explicitly.
+ */
+process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'agor-test-home-'));
+
+delete process.env.AGOR_DATA_HOME;
+delete process.env.AGOR_OUTER_SANDBOX;

--- a/packages/core/test/isolate-host-env.ts
+++ b/packages/core/test/isolate-host-env.ts
@@ -19,7 +19,12 @@ import path from 'node:path';
  * Host env vars that feed the same resolution are cleared for the same reason.
  * Tests that care about them set them explicitly.
  */
-process.env.HOME = mkdtempSync(path.join(os.tmpdir(), 'agor-test-home-'));
+const testHome = mkdtempSync(path.join(os.tmpdir(), 'agor-test-home-'));
+
+// `os.homedir()` reads HOME on POSIX and USERPROFILE on Windows; set both so
+// the isolation doesn't quietly become a no-op on one platform.
+process.env.HOME = testHome;
+process.env.USERPROFILE = testHome;
 
 delete process.env.AGOR_DATA_HOME;
 delete process.env.AGOR_OUTER_SANDBOX;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -26,5 +26,6 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 10000,
+    setupFiles: ['./test/isolate-host-env.ts'],
   },
 });


### PR DESCRIPTION
## The bug

#2362 added the bubblewrap executor sandbox, which masks the daemon's secrets with `--ro-bind /dev/null <path>`. That mount lands `nodev`, so from inside the sandbox the config path **stats fine as a character device but reads fail with EACCES — not ENOENT**.

`loadConfig`/`loadConfigSync` only special-case `ENOENT`, so every other errno became a bare `Failed to load config: EACCES` naming a file the caller was never supposed to read. Inside a sandboxed session that is exactly what `agor doctor` prints, against the installed build:

```
Error: Failed to load config: EACCES: permission denied, open '/home/…/.agor/config.yaml'
```

Worth noting for the record: #2362's description says daemon secrets present as `No such file`. That's true of the per-user-home **overlay** path, but not of this unconditional `/dev/null` mask, which yields EACCES. That gap is why this shipped.

## What this does — and deliberately does not do

Both core loaders now throw a **diagnostic** naming the cause and the correct mechanism, keyed on `AGOR_OUTER_SANDBOX` (the marker the daemon already injects at `sandbox-wrap.ts:188`, already read in three places).

It deliberately **does not** fall back to `getDefaultConfig()`. That was the obvious fix and it is wrong: the defaults carry no `paths` key and set `filesystem_isolation_enabled: false`, so tenant scoping is skipped entirely. Measured in a live sandbox:

```
before:  getTenantDataRoot('tenant-b')  →  throws
after (with a defaults fallback):       →  '/home/…/.agor'   ← bare, un-scoped
```

That trades a loud failure for a **silently wrong path across a tenant boundary**, and `agor doctor` would go on to report the sandbox as *disabled* while running inside it. `/dev/null` is the right mask precisely because it is loud; the fix is to explain it, not to paper over it.

`packages/client/src/config.ts` is a separate duplicate `loadConfigSync` backing `getDaemonUrl()` for every `BaseCommand` CLI command; it had the identical ENOENT-only gap and gets the matching diagnostic. Read and parse are caught separately there so malformed YAML is never misreported as a mask.

Outside the sandbox nothing changes: same `Error` type, same `Failed to load config: …` prefix. Grepped repo-wide — no production code string-matches it.

## The 566 failing tests were not a product bug

`getConfigPath()` resolves through `os.homedir()`, so the suites were reading whatever `~/.agor/config.yaml` the host happened to have. #2362 didn't cause that coupling, it only **exposed** it by making the file unreadable.

Proof: on completely unpatched source at `f044d17`, with `HOME` pointed at a clean empty temp dir, the full core suite passes **3773/0**. So this PR fixes the symptom in the test setup — `HOME` (and `USERPROFILE`) pointed at an empty per-run temp dir for `@agor/core` and `@agor/daemon`, with `AGOR_DATA_HOME`/`AGOR_OUTER_SANDBOX` cleared — and leaves the product alone. No sandbox special-casing in test code; the point is that tests shouldn't depend on host state at all.

## Numbers (this host, inside a sandbox)

| suite | before | after |
|---|---|---|
| `@agor/core` | 568 failed / 3208 passed, 1115 EACCES | **3776 passed / 0 failed, 0 EACCES** |
| `@agor/daemon` | — | 2838 passed / 1 failed |
| `@agor-live/client` | — | 42 passed / 0 failed |

The single daemon failure is `cursor-models.test.ts`, which needs network; it fails identically on a clean tree here.

## Known follow-ups (filed separately, not in this PR)

- The executor **contract hole**: `contract.test.ts` forbids importing `loadConfig`/`loadConfigSync`, but only matches direct import specifiers. `packages/executor/src/commands/git.ts:24` imports `getReposDir`, which reaches `loadConfigSync` transitively — so the executor violates its own contract today and the guard can't see it.
- `agor.db` masking gaps (security-sensitive; filed separately).

## CI note

`pnpm check` is **already red on `main`** at this branch's base commit `f044d17`, from #2362's `sandbox-wrap.ts` refactor: two `node:fs` calls moved into a new `canonicalizeExistingPath` helper without updating `scripts/daemon-filesystem-exceptions.json`. This PR's error set is byte-identical to the clean-tree baseline — it adds no new violations — but it can't be green until that registry drift is fixed. Left out deliberately: re-blessing fs capabilities for someone else's refactor doesn't belong in a config PR. Happy to send that as a one-line follow-up.

Regression source: #2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
