### PR TITLE
fix(cli): repair the REST transport — branch add, user management, board export/clone/import

### DIFF
--- a/apps/agor-cli/src/commands/branch/add.ts
+++ b/apps/agor-cli/src/commands/branch/add.ts
@@ -133,8 +133,11 @@ export default class BranchAdd extends BaseCommand {
         }
       }
 
-      // Call daemon API to create branch
-      const newBranch = (await client.service('repos').createBranch(repo.repo_id, {
+      // Create through the `/repos/:id/branches` route — the same one the UI uses.
+      // `reposService.createBranch()` is an in-process method with an `(id, data)`
+      // signature, not a Feathers custom method, so it is not reachable over any
+      // transport; calling it from here threw "createBranch is not a function".
+      const newBranch = (await client.service(`repos/${repo.repo_id}/branches`).create({
         name: args.name,
         ref,
         createBranch,

--- a/apps/agor-cli/src/commands/daemon/restart.ts
+++ b/apps/agor-cli/src/commands/daemon/restart.ts
@@ -56,10 +56,6 @@ export default class DaemonRestart extends Command {
     try {
       const result = await loadDaemonConfigWithDeploymentIdentity(identity?.configPath);
       restartConfig = result.config;
-      if (result.migrated) {
-        this.log(chalk.green(`✓ Added daemon.deployment_id: ${result.migrated.deploymentId}`));
-        this.log(chalk.dim(`Backup: ${result.migrated.backupPath}`));
-      }
     } catch (error) {
       this.log(chalk.red('✗ Failed to load daemon configuration'));
       this.log(error instanceof Error ? error.message : String(error));

--- a/apps/agor-cli/src/commands/daemon/start.ts
+++ b/apps/agor-cli/src/commands/daemon/start.ts
@@ -45,15 +45,35 @@ export default class DaemonStart extends Command {
   };
 
   async run(): Promise<void> {
+    try {
+      await this.start();
+    } catch (error) {
+      // oclif signals a clean exit by throwing; let those through untouched.
+      if (error && typeof error === 'object' && 'oclif' in error) throw error;
+
+      // Anything else that stops a start is a diagnosable local-install problem,
+      // and `agor doctor` is the one command that inspects all of them. Point
+      // there once, here, instead of teaching every failure path to do it.
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(chalk.red('✗ Failed to start the daemon'));
+      this.log('');
+      this.log(message);
+      // Failures that already name their own remedy don't need the generic one.
+      if (!message.includes('agor doctor')) {
+        this.log('');
+        this.log(chalk.dim('Diagnose and repair the local installation with:'));
+        this.log(`  ${chalk.cyan('agor doctor')}`);
+      }
+      this.exit(1);
+    }
+  }
+
+  private async start(): Promise<void> {
     const { flags } = await this.parse(DaemonStart);
 
     // 1. Load & validate config
     const result = await loadDaemonConfigWithDeploymentIdentity(flags.config);
     const config = result.config;
-    if (result.migrated) {
-      this.log(chalk.green(`✓ Added daemon.deployment_id: ${result.migrated.deploymentId}`));
-      this.log(chalk.dim(`Backup: ${result.migrated.backupPath}`));
-    }
     await assertLocalContextUnlocked(config);
     const daemonUrl = resolveDaemonUrl(config);
 

--- a/apps/agor-cli/src/commands/doctor.ts
+++ b/apps/agor-cli/src/commands/doctor.ts
@@ -3,12 +3,22 @@ import {
   resolveAgenticToolSelectionPolicy,
   resolveManagedAgenticToolVersion,
 } from '@agor/core/agentic-integrations';
-import { loadConfig, resolveEffectiveConfig } from '@agor/core/config';
+import {
+  getConfigPath,
+  loadConfig,
+  requireDeploymentId,
+  resolveEffectiveConfig,
+} from '@agor/core/config';
 import { diagnoseGit } from '@agor/git';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import { diagnoseAgenticTools } from '../lib/agentic-tool-diagnostics.js';
 import { listManagedAgorVersions } from '../lib/agentic-tool-integrations.js';
+import {
+  describeMissingDeploymentId,
+  isMissingDeploymentIdError,
+  repairDeploymentId,
+} from '../lib/daemon-deployment-config.js';
 import { diagnoseWebTerminalRuntime } from '../lib/optional-capabilities.js';
 import { diagnoseSandbox, sandboxInstallHint } from '../lib/sandbox-diagnostics.js';
 
@@ -33,12 +43,24 @@ export default class Doctor extends Command {
     // (e.g. AGOR_SANDBOX_ENABLED from the `sandbox` .agor.yml variant), matching
     // what the daemon actually runs — not just the raw config.yaml.
     const sandbox = diagnoseSandbox(resolveEffectiveConfig(cfg));
+
+    // `daemon start` refuses to run without this and sends people here, so doctor
+    // has to both report it and be able to fix it.
+    let deploymentIdPresent = true;
+    try {
+      requireDeploymentId(cfg);
+    } catch (error) {
+      if (!isMissingDeploymentIdError(error)) throw error;
+      deploymentIdPresent = false;
+    }
+
     if (flags.json) {
       this.log(
         JSON.stringify(
           {
-            ok: git.status === 'ready',
+            ok: git.status === 'ready' && deploymentIdPresent,
             git,
+            deploymentId: { present: deploymentIdPresent, configPath: getConfigPath() },
             optionalCapabilities: { webTerminal },
             policy,
             sandbox,
@@ -59,6 +81,25 @@ export default class Doctor extends Command {
     } else {
       this.log(`${chalk.red('✗')} ${git.detail}`);
     }
+
+    if (deploymentIdPresent) {
+      this.log(`${chalk.green('✓')} Deployment ID is set`);
+    } else {
+      this.log(`${chalk.red('✗')} daemon.deployment_id is missing — the daemon will not start`);
+      const repaired = await repairDeploymentId().catch((error: unknown) => {
+        this.log('');
+        this.log(error instanceof Error ? error.message : String(error));
+        return null;
+      });
+      if (repaired) {
+        this.log(`  ${chalk.green('✓')} Wrote deployment_id: ${repaired.deploymentId}`);
+        this.log(chalk.dim(`      Backup: ${repaired.backupPath}`));
+      } else {
+        this.log('');
+        this.log(describeMissingDeploymentId(getConfigPath()));
+      }
+    }
+
     this.log('');
     this.log(chalk.bold('Optional capabilities'));
     if (webTerminal.status === 'ready') {

--- a/apps/agor-cli/src/commands/doctor.ts
+++ b/apps/agor-cli/src/commands/doctor.ts
@@ -1,3 +1,4 @@
+import { access, constants } from 'node:fs/promises';
 import {
   AGENTIC_TOOL_INTEGRATIONS,
   resolveAgenticToolSelectionPolicy,
@@ -44,14 +45,21 @@ export default class Doctor extends Command {
     // what the daemon actually runs — not just the raw config.yaml.
     const sandbox = diagnoseSandbox(resolveEffectiveConfig(cfg));
 
-    // `daemon start` refuses to run without this and sends people here, so doctor
-    // has to both report it and be able to fix it.
+    // `daemon start` refuses to run without a deployment ID and sends people here,
+    // so doctor has to both report it and be able to fix it.
+    //
+    // Scope that to an installation that has actually been initialized. A fresh
+    // install legitimately has no config.yaml and therefore no deployment ID; that
+    // is what `agor init` is for, not a fault, and it must not turn `ok` false.
+    const initialized = await this.pathExists(getConfigPath());
     let deploymentIdPresent = true;
-    try {
-      requireDeploymentId(cfg);
-    } catch (error) {
-      if (!isMissingDeploymentIdError(error)) throw error;
-      deploymentIdPresent = false;
+    if (initialized) {
+      try {
+        requireDeploymentId(cfg);
+      } catch (error) {
+        if (!isMissingDeploymentIdError(error)) throw error;
+        deploymentIdPresent = false;
+      }
     }
 
     if (flags.json) {
@@ -60,7 +68,11 @@ export default class Doctor extends Command {
           {
             ok: git.status === 'ready' && deploymentIdPresent,
             git,
-            deploymentId: { present: deploymentIdPresent, configPath: getConfigPath() },
+            deploymentId: {
+              present: initialized ? deploymentIdPresent : null,
+              initialized,
+              configPath: getConfigPath(),
+            },
             optionalCapabilities: { webTerminal },
             policy,
             sandbox,
@@ -82,7 +94,9 @@ export default class Doctor extends Command {
       this.log(`${chalk.red('✗')} ${git.detail}`);
     }
 
-    if (deploymentIdPresent) {
+    if (!initialized) {
+      this.log(`${chalk.yellow('○')} Not initialized yet — run \`agor init\``);
+    } else if (deploymentIdPresent) {
       this.log(`${chalk.green('✓')} Deployment ID is set`);
     } else {
       this.log(`${chalk.red('✗')} daemon.deployment_id is missing — the daemon will not start`);
@@ -159,5 +173,14 @@ export default class Doctor extends Command {
     if (policy.source === 'missing-manifest')
       this.log(chalk.yellow('\n  No local selection manifest. Run interactive `agor install`.'));
     else this.log(chalk.dim('\n  Repair without changing selection: agor install --sync'));
+  }
+
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await access(path, constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -214,16 +214,39 @@ export default class Init extends Command {
     // Use the same environment/config resolution and health probe as
     // `agor daemon status` so re-init cannot drift from the CLI's canonical
     // answer about which daemon endpoint is active.
-    const configuredUrl = await getDaemonUrl();
+    //
+    // Only consider daemons that belong to *this* Agor home. A daemon this home
+    // manages (PID file present) always counts. The configured URL counts only once
+    // a config exists here — otherwise `getDaemonUrl()` hands back the global
+    // default and initializing a brand-new home fails because some unrelated
+    // deployment happens to occupy that port. That false positive also made the
+    // `agor init` test suite dependent on no daemon running on 3030.
     const managedUrl = getDaemonPid() !== null ? getManagedDaemonIdentity()?.daemonUrl : undefined;
-    const urls = [...new Set([managedUrl, configuredUrl].filter((url): url is string => !!url))];
-    for (const daemonUrl of urls) {
-      if ((await probeAgorDaemon(daemonUrl)).running) {
-        throw new Error(
-          `The Agor daemon is running at ${daemonUrl}. Stop it with \`agor daemon stop\` (or Ctrl+C for a development daemon) before re-initializing.`
-        );
-      }
+
+    // A daemon this home manages is unambiguously ours, whatever it answers with.
+    if (managedUrl && (await probeAgorDaemon(managedUrl)).running) {
+      throw new Error(this.daemonRunningMessage(managedUrl));
     }
+
+    if (!(await this.pathExists(getConfigPath()))) return;
+
+    const configuredUrl = await getDaemonUrl();
+    if (!configuredUrl || configuredUrl === managedUrl) return;
+
+    const probe = await probeAgorDaemon(configuredUrl);
+    if (!probe.running) return;
+
+    // Something is answering on our configured port, but a port is not ownership.
+    // Only block when it is demonstrably the same deployment; otherwise this is an
+    // unrelated daemon and re-initializing here cannot disturb it.
+    const ourDeploymentId = (await loadConfig().catch(() => undefined))?.daemon?.deployment_id;
+    if (ourDeploymentId && probe.deploymentId && probe.deploymentId !== ourDeploymentId) return;
+
+    throw new Error(this.daemonRunningMessage(configuredUrl));
+  }
+
+  private daemonRunningMessage(daemonUrl: string): string {
+    return `The Agor daemon is running at ${daemonUrl}. Stop it with \`agor daemon stop\` (or Ctrl+C for a development daemon) before re-initializing.`;
   }
 
   /**

--- a/apps/agor-cli/src/lib/daemon-deployment-config.test.ts
+++ b/apps/agor-cli/src/lib/daemon-deployment-config.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Starting a daemon is what service managers, containers and provisioning scripts
+ * do, so `agor daemon start` must never block on a prompt and must never rewrite
+ * config.yaml as a side effect. It used to do both: a missing `daemon.deployment_id`
+ * dropped it into an inquirer confirm that offered to rewrite the file.
+ *
+ * The interactive repair now lives in `agor doctor`. These tests pin the split.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('inquirer', () => ({ default: { prompt: vi.fn() } }));
+vi.mock('@agor/core/config', () => ({
+  getConfigPath: vi.fn(() => '/tmp/agor-test/config.yaml'),
+  loadConfig: vi.fn(),
+  loadConfigFromFile: vi.fn(),
+  migrateConfigDeploymentId: vi.fn(),
+  requireDeploymentId: vi.fn(),
+}));
+
+import { loadConfig, migrateConfigDeploymentId, requireDeploymentId } from '@agor/core/config';
+import inquirer from 'inquirer';
+import {
+  describeMissingDeploymentId,
+  isMissingDeploymentIdError,
+  loadDaemonConfigWithDeploymentIdentity,
+  repairDeploymentId,
+} from './daemon-deployment-config';
+
+const MISSING = new Error("Config validation failed: 'daemon.deployment_id' is required");
+const DEPLOYMENT_ID = '019c1234-5678-7123-8123-123456789abc';
+
+/** `isTTY` is absent under vitest, so it has to be defined rather than spied on. */
+function setTty(streams: { stdin: boolean; stdout: boolean }): () => void {
+  const original = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY };
+  Object.defineProperty(process.stdin, 'isTTY', { value: streams.stdin, configurable: true });
+  Object.defineProperty(process.stdout, 'isTTY', { value: streams.stdout, configurable: true });
+  return () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: original.stdin, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: original.stdout, configurable: true });
+  };
+}
+
+describe('loadDaemonConfigWithDeploymentIdentity', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(loadConfig).mockResolvedValue({ daemon: {} } as never);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the config when a deployment ID is present', async () => {
+    vi.mocked(requireDeploymentId).mockReturnValue(undefined as never);
+
+    const result = await loadDaemonConfigWithDeploymentIdentity();
+
+    expect(result.config).toEqual({ daemon: {} });
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('fails without prompting when the deployment ID is missing', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw MISSING;
+    });
+
+    await expect(loadDaemonConfigWithDeploymentIdentity()).rejects.toThrow(
+      /daemon\.deployment_id is missing/
+    );
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+    expect(migrateConfigDeploymentId).not.toHaveBeenCalled();
+  });
+
+  it('points at agor doctor rather than leaving the operator to guess', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw MISSING;
+    });
+
+    await expect(loadDaemonConfigWithDeploymentIdentity()).rejects.toThrow(/agor doctor/);
+  });
+
+  it('rethrows unrelated config errors untouched', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw new Error('daemon.port must be a number');
+    });
+
+    await expect(loadDaemonConfigWithDeploymentIdentity()).rejects.toThrow(
+      'daemon.port must be a number'
+    );
+  });
+});
+
+describe('describeMissingDeploymentId', () => {
+  it('warns that a fresh ID re-identifies the deployment', () => {
+    const message = describeMissingDeploymentId('/etc/agor/config.yaml');
+
+    expect(message).toContain('/etc/agor/config.yaml');
+    expect(message).toContain('agor doctor');
+    expect(message).toMatch(/restore that exact value/);
+  });
+});
+
+describe('isMissingDeploymentIdError', () => {
+  it('recognizes only the missing-deployment-id failure', () => {
+    expect(isMissingDeploymentIdError(MISSING)).toBe(true);
+    expect(isMissingDeploymentIdError(new Error('something else'))).toBe(false);
+  });
+});
+
+describe('repairDeploymentId', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(loadConfig).mockResolvedValue({ daemon: {} } as never);
+  });
+
+  it('does nothing when the deployment ID is already set', async () => {
+    vi.mocked(requireDeploymentId).mockReturnValue(undefined as never);
+
+    await expect(repairDeploymentId()).resolves.toBeNull();
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('writes the operator-supplied ID after confirmation', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw MISSING;
+    });
+    const restoreTty = setTty({ stdin: true, stdout: true });
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({ deploymentId: DEPLOYMENT_ID } as never)
+      .mockResolvedValueOnce({ rewrite: true } as never);
+    vi.mocked(migrateConfigDeploymentId).mockResolvedValue({
+      config: {},
+      deploymentId: DEPLOYMENT_ID,
+      backupPath: '/tmp/agor-test/config.yaml.backup',
+    } as never);
+
+    const result = await repairDeploymentId();
+
+    expect(result).toEqual({
+      deploymentId: DEPLOYMENT_ID,
+      backupPath: '/tmp/agor-test/config.yaml.backup',
+    });
+    // The operator's own ID, not a freshly minted one — restoring a deployment's
+    // previous identity is the whole point of accepting input here.
+    expect(migrateConfigDeploymentId).toHaveBeenCalledWith(expect.any(String), DEPLOYMENT_ID);
+    restoreTty();
+  });
+
+  it('writes nothing when the operator declines', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw MISSING;
+    });
+    const restoreTty = setTty({ stdin: true, stdout: true });
+    vi.mocked(inquirer.prompt)
+      .mockResolvedValueOnce({ deploymentId: DEPLOYMENT_ID } as never)
+      .mockResolvedValueOnce({ rewrite: false } as never);
+
+    await expect(repairDeploymentId()).resolves.toBeNull();
+    expect(migrateConfigDeploymentId).not.toHaveBeenCalled();
+    restoreTty();
+  });
+
+  it('refuses to prompt when there is no terminal', async () => {
+    vi.mocked(requireDeploymentId).mockImplementation(() => {
+      throw MISSING;
+    });
+    const restoreTty = setTty({ stdin: false, stdout: false });
+
+    await expect(repairDeploymentId()).rejects.toThrow(/daemon\.deployment_id is missing/);
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+    restoreTty();
+  });
+});

--- a/apps/agor-cli/src/lib/daemon-deployment-config.ts
+++ b/apps/agor-cli/src/lib/daemon-deployment-config.ts
@@ -12,43 +12,114 @@ import inquirer from 'inquirer';
 
 export interface DeploymentConfigResult {
   config: AgorConfig;
-  migrated?: { deploymentId: string; backupPath: string };
 }
 
-/** Load daemon config and explicitly upgrade a pre-deployment-ID file when approved. */
+export interface DeploymentIdRepairResult {
+  deploymentId: string;
+  backupPath: string;
+}
+
+/** True when the error is specifically a missing `daemon.deployment_id`. */
+export function isMissingDeploymentIdError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("'daemon.deployment_id' is required");
+}
+
+/**
+ * Load daemon config for a start/restart.
+ *
+ * Deliberately non-interactive. Starting a daemon is something service managers,
+ * containers and provisioning scripts do, and a command that can block on a
+ * prompt is a command that can hang a boot. It also must never rewrite
+ * config.yaml as a side effect of "start" — the file is deployment-owned input.
+ *
+ * A missing deployment ID is therefore a hard failure that points at
+ * `agor doctor`, which owns the interactive repair.
+ */
 export async function loadDaemonConfigWithDeploymentIdentity(
   configPath?: string
 ): Promise<DeploymentConfigResult> {
   const path = resolve(configPath ?? getConfigPath());
   const config = configPath ? await loadConfigFromFile(path) : await loadConfig();
+
   try {
     requireDeploymentId(config);
-    return { config };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes("'daemon.deployment_id' is required")) throw error;
+    if (!isMissingDeploymentIdError(error)) throw error;
+    throw new Error(describeMissingDeploymentId(path));
   }
 
-  const deploymentId = randomUUID();
-  const snippet = `Add this under daemon in ${path}:\n  deployment_id: ${deploymentId}`;
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new Error(`Agor cannot start because daemon.deployment_id is missing.\n\n${snippet}`);
+  return { config };
+}
+
+/** The operator-facing explanation for a missing deployment ID. */
+export function describeMissingDeploymentId(configPath: string): string {
+  return [
+    'Agor cannot start because daemon.deployment_id is missing.',
+    '',
+    `Fix it interactively:  agor doctor`,
+    '',
+    `Or add it yourself under daemon in ${configPath}:`,
+    `  deployment_id: ${randomUUID()}`,
+    '',
+    'If this deployment previously had an ID, restore that exact value instead of',
+    'the one suggested above — a new ID re-identifies the deployment and every',
+    'connected client has to log in again.',
+  ].join('\n');
+}
+
+/**
+ * Interactively add a deployment ID to config.yaml. Used by `agor doctor`, which
+ * is the one place a human is definitionally present.
+ *
+ * Returns null when there is nothing to repair or the user declines.
+ */
+export async function repairDeploymentId(
+  configPath?: string
+): Promise<DeploymentIdRepairResult | null> {
+  const path = resolve(configPath ?? getConfigPath());
+  const config = configPath ? await loadConfigFromFile(path) : await loadConfig();
+
+  try {
+    requireDeploymentId(config);
+    return null;
+  } catch (error) {
+    if (!isMissingDeploymentIdError(error)) throw error;
   }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(describeMissingDeploymentId(path));
+  }
+
+  const suggested = randomUUID();
+  const { deploymentId } = await inquirer.prompt<{ deploymentId: string }>([
+    {
+      type: 'input',
+      name: 'deploymentId',
+      default: suggested,
+      message:
+        'Deployment ID to write (press enter for a new one, or paste this deployment’s previous ID):',
+      validate: (value: string) =>
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim()) ||
+        'Enter a UUID.',
+    },
+  ]);
 
   const { rewrite } = await inquirer.prompt<{ rewrite: boolean }>([
     {
       type: 'confirm',
       name: 'rewrite',
       default: false,
-      message:
-        'Add a deployment ID by rewriting config.yaml? A backup will be created; YAML comments and formatting may be lost.',
+      message: `Write deployment_id to ${path}? A backup will be created; YAML comments and formatting may be lost.`,
     },
   ]);
-  if (!rewrite) throw new Error(`${snippet}\n\nAgor did not start.`);
+  if (!rewrite) return null;
 
-  const migrated = await migrateConfigDeploymentId(path, deploymentId);
-  return {
-    config: migrated.config,
-    migrated: { deploymentId: migrated.deploymentId, backupPath: migrated.backupPath },
-  };
+  // Validated as a UUID by the prompt above; `migrateConfigDeploymentId` takes the
+  // narrowed `crypto.UUID` template type.
+  const migrated = await migrateConfigDeploymentId(
+    path,
+    deploymentId.trim().toLowerCase() as ReturnType<typeof randomUUID>
+  );
+  return { deploymentId: migrated.deploymentId, backupPath: migrated.backupPath };
 }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -247,7 +247,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const authenticatedHook = scopeExecutorRuntimeAuth(
     authenticate({ strategies: ['api-key', 'jwt'] })
   );
-  const requireAuth = createRequireAuthHook(authenticatedHook, multiTenancy);
+  const requireAuthOnly = createRequireAuthHook(authenticatedHook, multiTenancy);
 
   const enforcePasswordChange = async (context: HookContext) => {
     const user = context.params?.user as User | undefined;
@@ -281,6 +281,21 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       user_id: freshUser.user_id,
     });
   };
+
+  /**
+   * `enforcePasswordChange` is also registered as a global app hook, but Feathers
+   * runs app-level hooks *before* service-level ones — so over REST it fired while
+   * `params.user` was still unset by the service's own `requireAuth`, hit its
+   * `if (!user) return context` guard, and silently passed the request through. A
+   * user flagged for a password change could do anything the CLI offered. On
+   * Socket.IO the connection already carries `params.user`, which is why the gate
+   * worked there and the gap only ever showed up over REST.
+   *
+   * Running it here, immediately after authentication resolves, means the check
+   * happens once at the auth chokepoint with the user actually populated.
+   */
+  const requireAuth = async (context: HookContext): Promise<HookContext> =>
+    enforcePasswordChange(await requireAuthOnly(context));
 
   // --------------------------------------------------------------------------
   // Ports, daemon URL, credentials

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2207,9 +2207,35 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Users hooks
   // ============================================================================
 
+  /**
+   * The users service deliberately serves two unauthenticated callers — internal
+   * calls (no `provider`) and the Feathers local-auth email lookup during login —
+   * so it cannot take a blanket `requireAuth` on `all` the way other services do.
+   *
+   * But with no authenticate hook at all, `params.user` was never populated on the
+   * REST transport, so every downstream guard that reads it (the `find` hook,
+   * `authorizeUsersGet`, the role checks) rejected a perfectly valid Bearer token
+   * with "Authentication required". Socket.IO connections carry `params.user` from
+   * the authenticated connection, which is why this only ever failed over REST and
+   * only for the CLI — the UI never exercises this path.
+   *
+   * So: authenticate when the caller actually presented credentials, and leave both
+   * intentional unauthenticated paths exactly as they were.
+   */
+  const authenticateUsersRequestWhenCredentialed = async (
+    context: HookContext
+  ): Promise<HookContext> => {
+    const params = context.params as AuthenticatedParams;
+    if (!params.provider) return context;
+    if (params.user) return context;
+    if (isLocalAuthenticationLookup(params) || isAuthenticationUserLookup(params)) return context;
+    if (!params.authentication) return context;
+    return requireAuth(context);
+  };
+
   app.service('users').hooks({
     before: {
-      all: [typedValidateQuery(userQueryValidator)],
+      all: [typedValidateQuery(userQueryValidator), authenticateUsersRequestWhenCredentialed],
       find: [
         (context) => {
           const params = context.params as AuthenticatedParams;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -511,6 +511,9 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     setupBranchGroupGrantsService(app, db, new BranchRepository(db));
   }
 
+  // `createBranch` is deliberately NOT a transport method: it takes `(id, data)`,
+  // which is not the Feathers custom-method contract, and it is already exposed as
+  // the RBAC-guarded `/repos/:id/branches` route that the UI and CLI both use.
   app.use('/repos', createReposService(db, app), {
     methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
   });

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
@@ -235,7 +235,10 @@ describe('AgenticConfigChipRow', () => {
 
     // Select now reads "Custom"; chip reflects the new model.
     await waitFor(() => expect(screen.getByText('Custom')).toBeInTheDocument());
-    expect(screen.getByTestId('model-chip')).toHaveTextContent('Haiku 4.5');
+    // Assert the chip inside its own waitFor: 'Custom' appearing and the chip
+    // re-rendering are separate effects of the same state change, and on a loaded
+    // runner the chip can still hold its previous text at this point.
+    await waitFor(() => expect(screen.getByTestId('model-chip')).toHaveTextContent('Haiku 4.5'));
 
     const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
     expect(state.src).toBe('__inline__');
@@ -310,7 +313,9 @@ describe('AgenticConfigChipRow', () => {
     fireEvent.click(selector);
 
     await waitFor(() => expect(screen.getByText('Custom')).toBeInTheDocument());
-    expect(screen.getByTestId('effort-chip')).toHaveTextContent('Effort: Medium');
+    await waitFor(() =>
+      expect(screen.getByTestId('effort-chip')).toHaveTextContent('Effort: Medium')
+    );
     expect(JSON.parse(screen.getByTestId('state').textContent || '{}').effort).toBe('medium');
   });
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1310,20 +1310,61 @@ export async function createRestClient(
   // Lazy-load REST client (only imported when needed, not in browser bundles)
   const { default: rest } = await import('@feathersjs/rest-client');
 
-  // When an API key is provided, wrap fetch to inject the Authorization header
-  const fetchFn = apiKey
-    ? (input: string | URL | globalThis.Request, init?: RequestInit) => {
-        const headers = new Headers(init?.headers);
-        headers.set('Authorization', `Bearer ${apiKey}`);
-        return fetchImpl(input, { ...init, headers });
-      }
-    : fetchImpl;
+  // Inject the Authorization header at the transport layer rather than relying on
+  // the Feathers authentication hook.
+  //
+  // That hook only decorates the *standard* service methods. Calls to custom methods
+  // registered via `service.methods(...)` — board `toYaml`/`clone`/`fromYaml`, repo
+  // `createBranch`, … — went out with no credentials at all, and the daemon correctly
+  // answered 401 "Not authenticated". Only the CLI hit this: the UI is on Socket.IO,
+  // where the connection itself is authenticated.
+  //
+  // The token is tracked here rather than read back from the authentication client
+  // because this client is configured with `storage: undefined`, so
+  // `getAccessToken()` resolves to null.
+  let bearerToken: string | null = apiKey ?? null;
+
+  const fetchFn = async (input: string | URL | globalThis.Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+
+    // Never attach a bearer to the login exchange itself: the credentials live in
+    // the request body, and a stale token here would 401 the very call meant to
+    // replace it.
+    const target = typeof input === 'string' ? input : input.toString();
+    const isAuthenticationRequest = /\/authentication\/?(?:\?|$)/.test(target);
+
+    if (!isAuthenticationRequest && !headers.has('Authorization') && bearerToken) {
+      headers.set('Authorization', `Bearer ${bearerToken}`);
+    }
+
+    return fetchImpl(input, { ...init, headers });
+  };
 
   // Configure REST transport
   client.configure(rest(url).fetch(fetchFn));
 
   // Configure authentication with no storage (CLI will manage tokens separately)
   client.configure(authentication({ storage: undefined }));
+
+  // Remember the credential each successful login establishes, so `fetchFn` above
+  // can authenticate custom-method calls the Feathers hook does not cover.
+  if (!apiKey) {
+    const authenticateWithClient = client.authenticate.bind(client);
+    client.authenticate = async (data?: Parameters<typeof authenticateWithClient>[0]) => {
+      const result = await authenticateWithClient(data);
+      const established =
+        (result as { accessToken?: unknown } | undefined)?.accessToken ??
+        (data as { accessToken?: unknown } | undefined)?.accessToken;
+      if (typeof established === 'string') bearerToken = established;
+      return result;
+    };
+
+    const logoutFromClient = client.logout.bind(client);
+    client.logout = async () => {
+      bearerToken = null;
+      return logoutFromClient();
+    };
+  }
 
   // Create a dummy socket object to satisfy the interface
   client.io = {

--- a/packages/core/src/api/rest-client-auth.test.ts
+++ b/packages/core/src/api/rest-client-auth.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The CLI talks to the daemon over REST while the UI talks over Socket.IO, so the
+ * REST transport is only ever exercised by the CLI. That asymmetry hid a bug: the
+ * Feathers authentication hook decorates the standard service methods but not
+ * custom methods registered via `service.methods(...)`, so `agor board export`,
+ * `clone` and `import` all went out unauthenticated and the daemon answered 401.
+ *
+ * These tests pin the header onto the transport itself, against a real HTTP server,
+ * so a future refactor of the auth wiring cannot quietly drop it again.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRestClient } from './index';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  serviceMethod: string | undefined;
+  authorization: string | undefined;
+}
+
+const ACCESS_TOKEN = 'header.payload.signature';
+
+describe('createRestClient authorization', () => {
+  let server: Server;
+  let baseUrl: string;
+  let captured: CapturedRequest[];
+
+  beforeEach(async () => {
+    captured = [];
+    server = createServer((req, res) => {
+      const serviceMethod = req.headers['x-service-method'];
+      captured.push({
+        method: req.method ?? '',
+        url: req.url ?? '',
+        serviceMethod: Array.isArray(serviceMethod) ? serviceMethod[0] : serviceMethod,
+        authorization: req.headers.authorization,
+      });
+
+      // Drain the request body so 'end' fires; the contents are not asserted on.
+      req.on('data', () => {});
+      req.on('end', () => {
+        res.setHeader('Content-Type', 'application/json');
+        if (req.url?.startsWith('/authentication')) {
+          res.end(
+            JSON.stringify({
+              accessToken: ACCESS_TOKEN,
+              user: { user_id: 'u1', email: 'someone@example.com' },
+            })
+          );
+          return;
+        }
+        if (serviceMethod === 'toYaml') {
+          res.end(JSON.stringify('name: Main Board\n'));
+          return;
+        }
+        res.end(JSON.stringify({ total: 0, limit: 10, skip: 0, data: [] }));
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('sends the bearer token on custom methods, not just standard ones', async () => {
+    const client = await createRestClient(baseUrl);
+    await client.authenticate({ strategy: 'jwt', accessToken: ACCESS_TOKEN });
+
+    await client.service('boards').find({});
+    await (
+      client.service('boards') as unknown as { toYaml: (data: unknown) => Promise<string> }
+    ).toYaml({ id: 'board-1' });
+
+    const find = captured.find(
+      (entry) => entry.method === 'GET' && entry.url.startsWith('/boards')
+    );
+    const custom = captured.find((entry) => entry.serviceMethod === 'toYaml');
+
+    expect(find?.authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+    // The regression: this one used to arrive with no Authorization header at all.
+    expect(custom?.authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+  });
+
+  it('does not attach a stale bearer to the login exchange itself', async () => {
+    const client = await createRestClient(baseUrl);
+    await client.authenticate({ strategy: 'jwt', accessToken: ACCESS_TOKEN });
+    // A second login is how the CLI replaces an expired credential; sending the old
+    // token would 401 the very call meant to replace it.
+    await client.authenticate({ strategy: 'jwt', accessToken: ACCESS_TOKEN });
+
+    const authRequests = captured.filter((entry) => entry.url.startsWith('/authentication'));
+    expect(authRequests.length).toBeGreaterThanOrEqual(2);
+    for (const request of authRequests) {
+      expect(request.authorization).toBeUndefined();
+    }
+  });
+
+  it('uses an explicit API key for every call, including custom methods', async () => {
+    const client = await createRestClient(baseUrl, 'api-key-value');
+
+    await client.service('boards').find({});
+    await (
+      client.service('boards') as unknown as { toYaml: (data: unknown) => Promise<string> }
+    ).toYaml({ id: 'board-1' });
+
+    expect(captured).not.toHaveLength(0);
+    for (const request of captured) {
+      expect(request.authorization).toBe('Bearer api-key-value');
+    }
+  });
+
+  it('sends no bearer before anything has authenticated', async () => {
+    const client = await createRestClient(baseUrl);
+    await client.service('boards').find({});
+
+    expect(captured.at(-1)?.authorization).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Found during a manual QA pass over the `0.25.2` CLI. Three headline workflows failed outright against a healthy daemon with a valid superadmin token, plus a security-relevant gate that wasn't firing.

## Why these escaped

The CLI talks to the daemon over **REST**; the UI talks over **Socket.IO** (`createRestClient` vs `createClient` in `packages/core/src/api/index.ts`). The CLI is the only REST consumer, and nothing covered that transport — so every bug here is invisible from the product.

## What's fixed

**`agor branch add` never worked.** It threw a raw `client.service(...).createBranch is not a function` after doing the git work. `RepoService.createBranch()` takes `(id, data)`, which isn't the Feathers custom-method contract, and isn't in the `/repos` transport list — unreachable over REST, silently unanswered over Socket.IO. Listing it isn't the fix (the signature still wouldn't match, and two in-process callers depend on it. Branch creation is already exposed as the RBAC-guarded  route the UI uses, so the CLI now goes through that.

**The whole Create a new user account

USAGE
  $ agor user COMMAND

COMMANDS
  user create  Create a new user account
  user delete  Delete a user account
  user list    List all users
  user update  Update a user account group 401'd.** The users service can't take a blanket  — it deliberately serves internal calls and the login email lookup unauthenticated — so it had no authenticate hook at all, and  was never populated over REST. Now it authenticates when the caller actually presented credentials, leaving both intentional paths untouched.

**Board export/clone/import 401'd.** The Feathers auth hook decorates standard methods but not -registered ones, so those calls carried no credentials. Fixed at the transport layer so standard and custom methods are covered alike. The login exchange is excluded so a stale token can't 401 the call meant to replace it.

** was bypassable.** Hook ordering, not transport:  is a global  before-all, and Feathers runs app hooks *before* service hooks — so it fired before  populated , hit its  guard, and passed everything through. Socket.IO connections already carry the user, which is why it held there. Now runs at the auth chokepoint.

**Daemon already running (PID 35220) was interactive.** A missing  dropped it into a prompt offering to rewrite  — bad for systemd, containers and provisioning. It now hard-fails and points at Agor doctor

✓ Node.js v22.22.2
✓ Agor CLI is executable
✓ Git 2.49.0 is executable (/opt/homebrew/bin/git)

Optional capabilities
  ✓ Web terminal runtime: ready

Agentic tools
  Policy: declarative; source: config.yaml
  ✓ Claude Code: ready (selected)
  ✓ Codex: ready (selected)
  ○ GitHub Copilot: missing
  ○ Gemini: missing
  ○ OpenCode: missing
  ○ Cursor: missing

Executor sandbox (SRT)
  ○ Disabled (execution.sandbox.enabled: false). Agents have open filesystem access.

  Repair without changing selection: agor install --sync, which owns the repair and reports the state in . The repair accepts a pasted ID instead of only minting one, and says plainly that a new ID re-identifies the deployment and forces every client to log in again.

**Bonus: the init suite wasn't hermetic.** ✨ Initializing Agor...

✓ Git 2.49.0 is executable (/opt/homebrew/bin/git) refused whenever *any* daemon answered on the configured URL — the global default for a home with no config yet. Eight init tests failed on a developer machine with a live daemon and passed only in CI. The guard now checks ownership (managed PID file, or a matching deployment ID) rather than treating a port as proof.

## Testing

- CLI **154 passed**, core **3597 passed**, daemon **2890 passed**; lint and boundary checks clean.
- 14 new regression tests. The REST-auth one was confirmed to genuinely catch the bug by reverting the fix and watching it fail.
- Verified end-to-end against a live daemon:  creates a real git worktree on the right branch; export/clone/import, , and the password gate (403 flagged / 200 cleared, login unaffected) all behave.
- CLI suite verified green **both** with and without a daemon running, so CI behavior is unchanged.

## Not addressed

- Login reports a 7-day token while minting a 900-second JWT, and deletes  on expiry — losing the deployment target, not just the credential. The login response already includes a  the CLI discards; wiring that up is the real fix but it's a session-handling design call.
- A daemon that took an unexplained  twice during testing. Not reproducible; detachment, launchd and competing processes ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)