### PR TITLE
fix(executor): bound the Claude background-task wait so turns always settle

### DIFF
--- a/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
+++ b/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
@@ -7,6 +7,7 @@
 import {
   type AgorConfig,
   type ResolvedConfigSlice,
+  resolveClaudeBackgroundTaskConfig,
   resolveExecutorHeartbeatConfig,
   resolveSdkWatchdogConfig,
 } from '@agor/core/config';
@@ -49,6 +50,7 @@ export function buildResolvedConfigSlice(config: DeepReadonly<AgorConfig>): Reso
     interval_ms: heartbeat.interval_ms,
   };
   executionSlice.sdk_watchdog = resolveSdkWatchdogConfig(config.execution);
+  executionSlice.claude_background_tasks = resolveClaudeBackgroundTaskConfig(config.execution);
   if (Object.keys(executionSlice).length > 0) slice.execution = executionSlice;
 
   const hostIpAddress = config.daemon?.host_ip_address;

--- a/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
@@ -98,7 +98,22 @@ describe('buildResolvedConfigSlice', () => {
           abort_grace_ms: 15_000,
           claude_idle_timeout_ms: 3_600_000,
         },
+        claude_background_tasks: {
+          silence_timeout_ms: 1_800_000,
+          settled_grace_ms: 120_000,
+        },
       },
+    });
+  });
+
+  it('carries configured Claude background-task bounds through to the executor', async () => {
+    await writeConfigYaml(
+      'execution:\n  claude_background_tasks:\n    silence_timeout_ms: 5400000\n    settled_grace_ms: 30000\n'
+    );
+    const slice = buildResolvedConfigSlice(loadConfigSync());
+    expect(slice.execution?.claude_background_tasks).toEqual({
+      silence_timeout_ms: 5_400_000,
+      settled_grace_ms: 30_000,
     });
   });
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -914,11 +914,15 @@ not specific to containerized or delegated runtimes.
 
 Both bound only that held-open window, and only while the stream is quiet. Any
 SDK message re-arms them, a resumed top-level turn lifts them entirely until the
-next held result, and a wait the SDK announces — a rate-limit reset, an API
-retry backoff, a compaction — extends them by the declared duration. They are
-not a model-thinking timeout: a turn that has resumed is never force-settled,
-however long it then runs. Raise `silence_timeout_ms` if you run background
-agents that stay quiet on the parent stream for longer than half an hour.
+next held result, and a wait the SDK announces extends them for as long as it
+said it would be silent. Each announced wait is tracked separately and dropped
+when that particular wait ends, so the configured tier is what applies the rest
+of the time: a rate-limit reset or an API retry backoff extends by the delay the
+SDK reported, and a compaction or in-flight request extends by up to ten minutes
+but is dropped the moment the SDK reports it is no longer busy. They are not a
+model-thinking timeout: a turn that has resumed is never force-settled, however
+long it then runs. Raise `silence_timeout_ms` if you run background agents that
+stay quiet on the parent stream for longer than half an hour.
 
 When a bound does expire, Agor settles the turn on the accumulated parent
 result: the Task completes rather than fails, because the model had already

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -909,13 +909,24 @@ execution:
     settled_grace_ms: 120000 # 2m: nothing outstanding, waiting for the next turn
 ```
 
+These bounds apply to Claude execution in every mode — they are executor-side,
+not specific to containerized or delegated runtimes.
+
 Both bound only that held-open window, and only while the stream is quiet. Any
 SDK message re-arms them, a resumed top-level turn lifts them entirely until the
-next held result, and a rate-limit reset or API retry the SDK announces extends
-them by the wait it declared. They are not a model-thinking timeout: a turn that
-has resumed is never force-settled, however long it then runs. Raise
-`silence_timeout_ms` if you run background agents that stay quiet on the parent
-stream for longer than half an hour.
+next held result, and a wait the SDK announces — a rate-limit reset, an API
+retry backoff, a compaction — extends them by the declared duration. They are
+not a model-thinking timeout: a turn that has resumed is never force-settled,
+however long it then runs. Raise `silence_timeout_ms` if you run background
+agents that stay quiet on the parent stream for longer than half an hour.
+
+When a bound does expire, Agor settles the turn on the accumulated parent
+result: the Task completes rather than fails, because the model had already
+finished responding. **Background work that had not finished by then is
+discarded** — its output never reaches the model, and the session is not woken
+again for it. The executor logs the unsettled task IDs at that point, and a
+session blocked on a rate limit shows "Rate limited" on its pulse rather than
+appearing hung.
 
 SDK activity facts share the existing executor heartbeat transport. Disabling
 `execution.executor_heartbeat.enabled` therefore disables persisted pulse

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -890,7 +890,32 @@ execution:
 `observe` records what would have fired. Use `enforce` only after reviewing
 real-workload diagnostics for false positives; `disabled` is the rollback
 switch. Unknown SDK events fail open while they continue, permission/input
-waits pause the clock, and known active Claude tools are not timed out.
+waits pause the clock, and known active Claude tools are not timed out. A Claude
+background task relaxes the idle check to plain SDK silence rather than
+suspending it, so a task that never reports completion cannot disarm the
+watchdog for the rest of the query.
+
+### Claude Background Tasks
+
+A finished Claude turn is held open while its background Agent, Workflow, or
+shell tasks are still running, so the SDK can wake another turn with their
+output. Two last-resort bounds stop a task that never reports a terminal signal
+from wedging the Task in `running` forever:
+
+```yaml
+execution:
+  claude_background_tasks:
+    silence_timeout_ms: 1800000 # 30m: tasks outstanding, stream silent
+    settled_grace_ms: 120000 # 2m: nothing outstanding, waiting for the next turn
+```
+
+Both bound only that held-open window, and only while the stream is quiet. Any
+SDK message re-arms them, a resumed top-level turn lifts them entirely until the
+next held result, and a rate-limit reset or API retry the SDK announces extends
+them by the wait it declared. They are not a model-thinking timeout: a turn that
+has resumed is never force-settled, however long it then runs. Raise
+`silence_timeout_ms` if you run background agents that stay quiet on the parent
+stream for longer than half an hour.
 
 SDK activity facts share the existing executor heartbeat transport. Disabling
 `execution.executor_heartbeat.enabled` therefore disables persisted pulse

--- a/apps/agor-ui/src/components/Pill/TimerPill.test.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.test.tsx
@@ -2,7 +2,7 @@ import { TaskStatus } from '@agor-live/client';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TimerPill } from './TimerPill';
+import { isRateLimitPulse, TimerPill } from './TimerPill';
 
 vi.mock('antd', () => ({
   Popover: ({ children, content }: { children: ReactNode; content: ReactNode }) => (
@@ -82,5 +82,58 @@ describe('TimerPill pulse diagnostics', () => {
     render(<TimerPill status={TaskStatus.RUNNING} startedAt="2026-07-18T22:47:23.000Z" />);
 
     expect(screen.queryByText('Pulse')).not.toBeInTheDocument();
+  });
+
+  // A rate-limited task stays RUNNING and stops producing output, which is
+  // indistinguishable from a hang unless the label reads the pulse detail.
+  it.each([
+    ['rate_limit.five_hour', 'Rate limited'],
+    ['rate_limit.seven_day_opus', 'Rate limited'],
+    ['permission.request', 'Waiting'],
+  ])('distinguishes a waiting pulse detailed %s as %s', (detail, label) => {
+    render(
+      <TimerPill
+        status={TaskStatus.RUNNING}
+        startedAt="2026-07-18T22:47:23.000Z"
+        latestExecutorPulse={{
+          sequence: 1,
+          kind: 'waiting',
+          detail,
+          observed_at: '2026-07-18T22:47:24.000Z',
+        }}
+      />
+    );
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('reports a rate-limit block from the pulse alone', () => {
+    expect(
+      isRateLimitPulse({
+        sequence: 1,
+        kind: 'waiting',
+        detail: 'rate_limit.five_hour',
+        observed_at: '2026-07-18T22:47:24.000Z',
+      })
+    ).toBe(true);
+    // Not every wait is a block, and not every rate-limit detail is a wait:
+    // the resume signal rides the same prefix on a different kind.
+    expect(
+      isRateLimitPulse({
+        sequence: 2,
+        kind: 'waiting',
+        detail: 'permission.request',
+        observed_at: '2026-07-18T22:47:24.000Z',
+      })
+    ).toBe(false);
+    expect(
+      isRateLimitPulse({
+        sequence: 3,
+        kind: 'sdk_started',
+        detail: 'rate_limit.resolved',
+        observed_at: '2026-07-18T22:47:24.000Z',
+      })
+    ).toBe(false);
+    expect(isRateLimitPulse(null)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/Pill/TimerPill.test.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.test.tsx
@@ -1,8 +1,8 @@
-import { TaskStatus } from '@agor-live/client';
+import { isRateLimitBlockPulse, TaskStatus } from '@agor-live/client';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isRateLimitPulse, TimerPill } from './TimerPill';
+import { TimerPill } from './TimerPill';
 
 vi.mock('antd', () => ({
   Popover: ({ children, content }: { children: ReactNode; content: ReactNode }) => (
@@ -109,7 +109,7 @@ describe('TimerPill pulse diagnostics', () => {
 
   it('reports a rate-limit block from the pulse alone', () => {
     expect(
-      isRateLimitPulse({
+      isRateLimitBlockPulse({
         sequence: 1,
         kind: 'waiting',
         detail: 'rate_limit.five_hour',
@@ -119,7 +119,7 @@ describe('TimerPill pulse diagnostics', () => {
     // Not every wait is a block, and not every rate-limit detail is a wait:
     // the resume signal rides the same prefix on a different kind.
     expect(
-      isRateLimitPulse({
+      isRateLimitBlockPulse({
         sequence: 2,
         kind: 'waiting',
         detail: 'permission.request',
@@ -127,13 +127,13 @@ describe('TimerPill pulse diagnostics', () => {
       })
     ).toBe(false);
     expect(
-      isRateLimitPulse({
+      isRateLimitBlockPulse({
         sequence: 3,
         kind: 'sdk_started',
         detail: 'rate_limit.resolved',
         observed_at: '2026-07-18T22:47:24.000Z',
       })
     ).toBe(false);
-    expect(isRateLimitPulse(null)).toBe(false);
+    expect(isRateLimitBlockPulse(null)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -3,7 +3,7 @@ import type {
   SessionStatus as SessionStatusValue,
   TaskStatus as TaskStatusValue,
 } from '@agor-live/client';
-import { SessionStatus, TaskStatus } from '@agor-live/client';
+import { isRateLimitBlockPulse, SessionStatus, TaskStatus } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
@@ -49,24 +49,14 @@ const PULSE_LABELS: Record<ExecutorPulse['kind'], string> = {
 };
 
 /**
- * Executor detail prefix for a rate-limit block. The executor emits one
- * `waiting` pulse when the SDK is refused and the heartbeat re-sends it every
- * beat, so this stays true for the whole wait even though the SDK itself is
- * silent throughout.
- */
-const RATE_LIMIT_PULSE_PREFIX = 'rate_limit.';
-
-export function isRateLimitPulse(pulse?: ExecutorPulse | null): boolean {
-  return pulse?.kind === 'waiting' && (pulse.detail?.startsWith(RATE_LIMIT_PULSE_PREFIX) ?? false);
-}
-
-/**
  * A blocked session and a hung one look identical from the outside — both sit
  * in `running` with no output — so the label has to read the detail, not just
- * the kind.
+ * the kind. The executor emits one `waiting` pulse when the SDK is refused and
+ * the heartbeat re-sends it every beat, so this stays true for the whole wait
+ * even though the SDK itself is silent throughout.
  */
 export function pulseLabel(pulse: ExecutorPulse): string {
-  if (isRateLimitPulse(pulse)) return 'Rate limited';
+  if (isRateLimitBlockPulse(pulse)) return 'Rate limited';
   return PULSE_LABELS[pulse.kind];
 }
 
@@ -346,7 +336,7 @@ export const TimerPill: React.FC<TimerPillProps> = ({
   // working, without inventing a status. The elapsed timer keeps running,
   // which is the useful reading during a multi-hour reset.
   const config =
-    isActive && isRateLimitPulse(latestExecutorPulse)
+    isActive && isRateLimitBlockPulse(latestExecutorPulse)
       ? { ...baseConfig, icon: <PauseCircleOutlined />, color: PILL_COLORS.warning }
       : baseConfig;
   const label = config.label ?? formatDuration(elapsedMs);

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -48,6 +48,28 @@ const PULSE_LABELS: Record<ExecutorPulse['kind'], string> = {
   unknown_activity: 'Active',
 };
 
+/**
+ * Executor detail prefix for a rate-limit block. The executor emits one
+ * `waiting` pulse when the SDK is refused and the heartbeat re-sends it every
+ * beat, so this stays true for the whole wait even though the SDK itself is
+ * silent throughout.
+ */
+const RATE_LIMIT_PULSE_PREFIX = 'rate_limit.';
+
+export function isRateLimitPulse(pulse?: ExecutorPulse | null): boolean {
+  return pulse?.kind === 'waiting' && (pulse.detail?.startsWith(RATE_LIMIT_PULSE_PREFIX) ?? false);
+}
+
+/**
+ * A blocked session and a hung one look identical from the outside — both sit
+ * in `running` with no output — so the label has to read the detail, not just
+ * the kind.
+ */
+export function pulseLabel(pulse: ExecutorPulse): string {
+  if (isRateLimitPulse(pulse)) return 'Rate limited';
+  return PULSE_LABELS[pulse.kind];
+}
+
 const PulseIcon = () => (
   <svg
     aria-hidden="true"
@@ -303,7 +325,7 @@ export const TimerPill: React.FC<TimerPillProps> = ({
                 }
               >
                 <span style={{ color: token.colorTextSecondary, marginLeft: 6 }}>
-                  {PULSE_LABELS[latestExecutorPulse.kind]}
+                  {pulseLabel(latestExecutorPulse)}
                 </span>
               </Tooltip>
             </span>
@@ -317,7 +339,16 @@ export const TimerPill: React.FC<TimerPillProps> = ({
     return null;
   }
 
-  const config = statusConfig[status] || statusConfig.pending;
+  const baseConfig = statusConfig[status] || statusConfig.pending;
+  // A rate-limited task is still RUNNING — the status enum has no room for
+  // "running but blocked", which is what the pulse channel is for. Borrow the
+  // awaiting-permission affordance so the pill reads as parked rather than
+  // working, without inventing a status. The elapsed timer keeps running,
+  // which is the useful reading during a multi-hour reset.
+  const config =
+    isActive && isRateLimitPulse(latestExecutorPulse)
+      ? { ...baseConfig, icon: <PauseCircleOutlined />, color: PILL_COLORS.warning }
+      : baseConfig;
   const label = config.label ?? formatDuration(elapsedMs);
 
   const tag = (

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -122,7 +122,13 @@ The shared pulse vocabulary is:
 
 - `sdk_started` — the SDK boundary or a supervised resume was reached;
 - `progress` — known meaningful SDK activity;
-- `waiting` — a known permission/input wait that pauses watchdog time;
+- `waiting` — a known wait that pauses watchdog time. The pause is keyed by
+  source (`approval` for permission/input prompts, `rate_limit` for a Claude
+  rate-limit block) and lifts only when every source has reported its own
+  resume detail, so one wait clearing cannot un-pause another. **Every producer
+  of a `waiting` pulse owes a resume** — a pause has no clock of its own, so an
+  unmatched one disables the watchdog for the rest of the task. The shared
+  detail vocabulary is `ExecutorPulseDetail` in `packages/core/src/types/task.ts`;
 - `unknown_activity` — an unrecognized event that is retained as diagnostic
   evidence and fails open.
 
@@ -182,9 +188,14 @@ an explicit mapping-review point.
 - Starts at the executor boundary, before SDK import/subscription/prompt setup,
   so a silent SDK startup is covered.
 - Uses semantic activity rather than heartbeat time.
-- Pauses while waiting for a known permission/input decision.
-- Tracks known active tool/background-task lifetimes so healthy silent work is
-  not treated as idle.
+- Pauses while waiting for a known permission/input decision or a Claude
+  rate-limit block, keyed by wait source (see the pulse vocabulary above).
+- Tracks foreground tool lifetimes so healthy silent work is not treated as
+  idle. A Claude background task only _relaxes_ the idle policy to plain SDK
+  silence rather than suspending it: `task_progress` and forwarded subagent
+  traffic keep a healthy task alive, while a task ID that never reports a
+  terminal signal can no longer disarm the check that would notice the
+  resulting hang ([#2447](https://github.com/preset-io/agor/pull/2447)).
 - Records unknown vocabulary once as `unknown_activity` and continues rather
   than terminating work it cannot classify.
 - In `observe` mode, writes a `would_fire` diagnosis and leaves lifecycle state
@@ -354,3 +365,11 @@ the present boundaries:
   with durable quiescence reporting.
 - [#2057](https://github.com/preset-io/agor/pull/2057) aligned Claude
   background-task lifetime with query and watchdog lifetime.
+- [#2447](https://github.com/preset-io/agor/pull/2447) bounded that alignment:
+  the query a finished turn holds open for background tasks now has a two-tier
+  last-resort budget (`execution.claude_background_tasks`), background tasks no
+  longer suspend the watchdog outright, and `waiting` pauses are keyed to the
+  wait that installed them. **A timeout recovery settles the turn on the
+  accumulated parent result and may discard background work that had not
+  finished** — the turn is reported as completed, not failed, because the model
+  had already stopped responding.

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -17,6 +17,7 @@ import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
 import { validateRedisKeyPrefix, validateRedisUrl } from './deployment';
 import {
+  resolveClaudeBackgroundTaskConfig,
   resolveDispatchConnectTimeoutMs,
   resolveExecutorHeartbeatConfig,
   resolveSdkWatchdogConfig,
@@ -576,6 +577,7 @@ function validateConfig(config: AgorConfig): void {
   only(config.execution, 'execution', [
     'executor_heartbeat',
     'sdk_watchdog',
+    'claude_background_tasks',
     'dispatch_connect_timeout_ms',
     'unix_user_mode',
     'branch_rbac',
@@ -614,6 +616,13 @@ function validateConfig(config: AgorConfig): void {
   ]);
   if (config.execution?.sdk_watchdog) {
     resolveSdkWatchdogConfig(config.execution);
+  }
+  only(config.execution?.claude_background_tasks, 'execution.claude_background_tasks', [
+    'silence_timeout_ms',
+    'settled_grace_ms',
+  ]);
+  if (config.execution?.claude_background_tasks) {
+    resolveClaudeBackgroundTaskConfig(config.execution);
   }
   resolveDispatchConnectTimeoutMs(config.execution);
   only(config.execution?.branch_storage, 'execution.branch_storage', [

--- a/packages/core/src/config/executor-heartbeat.ts
+++ b/packages/core/src/config/executor-heartbeat.ts
@@ -7,6 +7,12 @@ export const EXECUTOR_DISPATCH_CONNECT_TIMEOUT_MS = 5 * 60_000;
 export type ResolvedSdkWatchdogConfig = Required<
   NonNullable<AgorExecutionSettings['sdk_watchdog']>
 >;
+export type ResolvedClaudeBackgroundTaskConfig = Required<
+  NonNullable<AgorExecutionSettings['claude_background_tasks']>
+>;
+
+export const CLAUDE_BACKGROUND_TASK_SILENCE_TIMEOUT_MS = 30 * 60_000;
+export const CLAUDE_BACKGROUND_TASK_SETTLED_GRACE_MS = 2 * 60_000;
 
 export interface ResolvedExecutorHeartbeatConfig {
   enabled: boolean;
@@ -68,6 +74,24 @@ export function resolveDispatchConnectTimeoutMs(execution?: AgorExecutionSetting
     EXECUTOR_DISPATCH_CONNECT_TIMEOUT_MS,
     'execution.dispatch_connect_timeout_ms'
   );
+}
+
+export function resolveClaudeBackgroundTaskConfig(
+  execution?: AgorExecutionSettings
+): ResolvedClaudeBackgroundTaskConfig {
+  const raw = execution?.claude_background_tasks;
+  return {
+    silence_timeout_ms: positiveSafeInteger(
+      raw?.silence_timeout_ms,
+      CLAUDE_BACKGROUND_TASK_SILENCE_TIMEOUT_MS,
+      'execution.claude_background_tasks.silence_timeout_ms'
+    ),
+    settled_grace_ms: positiveSafeInteger(
+      raw?.settled_grace_ms,
+      CLAUDE_BACKGROUND_TASK_SETTLED_GRACE_MS,
+      'execution.claude_background_tasks.settled_grace_ms'
+    ),
+  };
 }
 
 export function resolveSdkWatchdogConfig(

--- a/packages/core/src/config/resolved-config-slice.ts
+++ b/packages/core/src/config/resolved-config-slice.ts
@@ -52,6 +52,12 @@ export const ResolvedConfigSliceSchema = z.object({
           claude_idle_timeout_ms: z.number().int().positive().nullable(),
         })
         .optional(),
+      claude_background_tasks: z
+        .object({
+          silence_timeout_ms: z.number().int().positive(),
+          settled_grace_ms: z.number().int().positive(),
+        })
+        .optional(),
     })
     .optional(),
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -459,6 +459,36 @@ export interface AgorExecutionSettings {
     claude_idle_timeout_ms?: number | null;
   };
 
+  /**
+   * Last-resort bounds on the Claude query that a finished model turn keeps
+   * open for its background tasks.
+   *
+   * A successful `result` is held back while Agent / Workflow / background
+   * shell tasks are still running, so the SDK can wake another turn with their
+   * output. Both values bound only that window, and only while the stream is
+   * silent: any SDK message re-arms them, a resumed top-level turn lifts them
+   * entirely, and a rate-limit or API-retry wait the SDK announces extends
+   * them. They exist so a task that never reports a terminal signal cannot
+   * wedge the Task in `running` forever — they are not a general
+   * model-thinking timeout.
+   */
+  claude_background_tasks?: {
+    /**
+     * Silence budget while background tasks are still outstanding
+     * (default 1800000 = 30 minutes). Long, because those tasks can
+     * legitimately work for a long time with nothing to say on the parent
+     * stream.
+     */
+    silence_timeout_ms?: number;
+    /**
+     * Grace for the SDK to wake a continuation turn after the last background
+     * task settles and no work is outstanding (default 120000 = 2 minutes).
+     * Short, because all that remains is local scheduling plus the first
+     * message of the next turn.
+     */
+    settled_grace_ms?: number;
+  };
+
   dispatch_connect_timeout_ms?: number | null;
 
   /** Execution mode: trusted local, delegated external, or local Linux sandbox. */

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -72,8 +72,10 @@ export const ExecutorPulseDetail = {
 export function isRateLimitBlockPulse(
   pulse?: { kind: ExecutorPulseKind; detail?: string } | null
 ): boolean {
-  if (pulse?.kind !== ExecutorPulseKind.WAITING) return false;
-  return pulse.detail?.startsWith(ExecutorPulseDetail.RATE_LIMIT_PREFIX) ?? false;
+  return (
+    pulse?.kind === ExecutorPulseKind.WAITING &&
+    (pulse.detail?.startsWith(ExecutorPulseDetail.RATE_LIMIT_PREFIX) ?? false)
+  );
 }
 
 export interface RuntimeTelemetryInput {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -43,6 +43,39 @@ export interface ExecutorPulse {
   observed_at: string;
 }
 
+/**
+ * Shared `detail` vocabulary for executor pulses.
+ *
+ * A `waiting` pulse pauses the executor's SDK watchdog, and only a matching
+ * resume detail lifts that pause — so producer and reader agreeing on these
+ * exact strings is an invariant, not a style preference. They are declared once
+ * here because they are read in three places across two processes (the Claude
+ * prompt service that emits them, the watchdog that pairs pause with resume,
+ * and the UI that labels the pulse), and a rename that missed any one of them
+ * would silently unpair a pause from its resume.
+ */
+export const ExecutorPulseDetail = {
+  /** Prefix of a rate-limit block; the suffix is the SDK's own limit type. */
+  RATE_LIMIT_PREFIX: 'rate_limit.',
+  /** Lifts the pause a rate-limit block installed. */
+  RATE_LIMIT_RESOLVED: 'rate_limit.resolved',
+  /** Lifts the pause a permission / user-input prompt installed. */
+  PERMISSION_RESOLVED: 'permission.resolved',
+} as const;
+
+/**
+ * Whether a pulse says the session is blocked on a rate limit.
+ *
+ * Checks the kind as well as the prefix: {@link ExecutorPulseDetail.RATE_LIMIT_RESOLVED}
+ * shares the prefix but rides a `sdk_started` pulse and means the opposite.
+ */
+export function isRateLimitBlockPulse(
+  pulse?: { kind: ExecutorPulseKind; detail?: string } | null
+): boolean {
+  if (pulse?.kind !== ExecutorPulseKind.WAITING) return false;
+  return pulse.detail?.startsWith(ExecutorPulseDetail.RATE_LIMIT_PREFIX) ?? false;
+}
+
 export interface RuntimeTelemetryInput {
   task_id: string;
   pulse?: Omit<ExecutorPulse, 'observed_at'>;

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -5,6 +5,7 @@
  */
 
 import { TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
+import { resolveClaudeBackgroundTaskConfig } from '@agor/core/config';
 import type {
   ExecutorPulseKind,
   MessageSource,
@@ -42,6 +43,12 @@ export async function executeClaudeCodeTask(params: {
   // Permission timeout: daemon-resolved slice, fallback to 10-minute default.
   const permissionTimeoutMs = params.resolvedConfig?.execution?.permission_timeout_ms ?? 600_000;
 
+  // Bounds on the query a finished turn holds open for background tasks.
+  // Daemon-resolved slice, with the same defaults when running without one.
+  const backgroundTaskConfig =
+    params.resolvedConfig?.execution?.claude_background_tasks ??
+    resolveClaudeBackgroundTaskConfig();
+
   // Create PermissionService that emits via Feathers WebSocket
   const permissionService = new PermissionService(async (event, data) => {
     if (event === 'permission:request') params.onPulse?.('waiting', 'permission.request');
@@ -76,7 +83,8 @@ export async function executeClaudeCodeTask(params: {
           true, // mcpEnabled
           useNativeAuth, // Flag for Claude CLI OAuth (`claude login`)
           repos.users,
-          repos.mcpOAuthAuthHeaders
+          repos.mcpOAuthAuthHeaders,
+          backgroundTaskConfig
         ),
     });
   } finally {

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -26,6 +26,15 @@ const launches = (toolUseIds: string[], parentToolUseId: string | null) =>
     },
   });
 
+/** The same turn with the scope field absent, as an omitted JSON key arrives. */
+const launchesWithoutScope = (toolUseIds: string[]) =>
+  message({
+    type: 'assistant',
+    message: {
+      content: toolUseIds.map((id) => ({ type: 'tool_use', id, name: 'Task', input: {} })),
+    },
+  });
+
 describe('ClaudeBackgroundTaskLifecycle', () => {
   it('keeps a Workflow alive across its parent result until its completion turn', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
@@ -170,6 +179,18 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     expect(lifecycle.activeTaskIds).toEqual(['agent-1']);
     lifecycle.observe(settled('agent-1'));
     expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  // parent_tool_use_id crosses a JSON boundary, so an omitted key arrives as
+  // undefined however the .d.ts declares it. Reading that as "subagent" would
+  // put every top-level Task launch into the nested set, drop every task, and
+  // close the query on live background work — #1852 verbatim.
+  it('keeps tracking tasks when the message scope cannot be established', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(launchesWithoutScope(['tool-1']));
+    expect(lifecycle.observe(started('agent-1', 'agent', 'tool-1')).taskTransition).toBe('started');
+    expect(lifecycle.activeTaskIds).toEqual(['agent-1']);
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
   });
 
   it('releases nested tasks announced before their launch site is forwarded', () => {

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -3,13 +3,28 @@ import { describe, expect, it } from 'vitest';
 import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
 
 const message = (value: Record<string, unknown>) => value as SDKMessage;
-const started = (taskId: string, taskType = 'agent') =>
-  message({ type: 'system', subtype: 'task_started', task_id: taskId, task_type: taskType });
+const started = (taskId: string, taskType = 'agent', toolUseId?: string) =>
+  message({
+    type: 'system',
+    subtype: 'task_started',
+    task_id: taskId,
+    task_type: taskType,
+    tool_use_id: toolUseId,
+  });
 const settled = (taskId: string, status: 'completed' | 'failed' | 'stopped' = 'completed') =>
   message({ type: 'system', subtype: 'task_notification', task_id: taskId, status });
 const updated = (taskId: string, status: string) =>
   message({ type: 'system', subtype: 'task_updated', task_id: taskId, patch: { status } });
 const result = (subtype = 'success') => message({ type: 'result', subtype });
+/** An assistant turn that launched `toolUseIds`, either top-level or inside a subagent. */
+const launches = (toolUseIds: string[], parentToolUseId: string | null) =>
+  message({
+    type: 'assistant',
+    parent_tool_use_id: parentToolUseId,
+    message: {
+      content: toolUseIds.map((id) => ({ type: 'tool_use', id, name: 'Task', input: {} })),
+    },
+  });
 
 describe('ClaudeBackgroundTaskLifecycle', () => {
   it('keeps a Workflow alive across its parent result until its completion turn', () => {
@@ -40,7 +55,9 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     }
   );
 
-  it.each(['completed', 'failed', 'stopped'] as const)(
+  // `task_updated.patch.status` and `task_notification.status` are different SDK
+  // enums: only this one can report `killed`, and it can never report `stopped`.
+  it.each(['completed', 'failed', 'killed'] as const)(
     'settles a task from a terminal task_updated patch when no notification follows (%s)',
     (status) => {
       const lifecycle = new ClaudeBackgroundTaskLifecycle();
@@ -48,6 +65,16 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
       expect(lifecycle.observe(updated('bash-1', status)).taskTransition).toBe('settled');
       expect(lifecycle.activeTaskCount).toBe(0);
       expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+    }
+  );
+
+  it.each(['pending', 'running', 'paused'] as const)(
+    'keeps waiting through a non-terminal task_updated patch (%s)',
+    (status) => {
+      const lifecycle = new ClaudeBackgroundTaskLifecycle();
+      lifecycle.observe(started('bash-1'));
+      expect(lifecycle.observe(updated('bash-1', status)).taskTransition).toBeUndefined();
+      expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
     }
   );
 
@@ -118,7 +145,46 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     expect(lifecycle.observe(started('agent-1')).taskTransition).toBe('started');
     expect(lifecycle.observe(started('agent-1')).taskTransition).toBeUndefined();
     expect(lifecycle.observe(settled('unknown')).taskTransition).toBeUndefined();
+    expect(lifecycle.activeTaskIds).toEqual(['agent-1']);
     expect(lifecycle.clearActiveTasks()).toBe(1);
     expect(lifecycle.clearActiveTasks()).toBe(0);
+    expect(lifecycle.activeTaskIds).toEqual([]);
+  });
+
+  it('waits for a task the top-level turn launched', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(launches(['tool-1'], null));
+    expect(lifecycle.observe(started('agent-1', 'agent', 'tool-1')).taskTransition).toBe('started');
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
+  });
+
+  it('never waits for a task launched from inside a subagent', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(launches(['tool-1'], null));
+    lifecycle.observe(started('agent-1', 'agent', 'tool-1'));
+    // The subagent's own Task call is forwarded with parent_tool_use_id set.
+    lifecycle.observe(launches(['tool-2'], 'tool-1'));
+    expect(
+      lifecycle.observe(started('nested-1', 'agent', 'tool-2')).taskTransition
+    ).toBeUndefined();
+    expect(lifecycle.activeTaskIds).toEqual(['agent-1']);
+    lifecycle.observe(settled('agent-1'));
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it('releases nested tasks announced before their launch site is forwarded', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    expect(lifecycle.observe(started('nested-1', 'agent', 'tool-2')).taskTransition).toBe(
+      'started'
+    );
+    expect(lifecycle.observe(started('nested-2', 'agent', 'tool-3')).taskTransition).toBe(
+      'started'
+    );
+    expect(lifecycle.observe(result()).resultDisposition).toBe('await-background-tasks');
+    expect(lifecycle.observe(launches(['tool-2', 'tool-3'], 'tool-1'))).toMatchObject({
+      taskTransition: 'settled',
+      settledTaskCount: 2,
+    });
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -1,11 +1,60 @@
 import type { SDKMessage } from '@agor/core/sdk';
 
 type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
-const TERMINAL_TASK_STATUSES = new Set(['completed', 'failed', 'stopped']);
+
+type TaskNotificationMessage = Extract<SDKMessage, { subtype: 'task_notification' }>;
+type TaskUpdatedMessage = Extract<SDKMessage, { subtype: 'task_updated' }>;
+type AssistantMessage = Extract<SDKMessage, { type: 'assistant' }>;
+
+/**
+ * The two documented terminal signals carry *different* status enums, so one
+ * shared set misreads both: `task_updated.patch.status` can be `killed` — which
+ * a set built for notifications never matched, leaking the task ID forever —
+ * and can never be `stopped`, which only `task_notification.status` reports.
+ *
+ * Each enum is written out exhaustively as a `Record` keyed by the SDK type, so
+ * a status the SDK adds or renames is a compile error here instead of a turn
+ * that waits forever for a signal that can no longer arrive.
+ */
+const NOTIFICATION_STATUS_IS_TERMINAL: Record<TaskNotificationMessage['status'], boolean> = {
+  completed: true,
+  failed: true,
+  stopped: true,
+};
+
+const UPDATED_STATUS_IS_TERMINAL: Record<
+  NonNullable<TaskUpdatedMessage['patch']['status']>,
+  boolean
+> = {
+  completed: true,
+  failed: true,
+  killed: true,
+  paused: false,
+  pending: false,
+  running: false,
+};
+
+function terminalStatuses(table: Record<string, boolean>): ReadonlySet<string> {
+  return new Set(
+    Object.entries(table)
+      .filter(([, isTerminal]) => isTerminal)
+      .map(([status]) => status)
+  );
+}
+
+const TERMINAL_NOTIFICATION_STATUSES = terminalStatuses(NOTIFICATION_STATUS_IS_TERMINAL);
+const TERMINAL_UPDATED_STATUSES = terminalStatuses(UPDATED_STATUS_IS_TERMINAL);
 
 export interface ClaudeQueryLifecycleTransition {
   resultDisposition: ResultDisposition;
   taskTransition?: 'started' | 'settled';
+  /**
+   * How many tracked tasks this one message settled. Always 1 for the
+   * documented terminal signals; a single message can retire several tasks only
+   * on the nested-launch path below. Watchdog accounting needs the real count
+   * so every `background_task.start` gets its matching completion.
+   */
+  settledTaskCount?: number;
 }
 
 /**
@@ -14,12 +63,24 @@ export interface ClaudeQueryLifecycleTransition {
  * emit task notifications and wake another model turn on the same query.
  */
 export class ClaudeBackgroundTaskLifecycle {
-  private readonly activeTaskIds = new Set<string>();
+  /** Task ID -> the tool_use block that launched it (when the SDK reports one). */
+  private readonly activeTasks = new Map<string, string | undefined>();
+  /** tool_use IDs observed inside a subagent's own messages (see `observeToolUses`). */
+  private readonly nestedToolUseIds = new Set<string>();
 
   observe(message: SDKMessage): ClaudeQueryLifecycleTransition {
+    // Only a task launched by the top-level turn can settle on this stream, so
+    // learn which tool_use blocks belong to a subagent's conversation instead.
+    if (message.type === 'assistant' && message.parent_tool_use_id !== null) {
+      return this.observeNestedToolUses(message);
+    }
+
     if (message.type === 'system' && message.subtype === 'task_started') {
-      const wasActive = this.activeTaskIds.has(message.task_id);
-      this.activeTaskIds.add(message.task_id);
+      if (message.tool_use_id !== undefined && this.nestedToolUseIds.has(message.tool_use_id)) {
+        return { resultDisposition: 'not-result' };
+      }
+      const wasActive = this.activeTasks.has(message.task_id);
+      this.activeTasks.set(message.task_id, message.tool_use_id);
       return {
         resultDisposition: 'not-result',
         taskTransition: wasActive ? undefined : 'started',
@@ -27,7 +88,7 @@ export class ClaudeBackgroundTaskLifecycle {
     }
 
     if (message.type === 'system' && message.subtype === 'task_notification') {
-      if (!TERMINAL_TASK_STATUSES.has(message.status)) {
+      if (!TERMINAL_NOTIFICATION_STATUSES.has(message.status)) {
         return { resultDisposition: 'not-result' };
       }
       return this.settleTask(message.task_id);
@@ -41,7 +102,7 @@ export class ClaudeBackgroundTaskLifecycle {
       message.type === 'system' &&
       message.subtype === 'task_updated' &&
       typeof message.patch.status === 'string' &&
-      TERMINAL_TASK_STATUSES.has(message.patch.status)
+      TERMINAL_UPDATED_STATUSES.has(message.patch.status)
     ) {
       return this.settleTask(message.task_id);
     }
@@ -53,25 +114,56 @@ export class ClaudeBackgroundTaskLifecycle {
     if (message.subtype !== 'success') return { resultDisposition: 'terminal' };
 
     return {
-      resultDisposition: this.activeTaskIds.size > 0 ? 'await-background-tasks' : 'terminal',
+      resultDisposition: this.activeTasks.size > 0 ? 'await-background-tasks' : 'terminal',
     };
   }
 
   get activeTaskCount(): number {
-    return this.activeTaskIds.size;
+    return this.activeTasks.size;
+  }
+
+  /** IDs still waiting on a terminal signal — the evidence a leak needs. */
+  get activeTaskIds(): string[] {
+    return [...this.activeTasks.keys()];
   }
 
   clearActiveTasks(): number {
-    const count = this.activeTaskIds.size;
-    this.activeTaskIds.clear();
+    const count = this.activeTasks.size;
+    this.activeTasks.clear();
     return count;
   }
 
+  /**
+   * A subagent's own `tool_use` blocks are forwarded on the parent stream with
+   * `parent_tool_use_id` set. A task launched from one of those blocks is
+   * nested (spawn depth >= 2): the SDK announces its `task_started` here but
+   * routes its terminal signal to the subagent that owns it, so tracking it
+   * would hold the query open for a settlement that never arrives. The
+   * ancestor task we do track already covers the nested task's whole lifetime,
+   * so dropping it costs no protection.
+   *
+   * Either ordering is safe: a nested `task_started` seen after its launch site
+   * is never tracked, and one seen before is settled here.
+   */
+  private observeNestedToolUses(message: AssistantMessage): ClaudeQueryLifecycleTransition {
+    const content = message.message?.content;
+    if (!Array.isArray(content)) return { resultDisposition: 'not-result' };
+    let settledTaskCount = 0;
+    for (const block of content) {
+      if (block.type !== 'tool_use') continue;
+      this.nestedToolUseIds.add(block.id);
+      for (const [taskId, toolUseId] of this.activeTasks) {
+        if (toolUseId !== block.id) continue;
+        this.activeTasks.delete(taskId);
+        settledTaskCount++;
+      }
+    }
+    if (settledTaskCount === 0) return { resultDisposition: 'not-result' };
+    return { resultDisposition: 'not-result', taskTransition: 'settled', settledTaskCount };
+  }
+
   private settleTask(taskId: string): ClaudeQueryLifecycleTransition {
-    const settled = this.activeTaskIds.delete(taskId);
-    return {
-      resultDisposition: 'not-result',
-      taskTransition: settled ? 'settled' : undefined,
-    };
+    if (!this.activeTasks.delete(taskId)) return { resultDisposition: 'not-result' };
+    return { resultDisposition: 'not-result', taskTransition: 'settled', settledTaskCount: 1 };
   }
 }

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -1,4 +1,6 @@
 import type { SDKMessage } from '@agor/core/sdk';
+import { getSdkActivityVersion } from '../../sdk-watchdog.js';
+import { classifyTurnScope } from './message-scope.js';
 
 type ResultDisposition = 'not-result' | 'await-background-tasks' | 'terminal';
 
@@ -34,16 +36,10 @@ const UPDATED_STATUS_IS_TERMINAL: Record<
   running: false,
 };
 
-function terminalStatuses(table: Record<string, boolean>): ReadonlySet<string> {
-  return new Set(
-    Object.entries(table)
-      .filter(([, isTerminal]) => isTerminal)
-      .map(([status]) => status)
-  );
+/** Wire data can carry a status newer than the checked-in types; treat it as non-terminal. */
+function isTerminal(table: Record<string, boolean>, status: unknown): boolean {
+  return typeof status === 'string' && table[status] === true;
 }
-
-const TERMINAL_NOTIFICATION_STATUSES = terminalStatuses(NOTIFICATION_STATUS_IS_TERMINAL);
-const TERMINAL_UPDATED_STATUSES = terminalStatuses(UPDATED_STATUS_IS_TERMINAL);
 
 export interface ClaudeQueryLifecycleTransition {
   resultDisposition: ResultDisposition;
@@ -71,12 +67,19 @@ export class ClaudeBackgroundTaskLifecycle {
   observe(message: SDKMessage): ClaudeQueryLifecycleTransition {
     // Only a task launched by the top-level turn can settle on this stream, so
     // learn which tool_use blocks belong to a subagent's conversation instead.
-    if (message.type === 'assistant' && message.parent_tool_use_id !== null) {
+    // A message we cannot place is deliberately not treated as a subagent's:
+    // mislabelling one top-level turn that way would drop every task it
+    // launched and close the query on live background work.
+    if (message.type === 'assistant' && classifyTurnScope(message) === 'subagent') {
       return this.observeNestedToolUses(message);
     }
 
     if (message.type === 'system' && message.subtype === 'task_started') {
       if (message.tool_use_id !== undefined && this.nestedToolUseIds.has(message.tool_use_id)) {
+        console.log(
+          `[claude.background_task] event=nested_task_excluded task_id=${message.task_id} ` +
+            `tool_use_id=${message.tool_use_id} sdk=${getSdkActivityVersion('claude-code')}`
+        );
         return { resultDisposition: 'not-result' };
       }
       const wasActive = this.activeTasks.has(message.task_id);
@@ -88,7 +91,7 @@ export class ClaudeBackgroundTaskLifecycle {
     }
 
     if (message.type === 'system' && message.subtype === 'task_notification') {
-      if (!TERMINAL_NOTIFICATION_STATUSES.has(message.status)) {
+      if (!isTerminal(NOTIFICATION_STATUS_IS_TERMINAL, message.status)) {
         return { resultDisposition: 'not-result' };
       }
       return this.settleTask(message.task_id);
@@ -101,8 +104,7 @@ export class ClaudeBackgroundTaskLifecycle {
     if (
       message.type === 'system' &&
       message.subtype === 'task_updated' &&
-      typeof message.patch.status === 'string' &&
-      TERMINAL_UPDATED_STATUSES.has(message.patch.status)
+      isTerminal(UPDATED_STATUS_IS_TERMINAL, message.patch.status)
     ) {
       return this.settleTask(message.task_id);
     }

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -9,6 +9,7 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { ResolvedClaudeBackgroundTaskConfig } from '@agor/core/config';
 import { generateId, shortId } from '@agor/core/db';
 import type { PermissionMode as ClaudeSDKPermissionMode } from '@agor/core/sdk';
 import { mapPermissionMode } from '@agor/core/utils/permission-mode-mapper';
@@ -184,7 +185,8 @@ export class ClaudeTool implements ITool {
     mcpEnabled?: boolean,
     _useNativeAuth?: boolean, // Claude supports `claude login` OAuth, but no special handling needed in tool
     usersRepo?: import('../../db/feathers-repositories').UsersRepository,
-    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
+    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository,
+    backgroundTaskConfig?: ResolvedClaudeBackgroundTaskConfig
   ) {
     if (messagesRepo && sessionsRepo) {
       this.promptService = new ClaudePromptService(
@@ -201,7 +203,8 @@ export class ClaudeTool implements ITool {
         messagesService,
         mcpEnabled,
         usersRepo,
-        mcpOAuthAuthHeadersRepo
+        mcpOAuthAuthHeadersRepo,
+        backgroundTaskConfig
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/claude/message-scope.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-scope.ts
@@ -1,0 +1,45 @@
+import type { SDKMessage } from '@agor/core/sdk';
+import { getSdkActivityVersion } from '../../sdk-watchdog.js';
+
+/**
+ * Whose conversation a message belongs to.
+ *
+ * `unknown` is not a formality. `parent_tool_use_id` crosses a stdout/JSON
+ * boundary, so the `.d.ts` declaring it `string | null` constrains what the
+ * compiler accepts, not what arrives on the wire — an omitted key deserializes
+ * to `undefined` whatever the type says. Every other reader in this repo
+ * already coerces it (`message-processor.ts`, `claude-tool.ts`, the daemon's
+ * message validator), and the SDK is pinned by caret range, so a shape this
+ * code has never seen is a routine dependency bump away.
+ *
+ * Both readers therefore treat `unknown` as "not proven", and both land on the
+ * side that keeps work alive and bounded rather than the side that truncates
+ * it: an unclassifiable message never marks a task as nested (so the task
+ * stays tracked and the query stays open for it), and never counts as the
+ * top-level turn resuming (so the turn stays inside its silence budget).
+ */
+export type TurnScope = 'top-level' | 'subagent' | 'unknown';
+
+let warnedUnknownScope = false;
+
+export function classifyTurnScope(message: SDKMessage): TurnScope {
+  const parent = (message as { parent_tool_use_id?: unknown }).parent_tool_use_id;
+  if (parent === null) return 'top-level';
+  if (typeof parent === 'string' && parent.length > 0) return 'subagent';
+  // Once per process: this means the SDK contract moved, and every later
+  // decision made from it is a guess.
+  if (!warnedUnknownScope) {
+    warnedUnknownScope = true;
+    console.warn(
+      `⚠️  SDK message ${message.type} carries an unusable parent_tool_use_id ` +
+        `(${parent === undefined ? 'absent' : typeof parent}); background-task scoping ` +
+        `falls back to "keep tracking, stay bounded" [sdk=${getSdkActivityVersion('claude-code')}]`
+    );
+  }
+  return 'unknown';
+}
+
+/** Test seam: the unknown-shape warning is deliberately once per process. */
+export function resetTurnScopeWarningForTests(): void {
+  warnedUnknownScope = false;
+}

--- a/packages/executor/src/sdk-handlers/claude/message-scope.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-scope.ts
@@ -38,8 +38,3 @@ export function classifyTurnScope(message: SDKMessage): TurnScope {
   }
   return 'unknown';
 }
-
-/** Test seam: the unknown-shape warning is deliberately once per process. */
-export function resetTurnScopeWarningForTests(): void {
-  warnedUnknownScope = false;
-}

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -214,6 +214,123 @@ describe('ClaudePromptService background task query lifetime', () => {
     }
   });
 
+  it('force-settles a turn whose background task never reports a terminal signal', async () => {
+    vi.useFakeTimers();
+    try {
+      // The production hang: `end_turn` arrives, one task ID never settles, and
+      // the query then goes silent forever instead of waking another turn.
+      const query = fakeQuery(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'task_started',
+          task_id: 'task-1',
+          description: 'Explore',
+          uuid: 'start',
+          session_id: 'sdk-session',
+        };
+        yield sdkResult('parent-result');
+        await new Promise(() => {});
+      });
+      vi.mocked(setupQuery).mockResolvedValue({
+        query: query as never,
+        resolvedModel: 'claude-sonnet-4-6',
+        getStderr: () => '',
+      });
+      const activity = vi.fn();
+
+      const events: Array<{ type: string }> = [];
+      const drained = (async () => {
+        for await (const event of service().promptSessionStreaming(
+          sessionId,
+          'prompt',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          activity
+        )) {
+          events.push(event);
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(
+        ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS + 10
+      );
+      await drained;
+
+      // The turn settles on the aggregated result instead of staying `running`.
+      expect(events.at(-1)?.type).toBe('result');
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+      // Watchdog accounting is balanced again, so the next query is not born
+      // with a permanently suppressed stall check.
+      expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps waiting while the query is still producing messages', async () => {
+    vi.useFakeTimers();
+    try {
+      const query = fakeQuery(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'task_started',
+          task_id: 'task-1',
+          description: 'Explore',
+          uuid: 'start',
+          session_id: 'sdk-session',
+        };
+        yield sdkResult('parent-result');
+        // Background progress well past the silence budget: the wait is a
+        // silence budget, so a task that is still working is never cut short.
+        for (let tick = 0; tick < 3; tick++) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS - 1_000)
+          );
+          yield {
+            type: 'system',
+            subtype: 'task_progress',
+            task_id: 'task-1',
+            uuid: `progress-${tick}`,
+            session_id: 'sdk-session',
+          };
+        }
+        yield {
+          type: 'system',
+          subtype: 'task_notification',
+          task_id: 'task-1',
+          status: 'completed',
+          output_file: '/tmp/task-1',
+          summary: 'done',
+          uuid: 'notification',
+          session_id: 'sdk-session',
+        };
+        yield sdkResult('continuation-result');
+      });
+      vi.mocked(setupQuery).mockResolvedValue({
+        query: query as never,
+        resolvedModel: 'claude-sonnet-4-6',
+        getStderr: () => '',
+      });
+
+      const events: Array<{ type: string }> = [];
+      const drained = (async () => {
+        for await (const event of service().promptSessionStreaming(sessionId, 'prompt')) {
+          events.push(event);
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(3 * ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS);
+      await drained;
+
+      expect(events.filter((event) => event.type === 'result')).toHaveLength(2);
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('releases input and balances watchdog activity when cancellation interrupts a task', async () => {
     const query = fakeQuery(async function* () {
       yield {

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -105,6 +105,18 @@ const assistantMessage = (uuid: string, parentToolUseId: string | null = null): 
     session_id: 'sdk-session',
   }) as SDKMessage;
 
+const rateLimitEvent = (
+  status: string,
+  resetsAt?: number,
+  rateLimitType = 'five_hour'
+): SDKMessage =>
+  ({
+    type: 'rate_limit_event',
+    rate_limit_info: { status, rateLimitType, resetsAt },
+    uuid: `rate-limit-${status}`,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const never = () => new Promise(() => {});
 
@@ -439,7 +451,8 @@ describe('ClaudePromptService background task query lifetime', () => {
         yield taskNotification('task-1');
         yield sdkResult('continuation-result');
       });
-      const run = drain(query);
+      const activity = vi.fn();
+      const run = drain(query, activity);
 
       await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
       expect(run.settled()).toBe(false);
@@ -447,6 +460,58 @@ describe('ClaudePromptService background task query lifetime', () => {
       await run.done;
 
       expect(run.resultUuids()).toEqual(['parent-result', 'continuation-result']);
+    });
+  });
+
+  it('pulses the rate-limit block once and leaves it standing for the whole wait', async () => {
+    await withFakeTimers(async () => {
+      const resetsAt = Math.floor(Date.now() / 1_000) + 5 * 60 * 60;
+      // The block lands mid-turn, before any result: no held turn, nothing
+      // bounded — the pulse is the whole point here.
+      const query = fakeQuery(async function* () {
+        yield rateLimitEvent('rejected', resetsAt);
+        // The SDK emits nothing at all across the block, which is exactly why
+        // the pulse has to be sticky rather than event-driven.
+        await sleep(5 * 60 * 60 * 1_000);
+        yield assistantMessage('back-after-reset');
+        yield sdkResult('done');
+      });
+      const activity = vi.fn();
+      const run = drain(query, activity);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const waits = activity.mock.calls.filter(([kind]) => kind === 'waiting');
+      expect(waits).toEqual([['waiting', 'rate_limit.five_hour']]);
+      // Nothing after it, so the heartbeat keeps re-sending this pulse and the
+      // session reads as blocked rather than silent, for hours if need be.
+      expect(activity.mock.calls.at(-1)).toEqual(['waiting', 'rate_limit.five_hour']);
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 60 * 1_000);
+      await run.done;
+
+      // The pause the block installed is lifted, or the watchdog would stay
+      // disarmed for the rest of the query.
+      expect(activity).toHaveBeenCalledWith('sdk_started', 'rate_limit.resolved');
+    });
+  });
+
+  it('sanitizes an unexpected rate-limit type into a bounded pulse detail', async () => {
+    await withFakeTimers(async () => {
+      // The daemon rejects a detail outside [A-Za-z0-9._:/-] with a BadRequest,
+      // and the heartbeat re-sends the latest pulse on every beat — so one bad
+      // detail would fail every later heartbeat write, not just its own.
+      const query = fakeQuery(async function* () {
+        yield rateLimitEvent('rejected', undefined, 'weird type!! 🚫');
+        yield sdkResult('done');
+      });
+      const activity = vi.fn();
+      const run = drain(query, activity);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await run.done;
+      const [[, detail]] = activity.mock.calls.filter(([kind]) => kind === 'waiting');
+      expect(detail).toMatch(/^[A-Za-z0-9._:/-]+$/);
+      expect(Buffer.byteLength(detail as string, 'utf8')).toBeLessThanOrEqual(128);
     });
   });
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -60,9 +60,40 @@ function fakeQuery(messages: SDKMessage[] | (() => AsyncGenerator<SDKMessage>)) 
     releaseInput,
     getContextUsage,
     interrupt: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
     return: closed,
     closed,
   });
+}
+
+/**
+ * A query wedged the way production wedges it.
+ *
+ * The stream simply stops, and `interrupt()` — which in the shipped SDK is only
+ * `await this.request({subtype: 'interrupt'})`, a control request over that same
+ * stopped transport — never answers. `close()` is the structurally different
+ * one: `spawnAbort()`, `processStdin.end()`, abort-handler teardown, all local.
+ * So only `close()` can release the generator here, and `teardown.ran` records
+ * whether the generator's own `finally` ever got to run at all.
+ */
+function wedgedQuery() {
+  let unwedge = () => {};
+  const wedge = new Promise<void>((resolve) => {
+    unwedge = resolve;
+  });
+  const teardown = { ran: false };
+  const query = fakeQuery(async function* () {
+    try {
+      yield taskStarted('task-1');
+      yield sdkResult('parent-result');
+      await wedge;
+    } finally {
+      teardown.ran = true;
+    }
+  });
+  query.interrupt.mockReturnValue(new Promise(() => {}));
+  query.close.mockImplementation(() => unwedge());
+  return { query, teardown };
 }
 
 function service() {
@@ -143,12 +174,22 @@ const userMessage = (uuid: string): SDKMessage =>
     session_id: 'sdk-session',
   }) as SDKMessage;
 
-const statusMessage = (status: string): SDKMessage =>
+const statusMessage = (status: string | null): SDKMessage =>
   ({
     type: 'system',
     subtype: 'status',
     status,
     uuid: `status-${status}`,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const apiRetry = (retryDelayMs: unknown): SDKMessage =>
+  ({
+    type: 'system',
+    subtype: 'api_retry',
+    retry_delay_ms: retryDelayMs,
+    attempt: 1,
+    uuid: 'api-retry',
     session_id: 'sdk-session',
   }) as SDKMessage;
 
@@ -647,15 +688,167 @@ describe('ClaudePromptService background task query lifetime', () => {
     // reproduce that overflow clamp.
     const now = 1_700_000_000_000;
     const epochMsMistake = rateLimitEvent('rejected', now); // seconds field holding ms
-    expect(announcedQuietUntil(epochMsMistake, now)).toBe(now + MAX_ANNOUNCED_QUIET_MS);
+    expect(announcedQuietUntil(epochMsMistake, now)).toEqual({
+      source: 'rate_limit',
+      until: now + MAX_ANNOUNCED_QUIET_MS,
+    });
     // The clamp is itself under the overflow threshold, so no budget built from
     // it can ever reach the inverting path.
     expect(MAX_ANNOUNCED_QUIET_MS).toBeLessThan(2 ** 31 - 1);
     // A real seven-day reset is far under the clamp and passes through intact.
     const sevenDay = rateLimitEvent('rejected', Math.floor(now / 1_000) + 7 * 24 * 60 * 60);
-    expect(announcedQuietUntil(sevenDay, now)).toBe(now + 7 * 24 * 60 * 60 * 1_000);
+    expect(announcedQuietUntil(sevenDay, now)).toEqual({
+      source: 'rate_limit',
+      until: now + 7 * 24 * 60 * 60 * 1_000,
+    });
     // An already-elapsed reset grants nothing.
     expect(announcedQuietUntil(rateLimitEvent('rejected', 1), now)).toBeUndefined();
+  });
+
+  it('grants nothing for an announced wait that is not a finite number', () => {
+    // NaN defeats every guard here: `typeof NaN === 'number'` is true,
+    // `NaN <= 0` is false, and `NaN > MAX_ANNOUNCED_QUIET_MS` is false — so it
+    // would flow out as a grant, and `setTimeout(fn, NaN)` coerces to 1ms.
+    // Every held result for the life of that query would force-settle at once,
+    // discarding all background work: a full regression of #1852 out of the
+    // guard written to prevent it.
+    const now = 1_700_000_000_000;
+    expect(announcedQuietUntil(rateLimitEvent('rejected', Number.NaN), now)).toBeUndefined();
+    expect(announcedQuietUntil(apiRetry(Number.NaN), now)).toBeUndefined();
+    // Infinities are refused rather than clamped: a seven-day allowance built
+    // out of a value that is plainly garbage is the "unbounded in practice"
+    // hazard, and the tier still applies when nothing is granted.
+    expect(
+      announcedQuietUntil(rateLimitEvent('rejected', Number.POSITIVE_INFINITY), now)
+    ).toBeUndefined();
+    expect(
+      announcedQuietUntil(rateLimitEvent('rejected', Number.NEGATIVE_INFINITY), now)
+    ).toBeUndefined();
+    // A non-numeric delay off the wire is refused the same way.
+    expect(announcedQuietUntil(apiRetry('60000'), now)).toBeUndefined();
+    // The healthy shapes still grant.
+    expect(announcedQuietUntil(apiRetry(60_000), now)).toEqual({
+      source: 'api_retry',
+      until: now + 60_000,
+    });
+  });
+
+  it('force-settles on the plain tier when the announced reset is unparseable', async () => {
+    await withFakeTimers(async () => {
+      // The behavioural half of the guard above: a NaN grant used to poison the
+      // allowance permanently (`Math.max` is absorbing), so the turn settled on
+      // the next tick instead of on its budget.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield rateLimitEvent('rejected', Number.NaN);
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS - 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_010);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('keeps a still-valid compaction allowance when a rate limit clears', async () => {
+    await withFakeTimers(async () => {
+      // The allowance used to be one scalar, so clearing the rate limit zeroed
+      // it — discarding a compaction grant that had nothing to do with the
+      // limit and was still in force.
+      const resetsAt = Math.floor(Date.now() / 1_000) + 5 * 60 * 60;
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield taskNotification('task-1'); // nothing outstanding: the 2m tier
+        yield statusMessage('compacting');
+        yield rateLimitEvent('rejected', resetsAt);
+        yield rateLimitEvent('allowed');
+        await never();
+      });
+      const run = drain(query);
+
+      // Well past the bare grace: without the surviving compaction grant this
+      // turn would already have been force-settled mid-compaction.
+      await vi.advanceTimersByTimeAsync(GRACE_MS + 60_000);
+      expect(run.settled()).toBe(false);
+      // And it is still bounded — by the compaction allowance, not by the
+      // five-hour reset the cleared limit had bought.
+      await vi.advanceTimersByTimeAsync(GRACE_MS + 11 * 60_000);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('retires the announced waits once the model is producing again', async () => {
+    await withFakeTimers(async () => {
+      // A grant outlives the wait it was made for unless something drops it. A
+      // resumed top-level turn is proof the SDK is not sitting out a limit
+      // reset, a retry backoff or a compaction, so it drops all of them —
+      // otherwise the allowance would still be inflating the budget of the
+      // *next* held turn.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield statusMessage('requesting');
+        yield sdkResult('parent-result');
+        yield assistantMessage('resumed');
+        yield sdkResult('second-result');
+        yield taskNotification('task-1'); // nothing outstanding: the 2m tier
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(GRACE_MS - 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_010);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('settles the turn even if the wedged query throws out of close()', async () => {
+    await withFakeTimers(async () => {
+      // Teardown is the last thing a force-settled turn does; an SDK that
+      // throws from `close()` (or does not have it) must not turn an
+      // already-settled turn into a crash out of the `finally` block.
+      const { query } = wedgedQuery();
+      query.close.mockImplementation(() => {
+        throw new Error('transport already gone');
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      await expect(run.done).resolves.toBeUndefined();
+      expect(run.events.at(-1)?.type).toBe('result');
+    });
+  });
+
+  it('drops the busy allowance as soon as the SDK reports it is no longer busy', async () => {
+    await withFakeTimers(async () => {
+      // `requesting` grants a ten-minute allowance, and one almost always
+      // precedes the parent turn's final result — so leaving it standing would
+      // put a ~10 minute tail on the first bounded read and make the configured
+      // grace non-binding. `status: null` is the SDK's own end-of-busy signal.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield taskNotification('task-1');
+        yield statusMessage('requesting');
+        yield statusMessage(null);
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(GRACE_MS - 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_010);
+      // On the configured grace, not on the grace plus the retired allowance.
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
   });
 
   it('emits one completion per task when a launch site retires several at once', async () => {
@@ -684,26 +877,32 @@ describe('ClaudePromptService background task query lifetime', () => {
     });
   });
 
-  it('closes the query on every exit and cancels a wedged one', async () => {
+  it('closes the query on every exit and tears down a wedged one', async () => {
     await withFakeTimers(async () => {
-      const wedged = fakeQuery(async function* () {
-        yield taskStarted('task-1');
-        yield sdkResult('parent-result');
-        await never();
-      });
+      const { query: wedged, teardown } = wedgedQuery();
       const wedgedRun = drain(wedged);
       await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
       await wedgedRun.done;
-      // A pending read means `return()` can never run the SDK's own teardown,
-      // so the wedged path has to cancel rather than only abandon.
+      // Flush the microtasks the teardown resumes the generator on.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // `interrupt()` is attempted, and here — as in production on this path —
+      // it never resolves. If it were the thing being relied on, the read would
+      // stay pending, `return()` would queue behind it forever, and the SDK
+      // generator's `finally` would never run.
       expect(wedged.interrupt).toHaveBeenCalledTimes(1);
+      expect(wedged.close).toHaveBeenCalledTimes(1);
+      expect(teardown.ran).toBe(true);
       expect(wedged.closed).toHaveBeenCalledTimes(1);
 
       const healthy = fakeQuery([sdkResult('only-result')]);
       const healthyRun = drain(healthy);
       await healthyRun.done;
+      // A query that ended on its own is closed by `return()` alone: nothing is
+      // wedged, so neither the interrupt nor the forced close is warranted.
       expect(healthy.closed).toHaveBeenCalledTimes(1);
       expect(healthy.interrupt).not.toHaveBeenCalled();
+      expect(healthy.close).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -809,6 +809,31 @@ describe('ClaudePromptService background task query lifetime', () => {
     });
   });
 
+  it('settles the turn even if the query has no usable interrupt()', async () => {
+    await withFakeTimers(async () => {
+      // `Promise.resolve(x)` evaluates `x` before wrapping it, so a query shape
+      // that throws *synchronously* here — no such method, a test double, a
+      // future SDK — escapes the `.catch()` entirely and lands in the handler
+      // that reports the Task as failed. `interrupt()` is only the optional
+      // cooperative ask on this path; it has no business failing a turn that
+      // has already settled on the model's own output.
+      const { query, teardown } = wedgedQuery();
+      Reflect.deleteProperty(query, 'interrupt');
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      await expect(run.done).resolves.toBeUndefined();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Completed on the accumulated result, not failed — and `close()` still
+      // ran, so the cooperative ask failing does not skip the teardown after it.
+      expect(run.events.at(-1)?.type).toBe('result');
+      expect(run.resultUuids().at(-1)).toBe('parent-result');
+      expect(query.close).toHaveBeenCalledTimes(1);
+      expect(teardown.ran).toBe(true);
+    });
+  });
+
   it('settles the turn even if the wedged query throws out of close()', async () => {
     await withFakeTimers(async () => {
       // Teardown is the last thing a force-settled turn does; an SDK that

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -1,3 +1,4 @@
+import { resolveClaudeBackgroundTaskConfig } from '@agor/core/config';
 import type { SDKMessage } from '@agor/core/sdk';
 import type { SessionID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -67,6 +68,87 @@ function service() {
       }),
     } as never
   );
+}
+
+/** Defaults the service falls back to when no daemon-resolved slice is passed. */
+const { silence_timeout_ms: SILENCE_MS, settled_grace_ms: GRACE_MS } =
+  resolveClaudeBackgroundTaskConfig();
+
+const taskStarted = (taskId: string): SDKMessage =>
+  ({
+    type: 'system',
+    subtype: 'task_started',
+    task_id: taskId,
+    description: 'Explore',
+    uuid: `start-${taskId}`,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const taskNotification = (taskId: string): SDKMessage =>
+  ({
+    type: 'system',
+    subtype: 'task_notification',
+    task_id: taskId,
+    status: 'completed',
+    output_file: `/tmp/${taskId}`,
+    summary: 'done',
+    uuid: `notification-${taskId}`,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const assistantMessage = (uuid: string, parentToolUseId: string | null = null): SDKMessage =>
+  ({
+    type: 'assistant',
+    parent_tool_use_id: parentToolUseId,
+    message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    uuid,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const never = () => new Promise(() => {});
+
+async function withFakeTimers(body: () => Promise<void>) {
+  vi.useFakeTimers();
+  try {
+    await body();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+/** Start draining a query and expose whether the generator has finished yet. */
+function drain(query: ReturnType<typeof fakeQuery>, activity?: ReturnType<typeof vi.fn>) {
+  vi.mocked(setupQuery).mockResolvedValue({
+    query: query as never,
+    resolvedModel: 'claude-sonnet-4-6',
+    getStderr: () => '',
+  });
+  const events: Array<{ type: string; raw_sdk_message?: { uuid: string } }> = [];
+  let finished = false;
+  const done = (async () => {
+    for await (const event of service().promptSessionStreaming(
+      sessionId,
+      'prompt',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      activity
+    )) {
+      events.push(event);
+    }
+    finished = true;
+  })();
+  return {
+    events,
+    done,
+    settled: () => finished,
+    // A force-settle also emits a `result`, so counting them cannot tell the
+    // two outcomes apart — the terminal UUID can.
+    resultUuids: () =>
+      events.filter((event) => event.type === 'result').map((event) => event.raw_sdk_message?.uuid),
+  };
 }
 
 describe('ClaudePromptService background task query lifetime', () => {
@@ -215,79 +297,41 @@ describe('ClaudePromptService background task query lifetime', () => {
   });
 
   it('force-settles a turn whose background task never reports a terminal signal', async () => {
-    vi.useFakeTimers();
-    try {
+    await withFakeTimers(async () => {
       // The production hang: `end_turn` arrives, one task ID never settles, and
       // the query then goes silent forever instead of waking another turn.
       const query = fakeQuery(async function* () {
-        yield {
-          type: 'system',
-          subtype: 'task_started',
-          task_id: 'task-1',
-          description: 'Explore',
-          uuid: 'start',
-          session_id: 'sdk-session',
-        };
+        yield taskStarted('task-1');
         yield sdkResult('parent-result');
-        await new Promise(() => {});
-      });
-      vi.mocked(setupQuery).mockResolvedValue({
-        query: query as never,
-        resolvedModel: 'claude-sonnet-4-6',
-        getStderr: () => '',
+        await never();
       });
       const activity = vi.fn();
+      const run = drain(query, activity);
 
-      const events: Array<{ type: string }> = [];
-      const drained = (async () => {
-        for await (const event of service().promptSessionStreaming(
-          sessionId,
-          'prompt',
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          activity
-        )) {
-          events.push(event);
-        }
-      })();
-
-      await vi.advanceTimersByTimeAsync(
-        ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS + 10
-      );
-      await drained;
+      await vi.advanceTimersByTimeAsync(SILENCE_MS - 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_010);
+      expect(run.settled()).toBe(true);
+      await run.done;
 
       // The turn settles on the aggregated result instead of staying `running`.
-      expect(events.at(-1)?.type).toBe('result');
+      expect(run.events.at(-1)?.type).toBe('result');
       expect(query.releaseInput).toHaveBeenCalledTimes(1);
       // Watchdog accounting is balanced again, so the next query is not born
       // with a permanently suppressed stall check.
       expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
-  it('keeps waiting while the query is still producing messages', async () => {
-    vi.useFakeTimers();
-    try {
+  it('keeps waiting while background tasks are still reporting progress', async () => {
+    await withFakeTimers(async () => {
       const query = fakeQuery(async function* () {
-        yield {
-          type: 'system',
-          subtype: 'task_started',
-          task_id: 'task-1',
-          description: 'Explore',
-          uuid: 'start',
-          session_id: 'sdk-session',
-        };
+        yield taskStarted('task-1');
         yield sdkResult('parent-result');
-        // Background progress well past the silence budget: the wait is a
-        // silence budget, so a task that is still working is never cut short.
+        // Progress well past the silence budget: it is a silence budget, so a
+        // task that is still working is never cut short.
         for (let tick = 0; tick < 3; tick++) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS - 1_000)
-          );
+          await sleep(SILENCE_MS - 1_000);
           yield {
             type: 'system',
             subtype: 'task_progress',
@@ -296,39 +340,114 @@ describe('ClaudePromptService background task query lifetime', () => {
             session_id: 'sdk-session',
           };
         }
-        yield {
-          type: 'system',
-          subtype: 'task_notification',
-          task_id: 'task-1',
-          status: 'completed',
-          output_file: '/tmp/task-1',
-          summary: 'done',
-          uuid: 'notification',
-          session_id: 'sdk-session',
-        };
+        yield taskNotification('task-1');
         yield sdkResult('continuation-result');
       });
-      vi.mocked(setupQuery).mockResolvedValue({
-        query: query as never,
-        resolvedModel: 'claude-sonnet-4-6',
-        getStderr: () => '',
-      });
+      const run = drain(query);
 
-      const events: Array<{ type: string }> = [];
-      const drained = (async () => {
-        for await (const event of service().promptSessionStreaming(sessionId, 'prompt')) {
-          events.push(event);
-        }
-      })();
+      await vi.advanceTimersByTimeAsync(3 * SILENCE_MS);
+      await run.done;
 
-      await vi.advanceTimersByTimeAsync(3 * ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS);
-      await drained;
-
-      expect(events.filter((event) => event.type === 'result')).toHaveLength(2);
+      expect(run.resultUuids()).toEqual(['parent-result', 'continuation-result']);
       expect(query.releaseInput).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
+    });
+  });
+
+  it('ends the turn on the settled grace when the last task settles and no turn follows', async () => {
+    await withFakeTimers(async () => {
+      // `resultDisposition` is only recomputed on a `result`, so a last task
+      // that settles without waking a continuation turn leaves the query alive
+      // with zero outstanding work and nothing left to re-check it.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield taskNotification('task-1');
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(GRACE_MS - 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_010);
+      // Settled on the short grace, not after the far longer silence budget.
+      expect(run.settled()).toBe(true);
+      await run.done;
+
+      expect(GRACE_MS).toBeLessThan(SILENCE_MS);
+      expect(run.events.at(-1)?.type).toBe('result');
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('never bounds reads again once the model resumes, however long it then thinks', async () => {
+    await withFakeTimers(async () => {
+      // A task settles, the SDK wakes a continuation turn, and that turn makes
+      // one long silent call (a slow MCP tool, extended thinking). The turn is
+      // live work, not a wedge, and must not be force-settled.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield taskNotification('task-1');
+        yield assistantMessage('resumed');
+        await sleep(4 * SILENCE_MS);
+        yield sdkResult('continuation-result');
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(5 * SILENCE_MS);
+      await run.done;
+
+      // The continuation result, not a force-settled replay of the parent.
+      expect(run.resultUuids()).toEqual(['parent-result', 'continuation-result']);
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps background-task traffic bounded even after a subagent speaks', async () => {
+    await withFakeTimers(async () => {
+      // Forwarded subagent output proves background work is progressing, not
+      // that the top-level turn resumed, so it must not lift the budget.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield assistantMessage('subagent-chatter', 'tool-1');
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('does not force-settle a turn the SDK told us is waiting on a rate-limit reset', async () => {
+    await withFakeTimers(async () => {
+      // A rejected rate limit is announced once and then waited out in total
+      // silence — `resetsAt` here is five hours out, far past the budget.
+      const resetsAt = Math.floor(Date.now() / 1_000) + 5 * 60 * 60;
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield {
+          type: 'rate_limit_event',
+          rate_limit_info: { status: 'rejected', rateLimitType: 'five_hour', resetsAt },
+          uuid: 'rate-limit',
+          session_id: 'sdk-session',
+        };
+        await sleep(5 * 60 * 60 * 1_000);
+        yield taskNotification('task-1');
+        yield sdkResult('continuation-result');
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      expect(run.settled()).toBe(false);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 60 * 1_000);
+      await run.done;
+
+      expect(run.resultUuids()).toEqual(['parent-result', 'continuation-result']);
+    });
   });
 
   it('releases input and balances watchdog activity when cancellation interrupts a task', async () => {

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -7,7 +7,11 @@ vi.mock('./query-builder.js', () => ({
   setupQuery: vi.fn(),
 }));
 
-import { ClaudePromptService } from './prompt-service.js';
+import {
+  announcedQuietUntil,
+  ClaudePromptService,
+  MAX_ANNOUNCED_QUIET_MS,
+} from './prompt-service.js';
 import { setupQuery } from './query-builder.js';
 
 const sessionId = 'session-1' as SessionID;
@@ -51,10 +55,13 @@ function fakeQuery(messages: SDKMessage[] | (() => AsyncGenerator<SDKMessage>)) 
       : (async function* () {
           yield* messages;
         })();
+  const closed = vi.fn(generator.return.bind(generator));
   return Object.assign(generator, {
     releaseInput,
     getContextUsage,
-    interrupt: vi.fn(),
+    interrupt: vi.fn().mockResolvedValue(undefined),
+    return: closed,
+    closed,
   });
 }
 
@@ -74,11 +81,12 @@ function service() {
 const { silence_timeout_ms: SILENCE_MS, settled_grace_ms: GRACE_MS } =
   resolveClaudeBackgroundTaskConfig();
 
-const taskStarted = (taskId: string): SDKMessage =>
+const taskStarted = (taskId: string, toolUseId?: string): SDKMessage =>
   ({
     type: 'system',
     subtype: 'task_started',
     task_id: taskId,
+    tool_use_id: toolUseId,
     description: 'Explore',
     uuid: `start-${taskId}`,
     session_id: 'sdk-session',
@@ -96,11 +104,20 @@ const taskNotification = (taskId: string): SDKMessage =>
     session_id: 'sdk-session',
   }) as SDKMessage;
 
-const assistantMessage = (uuid: string, parentToolUseId: string | null = null): SDKMessage =>
+const assistantMessage = (
+  uuid: string,
+  parentToolUseId: string | null = null,
+  launchedToolUseIds: string[] = []
+): SDKMessage =>
   ({
     type: 'assistant',
     parent_tool_use_id: parentToolUseId,
-    message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    message: {
+      role: 'assistant',
+      content: launchedToolUseIds.length
+        ? launchedToolUseIds.map((id) => ({ type: 'tool_use', id, name: 'Task', input: {} }))
+        : [{ type: 'text', text: 'hi' }],
+    },
     uuid,
     session_id: 'sdk-session',
   }) as SDKMessage;
@@ -114,6 +131,24 @@ const rateLimitEvent = (
     type: 'rate_limit_event',
     rate_limit_info: { status, rateLimitType, resetsAt },
     uuid: `rate-limit-${status}`,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const userMessage = (uuid: string): SDKMessage =>
+  ({
+    type: 'user',
+    parent_tool_use_id: null,
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't', content: 'ok' }] },
+    uuid,
+    session_id: 'sdk-session',
+  }) as SDKMessage;
+
+const statusMessage = (status: string): SDKMessage =>
+  ({
+    type: 'system',
+    subtype: 'status',
+    status,
+    uuid: `status-${status}`,
     session_id: 'sdk-session',
   }) as SDKMessage;
 
@@ -463,7 +498,7 @@ describe('ClaudePromptService background task query lifetime', () => {
     });
   });
 
-  it('pulses the rate-limit block once and leaves it standing for the whole wait', async () => {
+  it('leaves the rate-limit block standing as the latest pulse for the whole wait', async () => {
     await withFakeTimers(async () => {
       const resetsAt = Math.floor(Date.now() / 1_000) + 5 * 60 * 60;
       // The block lands mid-turn, before any result: no held turn, nothing
@@ -481,9 +516,10 @@ describe('ClaudePromptService background task query lifetime', () => {
 
       await vi.advanceTimersByTimeAsync(60_000);
       const waits = activity.mock.calls.filter(([kind]) => kind === 'waiting');
-      expect(waits).toEqual([['waiting', 'rate_limit.five_hour']]);
-      // Nothing after it, so the heartbeat keeps re-sending this pulse and the
-      // session reads as blocked rather than silent, for hours if need be.
+      expect(waits.length).toBeGreaterThan(0);
+      expect(new Set(waits.map(([, detail]) => detail))).toEqual(new Set(['rate_limit.five_hour']));
+      // The heartbeat re-sends whichever pulse came last, so what matters is
+      // that the block is it — for hours, through a stream saying nothing.
       expect(activity.mock.calls.at(-1)).toEqual(['waiting', 'rate_limit.five_hour']);
 
       await vi.advanceTimersByTimeAsync(5 * 60 * 60 * 1_000);
@@ -512,6 +548,176 @@ describe('ClaudePromptService background task query lifetime', () => {
       const [[, detail]] = activity.mock.calls.filter(([kind]) => kind === 'waiting');
       expect(detail).toMatch(/^[A-Za-z0-9._:/-]+$/);
       expect(Buffer.byteLength(detail as string, 'utf8')).toBeLessThanOrEqual(128);
+    });
+  });
+
+  it('stays bounded when only the harness speaks on the held turn', async () => {
+    await withFakeTimers(async () => {
+      // A top-level `user` frame is a tool_result or an injected reminder, not
+      // the model resuming. Treating it as a resume would unbound the query for
+      // good, since the regime only re-arms on the next held result.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield userMessage('harness-chatter');
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('does not discard a continuation turn that is compacting', async () => {
+    await withFakeTimers(async () => {
+      // Auto-compaction emits `system/status` and then nothing until the
+      // summarization lands — easily past the settled grace, and the turn it
+      // is compacting for is live work.
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield taskNotification('task-1');
+        yield statusMessage('compacting');
+        await sleep(4 * GRACE_MS);
+        yield assistantMessage('post-compaction');
+        yield sdkResult('continuation-result');
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(5 * GRACE_MS);
+      await run.done;
+
+      expect(run.resultUuids()).toEqual(['parent-result', 'continuation-result']);
+    });
+  });
+
+  it('keeps the rate-limit pulse latest while background tasks keep talking', async () => {
+    await withFakeTimers(async () => {
+      // Every SDK frame overwrites the sticky pulse, so a block that coincides
+      // with a working background task would otherwise read as "Active".
+      const resetsAt = Math.floor(Date.now() / 1_000) + 5 * 60 * 60;
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield rateLimitEvent('rejected', resetsAt);
+        yield {
+          type: 'system',
+          subtype: 'task_progress',
+          task_id: 'task-1',
+          uuid: 'progress',
+          session_id: 'sdk-session',
+        };
+        yield taskNotification('task-1');
+        await never();
+      });
+      const activity = vi.fn();
+      drain(query, activity);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(activity.mock.calls.at(-1)).toEqual(['waiting', 'rate_limit.five_hour']);
+    });
+  });
+
+  it('clears the announced allowance once the block lifts', async () => {
+    await withFakeTimers(async () => {
+      // A seven-day reset grants a six-day allowance. If it survived the clear,
+      // every later read in this query would be bounded by "tier + six days".
+      const resetsAt = Math.floor(Date.now() / 1_000) + 6 * 24 * 60 * 60;
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        yield rateLimitEvent('rejected', resetsAt, 'seven_day');
+        yield rateLimitEvent('allowed');
+        await never();
+      });
+      const run = drain(query);
+
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      expect(run.settled()).toBe(true);
+      await run.done;
+    });
+  });
+
+  it('clamps an implausible announced wait instead of inverting the budget', () => {
+    // setTimeout clamps any delay past 2^31-1ms to *1ms*, so an unclamped
+    // epoch-milliseconds `resetsAt` would force-settle instantly — the exact
+    // opposite of what the extension exists for. Asserted on the function
+    // rather than through a fake-timer run, because fake timers do not
+    // reproduce that overflow clamp.
+    const now = 1_700_000_000_000;
+    const epochMsMistake = rateLimitEvent('rejected', now); // seconds field holding ms
+    expect(announcedQuietUntil(epochMsMistake, now)).toBe(now + MAX_ANNOUNCED_QUIET_MS);
+    // The clamp is itself under the overflow threshold, so no budget built from
+    // it can ever reach the inverting path.
+    expect(MAX_ANNOUNCED_QUIET_MS).toBeLessThan(2 ** 31 - 1);
+    // A real seven-day reset is far under the clamp and passes through intact.
+    const sevenDay = rateLimitEvent('rejected', Math.floor(now / 1_000) + 7 * 24 * 60 * 60);
+    expect(announcedQuietUntil(sevenDay, now)).toBe(now + 7 * 24 * 60 * 60 * 1_000);
+    // An already-elapsed reset grants nothing.
+    expect(announcedQuietUntil(rateLimitEvent('rejected', 1), now)).toBeUndefined();
+  });
+
+  it('emits one completion per task when a launch site retires several at once', async () => {
+    await withFakeTimers(async () => {
+      const query = fakeQuery(async function* () {
+        yield taskStarted('nested-1', 'tool-2');
+        yield taskStarted('nested-2', 'tool-3');
+        yield sdkResult('parent-result');
+        yield assistantMessage('subagent-launch', 'tool-1', ['tool-2', 'tool-3']);
+        await never();
+      });
+      const activity = vi.fn();
+      const run = drain(query, activity);
+
+      await vi.advanceTimersByTimeAsync(GRACE_MS + 1_000);
+      await run.done;
+
+      // Two starts, two completions: anything less leaves the watchdog counter
+      // above zero for the rest of the query.
+      const starts = activity.mock.calls.filter(([, detail]) => detail === 'background_task.start');
+      const completes = activity.mock.calls.filter(
+        ([, detail]) => detail === 'background_task.complete'
+      );
+      expect(starts).toHaveLength(2);
+      expect(completes).toHaveLength(2);
+    });
+  });
+
+  it('closes the query on every exit and cancels a wedged one', async () => {
+    await withFakeTimers(async () => {
+      const wedged = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+        yield sdkResult('parent-result');
+        await never();
+      });
+      const wedgedRun = drain(wedged);
+      await vi.advanceTimersByTimeAsync(SILENCE_MS + 1_000);
+      await wedgedRun.done;
+      // A pending read means `return()` can never run the SDK's own teardown,
+      // so the wedged path has to cancel rather than only abandon.
+      expect(wedged.interrupt).toHaveBeenCalledTimes(1);
+      expect(wedged.closed).toHaveBeenCalledTimes(1);
+
+      const healthy = fakeQuery([sdkResult('only-result')]);
+      const healthyRun = drain(healthy);
+      await healthyRun.done;
+      expect(healthy.closed).toHaveBeenCalledTimes(1);
+      expect(healthy.interrupt).not.toHaveBeenCalled();
+    });
+  });
+
+  it('releases input when the SDK generator ends with tasks outstanding', async () => {
+    await withFakeTimers(async () => {
+      const query = fakeQuery(async function* () {
+        yield taskStarted('task-1');
+      });
+      const activity = vi.fn();
+      const run = drain(query, activity);
+      await run.done;
+
+      expect(query.releaseInput).toHaveBeenCalledTimes(1);
+      expect(activity).toHaveBeenCalledWith('progress', 'background_task.complete');
     });
   });
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -5,8 +5,12 @@
  * Automatically loads CLAUDE.md and uses preset system prompts matching Claude Code CLI.
  */
 
+import {
+  type ResolvedClaudeBackgroundTaskConfig,
+  resolveClaudeBackgroundTaskConfig,
+} from '@agor/core/config';
 import { shortId } from '@agor/core/db';
-import type { PermissionMode, SDKResultMessage } from '@agor/core/sdk';
+import type { PermissionMode, SDKMessage, SDKResultMessage } from '@agor/core/sdk';
 import type {
   BranchRepository,
   MCPOAuthAuthHeadersRepository,
@@ -49,6 +53,53 @@ export interface PromptResult {
   outputTokens: number;
 }
 
+/**
+ * Whether a message proves the *top-level* model turn resumed, as opposed to
+ * background noise arriving while it stays finished.
+ *
+ * Only these lift the bounded-read regime below, and only at the top level:
+ * traffic forwarded from a subagent (`parent_tool_use_id` set) means background
+ * work is progressing, not that the model started thinking again, and must keep
+ * the silence budget armed so a background agent that dies mid-flight is still
+ * contained.
+ */
+function resumesTopLevelTurn(message: SDKMessage): boolean {
+  if (message.type !== 'assistant' && message.type !== 'user' && message.type !== 'stream_event') {
+    return false;
+  }
+  return message.parent_tool_use_id === null || message.parent_tool_use_id === undefined;
+}
+
+/**
+ * How long the SDK has told us it intends to be quiet, as an absolute epoch ms.
+ *
+ * A rejected rate limit and an API retry are both waits the SDK announces once
+ * and then sits out in complete silence — `SDKRateLimitEvent` is documented as
+ * firing only "when rate limit info changes", and `system/api_retry` fires once
+ * per attempt with the delay it is about to sleep. Without this the silence
+ * budget would kill a turn that was going to resume on its own, and a five-hour
+ * limit reset would do it every time.
+ */
+function announcedQuietUntil(message: SDKMessage, now: number): number | undefined {
+  if (message.type === 'rate_limit_event') {
+    const info = message.rate_limit_info;
+    if (info?.status !== 'rejected') return undefined;
+    // resetsAt is seconds since epoch.
+    if (typeof info.resetsAt === 'number') return info.resetsAt * 1_000;
+    // A rejection we cannot date is the one remaining false-kill window: the
+    // budget still applies, so say so where a force-settle can be traced to it.
+    console.warn(
+      `⚠️  Rate limit rejected with no resetsAt (type: ${info.rateLimitType ?? 'unknown'}); ` +
+        `a held turn stays bound by the background-task silence budget`
+    );
+    return undefined;
+  }
+  if (message.type === 'system' && message.subtype === 'api_retry') {
+    return now + message.retry_delay_ms;
+  }
+  return undefined;
+}
+
 export class ClaudePromptService {
   /** Enable token-level streaming from Claude Agent SDK */
   private static readonly ENABLE_TOKEN_STREAMING = true;
@@ -64,32 +115,6 @@ export class ClaudePromptService {
    * yet still bounds the hang; on timeout we settle the turn without a context
    * snapshot rather than wedge the query. */
   static readonly CONTEXT_USAGE_TIMEOUT_MS = 15_000;
-
-  /**
-   * Upper bound on SDK silence while a successful turn is held open for
-   * background tasks.
-   *
-   * The `await-background-tasks` disposition deliberately keeps the query
-   * generator open past the model's `end_turn` so a background Agent or
-   * Workflow can wake another turn on the same query. That wait had no
-   * deadline, so a task ID that never received a terminal signal wedged the
-   * turn forever: the Task stayed `running`, the executor kept heartbeating,
-   * and everything queued behind it — including cross-session callbacks —
-   * never drained.
-   *
-   * This is a *silence* budget, not a total one: every message the query yields
-   * re-arms it, so a background task still streaming progress, subagent
-   * output, or its own turns is never cut short. Only a stream that has gone
-   * completely quiet — the shape every observed hang had — is force-settled,
-   * and a background shell that is designed to outlive the turn settles the
-   * turn instead of owning it.
-   *
-   * 10 minutes sits well past the longest gap healthy background work produces
-   * (the SDK emits `tool_progress` while a single tool call is in flight, and
-   * forwards subagent tool_use/tool_result blocks as they land) while still
-   * letting a wedged session — and everything queued behind it — recover
-   * inside a working session rather than never. */
-  static readonly BACKGROUND_TASK_SILENCE_TIMEOUT_MS = 10 * 60_000;
 
   /** Serialize permission checks per session to prevent duplicate prompts for concurrent tool calls */
   private permissionLocks = new Map<SessionID, Promise<void>>();
@@ -108,9 +133,42 @@ export class ClaudePromptService {
     private messagesService?: MessagesService, // FeathersJS Messages service for creating permission requests
     private mcpEnabled?: boolean,
     private usersRepo?: UsersRepository,
-    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository,
+    /**
+     * Last-resort bounds on the query a finished turn holds open for its
+     * background tasks. See {@link ClaudePromptService.nextReadTimeoutMs}.
+     */
+    private backgroundTasksConfig: ResolvedClaudeBackgroundTaskConfig = resolveClaudeBackgroundTaskConfig()
   ) {
     // No client initialization needed - Agent SDK is stateless
+  }
+
+  /**
+   * Budget for the next read while a finished turn is held open for background
+   * tasks — the only state in which reads are bounded at all.
+   *
+   * Two tiers, because the two waits are nothing alike:
+   *
+   * - **Tasks outstanding** → `silence_timeout_ms` (30m). The tasks may
+   *   legitimately be working with nothing to say on the parent stream, so this
+   *   is a genuine last resort. Every message re-arms it.
+   * - **Nothing outstanding** → `settled_grace_ms` (2m). The last task settled
+   *   and `resultDisposition` is not recomputed until another `result` arrives,
+   *   so if the SDK does not wake a continuation turn nothing ever re-checks
+   *   and the query sits on zero work. All that legitimately remains here is
+   *   local scheduling plus the first message of the next turn.
+   *
+   * A wait the SDK announced (rate-limit reset, API retry backoff) is added on
+   * top of whichever tier applies, so an expected silence is never mistaken for
+   * a wedge. A rejected rate limit with no `resetsAt` gets no extension — the
+   * tier still applies — which is the one remaining false-kill window.
+   */
+  private nextReadTimeoutMs(activeTaskCount: number, quietUntil: number): number {
+    const tierMs =
+      activeTaskCount > 0
+        ? this.backgroundTasksConfig.silence_timeout_ms
+        : this.backgroundTasksConfig.settled_grace_ms;
+    return tierMs + Math.max(0, quietUntil - Date.now());
   }
 
   /**
@@ -299,27 +357,33 @@ If you continue to see authentication errors, please contact your Agor administr
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
 
     const iterator = result[Symbol.asyncIterator]();
-    // Set once a successful result is held back for background tasks. From
-    // that point the query is alive only on their behalf, so every read is
-    // bounded — the model has already finished responding.
-    let awaitingBackgroundTasks = false;
+    // True only while a successful result is held back and the model has not
+    // resumed. Reads are bounded exclusively inside that window: it is the one
+    // state in which nothing is left to wait for but background work.
+    let turnHeldForBackgroundTasks = false;
+    // Absolute epoch ms the SDK has announced it will be silent until.
+    let quietUntil = 0;
     // A force-settled query is presumed wedged; do not block teardown on it.
     let queryIsWedged = false;
 
     try {
       while (true) {
-        const next = awaitingBackgroundTasks
-          ? await awaitWithTimeout(
-              iterator.next(),
-              ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS
-            )
-          : await iterator.next();
+        const timeoutMs = turnHeldForBackgroundTasks
+          ? this.nextReadTimeoutMs(backgroundTasks.activeTaskCount, quietUntil)
+          : undefined;
+        const next =
+          timeoutMs === undefined
+            ? await iterator.next()
+            : await awaitWithTimeout(iterator.next(), timeoutMs);
 
         if (next === AWAIT_TIMEOUT) {
+          const leaked = backgroundTasks.activeTaskIds;
           console.warn(
-            `⚠️  No SDK activity for ${ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS}ms with ` +
-              `${backgroundTasks.activeTaskCount} background task(s) still unsettled ` +
-              `[${backgroundTasks.activeTaskIds.join(', ')}]; force-settling the turn`
+            leaked.length > 0
+              ? `⚠️  No SDK activity for ${timeoutMs}ms with ${leaked.length} background task(s) ` +
+                  `still unsettled [${leaked.join(', ')}]; force-settling the turn`
+              : `⚠️  Every background task settled but the SDK did not resume within ${timeoutMs}ms; ` +
+                  `force-settling the turn`
           );
           // Same escape hatch a non-success result already takes: stop
           // deferring, settle what the turn produced, and let the SDK close.
@@ -333,6 +397,13 @@ If you continue to see authentication errors, please contact your Agor administr
         }
         if (next.done) break;
         const msg = next.value;
+
+        // The model is producing again, so the turn is no longer merely parked
+        // on background work: stop bounding reads until the next held result.
+        // Without this, a resumed turn that thinks for a long time or makes one
+        // long silent tool call would be force-settled mid-flight.
+        if (resumesTopLevelTurn(msg)) turnHeldForBackgroundTasks = false;
+        quietUntil = Math.max(quietUntil, announcedQuietUntil(msg, Date.now()) ?? 0);
 
         reportSdkActivity(onActivity, 'claude-code', msg.type);
         const lifecycleTransition = backgroundTasks.observe(msg);
@@ -383,7 +454,7 @@ If you continue to see authentication errors, please contact your Agor administr
           if (event.type === 'result') {
             sdkResults.push(event.raw_sdk_message);
             if (resultDisposition === 'await-background-tasks') {
-              awaitingBackgroundTasks = true;
+              turnHeldForBackgroundTasks = true;
               console.log(
                 `⏳ Parent turn ended with ${backgroundTasks.activeTaskCount} background task(s) still active ` +
                   `[${backgroundTasks.activeTaskIds.join(', ')}]; keeping SDK query alive`

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -21,7 +21,7 @@ import type {
   UsersRepository,
 } from '../../db/feathers-repositories.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
-import { reportSdkActivity, type SdkActivityCallback } from '../../sdk-watchdog.js';
+import { boundedDetail, reportSdkActivity, type SdkActivityCallback } from '../../sdk-watchdog.js';
 import type { SessionID, TaskID } from '../../types.js';
 import { MessageRole } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
@@ -80,6 +80,11 @@ function resumesTopLevelTurn(message: SDKMessage): boolean {
  * budget would kill a turn that was going to resume on its own, and a five-hour
  * limit reset would do it every time.
  */
+/** Prefix marking a pulse detail as a rate-limit block, for the UI to key off. */
+export const RATE_LIMIT_PULSE_PREFIX = 'rate_limit.';
+/** Resume signal that lifts the watchdog pause the block pulse installs. */
+export const RATE_LIMIT_RESOLVED_DETAIL = 'rate_limit.resolved';
+
 function announcedQuietUntil(message: SDKMessage, now: number): number | undefined {
   if (message.type === 'rate_limit_event') {
     const info = message.rate_limit_info;
@@ -363,6 +368,9 @@ If you continue to see authentication errors, please contact your Agor administr
     let turnHeldForBackgroundTasks = false;
     // Absolute epoch ms the SDK has announced it will be silent until.
     let quietUntil = 0;
+    // Whether the session is currently blocked on a rate limit, so the pulse
+    // says "blocked", not "hung", and so the pause gets its matching resume.
+    let rateLimitBlocked = false;
     // A force-settled query is presumed wedged; do not block teardown on it.
     let queryIsWedged = false;
 
@@ -402,10 +410,31 @@ If you continue to see authentication errors, please contact your Agor administr
         // on background work: stop bounding reads until the next held result.
         // Without this, a resumed turn that thinks for a long time or makes one
         // long silent tool call would be force-settled mid-flight.
-        if (resumesTopLevelTurn(msg)) turnHeldForBackgroundTasks = false;
+        const modelResumed = resumesTopLevelTurn(msg);
+        if (modelResumed) turnHeldForBackgroundTasks = false;
         quietUntil = Math.max(quietUntil, announcedQuietUntil(msg, Date.now()) ?? 0);
 
         reportSdkActivity(onActivity, 'claude-code', msg.type);
+        // Emitted after the generic activity pulse so it wins as the sticky
+        // latest pulse: the heartbeat re-sends that pulse every beat, which is
+        // the only reason a block stays visible through a wait the SDK spends
+        // in complete silence.
+        const rateLimit = msg.type === 'rate_limit_event' ? msg.rate_limit_info : undefined;
+        if (rateLimit?.status === 'rejected') {
+          if (!rateLimitBlocked) {
+            rateLimitBlocked = true;
+            onActivity?.(
+              'waiting',
+              boundedDetail(`${RATE_LIMIT_PULSE_PREFIX}${rateLimit.rateLimitType ?? 'unknown'}`)
+            );
+          }
+        } else if (rateLimitBlocked && (rateLimit !== undefined || modelResumed)) {
+          // The limit lifted, or the model started producing again. Both end the
+          // block; the resume is mandatory because a `waiting` pulse pauses the
+          // watchdog until something explicitly lifts it.
+          rateLimitBlocked = false;
+          onActivity?.('sdk_started', RATE_LIMIT_RESOLVED_DETAIL);
+        }
         const lifecycleTransition = backgroundTasks.observe(msg);
         const { resultDisposition } = lifecycleTransition;
         if (

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -11,6 +11,7 @@ import {
 } from '@agor/core/config';
 import { shortId } from '@agor/core/db';
 import type { PermissionMode, SDKMessage, SDKResultMessage } from '@agor/core/sdk';
+import { ExecutorPulseDetail } from '@agor/core/types';
 import type {
   BranchRepository,
   MCPOAuthAuthHeadersRepository,
@@ -28,6 +29,7 @@ import type { MessagesService, SessionsPatchClient, TasksService } from '../base
 import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
 import { AWAIT_TIMEOUT, awaitWithTimeout } from './bounded-await.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
+import { classifyTurnScope } from './message-scope.js';
 import { type InterruptibleQuery, setupQuery } from './query-builder.js';
 import { aggregateClaudeResults } from './result-aggregation.js';
 
@@ -57,35 +59,72 @@ export interface PromptResult {
  * Whether a message proves the *top-level* model turn resumed, as opposed to
  * background noise arriving while it stays finished.
  *
- * Only these lift the bounded-read regime below, and only at the top level:
- * traffic forwarded from a subagent (`parent_tool_use_id` set) means background
- * work is progressing, not that the model started thinking again, and must keep
- * the silence budget armed so a background agent that dies mid-flight is still
- * contained.
+ * Only these lift the bounded-read regime below, and only at the top level.
+ * Traffic forwarded from a subagent means background work is progressing, not
+ * that the model started thinking again, and must keep the silence budget armed
+ * so a background agent that dies mid-flight is still contained. A message
+ * whose scope cannot be established counts as background for the same reason.
+ *
+ * `user` is excluded on purpose even though it carries the same scope field:
+ * a top-level `user` frame is the harness speaking — a tool_result, an injected
+ * reminder, a queued-input replay — not the model. A genuinely resumed turn
+ * always emits `assistant` or `stream_event` first, so the narrower set loses
+ * nothing and closes the hole where harness chatter permanently unbounds a
+ * query that then wedges.
  */
 function resumesTopLevelTurn(message: SDKMessage): boolean {
-  if (message.type !== 'assistant' && message.type !== 'user' && message.type !== 'stream_event') {
-    return false;
-  }
-  return message.parent_tool_use_id === null || message.parent_tool_use_id === undefined;
+  if (message.type !== 'assistant' && message.type !== 'stream_event') return false;
+  return classifyTurnScope(message) === 'top-level';
 }
+
+/**
+ * Longest silence the SDK is ever allowed to announce for itself.
+ *
+ * `resetsAt` is parsed from an external source and flows into `setTimeout`,
+ * which silently clamps any delay past 2^31-1 ms to *1 ms* — so a unit-confused
+ * value (a future SDK sending epoch milliseconds) would force-settle the turn
+ * immediately, the exact opposite of what the extension is for. This is a
+ * sanity bound on parsed input, not the policy ceiling we deliberately rejected:
+ * a real `seven_day` wait is two orders of magnitude under it.
+ */
+export const MAX_ANNOUNCED_QUIET_MS = 7 * 24 * 60 * 60 * 1_000;
+
+/**
+ * Quiet allowance for a compaction or an in-flight API request the SDK reports
+ * via `system/status`. Both are the SDK working, not waiting on us, and both
+ * emit nothing until they finish — auto-compaction of a near-full context can
+ * outlast the settled grace on its own.
+ */
+const SDK_BUSY_STATUS_QUIET_MS = 10 * 60_000;
 
 /**
  * How long the SDK has told us it intends to be quiet, as an absolute epoch ms.
  *
- * A rejected rate limit and an API retry are both waits the SDK announces once
- * and then sits out in complete silence — `SDKRateLimitEvent` is documented as
- * firing only "when rate limit info changes", and `system/api_retry` fires once
- * per attempt with the delay it is about to sleep. Without this the silence
- * budget would kill a turn that was going to resume on its own, and a five-hour
- * limit reset would do it every time.
+ * A rejected rate limit, an API retry, and a compaction are all waits the SDK
+ * announces once and then sits out in silence — `SDKRateLimitEvent` is
+ * documented as firing only "when rate limit info changes", `system/api_retry`
+ * fires once per attempt with the delay it is about to sleep, and
+ * `system/status` reports `compacting` / `requesting` with no follow-up until
+ * the work lands. Without this the silence budget would kill a turn that was
+ * going to resume on its own, and a five-hour limit reset would do it every
+ * time.
  */
-/** Prefix marking a pulse detail as a rate-limit block, for the UI to key off. */
-export const RATE_LIMIT_PULSE_PREFIX = 'rate_limit.';
-/** Resume signal that lifts the watchdog pause the block pulse installs. */
-export const RATE_LIMIT_RESOLVED_DETAIL = 'rate_limit.resolved';
+export function announcedQuietUntil(message: SDKMessage, now: number): number | undefined {
+  const target = announcedQuietTarget(message, now);
+  if (target === undefined) return undefined;
+  const requested = target - now;
+  if (requested <= 0) return undefined;
+  if (requested > MAX_ANNOUNCED_QUIET_MS) {
+    console.warn(
+      `⚠️  SDK announced an implausible ${requested}ms quiet period on ${message.type}; ` +
+        `clamping to ${MAX_ANNOUNCED_QUIET_MS}ms (check the timestamp units)`
+    );
+    return now + MAX_ANNOUNCED_QUIET_MS;
+  }
+  return target;
+}
 
-function announcedQuietUntil(message: SDKMessage, now: number): number | undefined {
+function announcedQuietTarget(message: SDKMessage, now: number): number | undefined {
   if (message.type === 'rate_limit_event') {
     const info = message.rate_limit_info;
     if (info?.status !== 'rejected') return undefined;
@@ -101,6 +140,13 @@ function announcedQuietUntil(message: SDKMessage, now: number): number | undefin
   }
   if (message.type === 'system' && message.subtype === 'api_retry') {
     return now + message.retry_delay_ms;
+  }
+  if (
+    message.type === 'system' &&
+    message.subtype === 'status' &&
+    (message.status === 'compacting' || message.status === 'requesting')
+  ) {
+    return now + SDK_BUSY_STATUS_QUIET_MS;
   }
   return undefined;
 }
@@ -368,14 +414,21 @@ If you continue to see authentication errors, please contact your Agor administr
     let turnHeldForBackgroundTasks = false;
     // Absolute epoch ms the SDK has announced it will be silent until.
     let quietUntil = 0;
-    // Whether the session is currently blocked on a rate limit, so the pulse
+    // Pulse detail while the session is blocked on a rate limit, so the pulse
     // says "blocked", not "hung", and so the pause gets its matching resume.
-    let rateLimitBlocked = false;
+    let rateLimitDetail: string | undefined;
     // A force-settled query is presumed wedged; do not block teardown on it.
     let queryIsWedged = false;
 
     try {
       while (true) {
+        // Re-assert the block immediately before every read. `reportSdkActivity`
+        // and background-task accounting both overwrite the latest pulse, and
+        // the pulse the heartbeat re-sends is whichever came last — so without
+        // this a block that coincides with a still-working background task
+        // would read as "Active" in the UI for its whole duration.
+        if (rateLimitDetail !== undefined) onActivity?.('waiting', rateLimitDetail);
+
         const timeoutMs = turnHeldForBackgroundTasks
           ? this.nextReadTimeoutMs(backgroundTasks.activeTaskCount, quietUntil)
           : undefined;
@@ -397,13 +450,25 @@ If you continue to see authentication errors, please contact your Agor administr
           // deferring, settle what the turn produced, and let the SDK close.
           clearBackgroundTaskActivity();
           queryIsWedged = true;
+          // Actively cancel rather than just abandoning: the pending read means
+          // `iterator.return()` queues behind it and never runs the generator's
+          // teardown, and `releaseInput()` only closes stdin. Not awaited — a
+          // wedged subprocess may never answer this control request either.
+          void Promise.resolve(result.interrupt()).catch(() => {});
           yield* this.finalizeTurn(result);
           if (sdkResults.length > 0) {
             yield { type: 'result', raw_sdk_message: aggregateClaudeResults(sdkResults) };
           }
           break;
         }
-        if (next.done) break;
+        if (next.done) {
+          // The SDK generator finished without an `end` event. Rare, but it
+          // still ends the turn, so it owes the same teardown every other
+          // turn-ending path does.
+          clearBackgroundTaskActivity();
+          result.releaseInput();
+          break;
+        }
         const msg = next.value;
 
         // The model is producing again, so the turn is no longer merely parked
@@ -415,25 +480,24 @@ If you continue to see authentication errors, please contact your Agor administr
         quietUntil = Math.max(quietUntil, announcedQuietUntil(msg, Date.now()) ?? 0);
 
         reportSdkActivity(onActivity, 'claude-code', msg.type);
-        // Emitted after the generic activity pulse so it wins as the sticky
-        // latest pulse: the heartbeat re-sends that pulse every beat, which is
-        // the only reason a block stays visible through a wait the SDK spends
-        // in complete silence.
         const rateLimit = msg.type === 'rate_limit_event' ? msg.rate_limit_info : undefined;
         if (rateLimit?.status === 'rejected') {
-          if (!rateLimitBlocked) {
-            rateLimitBlocked = true;
-            onActivity?.(
-              'waiting',
-              boundedDetail(`${RATE_LIMIT_PULSE_PREFIX}${rateLimit.rateLimitType ?? 'unknown'}`)
-            );
-          }
-        } else if (rateLimitBlocked && (rateLimit !== undefined || modelResumed)) {
+          rateLimitDetail = boundedDetail(
+            `${ExecutorPulseDetail.RATE_LIMIT_PREFIX}${rateLimit.rateLimitType ?? 'unknown'}`
+          );
+          onActivity?.('waiting', rateLimitDetail);
+        } else if (rateLimitDetail !== undefined && (rateLimit !== undefined || modelResumed)) {
           // The limit lifted, or the model started producing again. Both end the
           // block; the resume is mandatory because a `waiting` pulse pauses the
           // watchdog until something explicitly lifts it.
-          rateLimitBlocked = false;
-          onActivity?.('sdk_started', RATE_LIMIT_RESOLVED_DETAIL);
+          rateLimitDetail = undefined;
+          onActivity?.('sdk_started', ExecutorPulseDetail.RATE_LIMIT_RESOLVED);
+          // Drop the allowance the block bought. It is monotonic and decays only
+          // by wall clock, so a `seven_day` reset would otherwise leave every
+          // later read in this query bounded by "tier + six days" — unbounded in
+          // any practical sense, which is the hang this whole path exists to
+          // prevent.
+          quietUntil = 0;
         }
         const lifecycleTransition = backgroundTasks.observe(msg);
         const { resultDisposition } = lifecycleTransition;
@@ -555,6 +619,12 @@ If you continue to see authentication errors, please contact your Agor administr
       });
       throw enhancedError;
     } finally {
+      // Every `waiting` pulse owes a resume, or the watchdog stays paused for
+      // whatever is left of this task. Teardown — force-settle, generator end,
+      // error, Stop — must pay it too, not just the in-band clear.
+      if (rateLimitDetail !== undefined) {
+        onActivity?.('sdk_started', ExecutorPulseDetail.RATE_LIMIT_RESOLVED);
+      }
       // `for await` used to close the query on break or on an abandoned
       // consumer; keep doing that explicitly now that iteration is manual, so
       // the subprocess is still torn down. A force-settled query already has a

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -24,7 +24,7 @@ import type { MessagesService, SessionsPatchClient, TasksService } from '../base
 import { ClaudeBackgroundTaskLifecycle } from './background-task-lifecycle.js';
 import { AWAIT_TIMEOUT, awaitWithTimeout } from './bounded-await.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
-import { setupQuery } from './query-builder.js';
+import { type InterruptibleQuery, setupQuery } from './query-builder.js';
 import { aggregateClaudeResults } from './result-aggregation.js';
 
 export interface PromptResult {
@@ -65,6 +65,32 @@ export class ClaudePromptService {
    * snapshot rather than wedge the query. */
   static readonly CONTEXT_USAGE_TIMEOUT_MS = 15_000;
 
+  /**
+   * Upper bound on SDK silence while a successful turn is held open for
+   * background tasks.
+   *
+   * The `await-background-tasks` disposition deliberately keeps the query
+   * generator open past the model's `end_turn` so a background Agent or
+   * Workflow can wake another turn on the same query. That wait had no
+   * deadline, so a task ID that never received a terminal signal wedged the
+   * turn forever: the Task stayed `running`, the executor kept heartbeating,
+   * and everything queued behind it — including cross-session callbacks —
+   * never drained.
+   *
+   * This is a *silence* budget, not a total one: every message the query yields
+   * re-arms it, so a background task still streaming progress, subagent
+   * output, or its own turns is never cut short. Only a stream that has gone
+   * completely quiet — the shape every observed hang had — is force-settled,
+   * and a background shell that is designed to outlive the turn settles the
+   * turn instead of owning it.
+   *
+   * 10 minutes sits well past the longest gap healthy background work produces
+   * (the SDK emits `tool_progress` while a single tool call is in flight, and
+   * forwards subagent tool_use/tool_result blocks as they land) while still
+   * letting a wedged session — and everything queued behind it — recover
+   * inside a working session rather than never. */
+  static readonly BACKGROUND_TASK_SILENCE_TIMEOUT_MS = 10 * 60_000;
+
   /** Serialize permission checks per session to prevent duplicate prompts for concurrent tool calls */
   private permissionLocks = new Map<SessionID, Promise<void>>();
 
@@ -85,6 +111,38 @@ export class ClaudePromptService {
     private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     // No client initialization needed - Agent SDK is stateless
+  }
+
+  /**
+   * Close out a turn: take a bounded context snapshot, then release the input
+   * stream the SDK is holding stdin open for.
+   *
+   * Shared by the ordinary terminal result and the force-settle path below, so
+   * `releaseInput()` can never be skipped on a path that ends the turn.
+   */
+  private async *finalizeTurn(query: InterruptibleQuery): AsyncGenerator<ProcessedEvent> {
+    try {
+      // Bounded: a subprocess that never answers this control request
+      // must not wedge the query generator open (Task stuck running).
+      const contextUsage = await awaitWithTimeout(
+        query.getContextUsage(),
+        ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS
+      );
+      if (contextUsage === AWAIT_TIMEOUT) {
+        console.warn(
+          `⚠️  getContextUsage() did not respond within ${ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS}ms; settling turn without a context snapshot`
+        );
+      } else {
+        yield { type: 'context_usage', contextUsage };
+      }
+    } catch (error) {
+      console.warn(
+        `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      // Release the held input iterable so the SDK can close stdin
+      query.releaseInput();
+    }
   }
 
   /**
@@ -240,8 +298,42 @@ If you continue to see authentication errors, please contact your Agor administr
     // With AbortController passed to SDK, cancellation is handled natively.
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
 
+    const iterator = result[Symbol.asyncIterator]();
+    // Set once a successful result is held back for background tasks. From
+    // that point the query is alive only on their behalf, so every read is
+    // bounded — the model has already finished responding.
+    let awaitingBackgroundTasks = false;
+    // A force-settled query is presumed wedged; do not block teardown on it.
+    let queryIsWedged = false;
+
     try {
-      for await (const msg of result) {
+      while (true) {
+        const next = awaitingBackgroundTasks
+          ? await awaitWithTimeout(
+              iterator.next(),
+              ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS
+            )
+          : await iterator.next();
+
+        if (next === AWAIT_TIMEOUT) {
+          console.warn(
+            `⚠️  No SDK activity for ${ClaudePromptService.BACKGROUND_TASK_SILENCE_TIMEOUT_MS}ms with ` +
+              `${backgroundTasks.activeTaskCount} background task(s) still unsettled ` +
+              `[${backgroundTasks.activeTaskIds.join(', ')}]; force-settling the turn`
+          );
+          // Same escape hatch a non-success result already takes: stop
+          // deferring, settle what the turn produced, and let the SDK close.
+          clearBackgroundTaskActivity();
+          queryIsWedged = true;
+          yield* this.finalizeTurn(result);
+          if (sdkResults.length > 0) {
+            yield { type: 'result', raw_sdk_message: aggregateClaudeResults(sdkResults) };
+          }
+          break;
+        }
+        if (next.done) break;
+        const msg = next.value;
+
         reportSdkActivity(onActivity, 'claude-code', msg.type);
         const lifecycleTransition = backgroundTasks.observe(msg);
         const { resultDisposition } = lifecycleTransition;
@@ -258,7 +350,9 @@ If you continue to see authentication errors, please contact your Agor administr
           onActivity?.('progress', 'background_task.start');
         }
         if (lifecycleTransition.taskTransition === 'settled') {
-          onActivity?.('progress', 'background_task.complete');
+          for (let index = 0; index < (lifecycleTransition.settledTaskCount ?? 1); index++) {
+            onActivity?.('progress', 'background_task.complete');
+          }
         }
         // Process message through processor
         const events = await processor.process(msg);
@@ -289,33 +383,14 @@ If you continue to see authentication errors, please contact your Agor administr
           if (event.type === 'result') {
             sdkResults.push(event.raw_sdk_message);
             if (resultDisposition === 'await-background-tasks') {
+              awaitingBackgroundTasks = true;
               console.log(
-                `⏳ Parent turn ended with ${backgroundTasks.activeTaskCount} background task(s) still active; keeping SDK query alive`
+                `⏳ Parent turn ended with ${backgroundTasks.activeTaskCount} background task(s) still active ` +
+                  `[${backgroundTasks.activeTaskIds.join(', ')}]; keeping SDK query alive`
               );
             } else {
               event.raw_sdk_message = aggregateClaudeResults(sdkResults);
-              try {
-                // Bounded: a subprocess that never answers this control request
-                // must not wedge the query generator open (Task stuck running).
-                const contextUsage = await awaitWithTimeout(
-                  result.getContextUsage(),
-                  ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS
-                );
-                if (contextUsage === AWAIT_TIMEOUT) {
-                  console.warn(
-                    `⚠️  getContextUsage() did not respond within ${ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS}ms; settling turn without a context snapshot`
-                  );
-                } else {
-                  yield { type: 'context_usage', contextUsage } as ProcessedEvent;
-                }
-              } catch (error) {
-                console.warn(
-                  `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`
-                );
-              } finally {
-                // Release the held input iterable so the SDK can close stdin
-                result.releaseInput();
-              }
+              yield* this.finalizeTurn(result);
             }
           }
 
@@ -325,7 +400,7 @@ If you continue to see authentication errors, please contact your Agor administr
               continue;
             }
             console.log(`🏁 Conversation ended: ${event.reason}`);
-            break; // Exit for-await loop
+            break; // Stop draining this batch of processor events
           }
 
           // Yield all events including result (for token usage capture)
@@ -379,6 +454,13 @@ If you continue to see authentication errors, please contact your Agor administr
         stderr: stderrOutput || '(no stderr output)',
       });
       throw enhancedError;
+    } finally {
+      // `for await` used to close the query on break or on an abandoned
+      // consumer; keep doing that explicitly now that iteration is manual, so
+      // the subprocess is still torn down. A force-settled query already has a
+      // read in flight that will never resolve, so its close is not awaited.
+      const closed = Promise.resolve(iterator.return?.(undefined)).catch(() => {});
+      if (!queryIsWedged) await closed;
     }
   }
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -207,6 +207,27 @@ function announcedQuietRemainingMs(
 }
 
 /**
+ * `interrupt()`, best-effort in both dimensions.
+ *
+ * This is the *optional* cooperative half of a force-settle: the teardown that
+ * has to work is `close()`. So neither a rejection nor a synchronous throw may
+ * reach the turn. The synchronous case is the sharp one —
+ * `Promise.resolve(query.interrupt())` evaluates the call before it wraps it,
+ * so a query shape without the method throws straight past the `.catch()` and
+ * into the handler that reports the Task as **failed**, for a turn this path
+ * has just settled successfully.
+ */
+function interruptQuietly(query: InterruptibleQuery): void {
+  try {
+    void Promise.resolve(query.interrupt()).catch(() => {});
+  } catch (error) {
+    console.warn(
+      `⚠️  query.interrupt() failed during force-settle: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/**
  * `close()`, best-effort.
  *
  * This is the last thing a force-settled turn does, so an SDK that lacks the
@@ -531,7 +552,7 @@ If you continue to see authentication errors, please contact your Agor administr
           // control request that round-trips over the transport that just went
           // silent, so on this path it may well never resolve. The teardown
           // that actually ends the subprocess is `close()`, in the `finally`.
-          void Promise.resolve(result.interrupt()).catch(() => {});
+          interruptQuietly(result);
           yield* this.finalizeTurn(result);
           if (sdkResults.length > 0) {
             yield { type: 'result', raw_sdk_message: aggregateClaudeResults(sdkResults) };

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -94,11 +94,31 @@ export const MAX_ANNOUNCED_QUIET_MS = 7 * 24 * 60 * 60 * 1_000;
  * via `system/status`. Both are the SDK working, not waiting on us, and both
  * emit nothing until they finish — auto-compaction of a near-full context can
  * outlast the settled grace on its own.
+ *
+ * This is a ceiling, not the expected duration: `status: null` is the SDK's own
+ * "no longer busy" signal and drops the grant as soon as it arrives, so the
+ * extension normally tracks the announced window rather than this bound.
  */
 const SDK_BUSY_STATUS_QUIET_MS = 10 * 60_000;
 
 /**
- * How long the SDK has told us it intends to be quiet, as an absolute epoch ms.
+ * Independently-cleared sources of an announced silence.
+ *
+ * Kept apart rather than pooled into one `Math.max` scalar because they begin
+ * and end independently. Pooled, clearing a rate limit discarded a still-valid
+ * retry backoff or compaction grant, while those two — having no `Math.max`
+ * clear of their own — were never dropped at all.
+ */
+export type AnnouncedQuietSource = 'rate_limit' | 'api_retry' | 'sdk_busy';
+
+export interface AnnouncedQuiet {
+  source: AnnouncedQuietSource;
+  /** Absolute epoch ms the SDK has announced it will be silent until. */
+  until: number;
+}
+
+/**
+ * How long the SDK has told us it intends to be quiet, and on whose account.
  *
  * A rejected rate limit, an API retry, and a compaction are all waits the SDK
  * announces once and then sits out in silence — `SDKRateLimitEvent` is
@@ -109,9 +129,55 @@ const SDK_BUSY_STATUS_QUIET_MS = 10 * 60_000;
  * going to resume on its own, and a five-hour limit reset would do it every
  * time.
  */
-export function announcedQuietUntil(message: SDKMessage, now: number): number | undefined {
-  const target = announcedQuietTarget(message, now);
-  if (target === undefined) return undefined;
+export function announcedQuietUntil(message: SDKMessage, now: number): AnnouncedQuiet | undefined {
+  let source: AnnouncedQuietSource;
+  let target: number;
+
+  if (message.type === 'rate_limit_event') {
+    const info = message.rate_limit_info;
+    if (info?.status !== 'rejected') return undefined;
+    // resetsAt is seconds since epoch. Finite, not merely `typeof number`:
+    // `NaN` is a number and survives every later guard — `NaN <= 0` and
+    // `NaN > MAX_ANNOUNCED_QUIET_MS` are both false — after which `Math.max`
+    // is absorbing, so one unparseable timestamp would pin the allowance at
+    // `NaN` for the life of the query, and `setTimeout(fn, NaN)` coerces to
+    // 1ms. That force-settles every held result immediately: the exact
+    // regression this extension exists to prevent, from its own guard.
+    if (typeof info.resetsAt === 'number' && Number.isFinite(info.resetsAt)) {
+      source = 'rate_limit';
+      target = info.resetsAt * 1_000;
+    } else {
+      // A rejection we cannot date is the one remaining false-kill window: the
+      // budget still applies, so say so where a force-settle can be traced to it.
+      console.warn(
+        `⚠️  Rate limit rejected with no usable resetsAt (type: ${info.rateLimitType ?? 'unknown'}, ` +
+          `resetsAt: ${String(info.resetsAt)}); a held turn stays bound by the background-task silence budget`
+      );
+      return undefined;
+    }
+  } else if (message.type === 'system' && message.subtype === 'api_retry') {
+    // Same finiteness reasoning as `resetsAt` above: this value is parsed off
+    // the wire, and `NaN` would invert the budget rather than extend it.
+    if (typeof message.retry_delay_ms !== 'number' || !Number.isFinite(message.retry_delay_ms)) {
+      console.warn(
+        `⚠️  system/api_retry carried an unusable retry_delay_ms (${String(message.retry_delay_ms)}); ` +
+          `granting no quiet allowance for it`
+      );
+      return undefined;
+    }
+    source = 'api_retry';
+    target = now + message.retry_delay_ms;
+  } else if (
+    message.type === 'system' &&
+    message.subtype === 'status' &&
+    (message.status === 'compacting' || message.status === 'requesting')
+  ) {
+    source = 'sdk_busy';
+    target = now + SDK_BUSY_STATUS_QUIET_MS;
+  } else {
+    return undefined;
+  }
+
   const requested = target - now;
   if (requested <= 0) return undefined;
   if (requested > MAX_ANNOUNCED_QUIET_MS) {
@@ -119,36 +185,42 @@ export function announcedQuietUntil(message: SDKMessage, now: number): number | 
       `⚠️  SDK announced an implausible ${requested}ms quiet period on ${message.type}; ` +
         `clamping to ${MAX_ANNOUNCED_QUIET_MS}ms (check the timestamp units)`
     );
-    return now + MAX_ANNOUNCED_QUIET_MS;
+    return { source, until: now + MAX_ANNOUNCED_QUIET_MS };
   }
-  return target;
+  return { source, until: target };
 }
 
-function announcedQuietTarget(message: SDKMessage, now: number): number | undefined {
-  if (message.type === 'rate_limit_event') {
-    const info = message.rate_limit_info;
-    if (info?.status !== 'rejected') return undefined;
-    // resetsAt is seconds since epoch.
-    if (typeof info.resetsAt === 'number') return info.resetsAt * 1_000;
-    // A rejection we cannot date is the one remaining false-kill window: the
-    // budget still applies, so say so where a force-settle can be traced to it.
+/**
+ * Furthest-out live grant, as milliseconds from `now`.
+ *
+ * Every stored `until` is finite and in the future when granted, so no
+ * unparseable value can reach this and poison the maximum; an expired grant
+ * simply contributes nothing.
+ */
+function announcedQuietRemainingMs(
+  grants: ReadonlyMap<AnnouncedQuietSource, number>,
+  now: number
+): number {
+  let remaining = 0;
+  for (const until of grants.values()) remaining = Math.max(remaining, until - now);
+  return Math.max(0, remaining);
+}
+
+/**
+ * `close()`, best-effort.
+ *
+ * This is the last thing a force-settled turn does, so an SDK that lacks the
+ * method or throws from it must not replace an already-settled turn with a
+ * crash out of the `finally` block.
+ */
+function closeQuietly(query: InterruptibleQuery): void {
+  try {
+    query.close();
+  } catch (error) {
     console.warn(
-      `⚠️  Rate limit rejected with no resetsAt (type: ${info.rateLimitType ?? 'unknown'}); ` +
-        `a held turn stays bound by the background-task silence budget`
+      `⚠️  query.close() failed during force-settle teardown: ${error instanceof Error ? error.message : String(error)}`
     );
-    return undefined;
   }
-  if (message.type === 'system' && message.subtype === 'api_retry') {
-    return now + message.retry_delay_ms;
-  }
-  if (
-    message.type === 'system' &&
-    message.subtype === 'status' &&
-    (message.status === 'compacting' || message.status === 'requesting')
-  ) {
-    return now + SDK_BUSY_STATUS_QUIET_MS;
-  }
-  return undefined;
 }
 
 export class ClaudePromptService {
@@ -209,17 +281,21 @@ export class ClaudePromptService {
    *   and the query sits on zero work. All that legitimately remains here is
    *   local scheduling plus the first message of the next turn.
    *
-   * A wait the SDK announced (rate-limit reset, API retry backoff) is added on
-   * top of whichever tier applies, so an expected silence is never mistaken for
-   * a wedge. A rejected rate limit with no `resetsAt` gets no extension — the
-   * tier still applies — which is the one remaining false-kill window.
+   * A wait the SDK announced (rate-limit reset, API retry backoff, compaction)
+   * is added on top of whichever tier applies, so an expected silence is never
+   * mistaken for a wedge — the longest grant still live wins. A rejected rate
+   * limit with no `resetsAt` gets no extension — the tier still applies — which
+   * is the one remaining false-kill window.
    */
-  private nextReadTimeoutMs(activeTaskCount: number, quietUntil: number): number {
+  private nextReadTimeoutMs(
+    activeTaskCount: number,
+    announcedQuiet: ReadonlyMap<AnnouncedQuietSource, number>
+  ): number {
     const tierMs =
       activeTaskCount > 0
         ? this.backgroundTasksConfig.silence_timeout_ms
         : this.backgroundTasksConfig.settled_grace_ms;
-    return tierMs + Math.max(0, quietUntil - Date.now());
+    return tierMs + announcedQuietRemainingMs(announcedQuiet, Date.now());
   }
 
   /**
@@ -412,8 +488,9 @@ If you continue to see authentication errors, please contact your Agor administr
     // resumed. Reads are bounded exclusively inside that window: it is the one
     // state in which nothing is left to wait for but background work.
     let turnHeldForBackgroundTasks = false;
-    // Absolute epoch ms the SDK has announced it will be silent until.
-    let quietUntil = 0;
+    // Absolute epoch ms each announced wait runs until, kept per source so that
+    // one of them clearing never discards another that is still in force.
+    const announcedQuiet = new Map<AnnouncedQuietSource, number>();
     // Pulse detail while the session is blocked on a rate limit, so the pulse
     // says "blocked", not "hung", and so the pause gets its matching resume.
     let rateLimitDetail: string | undefined;
@@ -430,7 +507,7 @@ If you continue to see authentication errors, please contact your Agor administr
         if (rateLimitDetail !== undefined) onActivity?.('waiting', rateLimitDetail);
 
         const timeoutMs = turnHeldForBackgroundTasks
-          ? this.nextReadTimeoutMs(backgroundTasks.activeTaskCount, quietUntil)
+          ? this.nextReadTimeoutMs(backgroundTasks.activeTaskCount, announcedQuiet)
           : undefined;
         const next =
           timeoutMs === undefined
@@ -450,10 +527,10 @@ If you continue to see authentication errors, please contact your Agor administr
           // deferring, settle what the turn produced, and let the SDK close.
           clearBackgroundTaskActivity();
           queryIsWedged = true;
-          // Actively cancel rather than just abandoning: the pending read means
-          // `iterator.return()` queues behind it and never runs the generator's
-          // teardown, and `releaseInput()` only closes stdin. Not awaited — a
-          // wedged subprocess may never answer this control request either.
+          // Ask nicely first, and never wait on the answer: `interrupt()` is a
+          // control request that round-trips over the transport that just went
+          // silent, so on this path it may well never resolve. The teardown
+          // that actually ends the subprocess is `close()`, in the `finally`.
           void Promise.resolve(result.interrupt()).catch(() => {});
           yield* this.finalizeTurn(result);
           if (sdkResults.length > 0) {
@@ -476,8 +553,23 @@ If you continue to see authentication errors, please contact your Agor administr
         // Without this, a resumed turn that thinks for a long time or makes one
         // long silent tool call would be force-settled mid-flight.
         const modelResumed = resumesTopLevelTurn(msg);
-        if (modelResumed) turnHeldForBackgroundTasks = false;
-        quietUntil = Math.max(quietUntil, announcedQuietUntil(msg, Date.now()) ?? 0);
+        if (modelResumed) {
+          turnHeldForBackgroundTasks = false;
+          // The model is producing again, so nothing the SDK announced it was
+          // waiting on is still in force. Dropping the grants here is what
+          // stops one from outliving its wait into a later held turn.
+          announcedQuiet.clear();
+        }
+        // `status: null` is the SDK's own "no longer busy" signal, and it is
+        // what keeps the busy allowance honest. A `requesting` frame almost
+        // always precedes the final result of a turn, so without this clear the
+        // first bounded read after a held result would carry most of a
+        // ten-minute tail — silently making the configured grace non-binding.
+        if (msg.type === 'system' && msg.subtype === 'status' && msg.status === null) {
+          announcedQuiet.delete('sdk_busy');
+        }
+        const announced = announcedQuietUntil(msg, Date.now());
+        if (announced) announcedQuiet.set(announced.source, announced.until);
 
         reportSdkActivity(onActivity, 'claude-code', msg.type);
         const rateLimit = msg.type === 'rate_limit_event' ? msg.rate_limit_info : undefined;
@@ -492,12 +584,13 @@ If you continue to see authentication errors, please contact your Agor administr
           // watchdog until something explicitly lifts it.
           rateLimitDetail = undefined;
           onActivity?.('sdk_started', ExecutorPulseDetail.RATE_LIMIT_RESOLVED);
-          // Drop the allowance the block bought. It is monotonic and decays only
-          // by wall clock, so a `seven_day` reset would otherwise leave every
-          // later read in this query bounded by "tier + six days" — unbounded in
-          // any practical sense, which is the hang this whole path exists to
-          // prevent.
-          quietUntil = 0;
+          // Drop the allowance this block bought, and only it. The grant decays
+          // only by wall clock, so a `seven_day` reset would otherwise leave
+          // every later read in this query bounded by "tier + six days" —
+          // unbounded in any practical sense, which is the hang this whole path
+          // exists to prevent. A compaction or retry backoff running alongside
+          // keeps its own grant.
+          announcedQuiet.delete('rate_limit');
         }
         const lifecycleTransition = backgroundTasks.observe(msg);
         const { resultDisposition } = lifecycleTransition;
@@ -625,10 +718,19 @@ If you continue to see authentication errors, please contact your Agor administr
       if (rateLimitDetail !== undefined) {
         onActivity?.('sdk_started', ExecutorPulseDetail.RATE_LIMIT_RESOLVED);
       }
+      // A force-settled query is presumed wedged, and `iterator.return()` alone
+      // cannot recover it: the read that timed out is still pending, so the
+      // return queues behind it and the SDK generator's own `finally` never
+      // runs. `close()` is the one teardown that does not round-trip through
+      // that transport — it aborts the spawn, ends stdin and drops the abort
+      // handler locally — so it is what actually stops the subprocess, and the
+      // background agents still mutating the worktree behind it.
+      if (queryIsWedged) closeQuietly(result);
       // `for await` used to close the query on break or on an abandoned
       // consumer; keep doing that explicitly now that iteration is manual, so
-      // the subprocess is still torn down. A force-settled query already has a
-      // read in flight that will never resolve, so its close is not awaited.
+      // the subprocess is still torn down. Not awaited on the wedged path: the
+      // close above should unstick it, but a turn that has already settled must
+      // not be made to wait on a query that has stopped answering.
       const closed = Promise.resolve(iterator.return?.(undefined)).catch(() => {});
       if (!queryIsWedged) await closed;
     }

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -95,6 +95,17 @@ export interface QuerySetupDeps {
  */
 export interface InterruptibleQuery {
   interrupt(): Promise<void>;
+  /**
+   * Tear the query down locally: abort the spawn, end stdin, drop the abort
+   * handler, and reject anything still in flight.
+   *
+   * Structurally unlike {@link InterruptibleQuery.interrupt}, which is a
+   * *control request* — it round-trips over the same transport as the message
+   * stream, so on a wedged query it never resolves. `close()` touches only this
+   * process's own state, so it is the one teardown that still works when the
+   * subprocess has stopped answering. Synchronous, per the SDK's `Query`.
+   */
+  close(): void;
   getContextUsage(): Promise<import('@agor/core/sdk').SDKControlGetContextUsageResponse>;
   /**
    * Signal that post-result control requests (like getContextUsage) are done.

--- a/packages/executor/src/sdk-watchdog.test.ts
+++ b/packages/executor/src/sdk-watchdog.test.ts
@@ -93,18 +93,49 @@ describe('SdkWatchdog', () => {
   });
 
   it.each([
-    ['permission.resolved', 'permission wait'],
-    ['rate_limit.resolved', 'rate-limit block'],
-  ])('resumes from a %s that ends a %s', (resumeDetail) => {
+    ['permission.request', 'permission.resolved'],
+    ['rate_limit.five_hour', 'rate_limit.resolved'],
+  ])('lifts a %s pause on its own %s', (waitDetail, resumeDetail) => {
     const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');
     vi.advanceTimersByTime(400);
-    watchdog.record('waiting');
+    watchdog.record('waiting', waitDetail);
     // A pause has no clock of its own, so without a resume the watchdog would
     // stay disarmed for the rest of the query.
     vi.advanceTimersByTime(60_000);
     expect(decisions).toEqual([]);
     watchdog.record('sdk_started', resumeDetail);
+    vi.advanceTimersByTime(599);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('no_first_progress');
+  });
+
+  it.each([
+    ['permission.request', 'rate_limit.resolved'],
+    ['rate_limit.five_hour', 'permission.resolved'],
+  ])('does not lift a %s pause with an unrelated %s', (waitDetail, resumeDetail) => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    vi.advanceTimersByTime(400);
+    watchdog.record('waiting', waitDetail);
+    // Cross-lifting would time out a human still reading a permission prompt,
+    // or a session legitimately parked on a multi-hour limit reset.
+    watchdog.record('sdk_started', resumeDetail);
+    vi.advanceTimersByTime(60_000);
+    expect(decisions).toEqual([]);
+  });
+
+  it('stays paused until every overlapping wait is lifted', () => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    vi.advanceTimersByTime(400);
+    watchdog.record('waiting', 'permission.request');
+    watchdog.record('waiting', 'rate_limit.five_hour');
+    watchdog.record('sdk_started', 'permission.resolved');
+    vi.advanceTimersByTime(60_000);
+    expect(decisions).toEqual([]);
+    watchdog.record('sdk_started', 'rate_limit.resolved');
     vi.advanceTimersByTime(599);
     expect(decisions).toEqual([]);
     vi.advanceTimersByTime(1);

--- a/packages/executor/src/sdk-watchdog.test.ts
+++ b/packages/executor/src/sdk-watchdog.test.ts
@@ -92,6 +92,25 @@ describe('SdkWatchdog', () => {
     });
   });
 
+  it.each([
+    ['permission.resolved', 'permission wait'],
+    ['rate_limit.resolved', 'rate-limit block'],
+  ])('resumes from a %s that ends a %s', (resumeDetail) => {
+    const { watchdog, decisions } = harness();
+    watchdog.record('sdk_started');
+    vi.advanceTimersByTime(400);
+    watchdog.record('waiting');
+    // A pause has no clock of its own, so without a resume the watchdog would
+    // stay disarmed for the rest of the query.
+    vi.advanceTimersByTime(60_000);
+    expect(decisions).toEqual([]);
+    watchdog.record('sdk_started', resumeDetail);
+    vi.advanceTimersByTime(599);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('no_first_progress');
+  });
+
   it('preserves the remaining timeout across a permission wait', () => {
     const { watchdog, decisions } = harness();
     watchdog.record('sdk_started');

--- a/packages/executor/src/sdk-watchdog.test.ts
+++ b/packages/executor/src/sdk-watchdog.test.ts
@@ -124,14 +124,32 @@ describe('SdkWatchdog', () => {
     expect(decisions[0]?.reason).toBe('progress_stalled');
   });
 
-  it('pauses Claude idle policy while an SDK background task is active', () => {
+  it('keeps Claude idle policy disarmed while an SDK background task still reports activity', () => {
     const { watchdog, decisions } = harness({}, 'claude-code');
     watchdog.record('sdk_started');
     watchdog.record('progress', 'assistant');
     watchdog.record('progress', 'background_task.start');
-    vi.advanceTimersByTime(10_000);
+    // A live background task keeps the stream busy with system frames
+    // (task_progress, forwarded subagent traffic) that are not model progress.
+    for (let tick = 0; tick < 5; tick++) {
+      vi.advanceTimersByTime(1_500);
+      watchdog.record('sdk_started', 'system');
+    }
     expect(decisions).toEqual([]);
     watchdog.record('progress', 'background_task.complete');
+    vi.advanceTimersByTime(1_999);
+    expect(decisions).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(decisions[0]?.reason).toBe('progress_stalled');
+  });
+
+  it('lets a leaked background task stall out instead of disarming the watchdog forever', () => {
+    const { watchdog, decisions } = harness({}, 'claude-code');
+    watchdog.record('sdk_started');
+    watchdog.record('progress', 'assistant');
+    // The task never reports a terminal signal, so background_task.complete
+    // never arrives and the counter stays above zero for the rest of the query.
+    watchdog.record('progress', 'background_task.start');
     vi.advanceTimersByTime(1_999);
     expect(decisions).toEqual([]);
     vi.advanceTimersByTime(1);

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -61,8 +61,29 @@ const PROGRESS = new Set([
   'copilot:assistant.turn_end',
 ]);
 
-function boundedDetail(value: string): string {
+/**
+ * Coerce a detail into the bounded identifier the daemon accepts.
+ *
+ * `tasks.reportRuntimeTelemetry` rejects anything outside `[A-Za-z0-9._:/-]`
+ * or over 128 bytes with a BadRequest, and the heartbeat re-sends the latest
+ * pulse on every beat — so one unsanitized detail would fail every subsequent
+ * heartbeat write, not just its own.
+ */
+export function boundedDetail(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128) || 'unknown';
+}
+
+/**
+ * Details that lift a `waiting` pause.
+ *
+ * A pause has no clock of its own, so a pause with no matching resume disables
+ * the watchdog for the rest of the query. Every producer of a `waiting` pulse
+ * therefore owes a resume on the other side of its wait.
+ */
+const PAUSE_RESUME_DETAILS = new Set(['permission.resolved', 'rate_limit.resolved']);
+
+function liftsWait(kind: ExecutorPulseKind, detail?: string): boolean {
+  return kind === 'sdk_started' && detail !== undefined && PAUSE_RESUME_DETAILS.has(detail);
 }
 
 export function mapSdkActivity(
@@ -196,7 +217,7 @@ export class SdkWatchdog {
       return;
     }
     const pausedAt = this.state.pausedAt;
-    if (pausedAt !== undefined && !(kind === 'sdk_started' && detail === 'permission.resolved')) {
+    if (pausedAt !== undefined && !liftsWait(kind, detail)) {
       return;
     }
     const resumed = pausedAt !== undefined;
@@ -208,7 +229,7 @@ export class SdkWatchdog {
       this.state.pausedAt = undefined;
     }
     this.state.startedAt ??= now;
-    if (!(resumed && kind === 'sdk_started' && detail === 'permission.resolved')) {
+    if (!(resumed && liftsWait(kind, detail))) {
       this.state.lastRawAt = now;
     }
     if (kind === 'unknown_activity') this.state.unknownCount++;

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -1,6 +1,7 @@
 import { getAgenticToolIntegration } from '@agor/agentic-tools';
 import type { ResolvedSdkWatchdogConfig } from '@agor/core/config';
 import type { AgenticToolName, ExecutorPulseKind, SdkHealthFailureInput } from '@agor/core/types';
+import { ExecutorPulseDetail } from '@agor/core/types';
 import { hasAgorAbortCause, markAgorAbortCause } from './termination-state.js';
 
 export type SdkActivityAdapter = 'claude-code' | 'codex' | 'gemini' | 'copilot';
@@ -74,16 +75,31 @@ export function boundedDetail(value: string): string {
 }
 
 /**
- * Details that lift a `waiting` pause.
+ * Which wait a pause belongs to.
  *
  * A pause has no clock of its own, so a pause with no matching resume disables
- * the watchdog for the rest of the query. Every producer of a `waiting` pulse
- * therefore owes a resume on the other side of its wait.
+ * the watchdog for the rest of the query — every producer of a `waiting` pulse
+ * owes a resume. Waits are keyed by source rather than pooled into one flag
+ * because they overlap: with a single flag, a rate limit clearing would lift the
+ * pause held by a permission prompt a human has not answered yet (the watchdog
+ * then times out a healthy session, and aborts it under `enforce`), and
+ * `permission.resolved` would lift a live multi-hour rate-limit block.
+ *
+ * `approval` is the catch-all for every pre-existing `waiting` producer —
+ * permission prompts, user-input requests, tool-call confirmations — all of
+ * which are lifted by `permission.resolved` today and keep that behaviour.
  */
-const PAUSE_RESUME_DETAILS = new Set(['permission.resolved', 'rate_limit.resolved']);
+type WaitSource = 'approval' | 'rate_limit';
 
-function liftsWait(kind: ExecutorPulseKind, detail?: string): boolean {
-  return kind === 'sdk_started' && detail !== undefined && PAUSE_RESUME_DETAILS.has(detail);
+function waitSource(detail?: string): WaitSource {
+  return detail?.startsWith(ExecutorPulseDetail.RATE_LIMIT_PREFIX) ? 'rate_limit' : 'approval';
+}
+
+function resumedWaitSource(kind: ExecutorPulseKind, detail?: string): WaitSource | undefined {
+  if (kind !== 'sdk_started') return undefined;
+  if (detail === ExecutorPulseDetail.RATE_LIMIT_RESOLVED) return 'rate_limit';
+  if (detail === ExecutorPulseDetail.PERMISSION_RESOLVED) return 'approval';
+  return undefined;
 }
 
 export function mapSdkActivity(
@@ -122,7 +138,10 @@ interface WatchdogState {
   lastRawAt?: number;
   firstProgressAt?: number;
   idleAnchor?: number;
+  /** When the first still-unlifted wait began; time here is credited back. */
   pausedAt?: number;
+  /** Waits currently holding the pause. The policy resumes only when empty. */
+  pausedBy: Set<WaitSource>;
   /** Foreground tool calls in flight — these fully suspend the policy. */
   activeToolCount: number;
   /** SDK background tasks in flight — these only relax it (see below). */
@@ -188,6 +207,7 @@ function inspectSdkWatchdog(
 
 export class SdkWatchdog {
   private state: WatchdogState = {
+    pausedBy: new Set(),
     activeToolCount: 0,
     activeBackgroundTaskCount: 0,
     unknownCount: 0,
@@ -210,15 +230,23 @@ export class SdkWatchdog {
     if (this.decided || this.options.config.mode === 'disabled') return;
     const now = this.now();
     if (kind === 'waiting') {
-      if (this.state.startedAt !== undefined && this.state.pausedAt === undefined) {
-        this.state.pausedAt = now;
+      if (this.state.startedAt !== undefined) {
+        this.state.pausedBy.add(waitSource(detail));
+        this.state.pausedAt ??= now;
       }
       this.schedule();
       return;
     }
     const pausedAt = this.state.pausedAt;
-    if (pausedAt !== undefined && !liftsWait(kind, detail)) {
-      return;
+    if (pausedAt !== undefined) {
+      const lifted = resumedWaitSource(kind, detail);
+      // Anything that is not this pause's own resume stays suppressed, and a
+      // resume for one wait never lifts another's.
+      if (lifted === undefined || !this.state.pausedBy.delete(lifted)) return;
+      if (this.state.pausedBy.size > 0) {
+        this.schedule();
+        return;
+      }
     }
     const resumed = pausedAt !== undefined;
     if (pausedAt !== undefined) {
@@ -229,7 +257,7 @@ export class SdkWatchdog {
       this.state.pausedAt = undefined;
     }
     this.state.startedAt ??= now;
-    if (!(resumed && liftsWait(kind, detail))) {
+    if (!resumed) {
       this.state.lastRawAt = now;
     }
     if (kind === 'unknown_activity') this.state.unknownCount++;

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -102,7 +102,10 @@ interface WatchdogState {
   firstProgressAt?: number;
   idleAnchor?: number;
   pausedAt?: number;
+  /** Foreground tool calls in flight — these fully suspend the policy. */
   activeToolCount: number;
+  /** SDK background tasks in flight — these only relax it (see below). */
+  activeBackgroundTaskCount: number;
   unknownCount: number;
   unknownReported: boolean;
 }
@@ -138,10 +141,17 @@ function inspectSdkWatchdog(
   }
 
   if (tool === 'claude-code' && config.claude_idle_timeout_ms !== null) {
-    const idleDeadline =
-      (state.idleAnchor ?? state.firstProgressAt) + config.claude_idle_timeout_ms;
     const silenceDeadline =
       (state.lastRawAt ?? state.firstProgressAt) + config.claude_idle_timeout_ms;
+    // A background task relaxes the idle policy down to plain SDK silence
+    // instead of suspending it: task_progress and forwarded subagent traffic
+    // keep a healthy background task alive, while a task ID that leaked (no
+    // terminal signal, so it is never accounted as complete) can no longer
+    // disarm the one check that would notice the resulting hang.
+    const idleDeadline =
+      state.activeBackgroundTaskCount > 0
+        ? silenceDeadline
+        : (state.idleAnchor ?? state.firstProgressAt) + config.claude_idle_timeout_ms;
     if (now >= idleDeadline) {
       if (now >= silenceDeadline) return { reason: 'progress_stalled' };
       if (!state.unknownReported && state.unknownCount > 0) {
@@ -158,6 +168,7 @@ function inspectSdkWatchdog(
 export class SdkWatchdog {
   private state: WatchdogState = {
     activeToolCount: 0,
+    activeBackgroundTaskCount: 0,
     unknownCount: 0,
     unknownReported: false,
   };
@@ -204,11 +215,16 @@ export class SdkWatchdog {
     if (kind === 'progress') {
       this.state.firstProgressAt ??= now;
       this.state.idleAnchor = now;
-      if (detail === 'tool.start' || detail === 'background_task.start') {
-        this.state.activeToolCount++;
-      }
-      if (detail === 'tool.complete' || detail === 'background_task.complete') {
+      if (detail === 'tool.start') this.state.activeToolCount++;
+      if (detail === 'tool.complete') {
         this.state.activeToolCount = Math.max(0, this.state.activeToolCount - 1);
+      }
+      if (detail === 'background_task.start') this.state.activeBackgroundTaskCount++;
+      if (detail === 'background_task.complete') {
+        this.state.activeBackgroundTaskCount = Math.max(
+          0,
+          this.state.activeBackgroundTaskCount - 1
+        );
       }
     }
     this.check();


### PR DESCRIPTION
Fixes #2067

## The failure chain

A successful `result` with unsettled background tasks takes the `await-background-tasks` disposition: `prompt-service.ts` `continue`s past `end`, skips the loop break, skips `releaseInput()`, and keeps the SDK query generator open so a background Agent/Workflow can wake another turn (#2057). **That wait had no deadline and no exit condition.** Any task ID that never received a terminal signal wedged the turn permanently — Task stuck `running`, executor heartbeating, queued tasks and cross-session `is_agor_callback` callbacks stacked up behind it, manual Stop the only recovery.

And the same leak disarmed the safety net: `background_task.start` incremented the `activeToolCount` that makes `inspectSdkWatchdog()` return early, so a task that never completed suppressed the watchdog for the rest of the query.

Reported rate on `agor-2` over ~2 days: 17 runs entered this path, 7 hung permanently (~41%), 6 needed a manual Stop.

## Five defects

### 1. Per-enum terminal statuses (`background-task-lifecycle.ts`)

`TERMINAL_TASK_STATUSES = {'completed','failed','stopped'}` was one set tested against two different SDK enums. Verified against `@anthropic-ai/claude-agent-sdk@0.3.197` `sdk.d.ts`:

| message | enum |
|---|---|
| `SDKTaskNotificationMessage.status` (4126) | `'completed' \| 'failed' \| 'stopped'` |
| `SDKTaskUpdatedMessage.patch.status` (4190) | `'pending' \| 'running' \| 'completed' \| 'failed' \| 'killed' \| 'paused'` |

So **`killed` never settled** — a killed background task leaked its ID deterministically — and `stopped` was matched against an enum it cannot belong to.

Now two exhaustive `Record<Status, boolean>` tables keyed off the SDK types. A status the SDK adds or renames is a compile error rather than a silent hang (verified: deleting `killed` fails `tsc` with *"Property 'killed' is missing … but required in type `Record<NonNullable<"completed" | "failed" | "pending" | "running" | "killed" | "paused" | undefined>, boolean>`"*).

Behaviour narrowing worth flagging: `task_updated.patch.status === 'stopped'` is no longer treated as terminal, because that enum cannot produce it.

### 2. Nested (spawn-depth ≥ 2) subagent tasks are no longer awaited

`SDKTaskStartedMessage.tool_use_id` names the block that launched the task, and subagent `tool_use` blocks are forwarded on the parent stream with `parent_tool_use_id` set. A task whose launching block appeared inside a subagent's own message is nested: the SDK announces its `task_started` here but routes its terminal signal to the subagent that owns it. The ancestor task we *do* track stays active for the nested task's whole lifetime, so dropping it costs no protection.

**The discriminator does not trust the declaration.** `parent_tool_use_id` crosses a stdout/JSON boundary, so an omitted key deserializes to `undefined` however the `.d.ts` types it — and every other reader in this repo already coerces it (`message-processor.ts`, `claude-tool.ts`, the daemon's message validator). Reading `undefined` as "subagent" would have put every top-level `Task` launch into the nested set, dropped every `task_started`, and closed the query as the parent turn ended: #1852 verbatim.

Both new readers now share one three-way classifier (`message-scope.ts`), and `unknown` deliberately lands on the side that keeps work alive and bounded: never treated as nested (the task stays tracked), never treated as the turn resuming (the turn stays inside its budget), and logged once with the SDK version. A test constructs the message with the key absent entirely.

### 3. A missing exit condition, not just a missing timeout

`resultDisposition` is only recomputed when a `result` arrives. Once a result has been held back, if the last background task settles and the SDK does not happen to wake a new turn, `activeTaskCount` reaches 0 and **nothing re-checks** — the query sits alive with zero outstanding work.

That is the shape of the originally reported session (`01a01055-5daa-7fd8-b4b3-11e613f3ef18`): result held at 15:49:30 with 2 tasks active, `background_task.complete` pulse at 16:33:57, then nothing until the manual Stop at 16:34:59.

So the wait is now **two tiers**, selected per read:

| state | budget | why |
|---|---|---|
| tasks outstanding | `silence_timeout_ms` (30m) | the tasks may legitimately work for a long time with nothing to say on the parent stream — a genuine last resort |
| nothing outstanding | `settled_grace_ms` (2m) | all that remains is local scheduling plus the first message of the next turn |

**This is not an immediate settle, and I'd push back on making it one.** The SDK routinely *does* wake a continuation turn right after a settle — that is the whole reason #2057 holds the result, it is what the `retains the parent result and releases input only after the continuation result` test encodes, and #2072's managed-environment run confirmed it end to end. Finalizing the instant the count hits zero would cut off the very turn that reads the background task's output, i.e. re-open #1852.

The pulse evidence is also thinner than it looks for that specific claim: the gap between the 16:33:57 settle and the 16:34:59 Stop is **62 seconds**, which cannot distinguish "the SDK was never going to wake a turn" from "it had not woken one yet" — especially in a session whose last message is `You've hit your session limit · resets 8pm (UTC)`, i.e. one that could not have run a continuation turn for another ~3.5 hours. A short grace gets the recovery without betting on the stronger claim.

### 4. Bounded reads apply only where nothing else is pending

Previously `awaitingBackgroundTasks` was set on the held-back result and never cleared, so every later read for the life of the query was bounded — including reads during a fully active turn woken by a settled task. Kamil's objection was exactly right: a follow-up turn that thinks for a long time, or makes one long MCP call, would have been force-settled mid-flight.

Now any **top-level** `assistant` / `user` / `stream_event` message lifts the bounded regime until the next held result. Forwarded subagent traffic (`parent_tool_use_id` set) deliberately does not: it proves background work is progressing, not that the model came back, so a background agent that dies mid-flight is still contained.

Net effect: the budget is armed only in the window where the model is provably done and the only thing left is background work — which is the shape all four manually-stopped hangs had (last pulse detail `result`, then nothing).

### 5. Announced silences extend the budget (rate limits)

Investigated before merge, as asked, and it is a real false-kill risk:

- `SDKRateLimitEvent` doc: *"Rate limit event emitted when rate limit info **changes**."* One event, then silence.
- `SDKAPIRetryMessage` (`system/api_retry`) doc: *"Emitted **when** an API request fails with a retryable error and will be retried after a delay"* — once per attempt, carrying `retry_delay_ms`; nothing during the sleep.

So yes: **the SDK can go completely silent while waiting on a limit reset**, for hours. A rejected `rate_limit_event` with `resetsAt`, an `api_retry` with `retry_delay_ms`, and a `system/status` of `compacting` / `requesting` now extend whichever tier applies by the wait the SDK declared. A rejected limit with no `resetsAt` is the one remaining false-kill window and is logged as such, so a force-settle can always be traced back to it.

Five bounds on that extension, all from review:

- **Grants are tracked per source, not pooled.** The allowance was one scalar aggregating three independent waits through `Math.max`, which broke in both directions at once: clearing a rate limit set it to `0` unconditionally and so **discarded a still-valid retry backoff or compaction grant**, while those two — having no clear of their own — were **never dropped at all**. Each source (`rate_limit`, `api_retry`, `sdk_busy`) now holds its own deadline and the longest live one wins, so clearing one removes only its own contribution.
- **It is cleared when the block lifts.** The allowance decays only by wall clock, so a `seven_day` rejection would have left every later read in that query bounded by "tier + six days" — unbounded in any practical sense, reintroducing this issue's hang through the mechanism added to prevent false kills. A resumed top-level turn retires every grant for the same reason: the SDK is provably not waiting on any of them.
- **The value must be finite, not merely a number.** `typeof NaN === 'number'` is true, `NaN <= 0` is false, and `NaN > MAX_ANNOUNCED_QUIET_MS` is false — so `NaN` defeated **both** guards and returned as a grant. `Math.max` is absorbing, so the allowance was then `NaN` permanently, and `setTimeout(fn, NaN)` coerces to **1 ms**: every held result for the life of that query would have force-settled immediately, discarding all background work, silently, every turn. That is #1852 in full, out of the guard written to prevent it. `resetsAt` and `retry_delay_ms` are now both `Number.isFinite`-checked and logged when refused. (`±Infinity` was already survivable — the clamp caught `+∞`, the `<= 0` guard caught `−∞` — and is now refused outright rather than converted into a seven-day allowance built from a garbage value.)
- **It is clamped to seven days.** `resetsAt` is parsed input and flows into `setTimeout`, which silently clamps any delay past 2^31-1 ms to *1 ms* — so a unit-confused value (a future SDK emitting epoch milliseconds) would have force-settled *immediately*, the exact inverse of the intent. **This is not the policy ceiling we rejected** (see below); it is a sanity bound on an external value, and a real `seven_day` wait is two orders of magnitude under it.
- **Compaction is covered, and bounded by the SDK's own end-of-busy signal.** `SDKStatusMessage` is `type: 'system'`, so it re-armed the clock without lifting the regime, and the summarization that follows emits nothing until `compact_boundary`. A continuation turn waking on a near-full context could be discarded mid-compaction inside the 2-minute grace. The 10-minute grant `compacting` / `requesting` buys is a ceiling, not a duration: `status: null` (`sdk.d.ts:4077`) drops it. That clear is what keeps the documented tiers honest — a `requesting` frame almost always precedes the parent turn's final result, so without it the first bounded read after a held result carried a ~9-10 minute tail, making the effective grace ~12m and the effective silence ~40m while this PR and the guide both advertised 2m/30m. An operator tuning `settled_grace_ms` would have been tuning a non-binding constraint.

**No hard ceiling on the announced wait — considered and deliberately rejected.** Capping it would truncate a legitimate multi-hour wait to work around a display problem, and defect 7's indicator removes the motivation. The seven-day clamp above is a different thing: it bounds a *malformed* value, not a real one.

### 6. Watchdog suppression decoupled (`sdk-watchdog.ts`)

`background_task.start`/`.complete` now feed their own `activeBackgroundTaskCount` instead of the `activeToolCount` that short-circuits `inspectSdkWatchdog()`. Foreground `tool.start`/`tool.complete` suppression is untouched. A background task now only *relaxes* the Claude idle policy — the idle deadline collapses to the plain SDK-silence deadline — so forwarded subagent traffic keeps a healthy background task alive (preserving #2057's intent), while a leaked task can no longer disarm the check forever.

Defence in depth, not the recovery path: `sdk_watchdog.mode` defaults to `observe`, so it reports rather than aborts.

**Pauses are keyed to the wait that installed them.** Generalizing the resume lift to a set left one `pausedAt` with no producer identity, so either wait's resume lifted the other's pause: a rate limit clearing would un-pause a permission prompt a human had not answered yet (the watchdog then times out a healthy session, and aborts it under `enforce`), and `permission.resolved` would lift a live multi-hour rate-limit block. Waits now carry a source (`approval` for every pre-existing producer, `rate_limit` for the new one) and the policy resumes only when all of them have cleared.

### 7. A rate-limit block is visible on the session pulse

Defect 5 deliberately lets a rate-limited turn sit in `running` for hours. That's correct, but a blocked session and a hung one look identical from outside — so shipping the extension without an indicator would make "looks hung but isn't" *more* common right after we announce the hang is fixed. The two land together.

**Executor.** One `waiting` pulse with a `rate_limit.<type>` detail when the SDK reports a rejected limit. `startExecutorHeartbeat` re-sends `latestPulse` on every beat regardless of whether it changed (`executor-heartbeat.ts:42`, `:80`), so a single record stays fresh for the whole wait — which is the only thing that works here, since the SDK emits nothing at all while waiting out a reset. The detail is sanitized through `boundedDetail()`, because `tasks.reportRuntimeTelemetry` throws `BadRequest` on anything outside `[A-Za-z0-9._:/-]` or over 128 bytes (`tasks.ts:1440`), and a re-sent bad detail would fail *every later heartbeat write*, not just its own.

No schema change, no migration, no new channel, no new `SessionStatus` — the pulse already reaches the client on the existing subscription.

**The watchdog interaction had to be resolved, not absorbed.** A `waiting` pulse sets `pausedAt`, and the pause had exactly one lift, hard-coded to `sdk_started` + `permission.resolved`. A rate-limit block emits no such event, so left alone it would have disarmed the watchdog for the rest of the query — the same class of bug defect 6 just fixed, through a different door.

The pause itself is right (we do not want the watchdog firing during a genuine five-hour block), so the fix is to make it symmetric: the lift is now a small set of details, and the block emits `sdk_started` + `rate_limit.resolved` when the limit clears or the model starts producing again. **A `waiting` pulse now owes a resume** — that's the rule this generalizes, and it's worth knowing for any future producer of one.

**UI.** `TimerPill` reads the detail rather than only the kind, so the pulse renders "Rate limited" instead of the generic "Waiting". While blocked, the pill borrows the `awaiting_permission` affordance (pause icon + warning colour) without inventing a status — the elapsed timer keeps running, which is the useful reading during a multi-hour reset. The transcript half already ships (`RateLimitBlock`), so there's no detail view to build.

**No ceiling on the announced wait — considered and deliberately rejected.** Capping the extension would truncate a legitimate multi-hour wait to work around a display problem, and the indicator above removes the motivation for it. The extension stays uncapped.

**The pulse is re-asserted before every read.** `reportSdkActivity` fires on every SDK frame and background-task accounting emits its own pulses, so the sticky pulse is whichever came last — a block that coincided with a still-working background task would have read as "Active" for its whole duration, failing defect 7's goal in exactly the case that co-occurs with background tasks.

**⚠️ One correction to the scoping: this is not a board-card signal.** `TimerPill` renders in `SessionFooter` (session panel) and `TaskBlock` (transcript) — those and `TimerPill` itself are the *only* three UI files that touch `latestExecutorPulse`. The board card renders `<TaskStatusIcon status={session.status} />` (`SessionCard.tsx:165`), which is session-scoped and has no task record, so the pulse simply isn't in its data. Getting it onto the board would mean threading the latest task's pulse into `SessionCard` — real plumbing, and adjacent to the "wrong data source" trap you flagged. I did not do it. Say the word and I'll scope it as a follow-up.

### 8. Teardown and cancellation

- **A force-settle now tears the query down — with `close()`, not `interrupt()`.** After the read times out it stays pending, so `iterator.return()` queues behind it and never runs the SDK generator's `finally`, and `releaseInput()` only closes stdin. Between force-settle and executor exit, background agents were otherwise still running and mutating the worktree after we declared the turn done. The first attempt at this used `interrupt()`, which **cannot work on the path it runs on**: in 0.3.197 it is only `Jt("sdk_interrupt", async () => { await this.request({subtype: "interrupt"}) })` — a control request round-tripping over the very transport that has gone silent, so it does not resolve, and nothing downstream of it runs either. `Query.close()` is structurally different and entirely local: `spawnAbort(...)`, `processStdin.end()`, abort-handler teardown, no round-trip. It is now exposed on `InterruptibleQuery` and is what guarantees teardown; `interrupt()` is kept ahead of it as the cooperative ask, unawaited, and is allowed to never answer. Both calls are wrapped in `try/catch` — they are the last things a settled turn does, so an SDK that lacks either method or throws from it must not turn a settled turn into a crash.

  That guard is not cosmetic on the `interrupt()` side. `Promise.resolve(x)` evaluates `x` before wrapping it, so a **synchronous** throw — `result.interrupt is not a function` on an unexpected query shape — escaped before any promise existed, where `.catch()` could not see it, and propagated to the outer handler that builds and throws `enhancedError`. The force-settle would have reported the Task as **failed** for a turn it had just settled successfully, contradicting the line this same PR added to the guide. Caught by review as N1.
- **`next.done` runs the shared teardown.** `finalizeTurn` was extracted so `releaseInput()` could never be skipped on a turn-ending path, and this path skipped it.
- **The rate-limit resume is paid on teardown too.** Force-settle, generator end, error and Stop all left `rateLimitBlocked` set with no resume. Contained today because the watchdog is per-task, but the rule stated at the constant — *every `waiting` pulse owes a resume* — was not enforced.

## Configuration

The knob is in, and my earlier "too invasive to plumb" note was **wrong** — I had looked at the shared `executePromptWithStreaming` boundary instead of the constructor path. `executeClaudeCodeTask` already receives `resolvedConfig` and builds the tool, so this is Claude-only: no `ITool` / `BaseTool` change, no other adapter touched.

```yaml
execution:
  claude_background_tasks:
    silence_timeout_ms: 1800000 # 30m: tasks outstanding, stream silent
    settled_grace_ms: 120000 # 2m: nothing outstanding, waiting for the next turn
```

Daemon-resolved into the executor config slice, same path as `sdk_watchdog`, with the same defaults when running without a slice.

### Shared pulse vocabulary

`rate_limit.` / `rate_limit.resolved` was independently declared in three places across two processes — the executor that emits it, the watchdog that pairs pause with resume, and the UI that labels it. A rename missing the watchdog's set would silently unpair a pause from its resume, which silently reintroduces defect 6. They now live in `ExecutorPulseDetail` (`packages/core/src/types/task.ts`) with a shared `isRateLimitBlockPulse` helper. No migration: the strings are unchanged.

Tidying from the same round: `resetTurnScopeWarningForTests` is gone (exported with no callers), `announcedQuietTarget` is inlined into its single caller, and `isRateLimitBlockPulse` is a single return expression.

### Docs

`context/concepts/task-runtime-state.md` is required reading via `AGENTS.md` and still described the pre-#2447 watchdog, so the next agent in this code would have been briefed with a wrong model by our own instructions. Updated, along with the guide, and **both now state that timeout recovery settles on the accumulated parent result and discards background work that had not finished** — the Task completes rather than fails, because the model had already stopped responding.

**One number worth your call before merge:** the reported session's late settle landed 44 minutes after the held result, which is past the 30m default — with defaults it would force-settle at +30m rather than riding through to that settle. Given that session was rate-limited until 8pm UTC, settling it early looks like the better outcome to me, but if you'd rather honour late settles set `silence_timeout_ms: 3600000`.

## Corrections to earlier claims in this PR

- Dropped the justification that "the SDK emits `tool_progress` while a single tool call is in flight." The declarations document no emission cadence for `SDKToolProgressMessage`, and the CLI is a compiled binary. The only supporting evidence is this repo's own `message-processor.ts` comment (*"Fires constantly during tool execution — extremely noisy"*), which is suggestive but not a contract. The budget's safety now rests on what is verifiable: forwarded subagent traffic, the resumed-turn lift, the announced-silence extension, and the deadline being a last resort.

## Tests

`background-task-lifecycle.test.ts` — `killed` settles from a `task_updated` patch; `pending`/`running`/`paused` keep waiting; top-level tasks still awaited; subagent-launched tasks never tracked; nested tasks announced before their launch site are released with the right settled count.

`prompt-service.background-tasks.test.ts`
- **defect 8, teardown**: the force-settled query is modelled as production wedges it — the stream stops and `interrupt()` never resolves — and the test asserts the SDK generator's own `finally` ran, via a flag the generator sets. The previous version of this test asserted only that `return()` had been *invoked*, with an `interrupt()` mock that resolved immediately, so it could not observe teardown at all and passed against the broken implementation.
- **defect 8, best-effort teardown**: a query with `interrupt` deleted still settles on its accumulated result, still closes, and still runs the generator's teardown; a query that throws out of `close()` still settles.
- **defect 5, finiteness**: `NaN` / `±Infinity` / a string `retry_delay_ms` grant nothing, plus a run proving a `NaN` `resetsAt` force-settles on the plain tier rather than on the next tick.
- **defect 5, per source**: a compaction grant survives a rate limit clearing (and is itself still bounding — the cleared five-hour reset is gone), the busy grant is dropped on `status: null`, and a resumed top-level turn retires every grant.
- **regression for this issue**: `task_started` → `end_turn` → silence forever ⇒ force-settles at `silence_timeout_ms` (asserted not to have settled 1s earlier), `releaseInput()` once, `background_task.complete` emitted.
- **defect 3**: last task settles with no following result ⇒ turn ends on `settled_grace_ms`, asserted to be well before `silence_timeout_ms`.
- **defect 4**: a resumed turn that then sleeps 4× the silence budget runs to its own `continuation-result` — asserted on the terminal result UUID, since a force-settle also emits a `result` and counting them cannot tell the outcomes apart.
- **defect 4, other direction**: subagent chatter does not lift the budget.
- **defect 5**: a rejected rate limit with a five-hour `resetsAt` is not force-settled, and completes normally after the reset.
- silence-based: a task reporting progress past the budget still runs to its continuation result.

`sdk-watchdog.test.ts` — a background task reporting activity keeps the idle policy disarmed (#2057 intent); a leaked one no longer suppresses the watchdog; a `waiting` pause is lifted by either resume detail, asserted after 60s of pause to show a pause with no lift would stay disarmed.

**defect 7** — `prompt-service.background-tasks.test.ts`: a rejected limit records exactly one `waiting` / `rate_limit.five_hour` pulse and nothing after it (the sticky re-send is what the UI depends on), then a `rate_limit.resolved` resume once the model returns; an SDK-supplied limit type containing spaces and an emoji is sanitized to something the daemon's detail validator accepts. `TimerPill.test.tsx`: `waiting` + `rate_limit.*` renders "Rate limited" while `waiting` + `permission.request` still renders "Waiting", and `isRateLimitPulse` rejects the resume signal that shares the prefix on a different kind.

`spawn-executor.resolved-config.test.ts` — the new defaults are frozen into the slice, and configured values reach the executor.

Every new behaviour is mutation-checked: each fix in this PR has a mutation that fails exactly its own tests and no others — including reading unknown message scope as `subagent`, widening the resume lift back to `user`, dropping the compaction grant, never clearing the announced allowance, removing the seven-day clamp, pooling the watchdog pause back into one flag, skipping the `next.done` teardown, and emitting the block pulse only once. The ten mutations for this round: dropping the `close()` call (the wedged generator's `finally` never runs), un-finite-checking `resetsAt` and `retry_delay_ms`, pooling the rate-limit clear back into a whole-map clear, never clearing the rate-limit grant, never dropping the busy grant on `status: null`, not retiring grants on a resumed turn, removing the `try/catch` around `close()`, restoring the bare `void Promise.resolve(result.interrupt())`, and removing the `try/catch` around `interrupt()`. Each fails only the test(s) named for it — the two exceptions are both correct: "never clear the rate-limit grant" fails the two tests that are about that clear, and dropping `close()` fails both teardown tests, since both assert the generator's `finally` ran.

One of those checks caught a **vacuous test of my own**: the clamp test ran through fake timers, which do not reproduce `setTimeout`'s real overflow behaviour, so it passed with the clamp removed. It now asserts on the function directly, plus that the clamp is itself under the overflow threshold.

## Validation

- `pnpm --filter @agor/executor exec vitest run` (Claude + watchdog suites) — 65 passed
- full executor suite: 594 passed / 60 failed, failing set identical to `main` in this worktree (`query-builder` 18, `codex/prompt-service` 42, `gemini/*` import errors — missing local agentic-tool fixtures). `query-builder.test.ts` is the one of those this round touches: stashing the change reproduces the same 18 failures, so they are not from adding `close()` to the interface
- full daemon suite: 2831 passed / 73 skipped
- full UI suite: 1493 passed / 0 failed (the two suite-interaction flakes noted last round did not reproduce)
- `@agor/core`: 3563 passed
- `pnpm typecheck` (core + executor + daemon + ui) and `pnpm lint` — clean

## Not in scope — tracked as follow-up

Agreed with review to keep #2067 open until these exist:

- **Daemon-side semantic backstop** routed through the existing termination coordinator (this issue's third proposed fix, never built). Defect 8 is independent evidence for it: the executor cannot reliably cancel its own wedged query, only best-effort.
- **SDK contract canary** replaying captured transcripts across both nested orderings, killed tasks, continuation wake-up and a rate-limit reset. The dep is a caret range and dependabot bumps the agent-sdks group routinely, so the shapes this PR reasons about are one bump from moving.
- **Durable structured force-settle observability.** Today it is journald lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

