### PR TITLE
fix(cli): make open and version local-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Every release-version bump PR must include its finalized changelog section; a ve
 
 ## Unreleased
 
+### Fixes
+
+- **Local CLI inspection no longer requires login** — `agor open` and `agor version` now target the local deployment by default, retain `--local` as a compatibility alias, and use the connected deployment only with `--remote`. ([#2464](https://github.com/preset-io/agor/issues/2464))
+
 ## 0.25.2 (2026-08-18)
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Every release-version bump PR must include its finalized changelog section; a ve
 
 ### Fixes
 
-- **Local CLI inspection no longer requires login** — `agor open` and `agor version` now target the local deployment by default, retain `--local` as a compatibility alias, and use the connected deployment only with `--remote`. ([#2464](https://github.com/preset-io/agor/issues/2464))
+- **Local CLI inspection no longer requires login** — `agor open` and `agor version` now target the local deployment by default, retain `--local` as a compatibility alias, and use the connected deployment only with `--remote`. ([#2468](https://github.com/preset-io/agor/pull/2468))
 
 ## 0.25.2 (2026-08-18)
 

--- a/apps/agor-cli/src/commands/open.test.ts
+++ b/apps/agor-cli/src/commands/open.test.ts
@@ -1,0 +1,205 @@
+import { spawn } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const cliRoot = resolve(import.meta.dirname, '../..');
+const localDeploymentId = '019c1234-5678-7123-8123-123456789abc';
+const remoteDeploymentId = '019c9876-5432-7123-8123-123456789abc';
+const homes: string[] = [];
+const servers: Server[] = [];
+
+interface CliResult {
+  code: number | null;
+  output: string;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolveClose) => server.close(() => resolveClose())))
+  );
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe('open command deployment selection', () => {
+  it('uses local by default and with --local, and uses the login target with --remote', async () => {
+    const local = await startDaemon(localDeploymentId);
+    const remote = await startDaemon(remoteDeploymentId);
+    const home = await createHome();
+    await writeLocalConfig(home, local.port, localDeploymentId);
+    await writeLogin(home, remote.url, remoteDeploymentId);
+    const openedUrlFile = await installFakeBrowserOpener(home);
+
+    for (const args of [['open'], ['open', '--local']]) {
+      await rm(openedUrlFile, { force: true });
+      const result = await runCli(home, args, openedUrlFile);
+      expect(result.code).toBe(0);
+      expect(result.output).toContain('URL: http://localhost:5173');
+      await expect(readFile(openedUrlFile, 'utf8')).resolves.toBe('http://localhost:5173');
+    }
+
+    await rm(openedUrlFile, { force: true });
+    const remoteResult = await runCli(home, ['open', '--remote'], openedUrlFile);
+    expect(remoteResult.code).toBe(0);
+    expect(remoteResult.output).toContain(`URL: ${remote.url}/ui`);
+    await expect(readFile(openedUrlFile, 'utf8')).resolves.toBe(`${remote.url}/ui`);
+  }, 30_000);
+
+  it('requires a connected target only when --remote is explicit', async () => {
+    const local = await startDaemon(localDeploymentId);
+    const home = await createHome();
+    await writeLocalConfig(home, local.port, localDeploymentId);
+    const openedUrlFile = await installFakeBrowserOpener(home);
+
+    const localResult = await runCli(home, ['open'], openedUrlFile);
+    expect(localResult.code).toBe(0);
+
+    const remoteResult = await runCli(home, ['open', '--remote'], openedUrlFile);
+    expect(remoteResult.code).not.toBe(0);
+    expect(remoteResult.output).toContain('Not connected. Run agor login --url <daemon-url>.');
+  }, 20_000);
+
+  it('identifies an unreachable default target as local', async () => {
+    const local = await startDaemon(localDeploymentId);
+    const home = await createHome();
+    await writeLocalConfig(home, local.port, localDeploymentId);
+    const openedUrlFile = await installFakeBrowserOpener(home);
+    await local.close();
+
+    const result = await runCli(home, ['open'], openedUrlFile);
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toContain('Local daemon is not reachable');
+    expect(result.output).not.toContain('Connected daemon is not reachable');
+  }, 10_000);
+
+  it('does not fall back to a stored login when local config is missing or invalid', async () => {
+    const remote = await startDaemon(remoteDeploymentId);
+    const missingHome = await createHome();
+    await writeLogin(missingHome, remote.url, remoteDeploymentId);
+    const missingOpenedUrlFile = await installFakeBrowserOpener(missingHome);
+
+    const missingResult = await runCli(missingHome, ['open'], missingOpenedUrlFile);
+    expect(missingResult.code).not.toBe(0);
+    expect(missingResult.output).toContain('No local config found');
+    expect(missingResult.output).toContain('Run agor init.');
+
+    const invalidHome = await createHome();
+    await writeLogin(invalidHome, remote.url, remoteDeploymentId);
+    await mkdir(join(invalidHome, '.agor'), { recursive: true });
+    await writeFile(join(invalidHome, '.agor', 'config.yaml'), 'daemon: [invalid yaml');
+    const invalidOpenedUrlFile = await installFakeBrowserOpener(invalidHome);
+
+    const invalidResult = await runCli(invalidHome, ['open'], invalidOpenedUrlFile);
+    expect(invalidResult.code).not.toBe(0);
+    expect(invalidResult.output).toContain('Failed to load config');
+  }, 20_000);
+
+  it('rejects conflicting local and remote flags', async () => {
+    const home = await createHome();
+    const openedUrlFile = await installFakeBrowserOpener(home);
+
+    const result = await runCli(home, ['open', '--local', '--remote'], openedUrlFile);
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toMatch(/--local.*--remote|--remote.*--local/);
+  }, 10_000);
+});
+
+async function createHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agor-open-'));
+  homes.push(home);
+  return home;
+}
+
+async function installFakeBrowserOpener(home: string): Promise<string> {
+  const bin = join(home, 'bin');
+  const openedUrlFile = join(home, 'opened-url');
+  await mkdir(bin, { recursive: true });
+  const script = '#!/bin/sh\nprintf %s "$1" > "$AGOR_TEST_OPEN_FILE"\n';
+  for (const command of ['open', 'xdg-open']) {
+    const path = join(bin, command);
+    await writeFile(path, script);
+    await chmod(path, 0o755);
+  }
+  return openedUrlFile;
+}
+
+async function runCli(home: string, args: string[], openedUrlFile: string): Promise<CliResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    AGOR_TEST_OPEN_FILE: openedUrlFile,
+    HOME: home,
+    NO_COLOR: '1',
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --conditions=source`.trim(),
+    PATH: `${join(home, 'bin')}${delimiter}${process.env.PATH ?? ''}`,
+  };
+  delete env.AGOR_API_KEY;
+  delete env.AGOR_DEPLOYMENT_ID;
+  delete env.AGOR_OUTER_SANDBOX;
+  delete env.DAEMON_URL;
+  delete env.PORT;
+
+  return new Promise<CliResult>((resolveRun, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', 'bin/dev.ts', ...args], {
+      cwd: cliRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += String(chunk)));
+    child.stderr.on('data', (chunk) => (output += String(chunk)));
+    child.once('error', reject);
+    child.once('close', (code) => resolveRun({ code, output }));
+  });
+}
+
+async function startDaemon(
+  deploymentId: string
+): Promise<{ close: () => Promise<void>; port: number; url: string }> {
+  const server = createServer((_request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify({ service: 'agor-daemon', deploymentId }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Test server did not bind');
+  return {
+    close: async () => {
+      const index = servers.indexOf(server);
+      if (index >= 0) servers.splice(index, 1);
+      await new Promise<void>((resolveClose, rejectClose) =>
+        server.close((error) => (error ? rejectClose(error) : resolveClose()))
+      );
+    },
+    port: address.port,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function writeLocalConfig(home: string, port: number, deploymentId: string): Promise<void> {
+  await mkdir(join(home, '.agor'), { recursive: true });
+  await writeFile(
+    join(home, '.agor', 'config.yaml'),
+    `daemon:\n  host: 127.0.0.1\n  port: ${port}\n  deployment_id: ${deploymentId}\n`
+  );
+}
+
+async function writeLogin(home: string, url: string, deploymentId: string): Promise<void> {
+  await mkdir(join(home, '.agor'), { recursive: true });
+  await writeFile(
+    join(home, '.agor', 'cli-token'),
+    JSON.stringify({
+      version: 2,
+      target: { url, origin: new URL(url).origin, deploymentId },
+      accessToken: 'test-token',
+      user: { user_id: 'user-1', email: 'test@example.com', role: 'admin' },
+      expiresAt: Date.now() + 60_000,
+    })
+  );
+}

--- a/apps/agor-cli/src/commands/open.ts
+++ b/apps/agor-cli/src/commands/open.ts
@@ -16,28 +16,45 @@ import {
 const execAsync = promisify(exec);
 
 export default class Open extends Command {
-  static description = 'Open the connected deployment in a browser';
+  static description = 'Open the local deployment in a browser';
 
-  static examples = ['<%= config.bin %> <%= command.id %>'];
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --remote',
+  ];
 
   static flags = {
-    local: Flags.boolean({ description: 'Open the locally configured deployment', default: false }),
+    local: Flags.boolean({
+      description: 'Open the locally configured deployment (default)',
+      default: false,
+      exclusive: ['remote'],
+    }),
+    remote: Flags.boolean({
+      description: 'Open the connected remote deployment',
+      default: false,
+      exclusive: ['local'],
+    }),
   };
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Open);
-    const target = flags.local
-      ? await resolveLocalDeploymentTarget()
-      : await resolveConnectedDeploymentTarget();
+    const target = flags.remote
+      ? await resolveConnectedDeploymentTarget()
+      : await resolveLocalDeploymentTarget();
     if (!target) {
       this.error('Not connected. Run agor login --url <daemon-url>.');
     }
+    const isLocalTarget = target.source === 'local';
     const daemonUrl = target.url;
 
     const probe = await probeAgorDaemon(daemonUrl);
 
     if (!probe.running) {
-      this.log(chalk.red('✗ Connected daemon is not reachable'));
+      this.log(
+        chalk.red(
+          isLocalTarget ? '✗ Local daemon is not reachable' : '✗ Connected daemon is not reachable'
+        )
+      );
       this.log('');
       this.log(`Target: ${chalk.cyan(daemonUrl)}`);
       this.log('');
@@ -45,13 +62,13 @@ export default class Open extends Command {
     }
     if (probe.deploymentId !== target.deploymentId) {
       this.error(
-        flags.local
+        isLocalTarget
           ? `The local daemon identity at ${daemonUrl} does not match config.yaml.`
           : `The daemon identity at ${daemonUrl} changed. Run agor login --url ${daemonUrl} again.`
       );
     }
 
-    let localDevelopmentTarget = flags.local;
+    let localDevelopmentTarget = isLocalTarget;
     if (!localDevelopmentTarget) {
       try {
         const localTarget = await resolveLocalDeploymentTarget();

--- a/apps/agor-cli/src/commands/version.test.ts
+++ b/apps/agor-cli/src/commands/version.test.ts
@@ -1,0 +1,163 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const cliRoot = resolve(import.meta.dirname, '../..');
+const localDeploymentId = '019c1234-5678-7123-8123-123456789abc';
+const remoteDeploymentId = '019c9876-5432-7123-8123-123456789abc';
+const homes: string[] = [];
+const servers: Server[] = [];
+
+interface CliResult {
+  code: number | null;
+  output: string;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolveClose) => server.close(() => resolveClose())))
+  );
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe('version command deployment selection', () => {
+  it('uses local by default and with --local, and uses the login target with --remote', async () => {
+    const local = await startDaemon(localDeploymentId, 'local-version');
+    const remote = await startDaemon(remoteDeploymentId, 'remote-version');
+    const home = await createHome();
+    await writeLocalConfig(home, local.port, localDeploymentId);
+    await writeLogin(home, remote.url, remoteDeploymentId);
+
+    for (const args of [['version'], ['version', '--local']]) {
+      const result = await runCli(home, args);
+      expect(result.code).toBe(0);
+      expect(result.output).toContain('Daemon: local-version');
+      expect(result.output).toContain(`deployment: ${localDeploymentId}`);
+      expect(result.output).not.toContain('remote-version');
+    }
+
+    const remoteResult = await runCli(home, ['version', '--remote']);
+    expect(remoteResult.code).toBe(0);
+    expect(remoteResult.output).toContain('Daemon: remote-version');
+    expect(remoteResult.output).toContain(`deployment: ${remoteDeploymentId}`);
+  }, 30_000);
+
+  it('requires a connected target only when --remote is explicit', async () => {
+    const local = await startDaemon(localDeploymentId, 'local-version');
+    const home = await createHome();
+    await writeLocalConfig(home, local.port, localDeploymentId);
+
+    const localResult = await runCli(home, ['version']);
+    expect(localResult.code).toBe(0);
+
+    const remoteResult = await runCli(home, ['version', '--remote']);
+    expect(remoteResult.code).not.toBe(0);
+    expect(remoteResult.output).toContain('Not connected. Run agor login --url <daemon-url>.');
+  }, 20_000);
+
+  it('does not fall back to a stored login when local config is missing or invalid', async () => {
+    const remote = await startDaemon(remoteDeploymentId, 'remote-version');
+    const missingHome = await createHome();
+    await writeLogin(missingHome, remote.url, remoteDeploymentId);
+
+    const missingResult = await runCli(missingHome, ['version']);
+    expect(missingResult.code).not.toBe(0);
+    expect(missingResult.output).toContain('No local config found');
+    expect(missingResult.output).toContain('Run agor init.');
+    expect(missingResult.output).not.toContain('remote-version');
+
+    const invalidHome = await createHome();
+    await writeLogin(invalidHome, remote.url, remoteDeploymentId);
+    await mkdir(join(invalidHome, '.agor'), { recursive: true });
+    await writeFile(join(invalidHome, '.agor', 'config.yaml'), 'daemon: [invalid yaml');
+
+    const invalidResult = await runCli(invalidHome, ['version']);
+    expect(invalidResult.code).not.toBe(0);
+    expect(invalidResult.output).toContain('Failed to load config');
+    expect(invalidResult.output).not.toContain('remote-version');
+  }, 20_000);
+
+  it('rejects conflicting local and remote flags', async () => {
+    const home = await createHome();
+
+    const result = await runCli(home, ['version', '--local', '--remote']);
+
+    expect(result.code).not.toBe(0);
+    expect(result.output).toMatch(/--local.*--remote|--remote.*--local/);
+  }, 10_000);
+});
+
+async function createHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'agor-version-'));
+  homes.push(home);
+  return home;
+}
+
+async function runCli(home: string, args: string[]): Promise<CliResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    NO_COLOR: '1',
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --conditions=source`.trim(),
+  };
+  delete env.AGOR_API_KEY;
+  delete env.AGOR_DEPLOYMENT_ID;
+  delete env.AGOR_OUTER_SANDBOX;
+  delete env.DAEMON_URL;
+  delete env.PORT;
+
+  return new Promise<CliResult>((resolveRun, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', 'bin/dev.ts', ...args], {
+      cwd: cliRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += String(chunk)));
+    child.stderr.on('data', (chunk) => (output += String(chunk)));
+    child.once('error', reject);
+    child.once('close', (code) => resolveRun({ code, output }));
+  });
+}
+
+async function startDaemon(
+  deploymentId: string,
+  version: string
+): Promise<{ port: number; url: string }> {
+  const server = createServer((_request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify({ service: 'agor-daemon', deploymentId, version }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Test server did not bind');
+  return { port: address.port, url: `http://127.0.0.1:${address.port}` };
+}
+
+async function writeLocalConfig(home: string, port: number, deploymentId: string): Promise<void> {
+  await mkdir(join(home, '.agor'), { recursive: true });
+  await writeFile(
+    join(home, '.agor', 'config.yaml'),
+    `daemon:\n  host: 127.0.0.1\n  port: ${port}\n  deployment_id: ${deploymentId}\n`
+  );
+}
+
+async function writeLogin(home: string, url: string, deploymentId: string): Promise<void> {
+  await mkdir(join(home, '.agor'), { recursive: true });
+  await writeFile(
+    join(home, '.agor', 'cli-token'),
+    JSON.stringify({
+      version: 2,
+      target: { url, origin: new URL(url).origin, deploymentId },
+      accessToken: 'test-token',
+      user: { user_id: 'user-1', email: 'test@example.com', role: 'admin' },
+      expiresAt: Date.now() + 60_000,
+    })
+  );
+}

--- a/apps/agor-cli/src/commands/version.ts
+++ b/apps/agor-cli/src/commands/version.ts
@@ -15,31 +15,41 @@ interface HealthBuildInfo {
 }
 
 export default class Version extends Command {
-  static description = 'Show the connected daemon version';
+  static description = 'Show the local daemon version';
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> --local',
+    '<%= config.bin %> <%= command.id %> --remote',
   ];
 
   static flags = {
-    local: Flags.boolean({ description: 'Inspect the locally configured daemon', default: false }),
+    local: Flags.boolean({
+      description: 'Inspect the locally configured daemon (default)',
+      default: false,
+      exclusive: ['remote'],
+    }),
+    remote: Flags.boolean({
+      description: 'Inspect the connected remote daemon',
+      default: false,
+      exclusive: ['local'],
+    }),
   };
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Version);
-    const target = flags.local
-      ? await resolveLocalDeploymentTarget()
-      : await resolveConnectedDeploymentTarget();
+    const target = flags.remote
+      ? await resolveConnectedDeploymentTarget()
+      : await resolveLocalDeploymentTarget();
     if (!target) {
       this.error('Not connected. Run agor login --url <daemon-url>.');
     }
+    const isLocalTarget = target.source === 'local';
 
     const info = await fetchHealth(target.url);
     if (!info) this.error(`The daemon at ${target.url} is not reachable.`);
     if (info.deploymentId !== target.deploymentId) {
       this.error(
-        flags.local
+        isLocalTarget
           ? `The local daemon identity at ${target.url} does not match config.yaml.`
           : `The daemon identity at ${target.url} changed. Run agor login --url ${target.url} again.`
       );

--- a/apps/agor-cli/src/dev-entrypoint.test.ts
+++ b/apps/agor-cli/src/dev-entrypoint.test.ts
@@ -55,7 +55,7 @@ describe('CLI development entrypoint', () => {
     };
     delete env.AGOR_OUTER_SANDBOX;
     try {
-      const { stderr, stdout } = await execFileAsync('pnpm', ['dev', 'version'], {
+      const { stderr, stdout } = await execFileAsync('pnpm', ['dev', 'version', '--remote'], {
         cwd: new URL('..', import.meta.url),
         env,
         timeout: 30_000,
@@ -86,7 +86,8 @@ describe('CLI development entrypoint', () => {
       expect(stdout).toContain('LOCAL DEPLOYMENT');
       expect(stdout).toContain('CONNECTED DEPLOYMENT');
       expect(stdout).toContain('Show the effective local deployment configuration');
-      expect(stdout).toContain('Show the connected daemon version');
+      expect(stdout).toContain('Open the local deployment');
+      expect(stdout).toContain('Show the local daemon version');
       expect(stdout).not.toContain('Permanently delete all data belonging to a single tenant');
       expect(stdout).not.toContain('TOPICS');
       expect(stdout).not.toContain('COMMANDS');

--- a/apps/agor-cli/src/lib/command-groups.ts
+++ b/apps/agor-cli/src/lib/command-groups.ts
@@ -67,14 +67,14 @@ export const ROOT_COMMANDS = [
   },
   {
     name: 'open',
-    description: 'Open the connected deployment',
-    group: 'connected',
+    description: 'Open the local deployment',
+    group: 'local',
     policy: 'connection',
   },
   {
     name: 'version',
-    description: 'Show the connected daemon version',
-    group: 'connected',
+    description: 'Show the local daemon version',
+    group: 'local',
     policy: 'connection',
   },
   { name: 'board', description: 'Manage boards', group: 'connected', policy: 'connection' },

--- a/apps/agor-cli/src/lib/deployment-target.test.ts
+++ b/apps/agor-cli/src/lib/deployment-target.test.ts
@@ -1,13 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('node:fs/promises', () => ({ access: vi.fn() }));
 vi.mock('./auth.js', () => ({ loadToken: vi.fn() }));
 vi.mock('@agor/core/config', () => ({
+  getConfigPath: vi.fn(() => '/home/test/.agor/config.yaml'),
   loadConfig: vi.fn(),
   requireDeploymentId: vi.fn(),
   resolveDaemonUrl: vi.fn(),
 }));
 
-import { loadConfig, requireDeploymentId, resolveDaemonUrl } from '@agor/core/config';
+import { access } from 'node:fs/promises';
+import {
+  getConfigPath,
+  loadConfig,
+  requireDeploymentId,
+  resolveDaemonUrl,
+} from '@agor/core/config';
 import { loadToken } from './auth.js';
 import {
   resolveConnectedDeploymentTarget,
@@ -22,6 +30,7 @@ describe('deployment target resolution', () => {
     vi.stubEnv('AGOR_API_KEY', '');
     vi.stubEnv('AGOR_DEPLOYMENT_ID', '');
     vi.stubEnv('DAEMON_URL', '');
+    vi.mocked(access).mockResolvedValue(undefined);
   });
 
   afterEach(() => vi.unstubAllEnvs());
@@ -79,5 +88,30 @@ describe('deployment target resolution', () => {
     });
     expect(resolveDaemonUrl).toHaveBeenCalledWith(config);
     expect(requireDeploymentId).toHaveBeenCalledWith(config);
+  });
+
+  it('reports a missing local config without loading defaults', async () => {
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+
+    await expect(resolveLocalDeploymentTarget()).rejects.toThrow(
+      'No local config found at /home/test/.agor/config.yaml. Run agor init.'
+    );
+    expect(getConfigPath).toHaveBeenCalled();
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  it('preserves invalid local config errors', async () => {
+    vi.mocked(loadConfig).mockRejectedValue(new Error('Config error: invalid YAML'));
+
+    await expect(resolveLocalDeploymentTarget()).rejects.toThrow('Config error: invalid YAML');
+  });
+
+  it('preserves non-missing config access errors', async () => {
+    vi.mocked(access).mockRejectedValue(
+      Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    );
+
+    await expect(resolveLocalDeploymentTarget()).rejects.toThrow('permission denied');
+    expect(loadConfig).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-cli/src/lib/deployment-target.ts
+++ b/apps/agor-cli/src/lib/deployment-target.ts
@@ -1,4 +1,10 @@
-import { loadConfig, requireDeploymentId, resolveDaemonUrl } from '@agor/core/config';
+import { access } from 'node:fs/promises';
+import {
+  getConfigPath,
+  loadConfig,
+  requireDeploymentId,
+  resolveDaemonUrl,
+} from '@agor/core/config';
 import { normalizeHttpBaseUrl } from '@agor/core/utils/url';
 import { getApiKeyFromEnv } from '@agor-live/client';
 import { loadToken } from './auth.js';
@@ -31,6 +37,16 @@ export async function resolveConnectedDeploymentTarget(): Promise<DeploymentTarg
 
 /** Resolve the daemon owned by this host's effective local configuration. */
 export async function resolveLocalDeploymentTarget(): Promise<DeploymentTarget> {
+  const configPath = getConfigPath();
+  try {
+    await access(configPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`No local config found at ${configPath}. Run agor init.`);
+    }
+    throw error;
+  }
+
   const config = await loadConfig();
   return {
     url: resolveDaemonUrl(config),

--- a/apps/agor-cli/src/lib/execution-policy.test.ts
+++ b/apps/agor-cli/src/lib/execution-policy.test.ts
@@ -12,9 +12,11 @@ describe('executionPolicyFor', () => {
     ['db:migrate', 'local'],
     ['local:add-repo', 'local'],
     ['local:create-admin', 'local'],
+    ['open', 'connection'],
     ['repo:list', 'connection'],
     ['session:list', 'connection'],
     ['user:list', 'connection'],
+    ['version', 'connection'],
   ] as const)('classifies %s as %s', (command, policy) => {
     expect(executionPolicyFor(command)).toBe(policy);
   });
@@ -88,6 +90,14 @@ describe('executionPolicyFor', () => {
     const connectedNames = new Set<string>(connected);
     expect(local.filter((name) => connectedNames.has(name))).toEqual([]);
     expect([...new Set([...local, ...connected])].sort()).toEqual([...discoveredRoots].sort());
+  });
+
+  it('presents local-first target selectors with local deployment commands', () => {
+    const local = LOCAL_DEPLOYMENT_COMMANDS.map(({ name }) => name);
+    const connected = CONNECTED_DEPLOYMENT_COMMANDS.map(({ name }) => name);
+
+    expect(local).toEqual(expect.arrayContaining(['open', 'version']));
+    expect(connected).not.toEqual(expect.arrayContaining(['open', 'version']));
   });
 
   it('does not mix local deployment state with daemon-client access', () => {


### PR DESCRIPTION
## Linked issue

Fixes #2464

## Summary

- Make `agor open` and `agor version` target the local deployment by default.
- Add explicit `--remote` selection while retaining `--local` as a compatibility alias.
- Move both commands into the Local Deployment help group and add subprocess coverage for target selection and failures.

## Why / context

The remote-first behavior made local inspection require login even when the user only wanted their local deployment. Follow-up product discussion supersedes the issue's initial fallback proposal: selection is now deterministic, with bare commands targeting local and `--remote` targeting the authenticated connection. Neither path silently falls back to the other.

## Implementation notes

- `--local` and `--remote` are mutually exclusive.
- Missing local configuration now reports the config path and suggests `agor init`; invalid configuration errors remain unchanged.
- Presentation moves to the local group, while execution policy remains `connection` so an explicit `--remote` is not blocked by local deployment-mismatch guards.
- `open` uses the selected target source for local/connected identity and reachability messages.

## Validation / test plan

- [x] `pnpm --filter @agor/cli typecheck`
- [x] 37 focused tests covering `open`, `version`, target resolution, execution policy, and the development entrypoint
- [x] 137 tests across the remaining 25 CLI test files
- [x] Biome checks and `git diff --check`
- [ ] Full CLI suite in this workspace: the unrelated `init` subprocess tests detect the active Agor daemon on `localhost:3030` and stop before their fixture assertions

## Risks / rollout / rollback

This intentionally changes the default target for two read-only commands. Existing explicit `--local` usage remains valid, and remote use becomes explicit through `--remote`. Reverting the commit restores the previous selection behavior.

## Out of scope / follow-ups

- No changes to login, deployment identity, authentication storage, or other local/remote commands.
- Windows and packaged-bundle browser opening are unchanged; new opener subprocess coverage runs in POSIX source mode.
