### PR TITLE
fix: make hot-shots an optional peer dependency

### DIFF
--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -153,7 +153,46 @@ jobs:
             test -d "$PACKAGE_ROOT/node_modules/@agor/$package"
             test ! -L "$PACKAGE_ROOT/node_modules/@agor/$package"
           done
+          test ! -e "$PACKAGE_ROOT/node_modules/hot-shots"
+          test ! -e "$ROOT/prefix/lib/node_modules/hot-shots"
+          if find "$ROOT/prefix/lib/node_modules" -type d -name unix-dgram -print -quit | grep -q .; then
+            echo "Default install unexpectedly contains unix-dgram" >&2
+            exit 1
+          fi
           HOME="$ROOT/home" "$ROOT/prefix/bin/agor" doctor --json > "$ROOT/doctor.json"
+
+          # Importing the metrics composition module must not resolve the peer
+          # while the default-disabled exporter is in use.
+          node --input-type=module - "$PACKAGE_ROOT" <<'NODE'
+          import { join } from 'node:path';
+          import { pathToFileURL } from 'node:url';
+          const packageRoot = process.argv[2];
+          const metricsModule = await import(
+            pathToFileURL(join(packageRoot, 'dist/daemon/metrics/index.js')).href
+          );
+          const metrics = metricsModule.createDaemonMetrics(undefined, {
+            workIdentity: { instanceId: 'standalone', bootId: 'smoke' },
+            deploymentMode: 'standalone',
+            deploymentId: 'smoke',
+          });
+          if (metrics.enabled) throw new Error('Default metrics exporter must be disabled');
+          const warnings = [];
+          const originalWarn = console.warn;
+          console.warn = (message) => warnings.push(String(message));
+          const missingPeerMetrics = metricsModule.createDaemonMetrics(
+            { enabled: true },
+            {
+              workIdentity: { instanceId: 'standalone', bootId: 'smoke' },
+              deploymentMode: 'standalone',
+              deploymentId: 'smoke',
+            }
+          );
+          console.warn = originalWarn;
+          if (missingPeerMetrics.enabled) throw new Error('Missing peer must fall back to no-op');
+          if (!warnings.some((warning) => warning.includes('optional hot-shots peer dependency'))) {
+            throw new Error(`Missing peer warning was not actionable: ${JSON.stringify(warnings)}`);
+          }
+          NODE
 
           # A second install with lifecycle execution forcibly disabled must be
           # equally usable. This is a release invariant, not a user instruction.
@@ -180,6 +219,38 @@ jobs:
             if (exitCode === 0 && output.includes(marker)) resolve();
             else reject(new Error(`PTY failed: exit=${exitCode}, output=${JSON.stringify(output)}`));
           }));
+          NODE
+
+      - name: Optional StatsD peer works without lifecycle scripts
+        if: matrix.os == 'ubuntu-latest' && matrix.node == '24.19.0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="$RUNNER_TEMP/statsd-peer"
+          npm install -g --prefix "$ROOT/prefix" --cache "$ROOT/cache" \
+            --no-fund --no-audit "$CLIENT" "$LIVE"
+          npm install -g --prefix "$ROOT/prefix" --cache "$ROOT/cache" \
+            --no-fund --no-audit --ignore-scripts \
+            hot-shots@17.1.0
+          PACKAGE_ROOT="$ROOT/prefix/lib/node_modules/agor-live"
+          test -d "$ROOT/prefix/lib/node_modules/hot-shots"
+          node --input-type=module - "$PACKAGE_ROOT" <<'NODE'
+          import { join } from 'node:path';
+          import { pathToFileURL } from 'node:url';
+          const packageRoot = process.argv[2];
+          const metricsModule = await import(
+            pathToFileURL(join(packageRoot, 'dist/daemon/metrics/index.js')).href
+          );
+          const metrics = metricsModule.createDaemonMetrics(
+            { enabled: true, host: '127.0.0.1', port: 8125, prefix: 'agor.smoke.' },
+            {
+              workIdentity: { instanceId: 'standalone', bootId: 'smoke' },
+              deploymentMode: 'standalone',
+              deploymentId: 'smoke',
+            }
+          );
+          if (!metrics.enabled) throw new Error('StatsD peer did not initialize');
+          await metrics.close();
           NODE
 
       - name: A missing optional PTY does not block Agor

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -43,7 +43,6 @@
     "express-static-gzip": "^3.0.1",
     "feathers-swagger": "^3.0.0",
     "handlebars": "^4.7.8",
-    "hot-shots": "^17.1.0",
     "ioredis": "^5.11.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.2.0",
@@ -68,6 +67,7 @@
     "@types/node": "^24.6.0",
     "concurrently": "^9.2.1",
     "glob": "^11.0.3",
+    "hot-shots": "^17.1.0",
     "mdast-util-gfm": "^3.1.0",
     "mdast-util-to-markdown": "^2.1.2",
     "remark-gfm": "^4.0.1",
@@ -78,5 +78,13 @@
     "unified": "^11.0.5",
     "vitest": "^4.1.10",
     "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "hot-shots": "^17.1.0"
+  },
+  "peerDependenciesMeta": {
+    "hot-shots": {
+      "optional": true
+    }
   }
 }

--- a/apps/agor-daemon/src/metrics/index.ts
+++ b/apps/agor-daemon/src/metrics/index.ts
@@ -1,6 +1,6 @@
+import { createRequire } from 'node:module';
 import type { AgorDeploymentMode, AgorStatsDSettings } from '@agor/core/config';
 import type { DistributedWorkIdentity } from '@agor/core/coordination';
-import StatsD, { type ClientOptions } from 'hot-shots';
 import { NOOP_METRICS } from './noop.js';
 import {
   type MetricsErrorReporter,
@@ -9,7 +9,38 @@ import {
 } from './statsd.js';
 import type { DaemonMetrics } from './types.js';
 
-export type StatsDClientFactory = (options: ClientOptions) => StatsDTransportClient;
+interface StatsDClientOptions {
+  protocol: 'udp';
+  host: string;
+  port: number;
+  prefix: string;
+  globalTags: Record<string, string>;
+  datadog: true;
+  cardinality: 'low';
+  originDetection: true;
+  includeDataDogTags: false;
+  includeDatadogTelemetry: false;
+  errorHandler: MetricsErrorReporter;
+}
+
+type StatsDClientConstructor = new (options: StatsDClientOptions) => StatsDTransportClient;
+
+const requireFromDaemon = createRequire(import.meta.url);
+
+export type StatsDClientFactory = (options: StatsDClientOptions) => StatsDTransportClient;
+
+function createHotShotsClient(options: StatsDClientOptions): StatsDTransportClient {
+  let StatsD: StatsDClientConstructor;
+  try {
+    StatsD = requireFromDaemon('hot-shots') as StatsDClientConstructor;
+  } catch (error) {
+    throw new Error(
+      'DogStatsD metrics require the optional hot-shots peer dependency. Install hot-shots alongside agor-live, or disable metrics.statsd.',
+      { cause: error }
+    );
+  }
+  return new StatsD(options);
+}
 
 export interface DaemonMetricsFactoryContext {
   workIdentity: DistributedWorkIdentity;
@@ -39,7 +70,7 @@ export function buildStatsDClientOptions(
   config: AgorStatsDSettings,
   context: DaemonMetricsFactoryContext,
   reportError: MetricsErrorReporter
-): ClientOptions {
+): StatsDClientOptions {
   return {
     protocol: 'udp',
     host: config.host ?? '127.0.0.1',
@@ -73,7 +104,7 @@ function createRateLimitedErrorReporter(): MetricsErrorReporter {
 export function createDaemonMetrics(
   config: AgorStatsDSettings | undefined,
   context: DaemonMetricsFactoryContext,
-  factory: StatsDClientFactory = (options) => new StatsD(options)
+  factory: StatsDClientFactory = createHotShotsClient
 ): DaemonMetrics {
   if (config?.enabled !== true) return NOOP_METRICS;
   const reportError = createRateLimitedErrorReporter();

--- a/apps/agor-daemon/src/metrics/statsd.test.ts
+++ b/apps/agor-daemon/src/metrics/statsd.test.ts
@@ -1,5 +1,4 @@
 import type { DistributedWorkIdentity } from '@agor/core/coordination';
-import type { MetricOptions } from 'hot-shots';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildStatsDClientOptions,
@@ -10,25 +9,26 @@ import {
   StatsDDaemonMetrics,
   sanitizeMetricTags,
 } from './index.js';
-import type { StatsDTransportClient } from './statsd.js';
+import type { StatsDMetricOptions, StatsDTransportClient } from './statsd.js';
 
 class FakeStatsDClient implements StatsDTransportClient {
-  calls: Array<{ method: string; name?: string; value?: number; options?: MetricOptions }> = [];
+  calls: Array<{ method: string; name?: string; value?: number; options?: StatsDMetricOptions }> =
+    [];
   closeCalls = 0;
 
-  increment(name: string, value: number, options?: MetricOptions): void {
+  increment(name: string, value: number, options?: StatsDMetricOptions): void {
     this.calls.push({ method: 'increment', name, value, options });
   }
-  timing(name: string, value: number, options?: MetricOptions): void {
+  timing(name: string, value: number, options?: StatsDMetricOptions): void {
     this.calls.push({ method: 'timing', name, value, options });
   }
-  histogram(name: string, value: number, options?: MetricOptions): void {
+  histogram(name: string, value: number, options?: StatsDMetricOptions): void {
     this.calls.push({ method: 'histogram', name, value, options });
   }
-  distribution(name: string, value: number, options?: MetricOptions): void {
+  distribution(name: string, value: number, options?: StatsDMetricOptions): void {
     this.calls.push({ method: 'distribution', name, value, options });
   }
-  gauge(name: string, value: number, options?: MetricOptions): void {
+  gauge(name: string, value: number, options?: StatsDMetricOptions): void {
     this.calls.push({ method: 'gauge', name, value, options });
   }
   flush(callback?: (error?: Error) => void): void {

--- a/apps/agor-daemon/src/metrics/statsd.ts
+++ b/apps/agor-daemon/src/metrics/statsd.ts
@@ -1,13 +1,17 @@
 import { performance } from 'node:perf_hooks';
-import type { MetricOptions } from 'hot-shots';
 import type { DaemonMetrics, MetricTags } from './types.js';
 
+export interface StatsDMetricOptions {
+  tags?: Record<string, string>;
+  cardinality?: 'low' | 'orchestrator' | 'high' | 'none';
+}
+
 export interface StatsDTransportClient {
-  increment(name: string, value: number, options?: MetricOptions): void;
-  timing(name: string, value: number, options?: MetricOptions): void;
-  histogram(name: string, value: number, options?: MetricOptions): void;
-  distribution(name: string, value: number, options?: MetricOptions): void;
-  gauge(name: string, value: number, options?: MetricOptions): void;
+  increment(name: string, value: number, options?: StatsDMetricOptions): void;
+  timing(name: string, value: number, options?: StatsDMetricOptions): void;
+  histogram(name: string, value: number, options?: StatsDMetricOptions): void;
+  distribution(name: string, value: number, options?: StatsDMetricOptions): void;
+  gauge(name: string, value: number, options?: StatsDMetricOptions): void;
   flush(callback?: (error?: Error) => void): void;
   close(callback?: (error?: Error) => void): void;
 }
@@ -127,7 +131,7 @@ export class StatsDDaemonMetrics implements DaemonMetrics {
     name: string,
     value: number,
     tags: MetricTags | undefined,
-    send: (options: MetricOptions) => void
+    send: (options: StatsDMetricOptions) => void
   ): void {
     if (this.closed || !METRIC_NAME.test(name) || !Number.isFinite(value)) return;
     try {

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -91,6 +91,17 @@ Operational daemon metrics can be sent over UDP to a locally reachable
 Datadog Agent (DogStatsD's default port is `8125`). They are disabled by
 default:
 
+The DogStatsD client is an optional peer dependency, so a normal Agor install
+does not download it. Install it only on deployments that enable StatsD. The
+client's optional Unix-socket addon is unnecessary because Agor uses UDP, so
+the deployment install can safely disable dependency lifecycle scripts:
+
+```bash
+npm install -g --ignore-scripts hot-shots@^17.1.0
+```
+
+Then enable the exporter in the deployment-owned config:
+
 ```yaml
 metrics:
   statsd:
@@ -114,6 +125,8 @@ Metrics settings are resolved into the daemon's immutable startup snapshot.
 Changing YAML or environment variables requires a restart. Executors neither
 read this config nor receive the metrics settings. UDP delivery is best effort:
 an absent Agent drops metrics without changing request or executor behavior.
+If StatsD is enabled without `hot-shots` installed alongside `agor-live`, Agor
+logs a rate-limited exporter warning and continues with metrics disabled.
 
 `global_tags` is limited to 20 short static deployment labels. This is the
 supported place for ambient dimensions such as environment, region, cluster,

--- a/context/explorations/daemon-statsd-metrics.md
+++ b/context/explorations/daemon-statsd-metrics.md
@@ -8,7 +8,10 @@ Agor uses [`hot-shots`](https://github.com/bdeitte/hot-shots) behind an
 Agor-owned `DaemonMetrics` interface. Datadog lists hot-shots as a community
 DogStatsD client, it supports current Node releases and TypeScript, and it
 already owns UDP formatting, tag escaping, socket errors, flush, and close.
-The optional native `unix-dgram` addon is disabled because Agor uses UDP.
+The published package declares it as an optional peer and resolves it only
+when StatsD is enabled, so default installs have no dependency on hot-shots or
+its native `unix-dgram` addon. StatsD deployments install the peer with
+lifecycle scripts disabled because Agor uses UDP rather than Unix sockets.
 
 References: [Datadog DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/),
 [Datadog metric types](https://docs.datadoghq.com/metrics/types/), and
@@ -159,7 +162,9 @@ new immutable first-progress timestamp or event at the executor/SDK boundary.
 ## Lifecycle and failure contract
 
 - Construction happens once at daemon composition. Disabled config never
-  creates a socket.
+  loads the optional peer or creates a socket.
+- A deployment that enables StatsD without the peer logs a rate-limited
+  exporter warning and continues with the no-op implementation.
 - A startup ownership guard closes an initialized exporter if later database,
   service, route, worker, or listener startup fails before lifecycle ownership
   transfers to the registered shutdown handler.

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -86,7 +86,6 @@
     "express-static-gzip": "^3.0.1",
     "feathers-swagger": "^3.0.0",
     "handlebars": "^4.7.8",
-    "hot-shots": "^17.1.0",
     "inquirer": "^12.10.0",
     "ioredis": "^5.11.1",
     "js-yaml": "^5.2.3",
@@ -103,6 +102,14 @@
   },
   "optionalDependencies": {
     "@lydell/node-pty": "1.2.0-beta.15"
+  },
+  "peerDependencies": {
+    "hot-shots": "^17.1.0"
+  },
+  "peerDependenciesMeta": {
+    "hot-shots": {
+      "optional": true
+    }
   },
   "bundleDependencies": [
     "@agor/agentic-tool-opencode",

--- a/packages/agor-live/scripts/pack-release.test.js
+++ b/packages/agor-live/scripts/pack-release.test.js
@@ -93,6 +93,8 @@ test('release tarball materializes internal packages without postinstall', async
         type: 'module',
         files: ['bin', 'dist', 'LICENSE', 'README.md'],
         dependencies,
+        peerDependencies: { 'hot-shots': '^17.1.0' },
+        peerDependenciesMeta: { 'hot-shots': { optional: true } },
         bundleDependencies,
       })}\n`
     );
@@ -102,6 +104,8 @@ test('release tarball materializes internal packages without postinstall', async
     await execFileAsync('tar', ['-xzf', tarball, '-C', extract]);
     const manifest = JSON.parse(await readFile(join(extract, 'package', 'package.json'), 'utf8'));
     assert.equal(manifest.dependencies['@agor-live/client'], '1.2.3');
+    assert.equal(manifest.peerDependencies['hot-shots'], '^17.1.0');
+    assert.equal(manifest.peerDependenciesMeta['hot-shots'].optional, true);
     assert.equal(manifest.scripts?.postinstall, undefined);
     for (const bundledPackage of BUNDLED_INTERNAL_PACKAGES) {
       const internalManifest = JSON.parse(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
       handlebars:
         specifier: '>=4.7.9 <5'
         version: 4.7.9
-      hot-shots:
-        specifier: ^17.1.0
-        version: 17.1.0
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1(supports-color@8.1.1)
@@ -302,6 +299,9 @@ importers:
       glob:
         specifier: ^11.1.0
         version: 11.1.0
+      hot-shots:
+        specifier: ^17.1.0
+        version: 17.1.0
       mdast-util-gfm:
         specifier: ^3.1.0
         version: 3.1.0(supports-color@8.1.1)

--- a/scripts/sync-agor-live-deps.mjs
+++ b/scripts/sync-agor-live-deps.mjs
@@ -44,12 +44,19 @@ const writeJson = (relPath, data) =>
 const target = readJson(targetManifest);
 const targetDeps = { ...(target.dependencies ?? {}) };
 const targetOptionalDeps = { ...(target.optionalDependencies ?? {}) };
+const targetPeerDeps = { ...(target.peerDependencies ?? {}) };
+const targetPeerMeta = { ...(target.peerDependenciesMeta ?? {}) };
 // This is the only dependency owned directly by the publishable wrapper.
 // Everything else is derived from the copied workspace packages below.
 const targetOnlyDependencies = new Set(['@agor-live/client']);
+// These runtime capabilities stay out of default installs. Their published
+// peer contract is derived from the workspace package that implements them.
+const publishedPeerDependencies = new Set(['hot-shots']);
 
 const aggregated = new Map();
 const aggregatedOptional = new Map();
+const aggregatedPeers = new Map();
+const aggregatedPeerMeta = new Map();
 const conflicts = [];
 
 for (const manifest of sourceManifests) {
@@ -76,6 +83,27 @@ for (const manifest of sourceManifests) {
     } else if (!seen) {
       aggregatedOptional.set(dep, version);
     }
+  }
+  for (const [dep, version] of Object.entries(pkg.peerDependencies ?? {})) {
+    if (!publishedPeerDependencies.has(dep)) continue;
+    const seen = aggregatedPeers.get(dep);
+    if (seen && seen !== version) {
+      conflicts.push({ dep: `peer:${dep}`, seen, version, manifest });
+    } else if (!seen) {
+      aggregatedPeers.set(dep, version);
+      aggregatedPeerMeta.set(dep, pkg.peerDependenciesMeta?.[dep] ?? {});
+    }
+  }
+}
+
+for (const dep of publishedPeerDependencies) {
+  if (!aggregatedPeers.has(dep)) {
+    conflicts.push({
+      dep: `peer:${dep}`,
+      seen: 'missing',
+      version: 'required by the published peer contract',
+      manifest: 'workspace manifests',
+    });
   }
 }
 
@@ -118,6 +146,30 @@ for (const [dep, version] of aggregatedOptional) {
     if (mode === 'write') targetOptionalDeps[dep] = version;
   }
 }
+for (const dep of Object.keys(targetPeerDeps)) {
+  if (!publishedPeerDependencies.has(dep) || aggregatedPeers.has(dep)) continue;
+  updates.push({ dep: `peer:${dep}`, from: targetPeerDeps[dep], to: undefined });
+  if (mode === 'write') {
+    delete targetPeerDeps[dep];
+    delete targetPeerMeta[dep];
+  }
+}
+for (const [dep, version] of aggregatedPeers) {
+  const current = targetPeerDeps[dep];
+  if (current !== version) {
+    updates.push({ dep: `peer:${dep}`, from: current, to: version });
+    if (mode === 'write') targetPeerDeps[dep] = version;
+  }
+  const expectedMeta = aggregatedPeerMeta.get(dep);
+  if (JSON.stringify(targetPeerMeta[dep] ?? {}) !== JSON.stringify(expectedMeta)) {
+    updates.push({
+      dep: `peer-meta:${dep}`,
+      from: JSON.stringify(targetPeerMeta[dep] ?? {}),
+      to: JSON.stringify(expectedMeta),
+    });
+    if (mode === 'write') targetPeerMeta[dep] = expectedMeta;
+  }
+}
 
 if (mode === 'check') {
   if (updates.length) {
@@ -145,6 +197,12 @@ for (const dep of Object.keys(targetDeps).sort()) {
 target.dependencies = sortedDeps;
 target.optionalDependencies = Object.fromEntries(
   Object.entries(targetOptionalDeps).sort(([left], [right]) => left.localeCompare(right))
+);
+target.peerDependencies = Object.fromEntries(
+  Object.entries(targetPeerDeps).sort(([left], [right]) => left.localeCompare(right))
+);
+target.peerDependenciesMeta = Object.fromEntries(
+  Object.entries(targetPeerMeta).sort(([left], [right]) => left.localeCompare(right))
 );
 writeJson(targetManifest, target);
 


### PR DESCRIPTION
## Summary

- publish `hot-shots` as an optional peer dependency instead of installing it with every `agor-live` deployment
- resolve the StatsD transport lazily only when `metrics.statsd.enabled` is true
- fall back to no-op metrics with an actionable, rate-limited warning when an enabled deployment has not installed the peer
- document the separate `npm install -g --ignore-scripts hot-shots@^17.1.0` opt-in for StatsD deployments
- keep the release dependency synchronizer, package contract tests, lockfile, and packaged-install smoke coverage aligned

## Why

`hot-shots` declares `unix-dgram` as an optional dependency. npm still installs it and runs its native build script during a normal Agor installation, even though Agor exclusively uses UDP and never needs Unix-domain socket support. On current Node releases that native addon can fail under `node-gyp`, blocking the entire `agor-live` install.

With this change, a normal `npm install -g agor-live` contains neither `hot-shots` nor `unix-dgram`. Deployments that enable DogStatsD install Hot Shots explicitly with dependency lifecycle scripts disabled.

## Verification

- `./node_modules/.bin/vitest run src/metrics/statsd.test.ts` — 8 tests passed
- `node --test packages/agor-live/scripts/pack-release.test.js` — 4 tests passed
- `node scripts/sync-agor-live-deps.mjs --check`
- focused Biome and Prettier checks
- release smoke coverage verifies both the clean default install and the explicit StatsD peer install

## Multi-tenancy

This changes package loading and installation only. The existing system-global metrics classification, low-cardinality tag allow-list, and prohibition on tenant/resource identifiers are unchanged.
