### PR TITLE
feat(ui): Troubleshoot-this-error-with-an-agent button on error toasts (Phase 1, #2388)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -79,6 +79,7 @@ import {
   useOnboardingLifecycle,
 } from './hooks/useOnboardingLifecycle';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
+import { useTroubleshootError } from './hooks/useTroubleshootError';
 import { sessionCreated } from './store/agorRealtimeActions';
 import { agorStore, useAgorStore } from './store/agorStore';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
@@ -523,6 +524,9 @@ function AppContent() {
   // Session actions
   const { createSession, forkSession, btwForkSession, spawnSession, updateSession, deleteSession } =
     useSessionActions(client);
+
+  // Error toasts that can hand the error off to an agent (issue #2388).
+  const { showErrorWithTroubleshoot } = useTroubleshootError(client);
 
   // Board actions
   const { createBoard, updateBoard, deleteBoard, archiveBoard, unarchiveBoard } =
@@ -1366,7 +1370,10 @@ function AppContent() {
       showSuccess('Session forked successfully!');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fork session';
-      showError(`Failed to fork session: ${message}`);
+      showErrorWithTroubleshoot(`Failed to fork session: ${message}`, {
+        sessionId,
+        source: 'Forking a session',
+      });
       throw err;
     }
   };
@@ -1411,8 +1418,9 @@ function AppContent() {
       return isAuthenticationOwnerCurrent(operationUserId, operationAuthenticationGeneration);
     } catch (error) {
       if (isAuthenticationOwnerCurrent(operationUserId, operationAuthenticationGeneration)) {
-        showError(
-          `Failed to send prompt: ${error instanceof Error ? error.message : String(error)}`
+        showErrorWithTroubleshoot(
+          `Failed to send prompt: ${error instanceof Error ? error.message : String(error)}`,
+          { sessionId, source: 'Sending a prompt to a session' }
         );
         console.error('Prompt error:', error);
       }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@/utils/message', () => ({
   }),
 }));
 
+// The troubleshoot hook pulls in router + canvas-nav contexts that this bare
+// harness doesn't provide; stub it so the form renders in isolation.
+vi.mock('@/hooks/useTroubleshootError', () => ({
+  useTroubleshootError: () => ({ showErrorWithTroubleshoot: vi.fn() }),
+}));
+
 // `getByRole('button', { name })` prices in an accessible-name and visibility
 // pass over the whole form, and jsdom's getComputedStyle runs ~18ms per node
 // against antd's injected stylesheets — ~2.5s per query here, which is what

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -19,8 +19,9 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
+import { useTroubleshootError } from '@/hooks/useTroubleshootError';
 import { useThemedMessage } from '@/utils/message';
 import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
@@ -130,6 +131,13 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   managedOAuthCompatibilityMode,
 }) => {
   const { showSuccess, showError, showWarning, showInfo } = useThemedMessage();
+  // MCP OAuth connect is the motivating error for the troubleshoot button
+  // (issue #2271 / #2388): failures here get a one-click handoff to an agent.
+  const { showErrorWithTroubleshoot } = useTroubleshootError(client);
+  const showOAuthError = useCallback(
+    (msg: string) => showErrorWithTroubleshoot(msg, { source: 'Connecting an MCP server (OAuth)' }),
+    [showErrorWithTroubleshoot]
+  );
   const [testingAuth, setTestingAuth] = useState(false);
   const [oauthBrowserFlowAvailable, setOauthBrowserFlowAvailable] = useState(false);
   const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
@@ -161,7 +169,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     authorityKey,
     onPrepareOAuthStart,
     onOAuthSucceeded: () => setOauthBrowserFlowAvailable(false),
-    showError,
+    showError: showOAuthError,
     showInfo,
     showSuccess,
     startAllowed: oauthStartAllowed,

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -7,6 +7,14 @@ import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { agorStore } from '../../store/agorStore';
 import { MCPServersTable } from './MCPServersTable';
 
+// The edit modal mounts MCPServerFormFields, which pulls in the troubleshoot
+// hook (router + canvas-nav contexts) this bare harness doesn't provide; stub
+// it so opening a server row renders in isolation. Mirrors the stub in
+// MCPServerFormFields.test.tsx.
+vi.mock('@/hooks/useTroubleshootError', () => ({
+  useTroubleshootError: () => ({ showErrorWithTroubleshoot: vi.fn() }),
+}));
+
 const ADMIN: User = {
   user_id: 'user-admin',
   email: 'admin@agor.live',

--- a/apps/agor-ui/src/hooks/useTroubleshootError.test.ts
+++ b/apps/agor-ui/src/hooks/useTroubleshootError.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { AgorState } from '../store/agorStore';
+import {
+  buildTroubleshootPrompt,
+  type ErrorTroubleshootContext,
+  resolveTarget,
+} from './useTroubleshootError';
+
+// Minimal store snapshot — resolveTarget only touches these four maps (and the
+// real selectors it delegates to read the same ones).
+function makeState(overrides: Partial<Record<string, unknown>> = {}): AgorState {
+  return {
+    branchById: new Map(),
+    sessionById: new Map(),
+    boardById: new Map(),
+    boardObjectsByBoardId: new Map(),
+    ...overrides,
+  } as unknown as AgorState;
+}
+
+describe('resolveTarget', () => {
+  it('prefers an explicit branch from context', () => {
+    const state = makeState({
+      branchById: new Map([['b1', { branch_id: 'b1', board_id: 'board1' }]]),
+    });
+    expect(resolveTarget({ branchId: 'b1' }, state)).toEqual({ branchId: 'b1', boardId: 'board1' });
+  });
+
+  it('resolves the branch from a session when no branch is given', () => {
+    const state = makeState({
+      sessionById: new Map([
+        ['s1', { session_id: 's1', branch_id: 'b1', branch_board_id: 'board1' }],
+      ]),
+      branchById: new Map([['b1', { branch_id: 'b1', board_id: 'board1' }]]),
+    });
+    expect(resolveTarget({ sessionId: 's1' }, state)).toEqual({
+      branchId: 'b1',
+      boardId: 'board1',
+    });
+  });
+
+  it('falls back to a branch on the given board when context is thin', () => {
+    const state = makeState({
+      branchById: new Map([['b1', { branch_id: 'b1', board_id: 'board1' }]]),
+      boardById: new Map([['board1', { board_id: 'board1' }]]),
+      boardObjectsByBoardId: new Map([['board1', [{ branch_id: 'b1' }]]]),
+    });
+    expect(resolveTarget({ boardId: 'board1' }, state)).toEqual({
+      branchId: 'b1',
+      boardId: 'board1',
+    });
+  });
+
+  it('returns null when nothing can be resolved', () => {
+    expect(resolveTarget({}, makeState())).toBeNull();
+  });
+});
+
+describe('buildTroubleshootPrompt', () => {
+  const target = { branchId: 'b1', boardId: 'board1' };
+
+  it('embeds the error text in a fenced block', () => {
+    const prompt = buildTroubleshootPrompt('Boom went wrong', {}, target);
+    expect(prompt).toContain('## Error');
+    expect(prompt).toContain('Boom went wrong');
+    expect(prompt).toContain('- Branch: b1');
+  });
+
+  it('includes the context lines that are present', () => {
+    const context: ErrorTroubleshootContext = {
+      source: 'Sending a prompt',
+      sessionId: 's1',
+      boardId: 'board1',
+      branchId: 'b1',
+    };
+    const prompt = buildTroubleshootPrompt('nope', context, target);
+    expect(prompt).toContain('- Source: Sending a prompt');
+    expect(prompt).toContain('- Session: s1');
+    expect(prompt).toContain('- Board: board1');
+    expect(prompt).toContain('- Branch: b1');
+  });
+
+  it('omits the stack block unless a stack is supplied', () => {
+    expect(buildTroubleshootPrompt('x', {}, target)).not.toContain('## Stack');
+    expect(buildTroubleshootPrompt('x', { stack: 'at foo()' }, target)).toContain('at foo()');
+  });
+
+  it('degrades to a placeholder when the error text is empty', () => {
+    expect(buildTroubleshootPrompt('   ', {}, target)).toContain('(no message)');
+  });
+});

--- a/apps/agor-ui/src/hooks/useTroubleshootError.tsx
+++ b/apps/agor-ui/src/hooks/useTroubleshootError.tsx
@@ -1,0 +1,209 @@
+/**
+ * useTroubleshootError
+ *
+ * Phase 1 of "Troubleshoot this error with an agent" (issue #2388).
+ *
+ * Returns `showErrorWithTroubleshoot(content, context)` — a drop-in for
+ * `useThemedMessage().showError` that additionally renders a small
+ * "Troubleshoot" button on the error toast. Clicking it spins up an agent
+ * session on the relevant branch, seeds it with a structured prompt built from
+ * the error message + whatever session/board/branch context the caller had,
+ * and navigates to the new session.
+ *
+ * This lives apart from `useThemedMessage` on purpose: the plain toast helpers
+ * are used in ~59 files and must stay free of client / router / session
+ * dependencies. Callers that DO have the client (SessionPanel, App shell, MCP
+ * settings) opt in by using this hook instead.
+ *
+ * The button degrades gracefully:
+ *   - Thin context (only an error string) → agent still opens, prompt is just
+ *     the error text; the branch is resolved from the current/first board.
+ *   - No branch resolvable at all → a normal error toast explains why, no crash.
+ *   - Spawn failure → a normal error toast, the original toast is untouched.
+ */
+import type { AgorClient } from '@agor-live/client';
+import { App } from 'antd';
+import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+import { type AgorState, agorStore } from '../store/agorStore';
+import { makeBranchesForBoardSelector, selectFirstBoardId } from '../store/selectors';
+import { extractTextContent, MessageContent, type ThemedMessageOptions } from '../utils/message';
+import { useAppNavigation } from './useAppNavigation';
+import { useSessionActions } from './useSessionActions';
+
+/**
+ * Whatever context the error site could scrape together. Every field is
+ * optional — the button copes with as little as nothing.
+ */
+export interface ErrorTroubleshootContext {
+  /** Session the error is about (used to resolve the branch + labels). */
+  sessionId?: string;
+  /** Board the user was on when the error fired. */
+  boardId?: string;
+  /** Branch the error is about (preferred target for the new session). */
+  branchId?: string;
+  /** Human-readable label of where the error came from, e.g. "Sending a prompt". */
+  source?: string;
+  /** Optional stack / diagnostic detail to include in the agent prompt. */
+  stack?: string;
+}
+
+export interface ResolvedTarget {
+  branchId: string;
+  boardId?: string;
+}
+
+// Unique-enough keys so we can dismiss the originating toast once the agent
+// session is on its way. Module-level counter (not Math.random) keeps it
+// deterministic and dependency-free.
+let troubleshootToastSeq = 0;
+
+/**
+ * Resolve the branch to spawn the troubleshooting session on, reading the
+ * store at click time (context captured at error time may predate newer data).
+ * Prefers explicit branch/session context, then falls back to the given board,
+ * the first board, and finally any known branch.
+ */
+export function resolveTarget(
+  context: ErrorTroubleshootContext,
+  state: AgorState = agorStore.getState()
+): ResolvedTarget | null {
+  if (context.branchId) {
+    const branch = state.branchById.get(context.branchId);
+    if (branch) return { branchId: context.branchId, boardId: branch.board_id ?? undefined };
+  }
+
+  if (context.sessionId) {
+    const session = state.sessionById.get(context.sessionId);
+    if (session?.branch_id) {
+      const branch = state.branchById.get(session.branch_id);
+      return {
+        branchId: session.branch_id,
+        boardId: session.branch_board_id ?? branch?.board_id ?? undefined,
+      };
+    }
+  }
+
+  const boardId = context.boardId ?? selectFirstBoardId(state);
+  if (boardId) {
+    const branches = makeBranchesForBoardSelector(boardId)(state);
+    if (branches.length > 0) return { branchId: branches[0].branch_id, boardId };
+  }
+
+  const anyBranch = state.branchById.values().next().value;
+  if (anyBranch) return { branchId: anyBranch.branch_id, boardId: anyBranch.board_id ?? undefined };
+
+  return null;
+}
+
+/**
+ * Build the structured prompt handed to the agent. Only includes context
+ * blocks that are actually present so a thin error still reads cleanly.
+ */
+export function buildTroubleshootPrompt(
+  errorText: string,
+  context: ErrorTroubleshootContext,
+  target: ResolvedTarget
+): string {
+  const lines: string[] = [
+    'I hit an error in the Agor UI and need help troubleshooting it. Please diagnose the likely cause, then propose concrete steps or a fix.',
+    '',
+    '## Error',
+    '```',
+    errorText.trim() || '(no message)',
+    '```',
+  ];
+
+  const contextLines: string[] = [];
+  if (context.source) contextLines.push(`- Source: ${context.source}`);
+  if (context.sessionId) contextLines.push(`- Session: ${context.sessionId}`);
+  const boardId = context.boardId ?? target.boardId;
+  if (boardId) contextLines.push(`- Board: ${boardId}`);
+  contextLines.push(`- Branch: ${context.branchId ?? target.branchId}`);
+  if (contextLines.length > 0) {
+    lines.push('', '## Context', ...contextLines);
+  }
+
+  if (context.stack) {
+    lines.push('', '## Stack / details', '```', context.stack.trim(), '```');
+  }
+
+  return lines.join('\n');
+}
+
+export interface UseTroubleshootErrorResult {
+  /**
+   * Show an error toast that carries a "Troubleshoot" button. Behaves like
+   * `showError` otherwise (same 6s default duration + copy affordance).
+   */
+  showErrorWithTroubleshoot: (
+    content: ReactNode,
+    context?: ErrorTroubleshootContext,
+    options?: ThemedMessageOptions
+  ) => void;
+}
+
+export function useTroubleshootError(client: AgorClient | null): UseTroubleshootErrorResult {
+  const { message } = App.useApp();
+  const { createSession } = useSessionActions(client);
+  const { goToSession } = useAppNavigation();
+
+  const showErrorWithTroubleshoot = useCallback(
+    (
+      content: ReactNode,
+      context: ErrorTroubleshootContext = {},
+      options?: ThemedMessageOptions
+    ) => {
+      const errorText = extractTextContent(content);
+      const key = options?.key ?? `troubleshoot-error-${troubleshootToastSeq++}`;
+
+      const onTroubleshoot = async () => {
+        const target = resolveTarget(context);
+        if (!target) {
+          message.error('Open a branch first — a troubleshooting session needs somewhere to run.');
+          return;
+        }
+
+        const prompt = buildTroubleshootPrompt(errorText, context, target);
+
+        try {
+          const session = await createSession({
+            branch_id: target.branchId,
+            agent: 'claude-code',
+            title: 'Troubleshoot UI error',
+            initialPrompt: prompt,
+          });
+
+          // createSession stores the prompt as the session description but does
+          // not execute it — send it explicitly so the agent starts working.
+          if (client && prompt.trim()) {
+            await client.sessions.prompt(session.session_id, prompt);
+          }
+
+          message.destroy(key);
+          goToSession(session.session_id);
+        } catch (err) {
+          message.error(
+            `Failed to start troubleshooting session: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      };
+
+      message.error({
+        content: (
+          <MessageContent textContent={errorText} onTroubleshoot={onTroubleshoot}>
+            {content}
+          </MessageContent>
+        ),
+        duration: options?.duration ?? 6,
+        key,
+        onClose: options?.onClose,
+      });
+    },
+    [message, createSession, goToSession, client]
+  );
+
+  return { showErrorWithTroubleshoot };
+}

--- a/apps/agor-ui/src/utils/message.tsx
+++ b/apps/agor-ui/src/utils/message.tsx
@@ -21,8 +21,14 @@
  * ```
  */
 
-import { CheckOutlined, CloseCircleOutlined, CloseOutlined, CopyOutlined } from '@ant-design/icons';
-import { App, Button, Space } from 'antd';
+import {
+  CheckOutlined,
+  CloseCircleOutlined,
+  CloseOutlined,
+  CopyOutlined,
+  ThunderboltOutlined,
+} from '@ant-design/icons';
+import { App, Button, Space, theme } from 'antd';
 import type { ArgsProps, ConfigOptions, MessageInstance } from 'antd/es/message/interface';
 import React, { useCallback, useMemo } from 'react';
 import { copyToClipboard } from './clipboard';
@@ -52,27 +58,47 @@ function createErrorMessageKey(): string {
  * Shows an inline confirmation icon (check on success, X on failure) for
  * ~1.5s after click — otherwise there's no way for the user to tell whether
  * the copy worked, which reads as "the button is broken".
+ *
+ * When `onTroubleshoot` is supplied (error toasts raised via
+ * `useTroubleshootError().showErrorWithTroubleshoot`), a small "Troubleshoot"
+ * button is rendered next to the copy icon that hands the error off to an
+ * agent session. Plain toasts never pass it, so they look unchanged.
  */
-interface MessageContentProps {
+export interface MessageContentProps {
   children: React.ReactNode;
   textContent: string;
   kind?: 'error' | 'message';
   onDismiss?: () => void;
   returnFocusTo?: HTMLElement | null;
+  /**
+   * Optional handler that spins up an agent session seeded with this error.
+   * May be async — the button shows a loading spinner until it settles. The
+   * handler owns its own success/failure feedback.
+   */
+  onTroubleshoot?: () => Promise<void> | void;
+  troubleshootLabel?: string;
 }
 
-const MessageContent: React.FC<MessageContentProps> = ({
+export const MessageContent: React.FC<MessageContentProps> = ({
   children,
   textContent,
   kind = 'message',
   onDismiss,
   returnFocusTo,
+  onTroubleshoot,
+  troubleshootLabel = 'Troubleshoot',
 }) => {
+  const { token } = theme.useToken();
   const [copyState, setCopyState] = React.useState<'idle' | 'copied' | 'failed'>('idle');
+  const [troubleshooting, setTroubleshooting] = React.useState(false);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The toast auto-dismisses (~6s) and clicking Troubleshoot navigates away,
+  // so this node can unmount mid-flight; guard the post-await setState.
+  const mountedRef = React.useRef(true);
 
   React.useEffect(() => {
     return () => {
+      mountedRef.current = false;
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
@@ -83,6 +109,17 @@ const MessageContent: React.FC<MessageContentProps> = ({
     setCopyState(ok ? 'copied' : 'failed');
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => setCopyState('idle'), 1500);
+  };
+
+  const handleTroubleshoot = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!onTroubleshoot || troubleshooting) return;
+    try {
+      setTroubleshooting(true);
+      await onTroubleshoot();
+    } finally {
+      if (mountedRef.current) setTroubleshooting(false);
+    }
   };
 
   const handleDismiss = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -136,6 +173,19 @@ const MessageContent: React.FC<MessageContentProps> = ({
     >
       <span style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere' }}>{children}</span>
       <Space size="small">
+        {onTroubleshoot && (
+          <Button
+            type="link"
+            size="small"
+            icon={<ThunderboltOutlined />}
+            loading={troubleshooting}
+            onClick={handleTroubleshoot}
+            style={{ paddingInline: token.paddingXXS, fontSize: token.fontSizeSM }}
+            title="Hand this error to an agent to troubleshoot"
+          >
+            {troubleshootLabel}
+          </Button>
+        )}
         <Button
           type="text"
           size="small"
@@ -166,7 +216,7 @@ const MessageContent: React.FC<MessageContentProps> = ({
 /**
  * Extract text content from React nodes for clipboard copying
  */
-function extractTextContent(content: React.ReactNode): string {
+export function extractTextContent(content: React.ReactNode): string {
   if (typeof content === 'string') {
     return content;
   }


### PR DESCRIPTION
## Summary

Phase 1 of #2388: adds a **"Troubleshoot this error with an agent"** affordance to Agor's centralized error **toasts**. When an error toast carries context, a small **Troubleshoot** button appears next to the existing copy icon. Clicking it spins up an agent session on the relevant branch, seeds it with a structured prompt (error message + whatever session/board/branch context was available), and navigates to the new session — closing the "copy error → open a chat → paste → describe → ask" loop by hand.

> This is **Phase 1** of the phased plan in #2388 (**toasts only**). It intentionally does **not** close the issue — Phase 2 (inline `<Alert>` + ErrorBoundary) and Phase 3 (polish, agent selection, MCP inheritance) remain. Please keep #2388 open.

Motivating case: the strict MCP OAuth error (#2271), where the UI previously gave no path forward.

## What changed

- **`apps/agor-ui/src/utils/message.tsx`** — `MessageContent` now renders a small `Troubleshoot` button (with a loading state) **only** when an `onTroubleshoot` handler is supplied. Plain `showError` toasts are byte-for-byte unchanged, so the ~282 existing call sites are untouched. Exports `MessageContent` / `extractTextContent` for reuse.
- **`apps/agor-ui/src/hooks/useTroubleshootError.tsx`** (new) — `showErrorWithTroubleshoot(content, context)` wrapper. It:
  - resolves a target branch (explicit `branchId` → `sessionId`'s branch → given board → any known branch),
  - builds a structured agent prompt from the error + present context,
  - creates the session via `useSessionActions.createSession`, sends the prompt via `client.sessions.prompt`, and navigates with `useAppNavigation`,
  - **degrades gracefully**: thin context still opens an agent; no resolvable branch shows a normal explanatory toast; a spawn failure shows a normal error toast and never crashes.
  - Kept separate from `useThemedMessage` on purpose so the widely-used plain toast helpers stay free of client/router/session dependencies.

## Initial adopters (feature working end-to-end)

- **Prompt-send failure** — `App.tsx` `handleSendPrompt`
- **Session fork failure** — `App.tsx` `handleForkSession`
- **MCP OAuth connect failure** — `MCPServerFormFields` → `useMCPServerOAuthStart` (the #2271 case)

All other toasts remain on plain `showError`.

## Tests

- `useTroubleshootError.test.ts` covers branch-target resolution (branch/session/board/empty) and prompt building (context lines, stack block, empty-error placeholder).
- Stubbed the new hook in `MCPServerFormFields.test.tsx` (bare harness has no router/canvas-nav contexts).
- `biome check` passes on all changed files.

Refs #2388 · Related #2271

🤖 Generated with [Claude Code](https://claude.com/claude-code)