### PR TITLE
fix(ui): probe typed Slack tokens in the edit-channel connection test

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -642,7 +642,7 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     expect(writeText.mock.calls[0][0]).toContain('"channels:history"');
   });
 
-  it('tests an existing channel via gatewayChannelId (never form tokens)', async () => {
+  it('tests an existing channel via gatewayChannelId when no tokens are typed', async () => {
     const result = {
       ok: true,
       team: { id: 'T123', name: 'Acme' },
@@ -660,6 +660,26 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     expect(testCreate.mock.calls[0][0]).toEqual({ gatewayChannelId: 'channel-1' });
     expect(await screen.findByText('Connection succeeded')).toBeInTheDocument();
     expect(screen.getByText('Acme')).toBeInTheDocument();
+  });
+
+  it('probes the tokens typed into the edit form instead of the stored ones', async () => {
+    const { client, testCreate } = makeClient();
+    renderEditTable(client, makeSlackChannel());
+    expandPanel('Credentials');
+
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'xoxb-fresh' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), {
+      target: { value: 'xapp-fresh' },
+    });
+    clickButton(/Test connection/);
+
+    await waitFor(() => expect(testCreate).toHaveBeenCalledTimes(1));
+    expect(testCreate.mock.calls[0][0]).toEqual({
+      gatewayChannelId: 'channel-1',
+      config: { bot_token: 'xoxb-fresh', app_token: 'xapp-fresh' },
+    });
   });
 
   it('derives the Message Sources scope/event list (no stale message.* events)', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -682,6 +682,29 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     });
   });
 
+  it('sanitizes pasted Slack edit tokens the same way as Save', async () => {
+    const { client, testCreate } = makeClient();
+    const onUpdate = vi.fn();
+    renderEditTable(client, makeSlackChannel(), { onUpdate });
+    expandPanel('Credentials');
+
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: ' xoxb-\u200bfresh ' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), {
+      target: { value: ' xapp-\u2060fresh ' },
+    });
+    clickButton(/Test connection/);
+
+    await waitFor(() => expect(testCreate).toHaveBeenCalledTimes(1));
+    const tokens = { bot_token: 'xoxb-fresh', app_token: 'xapp-fresh' };
+    expect(testCreate.mock.calls[0][0]).toEqual({ gatewayChannelId: 'channel-1', config: tokens });
+
+    clickButton(/^Save$/);
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][1].config).toMatchObject(tokens);
+  });
+
   it('derives the Message Sources scope/event list (no stale message.* events)', async () => {
     renderEditTable(null, makeSlackChannel());
     expandPanel('Message Sources');

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -3969,13 +3969,22 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     runConnectionProbe,
   ]);
 
-  // Probe an existing Slack channel via the `gateway-channels/test` service. The
-  // backend resolves the stored decrypted tokens from `gatewayChannelId`, so the
-  // edit form never sends credentials.
+  // Probe an existing Slack channel via the `gateway-channels/test` service.
+  // Tokens typed into the edit form are forwarded as overrides so the probe
+  // tests what the user just entered; fields left blank fall back to the stored
+  // decrypted credentials the backend resolves from `gatewayChannelId`.
   const handleSlackEditTest = useCallback(async () => {
     if (!editingChannel) return;
-    await runConnectionProbe('slack', {}, editingChannel.id);
-  }, [editingChannel, runConnectionProbe]);
+    const values = editForm.getFieldsValue(true);
+    const config: Record<string, unknown> = {};
+    if (values.bot_token && values.bot_token !== GATEWAY_REDACTED_SENTINEL) {
+      config.bot_token = values.bot_token;
+    }
+    if (values.app_token && values.app_token !== GATEWAY_REDACTED_SENTINEL) {
+      config.app_token = values.app_token;
+    }
+    await runConnectionProbe('slack', config, editingChannel.id);
+  }, [editingChannel, editForm, runConnectionProbe]);
 
   const extractFormData = (
     values: Record<string, unknown>,

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -3978,10 +3978,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     const values = editForm.getFieldsValue(true);
     const config: Record<string, unknown> = {};
     if (values.bot_token && values.bot_token !== GATEWAY_REDACTED_SENTINEL) {
-      config.bot_token = values.bot_token;
+      config.bot_token = sanitizeSecretValue(values.bot_token);
     }
     if (values.app_token && values.app_token !== GATEWAY_REDACTED_SENTINEL) {
-      config.app_token = values.app_token;
+      config.app_token = sanitizeSecretValue(values.app_token);
     }
     await runConnectionProbe('slack', config, editingChannel.id);
   }, [editingChannel, editForm, runConnectionProbe]);


### PR DESCRIPTION
## What

Makes **Test Connection** in the Edit Gateway Channel dialog probe the Slack tokens currently typed
into the form, instead of always falling back to the credentials stored in the database.

## Why

Pasting new, valid `bot_token` / `app_token` values and clicking Test Connection reported
`invalid_auth` — the probe was silently testing the old stored credentials. Saving, reopening, and
retesting then succeeded with the exact same values, which made the failure look like a credential
problem rather than a UI one.

## How

`handleSlackEditTest` passed `config: {}`, so `runConnectionProbe` collapsed the payload to
`{ gatewayChannelId }` and the backend's `resolveEffectiveConfig` merge became a no-op.

It now reads `editForm` and forwards non-empty, non-redacted tokens as overrides — the same shape
`handleShortcutTest` already used, which the issue identifies as the natural template:

```ts
const values = editForm.getFieldsValue(true);
const config: Record<string, unknown> = {};
if (values.bot_token && values.bot_token !== GATEWAY_REDACTED_SENTINEL) {
  config.bot_token = values.bot_token;
}
if (values.app_token && values.app_token !== GATEWAY_REDACTED_SENTINEL) {
  config.app_token = values.app_token;
}
await runConnectionProbe('slack', config, editingChannel.id);
```

No backend change: `runConnectionProbe` already sends `{ gatewayChannelId, config }` when overrides
exist and `{ gatewayChannelId }` when they don't.

**Not a behaviour change unless you type a token.** `bot_token` / `app_token` are not prefilled when
the edit form opens, so a blank form still yields `config = {}` and the payload is byte-identical to
before. The existing test that pins that path still passes untouched.

### Scope

Checked the whole file for the same pattern. As rebased onto `main` there are four
connection-test handlers: `handleSlackTest` (create), `handleShortcutTest` (create + edit) and the
newly added `handleDiscordTest` (create + edit) all read their form correctly, so Slack's edit
handler was the only one affected — no other connector needed the same fix.

*(Rebased onto `main` to clear a conflict: Discord's new test handler landed immediately above
`handleSlackEditTest`, so the two changes were textually adjacent. Both are kept; nothing in this
fix changed.)*

I also renamed one existing test from `'tests an existing channel via gatewayChannelId (never form
tokens)'` to `'…when no tokens are typed'`. Its assertions and behaviour are unchanged and it still
passes; only the parenthetical stopped being an accurate statement of intent once overrides became
possible. Flagging it explicitly so it doesn't read as quietly reshaping a test around the fix.

## Testing

- **New:** `probes the tokens typed into the edit form instead of the stored ones` — fills both token
  fields in edit mode, clicks Test connection, and asserts the payload is
  `{ gatewayChannelId, config: { bot_token, app_token } }`. **Fails on `main`, passes with this
  change** (on `main` the received payload is `{ gatewayChannelId }` with no `config`).
- `GatewayChannelsTable.test.tsx`: 28/28 pass.
- Full `agor-ui` suite: **1490 passed** across 215 files.
- `pnpm typecheck` (21/21) and `pnpm lint` both clean.

**Gap, stated plainly:** I don't have a Slack workspace with valid tokens, so I could not verify the
round trip end to end against real Slack. The test asserts the request payload, which is the actual
contract that was broken, but the live probe itself is unverified from my side. No screenshots for
the same reason — a staged failure image wouldn't show anything the payload assertion doesn't.

Closes #2343

