### PR TITLE
fix(daemon): preserve tenant scope through HA task Stop

### DIFF
--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import {
   createTenantScopedDatabaseProxy,
   MissingTenantDatabaseScopeError,
@@ -8,6 +9,20 @@ import { createRequiredTenantDatabaseRunner } from './register-routes.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 
 describe('Stop route transaction scope', () => {
+  it('wires short tenant DB units and session-level RBAC through every Stop path', () => {
+    const source = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
+    const stop = source.slice(
+      source.indexOf('// Stop endpoint'),
+      source.indexOf('// Queue listing', source.indexOf('// Stop endpoint'))
+    );
+
+    expect(stop).toContain('resolveSessionPromptAccess({');
+    expect(stop).toContain('withTenantDatabase: inCurrentTenantDatabaseScope');
+    expect(stop).toMatch(
+      /const failedTask = await inCurrentTenantDatabaseScope\(\(\) =>\s+forceFailUnverifiedTask\(\{/
+    );
+  });
+
   it('production-injected long-route runner activates the guarded tenant unit', async () => {
     const rawDb = {
       transaction: async (work: (tx: unknown) => Promise<unknown>) =>

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -17,9 +17,12 @@ describe('Stop route transaction scope', () => {
     );
 
     expect(stop).toContain('resolveSessionPromptAccess({');
-    expect(stop).toContain('withTenantDatabase: inCurrentTenantDatabaseScope');
+    expect(stop).toContain('body.force_unverified !== true');
+    expect(stop).toContain(
+      'runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase'
+    );
     expect(stop).toMatch(
-      /const failedTask = await inCurrentTenantDatabaseScope\(\(\) =>\s+forceFailUnverifiedTask\(\{/
+      /const failedTask = await runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+forceFailUnverifiedTask\(\{/
     );
   });
 

--- a/apps/agor-daemon/src/register-routes.task-terminal.test.ts
+++ b/apps/agor-daemon/src/register-routes.task-terminal.test.ts
@@ -116,6 +116,20 @@ describe('force-fail route authorization and request fencing', () => {
     expect(findTask).not.toHaveBeenCalled();
   });
 
+  it('authorizes an administrator without requiring branch ownership', async () => {
+    const isBranchOwner = vi.fn().mockResolvedValue(false);
+    await expect(
+      authorizeForceFailRoute({
+        session: { session_id: 'session-a' as never, branch_id: 'branch-a' as never },
+        params: { user: { user_id: 'admin-a', role: 'admin' } } as never,
+        body,
+        findTask: async () => stopping,
+        isBranchOwner,
+      })
+    ).resolves.toMatchObject({ task: stopping });
+    expect(isBranchOwner).not.toHaveBeenCalled();
+  });
+
   it('rejects a stale Task epoch instead of selecting a later unverified Task', async () => {
     const later = {
       ...stopping,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -179,6 +179,7 @@ import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import { isAgenticToolEnabledForTenant } from './utils/tenant-agentic-tool-validation.js';
 import {
+  createFreshTenantWriteDatabaseRunner,
   createTenantDatabaseScopeAroundHook,
   deferWithTenantContext,
 } from './utils/tenant-db-scope.js';
@@ -2696,6 +2697,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!id) throw new Error('Session ID required');
         const body = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
         const sessionsServiceWithHooks = app.service('sessions') as unknown as SessionsServiceImpl;
+        const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
+          db,
+          getCurrentTenantId()
+        );
         const session = await inCurrentTenantDatabaseScope(() =>
           app.service('sessions').get(id, params)
         );
@@ -2703,8 +2708,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // Stop is process control and must use the same authorization policy as
         // prompting the target session. A session-tier collaborator may view a
         // teammate's session but must not stop an executor running with that
-        // teammate's identity and credentials.
+        // teammate's identity and credentials. Force-fail deliberately skips
+        // this check and applies its narrower owner-or-admin policy below.
         if (
+          body.force_unverified !== true &&
           branchRbacEnabled &&
           params.provider &&
           !(params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount
@@ -2781,7 +2788,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                   stopRouteRepositories.branchRepo.isOwner(branchId, userId),
               });
             });
-            const failedTask = await inCurrentTenantDatabaseScope(() =>
+            const failedTask = await runInFreshTerminationTenantWriteDatabase(() =>
               forceFailUnverifiedTask({
                 app,
                 taskId: target.task.task_id,
@@ -2811,7 +2818,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 inCurrentTenantDatabaseScope(() =>
                   findActiveTasksForSession(stopApp, sessionId, stopParams)
                 ),
-              withTenantDatabase: inCurrentTenantDatabaseScope,
+              runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase,
             },
             id as SessionID,
             params,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2696,6 +2696,59 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!id) throw new Error('Session ID required');
         const body = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
         const sessionsServiceWithHooks = app.service('sessions') as unknown as SessionsServiceImpl;
+        const session = await inCurrentTenantDatabaseScope(() =>
+          app.service('sessions').get(id, params)
+        );
+
+        // Stop is process control and must use the same authorization policy as
+        // prompting the target session. A session-tier collaborator may view a
+        // teammate's session but must not stop an executor running with that
+        // teammate's identity and credentials.
+        if (
+          branchRbacEnabled &&
+          params.provider &&
+          !(params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount
+        ) {
+          const stopUserId = params.user?.user_id as UUID | undefined;
+          if (!stopUserId) {
+            throw new NotAuthenticated('Authentication required to stop a session');
+          }
+          if (!session.branch_id) {
+            throw new Forbidden('Not authorized to stop this session');
+          }
+          const access = await inCurrentTenantDatabaseScope(async () => {
+            const branch = await branchRepository.findById(session.branch_id);
+            if (!branch) return null;
+            const isOwner = await branchRepository.isOwner(branch.branch_id, stopUserId);
+            const branchPermission = await branchRepository.resolveUserPermission(
+              branch,
+              stopUserId
+            );
+            return { branch, branchPermission, isOwner };
+          });
+          if (!access) {
+            throw new NotFound(`Branch ${session.branch_id} not found`);
+          }
+          const { allowed, effectiveLevel } = resolveSessionPromptAccess({
+            branch: access.branch,
+            session,
+            userId: stopUserId,
+            isOwner: access.isOwner,
+            userRole: params.user?.role,
+            allowSuperadmin: superadminOpts.allowSuperadmin,
+            branchPermission: access.branchPermission,
+          });
+          if (!allowed) {
+            throw new Forbidden(
+              effectiveLevel === 'session'
+                ? `You have 'session' permission — you can only stop sessions you created. ` +
+                    `This session was created by another user. Ask a branch owner to upgrade ` +
+                    `your access to 'prompt' if you need to stop other users' sessions.`
+                : `You need 'prompt' permission to stop this session. You have ` +
+                    `'${effectiveLevel}' permission.`
+            );
+          }
+        }
         const triggerPreservedQueue = () => {
           deferInFreshTenantScope(params, async () => {
             try {
@@ -2728,13 +2781,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                   stopRouteRepositories.branchRepo.isOwner(branchId, userId),
               });
             });
-            const failedTask = await forceFailUnverifiedTask({
-              app,
-              taskId: target.task.task_id,
-              terminationRequestedAt: target.terminationRequestedAt,
-              confirmation: target.confirmation,
-              params,
-            });
+            const failedTask = await inCurrentTenantDatabaseScope(() =>
+              forceFailUnverifiedTask({
+                app,
+                taskId: target.task.task_id,
+                terminationRequestedAt: target.terminationRequestedAt,
+                confirmation: target.confirmation,
+                params,
+              })
+            );
             return {
               success: true,
               status: failedTask.status,
@@ -2756,6 +2811,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 inCurrentTenantDatabaseScope(() =>
                   findActiveTasksForSession(stopApp, sessionId, stopParams)
                 ),
+              withTenantDatabase: inCurrentTenantDatabaseScope,
             },
             id as SessionID,
             params,

--- a/apps/agor-daemon/src/register-services.executor-exit-scope.test.ts
+++ b/apps/agor-daemon/src/register-services.executor-exit-scope.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('executor exit termination tenant scope', () => {
+  it('gives launcher-exit durable operations fresh tenant database units', () => {
+    const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
+    const executor = source.slice(
+      source.indexOf('const withTerminationTenantDatabase'),
+      source.indexOf('if (openCodeLaunch)', source.indexOf('const withTerminationTenantDatabase'))
+    );
+
+    expect(executor).toContain('withTenantDatabase: withTerminationTenantDatabase');
+    expect(executor).toMatch(
+      /withTerminationTenantDatabase\(\(\) =>\s+\(\s+app\.service\('tasks'\)/
+    );
+  });
+});

--- a/apps/agor-daemon/src/register-services.executor-exit-scope.test.ts
+++ b/apps/agor-daemon/src/register-services.executor-exit-scope.test.ts
@@ -5,13 +5,18 @@ describe('executor exit termination tenant scope', () => {
   it('gives launcher-exit durable operations fresh tenant database units', () => {
     const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
     const executor = source.slice(
-      source.indexOf('const withTerminationTenantDatabase'),
-      source.indexOf('if (openCodeLaunch)', source.indexOf('const withTerminationTenantDatabase'))
+      source.indexOf('const runInFreshTerminationTenantWriteDatabase'),
+      source.indexOf(
+        'if (openCodeLaunch)',
+        source.indexOf('const runInFreshTerminationTenantWriteDatabase')
+      )
     );
 
-    expect(executor).toContain('withTenantDatabase: withTerminationTenantDatabase');
+    expect(executor).toContain(
+      'runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase'
+    );
     expect(executor).toMatch(
-      /withTerminationTenantDatabase\(\(\) =>\s+\(\s+app\.service\('tasks'\)/
+      /runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+\(\s+app\.service\('tasks'\)/
     );
   });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -205,6 +205,7 @@ import {
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
 import { type SpawnExecutorOptions, spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
+import { createFreshTenantWriteDatabaseRunner } from './utils/tenant-db-scope.js';
 
 /**
  * Interface for dependencies needed by service registration.
@@ -973,8 +974,10 @@ function createExecuteHandler(
     );
 
     const taskId = data.taskId;
-    const withTerminationTenantDatabase = <T>(work: () => Promise<T>): Promise<T> =>
-      runWithTenantDatabaseScope(db, tenantId, () => work());
+    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
+      db,
+      tenantId
+    );
 
     // Get branch path (+ authoritative base repo path for the sandbox) and, for
     // RBAC-aware mounting, the session OWNER's effective filesystem access to
@@ -1274,7 +1277,7 @@ function createExecuteHandler(
           if (disposition !== 'authoritative') {
             if (disposition === 'ambiguous') {
               try {
-                await withTerminationTenantDatabase(() =>
+                await runInFreshTerminationTenantWriteDatabase(() =>
                   (
                     app.service('tasks') as unknown as TasksServiceImpl
                   ).recordExecutorStartupWarning(
@@ -1313,7 +1316,7 @@ function createExecuteHandler(
               tool: session.agentic_tool,
               termination: 'requested',
             },
-            withTenantDatabase: withTerminationTenantDatabase,
+            runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase,
             // A remote executor may connect while its launcher is exiting.
             // Resolve that race only at the row-locked claim.
             ...(spawnContext.mode === 'templated'

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -973,6 +973,8 @@ function createExecuteHandler(
     );
 
     const taskId = data.taskId;
+    const withTerminationTenantDatabase = <T>(work: () => Promise<T>): Promise<T> =>
+      runWithTenantDatabaseScope(db, tenantId, () => work());
 
     // Get branch path (+ authoritative base repo path for the sandbox) and, for
     // RBAC-aware mounting, the session OWNER's effective filesystem access to
@@ -1272,12 +1274,14 @@ function createExecuteHandler(
           if (disposition !== 'authoritative') {
             if (disposition === 'ambiguous') {
               try {
-                await (
-                  app.service('tasks') as unknown as TasksServiceImpl
-                ).recordExecutorStartupWarning(
-                  taskId,
-                  `Executor launcher exited with code ${code ?? 'unknown'}, but configuration says remote work may have been dispatched.`,
-                  { ...params, provider: undefined }
+                await withTerminationTenantDatabase(() =>
+                  (
+                    app.service('tasks') as unknown as TasksServiceImpl
+                  ).recordExecutorStartupWarning(
+                    taskId,
+                    `Executor launcher exited with code ${code ?? 'unknown'}, but configuration says remote work may have been dispatched.`,
+                    { ...params, provider: undefined }
+                  )
                 );
               } catch (error) {
                 console.warn(`${logPrefix} Failed to record ambiguous launcher exit:`, error);
@@ -1309,6 +1313,7 @@ function createExecuteHandler(
               tool: session.agentic_tool,
               termination: 'requested',
             },
+            withTenantDatabase: withTerminationTenantDatabase,
             // A remote executor may connect while its launcher is exiting.
             // Resolve that race only at the row-locked claim.
             ...(spawnContext.mode === 'templated'

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.ts
@@ -6,7 +6,6 @@ import {
   jitterDelay,
 } from '@agor/core/coordination';
 import {
-  assertTenantWritable,
   runWithSystemDatabaseScope,
   runWithTenantContext,
   runWithTenantDatabaseScope,
@@ -20,6 +19,7 @@ import { TaskStatus } from '@agor/core/types';
 import type { Application, TasksServiceImpl } from '../declarations.js';
 import { getTrackedExecutor } from '../executor-tracking.js';
 import { requestExecutorTermination } from '../termination-coordinator.js';
+import { createFreshTenantWriteDatabaseRunner } from '../utils/tenant-db-scope.js';
 
 export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =
   'Executor heartbeat lost; the executor may have crashed or disconnected.';
@@ -213,7 +213,7 @@ export class TaskRuntimeReconciler {
     return runWithTenantContext(tenantId, async () => {
       const params = tenantParams(tenantId);
       const tasks = this.options.app.service('tasks') as unknown as TasksServiceImpl;
-      const task = await this.withTenantDatabase(tenantId, () =>
+      const task = await this.runInFreshTenantWriteDatabase(tenantId, () =>
         tasks.get(candidate.task_id, params)
       );
       switch (candidate.kind) {
@@ -227,11 +227,11 @@ export class TaskRuntimeReconciler {
     });
   }
 
-  private withTenantDatabase<T>(tenantId: TenantID | string, work: () => Promise<T>): Promise<T> {
-    return runWithTenantDatabaseScope(this.options.db, tenantId, async (scopedDb) => {
-      await assertTenantWritable(scopedDb, tenantId);
-      return work();
-    });
+  private runInFreshTenantWriteDatabase<T>(
+    tenantId: TenantID | string,
+    work: () => Promise<T>
+  ): Promise<T> {
+    return createFreshTenantWriteDatabaseRunner(this.options.db, tenantId)(work);
   }
 
   private async reconcileDispatchTimeout(
@@ -241,7 +241,7 @@ export class TaskRuntimeReconciler {
     if (task.status !== TaskStatus.DISPATCHING || task.executor_connected_at) return false;
     if (task.executor_mode === 'templated') {
       const tasks = this.options.app.service('tasks') as unknown as TasksServiceImpl;
-      const warned = await this.withTenantDatabase(params.tenant!.tenant_id, () =>
+      const warned = await this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, () =>
         tasks.recordExecutorStartupWarning(
           task.task_id,
           'Remote executor has not connected within the configured startup window; still waiting.',
@@ -250,7 +250,7 @@ export class TaskRuntimeReconciler {
       );
       return !!warned;
     }
-    const session = await this.withTenantDatabase(params.tenant!.tenant_id, () =>
+    const session = await this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, () =>
       this.options.app.service('sessions').get(task.session_id, params)
     );
     const result = await requestExecutorTermination({
@@ -267,7 +267,8 @@ export class TaskRuntimeReconciler {
         tool: session.agentic_tool,
         termination: 'requested',
       },
-      withTenantDatabase: (work) => this.withTenantDatabase(params.tenant!.tenant_id, work),
+      runInFreshTenantWriteDatabase: (work) =>
+        this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, work),
     });
     return result.status !== 'condition_changed';
   }
@@ -288,7 +289,7 @@ export class TaskRuntimeReconciler {
     // Discovery is routing-only. If a fresh heartbeat won before the tenant
     // reload, do not turn that new fact into a new stale-termination claim.
     if (task.last_executor_heartbeat_at !== candidate.executor_heartbeat_at) return false;
-    const session = await this.withTenantDatabase(params.tenant!.tenant_id, () =>
+    const session = await this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, () =>
       this.options.app.service('sessions').get(task.session_id, params)
     );
     const result = await requestExecutorTermination({
@@ -308,7 +309,8 @@ export class TaskRuntimeReconciler {
         last_pulse: task.latest_executor_pulse,
         termination: 'requested',
       },
-      withTenantDatabase: (work) => this.withTenantDatabase(params.tenant!.tenant_id, work),
+      runInFreshTenantWriteDatabase: (work) =>
+        this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, work),
     });
     return result.status !== 'condition_changed';
   }
@@ -338,7 +340,8 @@ export class TaskRuntimeReconciler {
           }
         : {}),
       sdkFailure: task.sdk_failure,
-      withTenantDatabase: (work) => this.withTenantDatabase(params.tenant!.tenant_id, work),
+      runInFreshTenantWriteDatabase: (work) =>
+        this.runInFreshTenantWriteDatabase(params.tenant!.tenant_id, work),
     });
     return result.status !== 'condition_changed';
   }

--- a/apps/agor-daemon/src/services/tasks.sdk-health.test.ts
+++ b/apps/agor-daemon/src/services/tasks.sdk-health.test.ts
@@ -2,7 +2,17 @@ import { type SdkFailure, TaskStatus } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const beginExecutorTermination = vi.hoisted(() => vi.fn());
+const withFreshTenantWriteDatabase = vi.hoisted(() =>
+  vi.fn(async (work: () => Promise<unknown>) => work())
+);
+const createFreshTenantWriteDatabaseRunner = vi.hoisted(() =>
+  vi.fn(() => withFreshTenantWriteDatabase)
+);
 vi.mock('../termination-coordinator.js', () => ({ beginExecutorTermination }));
+vi.mock('../utils/tenant-db-scope.js', () => ({
+  createFreshTenantWriteDatabaseRunner,
+  deferWithTenantContext: vi.fn(),
+}));
 
 import { TasksService } from './tasks.js';
 
@@ -28,6 +38,7 @@ function serviceFor(current = task, observationAccepted = true) {
       ),
     },
   });
+  Object.defineProperty(service, 'db', { value: {} });
   service.app = {
     get: () => ({ execution: { sdk_watchdog: { abort_grace_ms: 25 } } }),
     service: (name: string) => {
@@ -40,7 +51,11 @@ function serviceFor(current = task, observationAccepted = true) {
 }
 
 describe('TasksService SDK health reports', () => {
-  beforeEach(() => beginExecutorTermination.mockReset());
+  beforeEach(() => {
+    beginExecutorTermination.mockReset();
+    withFreshTenantWriteDatabase.mockClear();
+    createFreshTenantWriteDatabaseRunner.mockClear();
+  });
 
   it('persists observe-only evidence without lifecycle side effects', async () => {
     const service = serviceFor();
@@ -89,18 +104,23 @@ describe('TasksService SDK health reports', () => {
     const service = serviceFor(current);
     beginExecutorTermination.mockResolvedValue({ ...current, status: TaskStatus.STOPPING });
 
-    await service.reportSdkHealthFailure({
-      task_id: task.task_id,
-      reason: 'no_first_progress',
-      watchdog_action: 'enforced',
-    });
+    await service.reportSdkHealthFailure(
+      {
+        task_id: task.task_id,
+        reason: 'no_first_progress',
+        watchdog_action: 'enforced',
+      },
+      { tenant: { tenant_id: 'tenant-a' } } as never
+    );
 
+    expect(createFreshTenantWriteDatabaseRunner).toHaveBeenCalledWith({}, 'tenant-a');
     expect(beginExecutorTermination).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: task.task_id,
         cause: 'sdk_health_failure',
         signalDelayMs: 25,
         sdkFailure: expect.objectContaining({ termination: 'requested' }),
+        runInFreshTenantWriteDatabase: withFreshTenantWriteDatabase,
       })
     );
   });

--- a/apps/agor-daemon/src/services/tasks.termination-report.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-report.test.ts
@@ -3,6 +3,12 @@ import { TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 
 const requestExecutorTermination = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+const withFreshTenantWriteDatabase = vi.hoisted(() =>
+  vi.fn(async (work: () => Promise<unknown>) => work())
+);
+const createFreshTenantWriteDatabaseRunner = vi.hoisted(() =>
+  vi.fn(() => withFreshTenantWriteDatabase)
+);
 const deferred = vi.hoisted(
   () =>
     ({ work: undefined as (() => Promise<void>) | undefined, schedule: vi.fn() }) as {
@@ -15,6 +21,7 @@ vi.mock('../termination-coordinator.js', () => ({
   requestExecutorTermination,
 }));
 vi.mock('../utils/tenant-db-scope.js', () => ({
+  createFreshTenantWriteDatabaseRunner,
   deferWithTenantContext: (
     params: unknown,
     work: () => Promise<void>,
@@ -61,6 +68,8 @@ describe('TasksService executor termination report', () => {
       task_id: task.task_id,
       requested_at: requestedAt,
     });
+    expect(createFreshTenantWriteDatabaseRunner).toHaveBeenCalledWith({}, 'tenant-a');
+    expect(withFreshTenantWriteDatabase).toHaveBeenCalledOnce();
     expect(emit).toHaveBeenCalledWith('patched', task, expect.objectContaining({ path: 'tasks' }));
     expect(deferred.schedule).toHaveBeenCalledWith(
       expect.objectContaining({ tenant: { tenant_id: 'tenant-a' } }),
@@ -75,7 +84,7 @@ describe('TasksService executor termination report', () => {
         taskId: task.task_id,
         cause: 'user_stop',
         params: expect.objectContaining({ provider: undefined }),
-        withTenantDatabase: expect.any(Function),
+        runInFreshTenantWriteDatabase: withFreshTenantWriteDatabase,
       })
     );
   });

--- a/apps/agor-daemon/src/services/tasks.termination-report.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-report.test.ts
@@ -45,6 +45,7 @@ describe('TasksService executor termination report', () => {
     const service = Object.create(TasksService.prototype) as TasksService;
     Reflect.set(service, 'taskRepo', { recordExecutorQuiescence });
     Reflect.set(service, 'app', { service: () => ({ emit }) });
+    Reflect.set(service, 'db', {});
 
     await expect(
       service.reportTerminationComplete(
@@ -74,6 +75,7 @@ describe('TasksService executor termination report', () => {
         taskId: task.task_id,
         cause: 'user_stop',
         params: expect.objectContaining({ provider: undefined }),
+        withTenantDatabase: expect.any(Function),
       })
     );
   });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -71,7 +71,10 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
-import { deferWithTenantContext } from '../utils/tenant-db-scope.js';
+import {
+  createFreshTenantWriteDatabaseRunner,
+  deferWithTenantContext,
+} from '../utils/tenant-db-scope.js';
 import type { SessionsService } from './sessions';
 
 /**
@@ -1361,7 +1364,14 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     data: ExecutorTerminationCompleteInput,
     params?: TaskParams
   ): Promise<Task> {
-    const task = await this.taskRepo.recordExecutorQuiescence(data);
+    const terminationTenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
+    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
+      this.db,
+      terminationTenantId
+    );
+    const task = await runInFreshTerminationTenantWriteDatabase(() =>
+      this.taskRepo.recordExecutorQuiescence(data)
+    );
     if (!task?.termination_request) {
       throw new Conflict(
         `Task ${shortId(data.task_id)} has no matching active termination request`
@@ -1383,7 +1393,6 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     // transaction commits and outside its ALS database scope; the durable
     // quiescence timestamp makes the deferred recovery restart/retry safe.
     const coordinatorParams = { ...(params ?? {}), provider: undefined };
-    const terminationTenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
     deferWithTenantContext(
       params,
       () => {
@@ -1397,12 +1406,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           cause: terminationRequest.cause,
           errorMessage: terminationRequest.error_message ?? 'Executor stopped cooperatively.',
           params: coordinatorParams,
-          withTenantDatabase: (work) => {
-            if (!terminationTenantId) {
-              throw new Error('Missing tenant context for executor termination settlement');
-            }
-            return runWithTenantDatabaseScope(this.db, terminationTenantId, () => work());
-          },
+          runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase,
         }).then(() => undefined);
       },
       (error) =>
@@ -1500,6 +1504,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       throw new BadRequest('sdk_version must be a bounded identifier');
     }
 
+    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
+      this.db,
+      getCurrentTenantId() ?? params?.tenant?.tenant_id
+    );
+
     const current = await this.get(data.task_id, params);
     const mode = current.sdk_watchdog_mode ?? 'observe';
     if (mode === 'disabled') throw new Conflict('SDK watchdog is disabled for this Task');
@@ -1536,7 +1545,9 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       termination: action === 'enforced' ? 'requested' : 'not_requested',
     };
     if (action === 'would_fire') {
-      const observed = await this.taskRepo.recordSdkHealthObservation(data.task_id, failure);
+      const observed = await runInFreshTerminationTenantWriteDatabase(() =>
+        this.taskRepo.recordSdkHealthObservation(data.task_id, failure)
+      );
       if (!observed) throw new Conflict(`Task ${shortId(data.task_id)} is no longer active`);
       emitServiceEvent(this.app, {
         path: 'tasks',
@@ -1556,6 +1567,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       params,
       signalDelayMs: resolveSdkWatchdogConfig(this.app.get?.('config')?.execution).abort_grace_ms,
       sdkFailure: failure,
+      runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase,
     });
   }
 

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -1383,6 +1383,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     // transaction commits and outside its ALS database scope; the durable
     // quiescence timestamp makes the deferred recovery restart/retry safe.
     const coordinatorParams = { ...(params ?? {}), provider: undefined };
+    const terminationTenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
     deferWithTenantContext(
       params,
       () => {
@@ -1396,6 +1397,12 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           cause: terminationRequest.cause,
           errorMessage: terminationRequest.error_message ?? 'Executor stopped cooperatively.',
           params: coordinatorParams,
+          withTenantDatabase: (work) => {
+            if (!terminationTenantId) {
+              throw new Error('Missing tenant context for executor termination settlement');
+            }
+            return runWithTenantDatabaseScope(this.db, terminationTenantId, () => work());
+          },
         }).then(() => undefined);
       },
       (error) =>

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -20,6 +20,7 @@ import {
 
 const taskId = '018f0000-0000-7000-8000-000000000001';
 const sessionId = '018f0000-0000-7000-8000-000000000002';
+const runInFreshTenantWriteDatabase = <T>(work: () => Promise<T>): Promise<T> => work();
 
 function task(status = TaskStatus.RUNNING, extra: Record<string, unknown> = {}) {
   return { task_id: taskId, session_id: sessionId, status, created_at: '2026-01-01', ...extra };
@@ -109,6 +110,7 @@ function request(app: never, cause: 'user_stop' | 'sdk_health_failure' | 'heartb
     taskId,
     cause,
     errorMessage: cause === 'user_stop' ? 'Stopped by user' : `${cause} failure`,
+    runInFreshTenantWriteDatabase,
   });
 }
 
@@ -176,6 +178,7 @@ describe('termination coordinator', () => {
       cause: 'user_stop',
       errorMessage: 'Stopped by user',
       cooperativeGraceMs: 100,
+      runInFreshTenantWriteDatabase,
     });
     setTimeout(() => {
       state.markExecutorQuiesced();
@@ -315,6 +318,7 @@ describe('termination coordinator', () => {
         cause: 'heartbeat_lost',
         errorMessage: 'heartbeat_lost failure',
         absenceVerified: true,
+        runInFreshTenantWriteDatabase,
       })
     ).resolves.toMatchObject({
       status: 'terminal',
@@ -344,6 +348,7 @@ describe('termination coordinator', () => {
       taskId,
       cause: 'sdk_health_failure',
       errorMessage: 'SDK stalled',
+      runInFreshTenantWriteDatabase,
     });
 
     expect(requested.status).toBe(TaskStatus.STOPPING);
@@ -364,6 +369,7 @@ describe('termination coordinator', () => {
       cause: 'heartbeat_lost',
       errorMessage: 'Heartbeat lost',
       cooperativeGraceMs: 40_000,
+      runInFreshTenantWriteDatabase,
     });
 
     expect(state.claimTerminationCoordination).toHaveBeenCalledWith(
@@ -397,6 +403,7 @@ describe('termination coordinator', () => {
       taskId,
       cause: 'sdk_health_failure',
       errorMessage: 'SDK stalled',
+      runInFreshTenantWriteDatabase,
     });
 
     expect(result.status).toBe(TaskStatus.COMPLETED);
@@ -419,6 +426,7 @@ describe('termination coordinator', () => {
       taskId,
       cause: 'sdk_health_failure',
       errorMessage: 'SDK stalled',
+      runInFreshTenantWriteDatabase,
     });
     const stop = request(state.app, 'user_stop');
     await vi.waitFor(() => expect(state.claimTermination).toHaveBeenCalledTimes(2));

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -49,10 +49,10 @@ export interface TerminationInput {
   /** Deterministic test seam. */
   coordinationToken?: string;
   /**
-   * Background workers provide a fresh, short tenant DB scope for each
-   * durable unit. Containment and cooperative waits remain outside it.
+   * Mutation entry points provide a fresh, short, write-gated tenant DB scope
+   * for each durable unit. Containment and cooperative waits remain outside it.
    */
-  withTenantDatabase?: <T>(work: () => Promise<T>) => Promise<T>;
+  runInFreshTenantWriteDatabase: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
 interface LocalTerminationOperation {
@@ -107,8 +107,11 @@ function internalParams(params?: Params): Params {
   return { ...(params ?? {}), provider: undefined };
 }
 
-function withTenantDatabase<T>(input: TerminationInput, work: () => Promise<T>): Promise<T> {
-  return input.withTenantDatabase ? input.withTenantDatabase(work) : work();
+function runInFreshTenantWriteDatabase<T>(
+  input: TerminationInput,
+  work: () => Promise<T>
+): Promise<T> {
+  return input.runInFreshTenantWriteDatabase(work);
 }
 
 function unverifiedMessage(taskId: string, detail: string): string {
@@ -121,7 +124,7 @@ function unverifiedMessage(taskId: string, detail: string): string {
 
 async function claimRequest(input: TerminationInput) {
   const tasks = input.app.service('tasks') as unknown as TasksServiceImpl;
-  return withTenantDatabase(input, () =>
+  return runInFreshTenantWriteDatabase(input, () =>
     tasks.claimTermination(
       {
         taskId: String(input.taskId),
@@ -139,7 +142,7 @@ async function claimRequest(input: TerminationInput) {
 }
 
 async function loadAgenticTool(input: TerminationInput): Promise<PersistedAgenticToolName> {
-  return withTenantDatabase(input, async () => {
+  return runInFreshTenantWriteDatabase(input, async () => {
     const task = await input.app.service('tasks').get(input.taskId, internalParams(input.params));
     const session = await input.app
       .service('sessions')
@@ -169,7 +172,7 @@ async function waitForExecutorQuiescence(input: TerminationInput, requested: Tas
     await new Promise<void>((resolve) =>
       setTimeout(resolve, Math.min(COOPERATIVE_POLL_MS, Math.max(0, deadline - Date.now())))
     );
-    current = await withTenantDatabase(input, () =>
+    current = await runInFreshTenantWriteDatabase(input, () =>
       tasks.get(requested.task_id, internalParams(input.params))
     );
     if (
@@ -256,7 +259,7 @@ async function runContainment(
           last_pulse: current.latest_executor_pulse,
           termination: 'unverified',
         };
-    const settlement = await withTenantDatabase(input, () =>
+    const settlement = await runInFreshTenantWriteDatabase(input, () =>
       tasks.settleTermination(
         {
           taskId: current.task_id,
@@ -277,7 +280,7 @@ async function runContainment(
     return { status: 'unverified', task: settlement.task, reason };
   }
 
-  const settlement = await withTenantDatabase(input, () =>
+  const settlement = await runInFreshTenantWriteDatabase(input, () =>
     tasks.settleTermination(
       {
         taskId: current.task_id,
@@ -323,7 +326,7 @@ async function claimContainmentCoordination(
   };
   const token = input.coordinationToken ?? generateId();
   const tasks = input.app.service('tasks') as unknown as TasksServiceImpl;
-  const claim = await withTenantDatabase(input, () =>
+  const claim = await runInFreshTenantWriteDatabase(input, () =>
     tasks.claimTerminationCoordination(
       {
         taskId: task.task_id,

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -10,6 +10,8 @@ const findActiveTasks = async (app: any, sessionId: string, params: unknown) => 
   return Array.isArray(result) ? result : result.data;
 };
 
+const runInFreshTenantWriteDatabase = <T>(work: () => Promise<T>): Promise<T> => work();
+
 describe('markStoppedSessionPromptableNoDrain', () => {
   it('marks the session promptable without triggering queue processing', async () => {
     const calls: string[] = [];
@@ -64,6 +66,7 @@ describe('stopSessionPreserveQueue', () => {
             patch: vi.fn(),
           } as never,
           requestTermination: requestTermination as never,
+          runInFreshTenantWriteDatabase,
         },
         'session-idle' as never
       )
@@ -102,6 +105,7 @@ describe('stopSessionPreserveQueue', () => {
           findActiveTasks: findActiveTasks as never,
           sessionsService: { get: vi.fn().mockResolvedValue(session), patch: vi.fn() } as never,
           requestTermination: requestTermination as never,
+          runInFreshTenantWriteDatabase,
         } as never,
         session.session_id as never
       )
@@ -151,7 +155,7 @@ describe('stopSessionPreserveQueue', () => {
     };
     const withTenantDatabase = vi.fn(async (work: () => Promise<unknown>) => work());
     const requestTermination = vi.fn(async (input) => {
-      await input.withTenantDatabase(async () => 'scoped');
+      await input.runInFreshTenantWriteDatabase(async () => 'scoped');
       return { status: 'terminal', task: runningTask };
     });
     const params = { provider: 'rest' };
@@ -163,7 +167,7 @@ describe('stopSessionPreserveQueue', () => {
         findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
-        withTenantDatabase,
+        runInFreshTenantWriteDatabase: withTenantDatabase,
       },
       sessionId as never,
       params,
@@ -180,7 +184,7 @@ describe('stopSessionPreserveQueue', () => {
       expect.objectContaining({
         taskId: runningTask.task_id,
         cause: 'user_stop',
-        withTenantDatabase,
+        runInFreshTenantWriteDatabase: withTenantDatabase,
       })
     );
     expect(withTenantDatabase).toHaveBeenCalledOnce();
@@ -230,6 +234,7 @@ describe('stopSessionPreserveQueue', () => {
         findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
+        runInFreshTenantWriteDatabase,
       },
       sessionId as never,
       {},
@@ -293,6 +298,7 @@ describe('stopSessionPreserveQueue', () => {
           findActiveTasks: findActiveTasks as never,
           sessionsService: sessionsService as never,
           requestTermination: requestTermination as never,
+          runInFreshTenantWriteDatabase,
         },
         sessionId as never,
         { provider: 'rest' }

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -149,7 +149,11 @@ describe('stopSessionPreserveQueue', () => {
         throw new Error(`unexpected service ${name}`);
       },
     };
-    const requestTermination = vi.fn(async () => ({ status: 'terminal', task: runningTask }));
+    const withTenantDatabase = vi.fn(async (work: () => Promise<unknown>) => work());
+    const requestTermination = vi.fn(async (input) => {
+      await input.withTenantDatabase(async () => 'scoped');
+      return { status: 'terminal', task: runningTask };
+    });
     const params = { provider: 'rest' };
 
     const result = await stopSessionPreserveQueue(
@@ -159,6 +163,7 @@ describe('stopSessionPreserveQueue', () => {
         findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
+        withTenantDatabase,
       },
       sessionId as never,
       params,
@@ -172,8 +177,13 @@ describe('stopSessionPreserveQueue', () => {
       queuedTasksPreserved: 1,
     });
     expect(requestTermination).toHaveBeenCalledWith(
-      expect.objectContaining({ taskId: runningTask.task_id, cause: 'user_stop' })
+      expect.objectContaining({
+        taskId: runningTask.task_id,
+        cause: 'user_stop',
+        withTenantDatabase,
+      })
     );
+    expect(withTenantDatabase).toHaveBeenCalledOnce();
   });
 
   it('stops an awaiting_input task when the session is awaiting input', async () => {

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -26,11 +26,11 @@ export interface StopSessionDeps {
   findActiveTasks: typeof findActiveTasksForSession;
   requestTermination?: typeof requestExecutorTermination;
   /**
-   * Opens one short tenant database unit for each durable termination step.
-   * The Stop route itself deliberately has no route-wide database transaction
-   * because it may wait for executor quiescence.
+   * Opens one fresh, write-gated tenant database unit for each durable
+   * termination step. The Stop route itself deliberately has no route-wide
+   * database transaction because it may wait for executor quiescence.
    */
-  withTenantDatabase?: TerminationInput['withTenantDatabase'];
+  runInFreshTenantWriteDatabase: TerminationInput['runInFreshTenantWriteDatabase'];
 }
 
 /**
@@ -129,7 +129,7 @@ export async function stopSessionPreserveQueue(
     cause: 'user_stop',
     errorMessage: options.reason ?? 'Stopped by user.',
     params,
-    withTenantDatabase: deps.withTenantDatabase,
+    runInFreshTenantWriteDatabase: deps.runInFreshTenantWriteDatabase,
   });
   if (termination.status !== 'terminal') {
     return {

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -3,7 +3,11 @@ import type { Application } from '@agor/core/feathers';
 import type { Params, SessionID } from '@agor/core/types';
 import { isSessionExecuting, SessionStatus } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
-import { requestExecutorTermination, type TerminationResult } from '../termination-coordinator.js';
+import {
+  requestExecutorTermination,
+  type TerminationInput,
+  type TerminationResult,
+} from '../termination-coordinator.js';
 import { requireActiveAgenticTool } from './agentic-tool-runtime.js';
 import type { findActiveTasksForSession } from './session-tasks.js';
 
@@ -21,6 +25,12 @@ export interface StopSessionDeps {
   sessionsService: Pick<SessionsServiceImpl, 'get' | 'patch'>;
   findActiveTasks: typeof findActiveTasksForSession;
   requestTermination?: typeof requestExecutorTermination;
+  /**
+   * Opens one short tenant database unit for each durable termination step.
+   * The Stop route itself deliberately has no route-wide database transaction
+   * because it may wait for executor quiescence.
+   */
+  withTenantDatabase?: TerminationInput['withTenantDatabase'];
 }
 
 /**
@@ -119,6 +129,7 @@ export async function stopSessionPreserveQueue(
     cause: 'user_stop',
     errorMessage: options.reason ?? 'Stopped by user.',
     params,
+    withTenantDatabase: deps.withTenantDatabase,
   });
   if (termination.status !== 'terminal') {
     return {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -4,12 +4,14 @@ import {
   getCurrentTenantId,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
+  TenantWriteGateActiveError,
 } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it, vi } from 'vitest';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 import {
+  createFreshTenantWriteDatabaseRunner,
   createTenantDatabaseScopeAroundHook,
   deferWithTenantContext,
   deferWithTenantDatabaseScope,
@@ -34,6 +36,63 @@ function signRuntimeJwt(secret: string, payload: Record<string, unknown>) {
     expiresIn: '5m',
   });
 }
+
+describe('createFreshTenantWriteDatabaseRunner', () => {
+  it('leaves an inherited DB scope and opens a new short tenant transaction', async () => {
+    let transactionNumber = 0;
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        transactionNumber += 1;
+        return callback({
+          execute: vi.fn(async () => []),
+          marker: `tx-${transactionNumber}`,
+        });
+      }),
+    };
+    const runMutation = createFreshTenantWriteDatabaseRunner(db as never, 'tenant-a');
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
+      expect(getCurrentTenantDatabaseScope()?.db).toMatchObject({ marker: 'tx-1' });
+      await runMutation(async () => {
+        expect(getCurrentTenantId()).toBe('tenant-a');
+        expect(getCurrentTenantDatabaseScope()?.db).toMatchObject({ marker: 'tx-2' });
+      });
+      expect(getCurrentTenantDatabaseScope()?.db).toMatchObject({ marker: 'tx-1' });
+    });
+
+    expect(db.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('checks the tenant write gate inside the fresh transaction before mutation work', async () => {
+    const work = vi.fn(async () => undefined);
+    const tx = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            value_text: JSON.stringify({
+              generation: 'gate-generation',
+              acquiredAt: '2026-08-18T00:00:00.000Z',
+            }),
+          },
+        ]),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (scoped: unknown) => Promise<unknown>) => callback(tx)),
+    };
+    const runMutation = createFreshTenantWriteDatabaseRunner(db as never, 'tenant-frozen');
+
+    await expect(runMutation(work)).rejects.toBeInstanceOf(TenantWriteGateActiveError);
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when no trusted tenant identity is available', () => {
+    expect(() => createFreshTenantWriteDatabaseRunner({} as never, undefined)).toThrow(
+      'Missing tenant context'
+    );
+  });
+});
 
 describe('createTenantDatabaseScopeAroundHook', () => {
   it('uses the configured static tenant for the hook and database scope', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -1,4 +1,5 @@
 import {
+  createDatabase,
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
@@ -38,6 +39,19 @@ function signRuntimeJwt(secret: string, payload: Record<string, unknown>) {
 }
 
 describe('createFreshTenantWriteDatabaseRunner', () => {
+  it('remains a no-op write gate on the single-tenant SQLite path', async () => {
+    const db = createDatabase({ url: ':memory:' });
+    const work = vi.fn(async () => {
+      expect(getCurrentTenantId()).toBe('default');
+      return 'written';
+    });
+
+    await expect(createFreshTenantWriteDatabaseRunner(db, 'default')(work)).resolves.toBe(
+      'written'
+    );
+    expect(work).toHaveBeenCalledOnce();
+  });
+
   it('leaves an inherited DB scope and opens a new short tenant transaction', async () => {
     let transactionNumber = 0;
     const db = {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -43,9 +43,36 @@ function readHeaderValue(
 
 type TenantScopedParams = { tenant?: Pick<TenantContext, 'tenant_id'> } | undefined;
 
+export type TenantDatabaseRunner = <T>(work: () => Promise<T>) => Promise<T>;
+
 export function resolveTenantIdForDeferredScope(params?: unknown): string | undefined {
   const scopedParams = params as TenantScopedParams;
   return scopedParams?.tenant?.tenant_id ?? getCurrentTenantId();
+}
+
+/**
+ * Build the mutation boundary used by long-lived tenant orchestration.
+ *
+ * Executor callbacks and termination coordinators can outlive the request
+ * transaction that created them. AsyncLocalStorage propagates that transaction
+ * object into callbacks, so merely calling runWithTenantDatabaseScope would
+ * rejoin a possibly committed scope. Always leave any inherited DB scope, open
+ * one new short tenant transaction, and enforce the write gate inside it.
+ */
+export function createFreshTenantWriteDatabaseRunner(
+  db: TenantScopeAwareDatabase,
+  tenantId: string | undefined
+): TenantDatabaseRunner {
+  if (!tenantId) {
+    throw new Error('Missing tenant context for tenant-scoped mutation');
+  }
+  return <T>(work: () => Promise<T>): Promise<T> =>
+    runWithoutTenantDatabaseScope(() =>
+      runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+        await assertTenantWritable(scoped, tenantId);
+        return work();
+      })
+    );
 }
 
 /**

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -242,20 +242,9 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
       name: 'Type STOP to confirm force-fail',
     });
     await waitFor(() => expect(confirmation).toHaveFocus());
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() =>
-      expect(screen.queryByRole('dialog', { name: 'Force-fail task?' })).not.toBeInTheDocument()
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
-    const reopenedConfirmation = await screen.findByRole('textbox', {
-      name: 'Type STOP to confirm force-fail',
-    });
-    const reopenedForceFail = screen.getByRole('button', { name: 'Force fail' });
-    expect(reopenedForceFail).toBeDisabled();
-    fireEvent.change(reopenedConfirmation, { target: { value: 'STOP' } });
-    expect(reopenedForceFail).toBeEnabled();
-    fireEvent.keyDown(reopenedConfirmation, { key: 'Enter', code: 'Enter' });
+    fireEvent.change(confirmation, { target: { value: 'STOP' } });
+    expect(forceFail).toBeEnabled();
+    fireEvent.keyDown(confirmation, { key: 'Enter', code: 'Enter' });
 
     await waitFor(() => expect(create).toHaveBeenCalledOnce());
     expect(create).toHaveBeenCalledWith({

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -147,6 +147,68 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
     expect(onOpenTerminal.mock.calls[0][0]).not.toContain(branch.path);
   });
 
+  it('surfaces an initial Stop request failure as retryable', async () => {
+    reactive.tasks = [
+      {
+        task_id: '018f0000-0000-7000-8000-000000000010',
+        session_id: session.session_id,
+        status: 'running',
+      } as Task,
+    ];
+    const create = vi.fn().mockRejectedValue(new Error('database scope missing'));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    renderPanel({
+      client: {
+        service: () => ({
+          create,
+          find: vi.fn().mockResolvedValue({ data: [] }),
+          on: vi.fn(),
+          off: vi.fn(),
+        }),
+      } as unknown as AgorClient,
+      activeSession: { ...session, status: 'running', agentic_tool: 'codex' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /stop/i }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledWith({}));
+    expect(await screen.findByText('Failed to stop execution. You can try again.')).toBeVisible();
+  });
+
+  it('distinguishes accepted-but-pending Stop from an initial request failure', async () => {
+    reactive.tasks = [
+      {
+        task_id: '018f0000-0000-7000-8000-000000000011',
+        session_id: session.session_id,
+        status: 'running',
+      } as Task,
+    ];
+    const create = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'Waiting for the daemon that owns the local executor process handle.',
+    });
+    renderPanel({
+      client: {
+        service: () => ({
+          create,
+          find: vi.fn().mockResolvedValue({ data: [] }),
+          on: vi.fn(),
+          off: vi.fn(),
+        }),
+      } as unknown as AgorClient,
+      activeSession: { ...session, status: 'running', agentic_tool: 'codex' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /stop/i }));
+
+    expect(
+      await screen.findByText('Waiting for the daemon that owns the local executor process handle.')
+    ).toBeVisible();
+    expect(
+      screen.queryByText('Failed to stop execution. You can try again.')
+    ).not.toBeInTheDocument();
+  });
+
   it('surfaces force-fail errors', async () => {
     reactive.tasks = [
       {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1115,7 +1115,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
     setStopRequestInFlight(true);
     try {
-      await client.service(`sessions/${session.session_id}/stop`).create({});
+      const result = (await client.service(`sessions/${session.session_id}/stop`).create({})) as {
+        success?: boolean;
+        reason?: string;
+      };
+      if (result.success === false) {
+        showInfo(result.reason ?? 'Stop requested; waiting for executor termination.');
+      }
     } catch (error) {
       console.error('Failed to stop execution:', error);
       showError('Failed to stop execution. You can try again.');

--- a/docker/ha/config.yaml
+++ b/docker/ha/config.yaml
@@ -48,6 +48,9 @@ multi_tenancy:
   mode: static
   static_tenant_id: default
 daemon:
+  # Stable identity shared by both replicas in the checked-in disposable
+  # Compose deployment. Production deployments must supply their own UUID.
+  deployment_id: 019c83b2-1f53-7e51-8e04-1f2df20d25de
   host: 0.0.0.0
   port: 3030
   trust_proxy_hops: 1


### PR DESCRIPTION
## Summary

- add the required stable `daemon.deployment_id` to the disposable two-replica HA fixture so it boots with current deployment-identity validation
- preserve tenant identity across Stop while opening a fresh, short PostgreSQL tenant scope for every durable termination/settlement operation
- apply prompt-equivalent branch RBAC to Stop, preventing a session-tier collaborator from controlling another user's executor context
- keep accepted-but-unverified Stop responses distinct from initial API rejection in the UI
- cover executor-launcher exit and deferred quiescence settlement paths that run after the original request/transaction scope has ended

## Root cause

The current Stop route correctly avoids holding a PostgreSQL transaction open while it waits for executor quiescence. However, after its short tenant-scoped reads completed, it invoked the termination coordinator without the coordinator's optional fresh tenant-database runner. With guarded PostgreSQL repositories, `claimTermination` therefore ran outside an active tenant database scope and the route returned HTTP 500 (`Missing tenant database scope`) before a durable termination claim or Redis/Socket.IO delivery could occur. This is the initial failure surfaced by the retry toast, not the later accepted `stopping` / unverified-termination state.

The same scope-loss pattern also existed in executor launcher-exit cleanup and deferred quiescence settlement. The checked-in HA fixture additionally no longer booted after deployment identity became mandatory because it had no stable `daemon.deployment_id`.

## Stop flow after this change

1. authenticate the request and load the Session in a short tenant database unit
2. authorize Stop using the Session's branch and prompt-equivalent RBAC policy
3. claim the current Task termination epoch/lease in a fresh tenant database unit
4. deliver the private task termination event locally or through Redis to the executor-owning replica
5. abort the provider, retain heartbeat/progress visibility during cleanup, and record quiescence
6. reconcile the HA lease and settle Task/Session only with authoritative termination proof

No route-wide transaction is held across Socket delivery or quiescence waiting, and remote/local executors are never reported stopped without the existing proof requirements.

## Security and tenancy

- tenant context is captured only from the authenticated request/execution context and is re-established around each durable repository operation
- cross-tenant access remains denied by authentication/RLS boundaries
- owners, admins, and collaborators with `prompt`/`all` may stop a Session; `session` collaborators may stop only Sessions they created
- force-fail and ambiguous configured-executor paths remain fail closed

## Live HA validation

Validated against the disposable PostgreSQL + Redis + two-daemon HA environment through both replicas:

- before: Stop returned HTTP 500 with missing tenant database scope; no termination claim or relay occurred
- after, request through non-owning replica B for Task `01a01708-58eb-71bd-8314-ac3bb84eaade`: HTTP 201 pending, Redis delivered the private termination event to owner A, provider cleanup completed in 23 ms, quiescence was recorded, and the Task settled stopped in 1263 ms
- after, request through owning replica A: HTTP 201 and authoritative stop settlement in 218 ms
- same-tenant private-branch and cross-tenant negative requests returned 403/401 without creating termination claims
- a request with no provable executor owner remained `stopping` and later unverified rather than being falsely settled

The HA environment remains running and healthy; named reproduction Sessions/Tasks and logs were preserved.

## Tests

- `pnpm i`
- `pnpm check`
- daemon Stop/termination/RBAC suite: **106 passed**
- SessionPanel Stop handling suite: **28 passed**
- focused SQLite Task termination repository tests: **11 passed**
- disposable PostgreSQL integration suite: **122 passed across 23 files**
