### PR TITLE
fix(mcp): require member role on the credential-issuing MCP endpoints

### DIFF
--- a/apps/agor-daemon/src/oauth-cache.test.ts
+++ b/apps/agor-daemon/src/oauth-cache.test.ts
@@ -15,6 +15,14 @@ vi.mock('@agor/core/db', () => ({
   },
 }));
 
+// The subject-entitlement precondition is enforced inside `persistOAuthToken`
+// and is driven for real, against a real database and a real demotion, in
+// `services/mcp-capability-role.test.ts`. Stubbed here so this file stays about
+// what it is about: which columns a completed flow lands.
+vi.mock('@agor/core/tools/mcp/grant-entitlement', () => ({
+  assertMcpGrantSubjectEntitled: vi.fn(async () => undefined),
+}));
+
 vi.mock('@agor/core/tools/mcp/oauth-token-expiry', () => ({
   resolveTokenExpiry: () => ({
     expiresAt: new Date(Date.now() + 3_600_000),

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -11,6 +11,7 @@ import {
   type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
 } from '@agor/core/db';
+import { assertMcpGrantSubjectEntitled } from '@agor/core/tools/mcp/grant-entitlement';
 import type { OAuthTokenResponse } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import { resolveTokenExpiry } from '@agor/core/tools/mcp/oauth-token-expiry';
 import type { MCPServerID, UserID } from '@agor/core/types';
@@ -80,6 +81,22 @@ export async function persistOAuthToken(
     );
     throw new Error('Per-user OAuth flow is missing its user binding');
   }
+
+  // The moment the grant becomes durable, and so the moment the subject's
+  // standing has to hold. Enforced here rather than at the endpoints that reach
+  // it: the OAuth callback is an unauthenticated browser redirect, and a check
+  // on one endpoint's caller says nothing about the next endpoint, an aliased
+  // import, or a wrapper. Everything that persists a grant this way arrives at
+  // this line.
+  //
+  // The flow's initiator is the subject even for a `shared` grant, which keeps
+  // the admin floor `oauth-start` applies. See `assertMcpGrantSubjectEntitled`
+  // for the residual window between this check and the write.
+  await assertMcpGrantSubjectEntitled({
+    db,
+    subjectUserId: pendingFlow.userId ?? null,
+    oauthMode,
+  });
 
   await userTokenRepo.saveToken(tokenUserId, pendingFlow.mcpServerId as MCPServerID, {
     accessToken: tokenResponse.access_token,

--- a/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
@@ -1,16 +1,20 @@
 /**
- * That the role floor runs, and that no `/mcp-servers/*` endpoint escapes the
- * question.
+ * That the guards run, and that no endpoint which mints a credential escapes
+ * being guarded by one of them.
  *
- * `mcp-capability-role.test.ts` proves the floor is correct by driving the real
- * registration against a real app. A floor that is correct and a floor that
- * runs are different claims, and the second one is what this file is for: the
- * endpoints live in ~1,800 lines of `register-services.ts`, so the failure mode
- * is a new one landing beside them and simply never being classified.
+ * The first version of this file asserted a hand-written list of "non-issuing"
+ * paths, which is how it managed to certify `oauth-auth-headers` as harmless
+ * while that endpoint called `refreshAndPersistToken` twice. A test that
+ * restates a decision cannot detect the decision being wrong; it just makes the
+ * mistake look considered. So the classification here is *derived* — the source
+ * is searched for the functions that actually mint or store a credential, and
+ * every endpoint containing one must be covered by a named guard that the same
+ * endpoint demonstrably carries.
  *
- * Source-level for the same reason the other `register-services.*` tests are —
+ * Source-level for the same reason the other `register-services.*` tests are:
  * standing up the whole registration needs a database, a config, an executor
- * and a socket server, none of which this is about.
+ * and a socket server, none of which this is about. The behaviour of each guard
+ * is driven for real in `services/mcp-capability-role.test.ts`.
  */
 
 import { readFileSync } from 'node:fs';
@@ -19,38 +23,121 @@ import { describe, expect, it } from 'vitest';
 import { MCP_CAPABILITY_ISSUING_SERVICE_PATHS } from './utils/mcp-server-authorization.js';
 
 /**
- * Every other `/mcp-servers/*` endpoint, with the reason it issues no
- * capability. Adding an endpoint means adding it here or to
- * `MCP_CAPABILITY_ISSUING_SERVICE_PATHS`; the last assertion refuses to let it
- * be neither.
+ * Calls that obtain, exchange, or persist a credential. An endpoint containing
+ * one of these is issuing capability, whatever its name suggests.
  */
-const NON_ISSUING_MCP_SERVICE_PATHS: Record<string, string> = {
-  // Revocation, which must not be refused to the user whose grant it is.
-  'mcp-servers/oauth-disconnect': 'drops a grant rather than issuing one',
-  // Reads of the caller's own state.
-  'mcp-servers/oauth-status': "reads the caller's own authenticated-server list",
-  'mcp-servers/oauth-attempt-status': "reads the caller's own pending attempt",
-  // Hands the executor a bearer for a grant that already exists, under a
-  // session token or service account rather than a user role.
-  'mcp-servers/oauth-auth-headers': 'vends an already-issued grant to the executor',
-  // Configuration CRUD, already floored by `authorizeMcpServerWrite`.
-  'mcp-servers': 'goes through authorizeMcpServerWrite',
+const CREDENTIAL_MINTING_CALLS = [
+  'refreshAndPersistToken(',
+  'persistOAuthToken(',
+  'persistOAuthTokenForPendingFlow(',
+  'completeMCPOAuthFlow(',
+  'startTwoPhaseMCPOAuthFlow(',
+  'startTwoPhaseMCPOAuthFlowAndAwaitToken(',
+];
+
+/**
+ * Endpoints that mint but cannot be guarded by flooring their caller, with the
+ * guard that covers them instead. The guard's name must appear in the
+ * endpoint's own source, so an exemption cannot outlive the guard it claims.
+ */
+const GUARDED_BY_SUBJECT_STANDING: Record<string, string> = {
+  // The provider's browser redirect. No caller, no session — only `state` — so
+  // the standing checked is the recorded initiator's.
+  'mcp-servers/oauth-callback': 'assertPendingFlowStillAuthorized',
+  // Called by an executor under a session token; the standing checked is the
+  // grant owner's.
+  'mcp-servers/oauth-auth-headers': 'isPerUserGrantOwnerEntitled',
 };
 
-describe('MCP capability role floor wiring', () => {
+describe('MCP capability guards', () => {
   const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
-  // Strip comments so prose naming the helper cannot satisfy the check.
+  // Strip comments so prose naming a helper cannot satisfy any check below.
   const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-  it('applies the floor from the shipped registration helper', () => {
-    // The helper, not a loop copied into this file — a copy is the thing that
-    // drifts from what ships.
+  /**
+   * The source of each `/mcp-servers/*` endpoint, from its `app.use(` to the
+   * next one. `oauth-callback` is not an `app.use` route — it is an express
+   * handler returned from this module — so it is sliced from its own function.
+   */
+  const endpointBlocks = (): Map<string, string> => {
+    const blocks = new Map<string, string>();
+    const mounts = [...codeOnly.matchAll(/app\.use\(\s*'\/(mcp-servers[^']*)'/g)];
+    mounts.forEach((mount, index) => {
+      const end = index + 1 < mounts.length ? mounts[index + 1].index : codeOnly.length;
+      blocks.set(mount[1], codeOnly.slice(mount.index, end));
+    });
+    const callbackAt = codeOnly.indexOf('const oauthCallbackHandler');
+    if (callbackAt > -1) {
+      const rest = codeOnly.slice(callbackAt);
+      const next = rest.slice(1).search(/\n {2}(const|async function) /);
+      blocks.set('mcp-servers/oauth-callback', next === -1 ? rest : rest.slice(0, next + 1));
+    }
+    return blocks;
+  };
+
+  it('finds the endpoints it means to classify (sanity)', () => {
+    const blocks = endpointBlocks();
+    expect(blocks.size).toBeGreaterThan(5);
+    expect([...blocks.keys()]).toEqual(expect.arrayContaining(['mcp-servers/oauth-callback']));
+  });
+
+  /**
+   * The offset of the first *call* to `name` in `block`, or -1.
+   *
+   * A call, not a mention: an earlier draft of this test asked whether the
+   * guard's name appeared anywhere in the endpoint, which the guard's own
+   * `const ... =` declaration satisfies. Deleting the refusal while leaving the
+   * declaration behind therefore passed — the test certified a guard that no
+   * longer ran. Requiring `name(` excludes the declaration, whose identifier is
+   * followed by `=` rather than `(`.
+   */
+  const firstCallAt = (block: string, name: string): number =>
+    block.search(new RegExp(`\\b${name}\\s*\\(`));
+
+  it('guards every endpoint that mints a credential, before it mints', () => {
+    const unguarded: string[] = [];
+    for (const [path, block] of endpointBlocks()) {
+      const mints = CREDENTIAL_MINTING_CALLS.filter((call) => block.includes(call));
+      if (mints.length === 0) continue;
+      if ((MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).includes(path)) continue;
+
+      const subjectGuard = GUARDED_BY_SUBJECT_STANDING[path];
+      const guardAt = subjectGuard ? firstCallAt(block, subjectGuard) : -1;
+      const firstMintAt = Math.min(
+        ...mints.map((call) => block.indexOf(call)).filter((at) => at > -1)
+      );
+
+      if (guardAt > -1 && guardAt < firstMintAt) continue;
+
+      unguarded.push(
+        !subjectGuard
+          ? `${path} calls ${mints.join(', ')} but carries no role guard`
+          : guardAt === -1
+            ? `${path} claims ${subjectGuard}, which its source never calls`
+            : `${path} calls ${subjectGuard} only after it has already minted`
+      );
+    }
+
+    // This is the assertion that would have caught `oauth-auth-headers`.
+    expect(unguarded).toEqual([]);
+  });
+
+  it('keeps the caller floor to endpoints a caller actually drives', () => {
+    // The converse mistake: flooring the caller on an endpoint the executor
+    // drives would refuse a robot for having no role.
+    for (const path of Object.keys(GUARDED_BY_SUBJECT_STANDING)) {
+      expect(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).not.toContain(path);
+    }
+  });
+
+  it('applies the caller floor from the shipped registration helper', () => {
+    // The helper, not a loop copied into this file — a copy is what drifts.
     expect(codeOnly).toContain('registerMcpCapabilityRoleFloor(app)');
   });
 
   it('applies it after the endpoints register their own auth hooks', () => {
-    // Feathers appends, so ordering here is what makes `ctx.requireAuth` run
-    // first and lets the floor decide on an authenticated caller.
+    // Feathers appends, so ordering is what makes `ctx.requireAuth` run first
+    // and lets the floor decide on an authenticated caller.
     const floorAt = codeOnly.indexOf('registerMcpCapabilityRoleFloor(app)');
     expect(floorAt).toBeGreaterThan(-1);
     for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
@@ -68,18 +155,15 @@ describe('MCP capability role floor wiring', () => {
     }
   });
 
-  it('classifies every mounted /mcp-servers endpoint as issuing or not', () => {
-    const mounted = [...codeOnly.matchAll(/app\.use\(\s*'\/(mcp-servers[^']*)'/g)].map((m) => m[1]);
-    expect(mounted.length).toBeGreaterThan(0);
-
-    const unclassified = mounted.filter(
-      (path) =>
-        !(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).includes(path) &&
-        !(path in NON_ISSUING_MCP_SERVICE_PATHS)
-    );
-
-    // A new endpoint lands here until somebody decides which it is. That is the
-    // point: the gap this closes was an endpoint nobody classified.
-    expect(unclassified).toEqual([]);
+  it('re-checks the flow initiator ahead of the durable-only branch', () => {
+    // The gap was not the check being absent but its being unreachable: it sat
+    // behind `if (!record) return`, which is every SQLite deployment.
+    const guardAt = codeOnly.indexOf('const assertPendingFlowStillAuthorized');
+    const body = codeOnly.slice(guardAt, guardAt + 1200);
+    const initiatorAt = body.indexOf('assertFlowInitiatorStillEntitled(');
+    const durableReturnAt = body.indexOf('if (!record) return;');
+    expect(initiatorAt).toBeGreaterThan(-1);
+    expect(durableReturnAt).toBeGreaterThan(-1);
+    expect(initiatorAt).toBeLessThan(durableReturnAt);
   });
 });

--- a/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
@@ -1,0 +1,85 @@
+/**
+ * That the role floor runs, and that no `/mcp-servers/*` endpoint escapes the
+ * question.
+ *
+ * `mcp-capability-role.test.ts` proves the floor is correct by driving the real
+ * registration against a real app. A floor that is correct and a floor that
+ * runs are different claims, and the second one is what this file is for: the
+ * endpoints live in ~1,800 lines of `register-services.ts`, so the failure mode
+ * is a new one landing beside them and simply never being classified.
+ *
+ * Source-level for the same reason the other `register-services.*` tests are —
+ * standing up the whole registration needs a database, a config, an executor
+ * and a socket server, none of which this is about.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { MCP_CAPABILITY_ISSUING_SERVICE_PATHS } from './utils/mcp-server-authorization.js';
+
+/**
+ * Every other `/mcp-servers/*` endpoint, with the reason it issues no
+ * capability. Adding an endpoint means adding it here or to
+ * `MCP_CAPABILITY_ISSUING_SERVICE_PATHS`; the last assertion refuses to let it
+ * be neither.
+ */
+const NON_ISSUING_MCP_SERVICE_PATHS: Record<string, string> = {
+  // Revocation, which must not be refused to the user whose grant it is.
+  'mcp-servers/oauth-disconnect': 'drops a grant rather than issuing one',
+  // Reads of the caller's own state.
+  'mcp-servers/oauth-status': "reads the caller's own authenticated-server list",
+  'mcp-servers/oauth-attempt-status': "reads the caller's own pending attempt",
+  // Hands the executor a bearer for a grant that already exists, under a
+  // session token or service account rather than a user role.
+  'mcp-servers/oauth-auth-headers': 'vends an already-issued grant to the executor',
+  // Configuration CRUD, already floored by `authorizeMcpServerWrite`.
+  'mcp-servers': 'goes through authorizeMcpServerWrite',
+};
+
+describe('MCP capability role floor wiring', () => {
+  const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
+  // Strip comments so prose naming the helper cannot satisfy the check.
+  const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  it('applies the floor from the shipped registration helper', () => {
+    // The helper, not a loop copied into this file — a copy is the thing that
+    // drifts from what ships.
+    expect(codeOnly).toContain('registerMcpCapabilityRoleFloor(app)');
+  });
+
+  it('applies it after the endpoints register their own auth hooks', () => {
+    // Feathers appends, so ordering here is what makes `ctx.requireAuth` run
+    // first and lets the floor decide on an authenticated caller.
+    const floorAt = codeOnly.indexOf('registerMcpCapabilityRoleFloor(app)');
+    expect(floorAt).toBeGreaterThan(-1);
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      const hooksAt = codeOnly.indexOf(`app.service('${path}').hooks(`);
+      expect(hooksAt, `${path} registers its own hooks`).toBeGreaterThan(-1);
+      expect(hooksAt, `${path} hooks must register before the floor`).toBeLessThan(floorAt);
+    }
+  });
+
+  it('mounts every path the floor names', () => {
+    // A typo in the list would otherwise fail silently — `app.service()` on an
+    // unmounted path does not throw in a way this registration would notice.
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      expect(codeOnly, `${path} is not mounted`).toContain(`app.use('/${path}'`);
+    }
+  });
+
+  it('classifies every mounted /mcp-servers endpoint as issuing or not', () => {
+    const mounted = [...codeOnly.matchAll(/app\.use\(\s*'\/(mcp-servers[^']*)'/g)].map((m) => m[1]);
+    expect(mounted.length).toBeGreaterThan(0);
+
+    const unclassified = mounted.filter(
+      (path) =>
+        !(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).includes(path) &&
+        !(path in NON_ISSUING_MCP_SERVICE_PATHS)
+    );
+
+    // A new endpoint lands here until somebody decides which it is. That is the
+    // point: the gap this closes was an endpoint nobody classified.
+    expect(unclassified).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
@@ -1,20 +1,37 @@
 /**
- * That the guards run, and that no endpoint which mints a credential escapes
- * being guarded by one of them.
+ * That the caller floor runs, and that the writes which make a grant durable
+ * carry the subject check.
  *
- * The first version of this file asserted a hand-written list of "non-issuing"
- * paths, which is how it managed to certify `oauth-auth-headers` as harmless
- * while that endpoint called `refreshAndPersistToken` twice. A test that
- * restates a decision cannot detect the decision being wrong; it just makes the
- * mistake look considered. So the classification here is *derived* — the source
- * is searched for the functions that actually mint or store a credential, and
- * every endpoint containing one must be covered by a named guard that the same
- * endpoint demonstrably carries.
+ * ## Why there is no longer a scan over endpoints
  *
- * Source-level for the same reason the other `register-services.*` tests are:
- * standing up the whole registration needs a database, a config, an executor
- * and a socket server, none of which this is about. The behaviour of each guard
- * is driven for real in `services/mcp-capability-role.test.ts`.
+ * Two earlier versions of this file tried to prove "no endpoint that mints a
+ * credential is missing a guard" by searching `register-services.ts` for the
+ * calls that mint. Both were wrong, in instructive ways:
+ *
+ * 1. The first hard-coded `oauth-auth-headers` as non-issuing. It calls
+ *    `refreshAndPersistToken` twice. The test asserted the wrong answer and
+ *    made the mistake look considered.
+ * 2. The second derived the list by scanning, but matched the guard's *name*
+ *    anywhere in the endpoint — which its own `const ... =` declaration
+ *    satisfies — so deleting the refusal still passed.
+ *
+ * Fixing the second did not fix the shape. A scan over call sites enumerates
+ * callers, and callers are the easy thing to add: `const mint =
+ * refreshAndPersistToken`, an imported wrapper, or a helper defined outside the
+ * block all mint without matching, and the endpoint is silently skipped. No
+ * amount of pattern-tightening makes a survey into a proof.
+ *
+ * So the enforcement moved to the choke point instead. `persistOAuthToken` and
+ * `refreshAndPersistToken` call `assertMcpGrantSubjectEntitled` themselves,
+ * immediately before their write, so aliasing, wrapping and new endpoints are
+ * all irrelevant — every route arrives at the same two functions. What is left
+ * to check here is small and structural: that those two writes carry the check,
+ * and that the caller floor is still wired.
+ *
+ * The caller floor is not redundant to that. It covers `discover` and
+ * `test-jwt`, which reach a provider on a stored credential without persisting
+ * a grant, and it gives the other four a fast, well-worded refusal instead of a
+ * provider round-trip that fails at the write.
  */
 
 import { readFileSync } from 'node:fs';
@@ -22,144 +39,121 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { MCP_CAPABILITY_ISSUING_SERVICE_PATHS } from './utils/mcp-server-authorization.js';
 
-/**
- * Calls that obtain, exchange, or persist a credential. An endpoint containing
- * one of these is issuing capability, whatever its name suggests.
- */
-const CREDENTIAL_MINTING_CALLS = [
-  'refreshAndPersistToken(',
-  'persistOAuthToken(',
-  'persistOAuthTokenForPendingFlow(',
-  'completeMCPOAuthFlow(',
-  'startTwoPhaseMCPOAuthFlow(',
-  'startTwoPhaseMCPOAuthFlowAndAwaitToken(',
-];
+/** Strip comments so prose naming a helper cannot satisfy a structural check. */
+const codeOf = (path: string): string =>
+  readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-/**
- * Endpoints that mint but cannot be guarded by flooring their caller, with the
- * guard that covers them instead. The guard's name must appear in the
- * endpoint's own source, so an exemption cannot outlive the guard it claims.
- */
-const GUARDED_BY_SUBJECT_STANDING: Record<string, string> = {
-  // The provider's browser redirect. No caller, no session — only `state` — so
-  // the standing checked is the recorded initiator's.
-  'mcp-servers/oauth-callback': 'assertPendingFlowStillAuthorized',
-  // Called by an executor under a session token; the standing checked is the
-  // grant owner's.
-  'mcp-servers/oauth-auth-headers': 'isPerUserGrantOwnerEntitled',
-};
+describe('grant entitlement is enforced at the write', () => {
+  const persistSource = codeOf(join(__dirname, 'oauth-cache.ts'));
+  const refreshSource = codeOf(
+    join(__dirname, '../../../packages/core/src/tools/mcp/oauth-refresh.ts')
+  );
 
-describe('MCP capability guards', () => {
-  const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
-  // Strip comments so prose naming a helper cannot satisfy any check below.
-  const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  it('checks the subject before persisting a completed flow', () => {
+    const checkAt = persistSource.indexOf('assertMcpGrantSubjectEntitled(');
+    const writeAt = persistSource.indexOf('saveToken(');
+    expect(checkAt).toBeGreaterThan(-1);
+    expect(writeAt).toBeGreaterThan(-1);
+    expect(checkAt, 'the check must precede the write').toBeLessThan(writeAt);
+  });
 
-  /**
-   * The source of each `/mcp-servers/*` endpoint, from its `app.use(` to the
-   * next one. `oauth-callback` is not an `app.use` route — it is an express
-   * handler returned from this module — so it is sliced from its own function.
-   */
-  const endpointBlocks = (): Map<string, string> => {
-    const blocks = new Map<string, string>();
-    const mounts = [...codeOnly.matchAll(/app\.use\(\s*'\/(mcp-servers[^']*)'/g)];
-    mounts.forEach((mount, index) => {
-      const end = index + 1 < mounts.length ? mounts[index + 1].index : codeOnly.length;
-      blocks.set(mount[1], codeOnly.slice(mount.index, end));
+  it('checks the subject before persisting every refreshed token', () => {
+    // Both dialect paths persist: `completeClaimedRefresh` on PostgreSQL and
+    // `saveToken` standalone. Neither may write without a preceding check.
+    const writes = [...refreshSource.matchAll(/\b(completeClaimedRefresh|saveToken)\s*\(/g)];
+    expect(writes.length).toBeGreaterThan(0);
+
+    const unchecked = writes.filter((write) => {
+      const before = refreshSource.slice(0, write.index);
+      const checkAt = before.lastIndexOf('assertGrantSubjectForRefresh(');
+      if (checkAt === -1) return true;
+      // The check has to be in the same function as the write, not merely
+      // earlier in the file. Nothing but a top-level `async function` opener
+      // may sit between them.
+      return /\nasync function /.test(before.slice(checkAt));
     });
-    const callbackAt = codeOnly.indexOf('const oauthCallbackHandler');
-    if (callbackAt > -1) {
-      const rest = codeOnly.slice(callbackAt);
-      const next = rest.slice(1).search(/\n {2}(const|async function) /);
-      blocks.set('mcp-servers/oauth-callback', next === -1 ? rest : rest.slice(0, next + 1));
-    }
-    return blocks;
-  };
 
-  it('finds the endpoints it means to classify (sanity)', () => {
-    const blocks = endpointBlocks();
-    expect(blocks.size).toBeGreaterThan(5);
-    expect([...blocks.keys()]).toEqual(expect.arrayContaining(['mcp-servers/oauth-callback']));
+    expect(unchecked.map((w) => `${w[1]} persists without a preceding subject check`)).toEqual([]);
   });
 
-  /**
-   * The offset of the first *call* to `name` in `block`, or -1.
-   *
-   * A call, not a mention: an earlier draft of this test asked whether the
-   * guard's name appeared anywhere in the endpoint, which the guard's own
-   * `const ... =` declaration satisfies. Deleting the refusal while leaving the
-   * declaration behind therefore passed — the test certified a guard that no
-   * longer ran. Requiring `name(` excludes the declaration, whose identifier is
-   * followed by `=` rather than `(`.
-   */
-  const firstCallAt = (block: string, name: string): number =>
-    block.search(new RegExp(`\\b${name}\\s*\\(`));
+  it('resolves the subject from stored state, not from a caller argument', () => {
+    // The point of moving the check inward: a caller cannot pre-satisfy it by
+    // passing a flag. It reads the role itself.
+    const guard = codeOf(
+      join(__dirname, '../../../packages/core/src/tools/mcp/grant-entitlement.ts')
+    );
+    expect(guard).toContain('UsersRepository');
+    expect(guard).toContain('isMcpGrantSubjectEntitled(');
+  });
+});
 
-  it('guards every endpoint that mints a credential, before it mints', () => {
-    const unguarded: string[] = [];
-    for (const [path, block] of endpointBlocks()) {
-      const mints = CREDENTIAL_MINTING_CALLS.filter((call) => block.includes(call));
-      if (mints.length === 0) continue;
-      if ((MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).includes(path)) continue;
+describe('standalone pending flows expire when taken, not only when swept', () => {
+  const source = codeOf(join(__dirname, 'register-services.ts'));
 
-      const subjectGuard = GUARDED_BY_SUBJECT_STANDING[path];
-      const guardAt = subjectGuard ? firstCallAt(block, subjectGuard) : -1;
-      const firstMintAt = Math.min(
-        ...mints.map((call) => block.indexOf(call)).filter((at) => at > -1)
-      );
+  it('checks flow age between claiming a flow and using it', () => {
+    // A TTL enforced only by the 60s sweeper is a TTL plus a jitter window, and
+    // the reason that extra minute matters is that a demotion can land inside
+    // it. Anchored on the assignment, which is where a callback or a manual
+    // completion claims a flow — the sweeper's own delete is the expiry itself,
+    // and the await-timeout's lookup discards rather than consumes.
+    const takes = [...source.matchAll(/pendingFlow = pendingOAuthFlows\.get\(state\)/g)];
+    expect(takes.length).toBeGreaterThan(0);
 
-      if (guardAt > -1 && guardAt < firstMintAt) continue;
-
-      unguarded.push(
-        !subjectGuard
-          ? `${path} calls ${mints.join(', ')} but carries no role guard`
-          : guardAt === -1
-            ? `${path} claims ${subjectGuard}, which its source never calls`
-            : `${path} calls ${subjectGuard} only after it has already minted`
-      );
-    }
-
-    // This is the assertion that would have caught `oauth-auth-headers`.
-    expect(unguarded).toEqual([]);
+    const unchecked = takes.filter((take) => {
+      // The window is "until the flow is acted on", not a character count: the
+      // age has to be settled before anything else looks at the flow.
+      const after = source.slice(take.index);
+      const usedAt = after.indexOf('assertPendingFlowStillAuthorized(');
+      const checkedAt = after.indexOf('isLocalOAuthFlowExpired(');
+      return checkedAt === -1 || (usedAt > -1 && checkedAt > usedAt);
+    });
+    expect(unchecked.map(() => 'a flow is claimed and used without an age check')).toEqual([]);
   });
 
-  it('keeps the caller floor to endpoints a caller actually drives', () => {
-    // The converse mistake: flooring the caller on an endpoint the executor
-    // drives would refuse a robot for having no role.
-    for (const path of Object.keys(GUARDED_BY_SUBJECT_STANDING)) {
-      expect(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).not.toContain(path);
-    }
+  it('shares one TTL between the sweeper and the take paths', () => {
+    expect(source).toContain('LOCAL_OAUTH_FLOW_TTL_MS');
+    // The sweeper must use the shared predicate rather than an inline literal,
+    // so the two cannot drift apart.
+    const sweeperAt = source.indexOf('const oauthCleanupTimer');
+    const sweeper = source.slice(sweeperAt, sweeperAt + 700);
+    expect(sweeper).toContain('isLocalOAuthFlowExpired(');
   });
+});
 
-  it('applies the caller floor from the shipped registration helper', () => {
-    // The helper, not a loop copied into this file — a copy is what drifts.
-    expect(codeOnly).toContain('registerMcpCapabilityRoleFloor(app)');
+describe('MCP caller floor wiring', () => {
+  const source = codeOf(join(__dirname, 'register-services.ts'));
+
+  it('applies the floor from the shipped registration helper', () => {
+    expect(source).toContain('registerMcpCapabilityRoleFloor(app)');
   });
 
   it('applies it after the endpoints register their own auth hooks', () => {
     // Feathers appends, so ordering is what makes `ctx.requireAuth` run first
     // and lets the floor decide on an authenticated caller.
-    const floorAt = codeOnly.indexOf('registerMcpCapabilityRoleFloor(app)');
+    const floorAt = source.indexOf('registerMcpCapabilityRoleFloor(app)');
     expect(floorAt).toBeGreaterThan(-1);
     for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
-      const hooksAt = codeOnly.indexOf(`app.service('${path}').hooks(`);
+      const hooksAt = source.indexOf(`app.service('${path}').hooks(`);
       expect(hooksAt, `${path} registers its own hooks`).toBeGreaterThan(-1);
       expect(hooksAt, `${path} hooks must register before the floor`).toBeLessThan(floorAt);
     }
   });
 
   it('mounts every path the floor names', () => {
-    // A typo in the list would otherwise fail silently — `app.service()` on an
-    // unmounted path does not throw in a way this registration would notice.
+    // A typo would otherwise fail silently — `app.service()` on an unmounted
+    // path does not throw in a way this registration would notice.
     for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
-      expect(codeOnly, `${path} is not mounted`).toContain(`app.use('/${path}'`);
+      expect(source, `${path} is not mounted`).toContain(`app.use('/${path}'`);
     }
   });
 
   it('re-checks the flow initiator ahead of the durable-only branch', () => {
-    // The gap was not the check being absent but its being unreachable: it sat
+    // The callback gap was not the check being absent but unreachable: it sat
     // behind `if (!record) return`, which is every SQLite deployment.
-    const guardAt = codeOnly.indexOf('const assertPendingFlowStillAuthorized');
-    const body = codeOnly.slice(guardAt, guardAt + 1200);
+    const guardAt = source.indexOf('const assertPendingFlowStillAuthorized');
+    const body = source.slice(guardAt, guardAt + 1200);
     const initiatorAt = body.indexOf('assertFlowInitiatorStillEntitled(');
     const durableReturnAt = body.indexOf('if (!record) return;');
     expect(initiatorAt).toBeGreaterThan(-1);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -200,6 +200,7 @@ import {
   shouldExposeMCPServerSecretsForSessionToken,
 } from './utils/mcp-header-secrets.js';
 import {
+  isMcpGrantOwnerEntitled,
   isSessionMcpServerLinkVisibleToCaller,
   loadMcpServerForCaller,
   registerMcpCapabilityRoleFloor,
@@ -1927,30 +1928,62 @@ async function registerMCPServices(
     (params as (AuthenticatedParams & { tenant?: { tenant_id?: string } }) | undefined)?.tenant
       ?.tenant_id ?? getCurrentTenantId();
 
-  const assertDurableFlowStillAuthorized = async (
+  /**
+   * The standing of whoever started a flow, re-asked at the moment it completes.
+   *
+   * `oauth-start` carries a role floor, but the provider redirect can arrive
+   * minutes later — up to the 10-minute pending-flow TTL — and the callback is
+   * unauthenticated, so nothing between the two re-asks. Without this, a member
+   * who starts a flow and is demoted before finishing it still gets a token
+   * exchanged and persisted, which is the floor being on the start rather than
+   * on the issuance.
+   *
+   * Keyed on the flow's recorded initiator, not on a caller: at the callback
+   * there is no caller, only `state`. Both deployment modes record one — the
+   * durable record on Postgres and the in-memory entry on SQLite — so this
+   * covers both, which is why it sits ahead of the `!record` return below
+   * rather than inside the durable-only block.
+   *
+   * Fails closed when the flow names no initiator. Every flow-start path takes
+   * its `userId` from an authenticated caller, so an unattributable flow is not
+   * a legitimate case to keep working.
+   */
+  const assertFlowInitiatorStillEntitled = async (
+    initiatorId: string | undefined,
+    tenantId: string | undefined,
+    oauthMode: 'per_user' | 'shared'
+  ): Promise<void> => {
+    if (!(await isMcpGrantOwnerEntitled(db, tenantId, initiatorId, oauthMode))) {
+      throw new Error(
+        oauthMode === 'shared'
+          ? 'Shared MCP OAuth grant requires current admin access'
+          : 'MCP OAuth grant requires current member access'
+      );
+    }
+  };
+
+  const assertPendingFlowStillAuthorized = async (
     pendingFlow: PendingOAuthFlow,
     afterProviderExchange = false
   ): Promise<void> => {
     const record = pendingFlow.durableRecord;
-    if (!record) return;
     try {
+      await assertFlowInitiatorStillEntitled(
+        record?.userId ?? pendingFlow.userId,
+        record?.tenantId ?? pendingFlow.tenantId,
+        record?.oauthMode ?? pendingFlow.oauthMode ?? 'per_user'
+      );
+      if (!record) return;
       await runInOAuthTenantScope(db, record.tenantId, async () => {
-        const [server, user] = await Promise.all([
-          new MCPServerRepository(db).findById(record.mcpServerId),
-          new UsersRepository(db).findById(record.userId),
-        ]);
+        const server = await new MCPServerRepository(db).findById(record.mcpServerId);
         if (
           !server?.enabled ||
-          !user ||
           server.auth?.type !== 'oauth' ||
           (server.auth.oauth_mode ?? 'per_user') !== record.oauthMode ||
           server.url !== pendingFlow.context.resourceUri ||
           !isMCPOAuthGrantBindingVersion(record.configFingerprintVersion)
         ) {
           throw new Error('MCP OAuth server configuration changed; restart authorization');
-        }
-        if (record.oauthMode === 'shared' && !hasMinimumRole(user.role, ROLES.ADMIN)) {
-          throw new Error('Shared MCP OAuth grant requires current admin access');
         }
         const fingerprint = fingerprintMCPOAuthGrantConfiguration(
           process.env.AGOR_MASTER_SECRET!,
@@ -2030,7 +2063,7 @@ async function registerMCPServices(
           pendingFlow.durableRecord.mcpServerId
         );
       }
-      await assertDurableFlowStillAuthorized(pendingFlow, true);
+      await assertPendingFlowStillAuthorized(pendingFlow, true);
       await work();
       if (pendingFlow.durableRecord) {
         const transitioned = await durableOAuthFlows!.finish(
@@ -2207,7 +2240,7 @@ async function registerMCPServices(
       }
 
       try {
-        await assertDurableFlowStillAuthorized(pendingFlow);
+        await assertPendingFlowStillAuthorized(pendingFlow);
         const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state, {
           cacheToken: false,
@@ -3041,7 +3074,7 @@ async function registerMCPServices(
           markLocalOAuthAttempt(pendingFlow, 'exchanging');
         }
 
-        await assertDurableFlowStillAuthorized(pendingFlow);
+        await assertPendingFlowStillAuthorized(pendingFlow);
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state, {
           cacheToken: false,
           issuer,
@@ -3310,6 +3343,25 @@ async function registerMCPServices(
         '@agor/core/tools/mcp/oauth-refresh'
       );
 
+      /**
+       * The grant owner's current standing, for the refresh paths below.
+       *
+       * A refresh is not a read: `refreshAndPersistToken` obtains and stores a
+       * *new* access token, which is issuance by the same definition the rest of
+       * this file uses. The caller here is an executor under a session token or
+       * a service account, so flooring the caller would floor a robot — the
+       * standing that matters belongs to the user the grant is keyed on.
+       *
+       * Resolved once. Every per-user grant in one request belongs to the same
+       * user: `tokenUserId` is the caller's own id, and cross-user lookup is
+       * reserved for service accounts by `resolveForUserIdWithGate`.
+       */
+      let perUserGrantOwnerEntitled: Promise<boolean> | undefined;
+      const isPerUserGrantOwnerEntitled = (): Promise<boolean> => {
+        perUserGrantOwnerEntitled ??= isMcpGrantOwnerEntitled(db, tenantId, userId, 'per_user');
+        return perUserGrantOwnerEntitled;
+      };
+
       await Promise.all(
         serverIds.map(async (serverId) => {
           if (headers[serverId]) return;
@@ -3360,6 +3412,35 @@ async function registerMCPServices(
               headers[serverId] = { error: 'needs_reauth' };
               return;
             }
+
+            /**
+             * Refuse to *extend* a grant whose owner no longer stands where they
+             * did, while still vending one that is already valid.
+             *
+             * That is deliberately where the line falls. A demoted user's
+             * running session keeps its MCP tools until the access token
+             * expires, then reports `needs_reauth` — an error the executor
+             * already surfaces and a person can act on, and which is literally
+             * true: re-authorizing needs member standing back. The alternative,
+             * cutting a running task off the moment its owner is demoted, fails
+             * mid-tool-call with nothing the agent or the user can do about it,
+             * and revoking a credential is not what a role change has ever meant
+             * here (#2301 — demotion is still a column write that revokes
+             * nothing).
+             *
+             * `shared` grants are out of scope: they belong to the tenant rather
+             * than to a person, are admin-only to establish, and have no owner
+             * whose demotion this could describe.
+             */
+            const refreshWouldRun =
+              row.refresh_status === 'refreshing' ||
+              (needsRefresh(row.oauth_token_expires_at) && !!row.oauth_refresh_token);
+            if (refreshWouldRun && mode === 'per_user' && !(await isPerUserGrantOwnerEntitled())) {
+              console.warn('[OAuth AuthHeaders] refresh_refused category=grant_owner_role');
+              headers[serverId] = { error: 'needs_reauth' };
+              return;
+            }
+
             if (row.refresh_status === 'refreshing') {
               try {
                 const observed = await refreshAndPersistToken({

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1520,13 +1520,25 @@ async function registerMCPServices(
    */
   const AWAIT_TOKEN_TIMEOUT_MS = 5 * 60 * 1000;
 
+  /**
+   * How long a standalone pending flow may sit between `oauth-start` and the
+   * provider redirect.
+   *
+   * Enforced wherever a flow is *taken*, not only by the sweeper below. A
+   * periodic job alone makes this a TTL plus up to one sweep interval of
+   * jitter, and the reason the extra minute matters is that a demotion can land
+   * inside it — the flow would then be consumed and its token persisted.
+   */
+  const LOCAL_OAUTH_FLOW_TTL_MS = 10 * 60 * 1000;
+  const isLocalOAuthFlowExpired = (flow: PendingOAuthFlow): boolean =>
+    Date.now() - flow.createdAt > LOCAL_OAUTH_FLOW_TTL_MS;
+
   // Standalone cleanup remains process-local. PostgreSQL cleanup is a
   // fleet-safe, idempotent state-machine transition plus terminal retention.
   const oauthCleanupTimer = setInterval(() => {
     const now = Date.now();
-    const tenMinutes = 10 * 60 * 1000;
     for (const [state, flow] of pendingOAuthFlows.entries()) {
-      if (now - flow.createdAt > tenMinutes) {
+      if (isLocalOAuthFlowExpired(flow)) {
         pendingOAuthFlows.delete(state);
         localOAuthAttemptStatuses.set(flow.attemptId, {
           status: 'expired',
@@ -2227,7 +2239,17 @@ async function registerMCPServices(
           // Consume before the provider call. A second callback can never run
           // the single-use authorization code concurrently.
           pendingOAuthFlows.delete(state);
-          markLocalOAuthAttempt(pendingFlow, 'exchanging');
+          // Age checked on retrieval, not left to the sweeper. That timer runs
+          // once a minute, so a flow created just after a pass stayed usable
+          // for up to 10m59s — a TTL with a jitter window, and the reason the
+          // window matters is that a demotion can land inside it.
+          if (isLocalOAuthFlowExpired(pendingFlow)) {
+            markLocalOAuthAttempt(pendingFlow, 'expired', 'authorization_timed_out');
+            pendingFlow.tokenReject?.(new Error('OAuth flow expired before callback was received'));
+            pendingFlow = undefined;
+          } else {
+            markLocalOAuthAttempt(pendingFlow, 'exchanging');
+          }
         }
       }
       if (!pendingFlow) {
@@ -3071,6 +3093,15 @@ async function registerMCPServices(
             };
           }
           pendingOAuthFlows.delete(state);
+          // Same age check the callback applies — see `isLocalOAuthFlowExpired`.
+          if (isLocalOAuthFlowExpired(pendingFlow)) {
+            markLocalOAuthAttempt(pendingFlow, 'expired', 'authorization_timed_out');
+            pendingFlow.tokenReject?.(new Error('OAuth flow expired before callback was received'));
+            return {
+              success: false,
+              error: 'OAuth flow expired or not found. Please start the flow again.',
+            };
+          }
           markLocalOAuthAttempt(pendingFlow, 'exchanging');
         }
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -202,6 +202,7 @@ import {
 import {
   isSessionMcpServerLinkVisibleToCaller,
   loadMcpServerForCaller,
+  registerMcpCapabilityRoleFloor,
 } from './utils/mcp-server-authorization.js';
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
 import { type SpawnExecutorOptions, spawnExecutor } from './utils/spawn-executor.js';
@@ -4097,6 +4098,25 @@ async function registerMCPServices(
   });
 
   app.service('mcp-servers/discover').hooks({ before: { create: [ctx.requireAuth] } });
+
+  /**
+   * Role floor for the endpoints that issue capability rather than exercise it.
+   *
+   * Each of the services above authenticates and then admits the caller who
+   * owns the named row (`loadMcpServerForCaller`). Ownership survives a role
+   * change — nothing revisits `owner_user_id` when a user is demoted — so
+   * without this a user demoted to `viewer` keeps every one of these: starting
+   * an OAuth flow, exchanging the code, refreshing the grant, and re-probing
+   * the server on its stored credential. Configuration CRUD already grew this
+   * floor (`authorizeMcpServerWrite`); these are the rest of it.
+   *
+   * Registered by one pass over `MCP_CAPABILITY_ISSUING_SERVICE_PATHS` — where
+   * the reasoning and the deliberate exclusions live — rather than added to
+   * each `.hooks()` call above, which is spread over ~1,800 lines and is
+   * exactly where the next endpoint would be forgotten. Same shape as the
+   * tenant-identity registration loop.
+   */
+  registerMcpCapabilityRoleFloor(app);
 
   return { oauthCallbackHandler };
 }

--- a/apps/agor-daemon/src/services/mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/services/mcp-capability-role.test.ts
@@ -26,26 +26,32 @@ import { isMCPServerUsableInSession } from '@agor/core/mcp';
 import type { AuthenticatedParams, MCPServer, User, UserID, UserRole } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  isMcpGrantOwnerEntitled,
+  isMcpGrantSubjectEntitled,
   isMcpServerUsableByCaller,
   MCP_CAPABILITY_ISSUING_SERVICE_PATHS,
   registerMcpCapabilityRoleFloor,
 } from '../utils/mcp-server-authorization.js';
 
 /**
- * The surfaces this change deliberately leaves open, named here so removing one
- * from the list is a decision somebody has to make in this file rather than a
- * side effect of editing the other one.
+ * The surfaces that issue nothing and so carry no floor, named here so removing
+ * one is a decision somebody has to make in this file rather than a side effect
+ * of editing the other one.
+ *
+ * `oauth-auth-headers` used to be on this list, on the reading that it only
+ * vends an already-issued bearer. It does not — it calls `refreshAndPersistToken`,
+ * which mints and stores a new one — and listing it here asserted the wrong
+ * classification and hid the gap. It is now guarded on the grant owner's
+ * standing instead, and which endpoints mint is derived from the source rather
+ * than listed by hand; see `register-services.mcp-capability-role.test.ts`.
  */
-const DELIBERATELY_UNGATED = [
+const ISSUE_NOTHING = [
   // Revocation. Refusing a demoted user the ability to drop their own grant
   // would strand the credential this change exists to contain.
   'mcp-servers/oauth-disconnect',
   // Reads of the caller's own state.
   'mcp-servers/oauth-status',
   'mcp-servers/oauth-attempt-status',
-  // Vends a bearer for an already-issued grant to the executor running a
-  // session, under a session token or service account rather than a user role.
-  'mcp-servers/oauth-auth-headers',
 ];
 
 async function buildDaemon(initialRole: UserRole = 'member') {
@@ -94,6 +100,7 @@ async function buildDaemon(initialRole: UserRole = 'member') {
     user,
     server,
     handlers,
+    rawDb: rawDb as never,
     demoteTo: (role: UserRole) => users.update(user.user_id, { role }),
     paramsForStoredRole,
     call: async (path: string) =>
@@ -251,9 +258,78 @@ describe('what demotion deliberately does not take away', () => {
     ).toBe(false);
   });
 
-  it('leaves revocation, status reads, and executor token vending ungated', () => {
-    for (const path of DELIBERATELY_UNGATED) {
+  it('leaves revocation and status reads ungated', () => {
+    for (const path of ISSUE_NOTHING) {
       expect(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).not.toContain(path);
     }
+  });
+});
+
+/**
+ * The other half of the gap: two surfaces mint a credential for a subject who
+ * is not the caller, so flooring the caller cannot reach them.
+ *
+ * `isMcpGrantOwnerEntitled` is the guard both of them call — the OAuth callback
+ * for its recorded flow initiator, and the executor auth-header refresh for the
+ * grant owner. Driving it against a real database with a real demoted user is
+ * what these assert; that each endpoint calls it, and where, is pinned in
+ * `register-services.mcp-capability-role.test.ts`.
+ */
+describe('minting for a subject who is not the caller', () => {
+  it('refuses to complete a flow whose initiator was demoted after starting it', async () => {
+    // start (as member, which the caller floor allowed) → demote → callback.
+    const { user, rawDb, demoteTo } = await buildDaemon('member');
+    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(true);
+
+    await demoteTo('viewer');
+
+    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(false);
+  });
+
+  it('refuses to refresh a per-user grant whose owner was demoted', async () => {
+    // The executor path: the caller is a session token, the subject is the
+    // grant owner, and it is the owner's standing that decides.
+    const { user, rawDb, demoteTo } = await buildDaemon('member');
+    await demoteTo('viewer');
+
+    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(false);
+  });
+
+  it('keeps the admin floor shared grants already had, and adds member beneath it', () => {
+    // `shared` was admin-only to start; that must not loosen to member now that
+    // a member floor exists beneath it.
+    expect(isMcpGrantSubjectEntitled('admin', 'shared')).toBe(true);
+    expect(isMcpGrantSubjectEntitled('member', 'shared')).toBe(false);
+    expect(isMcpGrantSubjectEntitled('viewer', 'shared')).toBe(false);
+
+    expect(isMcpGrantSubjectEntitled('admin', 'per_user')).toBe(true);
+    expect(isMcpGrantSubjectEntitled('member', 'per_user')).toBe(true);
+    expect(isMcpGrantSubjectEntitled('viewer', 'per_user')).toBe(false);
+  });
+
+  it('refuses a subject with no role, or none at all', async () => {
+    // Same reason as the caller floor: `hasMinimumRole(undefined, MEMBER)` is
+    // true, so an absent role must not be read as member here either.
+    for (const roleless of [undefined, '', null]) {
+      expect(isMcpGrantSubjectEntitled(roleless, 'per_user')).toBe(false);
+    }
+
+    const { rawDb } = await buildDaemon('member');
+    // Unattributable and unknown subjects both fail closed.
+    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, undefined, 'per_user')).toBe(false);
+    expect(
+      await isMcpGrantOwnerEntitled(
+        rawDb,
+        undefined,
+        '00000000-0000-7000-8000-0000000000ff',
+        'per_user'
+      )
+    ).toBe(false);
+  });
+
+  it('still permits a member owner, so the refusals above are about the role', async () => {
+    const { user, rawDb } = await buildDaemon('member');
+
+    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(true);
   });
 });

--- a/apps/agor-daemon/src/services/mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/services/mcp-capability-role.test.ts
@@ -20,14 +20,20 @@
  * purpose rather than wherever the last edit left it.
  */
 
-import { createDatabaseAsync, runMigrations, UsersRepository } from '@agor/core/db';
+import {
+  createDatabaseAsync,
+  MCPServerRepository,
+  runMigrations,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
 import { feathers } from '@agor/core/feathers';
-import { isMCPServerUsableInSession } from '@agor/core/mcp';
+import { isMCPServerUsableInSession, isMcpGrantSubjectEntitled } from '@agor/core/mcp';
+import { assertMcpGrantSubjectEntitled } from '@agor/core/tools/mcp/grant-entitlement';
 import type { AuthenticatedParams, MCPServer, User, UserID, UserRole } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { persistOAuthToken } from '../oauth-cache.js';
 import {
-  isMcpGrantOwnerEntitled,
-  isMcpGrantSubjectEntitled,
   isMcpServerUsableByCaller,
   MCP_CAPABILITY_ISSUING_SERVICE_PATHS,
   registerMcpCapabilityRoleFloor,
@@ -66,13 +72,17 @@ async function buildDaemon(initialRole: UserRole = 'member') {
   })) as User;
 
   // A server Bob owns, configured while he still could. The row outlives the
-  // role that produced it, which is the whole premise.
-  const server = {
-    mcp_server_id: 'server-1' as MCPServer['mcp_server_id'],
-    owner_user_id: user.user_id,
+  // role that produced it, which is the whole premise. Real, because the grant
+  // table this drives has a foreign key onto it.
+  const server = (await new MCPServerRepository(rawDb).create({
+    name: 'deepwiki',
     transport: 'http',
+    url: 'https://mcp.example.com/mcp',
+    source: 'user',
+    enabled: true,
     scope: 'session',
-  } as unknown as MCPServer;
+    owner_user_id: user.user_id,
+  } as never)) as MCPServer;
 
   const app = feathers();
   // Stand-ins for the endpoint bodies: what is under test is whether the
@@ -101,6 +111,7 @@ async function buildDaemon(initialRole: UserRole = 'member') {
     server,
     handlers,
     rawDb: rawDb as never,
+    serverId: server.mcp_server_id as string,
     demoteTo: (role: UserRole) => users.update(user.user_id, { role }),
     paramsForStoredRole,
     call: async (path: string) =>
@@ -266,70 +277,115 @@ describe('what demotion deliberately does not take away', () => {
 });
 
 /**
- * The other half of the gap: two surfaces mint a credential for a subject who
- * is not the caller, so flooring the caller cannot reach them.
+ * The half the caller floor cannot reach: credentials minted for a subject who
+ * is not the caller.
  *
- * `isMcpGrantOwnerEntitled` is the guard both of them call — the OAuth callback
- * for its recorded flow initiator, and the executor auth-header refresh for the
- * grant owner. Driving it against a real database with a real demoted user is
- * what these assert; that each endpoint calls it, and where, is pinned in
- * `register-services.mcp-capability-role.test.ts`.
+ * These drive `persistOAuthToken` — the real function the OAuth callback and
+ * `oauth-complete` both persist through — against a real database with a real
+ * demoted user, and read the token table back. That is the choke point the
+ * enforcement was moved to, so a test that gets past it would be a test of a
+ * bypass rather than of a guard.
+ *
+ * `refreshAndPersistToken` is the other choke point and carries the same check;
+ * it is not driven here because reaching its write needs a live provider
+ * exchange. Its structure is pinned in
+ * `register-services.mcp-capability-role.test.ts` and the shared predicate is
+ * exercised below.
  */
-describe('minting for a subject who is not the caller', () => {
-  it('refuses to complete a flow whose initiator was demoted after starting it', async () => {
-    // start (as member, which the caller floor allowed) → demote → callback.
-    const { user, rawDb, demoteTo } = await buildDaemon('member');
-    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(true);
+describe('a grant cannot become durable for a subject who lost standing', () => {
+  const flowFor = (
+    serverId: string,
+    userId: string,
+    oauthMode: 'per_user' | 'shared' = 'per_user'
+  ) => ({ mcpServerId: serverId, userId, oauthMode, clientId: 'client-1' });
+  const token = { access_token: 'at-1', expires_in: 3600, refresh_token: 'rt-1' };
 
-    await demoteTo('viewer');
+  it('persists for a member, so the refusal below is about the role', async () => {
+    const { user, rawDb, serverId } = await buildDaemon('member');
 
-    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(false);
+    await expect(
+      persistOAuthToken(rawDb, token, flowFor(serverId, user.user_id), 'Test')
+    ).resolves.toBeUndefined();
+
+    const row = await new UserMCPOAuthTokenRepository(rawDb).getToken(
+      user.user_id as never,
+      serverId as never
+    );
+    expect(row?.oauth_access_token).toBe('at-1');
   });
 
-  it('refuses to refresh a per-user grant whose owner was demoted', async () => {
-    // The executor path: the caller is a session token, the subject is the
-    // grant owner, and it is the owner's standing that decides.
-    const { user, rawDb, demoteTo } = await buildDaemon('member');
+  it('refuses the write, and writes nothing, once the subject is demoted', async () => {
+    // start (allowed by the caller floor, as a member) → demote → callback.
+    const { user, rawDb, serverId, demoteTo } = await buildDaemon('member');
     await demoteTo('viewer');
 
-    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(false);
+    await expect(
+      persistOAuthToken(rawDb, token, flowFor(serverId, user.user_id), 'Test')
+    ).rejects.toThrow(/member access/i);
+
+    const row = await new UserMCPOAuthTokenRepository(rawDb).getToken(
+      user.user_id as never,
+      serverId as never
+    );
+    expect(row, 'no grant may survive a refused write').toBeFalsy();
   });
 
-  it('keeps the admin floor shared grants already had, and adds member beneath it', () => {
-    // `shared` was admin-only to start; that must not loosen to member now that
-    // a member floor exists beneath it.
+  it('holds a shared grant to admin at the write, as flow start already does', async () => {
+    const { user, rawDb, serverId, demoteTo } = await buildDaemon('admin');
+    await expect(
+      persistOAuthToken(rawDb, token, flowFor(serverId, user.user_id, 'shared'), 'Test')
+    ).resolves.toBeUndefined();
+
+    await demoteTo('member');
+    await expect(
+      persistOAuthToken(rawDb, token, flowFor(serverId, user.user_id, 'shared'), 'Test')
+    ).rejects.toThrow(/admin access/i);
+  });
+
+  it('fails closed on a subject the database does not know', async () => {
+    const { rawDb, serverId } = await buildDaemon('member');
+
+    await expect(
+      persistOAuthToken(
+        rawDb,
+        token,
+        flowFor(serverId, '00000000-0000-7000-8000-0000000000ff'),
+        'Test'
+      )
+    ).rejects.toThrow(/member access/i);
+  });
+
+  it('reads the role itself rather than trusting a caller', async () => {
+    // The whole reason enforcement moved inward: `persistOAuthToken` takes no
+    // entitlement argument a caller could pre-satisfy or forge. Demoting
+    // between two otherwise identical calls flips the outcome.
+    const { user, rawDb, serverId, demoteTo } = await buildDaemon('member');
+    const call = () => persistOAuthToken(rawDb, token, flowFor(serverId, user.user_id), 'Test');
+
+    await expect(call()).resolves.toBeUndefined();
+    await demoteTo('viewer');
+    await expect(call()).rejects.toThrow(/member access/i);
+  });
+
+  it('keeps the floors the predicate promises', () => {
     expect(isMcpGrantSubjectEntitled('admin', 'shared')).toBe(true);
     expect(isMcpGrantSubjectEntitled('member', 'shared')).toBe(false);
     expect(isMcpGrantSubjectEntitled('viewer', 'shared')).toBe(false);
-
     expect(isMcpGrantSubjectEntitled('admin', 'per_user')).toBe(true);
     expect(isMcpGrantSubjectEntitled('member', 'per_user')).toBe(true);
     expect(isMcpGrantSubjectEntitled('viewer', 'per_user')).toBe(false);
-  });
-
-  it('refuses a subject with no role, or none at all', async () => {
-    // Same reason as the caller floor: `hasMinimumRole(undefined, MEMBER)` is
-    // true, so an absent role must not be read as member here either.
+    // Same absent-role hole the caller floor closes.
     for (const roleless of [undefined, '', null]) {
       expect(isMcpGrantSubjectEntitled(roleless, 'per_user')).toBe(false);
     }
-
-    const { rawDb } = await buildDaemon('member');
-    // Unattributable and unknown subjects both fail closed.
-    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, undefined, 'per_user')).toBe(false);
-    expect(
-      await isMcpGrantOwnerEntitled(
-        rawDb,
-        undefined,
-        '00000000-0000-7000-8000-0000000000ff',
-        'per_user'
-      )
-    ).toBe(false);
   });
 
-  it('still permits a member owner, so the refusals above are about the role', async () => {
-    const { user, rawDb } = await buildDaemon('member');
-
-    expect(await isMcpGrantOwnerEntitled(rawDb, undefined, user.user_id, 'per_user')).toBe(true);
+  it('leaves a tenant-owned grant with no individual subject alone', async () => {
+    // `subjectUserId: null` is the shared grant a refresh carries — there is no
+    // person whose demotion it could describe.
+    const { rawDb } = await buildDaemon('member');
+    await expect(
+      assertMcpGrantSubjectEntitled({ db: rawDb, subjectUserId: null, oauthMode: 'shared' })
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/agor-daemon/src/services/mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/services/mcp-capability-role.test.ts
@@ -1,0 +1,259 @@
+/**
+ * What a demotion takes away, and what it deliberately does not.
+ *
+ * `owner_user_id` is stamped when a server is configured and nothing revisits
+ * it when a user's role changes, so every MCP surface that admits "the owner of
+ * this row" kept admitting a user after they were demoted to `viewer`. For
+ * reading a server one owns that is arguably right — ownership is a durable
+ * grant. For starting an OAuth flow, exchanging the code, refreshing the grant,
+ * or re-probing the server on its stored credential it is not: those issue new
+ * capability, which a read-only account may not acquire.
+ *
+ * So this drives the real registration (`registerMcpCapabilityRoleFloor`, the
+ * same call `register-services.ts` makes) over the real service paths, with a
+ * real user row demoted in a real database, and reads the role back out of the
+ * database the way the auth strategy does rather than trusting the role the
+ * caller's params claim.
+ *
+ * The other half is as important: the read and session-resolution behaviour is
+ * asserted *unchanged* here, so the line is visibly where it was drawn on
+ * purpose rather than wherever the last edit left it.
+ */
+
+import { createDatabaseAsync, runMigrations, UsersRepository } from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import { isMCPServerUsableInSession } from '@agor/core/mcp';
+import type { AuthenticatedParams, MCPServer, User, UserID, UserRole } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isMcpServerUsableByCaller,
+  MCP_CAPABILITY_ISSUING_SERVICE_PATHS,
+  registerMcpCapabilityRoleFloor,
+} from '../utils/mcp-server-authorization.js';
+
+/**
+ * The surfaces this change deliberately leaves open, named here so removing one
+ * from the list is a decision somebody has to make in this file rather than a
+ * side effect of editing the other one.
+ */
+const DELIBERATELY_UNGATED = [
+  // Revocation. Refusing a demoted user the ability to drop their own grant
+  // would strand the credential this change exists to contain.
+  'mcp-servers/oauth-disconnect',
+  // Reads of the caller's own state.
+  'mcp-servers/oauth-status',
+  'mcp-servers/oauth-attempt-status',
+  // Vends a bearer for an already-issued grant to the executor running a
+  // session, under a session token or service account rather than a user role.
+  'mcp-servers/oauth-auth-headers',
+];
+
+async function buildDaemon(initialRole: UserRole = 'member') {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const users = new UsersRepository(rawDb);
+
+  const user = (await users.create({
+    email: 'bob@agor.live',
+    name: 'Bob',
+    role: initialRole,
+  })) as User;
+
+  // A server Bob owns, configured while he still could. The row outlives the
+  // role that produced it, which is the whole premise.
+  const server = {
+    mcp_server_id: 'server-1' as MCPServer['mcp_server_id'],
+    owner_user_id: user.user_id,
+    transport: 'http',
+    scope: 'session',
+  } as unknown as MCPServer;
+
+  const app = feathers();
+  // Stand-ins for the endpoint bodies: what is under test is whether the
+  // caller reaches them at all, and a spy states that more plainly than a
+  // network probe would.
+  const handlers = new Map<string, ReturnType<typeof vi.fn>>();
+  for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+    const handler = vi.fn(async () => ({ success: true }));
+    handlers.set(path, handler);
+    app.use(path, { create: handler } as never);
+  }
+  registerMcpCapabilityRoleFloor(app);
+
+  /** Params as a REST request arrives with them, carrying the *stored* role. */
+  const paramsForStoredRole = async (): Promise<AuthenticatedParams> => {
+    const current = await users.findById(user.user_id);
+    return {
+      provider: 'rest',
+      authenticated: true,
+      user: { user_id: user.user_id, role: current?.role },
+    } as unknown as AuthenticatedParams;
+  };
+
+  return {
+    user,
+    server,
+    handlers,
+    demoteTo: (role: UserRole) => users.update(user.user_id, { role }),
+    paramsForStoredRole,
+    call: async (path: string) =>
+      app.service(path).create({} as never, (await paramsForStoredRole()) as never),
+  };
+}
+
+describe('MCP capability follows current role, not ownership alone', () => {
+  it('refuses every credential-issuing surface to an owner demoted to viewer', async () => {
+    const { demoteTo, call, handlers } = await buildDaemon('member');
+    await demoteTo('viewer');
+
+    const outcomes = await Promise.all(
+      MCP_CAPABILITY_ISSUING_SERVICE_PATHS.map(async (path) => {
+        const refusal = await call(path).then(
+          () => 'allowed',
+          (error: Error & { code?: number }) => `${error.code} ${error.message}`
+        );
+        return [path, refusal] as const;
+      })
+    );
+
+    expect(Object.fromEntries(outcomes)).toEqual(
+      Object.fromEntries(
+        MCP_CAPABILITY_ISSUING_SERVICE_PATHS.map((path) => [
+          path,
+          '403 You need member access to connect and authorize MCP servers',
+        ])
+      )
+    );
+
+    // Refused in front of the endpoint, not inside it: none of these bodies
+    // should have run far enough to reach a provider or touch the row.
+    for (const [path, handler] of handlers) {
+      expect(handler, `${path} body ran`).not.toHaveBeenCalled();
+    }
+  });
+
+  it('leaves the same surfaces open while the owner is still a member', async () => {
+    const { call, handlers } = await buildDaemon('member');
+
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      await expect(call(path), path).resolves.toEqual({ success: true });
+      expect(handlers.get(path)).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('takes effect on the next request, without waiting for a re-login', async () => {
+    // The floor reads `params.user.role`, which is not a JWT claim: the token
+    // carries only the subject, and `ServiceJWTStrategy.getEntity` loads the
+    // user row from the database on every authenticated request. So a demotion
+    // lands on the next call rather than whenever the session's token expires,
+    // and there is no stale-credential window to close separately.
+    //
+    // `paramsForStoredRole` re-reads the row for that reason — it models what
+    // the strategy does, so the refusals above are about the stored role rather
+    // than about params this test handed itself.
+    const { call, demoteTo, paramsForStoredRole, handlers } = await buildDaemon('member');
+    const path = MCP_CAPABILITY_ISSUING_SERVICE_PATHS[0];
+
+    await expect(call(path)).resolves.toEqual({ success: true });
+
+    await demoteTo('viewer');
+
+    expect((await paramsForStoredRole()).user?.role).toBe('viewer');
+    await expect(call(path)).rejects.toThrow(/member access/i);
+    // The one call from before the demotion, and nothing after it.
+    expect(handlers.get(path)).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a caller carrying no role at all', async () => {
+    // `hasMinimumRole(undefined, MEMBER)` is true — `normalizeRole` answers
+    // MEMBER for an absent value — so the generic role hook would admit exactly
+    // this caller. The MCP floor decides on the raw role for that reason.
+    const { call } = await buildDaemon('member');
+    const app = feathers();
+    const handler = vi.fn(async () => ({ success: true }));
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      app.use(path, { create: handler } as never);
+    }
+    registerMcpCapabilityRoleFloor(app);
+
+    for (const roleless of [undefined, '', null]) {
+      await expect(
+        app.service(MCP_CAPABILITY_ISSUING_SERVICE_PATHS[0]).create(
+          {} as never,
+          {
+            provider: 'rest',
+            authenticated: true,
+            user: { user_id: 'u1', role: roleless },
+          } as never
+        )
+      ).rejects.toThrow(/member access/i);
+    }
+    expect(handler).not.toHaveBeenCalled();
+    // The fixture's own member still gets through, so the above is about the
+    // role rather than about the app being broken.
+    await expect(call(MCP_CAPABILITY_ISSUING_SERVICE_PATHS[0])).resolves.toBeDefined();
+  });
+
+  it('leaves internal daemon calls and executor service accounts alone', async () => {
+    const { demoteTo } = await buildDaemon('member');
+    await demoteTo('viewer');
+
+    const app = feathers();
+    const handler = vi.fn(async () => ({ success: true }));
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      app.use(path, { create: handler } as never);
+    }
+    registerMcpCapabilityRoleFloor(app);
+    const path = MCP_CAPABILITY_ISSUING_SERVICE_PATHS[0];
+
+    // No provider: a daemon-to-daemon call, which carries no role to floor.
+    await expect(app.service(path).create({} as never)).resolves.toEqual({ success: true });
+
+    // The executor's service account, likewise.
+    await expect(
+      app.service(path).create(
+        {} as never,
+        {
+          provider: 'rest',
+          user: { user_id: 'svc', role: 'viewer', _isServiceAccount: true },
+        } as never
+      )
+    ).resolves.toEqual({ success: true });
+  });
+});
+
+describe('what demotion deliberately does not take away', () => {
+  it('still lets a demoted owner read the server they own', async () => {
+    // Ownership as a durable grant. Changing this would change which servers
+    // resolve into already-running sessions, which is a separate decision from
+    // who may issue new credentials, and one #2301 leaves open.
+    const { server, paramsForStoredRole, demoteTo } = await buildDaemon('member');
+    await demoteTo('viewer');
+
+    expect(isMcpServerUsableByCaller(server, await paramsForStoredRole())).toBe(true);
+  });
+
+  it('still resolves that server into the sessions its owner created', async () => {
+    const { user, server, demoteTo } = await buildDaemon('member');
+    await demoteTo('viewer');
+
+    expect(isMCPServerUsableInSession(server, { created_by: user.user_id as UserID })).toBe(true);
+  });
+
+  it('keeps another user out of it regardless of role', async () => {
+    const { server } = await buildDaemon('member');
+
+    expect(
+      isMcpServerUsableByCaller(server, {
+        provider: 'rest',
+        user: { user_id: 'someone-else', role: 'member' },
+      } as unknown as AuthenticatedParams)
+    ).toBe(false);
+  });
+
+  it('leaves revocation, status reads, and executor token vending ungated', () => {
+    for (const path of DELIBERATELY_UNGATED) {
+      expect(MCP_CAPABILITY_ISSUING_SERVICE_PATHS as readonly string[]).not.toContain(path);
+    }
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -15,6 +15,11 @@
  * whether a caller may be shown a row, an attachment link, or load one by id.
  * They decide visibility, not policy, so they stay beside the write authorizer
  * rather than folding into it.
+ *
+ * Those reads answer "whose row is this?", which a role change does not revisit.
+ * The endpoints that issue a credential rather than read one need the second
+ * question too, so the role floor those carry lives here as well — see
+ * {@link MCP_CAPABILITY_ISSUING_SERVICE_PATHS}.
  */
 
 import {
@@ -180,6 +185,127 @@ function assertAtLeastMember(role: unknown): void {
  * {@link canConfigureMCPServers}; nothing is authorized by reading it.
  */
 export { canConfigureMCPServers as canConfigureMcpServers } from '@agor/core/mcp';
+
+/**
+ * The `/mcp-servers/*` endpoints that mint, refresh, or exchange a credential,
+ * rather than exercising one that already exists.
+ *
+ * Ownership is a durable grant; role is current standing. `owner_user_id`
+ * records who configured a row and is never revisited when a user's role
+ * changes, so `loadMcpServerForCaller` keeps admitting the owner of a server
+ * after they are demoted to `viewer` — it is answering "whose row is this?",
+ * which demotion does not change the answer to. For reading a server one owns
+ * that is defensible. For these endpoints it is not: starting an authorization
+ * flow, exchanging a code, or refreshing a grant issues *new* capability, and a
+ * read-only account may not acquire capability it did not already hold.
+ * Discovery belongs here too — it opens the server's transport on its stored
+ * credential and writes the result back onto the row.
+ *
+ * So each of these carries a role floor in front of the ownership check, the
+ * way {@link authorizeMcpServerWrite} does for configuration CRUD. Ownership
+ * still decides *which* server; role decides whether the caller may issue
+ * against any at all.
+ *
+ * Registered by iterating this list rather than by adding a hook to each
+ * `app.service(...).hooks(...)` call in turn: a floor that is correct and a
+ * floor that runs are different claims, and the endpoints are spread over
+ * ~1,800 lines of `register-services.ts`, so per-endpoint wiring is exactly
+ * where the next one gets forgotten.
+ *
+ * Deliberately absent, and pinned as absent by
+ * `register-services.mcp-capability-role.test.ts`:
+ * - `oauth-disconnect` — revocation. Refusing a demoted user the ability to
+ *   drop their own grant would strand the credential this change exists to
+ *   contain, so it stays open at every role.
+ * - `oauth-status`, `oauth-attempt-status` — reads of the caller's own state.
+ * - `oauth-auth-headers` — vends a bearer for an *already-issued* grant to the
+ *   executor running a session, under a session token or service account
+ *   rather than the owner's role, so there is frequently no user role here to
+ *   floor. Whether demotion should invalidate grants already stored is a
+ *   separate question from who may issue new ones, and is open — demotion is a
+ *   column write today and revokes nothing (#2301).
+ * - `oauth-callback` — the provider's redirect. Unauthenticated by
+ *   construction; its authorization is the one-shot `state` claim, and the
+ *   flow it completes was already gated at `oauth-start`.
+ */
+export const MCP_CAPABILITY_ISSUING_SERVICE_PATHS = [
+  // Mints an authorization URL and a pending flow against a saved server.
+  'mcp-servers/oauth-start',
+  // Exchanges the authorization code and persists the resulting token.
+  'mcp-servers/oauth-complete',
+  // Forces a refresh, extending a grant's lifetime on demand.
+  'mcp-servers/oauth-refresh',
+  // Writes a shared token onto the named row and backfills its token endpoint.
+  'mcp-servers/test-oauth',
+  // Fetches an access token from a caller-supplied endpoint with
+  // caller-supplied credentials.
+  'mcp-servers/test-jwt',
+  // Opens the server's transport on its stored credential and writes the
+  // capability list back onto the row.
+  'mcp-servers/discover',
+] as const;
+
+/**
+ * The role floor for the endpoints above.
+ *
+ * Shares {@link isAtLeastMemberRole} with the write path rather than reaching
+ * for the generic `requireMinimumRole(ROLES.MEMBER)` hook: that one normalizes
+ * through `normalizeRole`, which answers MEMBER for an absent or empty role, so
+ * it admits precisely the caller carrying no role at all. The MCP floor is
+ * decided on the raw role for that reason, and having two floors that disagree
+ * on the same question is how the first one was lost.
+ *
+ * The bypasses match `ensureMinimumRole`: an internal daemon call carries no
+ * provider, and an executor service account carries no role to floor.
+ */
+export function assertMcpCapabilityRole(
+  params: AuthenticatedParams | undefined,
+  action: string
+): void {
+  if (!params?.provider) return;
+  const user = params.user;
+  if (!user) throw new NotAuthenticated('Authentication required');
+  if ((user as { _isServiceAccount?: boolean })._isServiceAccount === true) return;
+  if (isAtLeastMemberRole(user.role)) return;
+  throw new Forbidden(`You need member access to ${action}`);
+}
+
+/** {@link assertMcpCapabilityRole} as a Feathers hook, for the registration below. */
+export function requireMcpCapabilityRole<T extends { params: AuthenticatedParams }>(
+  action: string
+): (context: T) => T {
+  return (context) => {
+    assertMcpCapabilityRole(context.params, action);
+    return context;
+  };
+}
+
+/**
+ * Wire the floor onto every path in {@link MCP_CAPABILITY_ISSUING_SERVICE_PATHS}.
+ *
+ * A function rather than a loop inlined at the call site so a test can apply
+ * the real wiring to a real app and drive it, instead of asserting against a
+ * copy of the loop that could drift from the one that ships — the same reason
+ * {@link createMcpServerWriteAuthorizationHook} is a factory.
+ *
+ * Feathers appends hooks, so the `ctx.requireAuth` each of these services
+ * registers inline still runs first and this decides on an authenticated
+ * caller. Called after those registrations for that reason.
+ */
+export function registerMcpCapabilityRoleFloor(app: {
+  // Method syntax, not a function-typed property: under `strictFunctionTypes`
+  // the latter checks `hooks`' parameter contravariantly and no structural
+  // stand-in for Feathers' `HookOptions<A, S>` is assignable to it. Methods are
+  // checked bivariantly, which is what lets a real app satisfy this without the
+  // util importing the whole `Application` type just to name a loop.
+  service(path: string): { hooks(map: unknown): unknown };
+}): void {
+  for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+    app.service(path).hooks({
+      before: { create: [requireMcpCapabilityRole('connect and authorize MCP servers')] },
+    });
+  }
+}
 
 /**
  * A member widening their own server's reach, which is what

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -32,6 +32,7 @@ import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import {
   isAtLeastMemberRole,
   isMCPServerUsableBy,
+  isMcpGrantSubjectEntitled,
   MEMBER_PRIVATE_MCP_SCOPE,
   mayMemberManageMCPServer,
   mayMemberUseMCPScope,
@@ -214,14 +215,22 @@ export { canConfigureMCPServers as canConfigureMcpServers } from '@agor/core/mcp
  * ~1,800 lines of `register-services.ts`, so per-endpoint wiring is exactly
  * where the next one gets forgotten.
  *
- * This list is only the surfaces where flooring the *caller* is the right
- * instrument. Two others mint a credential with no useful caller role to read,
- * and are guarded by {@link isMcpGrantSubjectEntitled} instead — see there.
- * `register-services.mcp-capability-role.test.ts` derives which endpoints mint
- * from the source rather than trusting either list, so an endpoint that mints
- * and appears in neither fails the build.
+ * This list is not the security boundary for durable credentials, and must not
+ * be read as one. Whether a grant may be *stored* is decided at the two writes
+ * that store it — `persistOAuthToken` and `refreshAndPersistToken` both call
+ * `assertMcpGrantSubjectEntitled` themselves — precisely so that no list of
+ * endpoints has to be complete for the rule to hold. An earlier revision tried
+ * to keep this list honest with a source scan for minting calls; a scan
+ * enumerates callers, and callers can be aliased, wrapped, or newly added, so
+ * it was replaced by enforcement at the choke point.
  *
- * Genuinely absent, because they issue nothing:
+ * What this list *is*: the endpoints a person drives where the caller's own
+ * role is the right question, and where refusing up front beats a provider
+ * round-trip that fails at the write. Two of them (`discover`, `test-jwt`)
+ * reach a provider on a stored credential without persisting a grant, so for
+ * those this is the only check there is.
+ *
+ * Absent because they issue nothing:
  * - `oauth-disconnect` — revocation. Refusing a demoted user the ability to
  *   drop their own grant would strand the credential this change exists to
  *   contain, so it stays open at every role.
@@ -270,14 +279,7 @@ export const MCP_CAPABILITY_ISSUING_SERVICE_PATHS = [
  * Deliberately not a `hasMinimumRole` call: see {@link assertMcpCapabilityRole}
  * for why an absent role must not read as MEMBER here.
  */
-export function isMcpGrantSubjectEntitled(
-  role: unknown,
-  oauthMode: 'per_user' | 'shared' | undefined
-): boolean {
-  if (!isAtLeastMemberRole(role)) return false;
-  if (oauthMode === 'shared') return hasMinimumRole(role as string, ROLES.ADMIN);
-  return true;
-}
+export { isMcpGrantSubjectEntitled } from '@agor/core/mcp';
 
 /**
  * {@link isMcpGrantSubjectEntitled} against the subject's stored role.

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -26,6 +26,7 @@ import {
   MCPServerRepository,
   resolveMcpMemberPolicy,
   type TenantScopeAwareDatabase,
+  UsersRepository,
 } from '@agor/core/db';
 import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import {
@@ -46,6 +47,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { runInOAuthTenantScope } from '../oauth-auth-helpers.js';
 
 export type McpServerWriteMethod = 'create' | 'update' | 'patch' | 'remove';
 
@@ -212,21 +214,18 @@ export { canConfigureMCPServers as canConfigureMcpServers } from '@agor/core/mcp
  * ~1,800 lines of `register-services.ts`, so per-endpoint wiring is exactly
  * where the next one gets forgotten.
  *
- * Deliberately absent, and pinned as absent by
- * `register-services.mcp-capability-role.test.ts`:
+ * This list is only the surfaces where flooring the *caller* is the right
+ * instrument. Two others mint a credential with no useful caller role to read,
+ * and are guarded by {@link isMcpGrantSubjectEntitled} instead — see there.
+ * `register-services.mcp-capability-role.test.ts` derives which endpoints mint
+ * from the source rather than trusting either list, so an endpoint that mints
+ * and appears in neither fails the build.
+ *
+ * Genuinely absent, because they issue nothing:
  * - `oauth-disconnect` — revocation. Refusing a demoted user the ability to
  *   drop their own grant would strand the credential this change exists to
  *   contain, so it stays open at every role.
  * - `oauth-status`, `oauth-attempt-status` — reads of the caller's own state.
- * - `oauth-auth-headers` — vends a bearer for an *already-issued* grant to the
- *   executor running a session, under a session token or service account
- *   rather than the owner's role, so there is frequently no user role here to
- *   floor. Whether demotion should invalidate grants already stored is a
- *   separate question from who may issue new ones, and is open — demotion is a
- *   column write today and revokes nothing (#2301).
- * - `oauth-callback` — the provider's redirect. Unauthenticated by
- *   construction; its authorization is the one-shot `state` claim, and the
- *   flow it completes was already gated at `oauth-start`.
  */
 export const MCP_CAPABILITY_ISSUING_SERVICE_PATHS = [
   // Mints an authorization URL and a pending flow against a saved server.
@@ -244,6 +243,67 @@ export const MCP_CAPABILITY_ISSUING_SERVICE_PATHS = [
   // capability list back onto the row.
   'mcp-servers/discover',
 ] as const;
+
+/**
+ * Whether the user a credential would be minted *for* still stands where they
+ * stood when the grant was first authorized.
+ *
+ * The caller floor above cannot answer this, because on these two surfaces the
+ * caller is frequently not the subject:
+ *
+ * - `oauth-callback` is the provider's browser redirect. It carries no session
+ *   at all — its authorization is the one-shot `state` — so the only identity
+ *   available is the one the pending flow recorded when it started. A member
+ *   who starts a flow, is demoted, and then completes the redirect would
+ *   otherwise have a token exchanged and persisted: the floor is on the start,
+ *   and nothing re-asked at the finish.
+ * - `oauth-auth-headers` refreshes and persists new access tokens
+ *   (`refreshAndPersistToken`), which is minting by the same definition, but is
+ *   called by an executor under a session token or service account. Flooring
+ *   that caller would floor a robot; the standing that matters is the grant
+ *   owner's.
+ *
+ * So both ask this about the *subject* rather than the requester. `shared`
+ * grants keep their admin floor — they were always admin-only to start
+ * (`oauth-start`) — and per-user grants get the member floor they never had.
+ *
+ * Deliberately not a `hasMinimumRole` call: see {@link assertMcpCapabilityRole}
+ * for why an absent role must not read as MEMBER here.
+ */
+export function isMcpGrantSubjectEntitled(
+  role: unknown,
+  oauthMode: 'per_user' | 'shared' | undefined
+): boolean {
+  if (!isAtLeastMemberRole(role)) return false;
+  if (oauthMode === 'shared') return hasMinimumRole(role as string, ROLES.ADMIN);
+  return true;
+}
+
+/**
+ * {@link isMcpGrantSubjectEntitled} against the subject's stored role.
+ *
+ * The role is read here rather than taken from the request because on both
+ * calling surfaces the subject is not the requester, so there is no
+ * `params.user` to read it from — the callback has no session at all, and the
+ * refresh path is driven by an executor. Reading it fresh is also what makes a
+ * demotion land without waiting for anything to expire.
+ *
+ * Fails closed on an unknown or unnamed subject: a credential that cannot be
+ * attributed to a current user is not one to keep minting.
+ */
+export async function isMcpGrantOwnerEntitled(
+  db: TenantScopeAwareDatabase,
+  tenantId: string | undefined,
+  ownerUserId: string | undefined,
+  oauthMode: 'per_user' | 'shared' | undefined
+): Promise<boolean> {
+  if (!ownerUserId) return false;
+  const owner = await runInOAuthTenantScope(db, tenantId, () =>
+    new UsersRepository(db).findById(ownerUserId)
+  );
+  if (!owner) return false;
+  return isMcpGrantSubjectEntitled(owner.role, oauthMode);
+}
 
 /**
  * The role floor for the endpoints above.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -340,6 +340,12 @@
       "import": "./dist/tools/mcp/oauth-refresh.js",
       "require": "./dist/tools/mcp/oauth-refresh.cjs"
     },
+    "./tools/mcp/grant-entitlement": {
+      "source": "./src/tools/mcp/grant-entitlement.ts",
+      "types": "./dist/tools/mcp/grant-entitlement.d.ts",
+      "import": "./dist/tools/mcp/grant-entitlement.js",
+      "require": "./dist/tools/mcp/grant-entitlement.cjs"
+    },
     "./tools/mcp/oauth-token-expiry": {
       "source": "./src/tools/mcp/oauth-token-expiry.ts",
       "types": "./dist/tools/mcp/oauth-token-expiry.d.ts",

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -5,6 +5,7 @@
 export {
   canConfigureMCPServers,
   isAtLeastMemberRole,
+  isMcpGrantSubjectEntitled,
   MEMBER_PRIVATE_MCP_SCOPE,
   mayMemberManageMCPServer,
   mayMemberUseMCPScope,

--- a/packages/core/src/mcp/member-policy.ts
+++ b/packages/core/src/mcp/member-policy.ts
@@ -38,6 +38,30 @@ export function isAtLeastMemberRole(role: unknown): boolean {
 }
 
 /**
+ * Whether the user an OAuth grant belongs to may hold one at their current role.
+ *
+ * Distinct from every other predicate here, which answer what a *caller* may
+ * do. This one answers for the grant's *subject*, because the surfaces that
+ * mint a credential are not all driven by the person it is minted for: the
+ * OAuth callback is an unauthenticated browser redirect, and the executor
+ * refreshes a grant on behalf of a session's creator. It is enforced at the
+ * writes that make a grant durable rather than at those entry points — see
+ * `assertMcpGrantSubjectEntitled` in `tools/mcp/grant-entitlement`.
+ *
+ * `shared` keeps the admin floor it has always had at flow start; `per_user`
+ * gets the member floor it never had. Decided on the raw role for the reason
+ * {@link isAtLeastMemberRole} documents.
+ */
+export function isMcpGrantSubjectEntitled(
+  role: unknown,
+  oauthMode: 'per_user' | 'shared' | undefined
+): boolean {
+  if (!isAtLeastMemberRole(role)) return false;
+  if (oauthMode === 'shared') return hasMinimumRole(role as string, ROLES.ADMIN);
+  return true;
+}
+
+/**
  * Whether this role and policy together permit configuring a server at all.
  *
  * The daemon answers it on `GET /mcp-member-policy` so a client greys out its

--- a/packages/core/src/tools/mcp/grant-entitlement.ts
+++ b/packages/core/src/tools/mcp/grant-entitlement.ts
@@ -1,0 +1,87 @@
+/**
+ * The entitlement an MCP OAuth grant must satisfy to become durable.
+ *
+ * This is enforced at the *writes* rather than at the endpoints, and that is
+ * the whole point of the module.
+ *
+ * The first attempt at #2301 floored the caller on each endpoint that mints a
+ * credential, and a test scanned `register-services.ts` to prove no endpoint
+ * had been forgotten. A scan over call sites cannot establish that property: it
+ * enumerates callers, and callers are exactly what is easy to add, alias
+ * (`const mint = refreshAndPersistToken`), or wrap. Every such bypass reaches
+ * the same two writes, so the check belongs there — at the choke point, where
+ * being reached is a fact about the code rather than a claim about a survey.
+ *
+ * A caller may not pre-satisfy this by having checked earlier. The functions
+ * that persist a grant call it themselves, immediately before the write and
+ * inside the same tenant unit of work, so a new endpoint, an aliased import or
+ * a helper defined elsewhere all arrive here regardless.
+ *
+ * ## Residual race — read before assuming this is airtight
+ *
+ * The check reads the subject's role and the write then lands. On PostgreSQL
+ * both happen inside one `runWithTenantDatabaseScope` transaction, which is why
+ * the assertion is invoked inside that callback rather than before it. Even so,
+ * the users row is not locked: a demotion committing between this read and the
+ * grant write can still be ordered such that the write lands. The window is a
+ * few statements rather than the provider round-trip it replaced, but it is not
+ * zero.
+ *
+ * Closing it entirely needs the users row locked for the duration
+ * (`SELECT ... FOR UPDATE`) or the grant write made conditional on the role in
+ * a single statement. Both are worth doing and neither is done here; see the
+ * PR discussion on #2301. Do not describe this as a closed race.
+ */
+
+import { runWithTenantDatabaseScope } from '../../db';
+import type { Database, TenantScopeAwareDatabase } from '../../db/client';
+import { UsersRepository } from '../../db/repositories';
+import { isMcpGrantSubjectEntitled } from '../../mcp/member-policy';
+
+/** Refusal to persist a grant for a subject who no longer stands where they did. */
+export class MCPGrantSubjectNotEntitledError extends Error {
+  constructor(
+    public readonly subjectUserId: string,
+    public readonly oauthMode: 'per_user' | 'shared'
+  ) {
+    super(
+      oauthMode === 'shared'
+        ? 'Shared MCP OAuth grant requires current admin access'
+        : 'MCP OAuth grant requires current member access'
+    );
+    this.name = 'MCPGrantSubjectNotEntitledError';
+  }
+}
+
+export interface McpGrantSubjectCheck {
+  db: TenantScopeAwareDatabase | Database;
+  tenantId?: string;
+  /**
+   * The user the grant is keyed on, or `null` for a tenant-owned `shared`
+   * grant. `null` passes: a shared grant belongs to the workspace rather than
+   * to a person, is admin-only to establish, and has no individual standing to
+   * re-check. Where a shared flow's *initiator* is known — the callback path —
+   * callers pass that id instead, and the admin floor applies.
+   */
+  subjectUserId: string | null | undefined;
+  oauthMode: 'per_user' | 'shared';
+}
+
+/**
+ * Refuse the write unless the grant's subject is still entitled to hold it.
+ *
+ * Fails closed on an unknown subject: a grant that cannot be attributed to a
+ * current user is not one to keep minting. An absent `subjectUserId` is the
+ * tenant-owned case and passes — see {@link McpGrantSubjectCheck}.
+ */
+export async function assertMcpGrantSubjectEntitled(check: McpGrantSubjectCheck): Promise<void> {
+  const { subjectUserId, oauthMode } = check;
+  if (subjectUserId === null || subjectUserId === undefined) return;
+
+  const subject = await runWithTenantDatabaseScope(check.db, check.tenantId, (scoped) =>
+    new UsersRepository(scoped as Database).findById(subjectUserId)
+  );
+  if (!subject || !isMcpGrantSubjectEntitled(subject.role, oauthMode)) {
+    throw new MCPGrantSubjectNotEntitledError(subjectUserId, oauthMode);
+  }
+}

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -44,12 +44,19 @@ import {
 // plain `function` constructors (not arrow factories) so `new X()` works.
 // ---------------------------------------------------------------------------
 
-const { mockGetToken, mockSaveToken, mockDeleteToken, mockFindById } = vi.hoisted(() => ({
-  mockGetToken: vi.fn(),
-  mockSaveToken: vi.fn(),
-  mockDeleteToken: vi.fn(),
-  mockFindById: vi.fn(),
-}));
+const { mockGetToken, mockSaveToken, mockDeleteToken, mockFindById, mockUserFindById } = vi.hoisted(
+  () => ({
+    mockGetToken: vi.fn(),
+    mockSaveToken: vi.fn(),
+    mockDeleteToken: vi.fn(),
+    mockFindById: vi.fn(),
+    // Persisting a refreshed token now requires the grant's subject to still be
+    // entitled to hold it (`assertMcpGrantSubjectEntitled`), so these
+    // orchestration tests need a subject who is. The refusal itself is covered
+    // where it is enforced — see the daemon's `mcp-capability-role` tests.
+    mockUserFindById: vi.fn(async () => ({ user_id: 'user-1', role: 'member' })),
+  })
+);
 
 vi.mock('../../db/repositories', () => ({
   UserMCPOAuthTokenRepository: function UserMCPOAuthTokenRepositoryMock() {
@@ -62,6 +69,11 @@ vi.mock('../../db/repositories', () => ({
   MCPServerRepository: function MCPServerRepositoryMock() {
     return {
       findById: mockFindById,
+    };
+  },
+  UsersRepository: function UsersRepositoryMock() {
+    return {
+      findById: mockUserFindById,
     };
   },
 }));

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -10,6 +10,7 @@ import {
 } from '../../db/repositories';
 import type { MCPServerID, UserID } from '../../types';
 import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import { assertMcpGrantSubjectEntitled } from './grant-entitlement';
 import { inferOAuthTokenUrl } from './oauth-auth';
 import { resolveTokenExpiry } from './oauth-token-expiry';
 
@@ -303,8 +304,13 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       allowLocalhostHttp: deps.allowLocalhostHttpDevelopment,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
-    const committed = await tenantWork(deps, (db) =>
-      new UserMCPOAuthTokenRepository(db).completeClaimedRefresh(
+    const committed = await tenantWork(deps, async (db) => {
+      // Inside this unit of work rather than before it: the entitlement is a
+      // precondition of the write, and on PostgreSQL this callback is the
+      // transaction the write commits in. See `assertMcpGrantSubjectEntitled`
+      // for the residual window this still leaves open.
+      await assertGrantSubjectForRefresh(deps, db);
+      return new UserMCPOAuthTokenRepository(db).completeClaimedRefresh(
         deps.userId,
         deps.mcpServerId,
         fence,
@@ -313,8 +319,8 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
           refreshToken: result.refresh_token,
           expiresAt: expiry.expiresAt,
         }
-      )
-    );
+      );
+    });
     if (!committed) return observeCommittedRefresh(deps, fence);
     console.log('[MCP OAuth Refresh] refresh_succeeded category=committed');
     return result.access_token;
@@ -350,6 +356,23 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
   }
 }
 
+/**
+ * The grant subject's standing, as a precondition of persisting a refreshed
+ * token. `userId === null` is the tenant-owned `shared` grant, which has no
+ * individual subject to re-check.
+ */
+async function assertGrantSubjectForRefresh(
+  deps: RefreshAndPersistDeps,
+  db: Database | TenantScopeAwareDatabase
+): Promise<void> {
+  await assertMcpGrantSubjectEntitled({
+    db,
+    tenantId: deps.tenantId ?? getCurrentTenantId(),
+    subjectUserId: deps.userId,
+    oauthMode: deps.userId === null ? 'shared' : 'per_user',
+  });
+}
+
 async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
   const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db as Database);
   const row = await userTokenRepo.getToken(deps.userId, deps.mcpServerId);
@@ -370,6 +393,7 @@ async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
       allowLocalhostHttp: true,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
+    await assertGrantSubjectForRefresh(deps, deps.db);
     await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
       accessToken: result.access_token,
       refreshToken: result.refresh_token,

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport
     'tools/mcp/oauth-refresh': 'src/tools/mcp/oauth-refresh.ts', // MCP OAuth refresh_token persistence + mutex
+    'tools/mcp/grant-entitlement': 'src/tools/mcp/grant-entitlement.ts', // MCP OAuth grant subject entitlement, enforced at the write
     'tools/mcp/oauth-token-expiry': 'src/tools/mcp/oauth-token-expiry.ts', // MCP OAuth token expiry resolution cascade
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for branch isolation
     'local-actions/index': 'src/local-actions/index.ts', // Shared host-local admin actions


### PR DESCRIPTION
Fixes #2301.

## The gap

Demoting a user from `member` to `viewer` did not take away the MCP capability they already had. The `/mcp-servers/*` OAuth, test, and discovery endpoints authenticated and then admitted whoever owned the named row; `owner_user_id` is stamped when a server is configured and nothing revisits it when a role changes. So a demoted user kept all of it: starting an OAuth flow, exchanging the code, refreshing the grant, and re-probing the server on its stored credential.

**Impact:** a read-only account could acquire new MCP credentials — including completing an OAuth authorization and having the token persisted — rather than merely continuing to use what it already had. It granted no access to another user's servers: the ownership check worked, it was simply the only check.

Ownership is a durable grant; role is current standing. Defensible for *reading* a server you own. Not defensible for issuing a credential.

## Where the enforcement lives

This went through three revisions in review. The final shape has two layers, and the split matters:

### Layer 1 — the write (authoritative)

`persistOAuthToken` and `refreshAndPersistToken` call `assertMcpGrantSubjectEntitled` **themselves**, immediately before their write and — on PostgreSQL — inside the transaction the write commits in. They read the subject's role from the database rather than accepting it as an argument, so no caller can pre-satisfy the check.

This is the security boundary for durable credentials. Aliasing (`const mint = refreshAndPersistToken`), wrappers, and endpoints nobody has written yet are all irrelevant, because every route arrives at the same two functions.

It replaced a per-endpoint approach that could not be made sound — see "What review caught" below.

### Layer 2 — the caller floor (defence in depth, plus real coverage)

`registerMcpCapabilityRoleFloor` floors the caller on `oauth-start`, `oauth-complete`, `oauth-refresh`, `test-oauth`, `test-jwt`, `discover`.

Not redundant: `discover` and `test-jwt` reach a provider on a stored credential **without persisting a grant**, so for those this is the only check there is. For the other four it saves a provider round-trip that would fail at the write anyway.

Genuinely ungated: `oauth-disconnect` (revocation — refusing it would strand the credential this contains), `oauth-status`, `oauth-attempt-status` (reads of the caller's own state).

### Why the subject, not the caller

On two surfaces the caller is not the person the credential is for. `oauth-callback` is an unauthenticated browser redirect — no session, only `state`. `oauth-auth-headers` is called by an executor under a session token. Flooring those callers would floor a robot. `shared` grants keep the admin floor they have always had; per-user grants get the member floor they never had.

## What a running session does when its owner is demoted

Deliberate: **a refresh is refused, an already-valid token is still vended.** The session keeps its MCP tools until the access token expires, then reports `needs_reauth` — an error the executor already surfaces, that a person can act on, and that is literally true.

Cutting a running task off the instant its owner is demoted fails mid-tool-call with nothing the agent or user can do. This draws the line where the rest of the PR draws it: minting follows current standing, exercising an already-issued credential does not.

## Residual risk — please read this rather than assuming it is airtight

**Narrowed, not closed.** The check reads the subject's role and the write then lands. The users row is **not** locked, so a demotion committing between the read and the write can still be ordered such that the write commits. The window went from a provider round-trip (hundreds of ms) to a few statements inside one transaction. It is not zero.

Closing it needs `SELECT ... FOR UPDATE` on the users row, or the grant write made conditional on the role in a single statement. Neither is done here; both are documented at the top of `grant-entitlement.ts` so the next person does not read this as a guarantee.

**Also open:** demotion is still a plain column write. It does not delete `user_mcp_oauth_tokens` rows, set `tokens_valid_after`, or stop running sessions. Grants issued before a demotion survive it — they simply stop being extendable. My view is that *pending flows* should be actively invalidated on demotion (short-lived, cheap to restart) while *stored grants* are better left to expire than yanked from a running task. Not fixed here.

Reassuring: `role` is not a JWT claim. `ServiceJWTStrategy.getEntity` loads the user row every authenticated request, so a demotion lands on the next call with no re-login window.

## What review caught, and what it says about the tests

Worth reading before trusting anything below.

1. **`oauth-callback` minted after demotion.** The re-validation checked role only for `shared` grants, and the whole guard sat behind `if (!record) return` — every SQLite deployment. A member could start a flow, be demoted, and still have the redirect persist a token. The pending flow records its initiator in *both* deployment modes, so the check is now hoisted ahead of that return; the SQLite half was coverable, not an inherent limit.

2. **`oauth-auth-headers` was misclassified as non-issuing.** It calls `refreshAndPersistToken` — it mints. My first pass listed it as harmless.

3. **The classification test made things worse twice.** v1 hard-coded that wrong answer, so it asserted the mistake and read as diligence. v2 derived the list by scanning for minting calls but matched the guard's *name* anywhere in the endpoint — which its own `const ... =` declaration satisfies — so deleting the refusal still passed. Fixing the pattern would not have fixed the shape: a scan enumerates callers, and callers are the easy thing to add.

**That test is now deleted, not tightened.** Enforcement moved to the choke point, which is a property of the code rather than a survey of it. What remains is a much smaller structural check that the two writes carry the check before writing.

## Tests

`services/mcp-capability-role.test.ts` drives real code against a real database with real demotions: the caller floor through the real registration helper, and `persistOAuthToken` — the actual function the callback and `oauth-complete` persist through — asserting the write is refused, that **nothing lands in the token table**, that shared grants hold to admin, that unknown subjects fail closed, and that reads and session resolution still admit the demoted owner.

`refreshAndPersistToken` carries the same check but is not driven end-to-end here: reaching its write needs a live provider exchange. Its structure is pinned structurally. That is the honest limit of the coverage.

**Mutation-verified.** Every guard was removed in turn and the suite re-run:

| Mutation | Result |
| --- | --- |
| `persistOAuthToken` subject check removed | 5 fail |
| refresh subject check removed (both dialect paths) | 1 fail |
| entitlement predicate neutered inside the guard | 5 fail |
| TTL check removed from the callback take | 1 fail |
| sweeper drifts back to an inline TTL literal | 1 fail |

Earlier rounds were verified the same way — that is how the v2 scan was caught passing with its guard deleted.

## Test counts

| Suite | Baseline | After |
| --- | --- | --- |
| `packages/core` | 566 failed / 3060 passed | 566 failed / 3207 passed |
| `apps/agor-daemon` | 221 failed / 2618 passed | 217 failed / 2647 passed |
| `apps/agor-ui` | — | 1 failed / 1477 passed |

Core is exactly at baseline. Daemon is 4 *below* baseline failures.

Two existing suites needed updating for the new precondition, and I want to be explicit that I changed them: the core refresh orchestration tests mock the repository layer and now supply an entitled subject, and `oauth-cache.test.ts` stubs the guard so it stays about which columns a completed flow lands. Both are unit tests of other concerns; the guard itself is driven for real elsewhere. Neither was weakened to make my change pass — the guard's own coverage is the table above.

The bulk of remaining failures fail on THIS HOST regardless: since #2362 the filesystem sandbox replaced `~/.agor/config.yaml` with a read-denied device, so anything constructing a branch hits `EACCES`. `cursor-models.test.ts` makes a live API call. The core passed count rises versus baseline because the baseline ran against a partially-built `@agor/core`.

The single `agor-ui` failure is a host parallelism flake — a *different* test each run (1, then 4, then 3, then 1), all passing in isolation. This branch touches no UI files.

`turbo run typecheck` 22/22, `biome check --error-on-warnings .` clean.

## Still open for the reviewer

**Should `owner_user_id` survive demotion for reads and session resolution?** Unchanged here, and asserted unchanged.

*Keep it:* ownership answers "whose row is this?", which demotion does not change. Reads disclose nothing new, and retroactively changing session resolution would silently alter the tool surface of sessions that already work.

*Subordinate it:* "read-only access" that still resolves a credentialed server into a session is a fuzzier promise than the role name makes.

**I recommend keeping it** — but the honest reason the asymmetry is tolerable is that `viewer` cannot drive a session today, which is a property of a different role floor. Worth writing down rather than relying on. If reads should follow role, the place is `isMcpServerUsableByCaller`, as a deliberate change with its own migration story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
