### PR TITLE
fix(ui): drop the raw manifest from the Slack wizard Options step

### DIFF
--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -177,7 +177,7 @@ Slack setup is **manifest-based**. Instead of clicking through OAuth scopes, eve
 
 There are two ways to get the manifest:
 
-- **The Add Channel wizard (UI).** When you create a Slack channel in Agor, a guided wizard builds the manifest from your choices and shows it (with a live scope/event preview) ready to copy.
+- **The Add Channel wizard (UI).** When you create a Slack channel in Agor, a guided wizard turns your choices into a live scope/event summary, then hands you the finished manifest ready to copy on the next step.
 - **The `agor_gateway_slack_manifest_generate` MCP tool (agent-driven).** Ask an agent to generate the manifest for you. The tool is the programmatic equivalent of the wizard, backed by the same generator: from a set of capability toggles it returns the manifest JSON, the derived bot scopes and events, ordered setup steps, and the channel config to pass to `agor_gateway_channels_create`. It is pure. It creates no Slack app, no Agor channel, and validates no tokens. When an agent completes setup, it creates the channel disabled and without tokens via `agor_gateway_channels_create` (`enabled: false`), then calls `agor_widgets_request_gateway_token` so you enter the `xoxb-`/`xapp-` tokens in a secure inline form. The agent never asks you to paste tokens into the chat or passes them as `agor_gateway_channels_create` arguments, because raw secrets in tool arguments would leak into the MCP transcript.
 
 Once a channel exists, its edit form also has an **App Manifest** panel showing the recommended manifest for the channel's current options. Re-paste it into Slack whenever you change surfaces or capabilities so the app's scopes stay aligned.
@@ -194,7 +194,7 @@ The one step neither path can cover is the **app-level token**: `connections:wri
    - **Surfaces.** Where the bot listens. Direct messages are always on; optionally add **Public channels** (all, or a specific list of channel IDs), **Private channels**, and **Group DMs**.
    - **Align Slack users.** Match each Slack profile's email to an Agor user (unmatched senders are rejected). When off, pick a single Agor user to run every session as.
    - **Enable outbound sends.** Allow authorized agents to post proactive Slack messages through this channel.
-5. As you toggle options, the wizard updates a **live manifest preview** and the derived **bot scopes** and **event subscriptions**. You never add a scope by hand. Click **Continue**.
+5. As you toggle options, the wizard updates a live summary of the derived **bot scopes** and **event subscriptions** under **What this app will be able to do**. You never add a scope by hand — the manifest itself is assembled for the **Create app** step, where you copy it. Click **Continue**.
 
 ### 2. Create the Slack app from the manifest
 

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -194,7 +194,7 @@ The one step neither path can cover is the **app-level token**: `connections:wri
    - **Surfaces.** Where the bot listens. Direct messages are always on; optionally add **Public channels** (all, or a specific list of channel IDs), **Private channels**, and **Group DMs**.
    - **Align Slack users.** Match each Slack profile's email to an Agor user (unmatched senders are rejected). When off, pick a single Agor user to run every session as.
    - **Enable outbound sends.** Allow authorized agents to post proactive Slack messages through this channel.
-5. As you toggle options, the wizard updates a live summary of the derived **bot scopes** and **event subscriptions** under **What this app will be able to do**. You never add a scope by hand — the manifest itself is assembled for the **Create app** step, where you copy it. Click **Continue**.
+5. As you toggle options, the wizard updates **Required Slack Scopes & Events** with the derived bot scopes and event subscriptions. You never add a scope by hand — the manifest itself is assembled for the **Create app** step, where you copy it. Click **Continue**.
 
 ### 2. Create the Slack app from the manifest
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -285,11 +285,19 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
   });
 
-  it('updates the manifest preview and scope list as surfaces change', async () => {
+  it('updates the derived scope/event list as surfaces change, without the raw manifest', async () => {
     renderTable(null);
     clickButton(/Add Channel/);
     // Surfaces live on the Options step (step 1).
     await advanceToOptions();
+
+    // The Options step configures; the raw JSON manifest is reserved for the
+    // "Create app" step, where it has a working copy button (issue #2448).
+    const manifestBlocks = Array.from(document.querySelectorAll('pre')).filter((el) =>
+      el.textContent?.includes('display_information')
+    );
+    expect(manifestBlocks).toHaveLength(1);
+    expect(manifestBlocks[0]).not.toBeVisible();
 
     // Public-channel scopes/events are absent until the surface is enabled.
     expect(screen.queryByText('channels:history')).not.toBeInTheDocument();

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -191,6 +191,16 @@ function clickButton(text: RegExp) {
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 /**
+ * Text of the rendered scope/event Tags. Scoped to `.ant-tag` on purpose: the
+ * Options step's explainer prose names `app_mention` in a `<code>`, so a bare
+ * `queryByText` would match the copy instead of the derived list — passing the
+ * "absent before the surface is enabled" check for the wrong reason.
+ */
+function scopeTagTexts(): string[] {
+  return Array.from(document.querySelectorAll('.ant-tag')).map((el) => el.textContent ?? '');
+}
+
+/**
  * Open the (real) channel-type antd Select and pick a platform by its option
  * label. `getByRole('combobox')` scans the whole antd-modal DOM computing roles
  * (~250ms per call in jsdom, same class of cost as the button-name lookup above)
@@ -300,17 +310,15 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(manifestBlocks[0]).not.toBeVisible();
 
     // Public-channel scopes/events are absent until the surface is enabled.
-    expect(screen.queryByText('channels:history')).not.toBeInTheDocument();
-    expect(screen.queryByText('app_mention')).not.toBeInTheDocument();
+    expect(scopeTagTexts()).not.toContain('channels:history');
+    expect(scopeTagTexts()).not.toContain('app_mention');
 
     fireEvent.click(screen.getByText('Public channels'));
 
     // Now they appear in the derived scope/event list (Form.useWatch flush).
-    await waitFor(() =>
-      expect(screen.queryAllByText('channels:history').length).toBeGreaterThan(0)
-    );
-    expect(screen.queryAllByText('app_mentions:read').length).toBeGreaterThan(0);
-    expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
+    await waitFor(() => expect(scopeTagTexts()).toContain('channels:history'));
+    expect(scopeTagTexts()).toContain('app_mentions:read');
+    expect(scopeTagTexts()).toContain('app_mention');
   });
 
   it('runs the connection probe and renders team/bot/notVerifiable honestly', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -888,9 +888,10 @@ const GatewayAgentConfigurationFields: React.FC<{
 
 /**
  * Guided Slack setup wizard shown on create. Step state is lifted to the parent
- * and navigation lives in the unified modal footer. Selections drive a live
- * manifest preview + derived scope/event list via {@link buildSlackManifest} /
- * {@link requiredBotScopes}, so the user never adds a scope by hand.
+ * and navigation lives in the unified modal footer. Selections drive the derived
+ * scope/event list on the Options step ({@link requiredBotScopes}) and the
+ * copyable manifest on the Create app step ({@link buildSlackManifest}), so the
+ * user never adds a scope by hand.
  */
 const SlackSetupWizard: React.FC<{
   client: AgorClient | null;

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1244,9 +1244,14 @@ const SlackSetupWizard: React.FC<{
           </Form.Item>
         )}
 
-        <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 8 }}>
-          What this app will be able to do
+        <Typography.Text strong style={{ fontSize: 13 }}>
+          {`Required Slack Scopes & Events (${scopes.length} scopes, ${events.length} events)`}
         </Typography.Text>
+        <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: '4px 0 12px' }}>
+          Derived from the selected surfaces — channel-like surfaces trigger on{' '}
+          <code>app_mention</code>, not <code>message.*</code> channel events. You copy the full
+          manifest on the next step.
+        </Typography.Paragraph>
         {scopeList}
       </div>
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1062,8 +1062,8 @@ const SlackSetupWizard: React.FC<{
       {/* Step 0: Options (kept mounted so Form.Items stay registered for validation) */}
       <div style={{ display: step === 0 ? undefined : 'none' }}>
         <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
-          Choose what the bot can do. Your selections build a Slack app manifest below — paste it
-          into Slack in the next step so every scope and event is preconfigured for you.
+          Choose what the bot can do. Your selections become a Slack app manifest you'll paste into
+          Slack on the next step, so every scope and event is preconfigured for you.
         </Typography.Paragraph>
 
         <Form.Item
@@ -1244,9 +1244,8 @@ const SlackSetupWizard: React.FC<{
         )}
 
         <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 8 }}>
-          Manifest preview
+          What this app will be able to do
         </Typography.Text>
-        {manifestPreview}
         {scopeList}
       </div>
 


### PR DESCRIPTION
## Problem

In the Slack Gateway setup wizard, the **Options** step rendered the full generated JSON manifest in a bare `<pre>` — no copy button, and the text isn't easily selectable (you can't click in and Cmd/Ctrl+A it). Right next to it sat copy telling you your selections "build a Slack app manifest below — paste it into Slack in the next step."

So the step *looked* copyable but functionally wasn't, and the natural move — drag-selecting the JSON by hand — is finicky. Meanwhile the very next step (**Create app**) already showed the same manifest content with a working **Copy manifest** button.

The friction isn't just a missing button: it's two near-identical widgets with different capabilities, one of which is a copy affordance that doesn't copy.

## Fix

Takes [option 2 (the issue's preferred one)](https://github.com/preset-io/agor/issues/2448): remove the half-working duplicate instead of patching it. The Options step's job is configuration, not copying — the full copyable manifest now lives exclusively on **Create app**, where it's actually actionable.

What replaces it on Options is what was already sitting right underneath: the derived **Bot scopes** / **Event subscriptions** tag list, retitled from nothing in particular to **"What this app will be able to do"**. That's the human-readable summary of what your selections generate, and it still updates live as you toggle surfaces.

The intro copy was reworded too — it pointed at a manifest "below" that is no longer there:

> Choose what the bot can do. Your selections become a Slack app manifest you'll paste into Slack on the next step, so every scope and event is preconfigured for you.

The **Create app** step is untouched: same manifest, same working Copy button.

## Scope

One component, `SlackSetupWizard` in `GatewayChannelsTable.tsx`. A copy + render change, not a refactor. Untouched: `buildSlackManifest` / `requiredBotScopes` / `requiredBotEvents` in `@agor/core/gateway/slack-manifest`, and the separate `SlackManifestPanel` (the edit-existing-channel "App Manifest" panel), which already has its own working copy button.

## Tests

Renamed `updates the manifest preview and scope list as surfaces change` → `updates the derived scope/event list as surfaces change, without the raw manifest`, since it asserts on the scope/event tags we kept.

Added a regression guard. Worth noting *how*: the wizard keeps every step mounted (`display: none`) so Form.Items stay registered for validation, which means a plain `queryByText('display_information')` would still hit the **Create app** step's hidden copy and pass vacuously. The assertion instead checks there is **exactly one** manifest `<pre>` in the DOM and that it is **not visible** on Options — that fails both if the Options render returns (count becomes 2) and if the remaining one somehow becomes visible.

```
Test Files  1 passed (1)
     Tests  27 passed (27)
```

Biome on both changed files: clean (`Checked 2 files. No fixes applied.`), and the pre-commit `biome ci` hook passed.

CI (`Lint, typecheck, build, test`) is green. A local `pnpm typecheck` in this worktree reported ~639 errors, but they were purely an unbuilt `@agor-live/client` workspace package — identical on stashed `main`, and CI confirms it.

## Credit

Reported by **Vitor Avila** in the `#agor` Slack thread, 2026-08-17.

Closes #2448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
