### PR TITLE
feat(mcp): enforce tool_permissions at every call-time hook; fix two fail-opens

### DIFF
--- a/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
+++ b/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
@@ -3,26 +3,39 @@
 **Date:** 2026-08-18
 **Scope:** MANAGE-2 — "tool on/off toggles must be enforced at the layer that
 brokers tool calls, not just hidden in the UI."
-**Status:** audit. One test gap closed (Codex); the headline gap is left open
-deliberately, and named below.
+**Status:** superseded in part. The first revision concluded MANAGE-2 needed a
+new MCP proxy and left it open on that basis. **That was wrong**, and a
+fact-check caught it: three of six handlers already route every tool call back
+through Agor. Enforcement has since been implemented on the two that were
+withholding servers instead. The remaining gap is the write path, not the
+enforcement path. Corrections are kept inline rather than deleted, because the
+first revision's claims were repeated onward as fact.
 
 ## The one-sentence finding
 
-The enforcement machinery is real, per-handler, and fail-closed — but **no
-user-facing path ever writes `tool_permissions`**, so for every server anyone
-connects from the marketplace the map is empty and every tool is allowed. The
-`permission_disclosure` a user acknowledges before connecting is, today,
+Enforcement now binds on five of six handlers — but **no user-facing path ever
+writes `tool_permissions`**, so for every server anyone connects from the
+marketplace the map is empty and every tool is allowed. The
+`permission_disclosure` a user acknowledges before connecting is still
 unenforced — not because enforcement is missing, but because nothing populates
-the field it reads.
+the field it reads. Everything else in this note is about making sure that when
+something finally does populate it, the value binds.
 
 That distinction matters for what to build next, so the rest of this note
 separates the two halves.
 
-## 1. There is no gateway, and there cannot easily be one
+## 1. There is no proxy, but there IS a call-time choke point on most handlers
 
-There is no choke point. Each handler writes the MCP server into the config it
-hands its own agent runtime, and the agent process opens the MCP connection
-itself. Agor is never in the data path of a tool call:
+**Correction.** The first revision said "Agor is never in the data path" and
+called Claude "the one partial exception". Both were wrong, and the error
+mattered: it priced MANAGE-2 as "stand up a per-session MCP proxy" and left the
+requirement open on that basis.
+
+Agor is not in the _data_ path — the agent process opens the MCP connection and
+the bytes never pass through Agor. But it is in the _decision_ path on four of
+six handlers, because their SDKs call back into the executor before a tool
+runs. That is all enforcement needs. The table below is the handoff, not the
+decision:
 
 | Handler  | MCP servers reach the runtime as                                |
 | -------- | --------------------------------------------------------------- |
@@ -33,16 +46,24 @@ itself. Agor is never in the data path of a tool call:
 | Cursor   | `mcpServers` config object (`handlers/sdk/cursor.ts:247`)       |
 | OpenCode | resolved server list (`handlers/sdk/opencode.ts:97`)            |
 
-So "enforce at the gateway" has no addressee. Building one would mean Agor
-standing up an MCP proxy per session, re-terminating each server's transport and
-auth, and pointing every handler at itself — a large change that also puts Agor
-in the path of every tool call's latency and failure modes.
+Where a call-time decision is available:
 
-**The one partial exception is Claude**, and it is worth being precise about why:
-its SDK invokes JS callbacks back into the executor process, so Agor gets a
-`PreToolUse` hook and `canUseTool` and can refuse a call at runtime. That is
-interception, not proxying — the bytes still flow directly — but it is the only
-handler where Agor can decide about a call it did not pre-declare.
+| Handler  | Call-time hook                                     | Carries enough to identify the tool?                 |
+| -------- | -------------------------------------------------- | ---------------------------------------------------- |
+| Claude   | `PreToolUse` + `canUseTool`                        | Yes — `mcp__<server>__<tool>`                        |
+| OpenCode | `createPermissionCallback` → the same `canUseTool` | Yes — permission type IS the tool key                |
+| Copilot  | `onPermissionRequest`                              | Yes — `serverName` and `toolName` as separate fields |
+| Codex    | none (headless; `disabled_tools` only)             | n/a                                                  |
+| Gemini   | none (headless; `excludeTools` only)               | n/a                                                  |
+| Cursor   | none                                               | n/a                                                  |
+
+Only **Cursor** is genuinely hookless. And Agor already points an agent at its
+own HTTP endpoint for the built-in `agor` server (`query-builder.ts:400-410`),
+so even the proxy precedent exists in-tree.
+
+Building a full proxy would still be a large change. It is also unnecessary:
+per-call enforcement on the hooks above is equally binding and costs nothing at
+the transport layer.
 
 ## 2. What `tool_permissions` does today — per handler
 
@@ -51,20 +72,26 @@ resolution boundary rather than assumed. `HandlerPermissionCapabilities`
 (`core/src/mcp/tool-permissions.ts:41`) has each caller state whether it can drop
 a named tool (`exclude`) or has no per-tool control (`none`).
 
-| Handler  | Declares                            | What actually happens                                                                                                                         |
-| -------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude   | `exclude` (`query-builder.ts:444`)  | Three layers: `disallowedTools` (`:558`), a `PreToolUse` hook (`:575`), and `canUseTool` (`base/permission-hooks.ts:73`). Genuinely enforced. |
-| Codex    | `exclude` (`prompt-service.ts:673`) | `disabled_tools` (`:105`), applied on both the stdio and HTTP branches. Genuinely enforced.                                                   |
-| Gemini   | `exclude` (`prompt-service.ts:756`) | `excludeTools` on all three transports (`:779`, `:788`, `:796`). Genuinely enforced.                                                          |
-| Copilot  | `none` (`prompt-service.ts:194`)    | Server withheld whole.                                                                                                                        |
-| Cursor   | `none` (`cursor.ts:232`)            | Server withheld whole.                                                                                                                        |
-| OpenCode | `none` (`opencode.ts:110`)          | Server withheld whole.                                                                                                                        |
+| Handler  | Declares                              | What actually happens                                                                                                                         |
+| -------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude   | `exclude` (`query-builder.ts:444`)    | Three layers: `disallowedTools` (`:558`), a `PreToolUse` hook (`:575`), and `canUseTool` (`base/permission-hooks.ts:73`). Genuinely enforced. |
+| Codex    | `exclude` (`prompt-service.ts:673`)   | `disabled_tools` (`:105`), applied on both the stdio and HTTP branches. Genuinely enforced.                                                   |
+| Gemini   | `exclude` (`prompt-service.ts:756`)   | `excludeTools` on all three transports (`:779`, `:788`, `:796`). Genuinely enforced.                                                          |
+| Copilot  | `intercept` (`prompt-service.ts:202`) | Refused at call time in `permission-mapper.ts`, ahead of every mode shortcut. **Changed in this PR** (was `none`/withheld).                   |
+| OpenCode | `intercept` (`opencode.ts:113`)       | Refused at call time in `applyPermissionEffect`. **Changed in this PR** (was `none`/withheld).                                                |
+| Cursor   | `none` (`cursor.ts:232`)              | Server withheld whole. Genuinely the only option — no hook of any kind.                                                                       |
 
-Withholding happens in one place — `core/src/mcp/scoping.ts:297-307` — which
-drops any server whose `deny`/`ask` entries the handler cannot honour, and
-reports it to the user rather than letting it vanish silently. This is the
-established fail-closed pattern and it is correct: attaching the server anyway
-would hand over exactly the tools someone switched off.
+Withholding still happens in one place — `core/src/mcp/scoping.ts:297-307` —
+and is still correct for Cursor. But it is a last resort, not the goal: a
+withheld server costs the user the whole integration to enforce one tool. Where
+a call-time hook exists, `intercept` gives them the server _and_ the
+restriction.
+
+`intercept` carries an obligation the type cannot express: the check must run
+BEFORE any permission-mode shortcut. Both handlers that claim it have one
+(`bypassPermissions` / `allow-all` / `yolo`) that auto-approves without ever
+consulting Agor, so a gate placed after it would be skipped in exactly the
+modes where nothing else is watching. Both are tested for that specifically.
 
 Three details worth recording, because each is a place this could have been fake
 and isn't:
@@ -83,18 +110,56 @@ and isn't:
   thing between the model and a switched-off tool there. There is no prompt to
   fall back on and no `canUseTool` equivalent.
 
-### Correction: there is no OpenCode "fail-closed throw"
+### Correction: there never was an OpenCode "fail-closed throw"
 
-An earlier revision of this note described a deliberate throw guarding
-`tool_permissions` on OpenCode. **No such throw exists.** A gated server is
-dropped by `scoping.ts:297-307`, exactly like Copilot and Cursor — the table
-row above is right and that prose was wrong. The throws in `opencode-tool.ts`
+An earlier revision described a deliberate throw guarding `tool_permissions` on
+OpenCode. **No such throw ever existed.** Gated servers were dropped by
+`scoping.ts`, exactly like Copilot and Cursor. The throws in `opencode-tool.ts`
 cover a missing dependency, malformed or unauthenticated config, and a failed
-permission round-trip; none of them is about `tool_permissions`.
+permission round-trip; none is about `tool_permissions`.
 
-The claim was inherited from the task framing and restated without being
-checked. It is recorded here rather than silently deleted because it was
-repeated onward as fact.
+The claim was inherited from the task framing and restated without checking. It
+is recorded rather than deleted because it was repeated onward as fact.
+
+### What OpenCode actually does, established from the shipped binary
+
+Worth writing down, because the naive fix here would have been worse than
+nothing:
+
+- OpenCode composes MCP tool keys as `CP(server) + "_" + CP(tool)`, where
+  `CP = s => s.replace(/[^a-zA-Z0-9_-]/g, "_")` — a **single** underscore.
+- The tool-execute path calls `ask({permission: <that key>})`, so the
+  permission _type_ is the tool key. This is why the `'*': 'ask'` rule Agor
+  installs does reach MCP tools; OpenCode's own default ruleset uses the same
+  wildcard key, which had been assumed rather than verified.
+- Agor mints the server half itself when registering the server, so the whole
+  key is determined on our side. Nothing needs parsing back out.
+
+The shared index is keyed `mcp__server__tool`. Passing it to OpenCode — the
+obvious reading of "pass the real index" — would have matched **nothing**, and
+a miss reads as unconfigured, i.e. allow. So OpenCode gets a flat exact-match
+map built from the same helper that mints the config key, and the shared index
+is left empty with a comment saying why.
+
+### A live fail-open found and fixed: `claude.ai ` connector names
+
+The Claude CLI sanitizes a server name as Agor does, then — only for names
+beginning `claude.ai ` — squeezes runs of underscores and trims them:
+
+```js
+let t = e.replace(/[^a-zA-Z0-9_-]/g, '_');
+if (e.startsWith('claude.ai ')) t = t.replace(/_+/g, '_').replace(/^_|_$/g, '');
+```
+
+Agor did not model that. For a connector called `claude.ai Gmail (Beta)` it
+emitted `mcp__claude_ai_Gmail__Beta___delete_email` while the CLI presents
+`mcp__claude_ai_Gmail_Beta__delete_email`. The rule matched nothing, so **a
+deny on a claude.ai connector silently did nothing.** Same root cause: the CLI
+resolves a namespaced name by `split("__")` taking the first segment as the
+server, so any alias containing `__` fragments and is unaddressable.
+
+Fixed by emitting a collapsed alias. This was the single most dangerous thing
+found, and it was on the handler that otherwise looked strongest.
 
 ## 3. The actual gap: nothing writes `tool_permissions`
 
@@ -135,34 +200,53 @@ Consequences, stated plainly:
 
 ## 4. What was changed in this PR, and what wasn't
 
-**Changed:** Codex's enforcement had no test. Every other case in
-`codex/prompt-service.test.ts` stubs `buildMcpServersConfig` out, so
-`disabled_tools` was never driven. Added coverage that runs the real builder per
-transport and asserts the denied tool is filtered while an allowed one survives.
+**Enforcement, on the two handlers that were withholding servers.** Copilot and
+OpenCode moved from `toolFiltering: 'none'` to a new `intercept` capability and
+now refuse a denied tool at call time. A gated server is no longer withheld
+from either, so users get the server _and_ the restriction rather than neither.
+Both gates run ahead of the permission-mode shortcut that would otherwise
+auto-approve without consulting Agor.
 
-Mutation-verified: deleting `applyMcpToolPermissions` from the HTTP branch alone
-fails the three remote-transport cases and leaves stdio green. That is the
-realistic regression — the catalog is remote endpoints, so an omission there
-would carry nearly every marketplace server while looking covered.
+**A live fail-open on Claude**, described above: `claude.ai ` connector names
+produced `disallowedTools` rules that could never match.
+
+**A pin that did not pin.** `gemini/mcp-server-config.test.ts` declared its own
+mirror of the SDK constructor and asserted the builder agreed with _that_, so
+it passed under all three mutations that matter — a parameter inserted before
+`excludeTools`, the field renamed, the field removed. Its header also claimed
+`tsc` covered arity and position; it does not, because the constructor is typed
+`new (...args: never[]) => T` and cast to `unknown[]`. The consequence fails
+open: slot 13 is `includeTools`, an allowlist, so an inserted parameter turns
+Agor's deny list into "permit only the tools the user switched off". Now read
+from the SDK's shipped `config.d.ts`. Mutation-verified both ways; the old test
+passed the SDK-side mutation 3/3 while the new one fails it 4/4.
+
+**Test coverage for enforcement that had none.** Codex's `disabled_tools` (the
+suite stubs `buildMcpServersConfig` out everywhere else), and the case where a
+server's permissions are all `allow` — a gate keyed on "has any
+`tool_permissions`" would withhold every permission-bearing server from the
+handlers that cannot filter and still pass every other test.
+
+**A leak found by the new tests:** OpenCode's permission map was reaching
+`OPENCODE_CONFIG_CONTENT`, which the OpenCode process parses. Stripped.
 
 **Not changed, deliberately:**
 
-- No per-tool UI toggles. Enforcement exists, so a toggle would now bind — but
-  the write path runs through catalog connect, which is owned by other in-flight
-  work. Flagging rather than editing.
-- No seeding of `tool_permissions` from catalog `permission_disclosure`. Same
-  reason, plus a design question below.
-- No weakening of OpenCode's throw.
+- **No per-tool UI toggles**, and no catalog seeding. Both run through
+  `mcp-catalog-connect.ts`, owned by other in-flight work. Flagged, not edited.
+- **Cursor stays withheld-whole.** It has no hook of any kind; withholding is
+  genuinely the only option there.
 
 ## 5. What it would take to close the real gap
 
 Roughly in order of value:
 
 1. **A write path.** Per-tool toggles in the MCP server drawer, persisting to
-   `tool_permissions`. This is the whole gap for users who want to narrow a
-   server by hand, and it binds immediately on Claude/Codex/Gemini. The honest
-   caveat to surface in that UI: switching a tool off on a Copilot/Cursor/
-   OpenCode session withholds the entire server rather than one tool.
+   `tool_permissions`. This is now the _whole_ remaining gap, and it binds
+   immediately on five of six handlers. The wire already works (§3), so this is
+   a form control rather than a new API. The one caveat left to surface in that
+   UI: switching a tool off on a **Cursor** session withholds the entire server
+   rather than one tool.
 2. **A tool inventory to toggle against.** `server.tools` is a cached discovery
    snapshot that nothing proves is current — `tool-permissions.ts:44-51` refuses
    to enforce from it for exactly that reason. A UI can offer it as a picker

--- a/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
+++ b/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
@@ -83,18 +83,34 @@ and isn't:
   thing between the model and a switched-off tool there. There is no prompt to
   fall back on and no `canUseTool` equivalent.
 
-### OpenCode's throw is deliberate — leave it
+### Correction: there is no OpenCode "fail-closed throw"
 
-OpenCode's declarative config _is_ its enforcement boundary; there is no
-call-time hook to fall back on. The fail-closed throw is what keeps a `deny`
-meaningful there, and it should not be relaxed to make anything else easier.
+An earlier revision of this note described a deliberate throw guarding
+`tool_permissions` on OpenCode. **No such throw exists.** A gated server is
+dropped by `scoping.ts:297-307`, exactly like Copilot and Cursor — the table
+row above is right and that prose was wrong. The throws in `opencode-tool.ts`
+cover a missing dependency, malformed or unauthenticated config, and a failed
+permission round-trip; none of them is about `tool_permissions`.
+
+The claim was inherited from the task framing and restated without being
+checked. It is recorded here rather than silently deleted because it was
+repeated onward as fact.
 
 ## 3. The actual gap: nothing writes `tool_permissions`
 
-Searched every write path. The field has exactly one writer:
+Searched every write path. The wire is open — `tool_permissions` is part of
+`UpdateMCPServerInput`, the Feathers service patches with that type, and the
+repository spreads it through with no field allowlist, so **any user authorised
+to edit the server can set it over REST or socket today**. What is missing is
+anything that _offers_ to.
+
+The only caller that does is:
 
 - `apps/agor-daemon/src/mcp/tools/mcp-servers.ts:871` — the
   `agor_mcp_servers_update` MCP admin tool, i.e. an agent calling Agor's own API.
+
+That the transport already works is good news for §5: the remaining gap is a
+form control, not a new API.
 
 And specifically **not**:
 
@@ -106,14 +122,16 @@ And specifically **not**:
 
 Consequences, stated plainly:
 
-1. For all 47 marketplace entries, `tool_permissions` is empty, so
+1. For all 48 marketplace entries, `tool_permissions` is empty, so
    `canEnforceMcpToolPermissions` returns `true` trivially, nothing is withheld,
    nothing is excluded, and **every tool the server exposes is callable** —
    including the destructive ones the disclosure describes.
 2. The disclosure is therefore prose the user acknowledges and nothing acts on.
    It is accurate about what the server _can_ do; it is not a control.
-3. `others_can`, OAuth scope, and server-level `enabled` are the only real
-   narrowing available today. None of them is per-tool.
+3. The real narrowings available today are `mcp_member_policy`, `owner_user_id`
+   privacy, and the per-session attachment `enabled` flag. None is per-tool.
+   (`others_can` is branch RBAC and is not consulted anywhere on the MCP paths;
+   an earlier revision listed it here in error.)
 
 ## 4. What was changed in this PR, and what wasn't
 
@@ -154,7 +172,7 @@ Roughly in order of value:
    list, so it cannot be mechanically turned into permissions. Making the
    disclosure enforceable would mean adding a structured field to
    `curated.yaml` — e.g. `default_denied_tools` — and seeding from it at connect
-   time. That is a curation cost across 47 entries and a change to the connect
+   time. That is a curation cost across 48 entries and a change to the connect
    path; worth it only if the product intends the disclosure to be a contract
    rather than a description.
 

--- a/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
+++ b/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
@@ -1,0 +1,163 @@
+# MCP tool-permission enforcement: where it binds, and where it doesn't
+
+**Date:** 2026-08-18
+**Scope:** MANAGE-2 — "tool on/off toggles must be enforced at the layer that
+brokers tool calls, not just hidden in the UI."
+**Status:** audit. One test gap closed (Codex); the headline gap is left open
+deliberately, and named below.
+
+## The one-sentence finding
+
+The enforcement machinery is real, per-handler, and fail-closed — but **no
+user-facing path ever writes `tool_permissions`**, so for every server anyone
+connects from the marketplace the map is empty and every tool is allowed. The
+`permission_disclosure` a user acknowledges before connecting is, today,
+unenforced — not because enforcement is missing, but because nothing populates
+the field it reads.
+
+That distinction matters for what to build next, so the rest of this note
+separates the two halves.
+
+## 1. There is no gateway, and there cannot easily be one
+
+There is no choke point. Each handler writes the MCP server into the config it
+hands its own agent runtime, and the agent process opens the MCP connection
+itself. Agor is never in the data path of a tool call:
+
+| Handler  | MCP servers reach the runtime as                                |
+| -------- | --------------------------------------------------------------- |
+| Claude   | `queryOptions.mcpServers` (`claude/query-builder.ts:541`)       |
+| Codex    | `--config mcp_servers.<name>.*` (`codex/prompt-service.ts:664`) |
+| Gemini   | `MCPServerConfig` (`gemini/prompt-service.ts:779`)              |
+| Copilot  | `mcpServers` config object (`copilot/prompt-service.ts:209`)    |
+| Cursor   | `mcpServers` config object (`handlers/sdk/cursor.ts:247`)       |
+| OpenCode | resolved server list (`handlers/sdk/opencode.ts:97`)            |
+
+So "enforce at the gateway" has no addressee. Building one would mean Agor
+standing up an MCP proxy per session, re-terminating each server's transport and
+auth, and pointing every handler at itself — a large change that also puts Agor
+in the path of every tool call's latency and failure modes.
+
+**The one partial exception is Claude**, and it is worth being precise about why:
+its SDK invokes JS callbacks back into the executor process, so Agor gets a
+`PreToolUse` hook and `canUseTool` and can refuse a call at runtime. That is
+interception, not proxying — the bytes still flow directly — but it is the only
+handler where Agor can decide about a call it did not pre-declare.
+
+## 2. What `tool_permissions` does today — per handler
+
+Enforcement is expressed per handler, and the capability is declared at the
+resolution boundary rather than assumed. `HandlerPermissionCapabilities`
+(`core/src/mcp/tool-permissions.ts:41`) has each caller state whether it can drop
+a named tool (`exclude`) or has no per-tool control (`none`).
+
+| Handler  | Declares                            | What actually happens                                                                                                                         |
+| -------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude   | `exclude` (`query-builder.ts:444`)  | Three layers: `disallowedTools` (`:558`), a `PreToolUse` hook (`:575`), and `canUseTool` (`base/permission-hooks.ts:73`). Genuinely enforced. |
+| Codex    | `exclude` (`prompt-service.ts:673`) | `disabled_tools` (`:105`), applied on both the stdio and HTTP branches. Genuinely enforced.                                                   |
+| Gemini   | `exclude` (`prompt-service.ts:756`) | `excludeTools` on all three transports (`:779`, `:788`, `:796`). Genuinely enforced.                                                          |
+| Copilot  | `none` (`prompt-service.ts:194`)    | Server withheld whole.                                                                                                                        |
+| Cursor   | `none` (`cursor.ts:232`)            | Server withheld whole.                                                                                                                        |
+| OpenCode | `none` (`opencode.ts:110`)          | Server withheld whole.                                                                                                                        |
+
+Withholding happens in one place — `core/src/mcp/scoping.ts:297-307` — which
+drops any server whose `deny`/`ask` entries the handler cannot honour, and
+reports it to the user rather than letting it vanish silently. This is the
+established fail-closed pattern and it is correct: attaching the server anyway
+would hand over exactly the tools someone switched off.
+
+Three details worth recording, because each is a place this could have been fake
+and isn't:
+
+- **The SDK keys are real.** Gemini's `excludeTools` is the 14th positional
+  constructor argument and lands on the right field (pinned by
+  `gemini/mcp-server-config.test.ts`). Codex's `disabled_tools` appears in the
+  shipped `codex` binary. Neither is an invented key that would no-op.
+- **`ask` fails closed where nobody can be asked.** Codex and Gemini are
+  headless, and Claude under `bypassPermissions` or with no task to attribute a
+  request to has no channel either; in all three cases `ask` collapses onto
+  `deny` rather than degrading to `allow`
+  (`PERMISSIONS_BLOCKED_WITHOUT_PROMPT`, `tool-permissions.ts:31`).
+- **Codex auto-approves everything else.** Every Codex server config carries
+  `default_tools_approval_mode: "approve"`, so `disabled_tools` is the _only_
+  thing between the model and a switched-off tool there. There is no prompt to
+  fall back on and no `canUseTool` equivalent.
+
+### OpenCode's throw is deliberate — leave it
+
+OpenCode's declarative config _is_ its enforcement boundary; there is no
+call-time hook to fall back on. The fail-closed throw is what keeps a `deny`
+meaningful there, and it should not be relaxed to make anything else easier.
+
+## 3. The actual gap: nothing writes `tool_permissions`
+
+Searched every write path. The field has exactly one writer:
+
+- `apps/agor-daemon/src/mcp/tools/mcp-servers.ts:871` — the
+  `agor_mcp_servers_update` MCP admin tool, i.e. an agent calling Agor's own API.
+
+And specifically **not**:
+
+- **The catalog.** `mcp-catalog-connect.ts` never sets `tool_permissions`. A
+  server installed from the marketplace gets an empty map.
+- **The UI.** There is no reference to `tool_permissions` anywhere in
+  `apps/agor-ui/src`. No per-tool toggles exist. (The one `Switch` in the MCP
+  form is the server-level `enabled` flag.)
+
+Consequences, stated plainly:
+
+1. For all 47 marketplace entries, `tool_permissions` is empty, so
+   `canEnforceMcpToolPermissions` returns `true` trivially, nothing is withheld,
+   nothing is excluded, and **every tool the server exposes is callable** —
+   including the destructive ones the disclosure describes.
+2. The disclosure is therefore prose the user acknowledges and nothing acts on.
+   It is accurate about what the server _can_ do; it is not a control.
+3. `others_can`, OAuth scope, and server-level `enabled` are the only real
+   narrowing available today. None of them is per-tool.
+
+## 4. What was changed in this PR, and what wasn't
+
+**Changed:** Codex's enforcement had no test. Every other case in
+`codex/prompt-service.test.ts` stubs `buildMcpServersConfig` out, so
+`disabled_tools` was never driven. Added coverage that runs the real builder per
+transport and asserts the denied tool is filtered while an allowed one survives.
+
+Mutation-verified: deleting `applyMcpToolPermissions` from the HTTP branch alone
+fails the three remote-transport cases and leaves stdio green. That is the
+realistic regression — the catalog is remote endpoints, so an omission there
+would carry nearly every marketplace server while looking covered.
+
+**Not changed, deliberately:**
+
+- No per-tool UI toggles. Enforcement exists, so a toggle would now bind — but
+  the write path runs through catalog connect, which is owned by other in-flight
+  work. Flagging rather than editing.
+- No seeding of `tool_permissions` from catalog `permission_disclosure`. Same
+  reason, plus a design question below.
+- No weakening of OpenCode's throw.
+
+## 5. What it would take to close the real gap
+
+Roughly in order of value:
+
+1. **A write path.** Per-tool toggles in the MCP server drawer, persisting to
+   `tool_permissions`. This is the whole gap for users who want to narrow a
+   server by hand, and it binds immediately on Claude/Codex/Gemini. The honest
+   caveat to surface in that UI: switching a tool off on a Copilot/Cursor/
+   OpenCode session withholds the entire server rather than one tool.
+2. **A tool inventory to toggle against.** `server.tools` is a cached discovery
+   snapshot that nothing proves is current — `tool-permissions.ts:44-51` refuses
+   to enforce from it for exactly that reason. A UI can offer it as a picker
+   (with free-text fallback), but a _default-deny_ posture would need a
+   refresh-on-connect guarantee that does not exist yet.
+3. **Catalog-seeded defaults.** `permission_disclosure` is prose, not a tool
+   list, so it cannot be mechanically turned into permissions. Making the
+   disclosure enforceable would mean adding a structured field to
+   `curated.yaml` — e.g. `default_denied_tools` — and seeding from it at connect
+   time. That is a curation cost across 47 entries and a change to the connect
+   path; worth it only if the product intends the disclosure to be a contract
+   rather than a description.
+
+Until at least (1) lands, the disclosure remains a description of what a
+connected server may do, and the enforcement machinery stays a correct engine
+with nothing feeding it.

--- a/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/mcp-admission.test.ts
@@ -1,9 +1,19 @@
 /**
- * OpenCode's invocation config carries no per-tool filter, so withholding the
- * whole server is the only way a `deny` or `ask` can bind here. That makes the
- * declarative config the enforcement boundary: a gated server must be absent
- * from what gets handed to the managed server, not merely absent from some
- * intermediate list.
+ * OpenCode's invocation config still carries no per-tool filter, but the
+ * server no longer has to be withheld to make a `deny` bind: every MCP tool
+ * call is asked back through Agor before it runs, using the tool's own key as
+ * the permission type. Agor mints that key when it registers the server, so
+ * the lookup is exact rather than a guess at where a namespaced name splits.
+ *
+ * These cases therefore pin the two halves that have to agree: the key the
+ * config registers a server under, and the key the permission map is built
+ * from. If those ever drift, every lookup misses, and a miss reads as
+ * "unconfigured" — which is `allow`.
+ *
+ * What is NOT proven here is that OpenCode reports exactly that string. That
+ * comes from the shipped 1.14.33 binary, where the MCP tool registry composes
+ * `CP(server) + "_" + CP(tool)` and the execute path calls
+ * `ask({permission: <that key>})`, with `CP = s => s.replace(/[^a-zA-Z0-9_-]/g, "_")`.
  */
 
 import { EventEmitter } from 'node:events';
@@ -13,7 +23,7 @@ import { getMcpServersForSession } from '@agor/core/mcp';
 import type { MCPServer, MessageID, SessionID, TaskID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import type { ManagedChild } from './managed-server';
-import { OpenCodeTool } from './opencode-tool';
+import { blockedByOpenCodeToolPermissions, OpenCodeTool } from './opencode-tool';
 
 const GATED = 'gated-server';
 const PLAIN = 'plain-server';
@@ -49,7 +59,7 @@ async function buildConfig(servers: MCPServer[]) {
           mcpServerRepo: { findAll: vi.fn().mockResolvedValue([]) } as never,
           onServerWithheld: (server) => withheld.push(server.name),
         },
-        { toolFiltering: 'none' }
+        { toolFiltering: 'intercept' }
       ),
     getDaemonUrl: async () => 'http://localhost:3030',
   });
@@ -66,33 +76,33 @@ async function buildConfig(servers: MCPServer[]) {
 }
 
 describe('MCP servers reaching OpenCode invocation config', () => {
-  it('omits a server whose tools are gated, while keeping the rest', async () => {
+  it('now keeps a server whose tools are gated, because the gate moved to call time', async () => {
     const { config, withheld } = await buildConfig([
       server(GATED, { write_file: 'deny' }),
       server(PLAIN),
     ]);
     const configured = Object.keys(config.mcp).join(' ');
 
-    expect(configured).not.toContain(sanitized(GATED));
-    // Positive control: the builder does emit servers, so the absence above is
-    // the gate and not an empty config.
+    // Previously this server was dropped whole. Users now get the server AND
+    // the restriction rather than neither.
+    expect(configured).toContain(sanitized(GATED));
     expect(configured).toContain(sanitized(PLAIN));
-    // A server that vanishes without a word is indistinguishable from a broken
-    // one, so the gate has to say so as well as act.
-    expect(withheld).toEqual([GATED]);
+    expect(withheld).toEqual([]);
   });
 
-  it('omits a server gated with ask, which has no prompt channel here', async () => {
-    const { config, withheld } = await buildConfig([
-      server(GATED, { write_file: 'ask' }),
-      server(PLAIN),
-    ]);
+  it('keys the permission map by exactly the name it registered the server under', async () => {
+    const gated = server(GATED, { write_file: 'deny', read_file: 'allow' });
+    const { config } = await buildConfig([gated, server(PLAIN)]);
 
-    const configured = Object.keys(config.mcp).join(' ');
-    expect(configured).not.toContain(sanitized(GATED));
-    // Positive control, as above: the config is not simply empty.
-    expect(configured).toContain(sanitized(PLAIN));
-    expect(withheld).toEqual([GATED]);
+    const registered = Object.keys(config.mcp).find((name) => name.includes(sanitized(GATED)));
+    expect(registered).toBeDefined();
+
+    // The load-bearing agreement: the map's key is the registered server key
+    // plus the tool name. A mismatch here is a silent fail-open.
+    expect(config.mcpToolPermissions?.get(`${registered}_write_file`)).toBe('deny');
+    // Every configured entry is carried, not just the gated ones, so the map
+    // stays a faithful copy of what the user set.
+    expect(config.mcpToolPermissions?.get(`${registered}_read_file`)).toBe('allow');
   });
 
   it('keeps the built-in Agor server addressable', async () => {
@@ -104,12 +114,49 @@ describe('MCP servers reaching OpenCode invocation config', () => {
 });
 
 /**
+ * The decision itself. Extracted from `applyPermissionEffect` so it is
+ * reachable without standing up a turn — the surrounding function is where
+ * this is easy to get wrong, because the permission-mode shortcut next to it
+ * answers `once` without ever consulting Agor.
+ */
+describe('the tool_permissions gate', () => {
+  const gate = (
+    configured: 'deny' | 'ask' | 'allow' | undefined,
+    modeWouldAutoAllow = false,
+    hasApprovalChannel = true
+  ) => blockedByOpenCodeToolPermissions({ configured, modeWouldAutoAllow, hasApprovalChannel });
+
+  it('refuses a denied tool even when the permission mode would auto-allow', () => {
+    // bypassPermissions / allow-all / yolo never reach canUseTool, so this is
+    // the only thing standing between the model and the tool in those modes.
+    expect(gate('deny', true)).toBe('deny');
+    expect(gate('deny', false)).toBe('deny');
+  });
+
+  it('lets an ask reach the prompt when someone can actually answer', () => {
+    expect(gate('ask', false, true)).toBeUndefined();
+  });
+
+  it('fails an unanswerable ask closed rather than letting it become allow', () => {
+    expect(gate('ask', true, true)).toBe('ask');
+    expect(gate('ask', false, false)).toBe('ask');
+  });
+
+  it('leaves allowed and unconfigured tools alone', () => {
+    // Unconfigured must mean "unchanged behaviour", never an implicit deny.
+    expect(gate('allow', true)).toBeUndefined();
+    expect(gate(undefined, true)).toBeUndefined();
+    expect(gate(undefined, false, false)).toBeUndefined();
+  });
+});
+
+/**
  * The config object is an intermediate. What the OpenCode process actually
  * obeys is `OPENCODE_CONFIG_CONTENT` on its own environment, so that string is
  * where a `deny` either binds or does not.
  */
 describe('MCP servers reaching the OpenCode process environment', () => {
-  it('never names a gated server in OPENCODE_CONFIG_CONTENT', async () => {
+  it('hands both servers to the process without leaking Agor-side state', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const child = Object.assign(new EventEmitter(), {
       stdout: new PassThrough(),
@@ -130,7 +177,7 @@ describe('MCP servers reaching the OpenCode process environment', () => {
             } as never,
             mcpServerRepo: { findAll: vi.fn().mockResolvedValue([]) } as never,
           },
-          { toolFiltering: 'none' }
+          { toolFiltering: 'intercept' }
         ),
       getDaemonUrl: async () => 'http://localhost:3030',
       resolveBinary: async () => ({ executable: process.execPath, argsPrefix: ['/opencode'] }),
@@ -167,10 +214,12 @@ describe('MCP servers reaching the OpenCode process environment', () => {
 
     expect(spawnEnvs).toHaveLength(1);
     const configContent = spawnEnvs[0].OPENCODE_CONFIG_CONTENT ?? '';
-    expect(configContent).not.toContain(sanitized(GATED));
-    expect(configContent).not.toContain(GATED);
-    // Positive control: an ungated server does make it into the same string,
-    // so the two absences above are the gate and not a stubbed-out config.
+    // Both servers now reach the process; the gated one is restrained at call
+    // time rather than by being kept out of the config.
+    expect(configContent).toContain(sanitized(GATED));
     expect(configContent).toContain(sanitized(PLAIN));
+    // The permission map is Agor-side state and must never be serialised into
+    // the config the OpenCode process reads.
+    expect(configContent).not.toContain('mcpToolPermissions');
   });
 });

--- a/packages/agentic-tool-opencode/src/runtime/opencode-tool.ts
+++ b/packages/agentic-tool-opencode/src/runtime/opencode-tool.ts
@@ -21,6 +21,7 @@ import {
   type SessionID,
   shortId,
   type TaskID,
+  type ToolPermission,
   type ToolUse,
 } from '@agor/core/types';
 import type { createOpencodeClient } from '@opencode-ai/sdk';
@@ -109,6 +110,11 @@ export type OpenCodeInvocationConfig = {
   mcp: Record<string, unknown>;
   permission?: Record<string, 'ask' | 'allow' | 'deny'>;
   tools?: Record<string, boolean>;
+  /**
+   * Gated MCP tools, keyed by the name OpenCode will report them under. Built
+   * alongside the `mcp` block above so the keys cannot disagree with it.
+   */
+  mcpToolPermissions?: ReadonlyMap<string, ToolPermission>;
   [key: string]: unknown;
 };
 
@@ -215,6 +221,80 @@ interface TurnContext {
   provider: string;
   /** Branch directory path for project-scoped operations. */
   branchPath: string;
+  /**
+   * OpenCode tool key → configured permission, for gated MCP tools only.
+   * Absent when nothing is gated. See `buildOpenCodeMcpToolPermissions`.
+   */
+  mcpToolPermissions?: ReadonlyMap<string, ToolPermission>;
+}
+
+/**
+ * The alphabet OpenCode rewrites a name into before using it as a tool key.
+ * Matches `CP` in the shipped binary exactly; a character we leave in but it
+ * rewrites would make a lookup miss, and a miss reads as "unconfigured".
+ */
+const sanitizeToOpenCodeToolKey = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+/**
+ * The config key Agor registers an MCP server under.
+ *
+ * Shared with `buildOpenCodeMcpToolPermissions` on purpose: the permission
+ * lookup below is only exact because Agor mints this name itself, so the two
+ * must never be able to drift apart.
+ */
+export function openCodeMcpServerKey(sessionId: string, server: MCPServer): string {
+  const sanitized = server.name.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  return `agor_${shortId(sessionId)}_${shortId(server.mcp_server_id)}_${sanitized}`;
+}
+
+/**
+ * Map every configured tool to the exact key OpenCode will report it under.
+ *
+ * OpenCode registers MCP tools as `<server key>_<tool>`, both halves put
+ * through its own sanitizer, and asks permission using that same string as the
+ * permission *type* — `ask({permission: <tool key>})` on the tool-execute path.
+ * Because Agor chooses the server key, the composed name is fully determined
+ * here: there is nothing to parse back out, and the single-underscore join is
+ * unambiguous in this direction. Hence a flat exact-match map rather than the
+ * namespaced index the other handlers use.
+ */
+export function buildOpenCodeMcpToolPermissions(
+  sessionId: string,
+  servers: readonly { server: MCPServer }[]
+): ReadonlyMap<string, ToolPermission> {
+  const keys = new Map<string, ToolPermission>();
+  for (const { server } of servers) {
+    const serverKey = sanitizeToOpenCodeToolKey(openCodeMcpServerKey(sessionId, server));
+    for (const [toolName, permission] of Object.entries(server.tool_permissions ?? {})) {
+      keys.set(`${serverKey}_${sanitizeToOpenCodeToolKey(toolName)}`, permission);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Whether `tool_permissions` alone refuses this call, and on which setting.
+ *
+ * Split out so the decision is reachable without standing up a turn, because
+ * the surrounding function is where it is easy to get wrong. It has to run
+ * BEFORE `automaticallyAllowsOpenCodePermission`: that shortcut answers
+ * `once` without ever calling `canUseTool`, so a gate placed after it is
+ * skipped under `bypassPermissions`, `allow-all` and `yolo` — the modes where
+ * nothing else is watching.
+ *
+ * `ask` needs somewhere to ask. Where the mode would auto-allow, or no
+ * approval callback exists at all, it collapses onto `deny` rather than
+ * degrading into `allow` — the same rule the headless handlers apply.
+ */
+export function blockedByOpenCodeToolPermissions(input: {
+  configured: ToolPermission | undefined;
+  modeWouldAutoAllow: boolean;
+  hasApprovalChannel: boolean;
+}): ToolPermission | undefined {
+  const { configured, modeWouldAutoAllow, hasApprovalChannel } = input;
+  if (configured === 'deny') return 'deny';
+  if (configured === 'ask' && (modeWouldAutoAllow || !hasApprovalChannel)) return 'ask';
+  return undefined;
 }
 
 type OpenCodePermissionEffect = Extract<OpenCodeEventEffect, { type: 'permission' }>;
@@ -231,10 +311,30 @@ async function applyPermissionEffect(input: {
   let handledByAgor = false;
   let interactionTimedOut = false;
 
-  if (effect.request.permission === 'question' || effect.request.permission === 'task') {
+  // `tool_permissions` is resolved before anything else can answer.
+  const configuredToolPermission = context.mcpToolPermissions?.get(effect.request.permission);
+  const modeWouldAutoAllow = automaticallyAllowsOpenCodePermission(
+    turn.permissionMode,
+    effect.request.permission
+  );
+  const blocking = blockedByOpenCodeToolPermissions({
+    configured: configuredToolPermission,
+    modeWouldAutoAllow,
+    hasApprovalChannel: Boolean(canUseTool),
+  });
+
+  if (blocking) {
+    console.warn(
+      `🛑 [OpenCode] MCP tool "${effect.request.permission}" blocked by tool_permissions (${blocking})`
+    );
+    handledByAgor = true;
+    response = 'reject';
+  } else if (effect.request.permission === 'question' || effect.request.permission === 'task') {
     handledByAgor = true;
   } else if (canUseTool) {
-    if (automaticallyAllowsOpenCodePermission(turn.permissionMode, effect.request.permission)) {
+    // An `ask` tool must reach the prompt rather than be waved through by the
+    // session's permission mode.
+    if (modeWouldAutoAllow && configuredToolPermission !== 'ask') {
       response = 'once';
     } else {
       handledByAgor = true;
@@ -496,6 +596,13 @@ export class OpenCodeTool {
   }
 
   private protectedInvocationConfig(resolved: OpenCodeInvocationConfig): OpenCodeInvocationConfig {
+    // `mcpToolPermissions` is Agor-side state read by `applyPermissionEffect`;
+    // this return value is serialised into OPENCODE_CONFIG_CONTENT, which the
+    // OpenCode process parses. Dropping it here keeps a key OpenCode has no
+    // schema for out of its config — and a Map would serialise to `{}` anyway,
+    // so leaving it in would be a confusing no-op rather than a useful one.
+    const { mcpToolPermissions: _agorOnly, ...serialisable } = resolved;
+    resolved = serialisable as OpenCodeInvocationConfig;
     const configuredAgents =
       typeof resolved.agent === 'object' && resolved.agent !== null
         ? (resolved.agent as Record<string, unknown>)
@@ -661,6 +768,7 @@ export class OpenCodeTool {
           model,
           provider,
           branchPath: input.directory,
+          mcpToolPermissions: resolvedInvocationConfig.mcpToolPermissions,
         },
         streamingCallbacks,
         (stop) => {
@@ -825,8 +933,7 @@ export class OpenCodeTool {
     const servers = await this.dependencies.resolveMcpServers(sessionId as SessionID);
 
     for (const { server } of servers) {
-      const sanitizedName = server.name.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-      const name = `agor_${shortId(sessionId)}_${shortId(server.mcp_server_id)}_${sanitizedName}`;
+      const name = openCodeMcpServerKey(sessionId, server);
       if (server.transport === 'stdio') {
         if (!server.command) {
           throw new Error(`Attached MCP server ${server.name} is missing its command`);
@@ -872,7 +979,11 @@ export class OpenCodeTool {
         );
       }
     }
-    return { mcp, permission: AGOR_PERMISSION_INTERCEPTION };
+    return {
+      mcp,
+      permission: AGOR_PERMISSION_INTERCEPTION,
+      mcpToolPermissions: buildOpenCodeMcpToolPermissions(sessionId, servers),
+    };
   }
 
   /** Create a new OpenCode session on the invocation's managed runtime. */

--- a/packages/core/src/mcp/scoping.test.ts
+++ b/packages/core/src/mcp/scoping.test.ts
@@ -284,6 +284,30 @@ describe('getMcpServersForSession - tool_permissions admission gate', () => {
     expect(servers.map(({ server }) => server.mcp_server_id)).toEqual(['plain']);
   });
 
+  // Only `deny` and `ask` need enforcing. A gate that keyed off "has any
+  // tool_permissions at all" would withhold every permission-bearing server
+  // from the handlers that cannot filter, and would still pass every case
+  // above, because none of them configures a permission meant to be harmless.
+  it('admits a server whose permissions are all allow, even where nothing can filter', async () => {
+    const allowOnly = makeServer('allow-only', 'global');
+    allowOnly.tool_permissions = { read_file: 'allow', list_files: 'allow' };
+
+    const servers = await resolve(allowOnly, { toolFiltering: 'none' });
+
+    expect(servers.map(({ server }) => server.mcp_server_id)).toEqual(['allow-only']);
+  });
+
+  it.each(['deny', 'ask'] as const)(
+    'keeps a server carrying a %s for a handler that enforces at call time',
+    async (permission) => {
+      // `intercept` cannot pre-filter but refuses the call itself, so
+      // withholding would cost the user the whole server for no added safety.
+      const servers = await resolve(gatedServer(permission), { toolFiltering: 'intercept' });
+
+      expect(servers.map(({ server }) => server.mcp_server_id)).toEqual(['gated']);
+    }
+  );
+
   // A server that vanishes without explanation is indistinguishable, from the
   // session, from one that is broken.
   it('reports each withheld server with a reason', async () => {

--- a/packages/core/src/mcp/tool-permissions.ts
+++ b/packages/core/src/mcp/tool-permissions.ts
@@ -40,16 +40,29 @@ export const PERMISSIONS_BLOCKED_WITHOUT_PROMPT: readonly ToolPermission[] = ['d
  */
 export interface HandlerPermissionCapabilities {
   /**
-   * Whether the handler can name a tool to drop in the config it hands its SDK
-   * (`exclude`) or has no per-tool control at all (`none`).
+   * How the handler can act on a per-tool permission.
+   *
+   * - `exclude` — it can name a tool to drop in the config it hands its SDK,
+   *   so a denied tool is never offered to the model.
+   * - `intercept` — it cannot pre-filter, but every MCP tool call is routed
+   *   back through Agor before it runs, so a denied tool can be refused at
+   *   call time. Equally binding, and it can additionally honour `ask`,
+   *   because the same channel carries a prompt.
+   * - `none` — neither. The server has to be withheld whole.
    *
    * Deliberately not "can express a tool set". An include-list can only say
    * "all but these" by enumerating the survivors, and the only inventory
    * available here is `server.tools` — a cached discovery snapshot that no SDK
    * reads and that nothing proves is current. Enforcing from it would turn a
    * stale cache into the authoritative tool set.
+   *
+   * An `intercept` handler carries an obligation the type cannot express: the
+   * check has to run BEFORE any permission-mode shortcut that would otherwise
+   * auto-approve. Both handlers that claim it have such a shortcut
+   * (`bypassPermissions` and friends), and enforcing after it would be no
+   * enforcement at all.
    */
-  toolFiltering: 'exclude' | 'none';
+  toolFiltering: 'exclude' | 'intercept' | 'none';
 }
 
 /** Bare tool names on `server` whose configured permission is one of `permissions`. */
@@ -80,6 +93,7 @@ export function canEnforceMcpToolPermissions(
 
   switch (caps.toolFiltering) {
     case 'exclude':
+    case 'intercept':
       return true;
     case 'none':
       return false;

--- a/packages/executor/src/handlers/sdk/opencode.test.ts
+++ b/packages/executor/src/handlers/sdk/opencode.test.ts
@@ -175,7 +175,7 @@ describe('OpenCode executor adapter', () => {
         forUserId: 'task-creator',
         sessionOwnerId: 'session-owner',
       }),
-      { toolFiltering: 'none' }
+      { toolFiltering: 'intercept' }
     );
   });
 

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -104,10 +104,13 @@ export async function executeOpenCodeTask(params: {
             sessionOwnerId: targetSession.created_by,
             onServerWithheld: reporter.onServerWithheld,
           },
-          // OpenCode's invocation config carries no per-tool filter, so a server
-          // with gated tools cannot be honoured and is withheld whole. This is
-          // the only enforcement point on this path.
-          { toolFiltering: 'none' }
+          // OpenCode's invocation config still carries no per-tool filter, but
+          // every MCP tool call comes back through Agor before it runs: the
+          // managed server asks permission using the tool's own key as the
+          // permission type, and Agor mints that key when it registers the
+          // server, so the match is exact. Enforcement happens there
+          // (`applyPermissionEffect`) instead of by withholding the server.
+          { toolFiltering: 'intercept' }
         );
         await reportWithheldMcpServers(repos.messages, {
           sessionId: targetSessionId,
@@ -127,8 +130,12 @@ export async function executeOpenCodeTask(params: {
           permissionLocks,
           mcpServerRepo: repos.mcpServers,
           sessionMCPRepo: repos.sessionMCP,
-          // Gated servers never reach this handler, so nothing here can be
-          // configured; the admission gate above already withheld them.
+          // Deliberately empty. This callback only ever sees OpenCode's own
+          // permission keys (`<server key>_<tool>`), which the namespaced
+          // `mcp__server__tool` resolver cannot match -- and a miss would read
+          // as "unconfigured", i.e. allow. The per-tool gate for this handler
+          // lives in `applyPermissionEffect`, keyed the way OpenCode names
+          // things, and runs before this callback is reached.
           mcpToolPermissions: EMPTY_MCP_TOOL_PERMISSION_INDEX,
         }),
       cancelPendingPermissions: (targetSessionId) =>

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildMcpToolPermissionIndex,
   EMPTY_MCP_TOOL_PERMISSION_INDEX,
+  mcpToolNameAliasesForServer,
   resolveMcpToolPermission,
 } from './mcp-tool-permissions.js';
 
@@ -133,5 +134,56 @@ describe('resolveMcpToolPermission', () => {
     ]);
 
     expect(resolveMcpToolPermission(reversed, 'mcp__a_b__search')).toBe('deny');
+  });
+});
+
+/**
+ * The Claude CLI sanitizes a server name the way we do, then applies an extra
+ * squeeze -- collapse runs of `_`, trim them from both ends -- but ONLY when
+ * the raw name begins `claude.ai `:
+ *
+ *     let t = e.replace(/[^a-zA-Z0-9_-]/g, "_");
+ *     if (e.startsWith("claude.ai ")) t = t.replace(/_+/g, "_").replace(/^_|_$/g, "");
+ *
+ * Transcribed from the shipped 0.3.197 CLI. It matters because those are
+ * exactly the names claude.ai connectors carry, and a name that misses reads
+ * as unconfigured -- which is `allow`.
+ */
+describe('claude.ai connector names', () => {
+  /** The CLI's own function, transcribed from the bundle. */
+  const cliServerName = (raw: string) => {
+    let t = raw.replace(/[^a-zA-Z0-9_-]/g, '_');
+    if (raw.startsWith('claude.ai ')) t = t.replace(/_+/g, '_').replace(/^_|_$/g, '');
+    return t;
+  };
+
+  it.each(['claude.ai Gmail (Beta)', 'claude.ai  Notion', 'claude.ai Drive.'])(
+    'covers the name the CLI actually mints for %s',
+    (raw) => {
+      // Without the collapsed alias this misses, and the deny fails OPEN.
+      expect(mcpToolNameAliasesForServer(raw)).toContain(cliServerName(raw));
+    }
+  );
+
+  it('binds a deny to the tool name the CLI will present', () => {
+    const raw = 'claude.ai Gmail (Beta)';
+    const index = buildMcpToolPermissionIndex([
+      server(raw, { delete_email: 'deny', list_email: 'allow' }),
+    ]);
+
+    expect(resolveMcpToolPermission(index, `mcp__${cliServerName(raw)}__delete_email`)).toBe(
+      'deny'
+    );
+    // Positive control: the same server's allowed tool is not swept up.
+    expect(resolveMcpToolPermission(index, `mcp__${cliServerName(raw)}__list_email`)).toBe('allow');
+  });
+
+  it('emits an alias free of doubled underscores, which the CLI would split on', () => {
+    // The CLI resolves `mcp__a__b` by splitting on `__` and taking the FIRST
+    // segment as the server, so an alias carrying `__` fragments and can never
+    // be addressed at all.
+    const aliases = mcpToolNameAliasesForServer('claude.ai Gmail (Beta)');
+    expect(aliases.some((alias) => !alias.includes('__'))).toBe(true);
+    expect(aliases).toContain('claude_ai_Gmail_Beta');
   });
 });

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
@@ -52,10 +52,35 @@ function sanitizeToToolNameAlphabet(name: string): string {
  * Indexing the rewritten server forms alongside the raw one keeps lookups
  * working for servers named e.g. "preset sdx" or "my.server". Codex also
  * lowercases, so that variant is indexed too.
+ *
+ * The collapsed form models a special case in the Claude CLI, which sanitizes
+ * a server name as we do and then, ONLY for names beginning `claude.ai `,
+ * additionally squeezes runs of underscores and trims them from both ends:
+ *
+ *     let t = e.replace(/[^a-zA-Z0-9_-]/g, "_");
+ *     if (e.startsWith("claude.ai ")) t = t.replace(/_+/g, "_").replace(/^_|_$/g, "");
+ *
+ * Without it, a connector called `claude.ai Gmail (Beta)` gets the rule
+ * `mcp__claude_ai_Gmail__Beta___delete_item` while the CLI mints
+ * `mcp__claude_ai_Gmail_Beta__delete_item`. The rule matches nothing and the
+ * deny silently becomes an allow — the exact failure this alias set exists to
+ * prevent, on precisely the names the claude.ai connectors carry.
+ *
+ * It also repairs a second problem with the same root: the CLI resolves a
+ * namespaced name by `split("__")` and taking the FIRST segment as the server,
+ * so any sanitized server name containing a doubled underscore fragments and
+ * can never be addressed. The collapsed alias contains no `__` by
+ * construction.
+ *
+ * Emitted for every name, not just `claude.ai ` ones. Over-emitting is safe in
+ * both directions: an extra `disallowedTools` rule that matches nothing is
+ * inert, and an extra index key can only ever add a denial, which errs closed.
+ * Under-emitting is the failure mode that matters.
  */
 export function mcpToolNameAliasesForServer(name: string): string[] {
   const sanitized = sanitizeToToolNameAlphabet(name);
-  return [name, sanitized, sanitized.toLowerCase()];
+  const collapsed = sanitized.replace(/_+/g, '_').replace(/^_|_$/g, '');
+  return [name, sanitized, sanitized.toLowerCase(), collapsed, collapsed.toLowerCase()];
 }
 
 /**

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.ts
@@ -107,6 +107,34 @@ export function buildMcpToolPermissionIndex(servers: MCPServer[]): McpToolPermis
 }
 
 /**
+ * Resolve a permission when the SDK hands over the server and tool separately.
+ *
+ * Copilot's `kind: 'mcp'` permission request carries `serverName` and
+ * `toolName` as distinct fields, so there is no namespaced string to take
+ * apart and no ambiguity to resolve — which makes this the exact lookup and
+ * `resolveMcpToolPermission` the one that has to guess where the boundary is.
+ *
+ * Both names go through the alias set because the server half reaches us as
+ * whatever key the handler registered the server under (Copilot lowercases and
+ * rewrites), while `tool_permissions` is keyed on the raw advertised name.
+ */
+export function resolveMcpToolPermissionByParts(
+  index: McpToolPermissionIndex,
+  serverName: string,
+  toolName: string
+): ToolPermission | undefined {
+  for (const serverAlias of new Set(mcpToolNameAliasesForServer(serverName))) {
+    const tools = index.byServer.get(serverAlias);
+    if (!tools) continue;
+    for (const toolAlias of new Set(mcpToolNameAliasesForTool(toolName))) {
+      const permission = tools.get(toolAlias);
+      if (permission) return permission;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Resolve the configured permission for a tool name as an SDK surfaced it.
  *
  * Returns `undefined` when nothing is configured — callers must treat that as

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -2384,3 +2384,114 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP `tool_permissions` enforcement
+//
+// `disabled_tools` is the ONLY thing standing between the model and a switched-
+// off tool on Codex. Every block above asserts Agor also emits
+// `default_tools_approval_mode: "approve"`, which auto-approves every MCP tool
+// call — so there is no prompt to fall back on, and no `canUseTool` equivalent:
+// Codex resolves the config in native code and Agor never sees the call.
+//
+// That makes an omission here silent and total. It is also easy to introduce:
+// the config is assembled in two separate transport branches, and the HTTP one
+// carries essentially every marketplace server (the catalog is remote
+// endpoints), so a `disabled_tools` line dropped from that branch alone would
+// leave stdio coverage intact and look fine.
+//
+// These cases therefore drive the real `buildMcpServersConfig` per transport.
+// The rest of the suite stubs that method out, which is exactly why this was
+// uncovered. Each case pairs the denied tool with an allowed one, so a passing
+// assertion means the filter is selective rather than empty or total.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CodexPromptService - MCP tool_permissions', () => {
+  const sessionOwnerId = '019e3700-owner-owner-owner-owner000001';
+  const sessionId = '019e3700-aaaa-bbbb-cccc-dddddddddddd';
+  const mockMcpServerRepo = { findById: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([]);
+    mcpAuthMocks.resolveMCPAuthHeaders.mockResolvedValue(null);
+    configMocks.getDaemonUrl.mockResolvedValue('http://localhost:3030');
+  });
+
+  const makeService = () =>
+    new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockMcpServerRepo
+    );
+
+  const build = async () =>
+    (await (makeService() as any).buildMcpServersConfig(sessionId, undefined, {
+      sessionOwnerId,
+    })) as { servers: Record<string, any>; total: number };
+
+  /** Same server, same permissions, addressed over each transport Codex accepts. */
+  const gatedServer = (transport: 'stdio' | 'http' | 'sse') => ({
+    server: {
+      name: 'sentry',
+      transport,
+      ...(transport === 'stdio'
+        ? { command: 'npx', args: ['-y', 'sentry-mcp'] }
+        : { url: 'https://mcp.sentry.dev/mcp' }),
+      tool_permissions: { delete_project: 'deny', list_issues: 'allow' },
+    },
+  });
+
+  for (const transport of ['stdio', 'http', 'sse'] as const) {
+    it(`disables a denied tool on a ${transport} server, leaving allowed tools reachable`, async () => {
+      mcpScopingMocks.getMcpServersForSession.mockResolvedValue([gatedServer(transport)]);
+
+      const { servers } = await build();
+
+      expect(servers.sentry.disabled_tools).toEqual(['delete_project']);
+      expect(servers.sentry.disabled_tools).not.toContain('list_issues');
+      // The gate has to coexist with the auto-approval that makes it load-bearing.
+      expect(servers.sentry.default_tools_approval_mode).toBe('approve');
+    });
+  }
+
+  it('fails closed on "ask", because Codex runs headless with no approval channel', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'sentry',
+          transport: 'http',
+          url: 'https://mcp.sentry.dev/mcp',
+          tool_permissions: { update_issue: 'ask', list_issues: 'allow' },
+        },
+      },
+    ]);
+
+    const { servers } = await build();
+
+    // An unanswerable "ask" must collapse onto deny, never onto allow.
+    expect(servers.sentry.disabled_tools).toEqual(['update_issue']);
+  });
+
+  it('leaves disabled_tools unset when a server gates nothing', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'sentry',
+          transport: 'http',
+          url: 'https://mcp.sentry.dev/mcp',
+          tool_permissions: { list_issues: 'allow' },
+        },
+      },
+    ]);
+
+    const { servers } = await build();
+
+    // Guards the other direction: an empty list must not be emitted as a filter
+    // Codex could read as "disable everything", and must not appear as noise.
+    expect(servers.sentry.disabled_tools).toBeUndefined();
+  });
+});

--- a/packages/executor/src/sdk-handlers/copilot/permission-mapper.test.ts
+++ b/packages/executor/src/sdk-handlers/copilot/permission-mapper.test.ts
@@ -1,5 +1,6 @@
 import type { SessionID, TaskID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { buildMcpToolPermissionIndex } from '../base/mcp-tool-permissions.js';
 import { createPermissionHandler } from './permission-mapper.js';
 
 describe('createPermissionHandler', () => {
@@ -109,5 +110,117 @@ describe('createPermissionHandler', () => {
         }),
       })
     );
+  });
+});
+
+/**
+ * Copilot cannot filter the tool list it offers the model, so this callback is
+ * the ONLY place a switched-off tool can be stopped. It is also crowded with
+ * shortcuts that return `approved` before any per-tool logic used to run —
+ * `bypassPermissions` short-circuits the whole handler, and an attached server
+ * auto-approves every tool on it. Each case below drives one of those paths.
+ */
+describe('createPermissionHandler - MCP tool_permissions', () => {
+  const sessionId = 'test-session' as SessionID;
+  const taskId = 'test-task' as TaskID;
+
+  const index = buildMcpToolPermissionIndex([
+    {
+      mcp_server_id: 's1',
+      name: 'sentry',
+      tool_permissions: { delete_project: 'deny', update_issue: 'ask', list_issues: 'allow' },
+    } as never,
+  ]);
+
+  /** Attached-and-listed, so the server-level fast path would approve it. */
+  const deps = (extra: Record<string, unknown> = {}) =>
+    ({
+      permissionService: {
+        emitRequest: vi.fn(),
+        waitForDecision: vi
+          .fn()
+          .mockResolvedValue({ allow: true, timedOut: false, remember: false, decidedBy: 'u' }),
+        cancelPendingRequests: vi.fn(),
+      },
+      tasksService: { patch: vi.fn().mockResolvedValue(undefined) },
+      sessionsRepo: {},
+      messagesRepo: { getNextIndexBySessionId: vi.fn().mockResolvedValue(0) },
+      messagesService: { create: vi.fn(), patch: vi.fn() },
+      sessionsService: { patch: vi.fn().mockResolvedValue(undefined) },
+      permissionLocks: new Map(),
+      sessionMCPRepo: { listServers: vi.fn().mockResolvedValue([{ name: 'sentry' }]) },
+      mcpToolPermissions: index,
+      ...extra,
+    }) as never;
+
+  const mcpRequest = (toolName: string) =>
+    ({ kind: 'mcp', serverName: 'sentry', toolName, toolCallId: 'c1' }) as never;
+
+  it('refuses a denied tool even though its server is attached', async () => {
+    const handler = createPermissionHandler(sessionId, taskId, 'ask', deps());
+
+    const result = await handler(mcpRequest('delete_project'), { sessionId });
+
+    expect(result).toMatchObject({ kind: 'denied-by-permission-request-hook' });
+  });
+
+  it('still approves an allowed tool on the same server', async () => {
+    const handler = createPermissionHandler(sessionId, taskId, 'ask', deps());
+
+    // Positive control: the deny above is per tool, not the server going dark.
+    expect(await handler(mcpRequest('list_issues'), { sessionId })).toEqual({ kind: 'approved' });
+  });
+
+  it('refuses a denied tool under bypassPermissions, which returns before the deps exist', async () => {
+    const handler = createPermissionHandler(sessionId, taskId, 'bypassPermissions', deps());
+
+    // The mode that skips every interactive path is exactly where a gate
+    // placed further down would have been missed.
+    expect(await handler(mcpRequest('delete_project'), { sessionId })).toMatchObject({
+      kind: 'denied-by-permission-request-hook',
+    });
+    expect(await handler(mcpRequest('list_issues'), { sessionId })).toEqual({ kind: 'approved' });
+  });
+
+  it('fails an unanswerable "ask" closed rather than letting it become allow', async () => {
+    const handler = createPermissionHandler(sessionId, taskId, 'bypassPermissions', deps());
+
+    expect(await handler(mcpRequest('update_issue'), { sessionId })).toMatchObject({
+      kind: 'denied-by-permission-request-hook',
+    });
+  });
+
+  it('prompts for an "ask" tool instead of letting server attachment answer for the user', async () => {
+    const emitRequest = vi.fn();
+    const handler = createPermissionHandler(
+      sessionId,
+      taskId,
+      'ask',
+      deps({
+        permissionService: {
+          emitRequest,
+          waitForDecision: vi
+            .fn()
+            .mockResolvedValue({ allow: true, timedOut: false, remember: false, decidedBy: 'u' }),
+          cancelPendingRequests: vi.fn(),
+        },
+      })
+    );
+
+    const result = await handler(mcpRequest('update_issue'), { sessionId });
+
+    expect(emitRequest).toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'approved' });
+  });
+
+  it('leaves servers with no configured permissions on their existing fast path', async () => {
+    const handler = createPermissionHandler(sessionId, taskId, 'ask', deps());
+
+    // Unconfigured must mean "unchanged behaviour", never an implicit deny.
+    const result = await handler(
+      { kind: 'mcp', serverName: 'other', toolName: 'whatever', toolCallId: 'c2' } as never,
+      { sessionId }
+    );
+    expect(result).toEqual({ kind: 'approved' });
   });
 });

--- a/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
+++ b/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
@@ -17,7 +17,7 @@
  */
 
 import { generateId, shortId } from '@agor/core';
-import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
+import type { Message, MessageID, SessionID, TaskID, ToolPermission } from '@agor/core/types';
 import { MessageRole, PermissionStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 import type {
   PermissionHandler,
@@ -33,6 +33,8 @@ import type {
 import type { PermissionService } from '../../permissions/permission-service.js';
 import type { PermissionMode } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
+import type { McpToolPermissionIndex } from '../base/mcp-tool-permissions.js';
+import { resolveMcpToolPermissionByParts } from '../base/mcp-tool-permissions.js';
 
 /**
  * Re-export SDK types for convenience
@@ -54,6 +56,26 @@ export interface PermissionDeps {
   permissionLocks: Map<SessionID, Promise<void>>;
   mcpServerRepo?: MCPServerRepository;
   sessionMCPRepo?: SessionMCPServerRepository;
+  /** Per-tool `tool_permissions` from the session's resolved MCP servers. */
+  mcpToolPermissions?: McpToolPermissionIndex;
+}
+
+/**
+ * The configured permission for an MCP request, or `undefined` if unconfigured.
+ *
+ * Copilot delivers `serverName` and `toolName` as separate fields, so nothing
+ * has to be split apart or guessed. That is the whole reason this handler can
+ * enforce per tool despite having no way to filter the list it offers a model.
+ */
+function resolveRequestPermission(
+  request: PermissionRequest,
+  index: McpToolPermissionIndex | undefined
+): ToolPermission | undefined {
+  if (!index || request.kind !== 'mcp') return undefined;
+  const serverName = request.serverName as string | undefined;
+  const toolName = request.toolName as string | undefined;
+  if (!serverName || !toolName) return undefined;
+  return resolveMcpToolPermissionByParts(index, serverName, toolName);
 }
 
 /**
@@ -172,10 +194,40 @@ export function createPermissionHandler(
   deps?: PermissionDeps
 ): CopilotPermissionHandler {
   const approved: CopilotPermissionDecision = { kind: 'approved' };
+  const index = deps?.mcpToolPermissions;
 
-  // bypassPermissions / allow-all → always auto-approve, no deps needed
+  /**
+   * The `tool_permissions` gate, which outranks every shortcut below it.
+   *
+   * Placed ahead of the mode checks on purpose: `bypassPermissions` returns
+   * before any of the interactive machinery exists, so a gate further down
+   * would be skipped in exactly the mode that most needs it. `canPrompt` says
+   * whether a human can still be asked; where nobody can be, `ask` collapses
+   * onto `deny` rather than degrading into `allow`.
+   */
+  const blockedByToolPermissions = (
+    request: PermissionRequest,
+    canPrompt: boolean
+  ): CopilotPermissionDecision | undefined => {
+    const permission = resolveRequestPermission(request, index);
+    if (permission === 'deny' || (permission === 'ask' && !canPrompt)) {
+      console.warn(
+        `🛑 [Copilot Permission] MCP tool "${request.serverName}.${request.toolName}" ` +
+          `blocked by tool_permissions (${permission})`
+      );
+      return {
+        kind: 'denied-by-permission-request-hook',
+        message: `Tool "${request.toolName}" is denied by its MCP server's tool permissions.`,
+      };
+    }
+    return undefined;
+  };
+
+  // bypassPermissions / allow-all → auto-approve, EXCEPT where a tool was
+  // switched off: there is no prompt channel here, so deny and ask both bind.
   if (permissionMode === 'bypassPermissions' || permissionMode === 'allow-all') {
-    return async () => approved;
+    return async (request: PermissionRequest) =>
+      blockedByToolPermissions(request, false) ?? approved;
   }
 
   // No deps → headless fallback (auto-approve everything)
@@ -188,8 +240,15 @@ export function createPermissionHandler(
 
   // Interactive permission handler
   return async (request: PermissionRequest): Promise<CopilotPermissionDecision> => {
+    const blocked = blockedByToolPermissions(request, true);
+    if (blocked) return blocked;
+
+    // An `ask` tool must reach the prompt below, so it skips both fast paths —
+    // otherwise "this server is attached" would silently answer for the user.
+    const configured = resolveRequestPermission(request, index);
+
     // Auto-approve based on mode + kind
-    if (shouldAutoApprove(permissionMode, request.kind)) {
+    if (configured !== 'ask' && shouldAutoApprove(permissionMode, request.kind)) {
       console.log(
         `✅ [Copilot Permission] Auto-approved ${request.kind} (mode: ${permissionMode})`
       );
@@ -197,7 +256,7 @@ export function createPermissionHandler(
     }
 
     // Auto-approve MCP tools from attached servers
-    if (await isAttachedMcpServer(request, sessionId, deps)) {
+    if (configured !== 'ask' && (await isAttachedMcpServer(request, sessionId, deps))) {
       console.log(
         `✅ [Copilot Permission] Auto-approved MCP tool from attached server: ${request.serverName}`
       );

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.test.ts
@@ -50,7 +50,7 @@ describe('CopilotPromptService MCP identity scoping', () => {
         forUserId: 'task-creator',
         sessionOwnerId: 'session-owner',
       }),
-      { toolFiltering: 'none' }
+      { toolFiltering: 'intercept' }
     );
   });
 });

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
@@ -36,6 +36,11 @@ import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
+import type { McpToolPermissionIndex } from '../base/mcp-tool-permissions.js';
+import {
+  buildMcpToolPermissionIndex,
+  EMPTY_MCP_TOOL_PERMISSION_INDEX,
+} from '../base/mcp-tool-permissions.js';
 import {
   collectWithheldMcpServers,
   reportWithheldMcpServers,
@@ -157,14 +162,14 @@ export class CopilotPromptService {
     sessionId: SessionID,
     taskId: TaskID,
     mcpToken?: string
-  ): Promise<Record<string, unknown>> {
+  ): Promise<{ servers: Record<string, unknown>; toolPermissions: McpToolPermissionIndex }> {
     const copilotMcpServers: Record<string, unknown> = {};
 
     // Fetch MCP servers for this session
     const session = await this.sessionsRepo.findById(sessionId);
     if (!session) {
       console.warn(`⚠️  [Copilot MCP] Session ${sessionId} not found; skipping MCP servers`);
-      return copilotMcpServers;
+      return { servers: copilotMcpServers, toolPermissions: EMPTY_MCP_TOOL_PERMISSION_INDEX };
     }
     const contextUserId = await resolveContextUserId({
       session,
@@ -182,16 +187,19 @@ export class CopilotPromptService {
         sessionOwnerId: session.created_by,
         onServerWithheld: reporter.onServerWithheld,
       },
-      // The per-server `tools` field below is an include-list, which cannot
-      // express "all but these" without enumerating a tool set that changes
-      // under us. `SessionConfig.excludedTools` is a true exclude-list, but the
-      // SDK forwards it verbatim to the Copilot CLI, which resolves it in
-      // native code against a name it mints itself (`namespacedName`) — a name
-      // Agor cannot construct, and a miss here reads as "allow". The CLI does
-      // document a `<mcp-server-name>(tool-name?)` permission pattern built
-      // from names Agor holds verbatim, but only for its `--deny-tool` flag,
-      // which `SessionConfig` does not expose.
-      { toolFiltering: 'none' }
+      // Still no way to filter the tool list handed to the model: the
+      // per-server `tools` field is an include-list, which cannot say "all but
+      // these" without enumerating a set that changes under us, and
+      // `SessionConfig.excludedTools` is resolved in the CLI's native code
+      // against a name it mints itself (`namespacedName`) that Agor cannot
+      // construct — a miss there reads as "allow".
+      //
+      // Enforcement happens at call time instead. `onPermissionRequest`
+      // delivers every MCP tool call as `kind: 'mcp'` carrying `serverName`
+      // and `toolName` as separate fields, which is an exact match against
+      // `tool_permissions` with nothing to guess. So a gated server no longer
+      // has to be withheld whole.
+      { toolFiltering: 'intercept' }
     );
     await reportWithheldMcpServers(this.messagesRepo, {
       sessionId,
@@ -244,7 +252,10 @@ export class CopilotPromptService {
       console.log(`   📝 [Copilot MCP] Configured Agor MCP server (HTTP)`);
     }
 
-    return copilotMcpServers;
+    return {
+      servers: copilotMcpServers,
+      toolPermissions: buildMcpToolPermissionIndex(mcpServers),
+    };
   }
 
   /**
@@ -309,6 +320,15 @@ export class CopilotPromptService {
       await this.client.start();
       console.log(`✅ [Copilot] Client started`);
 
+      // MCP resolution runs first: it produces the `tool_permissions` index the
+      // permission handler enforces from, and that handler is the only place a
+      // denied tool can be stopped on this runtime.
+      const { servers: mcpServers, toolPermissions } = await this.buildMcpServers(
+        sessionId,
+        taskId || ('' as TaskID),
+        session.mcp_token
+      );
+
       // Build session configuration with interactive permission support
       const permissionDeps: PermissionDeps | undefined =
         this.permissionService && this.tasksService && taskId
@@ -322,6 +342,7 @@ export class CopilotPromptService {
               permissionLocks: this.permissionLocks,
               mcpServerRepo: this.mcpServerRepo,
               sessionMCPRepo: this.sessionMCPServerRepo,
+              mcpToolPermissions: toolPermissions,
             }
           : undefined;
 
@@ -330,11 +351,6 @@ export class CopilotPromptService {
         taskId || ('' as TaskID),
         permissionMode,
         permissionDeps
-      );
-      const mcpServers = await this.buildMcpServers(
-        sessionId,
-        taskId || ('' as TaskID),
-        session.mcp_token
       );
       const systemMessage = await this.buildSystemMessage(sessionId);
 

--- a/packages/executor/src/sdk-handlers/gemini/mcp-server-config.test.ts
+++ b/packages/executor/src/sdk-handlers/gemini/mcp-server-config.test.ts
@@ -1,41 +1,113 @@
-import { describe, expect, it } from 'vitest';
-
 /**
- * `@google/gemini-cli-core` can't be loaded under vitest (its OpenTelemetry
- * dependency uses unsupported directory imports), so this mirrors the real
- * `MCPServerConfig` constructor signature from the SDK's type declarations.
- * The positional order is the thing under test — `tsc` covers the arity and
- * types against the real class, this covers which slot each value lands in.
+ * Pins Gemini's positional MCP config against the REAL shipped class.
+ *
+ * This is the one positional coupling in the codebase, and it fails OPEN: the
+ * slot immediately before `excludeTools` is `includeTools`, an ALLOWLIST. If
+ * the SDK ever inserts a parameter ahead of it, Agor's deny list slides one
+ * slot left and becomes "permit only the tools the user switched off" —
+ * every other tool on the server allowed, and no error anywhere.
+ *
+ * An earlier version of this file declared its own mirror of the constructor
+ * and passed that in, so it asserted the builder agreed with a copy of the
+ * signature rather than with the SDK. It therefore passed under exactly the
+ * three mutations that matter: a parameter inserted before `excludeTools`, the
+ * field renamed, or the field removed. Its header also claimed `tsc` covered
+ * arity and types against the real class; it does not, because the builder
+ * types the constructor as `new (...args: never[]) => T` and casts it to
+ * `unknown[]`, which erases positional checking entirely.
+ *
+ * The real module cannot be imported here — `@google/gemini-cli-core` pulls in
+ * an OpenTelemetry build that uses directory imports Node's ESM loader rejects,
+ * which is what drove the mirror in the first place. So the signature is read
+ * from the shipped `config.d.ts` instead. That is a real build artifact of the
+ * installed package: it moves when the SDK moves, which a hand-written mirror
+ * never does.
  */
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import { buildGeminiMcpServerConfig } from './mcp-server-config.js';
 
-/**
- * Mirrors the SDK's positional constructor. Passing it in beats mocking the
- * module: the builder's whole job is putting values in the right slots, and a
- * stub constructor lets the test see exactly which slot each landed in.
- */
-class MCPServerConfig {
-  constructor(
-    readonly command?: string,
-    readonly args?: string[],
-    readonly env?: Record<string, string>,
-    readonly cwd?: string,
-    readonly url?: string,
-    readonly httpUrl?: string,
-    readonly headers?: Record<string, string>,
-    readonly tcp?: string,
-    readonly type?: string,
-    readonly timeout?: number,
-    readonly trust?: boolean,
-    readonly description?: string,
-    readonly includeTools?: string[],
-    readonly excludeTools?: string[]
-  ) {}
+/** Splits on top-level commas only, so `Record<string, string>` stays intact. */
+function splitParams(raw: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of raw) {
+    if ('<([{'.includes(char)) depth++;
+    else if ('>)]}'.includes(char)) depth--;
+    if (char === ',' && depth === 0) {
+      out.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) out.push(current);
+  return out;
 }
 
+/**
+ * Constructor parameter names, in declaration order, from the installed SDK.
+ *
+ * Throws rather than falling back to a hardcoded list: if the declaration can
+ * no longer be found, the coupling is unverified, and silently "passing" is the
+ * failure this file exists to prevent.
+ */
+function readRealCtorParamOrder(): string[] {
+  const require = createRequire(import.meta.url);
+  const dts = join(
+    dirname(require.resolve('@google/gemini-cli-core/package.json')),
+    'dist/src/config/config.d.ts'
+  );
+  const source = readFileSync(dts, 'utf8');
+  const match =
+    /export declare class MCPServerConfig\b[\s\S]*?\n\s*constructor\(([\s\S]*?)\);/.exec(source);
+  if (!match) {
+    throw new Error(`Could not find the MCPServerConfig constructor in ${dts}`);
+  }
+
+  return splitParams(match[1]).map((param) => {
+    const name = /^\s*([A-Za-z_$][\w$]*)\s*\??\s*:/.exec(param)?.[1];
+    if (!name) throw new Error(`Could not parse a parameter name from "${param.trim()}"`);
+    return name;
+  });
+}
+
+const REAL_PARAMS = readRealCtorParamOrder();
+
+/** Captures raw positional arguments; nothing is interpreted for us. */
+class RecordingConfig {
+  readonly args: unknown[];
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+/** The value the builder placed in whichever slot the SDK calls `name`. */
+function slot(config: unknown, name: string): unknown {
+  const index = REAL_PARAMS.indexOf(name);
+  expect(index, `the SDK no longer declares a "${name}" constructor parameter`).toBeGreaterThan(-1);
+  return (config as RecordingConfig).args[index];
+}
+
+const build = (options: Parameters<typeof buildGeminiMcpServerConfig>[1]) =>
+  buildGeminiMcpServerConfig(RecordingConfig as never, options);
+
 describe('buildGeminiMcpServerConfig', () => {
-  it('lands excludeTools on the SDK field, not a neighbouring positional slot', () => {
-    const config = buildGeminiMcpServerConfig(MCPServerConfig, {
+  it('still matches the SDK signature it hardcodes positions against', () => {
+    // The builder pads to a fixed arity. If the SDK grew or shrank the
+    // constructor, every assertion below is comparing against stale offsets.
+    expect(REAL_PARAMS).toContain('excludeTools');
+    expect(REAL_PARAMS.indexOf('excludeTools')).toBe(13);
+    // The hazard is specifically that this allowlist sits directly before it.
+    expect(REAL_PARAMS[REAL_PARAMS.indexOf('excludeTools') - 1]).toBe('includeTools');
+  });
+
+  it('lands the deny list in the SDK slot actually named excludeTools', () => {
+    const config = build({
       command: 'npx',
       args: ['-y', 'server-github'],
       env: { GITHUB_TOKEN: 'x' },
@@ -43,54 +115,67 @@ describe('buildGeminiMcpServerConfig', () => {
       excludeTools: ['create_pull_request', 'merge_pull_request'],
     });
 
-    expect(config.excludeTools).toEqual(['create_pull_request', 'merge_pull_request']);
-    // Everything Agor never sets must stay unset — a shifted argument would
-    // silently populate one of these instead.
-    expect(config.includeTools).toBeUndefined();
-    expect(config.trust).toBeUndefined();
-    expect(config.description).toBeUndefined();
-    expect(config.timeout).toBeUndefined();
-    expect(config.tcp).toBeUndefined();
+    expect(slot(config, 'excludeTools')).toEqual(['create_pull_request', 'merge_pull_request']);
   });
 
-  it('preserves the transport fields for each shape Agor builds', () => {
-    const stdio = buildGeminiMcpServerConfig(MCPServerConfig, {
+  it('never lets the deny list reach includeTools, which would allow everything else', () => {
+    const config = build({
+      command: 'npx',
+      env: {},
+      excludeTools: ['delete_repository'],
+    });
+
+    // The fail-open case, asserted directly rather than inferred from a
+    // neighbouring field being undefined.
+    expect(slot(config, 'includeTools')).toBeUndefined();
+    expect(slot(config, 'excludeTools')).toEqual(['delete_repository']);
+  });
+
+  it('places every transport field in the slot the SDK names', () => {
+    const stdio = build({
       command: 'npx',
       args: ['-y', 'server-github'],
-      env: {},
+      env: { A: '1' },
       cwd: '/branch',
       excludeTools: [],
     });
-    expect(stdio).toMatchObject({ command: 'npx', args: ['-y', 'server-github'], cwd: '/branch' });
+    expect(slot(stdio, 'command')).toBe('npx');
+    expect(slot(stdio, 'args')).toEqual(['-y', 'server-github']);
+    expect(slot(stdio, 'env')).toEqual({ A: '1' });
+    expect(slot(stdio, 'cwd')).toBe('/branch');
 
-    const http = buildGeminiMcpServerConfig(MCPServerConfig, {
+    const http = build({
       env: {},
       httpUrl: 'https://example.com/mcp',
       headers: { Authorization: 'Bearer t' },
       excludeTools: [],
     });
-    expect(http).toMatchObject({
-      httpUrl: 'https://example.com/mcp',
-      headers: { Authorization: 'Bearer t' },
-    });
-    expect(http.url).toBeUndefined();
+    expect(slot(http, 'httpUrl')).toBe('https://example.com/mcp');
+    expect(slot(http, 'headers')).toEqual({ Authorization: 'Bearer t' });
+    expect(slot(http, 'url')).toBeUndefined();
 
-    const sse = buildGeminiMcpServerConfig(MCPServerConfig, {
+    const sse = build({ env: {}, url: 'https://example.com/sse', excludeTools: [] });
+    expect(slot(sse, 'url')).toBe('https://example.com/sse');
+    expect(slot(sse, 'httpUrl')).toBeUndefined();
+  });
+
+  it('leaves every slot Agor never sets empty', () => {
+    const config = build({
+      command: 'npx',
       env: {},
-      url: 'https://example.com/sse',
-      excludeTools: [],
+      cwd: '/branch',
+      excludeTools: ['x'],
     });
-    expect(sse).toMatchObject({ url: 'https://example.com/sse' });
-    expect(sse.httpUrl).toBeUndefined();
+
+    // A shifted argument would populate one of these instead of erroring.
+    for (const name of ['tcp', 'type', 'timeout', 'trust', 'description', 'includeTools']) {
+      expect(slot(config, name), `expected the SDK's "${name}" slot to stay unset`).toBeUndefined();
+    }
   });
 
   it('leaves excludeTools unset when nothing is gated', () => {
-    const config = buildGeminiMcpServerConfig(MCPServerConfig, {
-      command: 'npx',
-      env: {},
-      excludeTools: [],
-    });
+    const config = build({ command: 'npx', env: {}, excludeTools: [] });
 
-    expect(config.excludeTools).toBeUndefined();
+    expect(slot(config, 'excludeTools')).toBeUndefined();
   });
 });

--- a/packages/executor/src/sdk-handlers/gemini/mcp-server-config.ts
+++ b/packages/executor/src/sdk-handlers/gemini/mcp-server-config.ts
@@ -3,6 +3,16 @@
  * the 14th slot behind a run of options Agor never sets. Funnelling every
  * transport branch through one keyword-argument builder keeps the call sites
  * readable and the padding in exactly one place.
+ *
+ * SAFETY: this padding is load-bearing and fails OPEN. Slot 13 is
+ * `includeTools`, an allowlist. If the SDK inserts a parameter anywhere ahead
+ * of `excludeTools`, Agor's deny list slides into it and turns into "permit
+ * ONLY the tools the user switched off" — everything else on the server
+ * allowed. Nothing here can catch that: the constructor is typed
+ * `new (...args: never[]) => T` and cast to `unknown[]`, so `tsc` checks
+ * neither arity nor position. `mcp-server-config.test.ts` pins the order
+ * against the SDK's shipped `config.d.ts`; keep that test passing rather than
+ * adjusting it to match a new signature by hand.
  */
 export function buildGeminiMcpServerConfig<T>(
   MCPServerConfig: new (...args: never[]) => T,


### PR DESCRIPTION
## What changed since the first revision

The first revision of this PR concluded MANAGE-2 needed a new MCP proxy and left it open on that cost. **That was wrong**, and a fact-check caught it. Three of six handlers already route every tool call back through Agor. This revision does the work instead.

## 1. There is no proxy, but there IS a call-time choke point

Agor is not in the *data* path — the agent opens the MCP connection itself. But it is in the *decision* path almost everywhere, and that is all enforcement needs.

| Handler | Call-time hook | Enough to identify the tool? |
| --- | --- | --- |
| Claude | `PreToolUse` + `canUseTool` | Yes — `mcp__<server>__<tool>` |
| OpenCode | `createPermissionCallback` → same `canUseTool` | Yes — the permission type **is** the tool key |
| Copilot | `onPermissionRequest` | Yes — `serverName` + `toolName` as separate fields |
| Codex / Gemini | none (headless) | n/a — `disabled_tools` / `excludeTools` |
| Cursor | none | n/a — genuinely hookless |

Only Cursor has nothing. Agor also already points agents at its own `/mcp` endpoint for the built-in server (`query-builder.ts:400-410`), so the proxy precedent existed in-tree too.

## 2. Enforcement implemented — Copilot and OpenCode

Both moved from `toolFiltering: 'none'` (server withheld whole) to a new **`intercept`** capability: cannot pre-filter, but refuses the call. It also honours `ask`, which the headless handlers cannot. **Users now get the server *and* the restriction rather than neither.**

Both gates run **ahead of the permission-mode shortcut**. `bypassPermissions` / `allow-all` / `yolo` auto-approve without ever consulting Agor, so a gate placed after would be skipped in exactly the modes where nothing else is watching.

**OpenCode, established from the shipped 1.14.33 binary — the naive fix would have been worse than nothing.** Its tool keys are `CP(server) + "_" + CP(tool)` with a **single** underscore (`CP = s => s.replace(/[^a-zA-Z0-9_-]/g,"_")`), and the execute path calls `ask({permission: <that key>})` — so the permission type *is* the tool key, which also confirms the previously-unverified assumption that `'*': 'ask'` reaches MCP tools. The shared index is keyed `mcp__server__tool` and would have matched **nothing**; a miss reads as unconfigured, i.e. allow. So OpenCode gets a flat exact-match map built from the same helper that mints the config key, and the shared index stays empty with a comment saying why.

Cursor stays withheld-whole. OpenCode's throws are untouched.

## 3. Two live fail-opens found and fixed

**Claude, `claude.ai ` connectors.** The CLI sanitizes as Agor does, then — only for names starting `claude.ai ` — collapses underscore runs and trims them:
```js
let t = e.replace(/[^a-zA-Z0-9_-]/g,"_");
if (e.startsWith("claude.ai ")) t = t.replace(/_+/g,"_").replace(/^_|_$/g,"");
```
Agor didn't model it. `claude.ai Gmail (Beta)` produced the rule `mcp__claude_ai_Gmail__Beta___delete_email` while the CLI presents `mcp__claude_ai_Gmail_Beta__delete_email`. **A deny on a claude.ai connector silently did nothing.** Same root cause fixes rule fragmentation: the CLI resolves names by `split("__")` taking the first segment as the server, so any alias containing `__` is unaddressable.

**Gemini, F3 — the pin that didn't pin.** `mcp-server-config.test.ts` declared its own mirror of the SDK constructor, so it passed under a parameter inserted before `excludeTools`, the field renamed, or removed. Its header's claim that `tsc` covered arity/position was also false (`new (...args: never[]) => T`, cast to `unknown[]`). This fails **open**: slot 13 is `includeTools`, an allowlist, so an inserted parameter turns the deny list into "permit only the tools the user switched off". Now read from the SDK's shipped `config.d.ts`.

## 4. Test gaps closed

- **Codex `disabled_tools`** had no coverage — every other case stubs `buildMcpServersConfig` out.
- **All-`allow` admission**: a gate keyed on "has any `tool_permissions`" would withhold every permission-bearing server from the non-filtering handlers and pass everything else.
- **A leak found by the new tests**: OpenCode's permission map was reaching `OPENCODE_CONFIG_CONTENT`, which the OpenCode process parses. Stripped.

## 5. What is still unenforced — stated plainly

**Nothing writes `tool_permissions`.** The wire is open (it's in `UpdateMCPServerInput`, the service patches with that type, the repository spreads it through), so any user authorised to edit a server can already set it over REST or socket. But no UI or catalog path *offers* to — there is zero reference to `tool_permissions` in `apps/agor-ui/src`, and connect never sets it.

So for all **48** catalog entries the map is empty and every tool remains callable. The `permission_disclosure` is still unenforced. **Everything here makes the value bind once something finally sets it** — the remaining gap is a form control, not a new API.

Not done, deliberately: no per-tool UI toggles and no catalog seeding, since both run through `mcp-catalog-connect.ts`, owned by other in-flight work.

## Mutation verification

Every mechanism, not just asserted shapes:

| Mutation | Result |
| --- | --- |
| Gemini: drop a builder padding slot | 3 fail |
| Gemini: insert a param into the SDK's own `d.ts` | 4 fail — **old test passed this 3/3** |
| Claude: revert the collapsed alias | 5 fail |
| Copilot: move gate below `bypassPermissions` | 2 fail |
| Copilot: let attachment answer an `ask` | 1 fail |
| OpenCode: ignore the auto-allow modes | 2 fail |
| OpenCode: change key separator to `__` | 1 fail |
| Codex: drop enforcement from the HTTP branch only | 3 fail, stdio green |
| Core: match `'allow'` in the admission gate | 1 fail |

## Gate

`turbo run typecheck` 22/22; `biome check --error-on-warnings .` clean. `packages/core` 3595 pass; `agentic-tool-opencode` 144 pass; `apps/agor-daemon` 2890 pass.

`packages/executor`: **60 failures, identical to baseline** (same 4 files: Codex client-caching mocks, Claude/Gemini); 558 → 577 passing. Fails on THIS HOST.

UI: 2 failures, neither touched by this PR (no UI files changed). `MCPServersTable.oauth` also fails on baseline; `BoardEditModal.icon` passes when run alone. Fails on THIS HOST.
