### PR TITLE
fix(widgets): make credential-request widgets reliable + prefer them over manual Settings

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -68,7 +68,9 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         '(`cloning` | `ready` | `failed`). On `failed`, `clone_error.category` ' +
         '(`auth_failed` | `not_found` | `network` | `git_unavailable` | `unknown`) tells you what went wrong; ' +
         '`auth_failed` usually means the calling user has not configured a `GITHUB_TOKEN` ' +
-        'in User Settings → Env Vars (or it has expired/lost access).',
+        '(or it has expired/lost access). PREFER remediating by calling ' +
+        "`agor_widgets_request_env_vars({ names: ['GITHUB_TOKEN'], reason: ... })` to collect it " +
+        'inline, rather than telling the user to open Settings → Env Vars.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: mcpRequiredId('repoId', 'Repository'),
@@ -88,10 +90,11 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         'Clone a remote repository into Agor. Returns immediately with `{ status: "pending", ' +
         'slug, repo_id }` while the clone runs in the background. Poll `agor_repos_get(repo_id)` ' +
         'until `clone_status` is `ready` (success) or `failed` (see `clone_error` for details). ' +
-        'Private repos require the calling user to have `GITHUB_TOKEN` configured in ' +
-        'User Settings → Env Vars; without it, the clone will fail with `clone_error.category: ' +
-        '"auth_failed"`. Retrying after a failed clone is supported — the previous failed row ' +
-        'is replaced.',
+        'Private repos require the calling user to have `GITHUB_TOKEN` configured; without it, the ' +
+        'clone will fail with `clone_error.category: "auth_failed"`. If it is missing, PREFER calling ' +
+        "`agor_widgets_request_env_vars({ names: ['GITHUB_TOKEN'], reason: ... })` to collect it inline " +
+        'over pointing the user at Settings → Env Vars, then retry. Retrying after a failed clone is ' +
+        'supported — the previous failed row is replaced.',
       inputSchema: z.object({
         url: mcpRequiredString(
           'url',

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -40,6 +40,9 @@ function registerAndCapture(ctx: {
   db?: unknown;
   userId: string;
   sessionId: string;
+  /** Authenticated caller role — defaults to 'member'. Set 'admin' to exercise
+   * the gateway-token admin gate. */
+  role?: string;
   baseServiceParams?: Parameters<typeof registerWidgetTools>[1]['baseServiceParams'];
 }): Record<string, CapturedTool> {
   const captured: Record<string, CapturedTool> = {};
@@ -54,7 +57,7 @@ function registerAndCapture(ctx: {
     db: (ctx.db ?? {}) as Parameters<typeof registerWidgetTools>[1]['db'],
     userId: ctx.userId as unknown as Parameters<typeof registerWidgetTools>[1]['userId'],
     sessionId: ctx.sessionId as unknown as Parameters<typeof registerWidgetTools>[1]['sessionId'],
-    authenticatedUser: { user_id: ctx.userId, role: 'member' } as unknown as Parameters<
+    authenticatedUser: { user_id: ctx.userId, role: ctx.role ?? 'member' } as unknown as Parameters<
       typeof registerWidgetTools
     >[1]['authenticatedUser'],
     baseServiceParams: ctx.baseServiceParams ?? {},
@@ -600,5 +603,93 @@ describe('agor_widgets_request_env_vars', () => {
     expect(desc.toLowerCase()).toContain('fire-and-forget');
     expect(desc.toLowerCase()).toContain('end your turn');
     expect(desc.toLowerCase()).toContain('never enter your context');
+  });
+
+  it('tool description steers the agent to PREFER the widget over Settings instructions', () => {
+    // Regression guard for the "prefer widget over manual Settings" guidance:
+    // the agent-facing contract must keep telling agents to call the widget
+    // rather than pointing users at Settings → Environment Variables.
+    const { app } = makeApp({ sessionCreator: 'u' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+    const desc = (captured.agor_widgets_request_env_vars.cfg.description ?? '').toLowerCase();
+    expect(desc).toContain('prefer');
+    expect(desc).toContain('settings');
+  });
+
+  it('renders a grammatical singular/plural preview line for the widget row', async () => {
+    const captured = registerAndCapture({
+      app: makeApp({ sessionCreator: 'user-creator' }).app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+    await captured.agor_widgets_request_env_vars.cb({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      auto_resume: true,
+    });
+    expect(appendStub.mock.calls[0][0].content).toBe(
+      'Please provide variable HUBSPOT_API_KEY: call hubspot'
+    );
+
+    appendStub.mockClear();
+    const captured2 = registerAndCapture({
+      app: makeApp({ sessionCreator: 'user-creator' }).app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+    await captured2.agor_widgets_request_env_vars.cb({
+      names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+      reason: 'two integrations',
+      auto_resume: true,
+    });
+    expect(appendStub.mock.calls[0][0].content).toBe(
+      'Please provide variables HUBSPOT_API_KEY, STRIPE_SECRET_KEY: two integrations'
+    );
+  });
+});
+
+describe('agor_widgets_request_gateway_token', () => {
+  const appendStub = appendSystemMessage as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    appendStub.mockReset();
+  });
+
+  it('rejects a non-admin caller before creating any widget (admin-only)', async () => {
+    // The gateway-token widget mints platform credentials, so a non-admin agent
+    // must NOT be able to render the form. requireAdmin runs before any service
+    // call, so no gateway-channels/messages plumbing is needed here.
+    const { app } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-member',
+      sessionId: 'sess-1',
+      role: 'member',
+    });
+
+    await expect(
+      captured.agor_widgets_request_gateway_token.cb({ gatewayChannelId: 'channel-1' })
+    ).rejects.toThrow(/admin role required/i);
+
+    // No widget message was created for the dead-end form.
+    expect(appendStub).not.toHaveBeenCalled();
+  });
+
+  it('tool description marks it admin-only and prefers the widget over manual setup', () => {
+    const { app } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-admin',
+      sessionId: 'sess-1',
+      role: 'admin',
+    });
+    const desc = (captured.agor_widgets_request_gateway_token.cfg.description ?? '').toLowerCase();
+    expect(desc).toContain('admin-only');
+    expect(desc).toContain('prefer');
+    expect(desc).toContain('fire-and-forget');
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -61,9 +61,8 @@ function requireAdmin(ctx: McpContext, action: string): void {
  */
 function widgetContentPreview(params: EnvVarsParams): string {
   const list = params.names.join(', ');
-  return params.names.length === 1
-    ? `Please provide ${list}: ${params.reason}`
-    : `Please provide ${list}: ${params.reason}`;
+  const noun = params.names.length === 1 ? 'variable' : 'variables';
+  return `Please provide ${noun} ${list}: ${params.reason}`;
 }
 
 /**
@@ -90,6 +89,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
     {
       description:
         'Ask the user to provide one or more environment variables via a compact in-conversation form. ' +
+        'PREFER this tool whenever you need an env var, API key, or token the user has not set: call it instead of telling the user to open Settings → Environment Variables or asking them to paste a value into chat. ' +
         'FIRE-AND-FORGET: the widget renders inline; end your turn after calling. You will receive a user-role message ("[Agor] User submitted ...") when the user responds. ' +
         'Values never enter your context — only the variable NAMES do. Do NOT ask the user to paste values into chat. ' +
         'Keep `reason` to ONE short sentence (≤200 chars) — it shows as a small muted line; do not restate what the widget does or describe the security contract (the UI handles that).',
@@ -230,6 +230,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
     {
       description:
         "Ask an admin to securely provide a gateway channel's platform tokens (Slack bot/app tokens, GitHub private key, Teams app password) via a compact form that appears at the end of your message, so setup finishes without anyone pasting xoxb-/xapp- tokens into chat. " +
+        'PREFER this tool over telling the admin to open Settings and paste tokens manually: it collects and verifies the credentials inline. ' +
         'FIRE-AND-FORGET: the widget renders inline at the end of your turn; end your turn after calling. You will receive a user-role message when it is resolved. ' +
         'Token values never enter your context — only the channel identity and field NAMES do. ' +
         'Admin-only: a non-admin agent cannot mint this widget. Keep `reason` to ONE short sentence (≤200 chars).',

--- a/apps/agor-docs/content/guide/in-conversation-widgets.mdx
+++ b/apps/agor-docs/content/guide/in-conversation-widgets.mdx
@@ -17,6 +17,8 @@ Widgets are a primitive. v1 ships one widget type (`env_vars`) as the canonical 
 
 This is the widget the agent calls when it needs an environment variable it doesn't have. Typical use: an MCP integration needs `HUBSPOT_API_KEY` and the agent doesn't want to fail with "please go to Settings".
 
+> **Agents should prefer the widget over Settings instructions.** Agor's system prompt and the credential-related tool descriptions (e.g. `agor_repos_get`) tell agents that when a task needs a secret the user hasn't set, the correct move is to **call `agor_widgets_request_env_vars`** — not to write "open Settings → Environment Variables" or ask the user to paste a value into chat. A written Settings instruction is only a last-resort fallback for when the widget tools are unavailable.
+
 ### What the agent does
 
 The agent calls the MCP tool `agor_widgets_request_env_vars`:
@@ -25,10 +27,16 @@ The agent calls the MCP tool `agor_widgets_request_env_vars`:
 {
   "names": ["HUBSPOT_API_KEY"],
   "reason": "Needed to call the Hubspot Private Apps API.",
-  "instructions": "Get a key at https://app.hubspot.com/private-apps. Make sure the **CRM > contacts > read** scope is enabled.",
-  "default_scope": "global"
+  "variable_metadata": {
+    "HUBSPOT_API_KEY": {
+      "description": "Create one under Private Apps with the CRM > contacts > read scope.",
+      "format_hint": "Starts with pat-"
+    }
+  }
 }
 ```
+
+The scope (Session / Global) is the user's choice in the form — the agent does not set it.
 
 The tool returns within milliseconds. The agent ends its turn voluntarily. **No HTTP timeout, no executor pause, no daemon-side await.**
 
@@ -38,13 +46,13 @@ A small form renders inline in the transcript:
 
 - The variable name(s) the agent is asking for
 - A short reason
-- An optional instructions block (rendered as sanitized markdown, with links and emphasis only, no scripts)
-- A password input per variable
+- Optional per-variable `description` and `format_hint` text (from `variable_metadata`)
+- A password input per variable (or `text` / `textarea`, per `input_type`)
 - A scope selector (Session / Global)
-- **Dismiss** and **Save & continue** buttons
-- A disclaimer: *"Type values here, never paste them into chat."*
+- **Dismiss** and **Save** buttons
+- The security posture is conveyed by the lock/shield chrome — never paste values into chat
 
-When you hit **Save & continue**, the value goes **directly from the form to the daemon** via `POST /widgets/:widget_id/submit`. It does not traverse the model. The daemon writes it through the same encrypted-at-rest path as `Settings → Environment Variables` (AES-256-GCM via the daemon's master secret).
+When you hit **Save**, the value goes **directly from the form to the daemon** via `POST /widgets/:widget_id/submit`. It does not traverse the model. The daemon writes it through the same encrypted-at-rest path as `Settings → Environment Variables` (AES-256-GCM via the daemon's master secret).
 
 ### What the agent sees next
 
@@ -80,18 +88,18 @@ If you hit **Dismiss**, the widget marks itself dismissed and queues an explicit
 
 The widget primitive has one hard requirement: **submitted values never enter the LLM's context.** Triple-checked:
 
-| Path | Carries values? |
-|---|---|
-| Agent → MCP tool call | **No**, input schema only accepts names + reason + instructions |
-| Widget message row | **No**, the row stores params (names, reason, ...) and lifecycle state |
-| MCP tool return value | **No**, returns `{ widget_id, status }` only |
-| Browser → daemon submit | **Yes**, direct HTTP, authenticated, never traverses the agent |
-| Daemon → users service | **Yes**, encrypted at the boundary, never logged |
-| Auto-resume prompt to agent | **No**, built from sanitized `result_meta` (just names + scope) |
-| `widget:resolved` WebSocket event | **No**, same sanitized payload |
-| Transcript reload | **No**, the row never held values |
+| Path                              | Carries values?                                                        |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| Agent → MCP tool call             | **No**, input schema only accepts names + reason + variable_metadata   |
+| Widget message row                | **No**, the row stores params (names, reason, ...) and lifecycle state |
+| MCP tool return value             | **No**, returns `{ widget_id, status }` only                           |
+| Browser → daemon submit           | **Yes**, direct HTTP, authenticated, never traverses the agent         |
+| Daemon → users service            | **Yes**, encrypted at the boundary, never logged                       |
+| Auto-resume prompt to agent       | **No**, built from sanitized `result_meta` (just names + scope)        |
+| `widget:resolved` WebSocket event | **No**, same sanitized payload                                         |
+| Transcript reload                 | **No**, the row never held values                                      |
 
-The disclaimer text on the form (*"Type values here, never paste them into chat"*) is there for one specific reason: if the agent goes off-script and asks you to type a value into chat instead of into the widget, **don't**. The widget is the only path that preserves the no-LLM-context guarantee.
+The disclaimer text on the form (_"Type values here, never paste them into chat"_) is there for one specific reason: if the agent goes off-script and asks you to type a value into chat instead of into the widget, **don't**. The widget is the only path that preserves the no-LLM-context guarantee.
 
 For the full security analysis, see `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
 

--- a/packages/core/src/templates/agor-system-prompt.md
+++ b/packages/core/src/templates/agor-system-prompt.md
@@ -26,6 +26,8 @@ Agor MCP tool domains:
 Discover tools with `agor_search_tools` and inspect schemas with
 `agor_get_tool_details`.
 
+Credentials & secrets: When a task needs an environment variable, API key, token, or other secret the user has not provided, call `agor_widgets_request_env_vars` — it renders a secure inline form and auto-resumes you when the user responds — instead of telling the user to open Settings → Environment Variables or asking them to paste the value into chat. Secret values enter the encrypted store directly and never reach your context; you only ever see the variable NAMES. Admins wiring up a gateway channel's platform tokens (Slack, GitHub, Teams) should likewise call `agor_widgets_request_gateway_token`. A written "go to Settings" instruction is only a last-resort fallback for when these widget tools are genuinely unavailable.
+
 MCP guidance: Treat `agor_mcp_servers_list` as the authoritative catalog of configured servers eligible for the current user/session, and `attached_mcp_servers` as the authoritative list of servers attached to a session. Prefer official/configured entries returned by Agor. If the catalog is empty, do not invent an unvetted third-party server, ask for a broad Slack `xoxp` token, or direct the user to Claude connector settings. Configure per-user MCP OAuth in Agor User Settings → MCP Servers; the official Slack MCP endpoint is `https://mcp.slack.com/mcp`. Slack gateway channels and MCP tool access are separate systems.
 
 Use portable GitHub-flavored Markdown; the Agor UI additionally renders Mermaid, math, and GitHub callouts, while gateways such as Slack support fewer constructs.


### PR DESCRIPTION
## Summary

Evan reported that Agor's built-in in-conversation **credential-request widgets** "appear not to be working reliably." I mapped the full path end-to-end (MCP tool handlers → durable resolution state machine → env-var/gateway-token persistence → auto-resume task queueing → React transcript components → realtime sync).

**Root cause (substantiated): the widget *machinery* is solid — the gap is discovery/guidance.** The end-to-end mechanics are robust and already well-tested:
- Durable, claim-token resolution state machine (`pending → resolving → submitted/dismissed`) with per-row locking prevents double-submit; `applySubmit` runs at most once (`widgets/submissions.ts`, `resolution-store.ts`).
- Auto-resume uses a **stable idempotency task id** (`widgetAutoResumeTaskId`) so it fires exactly once even across daemon restarts (`durable-task-id.ts`, the "Never lose a prompt" path).
- Widget state lives on the `messages` row; resolution emits `messages patched`, which the transcript consumes (`useMessages.ts`) — so it **survives refresh/reconnect** and syncs to all viewers.
- Gateway-token is admin-gated at request, submit, and dismiss.

What was actually broken is that **nothing steered agents to the widgets**, and `repos.ts` actively told agents the opposite — to point users at "User Settings → Env Vars" on auth failure. So in practice an agent hitting a missing `GITHUB_TOKEN`/API key wrote "go to Settings" and the widget never rendered. That is exactly the user-visible "unreliable" experience: the feature exists but agents don't invoke it.

## Fixes

- **System prompt** (`packages/core/src/templates/agor-system-prompt.md`): added an explicit **"Credentials & secrets"** instruction — when a task needs an env var / API key / token the user hasn't set, **call `agor_widgets_request_env_vars`** (admins wiring a gateway channel: `agor_widgets_request_gateway_token`) instead of writing "open Settings" or asking the user to paste a value into chat. This reaches every agent.
- **Tool descriptions** (`apps/agor-daemon/src/mcp/tools/widgets.ts`): both tools now explicitly say to **PREFER the widget over Settings instructions**.
- **repos.ts** (`agor_repos_get`, `agor_repos_create_remote`): the `auth_failed` / private-repo hints now steer to `agor_widgets_request_env_vars({ names: ['GITHUB_TOKEN'], reason: ... })` as the preferred remediation, with "go to Settings" only as a fallback.
- **Robustness cleanup** (`widgets.ts`): fixed a dead ternary in `widgetContentPreview` (both branches were identical) so the transcript row reads grammatically (`variable` vs `variables`).
- **Docs** (`apps/agor-docs/content/guide/in-conversation-widgets.mdx`): added a "prefer the widget over Settings" callout and corrected a stale request example (`instructions`/`default_scope` → real `variable_metadata` schema; `Save & continue` → `Save`; markdown-instructions bullet → real per-variable `description`/`format_hint`).

## Tests added (`apps/agor-daemon/src/mcp/tools/widgets.test.ts`)

- Both tool descriptions carry the prefer-over-Settings guidance (regression guard so the guidance can't silently disappear).
- **Admin-only enforcement**: `agor_widgets_request_gateway_token` rejects a non-admin caller *before* creating any widget — this admin gate was previously untested at the MCP-tool layer (only exercised as admin in the boundary test).
- Singular/plural transcript preview line (covers the dead-ternary fix).

All widget suites pass (`vitest run src/mcp/tools/widgets*.test.ts src/widgets/` → 119 + 17). Daemon `tsc --noEmit` and `biome check` are clean; docs pass `prettier`.

## What I could NOT reproduce / deliberately did not change

- **No functional bug in the submit/resume/persistence path** was reproducible — the durable claim, idempotent auto-resume, and refresh survival all hold up under reading and existing tests. I did not rewrite any of it.
- **Archive-time cleanup gap (known, design-documented):** a widget left `pending` when its session is archived stays `pending` forever (no auto-resume ever fires). This is called out in the design doc as an intended-but-unimplemented hook. I left it out of this PR to keep the diff surgical and because it touches session-archive lifecycle; flagging it as a follow-up.
- `publishResolved` emits a `widget:resolved` event that the frontend does not consume; it's harmless because the `messages patched` path already syncs resolution. Left as-is.

No secrets or real tokens are included; tests use placeholder names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)