### PR TITLE
docs: remove unsupported Homebrew install path

### DIFF
--- a/.github/workflows/brew-formula-bump.yml
+++ b/.github/workflows/brew-formula-bump.yml
@@ -1,32 +1,23 @@
-# Auto-bump the Homebrew formula when a new agor-live version ships to npm.
+# Experimental helper for refreshing the unsupported Homebrew formula.
 #
 # Why this exists:
-#   The formula in `Formula/agor-live.rb` pins `url` + `sha256` to a specific
-#   npm tarball. Every release of `agor-live` makes the formula stale until a
-#   human remembers to bump it. This workflow makes the bump automatic.
+#   Homebrew is not currently a documented or release-gated installation
+#   channel. Keep this workflow manual until the formula has a supported smoke
+#   matrix and a reviewed ownership/release contract. It must not be coupled to
+#   npm publishing: an experimental formula failure cannot fail an npm release.
 #
 # Strategy:
-#   1. Poll npm for the latest `agor-live` version (daily cron + on-demand).
+#   1. On demand, read the latest `agor-live` version from npm.
 #   2. Diff against the version currently pinned in the formula.
 #   3. If different, download the tarball, compute sha256, rewrite the two
 #      lines in the formula, open a PR.
 #
-# Note on the 24h supply-chain delay:
-#   The formula passes `--min-release-age=1` to npm install, which refuses to
-#   install package versions less than ~24h old. This is intentional supply-
-#   chain protection. Bumping the formula immediately after publish is still
-#   correct — by the time most users `brew install`, the cooldown has lapsed.
-#   Early adopters who try within the first day will hit a `notarget` error;
-#   that's expected and documented in the install guide.
+# The current formula and its dependency-install policy require validation
+# before this can become release automation.
 
-name: Bump Homebrew formula
+name: Refresh experimental Homebrew formula
 
 on:
-  schedule:
-    # Daily at 14:00 UTC — a few hours after the typical npm publish window.
-    # A newly opened PR may still need the 24h `--min-release-age` cooldown
-    # to lapse before the bumped formula is installable.
-    - cron: '0 14 * * *'
   workflow_dispatch:
 
 permissions:
@@ -96,12 +87,8 @@ jobs:
             - **New:** `${{ steps.bump.outputs.version }}`
             - **sha256:** `${{ steps.bump.outputs.sha }}`
 
-            **Heads up:** the formula's `--min-release-age=1` (npm's 1-day
-            supply-chain delay) means `brew install agor-live` against this
-            version will fail with a `notarget` error until ~24h after the
-            npm publish. That's intentional. By the time this PR is reviewed
-            and merged the cooldown will almost always have lapsed; if you
-            merge early, the next install attempt within that window will
-            surface the npm error verbatim (no harm done — re-run succeeds).
+            This formula is experimental and is not part of the supported npm
+            release path. Validate installation and lifecycle behavior before
+            merging this update.
           labels: |
             dependencies

--- a/apps/agor-docs/components/InstallTabs.mdx
+++ b/apps/agor-docs/components/InstallTabs.mdx
@@ -1,6 +1,6 @@
 import { Tabs } from 'nextra/components';
 
-<Tabs items={['npm (Recommended)', 'Homebrew', 'Docker Compose']} defaultIndex={0}>
+<Tabs items={['npm (Recommended)', 'Docker Compose']} defaultIndex={0}>
   <Tabs.Tab>
     Most users should start here. It's the most universal path, and it's the one the rest of the docs assume.
 
@@ -15,40 +15,6 @@ import { Tabs } from 'nextra/components';
     agor daemon start
     agor open
     ```
-
-  </Tabs.Tab>
-
-  <Tabs.Tab>
-    If you already use Homebrew, this is a convenient alternative on macOS or Linux.
-
-    The Homebrew formula installs a compatible Node runtime for you.
-
-    ```bash
-    # Install Agor
-    brew tap preset-io/agor https://github.com/preset-io/agor
-    brew install agor-live
-
-    # First run
-    agor init
-    agor daemon start
-    agor open
-    ```
-
-    > **Heads up — 24h release cooldown.** The formula installs via npm with
-    > `--min-release-age=1` for supply-chain protection, so a brand-new
-    > `agor-live` release isn't installable via Homebrew until ~24 hours
-    > after it lands on npm. If `brew install` fails with
-    > `notarget No matching version found for @agor-live/client@<version>
-    > with a date before …`, wait until the cooldown lapses and retry.
-    > Re-running succeeds; nothing is broken.
-
-    > **Why a tap, not `brew install agor-live` directly?** Agor is licensed
-    > under [BUSL-1.1](https://spdx.org/licenses/BUSL-1.1.html), which is
-    > source-available rather than OSI-approved open source. Homebrew's
-    > [core repository](https://docs.brew.sh/License-Guidelines) only
-    > accepts DFSG-compatible licenses, so BUSL projects (Agor, HashiCorp's
-    > Terraform/Vault, CockroachDB, Sentry, …) ship via their own taps
-    > instead. The tap install path is the supported, long-term solution.
 
   </Tabs.Tab>
 

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -7,7 +7,7 @@ import InstallTabs from '../../components/InstallTabs.mdx';
 
 # Extended Installation
 
-The [Getting Started](/guide/getting-started) guide covers the recommended npm installation. This page covers everything else for **users and teams** running Agor, including Homebrew, optional companions, deployment alternatives, authentication options, and edge-case configurations.
+The [Getting Started](/guide/getting-started) guide covers the recommended npm installation. This page covers everything else for **users and teams** running Agor, including optional companions, deployment alternatives, authentication options, and edge-case configurations.
 
 > Want to **build, modify, or contribute to** Agor? Head to the [Development Guide](/guide/development). It covers `docker compose up`, the `.agor.yml` variant system (SQLite / Postgres / RBAC / docs), and developing Agor with Agor itself.
 
@@ -21,15 +21,11 @@ Agor supports Node releases that are Current, Active LTS, or Maintenance LTS ups
 the Node ≥ 22.12 minimum. The packaged release gate currently runs Node 22, 24, and 26 end to end.
 Upstream EOL releases such as Node 25 are not supported production runtimes.
 
-The Homebrew formula installs a compatible Node runtime for you. Everything below is either an alternative install method or an optional companion.
-
 ## Install paths
 
 Use whichever install method fits your setup:
 
 <InstallTabs />
-
-Homebrew is a convenience path for macOS/Linux users; npm remains the canonical cross-platform install path used throughout the docs.
 
 ---
 

--- a/apps/agor-docs/content/guide/index.mdx
+++ b/apps/agor-docs/content/guide/index.mdx
@@ -45,7 +45,7 @@ agor daemon start
 agor open
 ```
 
-Prefer Homebrew on macOS or Linux? See the [Getting Started Guide](/guide/getting-started) for that install path, then add your first repo. For Docker, source builds, and other options, see [Extended Installation](/guide/extended-install).
+Then add your first repo. For Docker, source builds, and other options, see [Extended Installation](/guide/extended-install).
 
 **Then dive in:**
 
@@ -66,42 +66,42 @@ _Multiplayer spatial canvas with zones, branches, live cursors, notes, and agent
   shots={[
     {
       src: '/screenshots/conversation_full_page.png',
-      alt: "Agor task-centric conversation UI showing AI agent messages, tool calls, and file changes in a structured timeline",
+      alt: 'Agor task-centric conversation UI showing AI agent messages, tool calls, and file changes in a structured timeline',
       caption: 'Task-centric conversation UI',
     },
     {
       src: '/screenshots/settings_modal.png',
-      alt: "Agor settings modal for configuring MCP servers, managing branches, and agent preferences",
+      alt: 'Agor settings modal for configuring MCP servers, managing branches, and agent preferences',
       caption: 'MCP server and branch management',
     },
     {
       src: '/screenshots/zone-trigger.png',
-      alt: "Agor zone trigger modal showing a templated prompt with mustache placeholders ({{ branch.name }}, {{ branch.pull_request_url }}) and Prompt/Fork/Spawn action choices",
+      alt: 'Agor zone trigger modal showing a templated prompt with mustache placeholders ({{ branch.name }}, {{ branch.pull_request_url }}) and Prompt/Fork/Spawn action choices',
       caption: 'Zone trigger with templated prompt',
     },
     {
       src: '/screenshots/tool-blocks.png',
-      alt: "Agor chat showing structured tool blocks: collapsible thinking, Grep with pattern badge, Edit with red/green inline diff, and Bash with expandable output",
+      alt: 'Agor chat showing structured tool blocks: collapsible thinking, Grep with pattern badge, Edit with red/green inline diff, and Bash with expandable output',
       caption: 'Structured tool blocks with inline diffs',
     },
     {
       src: '/screenshots/env-variants-full.png',
-      alt: "Agor branch environment tab showing YAML config with named variants (docs, full, sqlite, postgres) and Docker compose commands",
+      alt: 'Agor branch environment tab showing YAML config with named variants (docs, full, sqlite, postgres) and Docker compose commands',
       caption: 'Branch environment with named variants',
     },
     {
       src: '/screenshots/create-session-modal.png',
-      alt: "Agor create session modal showing five agent runtime cards side-by-side: Claude Code, Codex, Gemini, OpenCode, GitHub Copilot (BETA)",
+      alt: 'Agor create session modal showing five agent runtime cards side-by-side: Claude Code, Codex, Gemini, OpenCode, GitHub Copilot (BETA)',
       caption: 'Pick any SDK: Claude, Codex, Gemini, OpenCode, Copilot',
     },
     {
       src: '/screenshots/baked_in_terminal.png',
-      alt: "Agor built-in terminal with automatic branch context and environment variable injection",
+      alt: 'Agor built-in terminal with automatic branch context and environment variable injection',
       caption: 'Built-in terminal with branch context',
     },
     {
       src: '/screenshots/onboarding.png',
-      alt: "Agor onboarding welcome screen showing team status, recent activity, and quick start guide",
+      alt: 'Agor onboarding welcome screen showing team status, recent activity, and quick start guide',
       caption: 'Welcome screen showing team status',
     },
   ]}


### PR DESCRIPTION
## Summary

- remove the unsupported Homebrew path from Getting Started and related guide copy
- stop presenting the stale formula as an official long-term installation channel
- disable the failing daily formula updater while retaining it as a manual experimental helper
- keep Homebrew completely independent from the npm release workflow

## Why

The checked-in formula is still pinned to `agor-live@0.21.0`, and its scheduled updater has repeatedly failed because GitHub Actions cannot create pull requests in this repository. The formula also lacks the installation/lifecycle matrix needed to treat it as supported.

npm remains the canonical installation path. Homebrew can be restored later if we deliberately adopt a tested tap and a non-blocking post-npm update process.

## Checks

- `pnpm exec prettier --check apps/agor-docs/components/InstallTabs.mdx apps/agor-docs/content/guide/extended-install.mdx apps/agor-docs/content/guide/index.mdx .github/workflows/brew-formula-bump.yml`
- `git diff --check`
