### PR TITLE
ci: gate main image tags on successful checks

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,8 +7,9 @@
 # packages/agor-live/build.sh), so the image is pinned to the built commit
 # rather than `agor-live@latest` on npm.
 #
-# Publish model: a successful CI run for a main push publishes :<full-sha>,
-# :main, and :latest. v* tags and every in-repository PR commit publish
+# Publish model: a successful CI run for a main push first publishes
+# :<full-sha>, then a serialized promotion moves :main and :latest if that SHA
+# is still the main head. v* tags and every in-repository PR commit publish
 # directly (PRs use the PR *head* SHA and re-point :pr-<n> on each update), so
 # trusted commits remain deployable by their own SHA. Fork and Dependabot PRs
 # still build and run the boot smoke test, but cannot publish because GitHub
@@ -34,10 +35,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: build-image-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.ref }}
-  cancel-in-progress: true
-
 # docker.io is docker/login-action's default registry, so no `registry:` needed.
 env:
   IMAGE: preset/agor
@@ -60,6 +57,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: build-image-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -126,35 +126,18 @@ jobs:
           docker logs agor-smoke
           exit 1
 
-      # CI runs for consecutive main commits can finish out of order. Publish
-      # every successful commit by SHA, but only let the current main head move
-      # the mutable :main and :latest tags.
-      - name: Check current main head
-        if: github.event_name == 'workflow_run'
-        id: main
-        run: |
-          current_sha="$(git ls-remote origin refs/heads/main | cut -f1)"
-          if [[ "$current_sha" == "$IMAGE_REVISION" ]]; then
-            echo "current=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "current=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping mutable tags because main is now $current_sha"
-          fi
-
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
           # Full commit SHA on every build; PR ref and semver tags where
-          # applicable; main/latest only after CI passed for the current head.
+          # applicable. Mutable main tags are promoted in the serialized job.
           flavor: latest=false
           tags: |
             type=raw,value=${{ env.IMAGE_REVISION }}
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=raw,value=main,enable=${{ github.event_name == 'workflow_run' && steps.main.outputs.current == 'true' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' && steps.main.outputs.current == 'true' }}
           labels: |
             org.opencontainers.image.title=agor
             org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
@@ -181,3 +164,42 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=agor-image
+
+  # Mutable tags are a separate, serialized promotion. Immutable SHA builds
+  # can proceed independently, while main/latest can never be pushed by two
+  # workflow_run jobs at once. Do not cancel an in-flight promotion: the next
+  # queued current-head run will move the tags forward afterward.
+  promote-main:
+    name: Promote main image
+    needs: build
+    if: github.event_name == 'workflow_run' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: build-image-main-promotion
+      cancel-in-progress: false
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Keep the head check and registry mutation in one serialized step. If a
+      # newer main commit lands after the check, its own CI-gated promotion is
+      # queued behind this one and will be the final writer.
+      - name: Promote tested main image
+        run: |
+          current_sha="$(git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/main | cut -f1)"
+          if [[ "$current_sha" != "$IMAGE_REVISION" ]]; then
+            echo "::notice::Skipping mutable tags because main is now $current_sha"
+            exit 0
+          fi
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:main" \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${IMAGE_REVISION}"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,12 +8,14 @@
 # rather than `agor-live@latest` on npm.
 #
 # Publish model: a successful CI run for a main push first publishes
-# :<full-sha>, then a serialized promotion moves :main and :latest if that SHA
-# is still the main head. v* tags and every in-repository PR commit publish
-# directly (PRs use the PR *head* SHA and re-point :pr-<n> on each update), so
-# trusted commits remain deployable by their own SHA. Fork and Dependabot PRs
-# still build and run the boot smoke test, but cannot publish because GitHub
-# intentionally withholds repository secrets from them.
+# :<full-sha>, then a serialized promotion may move :main and :latest. Those
+# mutable tags always identify a successfully tested main image; when a newer
+# main commit is red, they remain on the last successful promotion. v* tags
+# and every in-repository PR commit publish directly (PRs use the PR *head* SHA
+# and re-point :pr-<n> on each update), so trusted commits remain deployable by
+# their own SHA. Fork and Dependabot PRs still build and run the boot smoke
+# test, but cannot publish because GitHub intentionally withholds repository
+# secrets from them.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -167,8 +169,8 @@ jobs:
 
   # Mutable tags are a separate, serialized promotion. Immutable SHA builds
   # can proceed independently, while main/latest can never be pushed by two
-  # workflow_run jobs at once. Do not cancel an in-flight promotion: the next
-  # queued current-head run will move the tags forward afterward.
+  # workflow_run jobs at once. Keep the full queue: builds may finish out of
+  # order, and dropping the one current-head promotion could strand the tags.
   promote-main:
     name: Promote main image
     needs: build
@@ -177,7 +179,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: build-image-main-promotion
-      cancel-in-progress: false
+      queue: max
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -188,9 +190,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Keep the head check and registry mutation in one serialized step. If a
-      # newer main commit lands after the check, its own CI-gated promotion is
-      # queued behind this one and will be the final writer.
+      # Keep the head check and registry mutation in one serialized step. A
+      # stale queued run skips; if main advances after this check, the tags
+      # intentionally remain on a tested image until a newer run passes CI.
       - name: Promote tested main image
         run: |
           current_sha="$(git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/main | cut -f1)"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,12 +7,12 @@
 # packages/agor-live/build.sh), so the image is pinned to the built commit
 # rather than `agor-live@latest` on npm.
 #
-# Publish model: the :<full-sha> image is built and pushed on pushes to
-# main, v* tags, AND every in-repository PR commit (tagged by the PR *head*
-# SHA, with :pr-<n> re-pointed on each update), so trusted commits are
-# deployable by their own SHA. Fork and Dependabot PRs still build and run the
-# boot smoke test, but cannot publish because GitHub intentionally withholds
-# repository secrets from them. Plus a branch tag, and `latest` on main only.
+# Publish model: a successful CI run for a main push publishes :<full-sha>,
+# :main, and :latest. v* tags and every in-repository PR commit publish
+# directly (PRs use the PR *head* SHA and re-point :pr-<n> on each update), so
+# trusted commits remain deployable by their own SHA. Fork and Dependabot PRs
+# still build and run the boot smoke test, but cannot publish because GitHub
+# intentionally withholds repository secrets from them.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -21,8 +21,11 @@
 name: Build image
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
+  push:
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -32,28 +35,37 @@ permissions:
   contents: read
 
 concurrency:
-  group: build-image-${{ github.ref }}
+  group: build-image-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 # docker.io is docker/login-action's default registry, so no `registry:` needed.
 env:
   IMAGE: preset/agor
-  # The commit we build, stamp, and tag: the PR head on pull_request events
-  # (github.sha is the ephemeral merge commit there), else the pushed commit.
+  # The commit we build, stamp, and tag: the PR head on pull_request events;
+  # the tested main commit on workflow_run events; otherwise the pushed commit.
   # Keeps the checkout, the :<sha> tag, and the in-app build banner in lockstep.
-  IMAGE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+  IMAGE_REVISION: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
   build:
     name: Build & push
+    # Branch filtering applies to both push- and PR-triggered CI runs. Only a
+    # successful push run is allowed to publish main; PRs keep using this
+    # workflow's direct pull_request trigger instead.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.conclusion == 'success'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Build the PR's real head commit, not the ephemeral merge commit, so
-          # image contents match the :<sha> tag. No effect on push events.
+          # Build the exact tested/main, PR-head, or tag commit so image
+          # contents match the :<sha> tag.
           ref: ${{ env.IMAGE_REVISION }}
 
       - name: Set up Docker Buildx
@@ -72,28 +84,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        env:
-          # Make `type=sha` emit the PR *head* SHA, so the tag equals
-          # `git rev-parse HEAD` of the PR branch. No effect on push events.
-          DOCKER_METADATA_PR_HEAD_SHA: 'true'
-        with:
-          images: ${{ env.IMAGE }}
-          # Full commit SHA on every build (push + PR); a branch/PR ref tag;
-          # semver on git tags; `latest` only on the default branch.
-          tags: |
-            type=sha,prefix=,format=long
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.title=agor
-            org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       # Build once into the local Docker store so it can be smoke-tested before
       # anything is published. The push step below reuses this build via the
@@ -135,6 +125,40 @@ jobs:
           echo "::error::Daemon did not become healthy within 120s"
           docker logs agor-smoke
           exit 1
+
+      # CI runs for consecutive main commits can finish out of order. Publish
+      # every successful commit by SHA, but only let the current main head move
+      # the mutable :main and :latest tags.
+      - name: Check current main head
+        if: github.event_name == 'workflow_run'
+        id: main
+        run: |
+          current_sha="$(git ls-remote origin refs/heads/main | cut -f1)"
+          if [[ "$current_sha" == "$IMAGE_REVISION" ]]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping mutable tags because main is now $current_sha"
+          fi
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          # Full commit SHA on every build; PR ref and semver tags where
+          # applicable; main/latest only after CI passed for the current head.
+          flavor: latest=false
+          tags: |
+            type=raw,value=${{ env.IMAGE_REVISION }}
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=raw,value=main,enable=${{ github.event_name == 'workflow_run' && steps.main.outputs.current == 'true' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' && steps.main.outputs.current == 'true' }}
+          labels: |
+            org.opencontainers.image.title=agor
+            org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       # Publish trusted events after the smoke test. Fork and Dependabot PRs
       # stop here after validating the same production image locally.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -181,10 +181,25 @@ jobs:
       group: build-image-main-promotion
       queue: max
     steps:
+      # Most queued jobs are stale when main advances quickly. Reject them
+      # before installing Buildx or opening an authenticated registry session.
+      - name: Preflight current main head
+        id: preflight
+        run: |
+          current_sha="$(git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/main | cut -f1)"
+          if [[ "$current_sha" == "$IMAGE_REVISION" ]]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping stale promotion because main is now $current_sha"
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.preflight.outputs.current == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        if: steps.preflight.outputs.current == 'true'
         uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -194,6 +209,7 @@ jobs:
       # stale queued run skips; if main advances after this check, the tags
       # intentionally remain on a tested image until a newer run passes CI.
       - name: Promote tested main image
+        if: steps.preflight.outputs.current == 'true'
         run: |
           current_sha="$(git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/main | cut -f1)"
           if [[ "$current_sha" != "$IMAGE_REVISION" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,11 @@
 name: CI
 
 on:
+  # Do not path-filter main pushes: every main-head transition must complete
+  # this gate so a docs-only successor cannot strand an already-tested image
+  # promotion. PRs keep the fast path filters below.
   push:
     branches: [main]
-    paths-ignore:
-      - 'apps/agor-docs/**'
-      - '*.md'
-      - 'context/**'
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Linked issue

Not linked.

## Summary

- Start main image publication only after the `CI` workflow succeeds for a main push.
- Publish each tested image by immutable commit SHA, then promote `main` and `latest` through a separate serialized queue.
- Run CI for every main push so docs-only successors cannot strand a pending image promotion.

## Why / context

The image workflow was independent from the required test workflow, so a main commit could publish `preset/agor:latest` while its full test run was red. That happened during this incident: the image build and smoke test passed, then the separate test gate failed.

The new flow is:

`main push → CI passes → build + smoke test → publish SHA → queued main/latest promotion`

Failed, cancelled, and pull-request CI runs cannot enter the main promotion path.

## Implementation notes

- Immutable SHA builds remain independent; only mutable `main`/`latest` promotion is serialized.
- The promotion group uses the full native queue so out-of-order builds cannot replace a pending current-head promotion.
- Stale queued runs preflight against current main before Buildx setup or registry login. Qualifying runs recheck the head in the same serialized step as the registry update.
- `main` and `latest` identify a successfully tested main image. If a newer main commit is red or cancelled, the tags intentionally remain on the last successful promotion rather than pointing at the red commit.
- PR and version-tag image workflows remain direct and retain their existing trust checks.
- Manual dispatches do not move the mutable main tags.
- Main pushes are no longer path-filtered; PRs retain their existing docs/context filters.
- No tenant or runtime application behavior changes.

## Validation / test plan

- [x] Workflow YAML parsed successfully
- [x] Workflow formatting and whitespace checks passed
- [x] GitHub accepted the queued-concurrency syntax and started both PR workflows
- [x] Current PR CI and image build passed
- [ ] The first successful post-merge main run will exercise the `workflow_run` promotion path end to end

The local generic workflow validator does not yet recognize the newly supported full-queue key; GitHub's workflow parser accepted it and scheduled the checks.

## Risks / rollout / rollback

Every main push, including docs-only changes, now runs CI so each main-head transition has a gated successor. This increases main-branch CI usage. The mutable tags may intentionally lag a newer red or cancelled main commit. Reverting this PR restores direct push-triggered publication.

## Out of scope / follow-ups

Repository ruleset changes to require current, passing CI before merge remain a separate provider-setting change.
