### PR TITLE
feat(mcp): add agor_environment_set_commands to configure branch env commands

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -335,6 +335,11 @@ export interface BranchesServiceImpl extends Service<Branch, Partial<Branch>, Fe
     data: { variant?: string } | undefined,
     params?: FeathersParams
   ): Promise<Branch>;
+  setEnvironmentCommands(
+    id: BranchID,
+    data: import('@agor/core/types').BranchEnvironmentCommandOverrides,
+    params?: FeathersParams
+  ): Promise<Branch>;
   checkHealth(
     id: BranchID,
     params?: FeathersParams,

--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -512,6 +512,118 @@ describe('agor_environment_set', () => {
 });
 
 // ---------------------------------------------------------------------------
+// agor_environment_set_commands
+// ---------------------------------------------------------------------------
+
+describe('agor_environment_set_commands', () => {
+  it('forwards only the provided command overrides and returns the effective set', async () => {
+    const setCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      branches: {
+        setEnvironmentCommands: async (...args: unknown[]) => {
+          setCalls.push(args);
+          return {
+            branch_id: 'wt-1',
+            start_command: 'pnpm dev',
+            stop_command: 'pnpm stop',
+          };
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { branch_id: 'wt-1' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_set_commands');
+    const result = await handler({ branchId: 'wt-1', start: 'pnpm dev', stop: 'pnpm stop' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(setCalls).toHaveLength(1);
+    // Only start + stop were supplied → only those keys reach the service.
+    expect(setCalls[0][1]).toEqual({ start: 'pnpm dev', stop: 'pnpm stop' });
+    expect(parsed.commands).toEqual({
+      start: 'pnpm dev',
+      stop: 'pnpm stop',
+      nuke: null,
+      logs: null,
+      health: null,
+      app: null,
+    });
+    expect(startCalls).toHaveLength(0);
+  });
+
+  it('starts the environment after setting when andStart=true', async () => {
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      branches: {
+        setEnvironmentCommands: async () => ({
+          branch_id: 'wt-1',
+          start_command: 'pnpm dev',
+        }),
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { branch_id: 'wt-1', start_command: 'pnpm dev' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_set_commands');
+    const result = await handler({ branchId: 'wt-1', start: 'pnpm dev', andStart: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.message).toMatch(/start requested/);
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('surfaces a service error (e.g. admin/running guard) as success:false', async () => {
+    const ctx = makeCtx({
+      branches: {
+        setEnvironmentCommands: async () => {
+          throw new Error(
+            'Cannot change environment commands while the environment is running. Stop the environment first.'
+          );
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_set_commands');
+    const result = await handler({ branchId: 'wt-1', start: 'pnpm dev' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/while the environment is running/);
+  });
+
+  it('when andStart succeeds-then-start-fails, reports commands_set:true and a clear error', async () => {
+    const ctx = makeCtx({
+      branches: {
+        setEnvironmentCommands: async () => ({
+          branch_id: 'wt-1',
+          start_command: 'pnpm dev',
+        }),
+        startEnvironment: async () => {
+          throw new Error('boom');
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_set_commands');
+    const result = await handler({ branchId: 'wt-1', start: 'pnpm dev', andStart: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.commands_set).toBe(true);
+    expect(parsed.error).toMatch(/start failed: boom/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // agor_branches_create — variant param
 // ---------------------------------------------------------------------------
 

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -1,8 +1,8 @@
-import type { BranchID } from '@agor/core/types';
+import type { BranchEnvironmentCommandOverrides, BranchID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import type { BranchesServiceImpl, ReposServiceImpl } from '../../declarations.js';
-import { mcpOptionalString, mcpRequiredId } from '../schema.js';
+import { mcpOptionalNonBlankString, mcpOptionalString, mcpRequiredId } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 import { assertValidVariant } from './_environment-helpers.js';
@@ -287,7 +287,160 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
     }
   );
 
-  // Tool 7: agor_environment_nuke
+  // Tool 7: agor_environment_set_commands
+  // Configuration verb: writes raw command strings straight onto the branch as
+  // per-branch overrides (the programmatic equivalent of editing the branch
+  // "snapshot" in the Environment settings tab). Unlike agor_environment_set,
+  // which SELECTS a vetted variant and re-renders from the repo config, this
+  // sets arbitrary executable commands — so it is admin-only.
+  server.registerTool(
+    'agor_environment_set_commands',
+    {
+      description:
+        "Set some or all of a branch's environment commands directly, then persist them so " +
+        'agor_environment_start/stop/health/logs/nuke/open_app use them. Provide any subset of ' +
+        'start, stop, nuke, logs (shell commands, or http(s) URLs to invoke as GET webhooks) and ' +
+        'health, app (http(s) URLs). Omitted fields keep their current value; to reset a field ' +
+        'back to the repo/variant default, use agor_environment_set to re-render instead. ' +
+        'Lets an agent apply the dev commands it discovered from a repo without a trip to Settings. ' +
+        'Requires ADMIN access: these strings execute as the system user, so branch `all` ' +
+        'permission alone is not sufficient (that tier only selects a vetted variant). ' +
+        'Refuses to change commands while the environment is running or starting — stop it first. ' +
+        'Pass andStart=true to start the environment after setting; otherwise call ' +
+        'agor_environment_start separately. Returns the resulting effective command set.',
+      annotations: { idempotentHint: true },
+      inputSchema: z.object({
+        branchId: mcpRequiredId('branchId', 'Branch'),
+        start: mcpOptionalNonBlankString(
+          'start',
+          'Start command (shell string, or an http(s) URL invoked as a GET webhook).'
+        ),
+        stop: mcpOptionalNonBlankString(
+          'stop',
+          'Stop command (shell string, or an http(s) URL invoked as a GET webhook).'
+        ),
+        nuke: mcpOptionalNonBlankString(
+          'nuke',
+          'Destructive reset command (shell string, or an http(s) URL invoked as a GET webhook).'
+        ),
+        logs: mcpOptionalNonBlankString(
+          'logs',
+          'Recent-logs command (shell string, or an http(s) URL invoked as a GET webhook).'
+        ),
+        health: mcpOptionalNonBlankString(
+          'health',
+          'Health check http(s) URL (may target localhost / branch-local services).'
+        ),
+        app: mcpOptionalNonBlankString(
+          'app',
+          'Application http(s) URL for the running environment.'
+        ),
+        andStart: z
+          .boolean()
+          .optional()
+          .describe(
+            'When true, start the environment after setting the commands. Defaults to false. ' +
+              'Convenience for one-shot configure-and-run workflows.'
+          ),
+      }),
+    },
+    async (args) => {
+      const branchId = coerceString(args.branchId)!;
+      const andStart = args.andStart === true;
+      const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
+
+      const overrides: BranchEnvironmentCommandOverrides = {};
+      const start = coerceString(args.start);
+      const stop = coerceString(args.stop);
+      const nuke = coerceString(args.nuke);
+      const logs = coerceString(args.logs);
+      const health = coerceString(args.health);
+      const app = coerceString(args.app);
+      if (start !== undefined) overrides.start = start;
+      if (stop !== undefined) overrides.stop = stop;
+      if (nuke !== undefined) overrides.nuke = nuke;
+      if (logs !== undefined) overrides.logs = logs;
+      if (health !== undefined) overrides.health = health;
+      if (app !== undefined) overrides.app = app;
+
+      const effectiveCommands = (branch: {
+        start_command?: string;
+        stop_command?: string;
+        nuke_command?: string;
+        logs_command?: string;
+        health_check_url?: string;
+        app_url?: string;
+      }) => ({
+        start: branch.start_command ?? null,
+        stop: branch.stop_command ?? null,
+        nuke: branch.nuke_command ?? null,
+        logs: branch.logs_command ?? null,
+        health: branch.health_check_url ?? null,
+        app: branch.app_url ?? null,
+      });
+
+      try {
+        const updated = await branchesService.setEnvironmentCommands(
+          branchId as BranchID,
+          overrides,
+          ctx.baseServiceParams
+        );
+
+        if (!andStart) {
+          return textResult({
+            success: true,
+            branch: updated,
+            commands: effectiveCommands(updated),
+            message: 'Environment commands updated.',
+          });
+        }
+
+        // Commands are persisted. If start fails, surface that distinctly so
+        // callers know the configuration change DID land.
+        try {
+          const started = await branchesService.startEnvironment(
+            branchId as BranchID,
+            ctx.baseServiceParams
+          );
+          return textResult({
+            success: true,
+            branch: started,
+            commands: effectiveCommands(started),
+            message:
+              'Environment commands updated and start requested. ' +
+              'Poll agor_environment_health and agor_environment_logs for readiness, progress, or failures.',
+          });
+        } catch (startError) {
+          const startMessage = startError instanceof Error ? startError.message : 'Unknown error';
+          const commandOutput =
+            startError instanceof Error
+              ? (startError as Error & { commandOutput?: string }).commandOutput
+              : undefined;
+          return textResult({
+            success: false,
+            commands_set: true,
+            branch: updated,
+            commands: effectiveCommands(updated),
+            error: `Commands were updated, but start failed: ${startMessage}`,
+            ...(commandOutput ? { output: commandOutput } : {}),
+          });
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        const commandOutput =
+          error instanceof Error
+            ? (error as Error & { commandOutput?: string }).commandOutput
+            : undefined;
+        return textResult({
+          success: false,
+          error: errorMessage,
+          ...(commandOutput ? { output: commandOutput } : {}),
+        });
+      }
+    }
+  );
+
+  // Tool 8: agor_environment_nuke
   server.registerTool(
     'agor_environment_nuke',
     {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -4104,6 +4104,28 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   registerLongAuthenticatedRoute(
     app,
+    '/branches/:id/set-environment-commands',
+    {
+      async create(data: unknown, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Branch ID required');
+        return branchesService.setEnvironmentCommands(
+          id as import('@agor/core/types').BranchID,
+          data as import('@agor/core/types').BranchEnvironmentCommandOverrides,
+          params
+        );
+      },
+    },
+    {
+      // Admin control is enforced at the service layer (raw command strings run
+      // as the system user, so branch `all` alone is not sufficient here).
+      create: { role: ROLES.VIEWER, action: 'set branch environment commands' },
+    },
+    requireAuth
+  );
+
+  registerLongAuthenticatedRoute(
+    app,
     '/branches/:id/health',
     {
       async find(params: RouteParams) {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -2080,6 +2080,136 @@ describe('BranchesService.renderEnvironment running-guard', () => {
   });
 });
 
+describe('BranchesService.setEnvironmentCommands', () => {
+  function createSetCommandsHarness(opts: {
+    status?: 'running' | 'starting' | 'stopped';
+    branch?: Record<string, unknown>;
+    mode?: 'hybrid' | 'webhook-only';
+  }) {
+    const config = opts.mode ? { execution: { managed_envs_execution_mode: opts.mode } } : {};
+    const app = {
+      get: () => config,
+      service(path: string) {
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    // Bypass the shared all-or-admin env-control gate; the admin check and the
+    // running/validation logic under test run separately.
+    vi.spyOn(service as never, 'ensureCanTriggerEnv').mockResolvedValue(undefined as never);
+    const branch = {
+      branch_id: 'wt-1',
+      repo_id: 'repo-1',
+      name: 'wt-1',
+      path: '/tmp/wt-1',
+      branch_unique_id: 1,
+      environment_instance: { status: opts.status ?? 'stopped' },
+      ...opts.branch,
+    };
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    const patchSpy = vi
+      .spyOn(service, 'patch')
+      .mockImplementation(async (_id, data) => ({ ...branch, ...(data as object) }) as never);
+    return { service, patchSpy };
+  }
+
+  it('requires admin — denies a non-admin caller before touching the branch', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({});
+    const getSpy = vi.spyOn(service, 'get');
+
+    await expect(
+      service.setEnvironmentCommands('wt-1' as BranchID, { start: 'echo hi' }, {
+        provider: 'rest',
+        user: { user_id: 'u1', role: 'member' },
+      } as never)
+    ).rejects.toThrow(/admin access/);
+    expect(getSpy).not.toHaveBeenCalled();
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('patches only the fields provided (partial update leaves others untouched)', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({
+      branch: { start_command: 'old start', stop_command: 'old stop' },
+    });
+
+    await service.setEnvironmentCommands('wt-1' as BranchID, { start: 'new start' });
+
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const patched = patchSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(patched.start_command).toBe('new start');
+    expect('stop_command' in patched).toBe(false);
+  });
+
+  it('trims provided command strings before persisting', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({});
+
+    await service.setEnvironmentCommands('wt-1' as BranchID, {
+      start: '  echo hi  ',
+      stop: 'echo bye',
+    });
+
+    const patched = patchSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(patched.start_command).toBe('echo hi');
+    expect(patched.stop_command).toBe('echo bye');
+  });
+
+  it('throws when no commands are provided', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({});
+
+    await expect(service.setEnvironmentCommands('wt-1' as BranchID, {})).rejects.toThrow(
+      /No environment commands provided/
+    );
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses to change commands while the environment is running', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({ status: 'running' });
+
+    await expect(
+      service.setEnvironmentCommands('wt-1' as BranchID, { start: 'echo hi' })
+    ).rejects.toThrow(/while the environment is running/);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses to change commands while the environment is starting', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({ status: 'starting' });
+
+    await expect(
+      service.setEnvironmentCommands('wt-1' as BranchID, { stop: 'echo bye' })
+    ).rejects.toThrow(/while the environment is starting/);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid health URL via the URL-field policy', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({});
+
+    await expect(
+      service.setEnvironmentCommands('wt-1' as BranchID, { health: 'not-a-url' })
+    ).rejects.toThrow();
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a shell command for a lifecycle field in webhook-only mode', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({ mode: 'webhook-only' });
+
+    await expect(
+      service.setEnvironmentCommands('wt-1' as BranchID, { start: 'echo hi' })
+    ).rejects.toThrow();
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a public https webhook for a lifecycle field in webhook-only mode', async () => {
+    const { service, patchSpy } = createSetCommandsHarness({ mode: 'webhook-only' });
+
+    await service.setEnvironmentCommands('wt-1' as BranchID, {
+      start: 'https://ci.example.com/start',
+    });
+
+    const patched = patchSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(patched.start_command).toBe('https://ci.example.com/start');
+  });
+});
+
 describe('BranchesService managed environment control authorization', () => {
   const branchId = 'wt-auth' as BranchID;
   const allUserId = 'user-all';

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -62,6 +62,8 @@ import type {
   Branch,
   BranchArchiveOrDeleteOptions,
   BranchArchiveOrDeleteResult,
+  BranchEnvironmentCommandField,
+  BranchEnvironmentCommandOverrides,
   BranchEnvironmentUpdate,
   BranchFsAccessLevel,
   BranchID,
@@ -74,6 +76,7 @@ import type {
 } from '@agor/core/types';
 import {
   BRANCH_ENVIRONMENT_CLEARABLE_FIELDS,
+  BRANCH_ENVIRONMENT_COMMAND_FIELDS,
   getTeammateConfig,
   hasMinimumRole,
   isTeammate,
@@ -84,6 +87,7 @@ import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
+import { ensureMinimumRole } from '../utils/authorization.js';
 import { consumeBranchArchiveDeleteAuthorization } from '../utils/branch-archive-delete-authorization.js';
 import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
 import { captureBranchRemovalRealtimeVisibility } from '../utils/branch-removal-realtime.js';
@@ -2935,6 +2939,122 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         params
       )
     );
+  }
+
+  /**
+   * Custom method: set some or all of a branch's materialized environment
+   * command fields directly (start / stop / nuke / logs / health / app), as
+   * branch-level overrides on top of whatever the variant last rendered.
+   *
+   * This is the programmatic equivalent of editing the "branch snapshot" in the
+   * Environment settings tab: it writes raw executable command strings straight
+   * onto the branch, so an agent that inspected a repo can apply the dev
+   * commands it discovered without a trip to Settings. Subsequent
+   * `startEnvironment`/`stopEnvironment`/etc. run the persisted strings.
+   *
+   * Authorization: because these strings execute as the system user, this
+   * requires ADMIN — the same bar as the `requireAdminForEnvConfig` hook that
+   * guards the REST/UI branch patch path. Branch `all` permission alone is NOT
+   * sufficient; that tier only lets a collaborator SELECT a vetted variant via
+   * {@link renderEnvironment}. Setting arbitrary command strings is strictly
+   * more powerful, so it stays admin-only to avoid a privilege escalation.
+   *
+   * Partial-update semantics: a field provided (non-blank) overrides the
+   * current value; an omitted field is left untouched (keeps its current
+   * rendered value). To reset a field back to the variant/repo default, use
+   * `renderEnvironment` (the `agor_environment_set` re-render path).
+   *
+   * Refuses to run while the environment is running/starting — the live process
+   * was launched with the current command strings; stop it first. Mirrors the
+   * variant-change guard in {@link renderEnvironment}.
+   *
+   * The effective set (existing merged with the provided overrides) is
+   * validated against the instance execution policy exactly like a freshly
+   * rendered snapshot, so webhook-only mode and SSRF/URL rules still apply.
+   */
+  async setEnvironmentCommands(
+    id: BranchID,
+    data: BranchEnvironmentCommandOverrides,
+    params?: BranchParams
+  ): Promise<BranchWithZoneAndSessions> {
+    // Raw command strings execute as the system user → admin-only, matching the
+    // requireAdminForEnvConfig hook on the REST/UI branch patch path. Internal
+    // calls (no provider) and service accounts bypass, per ensureMinimumRole.
+    ensureMinimumRole(params, ROLES.ADMIN, 'set branch environment commands');
+
+    // loadEnvironmentForAction also runs the shared env-control gate (all-or-
+    // admin) and loads the branch inside tenant scope. Admin clears both.
+    const branch = await this.loadEnvironmentForAction(
+      id,
+      params,
+      'set branch environment commands'
+    );
+
+    // Map each logical field to its branch column — single source of truth for
+    // the normalize / validate / patch passes below.
+    const FIELD_TO_COLUMN = {
+      start: 'start_command',
+      stop: 'stop_command',
+      nuke: 'nuke_command',
+      logs: 'logs_command',
+      health: 'health_check_url',
+      app: 'app_url',
+    } as const satisfies Record<BranchEnvironmentCommandField, keyof Branch>;
+
+    // Normalize: keep only fields the caller actually supplied (non-blank),
+    // trimmed. A blank/omitted field is treated as "not provided".
+    const normalized: Partial<Record<BranchEnvironmentCommandField, string>> = {};
+    for (const field of BRANCH_ENVIRONMENT_COMMAND_FIELDS) {
+      const value = data[field];
+      if (value !== undefined && value.trim().length > 0) normalized[field] = value.trim();
+    }
+    if (Object.keys(normalized).length === 0) {
+      throw new Error(
+        'No environment commands provided. Supply at least one of: ' +
+          `${BRANCH_ENVIRONMENT_COMMAND_FIELDS.join(', ')}.`
+      );
+    }
+
+    // Refuse while live: the running process was started with the current
+    // command strings; swapping them out from under it would leave us unable to
+    // stop/restart cleanly.
+    const envStatus = branch.environment_instance?.status;
+    if (envStatus === 'running' || envStatus === 'starting') {
+      throw new Error(
+        `Cannot change environment commands while the environment is ${envStatus}. ` +
+          'Stop the environment first.'
+      );
+    }
+
+    // Effective set = current branch fields with the provided overrides applied
+    // (provided wins; omitted keeps its current value).
+    const effectiveOf = (field: BranchEnvironmentCommandField): string | undefined =>
+      normalized[field] ?? (branch[FIELD_TO_COLUMN[field]] as string | undefined);
+
+    // Validate the EFFECTIVE set against the instance execution policy, exactly
+    // like renderEnvironment validates a rendered snapshot (and like the
+    // validateBranchEnvPolicyHook merge on the REST patch path).
+    await this.validateRenderedEnvironmentActions({
+      start: effectiveOf('start'),
+      stop: effectiveOf('stop'),
+      nuke: effectiveOf('nuke'),
+      logs: effectiveOf('logs'),
+    });
+    validateRenderedManagedEnvUrlFields({
+      health: effectiveOf('health'),
+      app: effectiveOf('app'),
+    });
+
+    // Patch only the fields the caller actually provided, so an omitted field is
+    // never accidentally cleared and `updated_at` reflects a real change.
+    const patchData: Partial<Branch> = { updated_at: new Date().toISOString() };
+    for (const field of BRANCH_ENVIRONMENT_COMMAND_FIELDS) {
+      const value = normalized[field];
+      if (value !== undefined)
+        (patchData as Record<string, string>)[FIELD_TO_COLUMN[field]] = value;
+    }
+
+    return await this.withTenantDatabase(params, () => this.patch(id, patchData, params));
   }
 }
 

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -109,6 +109,7 @@ so do not blindly replay branch creation.
 - **Bulk account provisioning:** Paste a CSV of emails; the agent calls MCP to create users and invite them automatically.
 - **Issue triage pipeline:** Source GitHub issues by label, triage them, and create branches linked to each issue, dropping them onto the active board as cards.
 - **Environment orchestration:** Start/stop branch environments via MCP before delegating work to collaborators or other agents.
+- **"Check out my project and just run it":** An agent inspects a freshly cloned repo, infers its dev commands, calls `agor_environment_set_commands` to persist them on the branch, and passes `andStart: true` to bring the environment up — no trip to Settings.
 
 Because MCP calls are just JSON-RPC, complex workflows can be scripted once and reused by any tool that speaks the protocol.
 
@@ -117,6 +118,16 @@ operator sets `execution.managed_envs_execution_mode: webhook-only`, MCP
 `agor_environment_start`, `agor_environment_stop`, `agor_environment_logs`, and
 `agor_environment_nuke` reject rendered shell commands and only invoke explicit
 HTTP(S) webhook URLs. See [Environments: webhook-only mode](/guide/environment-configuration#webhook-only-mode).
+
+Two configuration verbs pair with these lifecycle tools. `agor_environment_set`
+selects one of the repo's predefined environment variants and re-renders the
+branch's commands from it (requires branch `all` permission or admin).
+`agor_environment_set_commands` writes raw command strings directly onto the
+branch — the programmatic equivalent of editing the branch snapshot in the
+Environment settings tab. Because those strings execute as the system user, it
+is **admin-only** and refuses to change commands while the environment is
+running or starting. Both accept `andStart: true` for one-shot configure-and-run,
+and both honor webhook-only mode.
 
 ## External Agent Access
 

--- a/packages/core/src/types/branch.ts
+++ b/packages/core/src/types/branch.ts
@@ -598,6 +598,48 @@ export type BranchEnvironmentUpdate = Omit<
 };
 
 /**
+ * Partial override for a branch's materialized environment command fields.
+ *
+ * These are the raw executable command strings (or HTTP(S) webhook URLs) that
+ * `agor_environment_start`/`stop`/etc. run directly, keyed by the short logical
+ * name used in the repo's variant definitions and the Environment settings tab.
+ * A caller supplies only the fields it wants to change; omitted fields keep
+ * their current rendered value. Used by `BranchesService.setEnvironmentCommands`
+ * (and the `agor_environment_set_commands` MCP tool) to let an agent apply the
+ * dev commands it discovered from a repo without a trip to Settings.
+ *
+ * Because these strings execute as the system user, writing them is an
+ * admin-tier capability — stricter than selecting a vetted variant via
+ * `renderEnvironment`.
+ */
+export interface BranchEnvironmentCommandOverrides {
+  /** Start command (shell string, or http(s) URL webhook). Maps to `start_command`. */
+  start?: string;
+  /** Stop command (shell string, or http(s) URL webhook). Maps to `stop_command`. */
+  stop?: string;
+  /** Destructive reset command. Maps to `nuke_command`. */
+  nuke?: string;
+  /** Recent-logs command. Maps to `logs_command`. */
+  logs?: string;
+  /** Health check http(s) URL. Maps to `health_check_url`. */
+  health?: string;
+  /** App http(s) URL. Maps to `app_url`. */
+  app?: string;
+}
+
+/** Logical field names accepted by {@link BranchEnvironmentCommandOverrides}. */
+export const BRANCH_ENVIRONMENT_COMMAND_FIELDS = [
+  'start',
+  'stop',
+  'nuke',
+  'logs',
+  'health',
+  'app',
+] as const satisfies ReadonlyArray<keyof BranchEnvironmentCommandOverrides>;
+
+export type BranchEnvironmentCommandField = (typeof BRANCH_ENVIRONMENT_COMMAND_FIELDS)[number];
+
+/**
  * Legacy (v1) repository environment configuration — single flat command set.
  *
  * @deprecated Use {@link RepoEnvironment} (v2) with named variants. Retained


### PR DESCRIPTION
## User need

From Evan (Slack): _"Agor has no MCP tool to set environment commands. It's smart enough to look at the repo and find my project's startup commands, but not able to apply them for me. Can you add that MCP tool so others can say 'check out my project and just run it'?"_

An agent can already inspect a repo and infer the right dev commands, but had no way to **persist** them onto a branch over MCP — only the UI Settings tab could.

## The gap

The `environment` MCP domain could only **select a predefined variant** (`agor_environment_set` → `BranchesService.renderEnvironment`, which re-renders the branch's command strings from the repo's variant templates). There was no MCP path to set the raw `start` / `stop` / `health` / `logs` / `app` / `nuke` command strings that `agor_environment_start` and friends actually execute. In the UI those fields are edited via a direct `PATCH /branches/:id` (the "branch snapshot" editor in the Environment tab), gated by the admin-only `requireAdminForEnvConfig` hook.

## Design decision — new tool vs. extending `agor_environment_set`

Chose a **new tool** rather than overloading `agor_environment_set`, because the two verbs have different capabilities and different permission tiers:

| | `agor_environment_set` | `agor_environment_set_commands` (new) |
|---|---|---|
| Input | a variant name | raw command strings |
| Source of commands | repo's vetted variant templates | caller-supplied |
| Permission | branch `all` or admin | **admin only** |

**Security:** setting raw command strings is intentionally admin-only, matching the existing `requireAdminForEnvConfig` hook that guards the REST/UI patch path — these strings execute as the system user, so this is a strictly stronger capability than selecting a vetted variant. The task's suggested "branch `all` or admin" model was **not** adopted: it would have let a non-admin collaborator with branch `all` inject arbitrary system commands, bypassing `requireAdminForEnvConfig` — a privilege escalation. This is the one deliberate deviation from the original ask; flagging for Evan.

## What's in the change

- **`packages/core`** — `BranchEnvironmentCommandOverrides` type + `BRANCH_ENVIRONMENT_COMMAND_FIELDS` list (canonical, exported from `@agor/core/types`).
- **`BranchesService.setEnvironmentCommands`** — partial update of the branch's materialized command fields. Admin-enforced; refuses while the env is `running`/`starting` (mirrors `renderEnvironment`'s variant-change guard); validates the **effective** set (existing merged with overrides) against the instance execution policy via the same helpers `renderEnvironment` uses (`validateRenderedEnvironmentActions` + `validateRenderedManagedEnvUrlFields`), so webhook-only mode and SSRF/URL rules still apply. Patches only the fields provided, leaving others untouched.
- **`agor_environment_set_commands` MCP tool** — any subset of `start`/`stop`/`nuke`/`logs`/`health`/`app`, optional `andStart` for one-shot configure-and-run, returns the effective command set.
- **REST parity** — `POST /branches/:id/set-environment-commands`.
- **Docs** — `internal-mcp.mdx`: configure-verbs note + a "check out my project and just run it" example.

## Input schema (`agor_environment_set_commands`)

| field | type | notes |
|---|---|---|
| `branchId` | string (required) | branch UUIDv7 or short ID |
| `start` | string (optional) | shell string, or http(s) URL invoked as GET webhook |
| `stop` | string (optional) | " |
| `nuke` | string (optional) | " |
| `logs` | string (optional) | " |
| `health` | string (optional) | http(s) URL (may target localhost/branch-local) |
| `app` | string (optional) | app http(s) URL |
| `andStart` | boolean (optional) | start the env after setting; default false |

Omitted fields keep their current value; at least one command field is required. To reset a field back to the repo/variant default, re-render via `agor_environment_set`.

## Tests

- Service-layer (`branches.test.ts`): admin gate denies non-admins before touching the branch; partial update leaves omitted fields untouched; trims values; requires ≥1 field; refuses while running/starting; rejects invalid health URL; rejects shell command in webhook-only mode; accepts public https webhook in webhook-only mode.
- MCP handler (`environment.test.ts`): forwards only provided overrides + returns effective set; `andStart` starts after; surfaces service errors as `success:false`; `andStart` set-succeeds-then-start-fails reports `commands_set:true`.

Verification: `turbo run typecheck --filter=@agor/daemon` ✅ · biome ✅ · `vitest run src/mcp src/services/branches.test.ts` → 481 passed / 32 skipped ✅.

## Open questions for Evan

1. **Admin-only** is the deliberate deviation from the suggested "branch `all` or admin". OK to keep, or do you want branch-`all` collaborators to be able to set raw commands (accepting the system-user injection risk)?
2. No UI changes here — the existing Environment tab snapshot editor already covers humans; this is the MCP/agent path. Want a follow-up to route the UI editor through this same service method for a single code path?

Originated from Evan's Slack request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)