### PR TITLE
fix(knowledge): hydrate author attribution in API responses

### DIFF
--- a/apps/agor-daemon/src/services/knowledge-attribution.postgres.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-attribution.postgres.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Production-shaped Knowledge author attribution coverage. The shared
+ * PostgreSQL runner supplies a disposable non-superuser, NOBYPASSRLS role.
+ */
+
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  generateId,
+  initializeDatabase,
+  isPostgresDatabase,
+  KnowledgeDocumentRepository,
+  KnowledgeNamespaceRepository,
+  runWithTenantDatabaseScope,
+  sql,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import { NotFound } from '@agor/core/feathers';
+import type { User, UserID } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { KnowledgeDocumentsService } from './knowledge-documents.js';
+import { KnowledgeVersionsService } from './knowledge-versions.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+function params(user: User, query?: Record<string, unknown>) {
+  return { user, query } as never;
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'Knowledge author attribution service projection (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+    let db: TenantScopeAwareDatabase;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      const [role] = rowsOf(
+        await executeRaw(
+          rawDb,
+          sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+        )
+      );
+      expect(role).toMatchObject({ rolsuper: false, rolbypassrls: false });
+      db = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'knowledge-attribution-test',
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('projects human and teammate authors without profile data and isolates other tenants', async () => {
+      const tenantA = `knowledge-author-a-${generateId()}`;
+      const tenantB = `knowledge-author-b-${generateId()}`;
+      const documents = new KnowledgeDocumentsService(db);
+      const history = new KnowledgeVersionsService(db);
+
+      const a = await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+        const users = new UsersRepository(scoped);
+        const owner = (await users.create({
+          email: `owner-${generateId()}@tenant-a.test`,
+          name: 'Postgres Owner',
+        })) as User;
+        const teammate = (await users.create({
+          email: `teammate-${generateId()}@tenant-a.test`,
+          name: 'Postgres Teammate',
+        })) as User;
+        const namespace = await new KnowledgeNamespaceRepository(scoped).create({
+          slug: `attribution-${generateId()}`,
+          display_name: 'Attribution',
+          owner_user_id: owner.user_id,
+          others_can: 'write',
+        });
+        return { owner, teammate, namespace };
+      });
+      const b = await runWithTenantDatabaseScope(db, tenantB, async (scoped) => ({
+        user: (await new UsersRepository(scoped).create({
+          email: `private-${generateId()}@tenant-b.test`,
+          name: 'Tenant B Private Name',
+        })) as User,
+      }));
+
+      const created = await runWithTenantDatabaseScope(db, tenantA, () =>
+        documents.putDocument(
+          {
+            namespace_slug: a.namespace.slug,
+            path: 'authors.md',
+            content_text: '# Authors\n\nHuman',
+            edit_policy: 'public',
+          },
+          params(a.owner)
+        )
+      );
+      const sessionId = generateId();
+      await runWithTenantDatabaseScope(db, tenantA, () =>
+        documents.putDocument(
+          {
+            document_id: created.document_id,
+            content_text: '# Authors\n\nAssistant',
+            expected_version: 1,
+          },
+          {
+            user: a.teammate,
+            knowledgeWriteAttribution: {
+              sessionId,
+              agenticTool: 'codex',
+              teammateName: 'Scout',
+            },
+          }
+        )
+      );
+
+      const response = await runWithTenantDatabaseScope(db, tenantA, async () => ({
+        document: await documents.getDocument(
+          { document_id: created.document_id, include_content: true },
+          params(a.owner)
+        ),
+        versions: await history.find(
+          params(a.owner, { document_id: created.document_id, include_content: true })
+        ),
+      }));
+      expect(response.document).toMatchObject({
+        updated_by: a.teammate.user_id,
+        updated_by_user: { status: 'resolved', display_name: 'Postgres Teammate' },
+        updated_by_session_id: sessionId,
+        updated_by_agentic_tool: 'codex',
+        updated_by_teammate_name: 'Scout',
+        current_version: {
+          created_by_user: { status: 'resolved', display_name: 'Postgres Teammate' },
+          created_by_session_id: sessionId,
+          created_by_agentic_tool: 'codex',
+          created_by_teammate_name: 'Scout',
+        },
+      });
+      expect(response.versions).toHaveLength(2);
+      expect(response.versions[0]).toMatchObject({
+        created_by_user: { status: 'resolved', display_name: 'Postgres Teammate' },
+        created_by_teammate_name: 'Scout',
+      });
+      expect(response.versions[1]).toMatchObject({
+        created_by_user: { status: 'resolved', display_name: 'Postgres Owner' },
+        created_by_session_id: null,
+      });
+
+      const serialized = JSON.stringify(response);
+      expect(serialized).not.toContain(a.owner.email);
+      expect(serialized).not.toContain(a.teammate.email);
+      expect(serialized).not.toContain(b.user.name!);
+      expect(serialized).not.toContain(b.user.email);
+
+      await runWithTenantDatabaseScope(db, tenantB, async () => {
+        await expect(documents.get(created.document_id, params(b.user))).rejects.toBeInstanceOf(
+          NotFound
+        );
+        await expect(
+          history.find(params(b.user, { document_id: created.document_id }))
+        ).resolves.toEqual([]);
+      });
+    });
+
+    it('does not broaden an author lookup when a historical ID is invisible under RLS', async () => {
+      const tenantA = `knowledge-unavailable-a-${generateId()}`;
+      const tenantB = `knowledge-unavailable-b-${generateId()}`;
+      const documents = new KnowledgeDocumentsService(db);
+      const history = new KnowledgeVersionsService(db);
+
+      const hidden = await runWithTenantDatabaseScope(db, tenantB, async (scoped) =>
+        new UsersRepository(scoped).create({
+          email: `hidden-${generateId()}@tenant-b.test`,
+          name: 'Do Not Enumerate This Name',
+        })
+      );
+      const seeded = await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+        const viewer = (await new UsersRepository(scoped).create({
+          email: `viewer-${generateId()}@tenant-a.test`,
+          name: 'Tenant A Viewer',
+        })) as User;
+        const namespace = await new KnowledgeNamespaceRepository(scoped).create({
+          slug: `unavailable-${generateId()}`,
+          display_name: 'Unavailable historical author',
+          owner_user_id: viewer.user_id,
+        });
+        // The legacy schema has globally keyed author FKs. Deliberately create
+        // a malformed historical reference to prove the projection still
+        // resolves only inside the active tenant's RLS scope.
+        const document = await new KnowledgeDocumentRepository(scoped).create({
+          namespace_id: namespace.namespace_id,
+          path: 'legacy.md',
+          title: 'Legacy',
+          visibility: 'public',
+          content_text: 'legacy',
+          created_by: hidden.user_id as UserID,
+        });
+        return { viewer, document };
+      });
+
+      const response = await runWithTenantDatabaseScope(db, tenantA, async () => ({
+        document: await documents.getDocument(
+          { document_id: seeded.document.document_id, include_content: true },
+          params(seeded.viewer)
+        ),
+        versions: await history.find(
+          params(seeded.viewer, {
+            document_id: seeded.document.document_id,
+            include_content: true,
+          })
+        ),
+      }));
+      expect(response.document).toMatchObject({
+        updated_by: null,
+        updated_by_user: { status: 'unavailable', display_name: 'Unavailable user' },
+        current_version: {
+          created_by: null,
+          created_by_user: { status: 'unavailable', display_name: 'Unavailable user' },
+        },
+      });
+      expect(response.versions[0]).toMatchObject({
+        created_by: null,
+        created_by_user: { status: 'unavailable', display_name: 'Unavailable user' },
+      });
+      const serialized = JSON.stringify(response);
+      expect(serialized).not.toContain(hidden.user_id);
+      expect(serialized).not.toContain(hidden.name!);
+      expect(serialized).not.toContain(hidden.email);
+    });
+  }
+);

--- a/apps/agor-daemon/src/services/knowledge-attribution.postgres.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-attribution.postgres.test.ts
@@ -22,6 +22,7 @@ import { NotFound } from '@agor/core/feathers';
 import type { User, UserID } from '@agor/core/types';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { KnowledgeDocumentsService } from './knowledge-documents.js';
+import { KnowledgeSearchService } from './knowledge-search.js';
 import { KnowledgeVersionsService } from './knowledge-versions.js';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
@@ -69,6 +70,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       const tenantB = `knowledge-author-b-${generateId()}`;
       const documents = new KnowledgeDocumentsService(db);
       const history = new KnowledgeVersionsService(db);
+      const search = new KnowledgeSearchService(db);
 
       const a = await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
         const users = new UsersRepository(scoped);
@@ -157,7 +159,27 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         created_by_session_id: null,
       });
 
-      const serialized = JSON.stringify(response);
+      const searchResponse = await runWithTenantDatabaseScope(db, tenantA, () =>
+        search.find(params(a.owner, { q: 'Assistant' }))
+      );
+      expect(searchResponse).toHaveLength(1);
+      expect(searchResponse[0]).toMatchObject({
+        document: {
+          updated_by: a.teammate.user_id,
+          updated_by_user: { status: 'resolved', display_name: 'Postgres Teammate' },
+          updated_by_session_id: sessionId,
+          updated_by_agentic_tool: 'codex',
+          updated_by_teammate_name: 'Scout',
+        },
+        current_version: {
+          created_by_user: { status: 'resolved', display_name: 'Postgres Teammate' },
+          created_by_session_id: sessionId,
+          created_by_agentic_tool: 'codex',
+          created_by_teammate_name: 'Scout',
+        },
+      });
+
+      const serialized = JSON.stringify({ response, searchResponse });
       expect(serialized).not.toContain(a.owner.email);
       expect(serialized).not.toContain(a.teammate.email);
       expect(serialized).not.toContain(b.user.name!);
@@ -170,6 +192,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         await expect(
           history.find(params(b.user, { document_id: created.document_id }))
         ).resolves.toEqual([]);
+        await expect(search.find(params(b.user, { q: 'Assistant' }))).resolves.toEqual([]);
       });
     });
 

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -399,23 +399,76 @@ export class KnowledgeDocumentsService extends DrizzleService<
     document: KnowledgeDocument,
     params?: HydrateOptions
   ): Promise<KnowledgeDocument | HydratedKnowledgeDocument> {
+    const wantsHydration = params?.include_content === true || params?.include_links === true;
+    const rawVersion = wantsHydration ? await this.versionFor(document, params?.version) : null;
+    const projected = await this.attribution.attachToDocumentsAndVersions(
+      [document],
+      rawVersion ? [rawVersion] : []
+    );
+    const attributedDocument = projected.documents[0];
+    const version = projected.versions[0] ?? null;
     const withIndexing =
       params?.include_indexing === true || params?.includeIndexing === true
-        ? ((await this.repo.attachIndexingStatus(document)) as KnowledgeDocument)
-        : document;
-    if (params?.include_content !== true && params?.include_links !== true) return withIndexing;
-    const rawVersion = await this.versionFor(document, params?.version);
-    const version = rawVersion ? (await this.attribution.attachToVersions([rawVersion]))[0] : null;
+        ? ((await this.repo.attachIndexingStatus(attributedDocument)) as KnowledgeDocument)
+        : attributedDocument;
+    if (!wantsHydration) return withIndexing;
+    return this.buildHydratedDocument(withIndexing, version, params);
+  }
+
+  private buildHydratedDocument(
+    document: KnowledgeDocument,
+    version: KnowledgeDocumentVersion | null,
+    params?: HydrateOptions
+  ): HydratedKnowledgeDocument {
     return {
-      ...withIndexing,
-      document: withIndexing,
+      ...document,
+      document,
       current_version: version,
       content: version?.content_text ?? null,
-      first_line_is_title: withIndexing.metadata?.title_from_content === true,
+      first_line_is_title: document.metadata?.title_from_content === true,
       ...(params?.include_links
         ? { links: extractKnowledgeLinks(version?.content_text ?? '') }
         : {}),
     };
+  }
+
+  private async versionsForDocuments(
+    documents: readonly KnowledgeDocument[],
+    versionRef?: string | number
+  ): Promise<Array<KnowledgeDocumentVersion | null>> {
+    if (versionRef === undefined || versionRef === null || versionRef === '') {
+      const versions = await this.versions.findByIds(
+        documents.flatMap((document) =>
+          document.current_version_id ? [document.current_version_id] : []
+        )
+      );
+      const byId = new Map(versions.map((version) => [version.version_id, version]));
+      return documents.map((document) =>
+        document.current_version_id ? (byId.get(document.current_version_id) ?? null) : null
+      );
+    }
+    return Promise.all(documents.map((document) => this.versionFor(document, versionRef)));
+  }
+
+  private async hydrateDocuments(
+    documents: readonly KnowledgeDocument[],
+    params: HydrateOptions
+  ): Promise<HydratedKnowledgeDocument[]> {
+    const rawVersions = await this.versionsForDocuments(documents, params.version);
+    const projected = await this.attribution.attachToDocumentsAndVersions(
+      documents,
+      rawVersions.filter((version): version is KnowledgeDocumentVersion => version !== null)
+    );
+    const versionById = new Map(projected.versions.map((version) => [version.version_id, version]));
+    const projectedDocuments =
+      params.include_indexing === true || params.includeIndexing === true
+        ? ((await this.repo.attachIndexingStatus(projected.documents)) as KnowledgeDocument[])
+        : projected.documents;
+    return projectedDocuments.map((document, index) => {
+      const rawVersion = rawVersions[index];
+      const version = rawVersion ? (versionById.get(rawVersion.version_id) ?? null) : null;
+      return this.buildHydratedDocument(document, version, params);
+    });
   }
 
   private async assertExpectedVersion(
@@ -462,24 +515,20 @@ export class KnowledgeDocumentsService extends DrizzleService<
     for (const doc of rows) {
       if (await this.canRead(doc, user)) readable.push(doc);
     }
-    const attributed = await this.attribution.attachToDocuments(readable);
     if (params?.query?.include_content !== true && params?.query?.include_links !== true) {
+      const attributed = await this.attribution.attachToDocuments(readable);
       if (params?.query?.include_indexing === true || params?.query?.includeIndexing === true) {
         return this.repo.attachIndexingStatus(attributed) as Promise<KnowledgeDocument[]>;
       }
       return attributed;
     }
-    return Promise.all(
-      attributed.map((doc) =>
-        this.hydrateDocument(doc, {
-          include_content: params?.query?.include_content,
-          include_links: params?.query?.include_links,
-          include_indexing: params?.query?.include_indexing,
-          includeIndexing: params?.query?.includeIndexing,
-          version: params?.query?.version,
-        })
-      )
-    );
+    return this.hydrateDocuments(readable, {
+      include_content: params?.query?.include_content,
+      include_links: params?.query?.include_links,
+      include_indexing: params?.query?.include_indexing,
+      includeIndexing: params?.query?.includeIndexing,
+      version: params?.query?.version,
+    });
   }
 
   async get(id: Id, params?: KnowledgeDocumentParams): Promise<KnowledgeDocument> {
@@ -489,8 +538,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
-    const [attributed] = await this.attribution.attachToDocuments([doc]);
-    return this.hydrateDocument(attributed, params?.query);
+    return this.hydrateDocument(doc, params?.query);
   }
 
   async getDocument(
@@ -503,8 +551,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
-    const [attributed] = await this.attribution.attachToDocuments([doc]);
-    return this.hydrateDocument(attributed, data);
+    return this.hydrateDocument(doc, data);
   }
 
   async putDocument(

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -9,6 +9,7 @@ import { PAGINATION } from '@agor/core/config';
 import {
   type CreateKnowledgeDocumentInput,
   isPostgresDatabaseHandle,
+  KnowledgeAttributionRepository,
   type KnowledgeDocumentFilters,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
@@ -136,6 +137,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
   KnowledgeDocumentParams
 > {
   private repo: KnowledgeDocumentRepository;
+  private attribution: KnowledgeAttributionRepository;
   private semanticSettings: KnowledgeSemanticSettingsRepository;
   private versions: KnowledgeDocumentVersionRepository;
   private namespaces: KnowledgeNamespaceRepository;
@@ -155,6 +157,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       },
     });
     this.repo = repo;
+    this.attribution = new KnowledgeAttributionRepository(db);
     this.semanticSettings = new KnowledgeSemanticSettingsRepository(db);
     this.versions = new KnowledgeDocumentVersionRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
@@ -401,7 +404,8 @@ export class KnowledgeDocumentsService extends DrizzleService<
         ? ((await this.repo.attachIndexingStatus(document)) as KnowledgeDocument)
         : document;
     if (params?.include_content !== true && params?.include_links !== true) return withIndexing;
-    const version = await this.versionFor(document, params?.version);
+    const rawVersion = await this.versionFor(document, params?.version);
+    const version = rawVersion ? (await this.attribution.attachToVersions([rawVersion]))[0] : null;
     return {
       ...withIndexing,
       document: withIndexing,
@@ -458,14 +462,15 @@ export class KnowledgeDocumentsService extends DrizzleService<
     for (const doc of rows) {
       if (await this.canRead(doc, user)) readable.push(doc);
     }
+    const attributed = await this.attribution.attachToDocuments(readable);
     if (params?.query?.include_content !== true && params?.query?.include_links !== true) {
       if (params?.query?.include_indexing === true || params?.query?.includeIndexing === true) {
-        return this.repo.attachIndexingStatus(readable) as Promise<KnowledgeDocument[]>;
+        return this.repo.attachIndexingStatus(attributed) as Promise<KnowledgeDocument[]>;
       }
-      return readable;
+      return attributed;
     }
     return Promise.all(
-      readable.map((doc) =>
+      attributed.map((doc) =>
         this.hydrateDocument(doc, {
           include_content: params?.query?.include_content,
           include_links: params?.query?.include_links,
@@ -484,7 +489,8 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
-    return this.hydrateDocument(doc, params?.query);
+    const [attributed] = await this.attribution.attachToDocuments([doc]);
+    return this.hydrateDocument(attributed, params?.query);
   }
 
   async getDocument(
@@ -497,7 +503,8 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
-    return this.hydrateDocument(doc, data);
+    const [attributed] = await this.attribution.attachToDocuments([doc]);
+    return this.hydrateDocument(attributed, data);
   }
 
   async putDocument(
@@ -536,7 +543,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
         throw new Forbidden('You do not have permission to update this knowledge document');
       }
       await this.assertExpectedVersion(existing, data.expected_version);
-      const result = await this.repo.update(
+      const persisted = await this.repo.update(
         existing.document_id,
         this.prepareWriteData(
           {
@@ -550,8 +557,9 @@ export class KnowledgeDocumentsService extends DrizzleService<
           existing
         )
       );
-      await this.replaceSearchUnitsForContent(result, data.content_text);
-      await this.syncGraphReferences(result, data.content_text, userId);
+      await this.replaceSearchUnitsForContent(persisted, data.content_text);
+      await this.syncGraphReferences(persisted, data.content_text, userId);
+      const [result] = await this.attribution.attachToDocuments([persisted]);
       this.emitDocumentEvent('patched', result, params);
       return result;
     }
@@ -586,7 +594,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (namespace.archived) throw new NotFound(`Knowledge namespace not found: ${namespaceSlug}`);
     await this.assertCanWriteNamespace(namespace.namespace_id, params?.user as User | undefined);
 
-    const result = await this.repo.create(
+    const persisted = await this.repo.create(
       this.prepareWriteData({
         ...data,
         namespace_id: namespace.namespace_id,
@@ -597,8 +605,9 @@ export class KnowledgeDocumentsService extends DrizzleService<
         ...assistantAttribution(params),
       })
     );
-    await this.replaceSearchUnitsForContent(result, data.content_text);
-    await this.syncGraphReferences(result, data.content_text, userId);
+    await this.replaceSearchUnitsForContent(persisted, data.content_text);
+    await this.syncGraphReferences(persisted, data.content_text, userId);
+    const [result] = await this.attribution.attachToDocuments([persisted]);
     this.emitDocumentEvent('created', result, params);
     return result;
   }
@@ -624,14 +633,14 @@ export class KnowledgeDocumentsService extends DrizzleService<
         : null;
     if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
     await this.assertCanWriteNamespace(namespace.namespace_id, params?.user as User | undefined);
-    const result = await this.repo.create({
+    const persisted = await this.repo.create({
       ...prepared,
       namespace_id: namespace.namespace_id,
       namespace_slug: namespace.slug,
     });
-    await this.replaceSearchUnitsForContent(result, data.content_text);
-    await this.syncGraphReferences(result, data.content_text, userId);
-    return result;
+    await this.replaceSearchUnitsForContent(persisted, data.content_text);
+    await this.syncGraphReferences(persisted, data.content_text, userId);
+    return (await this.attribution.attachToDocuments([persisted]))[0];
   }
 
   async create(
@@ -684,22 +693,22 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canEdit(existing, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to update this knowledge document');
     }
-    const result = await this.repo.update(String(id), {
+    const persisted = await this.repo.update(String(id), {
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
       ...assistantAttribution(params),
     });
     await this.replaceSearchUnitsForContent(
-      result,
+      persisted,
       (data as KnowledgeDocumentWriteData).content_text
     );
     await this.syncGraphReferences(
-      result,
+      persisted,
       (data as KnowledgeDocumentWriteData).content_text,
       this.attributionUserId(params, data.updated_by)
     );
-    return result;
+    return (await this.attribution.attachToDocuments([persisted]))[0];
   }
 
   async update(
@@ -728,22 +737,22 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!(await this.canEdit(existing, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to update this knowledge document');
     }
-    const result = await this.repo.update(String(id), {
+    const persisted = await this.repo.update(String(id), {
       ...this.prepareWriteData(data as KnowledgeDocumentWriteData, existing),
       created_by: existing.created_by,
       updated_by: this.attributionUserId(params, data.updated_by),
       ...assistantAttribution(params),
     });
     await this.replaceSearchUnitsForContent(
-      result,
+      persisted,
       (data as KnowledgeDocumentWriteData).content_text
     );
     await this.syncGraphReferences(
-      result,
+      persisted,
       (data as KnowledgeDocumentWriteData).content_text,
       this.attributionUserId(params, data.updated_by)
     );
-    return result;
+    return (await this.attribution.attachToDocuments([persisted]))[0];
   }
 
   async remove(id: NullableId, params?: KnowledgeDocumentParams): Promise<KnowledgeDocument> {
@@ -756,7 +765,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       throw new Forbidden('You do not have permission to delete this knowledge document');
     }
     await this.repo.delete(String(id));
-    return existing;
+    return (await this.attribution.attachToDocuments([existing]))[0];
   }
 
   private emitDocumentEvent(

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -6,6 +6,7 @@ import { getBaseUrl } from '@agor/core/config';
 import {
   executeRaw,
   isPostgresDatabaseHandle,
+  KnowledgeAttributionRepository,
   KnowledgeDocumentRepository,
   KnowledgeNamespaceRepository,
   type KnowledgeSearchQuery,
@@ -40,6 +41,7 @@ export type KnowledgeSearchParams = QueryParams<KnowledgeSearchQuery> & Authenti
 
 export class KnowledgeSearchService {
   private repo: KnowledgeSearchRepository;
+  private attribution: KnowledgeAttributionRepository;
   private documents: KnowledgeDocumentRepository;
   private namespaces: KnowledgeNamespaceRepository;
   private semanticSettings: KnowledgeSemanticSettingsRepository;
@@ -47,6 +49,7 @@ export class KnowledgeSearchService {
 
   constructor(private db: TenantScopeAwareDatabase) {
     this.repo = new KnowledgeSearchRepository(db);
+    this.attribution = new KnowledgeAttributionRepository(db);
     this.documents = new KnowledgeDocumentRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
     this.semanticSettings = new KnowledgeSemanticSettingsRepository(db);
@@ -132,6 +135,41 @@ export class KnowledgeSearchService {
       ...result,
       document: docsWithIndexing[index],
     }));
+  }
+
+  private async attachAttributionToResults<T extends KnowledgeSearchResult>(
+    results: T[]
+  ): Promise<T[]> {
+    const versions = results.flatMap((result) =>
+      result.current_version ? [result.current_version] : []
+    );
+    const projected = await this.attribution.attachToDocumentsAndVersions(
+      results.map((result) => result.document),
+      versions
+    );
+    const documentsById = new Map(
+      projected.documents.map((document) => [document.document_id, document])
+    );
+    const versionsById = new Map(
+      projected.versions.map((version) => [version.version_id, version])
+    );
+    return results.map((result) => ({
+      ...result,
+      document: documentsById.get(result.document.document_id) ?? result.document,
+      current_version: result.current_version
+        ? (versionsById.get(result.current_version.version_id) ?? result.current_version)
+        : null,
+    }));
+  }
+
+  private async prepareReadableResults<T extends KnowledgeSearchResult>(
+    results: T[],
+    user: User | undefined,
+    query: KnowledgeSearchQuery
+  ): Promise<T[]> {
+    const readable = (await this.filterReadable(results, user)) as T[];
+    const attributed = await this.attachAttributionToResults(readable);
+    return this.attachIndexingToResults(attributed, query);
   }
 
   private async semanticSearch(
@@ -221,6 +259,9 @@ export class KnowledgeSearchService {
           d.created_by,
           d.created_at,
           d.updated_by,
+          d.updated_by_session_id,
+          d.updated_by_agentic_tool,
+          d.updated_by_teammate_name,
           d.updated_at,
           ns.slug AS namespace_slug,
           ns.display_name AS namespace_display_name,
@@ -313,6 +354,9 @@ export class KnowledgeSearchService {
           created_by: (row.created_by as never) ?? null,
           created_at: new Date(row.created_at as string | number | Date),
           updated_by: (row.updated_by as never) ?? null,
+          updated_by_session_id: (row.updated_by_session_id as never) ?? null,
+          updated_by_agentic_tool: (row.updated_by_agentic_tool as never) ?? null,
+          updated_by_teammate_name: (row.updated_by_teammate_name as string | null) ?? null,
           updated_at: row.updated_at ? new Date(row.updated_at as string | number | Date) : null,
           archived: false,
           archived_at: null,
@@ -344,8 +388,11 @@ export class KnowledgeSearchService {
         chunks: [chunk],
       });
     }
-    const values = await this.filterReadable([...byDoc.values()], user);
-    return this.attachIndexingToResults(values.slice(0, rawQuery.limit ?? 25), rawQuery);
+    const readable = await this.filterReadable([...byDoc.values()], user);
+    const attributed = await this.attachAttributionToResults(
+      readable.slice(0, rawQuery.limit ?? 25)
+    );
+    return this.attachIndexingToResults(attributed, rawQuery);
   }
 
   private hybridMerge(
@@ -358,7 +405,14 @@ export class KnowledgeSearchService {
         const id = result.document.document_id;
         const current = scores.get(id) ?? { result, score: 0 };
         current.score += weight / (index + 1);
-        current.result = { ...current.result, ...result, mode: 'hybrid' };
+        current.result = {
+          ...current.result,
+          ...result,
+          // Semantic results intentionally omit full version content. Preserve
+          // the text result's projected current version when both modes hit.
+          current_version: result.current_version ?? current.result.current_version,
+          mode: 'hybrid',
+        };
         scores.set(id, current);
       });
     };
@@ -374,16 +428,16 @@ export class KnowledgeSearchService {
     const query = await this.scopedQuery(params?.query, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
-    const textResults = await this.filterReadable(
+    const textResults = await this.prepareReadableResults(
       await this.repo.search({ ...query, mode: 'text' }),
-      user
+      user,
+      query
     );
-    const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
-      return this.hybridMerge(textResultsWithIndexing, semanticResults).slice(0, query.limit ?? 25);
+      return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);
     }
-    return textResultsWithIndexing;
+    return textResults;
   }
 
   async create(data: KnowledgeSearchQuery, params?: KnowledgeSearchParams) {
@@ -391,16 +445,16 @@ export class KnowledgeSearchService {
     const query = await this.scopedQuery(data, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
-    const textResults = await this.filterReadable(
+    const textResults = await this.prepareReadableResults(
       await this.repo.search({ ...query, mode: 'text' }),
-      user
+      user,
+      query
     );
-    const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
-      return this.hybridMerge(textResultsWithIndexing, semanticResults).slice(0, query.limit ?? 25);
+      return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);
     }
-    return textResultsWithIndexing;
+    return textResults;
   }
 }
 

--- a/apps/agor-daemon/src/services/knowledge-versions.ts
+++ b/apps/agor-daemon/src/services/knowledge-versions.ts
@@ -4,6 +4,7 @@
 
 import { PAGINATION } from '@agor/core/config';
 import {
+  KnowledgeAttributionRepository,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
   KnowledgeNamespaceRepository,
@@ -38,6 +39,7 @@ export class KnowledgeVersionsService extends DrizzleService<
   Partial<KnowledgeDocumentVersion>,
   KnowledgeVersionParams
 > {
+  private attribution: KnowledgeAttributionRepository;
   private versions: KnowledgeDocumentVersionRepository;
   private documents: KnowledgeDocumentRepository;
   private namespaces: KnowledgeNamespaceRepository;
@@ -52,6 +54,7 @@ export class KnowledgeVersionsService extends DrizzleService<
         max: PAGINATION.MAX_LIMIT,
       },
     });
+    this.attribution = new KnowledgeAttributionRepository(db);
     this.versions = versions;
     this.documents = new KnowledgeDocumentRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
@@ -90,8 +93,9 @@ export class KnowledgeVersionsService extends DrizzleService<
     const rawLimit = (query as { $limit?: unknown }).$limit ?? query.limit;
     const limit = typeof rawLimit === 'number' && Number.isFinite(rawLimit) ? rawLimit : undefined;
     const capped = limit ? versions.slice(0, Math.min(Math.max(limit, 1), 100)) : versions;
-    if (query.include_content === true) return capped;
-    return capped.map((version) => ({ ...version, content_text: null, content_blob: null }));
+    const attributed = await this.attribution.attachToVersions(capped);
+    if (query.include_content === true) return attributed;
+    return attributed.map((version) => ({ ...version, content_text: null, content_blob: null }));
   }
 
   async get(): Promise<never> {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -502,6 +502,160 @@ describe('KnowledgeDocumentsService permissions', () => {
   );
 
   dbTest(
+    'projects human and assistant authors on document and history service responses',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'Attribution Owner');
+      const teammate = await seedUser(db, 'Attribution Teammate');
+      const namespace = await seedNamespace(db, 'attribution-contract');
+      const documents = new KnowledgeDocumentsService(db);
+      const history = new KnowledgeVersionsService(db);
+
+      const created = await documents.putDocument(
+        {
+          namespace_slug: namespace.slug,
+          path: 'authors.md',
+          content_text: '# Authors\n\nHuman edit',
+          edit_policy: 'public',
+        },
+        params(owner)
+      );
+      expect(created.updated_by_user).toEqual({
+        status: 'resolved',
+        display_name: 'Attribution Owner',
+      });
+
+      const assistantSessionId = generateId();
+      await documents.putDocument(
+        {
+          document_id: created.document_id,
+          content_text: '# Authors\n\nAssistant edit',
+          expected_version: 1,
+        },
+        {
+          user: teammate,
+          knowledgeWriteAttribution: {
+            sessionId: assistantSessionId,
+            agenticTool: 'codex',
+            teammateName: 'Scout',
+          },
+        }
+      );
+
+      // Exercise the same hydrated service result consumed by the document
+      // subtitle and MCP get path, not the attribution repository in isolation.
+      const hydrated = await documents.getDocument(
+        { document_id: created.document_id, include_content: true },
+        params(owner)
+      );
+      expect(hydrated).toMatchObject({
+        updated_by: teammate.user_id,
+        updated_by_user: {
+          status: 'resolved',
+          display_name: 'Attribution Teammate',
+        },
+        updated_by_session_id: assistantSessionId,
+        updated_by_agentic_tool: 'codex',
+        updated_by_teammate_name: 'Scout',
+        current_version: {
+          created_by: teammate.user_id,
+          created_by_user: {
+            status: 'resolved',
+            display_name: 'Attribution Teammate',
+          },
+          created_by_session_id: assistantSessionId,
+          created_by_agentic_tool: 'codex',
+          created_by_teammate_name: 'Scout',
+        },
+      });
+
+      // Exercise the immutable history service response consumed by the left
+      // rail. Both the human-only and teammate-authored versions are covered.
+      const versions = await history.find(
+        params(owner, { document_id: created.document_id, include_content: true })
+      );
+      expect(versions).toHaveLength(2);
+      expect(versions[0]).toMatchObject({
+        created_by: teammate.user_id,
+        created_by_user: {
+          status: 'resolved',
+          display_name: 'Attribution Teammate',
+        },
+        created_by_session_id: assistantSessionId,
+        created_by_agentic_tool: 'codex',
+        created_by_teammate_name: 'Scout',
+      });
+      expect(versions[1]).toMatchObject({
+        created_by: owner.user_id,
+        created_by_user: {
+          status: 'resolved',
+          display_name: 'Attribution Owner',
+        },
+        created_by_session_id: null,
+      });
+    }
+  );
+
+  dbTest(
+    'labels system, legacy, and hard-deleted authors without exposing profiles',
+    async ({ db }) => {
+      const viewer = await seedUser(db, 'Attribution Viewer');
+      const formerAuthor = await seedUser(db, 'Former Author');
+      const namespace = await seedNamespace(db, 'attribution-former');
+      const repository = new KnowledgeDocumentRepository(db);
+      const documents = new KnowledgeDocumentsService(db);
+      const history = new KnowledgeVersionsService(db);
+
+      const systemDocument = await repository.create({
+        namespace_id: namespace.namespace_id,
+        path: 'system.md',
+        title: 'System',
+        visibility: 'public',
+        content_text: 'system content',
+        created_by: null,
+      });
+      const formerDocument = await repository.create({
+        namespace_id: namespace.namespace_id,
+        path: 'former.md',
+        title: 'Former',
+        visibility: 'public',
+        content_text: 'former content',
+        created_by: formerAuthor.user_id as UserID,
+      });
+      await new UsersRepository(db).delete(formerAuthor.user_id);
+
+      for (const document of [systemDocument, formerDocument]) {
+        const projected = await documents.getDocument(
+          { document_id: document.document_id, include_content: true },
+          params(viewer)
+        );
+        expect(projected.updated_by).toBeNull();
+        expect(projected.updated_by_user).toEqual({
+          status: 'unattributed',
+          display_name: 'System or former user',
+        });
+        expect(projected.current_version).toMatchObject({
+          created_by: null,
+          created_by_user: {
+            status: 'unattributed',
+            display_name: 'System or former user',
+          },
+        });
+        await expect(
+          history.find(params(viewer, { document_id: document.document_id }))
+        ).resolves.toEqual([
+          expect.objectContaining({
+            created_by: null,
+            created_by_user: {
+              status: 'unattributed',
+              display_name: 'System or former user',
+            },
+          }),
+        ]);
+      }
+    }
+  );
+
+  dbTest(
     'hides archived documents from direct get and recreates same path through upsert',
     async ({ db }) => {
       const owner = await seedUser(db, 'owner');

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -592,6 +592,50 @@ describe('KnowledgeDocumentsService permissions', () => {
         },
         created_by_session_id: null,
       });
+
+      // Text search is also a document-authorized response surface and feeds
+      // the active Knowledge snapshot directly on cold search navigation.
+      const searchResults = await new KnowledgeSearchService(db).find(
+        params(owner, { q: 'Assistant edit' })
+      );
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults[0]).toMatchObject({
+        document: {
+          updated_by_user: {
+            status: 'resolved',
+            display_name: 'Attribution Teammate',
+          },
+          updated_by_session_id: assistantSessionId,
+          updated_by_agentic_tool: 'codex',
+          updated_by_teammate_name: 'Scout',
+        },
+        current_version: {
+          created_by_user: {
+            status: 'resolved',
+            display_name: 'Attribution Teammate',
+          },
+          created_by_session_id: assistantSessionId,
+          created_by_agentic_tool: 'codex',
+          created_by_teammate_name: 'Scout',
+        },
+      });
+
+      const hydratedList = await documents.find(
+        params(owner, { namespace_id: namespace.namespace_id, include_content: true })
+      );
+      expect(hydratedList).toHaveLength(1);
+      expect(hydratedList[0]).toMatchObject({
+        updated_by_user: {
+          status: 'resolved',
+          display_name: 'Attribution Teammate',
+        },
+        current_version: {
+          created_by_user: {
+            status: 'resolved',
+            display_name: 'Attribution Teammate',
+          },
+        },
+      });
     }
   );
 

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.test.ts
@@ -4,6 +4,18 @@ import { knowledgeAttributionDisplay } from './knowledgeAttributionDisplay';
 const users = new Map([['user-1', { name: 'Ada', email: 'ada@example.com' }]]);
 
 describe('knowledgeAttributionDisplay', () => {
+  it('uses the document-authorized server projection when the workspace user map is cold', () => {
+    expect(
+      knowledgeAttributionDisplay(
+        {
+          userId: 'user-1',
+          user: { status: 'resolved', display_name: 'Ada' },
+        },
+        new Map()
+      )
+    ).toEqual({ userLabel: 'Ada', assistantLabel: null, editorLabel: 'Ada' });
+  });
+
   it('shows only the human identity for a human edit', () => {
     expect(knowledgeAttributionDisplay({ userId: 'user-1' }, users)).toEqual({
       userLabel: 'Ada',
@@ -12,11 +24,21 @@ describe('knowledgeAttributionDisplay', () => {
     });
   });
 
+  it('does not expose an email when a legacy user row has no display name', () => {
+    const emailOnlyUsers = new Map([['user-2', { name: null, email: 'private@example.com' }]]);
+    expect(knowledgeAttributionDisplay({ userId: 'user-2' }, emailOnlyUsers)).toEqual({
+      userLabel: 'Unknown user',
+      assistantLabel: null,
+      editorLabel: 'Unknown user',
+    });
+  });
+
   it('combines the human and teammate names without exposing the Session ID', () => {
     expect(
       knowledgeAttributionDisplay(
         {
           userId: 'user-1',
+          user: { status: 'resolved', display_name: 'Ada' },
           sessionId: '01abcdef-1234-7890-abcd-ef1234567890',
           agenticTool: 'codex',
           teammateName: 'Scout',
@@ -33,5 +55,20 @@ describe('knowledgeAttributionDisplay', () => {
         users
       )
     ).toEqual({ userLabel: 'Ada', assistantLabel: 'Codex', editorLabel: 'Ada and Codex' });
+  });
+
+  it('renders the explicit system/legacy label without a user lookup', () => {
+    expect(
+      knowledgeAttributionDisplay(
+        {
+          user: { status: 'unattributed', display_name: 'System or former user' },
+        },
+        new Map()
+      )
+    ).toEqual({
+      userLabel: 'System or former user',
+      assistantLabel: null,
+      editorLabel: 'System or former user',
+    });
   });
 });

--- a/apps/agor-ui/src/knowledgeAttributionDisplay.ts
+++ b/apps/agor-ui/src/knowledgeAttributionDisplay.ts
@@ -1,8 +1,11 @@
-import type { KnowledgeWriteAttribution } from '@agor/core/types';
+import type { KnowledgeUserAttribution, KnowledgeWriteAttribution } from '@agor/core/types';
 
-type UserSummary = { name?: string | null; email?: string | null };
+type UserSummary = { name?: string | null };
 
-export type KnowledgeAttribution = { userId?: string | null } & {
+export type KnowledgeAttribution = {
+  userId?: string | null;
+  user?: KnowledgeUserAttribution | null;
+} & {
   [Key in keyof KnowledgeWriteAttribution]?: KnowledgeWriteAttribution[Key] | null;
 };
 
@@ -11,7 +14,9 @@ export function knowledgeAttributionDisplay(
   userById: ReadonlyMap<string, UserSummary>
 ) {
   const user = attribution.userId ? userById.get(attribution.userId) : undefined;
-  const userLabel = user?.name?.trim() || user?.email || 'Unknown user';
+  // The Knowledge response is authoritative. The map lookup remains only for
+  // rolling compatibility with an older daemon, and never falls back to email.
+  const userLabel = attribution.user?.display_name.trim() || user?.name?.trim() || 'Unknown user';
   const teammateLabel = attribution.teammateName?.trim();
   if (!teammateLabel && !attribution.sessionId && !attribution.agenticTool) {
     return { userLabel, assistantLabel: null, editorLabel: userLabel };

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -892,6 +892,7 @@ export function KnowledgePage({
     ? knowledgeAttributionDisplay(
         {
           userId: activeDoc.updated_by,
+          user: activeDoc.updated_by_user,
           sessionId: activeDoc.updated_by_session_id,
           agenticTool: activeDoc.updated_by_agentic_tool,
           teammateName: activeDoc.updated_by_teammate_name,
@@ -3645,6 +3646,7 @@ export function KnowledgePage({
                 const attribution = knowledgeAttributionDisplay(
                   {
                     userId: version.created_by,
+                    user: version.created_by_user,
                     sessionId: version.created_by_session_id,
                     agenticTool: version.created_by_agentic_tool,
                     teammateName: version.created_by_teammate_name,

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -22,6 +22,7 @@ export * from './gateway-outbound-messages';
 export * from './github-install-states';
 export * from './groups';
 export * from './knowledge';
+export * from './knowledge-attribution';
 export * from './knowledge-embedding-work';
 export * from './knowledge-semantic-settings';
 export * from './mcp-member-policy';

--- a/packages/core/src/db/repositories/knowledge-attribution.ts
+++ b/packages/core/src/db/repositories/knowledge-attribution.ts
@@ -1,0 +1,87 @@
+import type {
+  KnowledgeDocument,
+  KnowledgeDocumentVersion,
+  KnowledgeUserAttribution,
+} from '@agor/core/types';
+import { inArray } from 'drizzle-orm';
+import type { Database } from '../client';
+import { select } from '../database-wrapper';
+import { users } from '../schema';
+
+const UNATTRIBUTED_USER: KnowledgeUserAttribution = {
+  status: 'unattributed',
+  display_name: 'System or former user',
+};
+
+const UNAVAILABLE_USER: KnowledgeUserAttribution = {
+  status: 'unavailable',
+  display_name: 'Unavailable user',
+};
+
+/**
+ * Resolve only the names attached to already-authorized Knowledge records.
+ *
+ * The query runs through the caller's existing tenant database scope, so
+ * PostgreSQL RLS remains the final boundary. A non-null ID that is invisible
+ * in that scope gets a generic result rather than a broader lookup. Emails and
+ * other User fields are never selected.
+ */
+export class KnowledgeAttributionRepository {
+  constructor(private db: Database) {}
+
+  private async usersById(ids: Array<string | null | undefined>) {
+    const uniqueIds = [...new Set(ids.filter((id): id is string => Boolean(id)))];
+    if (uniqueIds.length === 0) return new Map<string, string | null>();
+
+    const rows = (await select(this.db, { user_id: users.user_id, name: users.name })
+      .from(users)
+      .where(inArray(users.user_id, uniqueIds))
+      .all()) as Array<{ user_id: string; name: string | null }>;
+    return new Map<string, string | null>(rows.map((row) => [row.user_id, row.name]));
+  }
+
+  private attributionFor(
+    userId: string | null | undefined,
+    usersById: ReadonlyMap<string, string | null>
+  ): KnowledgeUserAttribution {
+    if (!userId) return { ...UNATTRIBUTED_USER };
+    if (!usersById.has(userId)) return { ...UNAVAILABLE_USER };
+    return {
+      status: 'resolved',
+      display_name: usersById.get(userId)?.trim() || 'User',
+    };
+  }
+
+  async attachToDocuments(documents: readonly KnowledgeDocument[]): Promise<KnowledgeDocument[]> {
+    const resolvedUsers = await this.usersById(
+      documents.flatMap((document) => [document.created_by, document.updated_by])
+    );
+    return documents.map((document) => {
+      const attribution = this.attributionFor(document.updated_by, resolvedUsers);
+      const creatorAttribution = this.attributionFor(document.created_by, resolvedUsers);
+      return {
+        ...document,
+        // Do not transport an opaque user identifier from outside the active
+        // tenant even when malformed historical data contains one.
+        created_by: creatorAttribution.status === 'unavailable' ? null : document.created_by,
+        updated_by: attribution.status === 'unavailable' ? null : document.updated_by,
+        updated_by_user: attribution,
+      };
+    });
+  }
+
+  async attachToVersions(
+    versions: readonly KnowledgeDocumentVersion[]
+  ): Promise<KnowledgeDocumentVersion[]> {
+    const resolvedUsers = await this.usersById(versions.map((version) => version.created_by));
+    return versions.map((version) => {
+      const attribution = this.attributionFor(version.created_by, resolvedUsers);
+      return {
+        ...version,
+        // Keep the same non-enumeration rule as the current-document response.
+        created_by: attribution.status === 'unavailable' ? null : version.created_by,
+        created_by_user: attribution,
+      };
+    });
+  }
+}

--- a/packages/core/src/db/repositories/knowledge-attribution.ts
+++ b/packages/core/src/db/repositories/knowledge-attribution.ts
@@ -52,10 +52,10 @@ export class KnowledgeAttributionRepository {
     };
   }
 
-  async attachToDocuments(documents: readonly KnowledgeDocument[]): Promise<KnowledgeDocument[]> {
-    const resolvedUsers = await this.usersById(
-      documents.flatMap((document) => [document.created_by, document.updated_by])
-    );
+  private projectDocuments(
+    documents: readonly KnowledgeDocument[],
+    resolvedUsers: ReadonlyMap<string, string | null>
+  ): KnowledgeDocument[] {
     return documents.map((document) => {
       const attribution = this.attributionFor(document.updated_by, resolvedUsers);
       const creatorAttribution = this.attributionFor(document.created_by, resolvedUsers);
@@ -70,10 +70,10 @@ export class KnowledgeAttributionRepository {
     });
   }
 
-  async attachToVersions(
-    versions: readonly KnowledgeDocumentVersion[]
-  ): Promise<KnowledgeDocumentVersion[]> {
-    const resolvedUsers = await this.usersById(versions.map((version) => version.created_by));
+  private projectVersions(
+    versions: readonly KnowledgeDocumentVersion[],
+    resolvedUsers: ReadonlyMap<string, string | null>
+  ): KnowledgeDocumentVersion[] {
     return versions.map((version) => {
       const attribution = this.attributionFor(version.created_by, resolvedUsers);
       return {
@@ -83,5 +83,37 @@ export class KnowledgeAttributionRepository {
         created_by_user: attribution,
       };
     });
+  }
+
+  /**
+   * Project documents and versions with one tenant-scoped User query. Search
+   * and hydrated-list responses use this to keep their nested contract
+   * consistent without an author-query N+1.
+   */
+  async attachToDocumentsAndVersions(
+    documents: readonly KnowledgeDocument[],
+    versions: readonly KnowledgeDocumentVersion[]
+  ): Promise<{
+    documents: KnowledgeDocument[];
+    versions: KnowledgeDocumentVersion[];
+  }> {
+    const resolvedUsers = await this.usersById([
+      ...documents.flatMap((document) => [document.created_by, document.updated_by]),
+      ...versions.map((version) => version.created_by),
+    ]);
+    return {
+      documents: this.projectDocuments(documents, resolvedUsers),
+      versions: this.projectVersions(versions, resolvedUsers),
+    };
+  }
+
+  async attachToDocuments(documents: readonly KnowledgeDocument[]): Promise<KnowledgeDocument[]> {
+    return (await this.attachToDocumentsAndVersions(documents, [])).documents;
+  }
+
+  async attachToVersions(
+    versions: readonly KnowledgeDocumentVersion[]
+  ): Promise<KnowledgeDocumentVersion[]> {
+    return (await this.attachToDocumentsAndVersions([], versions)).versions;
   }
 }

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -868,6 +868,16 @@ export class KnowledgeDocumentVersionRepository
     }
   }
 
+  async findByIds(ids: readonly KnowledgeDocumentVersionID[]): Promise<KnowledgeDocumentVersion[]> {
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) return [];
+    const rows = await select(this.db)
+      .from(kbDocumentVersions)
+      .where(inArray(kbDocumentVersions.version_id, uniqueIds))
+      .all();
+    return rows.map((row: KBDocumentVersionRow) => this.rowToVersion(row));
+  }
+
   async findAll(filter?: {
     document_id?: KnowledgeDocumentID;
   }): Promise<KnowledgeDocumentVersion[]> {

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -20,6 +20,22 @@ export interface KnowledgeWriteAttribution {
   teammateName?: string;
 }
 
+/**
+ * Document-authorized, transport-safe projection of the human behind a
+ * Knowledge write. It deliberately contains neither email nor profile data.
+ *
+ * `unattributed` covers system/legacy writes and authors whose hard-deleted
+ * user foreign key was cleared; those cases are indistinguishable in existing
+ * rows. `unavailable` means a non-null user ID did not resolve inside the
+ * active tenant scope (for example, malformed historical data); the response
+ * also clears that raw ID. Callers must not try a broader user lookup for
+ * either state.
+ */
+export interface KnowledgeUserAttribution {
+  status: 'resolved' | 'unattributed' | 'unavailable';
+  display_name: string;
+}
+
 export type KnowledgeNamespaceID = UUID;
 export type KnowledgeDocumentID = UUID;
 export type KnowledgeDocumentVersionID = UUID;
@@ -619,6 +635,8 @@ export interface KnowledgeDocument {
   created_by?: UserID | null;
   created_at: Date;
   updated_by?: UserID | null;
+  /** Safe human attribution projected only after document read authorization. */
+  updated_by_user?: KnowledgeUserAttribution | null;
   /** Trusted Session attribution for the most recent assistant-authored version. */
   updated_by_session_id?: SessionID | null;
   updated_by_agentic_tool?: PersistedAgenticToolName | null;
@@ -649,6 +667,8 @@ export interface KnowledgeDocumentVersion {
   metadata?: Record<string, unknown> | null;
   change_summary?: string | null;
   created_by?: UserID | null;
+  /** Safe human attribution projected only after version/document read authorization. */
+  created_by_user?: KnowledgeUserAttribution | null;
   /** Present only when this version was written through a Session-scoped agent request. */
   created_by_session_id?: SessionID | null;
   created_by_agentic_tool?: PersistedAgenticToolName | null;


### PR DESCRIPTION
## Linked issue

Related: #2383

## Summary

- Project the human author's safe display name into authorized Knowledge document and version responses.
- Preserve AI teammate/tool/session attribution while making cold `/kb/...` routes independent of the workspace user store.
- Add SQLite, UI, and production-shaped PostgreSQL/RLS regression coverage, including cross-tenant negatives.

## Why / context

#2383 added author attribution to the Knowledge subtitle and version rail, but the API returned only the human user ID. The UI resolved that ID through the global workspace user map. Lightweight direct Knowledge routes intentionally do not hydrate that store, so a cold page rendered `Last edited by Unknown user` even when the stored same-tenant author was valid.

This was not a PostgreSQL data-loss or RLS visibility issue: both dialects had the same incomplete response contract. PostgreSQL RLS correctly hid foreign-tenant users.

## Implementation notes

- Adds `updated_by_user` to Knowledge documents and `created_by_user` to versions.
- Resolves authors only after the document/version read check and through the existing tenant-scoped database context.
- Batches lookups and selects only `users.user_id` and `users.name`; it does not fetch or expose email/profile data.
- Uses explicit safe states for resolved, system/legacy/former, and unavailable authors.
- Clears malformed author IDs that cannot resolve inside the active tenant rather than transporting an opaque foreign-tenant identifier.
- Keeps a name-only UI store fallback for rolling compatibility with older daemons.
- Requires no migration or historical backfill.

## Validation / test plan

- [x] `pnpm i`
- [x] `pnpm check`
- [x] `pnpm --filter @agor/daemon exec vitest run src/services/knowledge.test.ts` — 34 passed
- [x] `pnpm --filter agor-ui exec vitest run src/knowledgeAttributionDisplay.test.ts src/pages/KnowledgePage.routing.test.ts` — 24 passed
- [x] `pnpm test:postgres:docker` — 124 passed across 24 files; runner cleanup passed

## Screenshots / demos

The managed branch application was unavailable during investigation, so there is no updated browser screenshot. Service/API and UI projection paths are covered directly by the tests above.

## Risks / rollout / rollback

- Deploy the backend before or together with the UI. The UI fallback supports warm-store responses from older daemons, but an old daemon cannot make a cold Knowledge route self-contained.
- Human display names are resolved live rather than snapshotted, so later user renames affect historical display.
- Existing null author IDs cannot distinguish system-created, legacy, and hard-deleted users; they intentionally share a safe label.
- Rollback is code-only because this change adds no schema migration or persisted data transformation.

## Out of scope / follow-ups

A composite tenant-aware author foreign key could further harden storage integrity, but it is not required for this response-layer fix and should be evaluated separately as a migration.
