### PR TITLE
fix(cli): default `agor open` to local deployment with remote fallback (#2464)

### DIFF
--- a/apps/agor-cli/src/commands/open.test.ts
+++ b/apps/agor-cli/src/commands/open.test.ts
@@ -1,0 +1,114 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const cliRoot = resolve(import.meta.dirname, '../..');
+const deploymentId = '019c1234-5678-7123-8123-123456789abc';
+
+/** Minimal daemon whose /health advertises the given deployment id. */
+async function startHealthServer(id: string): Promise<{ server: Server; port: number }> {
+  const server = createServer((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    if (request.url === '/health') {
+      response.end(JSON.stringify({ service: 'agor-daemon', deploymentId: id }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end('{}');
+  });
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Test server did not bind');
+  return { server, port: address.port };
+}
+
+function runOpen(home: string, args: string[]): Promise<{ code: number | null; output: string }> {
+  const env = { ...process.env };
+  delete env.AGOR_API_KEY;
+  delete env.AGOR_DEPLOYMENT_ID;
+  delete env.DAEMON_URL;
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', 'bin/dev.ts', 'open', ...args], {
+      cwd: cliRoot,
+      env: {
+        ...env,
+        HOME: home,
+        NO_COLOR: '1',
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --conditions=source`.trim(),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += String(chunk)));
+    child.stderr.on('data', (chunk) => (output += String(chunk)));
+    child.once('error', reject);
+    child.once('close', (code) => resolveRun({ code, output }));
+  });
+}
+
+describe('open command', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'agor-open-'));
+    await mkdir(join(home, '.agor'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it('defaults to the local deployment without a prior login', async () => {
+    const { server, port } = await startHealthServer(deploymentId);
+    try {
+      await writeFile(
+        join(home, '.agor', 'config.yaml'),
+        `daemon:\n  host: 127.0.0.1\n  port: ${port}\n  deployment_id: ${deploymentId}\n`
+      );
+
+      const result = await runOpen(home, []);
+
+      expect(result.code).toBe(0);
+      expect(result.output).toContain('Opening Agor UI in browser...');
+      expect(result.output).not.toContain('Not connected');
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  }, 15_000);
+
+  it('falls back to the stored login target when there is no local config', async () => {
+    const { server, port } = await startHealthServer(deploymentId);
+    try {
+      const url = `http://127.0.0.1:${port}`;
+      // No config.yaml — only a stored login token (remote-only user).
+      await writeFile(
+        join(home, '.agor', 'cli-token'),
+        JSON.stringify({
+          version: 2,
+          target: { url, origin: url, deploymentId },
+          accessToken: 'remote-token',
+          user: { user_id: 'u1', email: 'remote@example.com', role: 'admin' },
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      );
+
+      const result = await runOpen(home, []);
+
+      expect(result.code).toBe(0);
+      expect(result.output).toContain('Opening Agor UI in browser...');
+      expect(result.output).toContain(`${url}/ui`);
+    } finally {
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    }
+  }, 15_000);
+
+  it('errors when neither a local config nor a stored login exists', async () => {
+    const result = await runOpen(home, []);
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain('Not connected');
+  }, 15_000);
+});

--- a/apps/agor-cli/src/commands/open.ts
+++ b/apps/agor-cli/src/commands/open.ts
@@ -11,47 +11,63 @@ import { probeAgorDaemon } from '../lib/daemon-probe.js';
 import {
   resolveConnectedDeploymentTarget,
   resolveLocalDeploymentTarget,
+  resolveLocalDeploymentTargetOrNull,
 } from '../lib/deployment-target.js';
 
 const execAsync = promisify(exec);
 
 export default class Open extends Command {
-  static description = 'Open the connected deployment in a browser';
+  static description = 'Open the local deployment (or the connected deployment) in a browser';
 
   static examples = ['<%= config.bin %> <%= command.id %>'];
 
   static flags = {
-    local: Flags.boolean({ description: 'Open the locally configured deployment', default: false }),
+    local: Flags.boolean({
+      description: 'Force the locally configured deployment (skip the remote fallback)',
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Open);
+    // Default resolution prefers the locally configured deployment so a fresh
+    // `agor init` + `agor daemon start` works without a prior `agor login`.
+    // Remote-only users (stored login token / API key, no local config) fall
+    // back to the connected target. `--local` forces local with no fallback.
     const target = flags.local
       ? await resolveLocalDeploymentTarget()
-      : await resolveConnectedDeploymentTarget();
+      : ((await resolveLocalDeploymentTargetOrNull()) ??
+        (await resolveConnectedDeploymentTarget()));
     if (!target) {
-      this.error('Not connected. Run agor login --url <daemon-url>.');
+      this.error('Not connected. Run agor daemon start or agor login --url <daemon-url>.');
     }
     const daemonUrl = target.url;
+    const isLocalTarget = target.source === 'local';
 
     const probe = await probeAgorDaemon(daemonUrl);
 
     if (!probe.running) {
-      this.log(chalk.red('✗ Connected daemon is not reachable'));
-      this.log('');
-      this.log(`Target: ${chalk.cyan(daemonUrl)}`);
+      if (isLocalTarget) {
+        this.log(chalk.red('✗ Local deployment is not reachable'));
+        this.log('');
+        this.log(`Start it with:\n  ${chalk.cyan('agor daemon start')}`);
+      } else {
+        this.log(chalk.red('✗ Connected daemon is not reachable'));
+        this.log('');
+        this.log(`Target: ${chalk.cyan(daemonUrl)}`);
+      }
       this.log('');
       this.exit(1);
     }
     if (probe.deploymentId !== target.deploymentId) {
       this.error(
-        flags.local
+        isLocalTarget
           ? `The local daemon identity at ${daemonUrl} does not match config.yaml.`
           : `The daemon identity at ${daemonUrl} changed. Run agor login --url ${daemonUrl} again.`
       );
     }
 
-    let localDevelopmentTarget = flags.local;
+    let localDevelopmentTarget = isLocalTarget;
     if (!localDevelopmentTarget) {
       try {
         const localTarget = await resolveLocalDeploymentTarget();

--- a/apps/agor-cli/src/lib/deployment-target.test.ts
+++ b/apps/agor-cli/src/lib/deployment-target.test.ts
@@ -12,6 +12,7 @@ import { loadToken } from './auth.js';
 import {
   resolveConnectedDeploymentTarget,
   resolveLocalDeploymentTarget,
+  resolveLocalDeploymentTargetOrNull,
 } from './deployment-target';
 
 const deploymentId = '019c1234-5678-7123-8123-123456789abc';
@@ -79,5 +80,34 @@ describe('deployment target resolution', () => {
     });
     expect(resolveDaemonUrl).toHaveBeenCalledWith(config);
     expect(requireDeploymentId).toHaveBeenCalledWith(config);
+  });
+
+  it('resolves the local target through the nullable helper when config exists', async () => {
+    const config = { daemon: { deployment_id: deploymentId } };
+    vi.mocked(loadConfig).mockResolvedValue(config);
+    vi.mocked(resolveDaemonUrl).mockReturnValue('http://127.0.0.1:4040');
+    vi.mocked(requireDeploymentId).mockReturnValue(deploymentId);
+
+    await expect(resolveLocalDeploymentTargetOrNull()).resolves.toEqual({
+      url: 'http://127.0.0.1:4040',
+      deploymentId,
+      source: 'local',
+    });
+  });
+
+  it('returns null from the nullable helper when local config is unusable', async () => {
+    vi.mocked(loadConfig).mockRejectedValue(new Error('no config; run agor init'));
+
+    await expect(resolveLocalDeploymentTargetOrNull()).resolves.toBeNull();
+  });
+
+  it('returns null from the nullable helper when the deployment id is missing', async () => {
+    vi.mocked(loadConfig).mockResolvedValue({ daemon: {} });
+    vi.mocked(resolveDaemonUrl).mockReturnValue('http://127.0.0.1:4040');
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw new Error('deployment_id missing');
+    });
+
+    await expect(resolveLocalDeploymentTargetOrNull()).resolves.toBeNull();
   });
 });

--- a/apps/agor-cli/src/lib/deployment-target.ts
+++ b/apps/agor-cli/src/lib/deployment-target.ts
@@ -38,3 +38,16 @@ export async function resolveLocalDeploymentTarget(): Promise<DeploymentTarget> 
     source: 'local',
   };
 }
+
+/**
+ * Resolve the local deployment target, or `null` when this host has no usable
+ * local configuration (e.g. `agor init` was never run). Lets callers prefer the
+ * local deployment without treating its absence as a hard error.
+ */
+export async function resolveLocalDeploymentTargetOrNull(): Promise<DeploymentTarget | null> {
+  try {
+    return await resolveLocalDeploymentTarget();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2464 as a **behavior change** rather than a docs change (per maintainer review).

`agor init`'s "Next steps" tells fresh installs to run `agor daemon start` then `agor open`. But `agor open` defaulted to resolving a *connected* remote deployment via the stored login token (`~/.agor/cli-token`), so a fresh install hit:

```
Error: Not connected. Run agor login --url <daemon-url>.
```

...unless the user first ran `agor login`. This PR makes the documented onboarding sequence just work again by changing `agor open`'s **default** to target the local deployment.

## What changed

- **Default resolution is now local-first with a remote fallback.** Bare `agor open` tries `resolveLocalDeploymentTarget()` first (reads `~/.agor/config.yaml`). If there's no usable local config (e.g. `agor init` was never run), it falls back to the existing `resolveConnectedDeploymentTarget()` (stored login token / env API key).
- **`--local` is unchanged** — it still forces the local deployment with no fallback.
- New `resolveLocalDeploymentTargetOrNull()` helper wraps the throwing resolver so callers can prefer local without treating its absence as a hard error.
- Not-reachable / identity-mismatch messaging is now driven off the resolved target's `source` (`local` vs connected) rather than the `--local` flag, so a defaulted-to-local target gets the correct "Local deployment is not reachable — start it with `agor daemon start`" guidance (mirroring `agor login`'s local-detection flow).

## Backward compatibility

Remote-only users who only ever run `agor login --url <remote>` (no local daemon/config) are **not regressed**: with no local config, local resolution returns null and `agor open` falls back to their connected deployment exactly as before.

`init.ts`'s "Next steps" text already reads `agor daemon start` → `agor open` and is now correct, so it is left as-is.

## Testing

- `apps/agor-cli/src/lib/deployment-target.test.ts` — unit coverage for `resolveLocalDeploymentTargetOrNull()` (config present → target; unusable config / missing deployment id → `null`).
- `apps/agor-cli/src/commands/open.test.ts` (new) — CLI integration tests for: local-first default without a prior login, fallback to a stored login target when there's no local config, and the not-connected error when neither exists.
- `login.test.ts` still passes (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)