### PR TITLE
fix(ui): restore board emoji picker

### DIFF
--- a/apps/agor-ui/src/components/BoardCollapse/BoardCollapse.tsx
+++ b/apps/agor-ui/src/components/BoardCollapse/BoardCollapse.tsx
@@ -9,7 +9,7 @@ const { Text } = Typography;
 export interface BoardCollapseItem {
   key: string;
   board: Board;
-  /** Pre-resolved primary-assistant emoji (see {@link getBoardEmoji}). */
+  /** Pre-resolved board emoji (see {@link getBoardEmoji}). */
   emoji?: string;
   badge?: ReactNode;
   children: ReactNode;

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.icon.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.icon.test.tsx
@@ -1,0 +1,98 @@
+import type { AgorClient, Board } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { BoardEditModal } from './BoardEditModal';
+
+vi.mock('@/utils/message', () => ({ useThemedMessage: () => ({ showError: vi.fn() }) }));
+vi.mock('../JSONEditor', () => ({
+  JSONEditor: () => <textarea aria-label="Custom Context (JSON)" />,
+  validateJSON: () => Promise.resolve(),
+}));
+vi.mock('../EmojiPickerInput/AgorEmojiPickerInner', () => ({
+  default: ({ onEmojiClick }: { onEmojiClick: (data: { emoji: string }) => void }) => (
+    <button
+      type="button"
+      aria-label="Choose technologist"
+      onClick={() => onEmojiClick({ emoji: '👩🏽‍💻' })}
+    >
+      technologist
+    </button>
+  ),
+}));
+
+const listedBoard = {
+  board_id: 'board-1',
+  name: 'Emoji board',
+  created_by: 'owner-1',
+  created_at: '',
+  last_updated: '',
+} as Board;
+
+function makeClient(getBoard: () => Board): AgorClient {
+  const notFound = () => Promise.reject(Object.assign(new Error('not found'), { code: 404 }));
+  return {
+    service: (name: string) => {
+      if (name === 'boards') return { get: vi.fn().mockImplementation(getBoard) };
+      if (name === 'boards/:id/owners' || name === 'boards/:id/group-grants') {
+        return { find: vi.fn(notFound) };
+      }
+      return { findAll: vi.fn().mockResolvedValue([]) };
+    },
+  } as unknown as AgorClient;
+}
+
+describe('BoardEditModal — board icon', () => {
+  it('selects and persists a multi-codepoint emoji, then restores it on reopen', async () => {
+    let savedBoard = { ...listedBoard, icon: '🚩' } as Board;
+    const onUpdate = vi.fn(async (_id: string, updates: Partial<Board>) => {
+      savedBoard = { ...savedBoard, ...updates };
+    });
+    const client = makeClient(() => savedBoard);
+    const view = render(
+      <AntApp>
+        <BoardEditModal
+          board={listedBoard}
+          client={client}
+          open
+          onClose={vi.fn()}
+          onUpdate={onUpdate}
+        />
+      </AntApp>
+    );
+
+    const trigger = await screen.findByRole('button', { name: 'Choose emoji' });
+    expect(trigger).toHaveTextContent('🚩');
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose technologist' }));
+    expect(trigger).toHaveTextContent('👩🏽‍💻');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    expect(onUpdate.mock.calls[0]?.[1]).toMatchObject({ icon: '👩🏽‍💻' });
+
+    view.rerender(
+      <AntApp>
+        <BoardEditModal
+          board={listedBoard}
+          client={client}
+          open={false}
+          onClose={vi.fn()}
+          onUpdate={onUpdate}
+        />
+      </AntApp>
+    );
+    view.rerender(
+      <AntApp>
+        <BoardEditModal
+          board={listedBoard}
+          client={client}
+          open
+          onClose={vi.fn()}
+          onUpdate={onUpdate}
+        />
+      </AntApp>
+    );
+    expect(await screen.findByRole('button', { name: 'Choose emoji' })).toHaveTextContent('👩🏽‍💻');
+  });
+});

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -82,6 +82,7 @@ export function BoardEditModal({ board, client, open, onClose, onUpdate }: Board
         form.resetFields();
         form.setFieldsValue({
           name: fresh.name,
+          icon: fresh.icon,
           description: fresh.description,
           background_color: fresh.background_color,
           custom_css: fresh.custom_css,

--- a/apps/agor-ui/src/components/BoardTile/BoardTile.test.tsx
+++ b/apps/agor-ui/src/components/BoardTile/BoardTile.test.tsx
@@ -10,6 +10,13 @@ const board = (id: string, name: string, primary_teammate_id?: string): Board =>
   ({ board_id: id, name, primary_teammate_id }) as unknown as Board;
 
 describe('getBoardEmoji', () => {
+  it('prefers the board-owned icon over its primary teammate emoji', () => {
+    const branchById = new Map<string, Branch>([['b1', teammateBranch('🦊')]]);
+    expect(getBoardEmoji({ icon: '🧭', primary_teammate_id: 'b1' } as Board, branchById)).toBe(
+      '🧭'
+    );
+  });
+
   it('resolves the primary teammate branch emoji', () => {
     const branchById = new Map<string, Branch>([['b1', teammateBranch('🦊')]]);
     expect(getBoardEmoji({ primary_teammate_id: 'b1' } as Board, branchById)).toBe('🦊');
@@ -50,6 +57,16 @@ describe('boardSelectOptions', () => {
     render(<>{opt.label}</>);
     expect(screen.getByText('🦊')).toBeInTheDocument();
     expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+
+  it('renders the board-owned icon when it differs from the primary teammate', () => {
+    const [opt] = boardSelectOptions(
+      [{ ...board('1', 'Alpha', 'b1'), icon: '🧭' } as Board],
+      branchById
+    );
+    render(<>{opt.label}</>);
+    expect(screen.getByText('🧭')).toBeInTheDocument();
+    expect(screen.queryByText('🦊')).not.toBeInTheDocument();
   });
 
   it('renders the neutral tile (never a bare name) for an assistant-less board', () => {

--- a/apps/agor-ui/src/components/BoardTile/BoardTile.tsx
+++ b/apps/agor-ui/src/components/BoardTile/BoardTile.tsx
@@ -9,15 +9,16 @@ import type { CSSProperties } from 'react';
 export const NeutralBoardIcon = AppstoreOutlined;
 
 /**
- * A board's face is its primary assistant's emoji — boards no longer carry
- * their own icon. Resolves `primary_teammate_id → branch → teammate emoji`
- * from the already-loaded branch map; returns undefined when the board has no
- * primary teammate (or it isn't loaded), so callers render the neutral glyph.
+ * Resolve a board's own icon first. A primary teammate's emoji remains a
+ * compatibility fallback for boards that do not have an icon of their own.
+ * Auto-created teammate boards initialize `board.icon` from the teammate, but
+ * the two identities may intentionally diverge afterward.
  */
 export function getBoardEmoji(
-  board: Pick<Board, 'primary_teammate_id'>,
+  board: Pick<Board, 'icon' | 'primary_teammate_id'>,
   branchById?: Map<string, Branch> | null
 ): string | undefined {
+  if (board.icon) return board.icon;
   const teammateId = board.primary_teammate_id;
   if (!teammateId || !branchById) return undefined;
   const branch = branchById.get(teammateId);
@@ -25,7 +26,7 @@ export function getBoardEmoji(
 }
 
 export interface BoardTileProps {
-  /** Pre-resolved primary-assistant emoji (see {@link getBoardEmoji}). */
+  /** Pre-resolved board emoji (see {@link getBoardEmoji}). */
   emoji?: string;
   size?: number;
   style?: CSSProperties;
@@ -73,7 +74,7 @@ export interface BoardSelectOption {
 
 /**
  * Options for an AntD board `Select` where every board wears its face — the
- * primary-assistant emoji or the neutral {@link BoardTile} — so an
+ * board emoji, primary-teammate fallback, or neutral {@link BoardTile} — so an
  * assistant-less board never shows as a bare name. Pair with
  * `filterOption={boardSelectFilter}` to keep text search working against `name`.
  */

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
@@ -281,7 +281,7 @@ describe('useBranchModalForm — unified save', () => {
     expect(boardPatches).toHaveLength(0);
   });
 
-  it('does patch the board icon when teammate emoji actually changed', async () => {
+  it('does not overwrite the board icon when teammate emoji changes', async () => {
     const alice = makeUser({ user_id: 'user-1', email: 'alice@example.com', role: 'admin' });
     const branch = makeTeammateBranch({}, { emoji: '🤖' });
     const { client, calls } = makeStubClient({ owners: [alice], users: [alice] });
@@ -302,9 +302,7 @@ describe('useBranchModalForm — unified save', () => {
     });
 
     const boardPatches = calls.filter((c) => c.service === 'boards' && c.method === 'patch');
-    expect(boardPatches).toHaveLength(1);
-    const [, body] = boardPatches[0].args as [string, Record<string, unknown>];
-    expect(body).toMatchObject({ icon: '🎯' });
+    expect(boardPatches).toHaveLength(0);
   });
 
   it('does NOT call branches.patch for an owner-only transfer (no permission-field churn)', async () => {

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
@@ -609,22 +609,6 @@ export function useBranchModalForm({
         }
       }
 
-      // 5. Teammate emoji → board icon side effect. Cosmetic only — log on
-      // failure, don't fail the save.
-      if (teammateChanged && isTeammateBranch && canEditGeneral && branch.board_id) {
-        const config = getTeammateConfig(branch);
-        const emojiChanged = config && teammate.emoji !== (config.emoji || '');
-        if (emojiChanged) {
-          try {
-            await client.service('boards').patch(branch.board_id, {
-              icon: teammate.emoji || '🤖',
-            });
-          } catch (err) {
-            console.error('Failed to update board icon:', err);
-          }
-        }
-      }
-
       // Refresh owners cache so the next change-detection cycle reflects the
       // saved state. Doing this lazily here avoids forcing a parent re-fetch.
       if (rbacEnabled && permissionsChanged) {

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.test.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.test.tsx
@@ -36,6 +36,18 @@ describe('EmojiPickerInput', () => {
     expect(onChange).toHaveBeenCalledWith('😀');
   });
 
+  it('uses a native keyboard-focusable button and closes on Escape', async () => {
+    render(<EmojiPickerInput value="🤖" onChange={() => {}} />);
+    const tile = screen.getByRole('button', { name: 'Choose emoji' });
+    tile.focus();
+    expect(tile).toHaveFocus();
+    fireEvent.click(tile);
+    expect(await screen.findByLabelText('pick smile')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.getByLabelText('pick smile')).not.toBeVisible());
+    expect(tile).toHaveFocus();
+  });
+
   it('does not open the picker when disabled', async () => {
     render(<EmojiPickerInput value="🤖" onChange={() => {}} disabled />);
     const tile = screen.getByRole('button', { name: 'Choose emoji' });

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -92,7 +92,6 @@ export const EmojiPickerInput: React.FC<EmojiPickerInputProps> = ({
  * include it in submitted values.
  */
 export const FormEmojiPickerInput: React.FC<{
-  form: ReturnType<typeof Form.useForm>[0];
   fieldName: string;
   defaultEmoji?: string;
 }> = ({ fieldName, defaultEmoji }) => {

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -937,8 +937,8 @@ interface BoardPillProps extends BasePillProps {
   board: {
     name: string;
   };
-  /** Pre-resolved primary-assistant emoji (see `getBoardEmoji`); falls back to
-   * the neutral board glyph when absent — never a stored board icon. */
+  /** Pre-resolved board emoji (see `getBoardEmoji`); falls back to the neutral
+   * board glyph when the board has neither an icon nor a teammate fallback. */
   emoji?: string | null;
   compact?: boolean;
   title?: string;

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -266,7 +266,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       <Form.Item label="Name" style={{ marginBottom: 24 }}>
         <Flex gap={8}>
           <Form.Item name="emoji" noStyle>
-            <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="📋" />
+            <FormEmojiPickerInput fieldName="emoji" defaultEmoji="📋" />
           </Form.Item>
           <Form.Item name="name" noStyle rules={[{ required: true, message: 'Name is required' }]}>
             <Input placeholder="e.g. Support Ticket" style={{ flex: 1 }} />

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,6 +1,7 @@
 import type { Board, Group, User } from '@agor-live/client';
 import type { FormInstance } from 'antd';
-import { Alert, Form, Input, Tabs, Typography } from 'antd';
+import { Alert, Form, Input, Space, Tabs, Typography } from 'antd';
+import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import {
   RbacPermissionFields,
   type RbacPermissionValue,
@@ -46,6 +47,10 @@ export function extractBoardFormValues(form: FormInstance): Partial<Board> {
   const bgColor = values.background_color;
   return {
     name: values.name,
+    // Board icons are Unicode emoji strings. Keep the historical default when
+    // a new board has not selected one; existing multi-codepoint values pass
+    // through unchanged.
+    icon: values.icon || '📋',
     description: values.description,
     // background_color is usually a string (gradient/CSS/hex), but the
     // ColorPicker yields an AntD AggregationColor. Only serialize via
@@ -97,13 +102,17 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
 }) => {
   const generalFields = (
     <>
-      <Form.Item
-        label="Name"
-        name="name"
-        rules={[{ required: true, message: 'Please enter a board name' }]}
-        style={{ marginBottom: 24 }}
-      >
-        <Input placeholder="My Board" autoFocus={autoFocus} />
+      <Form.Item label="Name" required style={{ marginBottom: 24 }}>
+        <Space.Compact style={{ display: 'flex' }}>
+          <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
+          <Form.Item
+            name="name"
+            noStyle
+            rules={[{ required: true, message: 'Please enter a board name' }]}
+          >
+            <Input placeholder="My Board" style={{ flex: 1 }} autoFocus={autoFocus} />
+          </Form.Item>
+        </Space.Compact>
       </Form.Item>
 
       <Form.Item label="Description" name="description">

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -104,7 +104,7 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
     <>
       <Form.Item label="Name" required style={{ marginBottom: 24 }}>
         <Space.Compact style={{ display: 'flex' }}>
-          <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
+          <FormEmojiPickerInput fieldName="icon" defaultEmoji="📋" />
           <Form.Item
             name="name"
             noStyle

--- a/apps/agor-ui/src/components/forms/TeammateFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/TeammateFormFields.tsx
@@ -44,7 +44,7 @@ export const TeammateFormFields: React.FC<TeammateFormFieldsProps> = ({
     <>
       <Form.Item label="Name" required tooltip="Human-friendly name and icon for this AI teammate">
         <Space.Compact style={{ display: 'flex' }}>
-          <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="🤖" />
+          <FormEmojiPickerInput fieldName="emoji" defaultEmoji="🤖" />
           <Form.Item
             name="displayName"
             noStyle

--- a/apps/agor-ui/src/hooks/useBoardTitle.ts
+++ b/apps/agor-ui/src/hooks/useBoardTitle.ts
@@ -1,8 +1,9 @@
 /**
  * React hook for updating the browser tab title based on the current board.
  *
- * Shows the board name when one is selected (boards no longer carry their own
- * emoji), else resets to "Agor" when no board is active or on unmount.
+ * Shows the board name when one is selected, else resets to "Agor" when no
+ * board is active or on unmount. The board icon is intentionally omitted from
+ * the browser title.
  */
 
 import type { Board } from '@agor-live/client';


### PR DESCRIPTION
## Summary

- restore the shared board emoji picker to `BoardFormFields`, keeping create, Settings, and the current-board edit shortcut consistent
- hydrate `board.icon` when Edit Board opens and include the unchanged Unicode string in the existing board patch payload
- add focused coverage for picker presence, multi-codepoint selection (`👩🏽‍💻`), persistence, reopen behavior, Escape/focus, and the existing default

## Root cause / history

The picker was originally centralized in `BoardFormFields` by #857 and used by both board create and edit flows. It was **intentionally removed** in #2294 (`01797d0f`) as part of a proposal that boards should inherit their primary teammate's face. The database/API field was deliberately retained, however, and #2387 confirms the board-owned icon remains a supported first-class setting. This restores the prior shared affordance rather than introducing a native text field or a second picker implementation.

The implementation continues to use the existing lazy-loaded `EmojiPickerInput` / `emoji-picker-react` path (native emoji style, existing Popover portal and AntD interaction semantics), so there is no dependency or eager-bundle increase.

## Behavior

**Before:** Edit Board and all shared board forms rendered only a name input; `icon` could be changed only through API/MCP.

**After:** The accessible **Choose emoji** tile is joined to the board name in create/edit flows. Existing values rehydrate on every modal open; selecting an emoji closes the picker and Save sends it through the unchanged `Partial<Board>` update contract. Multi-codepoint Unicode is passed through without slicing or normalization. Boards without an explicit selection retain the historical `📋` create default; there is no new clear action because board creation has always required/defaulted this identity value.

## Validation

- `vitest` focused suites: **11 passed**
  - `EmojiPickerInput.test.tsx`
  - `BoardEditModal.icon.test.tsx`
  - `BoardEditModal.test.tsx`
  - `BoardEditModal.background.test.tsx`
- Biome on all touched files: **clean**
- Pre-commit hook / lint-staged: **passed**
- Disposable sqlite environment: **healthy (HTTP 200)**; Playwright authenticated against the live app and confirmed the seeded board's `Edit current board: Main Board` control in the computed accessibility tree. The environment's first-run onboarding overlay made the final modal screenshot nondeterministic; the full picker DOM and round-trip are covered by the focused browser-DOM component regression.
- UI typecheck was attempted but cannot run from a source-only workspace without built `@agor-live/client`, `@agor/core`, and `@agor/agentic-tools` declarations. Per repository guidance, no workspace build was run solely to manufacture those outputs.
- Current branch was checked against `origin/main`: **0 behind / 0 ahead before the fix**.

## Related work / risk

Open #2238 also refactors Workspace Settings editors and may touch the shared board form. Keeping this change in `BoardFormFields` minimizes the integration surface, but that PR should preserve the icon field when rebased. No persisted schema, daemon service, tenant boundary, or API contract changes are involved.

Closes #2387
