### PR TITLE
fix(session): model label clickable on new session before model change

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -140,11 +140,19 @@ describe('SessionFooter', () => {
     expect(container.querySelector('[data-icon="stop"]')).not.toBeInTheDocument();
   });
 
-  it('Model chip is hidden when no model is present', () => {
+  it('Model chip is hidden when no model is resolvable (tool without a static default)', () => {
     render(
       <SessionFooter
         {...baseProps}
-        session={{ ...baseSession, model_config: undefined } as unknown as Session}
+        // opencode has no static default model and needs a provider/model pair,
+        // so a fresh session with no model_config resolves to nothing.
+        session={
+          {
+            ...baseSession,
+            agentic_tool: 'opencode',
+            model_config: undefined,
+          } as unknown as Session
+        }
         tokenBreakdown={{ ...baseTokenBreakdown, total: 0 }}
       />,
       { wrapper: Wrapper }
@@ -152,6 +160,33 @@ describe('SessionFooter', () => {
     expect(screen.queryByTestId('model-chip')).not.toBeInTheDocument();
     expect(screen.queryByTestId('tokens-chip')).not.toBeInTheDocument();
     expect(screen.queryByTestId('stats-chip')).not.toBeInTheDocument();
+  });
+
+  it('Model chip renders and is clickable on a brand-new session before any model change', async () => {
+    // A fresh session persists no model into model_config — the model is
+    // resolved from tool defaults at runtime. The chip must still render and
+    // open its click-to-change popover (regression: it used to only appear
+    // after the user changed the model via Session Settings).
+    render(
+      <SessionFooter
+        {...baseProps}
+        session={
+          {
+            ...baseSession,
+            agentic_tool: 'claude-code',
+            model_config: undefined,
+          } as unknown as Session
+        }
+      />,
+      { wrapper: Wrapper }
+    );
+    const chip = screen.getByTestId('model-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip.style.cursor).toBe('pointer');
+
+    // Clicking opens the model-picker popover (ModelSelector is stubbed).
+    fireEvent.click(chip);
+    expect(await screen.findByTestId('model-selector-stub')).toBeInTheDocument();
   });
 
   it('Context chip shows warning styling when context usage is above 80%', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -10,6 +10,7 @@ import type {
   Session,
   Task,
 } from '@agor-live/client';
+import { getDefaultModelForTool } from '@agor-live/client';
 import {
   BranchesOutlined,
   ClockCircleOutlined,
@@ -184,12 +185,18 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
     });
   };
 
-  // Model name + token counts for individual chips
-  const modelName = session.model_config?.model
+  // Model name + token counts for individual chips. A brand-new session hasn't
+  // persisted its model into model_config yet — it's resolved from tool/user
+  // defaults at runtime — so fall back to the tool's default model. Without this
+  // the chip wouldn't render (and its click-to-change popover would be
+  // unreachable) until the user first changed the model via Session Settings.
+  const effectiveModel =
+    session.model_config?.model ?? getDefaultModelForTool(session.agentic_tool);
+  const modelName = effectiveModel
     ? getModelDisplayName(
-        session.model_config.provider
-          ? `${session.model_config.provider}/${session.model_config.model}`
-          : session.model_config.model
+        session.model_config?.provider
+          ? `${session.model_config.provider}/${effectiveModel}`
+          : effectiveModel
       )
     : null;
   const tokenDisplay =


### PR DESCRIPTION
## Problem

Reported by Rebeca (Slack #agor): *"The model label is not clickable when we open a new session. It only gets clickable after I open the session settings modal and change the model."*

## Root cause (confirmed)

The live clickable model label the user interacts with is the **info-bar model chip** in `SessionFooter.tsx` (`data-testid="model-chip"`), which is pinned by default (`useFooterPreferences` → `pinnedChips` includes `'model'`).

Its render was gated on `modelName`, computed **only** from the persisted `session.model_config?.model`:

```ts
const modelName = session.model_config?.model ? getModelDisplayName(...) : null;
```

On a brand-new session the model isn't persisted into `model_config.model` — it's resolved from tool/user defaults at runtime, and only written once the user explicitly changes it via Session Settings. So `modelName` was `null`, the chip (and its click-to-change `Popover` → `ModelSelector`) never rendered, and the label became reachable only after the first explicit model change.

> Note: the `SessionRunSettingsPopover` component referenced in the original hypothesis is **dead code** — its only importers are test files (all mock it to `null`), and `SessionFooter`'s `modelLabel` prop is likewise unused. I left both alone to keep this diff tight; they can be removed in a separate cleanup.

## Fix

Fall back to the tool's default model via `getDefaultModelForTool(session.agentic_tool)` (the same resolved-config helper `AgenticConfigChipRow` already uses) when `model_config.model` is absent, so the chip renders with the correct display name and stays clickable from the first render. `ModelSelector` already self-resolves a `fallbackModel` for its `value`, so the popover shows the right current selection.

Tools without a static default (opencode / cursor, which need an explicit provider/model pair) still resolve to nothing and keep the chip hidden — unchanged behavior.

## Tests

`SessionFooter.test.tsx`:
- Added: *"Model chip renders and is clickable on a brand-new session before any model change"* — asserts the chip renders, has `cursor: pointer`, and opens its model-picker popover on click, for a `claude-code` session with `model_config: undefined`.
- Repurposed the old *"hidden when no model"* case to use `opencode` (a tool with no static default), preserving the hidden-chip assertion for that path.

Results (in `apps/agor-ui`):
- `vitest run src/components/SessionPanel/` → **79 passed**
- `SessionFooter.test.tsx` → **24 passed**
- `pnpm biome check` (touched files) → clean
- `pnpm typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)