### PR TITLE
fix(ui): restore interactive cursors in branch cards

### DIFF
--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -76,6 +76,17 @@ const defaultProps = {
 };
 
 describe('EnvironmentPill', () => {
+  it('uses an Ant Design button for the unconfigured environment action', () => {
+    render(
+      <EnvironmentPill
+        {...defaultProps}
+        repo={{ repo_id: 'repo-unconfigured', slug: 'preset-io/unconfigured' } as Repo}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Configure environment' })).toHaveTextContent('env');
+  });
+
   it('shows a pointer only when the environment label links to a running app', () => {
     const { rerender } = render(
       <EnvironmentPill

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -71,30 +71,44 @@ export function EnvironmentPill({
 
   // Case 1: No config at all - show grayed discovery pill
   if (!hasConfig) {
+    const tag = (
+      <Tag
+        color="default"
+        style={{
+          cursor: onEdit ? 'pointer' : 'default',
+          userSelect: 'none',
+          opacity: 0.6,
+        }}
+      >
+        <Space size={4}>
+          <GlobalOutlined style={{ fontSize: 12 }} />
+          <span style={{ fontFamily: token.fontFamilyCode }}>env</span>
+          <EditOutlined style={{ fontSize: 12 }} />
+        </Space>
+      </Tag>
+    );
+
     return (
       <Tooltip title="Click to configure environment (optional)">
-        <Tag
-          color="default"
+        <button
+          type="button"
+          aria-label="Configure environment"
+          disabled={!onEdit}
           style={{
             cursor: onEdit ? 'pointer' : 'default',
-            userSelect: 'none',
-            opacity: 0.6,
+            padding: 0,
+            border: 0,
+            background: 'transparent',
+            color: 'inherit',
+            font: 'inherit',
           }}
-          onClick={
-            onEdit
-              ? (e) => {
-                  e.stopPropagation();
-                  onEdit();
-                }
-              : undefined
-          }
+          onClick={(event) => {
+            event.stopPropagation();
+            onEdit?.();
+          }}
         >
-          <Space size={4}>
-            <GlobalOutlined style={{ fontSize: 12 }} />
-            <span style={{ fontFamily: token.fontFamilyCode }}>env</span>
-            <EditOutlined style={{ fontSize: 12 }} />
-          </Space>
-        </Tag>
+          {tag}
+        </button>
       </Tooltip>
     );
   }

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -71,44 +71,29 @@ export function EnvironmentPill({
 
   // Case 1: No config at all - show grayed discovery pill
   if (!hasConfig) {
-    const tag = (
-      <Tag
-        color="default"
-        style={{
-          cursor: onEdit ? 'pointer' : 'default',
-          userSelect: 'none',
-          opacity: 0.6,
-        }}
-      >
-        <Space size={4}>
-          <GlobalOutlined style={{ fontSize: 12 }} />
-          <span style={{ fontFamily: token.fontFamilyCode }}>env</span>
-          <EditOutlined style={{ fontSize: 12 }} />
-        </Space>
-      </Tag>
-    );
-
     return (
       <Tooltip title="Click to configure environment (optional)">
-        <button
-          type="button"
+        <Button
+          size="small"
           aria-label="Configure environment"
+          icon={<GlobalOutlined style={{ fontSize: 12 }} />}
           disabled={!onEdit}
-          style={{
-            cursor: onEdit ? 'pointer' : 'default',
-            padding: 0,
-            border: 0,
-            background: 'transparent',
-            color: 'inherit',
-            font: 'inherit',
-          }}
           onClick={(event) => {
             event.stopPropagation();
             onEdit?.();
           }}
+          style={{
+            height: 22,
+            paddingInline: 7,
+            fontSize: 12,
+            opacity: 0.6,
+          }}
         >
-          {tag}
-        </button>
+          <Space size={4}>
+            <span style={{ fontFamily: token.fontFamilyCode }}>env</span>
+            <EditOutlined style={{ fontSize: 12 }} />
+          </Space>
+        </Button>
       </Tooltip>
     );
   }

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -4,6 +4,12 @@
  * Reduces heading sizes, margins, and ensures content doesn't blow up layout
  */
 
+/* Streamdown links are native anchors; make their interactive affordance
+   explicit so it remains stable inside canvas no-drag regions. */
+[data-streamdown="link"] {
+  cursor: pointer;
+}
+
 .markdown-compact h1 {
   font-size: 1.2em;
   margin-top: 0.5em;

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -4,12 +4,6 @@
  * Reduces heading sizes, margins, and ensures content doesn't blow up layout
  */
 
-/* Streamdown links are native anchors; make their interactive affordance
-   explicit so it remains stable inside canvas no-drag regions. */
-[data-streamdown="link"] {
-  cursor: pointer;
-}
-
 .markdown-compact h1 {
   font-size: 1.2em;
   margin-top: 0.5em;

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -100,6 +100,7 @@ describe('MarkdownRenderer', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/acme/repo/pull/1');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+    expect(getComputedStyle(link).cursor).toBe('pointer');
 
     fireEvent.click(link);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/apps/agor-ui/src/components/Pill/IssuePullRequestPill.test.tsx
+++ b/apps/agor-ui/src/components/Pill/IssuePullRequestPill.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { IssuePill, PullRequestPill } from './Pill';
+
+describe('GitHub link pills', () => {
+  it.each([
+    ['issue', () => <IssuePill issueUrl="https://github.com/preset-io/agor/issues/42" />],
+    ['pull request', () => <PullRequestPill prUrl="https://github.com/preset-io/agor/pull/43" />],
+  ])('renders the %s pill as a keyboard-focusable link', (_name, renderPill) => {
+    render(renderPill());
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+    expect(link).not.toHaveAttribute('tabindex', '-1');
+    expect(link.firstElementChild).toHaveStyle({ cursor: 'pointer' });
+  });
+});

--- a/apps/agor-ui/src/components/Pill/IssuePullRequestPill.test.tsx
+++ b/apps/agor-ui/src/components/Pill/IssuePullRequestPill.test.tsx
@@ -13,6 +13,7 @@ describe('GitHub link pills', () => {
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noreferrer');
     expect(link).not.toHaveAttribute('tabindex', '-1');
-    expect(link.firstElementChild).toHaveStyle({ cursor: 'pointer' });
+    expect(link).toHaveStyle({ cursor: 'pointer' });
+    expect(link).toHaveClass('ant-tag');
   });
 });

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -1143,14 +1143,21 @@ export const IssuePill: React.FC<IssuePillProps> = ({
 
   return (
     <Tooltip title={issueUrl}>
-      <Tag
-        icon={getIssueIcon(issueUrl)}
-        color={PILL_COLORS.git}
-        style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
-        onClick={() => window.open(issueUrl, '_blank')}
+      <a
+        href={issueUrl}
+        target="_blank"
+        rel="noreferrer"
+        onClick={(event) => event.stopPropagation()}
+        style={{ display: 'inline-flex', textDecoration: 'none' }}
       >
-        <span style={pillTextStyle}>Issue: {displayText}</span>
-      </Tag>
+        <Tag
+          icon={getIssueIcon(issueUrl)}
+          color={PILL_COLORS.git}
+          style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
+        >
+          <span style={pillTextStyle}>Issue: {displayText}</span>
+        </Tag>
+      </a>
     </Tooltip>
   );
 };
@@ -1171,14 +1178,21 @@ export const PullRequestPill: React.FC<PullRequestPillProps> = ({
 
   return (
     <Tooltip title={prUrl}>
-      <Tag
-        icon={getPrIcon(prUrl)}
-        color={PILL_COLORS.git}
-        style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
-        onClick={() => window.open(prUrl, '_blank')}
+      <a
+        href={prUrl}
+        target="_blank"
+        rel="noreferrer"
+        onClick={(event) => event.stopPropagation()}
+        style={{ display: 'inline-flex', textDecoration: 'none' }}
       >
-        <span style={pillTextStyle}>PR: {displayText}</span>
-      </Tag>
+        <Tag
+          icon={getPrIcon(prUrl)}
+          color={PILL_COLORS.git}
+          style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
+        >
+          <span style={pillTextStyle}>PR: {displayText}</span>
+        </Tag>
+      </a>
     </Tooltip>
   );
 };

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -1143,21 +1143,17 @@ export const IssuePill: React.FC<IssuePillProps> = ({
 
   return (
     <Tooltip title={issueUrl}>
-      <a
+      <Tag
+        icon={getIssueIcon(issueUrl)}
+        color={PILL_COLORS.git}
         href={issueUrl}
         target="_blank"
         rel="noreferrer"
         onClick={(event) => event.stopPropagation()}
-        style={{ display: 'inline-flex', textDecoration: 'none' }}
+        style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
       >
-        <Tag
-          icon={getIssueIcon(issueUrl)}
-          color={PILL_COLORS.git}
-          style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
-        >
-          <span style={pillTextStyle}>Issue: {displayText}</span>
-        </Tag>
-      </a>
+        <span style={pillTextStyle}>Issue: {displayText}</span>
+      </Tag>
     </Tooltip>
   );
 };
@@ -1178,21 +1174,17 @@ export const PullRequestPill: React.FC<PullRequestPillProps> = ({
 
   return (
     <Tooltip title={prUrl}>
-      <a
+      <Tag
+        icon={getPrIcon(prUrl)}
+        color={PILL_COLORS.git}
         href={prUrl}
         target="_blank"
         rel="noreferrer"
         onClick={(event) => event.stopPropagation()}
-        style={{ display: 'inline-flex', textDecoration: 'none' }}
+        style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
       >
-        <Tag
-          icon={getPrIcon(prUrl)}
-          color={PILL_COLORS.git}
-          style={{ ...style, cursor: 'pointer', maxWidth: 220 }}
-        >
-          <span style={pillTextStyle}>PR: {displayText}</span>
-        </Tag>
-      </a>
+        <span style={pillTextStyle}>PR: {displayText}</span>
+      </Tag>
     </Tooltip>
   );
 };

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -80,10 +80,14 @@
   cursor: grabbing;
 }
 
-/* Prevent nodrag children from inheriting grab cursor */
-.nodrag,
-.nodrag * {
+/* Prevent a nodrag region from inheriting the node's grab cursor. Set this on
+   the boundary only: descendants then inherit `auto` unless an interactive
+   element (link, button, clickable pill) supplies its own cursor. Resetting
+   every descendant used to override those affordances. A no-drag region is
+   also where ordinary text selection is safe without moving the node. */
+.nodrag {
   cursor: auto;
+  user-select: text;
 }
 
 /* Widen the resize hit-area on board items (zones, artifacts, apps) so the

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.cursor.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.cursor.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = fs.readFileSync('src/components/SessionCanvas/SessionCanvas.css', 'utf8');
+
+describe('React Flow no-drag cursor boundary', () => {
+  it('resets the drag cursor only on the boundary, not interactive descendants', () => {
+    expect(css).toMatch(/\.nodrag\s*{[^}]*cursor:\s*auto;/s);
+    expect(css).toMatch(/\.nodrag\s*{[^}]*user-select:\s*text;/s);
+    expect(css).not.toMatch(/\.nodrag\s*\*/);
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.cursor.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.cursor.test.ts
@@ -1,12 +1,37 @@
 import fs from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const css = fs.readFileSync('src/components/SessionCanvas/SessionCanvas.css', 'utf8');
+const appCss = fs.readFileSync('src/index.css', 'utf8');
+const canvasCss = fs.readFileSync('src/components/SessionCanvas/SessionCanvas.css', 'utf8');
+let styleElement: HTMLStyleElement;
 
 describe('React Flow no-drag cursor boundary', () => {
-  it('resets the drag cursor only on the boundary, not interactive descendants', () => {
-    expect(css).toMatch(/\.nodrag\s*{[^}]*cursor:\s*auto;/s);
-    expect(css).toMatch(/\.nodrag\s*{[^}]*user-select:\s*text;/s);
-    expect(css).not.toMatch(/\.nodrag\s*\*/);
+  beforeEach(() => {
+    styleElement = document.createElement('style');
+    // Match the production cascade: app semantics first, canvas overrides second.
+    styleElement.textContent = `${appCss}\n${canvasCss}`;
+    document.head.append(styleElement);
+  });
+
+  afterEach(() => styleElement.remove());
+
+  it('preserves interactive cursors and text selection inside a no-drag region', () => {
+    const region = document.createElement('div');
+    region.className = 'nodrag';
+    region.innerHTML = `
+      <a data-streamdown="link" href="https://example.test">Markdown link</a>
+      <button style="cursor: pointer">Action</button>
+      <span>Selectable text</span>
+    `;
+    document.body.append(region);
+
+    expect(getComputedStyle(region).cursor).toBe('auto');
+    expect(getComputedStyle(region).userSelect).toBe('text');
+    expect(getComputedStyle(region.querySelector('a') as HTMLAnchorElement).cursor).toBe('pointer');
+    expect(getComputedStyle(region.querySelector('button') as HTMLButtonElement).cursor).toBe(
+      'pointer'
+    );
+
+    region.remove();
   });
 });

--- a/apps/agor-ui/src/components/Tag/Tag.tsx
+++ b/apps/agor-ui/src/components/Tag/Tag.tsx
@@ -1,8 +1,10 @@
 import type { TagProps as AntTagProps } from 'antd';
 import { Tag as AntTag } from 'antd';
-import { type CSSProperties, forwardRef } from 'react';
+import { type AnchorHTMLAttributes, type CSSProperties, forwardRef } from 'react';
 
 export interface TagProps extends AntTagProps {
+  /** Forwarded when Ant Design renders the Tag as an anchor via `href`. */
+  rel?: AnchorHTMLAttributes<HTMLAnchorElement>['rel'];
   /**
    * Grow up to the available width, then ellipsize inside the border instead of
    * painting past it. Needs an ancestor with a definite width — a percentage
@@ -44,7 +46,7 @@ function withTruncateStyles(styles: AntTagProps['styles']): AntTagProps['styles'
  * Use this instead of importing Tag directly from 'antd' to ensure
  * consistent outlined styling across the application.
  */
-const TagComponent = forwardRef<HTMLSpanElement, TagProps>(
+const TagComponent = forwardRef<HTMLSpanElement | HTMLAnchorElement, TagProps>(
   ({ variant = 'outlined', truncate = false, icon, style, styles, children, ...props }, ref) => {
     return (
       <AntTag

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -139,6 +139,7 @@
 [data-streamdown="link"] {
   color: var(--ant-color-primary);
   text-decoration: underline;
+  cursor: pointer;
 }
 
 [data-streamdown="link"]:hover {


### PR DESCRIPTION
## Summary

- scope React Flow's `nodrag` cursor reset to the no-drag boundary instead of every descendant
- preserve text selection in no-drag content while keeping drag handles on the `grab` cursor
- render GitHub issue/PR pills and the environment configuration pill with native anchor/button semantics
- make Markdown links' pointer affordance explicit and add focused regressions

## Root cause

`SessionCanvas.css` applied `cursor: auto` to `.nodrag *`. That descendant selector reset the cursor on interactive content inside branch-card no-drag regions, overriding the intended affordances on pill contents, environment links/actions, and Markdown anchors.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-ui exec vitest run src/components/Pill/IssuePullRequestPill.test.tsx src/components/SessionCanvas/SessionCanvas.cursor.test.ts src/components/EnvironmentPill/EnvironmentPill.test.tsx src/components/MarkdownRenderer/MarkdownRenderer.test.tsx`
  - 4 files passed
  - 28 tests passed
- Playwright validation in a disposable branch environment confirmed:
  - issue and PR pills: native anchors, `cursor: pointer`, keyboard focusable
  - environment configuration pill: native button, `cursor: pointer`, keyboard focusable
  - Markdown link: native anchor, `cursor: pointer`, keyboard focusable
  - plain description text: selectable
  - React Flow drag handle: `cursor: grab`
