### PR TITLE
docs: update Codex/Claude OAuth design for HA

### DIFF
--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,6 +1,7 @@
 # Enabling Codex and Claude subscription OAuth sign-in in HA
 
 Status: **design proposal, not implemented.** August 2026.
+Revision 2 — corrects a refuted claim in revision 1; see [Revision history](#revision-history).
 
 Scope: make the two provider subscription sign-in flows — Codex device auth
 (`codex-auth/device`) and Claude subscription OAuth (`claude-auth/oauth`, added
@@ -9,36 +10,37 @@ by PR #2317) — actually work under `deployment.mode: ha` /
 `503 HA_FEATURE_UNSUPPORTED`.
 
 Non-goals: MCP OAuth (`mcp-servers/oauth-*`), OpenCode auth, and provider API-key
-paste flows. MCP OAuth has a distinct residual blocker described in
-[Why MCP OAuth stays gated](#why-mcp-oauth-stays-gated-and-why-that-does-not-apply-here);
-it is deliberately out of scope.
+paste flows.
 
 Throughout, **VERIFIED** means read from the tree at this commit with a
 `file:line` citation. **DESIGN** means proposed and not yet built.
+**PRECONDITION** means an external fact this design depends on that has *not*
+been established and must be before the corresponding phase ships.
 
 ---
 
 ## TL;DR
 
-1. There is only **one** real blocker, not two. Credential-file visibility
-   (Blocker 2) is **already solved and already ungated** — `codexCredentialFiles`
-   is the one HA capability that is computed rather than hardcoded, and
-   `codex-auth/import` / `codex-auth/logout` already pass in a correctly
-   configured HA deployment. The remaining blocker is the **in-memory `attempts`
-   map** that holds the PKCE verifier / device code between requests.
-2. `processAffineAuth` is **not** a ready-made hook. It has **zero consumers** —
-   it is declared, assigned `false`, and asserted in one test fixture. Nothing
-   reads it. It cannot be "flipped on".
-3. Redis is **fanout-only** and is the wrong place for this. Auth paths are
-   explicitly denied entry to the Redis relay, and the house pattern for every
-   other HA-coordinated subsystem is PostgreSQL claims/leases.
-4. Agor already ships a **complete, production-grade durable OAuth attempt
-   store** for MCP OAuth: sealed PKCE material, tenant scoping, TTL, atomic
-   one-shot claim, ambiguity handling. Codex/Claude should reuse that pattern
-   rather than invent one.
-5. **Recommended: Phase 1 ships affinity-based enablement (small, low risk,
-   unblocks the shared-local topology today); Phase 2 ships the durable
-   PostgreSQL attempt store (unblocks `external` / multi-replica Cloud).**
+1. The blocking mechanism is the **in-memory `attempts` map** that holds
+   per-attempt secret material between requests
+   (`codex-device-auth.ts:263`; `claude-oauth.ts:292` on #2317).
+2. Credential-file visibility is **solved for the checked-in `shared-local`
+   topology** and is a **declared, unverified contract** for `external` / Cloud.
+   It is not a second implementation blocker, but it is an open deployment
+   precondition (§1.6, §3).
+3. `processAffineAuth` has **zero consumers** — declared, assigned `false`, one
+   test fixture. It is not a switch. **Delete it**; do not rehabilitate it.
+4. Redis is fanout-only and auth paths are explicitly denied the relay.
+   PostgreSQL claims/leases are the house pattern. Redis is not a candidate.
+5. Agor's MCP OAuth authority provides reusable **primitives** — sealed envelope,
+   atomic one-shot claim, tenant scope, TTL/prune. Reuse the primitives.
+   **Do not** assume one generic table serves both providers: Codex's flow has a
+   materially different external-call shape and needs its own state machine (§2.3).
+6. **Recommended: Phase 1 = minimal affinity-scoped enablement for `shared-local`;
+   Phase 2 = durable PostgreSQL attempt state serving `external` too. Codex
+   poll-lease *resumption* stays gated behind proving provider semantics
+   (PRECONDITION B); until proven, owner death in the approval window is
+   `ambiguous` and the user restarts.**
 
 ---
 
@@ -46,11 +48,9 @@ Throughout, **VERIFIED** means read from the tree at this commit with a
 
 ### 1.1 The constrained HA profile and its fail-closed gate
 
-- The profile constant is `constrained-active-active`
-  (`apps/agor-daemon/src/ha-support.ts:6`).
-- `isConstrainedHa()` is simply `deployment.mode === 'ha'`
-  (`ha-support.ts:20-24`) — there is currently only one HA profile.
-- `isHaFeatureUnavailable()` (`ha-support.ts:33-40`) is the whole decision:
+- Profile constant `constrained-active-active` (`apps/agor-daemon/src/ha-support.ts:6`).
+- `isConstrainedHa()` is just `deployment.mode === 'ha'` (`:20-24`).
+- `isHaFeatureUnavailable()` (`:33-40`):
 
   ```ts
   if (!isConstrainedHa(deployment)) return false;
@@ -58,624 +58,726 @@ Throughout, **VERIFIED** means read from the tree at this commit with a
   return true;                       // <-- everything else: unconditionally gated
   ```
 
-  Note the shape: **`codexAuth` is the only feature with a real condition.**
-  Every other feature — including `codexDeviceAuth` — falls through to the
-  unconditional `return true`.
-- The gate is applied as a `before:{all}` hook over an explicit inventory,
-  `CONSTRAINED_HA_PROCESS_AFFINE_SERVICE_GATES`
-  (`apps/agor-daemon/src/register-hooks.ts:525-539`), which contains
-  `['codex-auth/device', 'codexDeviceAuth']`, `['codex-auth/import', 'codexAuth']`,
-  and `['codex-auth/logout', 'codexAuth']`. It throws `Unavailable` with
+  `codexAuth` is the only feature with a real condition; `codexDeviceAuth` falls
+  through to the unconditional `return true`.
+- Applied as a `before:{all}` hook over `CONSTRAINED_HA_PROCESS_AFFINE_SERVICE_GATES`
+  (`register-hooks.ts:525-539`), throwing `Unavailable` with
   `code: 'HA_FEATURE_UNSUPPORTED'` (`ha-support.ts:26-31`).
 
-This inventory-plus-capability shape is the key enablement lever: **the gates
-already read from capabilities, so making a capability conditionally true opens
-its gates with no change to the hook wiring.**
+**The gates already read from capabilities**, so making a capability
+conditionally true opens its gates with no change to hook wiring.
 
 ### 1.2 The capability flags are typed as literal `false`
 
-`ResolvedDeploymentConfig` (`packages/core/src/config/deployment.ts:55-88`):
+`ResolvedDeploymentConfig` (`deployment.ts:55-88`):
 
 ```ts
 codexCredentialFiles: boolean;   // :74  <-- computed
-codexDeviceAuth: false;          // :75  <-- literal type, not boolean
-processAffineAuth: false;        // :76  <-- literal type, not boolean
+codexDeviceAuth: false;          // :75  <-- literal type
+processAffineAuth: false;        // :76  <-- literal type
 ```
 
-and the values (`deployment.ts:469-472`):
+The *type* is the literal `false`, so assigning `true` is a compile error until
+the type widens. Enablement is necessarily a typed, reviewed change.
+`deployment.test.ts:50-58` pins the resolved object exactly.
 
-```ts
-codexCredentialFiles:
-  executorStorage.user_home !== 'replica-local' && tenantSafeCredentialHome,
-codexDeviceAuth: false,
-processAffineAuth: false,
-```
+### 1.3 `processAffineAuth` has no consumers — delete it
 
-**This is a stronger statement than "hardcoded false".** The *type* is the
-literal `false`, so assigning `true` is a compile error until the type widens to
-`boolean`. That is deliberate: it makes the capability un-flippable by accident,
-and it means enablement is necessarily a reviewed, typed change. `deployment.test.ts:50-58`
-asserts the resolved capability object exactly, so it pins this too.
+Three occurrences repo-wide: type declaration (`deployment.ts:76`), assignment
+(`:472`), test fixture (`ha-support.test.ts:31`). **No `capabilities.processAffineAuth`
+read exists anywhere.** It is absent from the support matrix's prose.
 
-### 1.3 `processAffineAuth` has no consumers — it is vestigial
+It is a documentary placeholder, not a switch. This design **deletes it** rather
+than giving it meaning: narrowly-named per-provider capabilities
+(`codexDeviceAuth`, `claudeOAuth`) express the actual conditions, and a
+general-sounding "process affine auth" flag would invite exactly the
+over-broad reasoning that produced revision 1's error.
 
-Repo-wide, `processAffineAuth` appears exactly three times:
+### 1.4 Blocker: process-local attempt maps
 
-| Site | What it is |
-| --- | --- |
-| `packages/core/src/config/deployment.ts:76` | type declaration (`false`) |
-| `packages/core/src/config/deployment.ts:472` | assignment (`false`) |
-| `apps/agor-daemon/src/ha-support.test.ts:31` | test fixture field |
+**Codex** — `codex-device-auth.ts:263`: `const attempts = new Map<string, DeviceAuthAttempt>()`.
+Attempt holds device auth ID, user code, target identity, status; a
+`setTimeout`-driven `pollTick()` (`:297-330`) polls OpenAI and writes credentials
+only after a local ownership check (`:330`).
 
-There is **no** `deployment.capabilities.processAffineAuth` read anywhere — not
-in `ha-support.ts`, not in `register-hooks.ts`, not in any service. It is also
-absent from the authoritative support matrix's prose
-(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md`), which
-discusses the concept but never names the flag.
+**Claude** (#2317) — `claude-oauth.ts:292`, keyed `` `${tenantId}:${userId}` ``
+(`:343`), holding `verifier` and `state` (`:253-254`), zeroed on completion
+(`:307-308`).
 
-**Conclusion:** `processAffineAuth` is a documentary placeholder, not a switch.
-The brief's hypothesis that it is "a ready-made hook intended to be flipped true
-when the deployment guarantees request affinity" is **not supported by the code**.
-Any affinity-based design must add its own wiring; it should either give this
-flag a real meaning and consumers, or delete it. Leaving an unread capability
-flag in the resolved config is itself a small hazard — it reads like a control
-and is not one.
+Stated intent (`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:253`):
 
-### 1.4 Blocker 1 (VERIFIED): process-local attempt maps
-
-**Codex device auth** — `apps/agor-daemon/src/services/codex-device-auth.ts:263`:
-
-```ts
-const attempts = new Map<string, DeviceAuthAttempt>();
-```
-
-The attempt holds the device auth ID, user code, target identity, and status;
-a `setTimeout`-driven `pollTick()` loop (`:297-330`) polls OpenAI and writes
-credentials only after a local ownership check (`isCurrent`, `:330`). A pruning
-sweep expires overdue attempts (`:290-292`).
-
-**Claude OAuth** — `apps/agor-daemon/src/services/claude-oauth.ts:292` (on
-PR #2317 branch `claude-code-oauth-signin`; not yet on `main`):
-
-```ts
-const attempts = new Map<string, OAuthAttempt>();
-```
-
-keyed `` `${tenantId}:${userId}` `` (`:343`), holding `verifier` and `state`
-(`:253-254`), zeroed on completion (`:307-308`).
-
-The authoritative support matrix already states the intended fix
-(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:253`, Codex
-device auth row):
-
-> Classification: **D** initially; later **P+E** per user.
-> Owner death stops polling and status becomes idle elsewhere. User must request
-> a fresh provider code. **Two replicas can each create a "single" attempt in
-> static HA.**
 > Initial HA disposition: Keep disabled in hosted/multi-tenant HA […] **A future
 > design needs durable attempt generation and a per-user poller lease/fence.
 > Device IDs, codes, authorization codes, and tokens never go to Redis.**
 
-This design follows that stated intent.
+### 1.5 The two flows differ structurally, and it drives the whole design
 
-### 1.5 The two flows are structurally different, and it matters
-
-| | Codex device auth | Claude OAuth (PR #2317) |
+| | Codex device auth | Claude OAuth (#2317) |
 | --- | --- | --- |
 | Grant | RFC 8628 device authorization | authorization-code + PKCE (S256) |
-| Secret in attempt | device auth ID + user code | PKCE `verifier` + `state` |
+| Who generates the PKCE verifier | **the provider** — returned in the poll response (`codex-device-auth.ts:151`) | **the daemon** (`claude-oauth.ts:114`) |
 | Who drives completion | **daemon background poll loop** | **the user's next request** (paste `CODE#STATE`) |
 | Needs a live in-process timer | **Yes** | **No** |
-| Client ID | fixed public `app_EMoamEEZ73f0CkXaXp7hrann` (`codex-device-auth.ts:56`) | fixed public `9d1c250a-…` (`claude-oauth.ts:65`) |
+| Authorization code arrives | mid-poll, unprompted (`:150-156`) | from the user, in a request |
+| Code lifetime | fixed 15 min constant `DEVICE_CODE_LIFETIME_MS` (`:57-58`), applied as `Date.now() + …` (`:435`) | 10 min daemon-side |
+| Client ID | fixed public `app_EMoamEEZ73f0CkXaXp7hrann` (`:56`) | fixed public `9d1c250a-…` (`claude-oauth.ts:65`) |
 
-The asymmetry is the crux. **Claude OAuth is purely request-driven** — three
-calls (`create({})` → `find()` → `create({code})`) with no server-side timer.
-Making it HA-safe requires only that the attempt be *findable*.
+Two consequences that revision 1 under-weighted:
 
-**Codex device auth additionally owns a live poll loop.** Even with durable
-attempt state, exactly one replica must own the polling, or N replicas each poll
-and race to redeem the same device code. That needs a lease, not just a row.
+**(a) Claude is purely request-driven.** Three calls (`create({})` → `find()` →
+`create({code})`) with no server-side timer. Making it HA-safe requires only that
+the attempt be *findable*.
 
-### 1.6 Blocker 2 (VERIFIED): largely already solved
+**(b) Codex receives the authorization code as an unprompted side effect of a
+poll.** `pollDeviceToken()` (`:137-157`) returns `{authorizationCode, codeVerifier}`
+the moment the user approves. That value exists only in the polling replica's
+heap until something durably records it. This is the crux of §2.3: **the
+observation itself may be the consuming event**, and Agor cannot assume
+re-polling reproduces it.
+
+Note also that the Codex `usercode` response parses only `device_auth_id`,
+`user_code`, and `interval` (`:115-128`) — **there is no `expires_in`**. Lifetime
+is the fixed local constant. Any durable design must keep using a fixed lifetime
+(preferably recomputed on the DB clock) and must not invent an `expires_in`.
+
+### 1.6 Credential-file visibility: solved for `shared-local`, declared for `external`
 
 `codexCredentialFiles` (`deployment.ts:469-470`) is true when
-`user_home !== 'replica-local'` **and** `hasTenantSafeExecutorCredentialHome()`,
-which is (`packages/core/src/config/executor-credential-storage.ts:8-15`):
+`user_home !== 'replica-local'` **and** `hasTenantSafeExecutorCredentialHome()`
+(`executor-credential-storage.ts:8-15`):
 
 ```ts
 config.multi_tenancy?.mode !== 'required_from_auth' ||
 config.execution?.executor_storage?.user_home === 'persistent-per-user'
 ```
 
-`user_home` accepts `replica-local` | `shared` | `persistent-per-user`
-(`packages/core/src/config/types.ts:716-740`). HA startup already *refuses to
-boot* without a tenant-safe home (`deployment.ts:375-380`).
-
-A shared credential home is **not hypothetical — it is already provisioned and
-exercised**. `docker-compose.ha.yml:47,157` mounts a named volume
-`agor-ha-user-home` at `/home/agor` on both daemons, and `docker/ha/config.yaml:31`
-declares `user_home: shared`, with the comment:
-
-> One shared execution home for this static smoke profile. This makes auth-file
-> import/logout and Tasks replica-consistent, but is not Cloud's per-user
-> isolation contract. **The device-code poller remains gated.**
-
+HA refuses to boot without a tenant-safe home (`deployment.ts:375-380`).
 Credential path resolution is already replica-independent: the daemon computes
-the target home (`resolveOwnerHomeStore()`,
-`apps/agor-daemon/src/utils/sandbox-context.ts:108-124` →
-`<data_home>/tenants/<tenant>/homes/<user>`), passes it to the executor as
-`CODEX_HOME` (`apps/agor-daemon/src/utils/executor-codex-auth.ts:25-43`), and the
-executor writes `0600` (`packages/executor/src/commands/codex-auth-file.ts:84-85`).
-Nothing in that path is process-affine.
+the target home (`sandbox-context.ts:108-124`), passes `CODEX_HOME`
+(`executor-codex-auth.ts:25-43`), and the executor writes `0600`
+(`packages/executor/src/commands/codex-auth-file.ts:84-85`).
 
-**Therefore: Blocker 2 needs no new mechanism for the supported topologies.**
-It needs (a) generalizing the Codex-specific capability name to cover Claude, and
-(b) an operator-facing storage contract for `persistent-per-user` on Cloud. It is
-a naming and documentation gap, not an architecture gap.
+**What is actually proven, and what is not:**
 
-### 1.7 Redis is fanout-only and is explicitly denied to auth paths
+| Topology | Status |
+| --- | --- |
+| `shared-local` (checked-in Compose HA stack) | **VERIFIED working.** `docker-compose.ha.yml:47,157` mounts named volume `agor-ha-user-home` at `/home/agor` on both daemons; `docker/ha/config.yaml:31` declares `user_home: shared`. The config comment states this "makes auth-file import/logout and Tasks replica-consistent". |
+| `external` / Cloud (`persistent-per-user`) | **PRECONDITION A — declared, not demonstrated.** `AgorExecutorStorageSettings` is explicitly a *"Declarative execution-substrate storage contract"* (`packages/core/src/config/types.ts:728-739`); `persistent-per-user` is described as *"the only mode suitable for user credential homes in a multi-tenant external executor fleet"*. That is a statement of what the operator must supply, **not evidence that any deployment supplies it.** No concrete provisioning of a durable, replica-consistent per-user home was located in this repo. |
+
+**Reconciling this with "one blocker":** the *implementation* blocker is the
+attempt map — no new credential mechanism needs to be built. But Phase 2/3
+enablement for `external` is **gated on PRECONDITION A**, which is a deployment
+fact this repo cannot settle. Revision 1's "already solved" was too strong; it
+was true of the smoke stack and asserted of Cloud.
+
+### 1.7 Redis is fanout-only and explicitly denied to auth paths
 
 - Redis is required in HA but used **solely** as the Socket.IO adapter /
-  `serverSideEmit` relay (`apps/agor-daemon/src/realtime/redis-realtime.ts`;
-  boot fails closed at `:129-130`). It is `ioredis` behind
-  `@socket.io/redis-adapter`; **no generic GET/SET/SETEX/lock surface is exposed
-  to application code.**
-- `REDIS_FEATHERS_DENIED_PATHS`
-  (`apps/agor-daemon/src/utils/realtime-publish.ts:251-273`) explicitly lists
-  `codex-auth/device`, `codex-auth/import`, `codex-auth/logout`, every
-  `mcp-servers/oauth-*`, `user-mcp-oauth-tokens`, `session-tokens`, and
-  `terminals`, under the comment (`:249-250`):
+  `serverSideEmit` relay (`realtime/redis-realtime.ts`; boot fails closed
+  `:129-130`). `ioredis` behind `@socket.io/redis-adapter`; **no generic
+  GET/SET/SETEX/lock surface is exposed to application code.**
+- `REDIS_FEATHERS_DENIED_PATHS` (`utils/realtime-publish.ts:251-273`) lists
+  `codex-auth/*`, every `mcp-servers/oauth-*`, `user-mcp-oauth-tokens`,
+  `session-tokens`, `terminals`, under (`:249-250`):
 
   > Authentication and credential control-plane results must never enter shared
   > Redis, even if a future service accidentally enables publication for them.
 
-- Every other HA-coordinated subsystem coordinates through **PostgreSQL**, not
-  Redis: knowledge-embedding claims
-  (`packages/core/src/db/repositories/knowledge-embedding-work.ts:29-49`),
-  environment-health leases (`repositories/environment-health.ts:26-41`), widget
-  resolution durable claims, gateway listener leases, executor session-token
-  bounded-use. All use the same idiom: atomic conditional `UPDATE` fenced by a
-  `claim_token` + `claim_generation` + DB-clock `expires_at`. There is no leader
-  election and no `SELECT … FOR UPDATE`.
+- All other HA coordination is **PostgreSQL**: knowledge-embedding claims
+  (`repositories/knowledge-embedding-work.ts:29-49`), environment-health leases
+  (`repositories/environment-health.ts:26-41`), widget resolution, gateway
+  listener leases, executor token bounded-use. Same idiom: atomic conditional
+  `UPDATE` fenced by `claim_token` + `claim_generation` + DB-clock expiry. No
+  leader election, no `SELECT … FOR UPDATE`.
 
-**Conclusion: Redis is not a candidate for attempt state.** Using it would mean
-building a new key/value surface, breaching a stated security boundary, and
-diverging from the house coordination pattern — three costs for no benefit over
-PostgreSQL.
+**Redis is not a candidate** and is recorded here only so it is not re-proposed.
 
-### 1.8 The durable-attempt pattern already exists (MCP OAuth)
+### 1.8 The MCP OAuth authority: what it actually seals
 
 `mcp_oauth_pending_flows` (`packages/core/src/db/schema.postgres.ts:1792-1858`)
-is a complete worked example of exactly the record this design needs:
+with `services/mcp-oauth-pending-flow-authority.ts`. Precisely:
 
-- `tenant_id`, `user_id`, `attempt_id` (PK), `status`
-  (`pending`/`exchanging`/`succeeded`/`failed`/`ambiguous`/`expired`).
-- `state_hash` — SHA-256 of the OAuth `state`, **UNIQUE** (`:1834`). The raw
-  state is never a column.
-- `sealed_material` — the PKCE verifier and state, **AES-256-GCM sealed** via
-  `sealMCPOAuthSecret()` (`packages/core/src/db/oauth-secret-envelope.ts`),
-  scrypt-derived key from `AGOR_MASTER_SECRET`, with the tenant/user/server/
-  attempt/generation binding as **AAD** so a moved or retagged row fails to open.
-  Cleared on terminal states.
-- `expires_at` — DB-clock TTL, 10 minutes
-  (`services/mcp-oauth-pending-flow-authority.ts:34`).
-- `exchange_claim_id` — the one-shot fence. Claim is a single atomic
-  `UPDATE … SET status='exchanging', exchange_claim_id=? WHERE state_hash=? AND
-  status='pending' AND expires_at > CURRENT_TIMESTAMP AND is_current=true
-  RETURNING *` (`repositories/mcp-oauth-pending-flows.ts:357-372`). Two racing
-  replicas: exactly one gets a row. Proven by a two-pool race test
-  (`mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`).
-- `maintain()` (`repositories/mcp-oauth-pending-flows.ts:532-575`) expires
-  overdue rows, marks abandoned exchanges `ambiguous` after 2 minutes, and
-  deletes terminal rows after 24h.
-- Tenant scoping via `runWithTenantDatabaseScope(db, tenantId, …)`
-  (`packages/core/src/db/tenant-scope.ts:200-240`), which opens a native
-  transaction and sets the tenant GUC for RLS.
+- **`state` is stored hash-only.** The row's `state_hash` is
+  `fingerprintMCPOAuthState(input.context.state)` (`authority.ts:165`), UNIQUE
+  (`schema.postgres.ts:1834`). **The raw `state` is never sealed and never
+  stored** — it is not a field of the sealed material at all.
+- **`sealed_material`** (`authority.ts:127-148`) contains `pkceVerifier`,
+  **`clientId`, optional `clientSecret`**, the resolved endpoints
+  (`authorizationEndpoint`, `tokenEndpoint`, `metadataUrl`, `redirectUri`,
+  `issuer`, `resourceUri`), `grantGeneration`, config fingerprint, and
+  compatibility flags. `clientId` is *required* by the validator (`:76`) and both
+  client fields are returned to the claiming replica (`:277-278`).
+- Sealed with `sealMCPOAuthSecret()` (`packages/core/src/db/oauth-secret-envelope.ts`)
+  — AES-256-GCM, scrypt-derived key from `AGOR_MASTER_SECRET`, purpose domain
+  `'pending-exchange'`, with tenant/user/server/attempt/generation binding as
+  **AAD** (`authority.ts:149-161`).
+- `expires_at` DB-clock TTL, 10 minutes (`authority.ts:34`).
+- One-shot claim: atomic `UPDATE … SET status='exchanging', exchange_claim_id=?
+  WHERE state_hash=? AND status='pending' AND expires_at > CURRENT_TIMESTAMP AND
+  is_current=true RETURNING *` (`repositories/mcp-oauth-pending-flows.ts:357-372`).
+  Two-pool race test: `mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`.
+- `maintain()` (`repositories/…:532-575`) expires overdue, marks abandoned
+  exchanges `ambiguous` after 2 min, deletes terminal rows after 24h.
+- Tenant scope via `runWithTenantDatabaseScope()`
+  (`packages/core/src/db/tenant-scope.ts:200-240`) — native transaction + tenant
+  GUC for RLS.
 
-**This is the blueprint.** Phase 2 below is largely "instantiate this table
-shape for provider sign-in", not "design a durable OAuth store".
+**Reusable primitives:** the envelope, the atomic claim idiom, tenant scoping,
+DB-clock TTL, `maintain()`. Reuse these. The *table* and the *state machine* are
+flow-specific — see §2.3.
 
-### 1.9 Why MCP OAuth stays gated, and why that does not apply here
+### 1.9 Why MCP OAuth is still gated (corrected)
 
-MCP OAuth has a durable table and is *still* gated. The residual reason is
-process-local **Dynamic Client Registration** state
-(`oauth-mcp-transport.ts:415-418`):
+**Revision 1 claimed MCP OAuth stays gated because its dynamically-registered
+`client_id`/`client_secret` is process-local. That claim is REFUTED.** The
+durable row seals `clientId` and `clientSecret` (`authority.ts:143-145`), the
+validator requires `clientId` (`:76`), and the claiming replica receives both
+(`:277-278`). A replica that wins the claim therefore *does* hold the client
+credentials. `dynamicClientCache` (`packages/core/src/tools/mcp/oauth-mcp-transport.ts:415`)
+is a registration-time optimization behind a `reuseLocalCache` flag (`:525`); it
+is not on the durable claim path, and no daemon source file references it.
 
-```ts
-// Cache for dynamically registered clients (per authorization server)
-const dynamicClientCache = new Map<string, { client_id; client_secret?; redirect_uri }>();
-```
+The actual reason is stated in the support matrix
+(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:250-252`):
 
-The sealed material does not carry the dynamically registered `client_id` /
-`client_secret`, so a replica that wins the durable claim may not hold the client
-credentials needed to complete the exchange.
+> The durable prerequisite is implemented after enforced offline migration `0078`,
+> a shared stable `AGOR_MASTER_SECRET`, and whole-cohort rollout, **but the
+> current constrained profile still gates MCP OAuth pending separate
+> activation.** […] Legacy providers require explicit per-server compatibility;
+> DCR is explicit fallback.
 
-**Codex and Claude have no DCR.** Both use a single fixed, public, compile-time
-client ID (`codex-device-auth.ts:56`; `claude-oauth.ts:65`). Every replica is
-identically configured to talk to the provider.
+and for the token authority (`:251`):
 
-This is the most consequential finding in this document: **provider sign-in is
-strictly easier to make HA-safe than MCP OAuth**, and it is blocked only by the
-attempt map, not by the harder problem that keeps MCP OAuth gated.
+> The active-active authority is implemented on PostgreSQL after `0078` […] **but
+> the constrained profile still gates the browser flow pending separate
+> activation.**
+
+So MCP OAuth is **technically durable and deliberately not yet activated** — a
+certification/rollout decision, not an unsolved mechanism.
+
+**What this means for provider sign-in.** The correct comparison is scope of
+client contract, not "MCP is blocked":
+
+| | MCP OAuth | Codex / Claude sign-in |
+| --- | --- | --- |
+| Client identity | per-server; may be dynamically registered (DCR as explicit fallback) | one fixed, public, compile-time client ID per provider |
+| Per-server config | issuer/resource/metadata/endpoint discovery, versioned config fingerprint, per-server compatibility modes | none — endpoints are constants |
+| Secret to seal | verifier **+ client credentials + resolved endpoints** | Claude: verifier only. Codex: provider-supplied verifier + authorization code |
+| Activation surface | every MCP server a user can add | two known providers |
+
+Provider sign-in is **narrower** — a fixed, non-negotiated client contract with
+no discovery and no DCR — which is why its durable record is simpler and its
+certification surface smaller. That is a genuine argument for it being easier to
+activate. It is **not** an argument that MCP is technically blocked and sign-in
+is not.
 
 ### 1.10 Ingress affinity is already mandatory
 
-- HA **refuses to boot** without it (`deployment.ts:349-353`):
-  `'Config error: HA requires deployment.ha.ingress_affinity: true for Engine.IO polling'`.
-- The resolved topology types it as literally `ingressAffinity: true` in both
-  variants (`deployment.ts:86-87`).
-- The browser talks to the daemon over **Socket.IO**
-  (`packages/core/src/api/index.ts:1413`, `transports: ['websocket','polling']`
-  at `:1384`), and the Claude sign-in pane calls
-  `client.service('claude-auth/oauth')`
-  (`ClaudeOAuthSignIn.tsx:44-52`) — so all three calls of one sign-in ride **one
-  sticky connection to one replica**.
-- Caveat, stated in the ops guidance
-  (`docs/internal/daemon-ha-redis-realtime-2026-08-07.md:92-93`): affinity is
-  configured for the `/socket.io/` path only — *"leave REST unsticky"*. A live
+- HA refuses to boot without it (`deployment.ts:349-353`).
+- Resolved topology types it literally `ingressAffinity: true` in both variants
+  (`:86-87`).
+- The browser uses Socket.IO (`packages/core/src/api/index.ts:1413`,
+  `transports: ['websocket','polling']` `:1384`); the sign-in pane calls
+  `client.service('claude-auth/oauth')` (`ClaudeOAuthSignIn.tsx:44-52`) — all
+  three calls of one sign-in ride **one sticky connection to one replica**.
+- Caveat (`docs/internal/daemon-ha-redis-realtime-2026-08-07.md:92-93`): affinity
+  is configured for `/socket.io/` only — *"leave REST unsticky"*. A live
   WebSocket never migrates; after daemon loss the client makes a **new**
   connection which may land anywhere.
-- There is an accepted precedent for shipping a feature on exactly this
-  contract: web terminals (`apps/agor-daemon/src/terminal-capability.ts:25-32`)
-  are enabled only when `execution === 'shared-local' && sharedFilesystem &&
-  ingressAffinity`, with the documented failure semantics in
-  `context/explorations/web-terminal-ownership-ha.md`: *"Owner loss ends the Agor
-  attachment. The UI displays Disconnected and requires an explicit Reconnect."*
+- Precedent: web terminals (`terminal-capability.ts:25-32`) ship on exactly this
+  contract, with *"Owner loss ends the Agor attachment… requires an explicit
+  Reconnect"* (`context/explorations/web-terminal-ownership-ha.md`).
 
 ---
 
-## 2. Blocker 1 — attempt state: options
+## 2. Design
 
-### Option A — affinity-scoped, owner-fenced in-process attempt
+### 2.1 Phase 1 — minimal affinity-scoped enablement (`shared-local` only)
 
-Keep the `attempts` map in process. Make the capability conditionally true when
-the deployment's topology guarantees affinity, and make owner loss an explicit,
-visible "start over" rather than a silent wrong answer.
+Sticky Socket.IO already routes all three calls of a sign-in to one replica.
+Until the socket reconnects, the existing in-process map is **already correct**.
+So Phase 1 needs almost nothing:
 
-**DESIGN sketch**
+1. Widen `codexDeviceAuth` / add `claudeOAuth` to `boolean`; compute as
+   `topology.execution === 'shared-local' && topology.ingressAffinity &&
+   executorCredentialFiles`.
+2. Delete `processAffineAuth` (§1.3).
+3. On reconnect to a replica with no live attempt, `find()` already returns "no
+   attempt" naturally (empty map) — surface it as **"sign-in lost, start over"**
+   in the UI, matching the terminal Reconnect contract.
 
-1. Widen `codexDeviceAuth` / add `claudeOAuth` from literal `false` to `boolean`
-   in `ResolvedDeploymentConfig`.
-2. Compute them from real guarantees, mirroring `terminal-capability.ts`:
-   `topology.ingressAffinity === true && topology.execution === 'shared-local'
-   && codexCredentialFiles`. (`shared-local` is required because Codex's poller
-   must write the credential file from the replica that owns the poll.)
-3. Stamp each attempt with the daemon **boot ID** and return it in the status
-   payload. A `find()`/`create({code})` arriving at a replica whose boot ID does
-   not match returns a distinct, non-scary `attempt_not_on_this_replica` status,
-   and the UI restarts the sign-in — the same UX contract as terminal Reconnect.
-4. Drain handling: on `SIGTERM`, cancel live attempts and push a terminal status
-   before the replica leaves the pool.
+**Explicitly dropped as over-engineering:** daemon boot-ID stamping and
+`SIGTERM` attempt-drain machinery. Neither buys anything the empty-map path does
+not already give, and both add protocol surface to a stopgap.
 
-**Pros.** Small and well-precedented; no schema, no migration, no new secret
-storage. **Keeps the PKCE verifier in-process, preserving the current security
-contract exactly** — no new place for a verifier to live. Ships for the
-`shared-local` topology, which is the checked-in HA smoke stack.
+**One narrow refinement is still required** (see push-back note in §7): the
+attempt key is `` `${tenantId}:${userId}` `` (`claude-oauth.ts:343`) with **no
+attempt identity**. If a user starts a sign-in on replica A, then reconnects to
+replica B that still holds an *older, unpruned* attempt for the same key,
+`find()` returns B's stale status and `submit()` validates the pasted code
+against B's stale `state` — failing as "wrong state" rather than "start over"
+(`claude-oauth.ts:392-407`). Fix by returning an opaque `attempt_id` to the
+client and requiring it to be echoed on `find`/`submit`; a mismatch means "start
+over". This is a few lines and removes a genuinely confusing failure, unlike
+boot-ID.
 
-**Cons.** Does **not** work for `execution_topology: external` (Cloud's intended
-shape), because affinity is only asserted for `/socket.io/` — a REST or
-external-callback entry can land anywhere. Rolling deploys become user-visible:
-every replica restart aborts in-flight sign-ins. Affinity is an *operational*
-promise from ingress config, and the daemon cannot verify it; a misconfigured
-ingress silently degrades to "sometimes works", which is a worse failure mode
-than the honest 503 today. Two replicas can still each create a "single" attempt
-if the client reconnects mid-flow (the matrix's stated concern,
-`process-affine-ha-support-matrix-2026-08-07.md:253`).
+**Risk: medium.** Correctness depends on operator ingress config the daemon
+cannot verify; a misconfigured ingress degrades to "sometimes works", which is
+worse than today's honest 503. Mitigate by scoping strictly to `shared-local`
+and documenting loudly. Phase 1 does **not** serve `external`.
 
-### Option B — durable attempt state in PostgreSQL (sealed), + poller lease
+### 2.2 Phase 2 — durable attempt state (shared primitives, per-flow tables)
 
-Instantiate the `mcp_oauth_pending_flows` pattern for provider sign-in.
+Reuse the §1.8 primitives: `sealMCPOAuthSecret`/`openMCPOAuthSecret` under a
+**new purpose domain** (`'provider-signin'`, so envelopes cannot be cross-used
+with MCP), the atomic-claim idiom, `runWithTenantDatabaseScope()`, DB-clock TTL,
+`maintain()`.
 
-**DESIGN sketch** — new table `provider_auth_pending_flows`:
+Common columns for both providers:
 
 | Column | Purpose |
 | --- | --- |
 | `tenant_id`, `user_id` | tenant scoping / RLS |
-| `attempt_id` (PK) | identity |
-| `provider` | `codex` \| `claude` — one table, both flows |
-| `state_hash` UNIQUE | SHA-256 of `state` (Claude); for Codex, of the device auth ID |
-| `sealed_material` | AES-256-GCM sealed `{verifier, state}` / `{deviceAuthId, userCode}`, AAD-bound to tenant+user+provider+attempt+generation |
-| `status` | `pending`/`exchanging`/`succeeded`/`failed`/`ambiguous`/`expired` |
-| `attempt_generation` | fences an older attempt against a newer one for the same user |
-| `expires_at` | DB-clock TTL (10 min Claude; provider `expires_in` for Codex) |
-| `exchange_claim_id` | one-shot exchange fence |
-| `poll_lease_owner`, `poll_lease_expires_at` | **Codex only** — single-poller lease |
-| `created_at`/`updated_at`/`finished_at` | lifecycle + `maintain()` pruning |
+| `attempt_id` (PK) | identity; echoed to the client |
+| `provider` | `codex` \| `claude` |
+| `attempt_generation` | monotonic per `(tenant_id, user_id)`; fences superseded attempts |
+| `is_current` | exactly one live attempt per user |
+| `status` | per-flow state machine (§2.3, §2.4) |
+| `expires_at` | DB-clock TTL — Claude 10 min; Codex fixed 15 min (§1.5), **not** a provider `expires_in` |
+| `sealed_material` | AES-256-GCM, AAD-bound; **contents differ per provider** |
+| `claim_id` | one-shot fence for the unreplayable step |
+| `created_at`/`updated_at`/`finished_at` | lifecycle + prune |
 
-- Reuse `sealMCPOAuthSecret()` / `openMCPOAuthSecret()` with a **new purpose
-  domain** (e.g. `'provider-signin'`) so envelopes cannot be cross-used between
-  MCP OAuth and provider sign-in.
-- Claude exchange = the existing atomic claim: `UPDATE … SET status='exchanging',
-  exchange_claim_id=? WHERE state_hash=? AND status='pending' AND expires_at >
-  CURRENT_TIMESTAMP RETURNING *`. Loser does not exchange.
-- Codex polling = a renewable lease (the `environment-health.ts:26-41` idiom).
-  Each replica's ticker tries to claim expired leases; exactly one polls. On
-  owner death another replica picks the lease up within one lease period and
-  **resumes polling the same device code** — a genuine availability improvement
-  over Option A, not just parity.
-- Credential write on success goes through the existing, already-replica-agnostic
-  executor path (§1.6). Requires `codexCredentialFiles` — i.e. a
-  non-`replica-local` home — which is orthogonal and already enforced.
-- Follow the MCP precedent on ambiguity: if a replica dies after the provider may
-  have consumed the code, the row becomes `ambiguous` and **is never replayed**.
+**`state_hash` (Claude only), UNIQUE.** Following the MCP authority exactly:
+**seal `{verifier}` only; store `state` as a hash and never in sealed material.**
+Validation compares `sha256(pasted_state)` against `state_hash`. This keeps the
+raw CSRF token out of the ciphertext entirely and matches `authority.ts:165`.
 
-**Pros.** Works for **both** topologies including `external`. Survives replica
-loss and rolling deploys. Matches the stated intent at
-`process-affine-ha-support-matrix-2026-08-07.md:253` ("durable attempt generation
-and a per-user poller lease/fence") and the house PostgreSQL-claims pattern. One
-table serves both providers.
+**Do not force one table on both flows.** Codex needs `poll_lease_owner` /
+`poll_lease_expires_at` and an `approval_observed` state that Claude has no
+analogue for; Claude needs `state_hash` that Codex has no analogue for. A single
+table would carry a union of mutually-exclusive nullable columns and a status
+enum whose values are only valid for one provider. Two tables (or one table with
+a genuinely shared core and a per-provider detail) with **shared primitives and
+separate state machines** is the honest shape.
 
-**Cons — and one must be called out explicitly.** This **breaks the current
-in-process-only security contract for the PKCE verifier.** Today the verifier
-exists only in one process's heap and is zeroed on completion
-(`claude-oauth.ts:307-308`); afterwards it is a sealed row in a shared database.
-Sealing with AAD binding makes that acceptable — it is precisely what MCP OAuth
-already does for the same class of secret — but it is a real change in blast
-radius and must be reviewed as one, not waved through by analogy. Also: requires
-a migration and whole-cohort rollout; hard-depends on a fleet-shared
-`AGOR_MASTER_SECRET`; and SQLite/standalone must retain the local Map, so the
-service carries two code paths (again, as MCP OAuth already does).
+### 2.3 Codex fenced state machine (the hard case)
 
-### Option C — Redis-hosted attempt state
+Two non-transactional external calls: the poll (`codex-device-auth.ts:137-157`)
+and the exchange (`:165-191`). The authorization code arrives *inside* the poll
+response, unprompted.
 
-**Rejected.** §1.7: Redis exposes no key/value surface to application code, auth
-paths are explicitly denied the relay, the matrix repeats "never go to Redis" for
-device codes and authorization codes, and nothing else in the system coordinates
-through Redis. Recorded here only so it is not re-proposed.
+States: `pending → approval_observed → exchanging → persisting → succeeded`,
+with terminals `failed` / `expired` / `ambiguous` / `superseded`.
+
+| # | Transition | Atomic predicate | Durable secret after commit | Crash in this window | Replay? |
+| --- | --- | --- | --- | --- | --- |
+| 1 | *(create)* → `pending` | In one tx: `UPDATE … SET is_current=false, status='superseded' WHERE tenant/user AND is_current`, then `INSERT` with `attempt_generation = prev+1`, `expires_at = now() + 15min` (DB clock) | `deviceAuthId`, `userCode` sealed | Nothing issued yet; user retries | n/a |
+| 2 | acquire poll lease | `UPDATE … SET poll_lease_owner=?, poll_lease_expires_at=now()+L WHERE attempt_id=? AND status='pending' AND is_current AND (poll_lease_expires_at IS NULL OR poll_lease_expires_at <= now()) RETURNING *` | unchanged | No owner polls until lease is free; attempt still valid | Lease re-acquire is safe |
+| 3 | `pending` → `approval_observed` | `UPDATE … SET status='approval_observed', sealed_material=? WHERE attempt_id=? AND status='pending' AND attempt_generation=? AND poll_lease_owner=? AND poll_lease_expires_at > now()` | + `authorizationCode`, `codeVerifier` (both provider-supplied) | **DANGEROUS — see below** | **No** |
+| 4 | `approval_observed` → `exchanging` | one-shot: `UPDATE … SET status='exchanging', claim_id=? WHERE attempt_id=? AND status='approval_observed' AND is_current AND attempt_generation=?` | unchanged | Abandoned `exchanging` → `ambiguous` after timeout | **No** — authorization codes are single-use |
+| 5 | `exchanging` → `persisting` | `UPDATE … SET status='persisting', sealed_material=? WHERE attempt_id=? AND status='exchanging' AND claim_id=?` | tokens sealed (separate purpose domain), code cleared | Crash before commit → `ambiguous`; tokens lost, user restarts | **No** |
+| 6 | `persisting` → `succeeded` | re-validate `(attempt_generation, claim_id, status='persisting', is_current)` **immediately before** the credential write **and again before** the user-method mutation; then `UPDATE … SET status='succeeded', sealed_material=NULL` | cleared | See §2.5 filesystem gap | Write is idempotent (same tokens, same path) |
+
+**Transition 3 is the one that must not over-promise.** The provider returns the
+authorization code in the poll response. Whether that response is
+single-delivery — i.e. whether *observing* approval consumes it — is
+**PRECONDITION B, unverified**. Therefore:
+
+- **Default (until B is proven): lease takeover of a `pending` attempt whose
+  lease expired transitions it to `ambiguous`, not back to polling.** The user
+  restarts sign-in. Owner death anywhere in the approval window is a restart, not
+  a transparent resume.
+- Rationale: if re-polling does *not* reproduce the code, a resuming owner silently
+  hangs until expiry; if the code *can* be delivered twice, two owners may both
+  proceed. Neither is acceptable without evidence.
+- Resumable polling (a genuine availability win) may be enabled **only** after B
+  is proven, and even then only for a `pending` attempt that has never reached
+  `approval_observed`.
+- Make lease expiry rare rather than relying on takeover: short renew interval
+  (~15 s) against a generous lease (~60 s), well inside the 15-minute window.
+
+**Retry policy.** The existing `exchangeWithOneRetry` (`:199`) must stay
+*within a single claim holder* — one process, one `claim_id`. A retry must never
+cross owners, because the second attempt cannot know whether the first consumed
+the code.
+
+### 2.4 Claude state machine (the easy case)
+
+`pending → exchanging → persisting → succeeded`; terminals as above. No lease —
+nothing polls.
+
+| # | Transition | Atomic predicate | Durable secret | Replay? |
+| --- | --- | --- | --- | --- |
+| 1 | *(create)* → `pending` | supersede-then-insert as Codex #1 | `{verifier}` sealed; `state_hash` stored | n/a |
+| 2 | `pending` → `exchanging` | one-shot: `UPDATE … SET status='exchanging', claim_id=? WHERE state_hash=? AND status='pending' AND is_current AND expires_at > now() RETURNING *`; the pasted state is validated by hash comparison **before** the claim | unchanged | **No** |
+| 3 | `exchanging` → `persisting` | as Codex #5 | tokens sealed | **No** |
+| 4 | `persisting` → `succeeded` | as Codex #6 | cleared | idempotent |
+
+Validating the pasted state by hash *before* reserving the attempt preserves the
+current ordering (`claude-oauth.ts:404-407`), where a malformed or wrong-state
+paste is rejected without burning the attempt.
+
+### 2.5 Durable logout and replacement fencing
+
+Today ownership is process-local `isCurrent()` — `attempts.get(key) === attempt`
+(`claude-oauth.ts:294-297`), re-checked after the exchange (`:426-428`) and again
+inside `persist()` immediately before the write (`:346-350`). In HA every one of
+those becomes a **durable** check.
+
+**Invalidation is atomic and generation-based.** Both "logout" and "start a new
+attempt" run, in one transaction:
+
+```sql
+UPDATE provider_auth_attempts
+   SET is_current = false, status = 'superseded', sealed_material = NULL
+ WHERE tenant_id = ? AND user_id = ? AND provider = ? AND is_current;
+```
+
+Logout additionally clears the stored auth method and deletes the credential
+file.
+
+**Every stale worker re-validates before each side effect.** A worker holding an
+in-flight claim must re-read and confirm `(attempt_generation, claim_id,
+status, is_current)` **immediately before the credential write** and **again
+immediately before the user-method mutation** — the two mutations are separate
+and a supersede can land between them. On mismatch it aborts and performs the
+cleanup below.
+
+**The filesystem↔DB transaction gap is real and must be stated.** The credential
+write is a file operation on the executor; it is not in the database
+transaction. A worker can therefore complete a write for a generation that was
+superseded microseconds earlier. Defined behavior:
+
+1. A worker whose post-write re-validation fails **immediately deletes the
+   credential file it just wrote** — it knows it wrote it and knows it lost.
+2. Because step 1 can itself crash, `logout` is **not** complete on its DB
+   commit alone. It records a `revoked_at` marker and a **second delete pass**
+   runs after the maximum `persisting` claim lifetime has elapsed, sweeping any
+   file written by a worker that lost the race and died before cleaning up.
+3. `maintain()` treats a `persisting` row older than that lifetime as
+   `ambiguous` and enqueues the same delete pass.
+4. Consequence to document: for a bounded window after logout, a superseded
+   credential file may exist on disk. It is deleted by pass 2. **Local deletion
+   is not provider-side revocation** in either case — the same caveat MCP OAuth
+   already carries.
 
 ---
 
-## 3. Blocker 2 — credential visibility: options
+## 3. Credential visibility: options
 
 ### Option A — shared / per-user executor credential home (RECOMMENDED)
 
-Already implemented and already exercised (§1.6). Nothing to build for
-`shared-local`. For Cloud (`external` + `required_from_auth`), the requirement is
-already enforced at boot: `user_home: persistent-per-user`
-(`deployment.ts:375-380`).
-
-**Remaining work is not code:** an operator-facing storage contract stating that
-`persistent-per-user` must be backed by storage that presents the same per-user
-home to every replica (RWX PVC / NFS / per-user volume), mounted at the same
-path. **UNVERIFIED / open:** the repo documents the *contract* but no concrete
-Cloud provisioning of `persistent-per-user` was found — only the `shared` Compose
-smoke stack. Cloud's actual backing store must be confirmed with whoever owns
-that deployment before Phase 3 is scoped.
+Nothing to build for `shared-local` (§1.6, VERIFIED). For `external` the
+requirement is already enforced at boot (`deployment.ts:375-380`), but the
+backing store is **PRECONDITION A** — a declarative contract
+(`types.ts:728-739`), not demonstrated provisioning. Must be confirmed with the
+deployment owner before Phase 3 is scoped: durable, replica-consistent,
+per-tenant/per-user home at a stable path (RWX PVC / NFS / per-user volume).
 
 ### Option B — credentials in encrypted DB, materialized per session
 
-Store the provider credential (access + refresh token) sealed in PostgreSQL and
-write it to the executor home at session start.
-
-**Pros.** Removes the shared-filesystem requirement entirely; would let
-`user_home: replica-local` work; centralizes revocation.
-
-**Cons.** Substantially larger. The provider CLIs **own** these files — Claude
-Code and Codex both refresh their tokens in place, so the DB copy goes stale and
-Agor would need read-back/reconciliation, or would clobber a refreshed token.
-Materializing a credential into a workspace on every session start widens
-exposure rather than narrowing it. Today the DB deliberately stores only the
-*method* identifier, never token material
-(`packages/core/src/db/schema.sqlite.ts:1041`) — this reverses a standing design
-decision.
-
-**Verdict: not now.** Revisit only if a topology genuinely cannot provide a
-consistent per-user home.
+**Not now.** The provider CLIs *own* these files and refresh tokens in place, so
+a DB copy goes stale or clobbers a refreshed token. Materializing credentials
+into a workspace on every session start widens exposure. The DB today
+deliberately stores only the auth *method*, never token material
+(`packages/core/src/db/schema.sqlite.ts:1041`). Revisit only if a topology
+genuinely cannot provide a consistent per-user home.
 
 ---
 
 ## 4. Enablement mechanism
 
-The gates are already capability-driven, so enablement is mostly typing and
-computation — plus deleting a misleading flag.
+1. Widen the literal types (`deployment.ts:74-76`): `codexDeviceAuth` → `boolean`;
+   add `claudeOAuth: boolean`.
+2. Rename `codexCredentialFiles` → `executorCredentialFiles` (same computation).
+   It already gates Claude in #2317 — correct behavior under a misleading name.
+3. **Delete `processAffineAuth`** (§1.3).
+4. `claudeAuth`/`claudeOAuth` feature keys and gate entries are **already added
+   by #2317** (`ha-support.ts`; `register-hooks.ts` +`['claude-auth/oauth','claudeOAuth']`,
+   `['claude-auth/logout','claudeAuth']`). This design builds on that.
+5. Extend `isHaFeatureUnavailable()` so `codexDeviceAuth` and `claudeOAuth` read
+   their capabilities instead of falling through to `return true`.
+6. Shared executor plumbing already de-duplicated by #2317
+   (`utils/executor-credential-auth.ts`,
+   `packages/executor/src/commands/credential-file-io.ts`). Reuse it. Attempt
+   *storage primitives* are shared; *state machines* are not (§2.2).
 
-1. **Widen the literal types** in `ResolvedDeploymentConfig`
-   (`deployment.ts:74-76`): `codexDeviceAuth: false` → `boolean`; add
-   `claudeOAuth: boolean`.
-2. **Generalize the credential-file capability name.** `codexCredentialFiles`
-   already gates Claude in PR #2317 — `ha-support.ts` there maps *both*
-   `codexAuth` and `claudeAuth` onto `capabilities.codexCredentialFiles`. That is
-   correct behavior under a misleading name. Rename to
-   `executorCredentialFiles` (keeping the same computation) so the next provider
-   does not have to read Codex's name to understand its own gate.
-3. **Resolve `processAffineAuth`.** It has no consumers (§1.3). Either give it a
-   real definition and readers (Phase 1) or delete it. Do not leave an unread
-   flag that looks like a control.
-4. **Add the `claudeOAuth` feature key** to `HA_UNSUPPORTED_FEATURES` and the
-   gate inventory — **already done by PR #2317**
-   (`ha-support.ts` +`claudeAuth`/`claudeOAuth`; `register-hooks.ts`
-   +`['claude-auth/oauth','claudeOAuth']`, `['claude-auth/logout','claudeAuth']`).
-   This design **builds on that**; it does not redo it.
-5. **Extend `isHaFeatureUnavailable()`** so `codexDeviceAuth` and `claudeOAuth`
-   read their capabilities instead of falling through to `return true`.
-6. **One implementation, both providers.** PR #2317 already de-duplicated the
-   executor plumbing (`utils/executor-credential-auth.ts`,
-   `packages/executor/src/commands/credential-file-io.ts`). The attempt store
-   should likewise be one module with a `provider` discriminator, not two.
-
-**Tests to update** (all currently pin the closed state):
-`apps/agor-daemon/src/ha-support.test.ts:116-138` (asserts the exact
-`HA_UNSUPPORTED_FEATURES` key list, and that `codexDeviceAuth` is unavailable);
-`packages/core/src/config/deployment.test.ts:50-58` (asserts the exact resolved
-capability object); `register-hooks.test.ts:386`. Add negative coverage: gates
-must still close when the enabling condition is absent.
+Tests currently pinning the closed state: `ha-support.test.ts:116-138`,
+`deployment.test.ts:50-58`, `register-hooks.test.ts:386`.
 
 ---
 
-## 5. Security review checklist
+## 5. Security review
 
-Any implementation must satisfy all of these before enablement ships.
+### 5.1 Secret handling
 
-**Secret handling**
-- [ ] PKCE verifier, `state`, device codes, authorization codes, and tokens are
-      never logged, never returned to the client, and never enter an agent/LLM
-      context (the current services already assert this — `claude-oauth.ts:29-30`).
-- [ ] Under Option B, the verifier is sealed with AES-256-GCM under a **distinct
-      purpose domain** from MCP OAuth, AAD-bound to tenant+user+provider+attempt+
-      generation, so a row cannot be replayed under a different binding.
-- [ ] Raw `state` is stored only as a SHA-256 hash in an indexed column; the
-      unique index is on the hash.
-- [ ] Sealed material is cleared on every terminal status.
-- [ ] `state` comparison stays constant-time (`claude-oauth.ts:160`).
-- [ ] Explicitly confirm these paths stay in `REDIS_FEATHERS_DENIED_PATHS`
-      (`realtime-publish.ts:251-273`) — and **add `claude-auth/oauth` and
-      `claude-auth/logout`, which are absent from that set on PR #2317.**
+- [ ] Verifiers, `state`, device codes, authorization codes, and tokens never
+      logged, never returned to the client, never in agent/LLM context
+      (`claude-oauth.ts:29-30`).
+- [ ] Claude: seal `{verifier}` only; store `state_hash`, never raw `state`
+      (matching `authority.ts:165`).
+- [ ] Distinct seal purpose domain (`'provider-signin'`) from MCP's
+      `'pending-exchange'`; separate domain again for transiently sealed tokens.
+- [ ] AAD binds tenant+user+provider+attempt+generation; a moved or retagged row
+      fails to open.
+- [ ] Sealed material cleared on every terminal status.
+- [ ] Add `claude-auth/oauth` and `claude-auth/logout` to
+      `REDIS_FEATHERS_DENIED_PATHS`. **Gap found in this review, best fixed on
+      #2317.** `mayEnterRedisRelay()` (`realtime-publish.ts:275-282`) is
+      **default-allow**; all three Codex counterparts are denied (`:268-270`) but
+      the Claude equivalents were not added. Not a confirmed leak — payloads are
+      status metadata and `claude-auth/logout` emits `patched` by design
+      (`register-services.ts:742-743`) — but the denied set is defense-in-depth
+      (`:249-250`), and HA enablement is what makes the omission load-bearing.
 
-      *Gap found during this review, and worth fixing on #2317 rather than here.*
-      `mayEnterRedisRelay()` (`realtime-publish.ts:275-282`) is **default-allow** —
-      a path is relayed unless it is explicitly denied. All three Codex
-      counterparts (`codex-auth/device`, `codex-auth/import`, `codex-auth/logout`)
-      *are* denied (`:268-270`); the Claude equivalents were not added. This is a
-      parity gap, not a confirmed leak: `claude-auth/logout` deliberately emits
-      `patched` (`register-services.ts:742-743`) and the oauth service returns
-      status metadata only — token material and the verifier are never in a
-      response (`claude-oauth.ts:29-30`). But the denied set exists precisely as
-      defense-in-depth "even if a future service accidentally enables publication
-      for them" (`:249-250`), and enabling these endpoints in HA is exactly the
-      change that makes the omission load-bearing.
+### 5.2 Blast radius of persisting secrets (expanded)
 
-**Tenant / user isolation**
-- [ ] Every read and write goes through `runWithTenantDatabaseScope()`; no
-      unscoped query on the attempt table.
+Persisting attempt material is a **real increase in blast radius**, not a
+formality. Sealing with AAD narrows misuse of a *stolen row*; it does nothing
+about the key, the backups, or the decrypt window.
+
+- [ ] **Master-secret rotation.** `AGOR_MASTER_SECRET` is scrypt-derived per
+      envelope with a random salt, so rotation is not transparent. Define: dual-key
+      read (try new, fall back to old) during a rotation window, and — because
+      attempt rows are short-lived (10–15 min) — **prefer draining over
+      re-encrypting**: stop issuing attempts, let the TTL expire the table, then
+      cut over. Persisted *tokens* (if §2.3 step 5 is adopted) live minutes, not
+      months, so the same drain applies. Document that a rotation with no drain
+      strands unopenable rows, which must fail closed to `ambiguous`, never
+      plaintext.
+- [ ] **Backups retain decryptable rows.** A database backup taken mid-flow
+      contains sealed verifiers/codes/tokens that remain decryptable for as long as
+      the master secret is valid — *far* longer than the 15-minute TTL. Rotation
+      policy and backup retention must be considered together; state the effective
+      exposure window as `max(backup retention, secret lifetime)`, not the TTL.
+- [ ] **Least privilege.** The attempt table should be readable/writable only by
+      the daemon role; no analytics/reporting/read-replica role should hold
+      `SELECT` on `sealed_material`. Confirm RLS policy plus explicit column or
+      table grants, and that the tenant GUC is required even for tenant `default`
+      (the pattern used by the GitHub install-state table).
+- [ ] **Plaintext lifetime after decrypt.** Once opened, the verifier/code/tokens
+      are ordinary heap strings. Keep the decrypt as late and as narrow as
+      possible; do not attach opened material to long-lived objects, logs, error
+      payloads, or Feathers context; zero references on completion as the current
+      in-memory code already does (`claude-oauth.ts:307-308`).
+- [ ] **Mixed / missing key across the fleet.** A replica without
+      `AGOR_MASTER_SECRET`, or with a different one, must **fail closed** — refuse
+      to seal or open, mark `ambiguous`, and never fall back to plaintext (the
+      SQLite dev fallback in `packages/core/src/db/encryption.ts` must not be
+      reachable in HA). A partially-keyed fleet is a rollout error and should be
+      loud, not silently degraded.
+- [ ] Reconfirm at review time that persisting the verifier is still judged worth
+      it versus Phase 1's in-process-only contract. This is a deliberate change of
+      contract, not an implementation detail.
+
+### 5.3 Tenant / user isolation
+
+- [ ] Every read and write via `runWithTenantDatabaseScope()`; no unscoped query.
 - [ ] An attempt is bound to `(tenant_id, user_id)` and can only be found,
-      claimed, or completed by that same identity — a replica must not complete
-      an attempt for a different user because the row happened to be visible.
-- [ ] Cross-tenant negative tests, per CLAUDE.md's multi-tenancy rule and
-      mirroring `mcp-oauth-pending-flow-authority.postgres.test.ts:228-293`.
-- [ ] Credential write still targets the caller's own resolved home; confirm
-      `required_from_auth` + non-`persistent-per-user` remains refused at boot.
+      claimed, or completed by that identity.
+- [ ] Cross-tenant and cross-user negative tests, mirroring
+      `mcp-oauth-pending-flow-authority.postgres.test.ts:228-293`.
+- [ ] Credential write targets the caller's own resolved home; `required_from_auth`
+      + non-`persistent-per-user` stays refused at boot.
 
-**Lifecycle**
-- [ ] Short TTL on DB clock (`CURRENT_TIMESTAMP`), never application clock.
-- [ ] `maintain()` sweep: expire overdue, mark abandoned exchanges `ambiguous`,
-      delete terminal rows.
-- [ ] One-shot exchange claim; an authorization/device code is **never replayed**
-      after an ambiguous outcome.
-- [ ] Codex poll lease is single-owner and fenced; two replicas never poll one
-      device code concurrently.
-- [ ] Newer attempt for a user fences older ones (`attempt_generation`).
+### 5.4 Lifecycle, revocation, rollout
 
-**Revocation & rollout**
-- [ ] Logout deletes the credential file *and* any live attempt rows.
-- [ ] Local deletion is not provider-side revocation — document that, as MCP
-      OAuth already does.
-- [ ] Rollout requires a fleet-shared stable `AGOR_MASTER_SECRET`; a replica
-      without it must fail closed, not fall back to plaintext.
-- [ ] Rate limiting: the auth limiter is in-memory and per-replica
-      (`process-affine-ha-support-matrix-2026-08-07.md`, "Auth/launch rate limit"
-      row) — N replicas multiply allowed attempts. Enabling these endpoints in HA
-      increases the value of edge/WAF quota enforcement; state this rather than
-      implying the local limiter is fleet enforcement.
+- [ ] TTL on DB clock (`CURRENT_TIMESTAMP`), never application clock. Codex uses
+      the fixed 15-minute constant (§1.5) — no invented `expires_in`.
+- [ ] `maintain()`: expire overdue, mark abandoned claims `ambiguous`, delete
+      terminal rows, enqueue the §2.5 delete pass.
+- [ ] One-shot claim on every unreplayable step; codes never replayed after
+      `ambiguous`.
+- [ ] Codex poll lease single-owner; resumption disabled until PRECONDITION B.
+- [ ] Newer attempt fences older via `attempt_generation`; logout invalidates
+      atomically (§2.5).
+- [ ] Fleet-shared stable `AGOR_MASTER_SECRET`; whole-cohort/offline cutover for
+      the migration (pattern of `0078`/`0082`).
+- [ ] Rate limiting: the auth limiter is in-memory and per-replica, so N replicas
+      multiply allowed attempts. Enabling these endpoints in HA raises the value of
+      edge/WAF quota enforcement; do not imply the local limiter is fleet
+      enforcement.
 
 ---
 
-## 6. Recommendation
+## 6. Testing strategy
 
-**Do Option B (durable PostgreSQL attempt state), but ship Option A first as a
-narrow, honestly-scoped Phase 1.**
+Beyond unit coverage of the state machines, the following crash/race cases must
+be covered — the two-pool PostgreSQL harness in
+`mcp-oauth-pending-flow-authority.postgres.test.ts:352-372` is the model.
 
-Rationale: Option A is cheap, is precedented by web terminals, keeps the verifier
-in-process, and unblocks the `shared-local` topology this week — but it cannot
-serve `external`, which is where Cloud is going, and it converts an honest 503
-into a silent dependence on ingress configuration the daemon cannot verify.
-Option B is the design the support matrix already asked for, reuses a shipped and
-race-tested mechanism, and is the only one that survives replica loss and rolling
-deploys. Phase 1 should therefore be gated on `shared-local` specifically, and
-framed as a stopgap that Phase 2 subsumes — not as the destination.
+**Claim and lease races**
+- [ ] Two replicas race the exchange claim; exactly one wins, loser does not call
+      the provider.
+- [ ] Poll lease expires while a poll is in flight; the old owner's transition-3
+      commit is rejected by the lease predicate.
+- [ ] Stale owner receives approval after losing its lease → cannot commit; row
+      resolves `ambiguous`.
 
-If only one phase can be funded, **do Phase 2 and skip Phase 1.**
+**Crash windows**
+- [ ] Death after approval observed, before the durable `approval_observed`
+      commit → `ambiguous`, user restarts (never silently resumed).
+- [ ] Death during `exchanging` → `ambiguous` after timeout; the authorization
+      code is never retried.
+- [ ] Death during `persisting` → `ambiguous`; §2.5 delete pass removes any file
+      written.
+
+**Invalidation races**
+- [ ] Logout during `exchanging` and during `persisting`.
+- [ ] New attempt supersedes an already-claimed older attempt; the older worker's
+      pre-write re-validation aborts it.
+- [ ] Post-write re-validation fails → worker deletes the file it wrote.
+- [ ] Worker dies between a losing write and its own cleanup → logout's second
+      delete pass removes the file.
+- [ ] Supersede lands *between* the credential write and the user-method
+      mutation.
+
+**Crypto and fleet**
+- [ ] AAD tamper (retagged tenant/user/generation) fails to open.
+- [ ] Replica with a different master secret fails closed, never plaintext.
+- [ ] Replica with a missing master secret refuses to seal/open in HA.
+- [ ] TTL expiry and `maintain()` prune, including terminal-row deletion.
+
+**Isolation**
+- [ ] Cross-tenant claim rejection; cross-user claim rejection within a tenant.
+
+**Integration**
+- [ ] Kill a replica mid-flow on the Compose HA stack for each crash window.
+- [ ] Phase 1 only: reconnect to a replica holding a stale attempt for the same
+      user → `attempt_id` mismatch yields "start over", not "wrong state" (§2.1).
 
 ---
 
-## 7. Phased implementation plan
+## 7. Recommendation
 
-### Phase 0 — land PR #2317 (prerequisite, already in flight)
+**Phase 1 = minimal affinity-scoped enablement for `shared-local`. Phase 2 =
+durable PostgreSQL attempt state, which also serves `external`. Codex
+resumable-lease stays gated behind PRECONDITION B.**
 
-Claude sign-in and its `claudeAuth`/`claudeOAuth` HA feature keys must be on
-`main` before either phase. No HA behavior change: both features fail closed.
+Phase 1 is genuinely small — sticky Socket.IO already does the routing, so it is
+capability wiring plus an `attempt_id` echo plus a "start over" message. It keeps
+the verifier in-process, preserving today's security contract exactly. It cannot
+serve `external`, and it trades an honest 503 for a silent dependence on ingress
+config, so it is a stopgap and should be labelled one.
 
-### Phase 1 — affinity-scoped enablement for `shared-local` (~2-3 days)
+Phase 2 is the design the support matrix already asked for. It reuses shipped,
+race-tested primitives, survives replica loss and rolling deploys, and is the
+only option that works for `external`. Its cost is a real change in blast radius
+(§5.2) and a migration/rollout.
 
-- Widen `codexDeviceAuth`/`claudeOAuth` to `boolean`; compute from
-  `topology.execution === 'shared-local' && topology.ingressAffinity &&
-  executorCredentialFiles`.
-- Give `processAffineAuth` a real meaning and readers, or delete it.
-- Boot-ID-stamp attempts; add an explicit `attempt_not_on_this_replica` status
-  and the UI restart affordance; drain live attempts on `SIGTERM`.
-- Rename `codexCredentialFiles` → `executorCredentialFiles`.
-- Update `ha-support.test.ts`, `deployment.test.ts`, `register-hooks.test.ts`;
-  add negative coverage for `external` (must stay 503).
-- Docs: `daemon-ha.mdx` — state the affinity requirement, and that replica loss
-  aborts an in-flight sign-in.
+If only one phase can be funded, do Phase 2.
 
-**Risk: medium.** Correctness depends on operator ingress config the daemon
-cannot verify. Mitigate by scoping strictly to `shared-local` and documenting the
-failure mode loudly.
+**Push-back on one review point.** The review asked to drop the boot-ID protocol
+and drain machinery entirely. Agreed on both — but *not* on dropping attempt
+identity with them. The attempt key is `` `${tenantId}:${userId}` ``
+(`claude-oauth.ts:343`) with no attempt ID, so a reconnect onto a replica holding
+an older unpruned attempt for the same user returns stale status and validates
+the pasted code against the wrong `state`, surfacing as "wrong state" instead of
+"start over" (`:392-407`). The `attempt_id` echo in §2.1 is a few lines, is
+needed by Phase 2 anyway, and removes a confusing failure. Boot-ID and drain stay
+dropped.
 
-### Phase 2 — durable attempt store + Codex poller lease (~1.5-2.5 weeks)
+---
 
-- Migration: `provider_auth_pending_flows` (+ RLS policy), modeled on migration
-  `0078`'s table.
-- `ProviderAuthPendingFlowRepository` (atomic claim, lease claim/renew/release,
-  `maintain()`); `ProviderAuthPendingFlowAuthority` service, new seal purpose
-  domain.
-- Refactor both services onto it; **keep the local Map for SQLite/standalone**,
-  as MCP OAuth does.
-- Codex poll lease + resume-on-new-owner; ambiguous-outcome handling with no
-  code replay.
-- Enable `codexDeviceAuth`/`claudeOAuth` for **both** topologies when
-  `executorCredentialFiles` and PostgreSQL are present.
-- Tests: two-pool PostgreSQL race (mirroring
-  `mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`), lease handoff,
-  cross-tenant negatives, TTL/prune, seal/open AAD-tamper rejection, kill-a-replica
-  mid-flow integration on the Compose HA stack.
+## 8. Phased plan
 
-**Risk: medium-high** — migration, rollout ordering, and a real change to where a
-PKCE verifier lives. Requires the §5 checklist signed off and a fleet-shared
-`AGOR_MASTER_SECRET`.
+### Phase 0 — land #2317 (prerequisite, in flight)
+Claude sign-in and its `claudeAuth`/`claudeOAuth` keys on `main`. No HA behavior
+change; both fail closed. Ideally also lands the §5.1 Redis-denied-paths fix.
 
-### Phase 3 — `external` topology / Cloud (scoping blocked)
+### Phase 1 — affinity-scoped `shared-local` (~1-2 days)
+Capability widening + computation; delete `processAffineAuth`; rename to
+`executorCredentialFiles`; `attempt_id` echo; "start over" UX; update
+`ha-support.test.ts` / `deployment.test.ts` / `register-hooks.test.ts`; negative
+coverage that `external` stays 503. Docs: `daemon-ha.mdx` — affinity requirement
+and that replica loss aborts an in-flight sign-in.
+**Risk: medium** (unverifiable operator dependency).
 
-Confirm how Cloud actually backs `persistent-per-user`, then validate the
-credential write path end-to-end there. **Cannot be scoped from this repo alone**
-(§3 Option A).
+### Phase 2 — durable attempt state (~2-3 weeks)
+Migration + RLS; repository with atomic claim, lease, `maintain()`; authority
+service with the new seal purpose domain; Claude state machine (§2.4); Codex
+state machine (§2.3) with resumption **disabled**; durable logout/replacement
+fencing incl. the filesystem-gap delete passes (§2.5); keep the local Map for
+SQLite/standalone as MCP OAuth does; §6 test matrix.
+**Risk: medium-high** — migration, rollout ordering, blast-radius change.
+Requires §5 signed off and a fleet-shared `AGOR_MASTER_SECRET`.
+
+### Phase 3 — `external` / Cloud (blocked on PRECONDITION A)
+Confirm Cloud's real `persistent-per-user` backing store, then validate the
+credential write path end-to-end. Cannot be scoped from this repo alone.
+
+### Phase 4 — Codex resumable polling (blocked on PRECONDITION B)
+Only after provider poll semantics are established. Until then, owner death in
+the approval window is `ambiguous` by design, not by omission.
 
 ### Rollout / flagging
-
-Enablement is already a config-derived capability, so no new feature flag is
-needed — a deployment opts in by declaring the storage and topology guarantees,
-and the existing gates open. Roll out Phase 2 as a whole-cohort cutover after the
-migration (the pattern used for `0078` and `0082`). Because gates are computed
-per-replica, a partially-upgraded fleet can advertise different capabilities;
-prefer an offline cutover over a rolling one.
+Enablement is config-derived; no new feature flag. A deployment opts in by
+declaring topology and storage guarantees and the existing gates open. Because
+capabilities are computed per-replica, a partially-upgraded fleet can advertise
+different capabilities — prefer an offline cutover to a rolling one.
 
 ---
 
-## 8. Open questions / not determined
+## 9. Preconditions and open questions
 
-1. **Cloud's `persistent-per-user` backing store.** Only the `shared` Compose
-   smoke stack exists in-repo. Needs the deployment owner. (§3)
-2. **`processAffineAuth` original intent.** Zero consumers, absent from the
-   matrix prose; whether it was a placeholder for this work or a leftover could
-   not be established from the tree or history. (§1.3)
-3. **Provider tolerance for a resumed device-code poll from a different source.**
-   Whether OpenAI's device endpoint objects to a poll resuming from another
-   replica IP was not tested; it is protocol-legal but should be verified before
-   Phase 2's lease-handoff is relied upon.
-4. **Whether `shared-local` should be a permanent supported topology for sign-in**
-   or only a stopgap — affects whether Phase 1's code is kept or removed after
-   Phase 2.
+- **PRECONDITION A — Cloud's `persistent-per-user` backing store.** Declared
+  contract (`types.ts:728-739`), no demonstrated provisioning found in-repo. Must
+  verify with the deployment owner **before enabling `external`**. (§1.6, §3)
+- **PRECONDITION B — Codex device-poll semantics.** Whether observing approval
+  consumes the authorization code, and whether re-polling reproduces it, is
+  unverified. **Must verify before enabling resumable polling.** Until then,
+  owner death in the approval window ⇒ `ambiguous` ⇒ user restarts. (§2.3)
+- Whether `shared-local` should remain a permanently supported sign-in topology
+  or Phase 1's code is deleted once Phase 2 lands.
+- Whether transiently sealing exchanged tokens (§2.3 step 5) is worth the
+  blast-radius increase versus making a post-exchange crash a full restart.
+
+---
+
+## 10. Notes on #2317's exploration doc
+
+`context/explorations/claude-code-oauth-signin.md` (on #2317) remains accurate
+for the shipped in-memory design. Two statements need qualifying if this design
+lands:
+
+1. **"The PKCE verifier never leaves the daemon."** True of the shipped design —
+   it lives in one process's heap and is zeroed on completion
+   (`claude-oauth.ts:307-308`). Under Phase 2 it becomes a sealed, AAD-bound row
+   in PostgreSQL. Still never leaves Agor's trust boundary, but it becomes
+   persisted and encrypted rather than memory-only, with the backup/rotation
+   consequences in §5.2.
+2. **"Token material flows browser → daemon → filesystem"** is imprecise. The
+   browser carries the *authorization code and state* (pasted `CODE#STATE`); the
+   access and refresh **tokens** never touch the browser — they go Anthropic →
+   daemon → executor → `~/.claude/.credentials.json`. Worth correcting there, as
+   the imprecise phrasing overstates browser exposure.
+
+---
+
+## Revision history
+
+- **r2** (this revision) — Corrected the refuted MCP/DCR claim (§1.9): the durable
+  MCP row seals `clientId`/`clientSecret`; MCP is gated pending separate
+  activation, not by process-local DCR state. Added the Codex fenced state machine
+  (§2.3) and durable logout/replacement fencing (§2.5). Made `state` hash-only and
+  removed the r1 internal contradiction. Softened "Blocker 2 already solved" to a
+  per-topology claim with PRECONDITION A. Corrected Codex TTL (fixed 15-min
+  constant, no `expires_in`). Expanded security to rotation/backups/least
+  privilege/plaintext lifetime/mixed keys. Reframed Phase 1 as minimal (dropped
+  boot-ID and drain). Added the testing matrix and the #2317 cross-reference notes.
+- **r1** — Initial design.
 
 ---
 
 ## Related
 
-- `context/explorations/claude-code-oauth-signin.md` (on PR #2317) — the Claude
-  flow's verified protocol details.
-- `context/explorations/web-terminal-ownership-ha.md` — the affinity + owner
-  fencing + visible reconnect precedent.
+- `context/explorations/claude-code-oauth-signin.md` (#2317) — Claude flow protocol
+  details; see §10.
+- `context/explorations/web-terminal-ownership-ha.md` — affinity + owner fencing +
+  visible reconnect precedent.
 - `docs/internal/process-affine-ha-support-matrix-2026-08-07.md` — authoritative
   per-flow HA classification and stated intent.
-- `docs/internal/daemon-ha-redis-realtime-2026-08-07.md` — Redis fanout contract
-  and ingress affinity operational guidance.
+- `docs/internal/daemon-ha-redis-realtime-2026-08-07.md` — Redis fanout contract,
+  ingress affinity operational guidance.
 - `apps/agor-docs/content/guide/daemon-ha.mdx` — operator-facing HA contract.

--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,7 +1,8 @@
 # Enabling Codex and Claude subscription OAuth sign-in in HA
 
 Status: **design proposal, not implemented.** August 2026.
-Revision 2 — corrects a refuted claim in revision 1; see [Revision history](#revision-history).
+Revision 3 — PRECONDITION A resolved by infra; two new EFS-derived requirements
+verified against the code. See [Revision history](#revision-history).
 
 Scope: make the two provider subscription sign-in flows — Codex device auth
 (`codex-auth/device`) and Claude subscription OAuth (`claude-auth/oauth`, added
@@ -24,10 +25,14 @@ been established and must be before the corresponding phase ships.
 1. The blocking mechanism is the **in-memory `attempts` map** that holds
    per-attempt secret material between requests
    (`codex-device-auth.ts:263`; `claude-oauth.ts:292` on #2317).
-2. Credential-file visibility is **solved for the checked-in `shared-local`
-   topology** and is a **declared, unverified contract** for `external` / Cloud.
-   It is not a second implementation blocker, but it is an open deployment
-   precondition (§1.6, §3).
+2. Credential-file visibility is **solved in both topologies**. PRECONDITION A is
+   **RESOLVED**: prod HA runs a shared-EFS RWX PVC with
+   `user_home: persistent-per-user` and per-tenant/per-user `subPath` isolation
+   (§1.6). Consequence: **Claude subscription OAuth in HA is not limited to an
+   affinity-scoped stopgap** — the only remaining blocker for Claude is durable
+   attempt state (Phase 2), in the general topology.
+   Two new EFS-derived requirements apply (§1.10): persistent identity on both
+   the credential-write and session-run paths, and fsync-before-rename.
 3. `processAffineAuth` has **zero consumers** — declared, assigned `false`, one
    test fixture. It is not a switch. **Delete it**; do not rehabilitate it.
 4. Redis is fanout-only and auth paths are explicitly denied the relay.
@@ -36,11 +41,12 @@ been established and must be before the corresponding phase ships.
    atomic one-shot claim, tenant scope, TTL/prune. Reuse the primitives.
    **Do not** assume one generic table serves both providers: Codex's flow has a
    materially different external-call shape and needs its own state machine (§2.3).
-6. **Recommended: Phase 1 = minimal affinity-scoped enablement for `shared-local`;
-   Phase 2 = durable PostgreSQL attempt state serving `external` too. Codex
-   poll-lease *resumption* stays gated behind proving provider semantics
-   (PRECONDITION B); until proven, owner death in the approval window is
-   `ambiguous` and the user restarts.**
+6. **Recommended: go straight to Phase 2 — durable PostgreSQL attempt state,
+   serving the general topology.** With A resolved, Phase 1's affinity-scoped
+   stopgap buys only a few days of earlier `shared-local` availability and is now
+   optional. Codex poll-lease *resumption* still stays gated behind proving
+   provider semantics (PRECONDITION B); until proven, owner death in the approval
+   window is `ambiguous` and the user restarts.
 
 ---
 
@@ -162,13 +168,46 @@ the target home (`sandbox-context.ts:108-124`), passes `CODEX_HOME`
 | Topology | Status |
 | --- | --- |
 | `shared-local` (checked-in Compose HA stack) | **VERIFIED working.** `docker-compose.ha.yml:47,157` mounts named volume `agor-ha-user-home` at `/home/agor` on both daemons; `docker/ha/config.yaml:31` declares `user_home: shared`. The config comment states this "makes auth-file import/logout and Tasks replica-consistent". |
-| `external` / Cloud (`persistent-per-user`) | **PRECONDITION A — declared, not demonstrated.** `AgorExecutorStorageSettings` is explicitly a *"Declarative execution-substrate storage contract"* (`packages/core/src/config/types.ts:728-739`); `persistent-per-user` is described as *"the only mode suitable for user credential homes in a multi-tenant external executor fleet"*. That is a statement of what the operator must supply, **not evidence that any deployment supplies it.** No concrete provisioning of a durable, replica-consistent per-user home was located in this repo. |
+| `external` / Cloud (`persistent-per-user`) | **PRECONDITION A — RESOLVED.** See below. `AgorExecutorStorageSettings` is a *"Declarative execution-substrate storage contract"* (`packages/core/src/config/types.ts:728-739`); infra has now confirmed the substrate that satisfies it. |
 
-**Reconciling this with "one blocker":** the *implementation* blocker is the
-attempt map — no new credential mechanism needs to be built. But Phase 2/3
-enablement for `external` is **gated on PRECONDITION A**, which is a deployment
-fact this repo cannot settle. Revision 1's "already solved" was too strong; it
-was true of the smoke stack and asserted of Cloud.
+#### PRECONDITION A — resolved (infra, both prod Cells)
+
+Reported by the infra owners. **These facts are external to this repo and were
+not independently verified here** — `apps/manager-api/` does not exist in this
+tree (`apps/` holds only `agor-cli`, `agor-daemon`, `agor-docs`, `agor-ui`), so
+the `runtimeInternal.ts` line references below are recorded as supplied.
+
+| Property | Confirmed state |
+| --- | --- |
+| Shared filesystem | One RWX PVC on StorageClass `efs-sc` (provisioner `efs.csi.aws.com`), mounted as `agor-home` on **every** executor pod — same filesystem on any node/replica, **not** replica-local (`runtimeInternal.ts:1341`) |
+| Consistency | AWS EFS read-after-write — **guaranteed on `write()`+`close()`/fsync, not per buffered write**. Drives §1.10 R2. |
+| Durability | PersistentVolume, StorageClass reclaim policy `Retain`, decoupled from pod lifecycle; survives reschedule, termination, autoscale |
+| Config | `executor_storage.user_home: persistent-per-user`, `branch_workspace: persistent-per-branch`; `multi_tenancy: { mode: required_from_auth, filesystem_isolation_enabled: true }` |
+| Isolation | `subPath: tenants/<tenantId>/home/<userSegment>` mounted at `/home/<userSegment>` (`runtimeInternal.ts:1310-1313`) — satisfies `hasTenantSafeExecutorCredentialHome()` (`executor-credential-storage.ts:8-15`), which requires exactly `user_home === 'persistent-per-user'` under `required_from_auth` |
+| Eviction | None on the homes. Only `ttlSecondsAfterFinished: 3600` on the executor Job (`runtimeInternal.ts:1358`) and `uploads.max_age_days` on uploads. Volume 20Gi, `ALLOWVOLUMEEXPANSION=false` → the risk is **exhaustion (write failure), not deletion** |
+
+**Consequence.** The credential home is replica-consistent in the *general*
+topology, not only under affinity. So:
+
+- **Claude subscription OAuth in HA is no longer stopgap-shaped.** Its only
+  remaining blocker is durable attempt state (§2.4). Once that lands it works on
+  `external` with no affinity dependency.
+- **Codex** likewise gets its credential side unblocked; its remaining
+  constraint is the poller/approval-window semantics (PRECONDITION B, §2.3) —
+  which limits *resumption*, not enablement.
+- Phase 3 as originally written (a blocked scoping exercise) **collapses into
+  Phase 2** for the credential side; see §8.
+
+**Attempt state does not touch this volume.** The durable attempt record lives in
+PostgreSQL (§2.2), so the 20Gi/no-expansion exhaustion risk applies only to the
+credential files and workspaces, not to sign-in state. Worth stating because it
+means a full volume degrades the *final write*, not the OAuth handshake — the
+failure surfaces as a persist error the user can retry after cleanup, not as a
+corrupted or half-committed attempt.
+
+**Revision 1's "already solved" was still too strong at the time** — it was true
+of the smoke stack and merely asserted of Cloud. It is now true of both, on
+evidence.
 
 ### 1.7 Redis is fanout-only and explicitly denied to auth paths
 
@@ -271,7 +310,115 @@ certification surface smaller. That is a genuine argument for it being easier to
 activate. It is **not** an argument that MCP is technically blocked and sign-in
 is not.
 
-### 1.10 Ingress affinity is already mandatory
+### 1.10 Two requirements the EFS substrate imposes (VERIFIED against our code)
+
+Resolving A introduces two hard requirements. Both were traced through this
+repo; results below.
+
+#### R1 — Persistent identity is mandatory on *both* paths
+
+Infra gates persistence on `hasPersistentIdentity` (`runtimeInternal.ts:1199`,
+as supplied): a run with no `userId` / `runtimeUserId` / sanitized unix user
+lands on `anonymous-home`, an **emptyDir that dies with the pod**
+(`runtimeInternal.ts:1343`). So the sign-in **credential write** and the later
+**session runs** must *both* carry a resolved persistent identity, or the
+credential is written somewhere that evaporates — or, worse, written to a real
+home and then read from a different one.
+
+**Verification result: both paths carry identity, and `delegated` mode fails
+closed. One divergence hazard found.**
+
+*Credential-write path — SAFE.*
+- `resolveCodexCredentialRoute()` returns `ok: false, reason: 'resolve-failed'`
+  when `userId` is absent: *"Codex credential routing requires an authenticated
+  user identity."* (`apps/agor-daemon/src/services/codex-auth-shared.ts:153-159`).
+- Under `delegated` it additionally requires a `unix_username`, returning
+  `missing-username` otherwise (`:124-143`), resolved from the **caller's** user
+  row (`UsersRepository.findById(userId)`, `:131-135`).
+- `credentialExecutorOptions()` always forwards `user_id: routing.userId` and
+  `unix_user: routing.reportedUnixUser ?? undefined`
+  (`apps/agor-daemon/src/utils/executor-credential-auth.ts`, and on `main`
+  `utils/executor-codex-auth.ts:27-30`).
+
+*Session-run path — SAFE in `delegated`, softer elsewhere.*
+- `register-services.ts:1215-1219` forwards `session_id`, `task_id`,
+  `branch_id`, and `user_id: userId`.
+- But `userId` is typed optional — `(params as AuthenticatedParams).user?.user_id
+  as UserID | undefined` (`register-services.ts:930`).
+- `resolveDelegatedHomeKey()` **throws** in `delegated` mode when the home key is
+  missing (`packages/core/src/unix/delegated-home-key.ts:60-65`) and again on a
+  malformed key (`:66-68`). Since prod is `required_from_auth` + delegated-style
+  external execution, a missing identity is a hard failure, **not** a silent
+  drop to `anonymous-home`. That is the reassuring result.
+- Residual sharp edge: `substituteTemplateVariables()` only substitutes defined
+  values (`utils/spawn-executor.ts:271-282`). An `undefined` `user_id` therefore
+  leaves the **literal `{user_id}` in the rendered command** rather than failing
+  or emptying it. Validation only runs when the value is defined
+  (`:249-255`). In any topology whose template consumes `{user_id}` without
+  `{unix_user}`, that is precisely the anonymous-home path.
+
+**HAZARD — identity source divergence (flag for the implementation phase).**
+The two paths resolve the home key from **different rows**:
+
+| Path | Home-key source |
+| --- | --- |
+| Credential write | the **caller's** `users.unix_username` (`codex-auth-shared.ts:131-135`) |
+| Session run | the **session's** `session.unix_username` (`register-services.ts:1064,1066-1069`) |
+
+Both are non-empty in `delegated` mode, but nothing constrains them to be the
+**same value**. When they diverge, the credential is written into user A's home
+and the session reads user B's — a silent "signed in, but the agent still says
+unauthenticated". This is not hypothetical: `dangerously_allow_session_sharing`
+exists precisely so a child session can inherit `parent.created_by` rather than
+the caller (see CLAUDE.md), and a session's `unix_username` is stamped at
+creation and can drift from the user's current value.
+
+**Required for HA (design):** before enabling, assert that the credential-write
+home key and the run home key resolve to the same value for the target user, and
+fail closed with an actionable message when they don't. Do not paper over it by
+writing to both.
+
+#### R2 — fsync/close before rename (EFS close-consistency)
+
+EFS cross-client visibility holds on `write()`+`close()`, not per buffered
+write. Our credential write is temp-file → rename.
+
+**Verification result: `close()` happens; `fsync()` does not.**
+
+The shared helper introduced by #2317
+(`packages/executor/src/commands/credential-file-io.ts`, and the equivalent
+inline sequence on `main` at `packages/executor/src/commands/codex-auth-file.ts:79-86`):
+
+```ts
+await writeFile(temporary, content, { mode: 0o600, flag: 'wx' });
+await chmod(temporary, 0o600);
+await rename(temporary, target);
+```
+
+- `fs/promises.writeFile` opens, writes, and **closes** the descriptor, so the
+  EFS close-to-open *visibility* contract is satisfied for the temp file before
+  the rename. This is the good news and it is why the current code mostly works.
+- There is **no `fsync` on the temp file** and **no `fsync` on the containing
+  directory** after the rename. So the bytes and the new directory entry are not
+  forced durable. A pod killed (or a node lost) between the rename and the
+  server-side flush can leave the credential file absent or truncated *after the
+  daemon has already reported success and flipped the user's auth method* — the
+  exact split-brain the §2.5 fencing is otherwise designed to prevent.
+- The code already anticipates this class of problem: the helper's own doc
+  comment says the read-back *"is retried once because some networked/overlay
+  filesystems briefly surface a rename before the new bytes are visible"*, and it
+  re-reads the target and compares against what it wrote
+  (`codex-auth-file.ts:88-100` on `main`). That read-back is a real mitigation
+  for visibility, but it is a **same-client** read and does not establish
+  durability.
+
+**Required change for HA on EFS (implementation phase, not now):** open the temp
+file explicitly, `write` → `fsync(fd)` → `close(fd)`, then `rename`, then
+`fsync` the containing directory. Keep the existing read-back verification.
+Because both providers now share `writeCredentialFileAtomically()`, this is
+**one fix in one function** covering Codex and Claude.
+
+### 1.11 Ingress affinity is already mandatory
 
 - HA refuses to boot without it (`deployment.ts:349-353`).
 - Resolved topology types it literally `ingressAffinity: true` in both variants
@@ -468,12 +615,15 @@ superseded microseconds earlier. Defined behavior:
 
 ### Option A — shared / per-user executor credential home (RECOMMENDED)
 
-Nothing to build for `shared-local` (§1.6, VERIFIED). For `external` the
-requirement is already enforced at boot (`deployment.ts:375-380`), but the
-backing store is **PRECONDITION A** — a declarative contract
-(`types.ts:728-739`), not demonstrated provisioning. Must be confirmed with the
-deployment owner before Phase 3 is scoped: durable, replica-consistent,
-per-tenant/per-user home at a stable path (RWX PVC / NFS / per-user volume).
+Nothing to build for `shared-local` (§1.6, VERIFIED). For `external`, the
+requirement is enforced at boot (`deployment.ts:375-380`) **and the backing store
+is now confirmed** — shared-EFS RWX PVC, `persistent-per-user`, per-tenant/user
+`subPath` isolation (§1.6, PRECONDITION A resolved).
+
+Two implementation obligations follow from that substrate rather than from the
+config contract, both detailed in §1.10: **R1** identity must resolve on the
+credential-write *and* session-run paths (with the divergence assertion), and
+**R2** the atomic write must `fsync` before rename.
 
 ### Option B — credentials in encrypted DB, materialized per session
 
@@ -580,6 +730,16 @@ about the key, the backups, or the decrypt window.
       `mcp-oauth-pending-flow-authority.postgres.test.ts:228-293`.
 - [ ] Credential write targets the caller's own resolved home; `required_from_auth`
       + non-`persistent-per-user` stays refused at boot.
+- [ ] **R1** — both the credential write and the session run resolve a persistent
+      identity, and the two home keys are asserted equal before enabling
+      (§1.10 R1). A run that cannot resolve one fails closed rather than
+      rendering an unsubstituted `{user_id}` (`spawn-executor.ts:271-282`).
+- [ ] **R2** — `fsync` the temp file before `rename` and `fsync` the directory
+      after, in `writeCredentialFileAtomically()` (§1.10 R2). Keep the read-back
+      verification.
+- [ ] Credential-home volume exhaustion (20Gi, no expansion) surfaces as an
+      explicit persist failure the user can retry, never as a partial write that
+      is reported as success. Attempt state is in PostgreSQL and is unaffected.
 
 ### 5.4 Lifecycle, revocation, rollout
 
@@ -642,6 +802,20 @@ be covered — the two-pool PostgreSQL harness in
 **Isolation**
 - [ ] Cross-tenant claim rejection; cross-user claim rejection within a tenant.
 
+**Shared credential home (EFS)**
+- [ ] Sign in on replica A, run a session on replica B → the session sees the
+      credential. This is the test that PRECONDITION A actually buys the general
+      topology, and it must run on the real substrate, not Compose.
+- [ ] Credential-write home key and session-run home key diverge → fails closed
+      with an actionable message, not a silent "still unauthenticated" (§1.10 R1).
+- [ ] A run with no resolvable user identity fails closed; assert no rendered
+      command ever contains a literal `{user_id}` or `{unix_user}`.
+- [ ] Kill the pod between `rename` and read-back → the credential is either
+      fully present or absent, never truncated, and the user's auth method is not
+      flipped on a write that did not survive (§1.10 R2).
+- [ ] Full volume (simulated ENOSPC) → explicit persist failure, retryable; the
+      attempt row is unaffected.
+
 **Integration**
 - [ ] Kill a replica mid-flow on the Compose HA stack for each crash window.
 - [ ] Phase 1 only: reconnect to a replica holding a stale attempt for the same
@@ -651,22 +825,25 @@ be covered — the two-pool PostgreSQL harness in
 
 ## 7. Recommendation
 
-**Phase 1 = minimal affinity-scoped enablement for `shared-local`. Phase 2 =
-durable PostgreSQL attempt state, which also serves `external`. Codex
-resumable-lease stays gated behind PRECONDITION B.**
+**Go to Phase 2 — durable PostgreSQL attempt state — and treat Phase 1 as
+optional. Codex resumable-lease stays gated behind PRECONDITION B.**
 
-Phase 1 is genuinely small — sticky Socket.IO already does the routing, so it is
-capability wiring plus an `attempt_id` echo plus a "start over" message. It keeps
-the verifier in-process, preserving today's security contract exactly. It cannot
-serve `external`, and it trades an honest 503 for a silent dependence on ingress
-config, so it is a stopgap and should be labelled one.
+Resolving PRECONDITION A changed the calculus. Previously Phase 1 was the only
+thing that could ship soon, because `external` was blocked on an unknown
+credential substrate. Now the credential home is confirmed replica-consistent in
+the general topology, so **durable attempt state is the single remaining blocker
+for Claude**, and it unblocks `external` directly. Phase 1 would buy a few days
+of earlier `shared-local` availability at the cost of code that Phase 2 deletes,
+plus a documented dependence on ingress config the daemon cannot verify. Ship it
+only if `shared-local` availability is independently urgent.
 
-Phase 2 is the design the support matrix already asked for. It reuses shipped,
-race-tested primitives, survives replica loss and rolling deploys, and is the
-only option that works for `external`. Its cost is a real change in blast radius
-(§5.2) and a migration/rollout.
+Phase 2 reuses shipped, race-tested primitives, survives replica loss and rolling
+deploys, and now needs no topology caveat. Its cost is the blast-radius change
+(§5.2), a migration/rollout, and the two §1.10 obligations — of which R2 is one
+fix in one shared function.
 
-If only one phase can be funded, do Phase 2.
+Codex is not held back by the credential side either; its remaining constraint is
+approval-window semantics, which limits *resumption*, not enablement.
 
 **Push-back on one review point.** The review asked to drop the boot-ID protocol
 and drain machinery entirely. Agreed on both — but *not* on dropping attempt
@@ -686,7 +863,10 @@ dropped.
 Claude sign-in and its `claudeAuth`/`claudeOAuth` keys on `main`. No HA behavior
 change; both fail closed. Ideally also lands the §5.1 Redis-denied-paths fix.
 
-### Phase 1 — affinity-scoped `shared-local` (~1-2 days)
+### Phase 1 — affinity-scoped `shared-local` (~1-2 days) — **OPTIONAL**
+Superseded in value by PRECONDITION A's resolution; ship only if early
+`shared-local` availability is independently urgent. Phase 2 deletes most of it.
+
 Capability widening + computation; delete `processAffineAuth`; rename to
 `executorCredentialFiles`; `attempt_id` echo; "start over" UX; update
 `ha-support.test.ts` / `deployment.test.ts` / `register-hooks.test.ts`; negative
@@ -703,9 +883,16 @@ SQLite/standalone as MCP OAuth does; §6 test matrix.
 **Risk: medium-high** — migration, rollout ordering, blast-radius change.
 Requires §5 signed off and a fleet-shared `AGOR_MASTER_SECRET`.
 
-### Phase 3 — `external` / Cloud (blocked on PRECONDITION A)
-Confirm Cloud's real `persistent-per-user` backing store, then validate the
-credential write path end-to-end. Cannot be scoped from this repo alone.
+### Phase 3 — `external` / Cloud — **collapsed into Phase 2**
+PRECONDITION A is resolved (§1.6), so this is no longer a separate blocked
+scoping exercise. What remains are the two §1.10 obligations, which belong inside
+Phase 2:
+- **R2 fsync-before-rename** in `writeCredentialFileAtomically()` — one function,
+  covers both providers. Do this first; it is small and independently correct.
+- **R1 identity assertion** — credential-write and session-run home keys must
+  resolve equal, failing closed otherwise.
+- End-to-end validation on the real EFS substrate (sign in on replica A, run on
+  replica B), which Compose cannot exercise.
 
 ### Phase 4 — Codex resumable polling (blocked on PRECONDITION B)
 Only after provider poll semantics are established. Until then, owner death in
@@ -721,9 +908,20 @@ different capabilities — prefer an offline cutover to a rolling one.
 
 ## 9. Preconditions and open questions
 
-- **PRECONDITION A — Cloud's `persistent-per-user` backing store.** Declared
-  contract (`types.ts:728-739`), no demonstrated provisioning found in-repo. Must
-  verify with the deployment owner **before enabling `external`**. (§1.6, §3)
+- **PRECONDITION A — RESOLVED.** Prod HA (both Cells) runs a shared-EFS RWX PVC,
+  `user_home: persistent-per-user`, per-tenant/user `subPath` isolation, `Retain`
+  reclaim, no home eviction. Supplied by infra and recorded in §1.6; the
+  `manager-api` line references were **not** independently verified here because
+  that repo is not in this tree. Two obligations follow (§1.10 R1/R2).
+- **Residual from A — volume headroom.** 20Gi with
+  `ALLOWVOLUMEEXPANSION=false` means the failure mode is exhaustion, not
+  deletion. Credential writes must fail loudly on ENOSPC rather than reporting
+  success. Attempt state is in PostgreSQL and is not exposed to this.
+- **New — identity-source divergence.** The credential write resolves the home
+  key from the caller's `users.unix_username`; the session run resolves it from
+  `session.unix_username`. Nothing constrains them to match, and
+  `dangerously_allow_session_sharing` makes divergence reachable. Needs the
+  equality assertion in §1.10 R1. (Design flag; no code change now.)
 - **PRECONDITION B — Codex device-poll semantics.** Whether observing approval
   consumes the authorization code, and whether re-polling reproduces it, is
   unverified. **Must verify before enabling resumable polling.** Until then,
@@ -757,7 +955,19 @@ lands:
 
 ## Revision history
 
-- **r2** (this revision) — Corrected the refuted MCP/DCR claim (§1.9): the durable
+- **r3** (this revision) — **PRECONDITION A resolved** by infra: prod HA runs a
+  shared-EFS RWX PVC with `persistent-per-user` and per-tenant/user `subPath`
+  isolation (§1.6). Consequence: Claude sign-in in HA is no longer stopgap-shaped
+  — durable attempt state is its only remaining blocker, in the general topology.
+  Phase 3 collapses into Phase 2; Phase 1 becomes optional; the recommendation
+  changes to "go straight to Phase 2". Added §1.10 with two EFS-derived
+  requirements **verified against our code**: R1 persistent identity on both the
+  credential-write and session-run paths (both carry it; `delegated` fails closed;
+  found an identity-source **divergence hazard** between `users.unix_username` and
+  `session.unix_username`), and R2 fsync-before-rename (**`close()` happens via
+  `writeFile`, `fsync` does not** — required change for EFS durability). Added
+  shared-credential-home test cases and the volume-exhaustion note.
+- **r2** — Corrected the refuted MCP/DCR claim (§1.9): the durable
   MCP row seals `clientId`/`clientSecret`; MCP is gated pending separate
   activation, not by process-local DCR state. Added the Codex fenced state machine
   (§2.3) and durable logout/replacement fencing (§2.5). Made `state` hash-only and

--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,8 +1,9 @@
 # Enabling Codex and Claude subscription OAuth sign-in in HA
 
 Status: **design proposal, not implemented.** August 2026.
-Revision 3 — PRECONDITION A resolved by infra; two new EFS-derived requirements
-verified against the code. See [Revision history](#revision-history).
+Revision 4 — **both preconditions now resolved**: A by infra (shared EFS), B by
+empirical probe (the device poll is re-fetchable). See
+[Revision history](#revision-history).
 
 Scope: make the two provider subscription sign-in flows — Codex device auth
 (`codex-auth/device`) and Claude subscription OAuth (`claude-auth/oauth`, added
@@ -15,8 +16,10 @@ paste flows.
 
 Throughout, **VERIFIED** means read from the tree at this commit with a
 `file:line` citation. **DESIGN** means proposed and not yet built.
-**PRECONDITION** means an external fact this design depends on that has *not*
-been established and must be before the corresponding phase ships.
+**PRECONDITION** means an external fact this design depends on which the repo
+alone cannot settle. Both preconditions raised by earlier revisions — A
+(credential substrate) and B (device-poll semantics) — are now **resolved**;
+see §1.6 and §1.12. Their residuals are tracked in §9.
 
 ---
 
@@ -44,9 +47,10 @@ been established and must be before the corresponding phase ships.
 6. **Recommended: go straight to Phase 2 — durable PostgreSQL attempt state,
    serving the general topology.** With A resolved, Phase 1's affinity-scoped
    stopgap buys only a few days of earlier `shared-local` availability and is now
-   optional. Codex poll-lease *resumption* still stays gated behind proving
-   provider semantics (PRECONDITION B); until proven, owner death in the approval
-   window is `ambiguous` and the user restarts.
+   optional. **PRECONDITION B is also resolved** (§1.12): the device-token poll
+   was measured re-fetchable, so Codex poll-lease resumption is unblocked and
+   owner death before the exchange is recoverable. Exactly-once lives entirely at
+   the exchange claim.
 
 ---
 
@@ -137,9 +141,13 @@ the attempt be *findable*.
 **(b) Codex receives the authorization code as an unprompted side effect of a
 poll.** `pollDeviceToken()` (`:137-157`) returns `{authorizationCode, codeVerifier}`
 the moment the user approves. That value exists only in the polling replica's
-heap until something durably records it. This is the crux of §2.3: **the
-observation itself may be the consuming event**, and Agor cannot assume
-re-polling reproduces it.
+heap until something durably records it.
+
+Revision 2 treated this as potentially *consumptive* — that observing approval
+might itself burn the code. **That worst case has been empirically refuted**
+(§1.12): re-polling after approval returns the same `authorization_code` and
+`code_verifier`. The poll is re-fetchable; the single-use step is the exchange
+alone. §2.3 is built on that measured behavior.
 
 Note also that the Codex `usercode` response parses only `device_auth_id`,
 `user_code`, and `interval` (`:115-128`) — **there is no `expires_in`**. Lifetime
@@ -192,9 +200,10 @@ topology, not only under affinity. So:
 - **Claude subscription OAuth in HA is no longer stopgap-shaped.** Its only
   remaining blocker is durable attempt state (§2.4). Once that lands it works on
   `external` with no affinity dependency.
-- **Codex** likewise gets its credential side unblocked; its remaining
-  constraint is the poller/approval-window semantics (PRECONDITION B, §2.3) —
-  which limits *resumption*, not enablement.
+- **Codex** likewise gets its credential side unblocked. Its approval-window
+  question (PRECONDITION B) has since also been resolved favorably (§1.12), so
+  Codex has no remaining precondition either — durable attempt state is the only
+  blocker for both providers.
 - Phase 3 as originally written (a blocked scoping exercise) **collapses into
   Phase 2** for the credential side; see §8.
 
@@ -435,6 +444,59 @@ Because both providers now share `writeCredentialFileAtomically()`, this is
   contract, with *"Owner loss ends the Agor attachment… requires an explicit
   Reconnect"* (`context/explorations/web-terminal-ownership-ha.md`).
 
+### 1.12 PRECONDITION B — measured: the device-token poll is re-fetchable
+
+**Probe run 2026-08-18** against the live OpenAI device endpoints with a real
+Codex subscription account, client_id `app_EMoamEEZ73f0CkXaXp7hrann`.
+`POST https://auth.openai.com/api/accounts/deviceauth/token` with
+`{device_auth_id, user_code}` — the exact request our `pollDeviceToken()` issues
+(`codex-device-auth.ts:141-147`):
+
+| Step | Result |
+| --- | --- |
+| Polls #1–#5 (before approval) | HTTP **403**, body key `error` |
+| Poll #6 (after in-browser approval) | HTTP **200**, body keys `{authorization_code, code_challenge, code_verifier, status, user_code, user_code_expiration}` |
+| **Re-polls #1, #2, #3 (after approval)** | **HTTP 200, all returning the SAME `authorization_code` and `code_verifier`** |
+
+Secrets redacted; the exchange was deliberately **not** performed, so no token
+was minted and the authorization code was never consumed.
+
+**Three findings.**
+
+1. **Observing approval is NOT consumptive.** The worst-case assumption behind
+   revision 2's `ambiguous`-on-owner-death default is **disproven**. A replica
+   that takes over a lease can re-poll the same `device_auth_id` / `user_code`
+   and receive the same code and verifier back.
+2. **Exactly-once lives entirely at the exchange.** The single-use step is
+   `POST /oauth/token` (`codex-device-auth.ts:165-191`); the poll is freely
+   repeatable. So the **atomic one-shot exchange claim is the correct and
+   sufficient exactly-once mechanism**, and poll-resume is safe alongside it.
+   This is a cleaner separation than r2 assumed: the lease governs *who polls*
+   (an efficiency and rate-limit concern), while the claim governs *who
+   exchanges* (the correctness concern).
+3. **`403` as "pending" is confirmed** — matching the existing comment *"403/404
+   are the server's 'authorization pending' signals for this endpoint"*
+   (`codex-device-auth.ts:136`), and the provider-supplied `code_verifier` in the
+   200 body confirms §1.5's reading of `:151`.
+
+**Residual, stated honestly.** The probe ran from a **single egress IP**. It
+proves *idempotency*; it does **not** prove *cross-replica-IP tolerance*. The
+assessment is that this is very likely fine — RFC 8628 device flow is designed
+for a *separate* device to poll, the request carries only `device_auth_id` +
+`user_code`, and no cookie or IP binding was observed — but it is unproven.
+
+**Design stance:** assume re-fetchable (proven) and **keep `ambiguous → restart`
+as the fallback** if a cross-replica re-poll ever fails in practice. A clean
+cross-IP test needs a second egress host; it is a nice-to-have, not a blocker.
+
+**Noted but out of scope:** the 200 body carries `user_code_expiration`, a real
+provider-supplied expiry. Our poll parses only `authorization_code` and
+`code_verifier` (`codex-device-auth.ts:148-156`) and the lifetime stays the fixed
+15-minute local constant (§1.5). Adopting the provider's value would be an
+accuracy improvement, but it is a separate change and does not affect this
+design — §1.5's point stands, since it was about the *usercode* response, which
+still has no expiry field (`:115-128`).
+
 ---
 
 ## 2. Design
@@ -521,28 +583,40 @@ with terminals `failed` / `expired` / `ambiguous` / `superseded`.
 | --- | --- | --- | --- | --- | --- |
 | 1 | *(create)* → `pending` | In one tx: `UPDATE … SET is_current=false, status='superseded' WHERE tenant/user AND is_current`, then `INSERT` with `attempt_generation = prev+1`, `expires_at = now() + 15min` (DB clock) | `deviceAuthId`, `userCode` sealed | Nothing issued yet; user retries | n/a |
 | 2 | acquire poll lease | `UPDATE … SET poll_lease_owner=?, poll_lease_expires_at=now()+L WHERE attempt_id=? AND status='pending' AND is_current AND (poll_lease_expires_at IS NULL OR poll_lease_expires_at <= now()) RETURNING *` | unchanged | No owner polls until lease is free; attempt still valid | Lease re-acquire is safe |
-| 3 | `pending` → `approval_observed` | `UPDATE … SET status='approval_observed', sealed_material=? WHERE attempt_id=? AND status='pending' AND attempt_generation=? AND poll_lease_owner=? AND poll_lease_expires_at > now()` | + `authorizationCode`, `codeVerifier` (both provider-supplied) | **DANGEROUS — see below** | **No** |
+| 3 | `pending` → `approval_observed` | `UPDATE … SET status='approval_observed', sealed_material=? WHERE attempt_id=? AND status='pending' AND attempt_generation=? AND poll_lease_owner=? AND poll_lease_expires_at > now()` | + `authorizationCode`, `codeVerifier` (both provider-supplied) | **Recoverable** — a new lease owner re-polls and gets the same code back (§1.12) | **Yes — the poll is re-fetchable** |
 | 4 | `approval_observed` → `exchanging` | one-shot: `UPDATE … SET status='exchanging', claim_id=? WHERE attempt_id=? AND status='approval_observed' AND is_current AND attempt_generation=?` | unchanged | Abandoned `exchanging` → `ambiguous` after timeout | **No** — authorization codes are single-use |
 | 5 | `exchanging` → `persisting` | `UPDATE … SET status='persisting', sealed_material=? WHERE attempt_id=? AND status='exchanging' AND claim_id=?` | tokens sealed (separate purpose domain), code cleared | Crash before commit → `ambiguous`; tokens lost, user restarts | **No** |
 | 6 | `persisting` → `succeeded` | re-validate `(attempt_generation, claim_id, status='persisting', is_current)` **immediately before** the credential write **and again before** the user-method mutation; then `UPDATE … SET status='succeeded', sealed_material=NULL` | cleared | See §2.5 filesystem gap | Write is idempotent (same tokens, same path) |
 
-**Transition 3 is the one that must not over-promise.** The provider returns the
-authorization code in the poll response. Whether that response is
-single-delivery — i.e. whether *observing* approval consumes it — is
-**PRECONDITION B, unverified**. Therefore:
+**Transition 3 was the feared one; the probe defused it.** The provider returns
+the authorization code in the poll response, and re-polling after approval
+returns the *same* code and verifier (§1.12). So:
 
-- **Default (until B is proven): lease takeover of a `pending` attempt whose
-  lease expired transitions it to `ambiguous`, not back to polling.** The user
-  restarts sign-in. Owner death anywhere in the approval window is a restart, not
-  a transparent resume.
-- Rationale: if re-polling does *not* reproduce the code, a resuming owner silently
-  hangs until expiry; if the code *can* be delivered twice, two owners may both
-  proceed. Neither is acceptable without evidence.
-- Resumable polling (a genuine availability win) may be enabled **only** after B
-  is proven, and even then only for a `pending` attempt that has never reached
-  `approval_observed`.
-- Make lease expiry rare rather than relying on takeover: short renew interval
-  (~15 s) against a generous lease (~60 s), well inside the 15-minute window.
+- **Lease takeover of a `pending` attempt whose lease expired resumes polling.**
+  The new owner re-polls the same `device_auth_id` / `user_code`. If the user has
+  already approved, the very first re-poll returns the code and the attempt
+  proceeds to transition 4 — owner death before the exchange is **recoverable**,
+  not a restart.
+- **`ambiguous → restart` is retained as the FALLBACK**, not the default. A
+  re-poll that returns a terminal provider error, or that keeps returning
+  `pending` past `expires_at`, resolves the attempt to `ambiguous`/`expired` and
+  the user restarts. This is what covers the unproven cross-IP case (§1.12) — if
+  a different egress IP is in fact rejected, the failure is a clean restart, not
+  a hang or a double-spend.
+- **Double-polling is now a non-issue for correctness.** If a slow owner and a
+  new lease owner briefly both poll, both simply receive the same code. Only one
+  can win transition 4's one-shot claim, and only that winner exchanges. The
+  lease remains worthwhile for rate-limit hygiene and to keep one clear owner,
+  but it is no longer load-bearing for exactly-once.
+- Still make lease expiry rare rather than relying on takeover: short renew
+  interval (~15 s) against a generous lease (~60 s), well inside the 15-minute
+  window.
+
+**Where exactly-once actually lives.** The authorization code is single-use at
+`POST /oauth/token` only. Transition 4's atomic claim is therefore the complete
+exactly-once mechanism: freely repeatable poll, exactly-once exchange. Transitions
+4–6 are unchanged by the probe — a crash *during or after* the exchange is still
+`ambiguous` and is still never replayed.
 
 **Retry policy.** The existing `exchangeWithOneRetry` (`:199`) must stay
 *within a single claim holder* — one process, one `claim_id`. A retry must never
@@ -749,7 +823,9 @@ about the key, the backups, or the decrypt window.
       terminal rows, enqueue the §2.5 delete pass.
 - [ ] One-shot claim on every unreplayable step; codes never replayed after
       `ambiguous`.
-- [ ] Codex poll lease single-owner; resumption disabled until PRECONDITION B.
+- [ ] Codex poll lease single-owner. Resumption is **enabled** (§1.12), with
+      `ambiguous → restart` retained as the fallback when a re-poll fails.
+      Exactly-once is enforced by the exchange claim, not by the lease.
 - [ ] Newer attempt fences older via `attempt_generation`; logout invalidates
       atomically (§2.5).
 - [ ] Fleet-shared stable `AGOR_MASTER_SECRET`; whole-cohort/offline cutover for
@@ -777,7 +853,12 @@ be covered — the two-pool PostgreSQL harness in
 
 **Crash windows**
 - [ ] Death after approval observed, before the durable `approval_observed`
-      commit → `ambiguous`, user restarts (never silently resumed).
+      commit → a new lease owner **re-polls and recovers the same code** (§1.12),
+      and the attempt completes. Assert the exchange still happens exactly once.
+- [ ] Re-poll fallback: stub the provider to reject or keep returning `pending`
+      after approval → the attempt resolves `ambiguous`/`expired` and the user
+      restarts, with no hang and no second exchange. This is the cross-IP
+      safety net (§1.12 residual).
 - [ ] Death during `exchanging` → `ambiguous` after timeout; the authorization
       code is never retried.
 - [ ] Death during `persisting` → `ambiguous`; §2.5 delete pass removes any file
@@ -826,7 +907,8 @@ be covered — the two-pool PostgreSQL harness in
 ## 7. Recommendation
 
 **Go to Phase 2 — durable PostgreSQL attempt state — and treat Phase 1 as
-optional. Codex resumable-lease stays gated behind PRECONDITION B.**
+optional. Both preconditions are now resolved, so Codex's resumable lease folds
+into Phase 2 rather than trailing it.**
 
 Resolving PRECONDITION A changed the calculus. Previously Phase 1 was the only
 thing that could ship soon, because `external` was blocked on an unknown
@@ -842,8 +924,10 @@ deploys, and now needs no topology caveat. Its cost is the blast-radius change
 (§5.2), a migration/rollout, and the two §1.10 obligations — of which R2 is one
 fix in one shared function.
 
-Codex is not held back by the credential side either; its remaining constraint is
-approval-window semantics, which limits *resumption*, not enablement.
+Codex is no longer held back on either side. The credential home is confirmed
+(§1.6) and the approval-window worst case is refuted (§1.12), so its resumable
+lease is buildable now — with the exchange claim carrying exactly-once and
+`ambiguous → restart` as the fallback.
 
 **Push-back on one review point.** The review asked to drop the boot-ID protocol
 and drain machinery entirely. Agreed on both — but *not* on dropping attempt
@@ -877,7 +961,8 @@ and that replica loss aborts an in-flight sign-in.
 ### Phase 2 — durable attempt state (~2-3 weeks)
 Migration + RLS; repository with atomic claim, lease, `maintain()`; authority
 service with the new seal purpose domain; Claude state machine (§2.4); Codex
-state machine (§2.3) with resumption **disabled**; durable logout/replacement
+state machine (§2.3) with resumption **enabled** (§1.12) and the re-poll failure
+fallback; durable logout/replacement
 fencing incl. the filesystem-gap delete passes (§2.5); keep the local Map for
 SQLite/standalone as MCP OAuth does; §6 test matrix.
 **Risk: medium-high** — migration, rollout ordering, blast-radius change.
@@ -894,9 +979,15 @@ Phase 2:
 - End-to-end validation on the real EFS substrate (sign in on replica A, run on
   replica B), which Compose cannot exercise.
 
-### Phase 4 — Codex resumable polling (blocked on PRECONDITION B)
-Only after provider poll semantics are established. Until then, owner death in
-the approval window is `ambiguous` by design, not by omission.
+### Phase 4 — Codex resumable polling — **unblocked; folded into Phase 2**
+PRECONDITION B is resolved (§1.12): the poll is re-fetchable, so resumption is
+safe to build alongside the state machine rather than as a follow-on. It is no
+longer a separate phase. Ship it with the `ambiguous → restart` fallback, which
+also covers the unproven cross-egress-IP case.
+
+Optional follow-up (not a blocker): re-run the §1.12 probe from a **second
+egress host** to close the cross-IP question directly. If it ever fails in
+production, the fallback already degrades to a clean restart.
 
 ### Rollout / flagging
 Enablement is config-derived; no new feature flag. A deployment opts in by
@@ -922,10 +1013,17 @@ different capabilities — prefer an offline cutover to a rolling one.
   `session.unix_username`. Nothing constrains them to match, and
   `dangerously_allow_session_sharing` makes divergence reachable. Needs the
   equality assertion in §1.10 R1. (Design flag; no code change now.)
-- **PRECONDITION B — Codex device-poll semantics.** Whether observing approval
-  consumes the authorization code, and whether re-polling reproduces it, is
-  unverified. **Must verify before enabling resumable polling.** Until then,
-  owner death in the approval window ⇒ `ambiguous` ⇒ user restarts. (§2.3)
+- **PRECONDITION B — RESOLVED (2026-08-18).** Measured against the live OpenAI
+  device endpoints: re-polling after approval returns the **same**
+  `authorization_code` and `code_verifier`, so observing approval is **not**
+  consumptive and owner death before the exchange is recoverable. Exactly-once is
+  carried by the exchange claim alone. (§1.12, §2.3)
+- **Residual from B — cross-egress-IP tolerance.** The probe ran from a single
+  egress IP, so it proves idempotency, not that a *different* replica's IP is
+  accepted. Assessed low-risk (device flow is designed for a separate polling
+  device; the request carries only `device_auth_id` + `user_code`; no cookie/IP
+  binding observed) and covered by the `ambiguous → restart` fallback. A
+  second-egress-host probe would close it; nice-to-have, not a blocker.
 - Whether `shared-local` should remain a permanently supported sign-in topology
   or Phase 1's code is deleted once Phase 2 lands.
 - Whether transiently sealing exchanged tokens (§2.3 step 5) is worth the
@@ -955,7 +1053,18 @@ lands:
 
 ## Revision history
 
-- **r3** (this revision) — **PRECONDITION A resolved** by infra: prod HA runs a
+- **r4** (this revision) — **PRECONDITION B resolved** by empirical probe against
+  the live OpenAI device endpoints (2026-08-18, §1.12): re-polling after approval
+  returns the **same** `authorization_code` and `code_verifier`, refuting r2's
+  worst-case assumption that observing approval might consume the code. Codex
+  transition 3 changes from "DANGEROUS / `ambiguous`" to **recoverable via
+  re-poll**, with `ambiguous → restart` retained as the fallback covering the
+  unproven cross-egress-IP case. Recorded the clean separation this buys: the
+  **lease governs who polls; the exchange claim governs who exchanges and is the
+  complete exactly-once mechanism.** Phase 4 is unblocked and folds into Phase 2.
+  Both preconditions are now closed. Also noted the poll response carries
+  `user_code_expiration`, which our code does not parse (out of scope).
+- **r3** — **PRECONDITION A resolved** by infra: prod HA runs a
   shared-EFS RWX PVC with `persistent-per-user` and per-tenant/user `subPath`
   isolation (§1.6). Consequence: Claude sign-in in HA is no longer stopgap-shaped
   — durable attempt state is its only remaining blocker, in the general topology.

--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,0 +1,681 @@
+# Enabling Codex and Claude subscription OAuth sign-in in HA
+
+Status: **design proposal, not implemented.** August 2026.
+
+Scope: make the two provider subscription sign-in flows — Codex device auth
+(`codex-auth/device`) and Claude subscription OAuth (`claude-auth/oauth`, added
+by PR #2317) — actually work under `deployment.mode: ha` /
+`support_profile: constrained-active-active`, instead of returning
+`503 HA_FEATURE_UNSUPPORTED`.
+
+Non-goals: MCP OAuth (`mcp-servers/oauth-*`), OpenCode auth, and provider API-key
+paste flows. MCP OAuth has a distinct residual blocker described in
+[Why MCP OAuth stays gated](#why-mcp-oauth-stays-gated-and-why-that-does-not-apply-here);
+it is deliberately out of scope.
+
+Throughout, **VERIFIED** means read from the tree at this commit with a
+`file:line` citation. **DESIGN** means proposed and not yet built.
+
+---
+
+## TL;DR
+
+1. There is only **one** real blocker, not two. Credential-file visibility
+   (Blocker 2) is **already solved and already ungated** — `codexCredentialFiles`
+   is the one HA capability that is computed rather than hardcoded, and
+   `codex-auth/import` / `codex-auth/logout` already pass in a correctly
+   configured HA deployment. The remaining blocker is the **in-memory `attempts`
+   map** that holds the PKCE verifier / device code between requests.
+2. `processAffineAuth` is **not** a ready-made hook. It has **zero consumers** —
+   it is declared, assigned `false`, and asserted in one test fixture. Nothing
+   reads it. It cannot be "flipped on".
+3. Redis is **fanout-only** and is the wrong place for this. Auth paths are
+   explicitly denied entry to the Redis relay, and the house pattern for every
+   other HA-coordinated subsystem is PostgreSQL claims/leases.
+4. Agor already ships a **complete, production-grade durable OAuth attempt
+   store** for MCP OAuth: sealed PKCE material, tenant scoping, TTL, atomic
+   one-shot claim, ambiguity handling. Codex/Claude should reuse that pattern
+   rather than invent one.
+5. **Recommended: Phase 1 ships affinity-based enablement (small, low risk,
+   unblocks the shared-local topology today); Phase 2 ships the durable
+   PostgreSQL attempt store (unblocks `external` / multi-replica Cloud).**
+
+---
+
+## 1. Verified baseline
+
+### 1.1 The constrained HA profile and its fail-closed gate
+
+- The profile constant is `constrained-active-active`
+  (`apps/agor-daemon/src/ha-support.ts:6`).
+- `isConstrainedHa()` is simply `deployment.mode === 'ha'`
+  (`ha-support.ts:20-24`) — there is currently only one HA profile.
+- `isHaFeatureUnavailable()` (`ha-support.ts:33-40`) is the whole decision:
+
+  ```ts
+  if (!isConstrainedHa(deployment)) return false;
+  if (feature === 'codexAuth') return !deployment.capabilities.codexCredentialFiles;
+  return true;                       // <-- everything else: unconditionally gated
+  ```
+
+  Note the shape: **`codexAuth` is the only feature with a real condition.**
+  Every other feature — including `codexDeviceAuth` — falls through to the
+  unconditional `return true`.
+- The gate is applied as a `before:{all}` hook over an explicit inventory,
+  `CONSTRAINED_HA_PROCESS_AFFINE_SERVICE_GATES`
+  (`apps/agor-daemon/src/register-hooks.ts:525-539`), which contains
+  `['codex-auth/device', 'codexDeviceAuth']`, `['codex-auth/import', 'codexAuth']`,
+  and `['codex-auth/logout', 'codexAuth']`. It throws `Unavailable` with
+  `code: 'HA_FEATURE_UNSUPPORTED'` (`ha-support.ts:26-31`).
+
+This inventory-plus-capability shape is the key enablement lever: **the gates
+already read from capabilities, so making a capability conditionally true opens
+its gates with no change to the hook wiring.**
+
+### 1.2 The capability flags are typed as literal `false`
+
+`ResolvedDeploymentConfig` (`packages/core/src/config/deployment.ts:55-88`):
+
+```ts
+codexCredentialFiles: boolean;   // :74  <-- computed
+codexDeviceAuth: false;          // :75  <-- literal type, not boolean
+processAffineAuth: false;        // :76  <-- literal type, not boolean
+```
+
+and the values (`deployment.ts:469-472`):
+
+```ts
+codexCredentialFiles:
+  executorStorage.user_home !== 'replica-local' && tenantSafeCredentialHome,
+codexDeviceAuth: false,
+processAffineAuth: false,
+```
+
+**This is a stronger statement than "hardcoded false".** The *type* is the
+literal `false`, so assigning `true` is a compile error until the type widens to
+`boolean`. That is deliberate: it makes the capability un-flippable by accident,
+and it means enablement is necessarily a reviewed, typed change. `deployment.test.ts:50-58`
+asserts the resolved capability object exactly, so it pins this too.
+
+### 1.3 `processAffineAuth` has no consumers — it is vestigial
+
+Repo-wide, `processAffineAuth` appears exactly three times:
+
+| Site | What it is |
+| --- | --- |
+| `packages/core/src/config/deployment.ts:76` | type declaration (`false`) |
+| `packages/core/src/config/deployment.ts:472` | assignment (`false`) |
+| `apps/agor-daemon/src/ha-support.test.ts:31` | test fixture field |
+
+There is **no** `deployment.capabilities.processAffineAuth` read anywhere — not
+in `ha-support.ts`, not in `register-hooks.ts`, not in any service. It is also
+absent from the authoritative support matrix's prose
+(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md`), which
+discusses the concept but never names the flag.
+
+**Conclusion:** `processAffineAuth` is a documentary placeholder, not a switch.
+The brief's hypothesis that it is "a ready-made hook intended to be flipped true
+when the deployment guarantees request affinity" is **not supported by the code**.
+Any affinity-based design must add its own wiring; it should either give this
+flag a real meaning and consumers, or delete it. Leaving an unread capability
+flag in the resolved config is itself a small hazard — it reads like a control
+and is not one.
+
+### 1.4 Blocker 1 (VERIFIED): process-local attempt maps
+
+**Codex device auth** — `apps/agor-daemon/src/services/codex-device-auth.ts:263`:
+
+```ts
+const attempts = new Map<string, DeviceAuthAttempt>();
+```
+
+The attempt holds the device auth ID, user code, target identity, and status;
+a `setTimeout`-driven `pollTick()` loop (`:297-330`) polls OpenAI and writes
+credentials only after a local ownership check (`isCurrent`, `:330`). A pruning
+sweep expires overdue attempts (`:290-292`).
+
+**Claude OAuth** — `apps/agor-daemon/src/services/claude-oauth.ts:292` (on
+PR #2317 branch `claude-code-oauth-signin`; not yet on `main`):
+
+```ts
+const attempts = new Map<string, OAuthAttempt>();
+```
+
+keyed `` `${tenantId}:${userId}` `` (`:343`), holding `verifier` and `state`
+(`:253-254`), zeroed on completion (`:307-308`).
+
+The authoritative support matrix already states the intended fix
+(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:253`, Codex
+device auth row):
+
+> Classification: **D** initially; later **P+E** per user.
+> Owner death stops polling and status becomes idle elsewhere. User must request
+> a fresh provider code. **Two replicas can each create a "single" attempt in
+> static HA.**
+> Initial HA disposition: Keep disabled in hosted/multi-tenant HA […] **A future
+> design needs durable attempt generation and a per-user poller lease/fence.
+> Device IDs, codes, authorization codes, and tokens never go to Redis.**
+
+This design follows that stated intent.
+
+### 1.5 The two flows are structurally different, and it matters
+
+| | Codex device auth | Claude OAuth (PR #2317) |
+| --- | --- | --- |
+| Grant | RFC 8628 device authorization | authorization-code + PKCE (S256) |
+| Secret in attempt | device auth ID + user code | PKCE `verifier` + `state` |
+| Who drives completion | **daemon background poll loop** | **the user's next request** (paste `CODE#STATE`) |
+| Needs a live in-process timer | **Yes** | **No** |
+| Client ID | fixed public `app_EMoamEEZ73f0CkXaXp7hrann` (`codex-device-auth.ts:56`) | fixed public `9d1c250a-…` (`claude-oauth.ts:65`) |
+
+The asymmetry is the crux. **Claude OAuth is purely request-driven** — three
+calls (`create({})` → `find()` → `create({code})`) with no server-side timer.
+Making it HA-safe requires only that the attempt be *findable*.
+
+**Codex device auth additionally owns a live poll loop.** Even with durable
+attempt state, exactly one replica must own the polling, or N replicas each poll
+and race to redeem the same device code. That needs a lease, not just a row.
+
+### 1.6 Blocker 2 (VERIFIED): largely already solved
+
+`codexCredentialFiles` (`deployment.ts:469-470`) is true when
+`user_home !== 'replica-local'` **and** `hasTenantSafeExecutorCredentialHome()`,
+which is (`packages/core/src/config/executor-credential-storage.ts:8-15`):
+
+```ts
+config.multi_tenancy?.mode !== 'required_from_auth' ||
+config.execution?.executor_storage?.user_home === 'persistent-per-user'
+```
+
+`user_home` accepts `replica-local` | `shared` | `persistent-per-user`
+(`packages/core/src/config/types.ts:716-740`). HA startup already *refuses to
+boot* without a tenant-safe home (`deployment.ts:375-380`).
+
+A shared credential home is **not hypothetical — it is already provisioned and
+exercised**. `docker-compose.ha.yml:47,157` mounts a named volume
+`agor-ha-user-home` at `/home/agor` on both daemons, and `docker/ha/config.yaml:31`
+declares `user_home: shared`, with the comment:
+
+> One shared execution home for this static smoke profile. This makes auth-file
+> import/logout and Tasks replica-consistent, but is not Cloud's per-user
+> isolation contract. **The device-code poller remains gated.**
+
+Credential path resolution is already replica-independent: the daemon computes
+the target home (`resolveOwnerHomeStore()`,
+`apps/agor-daemon/src/utils/sandbox-context.ts:108-124` →
+`<data_home>/tenants/<tenant>/homes/<user>`), passes it to the executor as
+`CODEX_HOME` (`apps/agor-daemon/src/utils/executor-codex-auth.ts:25-43`), and the
+executor writes `0600` (`packages/executor/src/commands/codex-auth-file.ts:84-85`).
+Nothing in that path is process-affine.
+
+**Therefore: Blocker 2 needs no new mechanism for the supported topologies.**
+It needs (a) generalizing the Codex-specific capability name to cover Claude, and
+(b) an operator-facing storage contract for `persistent-per-user` on Cloud. It is
+a naming and documentation gap, not an architecture gap.
+
+### 1.7 Redis is fanout-only and is explicitly denied to auth paths
+
+- Redis is required in HA but used **solely** as the Socket.IO adapter /
+  `serverSideEmit` relay (`apps/agor-daemon/src/realtime/redis-realtime.ts`;
+  boot fails closed at `:129-130`). It is `ioredis` behind
+  `@socket.io/redis-adapter`; **no generic GET/SET/SETEX/lock surface is exposed
+  to application code.**
+- `REDIS_FEATHERS_DENIED_PATHS`
+  (`apps/agor-daemon/src/utils/realtime-publish.ts:251-273`) explicitly lists
+  `codex-auth/device`, `codex-auth/import`, `codex-auth/logout`, every
+  `mcp-servers/oauth-*`, `user-mcp-oauth-tokens`, `session-tokens`, and
+  `terminals`, under the comment (`:249-250`):
+
+  > Authentication and credential control-plane results must never enter shared
+  > Redis, even if a future service accidentally enables publication for them.
+
+- Every other HA-coordinated subsystem coordinates through **PostgreSQL**, not
+  Redis: knowledge-embedding claims
+  (`packages/core/src/db/repositories/knowledge-embedding-work.ts:29-49`),
+  environment-health leases (`repositories/environment-health.ts:26-41`), widget
+  resolution durable claims, gateway listener leases, executor session-token
+  bounded-use. All use the same idiom: atomic conditional `UPDATE` fenced by a
+  `claim_token` + `claim_generation` + DB-clock `expires_at`. There is no leader
+  election and no `SELECT … FOR UPDATE`.
+
+**Conclusion: Redis is not a candidate for attempt state.** Using it would mean
+building a new key/value surface, breaching a stated security boundary, and
+diverging from the house coordination pattern — three costs for no benefit over
+PostgreSQL.
+
+### 1.8 The durable-attempt pattern already exists (MCP OAuth)
+
+`mcp_oauth_pending_flows` (`packages/core/src/db/schema.postgres.ts:1792-1858`)
+is a complete worked example of exactly the record this design needs:
+
+- `tenant_id`, `user_id`, `attempt_id` (PK), `status`
+  (`pending`/`exchanging`/`succeeded`/`failed`/`ambiguous`/`expired`).
+- `state_hash` — SHA-256 of the OAuth `state`, **UNIQUE** (`:1834`). The raw
+  state is never a column.
+- `sealed_material` — the PKCE verifier and state, **AES-256-GCM sealed** via
+  `sealMCPOAuthSecret()` (`packages/core/src/db/oauth-secret-envelope.ts`),
+  scrypt-derived key from `AGOR_MASTER_SECRET`, with the tenant/user/server/
+  attempt/generation binding as **AAD** so a moved or retagged row fails to open.
+  Cleared on terminal states.
+- `expires_at` — DB-clock TTL, 10 minutes
+  (`services/mcp-oauth-pending-flow-authority.ts:34`).
+- `exchange_claim_id` — the one-shot fence. Claim is a single atomic
+  `UPDATE … SET status='exchanging', exchange_claim_id=? WHERE state_hash=? AND
+  status='pending' AND expires_at > CURRENT_TIMESTAMP AND is_current=true
+  RETURNING *` (`repositories/mcp-oauth-pending-flows.ts:357-372`). Two racing
+  replicas: exactly one gets a row. Proven by a two-pool race test
+  (`mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`).
+- `maintain()` (`repositories/mcp-oauth-pending-flows.ts:532-575`) expires
+  overdue rows, marks abandoned exchanges `ambiguous` after 2 minutes, and
+  deletes terminal rows after 24h.
+- Tenant scoping via `runWithTenantDatabaseScope(db, tenantId, …)`
+  (`packages/core/src/db/tenant-scope.ts:200-240`), which opens a native
+  transaction and sets the tenant GUC for RLS.
+
+**This is the blueprint.** Phase 2 below is largely "instantiate this table
+shape for provider sign-in", not "design a durable OAuth store".
+
+### 1.9 Why MCP OAuth stays gated, and why that does not apply here
+
+MCP OAuth has a durable table and is *still* gated. The residual reason is
+process-local **Dynamic Client Registration** state
+(`oauth-mcp-transport.ts:415-418`):
+
+```ts
+// Cache for dynamically registered clients (per authorization server)
+const dynamicClientCache = new Map<string, { client_id; client_secret?; redirect_uri }>();
+```
+
+The sealed material does not carry the dynamically registered `client_id` /
+`client_secret`, so a replica that wins the durable claim may not hold the client
+credentials needed to complete the exchange.
+
+**Codex and Claude have no DCR.** Both use a single fixed, public, compile-time
+client ID (`codex-device-auth.ts:56`; `claude-oauth.ts:65`). Every replica is
+identically configured to talk to the provider.
+
+This is the most consequential finding in this document: **provider sign-in is
+strictly easier to make HA-safe than MCP OAuth**, and it is blocked only by the
+attempt map, not by the harder problem that keeps MCP OAuth gated.
+
+### 1.10 Ingress affinity is already mandatory
+
+- HA **refuses to boot** without it (`deployment.ts:349-353`):
+  `'Config error: HA requires deployment.ha.ingress_affinity: true for Engine.IO polling'`.
+- The resolved topology types it as literally `ingressAffinity: true` in both
+  variants (`deployment.ts:86-87`).
+- The browser talks to the daemon over **Socket.IO**
+  (`packages/core/src/api/index.ts:1413`, `transports: ['websocket','polling']`
+  at `:1384`), and the Claude sign-in pane calls
+  `client.service('claude-auth/oauth')`
+  (`ClaudeOAuthSignIn.tsx:44-52`) — so all three calls of one sign-in ride **one
+  sticky connection to one replica**.
+- Caveat, stated in the ops guidance
+  (`docs/internal/daemon-ha-redis-realtime-2026-08-07.md:92-93`): affinity is
+  configured for the `/socket.io/` path only — *"leave REST unsticky"*. A live
+  WebSocket never migrates; after daemon loss the client makes a **new**
+  connection which may land anywhere.
+- There is an accepted precedent for shipping a feature on exactly this
+  contract: web terminals (`apps/agor-daemon/src/terminal-capability.ts:25-32`)
+  are enabled only when `execution === 'shared-local' && sharedFilesystem &&
+  ingressAffinity`, with the documented failure semantics in
+  `context/explorations/web-terminal-ownership-ha.md`: *"Owner loss ends the Agor
+  attachment. The UI displays Disconnected and requires an explicit Reconnect."*
+
+---
+
+## 2. Blocker 1 — attempt state: options
+
+### Option A — affinity-scoped, owner-fenced in-process attempt
+
+Keep the `attempts` map in process. Make the capability conditionally true when
+the deployment's topology guarantees affinity, and make owner loss an explicit,
+visible "start over" rather than a silent wrong answer.
+
+**DESIGN sketch**
+
+1. Widen `codexDeviceAuth` / add `claudeOAuth` from literal `false` to `boolean`
+   in `ResolvedDeploymentConfig`.
+2. Compute them from real guarantees, mirroring `terminal-capability.ts`:
+   `topology.ingressAffinity === true && topology.execution === 'shared-local'
+   && codexCredentialFiles`. (`shared-local` is required because Codex's poller
+   must write the credential file from the replica that owns the poll.)
+3. Stamp each attempt with the daemon **boot ID** and return it in the status
+   payload. A `find()`/`create({code})` arriving at a replica whose boot ID does
+   not match returns a distinct, non-scary `attempt_not_on_this_replica` status,
+   and the UI restarts the sign-in — the same UX contract as terminal Reconnect.
+4. Drain handling: on `SIGTERM`, cancel live attempts and push a terminal status
+   before the replica leaves the pool.
+
+**Pros.** Small and well-precedented; no schema, no migration, no new secret
+storage. **Keeps the PKCE verifier in-process, preserving the current security
+contract exactly** — no new place for a verifier to live. Ships for the
+`shared-local` topology, which is the checked-in HA smoke stack.
+
+**Cons.** Does **not** work for `execution_topology: external` (Cloud's intended
+shape), because affinity is only asserted for `/socket.io/` — a REST or
+external-callback entry can land anywhere. Rolling deploys become user-visible:
+every replica restart aborts in-flight sign-ins. Affinity is an *operational*
+promise from ingress config, and the daemon cannot verify it; a misconfigured
+ingress silently degrades to "sometimes works", which is a worse failure mode
+than the honest 503 today. Two replicas can still each create a "single" attempt
+if the client reconnects mid-flow (the matrix's stated concern,
+`process-affine-ha-support-matrix-2026-08-07.md:253`).
+
+### Option B — durable attempt state in PostgreSQL (sealed), + poller lease
+
+Instantiate the `mcp_oauth_pending_flows` pattern for provider sign-in.
+
+**DESIGN sketch** — new table `provider_auth_pending_flows`:
+
+| Column | Purpose |
+| --- | --- |
+| `tenant_id`, `user_id` | tenant scoping / RLS |
+| `attempt_id` (PK) | identity |
+| `provider` | `codex` \| `claude` — one table, both flows |
+| `state_hash` UNIQUE | SHA-256 of `state` (Claude); for Codex, of the device auth ID |
+| `sealed_material` | AES-256-GCM sealed `{verifier, state}` / `{deviceAuthId, userCode}`, AAD-bound to tenant+user+provider+attempt+generation |
+| `status` | `pending`/`exchanging`/`succeeded`/`failed`/`ambiguous`/`expired` |
+| `attempt_generation` | fences an older attempt against a newer one for the same user |
+| `expires_at` | DB-clock TTL (10 min Claude; provider `expires_in` for Codex) |
+| `exchange_claim_id` | one-shot exchange fence |
+| `poll_lease_owner`, `poll_lease_expires_at` | **Codex only** — single-poller lease |
+| `created_at`/`updated_at`/`finished_at` | lifecycle + `maintain()` pruning |
+
+- Reuse `sealMCPOAuthSecret()` / `openMCPOAuthSecret()` with a **new purpose
+  domain** (e.g. `'provider-signin'`) so envelopes cannot be cross-used between
+  MCP OAuth and provider sign-in.
+- Claude exchange = the existing atomic claim: `UPDATE … SET status='exchanging',
+  exchange_claim_id=? WHERE state_hash=? AND status='pending' AND expires_at >
+  CURRENT_TIMESTAMP RETURNING *`. Loser does not exchange.
+- Codex polling = a renewable lease (the `environment-health.ts:26-41` idiom).
+  Each replica's ticker tries to claim expired leases; exactly one polls. On
+  owner death another replica picks the lease up within one lease period and
+  **resumes polling the same device code** — a genuine availability improvement
+  over Option A, not just parity.
+- Credential write on success goes through the existing, already-replica-agnostic
+  executor path (§1.6). Requires `codexCredentialFiles` — i.e. a
+  non-`replica-local` home — which is orthogonal and already enforced.
+- Follow the MCP precedent on ambiguity: if a replica dies after the provider may
+  have consumed the code, the row becomes `ambiguous` and **is never replayed**.
+
+**Pros.** Works for **both** topologies including `external`. Survives replica
+loss and rolling deploys. Matches the stated intent at
+`process-affine-ha-support-matrix-2026-08-07.md:253` ("durable attempt generation
+and a per-user poller lease/fence") and the house PostgreSQL-claims pattern. One
+table serves both providers.
+
+**Cons — and one must be called out explicitly.** This **breaks the current
+in-process-only security contract for the PKCE verifier.** Today the verifier
+exists only in one process's heap and is zeroed on completion
+(`claude-oauth.ts:307-308`); afterwards it is a sealed row in a shared database.
+Sealing with AAD binding makes that acceptable — it is precisely what MCP OAuth
+already does for the same class of secret — but it is a real change in blast
+radius and must be reviewed as one, not waved through by analogy. Also: requires
+a migration and whole-cohort rollout; hard-depends on a fleet-shared
+`AGOR_MASTER_SECRET`; and SQLite/standalone must retain the local Map, so the
+service carries two code paths (again, as MCP OAuth already does).
+
+### Option C — Redis-hosted attempt state
+
+**Rejected.** §1.7: Redis exposes no key/value surface to application code, auth
+paths are explicitly denied the relay, the matrix repeats "never go to Redis" for
+device codes and authorization codes, and nothing else in the system coordinates
+through Redis. Recorded here only so it is not re-proposed.
+
+---
+
+## 3. Blocker 2 — credential visibility: options
+
+### Option A — shared / per-user executor credential home (RECOMMENDED)
+
+Already implemented and already exercised (§1.6). Nothing to build for
+`shared-local`. For Cloud (`external` + `required_from_auth`), the requirement is
+already enforced at boot: `user_home: persistent-per-user`
+(`deployment.ts:375-380`).
+
+**Remaining work is not code:** an operator-facing storage contract stating that
+`persistent-per-user` must be backed by storage that presents the same per-user
+home to every replica (RWX PVC / NFS / per-user volume), mounted at the same
+path. **UNVERIFIED / open:** the repo documents the *contract* but no concrete
+Cloud provisioning of `persistent-per-user` was found — only the `shared` Compose
+smoke stack. Cloud's actual backing store must be confirmed with whoever owns
+that deployment before Phase 3 is scoped.
+
+### Option B — credentials in encrypted DB, materialized per session
+
+Store the provider credential (access + refresh token) sealed in PostgreSQL and
+write it to the executor home at session start.
+
+**Pros.** Removes the shared-filesystem requirement entirely; would let
+`user_home: replica-local` work; centralizes revocation.
+
+**Cons.** Substantially larger. The provider CLIs **own** these files — Claude
+Code and Codex both refresh their tokens in place, so the DB copy goes stale and
+Agor would need read-back/reconciliation, or would clobber a refreshed token.
+Materializing a credential into a workspace on every session start widens
+exposure rather than narrowing it. Today the DB deliberately stores only the
+*method* identifier, never token material
+(`packages/core/src/db/schema.sqlite.ts:1041`) — this reverses a standing design
+decision.
+
+**Verdict: not now.** Revisit only if a topology genuinely cannot provide a
+consistent per-user home.
+
+---
+
+## 4. Enablement mechanism
+
+The gates are already capability-driven, so enablement is mostly typing and
+computation — plus deleting a misleading flag.
+
+1. **Widen the literal types** in `ResolvedDeploymentConfig`
+   (`deployment.ts:74-76`): `codexDeviceAuth: false` → `boolean`; add
+   `claudeOAuth: boolean`.
+2. **Generalize the credential-file capability name.** `codexCredentialFiles`
+   already gates Claude in PR #2317 — `ha-support.ts` there maps *both*
+   `codexAuth` and `claudeAuth` onto `capabilities.codexCredentialFiles`. That is
+   correct behavior under a misleading name. Rename to
+   `executorCredentialFiles` (keeping the same computation) so the next provider
+   does not have to read Codex's name to understand its own gate.
+3. **Resolve `processAffineAuth`.** It has no consumers (§1.3). Either give it a
+   real definition and readers (Phase 1) or delete it. Do not leave an unread
+   flag that looks like a control.
+4. **Add the `claudeOAuth` feature key** to `HA_UNSUPPORTED_FEATURES` and the
+   gate inventory — **already done by PR #2317**
+   (`ha-support.ts` +`claudeAuth`/`claudeOAuth`; `register-hooks.ts`
+   +`['claude-auth/oauth','claudeOAuth']`, `['claude-auth/logout','claudeAuth']`).
+   This design **builds on that**; it does not redo it.
+5. **Extend `isHaFeatureUnavailable()`** so `codexDeviceAuth` and `claudeOAuth`
+   read their capabilities instead of falling through to `return true`.
+6. **One implementation, both providers.** PR #2317 already de-duplicated the
+   executor plumbing (`utils/executor-credential-auth.ts`,
+   `packages/executor/src/commands/credential-file-io.ts`). The attempt store
+   should likewise be one module with a `provider` discriminator, not two.
+
+**Tests to update** (all currently pin the closed state):
+`apps/agor-daemon/src/ha-support.test.ts:116-138` (asserts the exact
+`HA_UNSUPPORTED_FEATURES` key list, and that `codexDeviceAuth` is unavailable);
+`packages/core/src/config/deployment.test.ts:50-58` (asserts the exact resolved
+capability object); `register-hooks.test.ts:386`. Add negative coverage: gates
+must still close when the enabling condition is absent.
+
+---
+
+## 5. Security review checklist
+
+Any implementation must satisfy all of these before enablement ships.
+
+**Secret handling**
+- [ ] PKCE verifier, `state`, device codes, authorization codes, and tokens are
+      never logged, never returned to the client, and never enter an agent/LLM
+      context (the current services already assert this — `claude-oauth.ts:29-30`).
+- [ ] Under Option B, the verifier is sealed with AES-256-GCM under a **distinct
+      purpose domain** from MCP OAuth, AAD-bound to tenant+user+provider+attempt+
+      generation, so a row cannot be replayed under a different binding.
+- [ ] Raw `state` is stored only as a SHA-256 hash in an indexed column; the
+      unique index is on the hash.
+- [ ] Sealed material is cleared on every terminal status.
+- [ ] `state` comparison stays constant-time (`claude-oauth.ts:160`).
+- [ ] Explicitly confirm these paths stay in `REDIS_FEATHERS_DENIED_PATHS`
+      (`realtime-publish.ts:251-273`) — and **add `claude-auth/oauth` and
+      `claude-auth/logout`, which are absent from that set on PR #2317.**
+
+      *Gap found during this review, and worth fixing on #2317 rather than here.*
+      `mayEnterRedisRelay()` (`realtime-publish.ts:275-282`) is **default-allow** —
+      a path is relayed unless it is explicitly denied. All three Codex
+      counterparts (`codex-auth/device`, `codex-auth/import`, `codex-auth/logout`)
+      *are* denied (`:268-270`); the Claude equivalents were not added. This is a
+      parity gap, not a confirmed leak: `claude-auth/logout` deliberately emits
+      `patched` (`register-services.ts:742-743`) and the oauth service returns
+      status metadata only — token material and the verifier are never in a
+      response (`claude-oauth.ts:29-30`). But the denied set exists precisely as
+      defense-in-depth "even if a future service accidentally enables publication
+      for them" (`:249-250`), and enabling these endpoints in HA is exactly the
+      change that makes the omission load-bearing.
+
+**Tenant / user isolation**
+- [ ] Every read and write goes through `runWithTenantDatabaseScope()`; no
+      unscoped query on the attempt table.
+- [ ] An attempt is bound to `(tenant_id, user_id)` and can only be found,
+      claimed, or completed by that same identity — a replica must not complete
+      an attempt for a different user because the row happened to be visible.
+- [ ] Cross-tenant negative tests, per CLAUDE.md's multi-tenancy rule and
+      mirroring `mcp-oauth-pending-flow-authority.postgres.test.ts:228-293`.
+- [ ] Credential write still targets the caller's own resolved home; confirm
+      `required_from_auth` + non-`persistent-per-user` remains refused at boot.
+
+**Lifecycle**
+- [ ] Short TTL on DB clock (`CURRENT_TIMESTAMP`), never application clock.
+- [ ] `maintain()` sweep: expire overdue, mark abandoned exchanges `ambiguous`,
+      delete terminal rows.
+- [ ] One-shot exchange claim; an authorization/device code is **never replayed**
+      after an ambiguous outcome.
+- [ ] Codex poll lease is single-owner and fenced; two replicas never poll one
+      device code concurrently.
+- [ ] Newer attempt for a user fences older ones (`attempt_generation`).
+
+**Revocation & rollout**
+- [ ] Logout deletes the credential file *and* any live attempt rows.
+- [ ] Local deletion is not provider-side revocation — document that, as MCP
+      OAuth already does.
+- [ ] Rollout requires a fleet-shared stable `AGOR_MASTER_SECRET`; a replica
+      without it must fail closed, not fall back to plaintext.
+- [ ] Rate limiting: the auth limiter is in-memory and per-replica
+      (`process-affine-ha-support-matrix-2026-08-07.md`, "Auth/launch rate limit"
+      row) — N replicas multiply allowed attempts. Enabling these endpoints in HA
+      increases the value of edge/WAF quota enforcement; state this rather than
+      implying the local limiter is fleet enforcement.
+
+---
+
+## 6. Recommendation
+
+**Do Option B (durable PostgreSQL attempt state), but ship Option A first as a
+narrow, honestly-scoped Phase 1.**
+
+Rationale: Option A is cheap, is precedented by web terminals, keeps the verifier
+in-process, and unblocks the `shared-local` topology this week — but it cannot
+serve `external`, which is where Cloud is going, and it converts an honest 503
+into a silent dependence on ingress configuration the daemon cannot verify.
+Option B is the design the support matrix already asked for, reuses a shipped and
+race-tested mechanism, and is the only one that survives replica loss and rolling
+deploys. Phase 1 should therefore be gated on `shared-local` specifically, and
+framed as a stopgap that Phase 2 subsumes — not as the destination.
+
+If only one phase can be funded, **do Phase 2 and skip Phase 1.**
+
+---
+
+## 7. Phased implementation plan
+
+### Phase 0 — land PR #2317 (prerequisite, already in flight)
+
+Claude sign-in and its `claudeAuth`/`claudeOAuth` HA feature keys must be on
+`main` before either phase. No HA behavior change: both features fail closed.
+
+### Phase 1 — affinity-scoped enablement for `shared-local` (~2-3 days)
+
+- Widen `codexDeviceAuth`/`claudeOAuth` to `boolean`; compute from
+  `topology.execution === 'shared-local' && topology.ingressAffinity &&
+  executorCredentialFiles`.
+- Give `processAffineAuth` a real meaning and readers, or delete it.
+- Boot-ID-stamp attempts; add an explicit `attempt_not_on_this_replica` status
+  and the UI restart affordance; drain live attempts on `SIGTERM`.
+- Rename `codexCredentialFiles` → `executorCredentialFiles`.
+- Update `ha-support.test.ts`, `deployment.test.ts`, `register-hooks.test.ts`;
+  add negative coverage for `external` (must stay 503).
+- Docs: `daemon-ha.mdx` — state the affinity requirement, and that replica loss
+  aborts an in-flight sign-in.
+
+**Risk: medium.** Correctness depends on operator ingress config the daemon
+cannot verify. Mitigate by scoping strictly to `shared-local` and documenting the
+failure mode loudly.
+
+### Phase 2 — durable attempt store + Codex poller lease (~1.5-2.5 weeks)
+
+- Migration: `provider_auth_pending_flows` (+ RLS policy), modeled on migration
+  `0078`'s table.
+- `ProviderAuthPendingFlowRepository` (atomic claim, lease claim/renew/release,
+  `maintain()`); `ProviderAuthPendingFlowAuthority` service, new seal purpose
+  domain.
+- Refactor both services onto it; **keep the local Map for SQLite/standalone**,
+  as MCP OAuth does.
+- Codex poll lease + resume-on-new-owner; ambiguous-outcome handling with no
+  code replay.
+- Enable `codexDeviceAuth`/`claudeOAuth` for **both** topologies when
+  `executorCredentialFiles` and PostgreSQL are present.
+- Tests: two-pool PostgreSQL race (mirroring
+  `mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`), lease handoff,
+  cross-tenant negatives, TTL/prune, seal/open AAD-tamper rejection, kill-a-replica
+  mid-flow integration on the Compose HA stack.
+
+**Risk: medium-high** — migration, rollout ordering, and a real change to where a
+PKCE verifier lives. Requires the §5 checklist signed off and a fleet-shared
+`AGOR_MASTER_SECRET`.
+
+### Phase 3 — `external` topology / Cloud (scoping blocked)
+
+Confirm how Cloud actually backs `persistent-per-user`, then validate the
+credential write path end-to-end there. **Cannot be scoped from this repo alone**
+(§3 Option A).
+
+### Rollout / flagging
+
+Enablement is already a config-derived capability, so no new feature flag is
+needed — a deployment opts in by declaring the storage and topology guarantees,
+and the existing gates open. Roll out Phase 2 as a whole-cohort cutover after the
+migration (the pattern used for `0078` and `0082`). Because gates are computed
+per-replica, a partially-upgraded fleet can advertise different capabilities;
+prefer an offline cutover over a rolling one.
+
+---
+
+## 8. Open questions / not determined
+
+1. **Cloud's `persistent-per-user` backing store.** Only the `shared` Compose
+   smoke stack exists in-repo. Needs the deployment owner. (§3)
+2. **`processAffineAuth` original intent.** Zero consumers, absent from the
+   matrix prose; whether it was a placeholder for this work or a leftover could
+   not be established from the tree or history. (§1.3)
+3. **Provider tolerance for a resumed device-code poll from a different source.**
+   Whether OpenAI's device endpoint objects to a poll resuming from another
+   replica IP was not tested; it is protocol-legal but should be verified before
+   Phase 2's lease-handoff is relied upon.
+4. **Whether `shared-local` should be a permanent supported topology for sign-in**
+   or only a stopgap — affects whether Phase 1's code is kept or removed after
+   Phase 2.
+
+---
+
+## Related
+
+- `context/explorations/claude-code-oauth-signin.md` (on PR #2317) — the Claude
+  flow's verified protocol details.
+- `context/explorations/web-terminal-ownership-ha.md` — the affinity + owner
+  fencing + visible reconnect precedent.
+- `docs/internal/process-affine-ha-support-matrix-2026-08-07.md` — authoritative
+  per-flow HA classification and stated intent.
+- `docs/internal/daemon-ha-redis-realtime-2026-08-07.md` — Redis fanout contract
+  and ingress affinity operational guidance.
+- `apps/agor-docs/content/guide/daemon-ha.mdx` — operator-facing HA contract.

--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,1102 +1,406 @@
-# Enabling Codex and Claude subscription OAuth sign-in in HA
+# Provider subscription sign-in in HA
 
-Status: **design proposal, not implemented.** August 2026.
-Revision 4 — **both preconditions now resolved**: A by infra (shared EFS), B by
-empirical probe (the device poll is re-fetchable). See
-[Revision history](#revision-history).
+Status: **current-state record and remaining Claude design**, reviewed against
+`main` at `390e9216` on 2026-08-24.
 
-Scope: make the two provider subscription sign-in flows — Codex device auth
-(`codex-auth/device`) and Claude subscription OAuth (`claude-auth/oauth`, added
-by PR #2317) — actually work under `deployment.mode: ha` /
-`support_profile: constrained-active-active`, instead of returning
-`503 HA_FEATURE_UNSUPPORTED`.
+This document originally proposed one future design for Codex device sign-in and
+Claude subscription OAuth. That is no longer an accurate shape:
 
-Non-goals: MCP OAuth (`mcp-servers/oauth-*`), OpenCode auth, and provider API-key
-paste flows.
+- [PR #2521](https://github.com/preset-io/agor/pull/2521) has implemented the
+  Codex half on `main`, with materially stronger credential-mutation fencing than
+  the original proposal.
+- Claude subscription OAuth is not on `main`. Its standalone foundation remains
+  in [PR #2317](https://github.com/preset-io/agor/pull/2317), and the first durable
+  attempt implementation remains in the stacked
+  [PR #2462](https://github.com/preset-io/agor/pull/2462).
 
-Throughout, **VERIFIED** means read from the tree at this commit with a
-`file:line` citation. **DESIGN** means proposed and not yet built.
-**PRECONDITION** means an external fact this design depends on which the repo
-alone cannot settle. Both preconditions raised by earlier revisions — A
-(credential substrate) and B (device-poll semantics) — are now **resolved**;
-see §1.6 and §1.12. Their residuals are tracked in §9.
+The current Codex contract lives in
+[`codex-device-auth-ha.md`](./codex-device-auth-ha.md) and the operator contract
+lives in
+[`daemon-ha.mdx`](../../apps/agor-docs/content/guide/daemon-ha.mdx). Do not use
+the deleted revisions of this document as an implementation specification.
 
----
+## Scope
 
-## TL;DR
+This document does two things:
 
-1. The blocking mechanism is the **in-memory `attempts` map** that holds
-   per-attempt secret material between requests
-   (`codex-device-auth.ts:263`; `claude-oauth.ts:292` on #2317).
-2. Credential-file visibility is **solved in both topologies**. PRECONDITION A is
-   **RESOLVED**: prod HA runs a shared-EFS RWX PVC with
-   `user_home: persistent-per-user` and per-tenant/per-user `subPath` isolation
-   (§1.6). Consequence: **Claude subscription OAuth in HA is not limited to an
-   affinity-scoped stopgap** — the only remaining blocker for Claude is durable
-   attempt state (Phase 2), in the general topology.
-   Two new EFS-derived requirements apply (§1.10): persistent identity on both
-   the credential-write and session-run paths, and fsync-before-rename.
-3. `processAffineAuth` has **zero consumers** — declared, assigned `false`, one
-   test fixture. It is not a switch. **Delete it**; do not rehabilitate it.
-4. Redis is fanout-only and auth paths are explicitly denied the relay.
-   PostgreSQL claims/leases are the house pattern. Redis is not a candidate.
-5. Agor's MCP OAuth authority provides reusable **primitives** — sealed envelope,
-   atomic one-shot claim, tenant scope, TTL/prune. Reuse the primitives.
-   **Do not** assume one generic table serves both providers: Codex's flow has a
-   materially different external-call shape and needs its own state machine (§2.3).
-6. **Recommended: go straight to Phase 2 — durable PostgreSQL attempt state,
-   serving the general topology.** With A resolved, Phase 1's affinity-scoped
-   stopgap buys only a few days of earlier `shared-local` availability and is now
-   optional. **PRECONDITION B is also resolved** (§1.12): the device-token poll
-   was measured re-fetchable, so Codex poll-lease resumption is unblocked and
-   owner death before the exchange is recoverable. Exactly-once lives entirely at
-   the exchange claim.
+1. records the PR lineage and the currently shipped Codex behavior; and
+2. defines the smallest sound design still required before Claude subscription
+   OAuth may be enabled in `deployment.mode: ha`.
 
----
+MCP OAuth, OpenCode auth, and API-key-only flows are out of scope. The reusable
+MCP security primitives remain relevant; its state machine is not a generic
+provider-auth state machine.
 
-## 1. Verified baseline
+## PR lineage and review snapshot
 
-### 1.1 The constrained HA profile and its fail-closed gate
+The branches are siblings plus one stack, not one four-PR stack:
 
-- Profile constant `constrained-active-active` (`apps/agor-daemon/src/ha-support.ts:6`).
-- `isConstrainedHa()` is just `deployment.mode === 'ha'` (`:20-24`).
-- `isHaFeatureUnavailable()` (`:33-40`):
-
-  ```ts
-  if (!isConstrainedHa(deployment)) return false;
-  if (feature === 'codexAuth') return !deployment.capabilities.codexCredentialFiles;
-  return true;                       // <-- everything else: unconditionally gated
-  ```
-
-  `codexAuth` is the only feature with a real condition; `codexDeviceAuth` falls
-  through to the unconditional `return true`.
-- Applied as a `before:{all}` hook over `CONSTRAINED_HA_PROCESS_AFFINE_SERVICE_GATES`
-  (`register-hooks.ts:525-539`), throwing `Unavailable` with
-  `code: 'HA_FEATURE_UNSUPPORTED'` (`ha-support.ts:26-31`).
-
-**The gates already read from capabilities**, so making a capability
-conditionally true opens its gates with no change to hook wiring.
-
-### 1.2 The capability flags are typed as literal `false`
-
-`ResolvedDeploymentConfig` (`deployment.ts:55-88`):
-
-```ts
-codexCredentialFiles: boolean;   // :74  <-- computed
-codexDeviceAuth: false;          // :75  <-- literal type
-processAffineAuth: false;        // :76  <-- literal type
+```text
+main
+├── oauth-signin-ha-enablement-design      # PR #2449, this document
+├── claude-code-oauth-signin               # PR #2317
+│   └── oauth-signin-ha-durable-attempts   # PR #2462, exactly five commits
+└── #2521                                  # merged to main as a44bba08
 ```
 
-The *type* is the literal `false`, so assigning `true` is a compile error until
-the type widens. Enablement is necessarily a typed, reviewed change.
-`deployment.test.ts:50-58` pins the resolved object exactly.
-
-### 1.3 `processAffineAuth` has no consumers — delete it
-
-Three occurrences repo-wide: type declaration (`deployment.ts:76`), assignment
-(`:472`), test fixture (`ha-support.test.ts:31`). **No `capabilities.processAffineAuth`
-read exists anywhere.** It is absent from the support matrix's prose.
-
-It is a documentary placeholder, not a switch. This design **deletes it** rather
-than giving it meaning: narrowly-named per-provider capabilities
-(`codexDeviceAuth`, `claudeOAuth`) express the actual conditions, and a
-general-sounding "process affine auth" flag would invite exactly the
-over-broad reasoning that produced revision 1's error.
-
-### 1.4 Blocker: process-local attempt maps
-
-**Codex** — `codex-device-auth.ts:263`: `const attempts = new Map<string, DeviceAuthAttempt>()`.
-Attempt holds device auth ID, user code, target identity, status; a
-`setTimeout`-driven `pollTick()` (`:297-330`) polls OpenAI and writes credentials
-only after a local ownership check (`:330`).
-
-**Claude** (#2317) — `claude-oauth.ts:292`, keyed `` `${tenantId}:${userId}` ``
-(`:343`), holding `verifier` and `state` (`:253-254`), zeroed on completion
-(`:307-308`).
-
-Stated intent (`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:253`):
-
-> Initial HA disposition: Keep disabled in hosted/multi-tenant HA […] **A future
-> design needs durable attempt generation and a per-user poller lease/fence.
-> Device IDs, codes, authorization codes, and tokens never go to Redis.**
-
-### 1.5 The two flows differ structurally, and it drives the whole design
-
-| | Codex device auth | Claude OAuth (#2317) |
-| --- | --- | --- |
-| Grant | RFC 8628 device authorization | authorization-code + PKCE (S256) |
-| Who generates the PKCE verifier | **the provider** — returned in the poll response (`codex-device-auth.ts:151`) | **the daemon** (`claude-oauth.ts:114`) |
-| Who drives completion | **daemon background poll loop** | **the user's next request** (paste `CODE#STATE`) |
-| Needs a live in-process timer | **Yes** | **No** |
-| Authorization code arrives | mid-poll, unprompted (`:150-156`) | from the user, in a request |
-| Code lifetime | fixed 15 min constant `DEVICE_CODE_LIFETIME_MS` (`:57-58`), applied as `Date.now() + …` (`:435`) | 10 min daemon-side |
-| Client ID | fixed public `app_EMoamEEZ73f0CkXaXp7hrann` (`:56`) | fixed public `9d1c250a-…` (`claude-oauth.ts:65`) |
-
-Two consequences that revision 1 under-weighted:
-
-**(a) Claude is purely request-driven.** Three calls (`create({})` → `find()` →
-`create({code})`) with no server-side timer. Making it HA-safe requires only that
-the attempt be *findable*.
-
-**(b) Codex receives the authorization code as an unprompted side effect of a
-poll.** `pollDeviceToken()` (`:137-157`) returns `{authorizationCode, codeVerifier}`
-the moment the user approves. That value exists only in the polling replica's
-heap until something durably records it.
-
-Revision 2 treated this as potentially *consumptive* — that observing approval
-might itself burn the code. **That worst case has been empirically refuted**
-(§1.12): re-polling after approval returns the same `authorization_code` and
-`code_verifier`. The poll is re-fetchable; the single-use step is the exchange
-alone. §2.3 is built on that measured behavior.
-
-Note also that the Codex `usercode` response parses only `device_auth_id`,
-`user_code`, and `interval` (`:115-128`) — **there is no `expires_in`**. Lifetime
-is the fixed local constant. Any durable design must keep using a fixed lifetime
-(preferably recomputed on the DB clock) and must not invent an `expires_in`.
-
-### 1.6 Credential-file visibility: solved for `shared-local`, declared for `external`
-
-`codexCredentialFiles` (`deployment.ts:469-470`) is true when
-`user_home !== 'replica-local'` **and** `hasTenantSafeExecutorCredentialHome()`
-(`executor-credential-storage.ts:8-15`):
-
-```ts
-config.multi_tenancy?.mode !== 'required_from_auth' ||
-config.execution?.executor_storage?.user_home === 'persistent-per-user'
-```
-
-HA refuses to boot without a tenant-safe home (`deployment.ts:375-380`).
-Credential path resolution is already replica-independent: the daemon computes
-the target home (`sandbox-context.ts:108-124`), passes `CODEX_HOME`
-(`executor-codex-auth.ts:25-43`), and the executor writes `0600`
-(`packages/executor/src/commands/codex-auth-file.ts:84-85`).
-
-**What is actually proven, and what is not:**
-
-| Topology | Status |
-| --- | --- |
-| `shared-local` (checked-in Compose HA stack) | **VERIFIED working.** `docker-compose.ha.yml:47,157` mounts named volume `agor-ha-user-home` at `/home/agor` on both daemons; `docker/ha/config.yaml:31` declares `user_home: shared`. The config comment states this "makes auth-file import/logout and Tasks replica-consistent". |
-| `external` / Cloud (`persistent-per-user`) | **PRECONDITION A — RESOLVED.** See below. `AgorExecutorStorageSettings` is a *"Declarative execution-substrate storage contract"* (`packages/core/src/config/types.ts:728-739`); infra has now confirmed the substrate that satisfies it. |
-
-#### PRECONDITION A — resolved (infra, both prod Cells)
-
-Reported by the infra owners. **These facts are external to this repo and were
-not independently verified here** — `apps/manager-api/` does not exist in this
-tree (`apps/` holds only `agor-cli`, `agor-daemon`, `agor-docs`, `agor-ui`), so
-the `runtimeInternal.ts` line references below are recorded as supplied.
-
-| Property | Confirmed state |
-| --- | --- |
-| Shared filesystem | One RWX PVC on StorageClass `efs-sc` (provisioner `efs.csi.aws.com`), mounted as `agor-home` on **every** executor pod — same filesystem on any node/replica, **not** replica-local (`runtimeInternal.ts:1341`) |
-| Consistency | AWS EFS read-after-write — **guaranteed on `write()`+`close()`/fsync, not per buffered write**. Drives §1.10 R2. |
-| Durability | PersistentVolume, StorageClass reclaim policy `Retain`, decoupled from pod lifecycle; survives reschedule, termination, autoscale |
-| Config | `executor_storage.user_home: persistent-per-user`, `branch_workspace: persistent-per-branch`; `multi_tenancy: { mode: required_from_auth, filesystem_isolation_enabled: true }` |
-| Isolation | `subPath: tenants/<tenantId>/home/<userSegment>` mounted at `/home/<userSegment>` (`runtimeInternal.ts:1310-1313`) — satisfies `hasTenantSafeExecutorCredentialHome()` (`executor-credential-storage.ts:8-15`), which requires exactly `user_home === 'persistent-per-user'` under `required_from_auth` |
-| Eviction | None on the homes. Only `ttlSecondsAfterFinished: 3600` on the executor Job (`runtimeInternal.ts:1358`) and `uploads.max_age_days` on uploads. Volume 20Gi, `ALLOWVOLUMEEXPANSION=false` → the risk is **exhaustion (write failure), not deletion** |
-
-**Consequence.** The credential home is replica-consistent in the *general*
-topology, not only under affinity. So:
-
-- **Claude subscription OAuth in HA is no longer stopgap-shaped.** Its only
-  remaining blocker is durable attempt state (§2.4). Once that lands it works on
-  `external` with no affinity dependency.
-- **Codex** likewise gets its credential side unblocked. Its approval-window
-  question (PRECONDITION B) has since also been resolved favorably (§1.12), so
-  Codex has no remaining precondition either — durable attempt state is the only
-  blocker for both providers.
-- Phase 3 as originally written (a blocked scoping exercise) **collapses into
-  Phase 2** for the credential side; see §8.
-
-**Attempt state does not touch this volume.** The durable attempt record lives in
-PostgreSQL (§2.2), so the 20Gi/no-expansion exhaustion risk applies only to the
-credential files and workspaces, not to sign-in state. Worth stating because it
-means a full volume degrades the *final write*, not the OAuth handshake — the
-failure surfaces as a persist error the user can retry after cleanup, not as a
-corrupted or half-committed attempt.
-
-**Revision 1's "already solved" was still too strong at the time** — it was true
-of the smoke stack and merely asserted of Cloud. It is now true of both, on
-evidence.
-
-### 1.7 Redis is fanout-only and explicitly denied to auth paths
-
-- Redis is required in HA but used **solely** as the Socket.IO adapter /
-  `serverSideEmit` relay (`realtime/redis-realtime.ts`; boot fails closed
-  `:129-130`). `ioredis` behind `@socket.io/redis-adapter`; **no generic
-  GET/SET/SETEX/lock surface is exposed to application code.**
-- `REDIS_FEATHERS_DENIED_PATHS` (`utils/realtime-publish.ts:251-273`) lists
-  `codex-auth/*`, every `mcp-servers/oauth-*`, `user-mcp-oauth-tokens`,
-  `session-tokens`, `terminals`, under (`:249-250`):
-
-  > Authentication and credential control-plane results must never enter shared
-  > Redis, even if a future service accidentally enables publication for them.
-
-- All other HA coordination is **PostgreSQL**: knowledge-embedding claims
-  (`repositories/knowledge-embedding-work.ts:29-49`), environment-health leases
-  (`repositories/environment-health.ts:26-41`), widget resolution, gateway
-  listener leases, executor token bounded-use. Same idiom: atomic conditional
-  `UPDATE` fenced by `claim_token` + `claim_generation` + DB-clock expiry. No
-  leader election, no `SELECT … FOR UPDATE`.
-
-**Redis is not a candidate** and is recorded here only so it is not re-proposed.
-
-### 1.8 The MCP OAuth authority: what it actually seals
-
-`mcp_oauth_pending_flows` (`packages/core/src/db/schema.postgres.ts:1792-1858`)
-with `services/mcp-oauth-pending-flow-authority.ts`. Precisely:
-
-- **`state` is stored hash-only.** The row's `state_hash` is
-  `fingerprintMCPOAuthState(input.context.state)` (`authority.ts:165`), UNIQUE
-  (`schema.postgres.ts:1834`). **The raw `state` is never sealed and never
-  stored** — it is not a field of the sealed material at all.
-- **`sealed_material`** (`authority.ts:127-148`) contains `pkceVerifier`,
-  **`clientId`, optional `clientSecret`**, the resolved endpoints
-  (`authorizationEndpoint`, `tokenEndpoint`, `metadataUrl`, `redirectUri`,
-  `issuer`, `resourceUri`), `grantGeneration`, config fingerprint, and
-  compatibility flags. `clientId` is *required* by the validator (`:76`) and both
-  client fields are returned to the claiming replica (`:277-278`).
-- Sealed with `sealMCPOAuthSecret()` (`packages/core/src/db/oauth-secret-envelope.ts`)
-  — AES-256-GCM, scrypt-derived key from `AGOR_MASTER_SECRET`, purpose domain
-  `'pending-exchange'`, with tenant/user/server/attempt/generation binding as
-  **AAD** (`authority.ts:149-161`).
-- `expires_at` DB-clock TTL, 10 minutes (`authority.ts:34`).
-- One-shot claim: atomic `UPDATE … SET status='exchanging', exchange_claim_id=?
-  WHERE state_hash=? AND status='pending' AND expires_at > CURRENT_TIMESTAMP AND
-  is_current=true RETURNING *` (`repositories/mcp-oauth-pending-flows.ts:357-372`).
-  Two-pool race test: `mcp-oauth-pending-flow-authority.postgres.test.ts:352-372`.
-- `maintain()` (`repositories/…:532-575`) expires overdue, marks abandoned
-  exchanges `ambiguous` after 2 min, deletes terminal rows after 24h.
-- Tenant scope via `runWithTenantDatabaseScope()`
-  (`packages/core/src/db/tenant-scope.ts:200-240`) — native transaction + tenant
-  GUC for RLS.
-
-**Reusable primitives:** the envelope, the atomic claim idiom, tenant scoping,
-DB-clock TTL, `maintain()`. Reuse these. The *table* and the *state machine* are
-flow-specific — see §2.3.
-
-### 1.9 Why MCP OAuth is still gated (corrected)
-
-**Revision 1 claimed MCP OAuth stays gated because its dynamically-registered
-`client_id`/`client_secret` is process-local. That claim is REFUTED.** The
-durable row seals `clientId` and `clientSecret` (`authority.ts:143-145`), the
-validator requires `clientId` (`:76`), and the claiming replica receives both
-(`:277-278`). A replica that wins the claim therefore *does* hold the client
-credentials. `dynamicClientCache` (`packages/core/src/tools/mcp/oauth-mcp-transport.ts:415`)
-is a registration-time optimization behind a `reuseLocalCache` flag (`:525`); it
-is not on the durable claim path, and no daemon source file references it.
-
-The actual reason is stated in the support matrix
-(`docs/internal/process-affine-ha-support-matrix-2026-08-07.md:250-252`):
-
-> The durable prerequisite is implemented after enforced offline migration `0078`,
-> a shared stable `AGOR_MASTER_SECRET`, and whole-cohort rollout, **but the
-> current constrained profile still gates MCP OAuth pending separate
-> activation.** […] Legacy providers require explicit per-server compatibility;
-> DCR is explicit fallback.
-
-and for the token authority (`:251`):
-
-> The active-active authority is implemented on PostgreSQL after `0078` […] **but
-> the constrained profile still gates the browser flow pending separate
-> activation.**
-
-So MCP OAuth is **technically durable and deliberately not yet activated** — a
-certification/rollout decision, not an unsolved mechanism.
-
-**What this means for provider sign-in.** The correct comparison is scope of
-client contract, not "MCP is blocked":
-
-| | MCP OAuth | Codex / Claude sign-in |
-| --- | --- | --- |
-| Client identity | per-server; may be dynamically registered (DCR as explicit fallback) | one fixed, public, compile-time client ID per provider |
-| Per-server config | issuer/resource/metadata/endpoint discovery, versioned config fingerprint, per-server compatibility modes | none — endpoints are constants |
-| Secret to seal | verifier **+ client credentials + resolved endpoints** | Claude: verifier only. Codex: provider-supplied verifier + authorization code |
-| Activation surface | every MCP server a user can add | two known providers |
-
-Provider sign-in is **narrower** — a fixed, non-negotiated client contract with
-no discovery and no DCR — which is why its durable record is simpler and its
-certification surface smaller. That is a genuine argument for it being easier to
-activate. It is **not** an argument that MCP is technically blocked and sign-in
-is not.
-
-### 1.10 Two requirements the EFS substrate imposes (VERIFIED against our code)
-
-Resolving A introduces two hard requirements. Both were traced through this
-repo; results below.
-
-#### R1 — Persistent identity is mandatory on *both* paths
-
-Infra gates persistence on `hasPersistentIdentity` (`runtimeInternal.ts:1199`,
-as supplied): a run with no `userId` / `runtimeUserId` / sanitized unix user
-lands on `anonymous-home`, an **emptyDir that dies with the pod**
-(`runtimeInternal.ts:1343`). So the sign-in **credential write** and the later
-**session runs** must *both* carry a resolved persistent identity, or the
-credential is written somewhere that evaporates — or, worse, written to a real
-home and then read from a different one.
-
-**Verification result: both paths carry identity, and `delegated` mode fails
-closed. One divergence hazard found.**
-
-*Credential-write path — SAFE.*
-- `resolveCodexCredentialRoute()` returns `ok: false, reason: 'resolve-failed'`
-  when `userId` is absent: *"Codex credential routing requires an authenticated
-  user identity."* (`apps/agor-daemon/src/services/codex-auth-shared.ts:153-159`).
-- Under `delegated` it additionally requires a `unix_username`, returning
-  `missing-username` otherwise (`:124-143`), resolved from the **caller's** user
-  row (`UsersRepository.findById(userId)`, `:131-135`).
-- `credentialExecutorOptions()` always forwards `user_id: routing.userId` and
-  `unix_user: routing.reportedUnixUser ?? undefined`
-  (`apps/agor-daemon/src/utils/executor-credential-auth.ts`, and on `main`
-  `utils/executor-codex-auth.ts:27-30`).
-
-*Session-run path — SAFE in `delegated`, softer elsewhere.*
-- `register-services.ts:1215-1219` forwards `session_id`, `task_id`,
-  `branch_id`, and `user_id: userId`.
-- But `userId` is typed optional — `(params as AuthenticatedParams).user?.user_id
-  as UserID | undefined` (`register-services.ts:930`).
-- `resolveDelegatedHomeKey()` **throws** in `delegated` mode when the home key is
-  missing (`packages/core/src/unix/delegated-home-key.ts:60-65`) and again on a
-  malformed key (`:66-68`). Since prod is `required_from_auth` + delegated-style
-  external execution, a missing identity is a hard failure, **not** a silent
-  drop to `anonymous-home`. That is the reassuring result.
-- Residual sharp edge: `substituteTemplateVariables()` only substitutes defined
-  values (`utils/spawn-executor.ts:271-282`). An `undefined` `user_id` therefore
-  leaves the **literal `{user_id}` in the rendered command** rather than failing
-  or emptying it. Validation only runs when the value is defined
-  (`:249-255`). In any topology whose template consumes `{user_id}` without
-  `{unix_user}`, that is precisely the anonymous-home path.
-
-**HAZARD — identity source divergence (flag for the implementation phase).**
-The two paths resolve the home key from **different rows**:
-
-| Path | Home-key source |
-| --- | --- |
-| Credential write | the **caller's** `users.unix_username` (`codex-auth-shared.ts:131-135`) |
-| Session run | the **session's** `session.unix_username` (`register-services.ts:1064,1066-1069`) |
-
-Both are non-empty in `delegated` mode, but nothing constrains them to be the
-**same value**. When they diverge, the credential is written into user A's home
-and the session reads user B's — a silent "signed in, but the agent still says
-unauthenticated". This is not hypothetical: `dangerously_allow_session_sharing`
-exists precisely so a child session can inherit `parent.created_by` rather than
-the caller (see CLAUDE.md), and a session's `unix_username` is stamped at
-creation and can drift from the user's current value.
-
-**Required for HA (design):** before enabling, assert that the credential-write
-home key and the run home key resolve to the same value for the target user, and
-fail closed with an actionable message when they don't. Do not paper over it by
-writing to both.
-
-#### R2 — fsync/close before rename (EFS close-consistency)
-
-EFS cross-client visibility holds on `write()`+`close()`, not per buffered
-write. Our credential write is temp-file → rename.
-
-**Verification result: `close()` happens; `fsync()` does not.**
-
-The shared helper introduced by #2317
-(`packages/executor/src/commands/credential-file-io.ts`, and the equivalent
-inline sequence on `main` at `packages/executor/src/commands/codex-auth-file.ts:79-86`):
-
-```ts
-await writeFile(temporary, content, { mode: 0o600, flag: 'wx' });
-await chmod(temporary, 0o600);
-await rename(temporary, target);
-```
-
-- `fs/promises.writeFile` opens, writes, and **closes** the descriptor, so the
-  EFS close-to-open *visibility* contract is satisfied for the temp file before
-  the rename. This is the good news and it is why the current code mostly works.
-- There is **no `fsync` on the temp file** and **no `fsync` on the containing
-  directory** after the rename. So the bytes and the new directory entry are not
-  forced durable. A pod killed (or a node lost) between the rename and the
-  server-side flush can leave the credential file absent or truncated *after the
-  daemon has already reported success and flipped the user's auth method* — the
-  exact split-brain the §2.5 fencing is otherwise designed to prevent.
-- The code already anticipates this class of problem: the helper's own doc
-  comment says the read-back *"is retried once because some networked/overlay
-  filesystems briefly surface a rename before the new bytes are visible"*, and it
-  re-reads the target and compares against what it wrote
-  (`codex-auth-file.ts:88-100` on `main`). That read-back is a real mitigation
-  for visibility, but it is a **same-client** read and does not establish
-  durability.
-
-**Required change for HA on EFS (implementation phase, not now):** open the temp
-file explicitly, `write` → `fsync(fd)` → `close(fd)`, then `rename`, then
-`fsync` the containing directory. Keep the existing read-back verification.
-Because both providers now share `writeCredentialFileAtomically()`, this is
-**one fix in one function** covering Codex and Claude.
-
-### 1.11 Ingress affinity is already mandatory
-
-- HA refuses to boot without it (`deployment.ts:349-353`).
-- Resolved topology types it literally `ingressAffinity: true` in both variants
-  (`:86-87`).
-- The browser uses Socket.IO (`packages/core/src/api/index.ts:1413`,
-  `transports: ['websocket','polling']` `:1384`); the sign-in pane calls
-  `client.service('claude-auth/oauth')` (`ClaudeOAuthSignIn.tsx:44-52`) — all
-  three calls of one sign-in ride **one sticky connection to one replica**.
-- Caveat (`docs/internal/daemon-ha-redis-realtime-2026-08-07.md:92-93`): affinity
-  is configured for `/socket.io/` only — *"leave REST unsticky"*. A live
-  WebSocket never migrates; after daemon loss the client makes a **new**
-  connection which may land anywhere.
-- Precedent: web terminals (`terminal-capability.ts:25-32`) ship on exactly this
-  contract, with *"Owner loss ends the Agor attachment… requires an explicit
-  Reconnect"* (`context/explorations/web-terminal-ownership-ha.md`).
-
-### 1.12 PRECONDITION B — measured: the device-token poll is re-fetchable
-
-**Probe run 2026-08-18** against the live OpenAI device endpoints with a real
-Codex subscription account, client_id `app_EMoamEEZ73f0CkXaXp7hrann`.
-`POST https://auth.openai.com/api/accounts/deviceauth/token` with
-`{device_auth_id, user_code}` — the exact request our `pollDeviceToken()` issues
-(`codex-device-auth.ts:141-147`):
-
-| Step | Result |
-| --- | --- |
-| Polls #1–#5 (before approval) | HTTP **403**, body key `error` |
-| Poll #6 (after in-browser approval) | HTTP **200**, body keys `{authorization_code, code_challenge, code_verifier, status, user_code, user_code_expiration}` |
-| **Re-polls #1, #2, #3 (after approval)** | **HTTP 200, all returning the SAME `authorization_code` and `code_verifier`** |
-
-Secrets redacted; the exchange was deliberately **not** performed, so no token
-was minted and the authorization code was never consumed.
-
-**Three findings.**
-
-1. **Observing approval is NOT consumptive.** The worst-case assumption behind
-   revision 2's `ambiguous`-on-owner-death default is **disproven**. A replica
-   that takes over a lease can re-poll the same `device_auth_id` / `user_code`
-   and receive the same code and verifier back.
-2. **Exactly-once lives entirely at the exchange.** The single-use step is
-   `POST /oauth/token` (`codex-device-auth.ts:165-191`); the poll is freely
-   repeatable. So the **atomic one-shot exchange claim is the correct and
-   sufficient exactly-once mechanism**, and poll-resume is safe alongside it.
-   This is a cleaner separation than r2 assumed: the lease governs *who polls*
-   (an efficiency and rate-limit concern), while the claim governs *who
-   exchanges* (the correctness concern).
-3. **`403` as "pending" is confirmed** — matching the existing comment *"403/404
-   are the server's 'authorization pending' signals for this endpoint"*
-   (`codex-device-auth.ts:136`), and the provider-supplied `code_verifier` in the
-   200 body confirms §1.5's reading of `:151`.
-
-**Residual, stated honestly.** The probe ran from a **single egress IP**. It
-proves *idempotency*; it does **not** prove *cross-replica-IP tolerance*. The
-assessment is that this is very likely fine — RFC 8628 device flow is designed
-for a *separate* device to poll, the request carries only `device_auth_id` +
-`user_code`, and no cookie or IP binding was observed — but it is unproven.
-
-**Design stance:** assume re-fetchable (proven) and **keep `ambiguous → restart`
-as the fallback** if a cross-replica re-poll ever fails in practice. A clean
-cross-IP test needs a second egress host; it is a nice-to-have, not a blocker.
-
-**Noted but out of scope:** the 200 body carries `user_code_expiration`, a real
-provider-supplied expiry. Our poll parses only `authorization_code` and
-`code_verifier` (`codex-device-auth.ts:148-156`) and the lifetime stays the fixed
-15-minute local constant (§1.5). Adopting the provider's value would be an
-accuracy improvement, but it is a separate change and does not affect this
-design — §1.5's point stands, since it was about the *usercode* response, which
-still has no expiry field (`:115-128`).
-
----
-
-## 2. Design
-
-### 2.1 Phase 1 — minimal affinity-scoped enablement (`shared-local` only)
-
-Sticky Socket.IO already routes all three calls of a sign-in to one replica.
-Until the socket reconnects, the existing in-process map is **already correct**.
-So Phase 1 needs almost nothing:
-
-1. Widen `codexDeviceAuth` / add `claudeOAuth` to `boolean`; compute as
-   `topology.execution === 'shared-local' && topology.ingressAffinity &&
-   executorCredentialFiles`.
-2. Delete `processAffineAuth` (§1.3).
-3. On reconnect to a replica with no live attempt, `find()` already returns "no
-   attempt" naturally (empty map) — surface it as **"sign-in lost, start over"**
-   in the UI, matching the terminal Reconnect contract.
-
-**Explicitly dropped as over-engineering:** daemon boot-ID stamping and
-`SIGTERM` attempt-drain machinery. Neither buys anything the empty-map path does
-not already give, and both add protocol surface to a stopgap.
-
-**One narrow refinement is still required** (see push-back note in §7): the
-attempt key is `` `${tenantId}:${userId}` `` (`claude-oauth.ts:343`) with **no
-attempt identity**. If a user starts a sign-in on replica A, then reconnects to
-replica B that still holds an *older, unpruned* attempt for the same key,
-`find()` returns B's stale status and `submit()` validates the pasted code
-against B's stale `state` — failing as "wrong state" rather than "start over"
-(`claude-oauth.ts:392-407`). Fix by returning an opaque `attempt_id` to the
-client and requiring it to be echoed on `find`/`submit`; a mismatch means "start
-over". This is a few lines and removes a genuinely confusing failure, unlike
-boot-ID.
-
-**Risk: medium.** Correctness depends on operator ingress config the daemon
-cannot verify; a misconfigured ingress degrades to "sometimes works", which is
-worse than today's honest 503. Mitigate by scoping strictly to `shared-local`
-and documenting loudly. Phase 1 does **not** serve `external`.
-
-### 2.2 Phase 2 — durable attempt state (shared primitives, per-flow tables)
-
-Reuse the §1.8 primitives: `sealMCPOAuthSecret`/`openMCPOAuthSecret` under a
-**new purpose domain** (`'provider-signin'`, so envelopes cannot be cross-used
-with MCP), the atomic-claim idiom, `runWithTenantDatabaseScope()`, DB-clock TTL,
-`maintain()`.
-
-Common columns for both providers:
-
-| Column | Purpose |
-| --- | --- |
-| `tenant_id`, `user_id` | tenant scoping / RLS |
-| `attempt_id` (PK) | identity; echoed to the client |
-| `provider` | `codex` \| `claude` |
-| `attempt_generation` | monotonic per `(tenant_id, user_id)`; fences superseded attempts |
-| `is_current` | exactly one live attempt per user |
-| `status` | per-flow state machine (§2.3, §2.4) |
-| `expires_at` | DB-clock TTL — Claude 10 min; Codex fixed 15 min (§1.5), **not** a provider `expires_in` |
-| `sealed_material` | AES-256-GCM, AAD-bound; **contents differ per provider** |
-| `claim_id` | one-shot fence for the unreplayable step |
-| `created_at`/`updated_at`/`finished_at` | lifecycle + prune |
-
-**`state_hash` (Claude only), UNIQUE.** Following the MCP authority exactly:
-**seal `{verifier}` only; store `state` as a hash and never in sealed material.**
-Validation compares `sha256(pasted_state)` against `state_hash`. This keeps the
-raw CSRF token out of the ciphertext entirely and matches `authority.ts:165`.
-
-**Do not force one table on both flows.** Codex needs `poll_lease_owner` /
-`poll_lease_expires_at` and an `approval_observed` state that Claude has no
-analogue for; Claude needs `state_hash` that Codex has no analogue for. A single
-table would carry a union of mutually-exclusive nullable columns and a status
-enum whose values are only valid for one provider. Two tables (or one table with
-a genuinely shared core and a per-provider detail) with **shared primitives and
-separate state machines** is the honest shape.
-
-### 2.3 Codex fenced state machine (the hard case)
-
-Two non-transactional external calls: the poll (`codex-device-auth.ts:137-157`)
-and the exchange (`:165-191`). The authorization code arrives *inside* the poll
-response, unprompted.
-
-States: `pending → approval_observed → exchanging → persisting → succeeded`,
-with terminals `failed` / `expired` / `ambiguous` / `superseded`.
-
-| # | Transition | Atomic predicate | Durable secret after commit | Crash in this window | Replay? |
-| --- | --- | --- | --- | --- | --- |
-| 1 | *(create)* → `pending` | In one tx: `UPDATE … SET is_current=false, status='superseded' WHERE tenant/user AND is_current`, then `INSERT` with `attempt_generation = prev+1`, `expires_at = now() + 15min` (DB clock) | `deviceAuthId`, `userCode` sealed | Nothing issued yet; user retries | n/a |
-| 2 | acquire poll lease | `UPDATE … SET poll_lease_owner=?, poll_lease_expires_at=now()+L WHERE attempt_id=? AND status='pending' AND is_current AND (poll_lease_expires_at IS NULL OR poll_lease_expires_at <= now()) RETURNING *` | unchanged | No owner polls until lease is free; attempt still valid | Lease re-acquire is safe |
-| 3 | `pending` → `approval_observed` | `UPDATE … SET status='approval_observed', sealed_material=? WHERE attempt_id=? AND status='pending' AND attempt_generation=? AND poll_lease_owner=? AND poll_lease_expires_at > now()` | + `authorizationCode`, `codeVerifier` (both provider-supplied) | **Recoverable** — a new lease owner re-polls and gets the same code back (§1.12) | **Yes — the poll is re-fetchable** |
-| 4 | `approval_observed` → `exchanging` | one-shot: `UPDATE … SET status='exchanging', claim_id=? WHERE attempt_id=? AND status='approval_observed' AND is_current AND attempt_generation=?` | unchanged | Abandoned `exchanging` → `ambiguous` after timeout | **No** — authorization codes are single-use |
-| 5 | `exchanging` → `persisting` | `UPDATE … SET status='persisting', sealed_material=? WHERE attempt_id=? AND status='exchanging' AND claim_id=?` | tokens sealed (separate purpose domain), code cleared | Crash before commit → `ambiguous`; tokens lost, user restarts | **No** |
-| 6 | `persisting` → `succeeded` | re-validate `(attempt_generation, claim_id, status='persisting', is_current)` **immediately before** the credential write **and again before** the user-method mutation; then `UPDATE … SET status='succeeded', sealed_material=NULL` | cleared | See §2.5 filesystem gap | Write is idempotent (same tokens, same path) |
-
-**Transition 3 was the feared one; the probe defused it.** The provider returns
-the authorization code in the poll response, and re-polling after approval
-returns the *same* code and verifier (§1.12). So:
-
-- **Lease takeover of a `pending` attempt whose lease expired resumes polling.**
-  The new owner re-polls the same `device_auth_id` / `user_code`. If the user has
-  already approved, the very first re-poll returns the code and the attempt
-  proceeds to transition 4 — owner death before the exchange is **recoverable**,
-  not a restart.
-- **`ambiguous → restart` is retained as the FALLBACK**, not the default. A
-  re-poll that returns a terminal provider error, or that keeps returning
-  `pending` past `expires_at`, resolves the attempt to `ambiguous`/`expired` and
-  the user restarts. This is what covers the unproven cross-IP case (§1.12) — if
-  a different egress IP is in fact rejected, the failure is a clean restart, not
-  a hang or a double-spend.
-- **Double-polling is now a non-issue for correctness.** If a slow owner and a
-  new lease owner briefly both poll, both simply receive the same code. Only one
-  can win transition 4's one-shot claim, and only that winner exchanges. The
-  lease remains worthwhile for rate-limit hygiene and to keep one clear owner,
-  but it is no longer load-bearing for exactly-once.
-- Still make lease expiry rare rather than relying on takeover: short renew
-  interval (~15 s) against a generous lease (~60 s), well inside the 15-minute
-  window.
-
-**Where exactly-once actually lives.** The authorization code is single-use at
-`POST /oauth/token` only. Transition 4's atomic claim is therefore the complete
-exactly-once mechanism: freely repeatable poll, exactly-once exchange. Transitions
-4–6 are unchanged by the probe — a crash *during or after* the exchange is still
-`ambiguous` and is still never replayed.
-
-**Retry policy.** The existing `exchangeWithOneRetry` (`:199`) must stay
-*within a single claim holder* — one process, one `claim_id`. A retry must never
-cross owners, because the second attempt cannot know whether the first consumed
-the code.
-
-### 2.4 Claude state machine (the easy case)
-
-`pending → exchanging → persisting → succeeded`; terminals as above. No lease —
-nothing polls.
-
-| # | Transition | Atomic predicate | Durable secret | Replay? |
-| --- | --- | --- | --- | --- |
-| 1 | *(create)* → `pending` | supersede-then-insert as Codex #1 | `{verifier}` sealed; `state_hash` stored | n/a |
-| 2 | `pending` → `exchanging` | one-shot: `UPDATE … SET status='exchanging', claim_id=? WHERE state_hash=? AND status='pending' AND is_current AND expires_at > now() RETURNING *`; the pasted state is validated by hash comparison **before** the claim | unchanged | **No** |
-| 3 | `exchanging` → `persisting` | as Codex #5 | tokens sealed | **No** |
-| 4 | `persisting` → `succeeded` | as Codex #6 | cleared | idempotent |
-
-Validating the pasted state by hash *before* reserving the attempt preserves the
-current ordering (`claude-oauth.ts:404-407`), where a malformed or wrong-state
-paste is rejected without burning the attempt.
-
-### 2.5 Durable logout and replacement fencing
-
-Today ownership is process-local `isCurrent()` — `attempts.get(key) === attempt`
-(`claude-oauth.ts:294-297`), re-checked after the exchange (`:426-428`) and again
-inside `persist()` immediately before the write (`:346-350`). In HA every one of
-those becomes a **durable** check.
-
-**Invalidation is atomic and generation-based.** Both "logout" and "start a new
-attempt" run, in one transaction:
-
-```sql
-UPDATE provider_auth_attempts
-   SET is_current = false, status = 'superseded', sealed_material = NULL
- WHERE tenant_id = ? AND user_id = ? AND provider = ? AND is_current;
-```
-
-Logout additionally clears the stored auth method and deletes the credential
-file.
-
-**Every stale worker re-validates before each side effect.** A worker holding an
-in-flight claim must re-read and confirm `(attempt_generation, claim_id,
-status, is_current)` **immediately before the credential write** and **again
-immediately before the user-method mutation** — the two mutations are separate
-and a supersede can land between them. On mismatch it aborts and performs the
-cleanup below.
-
-**The filesystem↔DB transaction gap is real and must be stated.** The credential
-write is a file operation on the executor; it is not in the database
-transaction. A worker can therefore complete a write for a generation that was
-superseded microseconds earlier. Defined behavior:
-
-1. A worker whose post-write re-validation fails **immediately deletes the
-   credential file it just wrote** — it knows it wrote it and knows it lost.
-2. Because step 1 can itself crash, `logout` is **not** complete on its DB
-   commit alone. It records a `revoked_at` marker and a **second delete pass**
-   runs after the maximum `persisting` claim lifetime has elapsed, sweeping any
-   file written by a worker that lost the race and died before cleaning up.
-3. `maintain()` treats a `persisting` row older than that lifetime as
-   `ambiguous` and enqueues the same delete pass.
-4. Consequence to document: for a bounded window after logout, a superseded
-   credential file may exist on disk. It is deleted by pass 2. **Local deletion
-   is not provider-side revocation** in either case — the same caveat MCP OAuth
-   already carries.
-
----
-
-## 3. Credential visibility: options
-
-### Option A — shared / per-user executor credential home (RECOMMENDED)
-
-Nothing to build for `shared-local` (§1.6, VERIFIED). For `external`, the
-requirement is enforced at boot (`deployment.ts:375-380`) **and the backing store
-is now confirmed** — shared-EFS RWX PVC, `persistent-per-user`, per-tenant/user
-`subPath` isolation (§1.6, PRECONDITION A resolved).
-
-Two implementation obligations follow from that substrate rather than from the
-config contract, both detailed in §1.10: **R1** identity must resolve on the
-credential-write *and* session-run paths (with the divergence assertion), and
-**R2** the atomic write must `fsync` before rename.
-
-### Option B — credentials in encrypted DB, materialized per session
-
-**Not now.** The provider CLIs *own* these files and refresh tokens in place, so
-a DB copy goes stale or clobbers a refreshed token. Materializing credentials
-into a workspace on every session start widens exposure. The DB today
-deliberately stores only the auth *method*, never token material
-(`packages/core/src/db/schema.sqlite.ts:1041`). Revisit only if a topology
-genuinely cannot provide a consistent per-user home.
-
----
-
-## 4. Enablement mechanism
-
-1. Widen the literal types (`deployment.ts:74-76`): `codexDeviceAuth` → `boolean`;
-   add `claudeOAuth: boolean`.
-2. Rename `codexCredentialFiles` → `executorCredentialFiles` (same computation).
-   It already gates Claude in #2317 — correct behavior under a misleading name.
-3. **Delete `processAffineAuth`** (§1.3).
-4. `claudeAuth`/`claudeOAuth` feature keys and gate entries are **already added
-   by #2317** (`ha-support.ts`; `register-hooks.ts` +`['claude-auth/oauth','claudeOAuth']`,
-   `['claude-auth/logout','claudeAuth']`). This design builds on that.
-5. Extend `isHaFeatureUnavailable()` so `codexDeviceAuth` and `claudeOAuth` read
-   their capabilities instead of falling through to `return true`.
-6. Shared executor plumbing already de-duplicated by #2317
-   (`utils/executor-credential-auth.ts`,
-   `packages/executor/src/commands/credential-file-io.ts`). Reuse it. Attempt
-   *storage primitives* are shared; *state machines* are not (§2.2).
-
-Tests currently pinning the closed state: `ha-support.test.ts:116-138`,
-`deployment.test.ts:50-58`, `register-hooks.test.ts:386`.
-
----
-
-## 5. Security review
-
-### 5.1 Secret handling
-
-- [ ] Verifiers, `state`, device codes, authorization codes, and tokens never
-      logged, never returned to the client, never in agent/LLM context
-      (`claude-oauth.ts:29-30`).
-- [ ] Claude: seal `{verifier}` only; store `state_hash`, never raw `state`
-      (matching `authority.ts:165`).
-- [ ] Distinct seal purpose domain (`'provider-signin'`) from MCP's
-      `'pending-exchange'`; separate domain again for transiently sealed tokens.
-- [ ] AAD binds tenant+user+provider+attempt+generation; a moved or retagged row
-      fails to open.
-- [ ] Sealed material cleared on every terminal status.
-- [ ] Add `claude-auth/oauth` and `claude-auth/logout` to
-      `REDIS_FEATHERS_DENIED_PATHS`. **Gap found in this review, best fixed on
-      #2317.** `mayEnterRedisRelay()` (`realtime-publish.ts:275-282`) is
-      **default-allow**; all three Codex counterparts are denied (`:268-270`) but
-      the Claude equivalents were not added. Not a confirmed leak — payloads are
-      status metadata and `claude-auth/logout` emits `patched` by design
-      (`register-services.ts:742-743`) — but the denied set is defense-in-depth
-      (`:249-250`), and HA enablement is what makes the omission load-bearing.
-
-### 5.2 Blast radius of persisting secrets (expanded)
-
-Persisting attempt material is a **real increase in blast radius**, not a
-formality. Sealing with AAD narrows misuse of a *stolen row*; it does nothing
-about the key, the backups, or the decrypt window.
-
-- [ ] **Master-secret rotation.** `AGOR_MASTER_SECRET` is scrypt-derived per
-      envelope with a random salt, so rotation is not transparent. Define: dual-key
-      read (try new, fall back to old) during a rotation window, and — because
-      attempt rows are short-lived (10–15 min) — **prefer draining over
-      re-encrypting**: stop issuing attempts, let the TTL expire the table, then
-      cut over. Persisted *tokens* (if §2.3 step 5 is adopted) live minutes, not
-      months, so the same drain applies. Document that a rotation with no drain
-      strands unopenable rows, which must fail closed to `ambiguous`, never
-      plaintext.
-- [ ] **Backups retain decryptable rows.** A database backup taken mid-flow
-      contains sealed verifiers/codes/tokens that remain decryptable for as long as
-      the master secret is valid — *far* longer than the 15-minute TTL. Rotation
-      policy and backup retention must be considered together; state the effective
-      exposure window as `max(backup retention, secret lifetime)`, not the TTL.
-- [ ] **Least privilege.** The attempt table should be readable/writable only by
-      the daemon role; no analytics/reporting/read-replica role should hold
-      `SELECT` on `sealed_material`. Confirm RLS policy plus explicit column or
-      table grants, and that the tenant GUC is required even for tenant `default`
-      (the pattern used by the GitHub install-state table).
-- [ ] **Plaintext lifetime after decrypt.** Once opened, the verifier/code/tokens
-      are ordinary heap strings. Keep the decrypt as late and as narrow as
-      possible; do not attach opened material to long-lived objects, logs, error
-      payloads, or Feathers context; zero references on completion as the current
-      in-memory code already does (`claude-oauth.ts:307-308`).
-- [ ] **Mixed / missing key across the fleet.** A replica without
-      `AGOR_MASTER_SECRET`, or with a different one, must **fail closed** — refuse
-      to seal or open, mark `ambiguous`, and never fall back to plaintext (the
-      SQLite dev fallback in `packages/core/src/db/encryption.ts` must not be
-      reachable in HA). A partially-keyed fleet is a rollout error and should be
-      loud, not silently degraded.
-- [ ] Reconfirm at review time that persisting the verifier is still judged worth
-      it versus Phase 1's in-process-only contract. This is a deliberate change of
-      contract, not an implementation detail.
-
-### 5.3 Tenant / user isolation
-
-- [ ] Every read and write via `runWithTenantDatabaseScope()`; no unscoped query.
-- [ ] An attempt is bound to `(tenant_id, user_id)` and can only be found,
-      claimed, or completed by that identity.
-- [ ] Cross-tenant and cross-user negative tests, mirroring
-      `mcp-oauth-pending-flow-authority.postgres.test.ts:228-293`.
-- [ ] Credential write targets the caller's own resolved home; `required_from_auth`
-      + non-`persistent-per-user` stays refused at boot.
-- [ ] **R1** — both the credential write and the session run resolve a persistent
-      identity, and the two home keys are asserted equal before enabling
-      (§1.10 R1). A run that cannot resolve one fails closed rather than
-      rendering an unsubstituted `{user_id}` (`spawn-executor.ts:271-282`).
-- [ ] **R2** — `fsync` the temp file before `rename` and `fsync` the directory
-      after, in `writeCredentialFileAtomically()` (§1.10 R2). Keep the read-back
-      verification.
-- [ ] Credential-home volume exhaustion (20Gi, no expansion) surfaces as an
-      explicit persist failure the user can retry, never as a partial write that
-      is reported as success. Attempt state is in PostgreSQL and is unaffected.
-
-### 5.4 Lifecycle, revocation, rollout
-
-- [ ] TTL on DB clock (`CURRENT_TIMESTAMP`), never application clock. Codex uses
-      the fixed 15-minute constant (§1.5) — no invented `expires_in`.
-- [ ] `maintain()`: expire overdue, mark abandoned claims `ambiguous`, delete
-      terminal rows, enqueue the §2.5 delete pass.
-- [ ] One-shot claim on every unreplayable step; codes never replayed after
-      `ambiguous`.
-- [ ] Codex poll lease single-owner. Resumption is **enabled** (§1.12), with
-      `ambiguous → restart` retained as the fallback when a re-poll fails.
-      Exactly-once is enforced by the exchange claim, not by the lease.
-- [ ] Newer attempt fences older via `attempt_generation`; logout invalidates
-      atomically (§2.5).
-- [ ] Fleet-shared stable `AGOR_MASTER_SECRET`; whole-cohort/offline cutover for
-      the migration (pattern of `0078`/`0082`).
-- [ ] Rate limiting: the auth limiter is in-memory and per-replica, so N replicas
-      multiply allowed attempts. Enabling these endpoints in HA raises the value of
-      edge/WAF quota enforcement; do not imply the local limiter is fleet
-      enforcement.
-
----
-
-## 6. Testing strategy
-
-Beyond unit coverage of the state machines, the following crash/race cases must
-be covered — the two-pool PostgreSQL harness in
-`mcp-oauth-pending-flow-authority.postgres.test.ts:352-372` is the model.
-
-**Claim and lease races**
-- [ ] Two replicas race the exchange claim; exactly one wins, loser does not call
-      the provider.
-- [ ] Poll lease expires while a poll is in flight; the old owner's transition-3
-      commit is rejected by the lease predicate.
-- [ ] Stale owner receives approval after losing its lease → cannot commit; row
-      resolves `ambiguous`.
-
-**Crash windows**
-- [ ] Death after approval observed, before the durable `approval_observed`
-      commit → a new lease owner **re-polls and recovers the same code** (§1.12),
-      and the attempt completes. Assert the exchange still happens exactly once.
-- [ ] Re-poll fallback: stub the provider to reject or keep returning `pending`
-      after approval → the attempt resolves `ambiguous`/`expired` and the user
-      restarts, with no hang and no second exchange. This is the cross-IP
-      safety net (§1.12 residual).
-- [ ] Death during `exchanging` → `ambiguous` after timeout; the authorization
-      code is never retried.
-- [ ] Death during `persisting` → `ambiguous`; §2.5 delete pass removes any file
-      written.
-
-**Invalidation races**
-- [ ] Logout during `exchanging` and during `persisting`.
-- [ ] New attempt supersedes an already-claimed older attempt; the older worker's
-      pre-write re-validation aborts it.
-- [ ] Post-write re-validation fails → worker deletes the file it wrote.
-- [ ] Worker dies between a losing write and its own cleanup → logout's second
-      delete pass removes the file.
-- [ ] Supersede lands *between* the credential write and the user-method
-      mutation.
-
-**Crypto and fleet**
-- [ ] AAD tamper (retagged tenant/user/generation) fails to open.
-- [ ] Replica with a different master secret fails closed, never plaintext.
-- [ ] Replica with a missing master secret refuses to seal/open in HA.
-- [ ] TTL expiry and `maintain()` prune, including terminal-row deletion.
-
-**Isolation**
-- [ ] Cross-tenant claim rejection; cross-user claim rejection within a tenant.
-
-**Shared credential home (EFS)**
-- [ ] Sign in on replica A, run a session on replica B → the session sees the
-      credential. This is the test that PRECONDITION A actually buys the general
-      topology, and it must run on the real substrate, not Compose.
-- [ ] Credential-write home key and session-run home key diverge → fails closed
-      with an actionable message, not a silent "still unauthenticated" (§1.10 R1).
-- [ ] A run with no resolvable user identity fails closed; assert no rendered
-      command ever contains a literal `{user_id}` or `{unix_user}`.
-- [ ] Kill the pod between `rename` and read-back → the credential is either
-      fully present or absent, never truncated, and the user's auth method is not
-      flipped on a write that did not survive (§1.10 R2).
-- [ ] Full volume (simulated ENOSPC) → explicit persist failure, retryable; the
-      attempt row is unaffected.
-
-**Integration**
-- [ ] Kill a replica mid-flow on the Compose HA stack for each crash window.
-- [ ] Phase 1 only: reconnect to a replica holding a stale attempt for the same
-      user → `attempt_id` mismatch yields "start over", not "wrong state" (§2.1).
-
----
-
-## 7. Recommendation
-
-**Go to Phase 2 — durable PostgreSQL attempt state — and treat Phase 1 as
-optional. Both preconditions are now resolved, so Codex's resumable lease folds
-into Phase 2 rather than trailing it.**
-
-Resolving PRECONDITION A changed the calculus. Previously Phase 1 was the only
-thing that could ship soon, because `external` was blocked on an unknown
-credential substrate. Now the credential home is confirmed replica-consistent in
-the general topology, so **durable attempt state is the single remaining blocker
-for Claude**, and it unblocks `external` directly. Phase 1 would buy a few days
-of earlier `shared-local` availability at the cost of code that Phase 2 deletes,
-plus a documented dependence on ingress config the daemon cannot verify. Ship it
-only if `shared-local` availability is independently urgent.
-
-Phase 2 reuses shipped, race-tested primitives, survives replica loss and rolling
-deploys, and now needs no topology caveat. Its cost is the blast-radius change
-(§5.2), a migration/rollout, and the two §1.10 obligations — of which R2 is one
-fix in one shared function.
-
-Codex is no longer held back on either side. The credential home is confirmed
-(§1.6) and the approval-window worst case is refuted (§1.12), so its resumable
-lease is buildable now — with the exchange claim carrying exactly-once and
-`ambiguous → restart` as the fallback.
-
-**Push-back on one review point.** The review asked to drop the boot-ID protocol
-and drain machinery entirely. Agreed on both — but *not* on dropping attempt
-identity with them. The attempt key is `` `${tenantId}:${userId}` ``
-(`claude-oauth.ts:343`) with no attempt ID, so a reconnect onto a replica holding
-an older unpruned attempt for the same user returns stale status and validates
-the pasted code against the wrong `state`, surfacing as "wrong state" instead of
-"start over" (`:392-407`). The `attempt_id` echo in §2.1 is a few lines, is
-needed by Phase 2 anyway, and removes a confusing failure. Boot-ID and drain stay
-dropped.
-
----
-
-## 8. Phased plan
-
-### Phase 0 — land #2317 (prerequisite, in flight)
-Claude sign-in and its `claudeAuth`/`claudeOAuth` keys on `main`. No HA behavior
-change; both fail closed. Ideally also lands the §5.1 Redis-denied-paths fix.
-
-### Phase 1 — affinity-scoped `shared-local` (~1-2 days) — **OPTIONAL**
-Superseded in value by PRECONDITION A's resolution; ship only if early
-`shared-local` availability is independently urgent. Phase 2 deletes most of it.
-
-Capability widening + computation; delete `processAffineAuth`; rename to
-`executorCredentialFiles`; `attempt_id` echo; "start over" UX; update
-`ha-support.test.ts` / `deployment.test.ts` / `register-hooks.test.ts`; negative
-coverage that `external` stays 503. Docs: `daemon-ha.mdx` — affinity requirement
-and that replica loss aborts an in-flight sign-in.
-**Risk: medium** (unverifiable operator dependency).
-
-### Phase 2 — durable attempt state (~2-3 weeks)
-Migration + RLS; repository with atomic claim, lease, `maintain()`; authority
-service with the new seal purpose domain; Claude state machine (§2.4); Codex
-state machine (§2.3) with resumption **enabled** (§1.12) and the re-poll failure
-fallback; durable logout/replacement
-fencing incl. the filesystem-gap delete passes (§2.5); keep the local Map for
-SQLite/standalone as MCP OAuth does; §6 test matrix.
-**Risk: medium-high** — migration, rollout ordering, blast-radius change.
-Requires §5 signed off and a fleet-shared `AGOR_MASTER_SECRET`.
-
-### Phase 3 — `external` / Cloud — **collapsed into Phase 2**
-PRECONDITION A is resolved (§1.6), so this is no longer a separate blocked
-scoping exercise. What remains are the two §1.10 obligations, which belong inside
-Phase 2:
-- **R2 fsync-before-rename** in `writeCredentialFileAtomically()` — one function,
-  covers both providers. Do this first; it is small and independently correct.
-- **R1 identity assertion** — credential-write and session-run home keys must
-  resolve equal, failing closed otherwise.
-- End-to-end validation on the real EFS substrate (sign in on replica A, run on
-  replica B), which Compose cannot exercise.
-
-### Phase 4 — Codex resumable polling — **unblocked; folded into Phase 2**
-PRECONDITION B is resolved (§1.12): the poll is re-fetchable, so resumption is
-safe to build alongside the state machine rather than as a follow-on. It is no
-longer a separate phase. Ship it with the `ambiguous → restart` fallback, which
-also covers the unproven cross-egress-IP case.
-
-Optional follow-up (not a blocker): re-run the §1.12 probe from a **second
-egress host** to close the cross-IP question directly. If it ever fails in
-production, the fallback already degrades to a clean restart.
-
-### Rollout / flagging
-Enablement is config-derived; no new feature flag. A deployment opts in by
-declaring topology and storage guarantees and the existing gates open. Because
-capabilities are computed per-replica, a partially-upgraded fleet can advertise
-different capabilities — prefer an offline cutover to a rolling one.
-
----
-
-## 9. Preconditions and open questions
-
-- **PRECONDITION A — RESOLVED.** Prod HA (both Cells) runs a shared-EFS RWX PVC,
-  `user_home: persistent-per-user`, per-tenant/user `subPath` isolation, `Retain`
-  reclaim, no home eviction. Supplied by infra and recorded in §1.6; the
-  `manager-api` line references were **not** independently verified here because
-  that repo is not in this tree. Two obligations follow (§1.10 R1/R2).
-- **Residual from A — volume headroom.** 20Gi with
-  `ALLOWVOLUMEEXPANSION=false` means the failure mode is exhaustion, not
-  deletion. Credential writes must fail loudly on ENOSPC rather than reporting
-  success. Attempt state is in PostgreSQL and is not exposed to this.
-- **New — identity-source divergence.** The credential write resolves the home
-  key from the caller's `users.unix_username`; the session run resolves it from
-  `session.unix_username`. Nothing constrains them to match, and
-  `dangerously_allow_session_sharing` makes divergence reachable. Needs the
-  equality assertion in §1.10 R1. (Design flag; no code change now.)
-- **PRECONDITION B — RESOLVED (2026-08-18).** Measured against the live OpenAI
-  device endpoints: re-polling after approval returns the **same**
-  `authorization_code` and `code_verifier`, so observing approval is **not**
-  consumptive and owner death before the exchange is recoverable. Exactly-once is
-  carried by the exchange claim alone. (§1.12, §2.3)
-- **Residual from B — cross-egress-IP tolerance.** The probe ran from a single
-  egress IP, so it proves idempotency, not that a *different* replica's IP is
-  accepted. Assessed low-risk (device flow is designed for a separate polling
-  device; the request carries only `device_auth_id` + `user_code`; no cookie/IP
-  binding observed) and covered by the `ambiguous → restart` fallback. A
-  second-egress-host probe would close it; nice-to-have, not a blocker.
-- Whether `shared-local` should remain a permanently supported sign-in topology
-  or Phase 1's code is deleted once Phase 2 lands.
-- Whether transiently sealing exchanged tokens (§2.3 step 5) is worth the
-  blast-radius increase versus making a post-exchange crash a full restart.
-
----
-
-## 10. Notes on #2317's exploration doc
-
-`context/explorations/claude-code-oauth-signin.md` (on #2317) remains accurate
-for the shipped in-memory design. Two statements need qualifying if this design
-lands:
-
-1. **"The PKCE verifier never leaves the daemon."** True of the shipped design —
-   it lives in one process's heap and is zeroed on completion
-   (`claude-oauth.ts:307-308`). Under Phase 2 it becomes a sealed, AAD-bound row
-   in PostgreSQL. Still never leaves Agor's trust boundary, but it becomes
-   persisted and encrypted rather than memory-only, with the backup/rotation
-   consequences in §5.2.
-2. **"Token material flows browser → daemon → filesystem"** is imprecise. The
-   browser carries the *authorization code and state* (pasted `CODE#STATE`); the
-   access and refresh **tokens** never touch the browser — they go Anthropic →
-   daemon → executor → `~/.claude/.credentials.json`. Worth correcting there, as
-   the imprecise phrasing overstates browser exposure.
-
----
-
-## Revision history
-
-- **r4** (this revision) — **PRECONDITION B resolved** by empirical probe against
-  the live OpenAI device endpoints (2026-08-18, §1.12): re-polling after approval
-  returns the **same** `authorization_code` and `code_verifier`, refuting r2's
-  worst-case assumption that observing approval might consume the code. Codex
-  transition 3 changes from "DANGEROUS / `ambiguous`" to **recoverable via
-  re-poll**, with `ambiguous → restart` retained as the fallback covering the
-  unproven cross-egress-IP case. Recorded the clean separation this buys: the
-  **lease governs who polls; the exchange claim governs who exchanges and is the
-  complete exactly-once mechanism.** Phase 4 is unblocked and folds into Phase 2.
-  Both preconditions are now closed. Also noted the poll response carries
-  `user_code_expiration`, which our code does not parse (out of scope).
-- **r3** — **PRECONDITION A resolved** by infra: prod HA runs a
-  shared-EFS RWX PVC with `persistent-per-user` and per-tenant/user `subPath`
-  isolation (§1.6). Consequence: Claude sign-in in HA is no longer stopgap-shaped
-  — durable attempt state is its only remaining blocker, in the general topology.
-  Phase 3 collapses into Phase 2; Phase 1 becomes optional; the recommendation
-  changes to "go straight to Phase 2". Added §1.10 with two EFS-derived
-  requirements **verified against our code**: R1 persistent identity on both the
-  credential-write and session-run paths (both carry it; `delegated` fails closed;
-  found an identity-source **divergence hazard** between `users.unix_username` and
-  `session.unix_username`), and R2 fsync-before-rename (**`close()` happens via
-  `writeFile`, `fsync` does not** — required change for EFS durability). Added
-  shared-credential-home test cases and the volume-exhaustion note.
-- **r2** — Corrected the refuted MCP/DCR claim (§1.9): the durable
-  MCP row seals `clientId`/`clientSecret`; MCP is gated pending separate
-  activation, not by process-local DCR state. Added the Codex fenced state machine
-  (§2.3) and durable logout/replacement fencing (§2.5). Made `state` hash-only and
-  removed the r1 internal contradiction. Softened "Blocker 2 already solved" to a
-  per-topology claim with PRECONDITION A. Corrected Codex TTL (fixed 15-min
-  constant, no `expires_in`). Expanded security to rotation/backups/least
-  privilege/plaintext lifetime/mixed keys. Reframed Phase 1 as minimal (dropped
-  boot-ID and drain). Added the testing matrix and the #2317 cross-reference notes.
-- **r1** — Initial design.
-
----
-
-## Related
-
-- `context/explorations/claude-code-oauth-signin.md` (#2317) — Claude flow protocol
-  details; see §10.
-- `context/explorations/web-terminal-ownership-ha.md` — affinity + owner fencing +
-  visible reconnect precedent.
-- `docs/internal/process-affine-ha-support-matrix-2026-08-07.md` — authoritative
-  per-flow HA classification and stated intent.
-- `docs/internal/daemon-ha-redis-realtime-2026-08-07.md` — Redis fanout contract,
-  ingress affinity operational guidance.
-- `apps/agor-docs/content/guide/daemon-ha.mdx` — operator-facing HA contract.
+At the review snapshot:
+
+- #2462's GitHub base was `claude-code-oauth-signin` at
+  `019095cc1187bc9e6ea8da40606519aa018a31c1`, exactly the #2317 head. It is not
+  based on #2449.
+- #2317 conflicted with current `main`. Consequently, #2462 being clean against
+  its named base did not make it current-main mergeable.
+- #2462's migration names had already collided with `main`:
+  PostgreSQL `0088_claude_oauth_attempts` versus
+  `0088_session_recent_index`, and SQLite `0091_claude_oauth_attempts` versus
+  `0091_session_recent_index`.
+- #2462 also predates the credential-home, envelope, authority, realtime, and HA
+  admission primitives merged by #2521 and later main changes. It must be
+  rebased and reshaped, not merged as an isolated add-on to its stale base.
+
+## Current state on `main`
+
+### Codex device sign-in is implemented, conditionally
+
+PostgreSQL HA uses `codex_device_auth_attempts`; standalone SQLite deliberately
+keeps the process-local flow. The durable implementation is in:
+
+- `apps/agor-daemon/src/services/codex-device-auth-durable.ts`
+- `apps/agor-daemon/src/services/codex-device-auth-attempt-authority.ts`
+- `packages/core/src/db/repositories/codex-device-auth-attempts.ts`
+- `packages/core/src/codex/credential-file.ts`
+
+The flow reserves a short-lived `starting` row before requesting a provider user
+code, attaches the grant with a compare-and-set transition, leases polling on the
+database clock, claims exchange once, and serializes final credential mutation
+against start/cancel/import/logout. Provider network waits do not hold a database
+transaction.
+
+The approved poll result and exchanged tokens stay in the winning daemon's heap.
+They are not added to PostgreSQL. Death before the one-shot exchange claim can be
+recovered by polling the still-current device grant again; uncertainty after the
+claim becomes `ambiguous` and is never replayed automatically.
+
+`codexDeviceAuth` is now a `boolean` capability and
+`isHaFeatureUnavailable()` reads it. Admission is deliberately narrower than
+replica-visible storage:
+
+- exact tenant/user routing through local `sandbox` execution;
+- `executor_storage.user_home: persistent-per-user`; and
+- an operator-verified
+  `executor_storage.user_home_locking: cross-replica-flock` contract.
+
+Shared identities, `simple`, delegated writers, local-only locks, and user home
+overrides remain gated. A persistent path alone does not prove that two replicas
+cannot race or that a timed-out remote writer has stopped.
+
+### Claude subscription OAuth is not implemented on `main`
+
+The `claude-auth/oauth` and `claude-auth/logout` services, their UI, and the
+`claudeOAuth`/`claudeAuth` HA feature keys exist only on #2317/#2462. Any Claude
+HA plan therefore depends first on reconciling #2317 with current `main`.
+
+The useful foundation from #2317 remains the provider protocol and standalone
+UX: authorization code plus PKCE, a manual `CODE#STATE` paste, and a managed
+`~/.claude/.credentials.json`. The useful foundation from #2462 remains a
+tenant/user/attempt-bound PostgreSQL claim. Its filesystem and activation model
+must not be carried forward unchanged.
+
+### `processAffineAuth` is not an enablement switch
+
+`processAffineAuth` still has only a resolved-config declaration, assignment to
+`false`, and a test fixture. No runtime code reads it. Provider-specific
+capabilities must express provider-specific evidence. Removing this unused field
+is valid cleanup, but it is not part of the Claude safety mechanism.
+
+## Corrections to the original proposal
+
+### 1. Storage visibility is not credential mutation authority
+
+The old proposal treated a replica-visible executor home plus atomic rename as
+leaving only the attempt `Map` to solve. That was incomplete.
+
+Database revalidation immediately before and after a file write does not close
+the race. A worker can pass its first check, lose ownership, and write after a
+new login or logout. Deleting "the file it wrote" after a failed second check is
+also unsafe: the path may already contain a newer winner's credential. A delayed
+cleanup pass has the same flaw.
+
+#2521 added the missing authority:
+
+- one tenant/user database advisory lock for every competing mutation;
+- a monotonically increasing mutation generation;
+- a per-home generation tombstone;
+- a non-age-stealable cross-replica kernel `flock`;
+- file and directory fsync;
+- no-follow, opened-directory filesystem operations; and
+- a contained local writer whose lifetime cannot exceed the authority-owning
+  daemon unnoticed.
+
+Claude must reuse or generalize that mechanism. It must not add a second
+precheck/write/postcheck protocol.
+
+The old EFS-specific supporting claims are also not admission evidence. The
+[AWS EFS CSI driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver)
+documents PVC capacity as a Kubernetes placeholder for elastic EFS, so a
+reported 20 GiB claim is not by itself a 20 GiB quota. AWS documents Regional
+EFS writes as durable after either file close or a synchronous write such as
+`fsync` in its
+[data-consistency contract](https://docs.aws.amazon.com/efs/latest/ug/features.html).
+The current fsync behavior is useful general hardening; neither fact proves
+exact-user routing, cross-client locking, or stale-writer containment.
+
+### 2. An exchange claim does not make a provider retry safe
+
+The original proposal preserved `exchangeWithOneRetry` when both calls were made
+by one claim holder. That is unsafe. A claim prevents a second owner; it cannot
+tell whether a timed-out, reset, 5xx, or unusable-success request consumed the
+one-time authorization code.
+
+Make exactly one exchange request. A validated provider rejection is `failed`.
+Any outcome for which consumption cannot be disproved is `ambiguous`. The user
+starts a fresh attempt; no owner replays the old code.
+
+### 3. The approved Codex result does not need another durable secret state
+
+The repeatable-poll observation recorded on #2449 supports one narrow behavior:
+a new lease owner may re-poll before exchange. It does not justify persisting an
+`approval_observed` authorization code/verifier or transient tokens.
+
+The smaller shipped state machine is the model: keep the poll result in heap,
+atomically claim exchange, and make every post-claim uncertainty terminal. The
+initial provider user-code request also needs its shipped `starting` reservation;
+the old proposal omitted that nontransactional call.
+
+The 2026-08-18 probe used one egress IP and proprietary OpenAI endpoints. It did
+not establish RFC 8628 compliance or cross-egress-IP behavior. The implementation
+therefore retains safe restart behavior rather than inferring a broader provider
+contract.
+
+### 4. Browser-visible protocol material must be named honestly
+
+Codex's user code is intentionally returned to the owning browser. Claude's
+authorization URL includes raw `state`, and the authorization code and state
+return through the user's `CODE#STATE` paste. These values must be scoped,
+short-lived, excluded from logs/Redis/other users, and treated as capabilities;
+they cannot be described as never reaching the client.
+
+Server-only material includes the Codex `device_auth_id`, PKCE verifiers, Codex's
+polled authorization code, and access/refresh tokens. Claude's pasted
+authorization code necessarily touches its owning browser before the daemon.
+
+### 5. Master-secret rotation is deployment-wide
+
+Provider-attempt rows are short-lived, so draining them can simplify their part
+of a rotation. It is not a complete `AGOR_MASTER_SECRET` rotation plan. The same
+secret protects long-lived MCP OAuth grant material and other bound envelopes.
+A safe rotation must account for every encrypted-at-rest consumer and either
+re-encrypt or deliberately invalidate/reconnect it; never imply that waiting
+10-15 minutes makes the whole fleet safe to re-key.
+
+## Smallest sound remaining Claude design
+
+### Resource classification
+
+| Resource                           | Classification                       | Authority                                                             |
+| ---------------------------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| Claude OAuth attempt               | tenant-owned, user-scoped, transient | PostgreSQL in HA; in-memory in standalone                             |
+| Raw OAuth `state`                  | short-lived browser capability       | browser/request; PostgreSQL stores SHA-256 only in the minimal design |
+| PKCE verifier and credential route | secret/derived attempt material      | purpose-separated bound envelope                                      |
+| Authorization code and tokens      | single-use/credential material       | request-handler heap only, then exact-user credential file            |
+| `.credentials.json`                | tenant-owned, user-derived file      | generation-fenced exact-user home                                     |
+| Fleet maintenance                  | narrow system/global operation       | explicit maintenance capability plus forced RLS                       |
+
+Transient attempts are deleted with their tenant but are not portable. Exporting
+or restoring an in-flight provider capability is not a supported operation.
+
+### Attempt record and start
+
+Use a Claude-specific table and state machine. Reuse current generic primitives,
+not the MCP compatibility names:
+
+- `sealBoundSecret` / `openBoundSecret` with a new Claude-specific purpose;
+- `lockTenantAuthoritySubject` for concurrent generation allocation;
+- `runWithTenantDatabaseScope` for ordinary access; and
+- `runWithSystemDatabaseScope` with a narrow Claude maintenance capability for
+  expiry and pruning across tenants.
+
+The row needs trusted `tenant_id`, authenticated `user_id`, public-safe
+`attempt_id`, a monotonic generation, `is_current`, DB-clock expiry, status,
+`state_hash`, a one-shot exchange claim, a purpose/AAD-bound envelope, and
+lifecycle timestamps. Bind the envelope to tenant, user, attempt, and generation.
+Clear it on every terminal transition.
+
+The minimal envelope contains the PKCE verifier and exact credential route, not
+raw state. Start returns the authorization URL once. A page that loses the URL
+may continue with an already-open provider tab and its `attempt_id`, or start
+over. If product explicitly requires reconstructing the URL after a full reload,
+sealing raw state is an intentional additional exposure and must be documented;
+the implementation and security claim cannot say both "hash-only" and "sealed
+raw state".
+
+Starting a new attempt takes the tenant/user/provider authority lock, allocates a
+new generation, supersedes the prior live attempt, inserts the new row, and only
+then returns `{attemptId, verificationUrl, expiresAt}`. The UI must echo the exact
+`attemptId` on status, submit, and cancel; it is not optional fallback state.
+
+### Claim and exchange
+
+On submit:
+
+1. parse `CODE#STATE` without mutating the attempt;
+2. hash the pasted state;
+3. atomically transition the exact current, unexpired
+   `(tenant,user,attempt,state_hash)` row from `pending` to `exchanging` with a
+   random claim ID;
+4. commit before provider I/O;
+5. open and validate the bound verifier/route; and
+6. perform one token exchange outside the transaction.
+
+A malformed paste or wrong state does not consume the attempt. Two replicas
+racing the same submit produce one claimant and one provider call. A definite
+provider rejection becomes `failed`; uncertain provider/transport/response
+outcomes become `ambiguous`. No authorization code or token is persisted in the
+attempt table.
+
+### Credential and auth-method finalization
+
+Finalization is the hard boundary. It must generalize the authority shipped for
+Codex rather than relying on two reads around an executor call:
+
+1. take the tenant/user/provider credential-mutation authority;
+2. revalidate exact attempt generation, current status, and claim;
+3. mark `persisting`;
+4. write `~/.claude/.credentials.json` with the same per-home lock, generation
+   tombstone, no-follow directory capability, atomic write, and durability
+   semantics used for Codex;
+5. update the user's Claude auth method and clear a shadowing pasted token under
+   the same logical authority; and
+6. terminalize with the exact claim/generation.
+
+Provider I/O must never occur while this authority is held. A file/DB crash gap
+may still yield an `ambiguous` user-visible result, but a stale writer must not be
+able to overtake the next higher generation. Do not add loser-delete or delayed
+path-delete cleanup.
+
+The authority must cover **all** Claude credential-source and method mutations,
+not only OAuth start and logout. On #2317, ordinary `users.patch` calls can save
+or clear `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` and change
+`agentic_auth_methods`. If those paths do not participate in the authority (or a
+durable compare-and-set generation), an older OAuth completion can erase a newer
+token choice and flip the method back. This is a server boundary; UI sequencing
+is not a correctness mechanism.
+
+### HA capability and external execution
+
+Add narrow `claudeOAuth` and `claudeAuth` capabilities. For the first safe HA
+version, compute them from the same evidence as the local exact-user Codex route:
+
+- `sandbox` exact-user home;
+- `persistent-per-user`; and
+- verified `cross-replica-flock`.
+
+Do not key interactive Claude sign-in only from the broader
+`codexCredentialFiles` capability. A tenant-safe shared identity can be valid for
+an operator-managed import yet still be unsafe for one browser user replacing
+credentials on behalf of another.
+
+Keep delegated/external Claude sign-in gated until the external credential
+writer owns a reviewed protocol that provides all of the following:
+
+- exact trusted tenant/user routing;
+- a persistent per-home mutation generation and atomic stale-generation reject;
+- cross-client mutual exclusion;
+- idempotent operation identity and queryable completion state; and
+- a proof that timeout/authority loss cannot let an older writer commit after a
+  newer mutation (by containment, termination acknowledgement, or substrate-owned
+  generation CAS).
+
+`persistent-per-user` by itself proves none of those. Widen the capability only
+from an explicit, validated substrate contract.
+
+### Tenant, realtime, and secret boundaries
+
+- Register Claude auth services as tenant-identity-only request paths. Open short
+  tenant database units at each DB access; never hold an HTTP-long transaction
+  across provider I/O.
+- Force RLS on the attempt table and cover cross-tenant and cross-user reads,
+  claims, completion, cleanup, and ciphertext rebinding negatively.
+- Give fleet maintenance its own narrow system capability; normal tenant policy
+  must exclude it.
+- Add `claude-auth/oauth` and `claude-auth/logout` to
+  `REALTIME_PUBLISH_POLICY` with `audience: 'none'` and to
+  `REDIS_FEATHERS_DENIED_PATHS`. Current publication is default-deny, but the
+  explicit credential-control-plane barrier remains defense in depth.
+- Never log provider bodies, codes, state, verifiers, credential routes, or
+  tokens. Stable failure categories and aggregate counters are safe.
+- A missing or mismatched fleet master secret fails closed. Never fall back to
+  plaintext.
+
+## Required validation before activation
+
+### Database and service
+
+- two independent PostgreSQL pools complete one attempt across replicas;
+- simultaneous starts allocate ordered generations and leave one current row;
+- simultaneous submits result in exactly one provider exchange;
+- wrong state and malformed paste do not consume the attempt;
+- abandoned/uncertain exchange becomes `ambiguous` and is never replayed;
+- expiry and system-capability maintenance use the database clock;
+- cross-tenant, cross-user, and ciphertext-rebinding attempts fail; and
+- tenant deletion removes attempts while portability omits them.
+
+### Credential authority
+
+- logout, replacement OAuth, API-key save, pasted-token save/clear, and OAuth
+  completion are raced at each write/method boundary;
+- a lower filesystem generation cannot overwrite or delete a higher one;
+- lock contention and database-authority loss cannot release a still-live writer
+  into a later mutation;
+- symlink/path replacement cannot redirect a write to another home; and
+- file write success is not reported when durability/read-back fails.
+
+### HA and UI
+
+- start on replica A and submit/status/cancel on B;
+- kill the claimant before exchange versus after exchange and verify the distinct
+  retry contracts;
+- stale tabs cannot submit or cancel a replacement attempt;
+- auth results never enter Redis or a second user's connection;
+- supported sandbox topology reports the capabilities true; shared/simple,
+  missing-lock, home-override, and delegated cases remain false; and
+- a full page reload follows the chosen raw-state contract: reconstruct only if
+  raw state was deliberately sealed, otherwise offer a clean Start over path.
+
+After code changes, run the focused daemon/core/executor/UI suites, PostgreSQL
+non-superuser RLS tests, `pnpm check:multitenancy-boundaries`, typecheck/lint, and
+the managed two-daemon HA harness. External support additionally requires an
+environment test against the real writer protocol; Compose cannot certify it.
+
+## Rebase plan for #2317 / #2462
+
+1. Rebase #2317 onto current `main` and resolve its existing conflicts first.
+2. Rebase #2462 on that new #2317 head; regenerate migration IDs and journals
+   from the then-current schema.
+3. Replace duplicated pre-#2521 helpers with the current bound-envelope,
+   authority-lock, credential-home, and credential-file primitives.
+4. Make `attemptId` required end-to-end in the UI and service.
+5. Choose and document the raw-state/reload contract. Do not use MCP's
+   `pending-exchange` purpose for Claude material.
+6. Add the provider-wide credential/method mutation authority before HA
+   capability enablement.
+7. Add current realtime `audience: 'none'` declarations as well as the Redis hard
+   deny entries.
+8. Keep delegated/external capability false until its writer contract is proved.
+9. Preserve #2317's unresolved ToS/AUP review as a pre-GA product/legal
+   prerequisite; HA correctness does not answer that question.
+
+## Decision
+
+Codex is implemented and its existing focused document is authoritative. For
+Claude, durable PostgreSQL attempt state is necessary but not sufficient. The
+smallest sound first release is a request-driven, one-shot claim plus the existing
+generation-fenced **local exact-user sandbox** credential authority. External
+writer support is a separate protocol project, not a capability flip based on
+shared storage.

--- a/context/explorations/oauth-signin-in-ha.md
+++ b/context/explorations/oauth-signin-in-ha.md
@@ -1,7 +1,9 @@
 # Provider subscription sign-in in HA
 
-Status: **current-state record and remaining Claude design**, reviewed against
-`main` at `390e9216` on 2026-08-24.
+Status: **normative remaining Claude design with a dated implementation
+snapshot**. Code facts below were re-verified on 2026-08-25 against `main` and
+the live heads of PRs #2317, #2462, and #2521. The named revisions are historical
+evidence, not moving implementation requirements.
 
 This document originally proposed one future design for Codex device sign-in and
 Claude subscription OAuth. That is no longer an accurate shape:
@@ -15,8 +17,8 @@ Claude subscription OAuth. That is no longer an accurate shape:
   [PR #2462](https://github.com/preset-io/agor/pull/2462).
 
 The current Codex contract lives in
-[`codex-device-auth-ha.md`](./codex-device-auth-ha.md) and the operator contract
-lives in
+[`codex-device-auth-ha.md`](https://github.com/preset-io/agor/blob/main/context/explorations/codex-device-auth-ha.md)
+and the operator contract lives in
 [`daemon-ha.mdx`](../../apps/agor-docs/content/guide/daemon-ha.mdx). Do not use
 the deleted revisions of this document as an implementation specification.
 
@@ -24,7 +26,7 @@ the deleted revisions of this document as an implementation specification.
 
 This document does two things:
 
-1. records the PR lineage and the currently shipped Codex behavior; and
+1. records dated PR lineage and the currently shipped Codex behavior; and
 2. defines the smallest sound design still required before Claude subscription
    OAuth may be enabled in `deployment.mode: ha`.
 
@@ -32,32 +34,58 @@ MCP OAuth, OpenCode auth, and API-key-only flows are out of scope. The reusable
 MCP security primitives remain relevant; its state machine is not a generic
 provider-auth state machine.
 
-## PR lineage and review snapshot
+## Dated implementation snapshot (non-normative)
+
+This section answers "what had landed where when this design was reviewed?"
+It must not be used as a merge recipe. Commit counts, migration ordinals,
+mergeability, and branch divergence change as the branches move. An implementer
+must refresh all of them against the actual merge target.
+
+As verified on **2026-08-25**:
 
 The branches are siblings plus one stack, not one four-PR stack:
 
 ```text
-main
+main @ 84ee55c8
 ├── oauth-signin-ha-enablement-design      # PR #2449, this document
-├── claude-code-oauth-signin               # PR #2317
-│   └── oauth-signin-ha-durable-attempts   # PR #2462, exactly five commits
+├── claude-code-oauth-signin               # PR #2317 @ b57d7372
+│   └── oauth-signin-ha-durable-attempts   # PR #2462 @ 57e62ae8
 └── #2521                                  # merged to main as a44bba08
 ```
 
-At the review snapshot:
+- `main` was `84ee55c8a1674c7d6b037f50894ac0b74ae04c5b`.
+- #2521 had merged on 2026-08-22 as
+  `a44bba086dafd01a4504a8a693725ec2eaaa7bfa`; its PR head was `dc0dd9bf`.
+- #2317's head was `b57d737250d2367c3d23a15a72b05e9cb2ecc926`.
+  Its merge-base with that day's `main` was `390e9216`; `main` had advanced by
+  four commits.
+- #2462 was stacked directly on that exact #2317 head. Its head was
+  `57e62ae8ffd5547917e8e93c945f5d6df479b86c`, and the GitHub stack range held
+  eleven commits. Its merge-base with that day's `main` was `add0c0c0`; `main`
+  had advanced by two commits.
+- The Claude attempt migrations on that #2462 head were PostgreSQL
+  `0094_claude_oauth_attempts` and SQLite `0097_claude_oauth_attempts`.
 
-- #2462's GitHub base was `claude-code-oauth-signin` at
-  `019095cc1187bc9e6ea8da40606519aa018a31c1`, exactly the #2317 head. It is not
-  based on #2449.
-- #2317 conflicted with current `main`. Consequently, #2462 being clean against
-  its named base did not make it current-main mergeable.
-- #2462's migration names had already collided with `main`:
-  PostgreSQL `0088_claude_oauth_attempts` versus
-  `0088_session_recent_index`, and SQLite `0091_claude_oauth_attempts` versus
-  `0091_session_recent_index`.
-- #2462 also predates the credential-home, envelope, authority, realtime, and HA
-  admission primitives merged by #2521 and later main changes. It must be
-  rebased and reshaped, not merged as an isolated add-on to its stale base.
+Earlier revisions of this document recorded #2462 at five commits on the old
+`019095cc` #2317 head, with colliding `0088`/`0091` migration ordinals and
+pre-#2521 primitives. That was true historical context and is no longer current.
+In particular, the 2026-08-25 #2462 head already contains the shared bound-secret,
+credential-home, generation-fenced mutation, capability, realtime-deny, and
+offline-cutover work. Never preserve a migration ordinal or duplicate a helper
+merely because an older document named it.
+
+### Completed work versus remaining requirements
+
+| Location at the dated snapshot | Completed there                                                                                                                                  | Still required before activation on `main`                                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main`                         | #2521's durable Codex attempt and credential authority                                                                                           | No Claude subscription service or HA capability was present                                                                                                                                     |
+| #2317 head                     | Claude provider protocol, standalone service/logout, exact-user credential route, and UI                                                         | Integrate with the eventual merge target and the unified HA authority                                                                                                                           |
+| #2462 head                     | Durable Claude rows/claims, unified daemon-side mutation authority, generation-fenced file operations, capability computation, and HA tests/docs | Refresh against the eventual merge target; satisfy the normative continuation, runtime-writer, rollout/rollback, validation, and product/legal gates below before activating those capabilities |
+
+The remaining sections describe acceptance requirements regardless of whether
+the implementation arrives by rebasing these PRs, merging them, or replacing
+parts of them. A branch implementation is evidence, not shipped behavior, until
+it is on `main` and activated under the rollout contract.
 
 ## Current state on `main`
 
@@ -97,15 +125,18 @@ cannot race or that a timed-out remote writer has stopped.
 
 ### Claude subscription OAuth is not implemented on `main`
 
-The `claude-auth/oauth` and `claude-auth/logout` services, their UI, and the
-`claudeOAuth`/`claudeAuth` HA feature keys exist only on #2317/#2462. Any Claude
-HA plan therefore depends first on reconciling #2317 with current `main`.
+At the dated snapshot, the `claude-auth/oauth` and `claude-auth/logout` services,
+their UI, and the `claudeOAuth`/`claudeAuth` HA feature keys existed only on
+#2317/#2462. Any Claude HA release therefore still depends on integrating that
+work with the then-current `main`.
 
-The useful foundation from #2317 remains the provider protocol and standalone
-UX: authorization code plus PKCE, a manual `CODE#STATE` paste, and a managed
-`~/.claude/.credentials.json`. The useful foundation from #2462 remains a
-tenant/user/attempt-bound PostgreSQL claim. Its filesystem and activation model
-must not be carried forward unchanged.
+The useful foundation from #2317 is the provider protocol and standalone UX:
+authorization code plus PKCE, a manual `CODE#STATE` paste, and a managed
+`~/.claude/.credentials.json`. The 2026-08-25 #2462 head extends that foundation
+with tenant/user/attempt-bound PostgreSQL claims and the shared credential
+authority. Those implementations still must be reviewed against the normative
+contract below at integration time; older pre-authority revisions must not be
+resurrected.
 
 ### `processAffineAuth` is not an enablement switch
 
@@ -210,6 +241,7 @@ re-encrypt or deliberately invalidate/reconnect it; never imply that waiting
 | PKCE verifier and credential route | secret/derived attempt material      | purpose-separated bound envelope                                      |
 | Authorization code and tokens      | single-use/credential material       | request-handler heap only, then exact-user credential file            |
 | `.credentials.json`                | tenant-owned, user-derived file      | generation-fenced exact-user home                                     |
+| Runtime credential copy            | tenant-owned, user/session-derived   | session-private executor directory; never promoted implicitly         |
 | Fleet maintenance                  | narrow system/global operation       | explicit maintenance capability plus forced RLS                       |
 
 Transient attempts are deleted with their tenant but are not portable. Exporting
@@ -240,10 +272,38 @@ sealing raw state is an intentional additional exposure and must be documented;
 the implementation and security claim cannot say both "hash-only" and "sealed
 raw state".
 
-Starting a new attempt takes the tenant/user/provider authority lock, allocates a
-new generation, supersedes the prior live attempt, inserts the new row, and only
-then returns `{attemptId, verificationUrl, expiresAt}`. The UI must echo the exact
-`attemptId` on status, submit, and cancel; it is not optional fallback state.
+**Start over is the only replacement operation; there is no cancel operation in
+this contract.** Starting takes the tenant/user/provider authority lock and
+linearizes one transaction as follows:
+
+1. allocate a generation greater than every earlier credential/attempt mutation
+   for that tenant/user/provider;
+2. make the prior current row non-current and clear its sealed material;
+3. terminalize a prior `pending` row with status `failed` and failure code
+   `superseded_by_newer_attempt`; terminalize a prior `exchanging` or
+   `persisting` row with status `ambiguous` and the same failure code, because
+   provider or filesystem effects may already have occurred; and
+4. insert the new `pending`, `is_current` row, then commit before returning
+   `{attemptId, verificationUrl, expiresAt}`.
+
+This transition is intentionally not request-idempotent: two accepted Start over
+requests create two ordered generations and the later transaction wins. The UI
+disables duplicate clicks, but correctness comes from the authority lock and the
+one-current-row constraint. A race with submit is decided by database order: a
+claim that commits first is superseded as `ambiguous`; a supersede that commits
+first makes the old claim predicate fail before provider I/O. A race with
+finalization is serialized by the same mutation authority: finalization that
+wins may leave the existing credential usable, while a Start over that wins
+fences the old writer. Merely starting again does not delete a previously valid
+credential.
+
+The initial authenticated "discover my current attempt" status read may omit an
+ID. After a start or discovery returns one, every status continuation and submit
+must echo that exact `attemptId`; a stale tab never falls forward to a replacement
+attempt. Start over sends no old attempt ID because the atomic supersede is the
+entire operation. Adding cancel later would require its own atomic predicate,
+terminal state, idempotency, and ordering contract; it must not be implemented as
+an alias for logout or a best-effort flag.
 
 ### Claim and exchange
 
@@ -292,6 +352,45 @@ durable compare-and-set generation), an older OAuth completion can erase a newer
 token choice and flip the method back. This is a server boundary; UI sequencing
 is not a correctness mechanism.
 
+### Native runtime refresh is another credential writer
+
+The daemon services are not the only possible writers. #2317 deliberately relies
+on the pinned Claude CLI/SDK to auto-refresh from `.credentials.json`; that
+binary contains its own `.oauth_refresh.lock`, token-save path, and dead-refresh-
+token disk cleanup. A long-running native session with the canonical home
+writable could therefore update or clear the file without Agor's advisory lock,
+generation tombstone, or auth-method transaction. It could overtake a new login
+or recreate state after logout. Calling the daemon-side paths "one authority"
+without containing this writer would be false.
+
+For the first safe HA release, the daemon-owned canonical credential file must
+not be writable by a Claude runtime:
+
+1. under the tenant/user credential authority, launch takes a generation-checked
+   snapshot into a tenant/user/session-private credential directory;
+2. the executor exposes only that private directory to the Claude process, so
+   vendor refresh locking and token writes cannot reach the canonical home;
+3. the private credential never syncs back automatically, never enters Redis or
+   logs, and is deleted through tenant/session cleanup; and
+4. logout, replacement, or auth-source change advances the canonical generation
+   and governs future launches. It does not claim to revoke bytes already held by
+   an active process; immediate revocation additionally requires terminating that
+   process and/or provider-side revocation.
+
+This minimal containment trades availability for correctness if Anthropic
+rotates a refresh token in the private copy: a later launch may find the
+canonical refresh token unusable and must fail closed with an explicit fresh
+sign-in path. It must not promote a private copy opportunistically. A future
+write-back optimization needs an authenticated, secret-safe runtime-to-daemon
+operation bound to tenant, user, launch ID, and the launch's credential
+generation; the daemon then performs the normal locked generation CAS. The
+operation must be idempotent/queryable, and a stale generation must be rejected.
+
+If the execution substrate cannot prove that the native process writes only its
+private credential directory, `claudeOAuth` and `claudeAuth` remain false. A
+vendor-local lock is not a substitute: it neither participates in Agor's
+generation order nor covers API-key/method mutations.
+
 ### HA capability and external execution
 
 Add narrow `claudeOAuth` and `claudeAuth` capabilities. For the first safe HA
@@ -299,7 +398,9 @@ version, compute them from the same evidence as the local exact-user Codex route
 
 - `sandbox` exact-user home;
 - `persistent-per-user`; and
-- verified `cross-replica-flock`.
+- verified `cross-replica-flock`; and
+- session-private runtime credential routing that does not expose the canonical
+  file as writable to the pinned Claude process.
 
 Do not key interactive Claude sign-in only from the broader
 `codexCredentialFiles` capability. A tenant-safe shared identity can be valid for
@@ -319,6 +420,109 @@ writer owns a reviewed protocol that provides all of the following:
 
 `persistent-per-user` by itself proves none of those. Widen the capability only
 from an explicit, validated substrate contract.
+
+### Mixed-version rollout and rollback
+
+The unified authority is safe only when **every** writer participates. A schema
+table and a new daemon's capability check cannot fence an older daemon that does
+not acquire the advisory lock or honor the filesystem generation. The first
+Claude-authority release therefore requires an **offline, all-at-once cohort
+cutover**. Rolling replacement and old/new overlap are unsupported. A future
+rolling protocol would need a durable fleet activation epoch that every possible
+writer, including the old version, understands and refuses to cross; this design
+does not have one.
+
+#### Activation order
+
+1. **Preflight without activation.** Pin the exact activation and rollback
+   binaries; take and restore-test a PostgreSQL backup and, if rollback may need
+   credential restoration, a coordinated exact-user-home backup. Provision one
+   stable `AGOR_MASTER_SECRET` and verify exact-user routing,
+   `persistent-per-user`, cross-replica `flock`, and private runtime credential
+   routing on every future replica. Keep `claudeOAuth` and `claudeAuth`
+   unavailable. Credential-home backups contain
+   plaintext provider tokens at the consumption boundary: encrypt them, restrict
+   operator access, bound retention, and include their tenant-owned bytes in
+   deletion/offboarding procedures.
+2. **Quiesce the old cohort.** Remove all daemons from ingress so no OAuth start,
+   logout, API-key/token patch, auth-method change, or session launch can begin.
+   Let bounded provider exchanges and credential writers finish. Then stop every
+   old daemon, executor, native Claude session, and contained writer and verify
+   that none remains. Do not start a new daemon while an old process can still
+   touch a credential home.
+3. **Classify old in-flight work.** A process-local `pending` attempt is not
+   migrated; the user gets Start over after activation. A request known to have
+   failed before provider exchange is failed. Any request interrupted after the
+   exchange POST began, or after a credential mutation began without confirmed
+   completion, is operationally `ambiguous`: do not replay its code or delete a
+   path in compensation. Reconcile the user's method/file with the authenticated
+   inspect path or let the user explicitly Start over/disconnect after activation.
+4. **Migrate offline.** With no application daemon running, apply the activation
+   binary's complete migration set using the repository's offline-cutover path.
+   The Claude migration was `0094` on the dated #2462 head, but the actual
+   migration ledger and ordinal at cutover are authoritative. Do not hand-edit an
+   older ordinal into the ledger.
+5. **Start dark, then activate.** Start the whole new cohort out of ingress. Each
+   replica must verify the schema watermark, stable master secret, exact-user
+   route, shared locking contract, private runtime credential routing, and the
+   same capability result. In PostgreSQL HA, all Claude auth-source/method writers
+   must route through the unified authority even before interactive OAuth is
+   advertised. Only after every
+   replica reports the expected `claudeOAuth` and `claudeAuth` capabilities may
+   ingress and Claude credential mutation reopen. A nonempty secret on each pod
+   is insufficient evidence that the values match: the deployment must compare
+   an immutable secret revision out of band or require every replica to open a
+   purpose-bound activation canary written during the offline cutover. Do not
+   expose the secret or a reusable verifier in health output.
+
+Missing schema, a migration watermark the binary does not understand, missing or
+mismatched master secret, unsupported storage/locking, or cohort-version
+uncertainty fails closed. In HA, the daemon must not fall back to the standalone
+in-memory attempt store, an unfenced writer, plaintext material, a shared home,
+or a different auth source. Keep the user's method and credential bytes intact
+while denying the affected sign-in, mutation, or launch with a stable unavailable
+error.
+
+#### Binary rollback and subscription-auth users
+
+Rollback is also offline and all-at-once:
+
+1. remove the activation cohort from ingress, drain bounded work, stop every new
+   daemon/writer, and preserve its database plus credential-home state;
+2. treat any nonterminal durable attempt as abandoned. Never transfer or replay
+   its authorization code. Rows may remain inert for a later new-version
+   maintenance pass, or an offline procedure owned by the activation version may
+   terminalize them; an old binary must not mutate them;
+3. start at most one rollback daemon in `deployment.mode: standalone`, with no
+   new-version daemon or writer alive. A rollback to HA is prohibited because
+   that binary does not share the unified authority; and
+4. before reopening traffic, run the same authenticated file/method consistency
+   check for every subscription-auth user affected by an interrupted mutation.
+
+A rollback binary is **subscription-aware** only if it understands
+`agentic_auth_methods['claude-code'] = 'subscription'`, resolves the same exact
+user home and `.credentials.json` format, and leaves that method/file untouched
+on errors. Such a binary may continue using an already-confirmed credential in
+single-daemon standalone mode, but its Claude credential mutations remain closed
+during the rollback window unless its single-writer behavior has been explicitly
+validated.
+
+A binary that predates subscription auth, maps it to API-key or pasted-token
+auth, probes a daemon/shared home, or silently clears the method is not a valid
+in-place rollback for subscription-auth users. Keep Claude launches and auth
+mutation unavailable and either re-upgrade, move each user through an explicit
+new credential choice under a supported binary, or restore a tested pre-cutover
+**database and credential-home pair**. Never restore only PostgreSQL while
+leaving newer credential files, and never silently borrow an API key or token as
+a downgrade fallback. A restore rolls back credential changes and revocations
+made after its checkpoint; keep launches closed until those users are audited
+and any provider-side revocation or fresh sign-in is completed.
+
+The additive attempt table may remain only when the rollback binary is known to
+tolerate the newer migration watermark and will not perform unsafe lifecycle or
+tenant-deletion work. Otherwise restore the coordinated pre-cutover backup with
+all binaries stopped. Schema rollback is not ad hoc reverse DDL: it must restore
+or update both schema and migration ledger through a tested procedure.
 
 ### Tenant, realtime, and secret boundaries
 
@@ -355,6 +559,11 @@ from an explicit, validated substrate contract.
 
 - logout, replacement OAuth, API-key save, pasted-token save/clear, and OAuth
   completion are raced at each write/method boundary;
+- a native Claude session can refresh or clear only its private credential copy;
+  after logout or replacement it cannot recreate or overwrite the canonical
+  file, and a rotated private refresh token is never silently promoted;
+- normal completion, crash cleanup, tenant deletion, and offboarding remove
+  private copies without crossing tenant/user/session ownership;
 - a lower filesystem generation cannot overwrite or delete a higher one;
 - lock contention and database-authority loss cannot release a still-live writer
   into a later mutation;
@@ -363,44 +572,80 @@ from an explicit, validated substrate contract.
 
 ### HA and UI
 
-- start on replica A and submit/status/cancel on B;
+- start on replica A and submit/exact-attempt status on B;
 - kill the claimant before exchange versus after exchange and verify the distinct
   retry contracts;
-- stale tabs cannot submit or cancel a replacement attempt;
+- simultaneous Start over requests leave one current generation; Start over
+  versus submit/finalization follows the specified database/authority ordering;
+- stale tabs cannot submit or poll forward into a replacement attempt, and no
+  cancel endpoint or cancel-shaped client fallback exists;
 - auth results never enter Redis or a second user's connection;
 - supported sandbox topology reports the capabilities true; shared/simple,
   missing-lock, home-override, and delegated cases remain false; and
 - a full page reload follows the chosen raw-state contract: reconstruct only if
   raw state was deliberately sealed, otherwise offer a clean Start over path.
 
+### Rollout and rollback
+
+- migration preflight leaves both capabilities false, and schema/master-secret/
+  storage/private-runtime-routing mismatch fails closed without choosing the
+  in-memory store;
+- an old writer is deliberately held open while a new cohort tries to activate;
+  activation remains closed until the old cohort and writer are gone;
+- old process-local pending and uncertain exchange/write attempts become Start
+  over/ambiguous outcomes and are never replayed during cutover;
+- a full new cohort activates only after every replica reports the same schema
+  and capability evidence; mixed binaries never serve traffic together;
+- rollback leaves durable attempts inert, runs at most one standalone rollback
+  daemon, and never races a new-version writer; and
+- subscription-auth users retain the same method/file under a compatible
+  rollback binary, while an incompatible downgrade blocks Claude instead of
+  falling back to an API key, pasted token, or shared home.
+
 After code changes, run the focused daemon/core/executor/UI suites, PostgreSQL
 non-superuser RLS tests, `pnpm check:multitenancy-boundaries`, typecheck/lint, and
 the managed two-daemon HA harness. External support additionally requires an
 environment test against the real writer protocol; Compose cannot certify it.
 
-## Rebase plan for #2317 / #2462
+## Integration checklist (refresh at merge time)
 
-1. Rebase #2317 onto current `main` and resolve its existing conflicts first.
-2. Rebase #2462 on that new #2317 head; regenerate migration IDs and journals
-   from the then-current schema.
-3. Replace duplicated pre-#2521 helpers with the current bound-envelope,
-   authority-lock, credential-home, and credential-file primitives.
-4. Make `attemptId` required end-to-end in the UI and service.
-5. Choose and document the raw-state/reload contract. Do not use MCP's
-   `pending-exchange` purpose for Claude material.
-6. Add the provider-wide credential/method mutation authority before HA
-   capability enablement.
-7. Add current realtime `audience: 'none'` declarations as well as the Redis hard
-   deny entries.
-8. Keep delegated/external capability false until its writer contract is proved.
-9. Preserve #2317's unresolved ToS/AUP review as a pre-GA product/legal
-   prerequisite; HA correctness does not answer that question.
+Do not translate the dated snapshot into a mechanical rebase plan. On the
+2026-08-25 #2462 head, the migration renumbering, current shared helpers,
+provider-wide mutation authority, capability checks, explicit realtime deny,
+and Redis hard deny were already present. Re-doing those steps from an older
+revision would be a regression.
+
+The integration owner must instead:
+
+1. fetch the actual `main`, #2317, and #2462 heads; recompute ancestry and diffs;
+   then choose rebase, merge, or selective replacement based on code, not the
+   historical SHAs or commit counts above;
+2. regenerate or verify migration files and both journals against the merge
+   target's current schema. No ordinal in this document is reserved;
+3. review the resulting tree for exactly one current bound-envelope,
+   credential-home, credential-file, and tenant/user mutation authority path;
+   ensure OAuth, logout, Start over, API-key/token patch, and method changes all
+   enter it;
+4. contain the pinned CLI/SDK's refresh-token file writes in a session-private
+   credential directory, or keep both Claude HA capabilities false;
+5. require exact `attemptId` for every continuation after discovery/start, keep
+   Start over as the only replacement operation, and ensure no cancel API/client
+   or cancel validation case survives;
+6. choose and document the raw-state/reload contract. Do not use MCP's
+   `pending-exchange` purpose for Claude material;
+7. mirror the offline all-at-once activation, in-flight classification,
+   subscription-aware downgrade, and fail-closed rules in the operator guide;
+8. keep delegated/external capability false until its writer contract is proved;
+   and
+9. preserve #2317's unresolved ToS/AUP review as a pre-GA product/legal
+   prerequisite. HA correctness does not answer that question.
 
 ## Decision
 
 Codex is implemented and its existing focused document is authoritative. For
 Claude, durable PostgreSQL attempt state is necessary but not sufficient. The
-smallest sound first release is a request-driven, one-shot claim plus the existing
-generation-fenced **local exact-user sandbox** credential authority. External
-writer support is a separate protocol project, not a capability flip based on
-shared storage.
+smallest sound first release is a request-driven, one-shot claim plus a
+generation-fenced **local exact-user sandbox** canonical credential authority and
+a session-private native-runtime credential copy. External writer support and
+generation-checked refresh write-back are separate protocol projects, not
+capability flips based on shared storage.


### PR DESCRIPTION
## Summary

**Design docs only — no runtime behavior changes.** Refreshes
`context/explorations/oauth-signin-in-ha.md` against current `main` and the live
heads of #2317, #2462, and #2521, and resolves the remaining HA contract gaps.

The document now:

- makes **Start over** the only Claude attempt-replacement operation; there is no
  cancel contract or cancel validation case;
- defines the atomic supersede transition, exact-attempt continuation, duplicate
  starts, and start-versus-submit/finalization ordering;
- turns branch SHAs, divergence, commit counts, and migration ordinals into a
  clearly dated, non-normative 2026-08-25 snapshot;
- separates work shipped on `main`, work present only on #2317/#2462, and the
  requirements still blocking activation;
- requires an offline, all-at-once first activation because older daemons do not
  participate in the unified credential authority; and
- specifies schema/capability order, old/new in-flight handling, inert durable
  attempts on rollback, subscription-aware downgrade behavior, coordinated
  database/credential-home restore, and fail-closed outcomes.

## Correctness and architecture review

- Re-verified `main` at `84ee55c8`, #2317 at `b57d7372`, #2462 at `57e62ae8`,
  and #2521 at `dc0dd9bf` (merged as `a44bba08`).
- Confirmed the current #2462 stack is 11 commits on the exact #2317 head, with
  Claude migrations at PostgreSQL `0094` / SQLite `0097`, and already includes
  the daemon-side shared authority/capability/realtime work.
- Correctness review confirmed one-shot exchange, latest-wins supersede, exact
  submit identity, generation fencing, and conservative ambiguous outcomes.
- A separate architecture/system-fit review found one additional writer: the
  pinned Claude CLI/SDK refreshes and can clear `.credentials.json`. The design
  now keeps HA capabilities false until native sessions use a session-private
  credential copy (or an equivalent reviewed fenced protocol), so vendor writes
  cannot bypass logout/replacement generations.
- Backup, tenant deletion/offboarding, master-secret cohort matching, and
  incompatible subscription-auth downgrade behavior are explicit and fail
  closed.

## Validation

- Prettier write + check for the changed Markdown
- `git diff --check` through `simple-git`
- Relative Markdown link resolution and HTTP checks for all external links
- Live GitHub ref, ancestry, stack-count, migration-path, and implementation
  assertions for current `main`, #2317, #2462, and #2521
- Separate correctness and architecture/system-fit reviews

No HA/runtime suites were run because this PR changes documentation only.
