### PR TITLE
fix(mcp): redact MCP server secrets on every read path, and stop persisting the sentinel

### DIFF
--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -20,6 +20,20 @@ describe('register-hooks MCP server secret redaction', () => {
     );
   });
 
+  it('redacts every mcp-servers method that returns a row, remove included', () => {
+    // `remove` is the easy one to forget: it is a write, but the adapter
+    // returns the deleted row and that object is also the `removed`
+    // broadcast. Behaviour is covered in
+    // `services/mcp-servers.env-redaction.test.ts`; this pins the wiring.
+    const block = source.slice(source.indexOf("safeService('mcp-servers')?.hooks({"));
+    const afterBlock = block.slice(block.indexOf('after:'), block.indexOf('safeService', 1));
+    for (const method of ['find', 'get', 'create', 'patch', 'update', 'remove']) {
+      expect(afterBlock, `${method} is missing redaction`).toMatch(
+        new RegExp(`${method}:\\s*\\[[^\\]]*redactMCPServerSecretFields`)
+      );
+    }
+  });
+
   it('keeps full MCP server replacements behind the write gate', () => {
     // PUT replaces the whole row, so it must clear the same gate as the other
     // writes rather than the `all` chain alone. That gate is no longer a role

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -752,6 +752,30 @@ export function protectFilesystemHomeWrite(context: HookContext, config: AgorCon
   return context;
 }
 
+/**
+ * Strip secret-bearing MCP server fields from anything on its way out to an
+ * external caller.
+ *
+ * Module scope rather than a closure inside `registerHooks` so tests can drive
+ * the real hook against a real service instead of reproducing its body — a
+ * replica passes whatever the replica does, which is exactly the wrong
+ * property for a redaction gate. Which methods it is registered on is pinned
+ * separately in `register-hooks.mcp-headers-redaction.test.ts`.
+ */
+export const redactMCPServerSecretFields = async (context: HookContext) => {
+  if (shouldExposeMCPServerSecrets(context.params)) return context;
+
+  if (Array.isArray(context.result)) {
+    context.result = context.result.map(redactMCPServerSecrets);
+  } else if (context.result?.data && Array.isArray(context.result.data)) {
+    context.result.data = context.result.data.map(redactMCPServerSecrets);
+  } else if (context.result?.mcp_server_id) {
+    context.result = redactMCPServerSecrets(context.result);
+  }
+
+  return context;
+};
+
 export function registerHooks(ctx: RegisterHooksContext): void {
   const {
     db,
@@ -2009,20 +2033,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const redactMCPServerSecretFields = async (context: HookContext) => {
-    if (shouldExposeMCPServerSecrets(context.params)) return context;
-
-    if (Array.isArray(context.result)) {
-      context.result = context.result.map(redactMCPServerSecrets);
-    } else if (context.result?.data && Array.isArray(context.result.data)) {
-      context.result.data = context.result.data.map(redactMCPServerSecrets);
-    } else if (context.result?.mcp_server_id) {
-      context.result = redactMCPServerSecrets(context.result);
-    }
-
-    return context;
-  };
-
   // Writes are decided by `mcp_member_policy` plus ownership, not by role
   // alone — see `authorizeMcpServerWrite`. Reads are narrowed to the servers
   // the caller may use, because a private server is another user's
@@ -2083,6 +2093,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       create: [redactMCPServerSecretFields],
       patch: [redactMCPServerSecretFields],
       update: [redactMCPServerSecretFields],
+      // `remove` returns the deleted row: the adapter loads it in full before
+      // deleting so it can return it, and that same object becomes the
+      // `removed` payload broadcast to every authenticated connection in the
+      // tenant. Without this it is the one method that hands out raw `env`,
+      // `headers`, and `auth` — a delete is not an exemption from redaction.
+      remove: [redactMCPServerSecretFields],
     },
   });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -753,8 +753,44 @@ export function protectFilesystemHomeWrite(context: HookContext, config: AgorCon
 }
 
 /**
- * Strip secret-bearing MCP server fields from anything on its way out to an
- * external caller.
+ * Redact every MCP server row in a service payload, whatever shape it arrived
+ * in. Pure — callers decide what to do with the copy.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: hook results are untyped payloads
+function redactMCPServerPayload(result: any): any {
+  if (Array.isArray(result)) return result.map(redactMCPServerSecrets);
+  if (result?.data && Array.isArray(result.data)) {
+    return { ...result, data: result.data.map(redactMCPServerSecrets) };
+  }
+  if (result?.mcp_server_id) return redactMCPServerSecrets(result);
+  return result;
+}
+
+/**
+ * Strip secret-bearing MCP server fields from anything on its way out.
+ *
+ * `result` and `dispatch` answer different questions and get different
+ * answers:
+ *
+ * - `context.result` is what the CALLER receives. An in-process call or the
+ *   executor's service account legitimately needs raw values to start servers
+ *   and resolve templates, which is what `shouldExposeMCPServerSecrets`
+ *   decides.
+ * - `context.dispatch` is what EVERYONE ELSE receives — Feathers builds the
+ *   channel broadcast from `dispatch ?? result`, and `mcp-servers` events go
+ *   to the tenant-wide authenticated channel. Its audience is by definition
+ *   not the caller, so no fact about the caller can entitle it to secrets.
+ *   Redacting it is therefore unconditional.
+ *
+ * Without that split, an internal or service-account write fanned the raw row
+ * out to every connected socket precisely because the caller was trusted.
+ *
+ * Only set for methods Feathers actually emits an event for — `context.event`
+ * is `created`/`updated`/`patched`/`removed` there and `null` for find/get.
+ * Keying off it rather than a hard-coded method list keeps this from drifting
+ * out of step with what gets broadcast, and leaves find/get alone: those emit
+ * nothing, so a redacted `dispatch` there would only strip the values out of
+ * the executor's own socket reads and break execution.
  *
  * Module scope rather than a closure inside `registerHooks` so tests can drive
  * the real hook against a real service instead of reproducing its body — a
@@ -763,15 +799,13 @@ export function protectFilesystemHomeWrite(context: HookContext, config: AgorCon
  * separately in `register-hooks.mcp-headers-redaction.test.ts`.
  */
 export const redactMCPServerSecretFields = async (context: HookContext) => {
+  if (context.event) {
+    context.dispatch = redactMCPServerPayload(context.result);
+  }
+
   if (shouldExposeMCPServerSecrets(context.params)) return context;
 
-  if (Array.isArray(context.result)) {
-    context.result = context.result.map(redactMCPServerSecrets);
-  } else if (context.result?.data && Array.isArray(context.result.data)) {
-    context.result.data = context.result.data.map(redactMCPServerSecrets);
-  } else if (context.result?.mcp_server_id) {
-    context.result = redactMCPServerSecrets(context.result);
-  }
+  context.result = redactMCPServerPayload(context.result);
 
   return context;
 };

--- a/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
@@ -15,10 +15,12 @@
  * assert that the paths which must keep the real value still get it, because
  * a redaction that also blinded the executor would be worse than the leak.
  *
- * The redaction after-hook is reproduced here rather than imported: it is
- * defined inline inside `registerHooks`, which needs a loaded config and the
- * full service graph. That it is registered on `mcp-servers` find/get is
- * asserted structurally in `register-hooks.mcp-headers-redaction.test.ts`.
+ * These drive the real `redactMCPServerSecretFields` hook against a real
+ * service and a real database. Booting `registerHooks` itself would need a
+ * loaded config and the full service graph, so the one thing left to a
+ * source-level assertion is which methods the hook is registered on — pinned
+ * in `register-hooks.mcp-headers-redaction.test.ts`, and the reason `remove`
+ * being absent from that list was invisible for as long as it was.
  */
 
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
@@ -32,10 +34,8 @@ import { feathers } from '@agor/core/feathers';
 import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
 import type { AuthenticatedParams, MCPServer, User } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import {
-  redactMCPServerSecrets,
-  shouldExposeMCPServerSecrets,
-} from '../utils/mcp-header-secrets.js';
+import { redactMCPServerSecretFields } from '../register-hooks.js';
+import { shouldExposeMCPServerSecrets } from '../utils/mcp-header-secrets.js';
 import { createMCPServersService } from './mcp-servers.js';
 
 const REAL_TOKEN = 'ghp_liveTokenThatMustNeverLeaveTheDaemon';
@@ -77,33 +77,13 @@ async function buildDaemon() {
   const app = feathers();
   app.use('mcp-servers', createMCPServersService(db));
 
-  // Verbatim shape of `redactMCPServerSecretFields` in register-hooks.ts.
+  // The real production hook, not a reproduction of it. Which methods it is
+  // registered on is pinned in `register-hooks.mcp-headers-redaction.test.ts`.
   app.service('mcp-servers').hooks({
     after: {
-      find: [
-        async (context: {
-          params?: AuthenticatedParams;
-          result?: MCPServer[] | { data: MCPServer[] };
-        }) => {
-          if (shouldExposeMCPServerSecrets(context.params)) return context;
-          if (Array.isArray(context.result)) {
-            context.result = context.result.map(redactMCPServerSecrets);
-          } else if (Array.isArray(context.result?.data)) {
-            // The shape `mcp-servers` find actually returns — paginated.
-            context.result.data = context.result.data.map(redactMCPServerSecrets);
-          }
-          return context;
-        },
-      ],
-      get: [
-        async (context: { params?: AuthenticatedParams; result?: MCPServer }) => {
-          if (shouldExposeMCPServerSecrets(context.params)) return context;
-          if (context.result?.mcp_server_id) {
-            context.result = redactMCPServerSecrets(context.result);
-          }
-          return context;
-        },
-      ],
+      find: [redactMCPServerSecretFields],
+      get: [redactMCPServerSecretFields],
+      remove: [redactMCPServerSecretFields],
     },
   } as never);
 
@@ -124,8 +104,17 @@ async function buildDaemon() {
       app.service('mcp-servers').get(shared.mcp_server_id, params) as Promise<MCPServer>,
     patch: (data: Record<string, unknown>, params: AuthenticatedParams) =>
       app.service('mcp-servers').patch(shared.mcp_server_id, data, params) as Promise<MCPServer>,
+    remove: (params: AuthenticatedParams) =>
+      app.service('mcp-servers').remove(shared.mcp_server_id, params) as Promise<MCPServer>,
+    /** Payloads Feathers broadcasts to subscribed connections. */
+    captureRemovedEvents: () => {
+      const events: MCPServer[] = [];
+      app.service('mcp-servers').on('removed', (payload: MCPServer) => events.push(payload));
+      return events;
+    },
     storedEnv: async () =>
       (await repo.findById(shared.mcp_server_id as string))?.env as Record<string, string>,
+    storedServer: () => repo.findById(shared.mcp_server_id as string),
   };
 }
 
@@ -165,6 +154,33 @@ describe('a member reading a shared MCP server', () => {
       'GITHUB_TOKEN',
       'TEMPLATED_TOKEN',
     ]);
+  });
+
+  it('does not receive them from the deleted row a delete hands back', async () => {
+    // `DrizzleService.remove` loads the whole row before deleting so it can
+    // return it. A delete is not an exemption from redaction.
+    const daemon = await buildDaemon();
+
+    const deleted = await daemon.remove(daemon.memberParams);
+
+    expect(deleted.env?.GITHUB_TOKEN).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(deleted)).not.toContain(REAL_TOKEN);
+    expect(JSON.stringify(deleted)).not.toContain(REAL_API_KEY);
+  });
+
+  it('does not receive them in the removed event broadcast to every connection', async () => {
+    // The same object becomes the `removed` payload. `mcp-servers` events go
+    // to the tenant-wide authenticated channel, so an unredacted one hands
+    // the credentials to every connected member at once.
+    const daemon = await buildDaemon();
+    const broadcast = daemon.captureRemovedEvents();
+
+    await daemon.remove(daemon.memberParams);
+
+    expect(broadcast).toHaveLength(1);
+    expect(broadcast[0].env?.GITHUB_TOKEN).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(broadcast)).not.toContain(REAL_TOKEN);
+    expect(JSON.stringify(broadcast)).not.toContain(REAL_API_KEY);
   });
 
   it('still sees which env var a bare template points at', async () => {
@@ -256,5 +272,47 @@ describe('the paths that must keep the real env value', () => {
     const stored = await daemon.storedEnv();
     expect(stored.GITHUB_TOKEN).toBe('ghp_rotated');
     expect(stored.DATADOG_API_KEY).toBe(REAL_API_KEY);
+  });
+
+  it('does not resurrect a variable that a concurrent edit deleted', async () => {
+    // Two windows. The first hydrates its form and holds the sentinel. The
+    // second deletes GITHUB_TOKEN. Then the first saves an unrelated change,
+    // echoing the stale sentinel back. Persisting it would recreate
+    // GITHUB_TOKEN holding `••••••••` — every executor would then launch with
+    // a credential that is silently bogus, which is worse than either the
+    // deletion or the original value.
+    const daemon = await buildDaemon();
+
+    const staleForm = await daemon.get(daemon.memberParams);
+
+    const { GITHUB_TOKEN: _dropped, ...withoutToken } = staleForm.env ?? {};
+    await daemon.patch({ env: withoutToken }, undefined as unknown as AuthenticatedParams);
+    expect(await daemon.storedEnv()).not.toHaveProperty('GITHUB_TOKEN');
+
+    await daemon.patch(
+      { display_name: 'GitHub (prod)', env: staleForm.env },
+      undefined as unknown as AuthenticatedParams
+    );
+
+    const stored = await daemon.storedEnv();
+    expect(stored).not.toHaveProperty('GITHUB_TOKEN');
+    expect(JSON.stringify(stored)).not.toContain(MCP_HEADER_REDACTED_SENTINEL);
+    // The rest of the row is untouched by the dropped key.
+    expect(stored.DATADOG_API_KEY).toBe(REAL_API_KEY);
+  });
+
+  it('never lets the sentinel reach the database on any write', async () => {
+    // The invariant the two cases above are instances of. Once the sentinel
+    // is stored it looks like a real value to the next restore, so the
+    // corruption would be self-perpetuating.
+    const daemon = await buildDaemon();
+
+    await daemon.patch(
+      { env: { BRAND_NEW: MCP_HEADER_REDACTED_SENTINEL } },
+      undefined as unknown as AuthenticatedParams
+    );
+
+    const stored = await daemon.storedServer();
+    expect(JSON.stringify(stored)).not.toContain(MCP_HEADER_REDACTED_SENTINEL);
   });
 });

--- a/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
@@ -1,0 +1,260 @@
+/**
+ * What a member actually receives when they read an MCP server they did not
+ * configure — issue #2292.
+ *
+ * `env` is where a stdio MCP server keeps its credentials, and a shared
+ * (ownerless) server is usable, hence readable, by every member. Before the
+ * fix this file exercises, `redactMCPServerSecrets` covered `headers` and
+ * `auth` and stopped, so `GITHUB_TOKEN` came back in the clear to anyone who
+ * could list servers.
+ *
+ * The point of driving the real service and the real redaction gate rather
+ * than unit-testing the helper is that the helper was never the bug: the bug
+ * was which fields the read path handed over. So these tests assert from the
+ * caller's side — a member calling `find`/`get` — and the companion cases
+ * assert that the paths which must keep the real value still get it, because
+ * a redaction that also blinded the executor would be worse than the leak.
+ *
+ * The redaction after-hook is reproduced here rather than imported: it is
+ * defined inline inside `registerHooks`, which needs a loaded config and the
+ * full service graph. That it is registered on `mcp-servers` find/get is
+ * asserted structurally in `register-hooks.mcp-headers-redaction.test.ts`.
+ */
+
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  createDatabaseAsync,
+  MCPServerRepository,
+  runMigrations,
+  UsersRepository,
+} from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
+import type { AuthenticatedParams, MCPServer, User } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  redactMCPServerSecrets,
+  shouldExposeMCPServerSecrets,
+} from '../utils/mcp-header-secrets.js';
+import { createMCPServersService } from './mcp-servers.js';
+
+const REAL_TOKEN = 'ghp_liveTokenThatMustNeverLeaveTheDaemon';
+const REAL_API_KEY = 'dd-live-api-key-0001';
+
+const SHARED_SERVER_ENV = {
+  GITHUB_TOKEN: REAL_TOKEN,
+  DATADOG_API_KEY: REAL_API_KEY,
+  ALLOWED_PATHS: '/srv/projects',
+  // A bare placeholder references a variable instead of carrying its value.
+  TEMPLATED_TOKEN: '{{ user.env.PERSONAL_TOKEN }}',
+};
+
+async function buildDaemon() {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  const db = rawDb as unknown as TenantScopeAwareDatabase;
+  await runMigrations(rawDb);
+
+  const member = (await new UsersRepository(rawDb).create({
+    email: 'bob@agor.live',
+    name: 'Bob',
+    role: 'member',
+  })) as User;
+
+  const repo = new MCPServerRepository(rawDb);
+  // Ownerless: the shape every row predating MCP ownership has, and the shape
+  // that makes this a cross-user read rather than a self-read.
+  const shared = await repo.create({
+    name: 'github',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-github'],
+    env: { ...SHARED_SERVER_ENV },
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+  });
+
+  const app = feathers();
+  app.use('mcp-servers', createMCPServersService(db));
+
+  // Verbatim shape of `redactMCPServerSecretFields` in register-hooks.ts.
+  app.service('mcp-servers').hooks({
+    after: {
+      find: [
+        async (context: {
+          params?: AuthenticatedParams;
+          result?: MCPServer[] | { data: MCPServer[] };
+        }) => {
+          if (shouldExposeMCPServerSecrets(context.params)) return context;
+          if (Array.isArray(context.result)) {
+            context.result = context.result.map(redactMCPServerSecrets);
+          } else if (Array.isArray(context.result?.data)) {
+            // The shape `mcp-servers` find actually returns — paginated.
+            context.result.data = context.result.data.map(redactMCPServerSecrets);
+          }
+          return context;
+        },
+      ],
+      get: [
+        async (context: { params?: AuthenticatedParams; result?: MCPServer }) => {
+          if (shouldExposeMCPServerSecrets(context.params)) return context;
+          if (context.result?.mcp_server_id) {
+            context.result = redactMCPServerSecrets(context.result);
+          }
+          return context;
+        },
+      ],
+    },
+  } as never);
+
+  // The shape a REST request from a signed-in member arrives with.
+  const memberParams = {
+    provider: 'rest',
+    authenticated: true,
+    user: { user_id: member.user_id, role: 'member' },
+  } as unknown as AuthenticatedParams;
+
+  return {
+    member,
+    serverId: shared.mcp_server_id,
+    memberParams,
+    find: (params: AuthenticatedParams) =>
+      app.service('mcp-servers').find(params) as Promise<{ data: MCPServer[] }>,
+    get: (params: AuthenticatedParams) =>
+      app.service('mcp-servers').get(shared.mcp_server_id, params) as Promise<MCPServer>,
+    patch: (data: Record<string, unknown>, params: AuthenticatedParams) =>
+      app.service('mcp-servers').patch(shared.mcp_server_id, data, params) as Promise<MCPServer>,
+    storedEnv: async () =>
+      (await repo.findById(shared.mcp_server_id as string))?.env as Record<string, string>,
+  };
+}
+
+describe('a member reading a shared MCP server', () => {
+  it('does not receive another user`s env credentials from get', async () => {
+    const daemon = await buildDaemon();
+
+    const server = await daemon.get(daemon.memberParams);
+
+    expect(server.env?.GITHUB_TOKEN).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(server.env?.DATADOG_API_KEY).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(server)).not.toContain(REAL_TOKEN);
+    expect(JSON.stringify(server)).not.toContain(REAL_API_KEY);
+  });
+
+  it('does not receive them from a list either', async () => {
+    const daemon = await buildDaemon();
+
+    const page = await daemon.find(daemon.memberParams);
+
+    expect(page.data).toHaveLength(1);
+    expect(page.data[0].env?.GITHUB_TOKEN).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(page)).not.toContain(REAL_TOKEN);
+    expect(JSON.stringify(page)).not.toContain(REAL_API_KEY);
+  });
+
+  it('can still tell a configured variable from an unset one', async () => {
+    const daemon = await buildDaemon();
+
+    const server = await daemon.get(daemon.memberParams);
+
+    // Keys survive so the edit form renders "this server sets GITHUB_TOKEN"
+    // without rendering the token itself.
+    expect(Object.keys(server.env ?? {}).sort()).toEqual([
+      'ALLOWED_PATHS',
+      'DATADOG_API_KEY',
+      'GITHUB_TOKEN',
+      'TEMPLATED_TOKEN',
+    ]);
+  });
+
+  it('still sees which env var a bare template points at', async () => {
+    const daemon = await buildDaemon();
+
+    const server = await daemon.get(daemon.memberParams);
+
+    expect(server.env?.TEMPLATED_TOKEN).toBe('{{ user.env.PERSONAL_TOKEN }}');
+  });
+});
+
+describe('the paths that must keep the real env value', () => {
+  it('serves raw env to internal daemon calls, which is what session scoping reads', async () => {
+    const daemon = await buildDaemon();
+
+    // No `provider` — an in-process call, the shape `getMcpServersForSession`
+    // and the executor-facing routes resolve through.
+    const server = await daemon.get(undefined as unknown as AuthenticatedParams);
+
+    expect(server.env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
+    expect(server.env?.DATADOG_API_KEY).toBe(REAL_API_KEY);
+  });
+
+  it('serves raw env to the executor service account', async () => {
+    const daemon = await buildDaemon();
+
+    const server = await daemon.get({
+      provider: 'socketio',
+      authenticated: true,
+      user: { user_id: 'executor', role: 'service', _isServiceAccount: true },
+    } as unknown as AuthenticatedParams);
+
+    expect(server.env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
+  });
+
+  it('serves raw env on a session-token read narrowed to that session', async () => {
+    const daemon = await buildDaemon();
+
+    // The decision `/sessions/:id/mcp-servers` makes before returning servers
+    // to the executor (register-routes.ts).
+    const sessionParams = {
+      provider: 'socketio',
+      authenticated: true,
+      authentication: { strategy: 'session-token' },
+      session_id: 'session-1',
+      user: { user_id: 'bob', role: 'member' },
+    } as unknown as AuthenticatedParams;
+
+    expect(
+      shouldExposeMCPServerSecrets(sessionParams, {
+        allowSessionToken: true,
+        sessionId: 'session-1',
+      })
+    ).toBe(true);
+
+    const raw = await daemon.get(undefined as unknown as AuthenticatedParams);
+    expect(raw.env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
+  });
+
+  it('does not overwrite the stored secret when an edit form echoes the sentinel back', async () => {
+    const daemon = await buildDaemon();
+
+    // What the UI submits after hydrating its form from a redacted read and
+    // changing something unrelated.
+    const redacted = await daemon.get(daemon.memberParams);
+    await daemon.patch(
+      { display_name: 'GitHub (prod)', env: redacted.env },
+      // Patched in-process so the write-authorization hook, tested elsewhere,
+      // is not what this case is about.
+      undefined as unknown as AuthenticatedParams
+    );
+
+    const stored = await daemon.storedEnv();
+    expect(stored.GITHUB_TOKEN).toBe(REAL_TOKEN);
+    expect(stored.DATADOG_API_KEY).toBe(REAL_API_KEY);
+    expect(stored.ALLOWED_PATHS).toBe('/srv/projects');
+    expect(stored.TEMPLATED_TOKEN).toBe('{{ user.env.PERSONAL_TOKEN }}');
+  });
+
+  it('still accepts a genuinely rotated value', async () => {
+    const daemon = await buildDaemon();
+
+    const redacted = await daemon.get(daemon.memberParams);
+    await daemon.patch(
+      { env: { ...redacted.env, GITHUB_TOKEN: 'ghp_rotated' } },
+      undefined as unknown as AuthenticatedParams
+    );
+
+    const stored = await daemon.storedEnv();
+    expect(stored.GITHUB_TOKEN).toBe('ghp_rotated');
+    expect(stored.DATADOG_API_KEY).toBe(REAL_API_KEY);
+  });
+});

--- a/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts
@@ -77,15 +77,38 @@ async function buildDaemon() {
   const app = feathers();
   app.use('mcp-servers', createMCPServersService(db));
 
+  /**
+   * A direct service call resolves to `context.result`, but a socket client
+   * receives `returnedCtx.dispatch || returnedCtx.result`
+   * (@feathersjs/transport-commons socket/utils.js). Recording the finished
+   * context lets the assertions below use the transport's formula instead of
+   * the in-process one — without it, a `dispatch` set where it should not be
+   * is invisible to every test.
+   */
+  let lastContext: { dispatch?: unknown; result?: unknown } = {};
+  const recordFinishedContext = async (context: { dispatch?: unknown; result?: unknown }) => {
+    lastContext = context;
+    return context;
+  };
+
   // The real production hook, not a reproduction of it. Which methods it is
   // registered on is pinned in `register-hooks.mcp-headers-redaction.test.ts`.
   app.service('mcp-servers').hooks({
     after: {
-      find: [redactMCPServerSecretFields],
-      get: [redactMCPServerSecretFields],
-      remove: [redactMCPServerSecretFields],
+      find: [redactMCPServerSecretFields, recordFinishedContext],
+      get: [redactMCPServerSecretFields, recordFinishedContext],
+      create: [redactMCPServerSecretFields, recordFinishedContext],
+      patch: [redactMCPServerSecretFields, recordFinishedContext],
+      update: [redactMCPServerSecretFields, recordFinishedContext],
+      remove: [redactMCPServerSecretFields, recordFinishedContext],
     },
   } as never);
+
+  /** What a socket client would receive as the response to the last call. */
+  const overSocket = async <T>(call: Promise<unknown>): Promise<T> => {
+    await call;
+    return (lastContext.dispatch ?? lastContext.result) as T;
+  };
 
   // The shape a REST request from a signed-in member arrives with.
   const memberParams = {
@@ -106,11 +129,32 @@ async function buildDaemon() {
       app.service('mcp-servers').patch(shared.mcp_server_id, data, params) as Promise<MCPServer>,
     remove: (params: AuthenticatedParams) =>
       app.service('mcp-servers').remove(shared.mcp_server_id, params) as Promise<MCPServer>,
-    /** Payloads Feathers broadcasts to subscribed connections. */
-    captureRemovedEvents: () => {
-      const events: MCPServer[] = [];
-      app.service('mcp-servers').on('removed', (payload: MCPServer) => events.push(payload));
-      return events;
+    create: (data: Record<string, unknown>, params: AuthenticatedParams) =>
+      app.service('mcp-servers').create(data, params) as Promise<MCPServer>,
+    getOverSocket: (params: AuthenticatedParams) =>
+      overSocket<MCPServer>(app.service('mcp-servers').get(shared.mcp_server_id, params)),
+    findOverSocket: (params: AuthenticatedParams) =>
+      overSocket<{ data: MCPServer[] }>(app.service('mcp-servers').find(params)),
+    update: (data: Record<string, unknown>, params: AuthenticatedParams) =>
+      app.service('mcp-servers').update(shared.mcp_server_id, data, params) as Promise<MCPServer>,
+    /**
+     * What the socket transport would actually put on the wire for each
+     * emitted event.
+     *
+     * Feathers emits `(element, context)` where `element` comes from
+     * `context.result`, but @feathersjs/transport-commons sends
+     * `channel.dataFor(connection) || context.dispatch || context.result`.
+     * Asserting on `element` would therefore miss a raw `dispatch` entirely —
+     * which is exactly how the privileged-caller broadcast stayed invisible.
+     */
+    captureBroadcasts: (event: 'created' | 'updated' | 'patched' | 'removed') => {
+      const sent: MCPServer[] = [];
+      app
+        .service('mcp-servers')
+        .on(event, (_element: MCPServer, hook: { dispatch?: MCPServer; result?: MCPServer }) => {
+          sent.push((hook.dispatch ?? hook.result) as MCPServer);
+        });
+      return sent;
     },
     storedEnv: async () =>
       (await repo.findById(shared.mcp_server_id as string))?.env as Record<string, string>,
@@ -173,7 +217,7 @@ describe('a member reading a shared MCP server', () => {
     // to the tenant-wide authenticated channel, so an unredacted one hands
     // the credentials to every connected member at once.
     const daemon = await buildDaemon();
-    const broadcast = daemon.captureRemovedEvents();
+    const broadcast = daemon.captureBroadcasts('removed');
 
     await daemon.remove(daemon.memberParams);
 
@@ -189,6 +233,101 @@ describe('a member reading a shared MCP server', () => {
     const server = await daemon.get(daemon.memberParams);
 
     expect(server.env?.TEMPLATED_TOKEN).toBe('{{ user.env.PERSONAL_TOKEN }}');
+  });
+});
+
+/**
+ * The broadcast audience is not the caller, so nothing about the caller can
+ * entitle it to secrets. These are the cases the member-perspective tests
+ * above sail straight past: when the writer is trusted, `context.result`
+ * stays raw by design, and the event is built from it unless `dispatch` says
+ * otherwise.
+ */
+describe('a privileged write still broadcasts a redacted row', () => {
+  const INTERNAL = undefined as unknown as AuthenticatedParams;
+  const SERVICE_ACCOUNT = {
+    provider: 'socketio',
+    authenticated: true,
+    user: { user_id: 'executor', role: 'service', _isServiceAccount: true },
+  } as unknown as AuthenticatedParams;
+
+  const PRIVILEGED: Array<[string, AuthenticatedParams]> = [
+    ['an internal in-process call', INTERNAL],
+    ['the executor service account', SERVICE_ACCOUNT],
+  ];
+
+  describe.each(PRIVILEGED)('%s', (_label, params) => {
+    it('removing broadcasts a redacted row while the caller keeps the real one', async () => {
+      const daemon = await buildDaemon();
+      const broadcast = daemon.captureBroadcasts('removed');
+
+      const returnedToCaller = await daemon.remove(params);
+
+      expect(broadcast).toHaveLength(1);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_TOKEN);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_API_KEY);
+      // The caller's own entitlement is untouched — this is what keeps
+      // session scoping and stdio startup working.
+      expect(returnedToCaller.env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
+    });
+
+    it('patching broadcasts a redacted row', async () => {
+      const daemon = await buildDaemon();
+      const broadcast = daemon.captureBroadcasts('patched');
+
+      await daemon.patch({ display_name: 'GitHub (prod)' }, params);
+
+      expect(broadcast).toHaveLength(1);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_TOKEN);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_API_KEY);
+    });
+
+    it('updating broadcasts a redacted row', async () => {
+      const daemon = await buildDaemon();
+      const broadcast = daemon.captureBroadcasts('updated');
+
+      await daemon.update({ name: 'github', transport: 'stdio', command: 'npx' }, params);
+
+      expect(broadcast).toHaveLength(1);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_TOKEN);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_API_KEY);
+    });
+
+    it('creating broadcasts a redacted row', async () => {
+      const daemon = await buildDaemon();
+      const broadcast = daemon.captureBroadcasts('created');
+
+      await daemon.create(
+        {
+          name: 'second',
+          transport: 'stdio',
+          command: 'npx',
+          env: { OTHER_TOKEN: REAL_TOKEN },
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+        },
+        params
+      );
+
+      expect(broadcast).toHaveLength(1);
+      expect(JSON.stringify(broadcast)).not.toContain(REAL_TOKEN);
+    });
+  });
+
+  it('leaves find and get alone, since neither emits anything to redact for', async () => {
+    // `dispatch` is also what the socket transport hands back to the caller
+    // of a method. On a non-emitting method it would buy no broadcast safety
+    // and would strip the values out of the executor's own reads — which is
+    // how the executor loads MCP config. Asserted through the transport's
+    // formula, so a `dispatch` set here is not invisible.
+    const daemon = await buildDaemon();
+
+    const viaGet = await daemon.getOverSocket(SERVICE_ACCOUNT);
+    const viaFind = await daemon.findOverSocket(SERVICE_ACCOUNT);
+
+    expect(viaGet.env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
+    expect(viaFind.data[0].env?.GITHUB_TOKEN).toBe(REAL_TOKEN);
   });
 });
 

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -1,4 +1,5 @@
 import { redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
+import { redactMCPEnvSecrets } from '@agor/core/tools/mcp/env-secrets';
 import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer, Params } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -87,15 +88,20 @@ export const shouldExposeMCPHeaderSecrets = shouldExposeMCPServerSecrets;
 export function redactMCPServerSecrets(server: MCPServer): MCPServer {
   const headers = redactMCPCustomHeaders(server.headers);
   const auth = redactMCPAuthSecrets(server.auth);
+  // `env` is where a stdio server keeps its credentials, so it is redacted on
+  // the same terms as `headers`: a shared (ownerless) row is usable — and
+  // therefore readable — by every member, and its env routinely holds API keys.
+  const env = redactMCPEnvSecrets(server.env);
 
-  if (headers === server.headers && auth === server.auth) return server;
+  if (headers === server.headers && auth === server.auth && env === server.env) return server;
 
   return {
     ...server,
     ...(headers !== server.headers ? { headers } : {}),
     ...(auth !== server.auth ? { auth } : {}),
+    ...(env !== server.env ? { env } : {}),
   };
 }
 
-// Back-compat alias for older call-sites/tests; now covers auth+headers.
+// Back-compat alias for older call-sites/tests; now covers auth+headers+env.
 export const redactMCPServerHeaderSecrets = redactMCPServerSecrets;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -316,6 +316,12 @@
       "import": "./dist/tools/mcp/auth-secrets.js",
       "require": "./dist/tools/mcp/auth-secrets.cjs"
     },
+    "./tools/mcp/env-secrets": {
+      "source": "./src/tools/mcp/env-secrets.ts",
+      "types": "./dist/tools/mcp/env-secrets.d.ts",
+      "import": "./dist/tools/mcp/env-secrets.js",
+      "require": "./dist/tools/mcp/env-secrets.cjs"
+    },
     "./tools/mcp/jwt-auth": {
       "source": "./src/tools/mcp/jwt-auth.ts",
       "types": "./dist/tools/mcp/jwt-auth.d.ts",

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -16,6 +16,7 @@ import type {
 import { and, eq, isNull, like, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import { restoreRedactedMCPAuthSecrets } from '../../tools/mcp/auth-secrets';
+import { restoreRedactedMCPEnvSecrets } from '../../tools/mcp/env-secrets';
 import {
   normalizeMCPCustomHeaders,
   restoreRedactedMCPCustomHeaders,
@@ -282,6 +283,12 @@ export class MCPServerRepository
         merged.auth = restoreRedactedMCPAuthSecrets({
           current: current.auth,
           next: updates.auth,
+        });
+      }
+      if ('env' in updates) {
+        merged.env = restoreRedactedMCPEnvSecrets({
+          current: current.env,
+          next: updates.env,
         });
       }
       const insertData = this.mcpServerToInsert(merged);

--- a/packages/core/src/tools/mcp/auth-secrets.test.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.test.ts
@@ -161,4 +161,24 @@ describe('MCP auth secret helpers', () => {
       api_secret: 'stored-secret',
     });
   });
+
+  it('never persists the sentinel when there is nothing stored to restore', () => {
+    // The live case: `injectPerUserOAuthTokens` enriches the read with the
+    // caller's own `oauth_access_token`, redaction turns it into the
+    // sentinel, and the edit form echoes it back — but per-user tokens live
+    // in `user_mcp_oauth_tokens`, so the server row has nothing to restore
+    // from. Storing the sentinel would leave the row authenticating with a
+    // literal `••••••••`.
+    const restored = restoreRedactedMCPAuthSecrets({
+      current: { type: 'oauth', oauth_client_id: 'public-client-id' },
+      next: {
+        type: 'oauth',
+        oauth_client_id: 'public-client-id',
+        oauth_access_token: MCP_HEADER_REDACTED_SENTINEL,
+      },
+    });
+
+    expect(restored).toEqual({ type: 'oauth', oauth_client_id: 'public-client-id' });
+    expect(restored).not.toHaveProperty('oauth_access_token');
+  });
 });

--- a/packages/core/src/tools/mcp/auth-secrets.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.ts
@@ -54,6 +54,14 @@ export function redactMCPAuthSecrets(auth?: MCPAuth): MCPAuth | undefined {
   return changed ? redacted : auth;
 }
 
+/**
+ * INVARIANT: the sentinel is never persisted. See the long-form rationale on
+ * `restoreRedactedMCPEnvSecrets` — a submitted sentinel is a claim of
+ * "unchanged", never a value, so when there is nothing stored to restore (a
+ * stale form whose token a concurrent edit or an OAuth disconnect cleared)
+ * the field is dropped rather than written. Storing it would leave the server
+ * authenticating with a literal `••••••••`.
+ */
 export function restoreRedactedMCPAuthSecrets(options: {
   current?: MCPAuth;
   next?: MCPAuth;
@@ -64,11 +72,13 @@ export function restoreRedactedMCPAuthSecrets(options: {
   const record = restored as unknown as Record<string, unknown>;
 
   for (const field of MCP_AUTH_SECRET_FIELDS) {
-    if (
-      restored[field] === MCP_HEADER_REDACTED_SENTINEL &&
-      options.current?.[field] !== undefined
-    ) {
-      record[field] = options.current[field];
+    if (restored[field] !== MCP_HEADER_REDACTED_SENTINEL) continue;
+
+    const stored = options.current?.[field];
+    if (stored !== undefined) {
+      record[field] = stored;
+    } else {
+      delete record[field];
     }
   }
 

--- a/packages/core/src/tools/mcp/env-secrets.test.ts
+++ b/packages/core/src/tools/mcp/env-secrets.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { redactMCPEnvSecrets, restoreRedactedMCPEnvSecrets } from './env-secrets';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+describe('redactMCPEnvSecrets', () => {
+  it('replaces values with the sentinel while keeping the keys', () => {
+    expect(redactMCPEnvSecrets({ GITHUB_TOKEN: 'ghp_live', ALLOWED_PATHS: '/srv' })).toEqual({
+      GITHUB_TOKEN: MCP_HEADER_REDACTED_SENTINEL,
+      ALLOWED_PATHS: MCP_HEADER_REDACTED_SENTINEL,
+    });
+  });
+
+  it('keeps a configured-but-hidden variable distinguishable from an unset one', () => {
+    // The edit form needs to render "this server sets GITHUB_TOKEN" without
+    // rendering the token, so the key survives redaction and an absent env
+    // stays absent.
+    expect(Object.keys(redactMCPEnvSecrets({ GITHUB_TOKEN: 'ghp_live' }) ?? {})).toEqual([
+      'GITHUB_TOKEN',
+    ]);
+    expect(redactMCPEnvSecrets(undefined)).toBeUndefined();
+    expect(redactMCPEnvSecrets({})).toEqual({});
+  });
+
+  it('leaves a bare {{ user.env.NAME }} placeholder intact', () => {
+    // The placeholder names a variable rather than carrying its value, and
+    // the sentinel would turn a resolvable reference into a literal.
+    expect(redactMCPEnvSecrets({ TOKEN: '{{ user.env.GITHUB_TOKEN }}' })).toEqual({
+      TOKEN: '{{ user.env.GITHUB_TOKEN }}',
+    });
+  });
+
+  it('redacts partial, helper, and multi-expression templates', () => {
+    expect(
+      redactMCPEnvSecrets({
+        PARTIAL: 'prefix-{{ user.env.A }}',
+        HELPER: '{{default user.env.A "sk-live-fallback"}}',
+        OTHER: '{{ someOtherThing }}',
+      })
+    ).toEqual({
+      PARTIAL: MCP_HEADER_REDACTED_SENTINEL,
+      HELPER: MCP_HEADER_REDACTED_SENTINEL,
+      OTHER: MCP_HEADER_REDACTED_SENTINEL,
+    });
+  });
+
+  it('does not drop env vars that share a name with a reserved HTTP header', () => {
+    // Guards against routing `env` through `normalizeMCPCustomHeaders`, which
+    // filters these names out — they are ordinary environment variables.
+    expect(redactMCPEnvSecrets({ HOST: 'db.internal', TE: '1', UPGRADE: 'yes' })).toEqual({
+      HOST: MCP_HEADER_REDACTED_SENTINEL,
+      TE: MCP_HEADER_REDACTED_SENTINEL,
+      UPGRADE: MCP_HEADER_REDACTED_SENTINEL,
+    });
+  });
+});
+
+describe('restoreRedactedMCPEnvSecrets', () => {
+  it('restores the stored value where the form echoed the sentinel back', () => {
+    expect(
+      restoreRedactedMCPEnvSecrets({
+        current: { GITHUB_TOKEN: 'ghp_live', ALLOWED_PATHS: '/srv' },
+        next: { GITHUB_TOKEN: MCP_HEADER_REDACTED_SENTINEL, ALLOWED_PATHS: '/srv2' },
+      })
+    ).toEqual({ GITHUB_TOKEN: 'ghp_live', ALLOWED_PATHS: '/srv2' });
+  });
+
+  it('honours a real edit and a deletion', () => {
+    expect(
+      restoreRedactedMCPEnvSecrets({
+        current: { GITHUB_TOKEN: 'ghp_live', STALE: 'x' },
+        next: { GITHUB_TOKEN: 'ghp_rotated' },
+      })
+    ).toEqual({ GITHUB_TOKEN: 'ghp_rotated' });
+  });
+
+  it('keeps the sentinel when there is nothing stored to restore', () => {
+    expect(
+      restoreRedactedMCPEnvSecrets({
+        current: undefined,
+        next: { NEW: MCP_HEADER_REDACTED_SENTINEL },
+      })
+    ).toEqual({ NEW: MCP_HEADER_REDACTED_SENTINEL });
+  });
+
+  it('returns undefined when no env was submitted', () => {
+    expect(restoreRedactedMCPEnvSecrets({ current: { A: 'b' }, next: undefined })).toBeUndefined();
+  });
+});

--- a/packages/core/src/tools/mcp/env-secrets.test.ts
+++ b/packages/core/src/tools/mcp/env-secrets.test.ts
@@ -73,13 +73,41 @@ describe('restoreRedactedMCPEnvSecrets', () => {
     ).toEqual({ GITHUB_TOKEN: 'ghp_rotated' });
   });
 
-  it('keeps the sentinel when there is nothing stored to restore', () => {
+  it('never persists the sentinel when there is nothing stored to restore', () => {
     expect(
       restoreRedactedMCPEnvSecrets({
         current: undefined,
         next: { NEW: MCP_HEADER_REDACTED_SENTINEL },
       })
-    ).toEqual({ NEW: MCP_HEADER_REDACTED_SENTINEL });
+    ).toEqual({});
+  });
+
+  it('does not resurrect a variable a concurrent edit deleted', () => {
+    // Two windows open. One deletes GITHUB_TOKEN. The other, holding a form
+    // hydrated before that, saves an unrelated change and echoes the sentinel
+    // back. Persisting it would recreate GITHUB_TOKEN as the literal
+    // `••••••••`, and every executor would launch with a bogus credential.
+    const afterConcurrentDelete = { ALLOWED_PATHS: '/srv' };
+    const staleForm = {
+      GITHUB_TOKEN: MCP_HEADER_REDACTED_SENTINEL,
+      ALLOWED_PATHS: '/srv/changed',
+    };
+
+    expect(
+      restoreRedactedMCPEnvSecrets({ current: afterConcurrentDelete, next: staleForm })
+    ).toEqual({ ALLOWED_PATHS: '/srv/changed' });
+  });
+
+  it('cannot set a value that is literally the sentinel, by construction', () => {
+    // Documented limitation, not an oversight: the sentinel travels in the
+    // same channel as real values, so "unchanged" and "literally this string"
+    // are indistinguishable. Keeping the stored value is the safe reading.
+    expect(
+      restoreRedactedMCPEnvSecrets({
+        current: { TOKEN: 'real' },
+        next: { TOKEN: MCP_HEADER_REDACTED_SENTINEL },
+      })
+    ).toEqual({ TOKEN: 'real' });
   });
 
   it('returns undefined when no env was submitted', () => {

--- a/packages/core/src/tools/mcp/env-secrets.ts
+++ b/packages/core/src/tools/mcp/env-secrets.ts
@@ -1,0 +1,78 @@
+/**
+ * Utilities for MCP server `env` values, which are secret-bearing.
+ *
+ * `env` is where a stdio MCP server's credentials live (`GITHUB_TOKEN`,
+ * `DATADOG_API_KEY`, …), so it needs the same redact-on-read /
+ * restore-on-write treatment `headers` and `auth` already have.
+ *
+ * Deliberately NOT reusing `normalizeMCPCustomHeaders`: that normalizer
+ * enforces HTTP token syntax on the key and drops reserved header names, and
+ * several of those names — `HOST`, `CONNECTION`, `UPGRADE`, `TE` — are
+ * perfectly ordinary environment variables. Routing `env` through it would
+ * silently delete them on every read.
+ */
+
+import { isUserEnvPlaceholder } from '../../mcp/template-patterns';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+/**
+ * Replace every `env` value with the redaction sentinel.
+ *
+ * Keys are preserved so a caller can still see *which* variables a server is
+ * configured with, and so the UI can distinguish "unset" from "set but
+ * hidden" — an empty/absent `env` still renders as empty, a configured one
+ * renders as `{"GITHUB_TOKEN": "••••••••"}`.
+ *
+ * A bare `{{ user.env.NAME }}` placeholder is left intact, matching
+ * `redactMCPCustomHeaders`: it names a variable rather than carrying its
+ * value, it is the more useful thing to show in the edit form, and replacing
+ * it with the sentinel would turn a resolvable reference into a literal.
+ * Partial, multiple, and helper expressions can still carry secret material
+ * and are redacted.
+ */
+export function redactMCPEnvSecrets(
+  env?: Record<string, string>
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+
+  const entries = Object.entries(env);
+  if (entries.length === 0) return env;
+
+  let changed = false;
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of entries) {
+    if (typeof value === 'string' && isUserEnvPlaceholder(value)) {
+      redacted[key] = value;
+      continue;
+    }
+    redacted[key] = MCP_HEADER_REDACTED_SENTINEL;
+    changed = true;
+  }
+
+  return changed ? redacted : env;
+}
+
+/**
+ * Put the stored value back wherever an edit form submitted the sentinel
+ * unchanged. Without this, saving any unrelated field on a server would
+ * overwrite every secret with `••••••••`.
+ *
+ * A key absent from `next` is a deletion and stays deleted; a key whose value
+ * differs from the sentinel is a genuine edit and is taken as submitted.
+ */
+export function restoreRedactedMCPEnvSecrets(options: {
+  current?: Record<string, string>;
+  next?: Record<string, string>;
+}): Record<string, string> | undefined {
+  if (!options.next) return undefined;
+
+  const restored: Record<string, string> = {};
+  for (const [key, value] of Object.entries(options.next)) {
+    restored[key] =
+      value === MCP_HEADER_REDACTED_SENTINEL && options.current?.[key] !== undefined
+        ? options.current[key]
+        : value;
+  }
+
+  return restored;
+}

--- a/packages/core/src/tools/mcp/env-secrets.ts
+++ b/packages/core/src/tools/mcp/env-secrets.ts
@@ -59,6 +59,21 @@ export function redactMCPEnvSecrets(
  *
  * A key absent from `next` is a deletion and stays deleted; a key whose value
  * differs from the sentinel is a genuine edit and is taken as submitted.
+ *
+ * INVARIANT: the sentinel is never persisted. It is in-band signalling — it
+ * travels in the same channel as real values — so a submitted sentinel is
+ * only ever a claim of "unchanged", never a value. If there is nothing stored
+ * to restore, the claim refers to something that no longer exists (a stale
+ * form whose variable was deleted by a concurrent edit), and the key is
+ * dropped rather than written. Writing it would resurrect the variable
+ * holding `••••••••`, and every executor would then launch with a credential
+ * that is silently bogus.
+ *
+ * The cost is that a value which genuinely equals the sentinel cannot be set;
+ * it is indistinguishable from an unchanged field by construction. Eight
+ * bullet characters is not a credential anyone has, and the alternative —
+ * refusing every submitted sentinel — would break the ordinary round-trip
+ * this function exists to support.
  */
 export function restoreRedactedMCPEnvSecrets(options: {
   current?: Record<string, string>;
@@ -68,10 +83,12 @@ export function restoreRedactedMCPEnvSecrets(options: {
 
   const restored: Record<string, string> = {};
   for (const [key, value] of Object.entries(options.next)) {
-    restored[key] =
-      value === MCP_HEADER_REDACTED_SENTINEL && options.current?.[key] !== undefined
-        ? options.current[key]
-        : value;
+    if (value === MCP_HEADER_REDACTED_SENTINEL) {
+      const stored = options.current?.[key];
+      if (stored !== undefined) restored[key] = stored;
+      continue;
+    }
+    restored[key] = value;
   }
 
   return restored;

--- a/packages/core/src/tools/mcp/http-headers.test.ts
+++ b/packages/core/src/tools/mcp/http-headers.test.ts
@@ -90,4 +90,19 @@ describe('MCP HTTP header helpers', () => {
       'X-Datadog-Parent-Org-Id': '5678',
     });
   });
+
+  it('never persists the sentinel when there is nothing stored to restore', () => {
+    // A stale form echoes back a header that a concurrent edit removed.
+    // Storing the sentinel would send `••••••••` upstream as the literal
+    // header value.
+    expect(
+      restoreRedactedMCPCustomHeaders({
+        current: { 'X-Other': 'kept' },
+        next: {
+          'DD-API-KEY': MCP_HEADER_REDACTED_SENTINEL,
+          'X-Other': 'kept',
+        },
+      })
+    ).toEqual({ 'X-Other': 'kept' });
+  });
 });

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -72,6 +72,14 @@ export function redactMCPCustomHeaders(
   );
 }
 
+/**
+ * INVARIANT: the sentinel is never persisted. See the long-form rationale on
+ * `restoreRedactedMCPEnvSecrets` — a submitted sentinel is a claim of
+ * "unchanged", never a value, so when there is nothing stored to restore (a
+ * stale form whose header a concurrent edit removed) the key is dropped
+ * rather than written. Storing it would send `••••••••` upstream as a literal
+ * header value.
+ */
 export function restoreRedactedMCPCustomHeaders(options: {
   current?: Record<string, string>;
   next?: Record<string, string>;
@@ -80,10 +88,12 @@ export function restoreRedactedMCPCustomHeaders(options: {
 
   const restored: Record<string, string> = {};
   for (const [key, value] of Object.entries(options.next)) {
-    restored[key] =
-      value === MCP_HEADER_REDACTED_SENTINEL && options.current?.[key] !== undefined
-        ? options.current[key]
-        : value;
+    if (value === MCP_HEADER_REDACTED_SENTINEL) {
+      const stored = options.current?.[key];
+      if (stored !== undefined) restored[key] = stored;
+      continue;
+    }
+    restored[key] = value;
   }
 
   return normalizeMCPCustomHeaders(restored);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
     'client/claude-system-suppression': 'src/client/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
     'tools/mcp/http-headers': 'src/tools/mcp/http-headers.ts', // MCP custom HTTP header utilities
     'tools/mcp/auth-secrets': 'src/tools/mcp/auth-secrets.ts', // MCP auth secret redaction/restoration utilities
+    'tools/mcp/env-secrets': 'src/tools/mcp/env-secrets.ts', // MCP env secret redaction/restoration utilities
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport


### PR DESCRIPTION
Fixes #2292.

Started as "`env` is missing from the read-path redaction". Successive review passes turned up four more problems in the same machinery, all pre-existing on `main` and none specific to `env`, so the scope is now "make MCP server secret redaction actually hold". Two of those findings widen the severity well beyond `env`: **`headers` and `auth` have been leaking through `remove` and through the event broadcast all along.**

## 1. `env` was not redacted on the read path

`MCPServer.env` is documented in the type itself as secret-bearing, but `redactMCPServerSecrets` covered `headers` and `auth` and stopped.

A server with `owner_user_id = NULL` is *shared*: `isMCPServerUsableBy` returns true for everyone, so every member can see the row. Rows predating MCP ownership are all in that state, and on a long-lived instance those are exactly the servers someone configured with real credentials. The values already reached every member's browser via store hydration, so this was an API boundary issue rather than a rendering one.

**Fix:** `env` is redacted alongside `headers` and `auth`, following the convention already in that file.

- **Sentinel per value, keys preserved** — a caller still sees *which* variables a server sets, so "set but hidden" stays distinguishable from "unset", which the edit form needs.
- **A bare `{{ user.env.NAME }}` placeholder is left intact**, matching `redactMCPCustomHeaders`: it names a variable rather than carrying its value. Partial, multi-expression, and helper forms are redacted.
- **Unconditional — no owner carve-out.** The rows this issue is about have no owner, so "show it to the owner" is undefined for exactly the population at risk. An identity-conditional response shape also means every consumer must handle both variants and any future path that forgets the check leaks. `auth.token` already works this way. The owner loses only the ability to *read back* a secret they set.

`env` gets its own module rather than reusing the header helpers: `normalizeMCPCustomHeaders` drops reserved header names, and `HOST`, `TE`, `UPGRADE`, `CONNECTION` are ordinary environment variables. Routing `env` through it would have silently deleted them on every read. There is a regression test.

## 2. `remove` returned the row unredacted — including `headers` and `auth`

`remove` was the one `mcp-servers` method with no redaction after-hook. `DrizzleService.remove` loads the complete row before deleting so it can return it, so `DELETE /mcp-servers/<id>` handed back raw config. **Not confined to `env`** — deleting a server was a way to read its credentials, and has been since the hook was introduced.

Swept every path that can return an MCP server row rather than fixing only the reported one:

| path | returns a row? | redacted? |
| --- | --- | --- |
| `mcp-servers` find / get / create / patch / update | yes | already |
| **`mcp-servers` remove** | **yes** | **no → fixed** |
| `session-mcp-servers` find (its only method) | no — join columns | n/a |
| `/sessions/:id/mcp-servers` find | yes | already |
| `/sessions/:id/mcp-servers` create / update / remove / patch | no — join/relationship shapes | n/a |
| `/mcp-servers/{discover,test-jwt,test-oauth,oauth-*}` | no — result/status objects | n/a |
| `agor_mcp_servers_*` MCP tools | no — `McpServerSummary` | n/a |
| `agor config export`, `agor tenant export` | no | n/a |

## 3. The event broadcast leaked *because* the caller was trusted

The deepest one. `redactMCPServerSecretFields` early-returns for callers entitled to raw config — an internal in-process call or the executor service account — and only ever touched `context.result`. Feathers builds the channel broadcast from `dispatch ?? result`, and `mcp-servers` events go to the tenant-wide authenticated channel.

So **a write by exactly those trusted callers fanned the raw row out to every connected socket.** This is the whole emitting class, not just `remove` — `created`, `updated`, `patched` and `removed` all carry it, for both privileged caller shapes. Eight cases, every one leaking before this change, and every one confirmed by neutering the fix.

**Fix — `result` and `dispatch` answer different questions, so they get different answers:**

- `context.result` is what the **caller** receives. An internal call or the executor legitimately needs raw values to start servers and resolve templates; that stays governed by `shouldExposeMCPServerSecrets`.
- `context.dispatch` is what **everyone else** receives. Its audience is by definition not the caller, so no fact about the caller can entitle it to secrets. Redacted unconditionally.

**Deliberately not set on every method.** `dispatch` is *also* what the socket transport hands back to the caller of a method, and `find`/`get` emit no event — setting it there would buy no broadcast safety while stripping the values out of the executor's own reads, which is how it loads MCP config. That would be a fix strictly worse than the bug. The hook gates on `context.event`, which Feathers populates from the same map it uses to decide what to emit (`created`/`updated`/`patched`/`removed`, `null` for find/get), so the rule cannot drift out of step with what actually gets broadcast.

Swept `register-hooks.ts` for the same pattern elsewhere — an after-hook that sanitizes `result` only, has a caller-conditional bypass, and is registered on an emitting method. **This was the only instance.** The `gateway-channels` config/`envVars` redaction is unconditional (no caller bypass), and the boards artifact filters sit on `get`/`find`, which emit nothing.

## 4 & 5. The sentinel was persistable, so a stale form could corrupt a secret

Both came from one root cause: the sentinel is **in-band signalling**, so the restore helpers could not tell "unchanged" from "literally this string".

- **Resurrection.** A stale form holds `{TOKEN: "••••••••"}`; a concurrent edit deletes `TOKEN`; the stale form saves an unrelated field. Restore found nothing in `current`, treated the sentinel as a literal, and persisted it — every executor then launched with a credential that is silently bogus. Not hypothetical: `injectPerUserOAuthTokens` enriches the read with an `oauth_access_token` that lives in `user_mcp_oauth_tokens`, so the server row routinely has nothing to restore from, and `••••••••` was written onto the shared row.
- **Shadowing.** A value that genuinely equals the sentinel cannot be set.

**Fix — one invariant: the sentinel is never persisted.** A submitted sentinel is only ever a claim of "unchanged", never a value; with nothing stored to restore, the key is dropped. That also stops the corruption being self-perpetuating, since a stored sentinel would look like a real value to the next restore.

Shadowing stays as a documented limitation rather than a refusal: when there *is* a stored value the two cases are indistinguishable by construction, so refusing every submitted sentinel would break the ordinary round-trip. Erroring only in the no-stored-value case would make the common case — a stale form after a concurrent delete — fail loudly on save. No optimistic concurrency: the sentinel rule makes the bad write impossible rather than detecting it.

**Applied to all three fields.** `headers` and `auth` share the bug because they share the design; the auth case is the one with a live trigger.

## Redaction alone would have been worse than the leak

`env` is consumed at execution time and the edit form round-trips what it was served, so redacting the read path without a matching restore would silently overwrite every real secret on the next save. `MCPServerRepository.update` restores `env` from the stored row, as it already did for `headers` and `auth`.

Every part is independently falsifiable, verified by reverting each in turn:

| neutered | fails |
| --- | --- |
| `env` read-path redaction | member-reads-a-shared-server leak tests |
| `env` write-path restore | round-trip write tests |
| `remove` hook registration | method-coverage test |
| sentinel-drop in `env` | resurrection + never-reaches-DB, unit **and** end-to-end |
| sentinel-drop in `headers` / `auth` | their never-persisted tests |
| **redacted `dispatch`** | **all 8 privileged-broadcast cases** |
| **`context.event` gate (i.e. `dispatch` set unconditionally)** | **the find/get case — proving the over-broad fix is caught** |

## Execution paths are untouched

Every consumer that must receive real values still does: session scoping and template resolution (in-process, no `provider`), the executor service account, the session-token-narrowed `/sessions/:id/mcp-servers` route, and the Claude / Codex / Gemini / Copilot handlers that pass `env` to stdio startup. `/mcp-servers/discover` never sees `env` at all.

## Visible behaviour change

`agor mcp show` reads through the same API, so env values there now print as `••••••••` for ordinary users. That is the intended effect.

## Tests

Two things made the earlier gaps invisible, and both are now closed:

- `redactMCPServerSecretFields` moved to module scope so the tests drive the **real** hook rather than a reproduction of it — a replica passes whatever the replica does.
- Assertions go through the **transport's** formula, not the in-process one. A direct service call resolves to `context.result`, and Feathers emits `(element, context)` where `element` is also `context.result` — so both the raw-`dispatch` broadcast *and* an over-broad `dispatch` were invisible to assertions written the obvious way. The helpers model `dispatch ?? result` explicitly, citing `@feathersjs/transport-commons`.

Files: `apps/agor-daemon/src/services/mcp-servers.env-redaction.test.ts`, `apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts`, `packages/core/src/tools/mcp/{env,auth}-secrets.test.ts`, `packages/core/src/tools/mcp/http-headers.test.ts`.

No new failures in `@agor/core`, `@agor/daemon`, or `agor-ui`; `turbo run typecheck` and `biome check --error-on-warnings .` clean.

## Noted, not fixed

`args` and `url` remain unredacted and can carry secrets in practice (`["--api-key", "…"]`; credentials or a secret path segment in a URL). Neither is documented as secret-bearing, both are display-critical for identifying a server, and `args` is array-shaped with no restore machinery — so they want their own decision.

## Overlap with #2133

None. #2133 touches `register-services.ts`, `register-routes.ts`, `register-hooks.mcp-headers-redaction.test.ts`, and adds `executor/sdk-handlers/base/mcp-scoping.ts`. It does not touch `env`, `redactMCPServerSecrets`, `http-headers.ts`, `auth-secrets.ts`, `register-hooks.ts`, or the drizzle adapter. The one shared file is `register-hooks.mcp-headers-redaction.test.ts`, where I appended a single case rather than reworking existing ones, so the merge should be additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
