### PR TITLE
fix(mcp): don't hand an OAuth install a prompt it can't answer

### DIFF
--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -32,6 +32,42 @@ describe('buildMcpServerOptions', () => {
     ]);
   });
 
+  // Connecting a marketplace entry writes the install before anybody signs in,
+  // so an OAuth row with no grant is enabled and offered here looking exactly
+  // like a working one. These pin that the picker says otherwise, using the
+  // same `mcpServerNeedsAuth` the session footer and the settings table use.
+  it('marks an OAuth server the user has never signed in to', () => {
+    const oauth = server({ auth: { type: 'oauth' } } as Partial<MCPServer>);
+    const [option] = buildMcpServerOptions([oauth], [], new Set());
+    expect(option?.label).toContain('Not signed in');
+    // Still selectable: the fix for an unfinished install is to finish it, and
+    // detaching it from the session is not that.
+    expect(option?.disabled).toBe(false);
+  });
+
+  it('leaves a signed-in OAuth server unmarked', () => {
+    const oauth = server({ auth: { type: 'oauth' } } as Partial<MCPServer>);
+    const [option] = buildMcpServerOptions([oauth], [], new Set([oauth.mcp_server_id]));
+    expect(option?.label).not.toContain('Not signed in');
+  });
+
+  it('leaves an OAuth server holding a live token unmarked without the durable set', () => {
+    // The daemon injects the token on every read, so a caller with no store —
+    // the marketplace is one — still gets the right answer.
+    const oauth = server({
+      auth: {
+        type: 'oauth',
+        oauth_access_token: '••••••••',
+        oauth_token_expires_at: 4102444800000,
+      },
+    } as Partial<MCPServer>);
+    expect(buildMcpServerOptions([oauth])[0]?.label).not.toContain('Not signed in');
+  });
+
+  it('leaves a non-OAuth server unmarked', () => {
+    expect(buildMcpServerOptions([server({})])[0]?.label).not.toContain('Not signed in');
+  });
+
   it('shows a clear short fallback for a selected server missing from hydration', () => {
     const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     expect(buildMcpServerOptions([], [id])).toEqual([

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
@@ -1,5 +1,8 @@
 import { type MCPServer, shortId } from '@agor-live/client';
 import { Select, type SelectProps } from 'antd';
+import { useAgorStore } from '../../store/agorStore';
+import { selectUserAuthenticatedMcpServerIds } from '../../store/selectors';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 
 export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
   mcpServers: MCPServer[];
@@ -9,7 +12,26 @@ export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
   filterByScope?: 'global' | 'repo' | 'session';
 }
 
-export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: string[] = []) {
+/**
+ * How an install that never finished reads in the picker.
+ *
+ * Connecting a catalog entry creates the row before anyone signs in, so an
+ * OAuth install sits in this list looking exactly like a working one. Saying so
+ * in the label — rather than in a suffix only the renderer sees — keeps it in
+ * whatever `optionFilterProp="label"` searches.
+ */
+export const NEEDS_AUTH_OPTION_SUFFIX = ' · Not signed in';
+
+export function buildMcpServerOptions(
+  mcpServers: MCPServer[],
+  selectedIds: string[] = [],
+  /**
+   * Servers this user has a live OAuth grant for. Defaults to empty, which is
+   * the honest reading for a caller that has no store: `mcpServerNeedsAuth`
+   * still clears any server carrying an unexpired access token.
+   */
+  userAuthenticatedMcpServerIds: Set<string> = new Set()
+) {
   const selected = new Set(selectedIds);
   const options: Array<{ label: string; value: string; disabled: boolean }> = mcpServers
     // Disabled servers cannot be newly attached, but must remain an option when
@@ -24,8 +46,11 @@ export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: stri
           : server.auth?.type === 'bearer' || server.auth?.token
             ? ' · Token'
             : '';
+      const needsAuthSuffix = mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)
+        ? NEEDS_AUTH_OPTION_SUFFIX
+        : '';
       return {
-        label: `${name} (${server.transport})${authSuffix}`,
+        label: `${name} (${server.transport})${authSuffix}${needsAuthSuffix}`,
         value: server.mcp_server_id,
         disabled: !server.enabled,
       };
@@ -53,6 +78,7 @@ export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: stri
  * - Supports filtering by scope (global, repo, session)
  * - Multi-select mode with search
  * - Shows transport type in parentheses (stdio, http, sse)
+ * - Marks servers whose OAuth sign-in never happened
  */
 export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
   mcpServers,
@@ -62,12 +88,17 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
   filterByScope,
   ...selectProps
 }) => {
+  // Read here rather than as a prop: every caller of this picker would
+  // otherwise have to thread the same set through, and one that forgot would
+  // quietly go back to showing an unfinished install as a working one.
+  const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
+
   // Filter servers by scope if specified
   const filteredServers = filterByScope
     ? mcpServers.filter((server) => server.scope === filterByScope)
     : mcpServers;
 
-  const options = buildMcpServerOptions(filteredServers, value);
+  const options = buildMcpServerOptions(filteredServers, value, userAuthenticatedMcpServerIds);
 
   return (
     <Select

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -425,6 +425,78 @@ describe('connect', () => {
     expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBe(DEEPWIKI.starter_prompt);
   });
 
+  /**
+   * 42 of the 48 catalog entries are OAuth, and an OAuth install lands with no
+   * credentials — the row is written before anyone signs in. A starter prompt
+   * is written to exercise the server it ships with, so arming the composer
+   * with one here means the modal outcome of pressing Connect is a loaded
+   * prompt whose only result is a tool-less answer.
+   *
+   * These pin the split. Landing in the session is unchanged: the session is
+   * where the sign-in lives (the alert above the composer, the red MCP badge,
+   * the pill that starts OAuth on click). Only the loaded gun is withheld.
+   */
+  async function connectAndLand(mcpServer: Record<string, unknown>) {
+    connectImpl = async () => ({
+      mcp_server: mcpServer,
+      session: { session_id: SESSION_ID },
+      starter_prompt: DEEPWIKI.starter_prompt,
+      reused_existing_server: false,
+    });
+    const drawer = await openDrawer();
+    const connect = drawer.getByRole('button', { name: /Connect/ });
+    fireEvent.click(drawer.getByRole('checkbox'));
+    await waitFor(() => expect(connect).toBeEnabled());
+    fireEvent.click(connect);
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(sessionPath(SESSION_ID as SessionID))
+    );
+  }
+
+  it('does not arm the composer when the install still needs signing in', async () => {
+    await connectAndLand({ mcp_server_id: 'server-1', auth: { type: 'oauth' } });
+
+    expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBeNull();
+  });
+
+  it('still lands in the session so the sign-in is reachable', async () => {
+    await connectAndLand({ mcp_server_id: 'server-1', auth: { type: 'oauth' } });
+
+    // Withholding the prompt must not withhold the session: the MCP badge and
+    // the pill that starts OAuth are both inside it.
+    expect(mockNavigate).toHaveBeenCalledWith(sessionPath(SESSION_ID as SessionID));
+    expect(connectCalls).toHaveLength(1);
+  });
+
+  it('arms the composer when a reused install already holds a live token', async () => {
+    // A reused install comes back through `mcp-servers` find, where the daemon
+    // injects the caller's token — redacted to a sentinel, but present, which
+    // is all "is this finished" needs.
+    await connectAndLand({
+      mcp_server_id: 'server-1',
+      auth: {
+        type: 'oauth',
+        oauth_access_token: '••••••••',
+        oauth_token_expires_at: 4102444800000,
+      },
+    });
+
+    expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBe(DEEPWIKI.starter_prompt);
+  });
+
+  it('withholds the prompt when the token the install carries has expired', async () => {
+    await connectAndLand({
+      mcp_server_id: 'server-1',
+      auth: {
+        type: 'oauth',
+        oauth_access_token: '••••••••',
+        oauth_token_expires_at: 1,
+      },
+    });
+
+    expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBeNull();
+  });
+
   it('keeps the drawer open and reports why when connect fails', async () => {
     connectImpl = async () => {
       throw new Error('DeepWiki requires authentication, which is not supported yet');

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -12,6 +12,9 @@ import { sessionPath } from '@agor-live/client';
 import { Alert, Button, Col, Empty, Flex, Pagination, Row, Skeleton, theme } from 'antd';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAgorStore } from '../../store/agorStore';
+import { selectUserAuthenticatedMcpServerIds } from '../../store/selectors';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { savePromptDraft } from '../../utils/promptDrafts';
 import { CatalogCard } from './CatalogCard';
 import { CatalogDetailDrawer } from './CatalogDetailDrawer';
@@ -86,6 +89,12 @@ export interface CatalogTabProps {
 export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
+  // Same set the session panel reads, so "is this install finished?" is one
+  // question with one answer wherever it is asked. On this surface it is
+  // usually empty — the marketplace is standalone chrome and does not hydrate
+  // the workspace store — which costs nothing: `mcpServerNeedsAuth` falls back
+  // to the token the daemon injects on the read that produced `mcp_server`.
+  const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
 
   const [filters, setFilters] = useState<CatalogFilterState>(INITIAL_FILTERS);
   const [page, setPage] = useState(1);
@@ -172,7 +181,18 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => 
           acknowledged_disclosure: acknowledgedDisclosure,
         });
         rememberConnectBranchId(branchId);
-        if (result.starter_prompt) {
+        // A starter prompt is written to exercise the server it ships with, so
+        // it is only worth arming the composer with once that server can answer
+        // it. Most of the catalog is OAuth, and an OAuth install lands with no
+        // credentials: staging the prompt there hands the user a loaded
+        // composer whose only outcome is a tool-less answer, turning a
+        // recoverable state into an invitation to hit the failure. The session
+        // says what is missing instead — see the unauthenticated-server alert
+        // above the composer and the red MCP badge beside it.
+        if (
+          result.starter_prompt &&
+          !mcpServerNeedsAuth(result.mcp_server, userAuthenticatedMcpServerIds)
+        ) {
           savePromptDraft(result.session.session_id, result.starter_prompt);
         }
         setSelected(null);
@@ -183,7 +203,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => 
         setConnecting(false);
       }
     },
-    [client, navigate, selected]
+    [client, navigate, selected, userAuthenticatedMcpServerIds]
   );
 
   return (

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -485,3 +485,65 @@ describe('MCPServersTable ownership', () => {
     expect(shared.map((button) => button.disabled)).toEqual([false, true, true]);
   });
 });
+
+/**
+ * An install that was created but never authenticated.
+ *
+ * `usableByUserId` filters on ownership alone, so a marketplace connect the
+ * user walked away from is listed here in full — enabled, owned, and otherwise
+ * reading as a working server. Health is the column that answers "does this
+ * work", so it is the one that has to say so.
+ */
+describe('MCPServersTable unfinished installs', () => {
+  const oauthServer = (overrides: Partial<MCPServer> = {}) =>
+    makeServer({
+      name: 'linear',
+      display_name: 'Linear',
+      source: 'catalog',
+      auth: { type: 'oauth' },
+      ...overrides,
+    } as Partial<MCPServer>);
+
+  it('names an unauthenticated OAuth install rather than calling it untested', async () => {
+    renderTable({
+      policy: 'allow_crud',
+      currentUser: ADMIN,
+      servers: [oauthServer()],
+    });
+
+    expect(await screen.findByText('Not signed in')).toBeVisible();
+    // "Not tested" is the reading it would otherwise get, and it says nothing
+    // about the thing that actually stops this server working.
+    expect(screen.queryByText('Not tested')).not.toBeInTheDocument();
+  });
+
+  it('reports health normally once a live token is present', async () => {
+    renderTable({
+      policy: 'allow_crud',
+      currentUser: ADMIN,
+      servers: [
+        oauthServer({
+          auth: {
+            type: 'oauth',
+            oauth_access_token: '••••••••',
+            oauth_token_expires_at: 4102444800000,
+          },
+        } as Partial<MCPServer>),
+      ],
+    });
+
+    expect(await screen.findByText('Not tested')).toBeVisible();
+    expect(screen.queryByText('Not signed in')).not.toBeInTheDocument();
+  });
+
+  it('leaves the health of a non-OAuth server alone', async () => {
+    renderTable({
+      policy: 'allow_crud',
+      currentUser: ADMIN,
+      servers: [makeServer({ tools: [{ name: 'search' }] } as Partial<MCPServer>)],
+    });
+
+    expect(await screen.findByText('1 tools')).toBeVisible();
+    expect(screen.queryByText('Not signed in')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -36,7 +36,10 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMcpMemberPolicy } from '@/hooks/useMcpMemberPolicy';
+import { useAgorStore } from '@/store/agorStore';
+import { selectUserAuthenticatedMcpServerIds } from '@/store/selectors';
 import { mapToSortedArray } from '@/utils/mapHelpers';
+import { mcpServerNeedsAuth } from '@/utils/mcpAuth';
 import { useThemedMessage } from '@/utils/message';
 import { userSelectLabel } from '@/utils/selectSearch';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
@@ -80,9 +83,24 @@ const POLICY_LOADING_HINT = "Checking what this workspace's MCP policy allows…
 const POLICY_UNREADABLE_HINT =
   "This workspace's MCP policy could not be read, so nothing is offered here.";
 
-const getServerHealth = (server: MCPServer) => {
+const getServerHealth = (
+  server: MCPServer,
+  userAuthenticatedMcpServerIds: Set<string> = new Set()
+) => {
   const toolCount = server.tools?.length || 0;
   const transport = server.transport || (server.url ? 'http' : 'stdio');
+
+  // Ahead of every other reading, because it is the one that makes the row
+  // unusable. Connecting a catalog entry writes the install before anybody
+  // signs in, so an OAuth row that was never authenticated is enabled, owned,
+  // and indistinguishable from a working server — this is the only thing in
+  // the table that says the connect never finished.
+  if (mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)) {
+    return {
+      status: 'warning' as const,
+      text: 'Not signed in',
+    };
+  }
 
   if (transport === 'stdio') {
     return {
@@ -125,6 +143,9 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
 }) => {
   const { showError } = useThemedMessage();
   const { token } = theme.useToken();
+  // Same set the session panel and the picker read, so an install is
+  // "unfinished" in exactly one sense across all three.
+  const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
   const memberPolicy = useMcpMemberPolicy(client);
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
   // Which transports a user may configure turns on role alone, so this is known
@@ -471,7 +492,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         key: 'health',
         width: 120,
         render: (_: unknown, server: MCPServer) => {
-          const health = getServerHealth(server);
+          const health = getServerHealth(server, userAuthenticatedMcpServerIds);
           return <Badge status={health.status} text={health.text} />;
         },
       },
@@ -590,6 +611,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       policyPending,
       policyPendingHint,
       searchTerm,
+      userAuthenticatedMcpServerIds,
     ]
   );
 


### PR DESCRIPTION
Follow-up to #2377. Everything here is against merged `main`.

## The defect

`CatalogTab.handleConnect` staged the entry's starter prompt into the new session unconditionally:

```js
if (result.starter_prompt) {
  savePromptDraft(result.session.session_id, result.starter_prompt);
}
navigate(sessionPath(result.session.session_id));
```

**42 of the 48 catalog entries are `auth_type: oauth`.** An OAuth install is written before anybody signs in — the row comes back from `mcp-servers` `create`, whose after-hooks are redaction only, so it carries no token. So the modal outcome of pressing Connect was: the user lands in a session holding a prompt written specifically to exercise a server that has no credentials, with an armed composer. Press Enter and you get a confused tool-less answer — or on OpenCode, a session that fails to start.

The starter prompt turned a recoverable state into an invitation to hit the failure.

## 1. Don't stage a prompt into a session that can't answer it

`MCPCatalogConnectResult` already returns `mcp_server`, so the client can tell. The draft is now staged only when `mcpServerNeedsAuth` says the install is finished.

**Landing in the session is unchanged**, deliberately — the session is where the sign-in lives. Only the loaded gun is withheld.

### Why not chain the OAuth flow onto arrival

`useMCPServerOAuthStart` ends in `window.open(authorizationUrl)`, which needs transient user activation. Auto-starting after arrival means `navigate()` → panel mount → an async `oauth-start` round trip, by which point the activation from the Connect click is long gone: popup-blocked outright in Safari and Firefox, dependent on Chrome's activation window otherwise. That is precisely a version that sometimes fires, so it isn't built.

## 2. Mark incomplete catalog installs

`usableByUserId` filters on `owner_user_id` with no scope predicate, so an unauthenticated install is fully visible: it appears in the Settings table and in every future session's `MCPServerSelect`. Connect five entries, authenticate none, and you have five servers indistinguishable from working ones.

Both surfaces now reuse `mcpServerNeedsAuth` — the same function the session footer alert, the MCP badge and the pill already use — rather than introducing a second notion of "incomplete":

- **`MCPServerSelect`** appends `· Not signed in` to the option **label**, so it stays inside what `optionFilterProp="label"` searches. The picker reads the store itself instead of taking a prop, so a caller can't forget to pass it and silently regress.
- **`MCPServersTable`** reports Health as a warning `Not signed in`, ahead of every other reading — it's the one that makes the row unusable. "Not tested" was the reading it got before, which says nothing about what actually stops it working.

No GC needed: install reuse already bounds these at one row per (user, entry).

## What a user sees now

1. Connect an OAuth entry → lands in the new session. Composer **empty**.
2. Red error alert directly above the composer: *"Linear isn't connected. Click the MCP badge to connect it."*
3. MCP badge beside it carries a red count chip.
4. Click badge → popover with the server pill in its error state (red, login icon).
5. Click the pill → OAuth opens in a new tab (a real user gesture, so no popup block).
6. On success the daemon emits `oauth-completed`; the UI refetches durable state, `userAuthenticatedMcpServerIds` updates, and the alert, badge, pill, picker label and Settings Health row all clear together.

## Premises re-verified against `main`

| Claim | Status |
|---|---|
| Draft staged unconditionally at `CatalogTab.tsx:175` | Held (line 175) |
| `mcpServerNeedsAuth` exists and computes this state | Held, unchanged |
| 42/48 entries are `auth_type: oauth` | Held (42 oauth, 5 none, 1 credentials) |
| `usableByUserId` filters on ownership with no scope predicate | Held |
| `SessionFooter` renders the alert above the composer | Held (`SessionFooter.tsx:1505`) |
| MCP badge turns red with a count | Held (`tone: 'error'` in `mcp-session-summary.ts`) |
| `MCPServerPill` error state starts OAuth on click | Held (`MCPServerPill.tsx:182`) |

One thing worth recording that wasn't in the brief: `oauth_access_token` is **always** redacted to a sentinel on browser-facing reads (`redactMCPAuthSecrets`). `mcpServerNeedsAuth` only tests it for truthiness, so it still reads correctly as a presence signal — but it is a presence check, not a token check.

## Out of scope

The OpenCode throw is untouched. It's deliberately fail-closed — OpenCode's config format has no per-tool filter, so the declarative config is its enforcement boundary. #2193 is the right fix, at the admission gate in `scoping.ts`.

## Testing

11 new tests, all mutation-verified (each behaviour neutered in turn; a test failed each time).

- `apps/agor-ui` in full: **4 failed | 1499 passed**, against a clean-tree baseline of **4 failed | 1492 passed** — same 4 failed files, 211 passed files both runs.
- Every failure in the changed run was reproduced on the clean tree at `55e46064`: `MCPServersTable.oauth.test.tsx` and `SessionPanel.test.tsx` verified individually by stashing; `BoardFormFields.test.tsx` fails in both runs. **These fail on THIS HOST regardless of this change** — the documented "a different test each run" UI flake under parallel load.
- Marketplace suite: 47/47 in 77.5s. New `CatalogTab` tests run 3.1–4.5s each, well under the 15s timeout. They reuse the existing `findByLabelText` card/drawer helpers and add no role-based polling, so the timing-sensitivity that was fixed by waiting on labels is not reintroduced.
- `turbo run typecheck`: 22/22. `biome check --error-on-warnings .`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
