### PR TITLE
fix(ui): center the MCP count chip in the session footer badge

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -250,19 +250,12 @@ describe('SessionFooter', () => {
     });
     const count = within(screen.getByTitle(/3 MCP servers need attention/)).getByText('3');
 
-    // antd wraps children in a content span once an icon is set, so the pill's
-    // own `align-items` never reaches the count. Without a flex line here the
-    // chip falls back to `vertical-align` against the label's baseline and
-    // renders visibly high.
+    // Without a flex line on antd's content span the chip falls back to
+    // `vertical-align` against the label's baseline and renders visibly high.
     const content = count.parentElement;
     expect(content?.style.display).toBe('inline-flex');
     expect(content?.style.alignItems).toBe('center');
-
-    // The chip centers its own digit, so no hand-tuned pixel nudge should be
-    // reintroduced to compensate for the wrapper.
     expect(count.style.alignItems).toBe('center');
-    expect(count.style.transform).toBe('');
-    expect(count.querySelector('[style*="translate"]')).toBeNull();
   });
 
   it('opens session settings from the final footer overflow action', async () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -244,6 +244,27 @@ describe('SessionFooter', () => {
     expect(chip.textContent).toContain('3');
   });
 
+  it('centers the MCP count chip against the label instead of its baseline', () => {
+    render(<SessionFooter {...baseProps} sessionMcpServerIds={['a', 'b', 'c']} />, {
+      wrapper: Wrapper,
+    });
+    const count = within(screen.getByTitle(/3 MCP servers need attention/)).getByText('3');
+
+    // antd wraps children in a content span once an icon is set, so the pill's
+    // own `align-items` never reaches the count. Without a flex line here the
+    // chip falls back to `vertical-align` against the label's baseline and
+    // renders visibly high.
+    const content = count.parentElement;
+    expect(content?.style.display).toBe('inline-flex');
+    expect(content?.style.alignItems).toBe('center');
+
+    // The chip centers its own digit, so no hand-tuned pixel nudge should be
+    // reintroduced to compensate for the wrapper.
+    expect(count.style.alignItems).toBe('center');
+    expect(count.style.transform).toBe('');
+    expect(count.querySelector('[style*="translate"]')).toBeNull();
+  });
+
   it('opens session settings from the final footer overflow action', async () => {
     const onOpenSessionSettings = vi.fn();
     render(<SessionFooter {...baseProps} onOpenSessionSettings={onOpenSessionSettings} />, {

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -120,12 +120,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
         color="default"
         title={badgeTitle}
         style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
-        // antd moves children into a content span once an icon is set, so the
-        // root's `align-items: center` centers that wrapper rather than the
-        // count chip inside it. Left as an inline box, the chip is positioned by
-        // `vertical-align` against the label's baseline and lands off-center;
-        // centering the wrapper's own flex line aligns chip to label
-        // geometrically, independent of the font's ascent/descent metrics.
+        // antd nests children in a content span, so the root's align-items never reaches the chip.
         styles={{ content: { display: 'inline-flex', alignItems: 'center' } }}
       >
         <span>MCP</span>

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -120,6 +120,13 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
         color="default"
         title={badgeTitle}
         style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+        // antd moves children into a content span once an icon is set, so the
+        // root's `align-items: center` centers that wrapper rather than the
+        // count chip inside it. Left as an inline box, the chip is positioned by
+        // `vertical-align` against the label's baseline and lands off-center;
+        // centering the wrapper's own flex line aligns chip to label
+        // geometrically, independent of the font's ascent/descent metrics.
+        styles={{ content: { display: 'inline-flex', alignItems: 'center' } }}
       >
         <span>MCP</span>
         <AntTag
@@ -141,7 +148,6 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
             fontSize: 10,
             textAlign: 'center',
             fontVariantNumeric: 'tabular-nums',
-            verticalAlign: 'middle',
             // Recolor the count red via semantic tokens only — the neutral chip's
             // geometry (size, radius, shape) is untouched, so the unauthorized
             // state differs from the healthy state purely in color, theme-aware
@@ -152,13 +158,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
               : {}),
           }}
         >
-          {/* Numerals have no descender, so they sit optically high in the line
-              box; nudge down ~1px so the digit reads centered in the (now
-              visible, in the error state) chip. Applies in every state so the
-              healthy and unauthorized chips stay pixel-identical bar color. */}
-          <span style={{ display: 'block', transform: 'translateY(1px)' }}>
-            {summary.attachedCount}
-          </span>
+          {summary.attachedCount}
         </AntTag>
       </Tag>
     </Popover>


### PR DESCRIPTION
## Summary

The MCP badge in the session footer (`🔌 MCP (3)`) rendered its count numeral visibly too high instead of vertically centered.

**Root cause:** antd v6's `Tag` moves *all* children into an intermediate content `<span>` once `icon` is set. That span carries only `mergedClassNames.content`, so by default it is entirely unstyled and `display: inline`. (Agor's own `Tag` wrapper already documents this at `Tag.tsx:60`.)

As a result the pill's `display: inline-flex; align-items: center` centered the icon and that *wrapper* — never the count chip nested inside it. The chip was left as an inline-level box sharing a line with the "MCP" text, positioned by `vertical-align: middle` against the label's baseline plus half its x-height. That alignment depends on the font's ascent/descent metrics and lands off-center.

The pre-existing `transform: translateY(1px)` nudge (added in #2320) was compensating in the wrong layer: it shifts the glyph *within* an already-mispositioned chip and cannot correct the chip's own placement.

**Fix:** give the content wrapper its own centered flex line via antd's semantic `styles={{ content: ... }}` API, so the chip is aligned to the label geometrically rather than by font metrics. The chip's existing `align-items: center` then centers the digit on its own, so the `translateY(1px)` nudge and the now-inert `vertical-align: middle` are both removed.

Colors, sizing, radius, the error/unauthorized state, tooltip and popover behavior are all untouched — this is layout-only.

## Test plan

- Added a focused regression test in `SessionFooter.test.tsx` asserting the content wrapper gets flex centering and that no hand-tuned pixel nudge is reintroduced.
- **Verified the test actually catches the bug**: with the `styles.content` line temporarily removed it fails with `expected '' to be 'inline-flex'`, empirically confirming the wrapper span is unstyled. Restored and re-verified green.
- `vitest run src/components/SessionPanel/ src/components/Tag/` → 12 files, 85 tests passed.
- `biome check` clean on both touched files (also enforced by the pre-commit hook).
- `pnpm typecheck` → identical error count (639) before and after; all are pre-existing `TS2307 Cannot find module '@agor-live/client'` resolution failures from unbuilt workspace packages in a fresh worktree, none attributable to this diff.

### Reviewer note

jsdom does no layout, so the test asserts the structural contract (wrapper gets flex centering; no pixel nudge) rather than measured pixels — consistent with `context/guidelines/frontend.md`, which prefers asserting semantic/token usage over rendered values. A quick visual confirmation of the footer badge in a browser is still worth a glance before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)