### PR TITLE
fix(ui): keep error messages until dismissed

### DIFF
--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.message.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.message.test.tsx
@@ -1,0 +1,82 @@
+import type { AgorClient, Board, Branch } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { makeTeammateBranch } from '../BranchModal/testUtils';
+
+const messageApi = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock('../../utils/message', () => ({
+  useThemedMessage: () => messageApi,
+}));
+
+import { BoardTeammatePanel } from './BoardTeammatePanel';
+
+const board = {
+  board_id: 'board-1' as Board['board_id'],
+  name: 'Board',
+  slug: 'board',
+  created_at: '2026-08-14T00:00:00.000Z',
+  last_updated: '2026-08-14T00:00:00.000Z',
+  created_by: 'user-1',
+  url: '',
+  archived: false,
+} satisfies Board;
+const teammate: Branch = makeTeammateBranch(
+  {
+    branch_id: 'teammate-1' as Branch['branch_id'],
+    board_id: board.board_id,
+    name: 'helper',
+  },
+  { displayName: 'Helper' }
+);
+
+describe('BoardTeammatePanel messages', () => {
+  beforeEach(() => {
+    messageApi.showSuccess.mockReset();
+    messageApi.showError.mockReset();
+    agorStore.setState({
+      ...EMPTY_MAPS,
+      branchById: new Map([[teammate.branch_id, teammate]]),
+    });
+  });
+
+  it('routes teammate assignment failures through the centralized message wrapper', async () => {
+    const setPrimaryTeammate = vi.fn().mockRejectedValue(new Error('assignment refused'));
+    const client = {
+      service: (path: string) => {
+        if (path === 'boards') return { setPrimaryTeammate };
+        return {};
+      },
+    } as unknown as AgorClient;
+
+    render(
+      <AntApp>
+        <BoardTeammatePanel
+          board={board}
+          activeTab="teammate"
+          onTabChange={vi.fn()}
+          primaryTeammateInaccessible={false}
+          onSessionClick={vi.fn()}
+          client={client}
+        />
+      </AntApp>
+    );
+
+    const assign = screen.getByRole('button', { name: 'Assign' });
+    await waitFor(() => expect(assign).toBeEnabled());
+    fireEvent.click(assign);
+
+    await waitFor(() =>
+      expect(messageApi.showError).toHaveBeenCalledWith(
+        'Failed to assign teammate: assignment refused'
+      )
+    );
+    expect(messageApi.showSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -11,7 +11,6 @@ import { getTeammateConfig, isTeammate } from '@agor-live/client';
 import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
 import {
   Alert,
-  App as AntApp,
   Badge,
   Button,
   Empty,
@@ -35,6 +34,7 @@ import {
   selectUserById,
 } from '../../store/selectors';
 import { mapToArray } from '../../utils/mapHelpers';
+import { useThemedMessage } from '../../utils/message';
 import { BranchSessionSections } from '../BranchCard';
 import { BranchHeaderPill } from '../BranchHeaderPill';
 import { BoardBranchList, BoardSessionList } from '../BranchListDrawer';
@@ -139,7 +139,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
   client,
 }) => {
   const { token } = theme.useToken();
-  const { message } = AntApp.useApp();
+  const { showError, showSuccess } = useThemedMessage();
   // Subscribe to entity maps by slice from the store: each selector only wakes
   // this panel when its own slice changes.
   const sessionsByBranch = useAgorStore(selectSessionsByBranch);
@@ -334,9 +334,9 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
         boardId: board.board_id,
         branchId: selectedTeammateId,
       });
-      message.success('Teammate assigned');
+      showSuccess('Teammate assigned');
     } catch (error) {
-      message.error(
+      showError(
         `Failed to assign teammate: ${error instanceof Error ? error.message : String(error)}`
       );
     } finally {

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
@@ -1,0 +1,89 @@
+import type { AgorClient, Branch } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeBranch } from '../testUtils';
+
+const messageApi = vi.hoisted(() => ({
+  showLoading: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock('../../../utils/message', () => ({
+  useThemedMessage: () => messageApi,
+}));
+
+vi.mock('../../FileCollection/FileCollection', () => ({
+  FileCollection: ({ onDownload }: { onDownload: (file: unknown) => Promise<void> }) => (
+    <button
+      type="button"
+      onClick={() => onDownload({ path: 'archive.bin', size: 7, isText: false })}
+    >
+      Download fixture
+    </button>
+  ),
+}));
+
+vi.mock('../../CodePreviewModal/CodePreviewModal', () => ({ CodePreviewModal: () => null }));
+vi.mock('../../MarkdownModal/MarkdownModal', () => ({ MarkdownModal: () => null }));
+
+import { FilesTab } from './FilesTab';
+
+describe('FilesTab download messages', () => {
+  const get = vi.fn();
+  const findAll = vi.fn().mockResolvedValue([]);
+  const client = {
+    service: () => ({ get, findAll }),
+  } as unknown as AgorClient;
+  const branch: Branch = makeBranch();
+  let anchorClick: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    Object.values(messageApi).forEach((fn) => {
+      fn.mockReset();
+    });
+    get.mockReset();
+    findAll.mockClear();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:test'),
+      configurable: true,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      configurable: true,
+    });
+    anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    anchorClick.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('uses one key for loading, failure, and retry success replacements', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    get
+      .mockRejectedValueOnce(new Error('download failed'))
+      .mockResolvedValueOnce({ path: 'archive.bin', encoding: 'utf8', content: 'safe file' });
+
+    render(<FilesTab branch={branch} client={client} />);
+    const download = screen.getByRole('button', { name: 'Download fixture' });
+
+    fireEvent.click(download);
+    await waitFor(() => expect(messageApi.showError).toHaveBeenCalledTimes(1));
+    expect(messageApi.showLoading).toHaveBeenNthCalledWith(1, 'Downloading file...', {
+      key: 'download',
+    });
+    expect(messageApi.showError).toHaveBeenCalledWith('Failed to download file', {
+      key: 'download',
+    });
+
+    fireEvent.click(download);
+    await waitFor(() => expect(messageApi.showSuccess).toHaveBeenCalledTimes(1));
+    expect(messageApi.showLoading).toHaveBeenNthCalledWith(2, 'Downloading file...', {
+      key: 'download',
+    });
+    expect(messageApi.showSuccess).toHaveBeenCalledWith('Downloaded!', { key: 'download' });
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/StreamdownPortalApp.tsx
+++ b/apps/agor-ui/src/components/StreamdownPortalApp.tsx
@@ -9,6 +9,20 @@ interface StreamdownPortalStyle extends React.CSSProperties {
   '--streamdown-fullscreen-z-index': number;
 }
 
+// Keep every undismissed message independently reachable without AntD's
+// mouse-hover-only collapsed stack or maxCount eviction. The semantic list
+// style gives large error sets a bounded, keyboard-scrollable viewport.
+const MESSAGE_CONFIG = {
+  stack: false,
+  styles: {
+    list: {
+      maxHeight: 'calc(100vh - 16px)',
+      overflowY: 'auto',
+      scrollbarWidth: 'thin',
+    },
+  },
+} as const;
+
 /**
  * Keeps Streamdown portals aligned with Ant Design's theme.
  *
@@ -68,7 +82,7 @@ export const StreamdownPortalApp: React.FC<React.PropsWithChildren> = ({ childre
   }, [bodyPortalTokens]);
 
   return (
-    <AntApp className={STREAMDOWN_PORTAL_ROOT_CLASS_NAME} style={style}>
+    <AntApp className={STREAMDOWN_PORTAL_ROOT_CLASS_NAME} style={style} message={MESSAGE_CONFIG}>
       {children}
     </AntApp>
   );

--- a/apps/agor-ui/src/utils/message.test.tsx
+++ b/apps/agor-ui/src/utils/message.test.tsx
@@ -1,0 +1,171 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamdownPortalApp } from '../components/StreamdownPortalApp';
+
+const { copyToClipboard } = vi.hoisted(() => ({
+  copyToClipboard: vi.fn<(text: string) => Promise<boolean>>(),
+}));
+vi.mock('./clipboard', () => ({
+  copyToClipboard: (text: string) => copyToClipboard(text),
+}));
+
+import { useThemedMessage } from './message';
+
+const sleep = (duration: number) => new Promise((resolve) => setTimeout(resolve, duration));
+
+function MessageHarness({ onClose = () => {} }: { onClose?: () => void }) {
+  const { showError, showLoading, showSuccess } = useThemedMessage();
+
+  return (
+    <>
+      <button type="button" onClick={() => showError('Persistent failure', { onClose })}>
+        Show persistent error
+      </button>
+      <button type="button" onClick={() => showError('Transient failure', { duration: 0.05 })}>
+        Show transient error
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          showError(
+            <>
+              Public message <strong>safe detail</strong>
+            </>
+          )
+        }
+      >
+        Show copyable error
+      </button>
+      <button type="button" onClick={() => showError('First failure')}>
+        Show first error
+      </button>
+      <button type="button" onClick={() => showError('Second failure')}>
+        Show second error
+      </button>
+      <button type="button" onClick={() => showLoading('Working', { key: 'operation' })}>
+        Show keyed loading
+      </button>
+      <button type="button" onClick={() => showError('Operation failed', { key: 'operation' })}>
+        Show keyed error
+      </button>
+      <button type="button" onClick={() => showSuccess('Operation complete', { key: 'operation' })}>
+        Show keyed success
+      </button>
+    </>
+  );
+}
+
+function renderHarness(onClose?: () => void) {
+  return render(
+    <StreamdownPortalApp>
+      <MessageHarness onClose={onClose} />
+    </StreamdownPortalApp>
+  );
+}
+
+describe('useThemedMessage', () => {
+  beforeEach(() => {
+    copyToClipboard.mockReset();
+    copyToClipboard.mockResolvedValue(true);
+  });
+
+  it('keeps errors past the former timeout and preserves an explicit duration escape hatch', async () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show persistent error' }));
+    expect(await screen.findByText('Persistent failure')).toBeInTheDocument();
+
+    await act(() => sleep(6_100));
+    expect(screen.getByText('Persistent failure')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss error message' }));
+    await waitFor(() => expect(screen.queryByText('Persistent failure')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show transient error' }));
+    expect(await screen.findByText('Transient failure')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('Transient failure')).not.toBeInTheDocument());
+  });
+
+  it('copies only normalized visible text and exposes announced feedback without moving focus', async () => {
+    renderHarness();
+    const trigger = screen.getByRole('button', { name: 'Show copyable error' });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(await screen.findByText('Public message')).toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+
+    const copyButton = screen.getByRole('button', { name: 'Copy error message' });
+    copyButton.focus();
+    fireEvent.click(copyButton);
+
+    await waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith('Public message safe detail'));
+    expect(copyButton).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('Error message copied to clipboard.');
+    expect(copyButton).toHaveAccessibleName('Copied error message');
+  });
+
+  it('announces clipboard failures while keeping the copy control available', async () => {
+    copyToClipboard.mockResolvedValueOnce(false);
+    renderHarness();
+    fireEvent.click(screen.getByRole('button', { name: 'Show copyable error' }));
+
+    const copyButton = await screen.findByRole('button', { name: 'Copy error message' });
+    copyButton.focus();
+    fireEvent.click(copyButton);
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Could not copy error message.')
+    );
+    expect(copyButton).toHaveAccessibleName('Copy failed for error message');
+    expect(copyButton).toHaveFocus();
+  });
+
+  it('keeps multiple errors independently reviewable and moves focus to the next error on dismiss', async () => {
+    const onClose = vi.fn();
+    renderHarness(onClose);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show persistent error' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show second error' }));
+
+    expect(await screen.findByText('Persistent failure')).toBeInTheDocument();
+    expect(screen.getByText('Second failure')).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+
+    const dismissButtons = screen.getAllByRole('button', { name: 'Dismiss error message' });
+    dismissButtons[0].focus();
+    fireEvent.click(dismissButtons[0]);
+
+    await waitFor(() => expect(screen.queryByText('Persistent failure')).not.toBeInTheDocument());
+    expect(screen.getByText('Second failure')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss error message' })).toHaveFocus();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const list = document.querySelector<HTMLElement>('.ant-message-list');
+    expect(list).toHaveStyle({
+      maxHeight: 'calc(100vh - 16px)',
+      overflowY: 'auto',
+      scrollbarWidth: 'thin',
+    });
+  });
+
+  it('replaces keyed loading and errors in place, then resolves them with success', async () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show keyed loading' }));
+    expect(await screen.findByText('Working')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy message' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show keyed error' }));
+    await waitFor(() => expect(screen.queryByText('Working')).not.toBeInTheDocument());
+    expect(screen.getByText('Operation failed')).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Dismiss error message' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show keyed success' }));
+    await waitFor(() => expect(screen.queryByText('Operation failed')).not.toBeInTheDocument());
+    expect(screen.getByText('Operation complete')).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Dismiss error message' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/utils/message.tsx
+++ b/apps/agor-ui/src/utils/message.tsx
@@ -21,11 +21,30 @@
  * ```
  */
 
-import { CheckOutlined, CloseCircleOutlined, CopyOutlined } from '@ant-design/icons';
-import { App, Space, theme } from 'antd';
+import { CheckOutlined, CloseCircleOutlined, CloseOutlined, CopyOutlined } from '@ant-design/icons';
+import { App, Button, Space } from 'antd';
 import type { ArgsProps, ConfigOptions, MessageInstance } from 'antd/es/message/interface';
 import React, { useCallback, useMemo } from 'react';
 import { copyToClipboard } from './clipboard';
+
+const VISUALLY_HIDDEN_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+let nextErrorMessageKey = 0;
+
+function createErrorMessageKey(): string {
+  nextErrorMessageKey += 1;
+  return `agor-error-message-${nextErrorMessageKey}`;
+}
 
 /**
  * Message content wrapper with copy-to-clipboard functionality.
@@ -37,10 +56,18 @@ import { copyToClipboard } from './clipboard';
 interface MessageContentProps {
   children: React.ReactNode;
   textContent: string;
+  kind?: 'error' | 'message';
+  onDismiss?: () => void;
+  returnFocusTo?: HTMLElement | null;
 }
 
-const MessageContent: React.FC<MessageContentProps> = ({ children, textContent }) => {
-  const { token } = theme.useToken();
+const MessageContent: React.FC<MessageContentProps> = ({
+  children,
+  textContent,
+  kind = 'message',
+  onDismiss,
+  returnFocusTo,
+}) => {
   const [copyState, setCopyState] = React.useState<'idle' | 'copied' | 'failed'>('idle');
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -50,7 +77,7 @@ const MessageContent: React.FC<MessageContentProps> = ({ children, textContent }
     };
   }, []);
 
-  const handleCopy = async (e: React.MouseEvent) => {
+  const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     const ok = await copyToClipboard(textContent);
     setCopyState(ok ? 'copied' : 'failed');
@@ -58,42 +85,48 @@ const MessageContent: React.FC<MessageContentProps> = ({ children, textContent }
     timeoutRef.current = setTimeout(() => setCopyState('idle'), 1500);
   };
 
-  const iconStyle: React.CSSProperties = {
-    cursor: 'pointer',
-    marginLeft: token.marginSM,
-    transition: 'opacity 0.2s',
-    fontSize: token.fontSizeSM,
+  const handleDismiss = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    // Dismissing a focused alert should not strand focus on document.body.
+    // Prefer an adjacent persistent error, then return to the control that was
+    // focused when this error appeared. Errors resolved by a keyed update do
+    // not move focus.
+    const dismissButtons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[data-agor-error-dismiss]')
+    );
+    const currentIndex = dismissButtons.indexOf(e.currentTarget);
+    const nextFocusTarget =
+      dismissButtons[currentIndex + 1] ?? dismissButtons[currentIndex - 1] ?? returnFocusTo;
+
+    onDismiss?.();
+    queueMicrotask(() => {
+      if (nextFocusTarget?.isConnected) {
+        nextFocusTarget.focus({ preventScroll: true });
+      }
+    });
   };
 
-  let icon: React.ReactNode;
+  let copyIcon: React.ReactNode;
+  let copyLabel: string;
+  let copyAccessibleLabel: string;
+  let statusText = '';
   if (copyState === 'copied') {
-    icon = (
-      <CheckOutlined
-        style={{ ...iconStyle, color: token.colorSuccess, opacity: 1 }}
-        title="Copied!"
-      />
-    );
+    copyIcon = <CheckOutlined />;
+    copyLabel = 'Copied';
+    copyAccessibleLabel = kind === 'error' ? 'Copied error message' : 'Copied message';
+    statusText =
+      kind === 'error' ? 'Error message copied to clipboard.' : 'Message copied to clipboard.';
   } else if (copyState === 'failed') {
-    icon = (
-      <CloseCircleOutlined
-        style={{ ...iconStyle, color: token.colorError, opacity: 1 }}
-        title="Copy failed"
-      />
-    );
+    copyIcon = <CloseCircleOutlined />;
+    copyLabel = 'Copy failed';
+    copyAccessibleLabel =
+      kind === 'error' ? 'Copy failed for error message' : 'Copy failed for message';
+    statusText = `Could not copy ${kind} message.`;
   } else {
-    icon = (
-      <CopyOutlined
-        onClick={handleCopy}
-        style={{ ...iconStyle, opacity: 0.65 }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.opacity = '1';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.opacity = '0.65';
-        }}
-        title="Copy to clipboard"
-      />
-    );
+    copyIcon = <CopyOutlined />;
+    copyLabel = 'Copy';
+    copyAccessibleLabel = kind === 'error' ? 'Copy error message' : 'Copy message';
   }
 
   return (
@@ -105,8 +138,33 @@ const MessageContent: React.FC<MessageContentProps> = ({ children, textContent }
         width: '100%',
       }}
     >
-      <span style={{ flex: 1 }}>{children}</span>
-      {icon}
+      <span style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere' }}>{children}</span>
+      <Space size="small">
+        <Button
+          type="text"
+          size="small"
+          icon={copyIcon}
+          aria-label={copyAccessibleLabel}
+          onClick={handleCopy}
+        >
+          {copyLabel}
+        </Button>
+        {onDismiss && (
+          <Button
+            type="text"
+            size="small"
+            icon={<CloseOutlined />}
+            aria-label="Dismiss error message"
+            data-agor-error-dismiss
+            onClick={handleDismiss}
+          >
+            Dismiss
+          </Button>
+        )}
+      </Space>
+      <output aria-live="polite" aria-atomic="true" style={VISUALLY_HIDDEN_STYLE}>
+        {statusText}
+      </output>
     </Space>
   );
 };
@@ -121,16 +179,23 @@ function extractTextContent(content: React.ReactNode): string {
   if (typeof content === 'number') {
     return String(content);
   }
+  if (typeof content === 'bigint') {
+    return String(content);
+  }
   if (React.isValidElement<{ children?: React.ReactNode }>(content)) {
     // Try to extract text from React elements
-    if (content.props.children) {
+    if (content.props.children !== undefined && content.props.children !== null) {
       return extractTextContent(content.props.children);
     }
   }
   if (Array.isArray(content)) {
     return content.map(extractTextContent).join(' ');
   }
-  return String(content);
+  return '';
+}
+
+function extractVisibleTextContent(content: React.ReactNode): string {
+  return extractTextContent(content).replace(/\s+/g, ' ').trim();
 }
 
 /**
@@ -156,7 +221,9 @@ export function useThemedMessage() {
     (content: React.ReactNode, options?: ThemedMessageOptions) =>
       message.success({
         content: (
-          <MessageContent textContent={extractTextContent(content)}>{content}</MessageContent>
+          <MessageContent textContent={extractVisibleTextContent(content)}>
+            {content}
+          </MessageContent>
         ),
         duration: options?.duration ?? 3,
         key: options?.key,
@@ -165,17 +232,42 @@ export function useThemedMessage() {
     [message]
   );
 
-  // Errors get a longer default duration so users have time to read + copy.
+  // Errors persist until the user dismisses them or a keyed update replaces
+  // them. Callers can still opt into a finite duration explicitly.
   const showError = useCallback(
-    (content: React.ReactNode, options?: ThemedMessageOptions) =>
-      message.error({
+    (content: React.ReactNode, options?: ThemedMessageOptions) => {
+      const key = options?.key ?? createErrorMessageKey();
+      const returnFocusTo =
+        typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      let closed = false;
+      const handleClose = () => {
+        if (closed) return;
+        closed = true;
+        options?.onClose?.();
+      };
+      const handleDismiss = () => {
+        handleClose();
+        message.destroy(key);
+      };
+
+      return message.error({
         content: (
-          <MessageContent textContent={extractTextContent(content)}>{content}</MessageContent>
+          <MessageContent
+            textContent={extractVisibleTextContent(content)}
+            kind="error"
+            onDismiss={handleDismiss}
+            returnFocusTo={returnFocusTo}
+          >
+            {content}
+          </MessageContent>
         ),
-        duration: options?.duration ?? 6,
-        key: options?.key,
-        onClose: options?.onClose,
-      }),
+        duration: options?.duration ?? 0,
+        key,
+        onClose: handleClose,
+      });
+    },
     [message]
   );
 
@@ -183,7 +275,9 @@ export function useThemedMessage() {
     (content: React.ReactNode, options?: ThemedMessageOptions) =>
       message.warning({
         content: (
-          <MessageContent textContent={extractTextContent(content)}>{content}</MessageContent>
+          <MessageContent textContent={extractVisibleTextContent(content)}>
+            {content}
+          </MessageContent>
         ),
         duration: options?.duration ?? 4,
         key: options?.key,
@@ -196,7 +290,9 @@ export function useThemedMessage() {
     (content: React.ReactNode, options?: ThemedMessageOptions) =>
       message.info({
         content: (
-          <MessageContent textContent={extractTextContent(content)}>{content}</MessageContent>
+          <MessageContent textContent={extractVisibleTextContent(content)}>
+            {content}
+          </MessageContent>
         ),
         duration: options?.duration ?? 3,
         key: options?.key,
@@ -211,7 +307,9 @@ export function useThemedMessage() {
     (content: React.ReactNode, options?: ThemedMessageOptions) =>
       message.loading({
         content: (
-          <MessageContent textContent={extractTextContent(content)}>{content}</MessageContent>
+          <MessageContent textContent={extractVisibleTextContent(content)}>
+            {content}
+          </MessageContent>
         ),
         duration: options?.duration ?? 0,
         key: options?.key,

--- a/context/guidelines/toasts.md
+++ b/context/guidelines/toasts.md
@@ -26,8 +26,10 @@ It's the **static** message API. It mounts outside the React tree, so it does **
 ## What the wrapper gives you for free
 
 - **Theme integration.** Themed via `App.useApp()` under the hood.
-- **Copy-to-clipboard on every toast.** A subtle copy icon appears at the right of the message. Clicking it copies the rendered text — handy for IDs, error traces, and anything else worth pasting into a bug report. No need to reach for a separate `<CopyButton>` inside the toast.
-- **Standardized durations.** Success/info: 3s. Warning: 4s. Error: 6s (longer so users can read and copy). Override per-call with `{ duration }` if you have a reason.
+- **Copy-to-clipboard on every toast.** A semantic **Copy** button copies only the rendered, user-visible text. It does not add stacks, headers, response bodies, secrets, environment values, or other hidden diagnostics. Copy success or failure is shown visually and announced to assistive technology. No need to add a separate `<CopyButton>` inside the toast.
+- **Persistent, dismissible errors.** Errors remain until the user chooses **Dismiss** or a keyed loading/error/success update replaces them. Copy and Dismiss are keyboard-focusable buttons; dismissing a focused error moves focus to an adjacent error when available, then back to the control that preceded the error. Use `{ duration }` only when a genuinely transient error should expire.
+- **Bounded, non-evicting error review.** AntD's message list scrolls within the viewport. Do not add `maxCount`: it discards undismissed errors. Do not enable the collapsed message stack unless it gains a keyboard-operable expansion path.
+- **Standardized timing.** Success/info: 3s. Warning: 4s. Loading and errors: indefinite. Override per-call with `{ duration }` if you have a reason.
 - **Keyed loading→success/error.** Pass `{ key: 'download' }` to both `showLoading(...)` and the follow-up `showSuccess(...)` / `showError(...)`; antd replaces the toast in place instead of stacking. See `apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx`.
 - **Stable references.** The returned helpers (`showSuccess`, `showError`, etc.) are memoized over antd's stable `message` instance, so they're safe to put in `useCallback`/`useEffect` dep arrays without causing churn.
 
@@ -56,7 +58,7 @@ Until the notification system lands, **toast is the only option**, but flag dura
 ## Severity quick rules
 
 - **Success** — confirms a user-initiated action that completed.
-- **Error** — a failure tied to the user's current request. Default 6s so they can read + copy.
+- **Error** — a failure tied to the user's current request. Persistent by default so the user can read, copy, dismiss, or resolve it.
 - **Warning** — a precondition wasn't met or a soft-failure path triggered ("Refresh token no longer valid — sign in again").
 - **Info** — neutral status the user should see but not act on ("Retrying stop request…", "Complete sign-in in the new tab").
 - **Loading** — pending state. Always pair with a `key` and a follow-up success/error using the same key.


### PR DESCRIPTION
## Linked issue

Closes #2350

## Summary

- Keep actionable error messages visible until the user dismisses them or a keyed update resolves them; callers can still request a finite duration.
- Add labeled, keyboard-accessible **Copy** and **Dismiss** controls, polite copy feedback, predictable focus recovery, and a bounded scrolling list that does not evict undismissed errors.
- Preserve keyed replacement (`loading → error → success`) and existing success, information, warning, and loading durations.
- Route teammate-assignment failures through the centralized message wrapper and document the toast guidance.

## Why / context

Error messages could disappear before users had time to read or copy the actionable detail. This change keeps that feedback available in the current UI session without turning it into durable notification or inbox state.

## Implementation notes

- Unkeyed errors receive unique local keys so each error remains independently reviewable. Caller-supplied keys retain Ant Design replacement semantics.
- Copy extracts and normalizes only rendered message text. It does not add stacks, headers, response bodies, configuration, or other hidden diagnostics.
- Dismissing a focused error moves focus to the next or previous error when available, otherwise back to the control that opened it. Showing an error does not steal focus.
- The message list uses a viewport-bounded scroll container with stacking disabled; it does not use `maxCount`.
- Frontend-only: no database, API, socket, or durable-notification changes.

## Validation / test plan

- [x] Focused regressions: 3 files, 7 tests passed.
- [x] Full required test gate: 11/11 tasks passed, including UI (213 files, 1,485 tests), executor (65 files, 673 tests), daemon (230 passed/9 skipped files; 2,839 passed/73 skipped tests), core (152 passed/15 skipped files; 3,774 passed/88 skipped tests), and live client (4/4 tests).
- [x] Build and typecheck gate: 30/30 tasks passed.
- [x] Repository lint: 2,323 files checked; 330 frontend design-system fixture cases passed.
- [x] Changed-file hooks: Biome passed for 6 TypeScript/TSX files; Prettier passed for 1 Markdown file.
- [x] CLI regression suite: 13 files, 92 tests passed.
- [x] Browser/keyboard QA on the branch runtime:
  - Error remained visible after 6.5 seconds.
  - Keyboard activation preserved trigger focus; Tab reached Copy then Dismiss.
  - Copy placed exactly `Public QA error safe detail` on the clipboard and exposed `Error message copied to clipboard.` through a polite status region.
  - Dismiss removed the error and returned focus to its trigger; in a multi-error list, focus moved to the adjacent Dismiss control.
  - 20 errors remained present at once; the list measured 818 px high with 1,192 px scroll content and `overflow-y: auto`. Dismissing one left 19.
  - A single keyed alert changed from loading to error to success, then the unchanged success duration removed it.
- [x] Accessibility tree inspection confirmed alert/status roles and distinct Copy/Dismiss accessible names. A manual screen-reader session was not run.

## Screenshots / demos

Not included; this is transient overlay behavior, covered by the interaction evidence above.

## Risks / rollout / rollback

- Persistent errors can accumulate during repeated failures; bounded scrolling keeps every undismissed error reachable without growing beyond the viewport or silently discarding older errors.
- Explicit finite durations remain available for callers that need transient errors.
- Rollback is limited to the centralized UI message wrapper, message-list configuration, and the teammate-panel call-site migration.
- Active PRs #1135, #2000, and #2107 touch one of the same UI files and may require conflict resolution; this change does not adopt their broader behavior.

## Out of scope / follow-ups

- Durable notifications, inbox/history, persistence across reloads, and backend delivery are intentionally out of scope.
