### PR TITLE
Knowledge: show user and assistant edit attribution

### DIFF
--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -30,7 +30,13 @@ import {
   UserApiKeysRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { PersistedAgenticToolName, SessionID, TenantContext, UserID } from '@agor/core/types';
+import {
+  getTeammateConfig,
+  type PersistedAgenticToolName,
+  type SessionID,
+  type TenantContext,
+  type UserID,
+} from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import { createMcpHandler, type ListToolsResult, McpServer } from '@modelcontextprotocol/server';
@@ -84,7 +90,11 @@ export interface McpContext {
   /** Current Agor session context, when the caller supplied or authenticated with one. */
   sessionId?: SessionID;
   /** Trusted assistant identity resolved from the current tenant-scoped Session. */
-  assistantIdentity?: { sessionId: SessionID; agenticTool: PersistedAgenticToolName };
+  assistantIdentity?: {
+    sessionId: SessionID;
+    agenticTool: PersistedAgenticToolName;
+    teammateName?: string;
+  };
   authenticatedUser: AuthenticatedUser;
   baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider' | 'tenant'>;
 }
@@ -738,6 +748,16 @@ export function setupMCPRoutes(
               sessionId: session.session_id,
               agenticTool: session.agentic_tool,
             };
+            try {
+              const branch = await app
+                .service('branches')
+                .get(session.branch_id, baseServiceParams);
+              const teammateName = getTeammateConfig(branch)?.displayName.trim();
+              if (teammateName) assistantIdentity.teammateName = teammateName;
+            } catch {
+              // Attribution falls back to the agentic tool when the branch was removed
+              // between Session authorization and this optional display-name lookup.
+            }
           } catch {
             return res.status(403).json({
               ...jsonRpcError(

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -30,13 +30,7 @@ import {
   UserApiKeysRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import {
-  getTeammateConfig,
-  type PersistedAgenticToolName,
-  type SessionID,
-  type TenantContext,
-  type UserID,
-} from '@agor/core/types';
+import type { Session, SessionID, TenantContext, UserID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import { createMcpHandler, type ListToolsResult, McpServer } from '@modelcontextprotocol/server';
@@ -89,12 +83,8 @@ export interface McpContext {
   userId: UserID;
   /** Current Agor session context, when the caller supplied or authenticated with one. */
   sessionId?: SessionID;
-  /** Trusted assistant identity resolved from the current tenant-scoped Session. */
-  assistantIdentity?: {
-    sessionId: SessionID;
-    agenticTool: PersistedAgenticToolName;
-    teammateName?: string;
-  };
+  /** Freshly authorized Session identity available to session-aware tool boundaries. */
+  authenticatedSession?: Pick<Session, 'session_id' | 'agentic_tool' | 'branch_id'>;
   authenticatedUser: AuthenticatedUser;
   baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider' | 'tenant'>;
 }
@@ -739,25 +729,16 @@ export function setupMCPRoutes(
         // normal service on every request. Personal keys may supply a short ID;
         // internal tokens carry a signed full ID, but still need fresh branch
         // RBAC after a permission change. This also canonicalizes short IDs.
-        let assistantIdentity: McpContext['assistantIdentity'];
+        let authenticatedSession: McpContext['authenticatedSession'];
         if (sessionId) {
           try {
             const session = await app.service('sessions').get(sessionId, baseServiceParams);
             sessionId = session.session_id;
-            assistantIdentity = {
-              sessionId: session.session_id,
-              agenticTool: session.agentic_tool,
+            authenticatedSession = {
+              session_id: session.session_id,
+              agentic_tool: session.agentic_tool,
+              branch_id: session.branch_id,
             };
-            try {
-              const branch = await app
-                .service('branches')
-                .get(session.branch_id, baseServiceParams);
-              const teammateName = getTeammateConfig(branch)?.displayName.trim();
-              if (teammateName) assistantIdentity.teammateName = teammateName;
-            } catch {
-              // Attribution falls back to the agentic tool when the branch was removed
-              // between Session authorization and this optional display-name lookup.
-            }
           } catch {
             return res.status(403).json({
               ...jsonRpcError(
@@ -780,7 +761,7 @@ export function setupMCPRoutes(
           db,
           userId,
           sessionId,
-          assistantIdentity,
+          authenticatedSession,
           authenticatedUser,
           baseServiceParams,
         };

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -30,7 +30,7 @@ import {
   UserApiKeysRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { SessionID, TenantContext, UserID } from '@agor/core/types';
+import type { PersistedAgenticToolName, SessionID, TenantContext, UserID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import { createMcpHandler, type ListToolsResult, McpServer } from '@modelcontextprotocol/server';
@@ -83,6 +83,8 @@ export interface McpContext {
   userId: UserID;
   /** Current Agor session context, when the caller supplied or authenticated with one. */
   sessionId?: SessionID;
+  /** Trusted assistant identity resolved from the current tenant-scoped Session. */
+  assistantIdentity?: { sessionId: SessionID; agenticTool: PersistedAgenticToolName };
   authenticatedUser: AuthenticatedUser;
   baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider' | 'tenant'>;
 }
@@ -727,10 +729,15 @@ export function setupMCPRoutes(
         // normal service on every request. Personal keys may supply a short ID;
         // internal tokens carry a signed full ID, but still need fresh branch
         // RBAC after a permission change. This also canonicalizes short IDs.
+        let assistantIdentity: McpContext['assistantIdentity'];
         if (sessionId) {
           try {
             const session = await app.service('sessions').get(sessionId, baseServiceParams);
             sessionId = session.session_id;
+            assistantIdentity = {
+              sessionId: session.session_id,
+              agenticTool: session.agentic_tool,
+            };
           } catch {
             return res.status(403).json({
               ...jsonRpcError(
@@ -753,6 +760,7 @@ export function setupMCPRoutes(
           db,
           userId,
           sessionId,
+          assistantIdentity,
           authenticatedUser,
           baseServiceParams,
         };

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -222,7 +222,11 @@ describe('Knowledge MCP input schemas', () => {
     const tools = await captureKnowledgeTools(
       { 'kb/documents': { putDocument } },
       {
-        assistantIdentity: { sessionId: 'session-1', agenticTool: 'codex' },
+        assistantIdentity: {
+          sessionId: 'session-1',
+          agenticTool: 'codex',
+          teammateName: 'Scout',
+        },
       }
     );
 
@@ -233,7 +237,11 @@ describe('Knowledge MCP input schemas', () => {
     });
 
     expect(putDocument.mock.calls[0][1]).toMatchObject({
-      knowledgeWriteAttribution: { sessionId: 'session-1', agenticTool: 'codex' },
+      knowledgeWriteAttribution: {
+        sessionId: 'session-1',
+        agenticTool: 'codex',
+        teammateName: 'Scout',
+      },
     });
   });
 

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -37,8 +37,15 @@ vi.mock('../server.js', () => ({
 
 vi.mock('@agor/core/types', () => ({
   buildKnowledgeDocumentUri: (id: string) => `agor://kb/document/${id}`,
-  getTeammateConfig: (branch: { teammate?: unknown; assistant?: unknown }) =>
-    branch.teammate ?? branch.assistant,
+  getTeammateConfig: (branch: {
+    teammate?: unknown;
+    assistant?: unknown;
+    custom_context?: { teammate?: unknown; assistant?: unknown };
+  }) =>
+    branch.custom_context?.teammate ??
+    branch.custom_context?.assistant ??
+    branch.teammate ??
+    branch.assistant,
   isTeammate: (branch: { teammate?: unknown; assistant?: unknown }) =>
     Boolean(branch.teammate ?? branch.assistant),
   KNOWLEDGE_DOCUMENT_KINDS: ['doc', 'note'],
@@ -220,12 +227,19 @@ describe('Knowledge MCP input schemas', () => {
   it('passes trusted current-Session assistant attribution to Knowledge writes', async () => {
     const putDocument = vi.fn().mockResolvedValue({ document_id: 'doc-1' });
     const tools = await captureKnowledgeTools(
-      { 'kb/documents': { putDocument } },
       {
-        assistantIdentity: {
-          sessionId: 'session-1',
-          agenticTool: 'codex',
-          teammateName: 'Scout',
+        branches: {
+          get: vi.fn().mockResolvedValue({
+            custom_context: { teammate: { kind: 'teammate', displayName: 'Scout' } },
+          }),
+        },
+        'kb/documents': { putDocument },
+      },
+      {
+        authenticatedSession: {
+          session_id: 'session-1',
+          agentic_tool: 'codex',
+          branch_id: 'branch-1',
         },
       }
     );

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -217,6 +217,26 @@ describe('Knowledge MCP input schemas', () => {
     expect(data).not.toHaveProperty('first_line_is_title');
   });
 
+  it('passes trusted current-Session assistant attribution to Knowledge writes', async () => {
+    const putDocument = vi.fn().mockResolvedValue({ document_id: 'doc-1' });
+    const tools = await captureKnowledgeTools(
+      { 'kb/documents': { putDocument } },
+      {
+        assistantIdentity: { sessionId: 'session-1', agenticTool: 'codex' },
+      }
+    );
+
+    await tools.agor_kb_put.handler?.({
+      namespace: 'global',
+      path: 'page.md',
+      content: '# Page',
+    });
+
+    expect(putDocument.mock.calls[0][1]).toMatchObject({
+      knowledgeWriteAttribution: { sessionId: 'session-1', agenticTool: 'codex' },
+    });
+  });
+
   it('requires document content to be a string when provided', async () => {
     const tools = await captureKnowledgeTools();
 

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -13,6 +13,7 @@ import type {
   KnowledgeGraphNodeType,
   KnowledgeNamespace,
   KnowledgeVisibility,
+  KnowledgeWriteAttribution,
   TeammateKnowledgeGrantAccess,
   User,
   UserRole,
@@ -294,9 +295,29 @@ function knowledgeNotImplementedResult(toolName: string, servicePaths: string[])
 function mcpParams(ctx: McpContext, query?: Record<string, unknown>): Record<string, unknown> {
   return {
     ...ctx.baseServiceParams,
-    ...(ctx.assistantIdentity ? { knowledgeWriteAttribution: ctx.assistantIdentity } : {}),
     ...(query ? { query } : {}),
   };
+}
+
+async function knowledgeWriteParams(ctx: McpContext): Promise<Record<string, unknown>> {
+  const session = ctx.authenticatedSession;
+  if (!session) return mcpParams(ctx);
+
+  let teammateName: string | undefined;
+  try {
+    const branch = await ctx.app.service('branches').get(session.branch_id, ctx.baseServiceParams);
+    teammateName = getTeammateConfig(branch)?.displayName.trim() || undefined;
+  } catch (error) {
+    // A deleted branch must not erase the already-authorized Session/tool forensic trail.
+    if (!(error instanceof NotFound)) throw error;
+  }
+
+  const knowledgeWriteAttribution: KnowledgeWriteAttribution = {
+    sessionId: session.session_id,
+    agenticTool: session.agentic_tool,
+    ...(teammateName ? { teammateName } : {}),
+  };
+  return { ...ctx.baseServiceParams, knowledgeWriteAttribution };
 }
 
 /**
@@ -1837,14 +1858,15 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         );
       }
 
-      const customResult = await callCustomMethod(service, 'putDocument', data, mcpParams(ctx));
+      const writeParams = await knowledgeWriteParams(ctx);
+      const customResult = await callCustomMethod(service, 'putDocument', data, writeParams);
       if (customResult !== undefined) return textResult(customResult);
 
       if (documentId && service.patch) {
-        return textResult(await service.patch(documentId, data, mcpParams(ctx)));
+        return textResult(await service.patch(documentId, data, writeParams));
       }
 
-      if (service.create) return textResult(await service.create(data, mcpParams(ctx)));
+      if (service.create) return textResult(await service.create(data, writeParams));
       return knowledgeNotImplementedResult('agor_kb_put', [
         'kb/documents.putDocument',
         'kb/documents.patch',
@@ -1881,7 +1903,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       } as Record<string, unknown>;
 
       if (service.create) {
-        return textResult(await service.create(data, mcpParams(ctx)));
+        return textResult(await service.create(data, await knowledgeWriteParams(ctx)));
       }
       return knowledgeNotImplementedResult('agor_kb_edit', ['kb/document-edits.create']);
     }
@@ -2091,7 +2113,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
             ],
             returnContent: dryRun ? 'full' : 'none',
           },
-          mcpParams(ctx)
+          await knowledgeWriteParams(ctx)
         )) as Record<string, unknown>;
         const newVersion = editResult.newVersion as Record<string, unknown> | undefined;
         const editedDocument = editResult.document as Record<string, unknown> | undefined;
@@ -2160,7 +2182,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           edit_policy: args.editPolicy as KnowledgeEditPolicy | undefined,
           change_summary: coerceString(args.changeSummary) ?? `Publish from ${workspace.relative}`,
         },
-        mcpParams(ctx)
+        await knowledgeWriteParams(ctx)
       );
       if (customResult !== undefined) {
         const hydrated = await fetchKnowledgeDocument(ctx, {

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -292,7 +292,11 @@ function knowledgeNotImplementedResult(toolName: string, servicePaths: string[])
 }
 
 function mcpParams(ctx: McpContext, query?: Record<string, unknown>): Record<string, unknown> {
-  return query ? { ...ctx.baseServiceParams, query } : { ...ctx.baseServiceParams };
+  return {
+    ...ctx.baseServiceParams,
+    ...(ctx.assistantIdentity ? { knowledgeWriteAttribution: ctx.assistantIdentity } : {}),
+    ...(query ? { query } : {}),
+  };
 }
 
 /**

--- a/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
@@ -99,6 +99,7 @@ describe('KnowledgeDocumentEditsService', () => {
     const versionsRepo = new KnowledgeDocumentVersionRepository(db);
     const initialVersion = await versionsRepo.findLatestForDocument(document.document_id);
     expect(initialVersion).not.toBeNull();
+    const assistantSessionId = generateId();
 
     const response = await editsService.create(
       {
@@ -121,7 +122,10 @@ describe('KnowledgeDocumentEditsService', () => {
           },
         ],
       },
-      { user: owner }
+      {
+        user: owner,
+        knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+      }
     );
 
     expect(response.dryRun).toBe(false);
@@ -130,6 +134,17 @@ describe('KnowledgeDocumentEditsService', () => {
 
     const finalVersion = await versionsRepo.findLatestForDocument(document.document_id);
     expect(finalVersion?.content_text).toContain('New tail');
+    expect(finalVersion).toMatchObject({
+      created_by: owner.user_id,
+      created_by_session_id: assistantSessionId,
+      created_by_agentic_tool: 'codex',
+      metadata: expect.objectContaining({ session_id: assistantSessionId }),
+    });
+    expect(await new KnowledgeDocumentRepository(db).findById(document.document_id)).toMatchObject({
+      updated_by: owner.user_id,
+      updated_by_session_id: assistantSessionId,
+      updated_by_agentic_tool: 'codex',
+    });
   });
 
   dbTest('rejects edits when caller lacks permission', async ({ db }) => {

--- a/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
@@ -124,7 +124,11 @@ describe('KnowledgeDocumentEditsService', () => {
       },
       {
         user: owner,
-        knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+        knowledgeWriteAttribution: {
+          sessionId: assistantSessionId,
+          agenticTool: 'codex',
+          teammateName: 'Scout',
+        },
       }
     );
 
@@ -138,12 +142,14 @@ describe('KnowledgeDocumentEditsService', () => {
       created_by: owner.user_id,
       created_by_session_id: assistantSessionId,
       created_by_agentic_tool: 'codex',
+      created_by_teammate_name: 'Scout',
       metadata: expect.objectContaining({ session_id: assistantSessionId }),
     });
     expect(await new KnowledgeDocumentRepository(db).findById(document.document_id)).toMatchObject({
       updated_by: owner.user_id,
       updated_by_session_id: assistantSessionId,
       updated_by_agentic_tool: 'codex',
+      updated_by_teammate_name: 'Scout',
     });
   });
 

--- a/apps/agor-daemon/src/services/knowledge-document-edits.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.ts
@@ -182,7 +182,8 @@ export class KnowledgeDocumentEditsService {
       base_version_id: currentVersion.version_id,
       base_version_number: currentVersion.version_number,
       ops: data.ops,
-      session_id: (params as { sessionId?: string } | undefined)?.sessionId ?? null,
+      // Retained for older API consumers; first-class version columns are authoritative.
+      session_id: baseParams.knowledgeWriteAttribution?.sessionId ?? null,
     } satisfies Record<string, unknown>;
 
     const versionMetadata = {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -26,10 +26,9 @@ import type {
   KnowledgeDocument,
   KnowledgeDocumentVersion,
   KnowledgeNamespaceID,
+  KnowledgeWriteAttribution,
   NullableId,
-  PersistedAgenticToolName,
   QueryParams,
-  SessionID,
   User,
   UserID,
 } from '@agor/core/types';
@@ -77,11 +76,7 @@ export type KnowledgeDocumentParams = QueryParams<{
 }> &
   AuthenticatedParams & {
     /** Server-derived only; MCP callers cannot provide service params. */
-    knowledgeWriteAttribution?: {
-      sessionId: SessionID;
-      agenticTool: PersistedAgenticToolName;
-      teammateName?: string;
-    };
+    knowledgeWriteAttribution?: KnowledgeWriteAttribution;
   };
 
 type KnowledgeDocumentWriteData = (CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput) & {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -77,7 +77,11 @@ export type KnowledgeDocumentParams = QueryParams<{
 }> &
   AuthenticatedParams & {
     /** Server-derived only; MCP callers cannot provide service params. */
-    knowledgeWriteAttribution?: { sessionId: SessionID; agenticTool: PersistedAgenticToolName };
+    knowledgeWriteAttribution?: {
+      sessionId: SessionID;
+      agenticTool: PersistedAgenticToolName;
+      teammateName?: string;
+    };
   };
 
 type KnowledgeDocumentWriteData = (CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput) & {
@@ -95,6 +99,7 @@ function assistantAttribution(params?: KnowledgeDocumentParams) {
   return {
     updated_by_session_id: identity?.sessionId ?? null,
     updated_by_agentic_tool: identity?.agenticTool ?? null,
+    updated_by_teammate_name: identity?.teammateName ?? null,
   };
 }
 

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -545,7 +545,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
             namespace_slug: undefined,
             path: path ?? existing.path,
             updated_by: this.attributionUserId(params, data.updated_by),
-            ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
+            ...assistantAttribution(params),
           },
           existing
         )
@@ -688,7 +688,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
-      ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
+      ...assistantAttribution(params),
     });
     await this.replaceSearchUnitsForContent(
       result,
@@ -732,7 +732,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
-      ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
+      ...assistantAttribution(params),
     });
     await this.replaceSearchUnitsForContent(
       result,

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -27,7 +27,9 @@ import type {
   KnowledgeDocumentVersion,
   KnowledgeNamespaceID,
   NullableId,
+  PersistedAgenticToolName,
   QueryParams,
+  SessionID,
   User,
   UserID,
 } from '@agor/core/types';
@@ -73,7 +75,10 @@ export type KnowledgeDocumentParams = QueryParams<{
   includeIndexing?: boolean;
   version?: string | number;
 }> &
-  AuthenticatedParams;
+  AuthenticatedParams & {
+    /** Server-derived only; MCP callers cannot provide service params. */
+    knowledgeWriteAttribution?: { sessionId: SessionID; agenticTool: PersistedAgenticToolName };
+  };
 
 type KnowledgeDocumentWriteData = (CreateKnowledgeDocumentInput | UpdateKnowledgeDocumentInput) & {
   document_id?: string;
@@ -84,6 +89,14 @@ type KnowledgeDocumentWriteData = (CreateKnowledgeDocumentInput | UpdateKnowledg
   namespace_display_name?: string | null;
   expected_version?: string | number;
 };
+
+function assistantAttribution(params?: KnowledgeDocumentParams) {
+  const identity = params?.knowledgeWriteAttribution;
+  return {
+    updated_by_session_id: identity?.sessionId ?? null,
+    updated_by_agentic_tool: identity?.agenticTool ?? null,
+  };
+}
 
 type KnowledgeDocumentRef = {
   document_id?: string;
@@ -532,6 +545,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
             namespace_slug: undefined,
             path: path ?? existing.path,
             updated_by: this.attributionUserId(params, data.updated_by),
+            ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
           },
           existing
         )
@@ -580,6 +594,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
         path,
         created_by: userId,
         updated_by: this.attributionUserId(params, data.updated_by),
+        ...assistantAttribution(params),
       })
     );
     await this.replaceSearchUnitsForContent(result, data.content_text);
@@ -598,6 +613,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
         ...data,
         created_by: userId,
         updated_by: this.attributionUserId(params, data.updated_by),
+        ...assistantAttribution(params),
       },
       null
     );
@@ -672,6 +688,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
+      ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
     });
     await this.replaceSearchUnitsForContent(
       result,
@@ -715,6 +732,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
+      ...(typeof data.content_text === 'string' ? assistantAttribution(params) : {}),
     });
     await this.replaceSearchUnitsForContent(
       result,

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -447,7 +447,11 @@ describe('KnowledgeDocumentsService permissions', () => {
         },
         {
           user: owner,
-          knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+          knowledgeWriteAttribution: {
+            sessionId: assistantSessionId,
+            agenticTool: 'codex',
+            teammateName: 'Scout',
+          },
         } as never
       );
       expect(updated.document_id).toBe(created.document_id);
@@ -455,6 +459,7 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(updated).toMatchObject({
         updated_by_session_id: assistantSessionId,
         updated_by_agentic_tool: 'codex',
+        updated_by_teammate_name: 'Scout',
       });
 
       const iconOnlyUpdate = await service.putDocument(
@@ -470,6 +475,7 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(iconOnlyUpdate).toMatchObject({
         updated_by_session_id: null,
         updated_by_agentic_tool: null,
+        updated_by_teammate_name: null,
       });
 
       const assistantIconUpdate = await service.putDocument(
@@ -479,13 +485,18 @@ describe('KnowledgeDocumentsService permissions', () => {
         },
         {
           user: owner,
-          knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+          knowledgeWriteAttribution: {
+            sessionId: assistantSessionId,
+            agenticTool: 'codex',
+            teammateName: 'Scout',
+          },
         } as never
       );
       expect(assistantIconUpdate.current_version_id).toBe(updated.current_version_id);
       expect(assistantIconUpdate).toMatchObject({
         updated_by_session_id: assistantSessionId,
         updated_by_agentic_tool: 'codex',
+        updated_by_teammate_name: 'Scout',
       });
 
       const hydrated = await service.getDocument(

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -436,6 +436,8 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(created.uri).toBe('agor://kb/mcp-style/guide.md');
       expect(created.icon_emoji).toBe('📘');
 
+      const assistantSessionId = generateId();
+
       const updated = await service.putDocument(
         {
           namespace_slug: namespace.slug,
@@ -443,10 +445,17 @@ describe('KnowledgeDocumentsService permissions', () => {
           content_text: '# Guide\n\nUpdated',
           expected_version: 1,
         },
-        params(owner)
+        {
+          user: owner,
+          knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+        } as never
       );
       expect(updated.document_id).toBe(created.document_id);
       expect(updated.icon_emoji).toBe('📘');
+      expect(updated).toMatchObject({
+        updated_by_session_id: assistantSessionId,
+        updated_by_agentic_tool: 'codex',
+      });
 
       const iconOnlyUpdate = await service.putDocument(
         {
@@ -458,6 +467,26 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(iconOnlyUpdate.document_id).toBe(created.document_id);
       expect(iconOnlyUpdate.icon_emoji).toBe('🧭');
       expect(iconOnlyUpdate.current_version_id).toBe(updated.current_version_id);
+      expect(iconOnlyUpdate).toMatchObject({
+        updated_by_session_id: null,
+        updated_by_agentic_tool: null,
+      });
+
+      const assistantIconUpdate = await service.putDocument(
+        {
+          document_id: created.document_id,
+          icon_emoji: '🤖',
+        },
+        {
+          user: owner,
+          knowledgeWriteAttribution: { sessionId: assistantSessionId, agenticTool: 'codex' },
+        } as never
+      );
+      expect(assistantIconUpdate.current_version_id).toBe(updated.current_version_id);
+      expect(assistantIconUpdate).toMatchObject({
+        updated_by_session_id: assistantSessionId,
+        updated_by_agentic_tool: 'codex',
+      });
 
       const hydrated = await service.getDocument(
         { namespace_slug: namespace.slug, path: 'guide.md', include_content: true },

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -25,7 +25,7 @@ import { parseKnowledgeUri, ROLES } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { knowledgeChunkerOptionsFromSettings, knowledgeUnitsForMarkdown } from '../knowledge/units';
-import { KnowledgeDocumentsService } from './knowledge-documents';
+import { type KnowledgeDocumentParams, KnowledgeDocumentsService } from './knowledge-documents';
 import { KnowledgeEmbeddingIndexer } from './knowledge-embedding-indexer';
 import { KnowledgeGraphService } from './knowledge-graph';
 import { KnowledgeIndexingStatusService } from './knowledge-indexing';
@@ -437,6 +437,14 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(created.icon_emoji).toBe('📘');
 
       const assistantSessionId = generateId();
+      const assistantParams: KnowledgeDocumentParams = {
+        user: owner,
+        knowledgeWriteAttribution: {
+          sessionId: assistantSessionId,
+          agenticTool: 'codex',
+          teammateName: 'Scout',
+        },
+      };
 
       const updated = await service.putDocument(
         {
@@ -445,14 +453,7 @@ describe('KnowledgeDocumentsService permissions', () => {
           content_text: '# Guide\n\nUpdated',
           expected_version: 1,
         },
-        {
-          user: owner,
-          knowledgeWriteAttribution: {
-            sessionId: assistantSessionId,
-            agenticTool: 'codex',
-            teammateName: 'Scout',
-          },
-        } as never
+        assistantParams
       );
       expect(updated.document_id).toBe(created.document_id);
       expect(updated.icon_emoji).toBe('📘');
@@ -483,14 +484,7 @@ describe('KnowledgeDocumentsService permissions', () => {
           document_id: created.document_id,
           icon_emoji: '🤖',
         },
-        {
-          user: owner,
-          knowledgeWriteAttribution: {
-            sessionId: assistantSessionId,
-            agenticTool: 'codex',
-            teammateName: 'Scout',
-          },
-        } as never
+        assistantParams
       );
       expect(assistantIconUpdate.current_version_id).toBe(updated.current_version_id);
       expect(assistantIconUpdate).toMatchObject({

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
@@ -8,19 +8,30 @@ describe('knowledgeAttributionDisplay', () => {
     expect(knowledgeAttributionDisplay({ userId: 'user-1' }, users)).toEqual({
       userLabel: 'Ada',
       assistantLabel: null,
+      editorLabel: 'Ada',
     });
   });
 
-  it('shows the trusted assistant and Session attribution for an agent edit', () => {
+  it('combines the human and teammate names without exposing the Session ID', () => {
     expect(
       knowledgeAttributionDisplay(
         {
           userId: 'user-1',
           sessionId: '01abcdef-1234-7890-abcd-ef1234567890',
           agenticTool: 'codex',
+          teammateName: 'Scout',
         },
         users
       )
-    ).toEqual({ userLabel: 'Ada', assistantLabel: 'Codex · session 01abcdef12347890abcdef12' });
+    ).toEqual({ userLabel: 'Ada', assistantLabel: 'Scout', editorLabel: 'Ada and Scout' });
+  });
+
+  it('falls back to the agentic tool when the Session is not a named teammate', () => {
+    expect(
+      knowledgeAttributionDisplay(
+        { userId: 'user-1', sessionId: 'session-1', agenticTool: 'codex' },
+        users
+      )
+    ).toEqual({ userLabel: 'Ada', assistantLabel: 'Codex', editorLabel: 'Ada and Codex' });
   });
 });

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { knowledgeAttributionDisplay } from './knowledgeAttributionDisplay';
+
+const users = new Map([['user-1', { name: 'Ada', email: 'ada@example.com' }]]);
+
+describe('knowledgeAttributionDisplay', () => {
+  it('shows only the human identity for a human edit', () => {
+    expect(knowledgeAttributionDisplay({ userId: 'user-1' }, users)).toEqual({
+      userLabel: 'Ada',
+      assistantLabel: null,
+    });
+  });
+
+  it('shows the trusted assistant and Session attribution for an agent edit', () => {
+    expect(
+      knowledgeAttributionDisplay(
+        {
+          userId: 'user-1',
+          sessionId: '01abcdef-1234-7890-abcd-ef1234567890',
+          agenticTool: 'codex',
+        },
+        users
+      )
+    ).toEqual({ userLabel: 'Ada', assistantLabel: 'Codex · session 01abcdef12347890abcdef12' });
+  });
+});

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.ts
@@ -1,11 +1,10 @@
-import { shortId } from '@agor/core/types';
-
 type UserSummary = { name?: string | null; email?: string | null };
 
 export interface KnowledgeAttribution {
   userId?: string | null;
   sessionId?: string | null;
   agenticTool?: string | null;
+  teammateName?: string | null;
 }
 
 export function knowledgeAttributionDisplay(
@@ -14,16 +13,21 @@ export function knowledgeAttributionDisplay(
 ) {
   const user = attribution.userId ? userById.get(attribution.userId) : undefined;
   const userLabel = user?.name?.trim() || user?.email || 'Unknown user';
-  if (!attribution.sessionId) return { userLabel, assistantLabel: null };
+  const teammateLabel = attribution.teammateName?.trim();
+  if (!teammateLabel && !attribution.sessionId && !attribution.agenticTool) {
+    return { userLabel, assistantLabel: null, editorLabel: userLabel };
+  }
 
-  const toolLabel =
-    attribution.agenticTool === 'claude-code'
+  const assistantLabel =
+    teammateLabel ||
+    (attribution.agenticTool === 'claude-code'
       ? 'Claude Code'
       : attribution.agenticTool
         ? attribution.agenticTool.charAt(0).toUpperCase() + attribution.agenticTool.slice(1)
-        : 'Assistant';
+        : 'Assistant');
   return {
     userLabel,
-    assistantLabel: `${toolLabel} · session ${shortId(attribution.sessionId as never)}`,
+    assistantLabel,
+    editorLabel: `${userLabel} and ${assistantLabel}`,
   };
 }

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.ts
@@ -1,11 +1,10 @@
+import type { KnowledgeWriteAttribution } from '@agor/core/types';
+
 type UserSummary = { name?: string | null; email?: string | null };
 
-export interface KnowledgeAttribution {
-  userId?: string | null;
-  sessionId?: string | null;
-  agenticTool?: string | null;
-  teammateName?: string | null;
-}
+export type KnowledgeAttribution = { userId?: string | null } & {
+  [Key in keyof KnowledgeWriteAttribution]?: KnowledgeWriteAttribution[Key] | null;
+};
 
 export function knowledgeAttributionDisplay(
   attribution: KnowledgeAttribution,

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.ts
@@ -1,0 +1,29 @@
+import { shortId } from '@agor/core/types';
+
+type UserSummary = { name?: string | null; email?: string | null };
+
+export interface KnowledgeAttribution {
+  userId?: string | null;
+  sessionId?: string | null;
+  agenticTool?: string | null;
+}
+
+export function knowledgeAttributionDisplay(
+  attribution: KnowledgeAttribution,
+  userById: ReadonlyMap<string, UserSummary>
+) {
+  const user = attribution.userId ? userById.get(attribution.userId) : undefined;
+  const userLabel = user?.name?.trim() || user?.email || 'Unknown user';
+  if (!attribution.sessionId) return { userLabel, assistantLabel: null };
+
+  const toolLabel =
+    attribution.agenticTool === 'claude-code'
+      ? 'Claude Code'
+      : attribution.agenticTool
+        ? attribution.agenticTool.charAt(0).toUpperCase() + attribution.agenticTool.slice(1)
+        : 'Assistant';
+  return {
+    userLabel,
+    assistantLabel: `${toolLabel} · session ${shortId(attribution.sessionId as never)}`,
+  };
+}

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -894,6 +894,7 @@ export function KnowledgePage({
           userId: activeDoc.updated_by,
           sessionId: activeDoc.updated_by_session_id,
           agenticTool: activeDoc.updated_by_agentic_tool,
+          teammateName: activeDoc.updated_by_teammate_name,
         },
         userById
       )
@@ -3360,14 +3361,9 @@ export function KnowledgePage({
                           <Text type="secondary">{activeDoc.path}</Text>
                         </Space>
                         {!isEditing && activeAttribution && (
-                          <Space wrap size={6}>
-                            <Text type="secondary">
-                              Last edited by {activeAttribution.userLabel}
-                            </Text>
-                            {activeAttribution.assistantLabel && (
-                              <Tag color="purple">{activeAttribution.assistantLabel}</Tag>
-                            )}
-                          </Space>
+                          <Text type="secondary">
+                            Last edited by {activeAttribution.editorLabel}
+                          </Text>
                         )}
                         {isEditing && (
                           <Space orientation="vertical" size={4}>
@@ -3651,6 +3647,7 @@ export function KnowledgePage({
                     userId: version.created_by,
                     sessionId: version.created_by_session_id,
                     agenticTool: version.created_by_agentic_tool,
+                    teammateName: version.created_by_teammate_name,
                   },
                   userById
                 );
@@ -3713,12 +3710,7 @@ export function KnowledgePage({
                       description={
                         <Space orientation="vertical" size={2}>
                           <Text type="secondary">{formatTimestamp(version.created_at)}</Text>
-                          <Space wrap size={4}>
-                            <Text type="secondary">{attribution.userLabel}</Text>
-                            {attribution.assistantLabel && (
-                              <Tag color="purple">{attribution.assistantLabel}</Tag>
-                            )}
-                          </Space>
+                          <Text type="secondary">{attribution.editorLabel}</Text>
                           {version.change_summary && <Text>{version.change_summary}</Text>}
                         </Space>
                       }

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -100,6 +100,7 @@ import { KnowledgeGraph } from '../components/KnowledgeGraph';
 import { MarkdownRenderer } from '../components/MarkdownRenderer';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
 import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
+import { knowledgeAttributionDisplay } from '../knowledgeAttributionDisplay';
 import { useAgorStore } from '../store/agorStore';
 import { selectUserById } from '../store/selectors';
 import {
@@ -887,6 +888,16 @@ export function KnowledgePage({
       }),
     [activeDocId, activeDocSnapshot, documents, draftDocument]
   );
+  const activeAttribution = activeDoc
+    ? knowledgeAttributionDisplay(
+        {
+          userId: activeDoc.updated_by,
+          sessionId: activeDoc.updated_by_session_id,
+          agenticTool: activeDoc.updated_by_agentic_tool,
+        },
+        userById
+      )
+    : null;
   const isDraftDocument = activeDoc?.document_id === DRAFT_DOCUMENT_ID;
   const activeDocIconEmoji = activeDoc ? (isEditing ? iconEmojiDraft : activeDoc.icon_emoji) : null;
   const activeDocContentReady = isKnowledgeDocumentContentReady({
@@ -3348,6 +3359,16 @@ export function KnowledgePage({
                           )}
                           <Text type="secondary">{activeDoc.path}</Text>
                         </Space>
+                        {!isEditing && activeAttribution && (
+                          <Space wrap size={6}>
+                            <Text type="secondary">
+                              Last edited by {activeAttribution.userLabel}
+                            </Text>
+                            {activeAttribution.assistantLabel && (
+                              <Tag color="purple">{activeAttribution.assistantLabel}</Tag>
+                            )}
+                          </Space>
+                        )}
                         {isEditing && (
                           <Space orientation="vertical" size={4}>
                             <Checkbox
@@ -3625,6 +3646,14 @@ export function KnowledgePage({
               locale={{ emptyText: <Empty description="No version history yet" /> }}
               renderItem={(version, index) => {
                 const reuse = embeddingReuseIntoNext(version);
+                const attribution = knowledgeAttributionDisplay(
+                  {
+                    userId: version.created_by,
+                    sessionId: version.created_by_session_id,
+                    agenticTool: version.created_by_agentic_tool,
+                  },
+                  userById
+                );
                 const targetVersion = reuse?.targetVersionId
                   ? versions.find((item) => item.version_id === reuse.targetVersionId)
                   : null;
@@ -3684,6 +3713,12 @@ export function KnowledgePage({
                       description={
                         <Space orientation="vertical" size={2}>
                           <Text type="secondary">{formatTimestamp(version.created_at)}</Text>
+                          <Space wrap size={4}>
+                            <Text type="secondary">{attribution.userLabel}</Text>
+                            {attribution.assistantLabel && (
+                              <Tag color="purple">{attribution.assistantLabel}</Tag>
+                            )}
+                          </Space>
                           {version.change_summary && <Text>{version.change_summary}</Text>}
                         </Space>
                       }

--- a/packages/core/drizzle/postgres/0086_knowledge_assistant_attribution.sql
+++ b/packages/core/drizzle/postgres/0086_knowledge_assistant_attribution.sql
@@ -1,0 +1,7 @@
+-- Additive, nullable attribution keeps existing versions and supports rolling rollback.
+-- Session IDs intentionally are not foreign keys: immutable authorship survives Session deletion.
+-- Existing tenant RLS policies cover the new columns; no cross-tenant relation is introduced.
+ALTER TABLE "kb_documents" ADD COLUMN "updated_by_session_id" varchar(36);--> statement-breakpoint
+ALTER TABLE "kb_documents" ADD COLUMN "updated_by_agentic_tool" text;--> statement-breakpoint
+ALTER TABLE "kb_document_versions" ADD COLUMN "created_by_session_id" varchar(36);--> statement-breakpoint
+ALTER TABLE "kb_document_versions" ADD COLUMN "created_by_agentic_tool" text;

--- a/packages/core/drizzle/postgres/0087_knowledge_teammate_attribution.sql
+++ b/packages/core/drizzle/postgres/0087_knowledge_teammate_attribution.sql
@@ -1,0 +1,3 @@
+-- Snapshot the teammate display name so authorship remains readable after rename/deletion.
+ALTER TABLE "kb_documents" ADD COLUMN "updated_by_teammate_name" text;--> statement-breakpoint
+ALTER TABLE "kb_document_versions" ADD COLUMN "created_by_teammate_name" text;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1787100000000,
       "tag": "0086_knowledge_assistant_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1787184000000,
+      "tag": "0087_knowledge_teammate_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1787000000000,
       "tag": "0085_drop_mcp_catalog_entries",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1787100000000,
+      "tag": "0086_knowledge_assistant_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0089_knowledge_assistant_attribution.sql
+++ b/packages/core/drizzle/sqlite/0089_knowledge_assistant_attribution.sql
@@ -1,0 +1,6 @@
+-- Additive, nullable attribution keeps existing versions and supports rolling rollback.
+-- Session IDs intentionally are not foreign keys: immutable authorship survives Session deletion.
+ALTER TABLE `kb_documents` ADD COLUMN `updated_by_session_id` text;--> statement-breakpoint
+ALTER TABLE `kb_documents` ADD COLUMN `updated_by_agentic_tool` text;--> statement-breakpoint
+ALTER TABLE `kb_document_versions` ADD COLUMN `created_by_session_id` text;--> statement-breakpoint
+ALTER TABLE `kb_document_versions` ADD COLUMN `created_by_agentic_tool` text;

--- a/packages/core/drizzle/sqlite/0090_knowledge_teammate_attribution.sql
+++ b/packages/core/drizzle/sqlite/0090_knowledge_teammate_attribution.sql
@@ -1,0 +1,3 @@
+-- Snapshot the teammate display name so authorship remains readable after rename/deletion.
+ALTER TABLE `kb_documents` ADD COLUMN `updated_by_teammate_name` text;--> statement-breakpoint
+ALTER TABLE `kb_document_versions` ADD COLUMN `created_by_teammate_name` text;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1787000000000,
       "tag": "0088_drop_mcp_catalog_entries",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "6",
+      "when": 1787100000000,
+      "tag": "0089_knowledge_assistant_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1787100000000,
       "tag": "0089_knowledge_assistant_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "6",
+      "when": 1787184000000,
+      "tag": "0090_knowledge_teammate_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -795,6 +795,11 @@ export class KnowledgeDocumentVersionRepository
       metadata: row.metadata ?? null,
       change_summary: row.change_summary ?? null,
       created_by: (row.created_by as UserID | null) ?? null,
+      created_by_session_id:
+        (row.created_by_session_id as KnowledgeDocumentVersion['created_by_session_id']) ?? null,
+      created_by_agentic_tool:
+        (row.created_by_agentic_tool as KnowledgeDocumentVersion['created_by_agentic_tool']) ??
+        null,
       created_at: new Date(row.created_at),
     };
   }
@@ -822,6 +827,8 @@ export class KnowledgeDocumentVersionRepository
       metadata: data.metadata ?? null,
       change_summary: data.change_summary ?? null,
       created_by: data.created_by ?? null,
+      created_by_session_id: data.created_by_session_id ?? null,
+      created_by_agentic_tool: data.created_by_agentic_tool ?? null,
       created_at: data.created_at ? new Date(data.created_at) : new Date(),
     };
   }
@@ -928,6 +935,10 @@ export class KnowledgeDocumentRepository
       created_by: (row.created_by as UserID | null) ?? null,
       created_at: new Date(row.created_at),
       updated_by: (row.updated_by as UserID | null) ?? null,
+      updated_by_session_id:
+        (row.updated_by_session_id as KnowledgeDocument['updated_by_session_id']) ?? null,
+      updated_by_agentic_tool:
+        (row.updated_by_agentic_tool as KnowledgeDocument['updated_by_agentic_tool']) ?? null,
       updated_at: row.updated_at ? new Date(row.updated_at) : null,
       archived: Boolean(row.archived),
       archived_at: row.archived_at ? new Date(row.archived_at) : null,
@@ -982,6 +993,8 @@ export class KnowledgeDocumentRepository
       created_by: data.created_by ?? null,
       created_at: data.created_at ? new Date(data.created_at) : new Date(now),
       updated_by: data.updated_by ?? data.created_by ?? null,
+      updated_by_session_id: data.updated_by_session_id ?? null,
+      updated_by_agentic_tool: data.updated_by_agentic_tool ?? null,
       updated_at: data.updated_at ? new Date(data.updated_at) : new Date(now),
       archived: data.archived ?? false,
       archived_at: data.archived_at ? new Date(data.archived_at) : null,
@@ -1075,6 +1088,8 @@ export class KnowledgeDocumentRepository
           metadata: data.version_metadata ?? null,
           change_summary: data.change_summary ?? null,
           created_by: data.created_by ?? null,
+          created_by_session_id: data.updated_by_session_id ?? null,
+          created_by_agentic_tool: data.updated_by_agentic_tool ?? null,
           created_at: new Date(),
         })
         .run();
@@ -1352,6 +1367,8 @@ export class KnowledgeDocumentRepository
             metadata: updates.version_metadata ?? null,
             change_summary: updates.change_summary ?? null,
             created_by: updates.updated_by ?? current.updated_by ?? current.created_by ?? null,
+            created_by_session_id: updates.updated_by_session_id ?? null,
+            created_by_agentic_tool: updates.updated_by_agentic_tool ?? null,
             created_at: new Date(),
           })
           .run();

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -800,6 +800,7 @@ export class KnowledgeDocumentVersionRepository
       created_by_agentic_tool:
         (row.created_by_agentic_tool as KnowledgeDocumentVersion['created_by_agentic_tool']) ??
         null,
+      created_by_teammate_name: row.created_by_teammate_name ?? null,
       created_at: new Date(row.created_at),
     };
   }
@@ -829,6 +830,7 @@ export class KnowledgeDocumentVersionRepository
       created_by: data.created_by ?? null,
       created_by_session_id: data.created_by_session_id ?? null,
       created_by_agentic_tool: data.created_by_agentic_tool ?? null,
+      created_by_teammate_name: data.created_by_teammate_name ?? null,
       created_at: data.created_at ? new Date(data.created_at) : new Date(),
     };
   }
@@ -939,6 +941,7 @@ export class KnowledgeDocumentRepository
         (row.updated_by_session_id as KnowledgeDocument['updated_by_session_id']) ?? null,
       updated_by_agentic_tool:
         (row.updated_by_agentic_tool as KnowledgeDocument['updated_by_agentic_tool']) ?? null,
+      updated_by_teammate_name: row.updated_by_teammate_name ?? null,
       updated_at: row.updated_at ? new Date(row.updated_at) : null,
       archived: Boolean(row.archived),
       archived_at: row.archived_at ? new Date(row.archived_at) : null,
@@ -995,6 +998,7 @@ export class KnowledgeDocumentRepository
       updated_by: data.updated_by ?? data.created_by ?? null,
       updated_by_session_id: data.updated_by_session_id ?? null,
       updated_by_agentic_tool: data.updated_by_agentic_tool ?? null,
+      updated_by_teammate_name: data.updated_by_teammate_name ?? null,
       updated_at: data.updated_at ? new Date(data.updated_at) : new Date(now),
       archived: data.archived ?? false,
       archived_at: data.archived_at ? new Date(data.archived_at) : null,
@@ -1090,6 +1094,7 @@ export class KnowledgeDocumentRepository
           created_by: data.created_by ?? null,
           created_by_session_id: data.updated_by_session_id ?? null,
           created_by_agentic_tool: data.updated_by_agentic_tool ?? null,
+          created_by_teammate_name: data.updated_by_teammate_name ?? null,
           created_at: new Date(),
         })
         .run();
@@ -1369,6 +1374,7 @@ export class KnowledgeDocumentRepository
             created_by: updates.updated_by ?? current.updated_by ?? current.created_by ?? null,
             created_by_session_id: updates.updated_by_session_id ?? null,
             created_by_agentic_tool: updates.updated_by_agentic_tool ?? null,
+            created_by_teammate_name: updates.updated_by_teammate_name ?? null,
             created_at: new Date(),
           })
           .run();

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -2386,6 +2386,8 @@ export const kbDocuments = pgTable(
     updated_by: varchar('updated_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
     }),
+    updated_by_session_id: varchar('updated_by_session_id', { length: 36 }),
+    updated_by_agentic_tool: text('updated_by_agentic_tool'),
     updated_at: t.timestamp('updated_at'),
     archived: t.bool('archived').notNull().default(false),
     archived_at: t.timestamp('archived_at'),
@@ -2433,6 +2435,8 @@ export const kbDocumentVersions = pgTable(
     created_by: varchar('created_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
     }),
+    created_by_session_id: varchar('created_by_session_id', { length: 36 }),
+    created_by_agentic_tool: text('created_by_agentic_tool'),
     created_at: t.timestamp('created_at').notNull(),
   },
   (table) => ({

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -2388,6 +2388,7 @@ export const kbDocuments = pgTable(
     }),
     updated_by_session_id: varchar('updated_by_session_id', { length: 36 }),
     updated_by_agentic_tool: text('updated_by_agentic_tool'),
+    updated_by_teammate_name: text('updated_by_teammate_name'),
     updated_at: t.timestamp('updated_at'),
     archived: t.bool('archived').notNull().default(false),
     archived_at: t.timestamp('archived_at'),
@@ -2437,6 +2438,7 @@ export const kbDocumentVersions = pgTable(
     }),
     created_by_session_id: varchar('created_by_session_id', { length: 36 }),
     created_by_agentic_tool: text('created_by_agentic_tool'),
+    created_by_teammate_name: text('created_by_teammate_name'),
     created_at: t.timestamp('created_at').notNull(),
   },
   (table) => ({

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -2249,6 +2249,7 @@ export const kbDocuments = sqliteTable(
     }),
     updated_by_session_id: text('updated_by_session_id', { length: 36 }),
     updated_by_agentic_tool: text('updated_by_agentic_tool'),
+    updated_by_teammate_name: text('updated_by_teammate_name'),
     updated_at: t.timestamp('updated_at'),
     archived: t.bool('archived').notNull().default(false),
     archived_at: t.timestamp('archived_at'),
@@ -2294,6 +2295,7 @@ export const kbDocumentVersions = sqliteTable(
     }),
     created_by_session_id: text('created_by_session_id', { length: 36 }),
     created_by_agentic_tool: text('created_by_agentic_tool'),
+    created_by_teammate_name: text('created_by_teammate_name'),
     created_at: t.timestamp('created_at').notNull(),
   },
   (table) => ({

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -2247,6 +2247,8 @@ export const kbDocuments = sqliteTable(
     updated_by: text('updated_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
     }),
+    updated_by_session_id: text('updated_by_session_id', { length: 36 }),
+    updated_by_agentic_tool: text('updated_by_agentic_tool'),
     updated_at: t.timestamp('updated_at'),
     archived: t.bool('archived').notNull().default(false),
     archived_at: t.timestamp('archived_at'),
@@ -2290,6 +2292,8 @@ export const kbDocumentVersions = sqliteTable(
     created_by: text('created_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
     }),
+    created_by_session_id: text('created_by_session_id', { length: 36 }),
+    created_by_agentic_tool: text('created_by_agentic_tool'),
     created_at: t.timestamp('created_at').notNull(),
   },
   (table) => ({

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -614,6 +614,8 @@ export interface KnowledgeDocument {
   /** Trusted Session attribution for the most recent assistant-authored version. */
   updated_by_session_id?: SessionID | null;
   updated_by_agentic_tool?: PersistedAgenticToolName | null;
+  /** Teammate display name captured at write time, so attribution survives rename/deletion. */
+  updated_by_teammate_name?: string | null;
   updated_at?: Date | null;
   archived: boolean;
   archived_at?: Date | null;
@@ -642,6 +644,7 @@ export interface KnowledgeDocumentVersion {
   /** Present only when this version was written through a Session-scoped agent request. */
   created_by_session_id?: SessionID | null;
   created_by_agentic_tool?: PersistedAgenticToolName | null;
+  created_by_teammate_name?: string | null;
   created_at: Date;
 }
 

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -1,3 +1,4 @@
+import type { PersistedAgenticToolName } from './agentic-tool';
 import type {
   ArtifactID,
   BoardID,
@@ -610,6 +611,9 @@ export interface KnowledgeDocument {
   created_by?: UserID | null;
   created_at: Date;
   updated_by?: UserID | null;
+  /** Trusted Session attribution for the most recent assistant-authored version. */
+  updated_by_session_id?: SessionID | null;
+  updated_by_agentic_tool?: PersistedAgenticToolName | null;
   updated_at?: Date | null;
   archived: boolean;
   archived_at?: Date | null;
@@ -635,6 +639,9 @@ export interface KnowledgeDocumentVersion {
   metadata?: Record<string, unknown> | null;
   change_summary?: string | null;
   created_by?: UserID | null;
+  /** Present only when this version was written through a Session-scoped agent request. */
+  created_by_session_id?: SessionID | null;
+  created_by_agentic_tool?: PersistedAgenticToolName | null;
   created_at: Date;
 }
 

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -12,6 +12,14 @@ import type {
   UUID,
 } from './id';
 
+/** Trusted assistant attribution derived at the authenticated Knowledge write boundary. */
+export interface KnowledgeWriteAttribution {
+  sessionId: SessionID;
+  agenticTool: PersistedAgenticToolName;
+  /** Teammate display name captured at write time when the Session belongs to one. */
+  teammateName?: string;
+}
+
 export type KnowledgeNamespaceID = UUID;
 export type KnowledgeDocumentID = UUID;
 export type KnowledgeDocumentVersionID = UUID;


### PR DESCRIPTION
## Summary

- persist trusted human, Session, agentic-tool, and named-teammate attribution for Knowledge document versions and the document's latest edit
- derive the teammate name from the authenticated Session's tenant-scoped branch and snapshot it so attribution survives later branch/session rename, archival, or deletion
- show `Last edited by {user}` for human edits and `Last edited by {user} and {teammate}` for teammate edits, without exposing Session IDs in the UI
- propagate assistant identity only from authenticated MCP context across `agor_kb_put`, `agor_kb_edit`, and `agor_kb_publish_from_worktree`
- keep document-level human and assistant attribution synchronized for content and metadata-only edits
- add additive SQLite/PostgreSQL migrations and focused backend/UI regression coverage

## Root cause

Knowledge writes already recorded the authenticated human user, but the MCP layer discarded its freshly authorized Session before it built Feathers service params. Agent writes therefore lacked enough trusted context to identify either the Session or the named teammate that performed the work. The UI also did not render the existing human attribution.

Document metadata-only updates additionally changed `updated_by` without replacing or clearing the prior assistant attribution, which could pair a human editor with stale assistant data.

## Security and deployment

- Session/tool/teammate attribution is derived from the Session and branch fetched through normal tenant-scoped services; it is not accepted from MCP tool arguments.
- Existing Knowledge authorization and tenant RLS remain the read/write boundary; no cross-tenant lookup or relation was added.
- The teammate display name is copied into immutable version attribution, while the Session ID remains stored only for forensic use and is not presented in the UI.
- Migrations are nullable/additive for rolling deployment and rollback compatibility.
- Session IDs intentionally have no foreign key so immutable authorship survives Session deletion.

## Validation

- `pnpm check`
- daemon Knowledge/MCP tests: 108 passed
- Knowledge attribution UI tests: 3 passed
- core Knowledge repository/type tests: 24 passed
- `pnpm check:multitenancy-boundaries`

Fixes preset-io/agor-cloud#275
