### PR TITLE
test: restore main CI after validator changes

### DIFF
--- a/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
+++ b/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
@@ -15,13 +15,18 @@
  * the validator, it was in whether the validator was reached.
  */
 
-import type { HookContext } from '@agor/core/types';
+import {
+  type HookContext,
+  type MessageCreate,
+  MessageRole,
+  type SessionID,
+} from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import { type RegisterHooksContext, registerHooks } from './register-hooks';
 
 type RegisteredHook = (context: HookContext) => unknown;
 
-const SESSION_ID = '00000000-0000-7000-8000-000000000001';
+const SESSION_ID = '00000000-0000-7000-8000-000000000001' as SessionID;
 const BRANCH_ID = '00000000-0000-7000-8000-000000000002';
 const CREATOR_ID = '00000000-0000-7000-8000-000000000003';
 
@@ -119,21 +124,32 @@ const executorAuthentication = (sessionId: string) => ({
 });
 
 /** An external prompt write, as the REST/socket transports deliver it. */
-const makeContext = (path: 'messages' | 'tasks', asExecutor: false | string = false): HookContext =>
-  ({
+const makeContext = (
+  path: 'messages' | 'tasks',
+  asExecutor: false | string = false
+): HookContext => {
+  const message = {
+    session_id: SESSION_ID,
+    type: 'user',
+    role: MessageRole.USER,
+    index: 0,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    content_preview: 'ship it',
+    content: 'ship it',
+  } satisfies MessageCreate;
+
+  return {
     path,
     method: 'create',
-    data:
-      path === 'messages'
-        ? { session_id: SESSION_ID, role: 'user', content: 'ship it' }
-        : { session_id: SESSION_ID, full_prompt: 'ship it' },
+    data: path === 'messages' ? message : { session_id: SESSION_ID, full_prompt: 'ship it' },
     params: {
       provider: 'rest',
       user: { user_id: CREATOR_ID, role: 'member' },
       query: {},
       ...(asExecutor ? { authentication: executorAuthentication(asExecutor) } : {}),
     },
-  }) as unknown as HookContext;
+  } as unknown as HookContext;
+};
 
 const runCreateChain = async (
   harness: Harness,

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -130,7 +130,6 @@ const policyRadio = (name: RegExp) => screen.getByRole('radio', { name });
  * not yet mounted, rather than torn down on the way out.
  */
 const openPolicyPane = () => fireEvent.click(screen.getByRole('tab', { name: 'Member policy' }));
-const openServersPane = () => fireEvent.click(screen.getByRole('tab', { name: 'Servers' }));
 
 describe('MCPServersTable member policy', () => {
   it('opens on the servers, with the policy a pane away', async () => {
@@ -367,24 +366,6 @@ describe('MCPServersTable member policy', () => {
     await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
 
     expect(screen.getByRole('button', { name: /New MCP Server/i })).toBeDisabled();
-  });
-
-  it('leaves an admin working after a save whose answer carries no capability', async () => {
-    // A save answers with the same shape a read does, and the admin who just
-    // changed the policy must not lose the control they changed it with.
-    const { find, patch } = renderTable({
-      policy: 'use_existing_only',
-      currentUser: ADMIN,
-      omitCanConfigure: true,
-    });
-    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
-
-    openPolicyPane();
-    fireEvent.click(policyRadio(/Members can add shared servers/));
-    await waitFor(() => expect(patch).toHaveBeenCalled());
-
-    openServersPane();
-    expect(screen.getByRole('button', { name: /New MCP Server/i })).toBeEnabled();
   });
 
   it('withholds every action from a read-only account, whatever the policy allows', async () => {

--- a/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
+++ b/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
@@ -1,0 +1,30 @@
+import type { AgorClient } from '@agor-live/client';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useMcpMemberPolicy } from './useMcpMemberPolicy';
+
+describe('useMcpMemberPolicy', () => {
+  it('treats a save response without a capability as withheld', async () => {
+    const find = vi.fn().mockResolvedValue({
+      policy: 'use_existing_only',
+      can_configure: true,
+    });
+    const patch = vi.fn().mockResolvedValue({ policy: 'allow_crud' });
+    const client = {
+      service: () => ({ find, patch }),
+    } as unknown as AgorClient;
+
+    const { result } = renderHook(() => useMcpMemberPolicy(client));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(() => result.current.save('allow_crud'));
+
+    expect(patch).toHaveBeenCalledWith(null, { policy: 'allow_crud' });
+    expect(result.current).toMatchObject({
+      policy: 'allow_crud',
+      canConfigure: false,
+      saving: false,
+      error: null,
+    });
+  });
+});


### PR DESCRIPTION
## Linked issue

Related: #2286
Related: #2330

## Summary

- Make the Unix identity-drift harness send a complete, typed message-create payload.
- Keep the identity guard as the behavior under test instead of failing earlier in payload validation.
- Replace a slow duplicate settings-component scenario with focused hook coverage while retaining the existing admin UI coverage.

## Why / context

Two independently green changes combined badly on `main`: #2330 made message-create validation strict, while #2286's new harness still sent the older partial fixture. All 10 message-path identity-drift cases therefore failed before reaching the guard they were meant to exercise.

A separate settings test also exceeded the 15-second test limit. Its UI assertion already exists for the read path, so this keeps that component coverage and tests the save-response state transition at the hook boundary.

## Implementation notes

- The fixture now `satisfies MessageCreate`, so future schema drift fails at typecheck time.
- This is test-only: runtime behavior, RBAC, tenant isolation, and message validation are unchanged.

## Validation / test plan

- [x] Daemon identity-drift test: 20 passed
- [x] Focused UI tests: 23 passed
- [x] Daemon and UI typechecks passed with their dependency builds
- [x] Formatting and staged-file checks passed

## Risks / rollout / rollback

Low risk because only test code changes. Revert this commit to restore the previous fixtures and test shape.

## Out of scope / follow-ups

Repository ruleset changes to require current, passing CI before merge are intentionally separate from this code fix.
