### PR TITLE
fix(auth): harden Marketplace, Settings, realtime, and MCP authority

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -89,6 +89,7 @@ import {
   isBranchArchiveOrDeleteOptions,
   isTaskPendingDispatch,
   MCP_MEMBER_POLICIES,
+  MCP_MEMBER_POLICY_CHANGED_EVENT,
   MessageRole,
   ROLES,
   SessionStatus,
@@ -4508,6 +4509,17 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           throw new BadRequest(`policy must be one of: ${MCP_MEMBER_POLICIES.join(', ')}`);
         }
         await setMcpMemberPolicy(db, data.policy, getCurrentTenantId(), params.user?.user_id);
+        // Do not publish the caller-shaped endpoint response: `can_configure`
+        // differs by role. An empty tenant-scoped invalidation makes every
+        // connected browser refetch its own authoritative answer. The event is
+        // queued until the tenant DB unit of work commits by emitServiceEvent.
+        emitServiceEvent(app, {
+          path: 'mcp-servers',
+          event: MCP_MEMBER_POLICY_CHANGED_EVENT,
+          data: {},
+          params,
+          method: 'patch',
+        });
         return {
           policy: data.policy,
           can_configure: canConfigureMcpServers(params.user?.role, data.policy),

--- a/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
@@ -125,6 +125,12 @@ describe('standalone pending flows expire when taken, not only when swept', () =
 describe('MCP caller floor wiring', () => {
   const source = codeOf(join(__dirname, 'register-services.ts'));
 
+  it('never publishes caller-private OAuth browser reservation tokens', () => {
+    expect(source).toContain(
+      "app.service('mcp-servers/oauth-browser-reservations').publish?.(() => []);"
+    );
+  });
+
   it('applies the floor from the shipped registration helper', () => {
     expect(source).toContain('registerMcpCapabilityRoleFloor(app)');
   });

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -75,7 +75,7 @@ describe('register-services /mcp-servers/discover wiring', () => {
   });
 
   it('routes JWT and OAuth credentials through hosted-safe outbound/cache options', () => {
-    expect(discoverBlock).toContain('allowLocalhostHttp: !durableOAuthFlows');
+    expect(discoverBlock).toContain('allowLocalhostHttp: !postgresOAuthDeployment');
     expect(discoverBlock).toContain('cacheNamespace:');
     expect(discoverBlock).toContain('disableProcessTokenCache: !!durableOAuthFlows');
   });

--- a/apps/agor-daemon/src/register-services.mcp-tenant-scope.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-tenant-scope.test.ts
@@ -50,12 +50,13 @@ describe('register-services MCP tenant unit of work', () => {
     // and need no scope of their own, so they are not the subject here.
     expect(identityOnly.length).toBeGreaterThan(0);
 
-    // A scope opened for this read is the innermost thing wrapping it, so the
-    // opener sits within a short window before the call. Matching on the
-    // opener rather than on its arguments keeps this from breaking when a
-    // local is renamed.
+    // A scope opened for this read still directly wraps it, although an outer
+    // reservation/deadline fence may now add one nesting level. Matching on
+    // the opener rather than on its arguments keeps this from breaking when a
+    // local is renamed; the semicolon bound prevents an earlier unrelated
+    // scope from satisfying the check.
     const unscoped = identityOnly.filter((match) => {
-      const preceding = codeOnly.slice(Math.max(0, match.index - 160), match.index);
+      const preceding = codeOnly.slice(Math.max(0, match.index - 320), match.index);
       return !/runInOAuthTenantScope\s*\([^;]*$/.test(preceding);
     });
 

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { MCP_CAPABILITY_ISSUING_SERVICE_PATHS } from './utils/mcp-server-authorization.js';
 
 /**
  * Regression tests for the daemon-side MCP OAuth callback URL.
@@ -126,6 +127,78 @@ describe('register-services OAuth callback URL regression', () => {
     expect(testOauth).toMatch(/effectiveMcpUrl\s*=\s*authoritativeServer\?\.url/);
     expect(testOauth).toMatch(/compatibilityPolicy\?\.mode\s*\?\?/);
     expect(testOauth).toMatch(/effectiveClientId\s*=\s*authoritativeServer/);
+  });
+
+  it('enumerates an authority owner for every public MCP capability-issuing socket service', () => {
+    type CapabilityServicePath = (typeof MCP_CAPABILITY_ISSUING_SERVICE_PATHS)[number];
+    const requiredAuthorityContracts = {
+      // Reservation creation synchronously compares request and live socket
+      // authority before minting the one-shot server nonce.
+      'mcp-servers/oauth-browser-reservations': [/liveSocketAuthority\s*\(/],
+      // Standalone OAuth start and JWT test requests carry a live, immutable
+      // socket caller assertion through provider and database continuations.
+      'mcp-servers/oauth-start': [
+        /requestAuthorityAssertion\s*\(\s*params\s*\)/,
+        /requestAuthority:\s*assertRequestAuthority/,
+      ],
+      'mcp-servers/test-jwt': [
+        /requestAuthorityAssertion\s*\(\s*params\s*\)/,
+        /assertCurrent:\s*assertRequestAuthority/,
+      ],
+      // Callback completion is owned by the claimed, tenant/user-bound
+      // pending attempt rather than by a browser reservation.
+      'mcp-servers/oauth-complete': [/assertPendingFlowStillAuthorized\s*\(\s*pendingFlow\s*\)/],
+      // Refresh issuance is fenced by the exact durable grant generation and
+      // rechecks the grant subject at its persistence choke point.
+      'mcp-servers/oauth-refresh': [/observedRefreshVersion/, /refreshAndPersistToken\s*\(/],
+      'mcp-servers/test-oauth': [/assertInitialRequestAuthority/, /runWithinOAuthAuthority\s*\(/],
+      'mcp-servers/discover': [
+        /assertCurrentRequestAuthority/,
+        /createAuthorityGuardedMCPFetch\s*\(/,
+      ],
+    } satisfies Record<CapabilityServicePath, RegExp[]>;
+
+    for (const path of MCP_CAPABILITY_ISSUING_SERVICE_PATHS) {
+      const start = codeOnly.indexOf(`app.use('/${path}'`);
+      const end = codeOnly.indexOf(`app.service('${path}').hooks`, start);
+      expect(start, `${path} registration`).toBeGreaterThanOrEqual(0);
+      expect(end, `${path} hook registration`).toBeGreaterThan(start);
+      const serviceBody = codeOnly.slice(start, end);
+      for (const contract of requiredAuthorityContracts[path]) {
+        expect(serviceBody, `${path} authority contract ${contract}`).toMatch(contract);
+      }
+    }
+
+    // The only bearer-returning service is not public: it independently
+    // requires a trusted internal/service or session-executor capability.
+    const authHeadersBody = codeOnly.slice(
+      codeOnly.indexOf("app.use('/mcp-servers/oauth-auth-headers'"),
+      codeOnly.indexOf("app.service('mcp-servers/oauth-auth-headers').hooks")
+    );
+    expect(authHeadersBody).toMatch(/shouldExposeMCPServerSecrets\s*\(\s*params\s*\)/);
+    expect(authHeadersBody).toMatch(/shouldExposeMCPServerSecretsForSessionToken\s*\(/);
+
+    // Keep the audit closed over the registered surface, not just today's
+    // issuing list. Any newly registered OAuth/test/discovery service must be
+    // classified here (and, when it issues capability, in the canonical role
+    // floor list above) before this contract can pass.
+    const nonIssuingOrInternal = [
+      'mcp-servers/oauth-disconnect',
+      'mcp-servers/oauth-status',
+      'mcp-servers/oauth-attempt-status',
+      'mcp-servers/oauth-auth-headers',
+    ] as const;
+    const registeredAuthServices = new Set(
+      Array.from(
+        codeOnly.matchAll(
+          /app\.use\('\/(mcp-servers\/(?:oauth-[^']+|test-(?:jwt|oauth)|discover))'/g
+        ),
+        (match) => match[1]
+      )
+    );
+    expect(registeredAuthServices).toEqual(
+      new Set([...MCP_CAPABILITY_ISSUING_SERVICE_PATHS, ...nonIssuingOrInternal])
+    );
   });
 
   it('uses durable hashed state claims on PostgreSQL and never broadcasts raw flow state', () => {

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -132,6 +132,12 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/durableOAuthFlows\.claimForCallback\s*\(\s*state\s*\)/);
     expect(codeOnly).toMatch(/cacheToken:\s*false/);
     expect(codeOnly).toMatch(/attempt_id:\s*pendingFlow\.attemptId/);
+    expect(codeOnly).toMatch(/operation_id:\s*opts\.browserEvent\.operation_id/);
+    expect(codeOnly).toMatch(/auth_generation:\s*opts\.browserEvent\.auth_generation/);
+    expect(codeOnly).toMatch(/caller_user_id:\s*opts\.userId/);
+    expect(codeOnly).toMatch(
+      /opts\.socketId\s*&&\s*opts\.userId\s*&&\s*opts\.browserEvent\s*&&\s*app\.io/
+    );
     expect(codeOnly).toMatch(
       /app\.io\.local\.to\s*\(\s*opts\.socketId\s*\)\.emit\s*\(\s*['"]oauth:open_browser['"]/
     );

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -132,15 +132,13 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/durableOAuthFlows\.claimForCallback\s*\(\s*state\s*\)/);
     expect(codeOnly).toMatch(/cacheToken:\s*false/);
     expect(codeOnly).toMatch(/attempt_id:\s*pendingFlow\.attemptId/);
-    expect(codeOnly).toMatch(/operation_id:\s*opts\.browserEvent\.operation_id/);
-    expect(codeOnly).toMatch(/auth_generation:\s*opts\.browserEvent\.auth_generation/);
-    expect(codeOnly).toMatch(/caller_user_id:\s*opts\.userId/);
+    expect(codeOnly).toMatch(/reservation_token:\s*opts\.browserReservation\.reservationToken/);
+    expect(codeOnly).toMatch(/caller_user_id:\s*opts\.browserReservation\.userId/);
+    expect(codeOnly).toMatch(/awaitToken\s*&&\s*opts\.browserReservation\s*&&\s*app\.io/);
     expect(codeOnly).toMatch(
-      /opts\.socketId\s*&&\s*opts\.userId\s*&&\s*opts\.browserEvent\s*&&\s*app\.io/
+      /app\.io\.local\.to\s*\(\s*opts\.browserReservation\.socketId\s*\)\.emit\s*\(\s*['"]oauth:open_browser['"]/
     );
-    expect(codeOnly).toMatch(
-      /app\.io\.local\.to\s*\(\s*opts\.socketId\s*\)\.emit\s*\(\s*['"]oauth:open_browser['"]/
-    );
+    expect(codeOnly).toMatch(/assertOAuthBrowserReservationStillCurrent/);
     expect(codeOnly).not.toMatch(/app\.io\.emit\s*\(\s*['"]oauth:open_browser['"]/);
     expect(codeOnly).not.toMatch(/emit\s*\(\s*['"]oauth:completed['"][\s\S]{0,300}\bstate\b/);
   });

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -78,10 +78,12 @@ type TestProvider = {
   }>;
   tokenRequested: Deferred<void>;
   refreshRequested: Deferred<void>;
+  mcpRequested: Deferred<void>;
   releaseToken: () => void;
   releaseTokenRequest: (requestNumber: number) => void;
   waitForTokenRequest: (requestNumber: number) => Promise<void>;
   releaseRefresh: () => void;
+  releaseMcp: () => void;
   close: () => Promise<void>;
 };
 
@@ -94,6 +96,7 @@ async function createTestProvider(
     invalidRefresh?: boolean;
     rejectDynamicRegistration?: boolean;
     resourceScopes?: string[];
+    holdMcpChallenge?: boolean;
   } = {}
 ): Promise<TestProvider> {
   const requests: TestProvider['requests'] = [];
@@ -116,6 +119,8 @@ async function createTestProvider(
   const tokenRequested = tokenRequestMilestone(1);
   const refreshRequested = deferred<void>();
   const releaseRefresh = deferred<void>();
+  const mcpRequested = deferred<void>();
+  const releaseMcp = deferred<void>();
   let tokenRequestCount = 0;
   let baseUrl = '';
 
@@ -219,6 +224,8 @@ async function createTestProvider(
       return;
     }
     if (url.pathname === '/saved/mcp') {
+      mcpRequested.resolve();
+      if (options.holdMcpChallenge) await releaseMcp.promise;
       if (request.headers.authorization !== 'Bearer sqlite-access-token') {
         response.writeHead(401, {
           'www-authenticate': `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
@@ -271,15 +278,18 @@ async function createTestProvider(
     requests,
     tokenRequested,
     refreshRequested,
+    mcpRequested,
     releaseToken: () => {
       for (const gate of tokenReleaseGates.values()) gate.resolve();
     },
     releaseTokenRequest: (requestNumber: number) => tokenReleaseGate(requestNumber).resolve(),
     waitForTokenRequest: (requestNumber: number) => tokenRequestMilestone(requestNumber).promise,
     releaseRefresh: () => releaseRefresh.resolve(),
+    releaseMcp: () => releaseMcp.resolve(),
     close: () => {
       for (const gate of tokenReleaseGates.values()) gate.resolve();
       releaseRefresh.resolve();
+      releaseMcp.resolve();
       return new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
@@ -297,6 +307,11 @@ type SQLiteHarness = {
   nextAuthorizationUrl: () => Promise<string>;
   callback: (state: string) => Promise<{ status: number; body: string }>;
   deny: (state: string) => Promise<{ status: number; body: string }>;
+  liveSocket: {
+    id: string;
+    feathers: AuthenticatedParams & { id: string };
+    data: { tenant: { tenant_id: string; source: string } };
+  };
 };
 
 async function createHarness(
@@ -330,6 +345,18 @@ async function createHarness(
 
   let nextUrl = deferred<string>();
   const emittedBrowserEvents: Array<Record<string, unknown>> = [];
+  const liveSocket = {
+    id: 'sqlite-test-socket',
+    feathers: {
+      id: 'sqlite-test-socket',
+      user,
+      authentication: {
+        strategy: 'jwt',
+        accessToken: 'sqlite-initial-authority-token',
+      },
+    } as AuthenticatedParams & { id: string },
+    data: { tenant: { tenant_id: 'default', source: 'static' } },
+  };
   const io = {
     local: {
       to: () => ({
@@ -342,6 +369,7 @@ async function createHarness(
       }),
     },
     to: () => ({ emit: vi.fn() }),
+    sockets: { sockets: new Map([[liveSocket.id, liveSocket]]) },
   };
   const app = feathers() as Application & { io: typeof io };
   app.io = io;
@@ -398,15 +426,29 @@ async function createHarness(
     callback: (state: string) =>
       invokeCallback({ code: 'authorization-code', state, iss: provider.baseUrl }),
     deny: (state: string) => invokeCallback({ error: 'access_denied', state }),
+    liveSocket,
   } satisfies SQLiteHarness;
 }
 
 function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: { id: string } } {
   return {
-    user: harness.user,
+    user: harness.liveSocket.feathers.user,
     tenant: { tenant_id: 'default', source: 'static' },
-    connection: { id: 'sqlite-test-socket' },
+    connection: harness.liveSocket.feathers,
+    authentication: harness.liveSocket.feathers.authentication,
   } as AuthenticatedParams & { connection: { id: string } };
+}
+
+async function reserveBrowserEvent(
+  harness: SQLiteHarness,
+  operation: 'discover' | 'test-oauth'
+): Promise<{ reservation_token: string }> {
+  const reservation = (await harness.app
+    .service('mcp-servers/oauth-browser-reservations')
+    .create({ operation, mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+    reservation_token: string;
+  };
+  return { reservation_token: reservation.reservation_token };
 }
 
 async function authorizeSavedServer(harness: SQLiteHarness): Promise<void> {
@@ -570,6 +612,7 @@ describe('SQLite saved-row OAuth authority', () => {
     const harness = await createHarness(provider);
     databases.push(harness.rawDb);
 
+    const browserReservation = await reserveBrowserEvent(harness, 'discover');
     const discover = harness.app.service('mcp-servers/discover').create(
       {
         mcp_server_id: harness.server.mcp_server_id,
@@ -581,10 +624,7 @@ describe('SQLite saved-row OAuth authority', () => {
           oauth_client_id: 'transient-client-id',
           oauth_compatibility_mode: 'legacy',
         },
-        oauth_browser_event: {
-          operation_id: 'settings-discover-admin-a-0001',
-          auth_generation: 41,
-        },
+        oauth_browser_event: browserReservation,
       },
       paramsFor(harness)
     );
@@ -602,8 +642,7 @@ describe('SQLite saved-row OAuth authority', () => {
     expect(harness.emittedBrowserEvents).toEqual([
       expect.objectContaining({
         authUrl: authorizationUrl.toString(),
-        operation_id: 'settings-discover-admin-a-0001',
-        auth_generation: 41,
+        reservation_token: browserReservation.reservation_token,
         caller_user_id: harness.user.user_id,
         attempt_id: expect.any(String),
       }),
@@ -627,6 +666,262 @@ describe('SQLite saved-row OAuth authority', () => {
         harness.server.mcp_server_id as MCPServerID
       )
     ).toBeNull();
+  });
+
+  it('consumes reservations once and rejects caller/socket/tenant replacement before provider work', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const request = await reserveBrowserEvent(harness, 'discover');
+    const before = provider.requests.length;
+    const replacementParams = {
+      ...paramsFor(harness),
+      user: { ...harness.user, user_id: '01900000-0000-7000-8000-00000000beef' },
+    } as AuthenticatedParams & { connection: { id: string } };
+
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: request,
+        },
+        replacementParams
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: { reservation_token: 'malformed' },
+        },
+        paramsFor(harness)
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/invalid/i) });
+    const unrelatedOperation = await reserveBrowserEvent(harness, 'test-oauth');
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: unrelatedOperation,
+        },
+        paramsFor(harness)
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/operation/i) });
+    expect(provider.requests).toHaveLength(before);
+
+    // Mismatch consumed the nonce. Neither the original caller nor a replay on
+    // another socket can correct and reuse it.
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: request,
+        },
+        paramsFor(harness)
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+
+    const socketBound = await reserveBrowserEvent(harness, 'discover');
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: socketBound,
+        },
+        {
+          ...paramsFor(harness),
+          connection: { id: 'replacement-socket' },
+        } as AuthenticatedParams & {
+          connection: { id: string };
+        }
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+
+    const tokenReservation = await reserveBrowserEvent(harness, 'discover');
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: { reservation_token: tokenReservation.reservation_token },
+        },
+        {
+          ...paramsFor(harness),
+          authentication: { strategy: 'jwt', accessToken: 'replacement-authority-token' },
+        } as AuthenticatedParams & { connection: { id: string } }
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+
+    const tenantBound = await reserveBrowserEvent(harness, 'discover');
+    await expect(
+      harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: tenantBound,
+        },
+        {
+          ...paramsFor(harness),
+          tenant: { tenant_id: 'other-tenant', source: 'auth' },
+        } as AuthenticatedParams & { connection: { id: string } }
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+  });
+
+  it('abandons a delayed A discovery before provider metadata, DCR, or browser emission after the live socket becomes B', async () => {
+    const provider = await createTestProvider({ holdMcpChallenge: true });
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const request = await reserveBrowserEvent(harness, 'discover');
+
+    const discover = harness.app.service('mcp-servers/discover').create(
+      {
+        mcp_server_id: harness.server.mcp_server_id,
+        oauth_browser_event: request,
+      },
+      paramsFor(harness)
+    );
+    await provider.mcpRequested.promise;
+
+    // Feathers launch/JWT reauthentication updates the surviving socket's
+    // live connection object in place. The original service params still name
+    // A, so only a server-side current-socket check can catch this ordering.
+    harness.liveSocket.feathers.user = {
+      ...harness.user,
+      user_id: '01900000-0000-7000-8000-00000000b00b' as UserID,
+      email: 'admin-b@example.test',
+    };
+    provider.releaseMcp();
+
+    await expect(discover).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/authority|reservation/i),
+    });
+    expect(harness.emittedBrowserEvents).toEqual([]);
+    expect(
+      provider.requests.filter(
+        (request) =>
+          request.path.includes('.well-known') ||
+          request.path === '/register' ||
+          request.path === '/authorize'
+      )
+    ).toEqual([]);
+    expect(
+      await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).toBeNull();
+  });
+
+  it.each(['role', 'token'] as const)(
+    'abandons delayed discovery before provider work when the live socket %s authority changes',
+    async (transition) => {
+      const provider = await createTestProvider({ holdMcpChallenge: true });
+      providers.push(provider);
+      const harness = await createHarness(provider);
+      databases.push(harness.rawDb);
+      const request = await reserveBrowserEvent(harness, 'discover');
+
+      const discover = harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: request,
+        },
+        paramsFor(harness)
+      );
+      await provider.mcpRequested.promise;
+
+      if (transition === 'role') {
+        harness.liveSocket.feathers.user = {
+          ...harness.user,
+          role: 'viewer',
+        };
+      } else {
+        harness.liveSocket.feathers.authentication = {
+          strategy: 'jwt',
+          accessToken: 'replacement-authority-token',
+        };
+      }
+      provider.releaseMcp();
+
+      await expect(discover).resolves.toMatchObject({
+        success: false,
+        error: expect.stringMatching(/authority|reservation/i),
+      });
+      expect(harness.emittedBrowserEvents).toEqual([]);
+      expect(
+        provider.requests.filter(
+          (request) =>
+            request.path.includes('.well-known') ||
+            request.path === '/register' ||
+            request.path === '/authorize'
+        )
+      ).toEqual([]);
+    }
+  );
+
+  it('ignores nullish hints and requires a reservation before browser provider effects', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const before = provider.requests.length;
+
+    await expect(
+      harness.app.service('mcp-servers/test-oauth').create(
+        {
+          mcp_url: provider.savedMcpUrl,
+          mcp_server_id: harness.server.mcp_server_id,
+          start_browser_flow: true,
+          oauth_browser_event: null,
+        } as never,
+        paramsFor(harness)
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    await expect(
+      harness.app.service('mcp-servers/test-oauth').create(
+        {
+          mcp_url: provider.savedMcpUrl,
+          mcp_server_id: harness.server.mcp_server_id,
+          start_browser_flow: true,
+        },
+        paramsFor(harness)
+      )
+    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/reservation/i) });
+    expect(provider.requests).toHaveLength(before);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it('expires and cleans an unused one-shot reservation at its bounded TTL', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const issuedAt = Date.now();
+    const request = await reserveBrowserEvent(harness, 'discover');
+    const before = provider.requests.length;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 60_001);
+    try {
+      await expect(
+        harness.app.service('mcp-servers/discover').create(
+          {
+            mcp_server_id: harness.server.mcp_server_id,
+            oauth_browser_event: request,
+          },
+          paramsFor(harness)
+        )
+      ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/expired/i) });
+    } finally {
+      clock.mockRestore();
+    }
+    expect(provider.requests).toHaveLength(before);
   });
 
   it('refuses catalog reuse after a current versioned SQLite grant binding drifts', async () => {
@@ -741,15 +1036,13 @@ describe('SQLite saved-row OAuth authority', () => {
     const harness = await createHarness(provider);
     databases.push(harness.rawDb);
 
+    const browserReservation = await reserveBrowserEvent(harness, 'test-oauth');
     const testRequest = harness.app.service('mcp-servers/test-oauth').create(
       {
         mcp_url: provider.savedMcpUrl,
         mcp_server_id: harness.server.mcp_server_id,
         start_browser_flow: true,
-        oauth_browser_event: {
-          operation_id: 'test-oauth-admin-a-0001',
-          auth_generation: 43,
-        },
+        oauth_browser_event: browserReservation,
       },
       paramsFor(harness)
     );

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -17,6 +17,7 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
+import type { OutboundDnsLookup } from '@agor/core/utils/safe-outbound-fetch';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRegisteredMCPCatalogConnectService } from './register-routes.js';
 import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
@@ -88,11 +89,13 @@ type TestProvider = {
   tokenRequested: Deferred<void>;
   refreshRequested: Deferred<void>;
   mcpRequested: Deferred<void>;
+  dcrRequested: Deferred<void>;
   releaseToken: () => void;
   releaseTokenRequest: (requestNumber: number) => void;
   waitForTokenRequest: (requestNumber: number) => Promise<void>;
   releaseRefresh: () => void;
   releaseMcp: () => void;
+  releaseDcr: () => void;
   close: () => Promise<void>;
 };
 
@@ -104,6 +107,7 @@ async function createTestProvider(
     holdRefresh?: boolean;
     invalidRefresh?: boolean;
     rejectDynamicRegistration?: boolean;
+    holdDynamicRegistration?: boolean;
     resourceScopes?: string[];
     holdMcpChallenge?: boolean;
   } = {}
@@ -130,6 +134,8 @@ async function createTestProvider(
   const releaseRefresh = deferred<void>();
   const mcpRequested = deferred<void>();
   const releaseMcp = deferred<void>();
+  const dcrRequested = deferred<void>();
+  const releaseDcr = deferred<void>();
   let tokenRequestCount = 0;
   let baseUrl = '';
 
@@ -163,7 +169,7 @@ async function createTestProvider(
           issuer: baseUrl,
           authorization_endpoint: `${baseUrl}/authorize`,
           token_endpoint: `${baseUrl}/token`,
-          ...(options.rejectDynamicRegistration
+          ...(options.rejectDynamicRegistration || options.holdDynamicRegistration
             ? { registration_endpoint: `${baseUrl}/register` }
             : {}),
           response_types_supported: ['code'],
@@ -171,17 +177,38 @@ async function createTestProvider(
           // The DCR fixture deliberately omits RFC 9207 response-issuer
           // support. Reaching /register therefore proves that the canonical
           // catalog row selected Marketplace policy rather than strict.
-          ...(options.rejectDynamicRegistration
+          ...(options.rejectDynamicRegistration || options.holdDynamicRegistration
             ? {}
             : { authorization_response_iss_parameter_supported: true }),
         })
       );
       return;
     }
-    if (url.pathname === '/register' && options.rejectDynamicRegistration) {
+    if (
+      url.pathname === '/register' &&
+      (options.rejectDynamicRegistration || options.holdDynamicRegistration)
+    ) {
       let body = '';
       for await (const chunk of request) body += String(chunk);
       recordedRequest.jsonBody = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+      dcrRequested.resolve();
+      if (options.holdDynamicRegistration) {
+        await releaseDcr.promise;
+        const redirectUris = Array.isArray(recordedRequest.jsonBody?.redirect_uris)
+          ? recordedRequest.jsonBody.redirect_uris
+          : [];
+        response.writeHead(201, { 'content-type': 'application/json' });
+        response.end(
+          JSON.stringify({
+            client_id: 'held-dcr-client',
+            redirect_uris: redirectUris,
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none',
+          })
+        );
+        return;
+      }
       // The DCR POST has crossed the provider boundary here. This controlled
       // fixture records it, then returns 418 without allocating a client or
       // grant; it is not an Agor-side pre-provider-mutation abort seam.
@@ -230,6 +257,14 @@ async function createTestProvider(
           expires_in: 3600,
         })
       );
+      return;
+    }
+    if (url.pathname === '/jwt') {
+      let body = '';
+      for await (const chunk of request) body += String(chunk);
+      recordedRequest.jsonBody = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ access_token: 'jwt-provider-token' }));
       return;
     }
     if (url.pathname === '/saved/mcp') {
@@ -288,6 +323,7 @@ async function createTestProvider(
     tokenRequested,
     refreshRequested,
     mcpRequested,
+    dcrRequested,
     releaseToken: () => {
       for (const gate of tokenReleaseGates.values()) gate.resolve();
     },
@@ -295,10 +331,12 @@ async function createTestProvider(
     waitForTokenRequest: (requestNumber: number) => tokenRequestMilestone(requestNumber).promise,
     releaseRefresh: () => releaseRefresh.resolve(),
     releaseMcp: () => releaseMcp.resolve(),
+    releaseDcr: () => releaseDcr.resolve(),
     close: () => {
       for (const gate of tokenReleaseGates.values()) gate.resolve();
       releaseRefresh.resolve();
       releaseMcp.resolve();
+      releaseDcr.resolve();
       return new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
@@ -331,6 +369,7 @@ async function createHarness(
     catalogEntry?: MCPCatalogEntry;
     durableAuthority?: NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>;
     lockGrantConfiguration?: NonNullable<RegisterServicesContext['lockMcpOAuthGrantConfiguration']>;
+    outboundDnsLookup?: OutboundDnsLookup;
   } = {}
 ) {
   const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
@@ -402,6 +441,7 @@ async function createHarness(
     deployment: {} as RegisterServicesContext['deployment'],
     mcpOAuthPendingFlowAuthority: options.durableAuthority,
     lockMcpOAuthGrantConfiguration: options.lockGrantConfiguration,
+    mcpOutboundDnsLookup: options.outboundDnsLookup,
   });
 
   const invokeCallback = async (
@@ -453,6 +493,18 @@ function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: 
     connection: harness.liveSocket.feathers,
     authentication: harness.liveSocket.feathers.authentication,
   } as AuthenticatedParams & { connection: { id: string } };
+}
+
+function replaceLiveSocketAuthority(harness: SQLiteHarness, suffix = 'replacement'): void {
+  harness.liveSocket.feathers.user = {
+    ...harness.user,
+    user_id: `01900000-0000-7000-8000-${suffix.padStart(12, '0').slice(-12)}` as UserID,
+    email: `${suffix}@example.test`,
+  };
+  harness.liveSocket.feathers.authentication = {
+    strategy: 'jwt',
+    accessToken: `${suffix}-authority-token`,
+  };
 }
 
 function addLiveAuthority(
@@ -586,6 +638,188 @@ afterEach(async () => {
 });
 
 describe('SQLite saved-row OAuth authority', () => {
+  it('does not dispatch test-jwt caller secrets when socket authority changes during DNS', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const dnsStarted = deferred<void>();
+    const releaseDns = deferred<void>();
+    const outboundDnsLookup: OutboundDnsLookup = async (hostname) => {
+      expect(hostname).toBe('localhost');
+      dnsStarted.resolve();
+      await releaseDns.promise;
+      return [{ address: '127.0.0.1', family: 4 }];
+    };
+    const harness = await createHarness(provider, undefined, { outboundDnsLookup });
+    databases.push(harness.rawDb);
+
+    const request = harness.app.service('mcp-servers/test-jwt').create(
+      {
+        api_url: `${provider.baseUrl.replace('127.0.0.1', 'localhost')}/jwt`,
+        api_token: 'admin-a-api-token',
+        api_secret: 'admin-a-api-secret',
+      },
+      paramsFor(harness)
+    );
+    await dnsStarted.promise;
+    replaceLiveSocketAuthority(harness, 'b00b');
+    releaseDns.resolve();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests.filter((entry) => entry.path === '/jwt')).toEqual([]);
+    expect(
+      provider.requests.some(
+        (entry) =>
+          entry.jsonBody?.name === 'admin-a-api-token' ||
+          entry.jsonBody?.secret === 'admin-a-api-secret'
+      )
+    ).toBe(false);
+  });
+
+  it('tests JWT credentials normally while keeping provider tokens out of the response', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+
+    await expect(
+      harness.app.service('mcp-servers/test-jwt').create(
+        {
+          api_url: `${provider.baseUrl}/jwt`,
+          api_token: 'normal-api-token',
+          api_secret: 'normal-api-secret',
+        },
+        paramsFor(harness)
+      )
+    ).resolves.toEqual({ success: true, tokenValid: true });
+    expect(provider.requests.filter((entry) => entry.path === '/jwt')).toEqual([
+      expect.objectContaining({
+        jsonBody: { name: 'normal-api-token', secret: 'normal-api-secret' },
+      }),
+    ]);
+  });
+
+  it('does not dispatch oauth-start initialize when authority changes during DNS', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const dnsStarted = deferred<void>();
+    const releaseDns = deferred<void>();
+    const outboundDnsLookup: OutboundDnsLookup = async (hostname) => {
+      expect(hostname).toBe('localhost');
+      dnsStarted.resolve();
+      await releaseDns.promise;
+      return [{ address: '127.0.0.1', family: 4 }];
+    };
+    const harness = await createHarness(provider, undefined, { outboundDnsLookup });
+    databases.push(harness.rawDb);
+    await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+      url: provider.savedMcpUrl.replace('127.0.0.1', 'localhost'),
+    });
+
+    const request = harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await dnsStarted.promise;
+    replaceLiveSocketAuthority(harness, 'b00f');
+    releaseDns.resolve();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests).toEqual([]);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it('abandons oauth-start when its authoritative saved-row read finishes under B', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const rowRead = deferred<void>();
+    const releaseRow = deferred<void>();
+    const originalFindById = MCPServerRepository.prototype.findById;
+    let held = false;
+    const findSpy = vi
+      .spyOn(MCPServerRepository.prototype, 'findById')
+      .mockImplementation(async function (serverId) {
+        const row = await originalFindById.call(this, serverId);
+        if (!held && serverId === harness.server.mcp_server_id) {
+          held = true;
+          rowRead.resolve();
+          await releaseRow.promise;
+        }
+        return row;
+      });
+    try {
+      const request = harness.app
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      await rowRead.promise;
+      replaceLiveSocketAuthority(harness, 'b00c');
+      releaseRow.resolve();
+
+      await expect(request).rejects.toThrow(/authority/i);
+      expect(provider.requests).toEqual([]);
+      expect(harness.emittedBrowserEvents).toEqual([]);
+    } finally {
+      releaseRow.resolve();
+      findSpy.mockRestore();
+    }
+  });
+
+  it('stops oauth-start after a held initialize probe when the socket becomes B', async () => {
+    const provider = await createTestProvider({ holdMcpChallenge: true });
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+
+    const request = harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await provider.mcpRequested.promise;
+    replaceLiveSocketAuthority(harness, 'b00d');
+    provider.releaseMcp();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests.filter((entry) => entry.path.startsWith('/.well-known/'))).toEqual([]);
+    expect(provider.requests.filter((entry) => entry.path === '/register')).toEqual([]);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it('does not create an oauth-start pending flow when authority changes during DCR', async () => {
+    const provider = await createTestProvider({ holdDynamicRegistration: true });
+    providers.push(provider);
+    const catalogEntry = {
+      name: 'test/oauth-start-held-dcr',
+      title: 'Held DCR fixture',
+      category: 'developer-tools',
+      capabilities: ['testing'],
+      benefit: 'Exercises request authority around DCR.',
+      starter_prompt: 'Exercise request authority.',
+      permission_disclosure: 'Fixture only.',
+      popularity_rank: 999_998,
+      transport: 'streamable-http',
+      remote_url: provider.savedMcpUrl,
+      has_remote: true,
+      has_package: false,
+      auth_type: 'oauth',
+    } as MCPCatalogEntry;
+    vi.mocked(loadCatalog)
+      .mockResolvedValueOnce([catalogEntry])
+      .mockResolvedValueOnce([catalogEntry]);
+    const harness = await createHarness(provider, undefined, { catalogEntry });
+    databases.push(harness.rawDb);
+
+    const request = harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await provider.dcrRequested.promise;
+    replaceLiveSocketAuthority(harness, 'b00e');
+    provider.releaseDcr();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests.filter((entry) => entry.path === '/register')).toHaveLength(1);
+    expect(provider.requests.filter((entry) => entry.path === '/token')).toEqual([]);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
   it('derives Marketplace policy and all advertised scopes at the service DCR boundary', async () => {
     const advertisedScopes = ['configure', 'read', 'read:sensitive', 'write', 'write:live'];
     const provider = await createTestProvider({
@@ -1367,6 +1601,10 @@ describe('SQLite saved-row OAuth authority', () => {
     databases.push(harness.rawDb);
     const service = harness.app.service('mcp-servers/oauth-browser-reservations');
     const issuedAt = Date.now();
+    // The full daemon suite can take longer than the production TTL under
+    // worker contention. Freeze issuance so this quota contract tests its
+    // own explicit expiry transition rather than ambient wall-clock speed.
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt);
 
     const reserve = (tenant: number, user: number, socket: number) => {
       const params = addLiveAuthority(
@@ -1381,53 +1619,53 @@ describe('SQLite saved-row OAuth authority', () => {
       );
     };
 
-    // Fill tenant 1 in layers. Each rejected boundary is followed by a request
-    // in the next isolation scope to prove the lower-scope exhaustion is local.
-    for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, 1);
-    await expect(reserve(1, 1, 1)).rejects.toThrow(/connection/i);
-    await expect(reserve(1, 1, 2)).resolves.toMatchObject({
-      reservation_token: expect.any(String),
-    });
-    // Socket 2 already has one; bring the user's total to 32.
-    for (let slot = 1; slot < 8; slot += 1) await reserve(1, 1, 2);
-    for (let socket = 3; socket <= 4; socket += 1) {
-      for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, socket);
-    }
-    await expect(reserve(1, 1, 5)).rejects.toThrow(/user/i);
-    await expect(reserve(1, 2, 1)).resolves.toMatchObject({
-      reservation_token: expect.any(String),
-    });
-    // User 2 has one; fill it and two more users to the tenant cap of 128.
-    for (let slot = 1; slot < 8; slot += 1) await reserve(1, 2, 1);
-    for (let socket = 2; socket <= 4; socket += 1) {
-      for (let slot = 0; slot < 8; slot += 1) await reserve(1, 2, socket);
-    }
-    for (let user = 3; user <= 4; user += 1) {
-      for (let socket = 1; socket <= 4; socket += 1) {
-        for (let slot = 0; slot < 8; slot += 1) await reserve(1, user, socket);
+    try {
+      // Fill tenant 1 in layers. Each rejected boundary is followed by a request
+      // in the next isolation scope to prove the lower-scope exhaustion is local.
+      for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, 1);
+      await expect(reserve(1, 1, 1)).rejects.toThrow(/connection/i);
+      await expect(reserve(1, 1, 2)).resolves.toMatchObject({
+        reservation_token: expect.any(String),
+      });
+      // Socket 2 already has one; bring the user's total to 32.
+      for (let slot = 1; slot < 8; slot += 1) await reserve(1, 1, 2);
+      for (let socket = 3; socket <= 4; socket += 1) {
+        for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, socket);
       }
-    }
-    await expect(reserve(1, 5, 1)).rejects.toThrow(/tenant/i);
-    await expect(reserve(2, 1, 1)).resolves.toMatchObject({
-      reservation_token: expect.any(String),
-    });
-
-    // Tenant 2 already has one reservation; fill tenants 2–8 to the global
-    // cap. Per-tenant caps ensure tenant 1 could not starve tenant 2 by itself.
-    for (let tenant = 2; tenant <= 8; tenant += 1) {
-      for (let user = 1; user <= 4; user += 1) {
+      await expect(reserve(1, 1, 5)).rejects.toThrow(/user/i);
+      await expect(reserve(1, 2, 1)).resolves.toMatchObject({
+        reservation_token: expect.any(String),
+      });
+      // User 2 has one; fill it and two more users to the tenant cap of 128.
+      for (let slot = 1; slot < 8; slot += 1) await reserve(1, 2, 1);
+      for (let socket = 2; socket <= 4; socket += 1) {
+        for (let slot = 0; slot < 8; slot += 1) await reserve(1, 2, socket);
+      }
+      for (let user = 3; user <= 4; user += 1) {
         for (let socket = 1; socket <= 4; socket += 1) {
-          for (let slot = 0; slot < 8; slot += 1) {
-            if (tenant === 2 && user === 1 && socket === 1 && slot === 0) continue;
-            await reserve(tenant, user, socket);
+          for (let slot = 0; slot < 8; slot += 1) await reserve(1, user, socket);
+        }
+      }
+      await expect(reserve(1, 5, 1)).rejects.toThrow(/tenant/i);
+      await expect(reserve(2, 1, 1)).resolves.toMatchObject({
+        reservation_token: expect.any(String),
+      });
+
+      // Tenant 2 already has one reservation; fill tenants 2–8 to the global
+      // cap. Per-tenant caps ensure tenant 1 could not starve tenant 2 by itself.
+      for (let tenant = 2; tenant <= 8; tenant += 1) {
+        for (let user = 1; user <= 4; user += 1) {
+          for (let socket = 1; socket <= 4; socket += 1) {
+            for (let slot = 0; slot < 8; slot += 1) {
+              if (tenant === 2 && user === 1 && socket === 1 && slot === 0) continue;
+              await reserve(tenant, user, socket);
+            }
           }
         }
       }
-    }
-    await expect(reserve(9, 1, 1)).rejects.toThrow(/pending OAuth browser reservations$/i);
+      await expect(reserve(9, 1, 1)).rejects.toThrow(/pending OAuth browser reservations$/i);
 
-    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 60_001);
-    try {
+      clock.mockReturnValue(issuedAt + 60_001);
       await expect(reserve(9, 1, 1)).resolves.toMatchObject({
         reservation_token: expect.any(String),
       });

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -66,6 +66,15 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
+function durableAuthorityWithCreate(
+  create: NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>['create']
+): NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']> {
+  return {
+    create,
+    maintain: vi.fn(),
+  } as unknown as NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>;
+}
+
 type TestProvider = {
   baseUrl: string;
   savedMcpUrl: string;
@@ -317,7 +326,12 @@ type SQLiteHarness = {
 async function createHarness(
   provider: TestProvider,
   oauthMode?: 'per_user' | 'shared',
-  options: { catalogPeer?: boolean; catalogEntry?: MCPCatalogEntry } = {}
+  options: {
+    catalogPeer?: boolean;
+    catalogEntry?: MCPCatalogEntry;
+    durableAuthority?: NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>;
+    lockGrantConfiguration?: NonNullable<RegisterServicesContext['lockMcpOAuthGrantConfiguration']>;
+  } = {}
 ) {
   const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
   await runMigrations(rawDb);
@@ -386,6 +400,8 @@ async function createHarness(
     allowSuperadmin: false,
     requireAuth: async (context) => context,
     deployment: {} as RegisterServicesContext['deployment'],
+    mcpOAuthPendingFlowAuthority: options.durableAuthority,
+    lockMcpOAuthGrantConfiguration: options.lockGrantConfiguration,
   });
 
   const invokeCallback = async (
@@ -1008,6 +1024,166 @@ describe('SQLite saved-row OAuth authority', () => {
       clock.mockRestore();
     }
     expect(provider.requests).toHaveLength(before);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it.each(['expiry', 'socket replacement'] as const)(
+    'gives %s authority precedence when SQLite grant lookup rejects after provider discovery',
+    async (transition) => {
+      const provider = await createTestProvider();
+      providers.push(provider);
+      const harness = await createHarness(provider);
+      databases.push(harness.rawDb);
+      const issuedAt = Date.now();
+      const request = await reserveBrowserEvent(harness, 'discover');
+      const lookupStarted = deferred<void>();
+      const releaseLookup = deferred<void>();
+      const originalGetToken = UserMCPOAuthTokenRepository.prototype.getToken;
+      let heldGrantPreparation = false;
+      const lookupSpy = vi
+        .spyOn(UserMCPOAuthTokenRepository.prototype, 'getToken')
+        .mockImplementation(async function (...args) {
+          const providerDiscoveryFinished = provider.requests.some(
+            (request) => request.path === '/.well-known/oauth-authorization-server'
+          );
+          if (!heldGrantPreparation && providerDiscoveryFinished) {
+            heldGrantPreparation = true;
+            lookupStarted.resolve();
+            await releaseLookup.promise;
+            throw new Error('held SQLite grant lookup failed');
+          }
+          return originalGetToken.apply(this, args);
+        });
+      const clock =
+        transition === 'expiry'
+          ? vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 59_999)
+          : undefined;
+      try {
+        const discover = harness.app.service('mcp-servers/discover').create(
+          {
+            mcp_server_id: harness.server.mcp_server_id,
+            oauth_browser_event: request,
+          },
+          paramsFor(harness)
+        );
+        await lookupStarted.promise;
+        const requestsAtFailure = provider.requests.map((entry) => ({ ...entry }));
+
+        if (transition === 'expiry') {
+          clock!.mockReturnValue(issuedAt + 60_001);
+        } else {
+          harness.liveSocket.feathers.user = {
+            ...harness.user,
+            user_id: '01900000-0000-7000-8000-00000000cafe' as UserID,
+            email: 'replacement@example.test',
+          };
+        }
+        releaseLookup.resolve();
+
+        await expect(discover).resolves.toMatchObject({
+          success: false,
+          error: expect.stringMatching(/expired|authority|reservation/i),
+        });
+        expect(provider.requests).toEqual(requestsAtFailure);
+      } finally {
+        releaseLookup.resolve();
+        lookupSpy.mockRestore();
+        clock?.mockRestore();
+      }
+      expect(harness.emittedBrowserEvents).toEqual([]);
+      expect(
+        provider.requests.filter((request) => request.authorization?.startsWith('Bearer '))
+      ).toEqual([]);
+    }
+  );
+
+  it('gives expiry precedence when PostgreSQL grant locking rejects after discovery', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const lockStarted = deferred<void>();
+    const releaseLock = deferred<void>();
+    const durableCreate = vi.fn(async () => {
+      throw new Error('durable create must not run');
+    });
+    const lockGrantConfiguration = vi.fn(async () => {
+      lockStarted.resolve();
+      await releaseLock.promise;
+      throw new Error('held PostgreSQL lock failed');
+    });
+    const harness = await createHarness(provider, undefined, {
+      durableAuthority: durableAuthorityWithCreate(durableCreate),
+      lockGrantConfiguration,
+    });
+    databases.push(harness.rawDb);
+    const issuedAt = Date.now();
+    const request = await reserveBrowserEvent(harness, 'discover');
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 59_999);
+    try {
+      const discover = harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: request,
+        },
+        paramsFor(harness)
+      );
+      await lockStarted.promise;
+      const requestsAtFailure = provider.requests.map((entry) => ({ ...entry }));
+      clock.mockReturnValue(issuedAt + 60_001);
+      releaseLock.resolve();
+
+      await expect(discover).resolves.toMatchObject({
+        success: false,
+        error: expect.stringMatching(/expired/i),
+      });
+      expect(provider.requests).toEqual(requestsAtFailure);
+    } finally {
+      releaseLock.resolve();
+      clock.mockRestore();
+    }
+    expect(lockGrantConfiguration).toHaveBeenCalledOnce();
+    expect(durableCreate).not.toHaveBeenCalled();
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it('gives socket replacement precedence when PostgreSQL durable-flow creation rejects', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const createStarted = deferred<void>();
+    const releaseCreate = deferred<void>();
+    const durableCreate = vi.fn(async () => {
+      createStarted.resolve();
+      await releaseCreate.promise;
+      throw new Error('held PostgreSQL durable create failed');
+    });
+    const lockGrantConfiguration = vi.fn().mockResolvedValue(undefined);
+    const harness = await createHarness(provider, undefined, {
+      durableAuthority: durableAuthorityWithCreate(durableCreate),
+      lockGrantConfiguration,
+    });
+    databases.push(harness.rawDb);
+    const request = await reserveBrowserEvent(harness, 'discover');
+    const discover = harness.app.service('mcp-servers/discover').create(
+      {
+        mcp_server_id: harness.server.mcp_server_id,
+        oauth_browser_event: request,
+      },
+      paramsFor(harness)
+    );
+    await createStarted.promise;
+    const requestsAtFailure = provider.requests.map((entry) => ({ ...entry }));
+    harness.liveSocket.feathers.authentication = {
+      strategy: 'jwt',
+      accessToken: 'replacement-postgres-authority-token',
+    };
+    releaseCreate.resolve();
+
+    await expect(discover).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/authority|reservation/i),
+    });
+    expect(provider.requests).toEqual(requestsAtFailure);
+    expect(lockGrantConfiguration).toHaveBeenCalledOnce();
+    expect(durableCreate).toHaveBeenCalledOnce();
     expect(harness.emittedBrowserEvents).toEqual([]);
   });
 

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -439,6 +439,44 @@ function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: 
   } as AuthenticatedParams & { connection: { id: string } };
 }
 
+function addLiveAuthority(
+  harness: SQLiteHarness,
+  tenantId: string,
+  userId: string,
+  socketId: string
+): AuthenticatedParams & { connection: { id: string } } {
+  const user = {
+    ...harness.user,
+    user_id: userId as UserID,
+    email: `${userId}@example.test`,
+    role: 'member' as const,
+  };
+  const connection = {
+    id: socketId,
+    user,
+    authentication: {
+      strategy: 'jwt',
+      accessToken: `token:${tenantId}:${userId}:${socketId}`,
+    },
+  } as AuthenticatedParams & { id: string };
+  const socket = {
+    id: socketId,
+    feathers: connection,
+    data: { tenant: { tenant_id: tenantId, source: 'auth' } },
+  };
+  (
+    harness.app.io as {
+      sockets: { sockets: Map<string, unknown> };
+    }
+  ).sockets.sockets.set(socketId, socket);
+  return {
+    user,
+    tenant: { tenant_id: tenantId, source: 'auth' },
+    connection,
+    authentication: connection.authentication,
+  } as AuthenticatedParams & { connection: { id: string } };
+}
+
 async function reserveBrowserEvent(
   harness: SQLiteHarness,
   operation: 'discover' | 'test-oauth'
@@ -922,6 +960,138 @@ describe('SQLite saved-row OAuth authority', () => {
       clock.mockRestore();
     }
     expect(provider.requests).toHaveLength(before);
+  });
+
+  it('retains the immutable deadline after consumption and aborts held discovery before DCR or browser emit', async () => {
+    const provider = await createTestProvider({
+      holdMcpChallenge: true,
+      rejectDynamicRegistration: true,
+    });
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    // If the deadline guard were missing, this legacy no-client row would
+    // proceed through provider discovery and POST /register. Existing DCR
+    // coverage proves that counterfactual path; this test proves expiry stops
+    // it before the first durable provider side effect.
+    await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_compatibility_mode: 'legacy',
+      },
+    });
+    const issuedAt = Date.now();
+    const request = await reserveBrowserEvent(harness, 'discover');
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 59_999);
+    try {
+      const discover = harness.app.service('mcp-servers/discover').create(
+        {
+          mcp_server_id: harness.server.mcp_server_id,
+          oauth_browser_event: request,
+        },
+        paramsFor(harness)
+      );
+      await provider.mcpRequested.promise;
+
+      // The map entry has already been consumed. Advancing past its immutable
+      // claim deadline must still fence every continuation after the held MCP
+      // challenge completes.
+      clock.mockReturnValue(issuedAt + 60_001);
+      provider.releaseMcp();
+
+      await expect(discover).resolves.toMatchObject({
+        success: false,
+        error: expect.stringMatching(/expired/i),
+      });
+    } finally {
+      clock.mockRestore();
+    }
+    expect(harness.emittedBrowserEvents).toEqual([]);
+    expect(
+      provider.requests.filter(
+        (request) =>
+          request.path.includes('.well-known') ||
+          request.path === '/register' ||
+          request.path === '/authorize'
+      )
+    ).toEqual([]);
+  });
+
+  it('enforces layered socket/user/tenant/global reservation quotas with isolation and TTL recovery', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const service = harness.app.service('mcp-servers/oauth-browser-reservations');
+    const issuedAt = Date.now();
+
+    const reserve = (tenant: number, user: number, socket: number) => {
+      const params = addLiveAuthority(
+        harness,
+        `tenant-${tenant}`,
+        `tenant-${tenant}-user-${user}`,
+        `tenant-${tenant}-user-${user}-socket-${socket}`
+      );
+      return service.create(
+        { operation: 'discover', mcp_server_id: harness.server.mcp_server_id },
+        params
+      );
+    };
+
+    // Fill tenant 1 in layers. Each rejected boundary is followed by a request
+    // in the next isolation scope to prove the lower-scope exhaustion is local.
+    for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, 1);
+    await expect(reserve(1, 1, 1)).rejects.toThrow(/connection/i);
+    await expect(reserve(1, 1, 2)).resolves.toMatchObject({
+      reservation_token: expect.any(String),
+    });
+    // Socket 2 already has one; bring the user's total to 32.
+    for (let slot = 1; slot < 8; slot += 1) await reserve(1, 1, 2);
+    for (let socket = 3; socket <= 4; socket += 1) {
+      for (let slot = 0; slot < 8; slot += 1) await reserve(1, 1, socket);
+    }
+    await expect(reserve(1, 1, 5)).rejects.toThrow(/user/i);
+    await expect(reserve(1, 2, 1)).resolves.toMatchObject({
+      reservation_token: expect.any(String),
+    });
+    // User 2 has one; fill it and two more users to the tenant cap of 128.
+    for (let slot = 1; slot < 8; slot += 1) await reserve(1, 2, 1);
+    for (let socket = 2; socket <= 4; socket += 1) {
+      for (let slot = 0; slot < 8; slot += 1) await reserve(1, 2, socket);
+    }
+    for (let user = 3; user <= 4; user += 1) {
+      for (let socket = 1; socket <= 4; socket += 1) {
+        for (let slot = 0; slot < 8; slot += 1) await reserve(1, user, socket);
+      }
+    }
+    await expect(reserve(1, 5, 1)).rejects.toThrow(/tenant/i);
+    await expect(reserve(2, 1, 1)).resolves.toMatchObject({
+      reservation_token: expect.any(String),
+    });
+
+    // Tenant 2 already has one reservation; fill tenants 2–8 to the global
+    // cap. Per-tenant caps ensure tenant 1 could not starve tenant 2 by itself.
+    for (let tenant = 2; tenant <= 8; tenant += 1) {
+      for (let user = 1; user <= 4; user += 1) {
+        for (let socket = 1; socket <= 4; socket += 1) {
+          for (let slot = 0; slot < 8; slot += 1) {
+            if (tenant === 2 && user === 1 && socket === 1 && slot === 0) continue;
+            await reserve(tenant, user, socket);
+          }
+        }
+      }
+    }
+    await expect(reserve(9, 1, 1)).rejects.toThrow(/pending OAuth browser reservations$/i);
+
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 60_001);
+    try {
+      await expect(reserve(9, 1, 1)).resolves.toMatchObject({
+        reservation_token: expect.any(String),
+      });
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it('refuses catalog reuse after a current versioned SQLite grant binding drifts', async () => {

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -293,6 +293,7 @@ type SQLiteHarness = {
   rawDb: Awaited<ReturnType<typeof createDatabaseAsync>>;
   user: User;
   server: MCPServer;
+  emittedBrowserEvents: Array<Record<string, unknown>>;
   nextAuthorizationUrl: () => Promise<string>;
   callback: (state: string) => Promise<{ status: number; body: string }>;
   deny: (state: string) => Promise<{ status: number; body: string }>;
@@ -328,11 +329,15 @@ async function createHarness(
   });
 
   let nextUrl = deferred<string>();
+  const emittedBrowserEvents: Array<Record<string, unknown>> = [];
   const io = {
     local: {
       to: () => ({
-        emit: (event: string, value: { authUrl?: string }) => {
-          if (event === 'oauth:open_browser' && value.authUrl) nextUrl.resolve(value.authUrl);
+        emit: (event: string, value: Record<string, unknown>) => {
+          if (event === 'oauth:open_browser' && typeof value.authUrl === 'string') {
+            emittedBrowserEvents.push(value);
+            nextUrl.resolve(value.authUrl);
+          }
         },
       }),
     },
@@ -384,6 +389,7 @@ async function createHarness(
     rawDb,
     user,
     server,
+    emittedBrowserEvents,
     nextAuthorizationUrl: async () => {
       const value = await nextUrl.promise;
       nextUrl = deferred<string>();
@@ -575,6 +581,10 @@ describe('SQLite saved-row OAuth authority', () => {
           oauth_client_id: 'transient-client-id',
           oauth_compatibility_mode: 'legacy',
         },
+        oauth_browser_event: {
+          operation_id: 'settings-discover-admin-a-0001',
+          auth_generation: 41,
+        },
       },
       paramsFor(harness)
     );
@@ -589,6 +599,15 @@ describe('SQLite saved-row OAuth authority', () => {
     );
     expect(authorizationUrl.searchParams.get('client_id')).toBe('saved-client-id');
     expect(authorizationUrl.searchParams.get('resource')).toBe(provider.savedMcpUrl);
+    expect(harness.emittedBrowserEvents).toEqual([
+      expect.objectContaining({
+        authUrl: authorizationUrl.toString(),
+        operation_id: 'settings-discover-admin-a-0001',
+        auth_generation: 41,
+        caller_user_id: harness.user.user_id,
+        attempt_id: expect.any(String),
+      }),
+    ]);
     expect(provider.requests.some((request) => request.path === '/transient/mcp')).toBe(false);
     expect(provider.requests.some((request) => request.transientHeader)).toBe(false);
 
@@ -727,6 +746,10 @@ describe('SQLite saved-row OAuth authority', () => {
         mcp_url: provider.savedMcpUrl,
         mcp_server_id: harness.server.mcp_server_id,
         start_browser_flow: true,
+        oauth_browser_event: {
+          operation_id: 'test-oauth-admin-a-0001',
+          auth_generation: 43,
+        },
       },
       paramsFor(harness)
     );

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -962,6 +962,55 @@ describe('SQLite saved-row OAuth authority', () => {
     expect(provider.requests).toHaveLength(before);
   });
 
+  it('aborts test-oauth when its consumed reservation expires during saved-row DB prep', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const issuedAt = Date.now();
+    const request = await reserveBrowserEvent(harness, 'test-oauth');
+    const before = provider.requests.length;
+    const lookupStarted = deferred<void>();
+    const releaseLookup = deferred<void>();
+    const originalFindById = MCPServerRepository.prototype.findById;
+    let holdTargetLookup = true;
+    const lookupSpy = vi
+      .spyOn(MCPServerRepository.prototype, 'findById')
+      .mockImplementation(async function (id: string) {
+        if (holdTargetLookup && id === harness.server.mcp_server_id) {
+          holdTargetLookup = false;
+          lookupStarted.resolve();
+          await releaseLookup.promise;
+        }
+        return originalFindById.call(this, id);
+      });
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 59_999);
+    try {
+      const test = harness.app.service('mcp-servers/test-oauth').create(
+        {
+          mcp_url: provider.savedMcpUrl,
+          mcp_server_id: harness.server.mcp_server_id,
+          start_browser_flow: true,
+          oauth_browser_event: request,
+        },
+        paramsFor(harness)
+      );
+      await lookupStarted.promise;
+      clock.mockReturnValue(issuedAt + 60_001);
+      releaseLookup.resolve();
+
+      await expect(test).resolves.toMatchObject({
+        success: false,
+        error: expect.stringMatching(/expired/i),
+      });
+    } finally {
+      lookupSpy.mockRestore();
+      clock.mockRestore();
+    }
+    expect(provider.requests).toHaveLength(before);
+    expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
   it('retains the immutable deadline after consumption and aborts held discovery before DCR or browser emit', async () => {
     const provider = await createTestProvider({
       holdMcpChallenge: true,

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@agor/core/db';
 import {
   type Application,
+  AuthenticationService,
   feathers,
   feathersExpress,
   socketio,
@@ -26,7 +27,12 @@ import type {
 import type { OutboundDnsLookup } from '@agor/core/utils/safe-outbound-fetch';
 import { type Socket as ClientSocket, io as createSocketClient } from 'socket.io-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { issueRuntimeToken } from './auth/runtime-tokens.js';
+import { RuntimeJWTStrategy } from './auth/runtime-jwt-strategy.js';
+import {
+  issueRuntimeToken,
+  RUNTIME_JWT_AUDIENCE,
+  RUNTIME_JWT_ISSUER,
+} from './auth/runtime-tokens.js';
 import { createRegisteredMCPCatalogConnectService } from './register-routes.js';
 import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
 import { createSocketIOConfig } from './setup/socketio.js';
@@ -701,6 +707,26 @@ async function createRealSocketHarness(
       return user;
     },
   } as never);
+  const multiTenancy = {
+    mode: 'static',
+    static_tenant_id: 'default',
+  } as const;
+  app.set('authentication', {
+    secret: REAL_SOCKET_JWT_SECRET,
+    entity: 'user',
+    entityId: 'user_id',
+    service: 'users',
+    authStrategies: ['jwt'],
+    jwtOptions: {
+      header: { typ: 'access' },
+      audience: RUNTIME_JWT_AUDIENCE,
+      issuer: RUNTIME_JWT_ISSUER,
+      algorithm: 'HS256',
+    },
+  });
+  const authentication = new AuthenticationService(app);
+  authentication.register('jwt', new RuntimeJWTStrategy({ multiTenancy }));
+  app.use('authentication', authentication);
   app.use('/socket-authority-inspect', {
     async find(params?: AuthenticatedParams) {
       const descriptor = params?.connection
@@ -716,49 +742,11 @@ async function createRealSocketHarness(
       };
     },
   } as never);
-  app.use('/socket-authority-replace', {
-    async create(_data: unknown, params?: AuthenticatedParams) {
-      if (params?.provider !== 'socketio' || !params.connection) {
-        throw new Error('Expected a genuine Socket.IO replacement request');
-      }
-      const replacementToken = issueRuntimeToken(
-        { sub: userB.user_id, type: 'access' },
-        REAL_SOCKET_JWT_SECRET,
-        '5m'
-      );
-      params.connection.user = userB;
-      params.connection.authentication = {
-        strategy: 'jwt',
-        accessToken: replacementToken,
-      };
-      // This is the same server lifecycle event emitted after a successful
-      // Feathers authentication replacement, exercised through a second real
-      // service call on the surviving physical socket.
-      app.emit(
-        'login',
-        { user: userB, accessToken: replacementToken },
-        {
-          connection: params.connection,
-          params: {
-            ...params,
-            user: userB,
-            authentication: params.connection.authentication,
-            tenant: { tenant_id: 'default', source: 'static' },
-          },
-        }
-      );
-      return { replaced: true };
-    },
-  } as never);
-
   const socketConfig = createSocketIOConfig(app, {
     corsOrigin: '*',
     credentialsAllowed: false,
     jwtSecret: REAL_SOCKET_JWT_SECRET,
-    multiTenancy: {
-      mode: 'static',
-      static_tenant_id: 'default',
-    } as never,
+    multiTenancy,
   });
   app.configure(socketio(socketConfig.serverOptions, socketConfig.callback));
   await registerMCPServices({
@@ -806,8 +794,27 @@ async function createRealSocketHarness(
   client.configure(socketioClient(clientSocket));
   await waitForClientSocket(clientSocket);
 
+  const replacementSockets: ClientSocket[] = [];
   const replaceAuthorityWithB = async (): Promise<void> => {
-    await client.service('socket-authority-replace').create({});
+    // Newer-main makes socket authority immutable for the physical handshake:
+    // an A -> B transition retires A's registry entry and establishes B on a
+    // new socket. Remove A from the authoritative live map without tearing
+    // down its test transport yet, so the already-running RPC can deliver its
+    // expected authority rejection acknowledgement to the client.
+    app.io.sockets.sockets.delete(clientSocket.id!);
+
+    const replacementToken = issueRuntimeToken(
+      { sub: userB.user_id, type: 'access' },
+      REAL_SOCKET_JWT_SECRET,
+      '5m'
+    );
+    const replacement = createSocketClient(`http://127.0.0.1:${address.port}`, {
+      auth: { token: replacementToken },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+    replacementSockets.push(replacement);
+    await waitForClientSocket(replacement);
   };
 
   let closed = false;
@@ -825,6 +832,7 @@ async function createRealSocketHarness(
       if (closed) return;
       closed = true;
       clientSocket.close();
+      for (const replacement of replacementSockets) replacement.close();
       await new Promise<void>((resolve, reject) =>
         httpServer.close((error) => (error ? reject(error) : resolve()))
       );

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -722,6 +722,116 @@ describe('SQLite saved-row OAuth authority', () => {
     ).toBeNull();
   });
 
+  it('never sends A bearer credentials after test-oauth callback when the socket becomes B', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const browserReservation = await reserveBrowserEvent(harness, 'test-oauth');
+    const testRequest = harness.app.service('mcp-servers/test-oauth').create(
+      {
+        mcp_url: provider.savedMcpUrl,
+        mcp_server_id: harness.server.mcp_server_id,
+        start_browser_flow: true,
+        oauth_browser_event: browserReservation,
+      },
+      paramsFor(harness)
+    );
+    const authorizationUrl = new URL(await harness.nextAuthorizationUrl());
+    const replacementUserId = '01900000-0000-7000-8000-00000000b00b' as UserID;
+    let authorityReplaced = false;
+    (harness.app.io as { to: () => { emit: (event: string) => void } }).to = () => ({
+      emit: (event) => {
+        if (event !== 'oauth:completed' || authorityReplaced) return;
+        authorityReplaced = true;
+        // Completion is emitted after the token is durably persisted and
+        // immediately before the raw awaitToken promise resolves. Replace the
+        // surviving socket at that exact boundary so the post-await guard —
+        // not an earlier provider/DB guard — must stop the bearer probe.
+        harness.liveSocket.feathers.user = {
+          ...harness.user,
+          user_id: replacementUserId,
+          email: 'replacement-admin@example.test',
+        };
+        harness.liveSocket.feathers.authentication = {
+          strategy: 'jwt',
+          accessToken: 'replacement-admin-authority-token',
+        };
+      },
+    });
+
+    await expect(
+      harness.callback(authorizationUrl.searchParams.get('state')!)
+    ).resolves.toMatchObject({ status: 200 });
+    expect(authorityReplaced).toBe(true);
+
+    await expect(testRequest).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/attempt|authority/i),
+    });
+    expect(
+      provider.requests.filter((request) => request.authorization === 'Bearer sqlite-access-token')
+    ).toEqual([]);
+
+    // Callback persistence is intentionally bound to the server-issued A
+    // attempt/user/tenant, not to socket lifetime. Only use in the surviving
+    // request is socket-bound, so B can neither receive nor send A's token.
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({ oauth_access_token: 'sqlite-access-token' });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        replacementUserId,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('uses attempt-bound live authority after browser emit instead of the reservation TTL', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const issuedAt = Date.now();
+    const browserReservation = await reserveBrowserEvent(harness, 'test-oauth');
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(issuedAt + 59_999);
+    try {
+      const testRequest = harness.app.service('mcp-servers/test-oauth').create(
+        {
+          mcp_url: provider.savedMcpUrl,
+          mcp_server_id: harness.server.mcp_server_id,
+          start_browser_flow: true,
+          oauth_browser_event: browserReservation,
+        },
+        paramsFor(harness)
+      );
+      const authorizationUrl = new URL(await harness.nextAuthorizationUrl());
+
+      // The pre-browser reservation has done its job. The callback wait is
+      // bounded separately and remains usable only by the same live socket,
+      // caller, role, tenant, token fingerprint, and server-issued attempt.
+      clock.mockReturnValue(issuedAt + 60_001);
+      await expect(
+        harness.callback(authorizationUrl.searchParams.get('state')!)
+      ).resolves.toMatchObject({ status: 200 });
+      await expect(testRequest).resolves.toMatchObject({
+        success: true,
+        tokenValid: true,
+        mcpStatus: 200,
+      });
+      expect(
+        provider.requests.filter(
+          (request) => request.authorization === 'Bearer sqlite-access-token'
+        )
+      ).toHaveLength(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   it('consumes reservations once and rejects caller/socket/tenant replacement before provider work', async () => {
     const provider = await createTestProvider();
     providers.push(provider);
@@ -1098,6 +1208,11 @@ describe('SQLite saved-row OAuth authority', () => {
   );
 
   it('gives expiry precedence when PostgreSQL grant locking rejects after discovery', async () => {
+    // This injects the PostgreSQL-only control-flow boundaries into the real
+    // registered service while retaining SQLite storage. It proves request
+    // continuation ordering, not database rollback. The actual repository +
+    // pending-authority rollback contract lives in
+    // mcp-oauth-pending-flow-authority.postgres.test.ts.
     const provider = await createTestProvider();
     providers.push(provider);
     const lockStarted = deferred<void>();
@@ -1146,6 +1261,8 @@ describe('SQLite saved-row OAuth authority', () => {
   });
 
   it('gives socket replacement precedence when PostgreSQL durable-flow creation rejects', async () => {
+    // As above, this is a production service control-flow seam. It is kept
+    // explicitly distinct from the live-PostgreSQL atomicity test.
     const provider = await createTestProvider();
     providers.push(provider);
     const createStarted = deferred<void>();

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1,4 +1,4 @@
-import http from 'node:http';
+import http, { type Server as HttpServer } from 'node:http';
 import {
   createDatabaseAsync,
   MCPServerRepository,
@@ -7,7 +7,13 @@ import {
   UserMCPOAuthTokenRepository,
   UsersRepository,
 } from '@agor/core/db';
-import { type Application, feathers } from '@agor/core/feathers';
+import {
+  type Application,
+  feathers,
+  feathersExpress,
+  socketio,
+  socketioClient,
+} from '@agor/core/feathers';
 import { loadCatalog } from '@agor/core/mcp-catalog';
 import type {
   AuthenticatedParams,
@@ -18,9 +24,17 @@ import type {
   UserID,
 } from '@agor/core/types';
 import type { OutboundDnsLookup } from '@agor/core/utils/safe-outbound-fetch';
+import { type Socket as ClientSocket, io as createSocketClient } from 'socket.io-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { issueRuntimeToken } from './auth/runtime-tokens.js';
 import { createRegisteredMCPCatalogConnectService } from './register-routes.js';
 import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
+import { createSocketIOConfig } from './setup/socketio.js';
+import {
+  AGOR_SOCKET_AUTHORITY_ID_PROPERTY,
+  installSocketAuthorityId,
+  readSocketAuthorityId,
+} from './utils/socket-request-authority.js';
 
 // The boundary under test is daemon discovery/OAuth authority, not the MCP
 // SDK's stream parser. Mock only the post-grant capability client so Vitest
@@ -356,7 +370,7 @@ type SQLiteHarness = {
   deny: (state: string) => Promise<{ status: number; body: string }>;
   liveSocket: {
     id: string;
-    feathers: AuthenticatedParams & { id: string };
+    feathers: AuthenticatedParams;
     data: { tenant: { tenant_id: string; source: string } };
   };
 };
@@ -401,15 +415,18 @@ async function createHarness(
   const liveSocket = {
     id: 'sqlite-test-socket',
     feathers: {
-      id: 'sqlite-test-socket',
       user,
       authentication: {
         strategy: 'jwt',
         accessToken: 'sqlite-initial-authority-token',
       },
-    } as AuthenticatedParams & { id: string },
+    } as AuthenticatedParams,
     data: { tenant: { tenant_id: 'default', source: 'static' } },
   };
+  installSocketAuthorityId(
+    liveSocket.feathers as unknown as Record<PropertyKey, unknown>,
+    liveSocket.id
+  );
   const io = {
     local: {
       to: () => ({
@@ -486,13 +503,14 @@ async function createHarness(
   } satisfies SQLiteHarness;
 }
 
-function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: { id: string } } {
+function paramsFor(harness: SQLiteHarness): AuthenticatedParams {
   return {
+    provider: 'socketio',
     user: harness.liveSocket.feathers.user,
     tenant: { tenant_id: 'default', source: 'static' },
     connection: harness.liveSocket.feathers,
     authentication: harness.liveSocket.feathers.authentication,
-  } as AuthenticatedParams & { connection: { id: string } };
+  } as AuthenticatedParams;
 }
 
 function replaceLiveSocketAuthority(harness: SQLiteHarness, suffix = 'replacement'): void {
@@ -512,7 +530,7 @@ function addLiveAuthority(
   tenantId: string,
   userId: string,
   socketId: string
-): AuthenticatedParams & { connection: { id: string } } {
+): AuthenticatedParams {
   const user = {
     ...harness.user,
     user_id: userId as UserID,
@@ -520,13 +538,13 @@ function addLiveAuthority(
     role: 'member' as const,
   };
   const connection = {
-    id: socketId,
     user,
     authentication: {
       strategy: 'jwt',
       accessToken: `token:${tenantId}:${userId}:${socketId}`,
     },
-  } as AuthenticatedParams & { id: string };
+  } as AuthenticatedParams;
+  installSocketAuthorityId(connection as unknown as Record<PropertyKey, unknown>, socketId);
   const socket = {
     id: socketId,
     feathers: connection,
@@ -538,11 +556,12 @@ function addLiveAuthority(
     }
   ).sockets.sockets.set(socketId, socket);
   return {
+    provider: 'socketio',
     user,
     tenant: { tenant_id: tenantId, source: 'auth' },
     connection,
     authentication: connection.authentication,
-  } as AuthenticatedParams & { connection: { id: string } };
+  } as AuthenticatedParams;
 }
 
 async function reserveBrowserEvent(
@@ -614,8 +633,209 @@ async function replaceWithNewAuthorization(harness: SQLiteHarness): Promise<numb
   return generation;
 }
 
+const REAL_SOCKET_JWT_SECRET = 'real-socket-authority-integration-secret';
+
+type RealSocketHarness = {
+  app: Application & { io: import('socket.io').Server };
+  rawDb: Awaited<ReturnType<typeof createDatabaseAsync>>;
+  userA: User;
+  userB: User;
+  serverRow: MCPServer;
+  httpServer: HttpServer;
+  client: Application;
+  clientSocket: ClientSocket;
+  replaceAuthorityWithB: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+function waitForClientSocket(socket: ClientSocket): Promise<void> {
+  if (socket.connected) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Timed out connecting real Socket.IO client')),
+      5_000
+    );
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    socket.once('connect_error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+async function createRealSocketHarness(
+  provider: TestProvider,
+  options: { outboundDnsLookup?: OutboundDnsLookup } = {}
+): Promise<RealSocketHarness> {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const users = new UsersRepository(rawDb);
+  const userA = await users.create({
+    email: `real-socket-a-${Math.random()}@example.test`,
+    role: 'admin',
+  });
+  const userB = await users.create({
+    email: `real-socket-b-${Math.random()}@example.test`,
+    role: 'admin',
+  });
+  const serverRow = await new MCPServerRepository(rawDb).create({
+    name: 'real-socket-oauth-authority',
+    transport: 'http',
+    url: provider.savedMcpUrl,
+    scope: 'global',
+    owner_user_id: userA.user_id as UserID,
+    auth: { type: 'oauth', oauth_client_id: 'saved-client-id', oauth_mode: 'per_user' },
+  });
+
+  const app = feathersExpress(feathers()) as unknown as Application & {
+    io: import('socket.io').Server;
+    listen: (port: number, hostname: string) => Promise<HttpServer>;
+  };
+  app.use('/users', {
+    async get(id: string) {
+      const user = await users.findById(id);
+      if (!user) throw new Error('Unknown socket test user');
+      return user;
+    },
+  } as never);
+  app.use('/socket-authority-inspect', {
+    async find(params?: AuthenticatedParams) {
+      const descriptor = params?.connection
+        ? Object.getOwnPropertyDescriptor(params.connection, AGOR_SOCKET_AUTHORITY_ID_PROPERTY)
+        : undefined;
+      return {
+        provider: params?.provider,
+        authorityId: readSocketAuthorityId(params?.connection),
+        plainId: (params?.connection as { id?: unknown } | undefined)?.id,
+        enumerable: descriptor?.enumerable,
+        configurable: descriptor?.configurable,
+        writable: descriptor?.writable,
+      };
+    },
+  } as never);
+  app.use('/socket-authority-replace', {
+    async create(_data: unknown, params?: AuthenticatedParams) {
+      if (params?.provider !== 'socketio' || !params.connection) {
+        throw new Error('Expected a genuine Socket.IO replacement request');
+      }
+      const replacementToken = issueRuntimeToken(
+        { sub: userB.user_id, type: 'access' },
+        REAL_SOCKET_JWT_SECRET,
+        '5m'
+      );
+      params.connection.user = userB;
+      params.connection.authentication = {
+        strategy: 'jwt',
+        accessToken: replacementToken,
+      };
+      // This is the same server lifecycle event emitted after a successful
+      // Feathers authentication replacement, exercised through a second real
+      // service call on the surviving physical socket.
+      app.emit(
+        'login',
+        { user: userB, accessToken: replacementToken },
+        {
+          connection: params.connection,
+          params: {
+            ...params,
+            user: userB,
+            authentication: params.connection.authentication,
+            tenant: { tenant_id: 'default', source: 'static' },
+          },
+        }
+      );
+      return { replaced: true };
+    },
+  } as never);
+
+  const socketConfig = createSocketIOConfig(app, {
+    corsOrigin: '*',
+    credentialsAllowed: false,
+    jwtSecret: REAL_SOCKET_JWT_SECRET,
+    multiTenancy: {
+      mode: 'static',
+      static_tenant_id: 'default',
+    } as never,
+  });
+  app.configure(socketio(socketConfig.serverOptions, socketConfig.callback));
+  await registerMCPServices({
+    db: rawDb as unknown as TenantScopeAwareDatabase,
+    app,
+    config: {} as RegisterServicesContext['config'],
+    jwtSecret: REAL_SOCKET_JWT_SECRET,
+    daemonUrl: 'http://127.0.0.1:3030',
+    bundledUiAvailable: false,
+    DAEMON_PORT: 3030,
+    UI_PORT: 5173,
+    branchRbacEnabled: false,
+    allowSuperadmin: false,
+    requireAuth: async (context) => {
+      if (context.params.provider === 'socketio' && !context.params.user) {
+        throw new Error('Unauthenticated Socket.IO integration request');
+      }
+      context.params.tenant = { tenant_id: 'default', source: 'static' };
+      return context;
+    },
+    deployment: {} as RegisterServicesContext['deployment'],
+    mcpOutboundDnsLookup: options.outboundDnsLookup,
+  });
+
+  const httpServer = await app.listen(0, '127.0.0.1');
+  if (!httpServer.listening) {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once('listening', resolve);
+      httpServer.once('error', reject);
+    });
+  }
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') throw new Error('Expected Socket.IO test listener');
+  const accessToken = issueRuntimeToken(
+    { sub: userA.user_id, type: 'access' },
+    REAL_SOCKET_JWT_SECRET,
+    '5m'
+  );
+  const clientSocket = createSocketClient(`http://127.0.0.1:${address.port}`, {
+    auth: { token: accessToken },
+    transports: ['websocket'],
+    reconnection: false,
+  });
+  const client = feathers();
+  client.configure(socketioClient(clientSocket));
+  await waitForClientSocket(clientSocket);
+
+  const replaceAuthorityWithB = async (): Promise<void> => {
+    await client.service('socket-authority-replace').create({});
+  };
+
+  let closed = false;
+  return {
+    app,
+    rawDb,
+    userA,
+    userB,
+    serverRow,
+    httpServer,
+    client,
+    clientSocket,
+    replaceAuthorityWithB,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      clientSocket.close();
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((error) => (error ? reject(error) : resolve()))
+      );
+      (rawDb as unknown as { $client?: { close(): void } }).$client?.close();
+    },
+  };
+}
+
 const providers: TestProvider[] = [];
 const databases: SQLiteHarness['rawDb'][] = [];
+const realSocketHarnesses: RealSocketHarness[] = [];
 let previousBaseUrl: string | undefined;
 let previousMasterSecret: string | undefined;
 
@@ -627,6 +847,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  await Promise.all(realSocketHarnesses.splice(0).map((harness) => harness.close()));
   await Promise.all(providers.splice(0).map((provider) => provider.close()));
   for (const db of databases.splice(0)) {
     (db as unknown as { $client?: { close(): void } }).$client?.close();
@@ -635,6 +856,238 @@ afterEach(async () => {
   else process.env.AGOR_BASE_URL = previousBaseUrl;
   if (previousMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
   else process.env.AGOR_MASTER_SECRET = previousMasterSecret;
+});
+
+describe('real Feathers Socket.IO request authority', () => {
+  it('binds params.connection to the immutable physical socket and ignores spoofed ids', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createRealSocketHarness(provider);
+    realSocketHarnesses.push(harness);
+
+    const inspected = (await harness.client.service('socket-authority-inspect').find()) as {
+      provider?: string;
+      authorityId?: string;
+      plainId?: unknown;
+      enumerable?: boolean;
+      configurable?: boolean;
+      writable?: boolean;
+    };
+    expect(inspected).toEqual({
+      provider: 'socketio',
+      authorityId: harness.clientSocket.id,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+
+    const reservation = (await harness.client
+      .service('mcp-servers/oauth-browser-reservations')
+      .create({
+        operation: 'discover',
+        mcp_server_id: harness.serverRow.mcp_server_id,
+        // Neither a documented field nor this namespaced value can influence
+        // the server-derived transport binding.
+        socket_id: 'attacker-supplied-id',
+        [AGOR_SOCKET_AUTHORITY_ID_PROPERTY]: 'attacker-supplied-id',
+      })) as { reservation_token?: string };
+    expect(reservation.reservation_token).toMatch(/^[A-Za-z0-9_-]{32,128}$/);
+
+    const realConnection = harness.app.io.sockets.sockets.get(harness.clientSocket.id!)?.feathers;
+    expect(realConnection).toBeDefined();
+    const fakeConnection = {
+      id: harness.clientSocket.id,
+      user: harness.userA,
+      authentication: realConnection?.authentication,
+    } as AuthenticatedParams;
+    installSocketAuthorityId(
+      fakeConnection as unknown as Record<PropertyKey, unknown>,
+      harness.clientSocket.id!
+    );
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-browser-reservations')
+        .create({ operation: 'discover', mcp_server_id: harness.serverRow.mcp_server_id }, {
+          provider: 'socketio',
+          connection: fakeConnection,
+          user: harness.userA,
+          authentication: fakeConnection.authentication,
+          tenant: { tenant_id: 'default', source: 'static' },
+        } as AuthenticatedParams)
+    ).rejects.toThrow(/live socket/i);
+    await expect(
+      harness.app.service('mcp-servers/test-jwt').create(
+        {
+          api_url: `${provider.baseUrl}/jwt`,
+          api_token: 'must-not-dispatch',
+          api_secret: 'must-not-dispatch',
+        },
+        {
+          provider: 'socketio',
+          connection: { id: harness.clientSocket.id },
+          user: harness.userA,
+          tenant: { tenant_id: 'default', source: 'static' },
+        } as AuthenticatedParams
+      )
+    ).rejects.toThrow(/socket.*authority/i);
+    expect(provider.requests).toEqual([]);
+  });
+
+  it('drops one-shot reservations as soon as the physical socket disconnects', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createRealSocketHarness(provider);
+    realSocketHarnesses.push(harness);
+    const reserved = (await harness.client
+      .service('mcp-servers/oauth-browser-reservations')
+      .create({ operation: 'test-oauth', mcp_server_id: harness.serverRow.mcp_server_id })) as {
+      reservation_token: string;
+    };
+
+    const disconnected = new Promise<void>((resolve) => {
+      const serverSocket = harness.app.io.sockets.sockets.get(harness.clientSocket.id!);
+      serverSocket?.once('disconnect', () => resolve());
+    });
+    harness.clientSocket.close();
+    await disconnected;
+
+    await expect(
+      harness.app.service('mcp-servers/test-oauth').create(
+        {
+          mcp_url: provider.savedMcpUrl,
+          mcp_server_id: harness.serverRow.mcp_server_id,
+          start_browser_flow: true,
+          oauth_browser_event: { reservation_token: reserved.reservation_token },
+        },
+        {
+          provider: 'rest',
+          user: harness.userB,
+          tenant: { tenant_id: 'default', source: 'static' },
+        } as AuthenticatedParams
+      )
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/invalid, expired, or already used/i),
+    });
+    expect(provider.requests).toEqual([]);
+  });
+
+  it('fences A secrets at held DNS on a genuine test-jwt socket call', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const dnsStarted = deferred<void>();
+    const releaseDns = deferred<void>();
+    const harness = await createRealSocketHarness(provider, {
+      outboundDnsLookup: async (hostname) => {
+        expect(hostname).toBe('localhost');
+        dnsStarted.resolve();
+        await releaseDns.promise;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    realSocketHarnesses.push(harness);
+
+    const request = harness.client.service('mcp-servers/test-jwt').create({
+      api_url: `${provider.baseUrl.replace('127.0.0.1', 'localhost')}/jwt`,
+      api_token: 'admin-a-api-token',
+      api_secret: 'admin-a-api-secret',
+    });
+    await dnsStarted.promise;
+    await harness.replaceAuthorityWithB();
+    releaseDns.resolve();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests).toEqual([]);
+  });
+
+  it('fences oauth-start when A becomes B during the authoritative DB read', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createRealSocketHarness(provider);
+    realSocketHarnesses.push(harness);
+    const readStarted = deferred<void>();
+    const releaseRead = deferred<void>();
+    const originalFindById = MCPServerRepository.prototype.findById;
+    let held = false;
+    const findSpy = vi
+      .spyOn(MCPServerRepository.prototype, 'findById')
+      .mockImplementation(async function (id) {
+        const result = await originalFindById.call(this, id);
+        if (id === harness.serverRow.mcp_server_id && !held) {
+          held = true;
+          readStarted.resolve();
+          await releaseRead.promise;
+        }
+        return result;
+      });
+    try {
+      const request = harness.client
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.serverRow.mcp_server_id });
+      await readStarted.promise;
+      await harness.replaceAuthorityWithB();
+      releaseRead.resolve();
+
+      await expect(request).rejects.toThrow(/authority/i);
+      expect(provider.requests).toEqual([]);
+    } finally {
+      releaseRead.resolve();
+      findSpy.mockRestore();
+    }
+  });
+
+  it('fences oauth-start after a held initialize probe before discovery or flow creation', async () => {
+    const provider = await createTestProvider({ holdMcpChallenge: true });
+    providers.push(provider);
+    const harness = await createRealSocketHarness(provider);
+    realSocketHarnesses.push(harness);
+
+    const request = harness.client
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.serverRow.mcp_server_id });
+    await provider.mcpRequested.promise;
+    await harness.replaceAuthorityWithB();
+    provider.releaseMcp();
+
+    await expect(request).rejects.toThrow(/authority/i);
+    expect(provider.requests.map((entry) => entry.path)).toEqual(['/saved/mcp']);
+    expect(
+      provider.requests.some(
+        (entry) => entry.path.startsWith('/.well-known/') || entry.path === '/register'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps REST and internal calls on their non-socket request authority models', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createRealSocketHarness(provider);
+    realSocketHarnesses.push(harness);
+    const service = harness.app.service('mcp-servers/test-jwt');
+
+    await expect(
+      service.create(
+        {
+          api_url: `${provider.baseUrl}/jwt`,
+          api_token: 'rest-token',
+          api_secret: 'rest-secret',
+        },
+        {
+          provider: 'rest',
+          user: harness.userA,
+          tenant: { tenant_id: 'default', source: 'static' },
+        } as AuthenticatedParams
+      )
+    ).resolves.toMatchObject({ success: true });
+    await expect(
+      service.create({
+        api_url: `${provider.baseUrl}/jwt`,
+        api_token: 'internal-token',
+        api_secret: 'internal-secret',
+      })
+    ).resolves.toMatchObject({ success: true });
+    expect(provider.requests.filter((entry) => entry.path === '/jwt')).toHaveLength(2);
+  });
 });
 
 describe('SQLite saved-row OAuth authority', () => {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -80,6 +80,7 @@ import {
   assertPublicMCPOAuthCompatibilityMode,
   hasMinimumRole,
   isMCPOAuthGrantBindingVersion,
+  MCP_MEMBER_POLICY_CHANGED_EVENT,
   ROLES,
   TaskStatus,
 } from '@agor/core/types';
@@ -2593,7 +2594,12 @@ export async function registerMCPServices(
     }
   };
 
-  app.use('/mcp-servers', createMCPServersService(db));
+  app.use('/mcp-servers', createMCPServersService(db), {
+    // The policy endpoint is RPC-shaped and does not publish its caller-shaped
+    // response. It invalidates through this already tenant-scoped service
+    // instead; browsers then refetch their own `can_configure` answer.
+    events: [MCP_MEMBER_POLICY_CHANGED_EVENT],
+  });
   const invalidateOAuthGrantsAfterServerChange = async (
     context: HookContext,
     next: () => Promise<void>

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -224,6 +224,7 @@ import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
 import { renderOAuthResultPage } from './utils/html.js';
+import { createAuthorityGuardedMCPFetch } from './utils/mcp-authority-fetch.js';
 import { persistDiscoveredMCPCapabilities } from './utils/mcp-discovered-capabilities.js';
 import {
   shouldExposeMCPServerSecrets,
@@ -1470,8 +1471,10 @@ export async function registerMCPServices(
     ctx.lockMcpOAuthGrantConfiguration ?? lockMCPOAuthGrantConfiguration;
   const oauthFetch = async (
     input: string | URL | Request,
-    init: RequestInit = {}
+    init: RequestInit = {},
+    assertCurrent?: () => void
   ): Promise<Response> => {
+    assertCurrent?.();
     const requestInput = input instanceof Request ? input : undefined;
     const target: string | URL = input instanceof Request ? input.url : input;
     const { signal: _signal, redirect: _redirect, ...safeInit } = init;
@@ -1490,6 +1493,7 @@ export async function registerMCPServices(
       // PostgreSQL is the multi-daemon/hosted authority and must never turn
       // an admin-supplied endpoint into daemon-local egress.
       allowLocalhostHttp: !postgresOAuthDeployment,
+      assertCurrent,
     });
   };
   const refreshGrantValidator =
@@ -1708,6 +1712,17 @@ export async function registerMCPServices(
     authorityFingerprint?: string;
   };
 
+  type LiveSocketRequestAuthorityClaim = Pick<
+    OAuthBrowserReservationClaim,
+    'userId' | 'role' | 'tenantId' | 'socketId' | 'authorityFingerprint'
+  >;
+
+  type OAuthPostBrowserAuthorityClaim = LiveSocketRequestAuthorityClaim &
+    Pick<OAuthBrowserReservationClaim, 'operation' | 'mcpServerId'> & {
+      /** Server-issued attempt that promoted the pre-browser reservation. */
+      attemptId: MCPOAuthAttemptID;
+    };
+
   type StartTwoPhaseOAuthOptions = {
     mcpUrl: string;
     wwwAuthenticate: string;
@@ -1748,6 +1763,13 @@ export async function registerMCPServices(
 
   type StartTwoPhaseOAuthAndAwaitResult = StartTwoPhaseOAuthResult & {
     awaitToken: () => Promise<OAuthTokenResponse>;
+    /**
+     * The reservation TTL protects provider discovery, DCR, and browser emit.
+     * Once emitted, this attempt-bound assertion protects the longer callback
+     * wait and every use of its returned token without extending reservation
+     * capacity or accepting a client-supplied generation.
+     */
+    assertRequestAuthority?: () => void;
   };
 
   async function startTwoPhaseMCPOAuthFlow(
@@ -2166,6 +2188,28 @@ export async function registerMCPServices(
       });
     }
 
+    // The short reservation deadline intentionally ends after the browser URL
+    // is emitted. Provider interaction can legitimately outlive that minute,
+    // while the blocking HTTP request remains bounded by AWAIT_TOKEN_TIMEOUT.
+    // Promote only the server-issued attempt and its exact live socket/caller
+    // authority; no client generation or reflected token participates.
+    const postBrowserAuthorityClaim =
+      awaitToken && opts.browserReservation
+        ? ({
+            attemptId,
+            operation: opts.browserReservation.operation,
+            mcpServerId: opts.browserReservation.mcpServerId,
+            userId: opts.browserReservation.userId,
+            role: opts.browserReservation.role,
+            tenantId: opts.browserReservation.tenantId,
+            socketId: opts.browserReservation.socketId,
+            authorityFingerprint: opts.browserReservation.authorityFingerprint,
+          } satisfies OAuthPostBrowserAuthorityClaim)
+        : undefined;
+    const assertRequestAuthority = postBrowserAuthorityClaim
+      ? () => assertOAuthPostBrowserAuthorityStillCurrent(postBrowserAuthorityClaim)
+      : undefined;
+
     const base: StartTwoPhaseOAuthResult = {
       attemptId,
       state: context.state,
@@ -2177,19 +2221,23 @@ export async function registerMCPServices(
         const awaitDurableToken = async (): Promise<OAuthTokenResponse> => {
           const deadline = Date.now() + AWAIT_TOKEN_TIMEOUT_MS;
           while (Date.now() < deadline) {
-            const attempt = await durableOAuthFlows!.getForUser(
-              durableBinding.tenantId,
-              durableBinding.userId,
-              attemptId
+            const attempt = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+              durableOAuthFlows!.getForUser(
+                durableBinding.tenantId,
+                durableBinding.userId,
+                attemptId
+              )
             );
             if (!attempt) throw new Error('OAuth attempt is no longer available. Restart OAuth.');
             if (attempt.status === 'succeeded') {
               const tokenUserId: UserID | null =
                 durableBinding.oauthMode === 'per_user' ? durableBinding.userId : null;
-              const token = await runInOAuthTenantScope(db, durableBinding.tenantId, () =>
-                new UserMCPOAuthTokenRepository(db).getToken(
-                  tokenUserId,
-                  durableBinding.mcpServerId
+              const token = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+                runInOAuthTenantScope(db, durableBinding.tenantId, () =>
+                  new UserMCPOAuthTokenRepository(db).getToken(
+                    tokenUserId,
+                    durableBinding.mcpServerId
+                  )
                 )
               );
               if (!token) {
@@ -2215,15 +2263,26 @@ export async function registerMCPServices(
                   : 'OAuth did not complete. Start a new OAuth flow.'
               );
             }
-            await new Promise((resolve) => setTimeout(resolve, 500));
+            await runWithinOAuthAuthority(
+              assertRequestAuthority,
+              () => new Promise((resolve) => setTimeout(resolve, 500))
+            );
           }
           throw new Error(
             'Timed out waiting for OAuth callback. Restart OAuth if it completes later.'
           );
         };
-        return { ...base, awaitToken: awaitDurableToken };
+        return {
+          ...base,
+          assertRequestAuthority,
+          awaitToken: () => runWithinOAuthAuthority(assertRequestAuthority, awaitDurableToken),
+        };
       }
-      return { ...base, awaitToken: () => tokenPromise! };
+      return {
+        ...base,
+        assertRequestAuthority,
+        awaitToken: () => runWithinOAuthAuthority(assertRequestAuthority, () => tokenPromise!),
+      };
     }
     return base;
   }
@@ -2294,6 +2353,35 @@ export async function registerMCPServices(
       } as AuthenticatedParams),
     };
   };
+  const isLiveSocketRequestAuthorityCurrent = (claim: LiveSocketRequestAuthorityClaim): boolean => {
+    const authority = liveSocketAuthority(claim.socketId);
+    return !!(
+      authority &&
+      authority.userId === claim.userId &&
+      authority.role === claim.role &&
+      authority.tenantId === claim.tenantId &&
+      (claim.authorityFingerprint === undefined ||
+        authority.authorityFingerprint === claim.authorityFingerprint)
+    );
+  };
+  const requestAuthorityAssertion = (params?: AuthenticatedParams): (() => void) | undefined => {
+    const userId = params?.user?.user_id;
+    const role = params?.user?.role;
+    const socketId = socketIdFromParams(params);
+    if (!userId || !role || !socketId) return undefined;
+    const claim: LiveSocketRequestAuthorityClaim = {
+      userId,
+      role,
+      tenantId: tenantIdFromParams(params),
+      socketId,
+      authorityFingerprint: authorityFingerprintFromParams(params),
+    };
+    return () => {
+      if (!isLiveSocketRequestAuthorityCurrent(claim)) {
+        throw new Forbidden('MCP request socket authority is no longer current');
+      }
+    };
+  };
   const assertOAuthBrowserReservationStillCurrent = (
     reservation: OAuthBrowserReservationClaim
   ): void => {
@@ -2312,28 +2400,39 @@ export async function registerMCPServices(
       throw new Forbidden('OAuth browser reservation authority is no longer current');
     }
   };
+  const assertOAuthPostBrowserAuthorityStillCurrent = (
+    claim: OAuthPostBrowserAuthorityClaim
+  ): void => {
+    if (!isLiveSocketRequestAuthorityCurrent(claim)) {
+      throw new Forbidden(
+        `OAuth attempt ${claim.attemptId} request authority is no longer current`
+      );
+    }
+  };
   const reservationAssertion = (
     reservation?: OAuthBrowserReservationClaim
   ): (() => void) | undefined =>
     reservation ? () => assertOAuthBrowserReservationStillCurrent(reservation) : undefined;
-  const runWithinOAuthBrowserReservation = async <T>(
-    reservation: OAuthBrowserReservationClaim | undefined,
+  const runWithinOAuthAuthority = async <T>(
+    assertCurrent: (() => void) | undefined,
     work: () => Promise<T>
   ): Promise<T> => {
-    const assertCurrent = reservationAssertion(reservation);
     assertCurrent?.();
     try {
       const result = await work();
       assertCurrent?.();
       return result;
     } catch (error) {
-      // Expiry/authority replacement is terminal even when the held work also
-      // failed. Never let a provider/DB error turn it into a permissive
-      // fallback or another external request.
+      // Authority loss wins over simultaneous provider/DB/SDK failure. Never
+      // let an obsolete request fall into a permissive retry or fallback.
       assertCurrent?.();
       throw error;
     }
   };
+  const runWithinOAuthBrowserReservation = async <T>(
+    reservation: OAuthBrowserReservationClaim | undefined,
+    work: () => Promise<T>
+  ): Promise<T> => runWithinOAuthAuthority(reservationAssertion(reservation), work);
   const deleteOAuthBrowserReservation = (token: string): void => {
     const current = oauthBrowserReservations.get(token);
     if (!current) return;
@@ -3063,12 +3162,16 @@ export async function registerMCPServices(
   ): Promise<Response | null> {
     try {
       assertCurrent?.();
-      const listResponse = await oauthFetch(mcpUrl, {
-        method: 'POST',
-        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
-        signal: AbortSignal.timeout(15_000),
-      });
+      const listResponse = await oauthFetch(
+        mcpUrl,
+        {
+          method: 'POST',
+          headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+          signal: AbortSignal.timeout(15_000),
+        },
+        assertCurrent
+      );
       assertCurrent?.();
       if (!listResponse.ok) return null;
 
@@ -3082,17 +3185,21 @@ export async function registerMCPServices(
       if (!readOnlyTool?.name) return null;
 
       assertCurrent?.();
-      const callResponse = await oauthFetch(mcpUrl, {
-        method: 'POST',
-        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          id: 2,
-          params: { name: readOnlyTool.name, arguments: {} },
-        }),
-        signal: AbortSignal.timeout(15_000),
-      });
+      const callResponse = await oauthFetch(
+        mcpUrl,
+        {
+          method: 'POST',
+          headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            id: 2,
+            params: { name: readOnlyTool.name, arguments: {} },
+          }),
+          signal: AbortSignal.timeout(15_000),
+        },
+        assertCurrent
+      );
       assertCurrent?.();
       return callResponse.status === 401 ? callResponse : null;
     } catch (probeError) {
@@ -3136,7 +3243,9 @@ export async function registerMCPServices(
           throw new BadRequest('A valid OAuth browser reservation is required');
         }
         const assertBrowserReservation = reservationAssertion(browserReservation);
-        assertBrowserReservation?.();
+        const assertInitialRequestAuthority =
+          assertBrowserReservation ?? requestAuthorityAssertion(params);
+        assertInitialRequestAuthority?.();
         assertPublicMCPOAuthCompatibilityMode({
           oauth_compatibility_mode: data.compatibility_mode,
         });
@@ -3145,7 +3254,7 @@ export async function registerMCPServices(
         // saved-row authority as every other flow-start endpoint applies.
         // Testing a not-yet-created server passes no id and is unaffected.
         const authoritativeServer = data.mcp_server_id
-          ? await runWithinOAuthBrowserReservation(browserReservation, () =>
+          ? await runWithinOAuthAuthority(assertInitialRequestAuthority, () =>
               runInOAuthTenantScope(
                 db,
                 tenantIdFromParams(params as AuthenticatedParams | undefined),
@@ -3181,7 +3290,7 @@ export async function registerMCPServices(
         const effectiveMcpUrl = authoritativeServer?.url ?? data.mcp_url;
         const effectiveAuth = authoritativeServer?.auth;
         const compatibilityPolicy = authoritativeServer
-          ? await runWithinOAuthBrowserReservation(browserReservation, () =>
+          ? await runWithinOAuthAuthority(assertInitialRequestAuthority, () =>
               resolveMCPOAuthCompatibilityPolicy(authoritativeServer)
             )
           : undefined;
@@ -3216,16 +3325,20 @@ export async function registerMCPServices(
 
         let probeResponse: Response;
         try {
-          probeResponse = await runWithinOAuthBrowserReservation(browserReservation, () =>
-            oauthFetch(effectiveMcpUrl, {
-              method: 'POST',
-              headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-              body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-              signal: AbortSignal.timeout(15_000),
-            })
+          probeResponse = await runWithinOAuthAuthority(assertInitialRequestAuthority, () =>
+            oauthFetch(
+              effectiveMcpUrl,
+              {
+                method: 'POST',
+                headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+                signal: AbortSignal.timeout(15_000),
+              },
+              assertInitialRequestAuthority
+            )
           );
         } catch (fetchError) {
-          assertBrowserReservation?.();
+          assertInitialRequestAuthority?.();
           return {
             success: false,
             error: `Failed to connect to MCP server: ${fetchError instanceof Error ? fetchError.message : String(fetchError)}`,
@@ -3235,7 +3348,7 @@ export async function registerMCPServices(
         if (probeResponse.status !== 401) {
           const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(
             effectiveMcpUrl,
-            assertBrowserReservation
+            assertInitialRequestAuthority
           );
           if (fallbackProbe) {
             console.log(
@@ -3259,14 +3372,14 @@ export async function registerMCPServices(
           | null = null;
         let discoverySource: string | null = null;
         if (probeResponse.status === 401) {
-          assertBrowserReservation?.();
+          assertInitialRequestAuthority?.();
           const { resolveMCPOAuthDiscovery } = await import(
             '@agor/core/tools/mcp/oauth-mcp-transport'
           );
           const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
             compatibilityMode,
             allowLocalhostHttp: !postgresOAuthDeployment,
-            assertCurrent: assertBrowserReservation,
+            assertCurrent: assertInitialRequestAuthority,
           });
           if (discovery?.kind === 'resource-metadata') {
             metadataUrl = discovery.metadataUrl;
@@ -3328,18 +3441,32 @@ export async function registerMCPServices(
                 throw err;
               }
 
+              const assertRequestAuthority = started.assertRequestAuthority;
+              if (!assertRequestAuthority) {
+                throw new Forbidden('OAuth callback request authority is unavailable');
+              }
               const tokenResponse = await started.awaitToken();
 
-              const testResponse = await oauthFetch(effectiveMcpUrl, {
-                method: 'POST',
-                headers: {
-                  Authorization: `Bearer ${tokenResponse.access_token}`,
-                  Accept: 'application/json',
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-                signal: AbortSignal.timeout(15_000),
-              });
+              const testResponse = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+                oauthFetch(
+                  effectiveMcpUrl,
+                  {
+                    method: 'POST',
+                    headers: {
+                      Authorization: `Bearer ${tokenResponse.access_token}`,
+                      Accept: 'application/json',
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                      jsonrpc: '2.0',
+                      method: 'initialize',
+                      id: 1,
+                    }),
+                    signal: AbortSignal.timeout(15_000),
+                  },
+                  assertRequestAuthority
+                )
+              );
 
               return {
                 success: true,
@@ -3389,7 +3516,11 @@ export async function registerMCPServices(
             // RFC 9728 path: fetch resource metadata to get the AS URL.
             // (Above guard ensures `metadataUrl` is set when we reach here.)
             const rfc9728Url = metadataUrl as string;
-            const metadataResponse = await oauthFetch(rfc9728Url);
+            const metadataResponse = await oauthFetch(
+              rfc9728Url,
+              {},
+              assertInitialRequestAuthority
+            );
             if (!metadataResponse.ok) {
               return {
                 success: false,
@@ -3429,9 +3560,13 @@ export async function registerMCPServices(
               registration_endpoint?: string;
             } | null = null;
             try {
-              authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl);
+              authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl, {
+                allowLocalhostHttp: !postgresOAuthDeployment,
+                assertCurrent: assertInitialRequestAuthority,
+              });
               console.log('[OAuth Test] Authorization-server metadata resolved');
             } catch {
+              assertInitialRequestAuthority?.();
               console.log('[OAuth Test] Authorization-server metadata unavailable');
             }
 
@@ -3512,24 +3647,30 @@ export async function registerMCPServices(
                   (params as AuthenticatedParams | undefined)?.user?.user_id ?? '<unknown-user>',
                 ].join(':'),
                 cache: !durableOAuthFlows,
+                assertCurrent: assertInitialRequestAuthority,
               },
               true
             );
             let mcpStatus: number | undefined;
             let mcpStatusText: string | undefined;
             try {
-              const mcpResponse = await oauthFetch(effectiveMcpUrl, {
-                method: 'POST',
-                headers: {
-                  Authorization: `Bearer ${token}`,
-                  Accept: 'application/json',
-                  'Content-Type': 'application/json',
+              const mcpResponse = await oauthFetch(
+                effectiveMcpUrl,
+                {
+                  method: 'POST',
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
                 },
-                body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-              });
+                assertInitialRequestAuthority
+              );
               mcpStatus = mcpResponse.status;
               mcpStatusText = mcpResponse.statusText;
             } catch (mcpError) {
+              assertInitialRequestAuthority?.();
               mcpStatusText = mcpError instanceof Error ? mcpError.message : 'Connection failed';
             }
             return {
@@ -4493,6 +4634,11 @@ export async function registerMCPServices(
           }
         );
         const assertBrowserReservation = reservationAssertion(browserReservation);
+        // Before browser emit this is the expiring reservation assertion. A
+        // successful server-issued attempt promotes it to a non-expiring,
+        // request-bounded live-socket assertion while the callback is pending.
+        let assertRequestAuthority = assertBrowserReservation ?? requestAuthorityAssertion(params);
+        const assertCurrentRequestAuthority = () => assertRequestAuthority?.();
         assertBrowserReservation?.();
         assertPublicMCPOAuthCompatibilityMode(data.auth);
         const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
@@ -4675,19 +4821,24 @@ export async function registerMCPServices(
             allowLocalhostHttp: !postgresOAuthDeployment,
             cacheNamespace: [tenantId ?? '<standalone>', serverId ?? '<unsaved>', userId].join(':'),
             disableProcessTokenCache: !!durableOAuthFlows,
+            assertCurrent: assertRequestAuthority,
           })
         );
 
         const probeAndAcquireOAuthToken = async (mcpUrl: string): Promise<string | undefined> => {
           try {
             const probeResponse = await runWithinOAuthBrowserReservation(browserReservation, () =>
-              oauthFetch(mcpUrl, {
-                method: 'GET',
-                headers: mergeMCPRemoteHeaders({
-                  base: { Accept: 'application/json' },
-                  custom: serverConfig.headers,
-                }) ?? { Accept: 'application/json' },
-              })
+              oauthFetch(
+                mcpUrl,
+                {
+                  method: 'GET',
+                  headers: mergeMCPRemoteHeaders({
+                    base: { Accept: 'application/json' },
+                    custom: serverConfig.headers,
+                  }) ?? { Accept: 'application/json' },
+                },
+                assertRequestAuthority
+              )
             );
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
             if (probeResponse.status !== 401) return undefined;
@@ -4756,6 +4907,10 @@ export async function registerMCPServices(
               browserReservation,
             });
 
+            if (!started.assertRequestAuthority) {
+              throw new Forbidden('OAuth callback request authority is unavailable');
+            }
+            assertRequestAuthority = started.assertRequestAuthority;
             const tokenResponse = await started.awaitToken();
             // The callback durably persisted the token row. The access token
             // is returned only to this in-flight request and is never cached
@@ -4766,7 +4921,7 @@ export async function registerMCPServices(
             // token" only while this exact browser authority is still live.
             // Expiry or socket replacement must escape before callers build
             // private headers or open another MCP connection.
-            assertBrowserReservation?.();
+            assertRequestAuthority?.();
             // Misconfigured public base URL is a daemon-level problem, not a
             // missing-token signal — re-throw so the discover endpoint can
             // surface it to the caller instead of silently falling through to
@@ -4843,12 +4998,12 @@ export async function registerMCPServices(
             if (freshToken) oauthToken = freshToken;
           }
           if (oauthToken) {
-            assertBrowserReservation?.();
+            assertCurrentRequestAuthority();
             authHeaders = { Authorization: `Bearer ${oauthToken}` };
           }
         }
 
-        assertBrowserReservation?.();
+        assertCurrentRequestAuthority();
         const headers = mergeMCPRemoteHeaders({
           base: { Accept: 'application/json, text/event-stream' },
           custom: serverConfig.headers,
@@ -4856,22 +5011,10 @@ export async function registerMCPServices(
         }) ?? { Accept: 'application/json, text/event-stream' };
 
         const createMCPConnection = (connHeaders: Record<string, string>) => {
-          let sessionId: string | undefined;
-          const connSessionAwareFetch: typeof fetch = async (input, init) => {
-            if (sessionId && init?.headers) {
-              const headersObj =
-                init.headers instanceof Headers
-                  ? Object.fromEntries(init.headers.entries())
-                  : (init.headers as Record<string, string>);
-              if (!headersObj['mcp-session-id']) {
-                init = { ...init, headers: { ...headersObj, 'mcp-session-id': sessionId } };
-              }
-            }
-            const response = await oauthFetch(input, init);
-            const respSessionId = response.headers.get('mcp-session-id');
-            if (respSessionId) sessionId = respSessionId;
-            return response;
-          };
+          const connSessionAwareFetch = createAuthorityGuardedMCPFetch(
+            oauthFetch,
+            assertCurrentRequestAuthority
+          );
           const transport = new StreamableHTTPClientTransport(new URL(serverConfig.url!), {
             fetch: connSessionAwareFetch,
             requestInit: { headers: connHeaders },
@@ -4895,7 +5038,7 @@ export async function registerMCPServices(
             const timeout = new Promise<never>((_, reject) => {
               setTimeout(() => reject(new Error('Connection timeout after 10 seconds')), 10000);
             });
-            await runWithinOAuthBrowserReservation(browserReservation, () =>
+            await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
               Promise.race([mcpClient.connect(mcpTransport), timeout])
             );
           };
@@ -4903,12 +5046,12 @@ export async function registerMCPServices(
           try {
             await connectWithTimeout(client, httpTransport);
           } catch (connectError) {
-            assertBrowserReservation?.();
+            assertCurrentRequestAuthority();
             if (connectError instanceof Forbidden) throw connectError;
             if (hadCachedOAuthToken && serverConfig.url && serverConfig.auth?.type === 'oauth') {
               const freshToken = await probeAndAcquireOAuthToken(serverConfig.url);
               if (freshToken) {
-                assertBrowserReservation?.();
+                assertCurrentRequestAuthority();
                 const freshHeaders = mergeMCPRemoteHeaders({
                   base: { Accept: 'application/json, text/event-stream' },
                   custom: serverConfig.headers,
@@ -4949,14 +5092,14 @@ export async function registerMCPServices(
             arguments?: Array<{ name: string; description?: string; required?: boolean }>;
           }>;
 
-          const toolsResult = (await runWithinOAuthBrowserReservation(browserReservation, () =>
+          const toolsResult = (await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
             Promise.race([client.listTools(), listTimeout])
           )) as ToolsResult;
           const optionalList = async <T>(work: () => Promise<T>, fallback: T): Promise<T> => {
             try {
-              return await runWithinOAuthBrowserReservation(browserReservation, work);
+              return await runWithinOAuthAuthority(assertCurrentRequestAuthority, work);
             } catch {
-              assertBrowserReservation?.();
+              assertCurrentRequestAuthority();
               return fallback;
             }
           };
@@ -4970,7 +5113,7 @@ export async function registerMCPServices(
           ])) as PromptsResult;
 
           if (serverId) {
-            await runWithinOAuthBrowserReservation(browserReservation, () =>
+            await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
               persistDiscoveredMCPCapabilities(db, tenantId, serverId as MCPServerID, {
                 tools: toolsResult.tools.map((t) => ({
                   name: t.name,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5,6 +5,7 @@
  * Extracted from index.ts for maintainability.
  */
 
+import { createHash, randomBytes } from 'node:crypto';
 import { homedir } from 'node:os';
 import { performance } from 'node:perf_hooks';
 import { OPENCODE_DAEMON_CONTRIBUTION } from '@agor/agentic-tool-opencode/daemon';
@@ -65,6 +66,9 @@ import type {
   MCPAuth,
   MCPOAuthAttemptID,
   MCPOAuthBrowserEventRequest,
+  MCPOAuthBrowserOperation,
+  MCPOAuthBrowserReservation,
+  MCPOAuthBrowserReservationRequest,
   MCPOAuthDCRMode,
   MCPOAuthPendingFlowStatus,
   MCPOAuthRuntimeCompatibilityMode,
@@ -82,6 +86,7 @@ import {
   hasMinimumRole,
   isMCPOAuthGrantBindingVersion,
   MCP_MEMBER_POLICY_CHANGED_EVENT,
+  MCP_OAUTH_BROWSER_OPERATIONS,
   ROLES,
   TaskStatus,
 } from '@agor/core/types';
@@ -1683,30 +1688,15 @@ export async function registerMCPServices(
     return new URL('/mcp-servers/oauth-callback', baseUrl).toString();
   }
 
-  const readOAuthBrowserEventRequest = (
-    value: unknown
-  ): MCPOAuthBrowserEventRequest | undefined => {
-    if (value === undefined) return undefined;
-    if (!value || typeof value !== 'object') {
-      throw new BadRequest('oauth_browser_event must be an object');
-    }
-    const candidate = value as Partial<MCPOAuthBrowserEventRequest>;
-    if (
-      typeof candidate.operation_id !== 'string' ||
-      !/^[A-Za-z0-9_-]{16,128}$/.test(candidate.operation_id)
-    ) {
-      throw new BadRequest('oauth_browser_event.operation_id is invalid');
-    }
-    if (
-      !Number.isSafeInteger(candidate.auth_generation) ||
-      (candidate.auth_generation as number) < 0
-    ) {
-      throw new BadRequest('oauth_browser_event.auth_generation is invalid');
-    }
-    return {
-      operation_id: candidate.operation_id,
-      auth_generation: candidate.auth_generation as number,
-    };
+  type OAuthBrowserReservationClaim = {
+    reservationToken: string;
+    operation: MCPOAuthBrowserOperation;
+    mcpServerId?: string;
+    userId: string;
+    role: string;
+    tenantId?: string;
+    socketId: string;
+    authorityFingerprint?: string;
   };
 
   type StartTwoPhaseOAuthOptions = {
@@ -1737,7 +1727,7 @@ export async function registerMCPServices(
     compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     dcrMode?: MCPOAuthDCRMode;
     socketId?: string;
-    browserEvent?: MCPOAuthBrowserEventRequest;
+    browserReservation?: OAuthBrowserReservationClaim;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -1770,6 +1760,9 @@ export async function registerMCPServices(
     opts: StartTwoPhaseOAuthOptions,
     awaitToken: boolean
   ): Promise<StartTwoPhaseOAuthResult | StartTwoPhaseOAuthAndAwaitResult> {
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
     const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
 
     // Strict public base URL — see oauth-start endpoint for the rationale.
@@ -1863,6 +1856,13 @@ export async function registerMCPServices(
     // the pending-flow authority below instead.
     const localAttemptId = durableOAuthFlows ? undefined : (generateId() as MCPOAuthAttemptID);
 
+    // Metadata discovery and DCR are the first provider-owned side effects in
+    // this helper. Re-check the live socket authority immediately before they
+    // begin; consuming a valid A reservation is not enough if that same socket
+    // has since authenticated as B.
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
     const context = await startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
       authorizationUrlOverride: effectiveAuthorizationUrlOverride,
       tokenUrlOverride: effectiveTokenUrlOverride,
@@ -1882,6 +1882,9 @@ export async function registerMCPServices(
       dcrMode: effectiveDcrMode,
       allowLocalhostHttp: !durableOAuthFlows,
     });
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
 
     const resolvedGrantBinding = {
       resourceUri: context.resourceUri,
@@ -1898,6 +1901,9 @@ export async function registerMCPServices(
     let localGrantBinding: NonNullable<SaveTokenInput['grantBinding']> | undefined;
     let localGrantSubjectKey: string | undefined;
     if (savedServerAuthority && !durableOAuthFlows) {
+      if (opts.browserReservation) {
+        assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+      }
       localGrantBinding = await runInOAuthTenantScope(db, opts.tenantId, async () => {
         const currentServer = await new MCPServerRepository(db).findById(
           savedServerAuthority!.mcp_server_id
@@ -1916,6 +1922,9 @@ export async function registerMCPServices(
           throw new Error(
             'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
           );
+        }
+        if (opts.browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
         }
 
         const subjectUserId = effectiveOAuthMode === 'per_user' ? (opts.userId as UserID) : null;
@@ -1960,6 +1969,9 @@ export async function registerMCPServices(
       });
     }
 
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
     const attemptId = durableBinding
       ? await runInOAuthTenantWriteScope(db, durableBinding.tenantId, async () => {
           await lockMCPOAuthGrantConfiguration(
@@ -1977,6 +1989,9 @@ export async function registerMCPServices(
             throw new Error(
               'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
             );
+          }
+          if (opts.browserReservation) {
+            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
           return durableOAuthFlows!.create({
             context,
@@ -2035,6 +2050,9 @@ export async function registerMCPServices(
       });
     }
 
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
     if (!durableOAuthFlows) {
       for (const [olderState, older] of pendingOAuthFlows) {
         const sameSubject =
@@ -2072,17 +2090,17 @@ export async function registerMCPServices(
       });
     }
 
-    if (awaitToken && opts.socketId && opts.userId && opts.browserEvent && app.io) {
+    if (awaitToken && opts.browserReservation && app.io) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
       // Compatibility hint for blocking discover/test callers, which cannot
       // return the URL before their callback arrives. Target the exact
       // authenticated initiating socket only — never a user/tenant/global
       // room — and keep durable status as the completion authority.
-      app.io.local.to(opts.socketId).emit('oauth:open_browser', {
+      app.io.local.to(opts.browserReservation.socketId).emit('oauth:open_browser', {
         authUrl: context.authorizationUrl,
         attempt_id: attemptId,
-        operation_id: opts.browserEvent.operation_id,
-        auth_generation: opts.browserEvent.auth_generation,
-        caller_user_id: opts.userId,
+        reservation_token: opts.browserReservation.reservationToken,
+        caller_user_id: opts.browserReservation.userId,
       });
     }
 
@@ -2151,6 +2169,149 @@ export async function registerMCPServices(
   const tenantIdFromParams = (params?: AuthenticatedParams): string | undefined =>
     (params as (AuthenticatedParams & { tenant?: { tenant_id?: string } }) | undefined)?.tenant
       ?.tenant_id ?? getCurrentTenantId();
+
+  const OAUTH_BROWSER_RESERVATION_TTL_MS = 60_000;
+  const MAX_OAUTH_BROWSER_RESERVATIONS = 1_024;
+  type OAuthBrowserReservationRecord = OAuthBrowserReservationClaim & {
+    expiresAt: number;
+    authorityFingerprint?: string;
+    cleanupTimer: ReturnType<typeof setTimeout>;
+  };
+  const oauthBrowserReservations = new Map<string, OAuthBrowserReservationRecord>();
+
+  const socketIdFromParams = (params?: AuthenticatedParams): string | undefined => {
+    const id = (params?.connection as { id?: unknown } | undefined)?.id;
+    return typeof id === 'string' && id ? id : undefined;
+  };
+  const authorityFingerprintFromParams = (params?: AuthenticatedParams): string | undefined => {
+    const connection = params?.connection as
+      | { authentication?: { accessToken?: unknown } }
+      | undefined;
+    const token =
+      typeof params?.authentication?.accessToken === 'string'
+        ? params.authentication.accessToken
+        : typeof connection?.authentication?.accessToken === 'string'
+          ? connection.authentication.accessToken
+          : undefined;
+    return token ? createHash('sha256').update(token).digest('base64url').slice(0, 22) : undefined;
+  };
+  const liveSocketAuthority = (
+    socketId: string
+  ):
+    | {
+        userId?: string;
+        role?: string;
+        tenantId?: string;
+        authorityFingerprint?: string;
+      }
+    | undefined => {
+    const socket = app.io?.sockets?.sockets?.get(socketId) as
+      | {
+          feathers?: AuthenticatedParams & { id?: string };
+          data?: { tenant?: { tenant_id?: string } };
+        }
+      | undefined;
+    if (!socket) return undefined;
+    const connection = socket.feathers;
+    return {
+      userId: connection?.user?.user_id,
+      role: connection?.user?.role,
+      tenantId:
+        socket.data?.tenant?.tenant_id ??
+        (connection as (AuthenticatedParams & { tenant?: { tenant_id?: string } }) | undefined)
+          ?.tenant?.tenant_id,
+      authorityFingerprint: authorityFingerprintFromParams({
+        ...(connection ?? {}),
+        connection,
+        authentication: connection?.authentication,
+      } as AuthenticatedParams),
+    };
+  };
+  const assertOAuthBrowserReservationStillCurrent = (
+    reservation: OAuthBrowserReservationClaim
+  ): void => {
+    const authority = liveSocketAuthority(reservation.socketId);
+    if (
+      !authority ||
+      authority.userId !== reservation.userId ||
+      authority.role !== reservation.role ||
+      authority.tenantId !== reservation.tenantId ||
+      (reservation.authorityFingerprint !== undefined &&
+        authority.authorityFingerprint !== reservation.authorityFingerprint)
+    ) {
+      throw new Forbidden('OAuth browser reservation authority is no longer current');
+    }
+  };
+  const deleteOAuthBrowserReservation = (token: string): void => {
+    const current = oauthBrowserReservations.get(token);
+    if (!current) return;
+    clearTimeout(current.cleanupTimer);
+    oauthBrowserReservations.delete(token);
+  };
+  const pruneOAuthBrowserReservations = (now = Date.now()): void => {
+    for (const [token, reservation] of oauthBrowserReservations) {
+      if (reservation.expiresAt <= now) deleteOAuthBrowserReservation(token);
+    }
+  };
+  const readReservationToken = (value: unknown): string | undefined => {
+    // Older/non-browser callers may omit the compatibility hint. Nullish
+    // values are equivalently absent and must never crash the request path.
+    if (value === undefined || value === null) return undefined;
+    if (!value || typeof value !== 'object') {
+      throw new BadRequest('oauth_browser_event must be an object');
+    }
+    const token = (value as Partial<MCPOAuthBrowserEventRequest>).reservation_token;
+    if (typeof token !== 'string' || !/^[A-Za-z0-9_-]{32,128}$/.test(token)) {
+      throw new BadRequest('oauth_browser_event.reservation_token is invalid');
+    }
+    return token;
+  };
+  const consumeOAuthBrowserReservation = (
+    value: unknown,
+    params: AuthenticatedParams | undefined,
+    expected: { operation: MCPOAuthBrowserOperation; mcpServerId?: string }
+  ): OAuthBrowserReservationClaim | undefined => {
+    const token = readReservationToken(value);
+    if (!token) return undefined;
+    pruneOAuthBrowserReservations();
+    const reservation = oauthBrowserReservations.get(token);
+    if (!reservation) {
+      throw new Forbidden('OAuth browser reservation is invalid, expired, or already used');
+    }
+    // Consume before comparing any binding. A guessed or replayed token gets
+    // exactly one attempt and can never be corrected into a valid request.
+    deleteOAuthBrowserReservation(token);
+    const callerUserId = params?.user?.user_id;
+    const socketId = socketIdFromParams(params);
+    const tenantId = tenantIdFromParams(params);
+    const authorityFingerprint = authorityFingerprintFromParams(params);
+    if (
+      !callerUserId ||
+      !socketId ||
+      reservation.userId !== callerUserId ||
+      reservation.role !== params?.user?.role ||
+      reservation.socketId !== socketId ||
+      reservation.tenantId !== tenantId ||
+      reservation.operation !== expected.operation ||
+      reservation.mcpServerId !== expected.mcpServerId ||
+      (reservation.authorityFingerprint !== undefined &&
+        reservation.authorityFingerprint !== authorityFingerprint)
+    ) {
+      throw new Forbidden('OAuth browser reservation does not match this authority or operation');
+    }
+    const claim = {
+      reservationToken: token,
+      operation: reservation.operation,
+      mcpServerId: reservation.mcpServerId,
+      userId: reservation.userId,
+      role: reservation.role,
+      tenantId: reservation.tenantId,
+      socketId: reservation.socketId,
+      authorityFingerprint: reservation.authorityFingerprint,
+    };
+    assertOAuthBrowserReservationStillCurrent(claim);
+    return claim;
+  };
 
   /**
    * The standing of whoever started a flow, re-asked at the moment it completes.
@@ -2631,6 +2792,75 @@ export async function registerMCPServices(
     // instead; browsers then refetch their own `can_configure` answer.
     events: [MCP_MEMBER_POLICY_CHANGED_EVENT],
   });
+  app.use('/mcp-servers/oauth-browser-reservations', {
+    async create(
+      data: MCPOAuthBrowserReservationRequest,
+      params?: AuthenticatedParams
+    ): Promise<MCPOAuthBrowserReservation> {
+      if (
+        !data ||
+        !MCP_OAUTH_BROWSER_OPERATIONS.includes(data.operation as MCPOAuthBrowserOperation)
+      ) {
+        throw new BadRequest('OAuth browser reservation operation is invalid');
+      }
+      if (
+        data.mcp_server_id !== undefined &&
+        (typeof data.mcp_server_id !== 'string' || !data.mcp_server_id)
+      ) {
+        throw new BadRequest('OAuth browser reservation server is invalid');
+      }
+      const userId = params?.user?.user_id;
+      const role = params?.user?.role;
+      const socketId = socketIdFromParams(params);
+      const tenantId = tenantIdFromParams(params);
+      const authorityFingerprint = authorityFingerprintFromParams(params);
+      if (!userId || !role || !socketId || !authorityFingerprint) {
+        throw new BadRequest('OAuth browser reservations require an authenticated live socket');
+      }
+      const currentAuthority = liveSocketAuthority(socketId);
+      if (
+        currentAuthority?.userId !== userId ||
+        currentAuthority.role !== role ||
+        currentAuthority.tenantId !== tenantId ||
+        currentAuthority.authorityFingerprint !== authorityFingerprint
+      ) {
+        throw new Forbidden('OAuth browser reservation authority is not current');
+      }
+      pruneOAuthBrowserReservations();
+      if (oauthBrowserReservations.size >= MAX_OAUTH_BROWSER_RESERVATIONS) {
+        throw new BadRequest('Too many pending OAuth browser reservations');
+      }
+      const reservationToken = randomBytes(32).toString('base64url');
+      const expiresAt = Date.now() + OAUTH_BROWSER_RESERVATION_TTL_MS;
+      const cleanupTimer = setTimeout(
+        () => deleteOAuthBrowserReservation(reservationToken),
+        OAUTH_BROWSER_RESERVATION_TTL_MS
+      );
+      cleanupTimer.unref();
+      oauthBrowserReservations.set(reservationToken, {
+        reservationToken,
+        operation: data.operation,
+        mcpServerId: data.mcp_server_id,
+        userId,
+        role,
+        tenantId,
+        socketId,
+        expiresAt,
+        authorityFingerprint,
+        cleanupTimer,
+      });
+      return { reservation_token: reservationToken, expires_at: expiresAt };
+    },
+  });
+  app.service('mcp-servers/oauth-browser-reservations').hooks({
+    before: { create: [ctx.requireAuth] },
+  });
+  // The returned token is a caller-private, one-shot capability. Feathers'
+  // default `created` publication would otherwise put it on the tenant
+  // realtime channel before the browser can use it.
+  // `registerMCPServices` is also exercised without a realtime transport in
+  // service-only harnesses; there is nothing to publish in that shape.
+  app.service('mcp-servers/oauth-browser-reservations').publish?.(() => []);
   const invalidateOAuthGrantsAfterServerChange = async (
     context: HookContext,
     next: () => Promise<void>
@@ -2773,7 +3003,15 @@ export async function registerMCPServices(
       params?: AuthenticatedParams & { connection?: { id?: string } }
     ) {
       try {
-        const browserEvent = readOAuthBrowserEventRequest(data.oauth_browser_event);
+        const browserReservation = data.start_browser_flow
+          ? consumeOAuthBrowserReservation(data.oauth_browser_event, params, {
+              operation: 'test-oauth',
+              mcpServerId: data.mcp_server_id,
+            })
+          : undefined;
+        if (data.start_browser_flow && !browserReservation) {
+          throw new BadRequest('A valid OAuth browser reservation is required');
+        }
         assertPublicMCPOAuthCompatibilityMode({
           oauth_compatibility_mode: data.compatibility_mode,
         });
@@ -2886,6 +3124,9 @@ export async function registerMCPServices(
           | null = null;
         let discoverySource: string | null = null;
         if (probeResponse.status === 401) {
+          if (browserReservation) {
+            assertOAuthBrowserReservationStillCurrent(browserReservation);
+          }
           const { resolveMCPOAuthDiscovery } = await import(
             '@agor/core/tools/mcp/oauth-mcp-transport'
           );
@@ -2940,7 +3181,7 @@ export async function registerMCPServices(
                   clientId: effectiveClientId,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
                   socketId: connection?.id,
-                  browserEvent,
+                  browserReservation,
                   clientSecret: effectiveClientSecret,
                   scope: effectiveScope,
                   compatibilityMode,
@@ -4109,7 +4350,14 @@ export async function registerMCPServices(
       params?: AuthenticatedParams
     ) {
       try {
-        const browserEvent = readOAuthBrowserEventRequest(data.oauth_browser_event);
+        const browserReservation = consumeOAuthBrowserReservation(
+          data.oauth_browser_event,
+          params,
+          {
+            operation: 'discover',
+            mcpServerId: data.mcp_server_id,
+          }
+        );
         assertPublicMCPOAuthCompatibilityMode(data.auth);
         const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
         const { StreamableHTTPClientTransport } = await import(
@@ -4281,11 +4529,17 @@ export async function registerMCPServices(
 
         console.log('[MCP Discovery] Starting test for:', serverConfig.name || 'inline-config');
 
+        if (browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(browserReservation);
+        }
         let authHeaders = await resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url, {
           allowLocalhostHttp: !durableOAuthFlows,
           cacheNamespace: [tenantId ?? '<standalone>', serverId ?? '<unsaved>', userId].join(':'),
           disableProcessTokenCache: !!durableOAuthFlows,
         });
+        if (browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(browserReservation);
+        }
 
         const probeAndAcquireOAuthToken = async (mcpUrl: string): Promise<string | undefined> => {
           try {
@@ -4298,6 +4552,12 @@ export async function registerMCPServices(
             });
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
             if (probeResponse.status !== 401) return undefined;
+            // Provider discovery and dynamic client registration can create
+            // durable state outside Agor. Never begin either unless this
+            // exact socket/caller/operation already consumed a server-issued
+            // one-shot reservation.
+            if (!browserReservation) return undefined;
+            assertOAuthBrowserReservationStillCurrent(browserReservation);
             const { resolveMCPOAuthDiscovery } = await import(
               '@agor/core/tools/mcp/oauth-mcp-transport'
             );
@@ -4349,7 +4609,7 @@ export async function registerMCPServices(
               dcrMode: serverConfig.auth?.oauth_dcr_mode,
               tenantId,
               socketId: connection?.id,
-              browserEvent,
+              browserReservation,
             });
 
             const tokenResponse = await started.awaitToken();
@@ -4363,6 +4623,7 @@ export async function registerMCPServices(
             // surface it to the caller instead of silently falling through to
             // an unauthenticated MCP probe.
             if (error instanceof PublicBaseUrlNotConfiguredError) throw error;
+            if (error instanceof Forbidden) throw error;
             console.error(
               `[MCP Discovery] OAuth token acquisition failed category=${
                 error instanceof Error ? error.name : 'unknown'

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1690,6 +1690,8 @@ export async function registerMCPServices(
 
   type OAuthBrowserReservationClaim = {
     reservationToken: string;
+    /** Immutable deadline retained after the one-shot map entry is consumed. */
+    expiresAt: number;
     operation: MCPOAuthBrowserOperation;
     mcpServerId?: string;
     userId: string;
@@ -1881,6 +1883,11 @@ export async function registerMCPServices(
       compatibilityMode: effectiveCompatibilityMode,
       dcrMode: effectiveDcrMode,
       allowLocalhostHttp: !durableOAuthFlows,
+      // The reservation is consumed before provider work starts, but its
+      // deadline remains authoritative throughout discovery/DCR/flow setup.
+      assertCurrent: opts.browserReservation
+        ? () => assertOAuthBrowserReservationStillCurrent(opts.browserReservation!)
+        : undefined,
     });
     if (opts.browserReservation) {
       assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
@@ -2172,8 +2179,13 @@ export async function registerMCPServices(
 
   const OAUTH_BROWSER_RESERVATION_TTL_MS = 60_000;
   const MAX_OAUTH_BROWSER_RESERVATIONS = 1_024;
+  // Layered bounds prevent a single busy socket, user, or tenant from
+  // exhausting the process-global reservation pool. A tenant can use its full
+  // share without depending on reservation order in another tenant.
+  const MAX_OAUTH_BROWSER_RESERVATIONS_PER_TENANT = 128;
+  const MAX_OAUTH_BROWSER_RESERVATIONS_PER_USER = 32;
+  const MAX_OAUTH_BROWSER_RESERVATIONS_PER_SOCKET = 8;
   type OAuthBrowserReservationRecord = OAuthBrowserReservationClaim & {
-    expiresAt: number;
     authorityFingerprint?: string;
     cleanupTimer: ReturnType<typeof setTimeout>;
   };
@@ -2230,6 +2242,9 @@ export async function registerMCPServices(
   const assertOAuthBrowserReservationStillCurrent = (
     reservation: OAuthBrowserReservationClaim
   ): void => {
+    if (Date.now() >= reservation.expiresAt) {
+      throw new Forbidden('OAuth browser reservation has expired');
+    }
     const authority = liveSocketAuthority(reservation.socketId);
     if (
       !authority ||
@@ -2301,6 +2316,7 @@ export async function registerMCPServices(
     }
     const claim = {
       reservationToken: token,
+      expiresAt: reservation.expiresAt,
       operation: reservation.operation,
       mcpServerId: reservation.mcpServerId,
       userId: reservation.userId,
@@ -2827,6 +2843,25 @@ export async function registerMCPServices(
         throw new Forbidden('OAuth browser reservation authority is not current');
       }
       pruneOAuthBrowserReservations();
+      let tenantReservations = 0;
+      let userReservations = 0;
+      let socketReservations = 0;
+      for (const reservation of oauthBrowserReservations.values()) {
+        if (reservation.tenantId === tenantId) {
+          tenantReservations += 1;
+          if (reservation.userId === userId) userReservations += 1;
+        }
+        if (reservation.socketId === socketId) socketReservations += 1;
+      }
+      if (socketReservations >= MAX_OAUTH_BROWSER_RESERVATIONS_PER_SOCKET) {
+        throw new BadRequest('Too many pending OAuth browser reservations for this connection');
+      }
+      if (userReservations >= MAX_OAUTH_BROWSER_RESERVATIONS_PER_USER) {
+        throw new BadRequest('Too many pending OAuth browser reservations for this user');
+      }
+      if (tenantReservations >= MAX_OAUTH_BROWSER_RESERVATIONS_PER_TENANT) {
+        throw new BadRequest('Too many pending OAuth browser reservations for this tenant');
+      }
       if (oauthBrowserReservations.size >= MAX_OAUTH_BROWSER_RESERVATIONS) {
         throw new BadRequest('Too many pending OAuth browser reservations');
       }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -237,6 +237,10 @@ import {
   registerMcpCapabilityRoleFloor,
 } from './utils/mcp-server-authorization.js';
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
+import {
+  AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT,
+  readSocketAuthorityId,
+} from './utils/socket-request-authority.js';
 import { type SpawnExecutorOptions, spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
 import { withFreshTenantWrite } from './utils/tenant-db-scope.js';
@@ -2284,8 +2288,26 @@ export async function registerMCPServices(
   const oauthBrowserReservations = new Map<string, OAuthBrowserReservationRecord>();
 
   const socketIdFromParams = (params?: AuthenticatedParams): string | undefined => {
-    const id = (params?.connection as { id?: unknown } | undefined)?.id;
-    return typeof id === 'string' && id ? id : undefined;
+    // Feathers intentionally exposes `socket.feathers`, not the Socket.IO
+    // socket itself, as params.connection. Accept only the immutable marker
+    // installed on that exact server-owned connection object and prove that
+    // it still belongs to the live socket map. Never trust an id supplied in
+    // request data, headers, auth payload, or a fabricated connection object.
+    if (params?.provider !== 'socketio') return undefined;
+    const socketId = readSocketAuthorityId(params.connection);
+    if (!socketId) return undefined;
+    const socket = app.io?.sockets?.sockets?.get(socketId) as
+      | { feathers?: unknown; connected?: boolean }
+      | undefined;
+    if (
+      !socket ||
+      socket.connected === false ||
+      socket.feathers !== params.connection ||
+      readSocketAuthorityId(socket.feathers) !== socketId
+    ) {
+      return undefined;
+    }
+    return socketId;
   };
   const authorityFingerprintFromParams = (params?: AuthenticatedParams): string | undefined => {
     const connection = params?.connection as
@@ -2311,12 +2333,14 @@ export async function registerMCPServices(
     | undefined => {
     const socket = app.io?.sockets?.sockets?.get(socketId) as
       | {
-          feathers?: AuthenticatedParams & { id?: string };
+          feathers?: AuthenticatedParams;
           data?: { tenant?: { tenant_id?: string } };
+          connected?: boolean;
         }
       | undefined;
-    if (!socket) return undefined;
+    if (!socket || socket.connected === false) return undefined;
     const connection = socket.feathers;
+    if (readSocketAuthorityId(connection) !== socketId) return undefined;
     return {
       userId: connection?.user?.user_id,
       role: connection?.user?.role,
@@ -2343,10 +2367,17 @@ export async function registerMCPServices(
     );
   };
   const requestAuthorityAssertion = (params?: AuthenticatedParams): (() => void) | undefined => {
+    // REST requests are already tied to one authenticated HTTP request and
+    // internal calls intentionally use their caller-owned authority model.
+    // A real Socket.IO request, however, must always carry the server marker:
+    // silently falling back here would disable in-place identity fencing.
+    if (params?.provider !== 'socketio') return undefined;
     const userId = params?.user?.user_id;
     const role = params?.user?.role;
     const socketId = socketIdFromParams(params);
-    if (!userId || !role || !socketId) return undefined;
+    if (!userId || !role || !socketId) {
+      throw new Forbidden('MCP Socket.IO request authority is unavailable');
+    }
     const claim: LiveSocketRequestAuthorityClaim = {
       userId,
       role,
@@ -2422,6 +2453,15 @@ export async function registerMCPServices(
       if (reservation.expiresAt <= now) deleteOAuthBrowserReservation(token);
     }
   };
+  const clearOAuthBrowserReservationsForSocket = (socketId: string): void => {
+    for (const [token, reservation] of oauthBrowserReservations) {
+      if (reservation.socketId === socketId) deleteOAuthBrowserReservation(token);
+    }
+  };
+  // Reservations are bound to one physical transport. Socket setup emits this
+  // daemon-internal event synchronously for every disconnect, including when
+  // Socket.IO itself is created only after services have registered.
+  app.on(AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT, clearOAuthBrowserReservationsForSocket);
   const readReservationToken = (value: unknown): string | undefined => {
     // Older/non-browser callers may omit the compatibility hint. Nullish
     // values are equivalently absent and must never crash the request path.
@@ -3220,7 +3260,7 @@ export async function registerMCPServices(
         compatibility_mode?: 'strict' | 'legacy';
         dcr_mode?: MCPOAuthDCRMode;
       },
-      params?: AuthenticatedParams & { connection?: { id?: string } }
+      params?: AuthenticatedParams
     ) {
       try {
         const browserReservation = data.start_browser_flow
@@ -3395,10 +3435,6 @@ export async function registerMCPServices(
             console.log('[OAuth Test] Starting browser-based OAuth 2.1 flow...');
 
             try {
-              const connection = (params as AuthenticatedParams)?.connection as
-                | { id?: string }
-                | undefined;
-
               // Route through the daemon's two-phase flow so the redirect_uri
               // is the daemon's public base URL (browser-reachable for any
               // user) rather than a 127.0.0.1 callback server bound to the
@@ -3417,7 +3453,7 @@ export async function registerMCPServices(
                   oauthMode: effectiveOAuthMode,
                   clientId: effectiveClientId,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
-                  socketId: connection?.id,
+                  socketId: socketIdFromParams(params as AuthenticatedParams | undefined),
                   browserReservation,
                   clientSecret: effectiveClientSecret,
                   scope: effectiveScope,
@@ -3856,8 +3892,7 @@ export async function registerMCPServices(
           } satisfies MCPOAuthStartFailure;
         }
 
-        const connection = params?.connection as { id?: string } | undefined;
-        const socketId = connection?.id;
+        const socketId = socketIdFromParams(params);
 
         let result: StartTwoPhaseOAuthResult;
         try {
@@ -4896,7 +4931,6 @@ export async function registerMCPServices(
             // Route through the daemon's two-phase flow (callback → daemon's
             // public URL) instead of the legacy 127.0.0.1 callback server, so
             // remote browsers can complete the redirect on a deployed Agor.
-            const connection = params?.connection as { id?: string } | undefined;
             if (
               (serverConfig.auth?.oauth_mode ?? 'per_user') === 'shared' &&
               !hasMinimumRole(params?.user?.role, ROLES.ADMIN)
@@ -4926,7 +4960,7 @@ export async function registerMCPServices(
               compatibilityMode,
               dcrMode: serverConfig.auth?.oauth_dcr_mode,
               tenantId,
-              socketId: connection?.id,
+              socketId: socketIdFromParams(params),
               browserReservation,
             });
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1765,10 +1765,16 @@ export async function registerMCPServices(
     if (opts.browserReservation) {
       assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
     }
-    const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
+    const { startMCPOAuthFlow } = await runWithinOAuthBrowserReservation(
+      opts.browserReservation,
+      () => import('@agor/core/tools/mcp/oauth-mcp-transport')
+    );
 
     // Strict public base URL — see oauth-start endpoint for the rationale.
-    const redirectUri = await resolveMCPOAuthRedirectUri();
+    const redirectUri = await runWithinOAuthBrowserReservation(
+      opts.browserReservation,
+      resolveMCPOAuthRedirectUri
+    );
 
     const hasRfc9728 = !!opts.resourceMetadataUrl;
     const hasAsDirect = !!opts.prefetchedAuthServerMetadata;
@@ -1810,15 +1816,20 @@ export async function registerMCPServices(
           'Saved MCP OAuth requires an authenticated user binding. Sign in, then restart OAuth.'
         );
       }
-      const server = await runInOAuthTenantScope(db, opts.tenantId, () =>
-        new MCPServerRepository(db).findById(opts.mcpServerId!)
+      const server = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+        runInOAuthTenantScope(db, opts.tenantId, () =>
+          new MCPServerRepository(db).findById(opts.mcpServerId!)
+        )
       );
       if (!server?.enabled || server.url !== opts.mcpUrl || server.auth?.type !== 'oauth') {
         throw new Error(
           'The saved MCP server no longer matches this OAuth request. Save changes, then restart OAuth.'
         );
       }
-      const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(server);
+      const compatibilityPolicy = await runWithinOAuthBrowserReservation(
+        opts.browserReservation,
+        () => resolveMCPOAuthCompatibilityPolicy(server)
+      );
       logMCPOAuthCompatibilityPolicy('flow-start', server.mcp_server_id, compatibilityPolicy);
       // The row reloaded in the tenant scope is the only durable authority.
       // Callers may have discovered metadata from a transient form snapshot,
@@ -1833,8 +1844,10 @@ export async function registerMCPServices(
       effectiveDcrMode = server.auth.oauth_dcr_mode;
       effectiveOAuthMode = server.auth.oauth_mode ?? 'per_user';
       if (effectiveOAuthMode === 'shared') {
-        const initiatingUser = await runInOAuthTenantScope(db, opts.tenantId, () =>
-          new UsersRepository(db).findById(opts.userId!)
+        const initiatingUser = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+          runInOAuthTenantScope(db, opts.tenantId, () =>
+            new UsersRepository(db).findById(opts.userId!)
+          )
         );
         if (!hasMinimumRole(initiatingUser?.role, ROLES.ADMIN)) {
           throw new Forbidden('Shared MCP OAuth grants can only be started by an admin');
@@ -1915,9 +1928,15 @@ export async function registerMCPServices(
         const currentServer = await new MCPServerRepository(db).findById(
           savedServerAuthority!.mcp_server_id
         );
+        if (opts.browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+        }
         const currentPolicy = currentServer
           ? await resolveMCPOAuthCompatibilityPolicy(currentServer)
           : undefined;
+        if (opts.browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+        }
         if (
           !currentServer?.enabled ||
           currentServer.auth?.type !== 'oauth' ||
@@ -1944,6 +1963,9 @@ export async function registerMCPServices(
           subjectUserId,
           currentServer.mcp_server_id
         );
+        if (opts.browserReservation) {
+          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+        }
         const generation =
           Math.max(existingGrant?.grant_generation ?? 0, localOAuthGrantGenerationHighWater) + 1;
         if (!Number.isSafeInteger(generation)) {
@@ -1986,9 +2008,15 @@ export async function registerMCPServices(
             durableBinding.tenantId,
             durableBinding.mcpServerId
           );
+          if (opts.browserReservation) {
+            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+          }
           const currentServer = await new MCPServerRepository(db).findById(
             durableBinding.mcpServerId
           );
+          if (opts.browserReservation) {
+            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+          }
           if (
             !currentServer ||
             hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
@@ -2000,7 +2028,7 @@ export async function registerMCPServices(
           if (opts.browserReservation) {
             assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
-          return durableOAuthFlows!.create({
+          const createdAttempt = await durableOAuthFlows!.create({
             context,
             ...durableBinding,
             configFingerprint: fingerprintMCPOAuthGrantConfiguration(
@@ -2009,6 +2037,10 @@ export async function registerMCPServices(
               resolvedGrantBinding
             ),
           });
+          if (opts.browserReservation) {
+            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+          }
+          return createdAttempt;
         })
       : localAttemptId!;
 
@@ -2255,6 +2287,28 @@ export async function registerMCPServices(
         authority.authorityFingerprint !== reservation.authorityFingerprint)
     ) {
       throw new Forbidden('OAuth browser reservation authority is no longer current');
+    }
+  };
+  const reservationAssertion = (
+    reservation?: OAuthBrowserReservationClaim
+  ): (() => void) | undefined =>
+    reservation ? () => assertOAuthBrowserReservationStillCurrent(reservation) : undefined;
+  const runWithinOAuthBrowserReservation = async <T>(
+    reservation: OAuthBrowserReservationClaim | undefined,
+    work: () => Promise<T>
+  ): Promise<T> => {
+    const assertCurrent = reservationAssertion(reservation);
+    assertCurrent?.();
+    try {
+      const result = await work();
+      assertCurrent?.();
+      return result;
+    } catch (error) {
+      // Expiry/authority replacement is terminal even when the held work also
+      // failed. Never let a provider/DB error turn it into a permissive
+      // fallback or another external request.
+      assertCurrent?.();
+      throw error;
     }
   };
   const deleteOAuthBrowserReservation = (token: string): void => {
@@ -2980,24 +3034,31 @@ export async function registerMCPServices(
    * (`readOnlyHint: true`) so we don't risk side effects on write tools.
    * Returns the 401 Response if one is found this way, otherwise null.
    */
-  async function probeMcpAuthViaReadOnlyToolCall(mcpUrl: string): Promise<Response | null> {
+  async function probeMcpAuthViaReadOnlyToolCall(
+    mcpUrl: string,
+    assertCurrent?: () => void
+  ): Promise<Response | null> {
     try {
+      assertCurrent?.();
       const listResponse = await oauthFetch(mcpUrl, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
         signal: AbortSignal.timeout(15_000),
       });
+      assertCurrent?.();
       if (!listResponse.ok) return null;
 
       const listBody = (await listResponse.json()) as {
         result?: { tools?: Array<{ name?: string; annotations?: { readOnlyHint?: boolean } }> };
       };
+      assertCurrent?.();
       const readOnlyTool = listBody.result?.tools?.find(
         (tool) => tool.annotations?.readOnlyHint === true && typeof tool.name === 'string'
       );
       if (!readOnlyTool?.name) return null;
 
+      assertCurrent?.();
       const callResponse = await oauthFetch(mcpUrl, {
         method: 'POST',
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
@@ -3009,8 +3070,12 @@ export async function registerMCPServices(
         }),
         signal: AbortSignal.timeout(15_000),
       });
+      assertCurrent?.();
       return callResponse.status === 401 ? callResponse : null;
     } catch (probeError) {
+      // Do not downgrade an authority/deadline failure into "no fallback
+      // challenge" and continue the browser flow.
+      assertCurrent?.();
       console.log(
         '[OAuth Probe] Read-only tool-call fallback probe failed:',
         probeError instanceof Error ? probeError.message : String(probeError)
@@ -3047,6 +3112,8 @@ export async function registerMCPServices(
         if (data.start_browser_flow && !browserReservation) {
           throw new BadRequest('A valid OAuth browser reservation is required');
         }
+        const assertBrowserReservation = reservationAssertion(browserReservation);
+        assertBrowserReservation?.();
         assertPublicMCPOAuthCompatibilityMode({
           oauth_compatibility_mode: data.compatibility_mode,
         });
@@ -3055,15 +3122,17 @@ export async function registerMCPServices(
         // saved-row authority as every other flow-start endpoint applies.
         // Testing a not-yet-created server passes no id and is unaffected.
         const authoritativeServer = data.mcp_server_id
-          ? await runInOAuthTenantScope(
-              db,
-              tenantIdFromParams(params as AuthenticatedParams | undefined),
-              () =>
-                loadMcpServerForCaller(
-                  db,
-                  data.mcp_server_id as string,
-                  params as AuthenticatedParams | undefined
-                )
+          ? await runWithinOAuthBrowserReservation(browserReservation, () =>
+              runInOAuthTenantScope(
+                db,
+                tenantIdFromParams(params as AuthenticatedParams | undefined),
+                () =>
+                  loadMcpServerForCaller(
+                    db,
+                    data.mcp_server_id as string,
+                    params as AuthenticatedParams | undefined
+                  )
+              )
             )
           : undefined;
         if (
@@ -3089,7 +3158,9 @@ export async function registerMCPServices(
         const effectiveMcpUrl = authoritativeServer?.url ?? data.mcp_url;
         const effectiveAuth = authoritativeServer?.auth;
         const compatibilityPolicy = authoritativeServer
-          ? await resolveMCPOAuthCompatibilityPolicy(authoritativeServer)
+          ? await runWithinOAuthBrowserReservation(browserReservation, () =>
+              resolveMCPOAuthCompatibilityPolicy(authoritativeServer)
+            )
           : undefined;
         const compatibilityMode = compatibilityPolicy?.mode ?? data.compatibility_mode ?? 'strict';
         if (compatibilityPolicy) {
@@ -3122,13 +3193,16 @@ export async function registerMCPServices(
 
         let probeResponse: Response;
         try {
-          probeResponse = await oauthFetch(effectiveMcpUrl, {
-            method: 'POST',
-            headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-            signal: AbortSignal.timeout(15_000),
-          });
+          probeResponse = await runWithinOAuthBrowserReservation(browserReservation, () =>
+            oauthFetch(effectiveMcpUrl, {
+              method: 'POST',
+              headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+              body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+              signal: AbortSignal.timeout(15_000),
+            })
+          );
         } catch (fetchError) {
+          assertBrowserReservation?.();
           return {
             success: false,
             error: `Failed to connect to MCP server: ${fetchError instanceof Error ? fetchError.message : String(fetchError)}`,
@@ -3136,7 +3210,10 @@ export async function registerMCPServices(
         }
 
         if (probeResponse.status !== 401) {
-          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(effectiveMcpUrl);
+          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(
+            effectiveMcpUrl,
+            assertBrowserReservation
+          );
           if (fallbackProbe) {
             console.log(
               '[OAuth Test] Handshake-level probe returned no auth requirement; ' +
@@ -3159,15 +3236,14 @@ export async function registerMCPServices(
           | null = null;
         let discoverySource: string | null = null;
         if (probeResponse.status === 401) {
-          if (browserReservation) {
-            assertOAuthBrowserReservationStillCurrent(browserReservation);
-          }
+          assertBrowserReservation?.();
           const { resolveMCPOAuthDiscovery } = await import(
             '@agor/core/tools/mcp/oauth-mcp-transport'
           );
           const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
             compatibilityMode,
             allowLocalhostHttp: !durableOAuthFlows,
+            assertCurrent: assertBrowserReservation,
           });
           if (discovery?.kind === 'resource-metadata') {
             metadataUrl = discovery.metadataUrl;
@@ -4393,6 +4469,8 @@ export async function registerMCPServices(
             mcpServerId: data.mcp_server_id,
           }
         );
+        const assertBrowserReservation = reservationAssertion(browserReservation);
+        assertBrowserReservation?.();
         assertPublicMCPOAuthCompatibilityMode(data.auth);
         const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
         const { StreamableHTTPClientTransport } = await import(
@@ -4452,8 +4530,10 @@ export async function registerMCPServices(
             name: 'inline-test',
           };
           if (data.mcp_server_id) {
-            const server = await runInOAuthTenantScope(db, tenantId, () =>
-              loadMcpServerForCaller(db, data.mcp_server_id as string, params)
+            const server = await runWithinOAuthBrowserReservation(browserReservation, () =>
+              runInOAuthTenantScope(db, tenantId, () =>
+                loadMcpServerForCaller(db, data.mcp_server_id as string, params)
+              )
             );
             const denial = denyDiscoverOfAnotherUsersServer(server, params);
             if (denial) return denial;
@@ -4477,8 +4557,10 @@ export async function registerMCPServices(
             serverId = data.mcp_server_id;
           }
         } else if (data.mcp_server_id) {
-          const server = await runInOAuthTenantScope(db, tenantId, () =>
-            loadMcpServerForCaller(db, data.mcp_server_id as string, params)
+          const server = await runWithinOAuthBrowserReservation(browserReservation, () =>
+            runInOAuthTenantScope(db, tenantId, () =>
+              loadMcpServerForCaller(db, data.mcp_server_id as string, params)
+            )
           );
           const denial = denyDiscoverOfAnotherUsersServer(server, params);
           if (denial) return denial;
@@ -4530,8 +4612,8 @@ export async function registerMCPServices(
         const { resolveUserEnvironment } = await import('@agor/core/config');
         const { resolveProbeServerTemplates } = await import('./utils/mcp-probe-templates.js');
 
-        const userEnv = await runInOAuthTenantScope(db, tenantId, () =>
-          resolveUserEnvironment(userId, db)
+        const userEnv = await runWithinOAuthBrowserReservation(browserReservation, () =>
+          runInOAuthTenantScope(db, tenantId, () => resolveUserEnvironment(userId, db))
         );
         const resolution = resolveProbeServerTemplates(
           {
@@ -4564,27 +4646,26 @@ export async function registerMCPServices(
 
         console.log('[MCP Discovery] Starting test for:', serverConfig.name || 'inline-config');
 
-        if (browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(browserReservation);
-        }
-        let authHeaders = await resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url, {
-          allowLocalhostHttp: !durableOAuthFlows,
-          cacheNamespace: [tenantId ?? '<standalone>', serverId ?? '<unsaved>', userId].join(':'),
-          disableProcessTokenCache: !!durableOAuthFlows,
-        });
-        if (browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(browserReservation);
-        }
+        assertBrowserReservation?.();
+        let authHeaders = await runWithinOAuthBrowserReservation(browserReservation, () =>
+          resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url, {
+            allowLocalhostHttp: !durableOAuthFlows,
+            cacheNamespace: [tenantId ?? '<standalone>', serverId ?? '<unsaved>', userId].join(':'),
+            disableProcessTokenCache: !!durableOAuthFlows,
+          })
+        );
 
         const probeAndAcquireOAuthToken = async (mcpUrl: string): Promise<string | undefined> => {
           try {
-            const probeResponse = await oauthFetch(mcpUrl, {
-              method: 'GET',
-              headers: mergeMCPRemoteHeaders({
-                base: { Accept: 'application/json' },
-                custom: serverConfig.headers,
-              }) ?? { Accept: 'application/json' },
-            });
+            const probeResponse = await runWithinOAuthBrowserReservation(browserReservation, () =>
+              oauthFetch(mcpUrl, {
+                method: 'GET',
+                headers: mergeMCPRemoteHeaders({
+                  base: { Accept: 'application/json' },
+                  custom: serverConfig.headers,
+                }) ?? { Accept: 'application/json' },
+              })
+            );
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
             if (probeResponse.status !== 401) return undefined;
             // Provider discovery and dynamic client registration can create
@@ -4592,21 +4673,26 @@ export async function registerMCPServices(
             // exact socket/caller/operation already consumed a server-issued
             // one-shot reservation.
             if (!browserReservation) return undefined;
-            assertOAuthBrowserReservationStillCurrent(browserReservation);
+            assertBrowserReservation?.();
             const { resolveMCPOAuthDiscovery } = await import(
               '@agor/core/tools/mcp/oauth-mcp-transport'
             );
-            const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(
-              authoritativeServer ?? {
-                ...serverConfig,
-                source: serverConfig.source ?? 'user',
-              }
+            const compatibilityPolicy = await runWithinOAuthBrowserReservation(
+              browserReservation,
+              () =>
+                resolveMCPOAuthCompatibilityPolicy(
+                  authoritativeServer ?? {
+                    ...serverConfig,
+                    source: serverConfig.source ?? 'user',
+                  }
+                )
             );
             const compatibilityMode = compatibilityPolicy.mode;
             logMCPOAuthCompatibilityPolicy('discover', serverId, compatibilityPolicy);
             const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, mcpUrl, {
               compatibilityMode,
               allowLocalhostHttp: !durableOAuthFlows,
+              assertCurrent: assertBrowserReservation,
             });
             if (!discovery) return undefined;
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -3024,7 +3024,14 @@ export async function registerMCPServices(
       const socketId = socketIdFromParams(params);
       const tenantId = tenantIdFromParams(params);
       const authorityFingerprint = authorityFingerprintFromParams(params);
-      if (!userId || !role || !socketId || !authorityFingerprint) {
+      // Newer-main deliberately removes raw bearer material from the immutable
+      // Socket.IO connection projection. The physical socket id plus its
+      // server-owned user/role/tenant projection is therefore the authority
+      // binding for handshake-authenticated sockets. Keep the optional token
+      // fingerprint for legacy/synthetic callers that still expose one, but
+      // never require the bearer to be retained merely to reserve a browser
+      // event.
+      if (!userId || !role || !socketId) {
         throw new BadRequest('OAuth browser reservations require an authenticated live socket');
       }
       const currentAuthority = liveSocketAuthority(socketId);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -257,6 +257,10 @@ export interface RegisterServicesContext {
   allowSuperadmin: boolean;
   requireAuth: (context: HookContext) => Promise<HookContext>;
   deployment: ResolvedDeploymentConfig;
+  /** Injectable durable authority for boundary tests; production derives it from PostgreSQL. */
+  mcpOAuthPendingFlowAuthority?: MCPOAuthPendingFlowAuthority;
+  /** Injectable transaction-lock boundary paired with the durable authority. */
+  lockMcpOAuthGrantConfiguration?: typeof lockMCPOAuthGrantConfiguration;
 }
 
 /**
@@ -1458,9 +1462,12 @@ export async function registerMCPServices(
 ): Promise<{ oauthCallbackHandler: (req: express.Request, res: express.Response) => void }> {
   const { db, app } = ctx;
   const sessionsRepository = new SessionRepository(db);
-  const durableOAuthFlows = isPostgresDatabaseHandle(db)
-    ? new MCPOAuthPendingFlowAuthority(db)
-    : null;
+  const postgresOAuthDeployment = isPostgresDatabaseHandle(db);
+  const durableOAuthFlows =
+    ctx.mcpOAuthPendingFlowAuthority ??
+    (postgresOAuthDeployment ? new MCPOAuthPendingFlowAuthority(db) : null);
+  const lockOAuthGrantConfiguration =
+    ctx.lockMcpOAuthGrantConfiguration ?? lockMCPOAuthGrantConfiguration;
   const oauthFetch = async (
     input: string | URL | Request,
     init: RequestInit = {}
@@ -1482,7 +1489,7 @@ export async function registerMCPServices(
       // Loopback HTTP is retained only for standalone/SQLite development.
       // PostgreSQL is the multi-daemon/hosted authority and must never turn
       // an admin-supplied endpoint into daemon-local egress.
-      allowLocalhostHttp: !durableOAuthFlows,
+      allowLocalhostHttp: !postgresOAuthDeployment,
     });
   };
   const refreshGrantValidator =
@@ -1878,30 +1885,32 @@ export async function registerMCPServices(
     if (opts.browserReservation) {
       assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
     }
-    const context = await startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
-      authorizationUrlOverride: effectiveAuthorizationUrlOverride,
-      tokenUrlOverride: effectiveTokenUrlOverride,
-      clientSecret: effectiveClientSecret,
-      scope: effectiveScope,
-      resourceMetadataUrl: opts.resourceMetadataUrl,
-      prefetchedAuthServerMetadata: opts.prefetchedAuthServerMetadata,
-      // The core helper still needs a stable metadata key for its standalone
-      // flow context. Daemon callers never read or populate its origin-only
-      // bearer cache.
-      cacheKey: opts.prefetchedAuthServerMetadata ? effectiveMcpUrl : undefined,
-      // Process-global DCR credentials are not a tenant/user/server namespace.
-      // Daemon flows never share them, including in SQLite deployments.
-      reuseDynamicClientRegistration: false,
-      resourceUri: effectiveMcpUrl,
-      compatibilityMode: effectiveCompatibilityMode,
-      dcrMode: effectiveDcrMode,
-      allowLocalhostHttp: !durableOAuthFlows,
-      // The reservation is consumed before provider work starts, but its
-      // deadline remains authoritative throughout discovery/DCR/flow setup.
-      assertCurrent: opts.browserReservation
-        ? () => assertOAuthBrowserReservationStillCurrent(opts.browserReservation!)
-        : undefined,
-    });
+    const context = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+      startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
+        authorizationUrlOverride: effectiveAuthorizationUrlOverride,
+        tokenUrlOverride: effectiveTokenUrlOverride,
+        clientSecret: effectiveClientSecret,
+        scope: effectiveScope,
+        resourceMetadataUrl: opts.resourceMetadataUrl,
+        prefetchedAuthServerMetadata: opts.prefetchedAuthServerMetadata,
+        // The core helper still needs a stable metadata key for its standalone
+        // flow context. Daemon callers never read or populate its origin-only
+        // bearer cache.
+        cacheKey: opts.prefetchedAuthServerMetadata ? effectiveMcpUrl : undefined,
+        // Process-global DCR credentials are not a tenant/user/server namespace.
+        // Daemon flows never share them, including in SQLite deployments.
+        reuseDynamicClientRegistration: false,
+        resourceUri: effectiveMcpUrl,
+        compatibilityMode: effectiveCompatibilityMode,
+        dcrMode: effectiveDcrMode,
+        allowLocalhostHttp: !postgresOAuthDeployment,
+        // The reservation is consumed before provider work starts, but its
+        // deadline remains authoritative throughout discovery/DCR/flow setup.
+        assertCurrent: opts.browserReservation
+          ? () => assertOAuthBrowserReservationStillCurrent(opts.browserReservation!)
+          : undefined,
+      })
+    );
     if (opts.browserReservation) {
       assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
     }
@@ -1924,101 +1933,29 @@ export async function registerMCPServices(
       if (opts.browserReservation) {
         assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
       }
-      localGrantBinding = await runInOAuthTenantScope(db, opts.tenantId, async () => {
-        const currentServer = await new MCPServerRepository(db).findById(
-          savedServerAuthority!.mcp_server_id
-        );
-        if (opts.browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-        }
-        const currentPolicy = currentServer
-          ? await resolveMCPOAuthCompatibilityPolicy(currentServer)
-          : undefined;
-        if (opts.browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-        }
-        if (
-          !currentServer?.enabled ||
-          currentServer.auth?.type !== 'oauth' ||
-          currentServer.url !== context.resourceUri ||
-          (currentServer.auth.oauth_mode ?? 'per_user') !== effectiveOAuthMode ||
-          currentPolicy?.mode !== context.compatibilityMode ||
-          hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
-        ) {
-          throw new Error(
-            'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
-          );
-        }
-        if (opts.browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-        }
-
-        const subjectUserId = effectiveOAuthMode === 'per_user' ? (opts.userId as UserID) : null;
-        const subjectKey = [
-          currentServer.mcp_server_id,
-          effectiveOAuthMode,
-          subjectUserId ?? '<shared>',
-        ].join('\u001f');
-        const existingGrant = await new UserMCPOAuthTokenRepository(db).getToken(
-          subjectUserId,
-          currentServer.mcp_server_id
-        );
-        if (opts.browserReservation) {
-          assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-        }
-        const generation =
-          Math.max(existingGrant?.grant_generation ?? 0, localOAuthGrantGenerationHighWater) + 1;
-        if (!Number.isSafeInteger(generation)) {
-          throw new Error('Standalone OAuth grant generation authority is exhausted');
-        }
-        localOAuthGrantGenerationHighWater = generation;
-        const subjectReservations =
-          localOAuthGrantReservations.get(subjectKey) ??
-          new Map<MCPOAuthAttemptID, { generation: number; reservedAt: number }>();
-        subjectReservations.set(localAttemptId!, { generation, reservedAt: Date.now() });
-        localOAuthGrantReservations.set(subjectKey, subjectReservations);
-        localGrantSubjectKey = subjectKey;
-        const version = grantBindingVersionForCompatibilityMode(context.compatibilityMode);
-        return {
-          generation,
-          version,
-          fingerprint: fingerprintMCPOAuthGrantConfiguration(
-            process.env.AGOR_MASTER_SECRET!,
-            currentServer,
-            resolvedGrantBinding,
-            version
-          ),
-          metadataUri: context.metadataUrl,
-          resourceUri: context.resourceUri,
-          issuer: context.issuer,
-          authorizationEndpoint: context.authorizationEndpoint,
-          tokenEndpoint: context.tokenEndpoint,
-          redirectUri: context.redirectUri,
-        };
-      });
-    }
-
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
-    const attemptId = durableBinding
-      ? await runInOAuthTenantWriteScope(db, durableBinding.tenantId, async () => {
-          await lockMCPOAuthGrantConfiguration(
-            db,
-            durableBinding.tenantId,
-            durableBinding.mcpServerId
+      localGrantBinding = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+        runInOAuthTenantScope(db, opts.tenantId, async () => {
+          const currentServer = await runWithinOAuthBrowserReservation(
+            opts.browserReservation,
+            () => new MCPServerRepository(db).findById(savedServerAuthority!.mcp_server_id)
           );
           if (opts.browserReservation) {
             assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
-          const currentServer = await new MCPServerRepository(db).findById(
-            durableBinding.mcpServerId
-          );
+          const currentPolicy = currentServer
+            ? await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+                resolveMCPOAuthCompatibilityPolicy(currentServer)
+              )
+            : undefined;
           if (opts.browserReservation) {
             assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
           if (
-            !currentServer ||
+            !currentServer?.enabled ||
+            currentServer.auth?.type !== 'oauth' ||
+            currentServer.url !== context.resourceUri ||
+            (currentServer.auth.oauth_mode ?? 'per_user') !== effectiveOAuthMode ||
+            currentPolicy?.mode !== context.compatibilityMode ||
             hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
           ) {
             throw new Error(
@@ -2028,20 +1965,106 @@ export async function registerMCPServices(
           if (opts.browserReservation) {
             assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
-          const createdAttempt = await durableOAuthFlows!.create({
-            context,
-            ...durableBinding,
-            configFingerprint: fingerprintMCPOAuthGrantConfiguration(
-              process.env.AGOR_MASTER_SECRET!,
-              currentServer,
-              resolvedGrantBinding
-            ),
-          });
+
+          const subjectUserId = effectiveOAuthMode === 'per_user' ? (opts.userId as UserID) : null;
+          const subjectKey = [
+            currentServer.mcp_server_id,
+            effectiveOAuthMode,
+            subjectUserId ?? '<shared>',
+          ].join('\u001f');
+          const existingGrant = await runWithinOAuthBrowserReservation(
+            opts.browserReservation,
+            () =>
+              new UserMCPOAuthTokenRepository(db).getToken(
+                subjectUserId,
+                currentServer.mcp_server_id
+              )
+          );
           if (opts.browserReservation) {
             assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
           }
-          return createdAttempt;
+          const generation =
+            Math.max(existingGrant?.grant_generation ?? 0, localOAuthGrantGenerationHighWater) + 1;
+          if (!Number.isSafeInteger(generation)) {
+            throw new Error('Standalone OAuth grant generation authority is exhausted');
+          }
+          localOAuthGrantGenerationHighWater = generation;
+          const subjectReservations =
+            localOAuthGrantReservations.get(subjectKey) ??
+            new Map<MCPOAuthAttemptID, { generation: number; reservedAt: number }>();
+          subjectReservations.set(localAttemptId!, { generation, reservedAt: Date.now() });
+          localOAuthGrantReservations.set(subjectKey, subjectReservations);
+          localGrantSubjectKey = subjectKey;
+          const version = grantBindingVersionForCompatibilityMode(context.compatibilityMode);
+          return {
+            generation,
+            version,
+            fingerprint: fingerprintMCPOAuthGrantConfiguration(
+              process.env.AGOR_MASTER_SECRET!,
+              currentServer,
+              resolvedGrantBinding,
+              version
+            ),
+            metadataUri: context.metadataUrl,
+            resourceUri: context.resourceUri,
+            issuer: context.issuer,
+            authorizationEndpoint: context.authorizationEndpoint,
+            tokenEndpoint: context.tokenEndpoint,
+            redirectUri: context.redirectUri,
+          };
         })
+      );
+    }
+
+    if (opts.browserReservation) {
+      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+    }
+    const attemptId = durableBinding
+      ? await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+          runInOAuthTenantWriteScope(db, durableBinding.tenantId, async () => {
+            await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+              lockOAuthGrantConfiguration(db, durableBinding.tenantId, durableBinding.mcpServerId)
+            );
+            if (opts.browserReservation) {
+              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+            }
+            const currentServer = await runWithinOAuthBrowserReservation(
+              opts.browserReservation,
+              () => new MCPServerRepository(db).findById(durableBinding.mcpServerId)
+            );
+            if (opts.browserReservation) {
+              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+            }
+            if (
+              !currentServer ||
+              hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
+            ) {
+              throw new Error(
+                'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
+              );
+            }
+            if (opts.browserReservation) {
+              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+            }
+            const createdAttempt = await runWithinOAuthBrowserReservation(
+              opts.browserReservation,
+              () =>
+                durableOAuthFlows!.create({
+                  context,
+                  ...durableBinding,
+                  configFingerprint: fingerprintMCPOAuthGrantConfiguration(
+                    process.env.AGOR_MASTER_SECRET!,
+                    currentServer,
+                    resolvedGrantBinding
+                  ),
+                })
+            );
+            if (opts.browserReservation) {
+              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+            }
+            return createdAttempt;
+          })
+        )
       : localAttemptId!;
 
     let tokenPromise: Promise<OAuthTokenResponse> | undefined;
@@ -2562,7 +2585,7 @@ export async function registerMCPServices(
       // Recheck role and the complete server/config fingerprint inside the same
       // transaction that persists the grant and consumes the success fence.
       if (pendingFlow.durableRecord) {
-        await lockMCPOAuthGrantConfiguration(
+        await lockOAuthGrantConfiguration(
           db,
           pendingFlow.durableRecord.tenantId,
           pendingFlow.durableRecord.mcpServerId
@@ -2958,7 +2981,7 @@ export async function registerMCPServices(
     const serverId = String(context.id ?? '');
     await runInOAuthTenantWriteScope(db, tenantId, async () => {
       if (durableOAuthFlows && tenantId && serverId) {
-        await lockMCPOAuthGrantConfiguration(db, tenantId, serverId as MCPServerID);
+        await lockOAuthGrantConfiguration(db, tenantId, serverId as MCPServerID);
       }
       const before = serverId ? await new MCPServerRepository(db).findById(serverId) : null;
       await next();
@@ -3242,7 +3265,7 @@ export async function registerMCPServices(
           );
           const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
             compatibilityMode,
-            allowLocalhostHttp: !durableOAuthFlows,
+            allowLocalhostHttp: !postgresOAuthDeployment,
             assertCurrent: assertBrowserReservation,
           });
           if (discovery?.kind === 'resource-metadata') {
@@ -3482,7 +3505,7 @@ export async function registerMCPServices(
                 client_secret: effectiveClientSecret,
                 scope: effectiveScope,
                 grant_type: effectiveGrantType || 'client_credentials',
-                allowLocalhostHttp: !durableOAuthFlows,
+                allowLocalhostHttp: !postgresOAuthDeployment,
                 cacheNamespace: [
                   tenantIdFromParams(params as AuthenticatedParams | undefined) ?? '<standalone>',
                   data.mcp_server_id ?? '<unsaved>',
@@ -3675,7 +3698,7 @@ export async function registerMCPServices(
         );
         const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
           compatibilityMode,
-          allowLocalhostHttp: !durableOAuthFlows,
+          allowLocalhostHttp: !postgresOAuthDeployment,
         });
         if (!discovery) {
           return {
@@ -4649,7 +4672,7 @@ export async function registerMCPServices(
         assertBrowserReservation?.();
         let authHeaders = await runWithinOAuthBrowserReservation(browserReservation, () =>
           resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url, {
-            allowLocalhostHttp: !durableOAuthFlows,
+            allowLocalhostHttp: !postgresOAuthDeployment,
             cacheNamespace: [tenantId ?? '<standalone>', serverId ?? '<unsaved>', userId].join(':'),
             disableProcessTokenCache: !!durableOAuthFlows,
           })
@@ -4691,7 +4714,7 @@ export async function registerMCPServices(
             logMCPOAuthCompatibilityPolicy('discover', serverId, compatibilityPolicy);
             const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, mcpUrl, {
               compatibilityMode,
-              allowLocalhostHttp: !durableOAuthFlows,
+              allowLocalhostHttp: !postgresOAuthDeployment,
               assertCurrent: assertBrowserReservation,
             });
             if (!discovery) return undefined;
@@ -4739,6 +4762,11 @@ export async function registerMCPServices(
             // in an origin-only process namespace.
             return tokenResponse.access_token;
           } catch (error) {
+            // A provider/DB rejection is allowed to degrade to "no fresh
+            // token" only while this exact browser authority is still live.
+            // Expiry or socket replacement must escape before callers build
+            // private headers or open another MCP connection.
+            assertBrowserReservation?.();
             // Misconfigured public base URL is a daemon-level problem, not a
             // missing-token signal — re-throw so the discover endpoint can
             // surface it to the caller instead of silently falling through to
@@ -4759,57 +4787,68 @@ export async function registerMCPServices(
           // keyed solely by MCP origin could cross tenant/server/user grants.
           let oauthToken: string | undefined;
           if (serverId) {
-            oauthToken = await runInOAuthTenantScope(db, tenantId, async () => {
-              const tokenRepo = new UserMCPOAuthTokenRepository(db);
-              const lookupUserId =
-                serverConfig.auth?.oauth_mode === 'shared'
-                  ? null
-                  : ((params?.user?.user_id as UserID | undefined) ?? null);
-              const grant = await tokenRepo.getToken(lookupUserId, serverId as MCPServerID);
-              if (!grant) return undefined;
-              if (
-                shouldVerifyMCPOAuthGrantBinding(
-                  isPostgresDatabaseHandle(db),
-                  grant.grant_binding_version
-                ) &&
-                !isMCPOAuthGrantBoundToServer(
-                  process.env.AGOR_MASTER_SECRET!,
-                  {
-                    mcp_server_id: serverId as MCPServerID,
-                    enabled: true,
-                    transport: serverConfig.transport,
-                    url: serverConfig.url,
-                    source: serverConfig.source ?? 'user',
-                    catalog_entry_name: serverConfig.catalog_entry_name,
-                    headers: serverConfig.headers,
-                    auth: serverConfig.auth,
-                  },
-                  grant,
-                  (
-                    await resolveMCPOAuthCompatibilityPolicy(
+            oauthToken = await runWithinOAuthBrowserReservation(browserReservation, () =>
+              runInOAuthTenantScope(db, tenantId, async () => {
+                const tokenRepo = new UserMCPOAuthTokenRepository(db);
+                const lookupUserId =
+                  serverConfig.auth?.oauth_mode === 'shared'
+                    ? null
+                    : ((params?.user?.user_id as UserID | undefined) ?? null);
+                const grant = await runWithinOAuthBrowserReservation(browserReservation, () =>
+                  tokenRepo.getToken(lookupUserId, serverId as MCPServerID)
+                );
+                if (!grant) return undefined;
+                const compatibilityPolicy = await runWithinOAuthBrowserReservation(
+                  browserReservation,
+                  () =>
+                    resolveMCPOAuthCompatibilityPolicy(
                       authoritativeServer ?? {
                         ...serverConfig,
                         source: serverConfig.source ?? 'user',
                       }
                     )
-                  ).mode
-                )
-              ) {
-                return undefined;
-              }
-              if (grant.oauth_token_expires_at && grant.oauth_token_expires_at <= new Date()) {
-                return undefined;
-              }
-              return grant.oauth_access_token;
-            });
+                );
+                if (
+                  shouldVerifyMCPOAuthGrantBinding(
+                    isPostgresDatabaseHandle(db),
+                    grant.grant_binding_version
+                  ) &&
+                  !isMCPOAuthGrantBoundToServer(
+                    process.env.AGOR_MASTER_SECRET!,
+                    {
+                      mcp_server_id: serverId as MCPServerID,
+                      enabled: true,
+                      transport: serverConfig.transport,
+                      url: serverConfig.url,
+                      source: serverConfig.source ?? 'user',
+                      catalog_entry_name: serverConfig.catalog_entry_name,
+                      headers: serverConfig.headers,
+                      auth: serverConfig.auth,
+                    },
+                    grant,
+                    compatibilityPolicy.mode
+                  )
+                ) {
+                  return undefined;
+                }
+                if (grant.oauth_token_expires_at && grant.oauth_token_expires_at <= new Date()) {
+                  return undefined;
+                }
+                return grant.oauth_access_token;
+              })
+            );
           }
           if (!oauthToken) {
             const freshToken = await probeAndAcquireOAuthToken(serverConfig.url);
             if (freshToken) oauthToken = freshToken;
           }
-          if (oauthToken) authHeaders = { Authorization: `Bearer ${oauthToken}` };
+          if (oauthToken) {
+            assertBrowserReservation?.();
+            authHeaders = { Authorization: `Bearer ${oauthToken}` };
+          }
         }
 
+        assertBrowserReservation?.();
         const headers = mergeMCPRemoteHeaders({
           base: { Accept: 'application/json, text/event-stream' },
           custom: serverConfig.headers,
@@ -4856,15 +4895,20 @@ export async function registerMCPServices(
             const timeout = new Promise<never>((_, reject) => {
               setTimeout(() => reject(new Error('Connection timeout after 10 seconds')), 10000);
             });
-            await Promise.race([mcpClient.connect(mcpTransport), timeout]);
+            await runWithinOAuthBrowserReservation(browserReservation, () =>
+              Promise.race([mcpClient.connect(mcpTransport), timeout])
+            );
           };
 
           try {
             await connectWithTimeout(client, httpTransport);
           } catch (connectError) {
+            assertBrowserReservation?.();
+            if (connectError instanceof Forbidden) throw connectError;
             if (hadCachedOAuthToken && serverConfig.url && serverConfig.auth?.type === 'oauth') {
               const freshToken = await probeAndAcquireOAuthToken(serverConfig.url);
               if (freshToken) {
+                assertBrowserReservation?.();
                 const freshHeaders = mergeMCPRemoteHeaders({
                   base: { Accept: 'application/json, text/event-stream' },
                   custom: serverConfig.headers,
@@ -4905,41 +4949,50 @@ export async function registerMCPServices(
             arguments?: Array<{ name: string; description?: string; required?: boolean }>;
           }>;
 
-          const toolsResult = (await Promise.race([
-            client.listTools(),
-            listTimeout,
-          ])) as ToolsResult;
+          const toolsResult = (await runWithinOAuthBrowserReservation(browserReservation, () =>
+            Promise.race([client.listTools(), listTimeout])
+          )) as ToolsResult;
+          const optionalList = async <T>(work: () => Promise<T>, fallback: T): Promise<T> => {
+            try {
+              return await runWithinOAuthBrowserReservation(browserReservation, work);
+            } catch {
+              assertBrowserReservation?.();
+              return fallback;
+            }
+          };
           const resourcesResult = (await Promise.race([
-            client.listResources().catch(() => ({ resources: [] })),
+            optionalList(() => client.listResources(), { resources: [] }),
             listTimeout,
           ])) as ResourcesResult;
           const promptsResult = (await Promise.race([
-            client.listPrompts().catch(() => ({ prompts: [] })),
+            optionalList(() => client.listPrompts(), { prompts: [] }),
             listTimeout,
           ])) as PromptsResult;
 
           if (serverId) {
-            await persistDiscoveredMCPCapabilities(db, tenantId, serverId as MCPServerID, {
-              tools: toolsResult.tools.map((t) => ({
-                name: t.name,
-                description: t.description || '',
-                input_schema: t.inputSchema,
-              })),
-              resources: resourcesResult.resources.map((r) => ({
-                uri: r.uri,
-                name: r.name,
-                mimeType: r.mimeType,
-              })),
-              prompts: promptsResult.prompts.map((p) => ({
-                name: p.name,
-                description: p.description || '',
-                arguments: p.arguments?.map((a) => ({
-                  name: a.name,
-                  description: a.description || '',
-                  required: a.required,
+            await runWithinOAuthBrowserReservation(browserReservation, () =>
+              persistDiscoveredMCPCapabilities(db, tenantId, serverId as MCPServerID, {
+                tools: toolsResult.tools.map((t) => ({
+                  name: t.name,
+                  description: t.description || '',
+                  input_schema: t.inputSchema,
                 })),
-              })),
-            });
+                resources: resourcesResult.resources.map((r) => ({
+                  uri: r.uri,
+                  name: r.name,
+                  mimeType: r.mimeType,
+                })),
+                prompts: promptsResult.prompts.map((p) => ({
+                  name: p.name,
+                  description: p.description || '',
+                  arguments: p.arguments?.map((a) => ({
+                    name: a.name,
+                    description: a.description || '',
+                    required: a.required,
+                  })),
+                })),
+              })
+            );
           }
 
           return {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -52,7 +52,7 @@ import {
   visibleSessionReferenceAccessExists,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   OAuthFlowContext,
   OAuthTokenResponse,
@@ -64,6 +64,7 @@ import type {
   HookContext,
   MCPAuth,
   MCPOAuthAttemptID,
+  MCPOAuthBrowserEventRequest,
   MCPOAuthDCRMode,
   MCPOAuthPendingFlowStatus,
   MCPOAuthRuntimeCompatibilityMode,
@@ -1682,6 +1683,32 @@ export async function registerMCPServices(
     return new URL('/mcp-servers/oauth-callback', baseUrl).toString();
   }
 
+  const readOAuthBrowserEventRequest = (
+    value: unknown
+  ): MCPOAuthBrowserEventRequest | undefined => {
+    if (value === undefined) return undefined;
+    if (!value || typeof value !== 'object') {
+      throw new BadRequest('oauth_browser_event must be an object');
+    }
+    const candidate = value as Partial<MCPOAuthBrowserEventRequest>;
+    if (
+      typeof candidate.operation_id !== 'string' ||
+      !/^[A-Za-z0-9_-]{16,128}$/.test(candidate.operation_id)
+    ) {
+      throw new BadRequest('oauth_browser_event.operation_id is invalid');
+    }
+    if (
+      !Number.isSafeInteger(candidate.auth_generation) ||
+      (candidate.auth_generation as number) < 0
+    ) {
+      throw new BadRequest('oauth_browser_event.auth_generation is invalid');
+    }
+    return {
+      operation_id: candidate.operation_id,
+      auth_generation: candidate.auth_generation as number,
+    };
+  };
+
   type StartTwoPhaseOAuthOptions = {
     mcpUrl: string;
     wwwAuthenticate: string;
@@ -1710,6 +1737,7 @@ export async function registerMCPServices(
     compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     dcrMode?: MCPOAuthDCRMode;
     socketId?: string;
+    browserEvent?: MCPOAuthBrowserEventRequest;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -2044,7 +2072,7 @@ export async function registerMCPServices(
       });
     }
 
-    if (awaitToken && opts.socketId && app.io) {
+    if (awaitToken && opts.socketId && opts.userId && opts.browserEvent && app.io) {
       // Compatibility hint for blocking discover/test callers, which cannot
       // return the URL before their callback arrives. Target the exact
       // authenticated initiating socket only — never a user/tenant/global
@@ -2052,6 +2080,9 @@ export async function registerMCPServices(
       app.io.local.to(opts.socketId).emit('oauth:open_browser', {
         authUrl: context.authorizationUrl,
         attempt_id: attemptId,
+        operation_id: opts.browserEvent.operation_id,
+        auth_generation: opts.browserEvent.auth_generation,
+        caller_user_id: opts.userId,
       });
     }
 
@@ -2735,12 +2766,14 @@ export async function registerMCPServices(
         scope?: string;
         grant_type?: string;
         start_browser_flow?: boolean;
+        oauth_browser_event?: MCPOAuthBrowserEventRequest;
         compatibility_mode?: 'strict' | 'legacy';
         dcr_mode?: MCPOAuthDCRMode;
       },
       params?: AuthenticatedParams & { connection?: { id?: string } }
     ) {
       try {
+        const browserEvent = readOAuthBrowserEventRequest(data.oauth_browser_event);
         assertPublicMCPOAuthCompatibilityMode({
           oauth_compatibility_mode: data.compatibility_mode,
         });
@@ -2907,6 +2940,7 @@ export async function registerMCPServices(
                   clientId: effectiveClientId,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
                   socketId: connection?.id,
+                  browserEvent,
                   clientSecret: effectiveClientSecret,
                   scope: effectiveScope,
                   compatibilityMode,
@@ -4070,10 +4104,12 @@ export async function registerMCPServices(
           oauth_dcr_mode?: MCPOAuthDCRMode;
         };
         headers?: Record<string, string>;
+        oauth_browser_event?: MCPOAuthBrowserEventRequest;
       },
       params?: AuthenticatedParams
     ) {
       try {
+        const browserEvent = readOAuthBrowserEventRequest(data.oauth_browser_event);
         assertPublicMCPOAuthCompatibilityMode(data.auth);
         const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
         const { StreamableHTTPClientTransport } = await import(
@@ -4313,6 +4349,7 @@ export async function registerMCPServices(
               dcrMode: serverConfig.auth?.oauth_dcr_mode,
               tenantId,
               socketId: connection?.id,
+              browserEvent,
             });
 
             const tokenResponse = await started.awaitToken();

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -91,7 +91,7 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
-import { safeOutboundFetch } from '@agor/core/utils/safe-outbound-fetch';
+import { type OutboundDnsLookup, safeOutboundFetch } from '@agor/core/utils/safe-outbound-fetch';
 import type express from 'express';
 import { authenticatedTaskExecutorRuntimeScope } from './auth/executor-runtime-scope.js';
 import type {
@@ -262,6 +262,8 @@ export interface RegisterServicesContext {
   mcpOAuthPendingFlowAuthority?: MCPOAuthPendingFlowAuthority;
   /** Injectable transaction-lock boundary paired with the durable authority. */
   lockMcpOAuthGrantConfiguration?: typeof lockMCPOAuthGrantConfiguration;
+  /** Injectable DNS boundary for adversarial Socket.io authority tests. */
+  mcpOutboundDnsLookup?: OutboundDnsLookup;
 }
 
 /**
@@ -1494,6 +1496,7 @@ export async function registerMCPServices(
       // an admin-supplied endpoint into daemon-local egress.
       allowLocalhostHttp: !postgresOAuthDeployment,
       assertCurrent,
+      resolveDns: ctx.mcpOutboundDnsLookup,
     });
   };
   const refreshGrantValidator =
@@ -1752,6 +1755,11 @@ export async function registerMCPServices(
     dcrMode?: MCPOAuthDCRMode;
     socketId?: string;
     browserReservation?: OAuthBrowserReservationClaim;
+    /**
+     * Immutable live Socket.io request authority for public flows which do
+     * not use a browser-event reservation (notably oauth-start).
+     */
+    requestAuthority?: () => void;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -1791,17 +1799,24 @@ export async function registerMCPServices(
     opts: StartTwoPhaseOAuthOptions,
     awaitToken: boolean
   ): Promise<StartTwoPhaseOAuthResult | StartTwoPhaseOAuthAndAwaitResult> {
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
-    const { startMCPOAuthFlow } = await runWithinOAuthBrowserReservation(
-      opts.browserReservation,
+    const assertFlowAuthority =
+      opts.requestAuthority || opts.browserReservation
+        ? () => {
+            opts.requestAuthority?.();
+            if (opts.browserReservation) {
+              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+            }
+          }
+        : undefined;
+    assertFlowAuthority?.();
+    const { startMCPOAuthFlow } = await runWithinOAuthAuthority(
+      assertFlowAuthority,
       () => import('@agor/core/tools/mcp/oauth-mcp-transport')
     );
 
     // Strict public base URL — see oauth-start endpoint for the rationale.
-    const redirectUri = await runWithinOAuthBrowserReservation(
-      opts.browserReservation,
+    const redirectUri = await runWithinOAuthAuthority(
+      assertFlowAuthority,
       resolveMCPOAuthRedirectUri
     );
 
@@ -1845,7 +1860,7 @@ export async function registerMCPServices(
           'Saved MCP OAuth requires an authenticated user binding. Sign in, then restart OAuth.'
         );
       }
-      const server = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+      const server = await runWithinOAuthAuthority(assertFlowAuthority, () =>
         runInOAuthTenantScope(db, opts.tenantId, () =>
           new MCPServerRepository(db).findById(opts.mcpServerId!)
         )
@@ -1855,9 +1870,8 @@ export async function registerMCPServices(
           'The saved MCP server no longer matches this OAuth request. Save changes, then restart OAuth.'
         );
       }
-      const compatibilityPolicy = await runWithinOAuthBrowserReservation(
-        opts.browserReservation,
-        () => resolveMCPOAuthCompatibilityPolicy(server)
+      const compatibilityPolicy = await runWithinOAuthAuthority(assertFlowAuthority, () =>
+        resolveMCPOAuthCompatibilityPolicy(server)
       );
       logMCPOAuthCompatibilityPolicy('flow-start', server.mcp_server_id, compatibilityPolicy);
       // The row reloaded in the tenant scope is the only durable authority.
@@ -1873,7 +1887,7 @@ export async function registerMCPServices(
       effectiveDcrMode = server.auth.oauth_dcr_mode;
       effectiveOAuthMode = server.auth.oauth_mode ?? 'per_user';
       if (effectiveOAuthMode === 'shared') {
-        const initiatingUser = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+        const initiatingUser = await runWithinOAuthAuthority(assertFlowAuthority, () =>
           runInOAuthTenantScope(db, opts.tenantId, () =>
             new UsersRepository(db).findById(opts.userId!)
           )
@@ -1904,10 +1918,8 @@ export async function registerMCPServices(
     // this helper. Re-check the live socket authority immediately before they
     // begin; consuming a valid A reservation is not enough if that same socket
     // has since authenticated as B.
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
-    const context = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+    assertFlowAuthority?.();
+    const context = await runWithinOAuthAuthority(assertFlowAuthority, () =>
       startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
         authorizationUrlOverride: effectiveAuthorizationUrlOverride,
         tokenUrlOverride: effectiveTokenUrlOverride,
@@ -1928,14 +1940,10 @@ export async function registerMCPServices(
         allowLocalhostHttp: !postgresOAuthDeployment,
         // The reservation is consumed before provider work starts, but its
         // deadline remains authoritative throughout discovery/DCR/flow setup.
-        assertCurrent: opts.browserReservation
-          ? () => assertOAuthBrowserReservationStillCurrent(opts.browserReservation!)
-          : undefined,
+        assertCurrent: assertFlowAuthority,
       })
     );
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
+    assertFlowAuthority?.();
 
     const resolvedGrantBinding = {
       resourceUri: context.resourceUri,
@@ -1952,26 +1960,19 @@ export async function registerMCPServices(
     let localGrantBinding: NonNullable<SaveTokenInput['grantBinding']> | undefined;
     let localGrantSubjectKey: string | undefined;
     if (savedServerAuthority && !durableOAuthFlows) {
-      if (opts.browserReservation) {
-        assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-      }
-      localGrantBinding = await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+      assertFlowAuthority?.();
+      localGrantBinding = await runWithinOAuthAuthority(assertFlowAuthority, () =>
         runInOAuthTenantScope(db, opts.tenantId, async () => {
-          const currentServer = await runWithinOAuthBrowserReservation(
-            opts.browserReservation,
-            () => new MCPServerRepository(db).findById(savedServerAuthority!.mcp_server_id)
+          const currentServer = await runWithinOAuthAuthority(assertFlowAuthority, () =>
+            new MCPServerRepository(db).findById(savedServerAuthority!.mcp_server_id)
           );
-          if (opts.browserReservation) {
-            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-          }
+          assertFlowAuthority?.();
           const currentPolicy = currentServer
-            ? await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+            ? await runWithinOAuthAuthority(assertFlowAuthority, () =>
                 resolveMCPOAuthCompatibilityPolicy(currentServer)
               )
             : undefined;
-          if (opts.browserReservation) {
-            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-          }
+          assertFlowAuthority?.();
           if (
             !currentServer?.enabled ||
             currentServer.auth?.type !== 'oauth' ||
@@ -1984,9 +1985,7 @@ export async function registerMCPServices(
               'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
             );
           }
-          if (opts.browserReservation) {
-            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-          }
+          assertFlowAuthority?.();
 
           const subjectUserId = effectiveOAuthMode === 'per_user' ? (opts.userId as UserID) : null;
           const subjectKey = [
@@ -1994,17 +1993,10 @@ export async function registerMCPServices(
             effectiveOAuthMode,
             subjectUserId ?? '<shared>',
           ].join('\u001f');
-          const existingGrant = await runWithinOAuthBrowserReservation(
-            opts.browserReservation,
-            () =>
-              new UserMCPOAuthTokenRepository(db).getToken(
-                subjectUserId,
-                currentServer.mcp_server_id
-              )
+          const existingGrant = await runWithinOAuthAuthority(assertFlowAuthority, () =>
+            new UserMCPOAuthTokenRepository(db).getToken(subjectUserId, currentServer.mcp_server_id)
           );
-          if (opts.browserReservation) {
-            assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-          }
+          assertFlowAuthority?.();
           const generation =
             Math.max(existingGrant?.grant_generation ?? 0, localOAuthGrantGenerationHighWater) + 1;
           if (!Number.isSafeInteger(generation)) {
@@ -2038,25 +2030,18 @@ export async function registerMCPServices(
       );
     }
 
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
+    assertFlowAuthority?.();
     const attemptId = durableBinding
-      ? await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+      ? await runWithinOAuthAuthority(assertFlowAuthority, () =>
           runInOAuthTenantWriteScope(db, durableBinding.tenantId, async () => {
-            await runWithinOAuthBrowserReservation(opts.browserReservation, () =>
+            await runWithinOAuthAuthority(assertFlowAuthority, () =>
               lockOAuthGrantConfiguration(db, durableBinding.tenantId, durableBinding.mcpServerId)
             );
-            if (opts.browserReservation) {
-              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-            }
-            const currentServer = await runWithinOAuthBrowserReservation(
-              opts.browserReservation,
-              () => new MCPServerRepository(db).findById(durableBinding.mcpServerId)
+            assertFlowAuthority?.();
+            const currentServer = await runWithinOAuthAuthority(assertFlowAuthority, () =>
+              new MCPServerRepository(db).findById(durableBinding.mcpServerId)
             );
-            if (opts.browserReservation) {
-              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-            }
+            assertFlowAuthority?.();
             if (
               !currentServer ||
               hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
@@ -2065,25 +2050,19 @@ export async function registerMCPServices(
                 'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
               );
             }
-            if (opts.browserReservation) {
-              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-            }
-            const createdAttempt = await runWithinOAuthBrowserReservation(
-              opts.browserReservation,
-              () =>
-                durableOAuthFlows!.create({
-                  context,
-                  ...durableBinding,
-                  configFingerprint: fingerprintMCPOAuthGrantConfiguration(
-                    process.env.AGOR_MASTER_SECRET!,
-                    currentServer,
-                    resolvedGrantBinding
-                  ),
-                })
+            assertFlowAuthority?.();
+            const createdAttempt = await runWithinOAuthAuthority(assertFlowAuthority, () =>
+              durableOAuthFlows!.create({
+                context,
+                ...durableBinding,
+                configFingerprint: fingerprintMCPOAuthGrantConfiguration(
+                  process.env.AGOR_MASTER_SECRET!,
+                  currentServer,
+                  resolvedGrantBinding
+                ),
+              })
             );
-            if (opts.browserReservation) {
-              assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-            }
+            assertFlowAuthority?.();
             return createdAttempt;
           })
         )
@@ -2134,9 +2113,7 @@ export async function registerMCPServices(
       });
     }
 
-    if (opts.browserReservation) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
-    }
+    assertFlowAuthority?.();
     if (!durableOAuthFlows) {
       for (const [olderState, older] of pendingOAuthFlows) {
         const sameSubject =
@@ -2175,7 +2152,7 @@ export async function registerMCPServices(
     }
 
     if (awaitToken && opts.browserReservation && app.io) {
-      assertOAuthBrowserReservationStillCurrent(opts.browserReservation);
+      assertFlowAuthority?.();
       // Compatibility hint for blocking discover/test callers, which cannot
       // return the URL before their callback arrives. Target the exact
       // authenticated initiating socket only — never a user/tenant/global
@@ -2284,6 +2261,7 @@ export async function registerMCPServices(
         awaitToken: () => runWithinOAuthAuthority(assertRequestAuthority, () => tokenPromise!),
       };
     }
+    assertFlowAuthority?.();
     return base;
   }
 
@@ -3113,33 +3091,45 @@ export async function registerMCPServices(
 
   // JWT test endpoint
   app.use('/mcp-servers/test-jwt', {
-    async create(data: {
-      api_url: string;
-      api_token: string;
-      api_secret: string;
-      mcp_url?: string;
-    }) {
+    async create(
+      data: {
+        api_url: string;
+        api_token: string;
+        api_secret: string;
+        mcp_url?: string;
+      },
+      params?: AuthenticatedParams
+    ) {
+      const assertRequestAuthority = requestAuthorityAssertion(params);
       try {
-        const response = await oauthFetch(data.api_url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: data.api_token, secret: data.api_secret }),
-        });
-        if (!response.ok) {
-          const errorText = await response.text();
-          return {
-            success: false,
-            error: `JWT fetch failed: HTTP ${response.status}: ${errorText}`,
-          };
-        }
-        const result = (await response.json()) as {
-          access_token?: string;
-          payload?: { access_token?: string };
-        };
-        const token = result.access_token || result.payload?.access_token;
-        if (!token) return { success: false, error: 'Response missing access_token' };
+        const { fetchJWTToken } = await runWithinOAuthAuthority(
+          assertRequestAuthority,
+          () => import('@agor/core/tools/mcp/jwt-auth')
+        );
+        await runWithinOAuthAuthority(assertRequestAuthority, () =>
+          fetchJWTToken(
+            {
+              api_url: data.api_url,
+              api_token: data.api_token,
+              api_secret: data.api_secret,
+            },
+            {
+              allowLocalhostHttp: !postgresOAuthDeployment,
+              // A connection test must exercise the provider and must never
+              // leave a caller secret in the process-global compatibility cache.
+              cache: false,
+              assertCurrent: assertRequestAuthority,
+              resolveDns: ctx.mcpOutboundDnsLookup,
+            }
+          )
+        );
+        assertRequestAuthority?.();
         return { success: true, tokenValid: true };
       } catch (error) {
+        // Socket replacement wins over provider/DNS/parse failures. In
+        // particular, never downgrade a stale A request to a normal failure
+        // response that B's mounted UI could consume.
+        assertRequestAuthority?.();
         return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
     },
@@ -3719,7 +3709,9 @@ export async function registerMCPServices(
       data: { mcp_url?: string; mcp_server_id?: string; client_id?: string },
       params?: AuthenticatedParams
     ) {
+      const assertRequestAuthority = requestAuthorityAssertion(params);
       try {
+        assertRequestAuthority?.();
         console.log('[OAuth Start] Starting two-phase OAuth flow');
         const userId = params?.user?.user_id;
         const tenantId = tenantIdFromParams(params);
@@ -3736,9 +3728,11 @@ export async function registerMCPServices(
         // Its stored OAuth client configuration belongs to whoever owns the
         // row; a caller who may not use the server may not borrow it either.
         const savedServer = savedServerId
-          ? await runInOAuthTenantScope(db, tenantId, () => {
-              return loadMcpServerForCaller(db, savedServerId, params);
-            })
+          ? await runWithinOAuthAuthority(assertRequestAuthority, () =>
+              runInOAuthTenantScope(db, tenantId, () => {
+                return loadMcpServerForCaller(db, savedServerId, params);
+              })
+            )
           : null;
 
         if (
@@ -3787,7 +3781,9 @@ export async function registerMCPServices(
           clientIdFromConfig = savedServer.auth.oauth_client_id;
           clientSecretOverride = savedServer.auth.oauth_client_secret;
           scopeOverride = savedServer.auth.oauth_scope;
-          const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(savedServer);
+          const compatibilityPolicy = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+            resolveMCPOAuthCompatibilityPolicy(savedServer)
+          );
           compatibilityMode = compatibilityPolicy.mode;
           logMCPOAuthCompatibilityPolicy(
             'oauth-start',
@@ -3798,8 +3794,10 @@ export async function registerMCPServices(
           if (oauthMode === 'shared') {
             const currentUser =
               durableOAuthFlows && tenantId && userId
-                ? await runInOAuthTenantScope(db, tenantId, () =>
-                    new UsersRepository(db).findById(userId)
+                ? await runWithinOAuthAuthority(assertRequestAuthority, () =>
+                    runInOAuthTenantScope(db, tenantId, () =>
+                      new UsersRepository(db).findById(userId)
+                    )
                   )
                 : params?.user;
             if (!hasMinimumRole(currentUser?.role, ROLES.ADMIN)) {
@@ -3808,15 +3806,21 @@ export async function registerMCPServices(
           }
         }
 
-        let probeResponse = await oauthFetch(effectiveMcpUrl, {
-          method: 'POST',
-          headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-          body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-          signal: AbortSignal.timeout(15_000),
-        });
+        let probeResponse = await oauthFetch(
+          effectiveMcpUrl,
+          {
+            method: 'POST',
+            headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+            signal: AbortSignal.timeout(15_000),
+          },
+          assertRequestAuthority
+        );
 
         if (probeResponse.status !== 401) {
-          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(effectiveMcpUrl);
+          const fallbackProbe = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+            probeMcpAuthViaReadOnlyToolCall(effectiveMcpUrl, assertRequestAuthority)
+          );
           if (fallbackProbe) {
             console.log(
               '[OAuth Start] Handshake-level probe returned no auth requirement; ' +
@@ -3834,13 +3838,17 @@ export async function registerMCPServices(
         }
 
         const wwwAuthenticate = probeResponse.headers.get('www-authenticate') || '';
-        const { resolveMCPOAuthDiscovery } = await import(
-          '@agor/core/tools/mcp/oauth-mcp-transport'
+        const { resolveMCPOAuthDiscovery } = await runWithinOAuthAuthority(
+          assertRequestAuthority,
+          () => import('@agor/core/tools/mcp/oauth-mcp-transport')
         );
-        const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
-          compatibilityMode,
-          allowLocalhostHttp: !postgresOAuthDeployment,
-        });
+        const discovery = await runWithinOAuthAuthority(assertRequestAuthority, () =>
+          resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
+            compatibilityMode,
+            allowLocalhostHttp: !postgresOAuthDeployment,
+            assertCurrent: assertRequestAuthority,
+          })
+        );
         if (!discovery) {
           return {
             success: false,
@@ -3872,6 +3880,7 @@ export async function registerMCPServices(
             socketId,
             compatibilityMode,
             dcrMode,
+            requestAuthority: assertRequestAuthority,
           });
         } catch (err) {
           if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -3884,6 +3893,7 @@ export async function registerMCPServices(
           throw err;
         }
 
+        assertRequestAuthority?.();
         return {
           success: true,
           authorizationUrl: result.authorizationUrl,
@@ -3893,13 +3903,26 @@ export async function registerMCPServices(
             'Browser opened for authentication. After signing in, copy the callback URL and paste it below.',
         };
       } catch (error) {
+        // A live-authority failure must never be normalized into an ordinary
+        // provider diagnostic; callers may otherwise continue an obsolete
+        // flow under the replacement identity on the same socket.
+        assertRequestAuthority?.();
         console.error(
           `[OAuth Start] Failed category=${error instanceof Error ? error.name : 'unknown'}`
         );
         const diagnostic = error instanceof OAuthDCRFailure ? error.diagnostic : undefined;
-        const redirectUri = diagnostic
-          ? await resolveMCPOAuthRedirectUri().catch(() => null)
-          : null;
+        let redirectUri: string | null = null;
+        if (diagnostic) {
+          try {
+            redirectUri = await runWithinOAuthAuthority(
+              assertRequestAuthority,
+              resolveMCPOAuthRedirectUri
+            );
+          } catch {
+            assertRequestAuthority?.();
+          }
+        }
+        assertRequestAuthority?.();
         return {
           success: false,
           error: error instanceof Error ? error.message : String(error),

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
@@ -411,7 +411,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       expect(lockBAcquired).toBe(true);
     });
 
-    it('rolls back token persistence when the one-shot success fence is lost', async () => {
+    it('atomically rolls back the real token repository when pending authority loses its success fence', async () => {
       const bound = await seed('success-fence-rollback');
       const context = flowContext(crypto.randomUUID());
       await authorityA.create({
@@ -456,6 +456,17 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
 
       await expect(
         runWithTenantDatabaseScope(dbA, bound.tenantId, (scoped) =>
+          new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(
+            bound.userId,
+            bound.serverId
+          )
+        )
+      ).resolves.toBeNull();
+      // Read from the second daemon/pool as well: this is the real PostgreSQL
+      // repository + pending-flow authority transaction contract, not the
+      // injected control-flow seam used by register-services SQLite tests.
+      await expect(
+        runWithTenantDatabaseScope(dbB, bound.tenantId, (scoped) =>
           new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(
             bound.userId,
             bound.serverId

--- a/apps/agor-daemon/src/services/mcp-servers.member-policy.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.member-policy.test.ts
@@ -237,6 +237,7 @@ describe('member policy, as it lands in mcp_servers', () => {
  */
 describe('the MCP member policy endpoint, as it is registered', () => {
   const source = readFileSync(join(__dirname, '..', 'register-routes.ts'), 'utf8');
+  const servicesSource = readFileSync(join(__dirname, '..', 'register-services.ts'), 'utf8');
   const registration = source.slice(
     source.indexOf("'/mcp-member-policy'"),
     source.indexOf('MCP marketplace connect')
@@ -256,5 +257,22 @@ describe('the MCP member policy endpoint, as it is registered', () => {
 
   it('answers the caller their own capability, not only the tenant value', () => {
     expect(registration).toContain('can_configure: canConfigureMcpServers(params.user?.role');
+  });
+
+  it('emits an empty tenant-scoped invalidation after a policy write', () => {
+    expect(registration).toContain("path: 'mcp-servers'");
+    expect(registration).toContain('event: MCP_MEMBER_POLICY_CHANGED_EVENT');
+    expect(registration).toContain('data: {}');
+    // Request params carry the trusted tenant context into emitServiceEvent;
+    // without them a post-commit publish could cross or miss tenant channels.
+    expect(registration).toContain('params,');
+  });
+
+  it('registers the invalidation at the mcp-servers transport boundary', () => {
+    const serviceRegistration = servicesSource.slice(
+      servicesSource.indexOf("app.use('/mcp-servers', createMCPServersService(db)"),
+      servicesSource.indexOf('const invalidateOAuthGrantsAfterServerChange')
+    );
+    expect(serviceRegistration).toContain('events: [MCP_MEMBER_POLICY_CHANGED_EVENT]');
   });
 });

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -61,6 +61,10 @@ import {
   joinExecutorTaskChannel,
   leaveAllExecutorTaskChannels,
 } from '../utils/realtime-publish.js';
+import {
+  AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT,
+  installSocketAuthorityId,
+} from '../utils/socket-request-authority.js';
 import type { BuildInfo } from './build-info.js';
 import type { CorsOrigin } from './cors.js';
 
@@ -448,6 +452,13 @@ export function createSocketIOConfig(
     // must never remove another valid operation's membership.
     const terminalJoinQueues = new WeakMap<Socket, Map<string, Promise<void>>>();
 
+    const bindServerSocketAuthority = (socket: FeathersSocket): object => {
+      const connection = socket.feathers ?? {};
+      socket.feathers = connection;
+      installSocketAuthorityId(connection as Record<PropertyKey, unknown>, socket.id);
+      return connection;
+    };
+
     const invalidateTerminalRequestJoin = (socket: FeathersSocket): void => {
       terminalAuthGenerations.set(socket, (terminalAuthGenerations.get(socket) ?? 0) + 1);
       const connection = socket.feathers as TerminalRequestConnection | undefined;
@@ -610,6 +621,7 @@ export function createSocketIOConfig(
     io.use(async (socket, next) => {
       const fs = socket as FeathersSocket;
       try {
+        const connection = bindServerSocketAuthority(fs);
         const authToken =
           typeof socket.handshake.auth?.token === 'string'
             ? socket.handshake.auth.token
@@ -623,9 +635,6 @@ export function createSocketIOConfig(
         if (!token) {
           throw new Error('Authentication required');
         }
-
-        const connection = fs.feathers;
-        if (!connection) throw new Error('Feathers connection is unavailable');
 
         const authentication = app.service('authentication') as unknown as {
           authenticate(
@@ -808,6 +817,7 @@ export function createSocketIOConfig(
     // Configure Socket.io for cursor presence events
     io.on('connection', (socket) => {
       const feathersSocket = socket as FeathersSocket;
+      bindServerSocketAuthority(feathersSocket);
       const authority = getAuthenticatedConnectionAuthority(feathersSocket.feathers);
       if (
         authority &&
@@ -1478,6 +1488,8 @@ export function createSocketIOConfig(
 
       // Track disconnections
       socket.on('disconnect', (reason) => {
+        // Server-internal lifecycle signal for socket-bound one-shot state.
+        app.emit(AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT, socket.id);
         activeConnections--;
         clearAuthorityExpiry(socket);
         invalidateTerminalRequestJoin(socket as FeathersSocket);

--- a/apps/agor-daemon/src/utils/mcp-authority-fetch.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-authority-fetch.test.ts
@@ -1,0 +1,114 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const authorityFetchModule = new URL('./mcp-authority-fetch.ts', import.meta.url).href;
+
+async function runRealSDK(mode: 'current' | 'socket replacement' | 'reservation expiry') {
+  // Plain Node selects the SDK's production JS exports. Vitest's development
+  // conditions select eventsource-parser's published TS source, so the child
+  // process is both more production-realistic and avoids mocking the SDK's
+  // internal initialize -> notifications/initialized sequence.
+  const probe = `
+    import http from 'node:http';
+    import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+    import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+    import { createAuthorityGuardedMCPFetch } from ${JSON.stringify(authorityFetchModule)};
+
+    const mode = process.argv[1];
+    const methods = [];
+    let current = true;
+    const server = http.createServer(async (request, response) => {
+      let body = '';
+      for await (const chunk of request) body += String(chunk);
+      let message = {};
+      try { message = body ? JSON.parse(body) : {}; } catch {}
+      if (message.method) methods.push(message.method);
+
+      if (message.method === 'initialize') {
+        if (mode !== 'current') {
+          // Hold the real SDK's initialize response across authority loss. The
+          // guarded fetch must reject the response before the SDK can dispatch
+          // its initialized notification.
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          current = false;
+        }
+        response.writeHead(200, {
+          'content-type': 'application/json',
+          'mcp-session-id': 'authority-test-session',
+        });
+        response.end(JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: '2025-03-26',
+            capabilities: {},
+            serverInfo: { name: 'authority-test', version: '1.0.0' },
+          },
+        }));
+        return;
+      }
+      if (message.method === 'notifications/initialized') {
+        response.writeHead(202);
+        response.end();
+        return;
+      }
+      response.writeHead(request.method === 'DELETE' ? 200 : 404);
+      response.end();
+    });
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    const url = new URL('http://127.0.0.1:' + address.port + '/mcp');
+    const assertCurrent = () => {
+      if (!current) throw new Error(mode);
+    };
+    const guardedFetch = createAuthorityGuardedMCPFetch(
+      (input, init) => fetch(input, init),
+      assertCurrent,
+    );
+    const transport = new StreamableHTTPClientTransport(url, { fetch: guardedFetch });
+    const client = new Client({ name: 'authority-test-client', version: '1.0.0' });
+    let error;
+    try {
+      await client.connect(transport);
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    } finally {
+      await transport.close().catch(() => undefined);
+      await new Promise((resolve) => server.close(resolve));
+    }
+    console.log(JSON.stringify({ methods, error }));
+  `;
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ['--no-warnings', '--experimental-strip-types', '--input-type=module', '--eval', probe, mode],
+    { cwd: process.cwd(), encoding: 'utf8', timeout: 10_000 }
+  );
+  return JSON.parse(stdout.trim().split('\n').at(-1) ?? '{}') as {
+    methods: string[];
+    error?: string;
+  };
+}
+
+describe('authority-guarded MCP SDK fetch', () => {
+  it('allows the real SDK initialize and initialized-notification sequence while current', async () => {
+    const result = await runRealSDK('current');
+
+    expect(result.error).toBeUndefined();
+    expect(result.methods.slice(0, 2)).toEqual(['initialize', 'notifications/initialized']);
+  });
+
+  it.each(['socket replacement', 'reservation expiry'] as const)(
+    'blocks the real SDK initialized notification after %s during initialize',
+    async (transition) => {
+      const result = await runRealSDK(transition);
+
+      expect(result.error).toContain(transition);
+      expect(result.methods).toEqual(['initialize']);
+    }
+  );
+});

--- a/apps/agor-daemon/src/utils/mcp-authority-fetch.ts
+++ b/apps/agor-daemon/src/utils/mcp-authority-fetch.ts
@@ -1,0 +1,49 @@
+/**
+ * Fetch adapter for the MCP SDK's multi-request Streamable HTTP handshake.
+ *
+ * `Client.connect()` is not one network operation: the SDK can POST
+ * `initialize`, then POST `notifications/initialized`, and later issue more
+ * requests before the aggregate promise resolves. Guard each dispatch rather
+ * than trusting a wrapper around `connect()`.
+ */
+
+export type AuthorityAwareFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+  assertCurrent?: () => void
+) => Promise<Response>;
+
+export function createAuthorityGuardedMCPFetch(
+  outboundFetch: AuthorityAwareFetch,
+  assertCurrent?: () => void
+): typeof fetch {
+  let sessionId: string | undefined;
+
+  return async (input, init) => {
+    assertCurrent?.();
+
+    let effectiveInit = init;
+    if (sessionId) {
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined)
+      );
+      if (!headers.has('mcp-session-id')) headers.set('mcp-session-id', sessionId);
+      effectiveInit = { ...init, headers };
+    }
+
+    try {
+      // `outboundFetch` threads the same assertion into redirect handling, so
+      // every physical hop is fenced as well as every SDK-level request.
+      const response = await outboundFetch(input, effectiveInit, assertCurrent);
+      assertCurrent?.();
+      const responseSessionId = response.headers.get('mcp-session-id');
+      if (responseSessionId) sessionId = responseSessionId;
+      return response;
+    } catch (error) {
+      // Authority loss wins over a simultaneous transport error. Callers must
+      // not interpret identity replacement as a retryable MCP failure.
+      assertCurrent?.();
+      throw error;
+    }
+  };
+}

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -237,6 +237,9 @@ export { canConfigureMCPServers as canConfigureMcpServers } from '@agor/core/mcp
  * - `oauth-status`, `oauth-attempt-status` — reads of the caller's own state.
  */
 export const MCP_CAPABILITY_ISSUING_SERVICE_PATHS = [
+  // Reserves the one-shot socket/caller binding required before a blocking
+  // flow may create provider/DCR side effects.
+  'mcp-servers/oauth-browser-reservations',
   // Mints an authorization URL and a pending flow against a saved server.
   'mcp-servers/oauth-start',
   // Exchanges the authorization code and persists the resulting token.

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
@@ -32,6 +32,12 @@ describe('realtimePublishPolicyFor', () => {
     expect(realtimePublishPolicyFor('/kb/documents')?.audience).toBe('knowledge');
   });
 
+  it('declares the service read-role floors for privileged realtime rows', () => {
+    expect(realtimePublishPolicyFor('users')?.minimumRole).toBe('member');
+    expect(realtimePublishPolicyFor('board-objects')?.minimumRole).toBe('member');
+    expect(realtimePublishPolicyFor('boards')?.minimumRole).toBeUndefined();
+  });
+
   it('treats an explicit none declaration as not allowed', () => {
     expect(realtimePublishPolicyFor('mcp-catalog/connect')?.audience).toBe('none');
     expect(isRealtimePublishAllowed('mcp-catalog/connect')).toBe(false);

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -251,6 +251,10 @@ export const REALTIME_PUBLISH_POLICY = {
   },
   'codex-auth/logout': { audience: 'none', why: 'Credential control plane.' },
   'mcp-servers/oauth-start': { audience: 'none', why: 'OAuth control plane.' },
+  'mcp-servers/oauth-browser-reservations': {
+    audience: 'none',
+    why: 'Returns a caller/socket-bound one-shot browser capability.',
+  },
   'mcp-servers/oauth-callback': {
     audience: 'none',
     why: 'OAuth redirect handler (Express middleware, listed defensively).',

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -160,7 +160,7 @@ export const REALTIME_PUBLISH_POLICY = {
   },
   'mcp-servers': {
     audience: 'tenant',
-    why: 'useAgorData tracks server rows. Secrets are stripped from context.dispatch unconditionally by redactMCPServerSecretFields — the audience is tenant-wide, so the payload must never carry credentials.',
+    why: 'useAgorData tracks server rows, and useMcpMemberPolicy refetches its caller-specific capability on the empty member-policy invalidation. Secrets are stripped from context.dispatch unconditionally by redactMCPServerSecretFields — the audience is tenant-wide, so row payloads must never carry credentials.',
   },
   'gateway-channels': {
     audience: 'tenant',

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -1,3 +1,5 @@
+import type { UserRole } from '@agor/core/types';
+
 /**
  * The allowlist that decides which services may fan out over the socket at all.
  *
@@ -64,6 +66,15 @@ export type RealtimePublishAudience =
 
 export type RealtimePublishPolicy = {
   audience: RealtimePublishAudience;
+  /**
+   * Minimum authenticated browser role admitted to this event stream.
+   *
+   * This mirrors the service read floor at the publication boundary. Omitting
+   * a listener in the official UI is not authorization: an adversarial client
+   * can subscribe to any Feathers service event. Service-account connections
+   * remain admitted independently for internal runtime plumbing.
+   */
+  minimumRole?: UserRole;
   /**
    * Why this audience. For a fan-out audience, name the consumer that breaks
    * without it; for `'none'`, say what makes silence correct. Reviewers read
@@ -132,6 +143,7 @@ export const REALTIME_PUBLISH_POLICY = {
   // ---------------------------------------------------------------------------
   'board-objects': {
     audience: 'board-resource',
+    minimumRole: 'member',
     why: 'useAgorData and BoardBranchList track card/zone placement live.',
   },
   'board-comments': {
@@ -156,6 +168,7 @@ export const REALTIME_PUBLISH_POLICY = {
   repos: { audience: 'tenant', why: 'useAgorData and App.tsx track repo rows and clone progress.' },
   users: {
     audience: 'tenant',
+    minimumRole: 'member',
     why: 'useAgorData keeps the user directory current for attribution. rowToUser computes agentic_tools_public_values PER REQUESTER (decrypted plaintext, owner only), so redactUserOwnerOnlyFieldsForBroadcast strips it from context.dispatch — the audience is tenant-wide, so the payload must carry nothing the row owner alone may see.',
   },
   'mcp-servers': {

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -417,6 +417,51 @@ describe('HA Feathers publication relay', () => {
     expect(app.emit).not.toHaveBeenCalled();
   });
 
+  it('re-applies service role floors on the receiving replica', async () => {
+    const viewer = { user: user('viewer', ROLES.VIEWER) };
+    const member = { user: user('member', ROLES.MEMBER) };
+    const admin = { user: user('admin', ROLES.ADMIN) };
+    let remoteHandler: ((envelope: any) => Promise<void> | void) | undefined;
+    const relay = {
+      relay: vi.fn(),
+      setRelayHandler: vi.fn((handler) => {
+        remoteHandler = handler;
+      }),
+    };
+    const app = makeApp(
+      [viewer, member, admin],
+      {},
+      { 'tenant:tenant-a': [viewer, member, admin] }
+    );
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      branchRepository: {} as never,
+      sessionsRepository: {} as never,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'unused' as never,
+        auth_claim: 'tenant_id',
+      },
+      realtimeRelay: relay,
+    });
+
+    await remoteHandler?.({
+      version: REALTIME_RELAY_VERSION,
+      tenantId: 'tenant-a',
+      path: 'users',
+      event: 'patched',
+      method: 'patch',
+      id: 'changed-user',
+      data: { user_id: 'changed-user', role: ROLES.MEMBER },
+    });
+
+    expect(app.emit).toHaveBeenCalledOnce();
+    const channel = app.emit.mock.calls[0]?.[2] as FakeChannel;
+    expect(channel.connections).toEqual([member, admin]);
+    expect(channel.connections).not.toContain(viewer);
+  });
+
   it('relays a branch tombstone snapshot and re-applies tenant/RBAC containment on the receiving replica', async () => {
     const allowed = { user: user('allowed') };
     const denied = { user: user('denied') };
@@ -2708,6 +2753,48 @@ describe('configureRealtimePublish default-deny allowlist', () => {
       );
 
       expect(delivered(result)).toEqual([service]);
+    });
+
+    it('enforces the users read-role floor against adversarial viewer listeners', async () => {
+      const viewer = { user: user('viewer', ROLES.VIEWER) };
+      const member = { user: user('member', ROLES.MEMBER) };
+      const admin = { user: user('admin', ROLES.ADMIN) };
+      const service = { user: { _isServiceAccount: true, role: 'service' } };
+      const app = allowlistApp([viewer, member, admin, service]);
+      configureRealtimePublish({
+        app,
+        branchRbacEnabled: false,
+        ...repos({ branch: branch('b1'), permissions: {} }),
+      });
+
+      const result = await app.runPublish(
+        { user_id: 'changed-user', role: ROLES.ADMIN },
+        { path: 'users', method: 'patch', event: 'patched', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([member, admin, service]);
+      expect(delivered(result)).not.toContain(viewer);
+    });
+
+    it('enforces the board-object read-role floor after branch visibility admits a viewer', async () => {
+      const viewer = { user: user('viewer', ROLES.VIEWER) };
+      const member = { user: user('member', ROLES.MEMBER) };
+      const admin = { user: user('admin', ROLES.ADMIN) };
+      const service = { user: { _isServiceAccount: true, role: 'service' } };
+      const app = allowlistApp([viewer, member, admin, service]);
+      const allowed = repos({
+        branch: branch('b1', 'view'),
+        permissions: { viewer: 'view', member: 'view', admin: 'view' },
+      });
+      configureRealtimePublish({ app, branchRbacEnabled: true, ...allowed });
+
+      const result = await app.runPublish(
+        { board_object_id: 'o1', branch_id: 'b1' },
+        { path: 'board-objects', method: 'patch', event: 'patched', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([member, admin, service]);
+      expect(delivered(result)).not.toContain(viewer);
     });
 
     it.each([

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -265,6 +265,26 @@ function audienceFor(path: string | null | undefined): RealtimePublishAudience |
   return realtimePublishPolicyFor(path)?.audience;
 }
 
+/**
+ * Apply a service's read-role floor to realtime delivery.
+ *
+ * Channel membership proves authentication/tenant admission, not permission
+ * to read every service in that channel. Keeping this in the global publisher
+ * makes local and Redis-relayed events obey the same floor and prevents a raw
+ * Feathers listener from bypassing the service hook.
+ */
+function applyRealtimeRoleFloor(
+  channel: PublishChannel,
+  path: string | null | undefined
+): PublishChannel {
+  const minimumRole = realtimePublishPolicyFor(path)?.minimumRole;
+  if (!minimumRole) return channel;
+  return channel.filter((connection: unknown) => {
+    if (isServiceConnection(connection)) return true;
+    return hasMinimumRole(userFromConnection(connection)?.role, minimumRole);
+  });
+}
+
 // Authentication and credential control-plane results must never enter shared
 // Redis, even if a future service accidentally enables publication for them.
 export const REDIS_FEATHERS_DENIED_PATHS = new Set([
@@ -933,6 +953,12 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
         throw error;
       }
     }
+
+    // Authentication/tenant channels are deliberately broad. Narrow them to
+    // the declared service read floor before ANY audience resolution so the
+    // global, branch, knowledge, streaming, and Redis-relay paths cannot
+    // accidentally widen the result again.
+    tenantScoped = applyRealtimeRoleFloor(tenantScoped, context.path);
 
     const isExecutorControlEvent =
       (context.path === 'tasks' && context.event === 'termination_requested') ||

--- a/apps/agor-daemon/src/utils/socket-request-authority.ts
+++ b/apps/agor-daemon/src/utils/socket-request-authority.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-owned identity attached to the Feathers connection object for one
+ * live Socket.IO transport.
+ *
+ * Socket.IO's `socket.id` is not copied onto `params.connection`: Feathers
+ * intentionally exposes `socket.feathers` there. This non-enumerable,
+ * immutable property is the bridge between those two server-owned objects.
+ * It is never read from request data, query parameters, headers, or the
+ * handshake auth payload.
+ */
+export const AGOR_SOCKET_AUTHORITY_ID_PROPERTY = '__agor_socket_authority_id__' as const;
+/** Daemon-internal lifecycle signal; never transported to Socket.IO clients. */
+export const AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT =
+  'agor:socket-authority-disconnected' as const;
+
+type SocketAuthorityConnection = Record<PropertyKey, unknown>;
+
+export function installSocketAuthorityId(
+  connection: SocketAuthorityConnection,
+  socketId: string
+): void {
+  if (!socketId) throw new Error('Cannot bind an empty Socket.IO authority identifier');
+  const existing = Object.getOwnPropertyDescriptor(connection, AGOR_SOCKET_AUTHORITY_ID_PROPERTY);
+  if (existing) {
+    if (
+      existing.value !== socketId ||
+      existing.enumerable ||
+      existing.configurable ||
+      existing.writable
+    ) {
+      throw new Error('Socket.IO authority identifier was replaced or weakened');
+    }
+    return;
+  }
+  Object.defineProperty(connection, AGOR_SOCKET_AUTHORITY_ID_PROPERTY, {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: socketId,
+  });
+}
+
+export function readSocketAuthorityId(connection: unknown): string | undefined {
+  if (!connection || typeof connection !== 'object') return undefined;
+  const descriptor = Object.getOwnPropertyDescriptor(connection, AGOR_SOCKET_AUTHORITY_ID_PROPERTY);
+  if (
+    !descriptor ||
+    descriptor.enumerable ||
+    descriptor.configurable ||
+    descriptor.writable ||
+    typeof descriptor.value !== 'string' ||
+    !descriptor.value
+  ) {
+    return undefined;
+  }
+  return descriptor.value;
+}

--- a/apps/agor-ui/src/App.forced-password.integration.test.tsx
+++ b/apps/agor-ui/src/App.forced-password.integration.test.tsx
@@ -44,11 +44,19 @@ function authUser(id: string, mustChangePassword: boolean): User {
  * reauthentication unmounts the modal that initiated it. The durable ticket is
  * App-owned and therefore outlives that loading-gate unmount.
  */
-function ForcedPasswordAppComposition({ client }: { client: AgorClient }) {
+function ForcedPasswordAppComposition({
+  client,
+  authGeneration = 4,
+  onCompleted,
+}: {
+  client: AgorClient;
+  authGeneration?: number;
+  onCompleted?: (signedIn: boolean) => void;
+}) {
   const auth = useAuth();
   const appGuard = useAuthorityOperationGuard(
     auth.user?.user_id && auth.user.role && auth.authenticated
-      ? [auth.user.user_id, auth.user.role, client, 4]
+      ? [auth.user.user_id, auth.user.role, client, authGeneration]
       : null
   );
 
@@ -59,6 +67,7 @@ function ForcedPasswordAppComposition({ client }: { client: AgorClient }) {
     captureAuthorityCycle: auth.captureAuthorityCycle,
     reauthenticate: auth.loginForAuthorityCycle,
     logout: auth.logoutForAuthorityCycle,
+    onCompleted,
   });
 
   // This is the real App ordering: loading wins and unmounts the modal.
@@ -71,7 +80,7 @@ function ForcedPasswordAppComposition({ client }: { client: AgorClient }) {
       value={{
         connected: true,
         connecting: false,
-        authGeneration: 4,
+        authGeneration,
         outOfSync: false,
         capturedSha: null,
         currentSha: null,
@@ -133,7 +142,8 @@ describe('App forced-password authority composition', () => {
       user: User;
     }>();
     authenticate.mockImplementationOnce(() => login.promise);
-    render(<ForcedPasswordAppComposition client={client} />);
+    const onCompleted = vi.fn();
+    render(<ForcedPasswordAppComposition client={client} onCompleted={onCompleted} />);
 
     await submitPassword();
     expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
@@ -148,12 +158,15 @@ describe('App forced-password authority composition', () => {
     expect(await screen.findByText('Ready: admin-a')).toBeInTheDocument();
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-new-access');
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-a-new-refresh');
+    expect(onCompleted).toHaveBeenCalledOnce();
+    expect(onCompleted).toHaveBeenCalledWith(true);
   });
 
   it('clears loading and logs out stale credentials after relogin failure', async () => {
     const login = deferred<never>();
     authenticate.mockImplementationOnce(() => login.promise);
-    render(<ForcedPasswordAppComposition client={client} />);
+    const onCompleted = vi.fn();
+    render(<ForcedPasswordAppComposition client={client} onCompleted={onCompleted} />);
 
     await submitPassword();
     expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
@@ -162,6 +175,8 @@ describe('App forced-password authority composition', () => {
     expect(await screen.findByText('Signed out')).toBeInTheDocument();
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBeNull();
+    expect(onCompleted).toHaveBeenCalledOnce();
+    expect(onCompleted).toHaveBeenCalledWith(false);
   });
 
   it('cannot install or log out A after an in-place replacement by admin B', async () => {
@@ -171,7 +186,8 @@ describe('App forced-password authority composition', () => {
       user: User;
     }>();
     authenticate.mockImplementationOnce(() => login.promise);
-    render(<ForcedPasswordAppComposition client={client} />);
+    const onCompleted = vi.fn();
+    render(<ForcedPasswordAppComposition client={client} onCompleted={onCompleted} />);
 
     await submitPassword();
     expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
@@ -201,5 +217,42 @@ describe('App forced-password authority composition', () => {
     expect(screen.getByText('Ready: admin-b')).toBeInTheDocument();
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-b-access');
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-b-refresh');
+    expect(onCompleted).not.toHaveBeenCalled();
+  });
+
+  it('releases global loading on same-user generation cancellation before held REST auth settles', async () => {
+    const login = deferred<{
+      accessToken: string;
+      refreshToken: string;
+      user: User;
+    }>();
+    authenticate.mockImplementationOnce(() => login.promise);
+    const onCompleted = vi.fn();
+    const rendered = render(
+      <ForcedPasswordAppComposition client={client} authGeneration={4} onCompleted={onCompleted} />
+    );
+
+    await submitPassword();
+    expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
+
+    rendered.rerender(
+      <ForcedPasswordAppComposition client={client} authGeneration={5} onCompleted={onCompleted} />
+    );
+
+    // Cancellation, not the held REST response, must release the App loading
+    // gate. The same caller's required-password modal becomes usable again.
+    expect(await screen.findByRole('button', { name: 'Change Password' })).toBeInTheDocument();
+    expect(screen.queryByText('Authenticating…')).not.toBeInTheDocument();
+
+    login.resolve({
+      accessToken: 'obsolete-admin-a-access',
+      refreshToken: 'obsolete-admin-a-refresh',
+      user: authUser('admin-a', false),
+    });
+    await act(() => login.promise);
+
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-old-access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-a-old-refresh');
+    expect(onCompleted).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/App.forced-password.integration.test.tsx
+++ b/apps/agor-ui/src/App.forced-password.integration.test.tsx
@@ -1,0 +1,205 @@
+import type { AgorClient, User } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForcePasswordChangeModal } from './components/ForcePasswordChangeModal';
+import { ConnectionProvider } from './contexts/ConnectionContext';
+import { useAuth } from './hooks/useAuth';
+import { useAuthorityOperationGuard } from './hooks/useAuthorityOperationGuard';
+import { useForcedPasswordChangeHandler } from './hooks/useForcedPasswordChangeHandler';
+import { TOKENS_REFRESHED_EVENT } from './utils/singleFlightRefresh';
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from './utils/tokenRefresh';
+
+const authenticate = vi.fn();
+
+vi.mock('@agor-live/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor-live/client')>();
+  return {
+    ...actual,
+    createRestClient: vi.fn(async () => ({ authenticate })),
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function authUser(id: string, mustChangePassword: boolean): User {
+  return {
+    user_id: id,
+    email: `${id}@example.test`,
+    role: 'admin',
+    must_change_password: mustChangePassword,
+  } as User;
+}
+
+/**
+ * Exercises the production composition that caused the regression: useAuth's
+ * global loading state is checked before the forced-password modal, so local
+ * reauthentication unmounts the modal that initiated it. The durable ticket is
+ * App-owned and therefore outlives that loading-gate unmount.
+ */
+function ForcedPasswordAppComposition({ client }: { client: AgorClient }) {
+  const auth = useAuth();
+  const appGuard = useAuthorityOperationGuard(
+    auth.user?.user_id && auth.user.role && auth.authenticated
+      ? [auth.user.user_id, auth.user.role, client, 4]
+      : null
+  );
+
+  const changePassword = useForcedPasswordChangeHandler({
+    client,
+    user: auth.user,
+    appAuthorityGuard: appGuard,
+    captureAuthorityCycle: auth.captureAuthorityCycle,
+    reauthenticate: auth.loginForAuthorityCycle,
+    logout: auth.logoutForAuthorityCycle,
+  });
+
+  // This is the real App ordering: loading wins and unmounts the modal.
+  if (auth.loading) return <div>Authenticating…</div>;
+  if (!auth.authenticated || !auth.user) return <div>Signed out</div>;
+  if (!auth.user.must_change_password) return <div>Ready: {auth.user.user_id}</div>;
+
+  return (
+    <ConnectionProvider
+      value={{
+        connected: true,
+        connecting: false,
+        authGeneration: 4,
+        outOfSync: false,
+        capturedSha: null,
+        currentSha: null,
+      }}
+    >
+      <ForcePasswordChangeModal
+        open
+        user={auth.user}
+        onChangePassword={changePassword}
+        onLogout={auth.logout}
+      />
+    </ConnectionProvider>
+  );
+}
+
+describe('App forced-password authority composition', () => {
+  const patch = vi.fn();
+  const client = {
+    service: vi.fn((path: string) => {
+      if (path !== 'users') throw new Error(path);
+      return { patch };
+    }),
+  } as unknown as AgorClient;
+
+  beforeEach(() => {
+    localStorage.clear();
+    authenticate.mockReset();
+    patch.mockReset().mockResolvedValue({});
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-a-old-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-a-old-refresh');
+    authenticate.mockResolvedValueOnce({
+      accessToken: 'admin-a-old-access',
+      user: authUser('admin-a', true),
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  async function submitPassword() {
+    await screen.findByRole('button', { name: 'Change Password' });
+    fireEvent.change(screen.getByLabelText('New Password'), {
+      target: { value: 'new-password-1234' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'new-password-1234' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Change Password' }));
+    await waitFor(() => expect(patch).toHaveBeenCalledOnce());
+  }
+
+  it('installs successful credentials after the loading gate unmounts the modal', async () => {
+    const login = deferred<{
+      accessToken: string;
+      refreshToken: string;
+      user: User;
+    }>();
+    authenticate.mockImplementationOnce(() => login.promise);
+    render(<ForcedPasswordAppComposition client={client} />);
+
+    await submitPassword();
+    expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
+    expect(screen.queryByLabelText('New Password')).not.toBeInTheDocument();
+
+    login.resolve({
+      accessToken: 'admin-a-new-access',
+      refreshToken: 'admin-a-new-refresh',
+      user: authUser('admin-a', false),
+    });
+
+    expect(await screen.findByText('Ready: admin-a')).toBeInTheDocument();
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-new-access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-a-new-refresh');
+  });
+
+  it('clears loading and logs out stale credentials after relogin failure', async () => {
+    const login = deferred<never>();
+    authenticate.mockImplementationOnce(() => login.promise);
+    render(<ForcedPasswordAppComposition client={client} />);
+
+    await submitPassword();
+    expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
+    login.reject(new Error('new credentials rejected'));
+
+    expect(await screen.findByText('Signed out')).toBeInTheDocument();
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBeNull();
+  });
+
+  it('cannot install or log out A after an in-place replacement by admin B', async () => {
+    const login = deferred<{
+      accessToken: string;
+      refreshToken: string;
+      user: User;
+    }>();
+    authenticate.mockImplementationOnce(() => login.promise);
+    render(<ForcedPasswordAppComposition client={client} />);
+
+    await submitPassword();
+    expect(await screen.findByText('Authenticating…')).toBeInTheDocument();
+
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-b-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-b-refresh');
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TOKENS_REFRESHED_EVENT, {
+          detail: {
+            accessToken: 'admin-b-access',
+            refreshToken: 'admin-b-refresh',
+            user: authUser('admin-b', false),
+          },
+        })
+      );
+    });
+    expect(await screen.findByText('Ready: admin-b')).toBeInTheDocument();
+
+    login.resolve({
+      accessToken: 'stale-admin-a-access',
+      refreshToken: 'stale-admin-a-refresh',
+      user: authUser('admin-a', false),
+    });
+    await act(() => login.promise);
+
+    expect(screen.getByText('Ready: admin-b')).toBeInTheDocument();
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-b-access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-b-refresh');
+  });
+});

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1395,6 +1395,7 @@ function AppContent() {
     options: { silent?: boolean; shouldApply?: () => boolean } = {}
   ) => {
     if (!client || (options.shouldApply && !options.shouldApply())) return;
+    const authorityOperation = appAuthorityGuard.begin();
     try {
       const newPassword =
         typeof updates.password === 'string' && updates.password.length > 0
@@ -1403,15 +1404,20 @@ function AppContent() {
       const changesCurrentPassword = userId === currentUser?.user_id && !!newPassword;
       let signedIn = true;
       if (changesCurrentPassword && currentUser && newPassword) {
-        signedIn = await completeLocalPasswordChange({
+        const authorityCycle = captureAuthorityCycle(authorityOperation);
+        if (!authorityCycle) return;
+        const completion = await completeLocalPasswordChange({
           client,
           userId,
           emailAfterChange: updates.email ?? currentUser.email,
           newPassword,
           updates: updates as UpdateUserInput & { password: string },
-          login,
-          logout,
+          authorityCycle,
+          reauthenticate: loginForAuthorityCycle,
+          logout: logoutForAuthorityCycle,
         });
+        if (!completion) return;
+        signedIn = completion.status === 'signed-in' && completion.authority.isCurrent();
       } else {
         // Cast UpdateUserInput to Partial<User> - backend handles encryption/conversion
         await client.service('users').patch(userId, updates as Partial<User>);
@@ -1449,7 +1455,6 @@ function AppContent() {
       isAuthenticationOwnerCurrent(operationUserId, operationAuthenticationGeneration) &&
       (childShouldApply ? childShouldApply() : true);
     if (!shouldApply()) return;
-
 
     const preferences = { ...(currentUser.preferences ?? {}) } as NonNullable<User['preferences']>;
     delete preferences.onboarding;
@@ -2193,7 +2198,7 @@ function AppContent() {
           onDeleteBoard={handleDeleteBoard}
           onArchiveBoard={handleArchiveBoard}
           onUnarchiveBoard={handleUnarchiveBoard}
-          onCreateRepo={handleCreateRepo}
+          onCreateRepo={(data, shouldApply) => handleCreateRepo(data, { shouldApply })}
           onCreateLocalRepo={handleCreateLocalRepo}
           onUpdateRepo={handleUpdateRepo}
           onDeleteRepo={handleDeleteRepo}
@@ -2204,7 +2209,9 @@ function AppContent() {
           onStartEnvironment={handleStartEnvironment}
           onStopEnvironment={handleStopEnvironment}
           onCreateUser={handleCreateUser}
-          onUpdateUser={handleUpdateUser}
+          onUpdateUser={(userId, updates, shouldApply) =>
+            handleUpdateUser(userId, updates, { shouldApply })
+          }
           onDeleteUser={handleDeleteUser}
           onCreateMCPServer={handleCreateMCPServer}
           onDeleteMCPServer={handleDeleteMCPServer}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -2172,8 +2172,8 @@ function AppContent() {
           ))}
 
           {/* MCP marketplace: browse the catalog and connect a server. Its own
-                surface because it reads the global catalog table, not the
-                tenant's board/session store. */}
+                surface because it reads the checked-in curated catalog, not
+                the tenant's board/session store. */}
           {MARKETPLACE_ROUTE_PATHS.map((path) => (
             <Route key={path} path={path} element={marketplacePageElement} />
           ))}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -68,6 +68,7 @@ import {
   useServerVersion,
   useSessionActions,
 } from './hooks';
+import { useAuthorityOperationGuard } from './hooks/useAuthorityOperationGuard';
 import { useEnsureFrameworkRepo } from './hooks/useEnsureFrameworkRepo';
 import { findFrameworkRepo } from './hooks/useFrameworkRepo';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
@@ -385,8 +386,10 @@ function AppContent() {
     isAuthenticationGenerationCurrent,
     isAuthenticationOwnerCurrent,
     login,
+    loginForAuthorityCycle,
     logout,
-    reAuthenticate,
+    logoutForAuthorityCycle,
+    refreshCurrentUserForAuthorityCycle,
   } = useAuth();
 
   // Call ALL hooks unconditionally BEFORE any conditional returns.
@@ -404,6 +407,11 @@ function AppContent() {
     accessToken: authenticated ? accessToken : null,
     authorityGeneration: authenticationGeneration,
   });
+  const appAuthorityGuard = useAuthorityOperationGuard(
+    user?.user_id && user.role && client && connected && !connecting
+      ? [user.user_id, user.role, client, authGeneration]
+      : null
+  );
   const pendingEnvironmentToastsRef = useRef<Map<string, PendingEnvironmentToast>>(new Map());
 
   useEffect(() => {
@@ -662,6 +670,7 @@ function AppContent() {
   // that could race the hook's one-shot clone effect.
   const handleCreateRepo = useCallback(
     async (data: CreateRepoRequest, options: CreateRepoOptions = {}) => {
+      if (options.shouldApply && !options.shouldApply()) return;
       if (!client) {
         showError('Not connected to daemon — cannot clone repository');
         return;
@@ -689,6 +698,11 @@ function AppContent() {
       };
       const handleCreated = (repo: Repo) => {
         if (settled || repo.slug !== data.slug) return;
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
         // Skip the `'cloning'` placeholder — `handlePatched` will declare the
         // outcome once the executor finishes. `undefined` covers legacy rows
         // and any direct executor-path that bypasses the placeholder.
@@ -699,6 +713,11 @@ function AppContent() {
       };
       const handlePatched = (repo: Repo) => {
         if (settled || repo.slug !== data.slug) return;
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
         if (repo.clone_status === 'ready') {
           settled = true;
           if (!options.silent) showSuccess(`Cloned ${data.slug}`, { key: toastKey });
@@ -725,6 +744,11 @@ function AppContent() {
         clone_error?: Repo['clone_error'];
       }) => {
         if (settled) return;
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
         if (payload.slug !== data.slug && payload.url !== data.url) return;
         settled = true;
         const hint = cloneErrorHint(payload.clone_error);
@@ -738,6 +762,11 @@ function AppContent() {
       };
       const timeoutHandle = setTimeout(() => {
         if (settled) return;
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
         settled = true;
         if (!options.silent || options.showErrors) {
           showError(`Clone of ${data.slug} timed out after 2 minutes. Check daemon logs.`, {
@@ -757,6 +786,11 @@ function AppContent() {
           slug: data.slug,
           default_branch: data.default_branch,
         });
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
 
         // Daemon short-circuits with `status: 'exists'` when a repo with this
         // slug is already registered — no `repos.created` event will fire, so
@@ -770,6 +804,11 @@ function AppContent() {
         }
         return result;
       } catch (error) {
+        if (options.shouldApply && !options.shouldApply()) {
+          settled = true;
+          cleanup();
+          return;
+        }
         if (!settled) {
           settled = true;
           if (!options.silent || options.showErrors) {
@@ -1323,12 +1362,14 @@ function AppContent() {
   };
 
   // Handle create user
-  const handleCreateUser = async (data: CreateUserInput) => {
-    if (!client) return;
+  const handleCreateUser = async (data: CreateUserInput, shouldApply?: () => boolean) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('users').create(data);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('User created successfully!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(`Failed to create user: ${error instanceof Error ? error.message : String(error)}`);
       throw error;
     }
@@ -1337,9 +1378,9 @@ function AppContent() {
   const handleUpdateUser = async (
     userId: string,
     updates: UpdateUserInput,
-    options: { silent?: boolean } = {}
+    options: { silent?: boolean; shouldApply?: () => boolean } = {}
   ) => {
-    if (!client) return;
+    if (!client || (options.shouldApply && !options.shouldApply())) return;
     try {
       const newPassword =
         typeof updates.password === 'string' && updates.password.length > 0
@@ -1360,7 +1401,9 @@ function AppContent() {
       } else {
         // Cast UpdateUserInput to Partial<User> - backend handles encryption/conversion
         await client.service('users').patch(userId, updates as Partial<User>);
+        if (options.shouldApply && !options.shouldApply()) return;
       }
+
       if (updates.agentic_tools || updates.env_vars) {
         setCredentialVersion((v) => v + 1);
       }
@@ -1372,6 +1415,7 @@ function AppContent() {
         );
       }
     } catch (error) {
+      if (options.shouldApply && !options.shouldApply()) return;
       if (!options.silent) {
         showError(
           `Failed to update user: ${error instanceof Error ? error.message : String(error)}`
@@ -1381,55 +1425,79 @@ function AppContent() {
     }
   };
 
-  const handleRestartOnboarding = async () => {
+  const handleRestartOnboarding = async (childShouldApply?: () => boolean) => {
+    const operation = appAuthorityGuard.begin();
     if (!currentUser || !canRunOnboarding) return;
     const operationUserId = currentUser.user_id;
     const operationAuthenticationGeneration = authenticationGeneration;
+    const shouldApply = () =>
+      operation.isCurrent() &&
+      isAuthenticationOwnerCurrent(operationUserId, operationAuthenticationGeneration) &&
+      (childShouldApply ? childShouldApply() : true);
+    if (!shouldApply()) return;
+
 
     const preferences = { ...(currentUser.preferences ?? {}) } as NonNullable<User['preferences']>;
     delete preferences.onboarding;
 
     try {
-      await handleUpdateUser(currentUser.user_id, { preferences }, { silent: true });
+      await handleUpdateUser(
+        currentUser.user_id,
+        { preferences },
+        {
+          silent: true,
+          shouldApply,
+        }
+      );
     } catch (error) {
+      if (!shouldApply()) return;
       showError(
         `Failed to restart onboarding: ${error instanceof Error ? error.message : String(error)}`
       );
       return;
     }
 
-    if (!isAuthenticationOwnerCurrent(operationUserId, operationAuthenticationGeneration)) {
-      return;
-    }
+    if (!shouldApply()) return;
 
     setOpenUserSettings(false);
     activateOnboardingWizard(operationUserId, operationAuthenticationGeneration, true);
   };
 
   // Handle delete user
-  const handleDeleteUser = async (userId: string) => {
-    if (!client) return;
+  const handleDeleteUser = async (userId: string, shouldApply?: () => boolean) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('users').remove(userId);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('User deleted successfully!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(`Failed to delete user: ${error instanceof Error ? error.message : String(error)}`);
     }
   };
 
   // Handle forced password change (from ForcePasswordChangeModal)
-  const handleForcePasswordChange = async (userId: string, newPassword: string) => {
+  const handleForcePasswordChange = async (
+    userId: string,
+    newPassword: string,
+    shouldApply: () => boolean,
+    isSameIdentity: () => boolean
+  ) => {
     if (!client) throw new Error('Not connected');
     if (!currentUser?.email) throw new Error('Current user is unavailable');
+    if (currentUser.user_id !== userId || !shouldApply()) return;
 
     const signedIn = await completeForcedPasswordChange({
       client,
       userId,
       email: currentUser.email,
       newPassword,
-      login,
-      logout,
+      shouldApply,
+      reauthenticate: loginForAuthorityCycle,
+      logout: logoutForAuthorityCycle,
     });
+
+    if (signedIn === null || !isSameIdentity()) return;
 
     showSuccess(
       signedIn
@@ -1482,7 +1550,11 @@ function AppContent() {
     }
   };
 
-  const handleCreateLocalRepo = async (data: CreateLocalRepoRequest) => {
+  const handleCreateLocalRepo = async (
+    data: CreateLocalRepoRequest,
+    shouldApply?: () => boolean
+  ) => {
+    if (shouldApply && !shouldApply()) return;
     if (!client) {
       showError('Not connected to daemon — cannot add local repository');
       return;
@@ -1495,8 +1567,11 @@ function AppContent() {
         slug: data.slug,
       });
 
+      if (shouldApply && !shouldApply()) return;
+
       showSuccess('Local repository added successfully!', { key: 'add-local-repo' });
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to add local repository: ${error instanceof Error ? error.message : String(error)}`,
         { key: 'add-local-repo' }
@@ -1505,30 +1580,42 @@ function AppContent() {
     }
   };
 
-  const handleUpdateRepo = async (repoId: string, updates: Partial<Repo>) => {
-    if (!client) return;
+  const handleUpdateRepo = async (
+    repoId: string,
+    updates: Partial<Repo>,
+    shouldApply?: () => boolean
+  ) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('repos').patch(repoId, updates);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('Repository updated successfully!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to update repository: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   };
 
-  const handleDeleteRepo = async (repoId: string, cleanup: boolean) => {
-    if (!client) return;
+  const handleDeleteRepo = async (
+    repoId: string,
+    cleanup: boolean,
+    shouldApply?: () => boolean
+  ) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('repos').remove(repoId, {
         query: { cleanup },
       });
+      if (shouldApply && !shouldApply()) return;
       if (cleanup) {
         showSuccess('Repository and files deleted successfully!');
       } else {
         showSuccess('Repository removed from Agor (files preserved)');
       }
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       // Check for partial deletion (some files deleted, some failed)
@@ -1741,24 +1828,28 @@ function AppContent() {
   };
 
   // Handle MCP server CRUD
-  const handleCreateMCPServer = async (data: CreateMCPServerInput) => {
-    if (!client) return;
+  const handleCreateMCPServer = async (data: CreateMCPServerInput, shouldApply?: () => boolean) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('mcp-servers').create(data);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('MCP server added successfully!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to add MCP server: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   };
 
-  const handleDeleteMCPServer = async (serverId: string) => {
-    if (!client) return;
+  const handleDeleteMCPServer = async (serverId: string, shouldApply?: () => boolean) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('mcp-servers').remove(serverId);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('MCP server deleted successfully!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to delete MCP server: ${error instanceof Error ? error.message : String(error)}`
       );
@@ -1780,25 +1871,30 @@ function AppContent() {
 
   const handleUpdateGatewayChannel = async (
     channelId: string,
-    updates: GatewayChannelPatchData
+    updates: GatewayChannelPatchData,
+    shouldApply?: () => boolean
   ) => {
-    if (!client) return;
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('gateway-channels').patch(channelId, updates);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('Gateway channel updated!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to update gateway channel: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   };
 
-  const handleDeleteGatewayChannel = async (channelId: string) => {
-    if (!client) return;
+  const handleDeleteGatewayChannel = async (channelId: string, shouldApply?: () => boolean) => {
+    if (!client || (shouldApply && !shouldApply())) return;
     try {
       await client.service('gateway-channels').remove(channelId);
+      if (shouldApply && !shouldApply()) return;
       showSuccess('Gateway channel deleted!');
     } catch (error) {
+      if (shouldApply && !shouldApply()) return;
       showError(
         `Failed to delete gateway channel: ${error instanceof Error ? error.message : String(error)}`
       );
@@ -2039,7 +2135,9 @@ function AppContent() {
       onNukeEnvironment={handleNukeEnvironment}
       onExecuteScheduleNow={handleExecuteScheduleNow}
       onCreateUser={handleCreateUser}
-      onUpdateUser={handleUpdateUser}
+      onUpdateUser={(userId, updates, shouldApply) =>
+        handleUpdateUser(userId, updates, { shouldApply })
+      }
       onDeleteUser={handleDeleteUser}
       onCreateMCPServer={handleCreateMCPServer}
       onDeleteMCPServer={handleDeleteMCPServer}
@@ -2089,8 +2187,10 @@ function AppContent() {
           }}
           user={currentUser}
           client={client}
-          onUpdateUser={handleUpdateUser}
-          onRefreshCurrentUser={reAuthenticate}
+          onUpdateUser={(userId, updates, shouldApply) =>
+            handleUpdateUser(userId, updates, { shouldApply })
+          }
+          onRefreshCurrentUser={refreshCurrentUserForAuthorityCycle}
           onRestartOnboarding={canRunOnboarding ? handleRestartOnboarding : undefined}
           initialTab={userSettingsInitialTab}
         />

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -396,6 +396,7 @@ function AppContent() {
     client,
     connected,
     connecting,
+    authGeneration,
     error: connectionError,
     retryConnection,
   } = useAgorClient({
@@ -447,12 +448,13 @@ function AppContent() {
   // Referentially stable context value: without the memo, every App render
   // hands consumers a fresh object and defeats their own memoization.
   const connectionContextValue = useMemo(
-    () => ({ connected, connecting, outOfSync, capturedSha, currentSha }),
-    [connected, connecting, outOfSync, capturedSha, currentSha]
+    () => ({ connected, connecting, authGeneration, outOfSync, capturedSha, currentSha }),
+    [connected, connecting, authGeneration, outOfSync, capturedSha, currentSha]
   );
 
   const directSessionIdFromPath =
     location.pathname.match(/^\/(?:s|m\/session)\/([^/]+)\/?$/)?.[1] ?? null;
+  const authenticatedUserCanListUsers = hasMinimumRole(user?.role, ROLES.MEMBER);
 
   // Pass the stable client lifetime, not `connected ? client : null`:
   // useAgorData owns reconnect refetches and `null` is reserved for logout /
@@ -468,6 +470,7 @@ function AppContent() {
   } = useAgorData(client, {
     enabled: workspaceSurfaceShouldRun && !(user?.must_change_password && passwordWriteAvailable),
     directSessionId: directSessionIdFromPath,
+    authenticatedUserRole: user?.role,
   });
 
   // Entity maps are NOT subscribed here. Each surface that needs a whole map
@@ -551,7 +554,13 @@ function AppContent() {
   const storedCurrentUser = useAgorStore((s) =>
     user ? (s.userById.get(user.user_id) ?? null) : null
   );
-  const currentUser = user ? storedCurrentUser || user : null;
+  // A viewer cannot refresh the directory, so never let a row retained from a
+  // prior member identity/role override the current authentication response.
+  const currentUser = user
+    ? authenticatedUserCanListUsers
+      ? storedCurrentUser || user
+      : user
+    : null;
   const mcpServerCount = useAgorStore((s) => s.mcpServerById.size);
   // Slack/GitHub connections are gateway channels, a separate store map from MCP
   // servers. Narrow size selector so unrelated channel writes don't re-render the shell.
@@ -1947,6 +1956,8 @@ function AppContent() {
     <MarketplacePage
       client={client}
       connected={connected}
+      connecting={connecting}
+      authGeneration={authGeneration}
       currentUser={currentUser}
       onUserSettingsClick={() => setOpenUserSettings(true)}
       onLogout={logout}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -64,6 +64,7 @@ import {
   useAuth,
   useAuthConfig,
   useBoardActions,
+  useForcedPasswordChangeHandler,
   useInitialLoaderPhase,
   useServerVersion,
   useSessionActions,
@@ -87,10 +88,7 @@ import type { CreateRepoOptions } from './types';
 import { cloneErrorHint } from './utils/cloneErrorHint';
 import { enrichAuthenticatedUser } from './utils/currentUserAuthority';
 import { isMobileDevice } from './utils/deviceDetection';
-import {
-  completeForcedPasswordChange,
-  completeLocalPasswordChange,
-} from './utils/forcePasswordChange';
+import { completeLocalPasswordChange } from './utils/forcePasswordChange';
 import { useThemedMessage } from './utils/message';
 import { buildCompletedOnboardingPreferences } from './utils/onboardingGoals';
 import { savePromptDraft } from './utils/promptDrafts';
@@ -386,6 +384,7 @@ function AppContent() {
     isAuthenticationGenerationCurrent,
     isAuthenticationOwnerCurrent,
     login,
+    captureAuthorityCycle,
     loginForAuthorityCycle,
     logout,
     logoutForAuthorityCycle,
@@ -412,6 +411,21 @@ function AppContent() {
       ? [user.user_id, user.role, client, authGeneration]
       : null
   );
+  const handleForcePasswordChange = useForcedPasswordChangeHandler({
+    client,
+    user,
+    appAuthorityGuard,
+    captureAuthorityCycle,
+    reauthenticate: loginForAuthorityCycle,
+    logout: logoutForAuthorityCycle,
+    onCompleted: (signedIn) => {
+      showSuccess(
+        signedIn
+          ? 'Password changed successfully!'
+          : 'Password changed successfully. Please sign in again.'
+      );
+    },
+  });
   const pendingEnvironmentToastsRef = useRef<Map<string, PendingEnvironmentToast>>(new Map());
 
   useEffect(() => {
@@ -1474,36 +1488,6 @@ function AppContent() {
       if (shouldApply && !shouldApply()) return;
       showError(`Failed to delete user: ${error instanceof Error ? error.message : String(error)}`);
     }
-  };
-
-  // Handle forced password change (from ForcePasswordChangeModal)
-  const handleForcePasswordChange = async (
-    userId: string,
-    newPassword: string,
-    shouldApply: () => boolean,
-    isSameIdentity: () => boolean
-  ) => {
-    if (!client) throw new Error('Not connected');
-    if (!currentUser?.email) throw new Error('Current user is unavailable');
-    if (currentUser.user_id !== userId || !shouldApply()) return;
-
-    const signedIn = await completeForcedPasswordChange({
-      client,
-      userId,
-      email: currentUser.email,
-      newPassword,
-      shouldApply,
-      reauthenticate: loginForAuthorityCycle,
-      logout: logoutForAuthorityCycle,
-    });
-
-    if (signedIn === null || !isSameIdentity()) return;
-
-    showSuccess(
-      signedIn
-        ? 'Password changed successfully!'
-        : 'Password changed successfully. Please sign in again.'
-    );
   };
 
   // Handle board CRUD

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -84,6 +84,7 @@ import {
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
 import type { CreateRepoOptions } from './types';
 import { cloneErrorHint } from './utils/cloneErrorHint';
+import { enrichAuthenticatedUser } from './utils/currentUserAuthority';
 import { isMobileDevice } from './utils/deviceDetection';
 import {
   completeForcedPasswordChange,
@@ -470,7 +471,10 @@ function AppContent() {
   } = useAgorData(client, {
     enabled: workspaceSurfaceShouldRun && !(user?.must_change_password && passwordWriteAvailable),
     directSessionId: directSessionIdFromPath,
+    authenticatedUserId: user?.user_id,
     authenticatedUserRole: user?.role,
+    authGeneration,
+    connectionReady: connected && !connecting,
   });
 
   // Entity maps are NOT subscribed here. Each surface that needs a whole map
@@ -556,11 +560,10 @@ function AppContent() {
   );
   // A viewer cannot refresh the directory, so never let a row retained from a
   // prior member identity/role override the current authentication response.
-  const currentUser = user
-    ? authenticatedUserCanListUsers
-      ? storedCurrentUser || user
-      : user
-    : null;
+  const currentUser = enrichAuthenticatedUser(
+    user,
+    authenticatedUserCanListUsers ? storedCurrentUser : null
+  );
   const mcpServerCount = useAgorStore((s) => s.mcpServerById.size);
   // Slack/GitHub connections are gateway channels, a separate store map from MCP
   // servers. Narrow size selector so unrelated channel writes don't re-render the shell.

--- a/apps/agor-ui/src/components/ApiKeyFields.test.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.test.tsx
@@ -1,0 +1,53 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiKeyFields } from './ApiKeyFields';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('ApiKeyFields authority fencing', () => {
+  it('keeps a same-user reconnect draft but drops the obsolete save continuation', async () => {
+    const pending = deferred();
+    const onSave = vi.fn(() => pending.promise);
+    const view = (identityKey: string, generation: number) => (
+      <AntApp>
+        <ApiKeyFields
+          tool="claude-code"
+          fields={[
+            {
+              field: 'ANTHROPIC_API_KEY',
+              label: 'Anthropic API key',
+              placeholder: 'sk-ant-...',
+            },
+          ]}
+          fieldStatus={{}}
+          onSave={onSave}
+          onClear={vi.fn(async () => {})}
+          identityKey={identityKey}
+          operationScope={[identityKey, generation]}
+        />
+      </AntApp>
+    );
+    const rendered = render(view('admin-a:admin', 4));
+    const input = screen.getByPlaceholderText('sk-ant-...');
+    fireEvent.change(input, { target: { value: 'admin-a-private-key' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledWith('ANTHROPIC_API_KEY', 'admin-a-private-key');
+
+    rendered.rerender(view('admin-a:admin', 5));
+    await act(async () => {
+      pending.resolve();
+      await pending.promise;
+    });
+    expect(screen.getByPlaceholderText('sk-ant-...')).toHaveValue('admin-a-private-key');
+
+    rendered.rerender(view('admin-b:admin', 6));
+    expect(screen.getByPlaceholderText('sk-ant-...')).toHaveValue('');
+  });
+});

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -6,7 +6,8 @@ import {
   InfoCircleOutlined,
 } from '@ant-design/icons';
 import { Button, Input, Space, Tooltip, Typography, theme } from 'antd';
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { ClaudeSubscriptionTokenInstructions } from './ClaudeSubscriptionTokenInstructions';
 import { Tag } from './Tag';
 
@@ -169,6 +170,10 @@ export interface ApiKeyFieldsProps {
    * where the exact path matters.
    */
   publicValues?: Partial<Record<AgenticToolConfigField, string>>;
+  /** Erases raw drafts only when the caller identity/role changes. */
+  identityKey: string | null;
+  /** Cancels async continuations on reconnect/token/authority changes. */
+  operationScope: readonly unknown[] | null;
 }
 
 export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
@@ -180,20 +185,37 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
   disabled = false,
   fields,
   publicValues,
+  identityKey,
+  operationScope,
 }) => {
   const { token } = theme.useToken();
   const [inputValues, setInputValues] = useState<Partial<Record<AgenticToolConfigField, string>>>(
     {}
   );
+  const operationGuard = useAuthorityOperationGuard(operationScope);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey is the caller-private draft lifecycle key
+  useLayoutEffect(() => {
+    setInputValues({});
+  }, [identityKey]);
 
   const configs = fields ?? TOOL_FIELD_CONFIGS[tool] ?? [];
 
   const handleSave = async (field: AgenticToolConfigField) => {
+    const operation = operationGuard.begin();
     const value = inputValues[field]?.trim();
-    if (!value) return;
+    if (!value || !operation.isCurrent()) return;
 
     await onSave(field, value);
+    if (!operation.isCurrent()) return;
     setInputValues((prev) => ({ ...prev, [field]: '' }));
+  };
+
+  const handleClear = async (field: AgenticToolConfigField) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
+    await onClear(field);
+    if (!operation.isCurrent()) return;
   };
 
   const renderField = (config: AgenticToolFieldConfig) => {
@@ -247,7 +269,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
               <Button
                 danger
                 icon={<DeleteOutlined />}
-                onClick={() => onClear(field)}
+                onClick={() => void handleClear(field)}
                 loading={saving[field]}
                 disabled={disabled}
               >

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -64,7 +64,7 @@ import {
   selectFirstBoardId,
   selectSessionById,
 } from '../../store/selectors';
-import type { AgenticToolOption } from '../../types';
+import type { AgenticToolOption, CreateRepoOptions } from '../../types';
 import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
 import { resolveQuickStartMcpServerIds } from '../../utils/resolveQuickStartMcpServerIds';
@@ -167,7 +167,7 @@ export interface AppProps {
   openUserSettings?: boolean; // Open user settings modal directly (e.g., from onboarding)
   initialUserSettingsTab?: string; // Deep-link target tab when opening user settings
   onUserSettingsClose?: () => void; // Called when user settings modal closes
-  onRestartOnboarding?: () => void | Promise<void>;
+  onRestartOnboarding?: (shouldApply?: () => boolean) => void | Promise<void>;
   openNewBranchModal?: boolean; // Open new branch modal
   onNewBranchModalClose?: () => void; // Called when new branch modal closes
   suppressLeftPanel?: boolean; // Temporarily hide the teammate/comments panel behind modal-first flows
@@ -192,10 +192,13 @@ export interface AppProps {
   onDeleteBoard?: (boardId: string) => void;
   onArchiveBoard?: (boardId: string) => void;
   onUnarchiveBoard?: (boardId: string) => void;
-  onCreateRepo?: (data: CreateRepoRequest) => unknown;
-  onCreateLocalRepo?: (data: CreateLocalRepoRequest) => void | Promise<void>;
-  onUpdateRepo?: (repoId: string, updates: Partial<Repo>) => void;
-  onDeleteRepo?: (repoId: string, cleanup: boolean) => void;
+  onCreateRepo?: (data: CreateRepoRequest, options?: CreateRepoOptions) => unknown;
+  onCreateLocalRepo?: (
+    data: CreateLocalRepoRequest,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onUpdateRepo?: (repoId: string, updates: Partial<Repo>, shouldApply?: () => boolean) => void;
+  onDeleteRepo?: (repoId: string, cleanup: boolean, shouldApply?: () => boolean) => void;
   onArchiveOrDeleteBranch?: (branchId: string, options: BranchArchiveOrDeleteOptions) => void;
   onUnarchiveBranch?: (branchId: string, options?: { boardId?: string }) => void;
   onUpdateBranch?: (branchId: string, updates: BranchUpdate) => void | Promise<void>;
@@ -223,14 +226,25 @@ export interface AppProps {
   onStopEnvironment?: (branchId: string) => void;
   onNukeEnvironment?: (branchId: string) => void;
   onExecuteScheduleNow?: (branchId: string) => Promise<void>;
-  onCreateUser?: (data: CreateUserInput) => Promise<void>;
-  onUpdateUser?: (userId: string, updates: UpdateUserInput) => Promise<void>;
-  onDeleteUser?: (userId: string) => void;
-  onCreateMCPServer?: (data: CreateMCPServerInput) => void;
-  onDeleteMCPServer?: (mcpServerId: string) => void;
+  onCreateUser?: (data: CreateUserInput, shouldApply?: () => boolean) => void | Promise<void>;
+  onUpdateUser?: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDeleteUser?: (userId: string, shouldApply?: () => boolean) => void | Promise<void>;
+  onCreateMCPServer?: (
+    data: CreateMCPServerInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDeleteMCPServer?: (mcpServerId: string, shouldApply?: () => boolean) => void | Promise<void>;
   onCreateGatewayChannel?: (data: GatewayChannelCreateData) => void;
-  onUpdateGatewayChannel?: (channelId: string, updates: GatewayChannelPatchData) => void;
-  onDeleteGatewayChannel?: (channelId: string) => void;
+  onUpdateGatewayChannel?: (
+    channelId: string,
+    updates: GatewayChannelPatchData,
+    shouldApply?: () => boolean
+  ) => void;
+  onDeleteGatewayChannel?: (channelId: string, shouldApply?: () => boolean) => void;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
   onUpdateSessionMcpServers?: (sessionId: string, mcpServerIds: string[]) => void;
@@ -1791,7 +1805,7 @@ export const App: React.FC<AppProps> = ({
           onDeleteBoard={onDeleteBoard}
           onArchiveBoard={onArchiveBoard}
           onUnarchiveBoard={onUnarchiveBoard}
-          onCreateRepo={onCreateRepo}
+          onCreateRepo={(data, shouldApply) => onCreateRepo?.(data, { shouldApply })}
           onCreateLocalRepo={onCreateLocalRepo}
           onUpdateRepo={onUpdateRepo}
           onDeleteRepo={onDeleteRepo}
@@ -1903,11 +1917,13 @@ export const App: React.FC<AppProps> = ({
           currentUser={user || null}
           client={client}
           onUpdate={onUpdateUser}
-          onRestartOnboarding={async () => {
+          onRestartOnboarding={async (shouldApply) => {
+            if (shouldApply && !shouldApply()) return;
+            await onRestartOnboarding?.(shouldApply);
+            if (shouldApply && !shouldApply()) return;
             setUserSettingsOpen(false);
             setUserSettingsInitialTool(undefined);
             onUserSettingsClose?.();
-            await onRestartOnboarding?.();
           }}
         />
       </Layout>

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -91,30 +91,58 @@ describe('AppHeader navigation entries', () => {
     mockNavigate.mockClear();
   });
 
-  it('advertises exactly these surfaces', () => {
+  it('advertises exactly these surfaces, in order', () => {
     renderHeader();
 
     // The whole set, so adding or removing an entry has to be a deliberate
-    // edit here rather than something that slips in. Marketplace is absent on
-    // purpose: the surface answers at /marketplace but is not advertised while
-    // the feature is incomplete, so re-adding the link should fail this and
-    // make whoever does it confirm that decision has been reversed.
+    // edit here rather than something that slips in. Order matters: Marketplace
+    // is last of the two because it sits immediately left of the gear.
     const linkNames = screen
       .getAllByRole('link')
       .map((link) => link.getAttribute('aria-label') ?? link.textContent?.trim());
 
-    expect(linkNames).toEqual(['Knowledge Base']);
+    expect(linkNames).toEqual(['Knowledge Base', 'Marketplace']);
   });
 
-  it('does not link to the marketplace from anywhere in the header', () => {
+  it('renders the Marketplace entry as a real link to /marketplace', () => {
     renderHeader();
 
-    const marketplaceLinks = screen
-      .getAllByRole('link')
-      .filter((link) => (link.getAttribute('href') ?? '').includes('marketplace'));
+    // The href is what makes middle-click and cmd-click open a tab, so assert
+    // the resolved basename-aware path rather than merely that a button exists.
+    expect(screen.getByRole('link', { name: 'Marketplace' })).toHaveAttribute(
+      'href',
+      '/ui/marketplace'
+    );
+  });
 
-    expect(marketplaceLinks).toEqual([]);
+  it('navigates to /marketplace via SPA navigation on plain click', () => {
+    renderHeader();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Marketplace' }));
+
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/marketplace');
+  });
+
+  it('promotes Marketplace to the header rather than the gear dropdown', async () => {
+    renderHeader();
+
+    // Option A from the spec: a marketplace is a surface people revisit, so
+    // burying it in the settings menu is the failure this guards against.
+    fireEvent.click(screen.getByRole('button', { name: 'Settings menu' }));
+    await screen.findByText('Settings');
+
+    // The header entry is an icon button carrying its name on aria-label, so a
+    // rendered "Marketplace" text node could only be a dropdown menu item.
     expect(screen.queryByText('Marketplace')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Marketplace' })).toBeInTheDocument();
+  });
+
+  it('shows the Marketplace entry to a viewer', () => {
+    // Browsing the catalog is authenticated-only on the daemon, so no role is
+    // filtered out of the entry. Connect is gated separately, in the surface.
+    renderHeader({ user: { user_id: 'u1', email: 'v@agor.live', role: 'viewer' } as never });
+
+    expect(screen.getByRole('link', { name: 'Marketplace' })).toBeInTheDocument();
   });
 
   it('bounds the always-visible board switcher slot', () => {

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,6 +1,6 @@
 import type { ActiveUser, AgorClient, Board, BoardID, Branch, User } from '@agor-live/client';
 import { hasMinimumRole, ROLES } from '@agor-live/client';
-import { BulbOutlined } from '@ant-design/icons';
+import { BulbOutlined, ShopOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { memo, useMemo } from 'react';
@@ -148,6 +148,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const { token } = theme.useToken();
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
+  const marketplaceHref = useHref('/marketplace');
   const { themeMode, setThemeMode } = useTheme();
 
   // Entity state via narrow store subscriptions rather than props. Each
@@ -320,9 +321,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           boardById={boardById}
           onSettingsClick={onSettingsClick}
         />
-        {/* No Marketplace entry: the surface exists and answers at
-            /marketplace, but is not advertised while the feature is
-            incomplete. */}
         <Tooltip title="Knowledge Base">
           <Button
             type="text"
@@ -333,6 +331,29 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
               if (isPlainLeftClick(event)) {
                 event.preventDefault();
                 navigate('/knowledge');
+              }
+            }}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          />
+        </Tooltip>
+        {/* A marketplace is a surface people are meant to come back to, so it
+            gets promoted chrome next to the gear rather than a line inside the
+            gear's menu. Ungated by role: the catalog read is authenticated-only
+            (`mcp-catalog` takes `requireAuth` and nothing more), so everyone who
+            can see this header can browse it. Connecting is narrower, and
+            CatalogDetailDrawer asks the MCP member policy before offering it —
+            without that this entry would send a viewer to a Connect button that
+            403s, which is why the two changed together. */}
+        <Tooltip title="Marketplace">
+          <Button
+            type="text"
+            icon={<ShopOutlined style={{ fontSize: token.fontSizeLG }} />}
+            href={marketplaceHref}
+            aria-label="Marketplace"
+            onClick={(event) => {
+              if (isPlainLeftClick(event)) {
+                event.preventDefault();
+                navigate('/marketplace');
               }
             }}
             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -55,6 +55,8 @@ export interface CodexAuthSettingsProps {
    * false, only the API-key path is shown, and it still targets the edited user.
    */
   allowChatgptLogin?: boolean;
+  identityKey?: string | null;
+  operationScope?: readonly unknown[] | null;
 }
 
 /**
@@ -74,6 +76,8 @@ export function CodexAuthSettings({
   savingFields,
   publicValues,
   allowChatgptLogin = true,
+  identityKey,
+  operationScope,
 }: CodexAuthSettingsProps) {
   const { token } = useToken();
   const [view, setView] = useState<CodexMethodView>(() => viewForMethod(authMethod, 'chatgpt'));
@@ -100,14 +104,20 @@ export function CodexAuthSettings({
   //    the method to subscription (and persisting there if the re-probe then
   //    fails, since transport failures keep the last verdict). Clearing to null
   //    means the banner shows nothing until a verdict for the NEW method lands.
-  const { run } = useIdentityGuardedAsync([client, authMethod], () => {
-    setProbe(null);
-    setProbing(false);
-  });
+  const effectiveOperationScope =
+    operationScope === undefined ? ([client, authMethod] as const) : operationScope;
+  const operationAvailable = effectiveOperationScope !== null;
+  const { run } = useIdentityGuardedAsync(
+    [client, authMethod, ...(effectiveOperationScope ?? [null])],
+    () => {
+      setProbe(null);
+      setProbing(false);
+    }
+  );
   const runProbe = useCallback(async () => {
     // The probe checks the caller's own login; skip it entirely when the
     // caller-scoped controls are hidden (admin editing another user).
-    if (!client || !allowChatgptLogin) return;
+    if (!client || !allowChatgptLogin || !operationAvailable) return;
     setProbing(true);
     try {
       const result = await run(
@@ -124,7 +134,7 @@ export function CodexAuthSettings({
     } finally {
       setProbing(false);
     }
-  }, [client, run, allowChatgptLogin]);
+  }, [client, run, allowChatgptLogin, operationAvailable]);
 
   // API-key validation is cheap and stays local to the daemon/provider. Native
   // subscription validation may require scheduling a Cloud executor, so it is
@@ -153,11 +163,11 @@ export function CodexAuthSettings({
   // so the pane re-syncs to the disconnected state and re-probes on its own (no
   // local state to reset here).
   const handleRemoveLogin = useCallback(async () => {
-    if (!client) return;
+    if (!client || !operationAvailable) return;
     setRemoving(true);
     setRemoveError(null);
     try {
-      await client.service('codex-auth/logout').create({});
+      await run(() => client.service('codex-auth/logout').create({}));
     } catch (err) {
       setRemoveError(
         err instanceof Error && err.message
@@ -167,7 +177,7 @@ export function CodexAuthSettings({
     } finally {
       setRemoving(false);
     }
-  }, [client]);
+  }, [client, operationAvailable, run]);
 
   // Selecting a method is a pure view switch — it never persists the auth
   // method. Persisting on selection is destructive in BOTH directions: choosing
@@ -332,6 +342,8 @@ export function CodexAuthSettings({
 
         {(!allowChatgptLogin || view === 'api_key') && (
           <ApiKeyFields
+            identityKey={identityKey ?? 'standalone-codex'}
+            operationScope={effectiveOperationScope}
             tool="codex"
             fields={apiKeyFields}
             fieldStatus={fieldStatus}
@@ -349,6 +361,7 @@ export function CodexAuthSettings({
             </Text>
             <CodexDeviceSignIn
               client={client}
+              operationScope={effectiveOperationScope}
               onVerified={handleAuthenticated}
               onUseFallback={handleFallback}
               autoStart={false}
@@ -356,7 +369,11 @@ export function CodexAuthSettings({
           </div>
         )}
         {allowChatgptLogin && view === 'import' && (
-          <CodexImportAuthJson client={client} onImported={handleAuthenticated} />
+          <CodexImportAuthJson
+            client={client}
+            operationScope={effectiveOperationScope}
+            onImported={handleAuthenticated}
+          />
         )}
       </Space>
     </Form>

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -371,6 +371,7 @@ export function CodexAuthSettings({
         {allowChatgptLogin && view === 'import' && (
           <CodexImportAuthJson
             client={client}
+            identityKey={identityKey}
             operationScope={effectiveOperationScope}
             onImported={handleAuthenticated}
           />

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.test.tsx
@@ -10,12 +10,15 @@
  * so the code must route its copy through `useCopyToClipboard`.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 
-const copySpy = vi.fn(async () => true);
+const { copySpy } = vi.hoisted(() => ({
+  copySpy: vi.fn(async () => true),
+}));
 vi.mock('../../utils/clipboard', () => ({
-  useCopyToClipboard: () => [false, copySpy] as const,
+  copyToClipboard: copySpy,
 }));
 
 import { CodexDeviceSignIn } from './CodexDeviceSignIn';
@@ -108,5 +111,44 @@ describe('CodexDeviceSignIn copy', () => {
 
     expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
     expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not apply a delayed copy result after the auth generation changes', async () => {
+    let resolveCopy!: (copied: boolean) => void;
+    copySpy.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveCopy = resolve;
+      })
+    );
+    const client = makeClient();
+    const view = (authGeneration: number) => (
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          authGeneration,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <CodexDeviceSignIn
+          client={client}
+          operationScope={['admin-a', client, authGeneration]}
+          onVerified={vi.fn()}
+          onUseFallback={vi.fn()}
+        />
+      </ConnectionProvider>
+    );
+    const rendered = render(view(7));
+    expect(await screen.findByText(USER_CODE)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy sign-in code' }));
+    await waitFor(() => expect(copySpy).toHaveBeenCalledWith(USER_CODE));
+    rendered.rerender(view(8));
+    await act(async () => resolveCopy(true));
+
+    expect(screen.getByRole('img', { name: 'copy' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'check' })).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -6,9 +6,10 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Flex, Tooltip, Typography, theme } from 'antd';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 import { useIdentityGuardedAsync } from '../../hooks/useIdentityGuardedAsync';
-import { useCopyToClipboard } from '../../utils/clipboard';
+import { copyToClipboard } from '../../utils/clipboard';
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -48,6 +49,7 @@ export interface CodexDeviceSignInProps {
    * — that would wall off re-signing-in until the daemon prunes the attempt.
    */
   autoStart?: boolean;
+  operationScope?: readonly unknown[] | null;
 }
 
 /**
@@ -61,6 +63,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   onVerified,
   onUseFallback,
   autoStart = true,
+  operationScope,
 }: CodexDeviceSignInProps) {
   const { token } = useToken();
   const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
@@ -70,7 +73,8 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   // dev URLs (non-secure context) AntD awaits navigator.clipboard's rejection
   // first, which consumes the click's user activation and makes its execCommand
   // fallback fail too. copyToClipboard tries execCommand first when insecure.
-  const [codeCopied, copyCode] = useCopyToClipboard();
+  const [codeCopied, setCodeCopied] = useState(false);
+  const copiedResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const deviceService = useMemo(
     () =>
@@ -92,14 +96,46 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   // then decides what THIS service should show — and resets `starting` because a
   // replacement that ADOPTS an attempt never calls requestCode, so without the
   // reset the spinner would cover a live code.
-  const { run, isCurrent } = useIdentityGuardedAsync([deviceService], () => {
-    setStarting(false);
-    setStatus({ phase: 'idle' });
-    setRemainingMs(null);
-  });
+  const effectiveOperationScope =
+    operationScope === undefined ? ([deviceService] as const) : operationScope;
+  const operationAvailable = effectiveOperationScope !== null;
+  const authorityGuard = useAuthorityOperationGuard(effectiveOperationScope);
+  const { run, isCurrent } = useIdentityGuardedAsync(
+    [deviceService, ...(effectiveOperationScope ?? [null])],
+    () => {
+      if (copiedResetRef.current) clearTimeout(copiedResetRef.current);
+      copiedResetRef.current = null;
+      setCodeCopied(false);
+      setStarting(false);
+      setStatus({ phase: 'idle' });
+      setRemainingMs(null);
+    }
+  );
+
+  const copyCode = useCallback(
+    async (code: string) => {
+      const operation = authorityGuard.begin();
+      if (!operation.isCurrent()) return;
+      const copied = await copyToClipboard(code);
+      if (!operation.isCurrent() || !copied) return;
+      if (copiedResetRef.current) clearTimeout(copiedResetRef.current);
+      setCodeCopied(true);
+      copiedResetRef.current = setTimeout(() => {
+        if (operation.isCurrent()) setCodeCopied(false);
+      }, 2_000);
+    },
+    [authorityGuard]
+  );
+
+  useEffect(
+    () => () => {
+      if (copiedResetRef.current) clearTimeout(copiedResetRef.current);
+    },
+    []
+  );
 
   const requestCode = useCallback(async () => {
-    if (!deviceService) return;
+    if (!deviceService || !operationAvailable || !authorityGuard.isCurrent()) return;
     setStarting(true);
     try {
       const next = (await run(() => deviceService.create({}))) as CodexDeviceAuthStatus;
@@ -115,7 +151,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
     } finally {
       setStarting(false);
     }
-  }, [deviceService, run]);
+  }, [authorityGuard, deviceService, operationAvailable, run]);
 
   const cancelAttempt = useCallback(async () => {
     if (!deviceService || !status.attemptId) return;
@@ -139,7 +175,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   // and `run` (service swap): a find() resolving after the service swapped never
   // restores the previous client's code — matching requestCode's own guard.
   useEffect(() => {
-    if (!deviceService) return;
+    if (!deviceService || !operationAvailable) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -159,7 +195,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
     return () => {
       cancelled = true;
     };
-  }, [deviceService, requestCode, autoStart, run]);
+  }, [deviceService, requestCode, autoStart, run, operationAvailable]);
 
   // Poll while pending; terminal phases stop the loop. A self-scheduling
   // timeout (next poll armed only after the previous response lands) keeps
@@ -167,7 +203,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   // out-of-order pending. Identity-preserving setState keeps unchanged polls
   // from re-rendering even this pane.
   useEffect(() => {
-    if (status.phase !== 'pending' || !deviceService) return;
+    if (status.phase !== 'pending' || !deviceService || !operationAvailable) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
     const tick = async () => {
@@ -192,7 +228,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [status.phase, deviceService, isCurrent]);
+  }, [status.phase, deviceService, isCurrent, operationAvailable]);
 
   // 1s countdown while a code is live.
   useEffect(() => {
@@ -208,8 +244,8 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   }, [status.phase, status.expiresAt]);
 
   useEffect(() => {
-    if (status.phase === 'success') onVerified();
-  }, [status.phase, onVerified]);
+    if (status.phase === 'success' && authorityGuard.isCurrent()) onVerified();
+  }, [authorityGuard, status.phase, onVerified]);
 
   if (starting || (status.phase === 'idle' && autoStart)) {
     return (
@@ -227,7 +263,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   if (status.phase === 'idle') {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0' }}>
-        <Button type="primary" disabled={!client} onClick={requestCode}>
+        <Button type="primary" disabled={!client || !operationAvailable} onClick={requestCode}>
           Get a sign-in code
         </Button>
         {!client && (

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.test.tsx
@@ -1,0 +1,88 @@
+import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CodexImportAuthJson } from './CodexImportAuthJson';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+describe('CodexImportAuthJson authority lifetime', () => {
+  it('preserves a same-user reconnect draft, cancels the old import, and releases loading', async () => {
+    const pending = deferred<CodexAuthImportResult>();
+    const create = vi.fn(() => pending.promise);
+    const client = {
+      service: vi.fn(() => ({ create })),
+    } as unknown as AgorClient;
+    const onImported = vi.fn();
+    const view = (generation: number) => (
+      <CodexImportAuthJson
+        client={client}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', client, generation]}
+        onImported={onImported}
+      />
+    );
+    const rendered = render(view(1));
+    const input = screen.getByLabelText('Codex auth.json contents');
+    fireEvent.change(input, { target: { value: '{"tokens":"admin-a-secret"}' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Import login' }));
+    await waitFor(() => expect(create).toHaveBeenCalledOnce());
+    expect(screen.getByRole('button', { name: /Import login$/ })).toHaveClass('ant-btn-loading');
+
+    rendered.rerender(view(2));
+    expect(screen.getByLabelText('Codex auth.json contents')).toHaveValue(
+      '{"tokens":"admin-a-secret"}'
+    );
+    expect(screen.getByRole('button', { name: /Import login$/ })).not.toHaveClass(
+      'ant-btn-loading'
+    );
+
+    await act(async () => {
+      pending.resolve({ status: 'authenticated', authMode: 'chatgpt' });
+      await pending.promise;
+    });
+    expect(onImported).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Codex auth.json contents')).toHaveValue(
+      '{"tokens":"admin-a-secret"}'
+    );
+  });
+
+  it('erases A credentials and drops A continuation on same-role identity replacement', async () => {
+    const pending = deferred<CodexAuthImportResult>();
+    const create = vi.fn(() => pending.promise);
+    const client = {
+      service: vi.fn(() => ({ create })),
+    } as unknown as AgorClient;
+    const onImported = vi.fn();
+    const view = (identityKey: string, generation: number) => (
+      <CodexImportAuthJson
+        client={client}
+        identityKey={identityKey}
+        operationScope={[identityKey, client, generation]}
+        onImported={onImported}
+      />
+    );
+    const rendered = render(view('admin-a:admin', 8));
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"tokens":"admin-a-secret"}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import login' }));
+    await waitFor(() => expect(create).toHaveBeenCalledOnce());
+
+    rendered.rerender(view('admin-b:admin', 9));
+    expect(screen.getByLabelText('Codex auth.json contents')).toHaveValue('');
+    expect(screen.getByRole('button', { name: /Import login$/ })).not.toHaveClass(
+      'ant-btn-loading'
+    );
+
+    await act(async () => {
+      pending.resolve({ status: 'authenticated', authMode: 'chatgpt' });
+      await pending.promise;
+    });
+    expect(onImported).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Codex auth.json contents')).toHaveValue('');
+  });
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,7 +1,7 @@
 import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
 import { Alert, Button, Input, Space, Typography, theme } from 'antd';
-import { memo, useCallback, useState } from 'react';
-import { useIdentityGuardedAsync } from '../../hooks/useIdentityGuardedAsync';
+import { memo, useCallback, useLayoutEffect, useState } from 'react';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -17,6 +17,9 @@ export interface CodexImportAuthJsonProps {
   onImported: (result: CodexAuthImportResult) => void;
   /** Label for the submit action; surfaces frame it differently. */
   submitLabel?: string;
+  /** Identity-only key: changes erase the caller-private pasted credential. */
+  identityKey?: string | null;
+  /** Generation/connection scope: changes cancel work but preserve the draft. */
   operationScope?: readonly unknown[] | null;
 }
 
@@ -30,6 +33,7 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   client,
   onImported,
   submitLabel = 'Import login',
+  identityKey,
   operationScope,
 }: CodexImportAuthJsonProps) {
   const { token } = useToken();
@@ -37,43 +41,54 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // A client/identity swap (or unmount) must never carry a pasted secret across
-  // it, nor let an import in flight against the old client apply to — or lock —
-  // the replacement. The guard invalidates any in-flight submit synchronously on
-  // client change; the on-change reset drops the pasted secret and releases the
-  // submit lock so the new identity can import right away.
+  // Identity and operation lifetime are intentionally separate. Reconnecting
+  // the same caller invalidates an in-flight request but keeps their pasted
+  // draft; replacing the caller erases it synchronously during layout commit.
   const effectiveOperationScope =
     operationScope === undefined ? ([client] as const) : operationScope;
   const operationAvailable = effectiveOperationScope !== null;
-  const { run } = useIdentityGuardedAsync([client, ...(effectiveOperationScope ?? [null])], () => {
+  const operationGuard = useAuthorityOperationGuard(effectiveOperationScope);
+  const effectiveIdentityKey = identityKey === undefined ? client : identityKey;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effectiveIdentityKey intentionally owns secret-draft erasure, independently of auth generation
+  useLayoutEffect(() => {
     setAuthJson('');
     setError(null);
     setSubmitting(false);
-  });
+  }, [effectiveIdentityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: a new operation epoch releases the obsolete request's UI lock without erasing the same caller's draft
+  useLayoutEffect(() => {
+    setSubmitting(false);
+  }, [operationGuard]);
 
   const handleImport = useCallback(async () => {
     if (!client || !authJson.trim() || submitting || !operationAvailable) return;
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
+    const submittedAuthJson = authJson;
     setSubmitting(true);
     setError(null);
     try {
-      const result = await run(
-        () =>
-          client.service('codex-auth/import').create({ authJson }) as Promise<CodexAuthImportResult>
-      );
+      const result = (await client
+        .service('codex-auth/import')
+        .create({ authJson: submittedAuthJson })) as CodexAuthImportResult;
+      if (!operation.isCurrent()) return;
       // Drop the pasted token material as soon as the daemon has it — nothing
       // here needs it after a successful import.
       setAuthJson('');
       onImported(result);
     } catch (err) {
+      if (!operation.isCurrent()) return;
       setError(
         err instanceof Error && err.message
           ? err.message
           : 'Could not import the Codex login — try again.'
       );
     } finally {
-      setSubmitting(false);
+      if (operation.isCurrent()) setSubmitting(false);
     }
-  }, [authJson, client, onImported, operationAvailable, submitting, run]);
+  }, [authJson, client, onImported, operationAvailable, operationGuard, submitting]);
 
   return (
     <Space direction="vertical" size="small" style={{ width: '100%' }}>

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -17,6 +17,7 @@ export interface CodexImportAuthJsonProps {
   onImported: (result: CodexAuthImportResult) => void;
   /** Label for the submit action; surfaces frame it differently. */
   submitLabel?: string;
+  operationScope?: readonly unknown[] | null;
 }
 
 /**
@@ -29,6 +30,7 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   client,
   onImported,
   submitLabel = 'Import login',
+  operationScope,
 }: CodexImportAuthJsonProps) {
   const { token } = useToken();
   const [authJson, setAuthJson] = useState('');
@@ -40,14 +42,17 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   // the replacement. The guard invalidates any in-flight submit synchronously on
   // client change; the on-change reset drops the pasted secret and releases the
   // submit lock so the new identity can import right away.
-  const { run } = useIdentityGuardedAsync([client], () => {
+  const effectiveOperationScope =
+    operationScope === undefined ? ([client] as const) : operationScope;
+  const operationAvailable = effectiveOperationScope !== null;
+  const { run } = useIdentityGuardedAsync([client, ...(effectiveOperationScope ?? [null])], () => {
     setAuthJson('');
     setError(null);
     setSubmitting(false);
   });
 
   const handleImport = useCallback(async () => {
-    if (!client || !authJson.trim() || submitting) return;
+    if (!client || !authJson.trim() || submitting || !operationAvailable) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -68,7 +73,7 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
     } finally {
       setSubmitting(false);
     }
-  }, [authJson, client, onImported, submitting, run]);
+  }, [authJson, client, onImported, operationAvailable, submitting, run]);
 
   return (
     <Space direction="vertical" size="small" style={{ width: '100%' }}>
@@ -101,7 +106,7 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
       <Button
         type="primary"
         loading={submitting}
-        disabled={!client || !authJson.trim()}
+        disabled={!client || !authJson.trim() || !operationAvailable}
         onClick={handleImport}
       >
         {submitLabel}

--- a/apps/agor-ui/src/components/EnvVarEditor.test.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -9,6 +9,8 @@ function renderEditor(envVars: ComponentProps<typeof EnvVarEditor>['envVars']) {
     envVars,
     onSave: vi.fn(async () => {}),
     onDelete: vi.fn(async () => {}),
+    identityKey: 'user-a:member',
+    operationScope: ['user-a:member', 1],
   };
 
   return render(
@@ -32,5 +34,45 @@ describe('EnvVarEditor', () => {
     const renderedKeys = screen.getAllByText(/_TOKEN$/).map((node) => node.textContent);
     expect(renderedKeys).toEqual(['alpha_TOKEN', 'BETA_TOKEN', 'Z_TOKEN']);
     expect(Object.keys(envVars)).toEqual(originalKeys);
+  });
+
+  it('preserves a same-user reconnect draft while invalidating the old save', async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const onSave = vi.fn(() => pending);
+    const view = (identityKey: string, generation: number) => (
+      <AntApp>
+        <EnvVarEditor
+          envVars={{}}
+          onSave={onSave}
+          onDelete={vi.fn(async () => {})}
+          identityKey={identityKey}
+          operationScope={[identityKey, generation]}
+        />
+      </AntApp>
+    );
+    const rendered = render(view('member-a:member', 2));
+    fireEvent.change(screen.getByPlaceholderText(/variable name/i), {
+      target: { value: 'PRIVATE_TOKEN' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Value'), {
+      target: { value: 'member-a-secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+    expect(onSave).toHaveBeenCalledWith('PRIVATE_TOKEN', 'member-a-secret', 'global');
+
+    rendered.rerender(view('member-a:member', 3));
+    await act(async () => {
+      resolve();
+      await pending;
+    });
+    expect(screen.getByPlaceholderText(/variable name/i)).toHaveValue('PRIVATE_TOKEN');
+    expect(screen.getByPlaceholderText('Value')).toHaveValue('member-a-secret');
+
+    rendered.rerender(view('member-b:member', 4));
+    expect(screen.getByPlaceholderText(/variable name/i)).toHaveValue('');
+    expect(screen.getByPlaceholderText('Value')).toHaveValue('');
   });
 });

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -1,7 +1,8 @@
 import { ENV_VAR_SCOPES_V05, type EnvVarMetadata, type EnvVarScope } from '@agor-live/client';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Alert, Button, Input, Select, Space, Table, Tooltip, Typography } from 'antd';
-import { useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { Tag } from './Tag';
 
 const { Text } = Typography;
@@ -26,6 +27,8 @@ export interface EnvVarEditorProps {
   loading?: Record<string, boolean>;
   /** Disable all fields */
   disabled?: boolean;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
 }
 
 function entryToMetadata(entry: EnvVarEntry): { set: boolean; scope: EnvVarScope } {
@@ -65,6 +68,8 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   onDelete,
   loading = {},
   disabled = false,
+  identityKey,
+  operationScope,
 }) => {
   const [newKey, setNewKey] = useState('');
   const [newValue, setNewValue] = useState('');
@@ -72,52 +77,76 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey is the caller-private draft lifecycle key
+  useLayoutEffect(() => {
+    setNewKey('');
+    setNewValue('');
+    setNewScope('global');
+    setEditingKey(null);
+    setEditingValue('');
+    setError(null);
+  }, [identityKey]);
 
   const handleAdd = async () => {
-    if (!newKey.trim() || !newValue.trim()) return;
+    const operation = operationGuard.begin();
+    if (!newKey.trim() || !newValue.trim() || !operation.isCurrent()) return;
 
     try {
       setError(null);
       await onSave(newKey.trim(), newValue.trim(), newScope);
+      if (!operation.isCurrent()) return;
       setNewKey('');
       setNewValue('');
       setNewScope('global');
     } catch (err) {
+      if (!operation.isCurrent()) return;
       const message = err instanceof Error ? err.message : 'Failed to save environment variable';
       setError(message);
     }
   };
 
   const handleUpdate = async (key: string, scope: EnvVarScope) => {
-    if (!editingValue.trim()) return;
+    const operation = operationGuard.begin();
+    if (!editingValue.trim() || !operation.isCurrent()) return;
 
     try {
       setError(null);
       await onSave(key, editingValue.trim(), scope);
+      if (!operation.isCurrent()) return;
       setEditingKey(null);
       setEditingValue('');
     } catch (err) {
+      if (!operation.isCurrent()) return;
       const message = err instanceof Error ? err.message : 'Failed to update environment variable';
       setError(message);
     }
   };
 
   const handleScopeChange = async (key: string, scope: EnvVarScope) => {
-    if (!onScopeChange) return;
+    const operation = operationGuard.begin();
+    if (!onScopeChange || !operation.isCurrent()) return;
     try {
       setError(null);
       await onScopeChange(key, scope);
+      if (!operation.isCurrent()) return;
     } catch (err) {
+      if (!operation.isCurrent()) return;
       const message = err instanceof Error ? err.message : 'Failed to update scope';
       setError(message);
     }
   };
 
   const handleDeleteClick = async (key: string) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       setError(null);
       await onDelete(key);
+      if (!operation.isCurrent()) return;
     } catch (err) {
+      if (!operation.isCurrent()) return;
       const message = err instanceof Error ? err.message : 'Failed to delete environment variable';
       setError(message);
     }

--- a/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.test.tsx
+++ b/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.test.tsx
@@ -1,0 +1,86 @@
+import type { User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '@/contexts/ConnectionContext';
+import { ForcePasswordChangeModal } from './ForcePasswordChangeModal';
+
+const user = (id: string): User =>
+  ({
+    user_id: id,
+    email: `${id}@example.test`,
+    role: 'admin',
+    must_change_password: true,
+  }) as User;
+
+describe('ForcePasswordChangeModal authority fencing', () => {
+  it('erases A password fields and drops validation continuation before admin B can use it', async () => {
+    const onChangePassword = vi.fn().mockResolvedValue(undefined);
+    const view = (current: User, authGeneration: number) => (
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          authGeneration,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <ForcePasswordChangeModal
+          open
+          user={current}
+          onChangePassword={onChangePassword}
+          onLogout={vi.fn()}
+        />
+      </ConnectionProvider>
+    );
+    const rendered = render(view(user('admin-a'), 4));
+    fireEvent.change(screen.getByLabelText('New Password'), {
+      target: { value: 'admin-a-secret-password' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'admin-a-secret-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Change Password' }));
+
+    // Replace authority in the same commit window in which Ant validation's
+    // promise resolves. The render-invalidated operation must win.
+    rendered.rerender(view(user('admin-b'), 5));
+    await Promise.resolve();
+    expect(onChangePassword).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByLabelText('New Password')).toHaveValue(''));
+    expect(screen.getByLabelText('Confirm Password')).toHaveValue('');
+  });
+
+  it('keeps a same-user draft on reconnect but cancels its obsolete submit', async () => {
+    const onChangePassword = vi.fn().mockResolvedValue(undefined);
+    const makeView = (connected: boolean, generation: number) => (
+      <ConnectionProvider
+        value={{
+          connected,
+          connecting: !connected,
+          authGeneration: generation,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <ForcePasswordChangeModal
+          open
+          user={user('admin-a')}
+          onChangePassword={onChangePassword}
+          onLogout={vi.fn()}
+        />
+      </ConnectionProvider>
+    );
+    const rendered = render(makeView(true, 8));
+    fireEvent.change(screen.getByLabelText('New Password'), {
+      target: { value: 'same-user-draft-password' },
+    });
+    rendered.rerender(makeView(false, 8));
+    expect(screen.getByLabelText('New Password')).toHaveValue('same-user-draft-password');
+    fireEvent.click(screen.getByRole('button', { name: 'Change Password' }));
+    await Promise.resolve();
+    expect(onChangePassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
+++ b/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
@@ -8,7 +8,9 @@
 import type { User } from '@agor-live/client';
 import { LockOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert, Form, Input, Modal, Typography, theme } from 'antd';
-import { useState } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { useConnectionState } from '@/contexts/ConnectionContext';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useAuthConfig } from '../../hooks/useAuthConfig';
 import {
   passwordPolicyHelp,
@@ -21,7 +23,12 @@ const { Text } = Typography;
 interface ForcePasswordChangeModalProps {
   open: boolean;
   user: User | null;
-  onChangePassword: (userId: string, newPassword: string) => Promise<void>;
+  onChangePassword: (
+    userId: string,
+    newPassword: string,
+    shouldApply: () => boolean,
+    isSameIdentity: () => boolean
+  ) => Promise<void>;
   onLogout: () => void;
 }
 
@@ -37,27 +44,60 @@ export function ForcePasswordChangeModal({
   const { token } = theme.useToken();
   const { config: authConfig } = useAuthConfig();
   const passwordRequirements = passwordPolicyRequirements(authConfig?.passwordPolicy);
+  const { connected, connecting, authGeneration } = useConnectionState();
+  const identityKey = user ? `${user.user_id}:${user.role}` : null;
+  const authorityScope = useMemo(
+    () => (identityKey && connected && !connecting ? [identityKey, authGeneration] : null),
+    [authGeneration, connected, connecting, identityKey]
+  );
+  const operationGuard = useAuthorityOperationGuard(authorityScope);
+  const identityGuard = useAuthorityOperationGuard(identityKey ? [identityKey] : null);
+
+  // Password drafts are identity-private. A reconnect cancels the operation
+  // via authorityScope but deliberately does not erase a same-user draft.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey intentionally resets the Ant form for a replacement caller
+  useLayoutEffect(() => {
+    form.resetFields();
+    setLoading(false);
+    setError(null);
+  }, [form, identityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setLoading(false);
+  }, [authorityScope]);
 
   const handleSubmit = async () => {
     if (!user) return;
+    const operation = operationGuard.begin();
+    const identityOperation = identityGuard.begin();
+    if (!operation.isCurrent() || !identityOperation.isCurrent()) return;
 
     try {
       const values = await form.validateFields();
+      if (!operation.isCurrent()) return;
       setLoading(true);
       setError(null);
 
-      await onChangePassword(user.user_id, values.newPassword);
+      await onChangePassword(
+        user.user_id,
+        values.newPassword,
+        operation.isCurrent,
+        identityOperation.isCurrent
+      );
+      if (!operation.isCurrent()) return;
 
       // Success - modal will close when user.must_change_password becomes false
       form.resetFields();
     } catch (err) {
+      if (!operation.isCurrent()) return;
       if (err instanceof Error) {
         setError(err.message);
       } else {
         // Form validation error, ignore
       }
     } finally {
-      setLoading(false);
+      if (operation.isCurrent()) setLoading(false);
     }
   };
 
@@ -73,7 +113,9 @@ export function ForcePasswordChangeModal({
       onOk={handleSubmit}
       okText="Change Password"
       cancelText="Logout"
-      onCancel={onLogout}
+      onCancel={() => {
+        if (operationGuard.isCurrent()) onLogout();
+      }}
       confirmLoading={loading}
       closable={false}
       mask={{ closable: false }}
@@ -98,7 +140,7 @@ export function ForcePasswordChangeModal({
         />
       )}
 
-      <Form form={form} layout="vertical">
+      <Form key={identityKey ?? 'no-user'} form={form} layout="vertical">
         <Form.Item
           name="newPassword"
           label="New Password"

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -75,7 +75,14 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     } as MCPServer;
 
     render(
-      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        authorityKey="user-a:admin:1"
+        mutationAllowed
+        onClose={vi.fn()}
+      />
     );
 
     fireEvent.change(await screen.findByLabelText('Description'), {
@@ -121,6 +128,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           server={server}
           open
           client={client}
+          authorityKey="user-a:admin:1"
           mutationAllowed
           onClose={vi.fn()}
         />
@@ -159,7 +167,14 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     } as MCPServer;
 
     render(
-      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={onClose} />
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        authorityKey="user-a:admin:1"
+        mutationAllowed
+        onClose={onClose}
+      />
     );
 
     fireEvent.change(await screen.findByLabelText('Client ID'), {
@@ -206,7 +221,14 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     } as MCPServer;
 
     render(
-      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        authorityKey="user-a:admin:1"
+        mutationAllowed
+        onClose={vi.fn()}
+      />
     );
 
     fireEvent.change(await screen.findByLabelText('Client ID'), {
@@ -248,7 +270,14 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     } as MCPServer;
 
     render(
-      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        authorityKey="user-a:admin:1"
+        mutationAllowed
+        onClose={vi.fn()}
+      />
     );
 
     fireEvent.change(await screen.findByLabelText('URL'), {
@@ -300,6 +329,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           server={server}
           open
           client={client}
+          authorityKey={mutationAllowed ? 'user-a:admin:1' : null}
           mutationAllowed={mutationAllowed}
           mutationBlockedReason="Connection authority changed"
           onClose={vi.fn()}

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -79,6 +79,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         server={server}
         open
         client={client}
+        identityKey="user-a"
         authorityKey="user-a:admin:1"
         mutationAllowed
         onClose={vi.fn()}
@@ -128,6 +129,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           server={server}
           open
           client={client}
+          identityKey="user-a"
           authorityKey="user-a:admin:1"
           mutationAllowed
           onClose={vi.fn()}
@@ -171,6 +173,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         server={server}
         open
         client={client}
+        identityKey="user-a"
         authorityKey="user-a:admin:1"
         mutationAllowed
         onClose={onClose}
@@ -225,6 +228,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         server={server}
         open
         client={client}
+        identityKey="user-a"
         authorityKey="user-a:admin:1"
         mutationAllowed
         onClose={vi.fn()}
@@ -274,6 +278,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         server={server}
         open
         client={client}
+        identityKey="user-a"
         authorityKey="user-a:admin:1"
         mutationAllowed
         onClose={vi.fn()}
@@ -307,6 +312,71 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     expect(showError).not.toHaveBeenCalled();
   });
 
+  it('remounts same-server OAuth form state across admin A -> admin B', async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const client = {
+      service: vi.fn().mockReturnValue({ patch }),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const serverA = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000050',
+      name: 'same-server-id',
+      transport: 'http',
+      url: 'https://same.example/mcp',
+      scope: 'global',
+      enabled: true,
+      auth: {
+        type: 'oauth',
+        oauth_client_id: 'admin-a-client',
+        oauth_client_secret: 'admin-a-saved-secret',
+      },
+    } as MCPServer;
+    const serverB = {
+      ...serverA,
+      auth: {
+        type: 'oauth',
+        oauth_client_id: 'admin-b-client',
+        oauth_client_secret: 'admin-b-saved-secret',
+      },
+    } as MCPServer;
+    const view = (identityKey: string, server: MCPServer) => (
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        identityKey={identityKey}
+        authorityKey={`${identityKey}:admin:2`}
+        mutationAllowed
+        onClose={vi.fn()}
+      />
+    );
+    const rendered = render(view('admin-a', serverA));
+    const secret = await screen.findByLabelText('Client Secret');
+    fireEvent.change(secret, { target: { value: 'admin-a-unsaved-secret' } });
+    const staleSave = screen.getByRole('button', { name: 'Save' });
+
+    rendered.rerender(view('admin-b', serverB));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Client Secret')).toHaveValue('admin-b-saved-secret')
+    );
+    expect(screen.queryByDisplayValue('admin-a-unsaved-secret')).not.toBeInTheDocument();
+    fireEvent.click(staleSave);
+    expect(patch).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+    expect(patch).toHaveBeenCalledWith(
+      serverB.mcp_server_id,
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          oauth_client_id: 'admin-b-client',
+          oauth_client_secret: 'admin-b-saved-secret',
+        }),
+      })
+    );
+  });
+
   it.each(['Save', 'Start OAuth Flow'])(
     'blocks %s after authority is lost while the edit dialog remains open',
     async (action) => {
@@ -329,6 +399,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           server={server}
           open
           client={client}
+          identityKey="user-a"
           authorityKey={mutationAllowed ? 'user-a:admin:1' : null}
           mutationAllowed={mutationAllowed}
           mutationBlockedReason="Connection authority changed"

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -9,6 +9,7 @@ const preparedServerId = vi.fn();
 
 type FormFieldsMockProps = {
   onPrepareOAuthStart: () => Promise<string | null>;
+  onTestConnection: () => Promise<void>;
 };
 
 vi.mock('@/utils/message', () => ({
@@ -23,7 +24,7 @@ vi.mock('@/utils/message', () => ({
 vi.mock('./MCPServerFormFields', async () => {
   const { Button, Form, Input } = await import('antd');
   return {
-    MCPServerFormFields: ({ onPrepareOAuthStart }: FormFieldsMockProps) => (
+    MCPServerFormFields: ({ onPrepareOAuthStart, onTestConnection }: FormFieldsMockProps) => (
       <>
         <Form.Item label="Description" name="description">
           <Input />
@@ -46,6 +47,7 @@ vi.mock('./MCPServerFormFields', async () => {
         <Button onClick={() => void onPrepareOAuthStart().then(preparedServerId)}>
           Start OAuth Flow
         </Button>
+        <Button onClick={() => void onTestConnection()}>Test Connection</Button>
       </>
     ),
   };
@@ -81,6 +83,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         client={client}
         identityKey="user-a"
         authorityKey="user-a:admin:1"
+        authGeneration={1}
         mutationAllowed
         onClose={vi.fn()}
       />
@@ -131,6 +134,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           client={client}
           identityKey="user-a"
           authorityKey="user-a:admin:1"
+          authGeneration={1}
           mutationAllowed
           onClose={vi.fn()}
         />
@@ -175,6 +179,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         client={client}
         identityKey="user-a"
         authorityKey="user-a:admin:1"
+        authGeneration={1}
         mutationAllowed
         onClose={onClose}
       />
@@ -230,6 +235,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         client={client}
         identityKey="user-a"
         authorityKey="user-a:admin:1"
+        authGeneration={1}
         mutationAllowed
         onClose={vi.fn()}
       />
@@ -280,6 +286,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         client={client}
         identityKey="user-a"
         authorityKey="user-a:admin:1"
+        authGeneration={1}
         mutationAllowed
         onClose={vi.fn()}
       />
@@ -346,6 +353,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         client={client}
         identityKey={identityKey}
         authorityKey={`${identityKey}:admin:2`}
+        authGeneration={2}
         mutationAllowed
         onClose={vi.fn()}
       />
@@ -377,6 +385,82 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     );
   });
 
+  it('drops a delayed saved-server discovery browser event across admin A -> admin B', async () => {
+    let resolveDiscover: ((value: { success: boolean }) => void) | undefined;
+    const discover = vi.fn(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveDiscover = resolve;
+        })
+    );
+    const listeners = new Set<(event: Record<string, unknown>) => void>();
+    const client = {
+      service: vi.fn((path: string) =>
+        path === 'mcp-servers/discover' ? { create: discover } : { patch: vi.fn() }
+      ),
+      io: {
+        on: vi.fn((_event: string, listener: (event: Record<string, unknown>) => void) =>
+          listeners.add(listener)
+        ),
+        off: vi.fn((_event: string, listener: (event: Record<string, unknown>) => void) =>
+          listeners.delete(listener)
+        ),
+      },
+    } as unknown as AgorClient;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000060',
+      name: 'delayed-oauth',
+      transport: 'http',
+      url: 'https://delayed.example/mcp',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const view = (identityKey: string, authGeneration: number) => (
+      <MCPServerEditModal
+        server={server}
+        open
+        client={client}
+        identityKey={identityKey}
+        authorityKey={`${identityKey}:admin:${authGeneration}`}
+        authGeneration={authGeneration}
+        mutationAllowed
+        onClose={vi.fn()}
+      />
+    );
+    const rendered = render(view('admin-a', 31));
+    await screen.findByLabelText('URL');
+    fireEvent.click(screen.getByRole('button', { name: 'Test Connection' }));
+    await waitFor(() => expect(discover).toHaveBeenCalledOnce());
+    const request = discover.mock.calls[0]?.[0] as {
+      oauth_browser_event: { operation_id: string; auth_generation: number };
+    };
+    expect(request.oauth_browser_event.auth_generation).toBe(31);
+    expect(listeners.size).toBe(1);
+    // Socket.IO may already have snapshotted a callback for dispatch when the
+    // identity commit removes it. Exercise that queued callback directly.
+    const queuedListeners = [...listeners];
+
+    rendered.rerender(view('admin-b', 32));
+    expect(listeners.size).toBe(0);
+    for (const listener of queuedListeners) {
+      listener({
+        authUrl: 'https://provider.example/admin-a',
+        attempt_id: 'attempt-admin-a',
+        operation_id: request.oauth_browser_event.operation_id,
+        auth_generation: 31,
+        caller_user_id: 'admin-a',
+      });
+    }
+    resolveDiscover?.({ success: true });
+    await Promise.resolve();
+
+    expect(open).not.toHaveBeenCalled();
+    expect(discover).toHaveBeenCalledOnce();
+    open.mockRestore();
+  });
+
   it.each(['Save', 'Start OAuth Flow'])(
     'blocks %s after authority is lost while the edit dialog remains open',
     async (action) => {
@@ -401,6 +485,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
           client={client}
           identityKey="user-a"
           authorityKey={mutationAllowed ? 'user-a:admin:1' : null}
+          authGeneration={1}
           mutationAllowed={mutationAllowed}
           mutationBlockedReason="Connection authority changed"
           onClose={vi.fn()}

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -394,10 +394,16 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         })
     );
     const listeners = new Set<(event: Record<string, unknown>) => void>();
+    const reserve = vi.fn().mockResolvedValue({
+      reservation_token: 'server-reservation-admin-a-00000001',
+      expires_at: Date.now() + 60_000,
+    });
     const client = {
-      service: vi.fn((path: string) =>
-        path === 'mcp-servers/discover' ? { create: discover } : { patch: vi.fn() }
-      ),
+      service: vi.fn((path: string) => {
+        if (path === 'mcp-servers/discover') return { create: discover };
+        if (path === 'mcp-servers/oauth-browser-reservations') return { create: reserve };
+        return { patch: vi.fn() };
+      }),
       io: {
         on: vi.fn((_event: string, listener: (event: Record<string, unknown>) => void) =>
           listeners.add(listener)
@@ -434,9 +440,12 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Test Connection' }));
     await waitFor(() => expect(discover).toHaveBeenCalledOnce());
     const request = discover.mock.calls[0]?.[0] as {
-      oauth_browser_event: { operation_id: string; auth_generation: number };
+      oauth_browser_event: { reservation_token: string };
     };
-    expect(request.oauth_browser_event.auth_generation).toBe(31);
+    expect(reserve).toHaveBeenCalledWith({
+      operation: 'discover',
+      mcp_server_id: server.mcp_server_id,
+    });
     expect(listeners.size).toBe(1);
     // Socket.IO may already have snapshotted a callback for dispatch when the
     // identity commit removes it. Exercise that queued callback directly.
@@ -448,8 +457,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       listener({
         authUrl: 'https://provider.example/admin-a',
         attempt_id: 'attempt-admin-a',
-        operation_id: request.oauth_browser_event.operation_id,
-        auth_generation: 31,
+        reservation_token: request.oauth_browser_event.reservation_token,
         caller_user_id: 'admin-a',
       });
     }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -74,7 +74,9 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       auth: { type: 'oauth' },
     } as MCPServer;
 
-    render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+    render(
+      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+    );
 
     fireEvent.change(await screen.findByLabelText('Description'), {
       target: { value: 'after' },
@@ -114,7 +116,15 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
         },
       } as MCPServer;
 
-      render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+      render(
+        <MCPServerEditModal
+          server={server}
+          open
+          client={client}
+          mutationAllowed
+          onClose={vi.fn()}
+        />
+      );
 
       expect(await screen.findByLabelText('OAuth Compatibility')).toHaveValue('marketplace');
       fireEvent.click(screen.getByRole('button', { name: action }));
@@ -148,7 +158,9 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       },
     } as MCPServer;
 
-    render(<MCPServerEditModal server={server} open client={client} onClose={onClose} />);
+    render(
+      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={onClose} />
+    );
 
     fireEvent.change(await screen.findByLabelText('Client ID'), {
       target: { value: 'fresh-client-id' },
@@ -193,7 +205,9 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       },
     } as MCPServer;
 
-    render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+    render(
+      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+    );
 
     fireEvent.change(await screen.findByLabelText('Client ID'), {
       target: { value: 'fresh-client-id' },
@@ -233,7 +247,9 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       },
     } as MCPServer;
 
-    render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+    render(
+      <MCPServerEditModal server={server} open client={client} mutationAllowed onClose={vi.fn()} />
+    );
 
     fireEvent.change(await screen.findByLabelText('URL'), {
       target: { value: 'https://current.example/mcp' },
@@ -261,4 +277,45 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     await waitFor(() => expect(preparedServerId).toHaveBeenCalledWith(server.mcp_server_id));
     expect(showError).not.toHaveBeenCalled();
   });
+
+  it.each(['Save', 'Start OAuth Flow'])(
+    'blocks %s after authority is lost while the edit dialog remains open',
+    async (action) => {
+      const patch = vi.fn().mockResolvedValue({});
+      const client = {
+        service: vi.fn().mockReturnValue({ patch }),
+        io: { on: vi.fn(), off: vi.fn() },
+      } as unknown as AgorClient;
+      const server = {
+        mcp_server_id: '01900000-0000-7000-8000-000000000099',
+        name: 'transition-oauth',
+        transport: 'http',
+        url: 'https://transition.example/mcp',
+        scope: 'global',
+        enabled: true,
+        auth: { type: 'oauth' },
+      } as MCPServer;
+      const view = (mutationAllowed: boolean) => (
+        <MCPServerEditModal
+          server={server}
+          open
+          client={client}
+          mutationAllowed={mutationAllowed}
+          mutationBlockedReason="Connection authority changed"
+          onClose={vi.fn()}
+        />
+      );
+      const rendered = render(view(true));
+      await screen.findByLabelText('URL');
+
+      rendered.rerender(view(false));
+      fireEvent.click(screen.getByRole('button', { name: action }));
+
+      expect(patch).not.toHaveBeenCalled();
+      expect(preparedServerId).not.toHaveBeenCalled();
+      if (action === 'Save') {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+      }
+    }
+  );
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -5,8 +5,8 @@ import type {
   MCPTransport,
   UpdateMCPServerInput,
 } from '@agor-live/client';
-import { Button, Form, Modal, Space, Tooltip } from 'antd';
-import { useEffect, useState } from 'react';
+import { Alert, Button, Form, Modal, Space, Tooltip } from 'antd';
+import { useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerFormFields } from './MCPServerFormFields';
 import {
@@ -30,6 +30,9 @@ export interface MCPServerEditModalProps {
   offeredTransports?: MCPTransport[];
   /** The scopes this editor may switch to, on the same terms. */
   offeredScopes?: MCPScope[];
+  /** Current server-side capability/connection decision from the owner. */
+  mutationAllowed: boolean;
+  mutationBlockedReason?: string;
   onClose: () => void;
   /** Runs after the portal has finished closing (for example, to restore focus). */
   afterClose?: () => void;
@@ -62,6 +65,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   client,
   offeredTransports,
   offeredScopes,
+  mutationAllowed,
+  mutationBlockedReason = 'You can no longer change this MCP server.',
   onClose,
   afterClose,
   focusTriggerAfterClose,
@@ -87,7 +92,9 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     open && formHydrated
       ? missingMCPFieldLabels(form.getFieldsValue(true), { mode: 'edit', transport, authType })
       : [];
-  const saveBlocked = missingRequiredFields.length > 0;
+  const saveBlocked = !mutationAllowed || missingRequiredFields.length > 0;
+  const mutationStateRef = useRef({ allowed: mutationAllowed, reason: mutationBlockedReason });
+  mutationStateRef.current = { allowed: mutationAllowed, reason: mutationBlockedReason };
 
   // Hydrate the form when the modal opens or the user swaps to a different
   // server. Intentionally NOT keyed on `server` itself — that would clobber
@@ -256,9 +263,17 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
 
   const saveFormValues = async (): Promise<boolean> => {
     if (!server || !client) return false;
+    if (!mutationStateRef.current.allowed) {
+      showError(mutationStateRef.current.reason);
+      return false;
+    }
 
     try {
       await form.validateFields();
+      if (!mutationStateRef.current.allowed) {
+        showError(mutationStateRef.current.reason);
+        return false;
+      }
       const values = form.getFieldsValue(true);
 
       const updates: UpdateMCPServerInput = {
@@ -286,6 +301,10 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         preserveAbsentGrantType,
       });
 
+      if (!mutationStateRef.current.allowed) {
+        showError(mutationStateRef.current.reason);
+        return false;
+      }
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
       return true;
     } catch (error) {
@@ -324,7 +343,15 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         <Space>
           <Button onClick={closeAndReset}>Cancel</Button>
           {/* A disabled button can't host a tooltip of its own — hence the span. */}
-          <Tooltip title={saveBlocked ? describeMissingForSave(missingRequiredFields) : undefined}>
+          <Tooltip
+            title={
+              !mutationAllowed
+                ? mutationBlockedReason
+                : saveBlocked
+                  ? describeMissingForSave(missingRequiredFields)
+                  : undefined
+            }
+          >
             <span>
               <Button type="primary" disabled={saveBlocked} onClick={handleSave}>
                 Save
@@ -334,6 +361,15 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         </Space>
       }
     >
+      {!mutationAllowed && (
+        <Alert
+          type="warning"
+          showIcon
+          title="MCP server changes are unavailable"
+          description={mutationBlockedReason}
+          style={{ marginTop: 16 }}
+        />
+      )}
       <Form
         form={form}
         layout="vertical"
@@ -362,6 +398,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
           testing={testing}
           testResult={testResult}
           onPrepareOAuthStart={prepareOAuthStart}
+          mutationAllowed={mutationAllowed}
+          mutationBlockedReason={mutationBlockedReason}
           formRevision={formRevision}
           managedOAuthCompatibilityMode={
             server?.oauth_compatibility_policy?.managed_by_catalog &&

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -220,6 +220,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
       showError('Connection test is not available for stdio transport');
       return;
     }
+    let browserAttempt: Awaited<ReturnType<typeof oauthBrowserEvents.begin>> = null;
     try {
       await form.validateFields(['headers']);
     } catch {
@@ -229,11 +230,13 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     }
     if (!operation.isCurrent()) return;
 
-    setTesting(true);
-    setTestResult(null);
-    const browserAttempt = oauthBrowserEvents.begin();
-
     try {
+      setTesting(true);
+      setTestResult(null);
+      browserAttempt = await oauthBrowserEvents.begin({
+        operation: 'discover',
+        mcpServerId: server.mcp_server_id,
+      });
       if (!operation.isCurrent()) return;
       const data = (await client.service('mcp-servers/discover').create({
         mcp_server_id: server.mcp_server_id,

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -22,6 +22,8 @@ export interface MCPServerEditModalProps {
   server: MCPServer | null;
   open: boolean;
   client: AgorClient | null;
+  /** Authenticated identity that owns the form contents and selected server. */
+  identityKey: string | null;
   /** Current identity/role/auth generation, null while authority is unavailable. */
   authorityKey: string | null;
   /**
@@ -61,10 +63,11 @@ interface TestResult {
  * both `MCPServersTable` (settings) and `SessionMcpFooterControl` (admin
  * shortcut).
  */
-export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
+const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   server,
   open,
   client,
+  identityKey: _identityKey,
   authorityKey,
   offeredTransports,
   offeredScopes,
@@ -88,6 +91,13 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   // animates in.
   const [formHydrated, setFormHydrated] = useState(false);
   const [formRevision, bumpFormRevision] = useFormRevision();
+  const identityActiveRef = useRef(true);
+  useEffect(() => {
+    identityActiveRef.current = true;
+    return () => {
+      identityActiveRef.current = false;
+    };
+  }, []);
 
   // Only ask the form once it is rendered and filled — an unmounted instance
   // warns, and a half-hydrated one would flash Save disabled.
@@ -183,6 +193,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   };
 
   const handleTestConnection = async () => {
+    if (!identityActiveRef.current) return;
     if (!client || !server) {
       // Pre-flight failure — no inline result UI yet, so a toast is the
       // only signal we have. Result-bearing failures below set testResult
@@ -204,9 +215,11 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     try {
       await form.validateFields(['headers']);
     } catch {
+      if (!identityActiveRef.current) return;
       showError('Please fix custom HTTP headers before testing');
       return;
     }
+    if (!identityActiveRef.current) return;
 
     setTesting(true);
     setTestResult(null);
@@ -231,6 +244,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         prompts?: Array<{ name: string; description: string }>;
       };
 
+      if (!identityActiveRef.current) return;
+
       if (data.success && data.capabilities) {
         setTestResult({
           success: true,
@@ -251,6 +266,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         });
       }
     } catch (error) {
+      if (!identityActiveRef.current) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setTestResult({
         success: false,
@@ -260,12 +276,12 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         error: errorMessage,
       });
     } finally {
-      setTesting(false);
+      if (identityActiveRef.current) setTesting(false);
     }
   };
 
   const saveFormValues = async (): Promise<boolean> => {
-    if (!server || !client) return false;
+    if (!server || !client || !identityActiveRef.current) return false;
     if (!mutationStateRef.current.allowed) {
       showError(mutationStateRef.current.reason);
       return false;
@@ -273,7 +289,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
 
     try {
       await form.validateFields();
-      if (!mutationStateRef.current.allowed) {
+      if (!identityActiveRef.current || !mutationStateRef.current.allowed) {
         showError(mutationStateRef.current.reason);
         return false;
       }
@@ -304,13 +320,14 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         preserveAbsentGrantType,
       });
 
-      if (!mutationStateRef.current.allowed) {
+      if (!identityActiveRef.current || !mutationStateRef.current.allowed) {
         showError(mutationStateRef.current.reason);
         return false;
       }
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
-      return true;
+      return identityActiveRef.current;
     } catch (error) {
+      if (!identityActiveRef.current) return false;
       // Name the field, rather than letting a rejected validation surface as
       // the generic message its non-Error shape would produce.
       const errorMessage =
@@ -323,6 +340,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
 
   const handleSave = async () => {
     if (await saveFormValues()) {
+      if (!identityActiveRef.current) return;
       showSuccess('MCP server updated successfully');
       closeAndReset();
     }
@@ -417,3 +435,17 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     </Modal>
   );
 };
+
+/**
+ * The form can contain raw OAuth/JWT/bearer credentials. Remount its entire
+ * state owner when the authenticated identity changes so another same-role
+ * caller cannot inherit a selected row or any registered Ant Form value.
+ * `authorityKey` remains a finer mutation gate; it intentionally does not key
+ * this owner, preserving same-user reconnect and token-refresh edits.
+ */
+export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = (props) => (
+  <MCPServerEditModalForIdentity
+    key={props.identityKey ?? '__no-authenticated-user__'}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@agor-live/client';
 import { Alert, Button, Form, Modal, Space, Tooltip } from 'antd';
 import { useEffect, useRef, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerFormFields } from './MCPServerFormFields';
 import {
@@ -16,6 +17,7 @@ import {
   useFormRevision,
 } from './mcp-form-requirements';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from './mcp-oauth-utils';
+import { useOAuthBrowserEventAttempt } from './useOAuthBrowserEventAttempt';
 
 export interface MCPServerEditModalProps {
   /** The server being edited. Modal opens when this is non-null and `open` is true. */
@@ -24,6 +26,8 @@ export interface MCPServerEditModalProps {
   client: AgorClient | null;
   /** Authenticated identity that owns the form contents and selected server. */
   identityKey: string | null;
+  /** Successful socket-auth generation used to scope compatibility events. */
+  authGeneration: number;
   /** Current identity/role/auth generation, null while authority is unavailable. */
   authorityKey: string | null;
   /**
@@ -67,7 +71,8 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   server,
   open,
   client,
-  identityKey: _identityKey,
+  identityKey,
+  authGeneration,
   authorityKey,
   offeredTransports,
   offeredScopes,
@@ -91,13 +96,15 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   // animates in.
   const [formHydrated, setFormHydrated] = useState(false);
   const [formRevision, bumpFormRevision] = useFormRevision();
-  const identityActiveRef = useRef(true);
-  useEffect(() => {
-    identityActiveRef.current = true;
-    return () => {
-      identityActiveRef.current = false;
-    };
-  }, []);
+  const operationGuard = useAuthorityOperationGuard(
+    authorityKey && mutationAllowed ? [authorityKey, client, mutationAllowed] : null
+  );
+  const oauthBrowserEvents = useOAuthBrowserEventAttempt({
+    client,
+    currentUserId: identityKey,
+    authGeneration,
+    authorityGuard: operationGuard,
+  });
 
   // Only ask the form once it is rendered and filled — an unmounted instance
   // warns, and a half-hydrated one would flash Save disabled.
@@ -193,7 +200,8 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   };
 
   const handleTestConnection = async () => {
-    if (!identityActiveRef.current) return;
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!client || !server) {
       // Pre-flight failure — no inline result UI yet, so a toast is the
       // only signal we have. Result-bearing failures below set testResult
@@ -215,16 +223,18 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     try {
       await form.validateFields(['headers']);
     } catch {
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       showError('Please fix custom HTTP headers before testing');
       return;
     }
-    if (!identityActiveRef.current) return;
+    if (!operation.isCurrent()) return;
 
     setTesting(true);
     setTestResult(null);
+    const browserAttempt = oauthBrowserEvents.begin();
 
     try {
+      if (!operation.isCurrent()) return;
       const data = (await client.service('mcp-servers/discover').create({
         mcp_server_id: server.mcp_server_id,
         url: values.url,
@@ -235,6 +245,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
           preserveAbsentGrantType,
         }),
         headers: parseHeadersJSON(values.headers),
+        ...(browserAttempt ? { oauth_browser_event: browserAttempt.request } : {}),
       })) as {
         success: boolean;
         error?: string;
@@ -244,7 +255,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         prompts?: Array<{ name: string; description: string }>;
       };
 
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
 
       if (data.success && data.capabilities) {
         setTestResult({
@@ -266,7 +277,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         });
       }
     } catch (error) {
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setTestResult({
         success: false,
@@ -276,12 +287,15 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         error: errorMessage,
       });
     } finally {
-      if (identityActiveRef.current) setTesting(false);
+      browserAttempt?.cleanup();
+      if (operation.isCurrent()) setTesting(false);
     }
   };
 
-  const saveFormValues = async (): Promise<boolean> => {
-    if (!server || !client || !identityActiveRef.current) return false;
+  const saveFormValues = async (
+    operation: ReturnType<typeof operationGuard.begin>
+  ): Promise<boolean> => {
+    if (!server || !client || !operation.isCurrent()) return false;
     if (!mutationStateRef.current.allowed) {
       showError(mutationStateRef.current.reason);
       return false;
@@ -289,7 +303,8 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
 
     try {
       await form.validateFields();
-      if (!identityActiveRef.current || !mutationStateRef.current.allowed) {
+      if (!operation.isCurrent()) return false;
+      if (!mutationStateRef.current.allowed) {
         showError(mutationStateRef.current.reason);
         return false;
       }
@@ -320,14 +335,15 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         preserveAbsentGrantType,
       });
 
-      if (!identityActiveRef.current || !mutationStateRef.current.allowed) {
+      if (!operation.isCurrent()) return false;
+      if (!mutationStateRef.current.allowed) {
         showError(mutationStateRef.current.reason);
         return false;
       }
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
-      return identityActiveRef.current;
+      return operation.isCurrent();
     } catch (error) {
-      if (!identityActiveRef.current) return false;
+      if (!operation.isCurrent()) return false;
       // Name the field, rather than letting a rejected validation surface as
       // the generic message its non-Error shape would produce.
       const errorMessage =
@@ -339,15 +355,17 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   };
 
   const handleSave = async () => {
-    if (await saveFormValues()) {
-      if (!identityActiveRef.current) return;
+    const operation = operationGuard.begin();
+    if (await saveFormValues(operation)) {
+      if (!operation.isCurrent()) return;
       showSuccess('MCP server updated successfully');
       closeAndReset();
     }
   };
 
   const prepareOAuthStart = async (): Promise<string | null> => {
-    if (!(await saveFormValues())) return null;
+    const operation = operationGuard.begin();
+    if (!(await saveFormValues(operation)) || !operation.isCurrent()) return null;
     return server?.mcp_server_id ?? null;
   };
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -22,6 +22,8 @@ export interface MCPServerEditModalProps {
   server: MCPServer | null;
   open: boolean;
   client: AgorClient | null;
+  /** Current identity/role/auth generation, null while authority is unavailable. */
+  authorityKey: string | null;
   /**
    * The transports this editor may switch to. Omit to offer all of them — a
    * caller that knows the user is held to remote transports passes those, so
@@ -63,6 +65,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   server,
   open,
   client,
+  authorityKey,
   offeredTransports,
   offeredScopes,
   mutationAllowed,
@@ -393,6 +396,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
           onAuthTypeChange={setAuthType}
           form={form}
           client={client}
+          authorityKey={authorityKey}
           serverId={server?.mcp_server_id}
           onTestConnection={handleTestConnection}
           testing={testing}

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -83,6 +83,7 @@ describe('MCPServerFormFields OAuth start', () => {
             authType="oauth"
             form={form}
             client={client}
+            authorityKey="user-a:admin:1"
             onPrepareOAuthStart={onPrepareOAuthStart}
             formRevision={formRevision}
           />
@@ -162,6 +163,7 @@ describe('MCPServerFormFields OAuth start', () => {
             authType="oauth"
             form={form}
             client={client}
+            authorityKey="user-a:admin:1"
             onPrepareOAuthStart={onPrepareOAuthStart}
             formRevision={formRevision}
           />
@@ -226,6 +228,7 @@ describe('MCPServerFormFields OAuth start', () => {
             authType="oauth"
             form={form}
             client={client}
+            authorityKey="user-a:admin:1"
             serverId="saved-server"
             onPrepareOAuthStart={vi.fn().mockResolvedValue('saved-server')}
             managedOAuthCompatibilityMode="marketplace"

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -19,7 +19,7 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
 import { describeMissingForOAuth, missingMCPFieldLabels } from './mcp-form-requirements';
@@ -133,6 +133,13 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
 
   const [disconnectingOAuth, setDisconnectingOAuth] = useState(false);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const oauthStartAllowed = mutationAllowed && authorityKey !== null;
 
   // `Start OAuth Flow` writes the server row before it redirects, so it needs
@@ -226,6 +233,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       const data = (await client.service('mcp-servers/oauth-disconnect').create({
         mcp_server_id: serverId,
       })) as { success: boolean; message?: string; error?: string };
+      if (!mountedRef.current) return;
 
       if (data.success) {
         showSuccess(data.message || 'OAuth connection removed');
@@ -234,9 +242,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         showError(data.error || 'Failed to disconnect OAuth');
       }
     } catch (error) {
+      if (!mountedRef.current) return;
       showError(`Disconnect error: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
-      setDisconnectingOAuth(false);
+      if (mountedRef.current) setDisconnectingOAuth(false);
     }
   };
 
@@ -267,6 +276,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           api_token: apiToken,
           api_secret: apiSecret,
         })) as { success: boolean; error?: string };
+        if (!mountedRef.current) return;
 
         if (data.success) {
           showSuccess('JWT authentication successful - token received');
@@ -300,6 +310,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           hint?: string;
           debugInfo?: unknown;
         };
+        if (!mountedRef.current) return;
 
         if (data.success) {
           if (data.requiresBrowserFlow) {
@@ -339,10 +350,11 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         showInfo('No authentication required - ready to use');
       }
     } catch (error) {
+      if (!mountedRef.current) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       showError(`Connection test failed: ${errorMessage}`);
     } finally {
-      setTestingAuth(false);
+      if (mountedRef.current) setTestingAuth(false);
     }
   };
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -63,6 +63,8 @@ export interface MCPServerFormFieldsProps {
   onAuthTypeChange?: (authType: 'none' | 'bearer' | 'jwt' | 'oauth') => void;
   form: FormInstance;
   client: AgorClient | null;
+  /** Current identity/role/auth generation, null while authority is unavailable. */
+  authorityKey: string | null;
   serverId?: string;
   onTestConnection?: () => Promise<void>;
   testing?: boolean;
@@ -113,6 +115,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   onAuthTypeChange,
   form,
   client,
+  authorityKey,
   serverId,
   onTestConnection,
   testing = false,
@@ -130,6 +133,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
 
   const [disconnectingOAuth, setDisconnectingOAuth] = useState(false);
+  const oauthStartAllowed = mutationAllowed && authorityKey !== null;
 
   // `Start OAuth Flow` writes the server row before it redirects, so it needs
   // everything a save needs — not just the URL it puts in the request. Read
@@ -149,12 +153,13 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     startingOAuthFlow,
   } = useMCPServerOAuthStart({
     client,
+    authorityKey,
     onPrepareOAuthStart,
     onOAuthSucceeded: () => setOauthBrowserFlowAvailable(false),
     showError,
     showInfo,
     showSuccess,
-    startAllowed: mutationAllowed,
+    startAllowed: oauthStartAllowed,
     startBlockedReason: mutationBlockedReason,
   });
 
@@ -579,13 +584,13 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             )}
             {authType === 'oauth' &&
               oauthBrowserFlowAvailable &&
-              (!mutationAllowed || missingRequiredFields.length > 0 ? (
+              (!oauthStartAllowed || missingRequiredFields.length > 0 ? (
                 // Disabled rather than hidden: the user has already earned this
                 // button with a successful auth test, so it has to say what is
                 // still holding it back.
                 <Tooltip
                   title={
-                    !mutationAllowed
+                    !oauthStartAllowed
                       ? mutationBlockedReason
                       : describeMissingForOAuth(missingRequiredFields)
                   }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -78,6 +78,9 @@ export interface MCPServerFormFieldsProps {
   } | null;
   /** Persist current settings and return the authoritative server ID before every OAuth start. */
   onPrepareOAuthStart: () => Promise<string | null>;
+  /** Whether persistent mutations/OAuth preparation remain authorized. */
+  mutationAllowed?: boolean;
+  mutationBlockedReason?: string;
   /**
    * Changes whenever the owner's form values do. The connection actions read
    * the form store directly, so they need a reason to re-render — see
@@ -115,6 +118,8 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   testing = false,
   testResult,
   onPrepareOAuthStart,
+  mutationAllowed = true,
+  mutationBlockedReason = 'You can no longer change this MCP server.',
   // Consumed by re-rendering, not by reading — see `formRevision` above.
   formRevision: _formRevision,
   managedOAuthCompatibilityMode,
@@ -149,6 +154,8 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     showError,
     showInfo,
     showSuccess,
+    startAllowed: mutationAllowed,
+    startBlockedReason: mutationBlockedReason,
   });
 
   useEffect(() => {
@@ -196,6 +203,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     (typeof watchedDcrMode === 'string' && watchedDcrMode !== 'advertised');
 
   const handleDisconnectOAuth = async () => {
+    if (!mutationAllowed) {
+      showError(mutationBlockedReason);
+      return;
+    }
     if (!client) {
       showError('Client not available');
       return;
@@ -568,11 +579,17 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             )}
             {authType === 'oauth' &&
               oauthBrowserFlowAvailable &&
-              (missingRequiredFields.length > 0 ? (
+              (!mutationAllowed || missingRequiredFields.length > 0 ? (
                 // Disabled rather than hidden: the user has already earned this
                 // button with a successful auth test, so it has to say what is
                 // still holding it back.
-                <Tooltip title={describeMissingForOAuth(missingRequiredFields)}>
+                <Tooltip
+                  title={
+                    !mutationAllowed
+                      ? mutationBlockedReason
+                      : describeMissingForOAuth(missingRequiredFields)
+                  }
+                >
                   <span>
                     <Button type="primary" disabled>
                       {oauthStartLabel}
@@ -589,6 +606,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                 type="default"
                 danger
                 loading={disconnectingOAuth}
+                disabled={!mutationAllowed}
                 onClick={handleDisconnectOAuth}
               >
                 Disconnect OAuth

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -19,7 +19,8 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '@/utils/message';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
 import { describeMissingForOAuth, missingMCPFieldLabels } from './mcp-form-requirements';
@@ -133,14 +134,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const [oauthAdvancedOpen, setOauthAdvancedOpen] = useState(false);
 
   const [disconnectingOAuth, setDisconnectingOAuth] = useState(false);
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
   const oauthStartAllowed = mutationAllowed && authorityKey !== null;
+  const operationGuard = useAuthorityOperationGuard(
+    oauthStartAllowed ? [authorityKey, client, mutationAllowed] : null
+  );
 
   // `Start OAuth Flow` writes the server row before it redirects, so it needs
   // everything a save needs — not just the URL it puts in the request. Read
@@ -169,21 +166,6 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     startAllowed: oauthStartAllowed,
     startBlockedReason: mutationBlockedReason,
   });
-
-  useEffect(() => {
-    if (!client) return;
-    // Blocking discover/test endpoints cannot return the authorization URL
-    // before their callback. The daemon sends this compatibility hint only to
-    // this exact initiating socket; durable attempt/status refetch remains the
-    // completion authority.
-    const openBrowserForBlockingFlow = ({ authUrl }: { authUrl?: string }) => {
-      if (authUrl) window.open(authUrl, '_blank', 'noopener,noreferrer');
-    };
-    client.io.on('oauth:open_browser', openBrowserForBlockingFlow);
-    return () => {
-      client.io.off('oauth:open_browser', openBrowserForBlockingFlow);
-    };
-  }, [client]);
 
   // Watch advanced OAuth field values so we can show a "customized" dot on
   // the Advanced collapse header when any of them has a non-default value.
@@ -215,6 +197,8 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     (typeof watchedDcrMode === 'string' && watchedDcrMode !== 'advertised');
 
   const handleDisconnectOAuth = async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!mutationAllowed) {
       showError(mutationBlockedReason);
       return;
@@ -233,7 +217,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       const data = (await client.service('mcp-servers/oauth-disconnect').create({
         mcp_server_id: serverId,
       })) as { success: boolean; message?: string; error?: string };
-      if (!mountedRef.current) return;
+      if (!operation.isCurrent()) return;
 
       if (data.success) {
         showSuccess(data.message || 'OAuth connection removed');
@@ -242,14 +226,16 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         showError(data.error || 'Failed to disconnect OAuth');
       }
     } catch (error) {
-      if (!mountedRef.current) return;
+      if (!operation.isCurrent()) return;
       showError(`Disconnect error: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
-      if (mountedRef.current) setDisconnectingOAuth(false);
+      if (operation.isCurrent()) setDisconnectingOAuth(false);
     }
   };
 
   const handleTestAuth = async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!client) {
       showError('Client not available');
       return;
@@ -276,7 +262,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           api_token: apiToken,
           api_secret: apiSecret,
         })) as { success: boolean; error?: string };
-        if (!mountedRef.current) return;
+        if (!operation.isCurrent()) return;
 
         if (data.success) {
           showSuccess('JWT authentication successful - token received');
@@ -310,7 +296,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           hint?: string;
           debugInfo?: unknown;
         };
-        if (!mountedRef.current) return;
+        if (!operation.isCurrent()) return;
 
         if (data.success) {
           if (data.requiresBrowserFlow) {
@@ -350,11 +336,11 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         showInfo('No authentication required - ready to use');
       }
     } catch (error) {
-      if (!mountedRef.current) return;
+      if (!operation.isCurrent()) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       showError(`Connection test failed: ${errorMessage}`);
     } finally {
-      if (mountedRef.current) setTestingAuth(false);
+      if (operation.isCurrent()) setTestingAuth(false);
     }
   };
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
@@ -50,7 +50,16 @@ describe('MCPServerPill OAuth recovery', () => {
       auth: { type: 'oauth' },
     } as MCPServer;
 
-    render(<MCPServerPill server={server} needsAuth client={client} />);
+    render(
+      <MCPServerPill
+        server={server}
+        needsAuth
+        client={client}
+        authorityKey="user-a:member:1"
+        actionAllowed
+        actionBlockedReason="OAuth unavailable"
+      />
+    );
 
     const signIn = screen.getByRole('button', { name: 'Sign in to OAuth Server' });
     expect(signIn.tagName).toBe('BUTTON');
@@ -80,7 +89,17 @@ describe('MCPServerPill OAuth recovery', () => {
       auth: { type: 'oauth' },
     } as MCPServer;
 
-    render(<MCPServerPill server={server} needsAuth client={null} onEdit={onEdit} />);
+    render(
+      <MCPServerPill
+        server={server}
+        needsAuth
+        client={null}
+        authorityKey={null}
+        actionAllowed={false}
+        actionBlockedReason="OAuth unavailable"
+        onEdit={onEdit}
+      />
+    );
 
     const edit = screen.getByRole('button', { name: 'Edit OAuth Server MCP server' });
     expect(edit).toBeInTheDocument();
@@ -101,7 +120,16 @@ describe('MCPServerPill OAuth recovery', () => {
       auth: { type: 'oauth' },
     } as MCPServer;
 
-    render(<MCPServerPill server={server} needsAuth={false} client={client} />);
+    render(
+      <MCPServerPill
+        server={server}
+        needsAuth={false}
+        client={client}
+        authorityKey="user-a:member:1"
+        actionAllowed
+        actionBlockedReason="OAuth unavailable"
+      />
+    );
 
     const refresh = screen.getByRole('button', {
       name: 'Refresh OAuth credentials for OAuth Server',
@@ -114,8 +142,122 @@ describe('MCPServerPill OAuth recovery', () => {
     await waitFor(() =>
       expect(refreshAndRefetchMCPOAuthGrant).toHaveBeenCalledWith(
         client,
-        '01900000-0000-7000-8000-000000000006'
+        '01900000-0000-7000-8000-000000000006',
+        expect.any(Function)
       )
     );
+  });
+
+  it.each([
+    { transition: 'demotion', authorityKey: null, actionAllowed: false },
+    { transition: 'disconnect', authorityKey: null, actionAllowed: false },
+    {
+      transition: 'identity replacement',
+      authorityKey: 'user-b:member:2',
+      actionAllowed: true,
+    },
+  ])(
+    'guards refresh durable application across $transition while reads are in flight',
+    async ({ authorityKey, actionAllowed }) => {
+      let releaseRefresh!: () => void;
+      const refreshPending = new Promise<{ success: true; expires_at: number }>((resolve) => {
+        releaseRefresh = () => resolve({ success: true, expires_at: 123 });
+      });
+      refreshAndRefetchMCPOAuthGrant.mockImplementation(async () => refreshPending);
+      const client = {} as AgorClient;
+      const server = {
+        mcp_server_id: '01900000-0000-7000-8000-000000000007',
+        name: 'oauth-server',
+        display_name: 'OAuth Server',
+        transport: 'http',
+        scope: 'global',
+        enabled: true,
+        auth: { type: 'oauth' },
+      } as MCPServer;
+      const { rerender } = render(
+        <MCPServerPill
+          server={server}
+          needsAuth={false}
+          client={client}
+          authorityKey="user-a:member:1"
+          actionAllowed
+          actionBlockedReason="OAuth unavailable"
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Refresh OAuth credentials for OAuth Server' })
+      );
+      await waitFor(() => expect(refreshAndRefetchMCPOAuthGrant).toHaveBeenCalledOnce());
+      const shouldApply = refreshAndRefetchMCPOAuthGrant.mock.calls[0]?.[2] as () => boolean;
+      expect(shouldApply()).toBe(true);
+
+      rerender(
+        <MCPServerPill
+          server={server}
+          needsAuth={false}
+          client={client}
+          authorityKey={authorityKey}
+          actionAllowed={actionAllowed}
+          actionBlockedReason="OAuth unavailable"
+        />
+      );
+      expect(shouldApply()).toBe(false);
+
+      await act(async () => {
+        releaseRefresh();
+        await refreshPending;
+      });
+      expect(showSuccess).not.toHaveBeenCalled();
+      if (!actionAllowed) {
+        expect(
+          screen.queryByRole('button', {
+            name: 'Refresh OAuth credentials for OAuth Server',
+          })
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('OAuth Server').closest('.ant-tag')).toHaveStyle({
+          cursor: 'default',
+        });
+      }
+    }
+  );
+
+  it('guards refresh durable application when the pill unmounts during reads', async () => {
+    let releaseRefresh!: () => void;
+    const refreshPending = new Promise<{ success: true }>((resolve) => {
+      releaseRefresh = () => resolve({ success: true });
+    });
+    refreshAndRefetchMCPOAuthGrant.mockImplementation(async () => refreshPending);
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000008',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      transport: 'http',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+    const { unmount } = render(
+      <MCPServerPill
+        server={server}
+        needsAuth={false}
+        client={{} as AgorClient}
+        authorityKey="user-a:member:1"
+        actionAllowed
+        actionBlockedReason="OAuth unavailable"
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Refresh OAuth credentials for OAuth Server' })
+    );
+    await waitFor(() => expect(refreshAndRefetchMCPOAuthGrant).toHaveBeenCalledOnce());
+    const shouldApply = refreshAndRefetchMCPOAuthGrant.mock.calls[0]?.[2] as () => boolean;
+    unmount();
+    expect(shouldApply()).toBe(false);
+
+    releaseRefresh();
+    await refreshPending;
+    expect(showSuccess).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -1,7 +1,8 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
 import { ApiOutlined, EditOutlined, LoginOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { usePermissions } from '@/hooks/usePermissions';
 import { refreshAndRefetchMCPOAuthGrant } from '../../utils/mcpOAuthAttempt';
 import { useThemedMessage } from '../../utils/message';
@@ -93,25 +94,14 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   // Local override so the tooltip reflects a just-refreshed expiry without
   // waiting for a full MCPServer re-fetch from the parent.
   const [expiresAtOverride, setExpiresAtOverride] = useState<number | undefined>(undefined);
-  const mountedRef = useRef(true);
-  const authorityKeyRef = useRef(authorityKey);
-  authorityKeyRef.current = authorityKey;
-  const actionAllowedRef = useRef(actionAllowed);
-  actionAllowedRef.current = actionAllowed;
-  const clientRef = useRef(client);
-  clientRef.current = client;
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const operationGuard = useAuthorityOperationGuard(
+    authorityKey && actionAllowed ? [authorityKey, client, actionAllowed] : null
+  );
 
   // Local status/expiry is caller-shaped too. Clear it immediately when the
   // identity, role, auth generation, or connection authority changes.
   // biome-ignore lint/correctness/useExhaustiveDependencies: these props are the transition key
-  useEffect(() => {
+  useLayoutEffect(() => {
     setRefreshing(false);
     setExpiresAtOverride(undefined);
   }, [actionAllowed, authorityKey]);
@@ -132,14 +122,9 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   });
 
   const handleRefreshClick = async () => {
-    const refreshAuthorityKey = authorityKeyRef.current;
-    if (!client || !actionAllowed || !refreshAuthorityKey || refreshing) return;
-    const refreshClient = client;
-    const shouldApply = () =>
-      mountedRef.current &&
-      actionAllowedRef.current &&
-      authorityKeyRef.current === refreshAuthorityKey &&
-      clientRef.current === refreshClient;
+    const operation = operationGuard.begin();
+    if (!client || !actionAllowed || !authorityKey || refreshing || !operation.isCurrent()) return;
+    const shouldApply = operation.isCurrent;
     setRefreshing(true);
     try {
       const result = await refreshAndRefetchMCPOAuthGrant(

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -1,7 +1,7 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
 import { ApiOutlined, EditOutlined, LoginOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePermissions } from '@/hooks/usePermissions';
 import { refreshAndRefetchMCPOAuthGrant } from '../../utils/mcpOAuthAttempt';
 import { useThemedMessage } from '../../utils/message';
@@ -15,6 +15,11 @@ interface MCPServerPillProps {
   server: MCPServer;
   needsAuth: boolean;
   client: AgorClient | null;
+  /** Opaque identity + role + successful-auth generation, null while disconnected. */
+  authorityKey: string | null;
+  /** Current server-side role/connection floor for OAuth mutations. */
+  actionAllowed: boolean;
+  actionBlockedReason: string;
   /** Lets an overlay owner open an editor without nesting its lifecycle in this pill. */
   onEdit?: (server: MCPServer) => void;
 }
@@ -77,6 +82,9 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   server,
   needsAuth,
   client,
+  authorityKey,
+  actionAllowed,
+  actionBlockedReason,
   onEdit,
 }) => {
   const { showSuccess, showInfo, showWarning, showError } = useThemedMessage();
@@ -85,24 +93,61 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   // Local override so the tooltip reflects a just-refreshed expiry without
   // waiting for a full MCPServer re-fetch from the parent.
   const [expiresAtOverride, setExpiresAtOverride] = useState<number | undefined>(undefined);
+  const mountedRef = useRef(true);
+  const authorityKeyRef = useRef(authorityKey);
+  authorityKeyRef.current = authorityKey;
+  const actionAllowedRef = useRef(actionAllowed);
+  actionAllowedRef.current = actionAllowed;
+  const clientRef = useRef(client);
+  clientRef.current = client;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Local status/expiry is caller-shaped too. Clear it immediately when the
+  // identity, role, auth generation, or connection authority changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these props are the transition key
+  useEffect(() => {
+    setRefreshing(false);
+    setExpiresAtOverride(undefined);
+  }, [actionAllowed, authorityKey]);
 
   const isOAuthServer = server.auth?.type === 'oauth';
   const expiresAt = expiresAtOverride ?? server.auth?.oauth_token_expires_at;
 
   const { handleStartOAuthFlow, oauthFailure, startingOAuthFlow } = useMCPServerOAuthStart({
     client,
+    authorityKey,
     onPrepareOAuthStart: async () => server.mcp_server_id,
     onOAuthSucceeded: () => showSuccess(`${server.display_name || server.name} authenticated!`),
     showError,
     showInfo,
     showSuccess,
+    startAllowed: actionAllowed,
+    startBlockedReason: actionBlockedReason,
   });
 
   const handleRefreshClick = async () => {
-    if (!client || refreshing) return;
+    const refreshAuthorityKey = authorityKeyRef.current;
+    if (!client || !actionAllowed || !refreshAuthorityKey || refreshing) return;
+    const refreshClient = client;
+    const shouldApply = () =>
+      mountedRef.current &&
+      actionAllowedRef.current &&
+      authorityKeyRef.current === refreshAuthorityKey &&
+      clientRef.current === refreshClient;
     setRefreshing(true);
     try {
-      const result = await refreshAndRefetchMCPOAuthGrant(client, server.mcp_server_id);
+      const result = await refreshAndRefetchMCPOAuthGrant(
+        client,
+        server.mcp_server_id,
+        shouldApply
+      );
+      if (!shouldApply()) return;
 
       if (result.success) {
         setExpiresAtOverride(result.expires_at);
@@ -120,9 +165,10 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
         showError(`Refresh failed: ${formatRefreshError(result.error)}`);
       }
     } catch (err) {
+      if (!shouldApply()) return;
       showError(`Refresh error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      setRefreshing(false);
+      if (shouldApply()) setRefreshing(false);
     }
   };
 
@@ -163,17 +209,21 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
     );
   }
 
-  const needsAuthTooltip = `${server.display_name || server.name} isn’t connected. Activate to sign in.`;
+  const needsAuthTooltip = actionAllowed
+    ? `${server.display_name || server.name} isn’t connected. Activate to sign in.`
+    : actionBlockedReason;
 
   const label = server.display_name || server.name;
   // The pill's own action, or nothing for a non-OAuth server. Named here
   // because both the Tag's pointer target and the label button need to agree on
   // whether there is one.
-  const primaryAction = needsAuth
-    ? () => void handleStartOAuthFlow()
-    : isOAuthServer
-      ? handleRefreshClick
-      : undefined;
+  const primaryAction = actionAllowed
+    ? needsAuth
+      ? () => void handleStartOAuthFlow()
+      : isOAuthServer
+        ? handleRefreshClick
+        : undefined
+    : undefined;
 
   return (
     <>
@@ -182,11 +232,13 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
         // keyboard users receive on focus is available to pointer users on hover.
         trigger={['hover', 'focus']}
         title={
-          needsAuth
-            ? startingOAuthFlow
-              ? 'Starting OAuth authentication'
-              : needsAuthTooltip
-            : authedTooltip
+          !actionAllowed && isOAuthServer
+            ? actionBlockedReason
+            : needsAuth
+              ? startingOAuthFlow
+                ? 'Starting OAuth authentication'
+                : needsAuthTooltip
+              : authedTooltip
         }
       >
         <Tag
@@ -202,7 +254,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
           }
           style={{
             cursor:
-              refreshing || startingOAuthFlow ? 'wait' : isOAuthServer ? 'pointer' : 'default',
+              refreshing || startingOAuthFlow ? 'wait' : primaryAction ? 'pointer' : 'default',
           }}
           onClick={primaryAction}
         >

--- a/apps/agor-ui/src/components/MCPServer/memberPolicy.ts
+++ b/apps/agor-ui/src/components/MCPServer/memberPolicy.ts
@@ -43,6 +43,31 @@ export const MCP_MEMBER_POLICY_DESCRIPTIONS: Record<MCPMemberPolicy, MCPMemberPo
   },
 };
 
+/**
+ * What to say while the policy is not known.
+ *
+ * Until the read lands, a connect surface offers nothing and says only this.
+ * The restrictive value it falls back to is a safe assumption to act on, not a
+ * fact about this workspace to quote back as the reason.
+ *
+ * Shared so the Settings table and the Marketplace drawer — the two places a
+ * server can be attached — refuse in the same words.
+ */
+export const POLICY_LOADING_HINT = "Checking what this workspace's MCP policy allows…";
+export const POLICY_UNREADABLE_HINT =
+  "This workspace's MCP policy could not be read, so nothing is offered here.";
+
+/** Whether the policy is still unknown, and the hint that says which way. */
+export function policyPendingState(state: { loading: boolean; error: string | null }): {
+  pending: boolean;
+  hint: string;
+} {
+  return {
+    pending: state.loading || state.error !== null,
+    hint: state.error ? POLICY_UNREADABLE_HINT : POLICY_LOADING_HINT,
+  };
+}
+
 export interface MCPServerCapabilityContext {
   /**
    * The role as the daemon reads it — raw, because the roles beneath member are

--- a/apps/agor-ui/src/components/MCPServer/memberPolicy.ts
+++ b/apps/agor-ui/src/components/MCPServer/memberPolicy.ts
@@ -69,6 +69,8 @@ export function policyPendingState(state: { loading: boolean; error: string | nu
 }
 
 export interface MCPServerCapabilityContext {
+  /** Connected, authenticated, and outside reconnect/token-reauth transition. */
+  connectionReady: boolean;
   /**
    * The role as the daemon reads it — raw, because the roles beneath member are
    * the ones this has to tell apart, and a boolean cannot.
@@ -91,17 +93,19 @@ export interface MCPServerCapabilityContext {
 /**
  * Whether this user may add an MCP server at all.
  *
- * The daemon's answer, with the admin clause of that same answer as a floor
- * under it: {@link canConfigureMCPServers} returns true for every admin under
- * every policy, so the two cannot disagree — but an answer that arrives
- * without the field would otherwise leave an admin looking at a disabled
- * button and a reason that does not apply to them.
- *
- * This is about a capability that arrived. An answer that did not arrive at all
- * is a separate state its caller handles, and there the control is withheld
- * from everyone, admins included, rather than guessed at.
+ * Connection and role are checked again here rather than treated as facts that
+ * were true when `canConfigure` arrived. This closes the render in which an old
+ * permissive answer could otherwise survive a disconnect or demotion. Once the
+ * caller is still at least a member, admins retain their policy-independent
+ * authority and everyone else uses the caller-shaped daemon answer.
  */
-export function canAddMcpServer({ isAdmin, canConfigure }: MCPServerCapabilityContext): boolean {
+export function canAddMcpServer({
+  connectionReady,
+  role,
+  isAdmin,
+  canConfigure,
+}: MCPServerCapabilityContext): boolean {
+  if (!connectionReady || !isAtLeastMemberRole(role)) return false;
   return isAdmin || canConfigure;
 }
 
@@ -132,6 +136,7 @@ export function canEditMcpServer(
   server: Pick<MCPServer, 'owner_user_id' | 'transport'>,
   context: MCPServerCapabilityContext
 ): boolean {
+  if (!context.connectionReady) return false;
   if (context.isAdmin) return true;
   // The endpoint answers "may I configure at all"; which server, and whether
   // its transport is one a member may hold, it cannot — so the floor is asked
@@ -148,6 +153,7 @@ export function canDeleteMcpServer(
   server: Pick<MCPServer, 'owner_user_id'>,
   context: MCPServerCapabilityContext
 ): boolean {
+  if (!context.connectionReady) return false;
   if (context.isAdmin) return true;
   if (!isAtLeastMemberRole(context.role)) return false;
   return mayMemberManageMCPServer(server, context.policy, context.userId);

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.test.tsx
@@ -3,10 +3,15 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMCPServerOAuthStart } from './useMCPServerOAuthStart';
 
+const oauthAttempt = vi.hoisted(() => ({
+  refetch: vi.fn(),
+  wait: vi.fn(),
+}));
+
 vi.mock('@/utils/mcpOAuthAttempt', () => ({
   oauthAttemptFailureMessage: vi.fn(),
-  refetchMCPOAuthDurableState: vi.fn(),
-  waitForMCPOAuthAttempt: vi.fn(),
+  refetchMCPOAuthDurableState: oauthAttempt.refetch,
+  waitForMCPOAuthAttempt: oauthAttempt.wait,
 }));
 
 const showError = vi.fn();
@@ -41,6 +46,7 @@ describe('useMCPServerOAuthStart', () => {
     const { result } = renderHook(() =>
       useMCPServerOAuthStart({
         client,
+        authorityKey: 'user-a:admin:1',
         onPrepareOAuthStart,
         showError,
         showInfo,
@@ -74,6 +80,7 @@ describe('useMCPServerOAuthStart', () => {
     const { result, unmount } = renderHook(() =>
       useMCPServerOAuthStart({
         client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
         onPrepareOAuthStart,
         showError,
         showInfo,
@@ -112,6 +119,7 @@ describe('useMCPServerOAuthStart', () => {
     const { result, unmount } = renderHook(() =>
       useMCPServerOAuthStart({
         client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
         onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
         showError,
         showInfo,
@@ -149,6 +157,7 @@ describe('useMCPServerOAuthStart', () => {
     const { result } = renderHook(() =>
       useMCPServerOAuthStart({
         client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
         onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
         showError,
         showInfo,
@@ -172,6 +181,7 @@ describe('useMCPServerOAuthStart', () => {
     const { result } = renderHook(() =>
       useMCPServerOAuthStart({
         client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
         onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
         showError,
         showInfo,
@@ -185,5 +195,108 @@ describe('useMCPServerOAuthStart', () => {
       diagnostic: undefined,
       redirectUri: undefined,
     });
+  });
+
+  it.each([
+    {
+      transition: 'demotion',
+      nextAuthorityKey: 'user-a:viewer:2',
+      nextAllowed: false,
+    },
+    { transition: 'disconnect', nextAuthorityKey: null, nextAllowed: false },
+    {
+      transition: 'identity replacement',
+      nextAuthorityKey: 'user-b:admin:2',
+      nextAllowed: true,
+    },
+    {
+      transition: 'policy downgrade',
+      nextAuthorityKey: 'user-a:admin:1',
+      nextAllowed: false,
+    },
+  ])(
+    'guards the durable completion apply across $transition during its reads',
+    async ({ nextAuthorityKey, nextAllowed }) => {
+      let releaseRefetch!: () => void;
+      const refetchPending = new Promise<void>((resolve) => {
+        releaseRefetch = resolve;
+      });
+      oauthAttempt.wait.mockResolvedValue({
+        status: 'succeeded',
+        mcp_server_id: 'server-1',
+      });
+      oauthAttempt.refetch.mockImplementation(async () => refetchPending);
+      const startOAuth = vi.fn().mockResolvedValue({
+        success: true,
+        authorizationUrl: 'https://provider.example/authorize',
+        attempt_id: 'attempt-1',
+      });
+      const client = oauthClient(startOAuth);
+      const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+      const { result, rerender } = renderHook(
+        ({ authorityKey, startAllowed }: { authorityKey: string | null; startAllowed: boolean }) =>
+          useMCPServerOAuthStart({
+            client,
+            authorityKey,
+            onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
+            showError,
+            showInfo,
+            showSuccess,
+            startAllowed,
+          }),
+        { initialProps: { authorityKey: 'user-a:admin:1', startAllowed: true } }
+      );
+
+      await act(async () => result.current.handleStartOAuthFlow());
+      await waitFor(() => expect(oauthAttempt.refetch).toHaveBeenCalledOnce());
+      const shouldApply = oauthAttempt.refetch.mock.calls[0]?.[2] as () => boolean;
+      expect(shouldApply()).toBe(true);
+
+      rerender({ authorityKey: nextAuthorityKey, startAllowed: nextAllowed });
+      expect(shouldApply()).toBe(false);
+
+      await act(async () => {
+        releaseRefetch();
+        await refetchPending;
+      });
+      expect(showSuccess).not.toHaveBeenCalled();
+      windowOpen.mockRestore();
+    }
+  );
+
+  it('guards the durable completion apply when the OAuth owner unmounts during its reads', async () => {
+    let releaseRefetch!: () => void;
+    const refetchPending = new Promise<void>((resolve) => {
+      releaseRefetch = resolve;
+    });
+    oauthAttempt.wait.mockResolvedValue({ status: 'succeeded', mcp_server_id: 'server-1' });
+    oauthAttempt.refetch.mockImplementation(async () => refetchPending);
+    const startOAuth = vi.fn().mockResolvedValue({
+      success: true,
+      authorizationUrl: 'https://provider.example/authorize',
+      attempt_id: 'attempt-1',
+    });
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { result, unmount } = renderHook(() =>
+      useMCPServerOAuthStart({
+        client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
+        onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
+        showError,
+        showInfo,
+        showSuccess,
+      })
+    );
+
+    await act(async () => result.current.handleStartOAuthFlow());
+    await waitFor(() => expect(oauthAttempt.refetch).toHaveBeenCalledOnce());
+    const shouldApply = oauthAttempt.refetch.mock.calls[0]?.[2] as () => boolean;
+    unmount();
+    expect(shouldApply()).toBe(false);
+
+    releaseRefetch();
+    await refetchPending;
+    expect(showSuccess).not.toHaveBeenCalled();
+    windowOpen.mockRestore();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
@@ -1,6 +1,7 @@
 import type { MCPOAuthDCRDiagnostic, MCPOAuthStartFailure } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import {
   oauthAttemptFailureMessage,
   refetchMCPOAuthDurableState,
@@ -56,6 +57,9 @@ export function useMCPServerOAuthStart({
   authorityKeyRef.current = authorityKey;
   const clientRef = useRef(client);
   clientRef.current = client;
+  const operationGuard = useAuthorityOperationGuard(
+    authorityKey && startAllowed ? [authorityKey, client, startAllowed] : null
+  );
 
   const invalidateOAuthStart = useCallback(() => {
     oauthStartGenerationRef.current += 1;
@@ -103,10 +107,13 @@ export function useMCPServerOAuthStart({
     }
 
     const startClient = client;
+    const authorityOperation = operationGuard.begin();
+    if (!authorityOperation.isCurrent()) return;
     oauthStartInFlightRef.current = true;
     const startGeneration = ++oauthStartGenerationRef.current;
     const isCurrentStart = () =>
       oauthStartGenerationRef.current === startGeneration &&
+      authorityOperation.isCurrent() &&
       startAllowedRef.current &&
       authorityKeyRef.current === startAuthorityKey &&
       clientRef.current === startClient;
@@ -198,6 +205,7 @@ export function useMCPServerOAuthStart({
     client,
     onOAuthSucceeded,
     onPrepareOAuthStart,
+    operationGuard,
     showError,
     showInfo,
     showSuccess,

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
@@ -26,6 +26,9 @@ interface UseMCPServerOAuthStartOptions {
   showError: (message: string) => void;
   showInfo: (message: string) => void;
   showSuccess: (message: string) => void;
+  /** Current authority to persist/start this OAuth configuration. */
+  startAllowed?: boolean;
+  startBlockedReason?: string;
 }
 
 export function useMCPServerOAuthStart({
@@ -35,6 +38,8 @@ export function useMCPServerOAuthStart({
   showError,
   showInfo,
   showSuccess,
+  startAllowed = true,
+  startBlockedReason = 'You can no longer change this MCP server.',
 }: UseMCPServerOAuthStartOptions) {
   const [startingOAuthFlow, setStartingOAuthFlow] = useState(false);
   const [oauthFailure, setOauthFailure] = useState<MCPServerOAuthFailure | null>(null);
@@ -42,6 +47,8 @@ export function useMCPServerOAuthStart({
   const oauthStartInFlightRef = useRef(false);
   const oauthStartGenerationRef = useRef(0);
   const oauthCompletedCleanupRef = useRef<(() => void) | null>(null);
+  const startAllowedRef = useRef(startAllowed);
+  startAllowedRef.current = startAllowed;
 
   const invalidateOAuthStart = useCallback(() => {
     oauthStartGenerationRef.current += 1;
@@ -52,6 +59,14 @@ export function useMCPServerOAuthStart({
   useEffect(() => {
     return invalidateOAuthStart;
   }, [invalidateOAuthStart]);
+
+  useEffect(() => {
+    if (!startAllowed) {
+      invalidateOAuthStart();
+      setOauthCallbackModalVisible(false);
+      setStartingOAuthFlow(false);
+    }
+  }, [invalidateOAuthStart, startAllowed]);
 
   const clearOAuthFailure = useCallback(() => setOauthFailure(null), []);
 
@@ -67,6 +82,10 @@ export function useMCPServerOAuthStart({
       showError('Client not available');
       return;
     }
+    if (!startAllowedRef.current) {
+      showError(startBlockedReason);
+      return;
+    }
 
     oauthStartInFlightRef.current = true;
     const startGeneration = ++oauthStartGenerationRef.current;
@@ -78,6 +97,10 @@ export function useMCPServerOAuthStart({
       const targetServerId = await onPrepareOAuthStart();
       if (!isCurrentStart()) return;
       if (!targetServerId) return;
+      if (!startAllowedRef.current) {
+        showError(startBlockedReason);
+        return;
+      }
 
       showInfo('Starting OAuth authentication flow...');
       if (!isCurrentStart()) return;
@@ -151,7 +174,15 @@ export function useMCPServerOAuthStart({
         setStartingOAuthFlow(false);
       }
     }
-  }, [client, onOAuthSucceeded, onPrepareOAuthStart, showError, showInfo, showSuccess]);
+  }, [
+    client,
+    onOAuthSucceeded,
+    onPrepareOAuthStart,
+    showError,
+    showInfo,
+    showSuccess,
+    startBlockedReason,
+  ]);
 
   return {
     cancelOAuthWait,

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
@@ -21,6 +21,8 @@ interface OAuthStartSuccess {
 
 interface UseMCPServerOAuthStartOptions {
   client: AgorClient | null;
+  /** Opaque identity + role + successful-auth generation, null while disconnected. */
+  authorityKey: string | null;
   onPrepareOAuthStart: () => Promise<string | null>;
   onOAuthSucceeded?: () => void;
   showError: (message: string) => void;
@@ -33,6 +35,7 @@ interface UseMCPServerOAuthStartOptions {
 
 export function useMCPServerOAuthStart({
   client,
+  authorityKey,
   onPrepareOAuthStart,
   onOAuthSucceeded,
   showError,
@@ -49,6 +52,10 @@ export function useMCPServerOAuthStart({
   const oauthCompletedCleanupRef = useRef<(() => void) | null>(null);
   const startAllowedRef = useRef(startAllowed);
   startAllowedRef.current = startAllowed;
+  const authorityKeyRef = useRef(authorityKey);
+  authorityKeyRef.current = authorityKey;
+  const clientRef = useRef(client);
+  clientRef.current = client;
 
   const invalidateOAuthStart = useCallback(() => {
     oauthStartGenerationRef.current += 1;
@@ -56,17 +63,24 @@ export function useMCPServerOAuthStart({
     oauthCompletedCleanupRef.current?.();
   }, []);
 
-  useEffect(() => {
-    return invalidateOAuthStart;
-  }, [invalidateOAuthStart]);
+  // A long-lived socket client can survive identity, role, and token
+  // replacement. Abort the previous wait on any authority/client transition;
+  // render-time refs below close the window before this passive cleanup runs.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authority/client changes intentionally run cleanup
+  useEffect(
+    () => () => {
+      invalidateOAuthStart();
+    },
+    [authorityKey, client, invalidateOAuthStart]
+  );
 
   useEffect(() => {
-    if (!startAllowed) {
+    if (!startAllowed || !authorityKey || !client) {
       invalidateOAuthStart();
       setOauthCallbackModalVisible(false);
       setStartingOAuthFlow(false);
     }
-  }, [invalidateOAuthStart, startAllowed]);
+  }, [authorityKey, client, invalidateOAuthStart, startAllowed]);
 
   const clearOAuthFailure = useCallback(() => setOauthFailure(null), []);
 
@@ -82,14 +96,20 @@ export function useMCPServerOAuthStart({
       showError('Client not available');
       return;
     }
-    if (!startAllowedRef.current) {
+    const startAuthorityKey = authorityKeyRef.current;
+    if (!startAllowedRef.current || !startAuthorityKey) {
       showError(startBlockedReason);
       return;
     }
 
+    const startClient = client;
     oauthStartInFlightRef.current = true;
     const startGeneration = ++oauthStartGenerationRef.current;
-    const isCurrentStart = () => oauthStartGenerationRef.current === startGeneration;
+    const isCurrentStart = () =>
+      oauthStartGenerationRef.current === startGeneration &&
+      startAllowedRef.current &&
+      authorityKeyRef.current === startAuthorityKey &&
+      clientRef.current === startClient;
     setStartingOAuthFlow(true);
     setOauthFailure(null);
 
@@ -127,7 +147,7 @@ export function useMCPServerOAuthStart({
             if (!isCurrentStart()) return;
             if (attempt.status === 'succeeded') {
               try {
-                await refetchMCPOAuthDurableState(client, targetServerId);
+                await refetchMCPOAuthDurableState(client, targetServerId, isCurrentStart);
                 if (!isCurrentStart()) return;
               } catch {
                 if (isCurrentStart()) console.warn('[OAuth] Durable completion refetch failed');

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
@@ -49,6 +49,7 @@ describe('useOAuthBrowserEventAttempt', () => {
 
   beforeEach(() => vi.stubGlobal('open', open));
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -160,6 +161,31 @@ describe('useOAuthBrowserEventAttempt', () => {
     expect(socket.listenerCount()).toBe(1);
     rendered.unmount();
     expect(socket.listenerCount()).toBe(0);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('expires and removes a reserved listener at the daemon deadline', async () => {
+    vi.useFakeTimers();
+    const socket = createSocketClient();
+    socket.reserve.mockResolvedValueOnce({
+      reservation_token: 'server-reservation-expiring-00000',
+      expires_at: Date.now() + 1_000,
+    });
+    const rendered = renderHook(() => useHarness(socket.client, 'admin-a', 2));
+    const attempt = await rendered.result.current.begin({ operation: 'discover' });
+    expect(attempt).not.toBeNull();
+    expect(socket.listenerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(socket.listenerCount()).toBe(0);
+    act(() =>
+      socket.emit({
+        authUrl: 'https://provider.example/too-late',
+        attempt_id: 'attempt-expired',
+        reservation_token: attempt?.request.reservation_token,
+        caller_user_id: 'admin-a',
+      })
+    );
     expect(open).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
@@ -4,18 +4,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useOAuthBrowserEventAttempt } from './useOAuthBrowserEventAttempt';
 
-type BrowserListener = (event: Record<string, unknown>) => void;
+type BrowserListener = (event: Record<string, unknown> | null | undefined) => void;
 
 function createSocketClient() {
   const listeners = new Set<BrowserListener>();
+  let nextToken = 0;
+  const reserve = vi.fn(async () => ({
+    reservation_token: `server-reservation-${String(++nextToken).padStart(16, '0')}`,
+    expires_at: Date.now() + 60_000,
+  }));
   const io = {
     on: vi.fn((_event: string, listener: BrowserListener) => listeners.add(listener)),
     off: vi.fn((_event: string, listener: BrowserListener) => listeners.delete(listener)),
   };
   return {
-    client: { io } as unknown as AgorClient,
+    client: {
+      io,
+      service: (path: string) => {
+        if (path !== 'mcp-servers/oauth-browser-reservations') throw new Error(path);
+        return { create: reserve };
+      },
+    } as unknown as AgorClient,
     io,
-    emit: (event: Record<string, unknown>) => {
+    reserve,
+    emit: (event: Record<string, unknown> | null | undefined) => {
       for (const listener of [...listeners]) listener(event);
     },
     listenerCount: () => listeners.size,
@@ -35,44 +47,41 @@ function useHarness(client: AgorClient, userId: string, authGeneration: number, 
 describe('useOAuthBrowserEventAttempt', () => {
   const open = vi.fn();
 
-  beforeEach(() => {
-    vi.stubGlobal('open', open);
-  });
-
+  beforeEach(() => vi.stubGlobal('open', open));
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  it('opens only the exact caller/generation/operation once and removes the listener first', () => {
+  it('reserves server correlation and opens only the exact token/caller once', async () => {
     const socket = createSocketClient();
     const { result } = renderHook(() => useHarness(socket.client, 'admin-a', 7));
-    const attempt = result.current.begin();
+    const attempt = await act(() =>
+      result.current.begin({ operation: 'discover', mcpServerId: 'saved-server' })
+    );
+    expect(socket.reserve).toHaveBeenCalledWith({
+      operation: 'discover',
+      mcp_server_id: 'saved-server',
+    });
     expect(attempt).not.toBeNull();
     expect(socket.listenerCount()).toBe(1);
 
     act(() => {
+      socket.emit(null);
+      socket.emit(undefined);
       socket.emit({
         authUrl: 'https://provider.example/unrelated',
         attempt_id: 'attempt-wrong-operation',
-        operation_id: 'not-this-operation',
-        auth_generation: 7,
+        reservation_token: 'server-reservation-unrelated-0000',
         caller_user_id: 'admin-a',
       });
       socket.emit({
         authUrl: 'https://provider.example/wrong-user',
         attempt_id: 'attempt-wrong-user',
-        operation_id: attempt?.request.operation_id,
-        auth_generation: 7,
+        reservation_token: attempt?.request.reservation_token,
         caller_user_id: 'admin-b',
       });
-      socket.emit({
-        authUrl: 'https://provider.example/wrong-generation',
-        attempt_id: 'attempt-wrong-generation',
-        operation_id: attempt?.request.operation_id,
-        auth_generation: 8,
-        caller_user_id: 'admin-a',
-      });
+      socket.emit({ reservation_token: attempt?.request.reservation_token });
     });
     expect(open).not.toHaveBeenCalled();
     expect(socket.listenerCount()).toBe(1);
@@ -80,8 +89,7 @@ describe('useOAuthBrowserEventAttempt', () => {
     const matching = {
       authUrl: 'https://provider.example/authorize',
       attempt_id: 'attempt-a',
-      operation_id: attempt?.request.operation_id,
-      auth_generation: 7,
+      reservation_token: attempt?.request.reservation_token,
       caller_user_id: 'admin-a',
     };
     act(() => socket.emit(matching));
@@ -93,69 +101,63 @@ describe('useOAuthBrowserEventAttempt', () => {
       '_blank',
       'noopener,noreferrer'
     );
-
     act(() => socket.emit(matching));
     expect(open).toHaveBeenCalledOnce();
   });
 
-  it('discards a delayed A event after an in-place same-role A to B replacement', () => {
+  it('drops a reservation that resolves after A is replaced by same-role B', async () => {
     const socket = createSocketClient();
+    let release!: (value: { reservation_token: string; expires_at: number }) => void;
+    socket.reserve.mockImplementationOnce(() => new Promise((resolve) => (release = resolve)));
     const rendered = renderHook(
       ({ userId, generation }) => useHarness(socket.client, userId, generation),
       { initialProps: { userId: 'admin-a', generation: 12 } }
     );
-    const attemptA = rendered.result.current.begin();
-    expect(socket.listenerCount()).toBe(1);
-
+    const pending = rendered.result.current.begin({ operation: 'discover' });
     rendered.rerender({ userId: 'admin-b', generation: 13 });
+    release({ reservation_token: 'server-reservation-delayed-000000', expires_at: Date.now() });
+    await expect(pending).resolves.toBeNull();
     expect(socket.listenerCount()).toBe(0);
-
-    act(() => {
-      socket.emit({
-        authUrl: 'https://provider.example/a-authorize',
-        attempt_id: 'attempt-a',
-        operation_id: attemptA?.request.operation_id,
-        auth_generation: 12,
-        caller_user_id: 'admin-a',
-      });
-    });
     expect(open).not.toHaveBeenCalled();
   });
 
-  it('removes the listener in layout when the same identity loses authority', () => {
+  it('tears down delayed A events on identity, generation, and authority changes', async () => {
     const socket = createSocketClient();
     const rendered = renderHook(
-      ({ allowed }) => useHarness(socket.client, 'admin-a', 12, allowed),
-      { initialProps: { allowed: true } }
+      ({ userId, generation, allowed }) => useHarness(socket.client, userId, generation, allowed),
+      { initialProps: { userId: 'admin-a', generation: 12, allowed: true } }
     );
-    const attempt = rendered.result.current.begin();
+    const attemptA = await rendered.result.current.begin({ operation: 'discover' });
     expect(socket.listenerCount()).toBe(1);
-
-    rendered.rerender({ allowed: false });
+    rendered.rerender({ userId: 'admin-a', generation: 13, allowed: true });
     expect(socket.listenerCount()).toBe(0);
-    act(() => {
+    act(() =>
       socket.emit({
         authUrl: 'https://provider.example/a-authorize',
         attempt_id: 'attempt-a',
-        operation_id: attempt?.request.operation_id,
-        auth_generation: 12,
+        reservation_token: attemptA?.request.reservation_token,
         caller_user_id: 'admin-a',
-      });
-    });
+      })
+    );
     expect(open).not.toHaveBeenCalled();
+
+    const attemptB = await rendered.result.current.begin({ operation: 'discover' });
+    rendered.rerender({ userId: 'admin-b', generation: 14, allowed: true });
+    expect(socket.listenerCount()).toBe(0);
+    expect(attemptB).not.toBeNull();
+    rendered.rerender({ userId: 'admin-b', generation: 14, allowed: false });
+    expect(socket.listenerCount()).toBe(0);
   });
 
-  it('cleans up an abandoned request and all outstanding requests on unmount', () => {
+  it('cleans abandoned and outstanding reservations exactly once', async () => {
     const socket = createSocketClient();
     const rendered = renderHook(() => useHarness(socket.client, 'admin-a', 2));
-    const first = rendered.result.current.begin();
-    rendered.result.current.begin();
+    const first = await rendered.result.current.begin({ operation: 'discover' });
+    await rendered.result.current.begin({ operation: 'discover' });
     expect(socket.listenerCount()).toBe(2);
-
     first?.cleanup();
     first?.cleanup();
     expect(socket.listenerCount()).toBe(1);
-
     rendered.unmount();
     expect(socket.listenerCount()).toBe(0);
     expect(open).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.test.tsx
@@ -1,0 +1,163 @@
+import type { AgorClient } from '@agor-live/client';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
+import { useOAuthBrowserEventAttempt } from './useOAuthBrowserEventAttempt';
+
+type BrowserListener = (event: Record<string, unknown>) => void;
+
+function createSocketClient() {
+  const listeners = new Set<BrowserListener>();
+  const io = {
+    on: vi.fn((_event: string, listener: BrowserListener) => listeners.add(listener)),
+    off: vi.fn((_event: string, listener: BrowserListener) => listeners.delete(listener)),
+  };
+  return {
+    client: { io } as unknown as AgorClient,
+    io,
+    emit: (event: Record<string, unknown>) => {
+      for (const listener of [...listeners]) listener(event);
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+function useHarness(client: AgorClient, userId: string, authGeneration: number, allowed = true) {
+  const guard = useAuthorityOperationGuard(allowed ? [client, userId, authGeneration] : null);
+  return useOAuthBrowserEventAttempt({
+    client,
+    currentUserId: userId,
+    authGeneration,
+    authorityGuard: guard,
+  });
+}
+
+describe('useOAuthBrowserEventAttempt', () => {
+  const open = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('open', open);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('opens only the exact caller/generation/operation once and removes the listener first', () => {
+    const socket = createSocketClient();
+    const { result } = renderHook(() => useHarness(socket.client, 'admin-a', 7));
+    const attempt = result.current.begin();
+    expect(attempt).not.toBeNull();
+    expect(socket.listenerCount()).toBe(1);
+
+    act(() => {
+      socket.emit({
+        authUrl: 'https://provider.example/unrelated',
+        attempt_id: 'attempt-wrong-operation',
+        operation_id: 'not-this-operation',
+        auth_generation: 7,
+        caller_user_id: 'admin-a',
+      });
+      socket.emit({
+        authUrl: 'https://provider.example/wrong-user',
+        attempt_id: 'attempt-wrong-user',
+        operation_id: attempt?.request.operation_id,
+        auth_generation: 7,
+        caller_user_id: 'admin-b',
+      });
+      socket.emit({
+        authUrl: 'https://provider.example/wrong-generation',
+        attempt_id: 'attempt-wrong-generation',
+        operation_id: attempt?.request.operation_id,
+        auth_generation: 8,
+        caller_user_id: 'admin-a',
+      });
+    });
+    expect(open).not.toHaveBeenCalled();
+    expect(socket.listenerCount()).toBe(1);
+
+    const matching = {
+      authUrl: 'https://provider.example/authorize',
+      attempt_id: 'attempt-a',
+      operation_id: attempt?.request.operation_id,
+      auth_generation: 7,
+      caller_user_id: 'admin-a',
+    };
+    act(() => socket.emit(matching));
+    expect(socket.listenerCount()).toBe(0);
+    expect(socket.io.off).toHaveBeenCalledBefore(open);
+    expect(open).toHaveBeenCalledOnce();
+    expect(open).toHaveBeenCalledWith(
+      'https://provider.example/authorize',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    act(() => socket.emit(matching));
+    expect(open).toHaveBeenCalledOnce();
+  });
+
+  it('discards a delayed A event after an in-place same-role A to B replacement', () => {
+    const socket = createSocketClient();
+    const rendered = renderHook(
+      ({ userId, generation }) => useHarness(socket.client, userId, generation),
+      { initialProps: { userId: 'admin-a', generation: 12 } }
+    );
+    const attemptA = rendered.result.current.begin();
+    expect(socket.listenerCount()).toBe(1);
+
+    rendered.rerender({ userId: 'admin-b', generation: 13 });
+    expect(socket.listenerCount()).toBe(0);
+
+    act(() => {
+      socket.emit({
+        authUrl: 'https://provider.example/a-authorize',
+        attempt_id: 'attempt-a',
+        operation_id: attemptA?.request.operation_id,
+        auth_generation: 12,
+        caller_user_id: 'admin-a',
+      });
+    });
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener in layout when the same identity loses authority', () => {
+    const socket = createSocketClient();
+    const rendered = renderHook(
+      ({ allowed }) => useHarness(socket.client, 'admin-a', 12, allowed),
+      { initialProps: { allowed: true } }
+    );
+    const attempt = rendered.result.current.begin();
+    expect(socket.listenerCount()).toBe(1);
+
+    rendered.rerender({ allowed: false });
+    expect(socket.listenerCount()).toBe(0);
+    act(() => {
+      socket.emit({
+        authUrl: 'https://provider.example/a-authorize',
+        attempt_id: 'attempt-a',
+        operation_id: attempt?.request.operation_id,
+        auth_generation: 12,
+        caller_user_id: 'admin-a',
+      });
+    });
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('cleans up an abandoned request and all outstanding requests on unmount', () => {
+    const socket = createSocketClient();
+    const rendered = renderHook(() => useHarness(socket.client, 'admin-a', 2));
+    const first = rendered.result.current.begin();
+    rendered.result.current.begin();
+    expect(socket.listenerCount()).toBe(2);
+
+    first?.cleanup();
+    first?.cleanup();
+    expect(socket.listenerCount()).toBe(1);
+
+    rendered.unmount();
+    expect(socket.listenerCount()).toBe(0);
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
@@ -1,4 +1,10 @@
-import type { MCPOAuthBrowserEventRequest, MCPOAuthOpenBrowserEvent } from '@agor/core/types';
+import type {
+  MCPOAuthBrowserEventRequest,
+  MCPOAuthBrowserOperation,
+  MCPOAuthBrowserReservation,
+  MCPOAuthBrowserReservationRequest,
+  MCPOAuthOpenBrowserEvent,
+} from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { useLayoutEffect, useRef } from 'react';
 import type { AuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
@@ -15,10 +21,6 @@ interface OAuthBrowserEventAttemptOptions {
   authorityGuard: AuthorityOperationGuard;
 }
 
-function newOperationId(): string {
-  return globalThis.crypto.randomUUID();
-}
-
 /**
  * Register an exact, one-shot listener before starting a blocking discovery.
  * Socket targeting alone is insufficient because launch auth can replace the
@@ -29,7 +31,12 @@ export function useOAuthBrowserEventAttempt({
   currentUserId,
   authGeneration,
   authorityGuard,
-}: OAuthBrowserEventAttemptOptions): { begin: () => OAuthBrowserEventAttempt | null } {
+}: OAuthBrowserEventAttemptOptions): {
+  begin: (request: {
+    operation: MCPOAuthBrowserOperation;
+    mcpServerId?: string;
+  }) => Promise<OAuthBrowserEventAttempt | null>;
+} {
   const cleanupByOperationIdRef = useRef(new Map<string, () => void>());
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: these values and guard identity are the authority transition keys that trigger listener teardown
@@ -42,28 +49,46 @@ export function useOAuthBrowserEventAttempt({
   );
 
   return {
-    begin: () => {
+    begin: async ({ operation: operationKind, mcpServerId }) => {
       if (!client || !currentUserId || !authorityGuard.isCurrent()) return null;
       const operation = authorityGuard.begin();
       if (!operation.isCurrent()) return null;
+      const reservationService = client.service(
+        'mcp-servers/oauth-browser-reservations'
+      ) as unknown as {
+        create(data: MCPOAuthBrowserReservationRequest): Promise<MCPOAuthBrowserReservation>;
+      };
+      const reservation = await reservationService.create({
+        operation: operationKind,
+        ...(mcpServerId ? { mcp_server_id: mcpServerId as never } : {}),
+      });
+      if (
+        !operation.isCurrent() ||
+        !reservation ||
+        typeof reservation.reservation_token !== 'string' ||
+        !reservation.reservation_token
+      ) {
+        operation.cancel();
+        return null;
+      }
       const request: MCPOAuthBrowserEventRequest = {
-        operation_id: newOperationId(),
-        auth_generation: authGeneration,
+        reservation_token: reservation.reservation_token,
       };
       let active = true;
       const cleanup = () => {
         if (!active) return;
         active = false;
         client.io.off('oauth:open_browser', listener);
-        cleanupByOperationIdRef.current.delete(request.operation_id);
+        cleanupByOperationIdRef.current.delete(request.reservation_token);
         operation.cancel();
       };
-      const listener = (event: MCPOAuthOpenBrowserEvent) => {
+      const listener = (event: MCPOAuthOpenBrowserEvent | null | undefined) => {
         if (
+          !event ||
+          typeof event !== 'object' ||
           !active ||
           !operation.isCurrent() ||
-          event.operation_id !== request.operation_id ||
-          event.auth_generation !== authGeneration ||
+          event.reservation_token !== request.reservation_token ||
           event.caller_user_id !== currentUserId ||
           typeof event.attempt_id !== 'string' ||
           !event.attempt_id ||
@@ -77,7 +102,7 @@ export function useOAuthBrowserEventAttempt({
         cleanup();
         window.open(event.authUrl, '_blank', 'noopener,noreferrer');
       };
-      cleanupByOperationIdRef.current.set(request.operation_id, cleanup);
+      cleanupByOperationIdRef.current.set(request.reservation_token, cleanup);
       client.io.on('oauth:open_browser', listener);
       return { request, cleanup };
     },

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
@@ -1,0 +1,85 @@
+import type { MCPOAuthBrowserEventRequest, MCPOAuthOpenBrowserEvent } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { useLayoutEffect, useRef } from 'react';
+import type { AuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
+
+interface OAuthBrowserEventAttempt {
+  request: MCPOAuthBrowserEventRequest;
+  cleanup: () => void;
+}
+
+interface OAuthBrowserEventAttemptOptions {
+  client: AgorClient | null;
+  currentUserId: string | null;
+  authGeneration: number;
+  authorityGuard: AuthorityOperationGuard;
+}
+
+function newOperationId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+/**
+ * Register an exact, one-shot listener before starting a blocking discovery.
+ * Socket targeting alone is insufficient because launch auth can replace the
+ * socket's caller in place while an A-era discovery is still running.
+ */
+export function useOAuthBrowserEventAttempt({
+  client,
+  currentUserId,
+  authGeneration,
+  authorityGuard,
+}: OAuthBrowserEventAttemptOptions): { begin: () => OAuthBrowserEventAttempt | null } {
+  const cleanupByOperationIdRef = useRef(new Map<string, () => void>());
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these values and guard identity are the authority transition keys that trigger listener teardown
+  useLayoutEffect(
+    () => () => {
+      for (const cleanup of cleanupByOperationIdRef.current.values()) cleanup();
+      cleanupByOperationIdRef.current.clear();
+    },
+    [client, currentUserId, authGeneration, authorityGuard]
+  );
+
+  return {
+    begin: () => {
+      if (!client || !currentUserId || !authorityGuard.isCurrent()) return null;
+      const operation = authorityGuard.begin();
+      if (!operation.isCurrent()) return null;
+      const request: MCPOAuthBrowserEventRequest = {
+        operation_id: newOperationId(),
+        auth_generation: authGeneration,
+      };
+      let active = true;
+      const cleanup = () => {
+        if (!active) return;
+        active = false;
+        client.io.off('oauth:open_browser', listener);
+        cleanupByOperationIdRef.current.delete(request.operation_id);
+        operation.cancel();
+      };
+      const listener = (event: MCPOAuthOpenBrowserEvent) => {
+        if (
+          !active ||
+          !operation.isCurrent() ||
+          event.operation_id !== request.operation_id ||
+          event.auth_generation !== authGeneration ||
+          event.caller_user_id !== currentUserId ||
+          typeof event.attempt_id !== 'string' ||
+          !event.attempt_id ||
+          typeof event.authUrl !== 'string' ||
+          !event.authUrl
+        ) {
+          return;
+        }
+        // Remove first: a duplicate event dispatched synchronously by another
+        // listener cannot open a second provider tab for the same attempt.
+        cleanup();
+        window.open(event.authUrl, '_blank', 'noopener,noreferrer');
+      };
+      cleanupByOperationIdRef.current.set(request.operation_id, cleanup);
+      client.io.on('oauth:open_browser', listener);
+      return { request, cleanup };
+    },
+  };
+}

--- a/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
+++ b/apps/agor-ui/src/components/MCPServer/useOAuthBrowserEventAttempt.ts
@@ -66,7 +66,10 @@ export function useOAuthBrowserEventAttempt({
         !operation.isCurrent() ||
         !reservation ||
         typeof reservation.reservation_token !== 'string' ||
-        !reservation.reservation_token
+        !reservation.reservation_token ||
+        typeof reservation.expires_at !== 'number' ||
+        !Number.isFinite(reservation.expires_at) ||
+        reservation.expires_at <= Date.now()
       ) {
         operation.cancel();
         return null;
@@ -75,14 +78,20 @@ export function useOAuthBrowserEventAttempt({
         reservation_token: reservation.reservation_token,
       };
       let active = true;
+      let expiryTimer: ReturnType<typeof setTimeout> | undefined;
       const cleanup = () => {
         if (!active) return;
         active = false;
         client.io.off('oauth:open_browser', listener);
         cleanupByOperationIdRef.current.delete(request.reservation_token);
+        if (expiryTimer !== undefined) clearTimeout(expiryTimer);
         operation.cancel();
       };
       const listener = (event: MCPOAuthOpenBrowserEvent | null | undefined) => {
+        if (Date.now() >= reservation.expires_at) {
+          cleanup();
+          return;
+        }
         if (
           !event ||
           typeof event !== 'object' ||
@@ -104,6 +113,7 @@ export function useOAuthBrowserEventAttempt({
       };
       cleanupByOperationIdRef.current.set(request.reservation_token, cleanup);
       client.io.on('oauth:open_browser', listener);
+      expiryTimer = setTimeout(cleanup, Math.max(0, reservation.expires_at - Date.now()));
       return { request, cleanup };
     },
   };

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
@@ -53,6 +53,7 @@ function renderDrawer(
   const { capability = ALLOWED, policyPending = false } = options;
   const view = render(
     <CatalogDetailDrawer
+      identityKey={capability.userId ?? null}
       entry={entry}
       open
       onClose={vi.fn()}
@@ -71,6 +72,7 @@ function renderDrawer(
   const show = (next: MCPCatalogEntry) =>
     view.rerender(
       <CatalogDetailDrawer
+        identityKey={capability.userId ?? null}
         entry={next}
         open
         onClose={vi.fn()}
@@ -242,8 +244,10 @@ function renderWithConnect(entry: MCPCatalogEntry) {
   const props = (
     shown: MCPCatalogEntry,
     open = true,
-    credentialRequirement: MCPCatalogCredentialRequirement | null = null
+    credentialRequirement: MCPCatalogCredentialRequirement | null = null,
+    identityKey = ALLOWED.userId ?? null
   ) => ({
+    identityKey,
     entry: shown,
     open,
     onClose: vi.fn(),
@@ -254,7 +258,7 @@ function renderWithConnect(entry: MCPCatalogEntry) {
     connecting: false,
     connectError: null,
     credentialRequirement,
-    connectCapability: ALLOWED,
+    connectCapability: { ...ALLOWED, userId: identityKey ?? undefined },
     policyPending: false,
     policyPendingHint: POLICY_LOADING_HINT,
     onConnect,
@@ -270,12 +274,29 @@ function renderWithConnect(entry: MCPCatalogEntry) {
     /** What `CatalogTab` does after a refusal that named a requirement. */
     answerFromEndpoint: (requirement: MCPCatalogCredentialRequirement) =>
       view.rerender(<CatalogDetailDrawer {...props(entry, true, requirement)} />),
+    replaceIdentity: (identityKey: string) =>
+      view.rerender(<CatalogDetailDrawer {...props(entry, true, null, identityKey)} />),
   };
 }
 
 const keyField = () => screen.queryByPlaceholderText(/Paste your .* bearer access token/);
 
 describe('CatalogDetailDrawer API key', () => {
+  it('erases same-entry consent and the pasted key on same-role identity replacement', () => {
+    const { onConnect, replaceIdentity } = renderWithConnect(DATADOG);
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.change(keyField() as HTMLElement, { target: { value: 'admin-a-private-key' } });
+    expect(connectButton()).toBeEnabled();
+
+    replaceIdentity('user-admin-b');
+
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(keyField()).toHaveValue('');
+    expect(connectButton()).toBeDisabled();
+    fireEvent.click(connectButton());
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+
   it('offers a key field for an entry that needs one, and gates connect on it', () => {
     renderWithConnect(DATADOG);
     fireEvent.click(screen.getByRole('checkbox'));

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
@@ -16,6 +16,7 @@ import { type MCPServerCapabilityContext, POLICY_LOADING_HINT } from '../MCPServ
 import { CatalogDetailDrawer } from './CatalogDetailDrawer';
 
 const ALLOWED: MCPServerCapabilityContext = {
+  connectionReady: true,
   role: 'admin',
   isAdmin: true,
   policy: 'allow_crud',
@@ -138,6 +139,7 @@ describe('CatalogDetailDrawer consent', () => {
 
 describe('CatalogDetailDrawer connect capability', () => {
   const VIEWER: MCPServerCapabilityContext = {
+    connectionReady: true,
     role: 'viewer',
     isAdmin: false,
     policy: 'allow_crud',
@@ -145,6 +147,7 @@ describe('CatalogDetailDrawer connect capability', () => {
     canConfigure: false,
   };
   const RESTRICTED_MEMBER: MCPServerCapabilityContext = {
+    connectionReady: true,
     role: 'member',
     isAdmin: false,
     policy: 'use_existing_only',
@@ -175,6 +178,20 @@ describe('CatalogDetailDrawer connect capability', () => {
     fireEvent.click(screen.getByRole('checkbox'));
 
     expect(connectButton()).toBeEnabled();
+  });
+
+  it('fails closed during disconnect grace even with a previously granted capability', () => {
+    renderDrawer(DEEPWIKI, {
+      capability: {
+        ...RESTRICTED_MEMBER,
+        connectionReady: false,
+        policy: 'allow_crud',
+        canConfigure: true,
+      },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeDisabled();
   });
 
   it('fails closed without inventing a workspace policy while the read is pending', () => {

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.test.tsx
@@ -12,7 +12,16 @@
 import type { Branch, MCPCatalogCredentialRequirement, MCPCatalogEntry } from '@agor/core/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { type MCPServerCapabilityContext, POLICY_LOADING_HINT } from '../MCPServer/memberPolicy';
 import { CatalogDetailDrawer } from './CatalogDetailDrawer';
+
+const ALLOWED: MCPServerCapabilityContext = {
+  role: 'admin',
+  isAdmin: true,
+  policy: 'allow_crud',
+  userId: 'user-admin',
+  canConfigure: true,
+};
 
 const DEEPWIKI = {
   name: 'com.deepwiki/mcp',
@@ -36,7 +45,11 @@ const LINEAR = {
 
 const BRANCHES = [{ branch_id: 'branch-1', name: 'mkt-slice' }] as unknown as Branch[];
 
-function renderDrawer(entry: MCPCatalogEntry) {
+function renderDrawer(
+  entry: MCPCatalogEntry,
+  options: { capability?: MCPServerCapabilityContext; policyPending?: boolean } = {}
+) {
+  const { capability = ALLOWED, policyPending = false } = options;
   const view = render(
     <CatalogDetailDrawer
       entry={entry}
@@ -48,6 +61,9 @@ function renderDrawer(entry: MCPCatalogEntry) {
       defaultBranchId="branch-1"
       connecting={false}
       connectError={null}
+      connectCapability={capability}
+      policyPending={policyPending}
+      policyPendingHint={POLICY_LOADING_HINT}
       onConnect={vi.fn()}
     />
   );
@@ -63,6 +79,9 @@ function renderDrawer(entry: MCPCatalogEntry) {
         defaultBranchId="branch-1"
         connecting={false}
         connectError={null}
+        connectCapability={capability}
+        policyPending={policyPending}
+        policyPendingHint={POLICY_LOADING_HINT}
         onConnect={vi.fn()}
       />
     );
@@ -117,6 +136,57 @@ describe('CatalogDetailDrawer consent', () => {
   });
 });
 
+describe('CatalogDetailDrawer connect capability', () => {
+  const VIEWER: MCPServerCapabilityContext = {
+    role: 'viewer',
+    isAdmin: false,
+    policy: 'allow_crud',
+    userId: 'user-viewer',
+    canConfigure: false,
+  };
+  const RESTRICTED_MEMBER: MCPServerCapabilityContext = {
+    role: 'member',
+    isAdmin: false,
+    policy: 'use_existing_only',
+    userId: 'user-member',
+    canConfigure: false,
+  };
+
+  it('refuses a viewer at the action and explains the role restriction', () => {
+    renderDrawer(DEEPWIKI, { capability: VIEWER });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeDisabled();
+    expect(screen.getByText(/read-only access/i)).toBeInTheDocument();
+  });
+
+  it('refuses a member when the workspace policy forbids new servers', () => {
+    renderDrawer(DEEPWIKI, { capability: RESTRICTED_MEMBER });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeDisabled();
+    expect(screen.getByText(/Use existing servers only/)).toBeInTheDocument();
+  });
+
+  it('enables the action for a member with server-provided capability', () => {
+    renderDrawer(DEEPWIKI, {
+      capability: { ...RESTRICTED_MEMBER, policy: 'allow_crud', canConfigure: true },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeEnabled();
+  });
+
+  it('fails closed without inventing a workspace policy while the read is pending', () => {
+    renderDrawer(DEEPWIKI, { policyPending: true });
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(connectButton()).toBeDisabled();
+    expect(screen.getByText(POLICY_LOADING_HINT)).toBeInTheDocument();
+    expect(screen.queryByText(/does not let you add/i)).not.toBeInTheDocument();
+  });
+});
+
 /**
  * The API-key field.
  *
@@ -167,6 +237,9 @@ function renderWithConnect(entry: MCPCatalogEntry) {
     connecting: false,
     connectError: null,
     credentialRequirement,
+    connectCapability: ALLOWED,
+    policyPending: false,
+    policyPendingHint: POLICY_LOADING_HINT,
     onConnect,
   });
   const view = render(<CatalogDetailDrawer {...props(entry)} />);

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -52,6 +52,8 @@ const FALLBACK_DISCLOSURE =
   'This server has published no access statement. Anything it exposes becomes available to the agent in the session you connect it to.';
 
 export interface CatalogDetailDrawerProps {
+  /** Authenticated identity that owns consent, selections, and pasted credentials. */
+  identityKey: string | null;
   entry: MCPCatalogEntry | null;
   open: boolean;
   onClose: () => void;
@@ -99,7 +101,8 @@ export interface CatalogDetailDrawerProps {
   }) => void;
 }
 
-export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
+const CatalogDetailDrawerForIdentity: React.FC<CatalogDetailDrawerProps> = ({
+  identityKey: _identityKey,
   entry,
   open,
   onClose,
@@ -446,3 +449,16 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
     </Drawer>
   );
 };
+
+/**
+ * Consent, branch/agent selections, and bearer credentials are caller-entered
+ * authority. A keyed state owner destroys all of them during the A -> B render,
+ * including the same-role/same-entry case that entry-keying alone cannot see.
+ * Connection/auth-generation churn for one identity deliberately keeps them.
+ */
+export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = (props) => (
+  <CatalogDetailDrawerForIdentity
+    key={props.identityKey ?? '__no-authenticated-user__'}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogDetailDrawer.tsx
@@ -32,6 +32,11 @@ import {
 } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
+import {
+  canAddMcpServer,
+  explainAddRestriction,
+  type MCPServerCapabilityContext,
+} from '../MCPServer/memberPolicy';
 import { capabilityLabel, connectStatus, entryTitle } from './catalogPresentation';
 
 const { Title, Paragraph, Text, Link } = Typography;
@@ -69,6 +74,15 @@ export interface CatalogDetailDrawerProps {
    */
   credentialRequirement?: MCPCatalogCredentialRequirement | null;
   /**
+   * Connecting installs an MCP server, so the same server-provided capability
+   * that gates Settings must gate this action too. Catalog browsing itself
+   * remains available to every authenticated role.
+   */
+  connectCapability: MCPServerCapabilityContext;
+  /** The policy read has not landed; fail closed without claiming a policy value. */
+  policyPending: boolean;
+  policyPendingHint: string;
+  /**
    * `acknowledgedDisclosure` is the exact text this drawer put on screen, so
    * what the connect request claims was shown cannot drift from what was.
    *
@@ -96,6 +110,9 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
   connecting,
   connectError,
   credentialRequirement,
+  connectCapability,
+  policyPending,
+  policyPendingHint,
   onConnect,
 }) => {
   const { token } = theme.useToken();
@@ -206,8 +223,18 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
     );
   }, [open, entryId, needsApiKey]);
 
+  const policyRefusal = policyPending
+    ? policyPendingHint
+    : canAddMcpServer(connectCapability)
+      ? undefined
+      : explainAddRestriction(connectCapability);
   const canConnect = Boolean(
-    !blockedReason && acknowledged && branchId && !connecting && (!needsApiKey || bearerToken)
+    !blockedReason &&
+      !policyRefusal &&
+      acknowledged &&
+      branchId &&
+      !connecting &&
+      (!needsApiKey || bearerToken)
   );
 
   return (
@@ -376,6 +403,7 @@ export const CatalogDetailDrawer: React.FC<CatalogDetailDrawerProps> = ({
 
               {branchesError && <Alert type="error" showIcon message={branchesError} />}
               {connectError && <Alert type="error" showIcon message={connectError} />}
+              {policyRefusal && <Alert type="info" showIcon message={policyRefusal} />}
 
               <Button
                 type="primary"

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -21,6 +21,11 @@ const DEFAULT_ADMIN = {
   email: 'admin@agor.live',
   role: 'admin',
 } as User;
+const REPLACEMENT_ADMIN = {
+  user_id: 'user-admin-b',
+  email: 'admin-b@agor.live',
+  role: 'admin',
+} as User;
 
 const DEEPWIKI = {
   name: 'com.deepwiki/mcp',
@@ -414,6 +419,91 @@ describe('connect', () => {
     await waitFor(() => expect(connect).toBeEnabled());
   });
 
+  it('erases the active entry, refusal, consent, and key across admin A -> admin B', async () => {
+    const client = makeClient();
+    const view = (currentUser: User, authGeneration: number) => (
+      <MemoryRouter>
+        <CatalogTab
+          client={client}
+          connected
+          connecting={false}
+          authGeneration={authGeneration}
+          currentUser={currentUser}
+        />
+      </MemoryRouter>
+    );
+    const rendered = render(view(DEFAULT_ADMIN, 1));
+    fireEvent.click(await findCard('DeepWiki'));
+    let drawer = await findDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    const connect = drawer.getByRole('button', { name: /Connect/ });
+    await waitFor(() => expect(connect).toBeEnabled());
+    connectImpl = async () => {
+      throw Object.assign(new Error('Endpoint now requires a bearer token'), {
+        data: { credential_requirement: 'required' },
+      });
+    };
+    fireEvent.click(connect);
+    const keyInput = await drawer.findByPlaceholderText(/bearer access token/i);
+    fireEvent.change(keyInput, { target: { value: 'admin-a-private-key' } });
+    expect(drawer.getByText(/Endpoint now requires/)).toBeVisible();
+
+    rendered.rerender(view(REPLACEMENT_ADMIN, 2));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    fireEvent.click(await findCard('DeepWiki'));
+    drawer = await findDrawer();
+    expect(drawer.getByRole('checkbox')).not.toBeChecked();
+    expect(drawer.queryByPlaceholderText(/bearer access token/i)).not.toBeInTheDocument();
+    expect(drawer.queryByText(/Endpoint now requires/)).not.toBeInTheDocument();
+    expect(drawer.getByRole('button', { name: /Connect/ })).toBeDisabled();
+    expect(connectCalls).toHaveLength(1);
+  });
+
+  it('does not apply an admin-A connect response after admin B replaces it', async () => {
+    let releaseConnect!: () => void;
+    const pending = new Promise<unknown>((resolve) => {
+      releaseConnect = () =>
+        resolve({
+          mcp_server: { mcp_server_id: 'server-a' },
+          session: { session_id: SESSION_ID },
+          starter_prompt: DEEPWIKI.starter_prompt,
+          reused_existing_server: false,
+        });
+    });
+    connectImpl = async () => pending;
+    const client = makeClient();
+    const view = (currentUser: User, authGeneration: number) => (
+      <MemoryRouter>
+        <CatalogTab
+          client={client}
+          connected
+          connecting={false}
+          authGeneration={authGeneration}
+          currentUser={currentUser}
+        />
+      </MemoryRouter>
+    );
+    const rendered = render(view(DEFAULT_ADMIN, 1));
+    fireEvent.click(await findCard('DeepWiki'));
+    const drawer = await findDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    const connect = drawer.getByRole('button', { name: /Connect/ });
+    await waitFor(() => expect(connect).toBeEnabled());
+    fireEvent.click(connect);
+    await waitFor(() => expect(connectCalls).toHaveLength(1));
+
+    rendered.rerender(view(REPLACEMENT_ADMIN, 2));
+    await act(async () => {
+      releaseConnect();
+      await pending;
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(localStorage.getItem(`agor-draft-${SESSION_ID}`)).toBeNull();
+    expect(localStorage.getItem(`agor-marketplace-branch:${REPLACEMENT_ADMIN.user_id}`)).toBeNull();
+  });
+
   // Consent's two withdrawal rules — a different entry, and the same entry
   // with rewritten wording — are asserted in `CatalogDetailDrawer.test.tsx`.
   // Reaching them from here meant closing and reopening the drawer, mounting
@@ -442,6 +532,9 @@ describe('connect', () => {
       expect(mockNavigate).toHaveBeenCalledWith(sessionPath(SESSION_ID as SessionID))
     );
     expect(getPromptDraft(CURRENT_USER_ID, SESSION_ID)).toBe(DEEPWIKI.starter_prompt);
+    expect(localStorage.getItem(`agor-marketplace-branch:${DEFAULT_ADMIN.user_id}`)).toBe(
+      'branch-1'
+    );
   });
 
   /**

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -16,6 +16,11 @@ vi.mock('react-router-dom', async () => {
 
 const SESSION_ID = '019fd25a-7065-75f8-b6e6-f1963f9817d6';
 const CURRENT_USER_ID = '019fd25a-7065-75f8-b6e6-f1963f9817d7';
+const DEFAULT_ADMIN = {
+  user_id: CURRENT_USER_ID,
+  email: 'admin@agor.live',
+  role: 'admin',
+} as User;
 
 const DEEPWIKI = {
   name: 'com.deepwiki/mcp',
@@ -90,6 +95,9 @@ function makeClient(): AgorClient {
     if (path === 'mcp-member-policy') {
       return { find: async () => memberPolicyAnswer };
     }
+    if (path === 'mcp-servers') {
+      return { on: vi.fn(), removeListener: vi.fn() };
+    }
     throw new Error(`unexpected service: ${path}`);
   };
   return { service } as unknown as AgorClient;
@@ -97,14 +105,24 @@ function makeClient(): AgorClient {
 
 function renderTab({
   connected = true,
-  currentUser = { user_id: CURRENT_USER_ID, email: 'admin@agor.live', role: 'admin' } as User,
+  connecting = false,
+  authGeneration = 1,
+  currentUser = DEFAULT_ADMIN,
 }: {
   connected?: boolean;
+  connecting?: boolean;
+  authGeneration?: number;
   currentUser?: User | null;
 } = {}) {
   return render(
     <MemoryRouter>
-      <CatalogTab client={makeClient()} connected={connected} currentUser={currentUser} />
+      <CatalogTab
+        client={makeClient()}
+        connected={connected}
+        connecting={connecting}
+        authGeneration={authGeneration}
+        currentUser={currentUser}
+      />
     </MemoryRouter>
   );
 }
@@ -199,14 +217,14 @@ describe('catalog browsing', () => {
     const client = makeClient();
     const { rerender } = render(
       <MemoryRouter>
-        <CatalogTab client={client} connected={false} />
+        <CatalogTab client={client} connected={false} connecting={false} authGeneration={0} />
       </MemoryRouter>
     );
     expect(catalogReads).toHaveLength(0);
 
     rerender(
       <MemoryRouter>
-        <CatalogTab client={client} connected={true} />
+        <CatalogTab client={client} connected={true} connecting={false} authGeneration={1} />
       </MemoryRouter>
     );
 

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -1,5 +1,5 @@
 import type { SessionID } from '@agor/core/types';
-import type { AgorClient } from '@agor-live/client';
+import type { AgorClient, User } from '@agor-live/client';
 import { sessionPath } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -50,6 +50,10 @@ let catalogRows: (typeof DEEPWIKI)[];
 let connectCalls: Array<Record<string, unknown>>;
 let connectImpl: (data: Record<string, unknown>) => Promise<unknown>;
 let catalogFindError: Error | null;
+let memberPolicyAnswer: {
+  policy: 'use_existing_only' | 'allow_private_only' | 'allow_crud';
+  can_configure: boolean;
+};
 
 function makeClient(): AgorClient {
   const service = (path: string) => {
@@ -83,15 +87,24 @@ function makeClient(): AgorClient {
         },
       };
     }
+    if (path === 'mcp-member-policy') {
+      return { find: async () => memberPolicyAnswer };
+    }
     throw new Error(`unexpected service: ${path}`);
   };
   return { service } as unknown as AgorClient;
 }
 
-function renderTab({ connected = true }: { connected?: boolean } = {}) {
+function renderTab({
+  connected = true,
+  currentUser = { user_id: CURRENT_USER_ID, email: 'admin@agor.live', role: 'admin' } as User,
+}: {
+  connected?: boolean;
+  currentUser?: User | null;
+} = {}) {
   return render(
     <MemoryRouter>
-      <CatalogTab client={makeClient()} connected={connected} currentUserId={CURRENT_USER_ID} />
+      <CatalogTab client={makeClient()} connected={connected} currentUser={currentUser} />
     </MemoryRouter>
   );
 }
@@ -128,6 +141,7 @@ beforeEach(() => {
   catalogRows = [DEEPWIKI, LINEAR];
   catalogFindError = null;
   connectCalls = [];
+  memberPolicyAnswer = { policy: 'allow_crud', can_configure: true };
   connectImpl = async () => ({
     mcp_server: { mcp_server_id: 'server-1' },
     session: { session_id: SESSION_ID },
@@ -485,7 +499,7 @@ describe('connect', () => {
 
   it('keeps the drawer open and reports why when connect fails', async () => {
     connectImpl = async () => {
-      throw new Error('DeepWiki requires authentication, which is not supported yet');
+      throw new Error('DeepWiki is temporarily unavailable');
     };
     const drawer = await openDrawer();
     const connect = drawer.getByRole('button', { name: /Connect/ });
@@ -494,7 +508,7 @@ describe('connect', () => {
 
     fireEvent.click(connect);
 
-    expect(await drawer.findByText(/requires authentication/)).toBeVisible();
+    expect(await drawer.findByText(/temporarily unavailable/)).toBeVisible();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
@@ -511,5 +525,54 @@ describe('connect', () => {
     expect(drawer.getByText(/cannot be installed/)).toBeVisible();
     expect(drawer.queryByRole('button', { name: /Connect/ })).not.toBeInTheDocument();
     expect(drawer.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});
+
+describe('connect capability reaches the drawer', () => {
+  const VIEWER = {
+    user_id: 'user-viewer',
+    email: 'viewer@agor.live',
+    role: 'viewer',
+  } as User;
+  const MEMBER = {
+    user_id: 'user-member',
+    email: 'member@agor.live',
+    role: 'member',
+  } as User;
+
+  async function openAndAcknowledge(currentUser: User) {
+    renderTab({ currentUser });
+    fireEvent.click(await findCard('DeepWiki'));
+    const drawer = await findDrawer();
+    fireEvent.click(drawer.getByRole('checkbox'));
+    return drawer;
+  }
+
+  it('refuses a viewer before any connect request reaches the daemon', async () => {
+    memberPolicyAnswer = { policy: 'allow_crud', can_configure: false };
+
+    const drawer = await openAndAcknowledge(VIEWER);
+
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeDisabled());
+    expect(drawer.getByText(/read-only access/i)).toBeInTheDocument();
+    expect(connectCalls).toHaveLength(0);
+  });
+
+  it('refuses a member when the server says the policy is use-existing-only', async () => {
+    memberPolicyAnswer = { policy: 'use_existing_only', can_configure: false };
+
+    const drawer = await openAndAcknowledge(MEMBER);
+
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeDisabled());
+    expect(drawer.getByText(/Use existing servers only/)).toBeInTheDocument();
+    expect(connectCalls).toHaveLength(0);
+  });
+
+  it('enables Connect when the server grants the member capability', async () => {
+    memberPolicyAnswer = { policy: 'allow_private_only', can_configure: true };
+
+    const drawer = await openAndAcknowledge(MEMBER);
+
+    await waitFor(() => expect(drawer.getByRole('button', { name: /Connect/ })).toBeEnabled());
   });
 });

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -91,11 +91,21 @@ export interface CatalogTabProps {
   client: AgorClient | null;
   /** The socket has connected and authenticated, so reads will be answered. */
   connected: boolean;
+  /** Disconnect grace or in-place token authentication is underway. */
+  connecting: boolean;
+  /** Successful socket-auth generation; stable client identity is insufficient. */
+  authGeneration: number;
   /** Whose server-provided capability decides whether Connect is offered. */
   currentUser?: User | null;
 }
 
-export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, currentUser }) => {
+export const CatalogTab: React.FC<CatalogTabProps> = ({
+  client,
+  connected,
+  connecting: connectionPending,
+  authGeneration,
+  currentUser,
+}) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
   // Same set the session panel reads, so "is this install finished?" is one
@@ -130,20 +140,33 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, curre
     loading: branchesLoading,
     error: branchesError,
   } = useConnectTargets(client, connected && selected !== null);
-  // The standalone surface renders before socket authentication completes.
-  // Give the policy hook no client until reads can actually be answered so a
-  // pre-auth refusal cannot become the final capability state for this mount.
-  const memberPolicy = useMcpMemberPolicy(connected ? client : null);
+  // `connected` deliberately stays true during disconnect grace, while a token
+  // replacement keeps the same client object. Neither may preserve an enabled
+  // action: capability reads are scoped to the authenticated generation and
+  // connectionReady closes synchronously for both transitions.
+  const connectionReady = connected && !connectionPending;
+  const memberPolicy = useMcpMemberPolicy(client, {
+    connectionReady,
+    currentUser,
+    authGeneration,
+  });
   const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
   const connectCapability = useMemo<MCPServerCapabilityContext>(
     () => ({
       role: currentUser?.role,
       isAdmin: hasMinimumRole(currentUser?.role, ROLES.ADMIN),
+      connectionReady,
       policy: memberPolicy.policy,
       userId: currentUser?.user_id,
       canConfigure: memberPolicy.canConfigure,
     }),
-    [currentUser?.role, currentUser?.user_id, memberPolicy.policy, memberPolicy.canConfigure]
+    [
+      connectionReady,
+      currentUser?.role,
+      currentUser?.user_id,
+      memberPolicy.policy,
+      memberPolicy.canConfigure,
+    ]
   );
 
   // Any narrowing invalidates the current offset — page 4 of an unfiltered

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -13,15 +13,17 @@ import type {
   MCPCatalogEntry,
 } from '@agor/core/types';
 import { readCredentialRequirement } from '@agor/core/types';
-import type { AgorClient } from '@agor-live/client';
-import { sessionPath } from '@agor-live/client';
+import type { AgorClient, User } from '@agor-live/client';
+import { hasMinimumRole, ROLES, sessionPath } from '@agor-live/client';
 import { Alert, Button, Col, Empty, Flex, Pagination, Row, Skeleton, theme } from 'antd';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMcpMemberPolicy } from '../../hooks/useMcpMemberPolicy';
 import { useAgorStore } from '../../store/agorStore';
 import { selectUserAuthenticatedMcpServerIds } from '../../store/selectors';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { savePromptDraft } from '../../utils/promptDrafts';
+import { type MCPServerCapabilityContext, policyPendingState } from '../MCPServer/memberPolicy';
 import { CatalogCard } from './CatalogCard';
 import { CatalogDetailDrawer } from './CatalogDetailDrawer';
 import { CatalogToolbar } from './CatalogToolbar';
@@ -87,12 +89,13 @@ const CatalogGrid = memo<{
 
 export interface CatalogTabProps {
   client: AgorClient | null;
-  currentUserId?: string;
   /** The socket has connected and authenticated, so reads will be answered. */
   connected: boolean;
+  /** Whose server-provided capability decides whether Connect is offered. */
+  currentUser?: User | null;
 }
 
-export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, currentUserId }) => {
+export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, currentUser }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
   // Same set the session panel reads, so "is this install finished?" is one
@@ -127,6 +130,21 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, curre
     loading: branchesLoading,
     error: branchesError,
   } = useConnectTargets(client, connected && selected !== null);
+  // The standalone surface renders before socket authentication completes.
+  // Give the policy hook no client until reads can actually be answered so a
+  // pre-auth refusal cannot become the final capability state for this mount.
+  const memberPolicy = useMcpMemberPolicy(connected ? client : null);
+  const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
+  const connectCapability = useMemo<MCPServerCapabilityContext>(
+    () => ({
+      role: currentUser?.role,
+      isAdmin: hasMinimumRole(currentUser?.role, ROLES.ADMIN),
+      policy: memberPolicy.policy,
+      userId: currentUser?.user_id,
+      canConfigure: memberPolicy.canConfigure,
+    }),
+    [currentUser?.role, currentUser?.user_id, memberPolicy.policy, memberPolicy.canConfigure]
+  );
 
   // Any narrowing invalidates the current offset — page 4 of an unfiltered
   // catalog is usually past the end of a filtered one.
@@ -212,7 +230,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, curre
           result.starter_prompt &&
           !mcpServerNeedsAuth(result.mcp_server, userAuthenticatedMcpServerIds)
         ) {
-          savePromptDraft(currentUserId, result.session.session_id, result.starter_prompt);
+          savePromptDraft(currentUser?.user_id, result.session.session_id, result.starter_prompt);
         }
         setSelected(null);
         navigate(sessionPath(result.session.session_id));
@@ -230,7 +248,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, curre
         setConnecting(false);
       }
     },
-    [client, currentUserId, navigate, selected, userAuthenticatedMcpServerIds]
+    [client, currentUser?.user_id, navigate, selected, userAuthenticatedMcpServerIds]
   );
 
   return (
@@ -319,6 +337,9 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected, curre
         connecting={connecting}
         connectError={connectError}
         credentialRequirement={keyRequirement}
+        connectCapability={connectCapability}
+        policyPending={policyPending}
+        policyPendingHint={policyPendingHint}
         onConnect={handleConnect}
       />
     </Flex>

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -16,7 +16,7 @@ import { readCredentialRequirement } from '@agor/core/types';
 import type { AgorClient, User } from '@agor-live/client';
 import { hasMinimumRole, ROLES, sessionPath } from '@agor-live/client';
 import { Alert, Button, Col, Empty, Flex, Pagination, Row, Skeleton, theme } from 'antd';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMcpMemberPolicy } from '../../hooks/useMcpMemberPolicy';
 import { useAgorStore } from '../../store/agorStore';
@@ -99,7 +99,7 @@ export interface CatalogTabProps {
   currentUser?: User | null;
 }
 
-export const CatalogTab: React.FC<CatalogTabProps> = ({
+const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
   client,
   connected,
   connecting: connectionPending,
@@ -127,6 +127,16 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
   const [keyRequirement, setKeyRequirement] = useState<MCPCatalogCredentialRequirement | null>(
     null
   );
+  // The exported owner below is keyed by current user. This flag also stops a
+  // connect response initiated by caller A from navigating, persisting a
+  // branch preference, or restoring A's error state after caller B replaced it.
+  const identityActiveRef = useRef(true);
+  useEffect(() => {
+    identityActiveRef.current = true;
+    return () => {
+      identityActiveRef.current = false;
+    };
+  }, []);
   const showDisconnected = useSettledFlag(!connected, DISCONNECT_NOTICE_DELAY_MS);
 
   const { entries, status, matchCount, catalogSize, error, retry } = useCatalogSearch(
@@ -225,7 +235,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
       acknowledgedDisclosure: string;
       bearerToken?: string;
     }) => {
-      if (!selected || !client) return;
+      if (!selected || !client || !identityActiveRef.current) return;
       setConnecting(true);
       setConnectError(null);
       try {
@@ -240,7 +250,8 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
           // empty arrived.
           ...(bearerToken ? { bearer_token: bearerToken } : {}),
         });
-        rememberConnectBranchId(branchId);
+        if (!identityActiveRef.current) return;
+        rememberConnectBranchId(currentUser?.user_id, branchId);
         // A starter prompt is written to exercise the server it ships with, so
         // it is only worth arming the composer with once that server can answer
         // it. A new OAuth install with no reusable grant lands without
@@ -258,6 +269,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
         setSelected(null);
         navigate(sessionPath(result.session.session_id));
       } catch (err: unknown) {
+        if (!identityActiveRef.current) return;
         setConnectError(err instanceof Error ? err.message : 'Could not connect this server');
         // The catalog file is presentational; the endpoint decides. When those
         // disagree the daemon says so on the refusal, and taking it here is
@@ -268,7 +280,7 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
         const requirement = readCredentialRequirement(err);
         if (requirement) setKeyRequirement(requirement);
       } finally {
-        setConnecting(false);
+        if (identityActiveRef.current) setConnecting(false);
       }
     },
     [client, currentUser?.user_id, navigate, selected, userAuthenticatedMcpServerIds]
@@ -350,13 +362,14 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
       )}
 
       <CatalogDetailDrawer
+        identityKey={currentUser?.user_id ?? null}
         entry={selected}
         open={selected !== null}
         onClose={closeDrawer}
         branches={branches}
         branchesLoading={branchesLoading}
         branchesError={branchesError}
-        defaultBranchId={getLastConnectBranchId()}
+        defaultBranchId={getLastConnectBranchId(currentUser?.user_id)}
         connecting={connecting}
         connectError={connectError}
         credentialRequirement={keyRequirement}
@@ -368,3 +381,16 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({
     </Flex>
   );
 };
+
+/**
+ * The catalog grid itself is public workspace data, but its active drawer,
+ * refusal/error state, endpoint requirement, and in-flight interaction all
+ * belong to the authenticated caller. Replacing A with B remounts that state
+ * owner synchronously; same-user reconnects and token rotations retain it.
+ */
+export const CatalogTab: React.FC<CatalogTabProps> = (props) => (
+  <CatalogTabForIdentity
+    key={props.currentUser?.user_id ?? '__no-authenticated-user__'}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -16,8 +16,9 @@ import { readCredentialRequirement } from '@agor/core/types';
 import type { AgorClient, User } from '@agor-live/client';
 import { hasMinimumRole, ROLES, sessionPath } from '@agor-live/client';
 import { Alert, Button, Col, Empty, Flex, Pagination, Row, Skeleton, theme } from 'antd';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useMcpMemberPolicy } from '../../hooks/useMcpMemberPolicy';
 import { useAgorStore } from '../../store/agorStore';
 import { selectUserAuthenticatedMcpServerIds } from '../../store/selectors';
@@ -127,16 +128,6 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
   const [keyRequirement, setKeyRequirement] = useState<MCPCatalogCredentialRequirement | null>(
     null
   );
-  // The exported owner below is keyed by current user. This flag also stops a
-  // connect response initiated by caller A from navigating, persisting a
-  // branch preference, or restoring A's error state after caller B replaced it.
-  const identityActiveRef = useRef(true);
-  useEffect(() => {
-    identityActiveRef.current = true;
-    return () => {
-      identityActiveRef.current = false;
-    };
-  }, []);
   const showDisconnected = useSettledFlag(!connected, DISCONNECT_NOTICE_DELAY_MS);
 
   const { entries, status, matchCount, catalogSize, error, retry } = useCatalogSearch(
@@ -177,6 +168,18 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
       memberPolicy.policy,
       memberPolicy.canConfigure,
     ]
+  );
+  const operationGuard = useAuthorityOperationGuard(
+    connectionReady && currentUser?.user_id && currentUser.role && !policyPending
+      ? [
+          currentUser.user_id,
+          currentUser.role,
+          authGeneration,
+          client,
+          memberPolicy.policy,
+          memberPolicy.canConfigure,
+        ]
+      : null
   );
 
   // Any narrowing invalidates the current offset — page 4 of an unfiltered
@@ -235,7 +238,8 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
       acknowledgedDisclosure: string;
       bearerToken?: string;
     }) => {
-      if (!selected || !client || !identityActiveRef.current) return;
+      const operation = operationGuard.begin();
+      if (!selected || !client || !operation.isCurrent()) return;
       setConnecting(true);
       setConnectError(null);
       try {
@@ -250,7 +254,7 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
           // empty arrived.
           ...(bearerToken ? { bearer_token: bearerToken } : {}),
         });
-        if (!identityActiveRef.current) return;
+        if (!operation.isCurrent()) return;
         rememberConnectBranchId(currentUser?.user_id, branchId);
         // A starter prompt is written to exercise the server it ships with, so
         // it is only worth arming the composer with once that server can answer
@@ -269,7 +273,7 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
         setSelected(null);
         navigate(sessionPath(result.session.session_id));
       } catch (err: unknown) {
-        if (!identityActiveRef.current) return;
+        if (!operation.isCurrent()) return;
         setConnectError(err instanceof Error ? err.message : 'Could not connect this server');
         // The catalog file is presentational; the endpoint decides. When those
         // disagree the daemon says so on the refusal, and taking it here is
@@ -280,10 +284,17 @@ const CatalogTabForIdentity: React.FC<CatalogTabProps> = ({
         const requirement = readCredentialRequirement(err);
         if (requirement) setKeyRequirement(requirement);
       } finally {
-        if (identityActiveRef.current) setConnecting(false);
+        if (operation.isCurrent()) setConnecting(false);
       }
     },
-    [client, currentUser?.user_id, navigate, selected, userAuthenticatedMcpServerIds]
+    [
+      client,
+      currentUser?.user_id,
+      navigate,
+      operationGuard,
+      selected,
+      userAuthenticatedMcpServerIds,
+    ]
   );
 
   return (

--- a/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
+++ b/apps/agor-ui/src/components/Marketplace/useConnectTargets.ts
@@ -13,6 +13,10 @@ import { useEffect, useState } from 'react';
 
 const LAST_BRANCH_KEY = 'agor-marketplace-branch';
 
+function branchPreferenceKey(userId: string | undefined): string | null {
+  return userId ? `${LAST_BRANCH_KEY}:${userId}` : null;
+}
+
 export interface ConnectTargets {
   branches: Branch[];
   loading: boolean;
@@ -58,18 +62,22 @@ export function useConnectTargets(client: AgorClient | null, enabled: boolean): 
   return { branches, loading, error };
 }
 
-/** The branch the user last connected into, so the picker is usually pre-answered. */
-export function getLastConnectBranchId(): string | null {
+/** The branch this user last connected into, so the picker is usually pre-answered. */
+export function getLastConnectBranchId(userId: string | undefined): string | null {
+  const key = branchPreferenceKey(userId);
+  if (!key) return null;
   try {
-    return localStorage.getItem(LAST_BRANCH_KEY);
+    return localStorage.getItem(key);
   } catch {
     return null;
   }
 }
 
-export function rememberConnectBranchId(branchId: string): void {
+export function rememberConnectBranchId(userId: string | undefined, branchId: string): void {
+  const key = branchPreferenceKey(userId);
+  if (!key) return;
   try {
-    localStorage.setItem(LAST_BRANCH_KEY, branchId);
+    localStorage.setItem(key, branchId);
   } catch {
     // localStorage full or unavailable
   }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -28,6 +28,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuthenticatedAuthorityScope } from '../../hooks/useAuthorityOperationGuard';
 import { useAgorStore } from '../../store/agorStore';
 import {
   MAX_ONBOARDING_GOALS,
@@ -426,6 +427,10 @@ export function OnboardingWizard({
   // A stale/deleted preference must never be treated as a valid durable step.
   const savedBoard = useAgorStore((state) =>
     savedBoardId ? state.boardById.get(savedBoardId) : undefined
+  );
+  const onboardingAuthority = useAuthenticatedAuthorityScope(
+    client,
+    user ? `${user.user_id}:${user.role}` : null
   );
 
   // ── Token-derived styles (live, theme-aware) ────────────────────────────
@@ -1537,11 +1542,17 @@ export function OnboardingWizard({
                     {authMethod === 'codex-device-auth' ? (
                       <CodexDeviceSignIn
                         client={client}
+                        operationScope={onboardingAuthority.operationScope}
                         onVerified={handleCodexDeviceVerified}
                         onUseFallback={handleCodexAuthMethodFallback}
                       />
                     ) : authMethod === 'codex-auth-json' ? (
-                      <CodexImportAuthJson client={client} onImported={handleCodexImported} />
+                      <CodexImportAuthJson
+                        client={client}
+                        identityKey={onboardingAuthority.identityKey}
+                        operationScope={onboardingAuthority.operationScope}
+                        onImported={handleCodexImported}
+                      />
                     ) : authMethod === 'claude-subscription-token' ? (
                       <>
                         <Alert

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1388,6 +1388,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
             {showMcpControl && (
               <SessionMcpFooterControl
                 client={client}
+                currentUserId={currentUserId}
                 sessionId={session.session_id}
                 sessionMcpServerIds={sessionMcpServerIds}
                 mcpServerById={mcpServerById}

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
@@ -6,9 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionMcpFooterControl } from './SessionMcpFooterControl';
 
 const permissionState = vi.hoisted(() => ({ isAdmin: true }));
+const connectionState = vi.hoisted(() => ({ connected: true, connecting: false }));
 
 vi.mock('@/hooks/usePermissions', () => ({
   usePermissions: () => permissionState,
+}));
+
+vi.mock('@/contexts/ConnectionContext', () => ({
+  useConnectionState: () => connectionState,
 }));
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -29,14 +34,17 @@ const server = {
   auth: { type: 'none' },
 } as MCPServer;
 
+const patchServer = vi.fn();
 const client = {
-  service: vi.fn(() => ({ patch: vi.fn(), create: vi.fn() })),
+  service: vi.fn(() => ({ patch: patchServer, create: vi.fn() })),
   io: { on: vi.fn(), off: vi.fn() },
 } as unknown as AgorClient;
 
 describe('SessionMcpFooterControl overlay lifecycle', () => {
   beforeEach(() => {
     permissionState.isAdmin = true;
+    connectionState.connected = true;
+    connectionState.connecting = false;
     vi.clearAllMocks();
   });
 
@@ -101,5 +109,49 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     fireEvent.pointerDown(document.body);
     expect(screen.queryByRole('dialog', { name: 'Session MCP servers' })).not.toBeInTheDocument();
     expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('fails an open editor closed across disconnect and demotion', async () => {
+    const props = {
+      client,
+      sessionId: 'session-id',
+      sessionMcpServerIds: [server.mcp_server_id],
+      mcpServerById: new Map([[server.mcp_server_id, server]]),
+      userAuthenticatedMcpServerIds: new Set<string>(),
+    };
+    const { rerender } = render(<SessionMcpFooterControl {...props} />, { wrapper: Wrapper });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'MCP servers. 1 MCP server attached. Open to add or change MCP servers.',
+      })
+    );
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Session MCP servers' })).getByRole('button', {
+        name: 'Edit Portal Server MCP server',
+      })
+    );
+    const editDialog = await screen.findByRole('dialog', { name: 'Edit MCP Server' });
+    await waitFor(() =>
+      expect(within(editDialog).getByRole('button', { name: 'Save' })).toBeEnabled()
+    );
+
+    connectionState.connected = false;
+    connectionState.connecting = true;
+    rerender(<SessionMcpFooterControl {...props} />);
+    expect(await within(editDialog).findByText(/Reconnect to the Agor daemon/)).toBeVisible();
+    const save = within(editDialog).getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(patchServer).not.toHaveBeenCalled();
+
+    connectionState.connected = true;
+    connectionState.connecting = false;
+    permissionState.isAdmin = false;
+    rerender(<SessionMcpFooterControl {...props} />);
+    expect(await within(editDialog).findByText(/account can no longer change/)).toBeVisible();
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(patchServer).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
@@ -170,4 +170,67 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     fireEvent.click(save);
     expect(patchServer).not.toHaveBeenCalled();
   });
+
+  it('destroys the #2482-owned editor and its bearer secret on admin A -> admin B', async () => {
+    const adminAServer = {
+      ...server,
+      name: 'admin-a-bearer',
+      display_name: 'Admin A Bearer',
+      auth: {
+        type: 'bearer',
+        token: 'admin-a-saved-secret',
+      },
+    } as MCPServer;
+    const adminBServer = {
+      ...server,
+      mcp_server_id: '01900000-0000-7000-8000-000000000021',
+      name: 'admin-b-server',
+      display_name: 'Admin B Server',
+    } as MCPServer;
+    const props = (currentUserId: string, selectedServer: MCPServer) => ({
+      client,
+      currentUserId,
+      sessionId: 'session-id',
+      sessionMcpServerIds: [selectedServer.mcp_server_id],
+      mcpServerById: new Map([[selectedServer.mcp_server_id, selectedServer]]),
+      userAuthenticatedMcpServerIds: new Set<string>(),
+    });
+    const rendered = render(<SessionMcpFooterControl {...props('user-a', adminAServer)} />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'MCP servers. 1 MCP server attached. Open to add or change MCP servers.',
+      })
+    );
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Session MCP servers' })).getByRole('button', {
+        name: 'Edit Admin A Bearer MCP server',
+      })
+    );
+    const editDialog = await screen.findByRole('dialog', { name: 'Edit MCP Server' });
+    const clientSecret = await within(editDialog).findByLabelText('Token');
+    fireEvent.change(clientSecret, { target: { value: 'admin-a-unsaved-secret' } });
+    const staleSave = within(editDialog).getByRole('button', { name: 'Save' });
+
+    connectionState.authGeneration = 2;
+    rendered.rerender(<SessionMcpFooterControl {...props('user-b', adminBServer)} />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit MCP Server' })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByDisplayValue('admin-a-unsaved-secret')).not.toBeInTheDocument();
+    fireEvent.click(staleSave);
+    expect(patchServer).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'MCP servers. 1 MCP server attached. Open to add or change MCP servers.',
+      })
+    );
+    const replacementDialog = screen.getByRole('dialog', { name: 'Session MCP servers' });
+    expect(within(replacementDialog).getByText('Admin B Server')).toBeInTheDocument();
+    expect(within(replacementDialog).queryByText('Admin A Bearer')).not.toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
@@ -11,6 +11,8 @@ const connectionState = vi.hoisted(() => ({
   connecting: false,
   authGeneration: 1,
 }));
+const updateSessionMcpServers = vi.hoisted(() => vi.fn());
+const showSuccess = vi.hoisted(() => vi.fn());
 
 vi.mock('@/hooks/usePermissions', () => ({
   usePermissions: () => ({
@@ -21,6 +23,20 @@ vi.mock('@/hooks/usePermissions', () => ({
 
 vi.mock('@/contexts/ConnectionContext', () => ({
   useConnectionState: () => connectionState,
+}));
+
+vi.mock('@/utils/sessionMcpServers', () => ({ updateSessionMcpServers }));
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({ showSuccess, showError: vi.fn() }),
+}));
+
+vi.mock('../MCPServerSelect', () => ({
+  MCPServerSelect: ({ onChange }: { onChange: (ids: string[]) => void }) => (
+    <button type="button" onClick={() => onChange(['replacement-server'])}>
+      replace-session-mcp
+    </button>
+  ),
 }));
 
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -55,6 +71,40 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     connectionState.connecting = false;
     connectionState.authGeneration = 1;
     vi.clearAllMocks();
+  });
+
+  it('drops the attachment-save continuation when admin A is replaced by admin B', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    const pending = new Promise<void>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    updateSessionMcpServers.mockReturnValue(pending);
+    const props = (currentUserId: string) => ({
+      client,
+      currentUserId,
+      sessionId: 'session-id',
+      sessionMcpServerIds: [server.mcp_server_id],
+      mcpServerById: new Map([[server.mcp_server_id, server]]),
+      userAuthenticatedMcpServerIds: new Set<string>(),
+    });
+    const rendered = render(<SessionMcpFooterControl {...props('user-a')} />, {
+      wrapper: Wrapper,
+    });
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'MCP servers. 1 MCP server attached. Open to add or change MCP servers.',
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'replace-session-mcp' }));
+    await waitFor(() => expect(updateSessionMcpServers).toHaveBeenCalledOnce());
+
+    connectionState.authGeneration = 2;
+    rendered.rerender(<SessionMcpFooterControl {...props('user-b')} />);
+    resolveUpdate?.();
+    await act(async () => pending);
+
+    expect(showSuccess).not.toHaveBeenCalled();
+    expect(updateSessionMcpServers).toHaveBeenCalledOnce();
   });
 
   it('keeps the portaled editor usable and restores disclosure behavior and focus', async () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
@@ -5,11 +5,18 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionMcpFooterControl } from './SessionMcpFooterControl';
 
-const permissionState = vi.hoisted(() => ({ isAdmin: true }));
-const connectionState = vi.hoisted(() => ({ connected: true, connecting: false }));
+const permissionState = vi.hoisted(() => ({ isAdmin: true, role: 'admin' }));
+const connectionState = vi.hoisted(() => ({
+  connected: true,
+  connecting: false,
+  authGeneration: 1,
+}));
 
 vi.mock('@/hooks/usePermissions', () => ({
-  usePermissions: () => permissionState,
+  usePermissions: () => ({
+    ...permissionState,
+    hasRole: () => permissionState.role !== 'viewer',
+  }),
 }));
 
 vi.mock('@/contexts/ConnectionContext', () => ({
@@ -43,8 +50,10 @@ const client = {
 describe('SessionMcpFooterControl overlay lifecycle', () => {
   beforeEach(() => {
     permissionState.isAdmin = true;
+    permissionState.role = 'admin';
     connectionState.connected = true;
     connectionState.connecting = false;
+    connectionState.authGeneration = 1;
     vi.clearAllMocks();
   });
 
@@ -52,6 +61,7 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     render(
       <SessionMcpFooterControl
         client={client}
+        currentUserId="user-a"
         sessionId="session-id"
         sessionMcpServerIds={[server.mcp_server_id]}
         mcpServerById={new Map([[server.mcp_server_id, server]])}
@@ -114,6 +124,7 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
   it('fails an open editor closed across disconnect and demotion', async () => {
     const props = {
       client,
+      currentUserId: 'user-a',
       sessionId: 'session-id',
       sessionMcpServerIds: [server.mcp_server_id],
       mcpServerById: new Map([[server.mcp_server_id, server]]),
@@ -139,7 +150,9 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     connectionState.connected = false;
     connectionState.connecting = true;
     rerender(<SessionMcpFooterControl {...props} />);
-    expect(await within(editDialog).findByText(/Reconnect to the Agor daemon/)).toBeVisible();
+    await waitFor(() =>
+      expect(within(editDialog).getByText(/Reconnect to the Agor daemon/)).toBeVisible()
+    );
     const save = within(editDialog).getByRole('button', { name: 'Save' });
     expect(save).toBeDisabled();
     fireEvent.click(save);
@@ -148,8 +161,11 @@ describe('SessionMcpFooterControl overlay lifecycle', () => {
     connectionState.connected = true;
     connectionState.connecting = false;
     permissionState.isAdmin = false;
+    permissionState.role = 'viewer';
     rerender(<SessionMcpFooterControl {...props} />);
-    expect(await within(editDialog).findByText(/account can no longer change/)).toBeVisible();
+    await waitFor(() =>
+      expect(within(editDialog).getByText(/account can no longer change/)).toBeVisible()
+    );
     expect(save).toBeDisabled();
     fireEvent.click(save);
     expect(patchServer).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -4,6 +4,7 @@ import { ApiOutlined } from '@ant-design/icons';
 import { Tag as AntTag, Space, Typography, theme } from 'antd';
 import React from 'react';
 import { useConnectionState } from '@/contexts/ConnectionContext';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { usePermissions } from '@/hooks/usePermissions';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -68,13 +69,9 @@ const SessionMcpFooterControlForIdentity: React.FC<SessionMcpFooterControlProps>
   const [open, setOpen] = React.useState(false);
   const [editingServer, setEditingServer] = React.useState<MCPServer | null>(null);
   const [editModalOpen, setEditModalOpen] = React.useState(false);
-  const identityActiveRef = React.useRef(true);
-  React.useEffect(() => {
-    identityActiveRef.current = true;
-    return () => {
-      identityActiveRef.current = false;
-    };
-  }, []);
+  const operationGuard = useAuthorityOperationGuard(
+    durableAuthorityKey ? [durableAuthorityKey, client, editMutationAllowed] : null
+  );
   const rootRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const popupRef = React.useRef<HTMLDivElement>(null);
@@ -164,19 +161,20 @@ const SessionMcpFooterControlForIdentity: React.FC<SessionMcpFooterControlProps>
   const badgeAccessibleName = `MCP servers. ${badgeTitle}`;
 
   const handleChange = async (nextIds: string[]) => {
-    if (!client || !identityActiveRef.current) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
     setSaving(true);
     try {
       await updateSessionMcpServers(client, sessionId, sessionMcpServerIds, nextIds);
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       showSuccess('Session MCP servers updated');
     } catch (err) {
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       showError(
         `Failed to update MCP servers: ${err instanceof Error ? err.message : String(err)}`
       );
     } finally {
-      if (identityActiveRef.current) setSaving(false);
+      if (operation.isCurrent()) setSaving(false);
     }
   };
 
@@ -331,6 +329,7 @@ const SessionMcpFooterControlForIdentity: React.FC<SessionMcpFooterControlProps>
           open={editModalOpen}
           client={client}
           identityKey={currentUserId ?? null}
+          authGeneration={authGeneration}
           authorityKey={durableAuthorityKey}
           mutationAllowed={editMutationAllowed}
           mutationBlockedReason={

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -2,6 +2,8 @@ import type { AgorClient, MCPServer } from '@agor-live/client';
 import { ApiOutlined } from '@ant-design/icons';
 import { Tag as AntTag, Space, Typography, theme } from 'antd';
 import React from 'react';
+import { useConnectionState } from '@/contexts/ConnectionContext';
+import { usePermissions } from '@/hooks/usePermissions';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { updateSessionMcpServers } from '../../utils/sessionMcpServers';
@@ -27,6 +29,9 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
+  const { isAdmin } = usePermissions();
+  const { connected, connecting } = useConnectionState();
+  const editMutationAllowed = isAdmin && connected && !connecting;
   const [saving, setSaving] = React.useState(false);
   const [open, setOpen] = React.useState(false);
   const [editingServer, setEditingServer] = React.useState<MCPServer | null>(null);
@@ -266,6 +271,12 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           server={editingServer}
           open={editModalOpen}
           client={client}
+          mutationAllowed={editMutationAllowed}
+          mutationBlockedReason={
+            !connected || connecting
+              ? 'Reconnect to the Agor daemon before changing this MCP server.'
+              : 'Your account can no longer change this MCP server.'
+          }
           onClose={() => setEditModalOpen(false)}
           afterClose={finishEditModalClose}
           focusTriggerAfterClose={false}

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -1,4 +1,5 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
+import { ROLES } from '@agor-live/client';
 import { ApiOutlined } from '@ant-design/icons';
 import { Tag as AntTag, Space, Typography, theme } from 'antd';
 import React from 'react';
@@ -14,6 +15,7 @@ import { Tag } from '../Tag';
 
 export interface SessionMcpFooterControlProps {
   client: AgorClient | null;
+  currentUserId?: string;
   sessionId: string;
   sessionMcpServerIds: string[];
   mcpServerById: Map<string, MCPServer>;
@@ -22,6 +24,7 @@ export interface SessionMcpFooterControlProps {
 
 export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
   client,
+  currentUserId,
   sessionId,
   sessionMcpServerIds,
   mcpServerById,
@@ -29,9 +32,38 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
-  const { isAdmin } = usePermissions();
-  const { connected, connecting } = useConnectionState();
-  const editMutationAllowed = isAdmin && connected && !connecting;
+  const { hasRole, isAdmin, role } = usePermissions();
+  const { connected, connecting, authGeneration } = useConnectionState();
+  const connectionReady = connected && !connecting;
+  const identityRoleKey = currentUserId && role ? `${currentUserId}:${role}` : null;
+  const establishedAuthorityRef = React.useRef<{
+    client: AgorClient;
+    identityRoleKey: string;
+    authGeneration: number;
+  } | null>(null);
+  const establishedAuthority = establishedAuthorityRef.current;
+  const authorityMatchesEstablished =
+    !!establishedAuthority &&
+    establishedAuthority.client === client &&
+    establishedAuthority.identityRoleKey === identityRoleKey &&
+    authGeneration >= establishedAuthority.authGeneration;
+  const authorityHasNewAuthentication =
+    !establishedAuthority || authGeneration > establishedAuthority.authGeneration;
+  const callerAuthorityReady =
+    !!client &&
+    connectionReady &&
+    !!identityRoleKey &&
+    (authorityMatchesEstablished || authorityHasNewAuthentication);
+  React.useLayoutEffect(() => {
+    if (!callerAuthorityReady || !client || !identityRoleKey) return;
+    establishedAuthorityRef.current = { client, identityRoleKey, authGeneration };
+  }, [authGeneration, callerAuthorityReady, client, identityRoleKey]);
+  const oauthActionAllowed = callerAuthorityReady && hasRole(ROLES.MEMBER);
+  const durableAuthorityKey =
+    client && oauthActionAllowed && currentUserId && role
+      ? `${currentUserId}:${role}:${authGeneration}`
+      : null;
+  const editMutationAllowed = isAdmin && callerAuthorityReady;
   const [saving, setSaving] = React.useState(false);
   const [open, setOpen] = React.useState(false);
   const [editingServer, setEditingServer] = React.useState<MCPServer | null>(null);
@@ -148,6 +180,13 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
                 server={server}
                 needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
                 client={client}
+                authorityKey={durableAuthorityKey}
+                actionAllowed={oauthActionAllowed}
+                actionBlockedReason={
+                  !connectionReady
+                    ? 'Reconnect to the Agor daemon before changing OAuth credentials.'
+                    : 'Your account can no longer change OAuth credentials.'
+                }
                 onEdit={handleEditServer}
               />
             ))}
@@ -271,6 +310,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           server={editingServer}
           open={editModalOpen}
           client={client}
+          authorityKey={durableAuthorityKey}
           mutationAllowed={editMutationAllowed}
           mutationBlockedReason={
             !connected || connecting

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -22,7 +22,7 @@ export interface SessionMcpFooterControlProps {
   userAuthenticatedMcpServerIds: Set<string>;
 }
 
-export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
+const SessionMcpFooterControlForIdentity: React.FC<SessionMcpFooterControlProps> = ({
   client,
   currentUserId,
   sessionId,
@@ -68,6 +68,13 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
   const [open, setOpen] = React.useState(false);
   const [editingServer, setEditingServer] = React.useState<MCPServer | null>(null);
   const [editModalOpen, setEditModalOpen] = React.useState(false);
+  const identityActiveRef = React.useRef(true);
+  React.useEffect(() => {
+    identityActiveRef.current = true;
+    return () => {
+      identityActiveRef.current = false;
+    };
+  }, []);
   const rootRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const popupRef = React.useRef<HTMLDivElement>(null);
@@ -117,6 +124,17 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
     triggerRef.current?.focus();
   }, []);
 
+  React.useEffect(() => {
+    if (!editingServer) return;
+    const updatedServer = mcpServerById.get(editingServer.mcp_server_id);
+    if (!updatedServer) {
+      setEditModalOpen(false);
+      setEditingServer(null);
+    } else if (updatedServer !== editingServer) {
+      setEditingServer(updatedServer);
+    }
+  }, [editingServer, mcpServerById]);
+
   const summary = React.useMemo(
     () =>
       summarizeSessionMcpServers(sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds),
@@ -146,17 +164,19 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
   const badgeAccessibleName = `MCP servers. ${badgeTitle}`;
 
   const handleChange = async (nextIds: string[]) => {
-    if (!client) return;
+    if (!client || !identityActiveRef.current) return;
     setSaving(true);
     try {
       await updateSessionMcpServers(client, sessionId, sessionMcpServerIds, nextIds);
+      if (!identityActiveRef.current) return;
       showSuccess('Session MCP servers updated');
     } catch (err) {
+      if (!identityActiveRef.current) return;
       showError(
         `Failed to update MCP servers: ${err instanceof Error ? err.message : String(err)}`
       );
     } finally {
-      setSaving(false);
+      if (identityActiveRef.current) setSaving(false);
     }
   };
 
@@ -310,6 +330,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           server={editingServer}
           open={editModalOpen}
           client={client}
+          identityKey={currentUserId ?? null}
           authorityKey={durableAuthorityKey}
           mutationAllowed={editMutationAllowed}
           mutationBlockedReason={
@@ -325,3 +346,16 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
     </div>
   );
 };
+
+/**
+ * #2482 keeps the portaled editor owned outside the disclosure. Key that whole
+ * owner by identity rather than moving the modal back into the popup: A -> B
+ * closes and destroys both overlays and their form state, while same-user
+ * reconnects preserve the established lifecycle and focus behavior.
+ */
+export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (props) => (
+  <SessionMcpFooterControlForIdentity
+    key={props.currentUserId ?? '__no-authenticated-user__'}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.test.tsx
@@ -1,0 +1,62 @@
+import type { AgenticToolPreset, AgorClient } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AgenticToolPresetsManager } from './AgenticToolPresetsManager';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+describe('AgenticToolPresetsManager authority lifetime', () => {
+  it('releases a cancelled generation save while preserving the same-user form', async () => {
+    const pending = deferred<AgenticToolPreset>();
+    const find = vi.fn().mockResolvedValue([]);
+    const create = vi.fn(() => pending.promise);
+    const client = {
+      service: vi.fn((path: string) => {
+        if (path !== 'agentic-tool-presets') throw new Error(path);
+        return { find, create, patch: vi.fn(), remove: vi.fn() };
+      }),
+    } as unknown as AgorClient;
+    const onError = vi.fn();
+    const view = (generation: number) => (
+      <AgenticToolPresetsManager
+        client={client}
+        tool="claude-code"
+        onError={onError}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', client, generation]}
+      />
+    );
+    const rendered = render(view(1));
+    await screen.findByText('No presets');
+    fireEvent.click(screen.getByRole('button', { name: /New preset$/ }));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'A reconnect draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    await waitFor(() => expect(create).toHaveBeenCalledOnce());
+    expect(screen.getByRole('button', { name: /OK$/ })).toHaveClass('ant-btn-loading');
+
+    rendered.rerender(view(2));
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText('Name')).toHaveValue('A reconnect draft');
+    expect(screen.getByRole('button', { name: /OK$/ })).not.toHaveClass('ant-btn-loading');
+
+    await act(async () => {
+      pending.resolve({
+        preset_id: 'preset-a',
+        tool: 'claude-code',
+        name: 'A reconnect draft',
+        configuration: {},
+        is_default: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as AgenticToolPreset);
+      await pending.promise;
+    });
+    // The obsolete save cannot close or overwrite the preserved draft.
+    expect(screen.getByLabelText('Name')).toHaveValue('A reconnect draft');
+    expect(find).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
@@ -1,7 +1,23 @@
 import type { AgenticToolPreset, AgorClient, TenantAgenticToolName } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
-import { Button, Empty, Form, Input, List, Popconfirm, Space, Switch, Tag, Typography } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Empty,
+  Form,
+  Input,
+  List,
+  Modal,
+  Popconfirm,
+  Space,
+  Switch,
+  Tag,
+  Typography,
+} from 'antd';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import {
+  type AuthorityOperation,
+  useAuthorityOperationGuard,
+} from '../../hooks/useAuthorityOperationGuard';
 import {
   AgenticToolConfigForm,
   buildConfigFromFormValues,
@@ -14,29 +30,55 @@ interface Props {
   client: AgorClient;
   tool: TenantAgenticToolName;
   onError(message: string): void;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
 }
 
-export const AgenticToolPresetsManager: React.FC<Props> = ({ client, tool, onError }) => {
+export const AgenticToolPresetsManager: React.FC<Props> = ({
+  client,
+  tool,
+  onError,
+  identityKey,
+  operationScope,
+}) => {
   const [form] = Form.useForm();
   const [presets, setPresets] = useState<AgenticToolPreset[]>([]);
   const [editing, setEditing] = useState<AgenticToolPreset | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
-  const load = useCallback(async () => {
-    try {
-      const result = await client.service('agentic-tool-presets').find({ query: { tool } });
-      setPresets(Array.isArray(result) ? result : result.data);
-    } catch (error) {
-      onError(error instanceof Error ? error.message : 'Failed to load presets');
-    }
-  }, [client, onError, tool]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey intentionally erases the replacement caller's modal/form state
+  useLayoutEffect(() => {
+    form.resetFields();
+    setPresets([]);
+    setEditing(null);
+    setModalOpen(false);
+    setSaving(false);
+  }, [form, identityKey]);
+
+  const load = useCallback(
+    async (parentOperation?: AuthorityOperation) => {
+      const operation = parentOperation ?? operationGuard.begin();
+      if (!operation.isCurrent()) return;
+      try {
+        const result = await client.service('agentic-tool-presets').find({ query: { tool } });
+        if (!operation.isCurrent()) return;
+        setPresets(Array.isArray(result) ? result : result.data);
+      } catch (error) {
+        if (!operation.isCurrent()) return;
+        onError(error instanceof Error ? error.message : 'Failed to load presets');
+      }
+    },
+    [client, onError, operationGuard, tool]
+  );
 
   useEffect(() => {
     void load();
   }, [load]);
 
   const open = (preset?: AgenticToolPreset) => {
+    if (!operationGuard.isCurrent()) return;
     setEditing(preset ?? null);
     form.setFieldsValue({
       name: preset?.name,
@@ -48,9 +90,12 @@ export const AgenticToolPresetsManager: React.FC<Props> = ({ client, tool, onErr
   };
 
   const save = async () => {
-    const values = await form.validateFields();
-    setSaving(true);
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
+      const values = await form.validateFields();
+      if (!operation.isCurrent()) return;
+      setSaving(true);
       const data = {
         name: values.name.trim(),
         description: values.description?.trim() || undefined,
@@ -59,12 +104,14 @@ export const AgenticToolPresetsManager: React.FC<Props> = ({ client, tool, onErr
       };
       if (editing) await client.service('agentic-tool-presets').patch(editing.preset_id, data);
       else await client.service('agentic-tool-presets').create({ ...data, tool });
+      if (!operation.isCurrent()) return;
       setModalOpen(false);
-      await load();
+      await load(operation);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       onError(error instanceof Error ? error.message : 'Failed to save preset');
     } finally {
-      setSaving(false);
+      if (operation.isCurrent()) setSaving(false);
     }
   };
 
@@ -102,10 +149,14 @@ export const AgenticToolPresetsManager: React.FC<Props> = ({ client, tool, onErr
                   title="Delete this preset?"
                   description="Referenced presets cannot be deleted."
                   onConfirm={async () => {
+                    const operation = operationGuard.begin();
+                    if (!operation.isCurrent()) return;
                     try {
                       await client.service('agentic-tool-presets').remove(preset.preset_id);
-                      await load();
+                      if (!operation.isCurrent()) return;
+                      await load(operation);
                     } catch (error) {
+                      if (!operation.isCurrent()) return;
                       onError(error instanceof Error ? error.message : 'Failed to delete preset');
                     }
                   }}

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
@@ -1,18 +1,6 @@
 import type { AgenticToolPreset, AgorClient, TenantAgenticToolName } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
-import {
-  Button,
-  Empty,
-  Form,
-  Input,
-  List,
-  Modal,
-  Popconfirm,
-  Space,
-  Switch,
-  Tag,
-  Typography,
-} from 'antd';
+import { Button, Empty, Form, Input, List, Popconfirm, Space, Switch, Tag, Typography } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import {
   type AuthorityOperation,

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolPresetsManager.tsx
@@ -57,6 +57,14 @@ export const AgenticToolPresetsManager: React.FC<Props> = ({
     setSaving(false);
   }, [form, identityKey]);
 
+  // A same-user reconnect/auth-generation change cancels the old save. Keep
+  // their open form and draft, but release the generation-owned spinner even
+  // though the stale promise's finally block is correctly forbidden to write.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationGuard identity is the semantic authority-epoch key
+  useLayoutEffect(() => {
+    setSaving(false);
+  }, [operationGuard]);
+
   const load = useCallback(
     async (parentOperation?: AuthorityOperation) => {
       const operation = parentOperation ?? operationGuard.begin();

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
@@ -30,7 +30,7 @@ describe('AgenticToolsSection deployment availability', () => {
       service: vi.fn(() => ({ find: vi.fn().mockResolvedValue(settings) })),
     } as unknown as AgorClient;
 
-    render(<AgenticToolsSection client={client} />);
+    render(<AgenticToolsSection client={client} authorityKey="admin-a:admin" />);
 
     expect(await screen.findByText('Not installed by this deployment')).toBeInTheDocument();
     expect(

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.test.tsx
@@ -3,7 +3,7 @@ import type {
   TenantAgenticToolName,
   TenantAgenticToolSettings,
 } from '@agor-live/client';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AgenticToolsSection } from './AgenticToolsSection';
 
@@ -30,7 +30,13 @@ describe('AgenticToolsSection deployment availability', () => {
       service: vi.fn(() => ({ find: vi.fn().mockResolvedValue(settings) })),
     } as unknown as AgorClient;
 
-    render(<AgenticToolsSection client={client} authorityKey="admin-a:admin" />);
+    render(
+      <AgenticToolsSection
+        client={client}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', client, 1]}
+      />
+    );
 
     expect(await screen.findByText('Not installed by this deployment')).toBeInTheDocument();
     expect(
@@ -42,5 +48,49 @@ describe('AgenticToolsSection deployment availability', () => {
     expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
     expect(screen.queryByText('Credential resolution')).not.toBeInTheDocument();
     expect(screen.queryByText('Allow inline configuration')).not.toBeInTheDocument();
+  });
+
+  it('discards a credential/settings read from an older auth generation', async () => {
+    let resolve!: (value: TenantAgenticToolSettings[]) => void;
+    const oldRead = new Promise<TenantAgenticToolSettings[]>((done) => {
+      resolve = done;
+    });
+    const currentSettings: TenantAgenticToolSettings[] = tools.map((tool) => ({
+      tool,
+      deployment_available: true,
+      enabled: true,
+      resolution_policy: 'user_preferred',
+      inline_configuration_allowed: true,
+      connection: {},
+    }));
+    const find = vi
+      .fn()
+      .mockImplementationOnce(() => oldRead)
+      .mockResolvedValueOnce(currentSettings);
+    const client = { service: vi.fn(() => ({ find })) } as unknown as AgorClient;
+    const view = (generation: number) => (
+      <AgenticToolsSection
+        client={client}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', client, generation]}
+      />
+    );
+    const rendered = render(view(1));
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+    rendered.rerender(view(2));
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Credential resolution')).toBeInTheDocument();
+
+    await act(async () => {
+      resolve(
+        currentSettings.map((setting) => ({
+          ...setting,
+          deployment_available: false,
+          enabled: false,
+        }))
+      );
+      await oldRead;
+    });
+    expect(screen.queryByText('Not installed by this deployment')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -7,7 +7,8 @@ import type {
   TenantAgenticToolSettings,
 } from '@agor-live/client';
 import { Alert, Select, Space, Spin, Switch, Tabs, Typography, theme } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 import { agorStore } from '../../store/agorStore';
 import {
   type AgenticToolFieldConfig,
@@ -20,6 +21,7 @@ import { AgenticToolPresetsManager } from './AgenticToolPresetsManager';
 
 export interface AgenticToolsSectionProps {
   client: AgorClient | null;
+  authorityKey: string | null;
 }
 
 const TOOL_LABELS: Record<TenantAgenticToolName, string> = {
@@ -69,7 +71,10 @@ const RESOLUTION_POLICIES: Array<{
   },
 ];
 
-export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client }) => {
+export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({
+  client,
+  authorityKey,
+}) => {
   const { token } = theme.useToken();
   const [settings, setSettings] = useState<
     Partial<Record<TenantAgenticToolName, TenantAgenticToolSettings>>
@@ -77,13 +82,23 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Partial<Record<AgenticToolConfigField, boolean>>>({});
+  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases caller-private state
+  useLayoutEffect(() => {
+    setSettings({});
+    setError(null);
+    setSaving({});
+  }, [authorityKey]);
 
   const load = useCallback(async () => {
-    if (!client) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
     setLoading(true);
     setError(null);
     try {
       const result = await client.service('agentic-tool-settings').find();
+      if (!operation.isCurrent()) return;
       const rows = Array.isArray(result) ? result : result.data;
       setSettings(
         Object.fromEntries(rows.map((row) => [row.tool, row])) as Partial<
@@ -91,11 +106,12 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
         >
       );
     } catch (loadError) {
+      if (!operation.isCurrent()) return;
       setError(loadError instanceof Error ? loadError.message : 'Failed to load agentic tools');
     } finally {
-      setLoading(false);
+      if (operation.isCurrent()) setLoading(false);
     }
-  }, [client]);
+  }, [client, operationGuard]);
 
   useEffect(() => {
     void load();
@@ -110,14 +126,17 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
       connection?: Partial<Record<AgenticToolConfigField, string | null>>;
     }
   ) => {
-    if (!client) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
     try {
       setError(null);
       const updated = await client.service('agentic-tool-settings').patch(tool, data);
+      if (!operation.isCurrent()) return;
       setSettings((current) => ({ ...current, [tool]: updated }));
       // Single-row admin edit: merge without touching the hydration gate.
       agorStore.getState().upsertAgenticToolSetting(updated);
     } catch (saveError) {
+      if (!operation.isCurrent()) return;
       setError(saveError instanceof Error ? saveError.message : 'Failed to save agentic tool');
     }
   };

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -21,7 +21,8 @@ import { AgenticToolPresetsManager } from './AgenticToolPresetsManager';
 
 export interface AgenticToolsSectionProps {
   client: AgorClient | null;
-  authorityKey: string | null;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
 }
 
 const TOOL_LABELS: Record<TenantAgenticToolName, string> = {
@@ -73,7 +74,8 @@ const RESOLUTION_POLICIES: Array<{
 
 export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({
   client,
-  authorityKey,
+  identityKey,
+  operationScope,
 }) => {
   const { token } = theme.useToken();
   const [settings, setSettings] = useState<
@@ -82,14 +84,20 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<Partial<Record<AgenticToolConfigField, boolean>>>({});
-  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases caller-private state
   useLayoutEffect(() => {
     setSettings({});
     setError(null);
     setSaving({});
-  }, [authorityKey]);
+  }, [identityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setLoading(false);
+    setSaving({});
+  }, [operationScope]);
 
   const load = useCallback(async () => {
     const operation = operationGuard.begin();
@@ -257,23 +265,33 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({
                                 </Typography.Text>
                               </Space>
                               <ApiKeyFields
+                                identityKey={identityKey}
+                                operationScope={operationScope}
                                 tool={tool as AgenticToolName}
                                 fields={TENANT_TOOL_FIELDS[tool]}
                                 fieldStatus={fieldStatus}
                                 onSave={async (field, value) => {
+                                  const operation = operationGuard.begin();
+                                  if (!operation.isCurrent()) return;
                                   setSaving((state) => ({ ...state, [field]: true }));
                                   try {
                                     await patch(tool, { connection: { [field]: value } });
                                   } finally {
-                                    setSaving((state) => ({ ...state, [field]: false }));
+                                    if (operation.isCurrent()) {
+                                      setSaving((state) => ({ ...state, [field]: false }));
+                                    }
                                   }
                                 }}
                                 onClear={async (field) => {
+                                  const operation = operationGuard.begin();
+                                  if (!operation.isCurrent()) return;
                                   setSaving((state) => ({ ...state, [field]: true }));
                                   try {
                                     await patch(tool, { connection: { [field]: null } });
                                   } finally {
-                                    setSaving((state) => ({ ...state, [field]: false }));
+                                    if (operation.isCurrent()) {
+                                      setSaving((state) => ({ ...state, [field]: false }));
+                                    }
                                   }
                                 }}
                                 saving={saving}
@@ -314,6 +332,8 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({
                                 client={client}
                                 tool={tool}
                                 onError={setError}
+                                identityKey={identityKey}
+                                operationScope={operationScope}
                               />
                             )}
                           </Space>

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -1,8 +1,9 @@
 import type { AgorClient, Branch, GatewayChannel, MCPServer, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { GatewayChannelsTable } from './GatewayChannelsTable';
 
 // The real branch/user pickers are antd v6 `Select`s; opening their dropdowns in
@@ -929,6 +930,73 @@ describe('GatewayChannelsTable Slack edit mode', () => {
   });
 });
 
+describe('GatewayChannelsTable socket authority generations', () => {
+  it('preserves a same-admin edit secret but does not close from the obsolete save', async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const onUpdate = vi.fn(() => pending);
+    const branch = makeBranch();
+    const user = makeUser();
+    const channel = {
+      ...makeSlackChannel(),
+      channel_type: 'teams',
+      name: 'Team Teams',
+      config: {
+        app_id: 'azure-app',
+        tenant_id: 'azure-tenant',
+      },
+    } as GatewayChannel;
+    const table = (
+      <GatewayChannelsTable
+        client={null}
+        gatewayChannelById={new Map([[channel.id, channel]])}
+        branchById={new Map([[branch.branch_id, branch]])}
+        userById={new Map([[user.user_id, user]])}
+        mcpServerById={new Map<string, MCPServer>()}
+        currentUser={user}
+        onUpdate={onUpdate}
+      />
+    );
+    const view = (generation: number) => (
+      <MemoryRouter>
+        <AntdApp>
+          <ConnectionProvider
+            value={{
+              connected: true,
+              connecting: false,
+              authGeneration: generation,
+              outOfSync: false,
+              capturedSha: null,
+              currentSha: null,
+            }}
+          >
+            {table}
+          </ConnectionProvider>
+        </AntdApp>
+      </MemoryRouter>
+    );
+    const rendered = render(view(20));
+    fireEvent.click(screen.getByTitle('Edit'));
+    expandPanel('Azure Bot Credentials');
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'same-admin-azure-secret' },
+    });
+    clickButton(/^Save$/);
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledOnce());
+
+    rendered.rerender(view(21));
+    await act(async () => {
+      resolve();
+      await pending;
+    });
+
+    expect(screen.getByText('Edit Gateway Channel')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toHaveValue('same-admin-azure-secret');
+  });
+});
+
 describe('GatewayChannelsTable GitHub create wizard', () => {
   it('walks Channel → Create app → Credentials → Configure and builds a github payload', async () => {
     const { client, channelCreate } = makeClient();
@@ -947,7 +1015,7 @@ describe('GatewayChannelsTable GitHub create wizard', () => {
     await flush();
 
     // Step 1 (Create app): no required fields — Continue straight through.
-    expect(screen.getByText(/Create GitHub App on GitHub/)).toBeInTheDocument();
+    expect(await screen.findByText(/Create GitHub App on GitHub/)).toBeInTheDocument();
     clickButton(/^Continue$/);
     await flush();
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -115,6 +115,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     user_id: 'user-1',
     name: 'Ada Lovelace',
     email: 'ada@example.com',
+    role: 'admin',
     ...overrides,
   } as unknown as User;
 }
@@ -167,6 +168,7 @@ function renderTable(client: AgorClient | null) {
       branchById={new Map([[branch.branch_id, branch]])}
       userById={new Map([[user.user_id, user]])}
       mcpServerById={new Map<string, MCPServer>()}
+      currentUser={user}
     />
   );
 }
@@ -384,6 +386,51 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(channelCreate.mock.calls[0][0].agor_user_id).toBeFalsy();
   });
 
+  it('erases create secrets and cancels validation continuation on admin A -> admin B', async () => {
+    const { client, channelCreate } = makeClient();
+    const branch = makeBranch();
+    const adminA = makeUser({ user_id: 'admin-a', email: 'a@example.test' });
+    const adminB = makeUser({ user_id: 'admin-b', email: 'b@example.test' });
+    const users = new Map([
+      [adminA.user_id, adminA],
+      [adminB.user_id, adminB],
+    ]);
+    const table = (currentUser: User) => (
+      <MemoryRouter>
+        <AntdApp>
+          <GatewayChannelsTable
+            client={client}
+            gatewayChannelById={new Map()}
+            branchById={new Map([[branch.branch_id, branch]])}
+            userById={users}
+            mcpServerById={new Map()}
+            currentUser={currentUser}
+          />
+        </AntdApp>
+      </MemoryRouter>
+    );
+    const rendered = render(table(adminA));
+    clickButton(/Add Channel/);
+    await advanceToTokensStep();
+    fireEvent.change(screen.getByPlaceholderText('xoxb-...'), {
+      target: { value: 'xoxb-admin-a-secret' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), {
+      target: { value: 'xapp-admin-a-secret' },
+    });
+
+    // Ant validation resolves in a microtask. Commit B before that continuation
+    // can read the registered A form values and dispatch them.
+    clickButton(/Create channel/);
+    rendered.rerender(table(adminB));
+    await flush();
+
+    expect(channelCreate).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.queryByDisplayValue('xoxb-admin-a-secret')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('xapp-admin-a-secret')).not.toBeInTheDocument();
+  });
+
   it('invalidates a passing test result when a channel-scope option changes', async () => {
     const { client } = makeClient({ ok: true, failures: [], notVerifiable: [] });
     renderTable(client);
@@ -497,6 +544,43 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     // No unified step indicator and no wizard footer in edit mode.
     expect(screen.queryByText('Tokens & test')).not.toBeInTheDocument();
     expect(queryButton(/^Continue$/)).toBeUndefined();
+  });
+
+  it('erases edit secrets and cancels save continuation on admin A -> admin B', async () => {
+    const branch = makeBranch();
+    const channel = makeSlackChannel();
+    const adminA = makeUser({ user_id: 'admin-a', email: 'a@example.test' });
+    const adminB = makeUser({ user_id: 'admin-b', email: 'b@example.test' });
+    const onUpdate = vi.fn();
+    const table = (currentUser: User) => (
+      <MemoryRouter>
+        <AntdApp>
+          <GatewayChannelsTable
+            client={null}
+            gatewayChannelById={new Map([[channel.id, channel]])}
+            branchById={new Map([[branch.branch_id, branch]])}
+            userById={new Map([[currentUser.user_id, currentUser]])}
+            mcpServerById={new Map()}
+            currentUser={currentUser}
+            onUpdate={onUpdate}
+          />
+        </AntdApp>
+      </MemoryRouter>
+    );
+    const rendered = render(table(adminA));
+    fireEvent.click(screen.getByTitle('Edit'));
+    expandPanel('Credentials');
+    fireEvent.change(screen.getByLabelText(/Bot Token/), {
+      target: { value: 'xoxb-admin-a-rotation' },
+    });
+
+    clickButton(/^Save$/);
+    rendered.rerender(table(adminB));
+    await flush();
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.queryByDisplayValue('xoxb-admin-a-rotation')).not.toBeInTheDocument();
   });
 
   it('copies the recommended manifest derived from the channel options', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -95,6 +95,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { getDaemonUrl } from '@/config/daemon';
 import {
   type AuthorityOperationGuard,
+  useAuthenticatedAuthorityScope,
   useAuthorityOperationGuard,
 } from '@/hooks/useAuthorityOperationGuard';
 import { mapToSortedArray } from '@/utils/mapHelpers';
@@ -125,8 +126,12 @@ interface GatewayChannelsTableProps {
   mcpServerById: Map<string, MCPServer>;
   currentUser?: User | null;
   onCreate?: (data: GatewayChannelCreateData) => void;
-  onUpdate?: (channelId: string, updates: GatewayChannelPatchData) => void;
-  onDelete?: (channelId: string) => void;
+  onUpdate?: (
+    channelId: string,
+    updates: GatewayChannelPatchData,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDelete?: (channelId: string, shouldApply?: () => boolean) => void | Promise<void>;
 }
 
 const CHANNEL_TYPE_OPTIONS: {
@@ -3629,11 +3634,11 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
 }) => {
   const { showSuccess, showError } = useThemedMessage();
   const { token } = theme.useToken();
-  const operationGuard = useAuthorityOperationGuard(
-    currentUser?.user_id && currentUser.role
-      ? [currentUser.user_id, currentUser.role, client]
-      : null
+  const callerAuthority = useAuthenticatedAuthorityScope(
+    client,
+    currentUser ? `${currentUser.user_id}:${currentUser.role}` : null
   );
+  const operationGuard = useAuthorityOperationGuard(callerAuthority.operationScope);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingChannel, setEditingChannel] = useState<GatewayChannel | null>(null);
@@ -3799,6 +3804,14 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     loadingReferencedBranchIds.current.clear();
     resetCreateFlow();
   }, [createForm, currentUser?.role, currentUser?.user_id, editForm, resetCreateFlow]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setCreating(false);
+    setGithubLoading(false);
+    setConnectionTestLoading(false);
+    setConnectionTestResult(null);
+  }, [callerAuthority.operationScope]);
 
   const invalidateConnectionTest = useCallback(() => {
     setConnectionTestResult(null);
@@ -4429,7 +4442,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     setEditModalOpen(true);
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     const operation = operationGuard.begin();
     if (!operation.isCurrent()) return;
     if (!editingChannel) return;
@@ -4437,51 +4450,55 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       showError('Choose a supported agentic tool before saving this historical channel');
       return;
     }
-    editForm
-      .validateFields()
-      .then(() => {
-        if (!operation.isCurrent()) return;
-        // Use getFieldsValue(true) to include values from collapsed (unmounted)
-        // panels that validateFields() may omit.
-        const values = editForm.getFieldsValue(true);
-        if (values.channel_type === 'discord' && values.enabled !== false) {
-          const validation = validateDiscordConfig(discordConfigFromFormValues(values), {
-            requireBotToken: false,
-          });
-          if (!validation.ok) {
-            throw new Error(`Invalid Discord configuration: ${validation.errors.join('; ')}`);
-          }
+    try {
+      await editForm.validateFields();
+      if (!operation.isCurrent()) return;
+      // Use getFieldsValue(true) to include values from collapsed (unmounted)
+      // panels that validateFields() may omit.
+      const values = editForm.getFieldsValue(true);
+      if (values.channel_type === 'discord' && values.enabled !== false) {
+        const validation = validateDiscordConfig(discordConfigFromFormValues(values), {
+          requireBotToken: false,
+        });
+        if (!validation.ok) {
+          throw new Error(`Invalid Discord configuration: ${validation.errors.join('; ')}`);
         }
-        const updates = extractFormData(
-          values,
-          editingChannel.config as Record<string, unknown>,
-          selectedAgent
-        );
-        if (!operation.isCurrent()) return;
-        onUpdate?.(editingChannel.id, updates);
-        editForm.resetFields();
-        setEditModalOpen(false);
-        setEditingChannel(null);
-        setChannelType('slack');
-        setRequiresSupportedToolSelection(false);
-      })
-      .catch((error) => {
-        if (!operation.isCurrent()) return;
-        console.error('Form validation failed:', error);
-        if (error.errorFields?.length > 0) {
-          showError(error.errorFields[0].errors[0] || 'Please fill in required fields');
-        } else {
-          showError(error instanceof Error ? error.message : String(error));
-        }
-      });
+      }
+      const updates = extractFormData(
+        values,
+        editingChannel.config as Record<string, unknown>,
+        selectedAgent
+      );
+      if (!operation.isCurrent()) return;
+      await onUpdate?.(editingChannel.id, updates, operation.isCurrent);
+      if (!operation.isCurrent()) return;
+      editForm.resetFields();
+      setEditModalOpen(false);
+      setEditingChannel(null);
+      setChannelType('slack');
+      setRequiresSupportedToolSelection(false);
+    } catch (error) {
+      if (!operation.isCurrent()) return;
+      console.error('Form validation failed:', error);
+      const validation = error as { errorFields?: { errors?: string[] }[] };
+      if (validation.errorFields?.length) {
+        showError(validation.errorFields[0]?.errors?.[0] || 'Please fill in required fields');
+      } else {
+        showError(error instanceof Error ? error.message : String(error));
+      }
+    }
   };
 
   const handleToggleEnabled = (channel: GatewayChannel) => {
-    onUpdate?.(channel.id, { enabled: !channel.enabled });
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
+    onUpdate?.(channel.id, { enabled: !channel.enabled }, operation.isCurrent);
   };
 
   const handleDelete = (channelId: string) => {
-    onDelete?.(channelId);
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
+    onDelete?.(channelId, operation.isCurrent);
   };
 
   const columns = [

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -91,8 +91,12 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
+import {
+  type AuthorityOperationGuard,
+  useAuthorityOperationGuard,
+} from '@/hooks/useAuthorityOperationGuard';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
@@ -746,7 +750,8 @@ const SlackScopeChangeWarning: React.FC<{
   addedScopes: string[];
   appInfo: SlackAppInfo | null;
   options: SlackWizardOptions;
-}> = ({ addedScopes, appInfo, options }) => {
+  authorityGuard: AuthorityOperationGuard;
+}> = ({ addedScopes, appInfo, options, authorityGuard }) => {
   const { showError } = useThemedMessage();
   const [copied, setCopied] = useState(false);
   const scopeKey = addedScopes.join(',');
@@ -759,7 +764,10 @@ const SlackScopeChangeWarning: React.FC<{
   if (addedScopes.length === 0) return null;
 
   const handleCopy = async () => {
+    const operation = authorityGuard.begin();
+    if (!operation.isCurrent()) return;
     const ok = await copyTextToClipboard(JSON.stringify(buildSlackManifest(options), null, 2));
+    if (!operation.isCurrent()) return;
     if (ok) {
       setCopied(true);
     } else {
@@ -814,7 +822,8 @@ const SlackScopeChangeWarning: React.FC<{
 const SlackManifestPanel: React.FC<{
   options: SlackWizardOptions;
   appInfo: SlackAppInfo | null;
-}> = ({ options, appInfo }) => {
+  authorityGuard: AuthorityOperationGuard;
+}> = ({ options, appInfo, authorityGuard }) => {
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
   const [copied, setCopied] = useState(false);
@@ -830,7 +839,10 @@ const SlackManifestPanel: React.FC<{
   }, [manifestJson]);
 
   const handleCopy = async () => {
+    const operation = authorityGuard.begin();
+    if (!operation.isCurrent()) return;
     const ok = await copyTextToClipboard(manifestJson);
+    if (!operation.isCurrent()) return;
     if (ok) {
       setCopied(true);
     } else {
@@ -1003,6 +1015,7 @@ const SlackSetupWizard: React.FC<{
   testResult: GatewayConnectionTestResult | null;
   testLoading: boolean;
   onTest: () => void;
+  authorityGuard: AuthorityOperationGuard;
 }> = ({
   client,
   currentUser,
@@ -1016,6 +1029,7 @@ const SlackSetupWizard: React.FC<{
   testResult,
   testLoading,
   onTest,
+  authorityGuard,
 }) => {
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
@@ -1137,7 +1151,10 @@ const SlackSetupWizard: React.FC<{
   );
 
   const handleCopy = async () => {
+    const operation = authorityGuard.begin();
+    if (!operation.isCurrent()) return;
     const ok = await copyTextToClipboard(manifestJson);
+    if (!operation.isCurrent()) return;
     if (ok) {
       setCopied(true);
     } else {
@@ -1146,8 +1163,11 @@ const SlackSetupWizard: React.FC<{
   };
 
   const handleTestClick = async () => {
+    const operation = authorityGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       await form.validateFields(['bot_token', 'app_token']);
+      if (!operation.isCurrent()) return;
     } catch {
       return;
     }
@@ -2012,6 +2032,7 @@ const ChannelFormFields: React.FC<{
   onDiscordTest: () => void;
   /** Slack app identity resolved server-side on edit open (edit mode only). */
   slackAppInfo: SlackAppInfo | null;
+  authorityGuard: AuthorityOperationGuard;
 }> = ({
   client,
   currentUser,
@@ -2036,6 +2057,7 @@ const ChannelFormFields: React.FC<{
   onShortcutTest,
   onDiscordTest,
   slackAppInfo,
+  authorityGuard,
 }) => {
   const { showError } = useThemedMessage();
   const { token } = theme.useToken();
@@ -2150,6 +2172,7 @@ const ChannelFormFields: React.FC<{
       addedScopes={addedSlackScopes}
       appInfo={slackAppInfo}
       options={slackOptions}
+      authorityGuard={authorityGuard}
     />
   );
 
@@ -2327,6 +2350,8 @@ const ChannelFormFields: React.FC<{
                   icon={<GithubOutlined />}
                   block
                   onClick={async () => {
+                    const operation = authorityGuard.begin();
+                    if (!operation.isCurrent()) return;
                     const daemonUrl = getDaemonUrl();
                     const params = new URLSearchParams();
                     const appName = form.getFieldValue('github_app_name');
@@ -2350,10 +2375,12 @@ const ChannelFormFields: React.FC<{
                           'Content-Type': 'application/json',
                         },
                       });
+                      if (!operation.isCurrent()) return;
                       if (!stateRes.ok) {
                         const body = await stateRes
                           .json()
                           .catch(() => ({}) as Record<string, unknown>);
+                        if (!operation.isCurrent()) return;
                         const err =
                           typeof body?.error === 'string'
                             ? body.error
@@ -2362,6 +2389,7 @@ const ChannelFormFields: React.FC<{
                         return;
                       }
                       const { state } = (await stateRes.json()) as { state?: string };
+                      if (!operation.isCurrent()) return;
                       if (!state) {
                         showError('Daemon did not return an install state token.');
                         return;
@@ -2372,6 +2400,7 @@ const ChannelFormFields: React.FC<{
                         '_blank'
                       );
                     } catch (err) {
+                      if (!operation.isCurrent()) return;
                       showError(
                         err instanceof Error ? err.message : 'Failed to initiate GitHub App install'
                       );
@@ -2929,11 +2958,14 @@ const ChannelFormFields: React.FC<{
                       icon={<ThunderboltOutlined />}
                       loading={connectionTestLoading}
                       onClick={async () => {
+                        const operation = authorityGuard.begin();
+                        if (!operation.isCurrent()) return;
                         // The token is required only on create; in edit the stored
                         // token backs the redacted field, so skip validation there.
                         if (mode === 'create') {
                           try {
                             await form.validateFields(['shortcut_api_token']);
+                            if (!operation.isCurrent()) return;
                           } catch {
                             return;
                           }
@@ -3107,6 +3139,7 @@ const ChannelFormFields: React.FC<{
             testResult={connectionTestResult}
             testLoading={connectionTestLoading}
             onTest={onSlackTest}
+            authorityGuard={authorityGuard}
           />
         )}
 
@@ -3240,7 +3273,13 @@ const ChannelFormFields: React.FC<{
                     subtitle="recommended scopes & events"
                   />
                 ),
-                children: <SlackManifestPanel options={slackOptions} appInfo={slackAppInfo} />,
+                children: (
+                  <SlackManifestPanel
+                    options={slackOptions}
+                    appInfo={slackAppInfo}
+                    authorityGuard={authorityGuard}
+                  />
+                ),
               },
 
               // ── Message Sources ──
@@ -3590,6 +3629,11 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
 }) => {
   const { showSuccess, showError } = useThemedMessage();
   const { token } = theme.useToken();
+  const operationGuard = useAuthorityOperationGuard(
+    currentUser?.user_id && currentUser.role
+      ? [currentUser.user_id, currentUser.role, client]
+      : null
+  );
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingChannel, setEditingChannel] = useState<GatewayChannel | null>(null);
@@ -3654,7 +3698,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   }, [referencedBranchesById]);
 
   useEffect(() => {
-    if (!client) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
 
     const targetIds = new Set<string>();
     for (const channel of gatewayChannelById.values()) {
@@ -3668,7 +3713,6 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     );
     if (missingIds.length === 0) return;
 
-    let cancelled = false;
     void Promise.all(
       missingIds.map(async (id) => {
         if (loadingReferencedBranchIds.current.has(id)) return null;
@@ -3683,7 +3727,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         }
       })
     ).then((results) => {
-      if (cancelled) return;
+      if (!operation.isCurrent()) return;
       const resolved = results.filter((wt): wt is Branch => wt !== null);
       if (resolved.length === 0) return;
 
@@ -3697,9 +3741,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     });
 
     return () => {
-      cancelled = true;
+      operation.cancel();
     };
-  }, [client, gatewayChannelById, branchById]);
+  }, [client, gatewayChannelById, branchById, operationGuard]);
 
   const branchOptionsById = useMemo(() => {
     const merged = new Map<string, Branch>();
@@ -3735,6 +3779,26 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     resetGithubState();
     resetConnectionTest();
   }, [resetGithubState, resetConnectionTest]);
+
+  // Passwords/tokens and selected saved rows belong to the authenticated
+  // caller. Erase them during the identity commit, while the operation guard
+  // prevents an older validation/fetch continuation from recreating them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authenticated identity and role intentionally erase credential-bearing forms
+  useLayoutEffect(() => {
+    createForm.resetFields();
+    editForm.resetFields();
+    setCreateModalOpen(false);
+    setEditModalOpen(false);
+    setEditingChannel(null);
+    setChannelType('slack');
+    setSelectedAgent('claude-code');
+    setRequiresSupportedToolSelection(false);
+    setCreating(false);
+    setReferencedBranchesById(new Map());
+    referencedBranchesByIdRef.current = new Map();
+    loadingReferencedBranchIds.current.clear();
+    resetCreateFlow();
+  }, [createForm, currentUser?.role, currentUser?.user_id, editForm, resetCreateFlow]);
 
   const invalidateConnectionTest = useCallback(() => {
     setConnectionTestResult(null);
@@ -3774,6 +3838,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       config: Record<string, unknown>,
       gatewayChannelId?: string
     ): Promise<GatewayConnectionTestResult | null> => {
+      const operation = operationGuard.begin();
+      if (!operation.isCurrent()) return null;
       if (!client) {
         showError('Not connected to server');
         return null;
@@ -3792,9 +3858,11 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         const result = (await client
           .service('gateway-channels/test')
           .create(payload)) as GatewayConnectionTestResult;
+        if (!operation.isCurrent()) return null;
         setConnectionTestResult(result);
         return result;
       } catch (error) {
+        if (!operation.isCurrent()) return null;
         const result: GatewayConnectionTestResult = {
           ok: false,
           failures: [
@@ -3808,10 +3876,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         setConnectionTestResult(result);
         return result;
       } finally {
-        setConnectionTestLoading(false);
+        if (operation.isCurrent()) setConnectionTestLoading(false);
       }
     },
-    [client, showError]
+    [client, operationGuard, showError]
   );
 
   // Probe the entered Slack tokens against the live workspace. No
@@ -4075,6 +4143,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   };
 
   const handleCreate = async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!selectedAgent) {
       showError('Choose a supported agentic tool before creating this channel');
       return;
@@ -4082,6 +4152,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     setCreating(true);
     try {
       await createForm.validateFields();
+      if (!operation.isCurrent()) return;
       // Use getFieldsValue(true) to include values from collapsed (unmounted)
       // panels that validateFields() may omit.
       const values = createForm.getFieldsValue(true);
@@ -4154,13 +4225,16 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         return;
       }
 
+      if (!operation.isCurrent()) return;
       await client.service('gateway-channels').create(data);
+      if (!operation.isCurrent()) return;
       showSuccess('Gateway channel created!');
       createForm.resetFields();
       setCreateModalOpen(false);
       setChannelType('slack');
       resetCreateFlow();
     } catch (error: unknown) {
+      if (!operation.isCurrent()) return;
       const err = error as { errorFields?: { errors: string[] }[]; message?: string };
       if (err.errorFields?.length) {
         showError(err.errorFields[0].errors[0] || 'Please fill in required fields');
@@ -4168,7 +4242,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         showError(`Failed to create channel: ${err.message || String(error)}`);
       }
     } finally {
-      setCreating(false);
+      if (operation.isCurrent()) setCreating(false);
     }
   };
 
@@ -4178,6 +4252,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const isFinalCreateStep = createStep >= createSteps.length - 1;
 
   const handleCreatePrimary = async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (isFinalCreateStep) {
       await handleCreate();
       return;
@@ -4191,6 +4267,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     if (fields.length > 0) {
       try {
         await createForm.validateFields(fields);
+        if (!operation.isCurrent()) return;
       } catch {
         return;
       }
@@ -4224,6 +4301,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     // the wrong Slack app.
     slackAppInfoChannelIdRef.current = channel.channel_type === 'slack' ? channel.id : null;
     if (channel.channel_type === 'slack' && client) {
+      const operation = operationGuard.begin();
       void (async () => {
         let info: SlackAppInfo | null = null;
         try {
@@ -4234,7 +4312,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         } catch {
           info = null;
         }
-        if (slackAppInfoChannelIdRef.current === channel.id) {
+        if (operation.isCurrent() && slackAppInfoChannelIdRef.current === channel.id) {
           setSlackAppInfo(info);
         }
       })();
@@ -4352,6 +4430,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   };
 
   const handleUpdate = () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!editingChannel) return;
     if (!selectedAgent) {
       showError('Choose a supported agentic tool before saving this historical channel');
@@ -4360,6 +4440,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     editForm
       .validateFields()
       .then(() => {
+        if (!operation.isCurrent()) return;
         // Use getFieldsValue(true) to include values from collapsed (unmounted)
         // panels that validateFields() may omit.
         const values = editForm.getFieldsValue(true);
@@ -4376,6 +4457,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           editingChannel.config as Record<string, unknown>,
           selectedAgent
         );
+        if (!operation.isCurrent()) return;
         onUpdate?.(editingChannel.id, updates);
         editForm.resetFields();
         setEditModalOpen(false);
@@ -4384,6 +4466,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         setRequiresSupportedToolSelection(false);
       })
       .catch((error) => {
+        if (!operation.isCurrent()) return;
         console.error('Form validation failed:', error);
         if (error.errorFields?.length > 0) {
           showError(error.errorFields[0].errors[0] || 'Please fill in required fields');
@@ -4661,6 +4744,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             onShortcutTest={handleShortcutTest}
             onDiscordTest={handleDiscordTest}
             slackAppInfo={null}
+            authorityGuard={operationGuard}
           />
         </Form>
       </AdaptiveSettingsModal>
@@ -4723,6 +4807,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             onShortcutTest={handleShortcutTest}
             onDiscordTest={handleDiscordTest}
             slackAppInfo={slackAppInfo}
+            authorityGuard={operationGuard}
           />
         </Form>
       </AdaptiveSettingsModal>

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
@@ -125,5 +125,5 @@ describe('MCPServersTable OAuth creation', () => {
     expect(screen.getByTestId('prepared-server-id')).toHaveTextContent('server-2');
     expect(patch).toHaveBeenCalledTimes(1);
     expect(showError).not.toHaveBeenCalled();
-  });
+  }, 30_000);
 });

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
@@ -2,6 +2,7 @@ import type { AgorClient, MCPServer, User } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Button } from 'antd';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 
 const showError = vi.fn();
 
@@ -75,19 +76,30 @@ describe('MCPServersTable OAuth creation', () => {
                 can_configure: true,
               }),
             }
-          : { create, patch }
+          : { create, patch, on: vi.fn(), removeListener: vi.fn() }
       ),
     } as unknown as AgorClient;
 
     render(
-      <MCPServersTable
-        mcpServerById={new Map()}
-        client={client}
-        userById={new Map([[ADMIN.user_id, ADMIN]])}
-        currentUser={ADMIN}
-        onCreate={vi.fn()}
-        onDelete={vi.fn()}
-      />
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          authGeneration: 1,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <MCPServersTable
+          mcpServerById={new Map()}
+          client={client}
+          userById={new Map([[ADMIN.user_id, ADMIN]])}
+          currentUser={ADMIN}
+          onCreate={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </ConnectionProvider>
     );
 
     await waitFor(() =>

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -13,6 +13,13 @@ const ADMIN: User = {
   role: 'admin',
 } as User;
 
+const ADMIN_B: User = {
+  user_id: 'user-admin-b',
+  email: 'admin-b@agor.live',
+  name: 'Bea Admin',
+  role: 'admin',
+} as User;
+
 const MEMBER: User = {
   user_id: 'user-member',
   email: 'bob@agor.live',
@@ -29,6 +36,7 @@ const VIEWER: User = {
 
 const USER_BY_ID = new Map<string, User>([
   [ADMIN.user_id, ADMIN],
+  [ADMIN_B.user_id, ADMIN_B],
   [MEMBER.user_id, MEMBER],
 ]);
 
@@ -463,7 +471,7 @@ function renderTransitionTable(initial: {
     },
   } as unknown as AgorClient;
   const onCreate = vi.fn();
-  const servers = new Map((initial.servers ?? []).map((server) => [server.mcp_server_id, server]));
+  let servers = new Map((initial.servers ?? []).map((server) => [server.mcp_server_id, server]));
 
   const view = (currentUser: User, connected: boolean, connecting: boolean, generation: number) => (
     <AntdApp>
@@ -497,7 +505,23 @@ function renderTransitionTable(initial: {
     disconnect: () => rendered.rerender(view(initial.currentUser, false, true, 1)),
     replaceRole: (currentUser: User, generation = 2) => {
       role = currentUser.role;
+      rendered.rerender(
+        view(
+          { ...currentUser, user_id: initial.currentUser.user_id } as User,
+          true,
+          false,
+          generation
+        )
+      );
+    },
+    replaceIdentity: (currentUser: User, nextServers: MCPServer[] = [], generation = 2) => {
+      role = currentUser.role;
+      servers = new Map(nextServers.map((server) => [server.mcp_server_id, server]));
       rendered.rerender(view(currentUser, true, false, generation));
+    },
+    setServers: (nextServers: MCPServer[]) => {
+      servers = new Map(nextServers.map((server) => [server.mcp_server_id, server]));
+      rendered.rerender(view(initial.currentUser, true, false, 1));
     },
     setPolicy: async (next: MCPMemberPolicy) => {
       policy = next;
@@ -522,7 +546,142 @@ async function fillCreateRequirements(): Promise<void> {
   }
 }
 
+async function chooseSelect(label: string, option: string): Promise<void> {
+  const select = screen.getByLabelText(label);
+  fireEvent.mouseDown(select);
+  const optionContent = await screen.findByText(option, {
+    selector: '.ant-select-item-option-content',
+  });
+  fireEvent.click(optionContent);
+}
+
 describe('MCPServersTable open-dialog authority transitions', () => {
+  it('destroys an admin-A create form and raw credential before admin B can use it', async () => {
+    const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+    fireEvent.change(screen.getByLabelText('Name (Internal ID)'), {
+      target: { value: 'admin-a-private-server' },
+    });
+    await chooseSelect('Transport', 'HTTP');
+    fireEvent.change(await screen.findByLabelText('URL'), {
+      target: { value: 'https://admin-a.example/mcp' },
+    });
+    await chooseSelect('Auth Type', 'Bearer Token');
+    fireEvent.change(await screen.findByLabelText('Token'), {
+      target: { value: 'admin-a-raw-bearer-token' },
+    });
+    const staleCreate = screen.getByRole('button', { name: 'Create' });
+    await waitFor(() => expect(staleCreate).toBeEnabled());
+
+    // Validation settles asynchronously. Replace the principal in the same
+    // turn so this proves the old continuation cannot submit A's secret as B.
+    fireEvent.click(staleCreate);
+    seam.replaceIdentity(ADMIN_B);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Add MCP Server' })).not.toBeInTheDocument()
+    );
+    expect(seam.onCreate).not.toHaveBeenCalled();
+    expect(seam.serverCreate).not.toHaveBeenCalled();
+
+    await openCreateForm();
+    expect(screen.getByLabelText('Name (Internal ID)')).toHaveValue('');
+    await chooseSelect('Transport', 'HTTP');
+    await chooseSelect('Auth Type', 'Bearer Token');
+    expect(await screen.findByLabelText('Token')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  }, 60_000);
+
+  it('closes an admin-A view and erases its unredacted environment on admin B', async () => {
+    const privateServer = makeServer({
+      name: 'admin-a-private-view',
+      display_name: 'Admin A Private View',
+      env: { PRIVATE_TOKEN: 'admin-a-env-secret' },
+    });
+    const replacementServer = makeServer({
+      mcp_server_id: 'server-b-view',
+      name: 'admin-b-view-server',
+      display_name: 'Admin B View Server',
+    });
+    const seam = renderTransitionTable({
+      currentUser: ADMIN,
+      policy: 'allow_crud',
+      servers: [privateServer],
+    });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    const [view] = Array.from(rowFor('Admin A Private View').querySelectorAll('button'));
+    fireEvent.click(view as HTMLButtonElement);
+    expect(await screen.findByText(/admin-a-env-secret/)).toBeInTheDocument();
+
+    seam.replaceIdentity(ADMIN_B, [replacementServer]);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'MCP Server Details' })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByText(/admin-a-env-secret/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin A Private View')).not.toBeInTheDocument();
+    expect(screen.getByText('Admin B View Server')).toBeInTheDocument();
+  });
+
+  it('closes admin-A edit state when admin B receives a replacement map', async () => {
+    const privateServer = makeServer({
+      name: 'admin-a-private',
+      display_name: 'Admin A Private',
+      auth: { type: 'bearer', token: 'admin-a-bearer-secret' },
+    });
+    const replacementServer = makeServer({
+      mcp_server_id: 'server-b',
+      name: 'admin-b-server',
+      display_name: 'Admin B Server',
+    });
+    const seam = renderTransitionTable({
+      currentUser: ADMIN,
+      policy: 'allow_crud',
+      servers: [privateServer],
+    });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+
+    const edit = rowFor('Admin A Private').querySelector(
+      'button[title="Edit"]'
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(edit).toBeEnabled());
+    fireEvent.click(edit as HTMLButtonElement);
+    const token = await screen.findByLabelText('Token');
+    fireEvent.change(token, { target: { value: 'admin-a-edited-bearer-secret' } });
+    const staleSave = screen.getByRole('button', { name: 'Save' });
+
+    seam.replaceIdentity(ADMIN_B, [replacementServer]);
+
+    await waitFor(() => expect(screen.queryByText('Edit MCP Server')).not.toBeInTheDocument());
+    fireEvent.click(staleSave);
+    expect(seam.serverPatch).not.toHaveBeenCalled();
+    expect(screen.queryByText('Admin A Private')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('admin-a-edited-bearer-secret')).not.toBeInTheDocument();
+    expect(screen.getByText('Admin B Server')).toBeInTheDocument();
+  });
+
+  it('closes an editor when realtime replacement removes its selected server', async () => {
+    const privateServer = makeServer({ name: 'realtime-private' });
+    const seam = renderTransitionTable({
+      currentUser: ADMIN,
+      policy: 'allow_crud',
+      servers: [privateServer],
+    });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    const edit = rowFor('realtime-private').querySelector(
+      'button[title="Edit"]'
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(edit).toBeEnabled());
+    fireEvent.click(edit as HTMLButtonElement);
+    await screen.findByLabelText('URL');
+
+    seam.setServers([]);
+
+    await waitFor(() => expect(screen.queryByText('Edit MCP Server')).not.toBeInTheDocument());
+    expect(screen.queryByText('realtime-private')).not.toBeInTheDocument();
+  });
+
   it('blocks an already-open create dialog immediately on disconnect', async () => {
     const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
     await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -1,6 +1,6 @@
 import { canConfigureMCPServers } from '@agor/core/mcp/member-policy';
 import type { AgorClient, MCPMemberPolicy, MCPServer, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
@@ -139,6 +139,7 @@ async function openCreateForm(): Promise<void> {
   const addButton = screen.getByRole('button', { name: /New MCP Server/i });
   await waitFor(() => expect(addButton).toBeEnabled());
   fireEvent.click(addButton);
+  await screen.findByRole('dialog', { name: 'Add MCP Server' });
 }
 
 /**
@@ -428,6 +429,144 @@ describe('MCPServersTable member policy', () => {
 
     await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
     expect(find).toHaveBeenCalledTimes(1);
+  });
+});
+
+function renderTransitionTable(initial: {
+  currentUser: User;
+  policy: MCPMemberPolicy;
+  servers?: MCPServer[];
+}) {
+  let policy = initial.policy;
+  let role = initial.currentUser.role;
+  const policyListeners: Array<() => void> = [];
+  const find = vi.fn(async () => ({
+    policy,
+    can_configure: canConfigureMCPServers(role, policy),
+  }));
+  const serverCreate = vi.fn();
+  const serverPatch = vi.fn();
+  const mcpServersService = {
+    on: vi.fn((event: string, listener: () => void) => {
+      if (event === 'member-policy:changed') policyListeners.push(listener);
+    }),
+    removeListener: vi.fn(),
+    create: serverCreate,
+    patch: serverPatch,
+  };
+  const client = {
+    io: { on: vi.fn(), off: vi.fn() },
+    service: (path: string) => {
+      if (path === 'mcp-member-policy') return { find, patch: vi.fn() };
+      if (path === 'mcp-servers') return mcpServersService;
+      return { create: vi.fn() };
+    },
+  } as unknown as AgorClient;
+  const onCreate = vi.fn();
+  const servers = new Map((initial.servers ?? []).map((server) => [server.mcp_server_id, server]));
+
+  const view = (currentUser: User, connected: boolean, connecting: boolean, generation: number) => (
+    <AntdApp>
+      <ConnectionProvider
+        value={{
+          connected,
+          connecting,
+          authGeneration: generation,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <MCPServersTable
+          mcpServerById={servers}
+          client={client}
+          userById={USER_BY_ID}
+          currentUser={currentUser}
+          onCreate={onCreate}
+        />
+      </ConnectionProvider>
+    </AntdApp>
+  );
+  const rendered = render(view(initial.currentUser, true, false, 1));
+
+  return {
+    find,
+    onCreate,
+    serverCreate,
+    serverPatch,
+    disconnect: () => rendered.rerender(view(initial.currentUser, false, true, 1)),
+    replaceRole: (currentUser: User, generation = 2) => {
+      role = currentUser.role;
+      rendered.rerender(view(currentUser, true, false, generation));
+    },
+    setPolicy: async (next: MCPMemberPolicy) => {
+      policy = next;
+      await act(async () => {
+        for (const listener of policyListeners) listener();
+      });
+    },
+  };
+}
+
+async function fillCreateRequirements(): Promise<void> {
+  fireEvent.change(await screen.findByLabelText('Name (Internal ID)'), {
+    target: { value: 'transition-server' },
+  });
+  const command = screen.queryByLabelText('Command');
+  if (command) {
+    fireEvent.change(command, { target: { value: 'npx transition-server' } });
+  } else {
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://transition.example/mcp' },
+    });
+  }
+}
+
+describe('MCPServersTable open-dialog authority transitions', () => {
+  it('blocks an already-open create dialog immediately on disconnect', async () => {
+    const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+    await fillCreateRequirements();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled());
+
+    seam.disconnect();
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    expect(screen.getByText(/MCP server changes are unavailable/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(seam.onCreate).not.toHaveBeenCalled();
+    expect(seam.serverCreate).not.toHaveBeenCalled();
+  });
+
+  it('blocks an already-open create dialog immediately on demotion', async () => {
+    const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+    await fillCreateRequirements();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled());
+
+    seam.replaceRole(VIEWER);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(seam.onCreate).not.toHaveBeenCalled();
+    expect(seam.serverCreate).not.toHaveBeenCalled();
+  });
+
+  it('blocks an already-open member create dialog on a live policy downgrade', async () => {
+    const seam = renderTransitionTable({ currentUser: MEMBER, policy: 'allow_crud' });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+    await fillCreateRequirements();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled());
+
+    await seam.setPolicy('use_existing_only');
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(seam.onCreate).not.toHaveBeenCalled();
+    expect(seam.serverCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -444,6 +444,10 @@ function renderTransitionTable(initial: {
   currentUser: User;
   policy: MCPMemberPolicy;
   servers?: MCPServer[];
+  onCreate?: (
+    data: Parameters<NonNullable<React.ComponentProps<typeof MCPServersTable>['onCreate']>>[0],
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
 }) {
   let policy = initial.policy;
   let role = initial.currentUser.role;
@@ -470,7 +474,7 @@ function renderTransitionTable(initial: {
       return { create: vi.fn() };
     },
   } as unknown as AgorClient;
-  const onCreate = vi.fn();
+  const onCreate = vi.fn(initial.onCreate ?? (() => undefined));
   let servers = new Map((initial.servers ?? []).map((server) => [server.mcp_server_id, server]));
 
   const view = (currentUser: User, connected: boolean, connecting: boolean, generation: number) => (
@@ -592,6 +596,36 @@ describe('MCPServersTable open-dialog authority transitions', () => {
     expect(await screen.findByLabelText('Token')).toHaveValue('');
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
   }, 60_000);
+
+  it('does not close or continue an A create after its parent save crosses auth generation', async () => {
+    let resolveSave!: () => void;
+    const save = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    let parentGuard: (() => boolean) | undefined;
+    const seam = renderTransitionTable({
+      currentUser: ADMIN,
+      policy: 'allow_crud',
+      onCreate: async (_data, shouldApply) => {
+        parentGuard = shouldApply;
+        await save;
+      },
+    });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+    await fillCreateRequirements();
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() => expect(seam.onCreate).toHaveBeenCalledOnce());
+    expect(parentGuard?.()).toBe(true);
+
+    seam.replaceRole(ADMIN, 2);
+    expect(parentGuard?.()).toBe(false);
+    await act(async () => {
+      resolveSave();
+      await save;
+    });
+    expect(screen.getByRole('dialog', { name: 'Add MCP Server' })).toBeInTheDocument();
+  });
 
   it('closes an admin-A view and erases its unredacted environment on admin B', async () => {
     const privateServer = makeServer({

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -3,6 +3,7 @@ import type { AgorClient, MCPMemberPolicy, MCPServer, User } from '@agor-live/cl
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { MCPServersTable } from './MCPServersTable';
 
 const ADMIN: User = {
@@ -75,6 +76,7 @@ function makeClient(
     io: { on: vi.fn(), off: vi.fn() },
     service: (path: string) => {
       if (path === 'mcp-member-policy') return { find, patch };
+      if (path === 'mcp-servers') return { on: vi.fn(), removeListener: vi.fn() };
       return {};
     },
   } as unknown as AgorClient;
@@ -103,12 +105,23 @@ function renderTable(options: {
   );
   render(
     <AntdApp>
-      <MCPServersTable
-        mcpServerById={mcpServerById}
-        client={client}
-        userById={USER_BY_ID}
-        currentUser={options.currentUser}
-      />
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          authGeneration: 1,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <MCPServersTable
+          mcpServerById={mcpServerById}
+          client={client}
+          userById={USER_BY_ID}
+          currentUser={options.currentUser}
+        />
+      </ConnectionProvider>
     </AntdApp>
   );
   return { find, patch };

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -141,6 +141,15 @@ function renderTable(options: {
 const POLICY_LOADING_HINT = /Checking what this workspace's MCP policy allows/i;
 const POLICY_UNREADABLE_HINT = /MCP policy could not be read/i;
 
+// These remain state/event assertions rather than elapsed-time assertions, but
+// a cold antd Form/Select mount makes jsdom parse a large generated stylesheet.
+// The focused file completes in ~90 seconds; under the full 240-file UI run,
+// worker contention can make an individual cold mount exceed the global 15s
+// limit without changing the result. Keep the allowance local to these real
+// form integration suites rather than weakening the workspace-wide timeout.
+const ANT_FORM_INTEGRATION_TIMEOUT = 60_000;
+const AUTHORITY_TRANSITION_TIMEOUT = 120_000;
+
 const policyRadio = (name: RegExp) => screen.getByRole('radio', { name });
 
 async function openCreateForm(): Promise<void> {
@@ -159,7 +168,7 @@ async function openCreateForm(): Promise<void> {
  */
 const openPolicyPane = () => fireEvent.click(screen.getByRole('tab', { name: 'Member policy' }));
 
-describe('MCPServersTable member policy', () => {
+describe('MCPServersTable member policy', { timeout: ANT_FORM_INTEGRATION_TIMEOUT }, () => {
   it('opens on the servers, with the policy a pane away', async () => {
     const { find } = renderTable({ policy: 'use_existing_only', currentUser: ADMIN });
 
@@ -559,7 +568,9 @@ async function chooseSelect(label: string, option: string): Promise<void> {
   fireEvent.click(optionContent);
 }
 
-describe('MCPServersTable open-dialog authority transitions', () => {
+describe('MCPServersTable open-dialog authority transitions', {
+  timeout: AUTHORITY_TRANSITION_TIMEOUT,
+}, () => {
   it('destroys an admin-A create form and raw credential before admin B can use it', async () => {
     const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
     await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
@@ -595,7 +606,7 @@ describe('MCPServersTable open-dialog authority transitions', () => {
     await chooseSelect('Auth Type', 'Bearer Token');
     expect(await screen.findByLabelText('Token')).toHaveValue('');
     expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
-  }, 60_000);
+  });
 
   it('does not close or continue an A create after its parent save crosses auth generation', async () => {
     let resolveSave!: () => void;

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -152,6 +152,10 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   });
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
   const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
+  const durableAuthorityKey =
+    client && connectionReady && !policyPending && currentUser?.user_id && currentUser.role
+      ? `${currentUser.user_id}:${currentUser.role}:${authGeneration}`
+      : null;
   const capability = useMemo<MCPServerCapabilityContext>(
     () => ({
       role: currentUser?.role,
@@ -759,6 +763,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
             onAuthTypeChange={setAuthType}
             form={createForm}
             client={client}
+            authorityKey={durableAuthorityKey}
             serverId={createdServerId ?? undefined}
             onTestConnection={handleCreateTestConnection}
             testing={testing}
@@ -776,9 +781,12 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         server={editingServer}
         open={editModalOpen}
         client={client}
+        authorityKey={durableAuthorityKey}
         offeredTransports={offeredTransports}
         offeredScopes={editableScopes}
-        mutationAllowed={!!editingServer && canEditMcpServer(editingServer, capability)}
+        mutationAllowed={
+          !!editingServer && !policyPending && canEditMcpServer(editingServer, capability)
+        }
         mutationBlockedReason={
           policyPending ? policyPendingHint : explainManageRestriction(capability)
         }

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -131,7 +131,7 @@ interface TestResult {
   prompts?: Array<{ name: string; description: string }>;
 }
 
-export const MCPServersTable: React.FC<MCPServersTableProps> = ({
+const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
   mcpServerById,
   client,
   userById,
@@ -176,11 +176,23 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   );
   const canAdd = !policyPending && canAddMcpServer(capability);
   const addRestriction = policyPending ? policyPendingHint : explainAddRestriction(capability);
+  // This component is keyed by authenticated user below. Async continuations
+  // from the unmounted caller must not submit a form or surface results after
+  // an in-place launch-auth replacement has installed another identity.
+  const identityActiveRef = useRef(true);
+  useEffect(() => {
+    identityActiveRef.current = true;
+    return () => {
+      identityActiveRef.current = false;
+    };
+  }, []);
   const capabilityRef = useRef({ capability, policyPending, addRestriction });
   capabilityRef.current = { capability, policyPending, addRestriction };
   const addIsCurrentlyAllowed = () => {
     const current = capabilityRef.current;
-    return !current.policyPending && canAddMcpServer(current.capability);
+    return (
+      identityActiveRef.current && !current.policyPending && canAddMcpServer(current.capability)
+    );
   };
   // Which transports a user may configure turns on role alone, so this is known
   // before the policy fetch settles. The first entry is the default the create
@@ -222,16 +234,31 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   // the form should be able to trap the user behind it.
   const createBlocked = !createdServerId && (!canAdd || missingRequiredFields.length > 0);
 
-  // Sync editing server when mcpServerById updates (real-time WebSocket updates).
-  // Also keeps the open edit modal in sync if the underlying record changes.
+  // Sync modal records when mcpServerById updates (real-time WebSocket
+  // updates). An absent row is authoritative too: retaining the previous
+  // object would expose caller A's private server after caller B's replacement
+  // map has correctly omitted it.
   useEffect(() => {
-    if (editingServer && mcpServerById.has(editingServer.mcp_server_id)) {
-      const updatedServer = mcpServerById.get(editingServer.mcp_server_id);
-      if (updatedServer && updatedServer !== editingServer) {
-        setEditingServer(updatedServer);
-      }
+    if (!editingServer) return;
+    const updatedServer = mcpServerById.get(editingServer.mcp_server_id);
+    if (!updatedServer) {
+      setEditModalOpen(false);
+      setEditingServer(null);
+    } else if (updatedServer !== editingServer) {
+      setEditingServer(updatedServer);
     }
   }, [mcpServerById, editingServer]);
+
+  useEffect(() => {
+    if (!viewingServer) return;
+    const updatedServer = mcpServerById.get(viewingServer.mcp_server_id);
+    if (!updatedServer) {
+      setViewModalOpen(false);
+      setViewingServer(null);
+    } else if (updatedServer !== viewingServer) {
+      setViewingServer(updatedServer);
+    }
+  }, [mcpServerById, viewingServer]);
 
   const buildCreateData = (values: Record<string, unknown>): CreateMCPServerInput => {
     const data: CreateMCPServerInput = {
@@ -265,32 +292,35 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   // Persist the current form before every OAuth start. The saved row is the
   // daemon's tenant-scoped authority for provider URL and client credentials.
   const prepareOAuthStartForCreate = async (): Promise<string | null> => {
-    if (!client) return null;
+    if (!client || !identityActiveRef.current) return null;
     if (!addIsCurrentlyAllowed()) {
       showError(capabilityRef.current.addRestriction);
       return null;
     }
     try {
       await createForm.validateFields();
-      if (!addIsCurrentlyAllowed()) {
+      if (!identityActiveRef.current || !addIsCurrentlyAllowed()) {
         showError(capabilityRef.current.addRestriction);
         return null;
       }
       const data = buildCreateData(createForm.getFieldsValue(true));
 
       if (!createdServerId) {
-        if (!addIsCurrentlyAllowed()) return null;
+        if (!identityActiveRef.current || !addIsCurrentlyAllowed()) return null;
         const result = await client.service('mcp-servers').create(data);
+        if (!identityActiveRef.current) return null;
         const newServerId = (result as MCPServer).mcp_server_id || null;
         setCreatedServerId(newServerId);
         return newServerId;
       }
 
       const { name: _name, source: _source, ...updates } = data;
-      if (!addIsCurrentlyAllowed()) return null;
+      if (!identityActiveRef.current || !addIsCurrentlyAllowed()) return null;
       await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
+      if (!identityActiveRef.current) return null;
       return createdServerId;
     } catch (error) {
+      if (!identityActiveRef.current) return null;
       // Say which field. Swallowing a validation rejection here left the OAuth
       // button doing nothing at all, with nothing on screen to explain it.
       showError(
@@ -324,7 +354,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     createForm
       .validateFields()
       .then(() => {
-        if (!addIsCurrentlyAllowed()) {
+        if (!identityActiveRef.current || !addIsCurrentlyAllowed()) {
           showError(capabilityRef.current.addRestriction);
           return;
         }
@@ -333,6 +363,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         resetCreateModal();
       })
       .catch((error) => {
+        if (!identityActiveRef.current) return;
         console.error('Form validation failed:', error);
         showError(firstFormErrorMessage(error) || 'Please fill in required fields');
       });
@@ -340,6 +371,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
 
   // Test connection from create modal (always inline config, no persistence).
   const handleCreateTestConnection = async () => {
+    if (!identityActiveRef.current) return;
     if (!client) {
       showError('Client not available');
       return;
@@ -358,9 +390,11 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     try {
       await createForm.validateFields(['headers']);
     } catch {
+      if (!identityActiveRef.current) return;
       showError('Please fix custom HTTP headers before testing');
       return;
     }
+    if (!identityActiveRef.current) return;
 
     setTesting(true);
     setTestResult(null);
@@ -379,6 +413,8 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         resources?: Array<{ name: string; uri: string; mimeType?: string }>;
         prompts?: Array<{ name: string; description: string }>;
       };
+
+      if (!identityActiveRef.current) return;
 
       if (data.success && data.capabilities) {
         setTestResult({
@@ -400,6 +436,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         });
       }
     } catch (error) {
+      if (!identityActiveRef.current) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setTestResult({
         success: false,
@@ -409,7 +446,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         error: errorMessage,
       });
     } finally {
-      setTesting(false);
+      if (identityActiveRef.current) setTesting(false);
     }
   };
 
@@ -427,6 +464,11 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     setViewingServer(server);
     setViewModalOpen(true);
   }, []);
+
+  const resetViewModal = () => {
+    setViewModalOpen(false);
+    setViewingServer(null);
+  };
 
   const handleDelete = useCallback(
     (serverId: string) => {
@@ -781,6 +823,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         server={editingServer}
         open={editModalOpen}
         client={client}
+        identityKey={currentUser?.user_id ?? null}
         authorityKey={durableAuthorityKey}
         offeredTransports={offeredTransports}
         offeredScopes={editableScopes}
@@ -797,12 +840,9 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       <AdaptiveSettingsModal
         title="MCP Server Details"
         open={viewModalOpen}
-        onCancel={() => {
-          setViewModalOpen(false);
-          setViewingServer(null);
-        }}
+        onCancel={resetViewModal}
         footer={[
-          <Button key="close" onClick={() => setViewModalOpen(false)}>
+          <Button key="close" onClick={resetViewModal}>
             Close
           </Button>,
         ]}
@@ -942,3 +982,18 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     />
   );
 };
+
+/**
+ * Ant Form instances and modal state are caller-private: they can contain raw
+ * bearer/JWT/OAuth credentials and unredacted environment values. Key the
+ * complete state owner by authenticated identity so React destroys caller A's
+ * form and overlays in the same reconciliation that renders caller B. Socket
+ * reconnects and token rotations for the same user keep the key and therefore
+ * preserve ordinary in-progress work.
+ */
+export const MCPServersTable: React.FC<MCPServersTableProps> = (props) => (
+  <MCPServersTableForIdentity
+    key={props.currentUser?.user_id ?? '__no-authenticated-user__'}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -58,6 +58,7 @@ import {
   explainAddRestriction,
   explainManageRestriction,
   type MCPServerCapabilityContext,
+  policyPendingState,
 } from '../MCPServer/memberPolicy';
 import { AdaptiveSettingsModal } from './AdaptiveSettingsModal';
 import { MCPMemberPolicySetting } from './MCPMemberPolicySetting';
@@ -77,10 +78,6 @@ interface MCPServersTableProps {
 /** How an unowned server reads: it is the workspace's, not nobody's. */
 const SHARED_OWNER_LABEL = 'Shared with workspace';
 const SHARED_OWNER_HINT = 'No owner — everyone in this workspace can use this server.';
-
-const POLICY_LOADING_HINT = "Checking what this workspace's MCP policy allows…";
-const POLICY_UNREADABLE_HINT =
-  "This workspace's MCP policy could not be read, so nothing is offered here.";
 
 const getServerHealth = (
   server: MCPServer,
@@ -384,8 +381,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   // restrictive value it falls back to — while loading, or when the read failed
   // — is a safe assumption to act on, not a fact about this workspace to quote
   // back as the reason.
-  const policyPending = memberPolicy.loading || memberPolicy.error !== null;
-  const policyPendingHint = memberPolicy.error ? POLICY_UNREADABLE_HINT : POLICY_LOADING_HINT;
+  const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
 
   const capability = useMemo<MCPServerCapabilityContext>(
     () => ({

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -32,6 +32,7 @@ import {
   Typography,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useConnectionState } from '@/contexts/ConnectionContext';
 import { useMcpMemberPolicy } from '@/hooks/useMcpMemberPolicy';
 import { useAgorStore } from '@/store/agorStore';
 import { selectUserAuthenticatedMcpServerIds } from '@/store/selectors';
@@ -141,7 +142,13 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   // Same set the session panel and the picker read, so an install is
   // "unfinished" in exactly one sense across all three.
   const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
-  const memberPolicy = useMcpMemberPolicy(client);
+  const { connected, connecting, authGeneration } = useConnectionState();
+  const connectionReady = connected && !connecting;
+  const memberPolicy = useMcpMemberPolicy(client, {
+    connectionReady,
+    currentUser,
+    authGeneration,
+  });
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
   // Which transports a user may configure turns on role alone, so this is known
   // before the policy fetch settles. The first entry is the default the create
@@ -387,12 +394,14 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     () => ({
       role: currentUser?.role,
       isAdmin,
+      connectionReady,
       policy: memberPolicy.policy,
       userId: currentUser?.user_id,
       canConfigure: memberPolicy.canConfigure,
     }),
     [
       isAdmin,
+      connectionReady,
       currentUser?.role,
       currentUser?.user_id,
       memberPolicy.policy,

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -34,6 +34,7 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useConnectionState } from '@/contexts/ConnectionContext';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useMcpMemberPolicy } from '@/hooks/useMcpMemberPolicy';
 import { useAgorStore } from '@/store/agorStore';
 import { selectUserAuthenticatedMcpServerIds } from '@/store/selectors';
@@ -62,6 +63,7 @@ import {
   type MCPServerCapabilityContext,
   policyPendingState,
 } from '../MCPServer/memberPolicy';
+import { useOAuthBrowserEventAttempt } from '../MCPServer/useOAuthBrowserEventAttempt';
 import { AdaptiveSettingsModal } from './AdaptiveSettingsModal';
 import { MCPMemberPolicySetting } from './MCPMemberPolicySetting';
 import { ResponsiveSettingsHeader } from './ResponsiveSettingsHeader';
@@ -176,22 +178,23 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
   );
   const canAdd = !policyPending && canAddMcpServer(capability);
   const addRestriction = policyPending ? policyPendingHint : explainAddRestriction(capability);
-  // This component is keyed by authenticated user below. Async continuations
-  // from the unmounted caller must not submit a form or surface results after
-  // an in-place launch-auth replacement has installed another identity.
-  const identityActiveRef = useRef(true);
-  useEffect(() => {
-    identityActiveRef.current = true;
-    return () => {
-      identityActiveRef.current = false;
-    };
-  }, []);
+  const operationGuard = useAuthorityOperationGuard(
+    durableAuthorityKey
+      ? [durableAuthorityKey, client, memberPolicy.policy, memberPolicy.canConfigure]
+      : null
+  );
+  const oauthBrowserEvents = useOAuthBrowserEventAttempt({
+    client,
+    currentUserId: currentUser?.user_id ?? null,
+    authGeneration,
+    authorityGuard: operationGuard,
+  });
   const capabilityRef = useRef({ capability, policyPending, addRestriction });
   capabilityRef.current = { capability, policyPending, addRestriction };
   const addIsCurrentlyAllowed = () => {
     const current = capabilityRef.current;
     return (
-      identityActiveRef.current && !current.policyPending && canAddMcpServer(current.capability)
+      operationGuard.isCurrent() && !current.policyPending && canAddMcpServer(current.capability)
     );
   };
   // Which transports a user may configure turns on role alone, so this is known
@@ -292,35 +295,37 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
   // Persist the current form before every OAuth start. The saved row is the
   // daemon's tenant-scoped authority for provider URL and client credentials.
   const prepareOAuthStartForCreate = async (): Promise<string | null> => {
-    if (!client || !identityActiveRef.current) return null;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return null;
     if (!addIsCurrentlyAllowed()) {
       showError(capabilityRef.current.addRestriction);
       return null;
     }
     try {
       await createForm.validateFields();
-      if (!identityActiveRef.current || !addIsCurrentlyAllowed()) {
+      if (!operation.isCurrent()) return null;
+      if (!addIsCurrentlyAllowed()) {
         showError(capabilityRef.current.addRestriction);
         return null;
       }
       const data = buildCreateData(createForm.getFieldsValue(true));
 
       if (!createdServerId) {
-        if (!identityActiveRef.current || !addIsCurrentlyAllowed()) return null;
+        if (!operation.isCurrent() || !addIsCurrentlyAllowed()) return null;
         const result = await client.service('mcp-servers').create(data);
-        if (!identityActiveRef.current) return null;
+        if (!operation.isCurrent()) return null;
         const newServerId = (result as MCPServer).mcp_server_id || null;
         setCreatedServerId(newServerId);
         return newServerId;
       }
 
       const { name: _name, source: _source, ...updates } = data;
-      if (!identityActiveRef.current || !addIsCurrentlyAllowed()) return null;
+      if (!operation.isCurrent() || !addIsCurrentlyAllowed()) return null;
       await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
-      if (!identityActiveRef.current) return null;
+      if (!operation.isCurrent()) return null;
       return createdServerId;
     } catch (error) {
-      if (!identityActiveRef.current) return null;
+      if (!operation.isCurrent()) return null;
       // Say which field. Swallowing a validation rejection here left the OAuth
       // button doing nothing at all, with nothing on screen to explain it.
       showError(
@@ -351,10 +356,12 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       return;
     }
 
+    const operation = operationGuard.begin();
     createForm
       .validateFields()
       .then(() => {
-        if (!identityActiveRef.current || !addIsCurrentlyAllowed()) {
+        if (!operation.isCurrent()) return;
+        if (!addIsCurrentlyAllowed()) {
           showError(capabilityRef.current.addRestriction);
           return;
         }
@@ -363,7 +370,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         resetCreateModal();
       })
       .catch((error) => {
-        if (!identityActiveRef.current) return;
+        if (!operation.isCurrent()) return;
         console.error('Form validation failed:', error);
         showError(firstFormErrorMessage(error) || 'Please fill in required fields');
       });
@@ -371,7 +378,8 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
 
   // Test connection from create modal (always inline config, no persistence).
   const handleCreateTestConnection = async () => {
-    if (!identityActiveRef.current) return;
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     if (!client) {
       showError('Client not available');
       return;
@@ -390,21 +398,24 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
     try {
       await createForm.validateFields(['headers']);
     } catch {
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       showError('Please fix custom HTTP headers before testing');
       return;
     }
-    if (!identityActiveRef.current) return;
+    if (!operation.isCurrent()) return;
 
     setTesting(true);
     setTestResult(null);
+    const browserAttempt = oauthBrowserEvents.begin();
 
     try {
+      if (!operation.isCurrent()) return;
       const data = (await client.service('mcp-servers/discover').create({
         url: values.url,
         transport: values.transport || 'http',
         auth: buildAuthFromValues(values),
         headers: parseHeadersJSON(values.headers),
+        ...(browserAttempt ? { oauth_browser_event: browserAttempt.request } : {}),
       })) as {
         success: boolean;
         error?: string;
@@ -414,7 +425,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         prompts?: Array<{ name: string; description: string }>;
       };
 
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
 
       if (data.success && data.capabilities) {
         setTestResult({
@@ -436,7 +447,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         });
       }
     } catch (error) {
-      if (!identityActiveRef.current) return;
+      if (!operation.isCurrent()) return;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setTestResult({
         success: false,
@@ -446,7 +457,8 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         error: errorMessage,
       });
     } finally {
-      if (identityActiveRef.current) setTesting(false);
+      browserAttempt?.cleanup();
+      if (operation.isCurrent()) setTesting(false);
     }
   };
 
@@ -824,6 +836,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         open={editModalOpen}
         client={client}
         identityKey={currentUser?.user_id ?? null}
+        authGeneration={authGeneration}
         authorityKey={durableAuthorityKey}
         offeredTransports={offeredTransports}
         offeredScopes={editableScopes}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -75,8 +75,8 @@ interface MCPServersTableProps {
   /** Resolves `owner_user_id` to a person; unowned servers name no user. */
   userById: Map<string, User>;
   currentUser?: User | null;
-  onCreate?: (data: CreateMCPServerInput) => void;
-  onDelete?: (serverId: string) => void;
+  onCreate?: (data: CreateMCPServerInput, shouldApply?: () => boolean) => void | Promise<void>;
+  onDelete?: (serverId: string, shouldApply?: () => boolean) => void | Promise<void>;
 }
 
 /** How an unowned server reads: it is the workspace's, not nobody's. */
@@ -345,7 +345,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
     setCreatedServerId(null);
   };
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     if (createdServerId) {
       resetCreateModal();
       return;
@@ -357,23 +357,23 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
     }
 
     const operation = operationGuard.begin();
-    createForm
-      .validateFields()
-      .then(() => {
-        if (!operation.isCurrent()) return;
-        if (!addIsCurrentlyAllowed()) {
-          showError(capabilityRef.current.addRestriction);
-          return;
-        }
-        const data = buildCreateData(createForm.getFieldsValue(true));
-        onCreate?.(data);
-        resetCreateModal();
-      })
-      .catch((error) => {
-        if (!operation.isCurrent()) return;
-        console.error('Form validation failed:', error);
-        showError(firstFormErrorMessage(error) || 'Please fill in required fields');
-      });
+    try {
+      await createForm.validateFields();
+      if (!operation.isCurrent()) return;
+      if (!addIsCurrentlyAllowed()) {
+        showError(capabilityRef.current.addRestriction);
+        return;
+      }
+      const data = buildCreateData(createForm.getFieldsValue(true));
+      if (!operation.isCurrent()) return;
+      await onCreate?.(data, operation.isCurrent);
+      if (!operation.isCurrent()) return;
+      resetCreateModal();
+    } catch (error) {
+      if (!operation.isCurrent()) return;
+      console.error('Form validation failed:', error);
+      showError(firstFormErrorMessage(error) || 'Please fill in required fields');
+    }
   };
 
   // Test connection from create modal (always inline config, no persistence).
@@ -404,11 +404,11 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
     }
     if (!operation.isCurrent()) return;
 
-    setTesting(true);
-    setTestResult(null);
-    const browserAttempt = oauthBrowserEvents.begin();
-
+    let browserAttempt: Awaited<ReturnType<typeof oauthBrowserEvents.begin>> = null;
     try {
+      setTesting(true);
+      setTestResult(null);
+      browserAttempt = await oauthBrowserEvents.begin({ operation: 'discover' });
       if (!operation.isCurrent()) return;
       const data = (await client.service('mcp-servers/discover').create({
         url: values.url,
@@ -484,9 +484,11 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
 
   const handleDelete = useCallback(
     (serverId: string) => {
-      onDelete?.(serverId);
+      const operation = operationGuard.begin();
+      if (!operation.isCurrent()) return;
+      void onDelete?.(serverId, operation.isCurrent);
     },
-    [onDelete]
+    [onDelete, operationGuard]
   );
 
   // An editor must be able to show the scope a row already carries, including

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -18,6 +18,7 @@ import {
   UserOutlined,
 } from '@ant-design/icons';
 import {
+  Alert,
   Badge,
   Button,
   Descriptions,
@@ -31,7 +32,7 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useConnectionState } from '@/contexts/ConnectionContext';
 import { useMcpMemberPolicy } from '@/hooks/useMcpMemberPolicy';
 import { useAgorStore } from '@/store/agorStore';
@@ -150,6 +151,33 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     authGeneration,
   });
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
+  const capability = useMemo<MCPServerCapabilityContext>(
+    () => ({
+      role: currentUser?.role,
+      isAdmin,
+      connectionReady,
+      policy: memberPolicy.policy,
+      userId: currentUser?.user_id,
+      canConfigure: memberPolicy.canConfigure,
+    }),
+    [
+      isAdmin,
+      connectionReady,
+      currentUser?.role,
+      currentUser?.user_id,
+      memberPolicy.policy,
+      memberPolicy.canConfigure,
+    ]
+  );
+  const canAdd = !policyPending && canAddMcpServer(capability);
+  const addRestriction = policyPending ? policyPendingHint : explainAddRestriction(capability);
+  const capabilityRef = useRef({ capability, policyPending, addRestriction });
+  capabilityRef.current = { capability, policyPending, addRestriction };
+  const addIsCurrentlyAllowed = () => {
+    const current = capabilityRef.current;
+    return !current.policyPending && canAddMcpServer(current.capability);
+  };
   // Which transports a user may configure turns on role alone, so this is known
   // before the policy fetch settles. The first entry is the default the create
   // form starts from — `MCP_TRANSPORTS` is ordered for that.
@@ -188,7 +216,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     : [];
   // Once the row exists the button only dismisses the modal, so nothing about
   // the form should be able to trap the user behind it.
-  const createBlocked = !createdServerId && missingRequiredFields.length > 0;
+  const createBlocked = !createdServerId && (!canAdd || missingRequiredFields.length > 0);
 
   // Sync editing server when mcpServerById updates (real-time WebSocket updates).
   // Also keeps the open edit modal in sync if the underlying record changes.
@@ -234,11 +262,20 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   // daemon's tenant-scoped authority for provider URL and client credentials.
   const prepareOAuthStartForCreate = async (): Promise<string | null> => {
     if (!client) return null;
+    if (!addIsCurrentlyAllowed()) {
+      showError(capabilityRef.current.addRestriction);
+      return null;
+    }
     try {
       await createForm.validateFields();
+      if (!addIsCurrentlyAllowed()) {
+        showError(capabilityRef.current.addRestriction);
+        return null;
+      }
       const data = buildCreateData(createForm.getFieldsValue(true));
 
       if (!createdServerId) {
+        if (!addIsCurrentlyAllowed()) return null;
         const result = await client.service('mcp-servers').create(data);
         const newServerId = (result as MCPServer).mcp_server_id || null;
         setCreatedServerId(newServerId);
@@ -246,6 +283,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       }
 
       const { name: _name, source: _source, ...updates } = data;
+      if (!addIsCurrentlyAllowed()) return null;
       await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
       return createdServerId;
     } catch (error) {
@@ -274,9 +312,18 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       return;
     }
 
+    if (!addIsCurrentlyAllowed()) {
+      showError(capabilityRef.current.addRestriction);
+      return;
+    }
+
     createForm
       .validateFields()
       .then(() => {
+        if (!addIsCurrentlyAllowed()) {
+          showError(capabilityRef.current.addRestriction);
+          return;
+        }
         const data = buildCreateData(createForm.getFieldsValue(true));
         onCreate?.(data);
         resetCreateModal();
@@ -382,31 +429,6 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       onDelete?.(serverId);
     },
     [onDelete]
-  );
-
-  // Until the policy is known the table offers nothing and says only that. The
-  // restrictive value it falls back to — while loading, or when the read failed
-  // — is a safe assumption to act on, not a fact about this workspace to quote
-  // back as the reason.
-  const { pending: policyPending, hint: policyPendingHint } = policyPendingState(memberPolicy);
-
-  const capability = useMemo<MCPServerCapabilityContext>(
-    () => ({
-      role: currentUser?.role,
-      isAdmin,
-      connectionReady,
-      policy: memberPolicy.policy,
-      userId: currentUser?.user_id,
-      canConfigure: memberPolicy.canConfigure,
-    }),
-    [
-      isAdmin,
-      connectionReady,
-      currentUser?.role,
-      currentUser?.user_id,
-      memberPolicy.policy,
-      memberPolicy.canConfigure,
-    ]
   );
 
   // An editor must be able to show the scope a row already carries, including
@@ -638,8 +660,6 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     ]);
   }, [mcpServerById, searchTerm, describeOwner]);
 
-  const canAdd = !policyPending && canAddMcpServer(capability);
-
   const serversPane = (
     <>
       <ResponsiveSettingsHeader
@@ -697,7 +717,13 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
             <Button onClick={resetCreateModal}>Cancel</Button>
             {/* A disabled button can't host a tooltip of its own — hence the span. */}
             <Tooltip
-              title={createBlocked ? describeMissingForSave(missingRequiredFields) : undefined}
+              title={
+                !createdServerId && !canAdd
+                  ? addRestriction
+                  : createBlocked
+                    ? describeMissingForSave(missingRequiredFields)
+                    : undefined
+              }
             >
               <span>
                 <Button type="primary" disabled={createBlocked} onClick={handleCreate}>
@@ -708,6 +734,15 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
           </Space>
         }
       >
+        {!canAdd && (
+          <Alert
+            type="warning"
+            showIcon
+            title="MCP server changes are unavailable"
+            description={addRestriction}
+            style={{ marginBottom: 16 }}
+          />
+        )}
         <Form
           form={createForm}
           layout="vertical"
@@ -729,6 +764,8 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
             testing={testing}
             testResult={testResult}
             onPrepareOAuthStart={prepareOAuthStartForCreate}
+            mutationAllowed={canAdd}
+            mutationBlockedReason={addRestriction}
             formRevision={formRevision}
           />
         </Form>
@@ -741,6 +778,10 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         client={client}
         offeredTransports={offeredTransports}
         offeredScopes={editableScopes}
+        mutationAllowed={!!editingServer && canEditMcpServer(editingServer, capability)}
+        mutationBlockedReason={
+          policyPending ? policyPendingHint : explainManageRestriction(capability)
+        }
         onClose={handleEditClose}
       />
 

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.test.tsx
@@ -1,0 +1,51 @@
+import type { AgorClient } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { PersonalApiKeysTab } from './PersonalApiKeysTab';
+
+describe('PersonalApiKeysTab authority fencing', () => {
+  it('does not reveal an old-generation create result and preserves the name draft', async () => {
+    let resolve!: (value: unknown) => void;
+    const pendingCreate = new Promise<unknown>((done) => {
+      resolve = done;
+    });
+    const findAll = vi.fn().mockResolvedValue([]);
+    const create = vi.fn(() => pendingCreate);
+    const client = {
+      service: (path: string) => {
+        if (path !== 'api/v1/user/api-keys') throw new Error(path);
+        return { findAll, create, remove: vi.fn() };
+      },
+    } as unknown as AgorClient;
+    const view = (generation: number) => (
+      <AntApp>
+        <PersonalApiKeysTab
+          client={client}
+          identityKey="member-a:member"
+          operationScope={['member-a:member', generation]}
+        />
+      </AntApp>
+    );
+    const rendered = render(view(1));
+    await waitFor(() => expect(findAll).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /create new key/i }));
+    fireEvent.change(screen.getByPlaceholderText(/CI Pipeline/), {
+      target: { value: 'same-user draft key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+    expect(create).toHaveBeenCalledWith({ name: 'same-user draft key' });
+
+    rendered.rerender(view(2));
+    await act(async () => {
+      resolve({
+        rawKey: 'agor_old_generation_private_key',
+        key: { id: 'old', name: 'old', prefix: 'agor_old', created_at: new Date().toISOString() },
+      });
+      await pendingCreate;
+    });
+
+    expect(screen.queryByDisplayValue('agor_old_generation_private_key')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/CI Pipeline/)).toHaveValue('same-user draft key');
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
@@ -1,7 +1,11 @@
 import type { AgorClient } from '@agor-live/client';
 import { CopyOutlined, DeleteOutlined, KeyOutlined, PlusOutlined } from '@ant-design/icons';
-import { Alert, Button, Input, Popconfirm, Space, Table, Typography, theme } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Button, Input, Modal, Popconfirm, Space, Table, Typography, theme } from 'antd';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import {
+  type AuthorityOperation,
+  useAuthorityOperationGuard,
+} from '../../hooks/useAuthorityOperationGuard';
 import { copyToClipboard } from '../../utils/clipboard';
 import { useThemedMessage } from '../../utils/message';
 import { filterBySettingsSearch } from '../../utils/settingsSearch';
@@ -19,9 +23,10 @@ interface ApiKeyEntry {
 
 interface PersonalApiKeysTabProps {
   client: AgorClient | null;
+  authorityKey: string | null;
 }
 
-export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }) => {
+export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client, authorityKey }) => {
   const [keys, setKeys] = useState<ApiKeyEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -32,57 +37,86 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
   const [searchTerm, setSearchTerm] = useState('');
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
+  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
 
-  const fetchKeys = useCallback(async () => {
-    if (!client) return;
-    setLoading(true);
-    try {
-      const result = await client.service('api/v1/user/api-keys').findAll({});
-      setKeys(result as ApiKeyEntry[]);
-    } catch (err) {
-      console.error('Failed to fetch API keys:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [client]);
+  // A full key is caller-private and is intentionally erased in layout, rather
+  // than waiting for passive cleanup, when Settings changes identity in place.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases the displayed raw key
+  useLayoutEffect(() => {
+    setKeys([]);
+    setNewKeyName('');
+    setShowCreateModal(false);
+    setNewlyCreatedKey(null);
+    setDeletingId(null);
+  }, [authorityKey]);
+
+  const fetchKeys = useCallback(
+    async (operation?: AuthorityOperation) => {
+      const request = operation ?? operationGuard.begin();
+      if (!client || !request.isCurrent()) return;
+      setLoading(true);
+      try {
+        const result = await client.service('api/v1/user/api-keys').findAll({});
+        if (!request.isCurrent()) return;
+        setKeys(result as ApiKeyEntry[]);
+      } catch (err) {
+        if (!request.isCurrent()) return;
+        console.error('Failed to fetch API keys:', err);
+      } finally {
+        if (request.isCurrent()) setLoading(false);
+      }
+    },
+    [client, operationGuard]
+  );
 
   useEffect(() => {
     fetchKeys();
   }, [fetchKeys]);
 
   const handleCreate = async () => {
-    if (!client || !newKeyName.trim()) return;
+    const operation = operationGuard.begin();
+    if (!client || !newKeyName.trim() || !operation.isCurrent()) return;
+    const name = newKeyName.trim();
     setCreating(true);
     try {
-      const result = (await client
-        .service('api/v1/user/api-keys')
-        .create({ name: newKeyName.trim() })) as { rawKey: string; key: ApiKeyEntry };
+      const result = (await client.service('api/v1/user/api-keys').create({ name })) as {
+        rawKey: string;
+        key: ApiKeyEntry;
+      };
+      if (!operation.isCurrent()) return;
       setNewlyCreatedKey(result.rawKey);
       setNewKeyName('');
-      await fetchKeys();
+      await fetchKeys(operation);
     } catch (err: unknown) {
+      if (!operation.isCurrent()) return;
       showError((err as Error)?.message || 'Failed to create API key');
     } finally {
-      setCreating(false);
+      if (operation.isCurrent()) setCreating(false);
     }
   };
 
   const handleDelete = async (id: string) => {
-    if (!client) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
     setDeletingId(id);
     try {
       await client.service('api/v1/user/api-keys').remove(id);
+      if (!operation.isCurrent()) return;
       showSuccess('API key revoked');
-      await fetchKeys();
+      await fetchKeys(operation);
     } catch (err: unknown) {
+      if (!operation.isCurrent()) return;
       showError((err as Error)?.message || 'Failed to delete API key');
     } finally {
-      setDeletingId(null);
+      if (operation.isCurrent()) setDeletingId(null);
     }
   };
 
   const handleCopy = async (text: string) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     const ok = await copyToClipboard(text);
+    if (!operation.isCurrent()) return;
     if (ok) {
       showSuccess('Copied to clipboard');
     } else {

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient } from '@agor-live/client';
 import { CopyOutlined, DeleteOutlined, KeyOutlined, PlusOutlined } from '@ant-design/icons';
-import { Alert, Button, Input, Modal, Popconfirm, Space, Table, Typography, theme } from 'antd';
+import { Alert, Button, Input, Popconfirm, Space, Table, Typography, theme } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import {
   type AuthorityOperation,

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
@@ -23,10 +23,15 @@ interface ApiKeyEntry {
 
 interface PersonalApiKeysTabProps {
   client: AgorClient | null;
-  authorityKey: string | null;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
 }
 
-export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client, authorityKey }) => {
+export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({
+  client,
+  identityKey,
+  operationScope,
+}) => {
   const [keys, setKeys] = useState<ApiKeyEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -37,7 +42,7 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client, 
   const [searchTerm, setSearchTerm] = useState('');
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
-  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
   // A full key is caller-private and is intentionally erased in layout, rather
   // than waiting for passive cleanup, when Settings changes identity in place.
@@ -48,7 +53,14 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client, 
     setShowCreateModal(false);
     setNewlyCreatedKey(null);
     setDeletingId(null);
-  }, [authorityKey]);
+  }, [identityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setLoading(false);
+    setCreating(false);
+    setDeletingId(null);
+  }, [operationScope]);
 
   const fetchKeys = useCallback(
     async (operation?: AuthorityOperation) => {

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
@@ -1,6 +1,6 @@
 import type { Repo } from '@agor-live/client';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { ReposTable } from './ReposTable';
 
 function makeRepo(overrides: Partial<Repo>): Repo {
@@ -41,7 +41,13 @@ describe('ReposTable search', () => {
       ],
     ]);
 
-    render(<ReposTable repoById={repoById} authorityKey="admin-a:admin" />);
+    render(
+      <ReposTable
+        repoById={repoById}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', 1]}
+      />
+    );
 
     fireEvent.change(screen.getByPlaceholderText(/Search name, slug, URL/i), {
       target: { value: 'preset-docs' },
@@ -50,5 +56,43 @@ describe('ReposTable search', () => {
     expect(screen.queryByText('Agor')).not.toBeInTheDocument();
     expect(screen.getByText('Docs Site')).toBeInTheDocument();
     expect(screen.getByText('preset-docs').tagName.toLowerCase()).toBe('mark');
+  });
+});
+
+describe('ReposTable authority fencing', () => {
+  it('preserves a same-user reconnect draft but does not close from the obsolete create', async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const onCreate = vi.fn(() => pending);
+    const view = (generation: number) => (
+      <ReposTable
+        repoById={new Map()}
+        identityKey="admin-a:admin"
+        operationScope={['admin-a:admin', generation]}
+        onCreate={onCreate}
+      />
+    );
+    const rendered = render(view(1));
+    fireEvent.click(screen.getByRole('button', { name: /new repository/i }));
+    const url = screen.getByPlaceholderText('https://github.com/apache/superset.git');
+    fireEvent.change(url, { target: { value: 'https://github.com/preset-io/agor.git' } });
+    fireEvent.change(screen.getByPlaceholderText('apache/superset'), {
+      target: { value: 'preset-io/agor' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^clone$/i }));
+    await waitFor(() => expect(onCreate).toHaveBeenCalledOnce());
+
+    rendered.rerender(view(2));
+    await act(async () => {
+      resolve();
+      await pending;
+    });
+
+    expect(screen.getByText('Clone Repository')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('https://github.com/apache/superset.git')).toHaveValue(
+      'https://github.com/preset-io/agor.git'
+    );
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
@@ -41,7 +41,7 @@ describe('ReposTable search', () => {
       ],
     ]);
 
-    render(<ReposTable repoById={repoById} />);
+    render(<ReposTable repoById={repoById} authorityKey="admin-a:admin" />);
 
     fireEvent.change(screen.getByPlaceholderText(/Search name, slug, URL/i), {
       target: { value: 'preset-docs' },

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -1,8 +1,9 @@
 import type { CreateLocalRepoRequest, CreateRepoRequest, Repo } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, FolderOutlined, PlusOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
-import { Button, Card, Empty, Form, Input, Space, Typography } from 'antd';
-import { useMemo, useState } from 'react';
+import { Button, Card, Empty, Form, Input, Modal, Space, Typography } from 'antd';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { mapToArray } from '@/utils/mapHelpers';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { RepoFormFields } from '../forms/RepoFormFields';
@@ -13,6 +14,7 @@ import { ResponsiveSettingsHeader } from './ResponsiveSettingsHeader';
 
 interface ReposTableProps {
   repoById: Map<string, Repo>;
+  authorityKey: string | null;
   onCreate?: (data: CreateRepoRequest) => void;
   onCreateLocal?: (data: CreateLocalRepoRequest) => void;
   onUpdate?: (repoId: string, updates: Partial<Repo>) => void;
@@ -21,6 +23,7 @@ interface ReposTableProps {
 
 export const ReposTable: React.FC<ReposTableProps> = ({
   repoById,
+  authorityKey,
   onCreate,
   onCreateLocal,
   onUpdate,
@@ -37,6 +40,17 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   const [repoForm] = Form.useForm();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [repoToDelete, setRepoToDelete] = useState<Repo | null>(null);
+  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey] : null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases the selected caller-private row
+  useLayoutEffect(() => {
+    repoForm.resetFields();
+    setRepoModalOpen(false);
+    setEditingRepo(null);
+    setRepoMode('remote');
+    setDeleteModalOpen(false);
+    setRepoToDelete(null);
+  }, [authorityKey, repoForm]);
 
   const isEditing = !!editingRepo;
   const filteredRepos = useMemo(
@@ -86,7 +100,10 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   };
 
   const handleSaveRepo = () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     repoForm.validateFields().then((values) => {
+      if (!operation.isCurrent()) return;
       if (isEditing && editingRepo) {
         const updates: Partial<Repo> = {
           slug: values.slug,

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -14,16 +14,29 @@ import { ResponsiveSettingsHeader } from './ResponsiveSettingsHeader';
 
 interface ReposTableProps {
   repoById: Map<string, Repo>;
-  authorityKey: string | null;
-  onCreate?: (data: CreateRepoRequest) => void;
-  onCreateLocal?: (data: CreateLocalRepoRequest) => void;
-  onUpdate?: (repoId: string, updates: Partial<Repo>) => void;
-  onDelete?: (repoId: string, cleanup: boolean) => void;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
+  onCreate?: (data: CreateRepoRequest, shouldApply?: () => boolean) => unknown;
+  onCreateLocal?: (
+    data: CreateLocalRepoRequest,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onUpdate?: (
+    repoId: string,
+    updates: Partial<Repo>,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDelete?: (
+    repoId: string,
+    cleanup: boolean,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
 }
 
 export const ReposTable: React.FC<ReposTableProps> = ({
   repoById,
-  authorityKey,
+  identityKey,
+  operationScope,
   onCreate,
   onCreateLocal,
   onUpdate,
@@ -40,7 +53,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   const [repoForm] = Form.useForm();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [repoToDelete, setRepoToDelete] = useState<Repo | null>(null);
-  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey] : null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases the selected caller-private row
   useLayoutEffect(() => {
@@ -50,7 +63,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
     setRepoMode('remote');
     setDeleteModalOpen(false);
     setRepoToDelete(null);
-  }, [authorityKey, repoForm]);
+  }, [identityKey, repoForm]);
 
   const isEditing = !!editingRepo;
   const filteredRepos = useMemo(
@@ -71,9 +84,11 @@ export const ReposTable: React.FC<ReposTableProps> = ({
     setDeleteModalOpen(true);
   };
 
-  const handleConfirmDelete = (cleanup: boolean) => {
-    if (repoToDelete) {
-      onDelete?.(repoToDelete.repo_id, cleanup);
+  const handleConfirmDelete = async (cleanup: boolean) => {
+    const operation = operationGuard.begin();
+    if (repoToDelete && operation.isCurrent()) {
+      await onDelete?.(repoToDelete.repo_id, cleanup, operation.isCurrent);
+      if (!operation.isCurrent()) return;
       setDeleteModalOpen(false);
       setRepoToDelete(null);
     }
@@ -99,10 +114,11 @@ export const ReposTable: React.FC<ReposTableProps> = ({
     setRepoModalOpen(true);
   };
 
-  const handleSaveRepo = () => {
+  const handleSaveRepo = async () => {
     const operation = operationGuard.begin();
     if (!operation.isCurrent()) return;
-    repoForm.validateFields().then((values) => {
+    try {
+      const values = await repoForm.validateFields();
       if (!operation.isCurrent()) return;
       if (isEditing && editingRepo) {
         const updates: Partial<Repo> = {
@@ -111,25 +127,33 @@ export const ReposTable: React.FC<ReposTableProps> = ({
         if (values.default_branch) {
           updates.default_branch = values.default_branch;
         }
-        onUpdate?.(editingRepo.repo_id, updates);
+        await onUpdate?.(editingRepo.repo_id, updates, operation.isCurrent);
       } else {
         if (repoMode === 'local') {
-          onCreateLocal?.({
-            path: values.path,
-            slug: values.slug || undefined,
-          });
+          await onCreateLocal?.(
+            { path: values.path, slug: values.slug || undefined },
+            operation.isCurrent
+          );
         } else {
-          onCreate?.({
-            url: values.url,
-            slug: values.slug,
-            default_branch: values.default_branch,
-          });
+          await onCreate?.(
+            {
+              url: values.url,
+              slug: values.slug,
+              default_branch: values.default_branch,
+            },
+            operation.isCurrent
+          );
         }
       }
+      if (!operation.isCurrent()) return;
       repoForm.resetFields();
       setEditingRepo(null);
       setRepoModalOpen(false);
-    });
+    } catch {
+      // Ant Design displays validation errors. Parent mutation errors already
+      // own their user-facing message; either way stale continuations do not
+      // close or clear a reconnect-preserved draft.
+    }
   };
 
   const handleCancelModal = () => {

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -1,7 +1,7 @@
 import type { CreateLocalRepoRequest, CreateRepoRequest, Repo } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, FolderOutlined, PlusOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
-import { Button, Card, Empty, Form, Input, Modal, Space, Typography } from 'antd';
+import { Button, Card, Empty, Form, Input, Space, Typography } from 'antd';
 import { useLayoutEffect, useMemo, useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { mapToArray } from '@/utils/mapHelpers';

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
@@ -10,7 +10,9 @@
 
 import type { User } from '@agor-live/client';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
+import { type SettingsSection, useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { SettingsModal } from './SettingsModal';
 
 vi.mock('./BoardsTable', () => ({ BoardsTable: () => <div data-testid="boards-table" /> }));
@@ -28,6 +30,29 @@ function renderNav(role: string, activeTab = 'boards') {
       currentUser={makeUser(role)}
       activeTab={activeTab}
     />
+  );
+}
+
+function RoutedSettings({ role }: { role: string }) {
+  const settingsRoute = useSettingsRoute();
+  return (
+    <SettingsModal
+      open={settingsRoute.isOpen}
+      onClose={settingsRoute.closeSettings}
+      client={null}
+      currentUser={makeUser(role)}
+      activeTab={settingsRoute.section}
+      onTabChange={(section) => settingsRoute.setSection(section as SettingsSection)}
+    />
+  );
+}
+
+/** Drive the same URL parser and section prop seam App uses in production. */
+function renderDeepLink(role: string, section: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/settings/${section}/`]}>
+      <RoutedSettings role={role} />
+    </MemoryRouter>
   );
 }
 
@@ -88,7 +113,7 @@ describe('SettingsModal deep-linked sections', () => {
   const contentPane = () => document.querySelector('.ant-layout-content');
 
   it('renders nothing for a viewer deep-linked to users', () => {
-    renderNav('viewer', 'users');
+    renderDeepLink('viewer', 'users');
 
     expect(contentPane()).toBeEmptyDOMElement();
   });
@@ -97,7 +122,7 @@ describe('SettingsModal deep-linked sections', () => {
     // `groups`, `gateway` and `agentic-tools` already had this shape before the
     // users entry was gated; one predicate now covers all four.
     for (const section of ['groups', 'gateway', 'agentic-tools']) {
-      const { unmount } = renderNav('member', section);
+      const { unmount } = renderDeepLink('member', section);
       expect(contentPane(), `${section} should not render for a member`).toBeEmptyDOMElement();
       unmount();
     }
@@ -105,11 +130,11 @@ describe('SettingsModal deep-linked sections', () => {
 
   it('still renders the sections each role may open', () => {
     // The positive control: without it, a guard that hid everything would pass.
-    const { unmount } = renderNav('member', 'users');
+    const { unmount } = renderDeepLink('member', 'users');
     expect(contentPane()).not.toBeEmptyDOMElement();
     unmount();
 
-    renderNav('admin', 'groups');
+    renderDeepLink('admin', 'groups');
     expect(contentPane()).not.toBeEmptyDOMElement();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
@@ -10,14 +10,19 @@
 
 import type { User } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { Grid } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type SettingsSection, useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { SettingsModal } from './SettingsModal';
 
 vi.mock('./BoardsTable', () => ({
   BoardsTable: () => <input aria-label="settings-private-draft" defaultValue="" />,
 }));
+
+beforeEach(() => {
+  vi.spyOn(Grid, 'useBreakpoint').mockReturnValue({ md: true });
+});
 
 function makeUser(role: string): User {
   return { user_id: `user-${role}`, email: `${role}@agor.live`, name: role, role } as User;
@@ -134,12 +139,12 @@ describe('SettingsModal deep-linked sections', () => {
    * message (GroupsTable renders "Only admins can manage groups."), so checking
    * for an absent table would pass whether or not the section is guarded.
    */
-  const contentPane = () => document.querySelector('.ant-layout-content');
+  const contentPane = () => document.querySelector('.ant-layout-content')?.firstElementChild;
 
   it('renders nothing for a viewer deep-linked to users', () => {
     renderDeepLink('viewer', 'users');
 
-    expect(contentPane()).toBeEmptyDOMElement();
+    expect(contentPane()).toBeNull();
   });
 
   it('renders nothing for a member deep-linked to an admin-only section', () => {
@@ -147,7 +152,7 @@ describe('SettingsModal deep-linked sections', () => {
     // users entry was gated; one predicate now covers all four.
     for (const section of ['groups', 'gateway', 'agentic-tools']) {
       const { unmount } = renderDeepLink('member', section);
-      expect(contentPane(), `${section} should not render for a member`).toBeEmptyDOMElement();
+      expect(contentPane(), `${section} should not render for a member`).toBeNull();
       unmount();
     }
   });
@@ -155,10 +160,10 @@ describe('SettingsModal deep-linked sections', () => {
   it('still renders the sections each role may open', () => {
     // The positive control: without it, a guard that hid everything would pass.
     const { unmount } = renderDeepLink('member', 'users');
-    expect(contentPane()).not.toBeEmptyDOMElement();
+    expect(contentPane()).not.toBeNull();
     unmount();
 
     renderDeepLink('admin', 'groups');
-    expect(contentPane()).not.toBeEmptyDOMElement();
+    expect(contentPane()).not.toBeNull();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
@@ -9,13 +9,15 @@
  */
 
 import type { User } from '@agor-live/client';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { type SettingsSection, useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { SettingsModal } from './SettingsModal';
 
-vi.mock('./BoardsTable', () => ({ BoardsTable: () => <div data-testid="boards-table" /> }));
+vi.mock('./BoardsTable', () => ({
+  BoardsTable: () => <input aria-label="settings-private-draft" defaultValue="" />,
+}));
 
 function makeUser(role: string): User {
   return { user_id: `user-${role}`, email: `${role}@agor.live`, name: role, role } as User;
@@ -62,6 +64,28 @@ function menuLabels(): string[] {
 }
 
 describe('SettingsModal navigation gating', () => {
+  it('destroys the settings state tree on a same-role identity replacement', () => {
+    const adminA = { ...makeUser('admin'), user_id: 'admin-a' } as User;
+    const adminB = { ...makeUser('admin'), user_id: 'admin-b' } as User;
+    const view = (currentUser: User) => (
+      <SettingsModal
+        open
+        onClose={vi.fn()}
+        client={null}
+        currentUser={currentUser}
+        activeTab="boards"
+      />
+    );
+    const rendered = render(view(adminA));
+    fireEvent.change(screen.getByLabelText('settings-private-draft'), {
+      target: { value: 'admin-a-private-value' },
+    });
+
+    rendered.rerender(view(adminB));
+
+    expect(screen.getByLabelText('settings-private-draft')).toHaveValue('');
+  });
+
   it('offers an admin both Groups and Users', () => {
     renderNav('admin');
 

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.nav.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Which settings sections each role is offered.
+ *
+ * The rule the nav has to encode is the daemon's, not a taste: an entry may
+ * appear only where the service behind it will answer. `users.find` takes
+ * MEMBER, so members keep the roster; `groups` is ADMIN-only; a viewer ranks
+ * below MEMBER and gets neither, which must also take the now-empty "Admin"
+ * heading with it.
+ */
+
+import type { User } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingsModal } from './SettingsModal';
+
+vi.mock('./BoardsTable', () => ({ BoardsTable: () => <div data-testid="boards-table" /> }));
+
+function makeUser(role: string): User {
+  return { user_id: `user-${role}`, email: `${role}@agor.live`, name: role, role } as User;
+}
+
+function renderNav(role: string, activeTab = 'boards') {
+  return render(
+    <SettingsModal
+      open
+      onClose={vi.fn()}
+      client={null}
+      currentUser={makeUser(role)}
+      activeTab={activeTab}
+    />
+  );
+}
+
+/** Menu entry labels, which is what "is this offered?" means here. */
+function menuLabels(): string[] {
+  return screen.getAllByRole('menuitem').map((item) => item.textContent?.trim() ?? '');
+}
+
+describe('SettingsModal navigation gating', () => {
+  it('offers an admin both Groups and Users', () => {
+    renderNav('admin');
+
+    expect(menuLabels()).toContain('Groups');
+    expect(menuLabels()).toContain('Users');
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('offers a member Users but not Groups', () => {
+    renderNav('member');
+
+    // Kept on purpose: the daemon serves members the roster, so hiding it would
+    // withhold something they are allowed to read.
+    expect(menuLabels()).toContain('Users');
+    expect(menuLabels()).not.toContain('Groups');
+  });
+
+  it('offers a viewer neither, and drops the empty Admin heading with them', () => {
+    renderNav('viewer');
+
+    expect(menuLabels()).not.toContain('Users');
+    expect(menuLabels()).not.toContain('Groups');
+    // An "Admin" group label with nothing under it is the bug this guards.
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+  });
+
+  it('keeps the admin-only integrations gated the way they already were', () => {
+    renderNav('member');
+
+    expect(menuLabels()).not.toContain('Agentic Tools');
+    expect(menuLabels()).not.toContain('Gateway Channels');
+    // MCP Servers stays: members may read the policy that constrains them.
+    expect(menuLabels()).toContain('MCP Servers');
+  });
+});
+
+/**
+ * Every gated section is routable through useSettingsRoute, so gating only the
+ * menu leaves the pane reachable by URL with nothing selected in the sidebar.
+ * The menu and the content read one predicate; these hold them together.
+ */
+describe('SettingsModal deep-linked sections', () => {
+  /**
+   * The settings content region. Asserting it is *empty* is what makes these
+   * mutation-sensitive: several panes already refuse a non-admin with their own
+   * message (GroupsTable renders "Only admins can manage groups."), so checking
+   * for an absent table would pass whether or not the section is guarded.
+   */
+  const contentPane = () => document.querySelector('.ant-layout-content');
+
+  it('renders nothing for a viewer deep-linked to users', () => {
+    renderNav('viewer', 'users');
+
+    expect(contentPane()).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a member deep-linked to an admin-only section', () => {
+    // `groups`, `gateway` and `agentic-tools` already had this shape before the
+    // users entry was gated; one predicate now covers all four.
+    for (const section of ['groups', 'gateway', 'agentic-tools']) {
+      const { unmount } = renderNav('member', section);
+      expect(contentPane(), `${section} should not render for a member`).toBeEmptyDOMElement();
+      unmount();
+    }
+  });
+
+  it('still renders the sections each role may open', () => {
+    // The positive control: without it, a guard that hid everything would pass.
+    const { unmount } = renderNav('member', 'users');
+    expect(contentPane()).not.toBeEmptyDOMElement();
+    unmount();
+
+    renderNav('admin', 'groups');
+    expect(contentPane()).not.toBeEmptyDOMElement();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -429,6 +429,7 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
         return (
           <ReposTable
             repoById={repoById}
+            authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
             onCreate={onCreateRepo}
             onCreateLocal={onCreateLocalRepo}
             onUpdate={onUpdateRepo}
@@ -500,7 +501,12 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
           />
         );
       case 'agentic-tools':
-        return <AgenticToolsSection client={client} />;
+        return (
+          <AgenticToolsSection
+            client={client}
+            authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+          />
+        );
       case 'gateway':
         return (
           <GatewayChannelsTable

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -32,7 +32,7 @@ import {
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Drawer, Flex, Grid, Layout, Menu, Modal, Select, Typography, theme } from 'antd';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { SETTINGS_SECTIONS, type SettingsSection } from '../../hooks/useSettingsRoute';
@@ -215,6 +215,38 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
   // policy and the servers they can already use.
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
 
+  // The Users tab follows the MCP Servers pattern rather than the Agentic Tools
+  // one: the daemon deliberately serves the roster to members
+  // (`ensureMinimumRole(params, ROLES.MEMBER, 'list users')`), so seeing who is
+  // on the team is not something to take away. UsersTable separately exposes
+  // only the mutations the current role has authority to perform.
+  //
+  // Viewers rank below MEMBER, so the listing itself would 403 for them; they
+  // get no entry at all.
+  const canListUsers = hasMinimumRole(currentUser?.role, ROLES.MEMBER);
+
+  // One answer for "may this role open this section", read by both the menu and
+  // the content below. Every gated section is routable via useSettingsRoute, so
+  // gating only the menu leaves the pane reachable by URL with nothing selected
+  // in the sidebar — which is what `groups`, `gateway` and `agentic-tools`
+  // already did. Deriving both from this set is what stops the two from
+  // drifting apart again the next time a section is gated.
+  const canSeeSection = useCallback(
+    (section: string): boolean => {
+      switch (section) {
+        case 'agentic-tools':
+        case 'gateway':
+        case 'groups':
+          return isAdmin;
+        case 'users':
+          return canListUsers;
+        default:
+          return true;
+      }
+    },
+    [isAdmin, canListUsers]
+  );
+
   // Menu items for left sidebar navigation
   const menuItems: MenuProps['items'] = useMemo(
     () => [
@@ -278,7 +310,7 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
         label: 'Integrations',
         type: 'group' as const,
         children: [
-          ...(isAdmin
+          ...(canSeeSection('agentic-tools')
             ? [
                 {
                   key: 'agentic-tools',
@@ -292,7 +324,7 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
             label: 'MCP Servers',
             icon: <ApiOutlined />,
           },
-          ...(isAdmin
+          ...(canSeeSection('gateway')
             ? [
                 {
                   key: 'gateway',
@@ -303,27 +335,37 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
             : []),
         ],
       },
-      {
-        key: 'admin',
-        label: 'Admin',
-        type: 'group' as const,
-        children: [
-          ...(isAdmin
-            ? [
-                {
-                  key: 'groups',
-                  label: 'Groups',
-                  icon: <TeamOutlined />,
-                },
-              ]
-            : []),
-          {
-            key: 'users',
-            label: 'Users',
-            icon: <TeamOutlined />,
-          },
-        ],
-      },
+      // Rendered only when it has something under it — an "Admin" heading with
+      // an empty body is what a viewer would otherwise get.
+      ...(canSeeSection('groups') || canSeeSection('users')
+        ? [
+            {
+              key: 'admin',
+              label: 'Admin',
+              type: 'group' as const,
+              children: [
+                ...(canSeeSection('groups')
+                  ? [
+                      {
+                        key: 'groups',
+                        label: 'Groups',
+                        icon: <TeamOutlined />,
+                      },
+                    ]
+                  : []),
+                ...(canSeeSection('users')
+                  ? [
+                      {
+                        key: 'users',
+                        label: 'Users',
+                        icon: <TeamOutlined />,
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          ]
+        : []),
       {
         key: 'system',
         label: 'System',
@@ -337,7 +379,7 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
         ],
       },
     ],
-    [isAdmin, token]
+    [canSeeSection, token]
   );
 
   const mobileSectionOptions = useMemo(
@@ -349,21 +391,25 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
       { label: 'Workspace · Cards (Beta)', value: 'cards' },
       { label: 'Workspace · Artifacts', value: 'artifacts' },
       { label: 'Integrations · MCP Servers', value: 'mcp' },
-      ...(isAdmin
-        ? [
-            { label: 'Integrations · Agentic Tools', value: 'agentic-tools' },
-            { label: 'Integrations · Gateway Channels', value: 'gateway' },
-            { label: 'Admin · Groups', value: 'groups' },
-          ]
+      ...(canSeeSection('agentic-tools')
+        ? [{ label: 'Integrations · Agentic Tools', value: 'agentic-tools' }]
         : []),
-      { label: 'Admin · Users', value: 'users' },
+      ...(canSeeSection('gateway')
+        ? [{ label: 'Integrations · Gateway Channels', value: 'gateway' }]
+        : []),
+      ...(canSeeSection('groups') ? [{ label: 'Admin · Groups', value: 'groups' }] : []),
+      ...(canSeeSection('users') ? [{ label: 'Admin · Users', value: 'users' }] : []),
       { label: 'System · About', value: 'about' },
     ],
-    [isAdmin]
+    [canSeeSection]
   );
 
   // Render content based on active section
   const renderContent = () => {
+    // A gated section is routable, so this is reachable by URL even with no
+    // menu entry to click. Same answer in both places.
+    if (!canSeeSection(activeTab)) return null;
+
     switch (activeTab) {
       case 'boards':
         return (

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -33,6 +33,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Button, Drawer, Flex, Grid, Layout, Menu, Modal, Select, Typography, theme } from 'antd';
 import { useCallback, useMemo, useState } from 'react';
+import { useAuthenticatedAuthorityScope } from '@/hooks/useAuthorityOperationGuard';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { SETTINGS_SECTIONS, type SettingsSection } from '../../hooks/useSettingsRoute';
@@ -79,10 +80,13 @@ export interface SettingsModalProps {
   onDeleteBoard?: (boardId: string) => void;
   onArchiveBoard?: (boardId: string) => void;
   onUnarchiveBoard?: (boardId: string) => void;
-  onCreateRepo?: (data: CreateRepoRequest) => unknown;
-  onCreateLocalRepo?: (data: CreateLocalRepoRequest) => void | Promise<void>;
-  onUpdateRepo?: (repoId: string, updates: Partial<Repo>) => void;
-  onDeleteRepo?: (repoId: string, cleanup: boolean) => void;
+  onCreateRepo?: (data: CreateRepoRequest, shouldApply?: () => boolean) => unknown;
+  onCreateLocalRepo?: (
+    data: CreateLocalRepoRequest,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onUpdateRepo?: (repoId: string, updates: Partial<Repo>, shouldApply?: () => boolean) => void;
+  onDeleteRepo?: (repoId: string, cleanup: boolean, shouldApply?: () => boolean) => void;
   onArchiveOrDeleteBranch?: (branchId: string, options: BranchArchiveOrDeleteOptions) => void;
   onUnarchiveBranch?: (branchId: string, options?: { boardId?: string }) => void;
   onUpdateBranch?: (branchId: string, updates: BranchUpdate) => void;
@@ -102,14 +106,25 @@ export interface SettingsModalProps {
   ) => Promise<Branch | null>;
   onStartEnvironment?: (branchId: string) => void;
   onStopEnvironment?: (branchId: string) => void;
-  onCreateUser?: (data: CreateUserInput) => Promise<void>;
-  onUpdateUser?: (userId: string, updates: UpdateUserInput) => Promise<void>;
-  onDeleteUser?: (userId: string) => void;
-  onCreateMCPServer?: (data: CreateMCPServerInput) => void;
-  onDeleteMCPServer?: (serverId: string) => void;
+  onCreateUser?: (data: CreateUserInput, shouldApply?: () => boolean) => void | Promise<void>;
+  onUpdateUser?: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDeleteUser?: (userId: string, shouldApply?: () => boolean) => void | Promise<void>;
+  onCreateMCPServer?: (
+    data: CreateMCPServerInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDeleteMCPServer?: (serverId: string, shouldApply?: () => boolean) => void | Promise<void>;
   onCreateGatewayChannel?: (data: GatewayChannelCreateData) => void;
-  onUpdateGatewayChannel?: (channelId: string, updates: GatewayChannelPatchData) => void;
-  onDeleteGatewayChannel?: (channelId: string) => void;
+  onUpdateGatewayChannel?: (
+    channelId: string,
+    updates: GatewayChannelPatchData,
+    shouldApply?: () => boolean
+  ) => void;
+  onDeleteGatewayChannel?: (channelId: string, shouldApply?: () => boolean) => void;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
   onCreateTeammate?: () => void;
@@ -167,6 +182,10 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
   const gatewayChannelById = useAgorStore(selectGatewayChannelById);
   const artifactById = useAgorStore(selectArtifactById);
   const boardObjects = useMemo(() => mapToArray(boardObjectById), [boardObjectById]);
+  const settingsAuthority = useAuthenticatedAuthorityScope(
+    client,
+    currentUser ? `${currentUser.user_id}:${currentUser.role}` : null
+  );
 
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
@@ -429,7 +448,8 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
         return (
           <ReposTable
             repoById={repoById}
-            authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+            identityKey={settingsAuthority.identityKey}
+            operationScope={settingsAuthority.operationScope}
             onCreate={onCreateRepo}
             onCreateLocal={onCreateLocalRepo}
             onUpdate={onUpdateRepo}
@@ -504,7 +524,8 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
         return (
           <AgenticToolsSection
             client={client}
-            authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+            identityKey={settingsAuthority.identityKey}
+            operationScope={settingsAuthority.operationScope}
           />
         );
       case 'gateway':

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -726,5 +726,14 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
 
 export const SettingsModal: React.FC<SettingsModalProps> = (props) => {
   if (!props.open) return null;
-  return <SettingsModalContent {...props} />;
+  // Settings contains other caller-private editors (gateway credentials,
+  // environment values, selected records) besides MCP. Destroy the whole
+  // modal state tree on an in-place identity replacement. Connection and
+  // token churn for the same user deliberately retain the tree.
+  return (
+    <SettingsModalContent
+      key={props.currentUser?.user_id ?? '__no-authenticated-user__'}
+      {...props}
+    />
+  );
 };

--- a/apps/agor-ui/src/components/SettingsModal/UploadsTab.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UploadsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UploadsTab } from './UploadsTab';
 
@@ -52,7 +52,7 @@ describe('UploadsTab', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<UploadsTab authorityKey="user-a:member" />);
+    render(<UploadsTab identityKey="user-a:member" operationScope={['user-a:member', 1]} />);
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith('http://daemon.test:3030/uploads', {
@@ -73,9 +73,57 @@ describe('UploadsTab', () => {
       vi.fn().mockResolvedValue(new Response('<!doctype html>', { status: 200 }))
     );
 
-    render(<UploadsTab authorityKey="user-a:member" />);
+    render(<UploadsTab identityKey="user-a:member" operationScope={['user-a:member', 1]} />);
 
     await waitFor(() => expect(showError).toHaveBeenCalledOnce());
     expect(showError.mock.calls[0]?.[0]).toMatch(/Unexpected token|JSON/);
+  });
+
+  it('discards an older generation response while allowing the reauthenticated reload', async () => {
+    let resolve!: (response: Response) => void;
+    const oldResponse = new Promise<Response>((done) => {
+      resolve = done;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => oldResponse)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ uploads: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const view = (generation: number) => (
+      <UploadsTab identityKey="user-a:member" operationScope={['user-a:member', generation]} />
+    );
+    const rendered = render(view(1));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    rendered.rerender(view(2));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolve(
+        new Response(
+          JSON.stringify({
+            uploads: [
+              {
+                ref: 'old-private-ref',
+                displayName: 'old-private-file.txt',
+                mimeType: 'text/plain',
+                size: 4,
+                provenance: 'browser',
+                createdAt: '2026-08-20T00:00:00.000Z',
+                expiresAt: null,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+      await oldResponse;
+    });
+    expect(screen.queryByText('old-private-file.txt')).not.toBeInTheDocument();
+    expect(showError).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UploadsTab.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UploadsTab.test.tsx
@@ -52,7 +52,7 @@ describe('UploadsTab', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<UploadsTab />);
+    render(<UploadsTab authorityKey="user-a:member" />);
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith('http://daemon.test:3030/uploads', {
@@ -73,7 +73,7 @@ describe('UploadsTab', () => {
       vi.fn().mockResolvedValue(new Response('<!doctype html>', { status: 200 }))
     );
 
-    render(<UploadsTab />);
+    render(<UploadsTab authorityKey="user-a:member" />);
 
     await waitFor(() => expect(showError).toHaveBeenCalledOnce());
     expect(showError.mock.calls[0]?.[0]).toMatch(/Unexpected token|JSON/);

--- a/apps/agor-ui/src/components/SettingsModal/UploadsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UploadsTab.tsx
@@ -35,17 +35,28 @@ async function fetchContent(upload: UploadRow): Promise<Blob> {
   return response.blob();
 }
 
-export function UploadsTab({ authorityKey }: { authorityKey: string | null }) {
+export function UploadsTab({
+  identityKey,
+  operationScope,
+}: {
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
+}) {
   const { showError } = useThemedMessage();
   const [uploads, setUploads] = useState<UploadRow[]>([]);
   const [loading, setLoading] = useState(false);
-  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey] : null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases the caller-private list
   useLayoutEffect(() => {
     setUploads([]);
     setLoading(false);
-  }, [authorityKey]);
+  }, [identityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setLoading(false);
+  }, [operationScope]);
 
   const refresh = useCallback(async () => {
     const operation = operationGuard.begin();

--- a/apps/agor-ui/src/components/SettingsModal/UploadsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UploadsTab.tsx
@@ -1,7 +1,8 @@
 import { DeleteOutlined, DownloadOutlined, EyeOutlined } from '@ant-design/icons';
 import { Button, Empty, Popconfirm, Space, Table, Tooltip, Typography } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 import { getAuthHeaders } from '../../utils/authHeaders';
 import { useThemedMessage } from '../../utils/message';
 import { SettingsActionGroup } from './SettingsActionGroup';
@@ -34,32 +35,50 @@ async function fetchContent(upload: UploadRow): Promise<Blob> {
   return response.blob();
 }
 
-export function UploadsTab() {
+export function UploadsTab({ authorityKey }: { authorityKey: string | null }) {
   const { showError } = useThemedMessage();
   const [uploads, setUploads] = useState<UploadRow[]>([]);
   const [loading, setLoading] = useState(false);
+  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey] : null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases the caller-private list
+  useLayoutEffect(() => {
+    setUploads([]);
+    setLoading(false);
+  }, [authorityKey]);
 
   const refresh = useCallback(async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     setLoading(true);
     try {
       const response = await fetch(uploadsUrl(), { headers: getAuthHeaders() });
+      if (!operation.isCurrent()) return;
       if (!response.ok) throw new Error('Unable to load uploads');
       const body = (await response.json()) as { uploads?: UploadRow[] };
+      if (!operation.isCurrent()) return;
       setUploads([...(body.uploads ?? [])].sort((a, b) => b.createdAt.localeCompare(a.createdAt)));
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(error instanceof Error ? error.message : 'Unable to load uploads');
     } finally {
-      setLoading(false);
+      if (operation.isCurrent()) setLoading(false);
     }
-  }, [showError]);
+  }, [operationGuard, showError]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
   const openBlob = async (upload: UploadRow, download: boolean) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       const url = URL.createObjectURL(await fetchContent(upload));
+      if (!operation.isCurrent()) {
+        URL.revokeObjectURL(url);
+        return;
+      }
       const anchor = document.createElement('a');
       anchor.href = url;
       if (download) anchor.download = upload.displayName;
@@ -68,35 +87,44 @@ export function UploadsTab() {
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(url), 60_000);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(error instanceof Error ? error.message : 'Upload is unavailable');
     }
   };
 
   const remove = async (upload: UploadRow) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       const response = await fetch(uploadsUrl(`/${encodeURIComponent(upload.ref)}`), {
         method: 'DELETE',
         headers: getAuthHeaders(),
       });
+      if (!operation.isCurrent()) return;
       if (!response.ok) throw new Error('Unable to delete upload');
       setUploads((current) => current.filter((item) => item.ref !== upload.ref));
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(error instanceof Error ? error.message : 'Unable to delete upload');
     }
   };
 
   const rename = async (upload: UploadRow, displayName: string) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       const response = await fetch(uploadsUrl(`/${encodeURIComponent(upload.ref)}`), {
         method: 'PATCH',
         headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ displayName }),
       });
+      if (!operation.isCurrent()) return;
       if (!response.ok) throw new Error('Unable to rename upload');
       setUploads((current) =>
         current.map((item) => (item.ref === upload.ref ? { ...item, displayName } : item))
       );
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(error instanceof Error ? error.message : 'Unable to rename upload');
     }
   };

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.test.tsx
@@ -1,0 +1,55 @@
+import type { AgorClient, UserAvatarSettings } from '@agor-live/client';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { UserAvatarsTab } from './UserAvatarsTab';
+
+describe('UserAvatarsTab authority fencing', () => {
+  it('does not apply an old auth-generation settings read', async () => {
+    let resolve!: (value: UserAvatarSettings) => void;
+    const oldRead = new Promise<UserAvatarSettings>((done) => {
+      resolve = done;
+    });
+    const getAvatarSettings = vi
+      .fn()
+      .mockImplementationOnce(() => oldRead)
+      .mockResolvedValueOnce({ enabled: false, provider: null, gateway_channel_id: null });
+    const client = {
+      service: (path: string) => {
+        if (path !== 'users') throw new Error(path);
+        return {
+          getAvatarSettings,
+          updateAvatarSettings: vi.fn(),
+          syncAvatars: vi.fn(),
+        };
+      },
+    } as unknown as AgorClient;
+    const view = (generation: number) => (
+      <AntApp>
+        <UserAvatarsTab
+          client={client}
+          gatewayChannelById={new Map()}
+          identityKey="admin-a:admin"
+          operationScope={['admin-a:admin', generation]}
+        />
+      </AntApp>
+    );
+    const rendered = render(view(1));
+    await waitFor(() => expect(getAvatarSettings).toHaveBeenCalledTimes(1));
+    rendered.rerender(view(2));
+    await waitFor(() => expect(getAvatarSettings).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolve({
+        enabled: true,
+        provider: 'slack',
+        gateway_channel_id: 'old-private-gateway',
+      });
+      await oldRead;
+    });
+
+    expect(
+      screen.getByRole('checkbox', { name: /Enable Slack-synced avatars/i })
+    ).not.toBeChecked();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
@@ -16,7 +16,8 @@ import { useThemedMessage } from '../../utils/message';
 interface UserAvatarsTabProps {
   client: AgorClient | null;
   gatewayChannelById: Map<string, GatewayChannel>;
-  authorityKey: string | null;
+  identityKey: string | null;
+  operationScope: readonly unknown[] | null;
 }
 
 type UsersAvatarClient = {
@@ -41,7 +42,8 @@ const DEFAULT_SETTINGS: UserAvatarSettings = {
 export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({
   client,
   gatewayChannelById,
-  authorityKey,
+  identityKey,
+  operationScope,
 }) => {
   const { showSuccess, showError } = useThemedMessage();
   const [settings, setSettings] = useState<UserAvatarSettings>(DEFAULT_SETTINGS);
@@ -50,7 +52,7 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [lastResult, setLastResult] = useState<UserAvatarSyncResult | null>(null);
-  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
+  const operationGuard = useAuthorityOperationGuard(operationScope);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases caller-specific status
   useLayoutEffect(() => {
@@ -60,7 +62,13 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({
     setLoading(false);
     setSyncing(false);
     setLastResult(null);
-  }, [authorityKey]);
+  }, [identityKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setLoading(false);
+    setSyncing(false);
+  }, [operationScope]);
 
   const slackGateways = useMemo(
     () =>

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
@@ -5,13 +5,18 @@ import type {
   UserAvatarSyncResult,
 } from '@agor-live/client';
 import { Alert, Button, Card, Checkbox, Flex, Select, Space, Typography } from 'antd';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
+import {
+  type AuthorityOperation,
+  useAuthorityOperationGuard,
+} from '../../hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '../../utils/message';
 
 interface UserAvatarsTabProps {
   client: AgorClient | null;
   gatewayChannelById: Map<string, GatewayChannel>;
+  authorityKey: string | null;
 }
 
 type UsersAvatarClient = {
@@ -33,7 +38,11 @@ const DEFAULT_SETTINGS: UserAvatarSettings = {
   gateway_channel_id: null,
 };
 
-export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayChannelById }) => {
+export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({
+  client,
+  gatewayChannelById,
+  authorityKey,
+}) => {
   const { showSuccess, showError } = useThemedMessage();
   const [settings, setSettings] = useState<UserAvatarSettings>(DEFAULT_SETTINGS);
   const [enabled, setEnabled] = useState(false);
@@ -41,6 +50,17 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [lastResult, setLastResult] = useState<UserAvatarSyncResult | null>(null);
+  const operationGuard = useAuthorityOperationGuard(authorityKey ? [authorityKey, client] : null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authorityKey intentionally erases caller-specific status
+  useLayoutEffect(() => {
+    setSettings(DEFAULT_SETTINGS);
+    setEnabled(false);
+    setGatewayId(null);
+    setLoading(false);
+    setSyncing(false);
+    setLastResult(null);
+  }, [authorityKey]);
 
   const slackGateways = useMemo(
     () =>
@@ -51,42 +71,57 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
   );
 
   useEffect(() => {
-    if (!client) return;
+    const operation = operationGuard.begin();
+    if (!client || !operation.isCurrent()) return;
     setLoading(true);
     usersAvatarClient(client)
       .getAvatarSettings({})
       .then((value) => {
+        if (!operation.isCurrent()) return;
         const next = value as unknown as UserAvatarSettings;
         setSettings(next);
         setEnabled(next.enabled);
         setGatewayId(next.gateway_channel_id);
         setLastResult(next.last_sync_result ?? null);
       })
-      .catch((error) => showError(`Failed to load avatar settings: ${error.message}`))
-      .finally(() => setLoading(false));
-  }, [client, showError]);
+      .catch((error) => {
+        if (operation.isCurrent()) showError(`Failed to load avatar settings: ${error.message}`);
+      })
+      .finally(() => {
+        if (operation.isCurrent()) setLoading(false);
+      });
+    return () => operation.cancel();
+  }, [client, operationGuard, showError]);
 
-  const save = async (nextEnabled = enabled, nextGatewayId = gatewayId) => {
-    if (!client) return;
+  const save = async (
+    operation: AuthorityOperation,
+    nextEnabled = enabled,
+    nextGatewayId = gatewayId
+  ) => {
+    if (!client || !operation.isCurrent()) return;
     const saved = (await usersAvatarClient(client).updateAvatarSettings({
       enabled: nextEnabled,
       provider: nextEnabled ? 'slack' : null,
       gateway_channel_id: nextEnabled ? nextGatewayId : null,
     } as Partial<UserAvatarSettings>)) as UserAvatarSettings;
+    if (!operation.isCurrent()) return;
     setSettings(saved);
     setEnabled(saved.enabled);
     setGatewayId(saved.gateway_channel_id);
   };
 
   const enableWithCurrentGateway = async (nextEnabled: boolean) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     const previousEnabled = enabled;
     setEnabled(nextEnabled);
     if (nextEnabled && !gatewayId) {
       return;
     }
     try {
-      await save(nextEnabled, gatewayId);
+      await save(operation, nextEnabled, gatewayId);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       setEnabled(previousEnabled);
       showError(
         `Failed to update avatar settings: ${error instanceof Error ? error.message : String(error)}`
@@ -95,14 +130,17 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
   };
 
   const selectGateway = async (nextGatewayId: string) => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     const previousGatewayId = gatewayId;
     setGatewayId(nextGatewayId);
     if (!enabled) {
       return;
     }
     try {
-      await save(true, nextGatewayId);
+      await save(operation, true, nextGatewayId);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       setGatewayId(previousGatewayId);
       showError(
         `Failed to update avatar settings: ${error instanceof Error ? error.message : String(error)}`
@@ -111,24 +149,28 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
   };
 
   const runSync = async () => {
-    if (!client || !gatewayId) return;
+    const operation = operationGuard.begin();
+    if (!client || !gatewayId || !operation.isCurrent()) return;
     setSyncing(true);
     try {
-      await save(true, gatewayId);
+      await save(operation, true, gatewayId);
+      if (!operation.isCurrent()) return;
       const result = (await usersAvatarClient(client).syncAvatars({
         gateway_channel_id: gatewayId,
       })) as UserAvatarSyncResult;
+      if (!operation.isCurrent()) return;
       setLastResult(result);
       showSuccess(
         `Synced Slack avatars: ${result.updated} updated, ${result.skipped} skipped, ` +
           `${result.failed} failed`
       );
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(
         `Slack avatar sync failed: ${error instanceof Error ? error.message : String(error)}`
       );
     } finally {
-      setSyncing(false);
+      if (operation.isCurrent()) setSyncing(false);
     }
   };
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1388,3 +1388,93 @@ afterEach(() => {
   agorStore.getState().setAgenticToolSettings([]);
   vi.unstubAllGlobals();
 });
+
+/**
+ * Administrative fields are not self-edit profile data. `role` and
+ * `unix_username` were seeded from the user and sent whenever their panel was
+ * dirty — and the panel in view is marked dirty on open. These pin the payload,
+ * because that is where the defect lived; a disabled field is not a request
+ * boundary.
+ */
+describe('UserSettingsModal — administrative fields in save payloads', () => {
+  it('omits role when a member saves their own profile', async () => {
+    const user = makeUser({ role: 'member', unix_username: 'bob' });
+    const onUpdate = vi.fn(async () => {});
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={user}
+        currentUser={user}
+        client={null as AgorClient | null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    // No edit at all: the Profile panel is dirty from opening on it, which is
+    // exactly the path that used to 403.
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    }, ASYNC);
+
+    const [, updates] = onUpdate.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(updates).not.toHaveProperty('role');
+    expect(updates).not.toHaveProperty('unix_username');
+    // The fields they may set still go, so this is a narrowing and not a mute.
+    expect(updates).toHaveProperty('name');
+    expect(updates).toHaveProperty('email');
+  });
+
+  it('does not submit the disabled role selector when an admin edits themselves', async () => {
+    const admin = makeUser({ role: 'admin' });
+    const onUpdate = vi.fn(async () => {});
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={admin}
+        currentUser={admin}
+        client={null as AgorClient | null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1), ASYNC);
+    const [, updates] = onUpdate.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(updates).not.toHaveProperty('role');
+    expect(updates).toHaveProperty('name');
+    expect(updates).toHaveProperty('email');
+  });
+
+  it('still sends role when an admin edits someone', async () => {
+    const target = makeUser({ user_id: 'user-2', role: 'member' });
+    const admin = makeUser({ user_id: 'user-1', role: 'admin' });
+    const onUpdate = vi.fn(async () => {});
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={target}
+        currentUser={admin}
+        client={null as AgorClient | null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    }, ASYNC);
+
+    const [, updates] = onUpdate.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(updates).toHaveProperty('role', 'member');
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { App as AntApp, ConfigProvider, type FormInstance, Grid } from 'antd';
 import { type ReactNode, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { agorStore } from '../../store/agorStore';
 import { UserSettingsModal } from './UserSettingsModal';
@@ -281,17 +282,21 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
     await waitFor(() => {
-      expect(onUpdate).toHaveBeenCalledWith('user-1', {
-        default_agentic_config: {
-          'claude-code': { permissionMode: 'acceptEdits' },
-          codex: { permissionMode: 'allow-all' },
+      expect(onUpdate).toHaveBeenCalledWith(
+        'user-1',
+        {
+          default_agentic_config: {
+            'claude-code': { permissionMode: 'acceptEdits' },
+            codex: { permissionMode: 'allow-all' },
+          },
+          default_agentic_selection: {
+            'claude-code': { source: 'inline' },
+            codex: { source: 'inline' },
+          },
+          default_mcp_server_ids: [],
         },
-        default_agentic_selection: {
-          'claude-code': { source: 'inline' },
-          codex: { source: 'inline' },
-        },
-        default_mcp_server_ids: [],
-      });
+        expect.any(Function)
+      );
     }, ASYNC);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -357,18 +362,22 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
     await waitFor(() => {
-      expect(onUpdate).toHaveBeenCalledWith('user-1', {
-        default_agentic_config: {
-          'claude-code': {
-            permissionMode: 'default',
-            modelConfig: { mode: 'alias', model: 'claude-opus-4-8' },
+      expect(onUpdate).toHaveBeenCalledWith(
+        'user-1',
+        {
+          default_agentic_config: {
+            'claude-code': {
+              permissionMode: 'default',
+              modelConfig: { mode: 'alias', model: 'claude-opus-4-8' },
+            },
           },
+          default_agentic_selection: {
+            'claude-code': { source: 'inline' },
+          },
+          default_mcp_server_ids: [],
         },
-        default_agentic_selection: {
-          'claude-code': { source: 'inline' },
-        },
-        default_mcp_server_ids: [],
-      });
+        expect.any(Function)
+      );
     }, ASYNC);
 
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -400,7 +409,8 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     await waitFor(() => {
       expect(onUpdate).toHaveBeenCalledWith(
         'user-1',
-        expect.objectContaining({ password: 'new-secure-password' })
+        expect.objectContaining({ password: 'new-secure-password' }),
+        expect.any(Function)
       );
     }, ASYNC);
 
@@ -1543,5 +1553,58 @@ describe('UserSettingsModal — administrative fields in save payloads', () => {
 
     const [, updates] = onUpdate.mock.calls[0] as unknown as [string, Record<string, unknown>];
     expect(updates).toHaveProperty('role', 'member');
+  });
+});
+
+describe('UserSettingsModal — socket authority generations', () => {
+  it('preserves a same-user password draft but never closes from an obsolete save', async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const onUpdate = vi.fn(() => pending);
+    const onClose = vi.fn();
+    const user = makeUser({ user_id: 'same-user', role: 'member' });
+    const view = (generation: number) => (
+      <ConfigProvider theme={{ hashed: false }}>
+        <AntApp>
+          <ConnectionProvider
+            value={{
+              connected: true,
+              connecting: false,
+              authGeneration: generation,
+              outOfSync: false,
+              capturedSha: null,
+              currentSha: null,
+            }}
+          >
+            <UserSettingsModal
+              open
+              onClose={onClose}
+              user={user}
+              currentUser={user}
+              client={null}
+              onUpdate={onUpdate}
+            />
+          </ConnectionProvider>
+        </AntApp>
+      </ConfigProvider>
+    );
+    const rendered = render(view(10));
+    fireEvent.click(screen.getByRole('menuitem', { name: /security/i }));
+    const password = await screen.findByPlaceholderText('••••••••');
+    fireEvent.change(password, { target: { value: 'same-user-password-draft' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledOnce(), ASYNC);
+
+    rendered.rerender(view(11));
+    await act(async () => {
+      resolve();
+      await pending;
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText('••••••••')).toHaveValue('same-user-password-draft');
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1109,11 +1109,12 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
   it('shows and saves the primary coding agent from Preferences', async () => {
     const user = makeUser({ primary_agentic_tool: 'codex' });
     const onUpdate = vi.fn(async () => {});
+    const onClose = vi.fn();
 
     renderWithApp(
       <UserSettingsModal
         open
-        onClose={vi.fn()}
+        onClose={onClose}
         user={user}
         currentUser={user}
         client={null as AgorClient | null}
@@ -1134,9 +1135,13 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     await waitFor(() => {
       expect(onUpdate).toHaveBeenCalledWith(
         user.user_id,
-        expect.objectContaining({ primary_agentic_tool: 'gemini' })
+        expect.objectContaining({ primary_agentic_tool: 'gemini' }),
+        expect.any(Function)
       );
     }, ASYNC);
+    const [, , shouldApply] = onUpdate.mock.calls[0] as unknown as [string, unknown, () => boolean];
+    expect(shouldApply()).toBe(true);
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it('opens a provider search hit on its own sub-tab (Session defaults, not Authentication)', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -372,7 +372,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
   });
 
   it('saves a new password from the Security panel and closes from the footer', async () => {
-    const user = makeUser();
+    const user = makeUser({ role: 'member', unix_username: 'member-home' });
     const onUpdate = vi.fn(async () => {});
     const onClose = vi.fn();
 
@@ -400,6 +400,12 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
         expect.objectContaining({ password: 'new-secure-password' })
       );
     }, ASYNC);
+
+    const [, updates] = onUpdate.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    // This is a dirty Security-panel save, not a Profile-only false positive:
+    // the stored admin-owned field is present in the form but must not cross
+    // the self-edit request boundary for a member.
+    expect(updates).not.toHaveProperty('unix_username');
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1,11 +1,14 @@
 import type { AgenticToolName, AgorClient, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp, ConfigProvider, type FormInstance, Grid } from 'antd';
 import { type ReactNode, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { agorStore } from '../../store/agorStore';
 import { UserSettingsModal } from './UserSettingsModal';
+
+const { syncGroupsForUser } = vi.hoisted(() => ({ syncGroupsForUser: vi.fn() }));
+vi.mock('./groupMembershipSync', () => ({ syncGroupsForUser }));
 
 vi.mock('../ApiKeyFields', () => ({
   ApiKeyFields: () => null,
@@ -969,6 +972,63 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(services).not.toContain('api/v1/user/api-keys');
   });
 
+  it('cancels group sync and onClose when caller identity changes during a multi-step save', async () => {
+    const adminA = makeUser({ user_id: 'admin-a', email: 'a@example.test', role: 'admin' });
+    const adminB = makeUser({ user_id: 'admin-b', email: 'b@example.test', role: 'admin' });
+    const target = makeUser({ user_id: 'target-user', email: 'target@example.test' });
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+    const onClose = vi.fn();
+    const client = {
+      service: (name: string) => ({
+        findAll: vi.fn(async () =>
+          name === 'groups'
+            ? [{ group_id: 'group-1', name: 'Engineering', slug: 'engineering' }]
+            : []
+        ),
+      }),
+    } as unknown as AgorClient;
+    let replaceCaller: (() => void) | undefined;
+
+    function Harness() {
+      const [caller, setCaller] = useState(adminA);
+      replaceCaller = () => setCaller(adminB);
+      return (
+        <UserSettingsModal
+          open
+          onClose={onClose}
+          user={target}
+          currentUser={caller}
+          client={client}
+          onUpdate={onUpdate}
+          initialTab="groups"
+        />
+      );
+    }
+
+    renderWithApp(<Harness />);
+    await screen.findByRole('heading', { name: 'Groups & access' });
+    await waitFor(() => expect(screen.getByLabelText('Groups')).toBeEnabled(), ASYNC);
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledOnce(), ASYNC);
+
+    // The first update was dispatched as A. Replace the caller after commit but
+    // before its promise continuation can read group form state or close B's UI.
+    act(() => replaceCaller?.());
+    resolveUpdate?.();
+    await act(async () => Promise.resolve());
+
+    expect(syncGroupsForUser).not.toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalledOnce();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Editing Admin')).toBeInTheDocument();
+  });
+
   it('falls back to Profile for a deep link to a tenant-disabled provider', async () => {
     // Gemini is disabled for the tenant, so `provider:gemini` is not a visible
     // panel; a stale deep link to it must not render its credential controls.
@@ -1386,6 +1446,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 // every tool enabled) before each test so provider panels render, and clear any
 // per-test override afterwards so visibility never leaks between tests.
 beforeEach(() => {
+  syncGroupsForUser.mockReset();
   __setAuthConfigForTests({ requireAuth: true });
   vi.spyOn(Grid, 'useBreakpoint').mockReturnValue({ md: true });
   agorStore.getState().setAgenticToolSettings([]);

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -62,9 +62,12 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
-import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
+import {
+  useAuthenticatedAuthorityScope,
+  useAuthorityOperationGuard,
+} from '../../hooks/useAuthorityOperationGuard';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById } from '../../store/selectors';
 import { buildAgenticToolCredentialPatch } from '../../utils/agenticToolCredentials';
@@ -252,8 +255,12 @@ export interface UserSettingsModalProps {
   user: User | null;
   client: AgorClient | null;
   currentUser?: User | null;
-  onUpdate?: (userId: string, updates: UpdateUserInput) => Promise<void>;
-  onRestartOnboarding?: () => void | Promise<void>;
+  onUpdate?: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onRestartOnboarding?: (shouldApply?: () => boolean) => void | Promise<void>;
   initialTab?: string;
 }
 
@@ -325,11 +332,18 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   const isSelf = !!user && !!currentUser && user.user_id === currentUser.user_id;
   const canEditTarget =
     !isEditingOther || (isAdmin && hasRoleAuthorityOver(currentUser?.role, user?.role));
-  const operationGuard = useAuthorityOperationGuard(
-    open && currentUser?.user_id && currentUser.role && user?.user_id
-      ? [currentUser.user_id, currentUser.role, user.user_id, client, canEditTarget]
-      : null
+  const callerIdentityKey = currentUser
+    ? `${currentUser.user_id}:${currentUser.role}:${user?.user_id ?? '__no-target__'}`
+    : null;
+  const callerAuthority = useAuthenticatedAuthorityScope(client, callerIdentityKey);
+  const operationScope = useMemo(
+    () =>
+      open && user?.user_id && callerAuthority.operationScope
+        ? [...callerAuthority.operationScope, user.user_id, canEditTarget]
+        : null,
+    [callerAuthority.operationScope, canEditTarget, open, user?.user_id]
   );
+  const operationGuard = useAuthorityOperationGuard(operationScope);
   const canAdministerTarget = isAdmin && canEditTarget;
   const canWriteIdentity = canEditTarget && identityWriteAvailable;
   const canWriteRole = canAdministerTarget && !isSelf && roleWriteAvailable;
@@ -442,6 +456,18 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   // Track which of those panels the user has edited so Save flushes ALL of them
   // — otherwise editing one panel and saving from another would drop the edit.
   const [dirtyMainPanels, setDirtyMainPanels] = useState<Set<string>>(() => new Set());
+
+  // Socket reauthentication preserves this same user's form drafts, but any
+  // spinner/result ownership belongs to the old authority generation. Release
+  // those locks synchronously so a stale finally block cannot wedge Settings.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: operationScope intentionally releases stale generation-owned UI locks
+  useLayoutEffect(() => {
+    setSavingModal(false);
+    setSavingToolField({});
+    setSavingEnvVars({});
+    setLoadingGroups(false);
+  }, [operationScope]);
+
   const markMainPanelDirty = useCallback((panel: string) => {
     setDirtyMainPanels((prev) => (prev.has(panel) ? prev : new Set(prev).add(panel)));
   }, []);
@@ -707,11 +733,15 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
           agenticFormByTool[mcpSourceTool].getFieldValue('mcpServerIds')) as string[] | undefined)
       : user.default_mcp_server_ids;
     if (!operation.isCurrent()) return;
-    await onUpdate?.(user.user_id, {
-      default_agentic_config: nextConfig,
-      default_agentic_selection: nextSelections,
-      default_mcp_server_ids: defaultMcpServerIds ?? [],
-    });
+    await onUpdate?.(
+      user.user_id,
+      {
+        default_agentic_config: nextConfig,
+        default_agentic_selection: nextSelections,
+        default_mcp_server_ids: defaultMcpServerIds ?? [],
+      },
+      operation.isCurrent
+    );
     if (!operation.isCurrent()) return;
 
     setDirtyAgenticConfigTools((prev) => {
@@ -811,7 +841,9 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       if (preferencesTouched) updates.preferences = nextPreferences;
 
       if (!operation.isCurrent()) return false;
-      if (Object.keys(updates).length > 0) await onUpdate?.(user.user_id, updates);
+      if (Object.keys(updates).length > 0) {
+        await onUpdate?.(user.user_id, updates, operation.isCurrent);
+      }
       if (!operation.isCurrent()) return false;
       if (panels.has('security')) form.setFieldValue('password', '');
       if (panels.has('access')) {
@@ -841,7 +873,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
       const patch = buildAgenticToolCredentialPatch(tool, field, value);
-      await onUpdate?.(user.user_id, patch);
+      await onUpdate?.(user.user_id, patch, operation.isCurrent);
       if (!operation.isCurrent()) return;
       if (patch.agentic_auth_methods) {
         setAgenticAuthMethods((current) => ({ ...current, ...patch.agentic_auth_methods }));
@@ -872,7 +904,11 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
 
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
-      await onUpdate?.(user.user_id, buildAgenticToolCredentialPatch(tool, field, null));
+      await onUpdate?.(
+        user.user_id,
+        buildAgenticToolCredentialPatch(tool, field, null),
+        operation.isCurrent
+      );
       if (!operation.isCurrent()) return;
       setAgenticToolStatus((prev) => {
         const nextToolFields = { ...(prev[tool] ?? {}) };
@@ -899,7 +935,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     const next = { ...agenticAuthMethods, [tool]: method };
     setAgenticAuthMethods(next);
     try {
-      await onUpdate?.(user.user_id, { agentic_auth_methods: next });
+      await onUpdate?.(user.user_id, { agentic_auth_methods: next }, operation.isCurrent);
     } catch (error) {
       if (!operation.isCurrent()) return;
       setAgenticAuthMethods(user.agentic_auth_methods ?? {});
@@ -914,10 +950,14 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
 
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
-      await onUpdate?.(user.user_id, {
-        env_vars: { [key]: value },
-        env_var_scopes: { [key]: scope },
-      });
+      await onUpdate?.(
+        user.user_id,
+        {
+          env_vars: { [key]: value },
+          env_var_scopes: { [key]: scope },
+        },
+        operation.isCurrent
+      );
       if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => ({
         ...prev,
@@ -938,9 +978,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     if (!user || !operation.isCurrent()) return;
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
-      await onUpdate?.(user.user_id, {
-        env_var_scopes: { [key]: scope },
-      });
+      await onUpdate?.(user.user_id, { env_var_scopes: { [key]: scope } }, operation.isCurrent);
       if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => ({
         ...prev,
@@ -962,9 +1000,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
 
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
-      await onUpdate?.(user.user_id, {
-        env_vars: { [key]: null },
-      });
+      await onUpdate?.(user.user_id, { env_vars: { [key]: null } }, operation.isCurrent);
       if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => {
         const updated = { ...prev };
@@ -1607,6 +1643,15 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     }
   };
 
+  const handleRestartOnboarding = async () => {
+    const operation = operationGuard.begin();
+    if (!onRestartOnboarding || !operation.isCurrent()) return;
+    await onRestartOnboarding(operation.isCurrent);
+    // The owner callback may close Settings/open another surface only while
+    // this exact authority cycle is still current; stale children do nothing.
+    if (!operation.isCurrent()) return;
+  };
+
   const renderProfilePanel = () => (
     <>
       <PanelHeader title={PANEL_META.profile.title} />
@@ -1691,7 +1736,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
             description="This clears saved wizard progress and opens onboarding again."
             okText="Restart"
             cancelText="Cancel"
-            onConfirm={onRestartOnboarding}
+            onConfirm={handleRestartOnboarding}
           >
             <Button>Restart onboarding</Button>
           </Popconfirm>
@@ -1846,6 +1891,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         }
       />
       <EnvVarEditor
+        identityKey={callerIdentityKey}
+        operationScope={operationScope}
         envVars={userEnvVars}
         onSave={handleEnvVarSave}
         onScopeChange={handleEnvVarScopeChange}
@@ -2078,6 +2125,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         ) : tool === 'codex' ? (
           <CodexAuthSettings
             client={client}
+            identityKey={callerIdentityKey}
+            operationScope={operationScope}
             authMethod={authMethod ?? 'api_key'}
             allowChatgptLogin={isSelf}
             apiKeyFields={allToolFields}
@@ -2114,6 +2163,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
               </FieldRow>
             )}
             <ApiKeyFields
+              identityKey={callerIdentityKey}
+              operationScope={operationScope}
               tool={tool}
               fields={toolFields}
               fieldStatus={fieldStatus}
@@ -2178,7 +2229,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
             </Typography.Paragraph>
             <PersonalApiKeysTab
               client={client}
-              authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+              identityKey={callerIdentityKey}
+              operationScope={operationScope}
             />
           </>
         );
@@ -2186,9 +2238,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         return (
           <>
             <PanelHeader title={PANEL_META.uploads.title} />
-            <UploadsTab
-              authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
-            />
+            <UploadsTab identityKey={callerIdentityKey} operationScope={operationScope} />
           </>
         );
       case 'access':
@@ -2441,7 +2491,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
  */
 export const UserSettingsModal: React.FC<UserSettingsModalProps> = (props) => (
   <UserSettingsModalForIdentity
-    key={`${props.currentUser?.user_id ?? '__no-authenticated-user__'}:${props.user?.user_id ?? '__no-target-user__'}`}
+    key={`${props.currentUser?.user_id ?? '__no-authenticated-user__'}:${props.currentUser?.role ?? '__no-authenticated-role__'}:${props.user?.user_id ?? '__no-target-user__'}:${props.user?.role ?? '__no-target-role__'}`}
     {...props}
   />
 );

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -64,6 +64,7 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById } from '../../store/selectors';
 import { buildAgenticToolCredentialPatch } from '../../utils/agenticToolCredentials';
@@ -324,6 +325,11 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   const isSelf = !!user && !!currentUser && user.user_id === currentUser.user_id;
   const canEditTarget =
     !isEditingOther || (isAdmin && hasRoleAuthorityOver(currentUser?.role, user?.role));
+  const operationGuard = useAuthorityOperationGuard(
+    open && currentUser?.user_id && currentUser.role && user?.user_id
+      ? [currentUser.user_id, currentUser.role, user.user_id, client, canEditTarget]
+      : null
+  );
   const canAdministerTarget = isAdmin && canEditTarget;
   const canWriteIdentity = canEditTarget && identityWriteAvailable;
   const canWriteRole = canAdministerTarget && !isSelf && roleWriteAvailable;
@@ -477,7 +483,9 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   );
 
   const loadUserGroups = useCallback(async () => {
+    const operation = operationGuard.begin();
     const userId = user?.user_id;
+    if (!operation.isCurrent()) return;
     if (!client || !userId || !canAdministerTarget) {
       setAvailableGroups([]);
       setUserGroupIds([]);
@@ -493,6 +501,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         client.service('groups').findAll({ query: { archived: false } }),
         client.service('group-memberships').findAll({ query: { user_id: userId } }),
       ]);
+      if (!operation.isCurrent()) return;
       const nextGroupIds = (memberships as GroupMembership[]).map(
         (membership) => membership.group_id
       );
@@ -501,11 +510,12 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       setGroupsLoaded(true);
       form.setFieldValue('groupIds', nextGroupIds);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       console.error('Failed to load user groups:', error);
     } finally {
-      setLoadingGroups(false);
+      if (operation.isCurrent()) setLoadingGroups(false);
     }
-  }, [canAdministerTarget, client, form, user?.user_id]);
+  }, [canAdministerTarget, client, form, operationGuard, user?.user_id]);
 
   // Initialize when modal opens with user data
   useEffect(() => {
@@ -640,9 +650,15 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     onClose();
   };
 
-  const syncUserGroups = async (nextGroupIds: string[]) => {
-    if (!client || !user || !canAdministerTarget || !groupsLoaded) return;
+  const syncUserGroups = async (
+    nextGroupIds: string[],
+    operation: ReturnType<typeof operationGuard.begin>
+  ) => {
+    if (!client || !user || !canAdministerTarget || !groupsLoaded || !operation.isCurrent()) {
+      return;
+    }
     await syncGroupsForUser(client, user.user_id, userGroupIds, nextGroupIds);
+    if (!operation.isCurrent()) return;
     setUserGroupIds(nextGroupIds);
   };
 
@@ -653,8 +669,11 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     ] satisfies AgenticToolName[]),
   ];
 
-  const saveAgenticConfigs = async (tools: AgenticToolName[]) => {
-    if (!user || tools.length === 0) return;
+  const saveAgenticConfigs = async (
+    tools: AgenticToolName[],
+    operation: ReturnType<typeof operationGuard.begin>
+  ) => {
+    if (!user || tools.length === 0 || !operation.isCurrent()) return;
 
     const nextConfig: NonNullable<UpdateUserInput['default_agentic_config']> = {
       ...(user.default_agentic_config ?? {}),
@@ -687,11 +706,13 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       ? ((agenticConfigDraftByTool[mcpSourceTool]?.mcpServerIds ??
           agenticFormByTool[mcpSourceTool].getFieldValue('mcpServerIds')) as string[] | undefined)
       : user.default_mcp_server_ids;
+    if (!operation.isCurrent()) return;
     await onUpdate?.(user.user_id, {
       default_agentic_config: nextConfig,
       default_agentic_selection: nextSelections,
       default_mcp_server_ids: defaultMcpServerIds ?? [],
     });
+    if (!operation.isCurrent()) return;
 
     setDirtyAgenticConfigTools((prev) => {
       if (prev.size === 0) return prev;
@@ -711,8 +732,9 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     if (mcpEditSourceTool && tools.includes(mcpEditSourceTool)) setMcpEditSourceTool(null);
   };
 
-  const saveDirtyAgenticConfigs = async () => {
-    await saveAgenticConfigs(getAgenticConfigToolsToSave());
+  const saveDirtyAgenticConfigs = async (operation: ReturnType<typeof operationGuard.begin>) => {
+    if (!operation.isCurrent()) return;
+    await saveAgenticConfigs(getAgenticConfigToolsToSave(), operation);
   };
 
   // Profile panel: identity fields + Slack-avatar preference.
@@ -720,8 +742,11 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   // `preferences` object here (rather than one patch per panel) is what keeps a
   // Profile edit and a Preferences edit from clobbering each other's keys when
   // both are flushed against the same not-yet-refreshed `user` prop.
-  const commitMainPanels = async (panels: Set<string>): Promise<boolean> => {
-    if (!user || !canEditTarget) return false;
+  const commitMainPanels = async (
+    panels: Set<string>,
+    operation: ReturnType<typeof operationGuard.begin>
+  ): Promise<boolean> => {
+    if (!user || !canEditTarget || !operation.isCurrent()) return false;
 
     try {
       const toValidate: string[] = [];
@@ -732,6 +757,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         toValidate.push('password');
       }
       if (toValidate.length) await form.validateFields(toValidate);
+      if (!operation.isCurrent()) return false;
 
       const updates: UpdateUserInput = {};
       const nextPreferences: NonNullable<UpdateUserInput['preferences']> = { ...user.preferences };
@@ -784,11 +810,17 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
 
       if (preferencesTouched) updates.preferences = nextPreferences;
 
+      if (!operation.isCurrent()) return false;
       if (Object.keys(updates).length > 0) await onUpdate?.(user.user_id, updates);
+      if (!operation.isCurrent()) return false;
       if (panels.has('security')) form.setFieldValue('password', '');
-      if (panels.has('access')) await syncUserGroups(form.getFieldValue('groupIds') || []);
-      return true;
+      if (panels.has('access')) {
+        if (!operation.isCurrent()) return false;
+        await syncUserGroups(form.getFieldValue('groupIds') || [], operation);
+      }
+      return operation.isCurrent();
     } catch (err) {
+      if (!operation.isCurrent()) return false;
       console.error('Failed to save settings:', err);
       return false;
     }
@@ -802,13 +834,15 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     field: AgenticToolConfigField,
     value: string
   ): Promise<void> => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
     const spinnerKey = `${tool}.${field}`;
 
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
       const patch = buildAgenticToolCredentialPatch(tool, field, value);
       await onUpdate?.(user.user_id, patch);
+      if (!operation.isCurrent()) return;
       if (patch.agentic_auth_methods) {
         setAgenticAuthMethods((current) => ({ ...current, ...patch.agentic_auth_methods }));
       }
@@ -817,10 +851,13 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         [tool]: { ...(prev[tool] ?? {}), [field]: true },
       }));
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to save ${tool}.${field}:`, err);
       throw err;
     } finally {
-      setSavingToolField((prev) => ({ ...prev, [spinnerKey]: false }));
+      if (operation.isCurrent()) {
+        setSavingToolField((prev) => ({ ...prev, [spinnerKey]: false }));
+      }
     }
   };
 
@@ -829,22 +866,27 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     tool: AgenticToolName,
     field: AgenticToolConfigField
   ): Promise<void> => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
     const spinnerKey = `${tool}.${field}`;
 
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
       await onUpdate?.(user.user_id, buildAgenticToolCredentialPatch(tool, field, null));
+      if (!operation.isCurrent()) return;
       setAgenticToolStatus((prev) => {
         const nextToolFields = { ...(prev[tool] ?? {}) };
         delete nextToolFields[field];
         return { ...prev, [tool]: nextToolFields };
       });
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to clear ${tool}.${field}:`, err);
       throw err;
     } finally {
-      setSavingToolField((prev) => ({ ...prev, [spinnerKey]: false }));
+      if (operation.isCurrent()) {
+        setSavingToolField((prev) => ({ ...prev, [spinnerKey]: false }));
+      }
     }
   };
 
@@ -852,12 +894,14 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
     tool: 'claude-code' | 'codex',
     method: AgenticAuthMethod
   ) => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
     const next = { ...agenticAuthMethods, [tool]: method };
     setAgenticAuthMethods(next);
     try {
       await onUpdate?.(user.user_id, { agentic_auth_methods: next });
     } catch (error) {
+      if (!operation.isCurrent()) return;
       setAgenticAuthMethods(user.agentic_auth_methods ?? {});
       throw error;
     }
@@ -865,7 +909,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
 
   // Handle env var save (value + scope). v0.5 env-var-access.
   const handleEnvVarSave = async (key: string, value: string, scope: EnvVarScope) => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
 
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
@@ -873,69 +918,82 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         env_vars: { [key]: value },
         env_var_scopes: { [key]: scope },
       });
+      if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => ({
         ...prev,
         [key]: { set: true, scope, resource_id: null },
       }));
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to save ${key}:`, err);
       throw err;
     } finally {
-      setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
+      if (operation.isCurrent()) setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
     }
   };
 
   // Handle scope change for an existing env var (no value rotation).
   const handleEnvVarScopeChange = async (key: string, scope: EnvVarScope) => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
       await onUpdate?.(user.user_id, {
         env_var_scopes: { [key]: scope },
       });
+      if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => ({
         ...prev,
         [key]: { ...(prev[key] ?? { set: true }), set: true, scope, resource_id: null },
       }));
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to update scope for ${key}:`, err);
       throw err;
     } finally {
-      setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
+      if (operation.isCurrent()) setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
     }
   };
 
   // Handle env var delete
   const handleEnvVarDelete = async (key: string) => {
-    if (!user) return;
+    const operation = operationGuard.begin();
+    if (!user || !operation.isCurrent()) return;
 
     try {
       setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
       await onUpdate?.(user.user_id, {
         env_vars: { [key]: null },
       });
+      if (!operation.isCurrent()) return;
       setUserEnvVars((prev) => {
         const updated = { ...prev };
         delete updated[key];
         return updated;
       });
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to delete ${key}:`, err);
       throw err;
     } finally {
-      setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
+      if (operation.isCurrent()) setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
     }
   };
 
   // Handle agentic tool config save. The footer's shared saving state guards the
   // in-flight UI; this only needs to flush the dirty tools and surface errors.
-  const handleAgenticConfigSave = async (tool: AgenticToolName) => {
-    if (!user) return;
+  const handleAgenticConfigSave = async (
+    tool: AgenticToolName,
+    operation = operationGuard.begin()
+  ) => {
+    if (!user || !operation.isCurrent()) return;
 
     try {
       await agenticFormByTool[tool].validateFields();
-      await saveAgenticConfigs(getAgenticConfigToolsToSave(tool));
+      if (!operation.isCurrent()) return;
+      await saveAgenticConfigs(getAgenticConfigToolsToSave(tool), operation);
     } catch (err) {
+      if (!operation.isCurrent()) return;
       console.error(`Failed to save ${tool} config:`, err);
       throw err;
     }
@@ -1520,6 +1578,8 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   // from another provider before closing.
   const handleModalSave = async () => {
     if (!user || savingModal || !canEditTarget) return;
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     setSavingModal(true);
     try {
       // Flush EVERY edited main panel (plus the active one if it owns the shared
@@ -1530,18 +1590,20 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       if (MAIN_FORM_KEYS.includes(activeKey as (typeof MAIN_FORM_KEYS)[number])) {
         mainPanels.add(activeKey);
       }
-      if (mainPanels.size > 0 && !(await commitMainPanels(mainPanels))) return;
+      if (mainPanels.size > 0 && !(await commitMainPanels(mainPanels, operation))) return;
+      if (!operation.isCurrent()) return;
 
       // Then persist agentic configs once: the active provider's session
       // defaults plus any dirty defaults left over from other provider tabs.
       if (activeTool && providerSubtab === 'defaults') {
-        await handleAgenticConfigSave(activeTool);
+        await handleAgenticConfigSave(activeTool, operation);
       } else {
-        await saveDirtyAgenticConfigs();
+        await saveDirtyAgenticConfigs(operation);
       }
+      if (!operation.isCurrent()) return;
       handleClose();
     } finally {
-      setSavingModal(false);
+      if (operation.isCurrent()) setSavingModal(false);
     }
   };
 
@@ -2114,14 +2176,19 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
               Agor API tokens allow you to authenticate with the Agor API from scripts, CI
               pipelines, and external tools. Tokens have the same permissions as your user account.
             </Typography.Paragraph>
-            <PersonalApiKeysTab client={client} />
+            <PersonalApiKeysTab
+              client={client}
+              authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+            />
           </>
         );
       case 'uploads':
         return (
           <>
             <PanelHeader title={PANEL_META.uploads.title} />
-            <UploadsTab />
+            <UploadsTab
+              authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+            />
           </>
         );
       case 'access':

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -256,7 +256,7 @@ export interface UserSettingsModalProps {
   initialTab?: string;
 }
 
-export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
+const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
   open,
   onClose,
   user,
@@ -2365,3 +2365,16 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     </Modal>
   );
 };
+
+/**
+ * Provider tokens, personal environment values, API keys, and Ant Form drafts
+ * are private to both the authenticated caller and the selected target. A
+ * launch-auth identity replacement must destroy them even when both callers
+ * have the same role; same-user reconnects retain the stable key.
+ */
+export const UserSettingsModal: React.FC<UserSettingsModalProps> = (props) => (
+  <UserSettingsModalForIdentity
+    key={`${props.currentUser?.user_id ?? '__no-authenticated-user__'}:${props.user?.user_id ?? '__no-target-user__'}`}
+    {...props}
+  />
+);

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
@@ -45,6 +45,17 @@ describe('UsersTable role authority', () => {
     __setAuthConfigForTests({ requireAuth: true });
   });
 
+  it('offers a member only their own edit action', () => {
+    const member = user('member', 'member');
+    const other = user('other', 'member');
+    renderTable(member, [member, other]);
+
+    expect(screen.getByLabelText('Edit member@example.test')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Edit other@example.test')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Delete /)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /new user/i })).not.toBeInTheDocument();
+  });
+
   it('hides superadmin mutation actions from admins but keeps member actions', () => {
     const admin = user('admin', 'admin');
     const superadmin = user('superadmin', 'superadmin');

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
@@ -1,8 +1,9 @@
 import type { User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp, ConfigProvider } from 'antd';
 import type { ComponentProps } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { UsersTable } from './UsersTable';
 
@@ -139,5 +140,56 @@ describe('UsersTable role authority', () => {
     expect(screen.getByLabelText('Edit admin@example.test')).toBeInTheDocument();
     expect(screen.getByLabelText('Edit member@example.test')).toBeInTheDocument();
     expect(screen.queryByLabelText('Delete member@example.test')).not.toBeInTheDocument();
+  });
+
+  it('preserves a same-admin create draft but drops the obsolete completion on reauth', async () => {
+    const admin = user('admin', 'admin');
+    let resolve!: () => void;
+    const pending = new Promise<void>((done) => {
+      resolve = done;
+    });
+    const onCreate = vi.fn(() => pending);
+    const view = (generation: number) => (
+      <ConfigProvider theme={{ hashed: false }}>
+        <AntApp>
+          <ConnectionProvider
+            value={{
+              connected: true,
+              connecting: false,
+              authGeneration: generation,
+              outOfSync: false,
+              capturedSha: null,
+              currentSha: null,
+            }}
+          >
+            <UsersTable
+              userById={new Map([[admin.user_id, admin]])}
+              client={null}
+              currentUser={admin}
+              onCreate={onCreate}
+            />
+          </ConnectionProvider>
+        </AntApp>
+      </ConfigProvider>
+    );
+    const rendered = render(view(30));
+    fireEvent.click(screen.getByRole('button', { name: /new user/i }));
+    fireEvent.change(screen.getByPlaceholderText('user@example.com'), {
+      target: { value: 'new-user@example.test' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'new-user-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+    await waitFor(() => expect(onCreate).toHaveBeenCalledOnce());
+
+    rendered.rerender(view(31));
+    await act(async () => {
+      resolve();
+      await pending;
+    });
+
+    expect(screen.getByText('Create User')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toHaveValue('new-user-password');
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -39,7 +39,10 @@ import {
 } from '@/utils/passwordPolicy';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
-import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
+import {
+  useAuthenticatedAuthorityScope,
+  useAuthorityOperationGuard,
+} from '../../hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '../../utils/message';
 import { HighlightMatch } from '../HighlightMatch';
 import { UserIdentityAvatar } from '../UserIdentityAvatar';
@@ -54,9 +57,14 @@ interface UsersTableProps {
   gatewayChannelById?: Map<string, GatewayChannel>;
   client: AgorClient | null;
   currentUser?: User | null;
-  onCreate?: (data: CreateUserInput) => Promise<void>;
-  onUpdate?: (userId: string, updates: UpdateUserInput) => Promise<void>;
-  onDelete?: (userId: string) => void;
+  onCreate?: (data: CreateUserInput, shouldApply?: () => boolean) => void | Promise<void>;
+  onUpdate?: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => void | Promise<void>;
+  onDelete?: (userId: string, shouldApply?: () => boolean) => void | Promise<void>;
+
 }
 
 export const UsersTable: React.FC<UsersTableProps> = ({
@@ -77,9 +85,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
-  const operationGuard = useAuthorityOperationGuard(
-    currentUser ? [currentUser.user_id, currentUser.role, client] : null
+  const callerAuthority = useAuthenticatedAuthorityScope(
+    client,
+    currentUser ? `${currentUser.user_id}:${currentUser.role}` : null
   );
+  const operationGuard = useAuthorityOperationGuard(callerAuthority.operationScope);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: authenticated identity and role intentionally erase password-bearing forms
   useLayoutEffect(() => {
@@ -171,7 +181,9 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   }, [userById, searchTerm, groupsByUser, groupById]);
 
   const handleDelete = (userId: string) => {
-    onDelete?.(userId);
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
+    onDelete?.(userId, operation.isCurrent);
   };
 
   const handleCreate = async () => {
@@ -180,14 +192,17 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     try {
       const values = await form.validateFields();
       if (!operation.isCurrent()) return;
-      await onCreate?.({
-        email: values.email,
-        password: values.password,
-        name: values.name,
-        role: values.role || ROLES.MEMBER,
-        unix_username: values.unix_username,
-        must_change_password: values.must_change_password || false,
-      });
+      await onCreate?.(
+        {
+          email: values.email,
+          password: values.password,
+          name: values.name,
+          role: values.role || ROLES.MEMBER,
+          unix_username: values.unix_username,
+          must_change_password: values.must_change_password || false,
+        },
+        operation.isCurrent
+      );
       if (!operation.isCurrent()) return;
       form.resetFields();
       setCreateModalOpen(false);
@@ -465,7 +480,8 @@ export const UsersTable: React.FC<UsersTableProps> = ({
                   <UserAvatarsTab
                     client={client}
                     gatewayChannelById={gatewayChannelById}
-                    authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+                    identityKey={callerAuthority.identityKey}
+                    operationScope={callerAuthority.operationScope}
                   />
                 ),
               },

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -64,7 +64,6 @@ interface UsersTableProps {
     shouldApply?: () => boolean
   ) => void | Promise<void>;
   onDelete?: (userId: string, shouldApply?: () => boolean) => void | Promise<void>;
-
 }
 
 export const UsersTable: React.FC<UsersTableProps> = ({

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -30,7 +30,7 @@ import {
   Tag,
   Typography,
 } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import {
   passwordPolicyHelp,
@@ -39,6 +39,7 @@ import {
 } from '@/utils/passwordPolicy';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
+import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '../../utils/message';
 import { HighlightMatch } from '../HighlightMatch';
 import { UserIdentityAvatar } from '../UserIdentityAvatar';
@@ -76,6 +77,16 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  const operationGuard = useAuthorityOperationGuard(
+    currentUser ? [currentUser.user_id, currentUser.role, client] : null
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authenticated identity and role intentionally erase password-bearing forms
+  useLayoutEffect(() => {
+    form.resetFields();
+    setCreateModalOpen(false);
+    setEditingUser(null);
+  }, [currentUser?.role, currentUser?.user_id, form]);
   const externallyManaged =
     authConfig?.identity?.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL;
   const canCreateUsers =
@@ -101,26 +112,31 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     hasRoleAuthorityOver(currentUser.role, target.role);
 
   const loadGroups = useCallback(async () => {
+    const operation = operationGuard.begin();
     if (!client || !isAdmin) {
       setGroups([]);
       setMemberships([]);
       return;
     }
-    const [nextGroups, nextMemberships] = await Promise.all([
-      client.service('groups').findAll({ query: { archived: false } }),
-      client.service('group-memberships').findAll({}),
-    ]);
-    setGroups(nextGroups as Group[]);
-    setMemberships(nextMemberships as GroupMembership[]);
-  }, [client, isAdmin]);
-
-  useEffect(() => {
-    loadGroups().catch((error) =>
+    try {
+      const [nextGroups, nextMemberships] = await Promise.all([
+        client.service('groups').findAll({ query: { archived: false } }),
+        client.service('group-memberships').findAll({}),
+      ]);
+      if (!operation.isCurrent()) return;
+      setGroups(nextGroups as Group[]);
+      setMemberships(nextMemberships as GroupMembership[]);
+    } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(
         `Failed to load user groups: ${error instanceof Error ? error.message : String(error)}`
-      )
-    );
-  }, [loadGroups, showError]);
+      );
+    }
+  }, [client, isAdmin, operationGuard, showError]);
+
+  useEffect(() => {
+    void loadGroups();
+  }, [loadGroups]);
 
   const groupsByUser = useMemo(() => {
     const map = new Map<string, Group['group_id'][]>();
@@ -159,8 +175,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   };
 
   const handleCreate = async () => {
+    const operation = operationGuard.begin();
+    if (!operation.isCurrent()) return;
     try {
       const values = await form.validateFields();
+      if (!operation.isCurrent()) return;
       await onCreate?.({
         email: values.email,
         password: values.password,
@@ -169,9 +188,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         unix_username: values.unix_username,
         must_change_password: values.must_change_password || false,
       });
+      if (!operation.isCurrent()) return;
       form.resetFields();
       setCreateModalOpen(false);
     } catch (error) {
+      if (!operation.isCurrent()) return;
       const code = (error as { data?: { code?: unknown } } | undefined)?.data?.code;
       if (typeof code === 'string' && code.startsWith('PASSWORD_')) {
         form.setFields([
@@ -441,7 +462,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
                 key: 'avatars',
                 label: 'Avatars',
                 children: (
-                  <UserAvatarsTab client={client} gatewayChannelById={gatewayChannelById} />
+                  <UserAvatarsTab
+                    client={client}
+                    gatewayChannelById={gatewayChannelById}
+                    authorityKey={currentUser ? `${currentUser.user_id}:${currentUser.role}` : null}
+                  />
                 ),
               },
             ]

--- a/apps/agor-ui/src/contexts/ConnectionContext.tsx
+++ b/apps/agor-ui/src/contexts/ConnectionContext.tsx
@@ -22,14 +22,16 @@ interface ConnectionContextValue {
   currentSha: string | null;
 }
 
-const ConnectionContext = createContext<ConnectionContextValue>({
+const DEFAULT_CONNECTION_CONTEXT: ConnectionContextValue = {
   connected: false,
   connecting: false,
   authGeneration: 0,
   outOfSync: false,
   capturedSha: null,
   currentSha: null,
-});
+};
+
+const ConnectionContext = createContext<ConnectionContextValue | null>(null);
 
 export const ConnectionProvider = ConnectionContext.Provider;
 
@@ -50,6 +52,11 @@ export function useConnectionDisabled(): boolean {
  * Hook to get full connection state
  */
 export function useConnectionState(): ConnectionContextValue {
+  return useContext(ConnectionContext) ?? DEFAULT_CONNECTION_CONTEXT;
+}
+
+/** Null only for independently-mounted/tested leaf surfaces without App's provider. */
+export function useOptionalConnectionState(): ConnectionContextValue | null {
   return useContext(ConnectionContext);
 }
 
@@ -73,7 +80,8 @@ export interface MutationGate {
  * `useConnectionDisabled()`, which now delegates here.
  */
 export function useMutationGate(): MutationGate {
-  const { connected, connecting, outOfSync } = useContext(ConnectionContext);
+  const { connected, connecting, outOfSync } =
+    useContext(ConnectionContext) ?? DEFAULT_CONNECTION_CONTEXT;
 
   if (outOfSync) {
     return {

--- a/apps/agor-ui/src/contexts/ConnectionContext.tsx
+++ b/apps/agor-ui/src/contexts/ConnectionContext.tsx
@@ -15,6 +15,8 @@ import { createContext, useContext } from 'react';
 interface ConnectionContextValue {
   connected: boolean;
   connecting: boolean;
+  /** Successful socket-auth generation; changes even when the client does not. */
+  authGeneration: number;
   outOfSync: boolean;
   capturedSha: string | null;
   currentSha: string | null;
@@ -23,6 +25,7 @@ interface ConnectionContextValue {
 const ConnectionContext = createContext<ConnectionContextValue>({
   connected: false,
   connecting: false,
+  authGeneration: 0,
   outOfSync: false,
   capturedSha: null,
   currentSha: null,

--- a/apps/agor-ui/src/hooks/index.ts
+++ b/apps/agor-ui/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from './useAuth';
 export * from './useAuthConfig';
 export * from './useBoardActions';
 export * from './useConfirmNukeEnvironment';
+export * from './useForcedPasswordChangeHandler';
 export * from './useIdentityGuardedAsync';
 export * from './useInitialLoaderPhase';
 export * from './useLocalStorage';

--- a/apps/agor-ui/src/hooks/useAgorClient.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorClient.test.tsx
@@ -127,7 +127,7 @@ describe('useAgorClient authenticated handshake lifecycle', () => {
     const { client, create } = makeSeamClient();
     vi.mocked(createClient).mockReturnValue(client as never);
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useAgorClient({
         url: 'http://daemon.test',
         accessToken: 'access-token',
@@ -139,13 +139,14 @@ describe('useAgorClient authenticated handshake lifecycle', () => {
     expect(create).toHaveBeenCalledWith({ capability: true });
     expect(client.authenticate).not.toHaveBeenCalled();
     expect(client.hooks).not.toHaveBeenCalled();
+    expect(result.current.authGeneration).toBe(1);
   });
 
   it('re-announces socket-scoped capability after a normal transport reconnect', async () => {
     const { client, create, fireIo, io } = makeSeamClient();
     vi.mocked(createClient).mockReturnValue(client as never);
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useAgorClient({
         url: 'http://daemon.test',
         accessToken: 'access-token',
@@ -153,6 +154,7 @@ describe('useAgorClient authenticated handshake lifecycle', () => {
       })
     );
     await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(result.current.authGeneration).toBe(1);
 
     act(() => {
       io.connected = false;
@@ -163,6 +165,7 @@ describe('useAgorClient authenticated handshake lifecycle', () => {
     await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
     expect(create).toHaveBeenLastCalledWith({ capability: true });
     expect(client.authenticate).not.toHaveBeenCalled();
+    expect(result.current.authGeneration).toBe(2);
   });
 
   it('updates the next handshake token without replacing a same-authority socket', async () => {

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -21,6 +21,8 @@ interface UseAgorClientResult {
   client: AgorClient | null;
   connected: boolean;
   connecting: boolean;
+  /** Monotonic generation of successful authenticated socket handshakes. */
+  authGeneration: number;
   error: string | null;
   retryConnection: () => void;
 }
@@ -49,6 +51,7 @@ export function useAgorClient(options: UseAgorClientOptions): UseAgorClientResul
   const { url = getDaemonUrl(), accessToken, authorityGeneration } = options;
   const [connected, setConnected] = useState(false);
   const [connecting, setConnecting] = useState(!!accessToken);
+  const [authGeneration, setAuthGeneration] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const clientBindingRef = useRef<BoundAgorClient | null>(null);
   const hasToken = !!accessToken;
@@ -236,6 +239,7 @@ export function useAgorClient(options: UseAgorClientOptions): UseAgorClientResul
         // Socket.IO emits `connect` only after the daemon has verified the
         // handshake and installed immutable user/tenant authority.
         announceSessionStreamsCapability(socketClient);
+        setAuthGeneration((generation) => generation + 1);
         setConnected(true);
         setConnecting(false);
         setError(null);
@@ -430,6 +434,7 @@ export function useAgorClient(options: UseAgorClientOptions): UseAgorClientResul
     client: visibleBinding?.client ?? null,
     connected: !!visibleBinding && connected,
     connecting: hasToken ? !visibleBinding || connecting : false,
+    authGeneration,
     error: hasToken && !visibleBinding ? null : error,
     retryConnection,
   };

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -25,6 +25,8 @@ import { agorStore } from '../store/agorStore';
 import { flushRealtimeNow } from '../store/realtimeBatch';
 import { useAgorData } from './useAgorData';
 
+const STANDALONE_AUTHORITY_SCOPE = '__standalone__:__standalone__:0';
+
 /**
  * Minimal AgorClient stand-in. Implements just enough of the service /
  * socket surface the hook touches:
@@ -329,7 +331,7 @@ describe('useAgorData — socket-event bailouts', () => {
 
     act(() => {
       emit('sessions', 'patched', { ...session, status: 'running' });
-      flushRealtimeNow();
+      flushRealtimeNow(STANDALONE_AUTHORITY_SCOPE);
     });
 
     expect(agorStore.getState().sessionById).not.toBe(beforeSessions);
@@ -348,7 +350,7 @@ describe('useAgorData — socket-event bailouts', () => {
         status: 'idle',
         ready_for_prompt: true,
       });
-      flushRealtimeNow();
+      flushRealtimeNow(STANDALONE_AUTHORITY_SCOPE);
     });
 
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({
@@ -476,7 +478,7 @@ describe('useAgorData — socket-event bailouts', () => {
 
     act(() => {
       emit('sessions', 'patched', { ...session, branch_id: 'b-2' });
-      flushRealtimeNow();
+      flushRealtimeNow(STANDALONE_AUTHORITY_SCOPE);
     });
 
     // Old branch bucket is cleaned up; new branch bucket holds the session.

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -56,6 +56,7 @@ import {
   discardRealtimeNow,
   enqueueSessionPatch,
   flushRealtimeNow,
+  setRealtimeAuthorityScope,
   tombstoneSession,
   untombstoneSession,
 } from '../store/realtimeBatch';
@@ -322,6 +323,22 @@ export function useAgorData(
   // asynchronous apply below compares its captured scope against this value.
   const authorityScopeKeyRef = useRef(authorityScopeKey);
   authorityScopeKeyRef.current = authorityScopeKey;
+
+  // Advance the singleton realtime queue in the layout phase. React runs this
+  // before the authority-transition map reset below and before the previous
+  // subscription's passive cleanup, so that cleanup cannot flush a queued row
+  // from the previous identity/role/auth generation into the replacement
+  // authority's store. Socket callbacks also consult this scope synchronously,
+  // closing the short layout→passive-cleanup listener overlap.
+  useLayoutEffect(() => {
+    setRealtimeAuthorityScope(authorityScopeKey);
+  }, [authorityScopeKey]);
+
+  // On a true owner unmount, discard rather than preserve a final frame. The
+  // subscription cleanup cannot distinguish unmount from a same-authority
+  // resubscribe, while layout cleanup ordering can: it runs first and makes the
+  // later scoped flush a no-op.
+  useLayoutEffect(() => () => setRealtimeAuthorityScope(null), []);
 
   useLayoutEffect(() => {
     if (!hasAuthorityContext || !client || !connectionReady || !identityRoleKey) return;
@@ -1285,9 +1302,9 @@ export function useAgorData(
 
   // Subscribe to real-time updates
   //
-  // Every socket event is wired straight to the matching store action in
-  // `agorRealtimeActions` (module singletons → stable references, so cleanup
-  // `removeListener` matches). The store action does the
+  // Every socket event is wired through an authority-scoped stable wrapper to
+  // the matching store action in `agorRealtimeActions` (the wrappers live for
+  // this effect, so cleanup `removeListener` matches). The store action does the
   // `replaceIfChanged` / cascade / index-rebuild + per-collection `bumpRevision`.
   // OAuth + agor-query handlers stay local: they need `client` (async refetch)
   // or are pure window side-effects.
@@ -1298,6 +1315,21 @@ export function useAgorData(
       agorStore.getState().setLoadingStage('idle');
       return;
     }
+
+    const subscriptionAuthorityScope = authorityScopeKey;
+    const subscriptionIsCurrent = () => authorityScopeKeyRef.current === subscriptionAuthorityScope;
+    // All direct store handlers are authority-scoped too. Although only
+    // sessions are frame-batched, an old Feathers listener remains live until
+    // passive cleanup and must not write during the layout→cleanup overlap.
+    const scopedRealtime = Object.fromEntries(
+      Object.entries(realtime).map(([name, handler]) => [
+        name,
+        (...args: unknown[]) => {
+          if (!subscriptionIsCurrent()) return;
+          (handler as (...values: unknown[]) => void)(...args);
+        },
+      ])
+    ) as typeof realtime;
 
     // Subscribe to session events. `patched`/`updated` are the streaming hot
     // path (a patch per token batch), so they're coalesced into one keyed store
@@ -1310,19 +1342,22 @@ export function useAgorData(
     // hydration's quiet-window guard, and the queue's own stale-drop stamp, both
     // depend on the bump landing the instant the event does, not a frame later.
     const sessionPatchedBatched = (session: Session) => {
+      if (!subscriptionIsCurrent()) return;
       bumpRevision('sessions');
-      enqueueSessionPatch(session);
+      enqueueSessionPatch(subscriptionAuthorityScope, session);
     };
     // `created` clears any tombstone (remove-then-recreate in one frame) and
     // `removed` sets one + drops the id's queued patch, before the synchronous
     // store write.
     const sessionCreatedSync = (session: Session) => {
-      untombstoneSession(session.session_id);
-      realtime.sessionCreated(session);
+      if (!subscriptionIsCurrent()) return;
+      untombstoneSession(subscriptionAuthorityScope, session.session_id);
+      scopedRealtime.sessionCreated(session);
     };
     const sessionRemovedSync = (session: Session) => {
-      tombstoneSession(session.session_id);
-      realtime.sessionRemoved(session);
+      if (!subscriptionIsCurrent()) return;
+      tombstoneSession(subscriptionAuthorityScope, session.session_id);
+      scopedRealtime.sessionRemoved(session);
     };
     sessionsService.on('created', sessionCreatedSync);
     sessionsService.on('patched', sessionPatchedBatched);
@@ -1331,31 +1366,32 @@ export function useAgorData(
 
     // Subscribe to board events
     const boardsService = client.service('boards');
-    boardsService.on('created', realtime.boardCreated);
-    boardsService.on('patched', realtime.boardPatched);
-    boardsService.on('updated', realtime.boardPatched);
-    boardsService.on('removed', realtime.boardRemoved);
+    boardsService.on('created', scopedRealtime.boardCreated);
+    boardsService.on('patched', scopedRealtime.boardPatched);
+    boardsService.on('updated', scopedRealtime.boardPatched);
+    boardsService.on('removed', scopedRealtime.boardRemoved);
 
     // Subscribe to board object events
     const boardObjectsService = canUseMemberWorkspaceServices
       ? client.service('board-objects')
       : null;
-    boardObjectsService?.on('created', realtime.boardObjectCreated);
-    boardObjectsService?.on('patched', realtime.boardObjectPatched);
-    boardObjectsService?.on('updated', realtime.boardObjectPatched);
-    boardObjectsService?.on('removed', realtime.boardObjectRemoved);
+    boardObjectsService?.on('created', scopedRealtime.boardObjectCreated);
+    boardObjectsService?.on('patched', scopedRealtime.boardObjectPatched);
+    boardObjectsService?.on('updated', scopedRealtime.boardObjectPatched);
+    boardObjectsService?.on('removed', scopedRealtime.boardObjectRemoved);
 
     // Subscribe to repo events
     const reposService = client.service('repos');
-    reposService.on('created', realtime.repoCreated);
-    reposService.on('patched', realtime.repoPatched);
-    reposService.on('updated', realtime.repoPatched);
-    reposService.on('removed', realtime.repoRemoved);
+    reposService.on('created', scopedRealtime.repoCreated);
+    reposService.on('patched', scopedRealtime.repoPatched);
+    reposService.on('updated', scopedRealtime.repoPatched);
+    reposService.on('removed', scopedRealtime.repoRemoved);
 
     // Subscribe to branch events
     const branchesService = client.service('branches');
     const branchRemovedSync = (branch: Branch) => {
-      realtime.branchRemoved(branch);
+      if (!subscriptionIsCurrent()) return;
+      scopedRealtime.branchRemoved(branch);
       // Branch deletion cascades tasks/messages without child Feathers events.
       // Comments survive those cascades with task_id/message_id SET NULL, but
       // the branch tombstone does not contain the deleted descendant IDs.
@@ -1373,17 +1409,17 @@ export function useAgorData(
           }))
       );
     };
-    branchesService.on('created', realtime.branchCreated);
-    branchesService.on('patched', realtime.branchPatched);
-    branchesService.on('updated', realtime.branchPatched);
+    branchesService.on('created', scopedRealtime.branchCreated);
+    branchesService.on('patched', scopedRealtime.branchPatched);
+    branchesService.on('updated', scopedRealtime.branchPatched);
     branchesService.on('removed', branchRemovedSync);
 
     // Subscribe to user events
     const usersService = canListUsers ? client.service('users') : null;
-    usersService?.on('created', realtime.userCreated);
-    usersService?.on('patched', realtime.userPatched);
-    usersService?.on('updated', realtime.userPatched);
-    usersService?.on('removed', realtime.userRemoved);
+    usersService?.on('created', scopedRealtime.userCreated);
+    usersService?.on('patched', scopedRealtime.userPatched);
+    usersService?.on('updated', scopedRealtime.userPatched);
+    usersService?.on('removed', scopedRealtime.userRemoved);
 
     const agenticToolSettingsService = client.service('agentic-tool-settings');
     // A single-row realtime event is an INCREMENTAL upsert, not a complete
@@ -1392,6 +1428,7 @@ export function useAgorData(
     const agenticToolSettingsPatched = (
       updated: import('@agor-live/client').TenantAgenticToolSettings
     ) => {
+      if (!subscriptionIsCurrent()) return;
       // Bump the live-write revision so a background full-fetch that raced this
       // upsert discards its (now-stale) snapshot instead of overwriting it.
       bumpRevision('agenticToolSettings');
@@ -1402,38 +1439,38 @@ export function useAgorData(
 
     // Subscribe to MCP server events
     const mcpServersService = client.service('mcp-servers');
-    mcpServersService.on('created', realtime.mcpServerCreated);
-    mcpServersService.on('patched', realtime.mcpServerPatched);
-    mcpServersService.on('updated', realtime.mcpServerPatched);
-    mcpServersService.on('removed', realtime.mcpServerRemoved);
+    mcpServersService.on('created', scopedRealtime.mcpServerCreated);
+    mcpServersService.on('patched', scopedRealtime.mcpServerPatched);
+    mcpServersService.on('updated', scopedRealtime.mcpServerPatched);
+    mcpServersService.on('removed', scopedRealtime.mcpServerRemoved);
 
     // Subscribe to gateway channel events
     const gatewayChannelsService = client.service('gateway-channels');
-    gatewayChannelsService.on('created', realtime.gatewayChannelCreated);
-    gatewayChannelsService.on('patched', realtime.gatewayChannelPatched);
-    gatewayChannelsService.on('updated', realtime.gatewayChannelPatched);
-    gatewayChannelsService.on('removed', realtime.gatewayChannelRemoved);
+    gatewayChannelsService.on('created', scopedRealtime.gatewayChannelCreated);
+    gatewayChannelsService.on('patched', scopedRealtime.gatewayChannelPatched);
+    gatewayChannelsService.on('updated', scopedRealtime.gatewayChannelPatched);
+    gatewayChannelsService.on('removed', scopedRealtime.gatewayChannelRemoved);
 
     // Subscribe to card events
     const cardsService = client.service('cards');
-    cardsService.on('created', realtime.cardCreated);
-    cardsService.on('patched', realtime.cardPatched);
-    cardsService.on('updated', realtime.cardPatched);
-    cardsService.on('removed', realtime.cardRemoved);
+    cardsService.on('created', scopedRealtime.cardCreated);
+    cardsService.on('patched', scopedRealtime.cardPatched);
+    cardsService.on('updated', scopedRealtime.cardPatched);
+    cardsService.on('removed', scopedRealtime.cardRemoved);
 
     // Subscribe to card type events
     const cardTypesService = client.service('card-types');
-    cardTypesService.on('created', realtime.cardTypeCreated);
-    cardTypesService.on('patched', realtime.cardTypePatched);
-    cardTypesService.on('updated', realtime.cardTypePatched);
-    cardTypesService.on('removed', realtime.cardTypeRemoved);
+    cardTypesService.on('created', scopedRealtime.cardTypeCreated);
+    cardTypesService.on('patched', scopedRealtime.cardTypePatched);
+    cardTypesService.on('updated', scopedRealtime.cardTypePatched);
+    cardTypesService.on('removed', scopedRealtime.cardTypeRemoved);
 
     // Subscribe to artifact events
     const artifactsService = client.service('artifacts');
-    artifactsService.on('created', realtime.artifactCreated);
-    artifactsService.on('patched', realtime.artifactPatched);
-    artifactsService.on('updated', realtime.artifactPatched);
-    artifactsService.on('removed', realtime.artifactRemoved);
+    artifactsService.on('created', scopedRealtime.artifactCreated);
+    artifactsService.on('patched', scopedRealtime.artifactPatched);
+    artifactsService.on('updated', scopedRealtime.artifactPatched);
+    artifactsService.on('removed', scopedRealtime.artifactRemoved);
 
     // Agent-driven runtime queries: daemon emits when an MCP tool wants to
     // introspect the iframe DOM. ArtifactNode components listen for the
@@ -1446,21 +1483,22 @@ export function useAgorData(
       kind: string;
       args: Record<string, unknown>;
     }) => {
+      if (!subscriptionIsCurrent()) return;
       window.dispatchEvent(new CustomEvent('agor:artifact-runtime-query', { detail: event }));
     };
     artifactsService.on('agor-query', handleAgorQuery);
 
     // Subscribe to session-MCP server relationship events
     const sessionMcpService = client.service('session-mcp-servers');
-    sessionMcpService.on('created', realtime.sessionMcpCreated);
-    sessionMcpService.on('removed', realtime.sessionMcpRemoved);
+    sessionMcpService.on('created', scopedRealtime.sessionMcpCreated);
+    sessionMcpService.on('removed', scopedRealtime.sessionMcpRemoved);
 
     // Subscribe to board comment events
     const commentsService = client.service('board-comments');
-    commentsService.on('created', realtime.commentCreated);
-    commentsService.on('patched', realtime.commentPatched);
-    commentsService.on('updated', realtime.commentPatched);
-    commentsService.on('removed', realtime.commentRemoved);
+    commentsService.on('created', scopedRealtime.commentCreated);
+    commentsService.on('patched', scopedRealtime.commentPatched);
+    commentsService.on('updated', scopedRealtime.commentPatched);
+    commentsService.on('removed', scopedRealtime.commentRemoved);
 
     // Realtime OAuth events are latency hints only. Correctness comes from
     // refetching the durable, authenticated token status and server record;
@@ -1559,11 +1597,11 @@ export function useAgorData(
 
     // Cleanup listeners on unmount
     return () => {
-      // APPLY (not discard) any frame-batched session patches here: this cleanup
-      // also runs when the effect merely re-subscribes (a dep changes), so
-      // dropping would lose live updates mid-session. The logout path discards
-      // explicitly instead (see the `client`-null effect above).
-      flushRealtimeNow();
+      // APPLY only when this is a same-authority resubscribe. The layout-phase
+      // scope transition has already discarded an identity/role/auth/connection
+      // queue, and makes this old passive cleanup a no-op. This preserves live
+      // updates on ordinary effect churn without crossing an authority boundary.
+      flushRealtimeNow(subscriptionAuthorityScope);
       client.io.off('oauth:completed', handleOAuthCompleted);
       client.io.off('oauth:disconnected', handleOAuthDisconnected);
       client.io.off('connect', refetchSilently);
@@ -1573,66 +1611,66 @@ export function useAgorData(
       sessionsService.removeListener('updated', sessionPatchedBatched);
       sessionsService.removeListener('removed', sessionRemovedSync);
 
-      boardsService.removeListener('created', realtime.boardCreated);
-      boardsService.removeListener('patched', realtime.boardPatched);
-      boardsService.removeListener('updated', realtime.boardPatched);
-      boardsService.removeListener('removed', realtime.boardRemoved);
+      boardsService.removeListener('created', scopedRealtime.boardCreated);
+      boardsService.removeListener('patched', scopedRealtime.boardPatched);
+      boardsService.removeListener('updated', scopedRealtime.boardPatched);
+      boardsService.removeListener('removed', scopedRealtime.boardRemoved);
 
-      boardObjectsService?.removeListener('created', realtime.boardObjectCreated);
-      boardObjectsService?.removeListener('patched', realtime.boardObjectPatched);
-      boardObjectsService?.removeListener('updated', realtime.boardObjectPatched);
-      boardObjectsService?.removeListener('removed', realtime.boardObjectRemoved);
+      boardObjectsService?.removeListener('created', scopedRealtime.boardObjectCreated);
+      boardObjectsService?.removeListener('patched', scopedRealtime.boardObjectPatched);
+      boardObjectsService?.removeListener('updated', scopedRealtime.boardObjectPatched);
+      boardObjectsService?.removeListener('removed', scopedRealtime.boardObjectRemoved);
 
-      reposService.removeListener('created', realtime.repoCreated);
-      reposService.removeListener('patched', realtime.repoPatched);
-      reposService.removeListener('updated', realtime.repoPatched);
-      reposService.removeListener('removed', realtime.repoRemoved);
+      reposService.removeListener('created', scopedRealtime.repoCreated);
+      reposService.removeListener('patched', scopedRealtime.repoPatched);
+      reposService.removeListener('updated', scopedRealtime.repoPatched);
+      reposService.removeListener('removed', scopedRealtime.repoRemoved);
 
-      branchesService.removeListener('created', realtime.branchCreated);
-      branchesService.removeListener('patched', realtime.branchPatched);
-      branchesService.removeListener('updated', realtime.branchPatched);
+      branchesService.removeListener('created', scopedRealtime.branchCreated);
+      branchesService.removeListener('patched', scopedRealtime.branchPatched);
+      branchesService.removeListener('updated', scopedRealtime.branchPatched);
       branchesService.removeListener('removed', branchRemovedSync);
 
-      usersService?.removeListener('created', realtime.userCreated);
-      usersService?.removeListener('patched', realtime.userPatched);
-      usersService?.removeListener('updated', realtime.userPatched);
-      usersService?.removeListener('removed', realtime.userRemoved);
+      usersService?.removeListener('created', scopedRealtime.userCreated);
+      usersService?.removeListener('patched', scopedRealtime.userPatched);
+      usersService?.removeListener('updated', scopedRealtime.userPatched);
+      usersService?.removeListener('removed', scopedRealtime.userRemoved);
 
       agenticToolSettingsService.removeListener('patched', agenticToolSettingsPatched);
       agenticToolSettingsService.removeListener('created', agenticToolSettingsPatched);
 
-      mcpServersService.removeListener('created', realtime.mcpServerCreated);
-      mcpServersService.removeListener('patched', realtime.mcpServerPatched);
-      mcpServersService.removeListener('updated', realtime.mcpServerPatched);
-      mcpServersService.removeListener('removed', realtime.mcpServerRemoved);
+      mcpServersService.removeListener('created', scopedRealtime.mcpServerCreated);
+      mcpServersService.removeListener('patched', scopedRealtime.mcpServerPatched);
+      mcpServersService.removeListener('updated', scopedRealtime.mcpServerPatched);
+      mcpServersService.removeListener('removed', scopedRealtime.mcpServerRemoved);
 
-      sessionMcpService.removeListener('created', realtime.sessionMcpCreated);
-      sessionMcpService.removeListener('removed', realtime.sessionMcpRemoved);
+      sessionMcpService.removeListener('created', scopedRealtime.sessionMcpCreated);
+      sessionMcpService.removeListener('removed', scopedRealtime.sessionMcpRemoved);
 
-      commentsService.removeListener('created', realtime.commentCreated);
-      commentsService.removeListener('patched', realtime.commentPatched);
-      commentsService.removeListener('updated', realtime.commentPatched);
-      commentsService.removeListener('removed', realtime.commentRemoved);
+      commentsService.removeListener('created', scopedRealtime.commentCreated);
+      commentsService.removeListener('patched', scopedRealtime.commentPatched);
+      commentsService.removeListener('updated', scopedRealtime.commentPatched);
+      commentsService.removeListener('removed', scopedRealtime.commentRemoved);
 
-      gatewayChannelsService.removeListener('created', realtime.gatewayChannelCreated);
-      gatewayChannelsService.removeListener('patched', realtime.gatewayChannelPatched);
-      gatewayChannelsService.removeListener('updated', realtime.gatewayChannelPatched);
-      gatewayChannelsService.removeListener('removed', realtime.gatewayChannelRemoved);
+      gatewayChannelsService.removeListener('created', scopedRealtime.gatewayChannelCreated);
+      gatewayChannelsService.removeListener('patched', scopedRealtime.gatewayChannelPatched);
+      gatewayChannelsService.removeListener('updated', scopedRealtime.gatewayChannelPatched);
+      gatewayChannelsService.removeListener('removed', scopedRealtime.gatewayChannelRemoved);
 
-      cardsService.removeListener('created', realtime.cardCreated);
-      cardsService.removeListener('patched', realtime.cardPatched);
-      cardsService.removeListener('updated', realtime.cardPatched);
-      cardsService.removeListener('removed', realtime.cardRemoved);
+      cardsService.removeListener('created', scopedRealtime.cardCreated);
+      cardsService.removeListener('patched', scopedRealtime.cardPatched);
+      cardsService.removeListener('updated', scopedRealtime.cardPatched);
+      cardsService.removeListener('removed', scopedRealtime.cardRemoved);
 
-      cardTypesService.removeListener('created', realtime.cardTypeCreated);
-      cardTypesService.removeListener('patched', realtime.cardTypePatched);
-      cardTypesService.removeListener('updated', realtime.cardTypePatched);
-      cardTypesService.removeListener('removed', realtime.cardTypeRemoved);
+      cardTypesService.removeListener('created', scopedRealtime.cardTypeCreated);
+      cardTypesService.removeListener('patched', scopedRealtime.cardTypePatched);
+      cardTypesService.removeListener('updated', scopedRealtime.cardTypePatched);
+      cardTypesService.removeListener('removed', scopedRealtime.cardTypeRemoved);
 
-      artifactsService.removeListener('created', realtime.artifactCreated);
-      artifactsService.removeListener('patched', realtime.artifactPatched);
-      artifactsService.removeListener('updated', realtime.artifactPatched);
-      artifactsService.removeListener('removed', realtime.artifactRemoved);
+      artifactsService.removeListener('created', scopedRealtime.artifactCreated);
+      artifactsService.removeListener('patched', scopedRealtime.artifactPatched);
+      artifactsService.removeListener('updated', scopedRealtime.artifactPatched);
+      artifactsService.removeListener('removed', scopedRealtime.artifactRemoved);
       artifactsService.removeListener('agor-query', handleAgorQuery);
     };
   }, [

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -31,7 +31,9 @@ import {
   ARTIFACT_METADATA_LIST_FIELDS,
   ENTITY_PATH_SEGMENTS,
   findByShortIdPrefix,
+  hasMinimumRole,
   PAGINATION,
+  ROLES,
 } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -247,10 +249,27 @@ function hasIdMatchingPrefix<T>(
  */
 export function useAgorData(
   client: AgorClient | null,
-  options?: { enabled?: boolean; directSessionId?: string | null }
+  options?: {
+    enabled?: boolean;
+    directSessionId?: string | null;
+    /**
+     * Role from the authenticated user response, not from the optional users
+     * directory. Viewer bootstrap must decide whether member-only workspace
+     * requests exist before attempting them; otherwise one expected 403 hides
+     * the authenticated header and viewer-safe routes such as Marketplace.
+     */
+    authenticatedUserRole?: string;
+  }
 ): UseAgorDataResult {
   const enabled = options?.enabled ?? true;
   const directSessionId = options?.directSessionId ?? null;
+  // Preserve the hook's historical standalone-test/default behavior when the
+  // caller does not provide role context. App always provides the property,
+  // including `undefined` before auth resolves, and therefore fails closed.
+  const hasAuthenticatedRoleContext = Object.hasOwn(options ?? {}, 'authenticatedUserRole');
+  const canUseMemberWorkspaceServices =
+    !hasAuthenticatedRoleContext || hasMinimumRole(options?.authenticatedUserRole, ROLES.MEMBER);
+  const canListUsers = canUseMemberWorkspaceServices;
 
   // Reset the shared singleton store once per hook (re)mount, synchronously
   // BEFORE the first store-subscription read below. This mirrors the old per-mount
@@ -513,7 +532,9 @@ export function useAgorData(
           ),
           track(
             'users',
-            client.service('users').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+            canListUsers
+              ? client.service('users').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+              : Promise.resolve([])
           ),
         ]);
 
@@ -664,12 +685,19 @@ export function useAgorData(
             : Promise.resolve([] as Session[]),
           track(
             'board-objects',
-            client.service('board-objects').findAll({
-              query: {
-                $limit: PAGINATION.DEFAULT_LIMIT,
-                ...(boardScope ? { board_id: boardScope } : {}),
-              },
-            })
+            // The daemon intentionally keeps the whole board-objects service at
+            // the MEMBER floor (the rows carry editable canvas layout). A global
+            // viewer can still read the workspace shell and Marketplace, so an
+            // expected authorization failure here is not an essential bootstrap
+            // failure. Keep the collection empty and don't subscribe below.
+            canUseMemberWorkspaceServices
+              ? client.service('board-objects').findAll({
+                  query: {
+                    $limit: PAGINATION.DEFAULT_LIMIT,
+                    ...(boardScope ? { board_id: boardScope } : {}),
+                  },
+                })
+              : Promise.resolve([])
           ),
           track(
             'board-comments',
@@ -904,25 +932,27 @@ export function useAgorData(
         // global snapshot is a superset of its board-scoped first-paint slice, so
         // no overlay is needed; the quiet-window guard prevents clobber/resurrect.
         if (boardScope) {
-          void runHydration(
-            'board-objects',
-            ['boardObjects'],
-            () =>
-              client
-                .service('board-objects')
-                .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-            (allBoardObjects) =>
-              agorStore.getState().applyMaps((prev) => {
-                const base = buildBoardObjectMaps(allBoardObjects);
-                return {
-                  ...prev,
-                  boardObjectById: base.boardObjectById,
-                  boardObjectsByBoardId: base.boardObjectsByBoardId,
-                  boardObjectByBranchId: base.boardObjectByBranchId,
-                  boardObjectByCardId: base.boardObjectByCardId,
-                };
-              })
-          );
+          if (canUseMemberWorkspaceServices) {
+            void runHydration(
+              'board-objects',
+              ['boardObjects'],
+              () =>
+                client
+                  .service('board-objects')
+                  .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+              (allBoardObjects) =>
+                agorStore.getState().applyMaps((prev) => {
+                  const base = buildBoardObjectMaps(allBoardObjects);
+                  return {
+                    ...prev,
+                    boardObjectById: base.boardObjectById,
+                    boardObjectsByBoardId: base.boardObjectsByBoardId,
+                    boardObjectByBranchId: base.boardObjectByBranchId,
+                    boardObjectByCardId: base.boardObjectByCardId,
+                  };
+                })
+            );
+          }
           void runHydration(
             'cards',
             ['cards'],
@@ -998,8 +1028,39 @@ export function useAgorData(
         }
       }
     },
-    [client, directSessionId, enabled]
+    [canListUsers, canUseMemberWorkspaceServices, client, directSessionId, enabled]
   );
+
+  // A role replacement can leave the long-lived client and hook mounted. Drop
+  // member-only data the new viewer is no longer allowed to read immediately;
+  // then resync every caller-readable collection under the replacement role.
+  // This is deliberately keyed to the authenticated role rather than a row
+  // from userById, because that directory is itself privileged data.
+  const previousCanUseMemberWorkspaceServicesRef = useRef(canUseMemberWorkspaceServices);
+  useEffect(() => {
+    const previous = previousCanUseMemberWorkspaceServicesRef.current;
+    previousCanUseMemberWorkspaceServicesRef.current = canUseMemberWorkspaceServices;
+    if (previous === canUseMemberWorkspaceServices) return;
+
+    if (!canUseMemberWorkspaceServices) {
+      // Cancel a member-authenticated board-object snapshot before clearing it;
+      // otherwise an in-flight hydration could repopulate the forbidden rows.
+      // The silent resync below restarts every viewer-readable hydration.
+      cancelAllHydrations();
+      bumpRevision('boardObjects');
+      agorStore.getState().applyMaps((previousMaps) => ({
+        ...previousMaps,
+        userById: new Map(),
+        boardObjectById: new Map(),
+        boardObjectsByBoardId: new Map(),
+        boardObjectByBranchId: new Map(),
+        boardObjectByCardId: new Map(),
+      }));
+    }
+    if (client && enabled && hasInitiallyFetched) {
+      void fetchData({ silent: true });
+    }
+  }, [canUseMemberWorkspaceServices, client, enabled, fetchData, hasInitiallyFetched]);
 
   // Clear all data when client goes away (logout / token revocation).
   //
@@ -1158,11 +1219,13 @@ export function useAgorData(
     boardsService.on('removed', realtime.boardRemoved);
 
     // Subscribe to board object events
-    const boardObjectsService = client.service('board-objects');
-    boardObjectsService.on('created', realtime.boardObjectCreated);
-    boardObjectsService.on('patched', realtime.boardObjectPatched);
-    boardObjectsService.on('updated', realtime.boardObjectPatched);
-    boardObjectsService.on('removed', realtime.boardObjectRemoved);
+    const boardObjectsService = canUseMemberWorkspaceServices
+      ? client.service('board-objects')
+      : null;
+    boardObjectsService?.on('created', realtime.boardObjectCreated);
+    boardObjectsService?.on('patched', realtime.boardObjectPatched);
+    boardObjectsService?.on('updated', realtime.boardObjectPatched);
+    boardObjectsService?.on('removed', realtime.boardObjectRemoved);
 
     // Subscribe to repo events
     const reposService = client.service('repos');
@@ -1198,11 +1261,11 @@ export function useAgorData(
     branchesService.on('removed', branchRemovedSync);
 
     // Subscribe to user events
-    const usersService = client.service('users');
-    usersService.on('created', realtime.userCreated);
-    usersService.on('patched', realtime.userPatched);
-    usersService.on('updated', realtime.userPatched);
-    usersService.on('removed', realtime.userRemoved);
+    const usersService = canListUsers ? client.service('users') : null;
+    usersService?.on('created', realtime.userCreated);
+    usersService?.on('patched', realtime.userPatched);
+    usersService?.on('updated', realtime.userPatched);
+    usersService?.on('removed', realtime.userRemoved);
 
     const agenticToolSettingsService = client.service('agentic-tool-settings');
     // A single-row realtime event is an INCREMENTAL upsert, not a complete
@@ -1382,10 +1445,10 @@ export function useAgorData(
       boardsService.removeListener('updated', realtime.boardPatched);
       boardsService.removeListener('removed', realtime.boardRemoved);
 
-      boardObjectsService.removeListener('created', realtime.boardObjectCreated);
-      boardObjectsService.removeListener('patched', realtime.boardObjectPatched);
-      boardObjectsService.removeListener('updated', realtime.boardObjectPatched);
-      boardObjectsService.removeListener('removed', realtime.boardObjectRemoved);
+      boardObjectsService?.removeListener('created', realtime.boardObjectCreated);
+      boardObjectsService?.removeListener('patched', realtime.boardObjectPatched);
+      boardObjectsService?.removeListener('updated', realtime.boardObjectPatched);
+      boardObjectsService?.removeListener('removed', realtime.boardObjectRemoved);
 
       reposService.removeListener('created', realtime.repoCreated);
       reposService.removeListener('patched', realtime.repoPatched);
@@ -1397,10 +1460,10 @@ export function useAgorData(
       branchesService.removeListener('updated', realtime.branchPatched);
       branchesService.removeListener('removed', branchRemovedSync);
 
-      usersService.removeListener('created', realtime.userCreated);
-      usersService.removeListener('patched', realtime.userPatched);
-      usersService.removeListener('updated', realtime.userPatched);
-      usersService.removeListener('removed', realtime.userRemoved);
+      usersService?.removeListener('created', realtime.userCreated);
+      usersService?.removeListener('patched', realtime.userPatched);
+      usersService?.removeListener('updated', realtime.userPatched);
+      usersService?.removeListener('removed', realtime.userRemoved);
 
       agenticToolSettingsService.removeListener('patched', agenticToolSettingsPatched);
       agenticToolSettingsService.removeListener('created', agenticToolSettingsPatched);
@@ -1439,7 +1502,14 @@ export function useAgorData(
       artifactsService.removeListener('removed', realtime.artifactRemoved);
       artifactsService.removeListener('agor-query', handleAgorQuery);
     };
-  }, [client, enabled, fetchData, hasInitiallyFetched]);
+  }, [
+    canListUsers,
+    canUseMemberWorkspaceServices,
+    client,
+    enabled,
+    fetchData,
+    hasInitiallyFetched,
+  ]);
 
   // Derived render model for the loading checklist. Memoized so the array
   // identity is stable across renders where no per-item count changed.

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -35,7 +35,7 @@ import {
   PAGINATION,
   ROLES,
 } from '@agor-live/client';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   bumpFirstPaintMergeRevisions,
   bumpRevision,
@@ -252,6 +252,8 @@ export function useAgorData(
   options?: {
     enabled?: boolean;
     directSessionId?: string | null;
+    /** Authenticated identity, independent from the privileged users directory. */
+    authenticatedUserId?: string;
     /**
      * Role from the authenticated user response, not from the optional users
      * directory. Viewer bootstrap must decide whether member-only workspace
@@ -259,6 +261,10 @@ export function useAgorData(
      * the authenticated header and viewer-safe routes such as Marketplace.
      */
     authenticatedUserRole?: string;
+    /** Successful socket authentication generation from useAgorClient. */
+    authGeneration?: number;
+    /** Socket is connected, authenticated, and outside a reauth transition. */
+    connectionReady?: boolean;
   }
 ): UseAgorDataResult {
   const enabled = options?.enabled ?? true;
@@ -270,6 +276,65 @@ export function useAgorData(
   const canUseMemberWorkspaceServices =
     !hasAuthenticatedRoleContext || hasMinimumRole(options?.authenticatedUserRole, ROLES.MEMBER);
   const canListUsers = canUseMemberWorkspaceServices;
+  const hasAuthorityContext =
+    Object.hasOwn(options ?? {}, 'authenticatedUserId') ||
+    Object.hasOwn(options ?? {}, 'authGeneration') ||
+    Object.hasOwn(options ?? {}, 'connectionReady');
+  const authenticatedUserId = options?.authenticatedUserId;
+  const authGeneration = options?.authGeneration ?? 0;
+  const connectionReady = options?.connectionReady ?? true;
+  const identityRoleKey =
+    authenticatedUserId && options?.authenticatedUserRole
+      ? `${authenticatedUserId}:${options.authenticatedUserRole}`
+      : null;
+  // A role/identity value can render before the socket has authenticated the
+  // replacement token. Remember the last pair proven by a ready connection;
+  // changing that pair requires a strictly newer auth generation. Demotions
+  // therefore fail closed immediately, while promotions cannot issue a
+  // viewer-era request merely because React observed the refreshed user first.
+  const establishedAuthorityRef = useRef<{
+    client: AgorClient;
+    identityRoleKey: string;
+    authGeneration: number;
+  } | null>(null);
+  const establishedAuthority = establishedAuthorityRef.current;
+  const authorityMatchesEstablished =
+    !!establishedAuthority &&
+    establishedAuthority.client === client &&
+    establishedAuthority.identityRoleKey === identityRoleKey &&
+    authGeneration >= establishedAuthority.authGeneration;
+  const authorityHasNewAuthentication =
+    !establishedAuthority || authGeneration > establishedAuthority.authGeneration;
+  const authorityIsEstablished =
+    !hasAuthorityContext ||
+    (!!client &&
+      connectionReady &&
+      !!identityRoleKey &&
+      (authorityMatchesEstablished || authorityHasNewAuthentication));
+  const authorityScopeKey =
+    client &&
+    enabled &&
+    authorityIsEstablished &&
+    (!hasAuthorityContext || (authenticatedUserId && options?.authenticatedUserRole))
+      ? `${authenticatedUserId ?? '__standalone__'}:${options?.authenticatedUserRole ?? '__standalone__'}:${authGeneration}`
+      : null;
+  // Render-time update closes the window before transition effects run: every
+  // asynchronous apply below compares its captured scope against this value.
+  const authorityScopeKeyRef = useRef(authorityScopeKey);
+  authorityScopeKeyRef.current = authorityScopeKey;
+
+  useLayoutEffect(() => {
+    if (!hasAuthorityContext || !client || !connectionReady || !identityRoleKey) return;
+    if (!authorityIsEstablished) return;
+    establishedAuthorityRef.current = { client, identityRoleKey, authGeneration };
+  }, [
+    authGeneration,
+    authorityIsEstablished,
+    client,
+    connectionReady,
+    hasAuthorityContext,
+    identityRoleKey,
+  ]);
 
   // Reset the shared singleton store once per hook (re)mount, synchronously
   // BEFORE the first store-subscription read below. This mirrors the old per-mount
@@ -316,9 +381,9 @@ export function useAgorData(
   const [hasInitiallyFetched, setHasInitiallyFetched] = useState(false);
 
   // Single-flight guard for reconnect-triggered refetches. Prevents stampedes
-  // when the socket flaps (e.g. waking from sleep on a flaky network). We also
-  // don't want to issue 14 parallel service calls multiple times in a row.
-  const refetchInflightRef = useRef(false);
+  // when the socket flaps (e.g. waking from sleep on a flaky network). The
+  // authority key prevents an older identity's flight from blocking the next.
+  const refetchInflightRef = useRef<string | null>(null);
 
   // Tracks whether the most recent silent refetch failed. Set by the silent
   // catch branch in `fetchData`, cleared on success. Read by the
@@ -341,9 +406,20 @@ export function useAgorData(
   // reconnect or token replacement gets another shot.
   const fetchData = useCallback(
     async ({ silent = false }: { silent?: boolean } = {}) => {
-      if (!client || !enabled) {
-        return;
+      const fetchAuthorityScope = authorityScopeKey;
+      if (!client || !enabled || !fetchAuthorityScope) {
+        return false;
       }
+      const authorityIsCurrent = () => authorityScopeKeyRef.current === fetchAuthorityScope;
+      const runAuthorityHydration = (
+        name: string,
+        revisions: Parameters<typeof runHydration>[1],
+        fetcher: () => Promise<unknown>,
+        apply: (value: unknown) => void
+      ) =>
+        runHydration(name, revisions, fetcher, (value) => {
+          if (authorityIsCurrent()) apply(value);
+        });
 
       const debugTimer =
         !silent && isInitialLoadDebugEnabled()
@@ -370,7 +446,7 @@ export function useAgorData(
         ): Promise<T> => {
           const timedPromise = debugTimer?.track(key, p) ?? p;
           return timedPromise.then((r) => {
-            if (!silent)
+            if (!silent && authorityIsCurrent())
               agorStore.getState().setItemCounts((prev) => ({ ...prev, [key]: r.length }));
             return r;
           });
@@ -393,14 +469,14 @@ export function useAgorData(
         // clobber a newer realtime upsert, and a fetch resolving after logout is
         // dropped instead of repopulating the previous tenant. The apply sets the
         // hydration gate, so it only flips once a quiet, current snapshot lands.
-        void runHydration(
+        void runAuthorityHydration(
           'agentic-tool-settings',
           ['agenticToolSettings'],
           () => client.service('agentic-tool-settings').findAll(),
           (settings) => agorStore.getState().setAgenticToolSettings(settings)
         );
 
-        void runHydration(
+        void runAuthorityHydration(
           'mcp-servers',
           ['mcpServers'],
           () =>
@@ -413,7 +489,7 @@ export function useAgorData(
             agorStore.getState().markHydrated('mcpServersHydrated');
           }
         );
-        void runHydration(
+        void runAuthorityHydration(
           'session-mcp-servers',
           ['sessionMcp'],
           () =>
@@ -425,7 +501,7 @@ export function useAgorData(
               .getState()
               .applyMaps((prev) => ({ ...prev, sessionMcpServerIds: buildSessionMcpMap(list) }))
         );
-        void runHydration(
+        void runAuthorityHydration(
           'gateway-channels',
           ['gatewayChannels'],
           () =>
@@ -440,7 +516,7 @@ export function useAgorData(
             agorStore.getState().markHydrated('gatewayChannelsHydrated');
           }
         );
-        void runHydration(
+        void runAuthorityHydration(
           'artifacts',
           ['artifacts'],
           () =>
@@ -456,7 +532,7 @@ export function useAgorData(
               artifactById: buildById(list, 'artifact_id', prev.artifactById),
             }))
         );
-        void runHydration(
+        void runAuthorityHydration(
           'oauth-status',
           ['oauth'],
           () => client.service('mcp-servers/oauth-status').find(),
@@ -537,6 +613,7 @@ export function useAgorData(
               : Promise.resolve([])
           ),
         ]);
+        if (!authorityIsCurrent()) return false;
 
         // Branches healed into first paint by a direct deep link — the URL
         // session's branch, or a `/w/<id>` branch link. They seed `branchById`
@@ -730,6 +807,7 @@ export function useAgorData(
               (client.service('boards').get(boardScope) as Promise<Board>).catch(() => null)
             : Promise.resolve(null),
         ]);
+        if (!authorityIsCurrent()) return false;
         debugTimer?.endFetchPhase();
 
         if (!silent) {
@@ -750,6 +828,7 @@ export function useAgorData(
             window.requestAnimationFrame(() => resolve());
           });
         }
+        if (!authorityIsCurrent()) return false;
 
         // Build board object Maps for efficient lookups (shared with the
         // background full-hydration pass so the two index builds stay identical)
@@ -868,7 +947,7 @@ export function useAgorData(
         // branches apply on their own quiet window (almost immediately)
         // regardless of session churn.
         if (!silent) {
-          void runHydration(
+          void runAuthorityHydration(
             'sessions',
             ['sessions'],
             () =>
@@ -904,7 +983,7 @@ export function useAgorData(
                 return { ...prev, sessionById, sessionsByBranch };
               })
           );
-          void runHydration(
+          void runAuthorityHydration(
             'branches',
             ['branches'],
             () =>
@@ -933,7 +1012,7 @@ export function useAgorData(
         // no overlay is needed; the quiet-window guard prevents clobber/resurrect.
         if (boardScope) {
           if (canUseMemberWorkspaceServices) {
-            void runHydration(
+            void runAuthorityHydration(
               'board-objects',
               ['boardObjects'],
               () =>
@@ -953,7 +1032,7 @@ export function useAgorData(
                 })
             );
           }
-          void runHydration(
+          void runAuthorityHydration(
             'cards',
             ['cards'],
             () => client.service('cards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
@@ -963,7 +1042,7 @@ export function useAgorData(
                 cardById: buildById(allCards, 'card_id', prev.cardById),
               }))
           );
-          void runHydration(
+          void runAuthorityHydration(
             'board-comments',
             ['comments'],
             () =>
@@ -985,7 +1064,7 @@ export function useAgorData(
         // above. The displayed board already carries its objects from the
         // targeted get; the full set is a superset of it.
         if (!silent) {
-          void runHydration(
+          void runAuthorityHydration(
             'boards',
             ['boards'],
             () => client.service('boards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
@@ -1002,7 +1081,9 @@ export function useAgorData(
         if (silent) {
           lastSilentFetchFailedRef.current = false;
         }
+        return true;
       } catch (err) {
+        if (!authorityIsCurrent()) return false;
         if (silent) {
           // Background refetch failed (e.g. transient 401 racing an authenticated
           // reconnect, or a 5xx). Don't escalate to the fullscreen error overlay —
@@ -1017,8 +1098,9 @@ export function useAgorData(
             .getState()
             .setError(err instanceof Error ? err.message : 'Failed to fetch data');
         }
+        return true;
       } finally {
-        if (!silent) {
+        if (!silent && authorityIsCurrent()) {
           agorStore.getState().setLoading(false);
           agorStore.getState().setLoadingStage('idle');
           debugTimer?.markStage('idle');
@@ -1028,25 +1110,49 @@ export function useAgorData(
         }
       }
     },
-    [canListUsers, canUseMemberWorkspaceServices, client, directSessionId, enabled]
+    [
+      authorityScopeKey,
+      canListUsers,
+      canUseMemberWorkspaceServices,
+      client,
+      directSessionId,
+      enabled,
+    ]
   );
 
-  // A role replacement can leave the long-lived client and hook mounted. Drop
-  // member-only data the new viewer is no longer allowed to read immediately;
-  // then resync every caller-readable collection under the replacement role.
-  // This is deliberately keyed to the authenticated role rather than a row
-  // from userById, because that directory is itself privileged data.
-  const previousCanUseMemberWorkspaceServicesRef = useRef(canUseMemberWorkspaceServices);
-  useEffect(() => {
-    const previous = previousCanUseMemberWorkspaceServicesRef.current;
-    previousCanUseMemberWorkspaceServicesRef.current = canUseMemberWorkspaceServices;
-    if (previous === canUseMemberWorkspaceServices) return;
+  // The long-lived client survives role, token, identity, and reconnect
+  // transitions. Invalidate every older fetch/hydration at commit time before
+  // it can apply under the replacement authority. A promotion deliberately
+  // does NOT refetch while connectionReady is false; the new authGeneration
+  // produces a non-null scope only after socket reauthentication succeeds.
+  const previousAuthorityTransitionRef = useRef({
+    scopeKey: authorityScopeKey,
+    userId: authenticatedUserId,
+    canUseMemberWorkspaceServices,
+  });
+  useLayoutEffect(() => {
+    const previous = previousAuthorityTransitionRef.current;
+    const identityChanged = previous.userId !== authenticatedUserId;
+    const privilegeChanged =
+      previous.canUseMemberWorkspaceServices !== canUseMemberWorkspaceServices;
+    const scopeChanged = previous.scopeKey !== authorityScopeKey;
+    previousAuthorityTransitionRef.current = {
+      scopeKey: authorityScopeKey,
+      userId: authenticatedUserId,
+      canUseMemberWorkspaceServices,
+    };
+    if (!identityChanged && !privilegeChanged && !scopeChanged) return;
 
-    if (!canUseMemberWorkspaceServices) {
-      // Cancel a member-authenticated board-object snapshot before clearing it;
-      // otherwise an in-flight hydration could repopulate the forbidden rows.
-      // The silent resync below restarts every viewer-readable hydration.
-      cancelAllHydrations();
+    cancelAllHydrations();
+    refetchInflightRef.current = null;
+    lastSilentFetchFailedRef.current = false;
+
+    if (identityChanged) {
+      // All normalized rows may contain caller-scoped/private data (MCP rows,
+      // OAuth state, credential presence), so an in-place identity replacement
+      // gets the same map boundary as logout before the new authority resyncs.
+      agorStore.getState().resetMaps();
+    } else if (!canUseMemberWorkspaceServices) {
       bumpRevision('boardObjects');
       agorStore.getState().applyMaps((previousMaps) => ({
         ...previousMaps,
@@ -1057,10 +1163,19 @@ export function useAgorData(
         boardObjectByCardId: new Map(),
       }));
     }
-    if (client && enabled && hasInitiallyFetched) {
+
+    if (authorityScopeKey && client && enabled && hasInitiallyFetched) {
       void fetchData({ silent: true });
     }
-  }, [canUseMemberWorkspaceServices, client, enabled, fetchData, hasInitiallyFetched]);
+  }, [
+    authenticatedUserId,
+    authorityScopeKey,
+    canUseMemberWorkspaceServices,
+    client,
+    enabled,
+    fetchData,
+    hasInitiallyFetched,
+  ]);
 
   // Clear all data when client goes away (logout / token revocation).
   //
@@ -1099,7 +1214,10 @@ export function useAgorData(
   // load that one session by ID as well. This keeps direct links to archived
   // sessions openable without changing the default list query.
   useEffect(() => {
-    if (!client || !enabled || !hasInitiallyFetched || !directSessionId) return;
+    if (!client || !enabled || !authorityScopeKey || !hasInitiallyFetched || !directSessionId)
+      return;
+    const directFetchAuthorityScope = authorityScopeKey;
+    const authorityIsCurrent = () => authorityScopeKeyRef.current === directFetchAuthorityScope;
     const { sessionById } = agorStore.getState();
     if (sessionById.has(directSessionId)) return;
     if (hasIdMatchingPrefix(directSessionId, sessionById.values(), (s) => s.session_id)) {
@@ -1110,7 +1228,7 @@ export function useAgorData(
     (async () => {
       try {
         const directSession = (await client.service('sessions').get(directSessionId)) as Session;
-        if (cancelled) return;
+        if (cancelled || !authorityIsCurrent()) return;
 
         // This is a live write to the sessions maps — bump so a sessions
         // hydration in flight discards its (session-missing) snapshot rather
@@ -1141,7 +1259,7 @@ export function useAgorData(
             const directBranch = (await client
               .service('branches')
               .get(directSession.branch_id)) as Branch;
-            if (cancelled) return;
+            if (cancelled || !authorityIsCurrent()) return;
             bumpRevision('branches');
             agorStore.getState().setMap('branchById', (prev) => {
               if (directBranch.archived) return prev;
@@ -1163,7 +1281,7 @@ export function useAgorData(
     return () => {
       cancelled = true;
     };
-  }, [client, directSessionId, enabled, hasInitiallyFetched]);
+  }, [authorityScopeKey, client, directSessionId, enabled, hasInitiallyFetched]);
 
   // Subscribe to real-time updates
   //
@@ -1174,7 +1292,7 @@ export function useAgorData(
   // OAuth + agor-query handlers stay local: they need `client` (async refetch)
   // or are pure window side-effects.
   useEffect(() => {
-    if (!client || !enabled) {
+    if (!client || !enabled || !authorityScopeKey) {
       // No client or disabled = not ready for data fetch, set loading to false
       agorStore.getState().setLoading(false);
       agorStore.getState().setLoadingStage('idle');
@@ -1355,7 +1473,12 @@ export function useAgorData(
     }) => {
       if (!event.success || !event.mcp_server_id) return;
       try {
-        await refetchMCPOAuthDurableState(client, event.mcp_server_id);
+        await refetchMCPOAuthDurableState(
+          client,
+          event.mcp_server_id,
+          () => authorityScopeKeyRef.current === authorityScopeKey
+        );
+        if (authorityScopeKeyRef.current !== authorityScopeKey) return;
         bumpRevision('oauth');
         bumpRevision('mcpServers');
       } catch (err) {
@@ -1369,7 +1492,12 @@ export function useAgorData(
     const handleOAuthDisconnected = async (event: { mcp_server_id: string }) => {
       if (!event.mcp_server_id) return;
       try {
-        await refetchMCPOAuthDurableState(client, event.mcp_server_id);
+        await refetchMCPOAuthDurableState(
+          client,
+          event.mcp_server_id,
+          () => authorityScopeKeyRef.current === authorityScopeKey
+        );
+        if (authorityScopeKeyRef.current !== authorityScopeKey) return;
         bumpRevision('oauth');
         bumpRevision('mcpServers');
       } catch (err) {
@@ -1393,13 +1521,16 @@ export function useAgorData(
     // doesn't blank the whole app via App.tsx's `dataError`
     // path — see the silent branch in `fetchData`.
     const refetchSilently = async () => {
-      if (!hasInitiallyFetched) return;
-      if (refetchInflightRef.current) return;
-      refetchInflightRef.current = true;
+      const refetchScope = authorityScopeKey;
+      if (!hasInitiallyFetched || !refetchScope) return;
+      if (refetchInflightRef.current === refetchScope) return;
+      refetchInflightRef.current = refetchScope;
       try {
         await fetchData({ silent: true });
       } finally {
-        refetchInflightRef.current = false;
+        if (refetchInflightRef.current === refetchScope) {
+          refetchInflightRef.current = null;
+        }
       }
     };
     client.io.on('connect', refetchSilently);
@@ -1420,8 +1551,10 @@ export function useAgorData(
     // created/patched/removed events that fire while fetchData's requests are
     // in flight are captured (and bump the per-collection revision counters)
     // instead of being dropped in the gap between fetch-start and listener-attach.
-    if (!hasInitiallyFetched) {
-      fetchData().then(() => setHasInitiallyFetched(true));
+    if (!hasInitiallyFetched && authorityScopeKey) {
+      fetchData().then((completedForAuthority) => {
+        if (completedForAuthority) setHasInitiallyFetched(true);
+      });
     }
 
     // Cleanup listeners on unmount
@@ -1505,6 +1638,7 @@ export function useAgorData(
   }, [
     canListUsers,
     canUseMemberWorkspaceServices,
+    authorityScopeKey,
     client,
     enabled,
     fetchData,

--- a/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Viewer workspace bootstrap integration.
+ *
+ * The Marketplace link is only useful if the real workspace bootstrap reaches
+ * AppHeader. This mounts useAgorData in front of the actual header while the
+ * daemon seam enforces the MEMBER floor on users.findAll and board-objects;
+ * a direct AppHeader render would miss the full-screen failure this guards.
+ */
+
+import type { AgorClient, User } from '@agor-live/client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { AppHeader } from '../components/AppHeader';
+import { ConnectionProvider } from '../contexts/ConnectionContext';
+import { useAgorData } from './useAgorData';
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ themeMode: 'dark', setThemeMode: vi.fn() }),
+}));
+vi.mock('../components/BoardSwitcher', () => ({ BoardSwitcher: () => null }));
+vi.mock('../components/BrandLogo', () => ({ BrandLogo: () => null }));
+vi.mock('../components/BrandMark', () => ({ BrandMark: () => null }));
+vi.mock('../components/ConnectionStatus', () => ({ ConnectionStatus: () => null }));
+vi.mock('../components/GlobalUserMenu', () => ({ GlobalUserMenu: () => null }));
+vi.mock('../components/MarkdownRenderer', () => ({ MarkdownRenderer: () => null }));
+vi.mock('../components/AppHeader/AppHeaderGlobalSearch', () => ({
+  AppHeaderGlobalSearch: () => null,
+}));
+vi.mock('../components/AppHeader/GlobalPresenceFacepile', () => ({
+  GlobalPresenceFacepile: () => null,
+}));
+
+type FailurePath = 'users' | 'board-objects' | 'boards';
+
+function makeWorkspaceClient(failurePaths: FailurePath | FailurePath[] | null) {
+  const failures = new Set(failurePaths ? [failurePaths].flat() : []);
+  const usersFindAll = vi.fn(async () => {
+    if (failures.has('users')) throw new Error('Forbidden: member role required');
+    return [];
+  });
+  const boardObjectsFindAll = vi.fn(async () => {
+    if (failures.has('board-objects')) {
+      throw new Error('You need member access to manage board objects');
+    }
+    return [];
+  });
+  const services = new Map<string, Record<string, unknown>>();
+  const service = (path: string) => {
+    const existing = services.get(path);
+    if (existing) return existing;
+    const value = {
+      findAll:
+        path === 'users'
+          ? usersFindAll
+          : path === 'board-objects'
+            ? boardObjectsFindAll
+            : vi.fn(async () => {
+                if (failures.has(path as FailurePath)) throw new Error(`Failed to load ${path}`);
+                return [];
+              }),
+      find: vi.fn(async () => []),
+      get: vi.fn(async () => null),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    services.set(path, value);
+    return value;
+  };
+  return {
+    client: {
+      service,
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient,
+    usersFindAll,
+    boardObjectsFindAll,
+  };
+}
+
+const VIEWER = {
+  user_id: 'viewer-1',
+  email: 'viewer@agor.live',
+  name: 'Viewer',
+  role: 'viewer',
+} as User;
+
+function WorkspaceBootstrap({ client, user }: { client: AgorClient; user: User }) {
+  const data = useAgorData(client, { authenticatedUserRole: user.role });
+  if (data.loading) return <div>Loading workspace</div>;
+  if (data.error) return <div role="alert">{data.error}</div>;
+  return (
+    <ConnectionProvider
+      value={{
+        connected: true,
+        connecting: false,
+        authGeneration: 1,
+        outOfSync: false,
+        capturedSha: null,
+        currentSha: null,
+      }}
+    >
+      <AppHeader user={user} connected currentUserId={user.user_id} />
+    </ConnectionProvider>
+  );
+}
+
+function renderWorkspace(client: AgorClient, user: User) {
+  return render(
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      <WorkspaceBootstrap client={client} user={user} />
+    </MemoryRouter>
+  );
+}
+
+describe('viewer-safe workspace bootstrap', () => {
+  it('reaches the real workspace header and Marketplace without member-only bootstrap calls', async () => {
+    const { client, usersFindAll, boardObjectsFindAll } = makeWorkspaceClient([
+      'users',
+      'board-objects',
+    ]);
+
+    renderWorkspace(client, VIEWER);
+
+    expect(await screen.findByRole('link', { name: 'Marketplace' })).toHaveAttribute(
+      'href',
+      '/ui/marketplace'
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(usersFindAll).not.toHaveBeenCalled();
+    expect(boardObjectsFindAll).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Users directory essential for members', async () => {
+    const { client, usersFindAll } = makeWorkspaceClient('users');
+
+    renderWorkspace(client, { ...VIEWER, user_id: 'member-1', role: 'member' } as User);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('member role required');
+    expect(usersFindAll).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('link', { name: 'Marketplace' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the privileged directory bootstrap for admins', async () => {
+    const { client, usersFindAll } = makeWorkspaceClient(null);
+
+    renderWorkspace(client, { ...VIEWER, user_id: 'admin-1', role: 'admin' } as User);
+
+    expect(await screen.findByRole('link', { name: 'Marketplace' })).toBeInTheDocument();
+    expect(usersFindAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not downgrade genuine essential failures for viewers', async () => {
+    const { client } = makeWorkspaceClient('boards');
+
+    renderWorkspace(client, VIEWER);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('boards'));
+    expect(screen.queryByRole('link', { name: 'Marketplace' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
@@ -7,7 +7,8 @@
  * a direct AppHeader render would miss the full-screen failure this guards.
  */
 
-import type { AgorClient, User } from '@agor-live/client';
+import { EventEmitter } from 'node:events';
+import type { AgorClient, Session, User } from '@agor-live/client';
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
@@ -50,7 +51,7 @@ function makeWorkspaceClient(failurePaths: FailurePath | FailurePath[] | null) {
   const service = (path: string) => {
     const existing = services.get(path);
     if (existing) return existing;
-    const value = {
+    const value: Record<string, unknown> = {
       findAll:
         path === 'users'
           ? usersFindAll
@@ -172,20 +173,41 @@ function transitionClient() {
   const usersFindAll = vi.fn(() => usersAnswers.shift() ?? Promise.resolve([]));
   const boardObjectsFindAll = vi.fn(() => boardObjectAnswers.shift() ?? Promise.resolve([]));
   const services = new Map<string, Record<string, unknown>>();
+  const serviceEmitters = new Map<string, EventEmitter>();
+  const failingServices = new Set<string>();
   const service = (path: string) => {
     const existing = services.get(path);
     if (existing) return existing;
+    const emitter = new EventEmitter();
+    serviceEmitters.set(path, emitter);
     const value = {
       findAll:
         path === 'users'
           ? usersFindAll
           : path === 'board-objects'
             ? boardObjectsFindAll
-            : vi.fn(async () => []),
-      find: vi.fn(async () => []),
-      get: vi.fn(async () => null),
-      on: vi.fn(),
-      removeListener: vi.fn(),
+            : vi.fn(async () => {
+                if (failingServices.has(path)) throw new Error(`${path} resync failed`);
+                return [];
+              }),
+      find: vi.fn(async () => {
+        if (failingServices.has(path)) throw new Error(`${path} resync failed`);
+        return [];
+      }),
+      get: vi.fn(async () => {
+        if (failingServices.has(path)) throw new Error(`${path} resync failed`);
+        return null;
+      }),
+      // Exercise the same EventEmitter subscription/removal/delivery timing as
+      // a Feathers service instead of merely recording inert `.on` calls.
+      on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+        emitter.on(event, listener);
+        return value;
+      }),
+      removeListener: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+        emitter.removeListener(event, listener);
+        return value;
+      }),
     };
     services.set(path, value);
     return value;
@@ -212,6 +234,21 @@ function transitionClient() {
     emitConnect: () => {
       for (const listener of ioListeners.get('connect') ?? []) listener();
     },
+    emitService: (path: string, event: string, payload: unknown) => {
+      service(path);
+      serviceEmitters.get(path)?.emit(event, payload);
+    },
+    serviceListenerCount: (path: string, event: string) => {
+      service(path);
+      return serviceEmitters.get(path)?.listenerCount(event) ?? 0;
+    },
+    setServiceFailure: (path: string, failing: boolean) => {
+      if (failing) failingServices.add(path);
+      else failingServices.delete(path);
+    },
+    getService: (path: string) => service(path),
+    findAllCallCount: (path: string) =>
+      (service(path).findAll as ReturnType<typeof vi.fn> | undefined)?.mock.calls.length ?? 0,
   };
 }
 
@@ -319,5 +356,91 @@ describe('workspace authority generation ordering', () => {
     rerender({ ready: true, generation: 2 });
     await waitFor(() => expect(seam.usersFindAll).toHaveBeenCalledTimes(2));
     expect(result.current.error).toBeNull();
+  });
+
+  it('never flushes real queued service events across identity, disconnect, or role authority', async () => {
+    const seam = transitionClient();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { result, rerender } = renderHook(
+      ({
+        userId,
+        role,
+        ready,
+        generation,
+      }: {
+        userId: string;
+        role: string;
+        ready: boolean;
+        generation: number;
+      }) =>
+        useAgorData(seam.client, {
+          authenticatedUserId: userId,
+          authenticatedUserRole: role,
+          authGeneration: generation,
+          connectionReady: ready,
+        }),
+      {
+        initialProps: {
+          userId: 'user-a',
+          role: 'member',
+          ready: true,
+          generation: 1,
+        },
+      }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(seam.serviceListenerCount('sessions', 'patched')).toBe(1));
+
+    const fromA = {
+      session_id: 'session-from-a',
+      branch_id: 'branch-a',
+      status: 'running',
+      archived: false,
+      created_at: '2026-08-20T00:00:00.000Z',
+    } as unknown as Session;
+    act(() => seam.emitService('sessions', 'patched', fromA));
+
+    // B's essential silent resync fails. The identity layout reset must remain
+    // empty even when A's old passive cleanup runs after that reset.
+    const beforeFailedResync = seam.findAllCallCount('sessions');
+    seam.setServiceFailure('sessions', true);
+    rerender({ userId: 'user-b', role: 'member', ready: true, generation: 2 });
+    await waitFor(() =>
+      expect(seam.findAllCallCount('sessions')).toBeGreaterThan(beforeFailedResync)
+    );
+    expect(agorStore.getState().sessionById.has('session-from-a')).toBe(false);
+    expect(agorStore.getState().sessionsByBranch.has('branch-a')).toBe(false);
+
+    // Let B re-establish a healthy generation, then queue one of B's patches
+    // and disconnect before the frame flushes. Reconnect must not replay it.
+    seam.setServiceFailure('sessions', false);
+    rerender({ userId: 'user-b', role: 'member', ready: true, generation: 3 });
+    await waitFor(() => expect(seam.serviceListenerCount('sessions', 'patched')).toBe(1));
+    const beforeDisconnect = {
+      ...fromA,
+      session_id: 'session-before-disconnect',
+      branch_id: 'branch-b',
+    } as Session;
+    act(() => seam.emitService('sessions', 'patched', beforeDisconnect));
+    rerender({ userId: 'user-b', role: 'member', ready: false, generation: 3 });
+    expect(agorStore.getState().sessionById.has('session-before-disconnect')).toBe(false);
+
+    rerender({ userId: 'user-b', role: 'member', ready: true, generation: 4 });
+    await waitFor(() => expect(seam.serviceListenerCount('sessions', 'patched')).toBe(1));
+    expect(agorStore.getState().sessionById.has('session-before-disconnect')).toBe(false);
+
+    // The same protection applies when a role changes before the replacement
+    // socket authentication generation is established.
+    const beforeDemotion = {
+      ...fromA,
+      session_id: 'session-before-demotion',
+      branch_id: 'branch-b',
+    } as Session;
+    act(() => seam.emitService('sessions', 'patched', beforeDemotion));
+    rerender({ userId: 'user-b', role: 'viewer', ready: true, generation: 4 });
+    rerender({ userId: 'user-b', role: 'viewer', ready: true, generation: 5 });
+    expect(agorStore.getState().sessionById.has('session-before-demotion')).toBe(false);
+
+    warn.mockRestore();
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.viewer-workspace.test.tsx
@@ -8,11 +8,12 @@
  */
 
 import type { AgorClient, User } from '@agor-live/client';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { AppHeader } from '../components/AppHeader';
 import { ConnectionProvider } from '../contexts/ConnectionContext';
+import { agorStore } from '../store/agorStore';
 import { useAgorData } from './useAgorData';
 
 vi.mock('../contexts/ThemeContext', () => ({
@@ -85,7 +86,12 @@ const VIEWER = {
 } as User;
 
 function WorkspaceBootstrap({ client, user }: { client: AgorClient; user: User }) {
-  const data = useAgorData(client, { authenticatedUserRole: user.role });
+  const data = useAgorData(client, {
+    authenticatedUserId: user.user_id,
+    authenticatedUserRole: user.role,
+    authGeneration: 1,
+    connectionReady: true,
+  });
   if (data.loading) return <div>Loading workspace</div>;
   if (data.error) return <div role="alert">{data.error}</div>;
   return (
@@ -156,5 +162,162 @@ describe('viewer-safe workspace bootstrap', () => {
 
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('boards'));
     expect(screen.queryByRole('link', { name: 'Marketplace' })).not.toBeInTheDocument();
+  });
+});
+
+function transitionClient() {
+  const usersAnswers: Array<Promise<unknown[]>> = [];
+  const boardObjectAnswers: Array<Promise<unknown[]>> = [];
+  const ioListeners = new Map<string, Array<() => void>>();
+  const usersFindAll = vi.fn(() => usersAnswers.shift() ?? Promise.resolve([]));
+  const boardObjectsFindAll = vi.fn(() => boardObjectAnswers.shift() ?? Promise.resolve([]));
+  const services = new Map<string, Record<string, unknown>>();
+  const service = (path: string) => {
+    const existing = services.get(path);
+    if (existing) return existing;
+    const value = {
+      findAll:
+        path === 'users'
+          ? usersFindAll
+          : path === 'board-objects'
+            ? boardObjectsFindAll
+            : vi.fn(async () => []),
+      find: vi.fn(async () => []),
+      get: vi.fn(async () => null),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    services.set(path, value);
+    return value;
+  };
+  return {
+    client: {
+      service,
+      io: {
+        on: vi.fn((event: string, listener: () => void) =>
+          ioListeners.set(event, [...(ioListeners.get(event) ?? []), listener])
+        ),
+        off: vi.fn((event: string, listener: () => void) =>
+          ioListeners.set(
+            event,
+            (ioListeners.get(event) ?? []).filter((candidate) => candidate !== listener)
+          )
+        ),
+      },
+    } as unknown as AgorClient,
+    usersFindAll,
+    boardObjectsFindAll,
+    queueUsers: (answer: Promise<unknown[]>) => usersAnswers.push(answer),
+    queueBoardObjects: (answer: Promise<unknown[]>) => boardObjectAnswers.push(answer),
+    emitConnect: () => {
+      for (const listener of ioListeners.get('connect') ?? []) listener();
+    },
+  };
+}
+
+function deferredList() {
+  let resolve!: (value: unknown[]) => void;
+  const promise = new Promise<unknown[]>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('workspace authority generation ordering', () => {
+  it('discards delayed member responses after demotion', async () => {
+    const seam = transitionClient();
+    const objects = deferredList();
+    seam.queueUsers(Promise.resolve([{ ...VIEWER, user_id: 'same-user', role: 'member' }]));
+    seam.queueBoardObjects(objects.promise);
+    const { result, rerender } = renderHook(
+      ({ role, ready, generation }: { role: string; ready: boolean; generation: number }) =>
+        useAgorData(seam.client, {
+          authenticatedUserId: 'same-user',
+          authenticatedUserRole: role,
+          authGeneration: generation,
+          connectionReady: ready,
+        }),
+      { initialProps: { role: 'member', ready: true, generation: 1 } }
+    );
+    await waitFor(() => expect(seam.boardObjectsFindAll).toHaveBeenCalledTimes(1));
+
+    // The role can render before useAgorClient publishes its reauthenticated
+    // generation. Even with a still-true connection bit, the old member fetch
+    // is invalid and no viewer-era resync may start.
+    rerender({ role: 'viewer', ready: true, generation: 1 });
+    await act(async () => {
+      objects.resolve([{ object_id: 'old-object', board_id: 'board-1' }]);
+      await objects.promise;
+    });
+    expect(agorStore.getState().userById.size).toBe(0);
+    expect(agorStore.getState().boardObjectById.size).toBe(0);
+
+    rerender({ role: 'viewer', ready: true, generation: 2 });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(agorStore.getState().userById.size).toBe(0);
+    expect(agorStore.getState().boardObjectById.size).toBe(0);
+  });
+
+  it('waits for member socket reauthentication before promotion resync', async () => {
+    const seam = transitionClient();
+    const promoted = { ...VIEWER, user_id: 'same-user', role: 'member' };
+    seam.queueUsers(Promise.resolve([promoted]));
+    seam.queueBoardObjects(Promise.resolve([{ object_id: 'member-object', board_id: 'board-1' }]));
+    const { result, rerender } = renderHook(
+      ({ role, ready, generation }: { role: string; ready: boolean; generation: number }) =>
+        useAgorData(seam.client, {
+          authenticatedUserId: 'same-user',
+          authenticatedUserRole: role,
+          authGeneration: generation,
+          connectionReady: ready,
+        }),
+      { initialProps: { role: 'viewer', ready: true, generation: 1 } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(seam.usersFindAll).not.toHaveBeenCalled();
+
+    // Adversarial ordering: fresh identity renders before the connection hook
+    // has closed its gate. The unchanged auth generation must still withhold.
+    rerender({ role: 'member', ready: true, generation: 1 });
+    await act(async () => Promise.resolve());
+    expect(seam.usersFindAll).not.toHaveBeenCalled();
+
+    rerender({ role: 'member', ready: false, generation: 1 });
+    expect(seam.usersFindAll).not.toHaveBeenCalled();
+
+    rerender({ role: 'member', ready: true, generation: 2 });
+    await waitFor(() => expect(seam.usersFindAll).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(agorStore.getState().userById.get('same-user')).toBeDefined());
+    expect(agorStore.getState().boardObjectById.has('member-object')).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('ignores reconnect delivery until the new authenticated generation is ready', async () => {
+    const seam = transitionClient();
+    seam.queueUsers(Promise.resolve([]));
+    seam.queueBoardObjects(Promise.resolve([]));
+    const { result, rerender } = renderHook(
+      ({ ready, generation }: { ready: boolean; generation: number }) =>
+        useAgorData(seam.client, {
+          authenticatedUserId: 'member-user',
+          authenticatedUserRole: 'member',
+          authGeneration: generation,
+          connectionReady: ready,
+        }),
+      { initialProps: { ready: true, generation: 1 } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(seam.usersFindAll).toHaveBeenCalledTimes(1);
+
+    rerender({ ready: false, generation: 1 });
+    act(() => seam.emitConnect());
+    await act(async () => Promise.resolve());
+    expect(seam.usersFindAll).toHaveBeenCalledTimes(1);
+
+    seam.queueUsers(Promise.resolve([]));
+    seam.queueBoardObjects(Promise.resolve([]));
+    rerender({ ready: true, generation: 2 });
+    await waitFor(() => expect(seam.usersFindAll).toHaveBeenCalledTimes(2));
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -263,7 +263,6 @@ describe('useAuth launch-code fallback', () => {
     expect(result.current.authenticationGeneration).toBeGreaterThan(invalidatedGeneration);
   });
 
-
   it.each(['success', 'failure'] as const)(
     'does not let a delayed A local-login %s overwrite B tokens or auth state',
     async (outcome) => {

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -8,6 +8,16 @@ const authenticate = vi.fn();
 const launchCreate = vi.fn();
 const refreshCreate = vi.fn();
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
 vi.mock('@agor-live/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor-live/client')>();
   return {
@@ -236,6 +246,125 @@ describe('useAuth launch-code fallback', () => {
 
     expect(result.current.authenticated).toBe(true);
     expect(result.current.authenticationGeneration).toBeGreaterThan(invalidatedGeneration);
+  });
+
+
+  it.each(['success', 'failure'] as const)(
+    'does not let a delayed A local-login %s overwrite B tokens or auth state',
+    async (outcome) => {
+      window.history.replaceState({}, '', '/ui/');
+      const pendingAuth = deferred<{
+        accessToken: string;
+        refreshToken: string;
+        user: { user_id: string; email: string };
+      }>();
+      authenticate.mockImplementationOnce(() => pendingAuth.promise);
+      const refreshed = vi.fn();
+      window.addEventListener(TOKENS_REFRESHED_EVENT, refreshed);
+
+      try {
+        const { result } = renderHook(() => useAuth());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        let authorityA = true;
+        let login!: Promise<'signed-in' | 'failed' | 'obsolete'>;
+        act(() => {
+          login = result.current.loginForAuthorityCycle(
+            'admin-a@example.test',
+            'new-password',
+            () => authorityA
+          );
+        });
+
+        authorityA = false;
+        localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-b-access');
+        localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-b-refresh');
+        act(() => {
+          window.dispatchEvent(
+            new CustomEvent(TOKENS_REFRESHED_EVENT, {
+              detail: {
+                accessToken: 'admin-b-access',
+                refreshToken: 'admin-b-refresh',
+                user: { user_id: 'admin-b', email: 'admin-b@example.test' },
+              },
+            })
+          );
+        });
+
+        if (outcome === 'success') {
+          pendingAuth.resolve({
+            accessToken: 'stale-admin-a-access',
+            refreshToken: 'stale-admin-a-refresh',
+            user: { user_id: 'admin-a', email: 'admin-a@example.test' },
+          });
+        } else {
+          pendingAuth.reject(new Error('stale A credentials failed'));
+        }
+        await act(async () => {
+          await expect(login).resolves.toBe('obsolete');
+        });
+
+        expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-b-access');
+        expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('admin-b-refresh');
+        expect(result.current.user?.user_id).toBe('admin-b');
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
+        // Only B's explicit authority establishment was announced. A's stale
+        // disposable REST result never dispatches a second replacement event.
+        expect(refreshed).toHaveBeenCalledOnce();
+      } finally {
+        window.removeEventListener(TOKENS_REFRESHED_EVENT, refreshed);
+      }
+    }
+  );
+
+  it('does not let a delayed guarded current-user refresh install an obsolete row', async () => {
+    window.history.replaceState({}, '', '/ui/');
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-a-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-a-refresh');
+    authenticate.mockResolvedValueOnce({
+      accessToken: 'admin-a-access',
+      user: { user_id: 'admin-a', email: 'admin-a@example.test' },
+    });
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.user?.user_id).toBe('admin-a'));
+
+    const pendingRefresh = deferred<{
+      accessToken: string;
+      user: { user_id: string; email: string };
+    }>();
+    authenticate.mockImplementationOnce(() => pendingRefresh.promise);
+    let authorityA = true;
+    let refresh!: Promise<boolean>;
+    act(() => {
+      refresh = result.current.refreshCurrentUserForAuthorityCycle(() => authorityA);
+    });
+
+    authorityA = false;
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-b-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-b-refresh');
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TOKENS_REFRESHED_EVENT, {
+          detail: {
+            accessToken: 'admin-b-access',
+            refreshToken: 'admin-b-refresh',
+            user: { user_id: 'admin-b', email: 'admin-b@example.test' },
+          },
+        })
+      );
+    });
+    pendingRefresh.resolve({
+      accessToken: 'admin-a-access',
+      user: { user_id: 'admin-a', email: 'stale-admin-a@example.test' },
+    });
+
+    await act(async () => {
+      await expect(refresh).resolves.toBe(false);
+    });
+    expect(result.current.user?.user_id).toBe('admin-b');
+    expect(result.current.user?.email).toBe('admin-b@example.test');
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-b-access');
   });
 
   it('preserves stored tokens when stored-session auth gets a non-auth transport response', async () => {

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -258,7 +258,6 @@ describe('useAuth launch-code fallback', () => {
         refreshToken: string;
         user: { user_id: string; email: string };
       }>();
-      authenticate.mockImplementationOnce(() => pendingAuth.promise);
       const refreshed = vi.fn();
       window.addEventListener(TOKENS_REFRESHED_EVENT, refreshed);
 
@@ -266,12 +265,32 @@ describe('useAuth launch-code fallback', () => {
         const { result } = renderHook(() => useAuth());
         await waitFor(() => expect(result.current.loading).toBe(false));
         let authorityA = true;
+        localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-a-access');
+        localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-a-refresh');
+        act(() => {
+          window.dispatchEvent(
+            new CustomEvent(TOKENS_REFRESHED_EVENT, {
+              detail: {
+                accessToken: 'admin-a-access',
+                refreshToken: 'admin-a-refresh',
+                user: {
+                  user_id: 'admin-a',
+                  email: 'admin-a@example.test',
+                  role: 'admin',
+                },
+              },
+            })
+          );
+        });
+        const authorityCycle = result.current.captureAuthorityCycle(() => authorityA);
+        expect(authorityCycle).not.toBeNull();
+        authenticate.mockImplementationOnce(() => pendingAuth.promise);
         let login!: Promise<'signed-in' | 'failed' | 'obsolete'>;
         act(() => {
           login = result.current.loginForAuthorityCycle(
             'admin-a@example.test',
             'new-password',
-            () => authorityA
+            authorityCycle!
           );
         });
 
@@ -284,7 +303,7 @@ describe('useAuth launch-code fallback', () => {
               detail: {
                 accessToken: 'admin-b-access',
                 refreshToken: 'admin-b-refresh',
-                user: { user_id: 'admin-b', email: 'admin-b@example.test' },
+                user: { user_id: 'admin-b', email: 'admin-b@example.test', role: 'admin' },
               },
             })
           );
@@ -294,7 +313,7 @@ describe('useAuth launch-code fallback', () => {
           pendingAuth.resolve({
             accessToken: 'stale-admin-a-access',
             refreshToken: 'stale-admin-a-refresh',
-            user: { user_id: 'admin-a', email: 'admin-a@example.test' },
+            user: { user_id: 'admin-a', email: 'admin-a@example.test', role: 'admin' },
           });
         } else {
           pendingAuth.reject(new Error('stale A credentials failed'));
@@ -308,14 +327,66 @@ describe('useAuth launch-code fallback', () => {
         expect(result.current.user?.user_id).toBe('admin-b');
         expect(result.current.loading).toBe(false);
         expect(result.current.error).toBeNull();
-        // Only B's explicit authority establishment was announced. A's stale
-        // disposable REST result never dispatches a second replacement event.
-        expect(refreshed).toHaveBeenCalledOnce();
+        // Only the explicit A fixture and B replacement were announced. A's
+        // stale disposable REST result never dispatches a third event.
+        expect(refreshed).toHaveBeenCalledTimes(2);
       } finally {
         window.removeEventListener(TOKENS_REFRESHED_EVENT, refreshed);
       }
     }
   );
+
+  it('deterministically releases loading when a captured reconnect cycle becomes obsolete', async () => {
+    window.history.replaceState({}, '', '/ui/');
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-a-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-a-refresh');
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(TOKENS_REFRESHED_EVENT, {
+          detail: {
+            accessToken: 'admin-a-access',
+            refreshToken: 'admin-a-refresh',
+            user: { user_id: 'admin-a', email: 'admin-a@example.test', role: 'admin' },
+          },
+        })
+      );
+    });
+    let connectionReady = true;
+    const authorityCycle = result.current.captureAuthorityCycle(() => connectionReady);
+    expect(authorityCycle).not.toBeNull();
+    const pendingAuth = deferred<{
+      accessToken: string;
+      refreshToken: string;
+      user: { user_id: string; email: string; role: string };
+    }>();
+    authenticate.mockImplementationOnce(() => pendingAuth.promise);
+
+    let login!: Promise<'signed-in' | 'failed' | 'obsolete'>;
+    act(() => {
+      login = result.current.loginForAuthorityCycle(
+        'admin-a@example.test',
+        'new-password',
+        authorityCycle!
+      );
+    });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    connectionReady = false;
+    pendingAuth.resolve({
+      accessToken: 'obsolete-access',
+      refreshToken: 'obsolete-refresh',
+      user: { user_id: 'admin-a', email: 'admin-a@example.test', role: 'admin' },
+    });
+
+    await act(async () => {
+      await expect(login).resolves.toBe('obsolete');
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.user?.user_id).toBe('admin-a');
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-access');
+  });
 
   it('does not let a delayed guarded current-user refresh install an obsolete row', async () => {
     window.history.replaceState({}, '', '/ui/');

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -18,6 +18,21 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+function authorityOperation(isCurrent: () => boolean) {
+  const listeners = new Set<() => void>();
+  return {
+    isCurrent,
+    onInvalidate(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    invalidate() {
+      for (const listener of [...listeners]) listener();
+      listeners.clear();
+    },
+  };
+}
+
 vi.mock('@agor-live/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor-live/client')>();
   return {
@@ -282,10 +297,11 @@ describe('useAuth launch-code fallback', () => {
             })
           );
         });
-        const authorityCycle = result.current.captureAuthorityCycle(() => authorityA);
+        const operation = authorityOperation(() => authorityA);
+        const authorityCycle = result.current.captureAuthorityCycle(operation);
         expect(authorityCycle).not.toBeNull();
         authenticate.mockImplementationOnce(() => pendingAuth.promise);
-        let login!: Promise<'signed-in' | 'failed' | 'obsolete'>;
+        let login!: ReturnType<typeof result.current.loginForAuthorityCycle>;
         act(() => {
           login = result.current.loginForAuthorityCycle(
             'admin-a@example.test',
@@ -295,6 +311,7 @@ describe('useAuth launch-code fallback', () => {
         });
 
         authorityA = false;
+        operation.invalidate();
         localStorage.setItem(ACCESS_TOKEN_KEY, 'admin-b-access');
         localStorage.setItem(REFRESH_TOKEN_KEY, 'admin-b-refresh');
         act(() => {
@@ -319,7 +336,7 @@ describe('useAuth launch-code fallback', () => {
           pendingAuth.reject(new Error('stale A credentials failed'));
         }
         await act(async () => {
-          await expect(login).resolves.toBe('obsolete');
+          await expect(login).resolves.toEqual({ status: 'obsolete' });
         });
 
         expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-b-access');
@@ -355,7 +372,8 @@ describe('useAuth launch-code fallback', () => {
       );
     });
     let connectionReady = true;
-    const authorityCycle = result.current.captureAuthorityCycle(() => connectionReady);
+    const operation = authorityOperation(() => connectionReady);
+    const authorityCycle = result.current.captureAuthorityCycle(operation);
     expect(authorityCycle).not.toBeNull();
     const pendingAuth = deferred<{
       accessToken: string;
@@ -364,7 +382,7 @@ describe('useAuth launch-code fallback', () => {
     }>();
     authenticate.mockImplementationOnce(() => pendingAuth.promise);
 
-    let login!: Promise<'signed-in' | 'failed' | 'obsolete'>;
+    let login!: ReturnType<typeof result.current.loginForAuthorityCycle>;
     act(() => {
       login = result.current.loginForAuthorityCycle(
         'admin-a@example.test',
@@ -374,17 +392,25 @@ describe('useAuth launch-code fallback', () => {
     });
     await waitFor(() => expect(result.current.loading).toBe(true));
     connectionReady = false;
+    act(() => {
+      operation.invalidate();
+    });
+
+    await act(async () => {
+      await expect(login).resolves.toEqual({ status: 'obsolete' });
+    });
+    // The held REST authentication has not resolved. Cancellation itself owns
+    // and releases the global loading gate.
+    expect(result.current.loading).toBe(false);
+    expect(result.current.user?.user_id).toBe('admin-a');
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-access');
+
     pendingAuth.resolve({
       accessToken: 'obsolete-access',
       refreshToken: 'obsolete-refresh',
       user: { user_id: 'admin-a', email: 'admin-a@example.test', role: 'admin' },
     });
-
-    await act(async () => {
-      await expect(login).resolves.toBe('obsolete');
-    });
-    expect(result.current.loading).toBe(false);
-    expect(result.current.user?.user_id).toBe('admin-a');
+    await act(() => pendingAuth.promise);
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('admin-a-access');
   });
 

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -31,6 +31,7 @@ import {
   type RefreshResult,
   storeTokens,
 } from '../utils/tokenRefresh';
+import type { AuthorityOperation } from './useAuthorityOperationGuard';
 
 interface AuthState {
   user: User | null;
@@ -55,7 +56,21 @@ export interface CapturedAuthAuthorityCycle {
   role: string;
   accessToken: string;
   isCurrent: () => boolean;
+  onInvalidate: AuthorityOperation['onInvalidate'];
 }
+
+export interface EstablishedAuthAuthorityReceipt {
+  userId: string;
+  role: string;
+  accessToken: string;
+  /** Exact freshly-installed authority, independent of the initiating modal/generation. */
+  isCurrent: () => boolean;
+}
+
+export type AuthorityCycleLoginResult =
+  | { status: 'signed-in'; authority: EstablishedAuthAuthorityReceipt }
+  | { status: 'failed' }
+  | { status: 'obsolete' };
 
 interface UseAuthReturn extends AuthState {
   /** Monotonic owner for caller-scoped async work. Routine token refresh does not advance it. */
@@ -63,12 +78,14 @@ interface UseAuthReturn extends AuthState {
   isAuthenticationGenerationCurrent: (generation: number) => boolean;
   isAuthenticationOwnerCurrent: (userId: UserID, generation: number) => boolean;
   login: (email: string, password: string) => Promise<boolean>;
-  captureAuthorityCycle: (shouldApply: () => boolean) => CapturedAuthAuthorityCycle | null;
+  captureAuthorityCycle: (
+    authorityOperation: Pick<AuthorityOperation, 'isCurrent' | 'onInvalidate'>
+  ) => CapturedAuthAuthorityCycle | null;
   loginForAuthorityCycle: (
     email: string,
     password: string,
     authorityCycle: CapturedAuthAuthorityCycle
-  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
+  ) => Promise<AuthorityCycleLoginResult>;
   logout: () => Promise<void>;
   logoutForAuthorityCycle: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
   reAuthenticate: () => Promise<void>;
@@ -491,14 +508,19 @@ export function useAuth(): UseAuthReturn {
       const detail = (event as CustomEvent<RefreshResult>).detail;
       if (!detail) return;
       localLoginAttemptRef.current = null;
-      setState((prev) => ({
-        ...prev,
+      const nextState: AuthState = {
+        ...authStateRef.current,
         accessToken: detail.accessToken,
         user: detail.user,
         authenticated: true,
         loading: false,
         error: null,
-      }));
+      };
+      // Update the authority ref synchronously with the token event. A stale
+      // local-auth continuation can otherwise run in the microtask before
+      // React commits the replacement identity.
+      authStateRef.current = nextState;
+      setState(nextState);
     };
 
     window.addEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
@@ -534,13 +556,15 @@ export function useAuth(): UseAuthReturn {
    * Login with email and password
    */
   const captureAuthorityCycle = useCallback(
-    (shouldApply: () => boolean): CapturedAuthAuthorityCycle | null => {
+    (
+      authorityOperation: Pick<AuthorityOperation, 'isCurrent' | 'onInvalidate'>
+    ): CapturedAuthAuthorityCycle | null => {
       const captured = authStateRef.current;
       const userId = captured.user?.user_id;
       const role = captured.user?.role;
       const accessToken = captured.accessToken;
       if (
-        !shouldApply() ||
+        !authorityOperation.isCurrent() ||
         !captured.authenticated ||
         !userId ||
         !role ||
@@ -554,10 +578,11 @@ export function useAuth(): UseAuthReturn {
         userId,
         role,
         accessToken,
+        onInvalidate: authorityOperation.onInvalidate,
         isCurrent: () => {
           const current = authStateRef.current;
           return (
-            shouldApply() &&
+            authorityOperation.isCurrent() &&
             current.authenticated &&
             current.user?.user_id === userId &&
             current.user?.role === role &&
@@ -574,29 +599,44 @@ export function useAuth(): UseAuthReturn {
     email: string,
     password: string,
     authorityCycle: CapturedAuthAuthorityCycle
-  ): Promise<'signed-in' | 'failed' | 'obsolete'> => {
-    if (!authorityCycle.isCurrent()) return 'obsolete';
+  ): Promise<AuthorityCycleLoginResult> => {
+    if (!authorityCycle.isCurrent()) return { status: 'obsolete' };
     const attempt = {};
     localLoginAttemptRef.current = attempt;
     setState((prev) => ({ ...prev, loading: true, error: null }));
 
-    const finishObsolete = (): 'obsolete' => {
+    const finishObsolete = (): AuthorityCycleLoginResult => {
       if (localLoginAttemptRef.current === attempt) {
         localLoginAttemptRef.current = null;
         setState((prev) => ({ ...prev, loading: false }));
       }
-      return 'obsolete';
+      return { status: 'obsolete' };
     };
 
     try {
-      const client = await createRestClient(getDaemonUrl());
-
-      // Authenticate
-      const result = await client.authenticate({
-        strategy: 'local',
-        email,
-        password,
+      const authentication = (async () => {
+        const client = await createRestClient(getDaemonUrl());
+        return client.authenticate({ strategy: 'local', email, password });
+      })();
+      let unsubscribeCancellation = () => {};
+      const cancellation = new Promise<{ kind: 'cancelled' }>((resolve) => {
+        unsubscribeCancellation = authorityCycle.onInvalidate(() => {
+          resolve({ kind: 'cancelled' });
+        });
       });
+      // Convert rejection to a value before racing so an authentication
+      // promise held past cancellation can never later reject unhandled.
+      const outcome = await Promise.race([
+        authentication.then(
+          (result) => ({ kind: 'authenticated' as const, result }),
+          (error: unknown) => ({ kind: 'failed' as const, error })
+        ),
+        cancellation,
+      ]);
+      unsubscribeCancellation();
+      if (outcome.kind === 'cancelled') return finishObsolete();
+      if (outcome.kind === 'failed') throw outcome.error;
+      const result = outcome.result;
 
       // Local authentication is deliberately performed on a disposable REST
       // client. Do not install its tokens or identity into the long-lived app
@@ -615,7 +655,7 @@ export function useAuth(): UseAuthReturn {
           error:
             'Your account authority changed while the password was being updated. Sign in again.',
         }));
-        return 'failed';
+        return { status: 'failed' };
       }
 
       // Store both access and refresh tokens. This is an explicit credential
@@ -630,16 +670,38 @@ export function useAuth(): UseAuthReturn {
       // ever gets tried.
       resetRefreshFailureState();
 
-      setState({
+      const nextState: AuthState = {
         user: result.user,
         accessToken: result.accessToken,
         authenticated: true,
         loading: false,
         error: null,
-      });
+      };
+      authStateRef.current = nextState;
+      setState(nextState);
       dispatchTokensRefreshed(result);
 
-      return 'signed-in';
+      const establishedUserId = result.user.user_id;
+      const establishedRole = result.user.role;
+      const establishedAccessToken = result.accessToken;
+      return {
+        status: 'signed-in',
+        authority: {
+          userId: establishedUserId,
+          role: establishedRole,
+          accessToken: establishedAccessToken,
+          isCurrent: () => {
+            const current = authStateRef.current;
+            return (
+              current.authenticated &&
+              current.user?.user_id === establishedUserId &&
+              current.user?.role === establishedRole &&
+              current.accessToken === establishedAccessToken &&
+              getStoredAccessToken() === establishedAccessToken
+            );
+          },
+        },
+      };
     } catch (error) {
       if (localLoginAttemptRef.current !== attempt || !authorityCycle.isCurrent()) {
         return finishObsolete();
@@ -654,7 +716,7 @@ export function useAuth(): UseAuthReturn {
         loading: false,
         error: userFacingMessage,
       }));
-      return 'failed';
+      return { status: 'failed' };
     }
   };
 
@@ -699,13 +761,15 @@ export function useAuth(): UseAuthReturn {
     localLoginAttemptRef.current = null;
     invalidateAuthentication();
     clearTokens();
-    setState({
+    const nextState: AuthState = {
       user: null,
       accessToken: null,
       authenticated: false,
       loading: false,
       error: null,
-    });
+    };
+    authStateRef.current = nextState;
+    setState(nextState);
   };
 
   const logoutForAuthorityCycle = async (
@@ -718,13 +782,15 @@ export function useAuth(): UseAuthReturn {
     // the guard and the mutation.
     localLoginAttemptRef.current = null;
     clearTokens();
-    setState({
+    const nextState: AuthState = {
       user: null,
       accessToken: null,
       authenticated: false,
       loading: false,
       error: null,
-    });
+    };
+    authStateRef.current = nextState;
+    setState(nextState);
     return true;
   };
 

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -40,23 +40,37 @@ interface AuthState {
   error: string | null;
 }
 
+/**
+ * Exact authenticated authority captured before an operation invalidates its
+ * own old credentials (for example, a required password change).
+ *
+ * Component mount lifetime is deliberately not part of this ticket. The App
+ * loading gate may unmount the initiating modal while a replacement login is
+ * in flight. Identity, role, credential, connection and auth-generation
+ * changes still invalidate it through the supplied authority guard and the
+ * exact auth/storage snapshots.
+ */
+export interface CapturedAuthAuthorityCycle {
+  userId: string;
+  role: string;
+  accessToken: string;
+  isCurrent: () => boolean;
+}
+
 interface UseAuthReturn extends AuthState {
-  /** Monotonic owner for caller-scoped async work. Token refresh does not advance it. */
+  /** Monotonic owner for caller-scoped async work. Routine token refresh does not advance it. */
   authenticationGeneration: number;
   isAuthenticationGenerationCurrent: (generation: number) => boolean;
-  /**
-   * Synchronously verifies the complete authenticated owner. Unlike render-time
-   * user state, this cannot be changed by an abandoned React render.
-   */
   isAuthenticationOwnerCurrent: (userId: UserID, generation: number) => boolean;
   login: (email: string, password: string) => Promise<boolean>;
+  captureAuthorityCycle: (shouldApply: () => boolean) => CapturedAuthAuthorityCycle | null;
   loginForAuthorityCycle: (
     email: string,
     password: string,
-    shouldApply: () => boolean
+    authorityCycle: CapturedAuthAuthorityCycle
   ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
   logout: () => Promise<void>;
-  logoutForAuthorityCycle: (shouldApply: () => boolean) => Promise<boolean>;
+  logoutForAuthorityCycle: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
   reAuthenticate: () => Promise<void>;
   refreshCurrentUserForAuthorityCycle: (shouldApply: () => boolean) => Promise<boolean>;
 }
@@ -94,9 +108,14 @@ export function useAuth(): UseAuthReturn {
     loading: true,
     error: null,
   });
+  const authStateRef = useRef(state);
+  authStateRef.current = state;
+  // Only the latest local-login attempt may install credentials or own the
+  // global loading bit. Other auth establishments explicitly supersede it.
+  const localLoginAttemptRef = useRef<object | null>(null);
   const authenticationGenerationRef = useRef(0);
   const [authenticationGeneration, setAuthenticationGeneration] = useState(0);
-  const activeUserIdRef = useRef<UserID | null>(null);
+  const activeAuthorityRef = useRef<{ userId: UserID; role: User['role'] } | null>(null);
 
   const advanceAuthenticationGeneration = useCallback(() => {
     authenticationGenerationRef.current += 1;
@@ -104,30 +123,23 @@ export function useAuth(): UseAuthReturn {
   }, []);
 
   const invalidateAuthentication = useCallback(() => {
-    activeUserIdRef.current = null;
+    activeAuthorityRef.current = null;
     advanceAuthenticationGeneration();
   }, [advanceAuthenticationGeneration]);
 
   const noteAuthenticatedUser = useCallback(
     (user: User) => {
-      const nextUserId = user.user_id;
-      // The generation identifies a committed authenticated authority, not
-      // merely an explicit logout/login operation. The first null -> user
-      // commit and a live A -> B replacement must both retire work owned by
-      // the preceding authority. A routine token refresh for the same user
-      // deliberately preserves the generation (and therefore the socket).
-      if (activeUserIdRef.current !== nextUserId) {
+      const previous = activeAuthorityRef.current;
+      if (!previous || previous.userId !== user.user_id || previous.role !== user.role) {
         advanceAuthenticationGeneration();
       }
-      activeUserIdRef.current = nextUserId;
+      activeAuthorityRef.current = { userId: user.user_id, role: user.role };
     },
     [advanceAuthenticationGeneration]
   );
 
   const noteUnauthenticated = useCallback(() => {
-    if (activeUserIdRef.current) {
-      invalidateAuthentication();
-    }
+    if (activeAuthorityRef.current) invalidateAuthentication();
   }, [invalidateAuthentication]);
 
   const isAuthenticationGenerationCurrent = useCallback(
@@ -136,7 +148,8 @@ export function useAuth(): UseAuthReturn {
   );
   const isAuthenticationOwnerCurrent = useCallback(
     (userId: UserID, generation: number) =>
-      activeUserIdRef.current === userId && authenticationGenerationRef.current === generation,
+      activeAuthorityRef.current?.userId === userId &&
+      authenticationGenerationRef.current === generation,
     []
   );
 
@@ -144,9 +157,9 @@ export function useAuth(): UseAuthReturn {
    * Re-authenticate using stored token (with automatic refresh)
    * Retries up to 3 times to handle daemon restarts gracefully
    */
-  // biome-ignore lint/correctness/useExhaustiveDependencies: auth-generation helpers are stable for the hook lifetime; reAuthenticate must remain stable for retry/effect callers
   const reAuthenticate = useCallback(async (retryCount = 0, pendingLaunchCode?: string) => {
     const MAX_RETRIES = 5;
+    localLoginAttemptRef.current = null;
     setState((prev) => ({ ...prev, loading: true, error: null }));
 
     const storedAccessToken = getStoredAccessToken();
@@ -172,7 +185,6 @@ export function useAuth(): UseAuthReturn {
           });
 
           noteAuthenticatedUser(result.user);
-
           setState({
             user: result.user,
             accessToken: result.accessToken,
@@ -194,7 +206,6 @@ export function useAuth(): UseAuthReturn {
           const refreshResult = await refreshTokensSingleFlight(client, storedRefreshToken);
 
           noteAuthenticatedUser(refreshResult.user);
-
           setState({
             user: refreshResult.user,
             accessToken: refreshResult.accessToken,
@@ -469,17 +480,17 @@ export function useAuth(): UseAuthReturn {
     }, delay);
 
     return () => clearTimeout(timer);
-  }, [state.authenticated, state.accessToken, noteUnauthenticated]);
+  }, [state.authenticated, state.accessToken]);
 
   // When the single-flight refresh helper completes from a non-React path
-  // (e.g. rejected-handshake recovery or a concurrent visibility refresh),
-  // sync our React state so the next render uses the fresh
+  // (e.g. the socket-client 401-retry hook, or a concurrent refresh in
+  // useAgorClient), sync our React state so the next render uses the fresh
   // token and the auto-refresh effect re-schedules around the new `exp`.
   useEffect(() => {
     const handleRefreshed = (event: Event) => {
       const detail = (event as CustomEvent<RefreshResult>).detail;
       if (!detail) return;
-      noteAuthenticatedUser(detail.user);
+      localLoginAttemptRef.current = null;
       setState((prev) => ({
         ...prev,
         accessToken: detail.accessToken,
@@ -492,15 +503,17 @@ export function useAuth(): UseAuthReturn {
 
     window.addEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
     return () => window.removeEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
-  }, [noteAuthenticatedUser]);
+  }, []);
 
   // When the single-flight refresh helper determines the refresh token is
   // permanently dead (e.g. the server returned 401 / NotAuthenticated from
   // the refresh endpoint), clear tokens and flip to unauthenticated. Without
-  // this, repeated rejected handshakes could leave the app disconnected
-  // without clearing a session that can no longer authenticate.
+  // this, the socket around-hook and connect-handler would each re-throw
+  // the original auth error without cleanup, and a page reload would be the
+  // only way to escape the resulting refresh/reconnect loop.
   useEffect(() => {
     const handleUnrecoverable = () => {
+      localLoginAttemptRef.current = null;
       clearTokens();
       noteUnauthenticated();
       setState({
@@ -515,64 +528,65 @@ export function useAuth(): UseAuthReturn {
     window.addEventListener(TOKENS_REFRESH_UNRECOVERABLE_EVENT, handleUnrecoverable);
     return () =>
       window.removeEventListener(TOKENS_REFRESH_UNRECOVERABLE_EVENT, handleUnrecoverable);
-  }, [noteUnauthenticated]);
+  }, []);
 
   /**
    * Login with email and password
    */
+  const captureAuthorityCycle = useCallback(
+    (shouldApply: () => boolean): CapturedAuthAuthorityCycle | null => {
+      const captured = authStateRef.current;
+      const userId = captured.user?.user_id;
+      const role = captured.user?.role;
+      const accessToken = captured.accessToken;
+      if (
+        !shouldApply() ||
+        !captured.authenticated ||
+        !userId ||
+        !role ||
+        !accessToken ||
+        getStoredAccessToken() !== accessToken
+      ) {
+        return null;
+      }
+
+      return {
+        userId,
+        role,
+        accessToken,
+        isCurrent: () => {
+          const current = authStateRef.current;
+          return (
+            shouldApply() &&
+            current.authenticated &&
+            current.user?.user_id === userId &&
+            current.user?.role === role &&
+            current.accessToken === accessToken &&
+            getStoredAccessToken() === accessToken
+          );
+        },
+      };
+    },
+    []
+  );
+
   const loginForAuthorityCycle = async (
     email: string,
     password: string,
-    shouldApply: () => boolean
+    authorityCycle: CapturedAuthAuthorityCycle
   ): Promise<'signed-in' | 'failed' | 'obsolete'> => {
-    if (!shouldApply()) return 'obsolete';
+    if (!authorityCycle.isCurrent()) return 'obsolete';
+    const attempt = {};
+    localLoginAttemptRef.current = attempt;
     setState((prev) => ({ ...prev, loading: true, error: null }));
 
-    try {
-      const client = await createRestClient(getDaemonUrl());
-      const result = await client.authenticate({ strategy: 'local', email, password });
-      if (!shouldApply()) return 'obsolete';
-
-      // This is an explicit authority replacement, even when the user id is
-      // unchanged. Retire work owned by the revoked credential before exposing
-      // the new one.
-      invalidateAuthentication();
-      storeTokens(result.accessToken, result.refreshToken);
-      resetRefreshFailureState();
-      noteAuthenticatedUser(result.user);
-      setState({
-        user: result.user,
-        accessToken: result.accessToken,
-        authenticated: true,
-        loading: false,
-        error: null,
-      });
-      dispatchTokensRefreshed(result);
-      return 'signed-in';
-    } catch (error) {
-      if (!shouldApply()) return 'obsolete';
-      console.error('❌ Login failed:', error);
-      const userFacingMessage = loginErrorMessage(error);
-      const rawMessage = error instanceof Error ? error.message : 'Login failed';
-      console.error('❌ Error message:', rawMessage);
-      setState((prev) => ({ ...prev, loading: false, error: userFacingMessage }));
-      return 'failed';
-    }
-  };
-
-  const login = async (email: string, password: string): Promise<boolean> => {
-    // Invalidate caller-owned work synchronously, including a same-user
-    // logout/login or explicit re-login.
-    invalidateAuthentication();
-    // Do not keep exposing the preceding user's access token under the newly
-    // advanced generation while the replacement login is in flight.
-    setState({
-      user: null,
-      accessToken: null,
-      authenticated: false,
-      loading: true,
-      error: null,
-    });
+    const finishObsolete = (): 'obsolete' => {
+      if (localLoginAttemptRef.current === attempt) {
+        localLoginAttemptRef.current = null;
+        setState((prev) => ({ ...prev, loading: false }));
+      }
+      return 'obsolete';
+    };
 
     try {
       const client = await createRestClient(getDaemonUrl());
@@ -584,14 +598,37 @@ export function useAuth(): UseAuthReturn {
         password,
       });
 
-      // Store both access and refresh tokens
+      // Local authentication is deliberately performed on a disposable REST
+      // client. Do not install its tokens or identity into the long-lived app
+      // after the exact caller/socket authority cycle that requested it ended.
+      if (localLoginAttemptRef.current !== attempt || !authorityCycle.isCurrent()) {
+        return finishObsolete();
+      }
+      if (
+        result.user?.user_id !== authorityCycle.userId ||
+        result.user?.role !== authorityCycle.role
+      ) {
+        localLoginAttemptRef.current = null;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error:
+            'Your account authority changed while the password was being updated. Sign in again.',
+        }));
+        return 'failed';
+      }
+
+      // Store both access and refresh tokens. This is an explicit credential
+      // replacement, so advance authority even when user id and role are unchanged.
+      localLoginAttemptRef.current = null;
+      invalidateAuthentication();
       storeTokens(result.accessToken, result.refreshToken);
+      noteAuthenticatedUser(result.user);
 
       // Fresh session — clear any stale "refresh is dead" latch from a
       // previous login so the new refresh token isn't rejected before it
       // ever gets tried.
       resetRefreshFailureState();
-      noteAuthenticatedUser(result.user);
 
       setState({
         user: result.user,
@@ -602,8 +639,12 @@ export function useAuth(): UseAuthReturn {
       });
       dispatchTokensRefreshed(result);
 
-      return true;
+      return 'signed-in';
     } catch (error) {
+      if (localLoginAttemptRef.current !== attempt || !authorityCycle.isCurrent()) {
+        return finishObsolete();
+      }
+      localLoginAttemptRef.current = null;
       console.error('❌ Login failed:', error);
       const userFacingMessage = loginErrorMessage(error);
       const rawMessage = error instanceof Error ? error.message : 'Login failed';
@@ -613,11 +654,49 @@ export function useAuth(): UseAuthReturn {
         loading: false,
         error: userFacingMessage,
       }));
+      return 'failed';
+    }
+  };
+
+  const login = async (email: string, password: string): Promise<boolean> => {
+    invalidateAuthentication();
+    // Ordinary login begins without an existing authenticated authority. Use a
+    // dedicated path rather than fabricating a captured cycle.
+    const attempt = {};
+    localLoginAttemptRef.current = attempt;
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const client = await createRestClient(getDaemonUrl());
+      const result = await client.authenticate({ strategy: 'local', email, password });
+      if (localLoginAttemptRef.current !== attempt) return false;
+      localLoginAttemptRef.current = null;
+      storeTokens(result.accessToken, result.refreshToken);
+      resetRefreshFailureState();
+      noteAuthenticatedUser(result.user);
+      setState({
+        user: result.user,
+        accessToken: result.accessToken,
+        authenticated: true,
+        loading: false,
+        error: null,
+      });
+      dispatchTokensRefreshed(result);
+      return true;
+    } catch (error) {
+      if (localLoginAttemptRef.current !== attempt) return false;
+      localLoginAttemptRef.current = null;
+      console.error('❌ Login failed:', error);
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: loginErrorMessage(error),
+      }));
       return false;
     }
   };
 
   const logout = async () => {
+    localLoginAttemptRef.current = null;
     invalidateAuthentication();
     clearTokens();
     setState({
@@ -629,12 +708,15 @@ export function useAuth(): UseAuthReturn {
     });
   };
 
-  const logoutForAuthorityCycle = async (shouldApply: () => boolean): Promise<boolean> => {
-    if (!shouldApply()) return false;
+  const logoutForAuthorityCycle = async (
+    authorityCycle: CapturedAuthAuthorityCycle
+  ): Promise<boolean> => {
+    if (!authorityCycle.isCurrent()) return false;
     invalidateAuthentication();
     // Token clearing and the React authority update are synchronous together;
     // no await boundary exists where a replacement identity can slip between
     // the guard and the mutation.
+    localLoginAttemptRef.current = null;
     clearTokens();
     setState({
       user: null,
@@ -697,6 +779,7 @@ export function useAuth(): UseAuthReturn {
     isAuthenticationGenerationCurrent,
     isAuthenticationOwnerCurrent,
     login,
+    captureAuthorityCycle,
     loginForAuthorityCycle,
     logout,
     logoutForAuthorityCycle,

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -174,6 +174,7 @@ export function useAuth(): UseAuthReturn {
    * Re-authenticate using stored token (with automatic refresh)
    * Retries up to 3 times to handle daemon restarts gracefully
    */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: auth-generation helpers are stable for the hook lifetime; reAuthenticate must remain stable for retry/effect callers
   const reAuthenticate = useCallback(async (retryCount = 0, pendingLaunchCode?: string) => {
     const MAX_RETRIES = 5;
     localLoginAttemptRef.current = null;
@@ -497,7 +498,7 @@ export function useAuth(): UseAuthReturn {
     }, delay);
 
     return () => clearTimeout(timer);
-  }, [state.authenticated, state.accessToken]);
+  }, [state.authenticated, state.accessToken, noteUnauthenticated]);
 
   // When the single-flight refresh helper completes from a non-React path
   // (e.g. the socket-client 401-retry hook, or a concurrent refresh in
@@ -508,6 +509,7 @@ export function useAuth(): UseAuthReturn {
       const detail = (event as CustomEvent<RefreshResult>).detail;
       if (!detail) return;
       localLoginAttemptRef.current = null;
+      noteAuthenticatedUser(detail.user);
       const nextState: AuthState = {
         ...authStateRef.current,
         accessToken: detail.accessToken,
@@ -525,7 +527,7 @@ export function useAuth(): UseAuthReturn {
 
     window.addEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
     return () => window.removeEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
-  }, []);
+  }, [noteAuthenticatedUser]);
 
   // When the single-flight refresh helper determines the refresh token is
   // permanently dead (e.g. the server returned 401 / NotAuthenticated from
@@ -550,7 +552,7 @@ export function useAuth(): UseAuthReturn {
     window.addEventListener(TOKENS_REFRESH_UNRECOVERABLE_EVENT, handleUnrecoverable);
     return () =>
       window.removeEventListener(TOKENS_REFRESH_UNRECOVERABLE_EVENT, handleUnrecoverable);
-  }, []);
+  }, [noteUnauthenticated]);
 
   /**
    * Login with email and password
@@ -825,17 +827,16 @@ export function useAuth(): UseAuthReturn {
     // matching identity/authGeneration render yet.
     if (!shouldApply() || getStoredAccessToken() !== accessToken) return false;
 
-    setState((previous) => {
-      if (!shouldApply() || getStoredAccessToken() !== accessToken) return previous;
-      noteAuthenticatedUser(result.user);
-      return {
-        user: result.user,
-        accessToken,
-        authenticated: true,
-        loading: false,
-        error: null,
-      };
-    });
+    noteAuthenticatedUser(result.user);
+    const nextState: AuthState = {
+      user: result.user,
+      accessToken,
+      authenticated: true,
+      loading: false,
+      error: null,
+    };
+    authStateRef.current = nextState;
+    setState(nextState);
     return true;
   };
 

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -50,8 +50,15 @@ interface UseAuthReturn extends AuthState {
    */
   isAuthenticationOwnerCurrent: (userId: UserID, generation: number) => boolean;
   login: (email: string, password: string) => Promise<boolean>;
+  loginForAuthorityCycle: (
+    email: string,
+    password: string,
+    shouldApply: () => boolean
+  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
   logout: () => Promise<void>;
+  logoutForAuthorityCycle: (shouldApply: () => boolean) => Promise<boolean>;
   reAuthenticate: () => Promise<void>;
+  refreshCurrentUserForAuthorityCycle: (shouldApply: () => boolean) => Promise<boolean>;
 }
 
 const UNEXPECTED_LOGIN_RESPONSE_MESSAGE =
@@ -478,6 +485,8 @@ export function useAuth(): UseAuthReturn {
         accessToken: detail.accessToken,
         user: detail.user,
         authenticated: true,
+        loading: false,
+        error: null,
       }));
     };
 
@@ -511,6 +520,46 @@ export function useAuth(): UseAuthReturn {
   /**
    * Login with email and password
    */
+  const loginForAuthorityCycle = async (
+    email: string,
+    password: string,
+    shouldApply: () => boolean
+  ): Promise<'signed-in' | 'failed' | 'obsolete'> => {
+    if (!shouldApply()) return 'obsolete';
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const client = await createRestClient(getDaemonUrl());
+      const result = await client.authenticate({ strategy: 'local', email, password });
+      if (!shouldApply()) return 'obsolete';
+
+      // This is an explicit authority replacement, even when the user id is
+      // unchanged. Retire work owned by the revoked credential before exposing
+      // the new one.
+      invalidateAuthentication();
+      storeTokens(result.accessToken, result.refreshToken);
+      resetRefreshFailureState();
+      noteAuthenticatedUser(result.user);
+      setState({
+        user: result.user,
+        accessToken: result.accessToken,
+        authenticated: true,
+        loading: false,
+        error: null,
+      });
+      dispatchTokensRefreshed(result);
+      return 'signed-in';
+    } catch (error) {
+      if (!shouldApply()) return 'obsolete';
+      console.error('❌ Login failed:', error);
+      const userFacingMessage = loginErrorMessage(error);
+      const rawMessage = error instanceof Error ? error.message : 'Login failed';
+      console.error('❌ Error message:', rawMessage);
+      setState((prev) => ({ ...prev, loading: false, error: userFacingMessage }));
+      return 'failed';
+    }
+  };
+
   const login = async (email: string, password: string): Promise<boolean> => {
     // Invalidate caller-owned work synchronously, including a same-user
     // logout/login or explicit re-login.
@@ -580,13 +629,78 @@ export function useAuth(): UseAuthReturn {
     });
   };
 
+  const logoutForAuthorityCycle = async (shouldApply: () => boolean): Promise<boolean> => {
+    if (!shouldApply()) return false;
+    invalidateAuthentication();
+    // Token clearing and the React authority update are synchronous together;
+    // no await boundary exists where a replacement identity can slip between
+    // the guard and the mutation.
+    clearTokens();
+    setState({
+      user: null,
+      accessToken: null,
+      authenticated: false,
+      loading: false,
+      error: null,
+    });
+    return true;
+  };
+
+  /**
+   * Refresh the authenticated directory row without replacing credentials.
+   *
+   * Settings uses this after a self-update so role/name changes returned by
+   * the authentication strategy become the current identity authority. Keep
+   * it separate from `reAuthenticate`: a settings continuation belongs to one
+   * exact socket authority generation and must never start a refresh/login
+   * cycle whose tokens could be installed after that generation was replaced.
+   */
+  const refreshCurrentUserForAuthorityCycle = async (
+    shouldApply: () => boolean
+  ): Promise<boolean> => {
+    if (!shouldApply()) return false;
+
+    const accessToken = getStoredAccessToken();
+    if (!accessToken) return false;
+
+    const client = await createRestClient(getDaemonUrl());
+    if (!shouldApply() || getStoredAccessToken() !== accessToken) return false;
+
+    const result = await client.authenticate({
+      strategy: 'jwt',
+      accessToken,
+    });
+
+    // Check both the render/layout-invalidated authority operation and the
+    // exact credential snapshot. The latter closes the microtask window where
+    // another auth path has replaced storage but React has not committed the
+    // matching identity/authGeneration render yet.
+    if (!shouldApply() || getStoredAccessToken() !== accessToken) return false;
+
+    setState((previous) => {
+      if (!shouldApply() || getStoredAccessToken() !== accessToken) return previous;
+      noteAuthenticatedUser(result.user);
+      return {
+        user: result.user,
+        accessToken,
+        authenticated: true,
+        loading: false,
+        error: null,
+      };
+    });
+    return true;
+  };
+
   return {
     ...state,
     authenticationGeneration,
     isAuthenticationGenerationCurrent,
     isAuthenticationOwnerCurrent,
     login,
+    loginForAuthorityCycle,
     logout,
+    logoutForAuthorityCycle,
     reAuthenticate,
+    refreshCurrentUserForAuthorityCycle,
   };
 }

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
@@ -1,7 +1,7 @@
 import type { AgorClient } from '@agor-live/client';
 import { act, render, renderHook } from '@testing-library/react';
 import { type PropsWithChildren, StrictMode } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '@/contexts/ConnectionContext';
 import {
   useAuthenticatedAuthorityScope,
@@ -21,6 +21,21 @@ describe('useAuthorityOperationGuard', () => {
 
     expect(operation.isCurrent()).toBe(false);
     expect(result.current.isCurrent()).toBe(true);
+  });
+
+  it('notifies an in-flight owner when its generation is invalidated', async () => {
+    const { result, rerender } = renderHook(
+      ({ generation }) => useAuthorityOperationGuard(['admin-a', generation]),
+      { initialProps: { generation: 1 } }
+    );
+    const operation = result.current.begin();
+    const invalidated = vi.fn();
+    operation.onInvalidate(invalidated);
+
+    rerender({ generation: 2 });
+    expect(operation.isCurrent()).toBe(false);
+    await Promise.resolve();
+    expect(invalidated).toHaveBeenCalledOnce();
   });
 
   it('invalidates in layout cleanup for keyed replacement and explicit cancellation', () => {

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
@@ -1,7 +1,12 @@
-import { act, renderHook } from '@testing-library/react';
+import type { AgorClient } from '@agor-live/client';
+import { act, render, renderHook } from '@testing-library/react';
 import { type PropsWithChildren, StrictMode } from 'react';
 import { describe, expect, it } from 'vitest';
-import { useAuthorityOperationGuard } from './useAuthorityOperationGuard';
+import { ConnectionProvider } from '@/contexts/ConnectionContext';
+import {
+  useAuthenticatedAuthorityScope,
+  useAuthorityOperationGuard,
+} from './useAuthorityOperationGuard';
 
 describe('useAuthorityOperationGuard', () => {
   it('invalidates an old operation synchronously on an in-place authority render', () => {
@@ -50,5 +55,53 @@ describe('useAuthorityOperationGuard', () => {
 
     expect(result.current.isCurrent()).toBe(true);
     expect(result.current.begin().isCurrent()).toBe(true);
+  });
+
+  it('preserves identity scope but cancels operations across disconnect and auth generation', () => {
+    const client = {} as AgorClient;
+    let current:
+      | {
+          authority: ReturnType<typeof useAuthenticatedAuthorityScope>;
+          guard: ReturnType<typeof useAuthorityOperationGuard>;
+        }
+      | undefined;
+    const Inner = () => {
+      const authority = useAuthenticatedAuthorityScope(client, 'admin-a:admin');
+      current = { authority, guard: useAuthorityOperationGuard(authority.operationScope) };
+      return null;
+    };
+    const Harness = ({
+      connected,
+      connecting,
+      generation,
+    }: {
+      connected: boolean;
+      connecting: boolean;
+      generation: number;
+    }) => (
+      <ConnectionProvider
+        value={{
+          connected,
+          connecting,
+          authGeneration: generation,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <Inner />
+      </ConnectionProvider>
+    );
+    const rendered = render(<Harness connected connecting={false} generation={7} />);
+    const old = current!.guard.begin();
+
+    rendered.rerender(<Harness connected connecting generation={7} />);
+    expect(old.isCurrent()).toBe(false);
+    expect(current!.authority.identityKey).toBe('admin-a:admin');
+    expect(current!.authority.operationScope).toBeNull();
+
+    rendered.rerender(<Harness connected connecting={false} generation={8} />);
+    expect(current!.authority.identityKey).toBe('admin-a:admin');
+    expect(current!.guard.begin().isCurrent()).toBe(true);
   });
 });

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.test.tsx
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react';
+import { type PropsWithChildren, StrictMode } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useAuthorityOperationGuard } from './useAuthorityOperationGuard';
+
+describe('useAuthorityOperationGuard', () => {
+  it('invalidates an old operation synchronously on an in-place authority render', () => {
+    const { result, rerender } = renderHook(
+      ({ userId, generation }) => useAuthorityOperationGuard([userId, generation]),
+      { initialProps: { userId: 'admin-a', generation: 1 } }
+    );
+    const operation = result.current.begin();
+    expect(operation.isCurrent()).toBe(true);
+
+    rerender({ userId: 'admin-b', generation: 2 });
+
+    expect(operation.isCurrent()).toBe(false);
+    expect(result.current.isCurrent()).toBe(true);
+  });
+
+  it('invalidates in layout cleanup for keyed replacement and explicit cancellation', () => {
+    const first = renderHook(() => useAuthorityOperationGuard(['admin-a', 1]));
+    const operation = first.result.current.begin();
+    first.unmount();
+    expect(operation.isCurrent()).toBe(false);
+
+    const second = renderHook(() => useAuthorityOperationGuard(['admin-a', 1]));
+    const cancelled = second.result.current.begin();
+    act(() => cancelled.cancel());
+    expect(cancelled.isCurrent()).toBe(false);
+  });
+
+  it('keeps operations current when the same authority parts re-render', () => {
+    const client = {};
+    const { result, rerender } = renderHook(
+      ({ label }) => {
+        void label;
+        return useAuthorityOperationGuard(['admin-a', 1, client]);
+      },
+      { initialProps: { label: 'before reconnect' } }
+    );
+    const operation = result.current.begin();
+    rerender({ label: 'same caller UI update' });
+    expect(operation.isCurrent()).toBe(true);
+  });
+
+  it('remains usable after StrictMode replays layout-effect cleanup', () => {
+    const wrapper = ({ children }: PropsWithChildren) => <StrictMode>{children}</StrictMode>;
+    const { result } = renderHook(() => useAuthorityOperationGuard(['admin-a', 1]), { wrapper });
+
+    expect(result.current.isCurrent()).toBe(true);
+    expect(result.current.begin().isCurrent()).toBe(true);
+  });
+});

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
@@ -5,11 +5,14 @@ import { useOptionalConnectionState } from '@/contexts/ConnectionContext';
 interface AuthorityEpoch {
   parts: readonly unknown[] | null;
   valid: boolean;
+  invalidationListeners: Set<() => void>;
 }
 
 export interface AuthorityOperation {
   /** False as soon as the caller/client/authority scope changes or unmounts. */
   isCurrent: () => boolean;
+  /** Subscribe to synchronous scope invalidation without coupling to mount cleanup. */
+  onInvalidate: (listener: () => void) => () => void;
   /** Explicitly end a one-shot operation before its authority epoch ends. */
   cancel: () => void;
 }
@@ -61,6 +64,14 @@ function sameScope(left: readonly unknown[] | null, right: readonly unknown[] | 
   return left.length === right.length && left.every((part, index) => Object.is(part, right[index]));
 }
 
+function invalidateEpoch(epoch: AuthorityEpoch): void {
+  if (!epoch.valid && epoch.invalidationListeners.size === 0) return;
+  epoch.valid = false;
+  const listeners = [...epoch.invalidationListeners];
+  epoch.invalidationListeners.clear();
+  for (const listener of listeners) listener();
+}
+
 /**
  * Synchronous authority fence for caller-private async UI work.
  *
@@ -77,10 +88,11 @@ export function useAuthorityOperationGuard(
   const epochRef = useRef<AuthorityEpoch | null>(null);
   let epoch = epochRef.current;
   if (!epoch || !sameScope(epoch.parts, scopeParts)) {
-    if (epoch) epoch.valid = false;
+    if (epoch) invalidateEpoch(epoch);
     epoch = {
       parts: scopeParts === null ? null : [...scopeParts],
       valid: scopeParts !== null,
+      invalidationListeners: new Set(),
     };
     epochRef.current = epoch;
   }
@@ -92,7 +104,7 @@ export function useAuthorityOperationGuard(
     // be revived because it no longer equals epochRef.current.
     if (epochRef.current === epoch && epoch.parts !== null) epoch.valid = true;
     return () => {
-      epoch.valid = false;
+      invalidateEpoch(epoch);
     };
   }, [epoch]);
 
@@ -101,11 +113,47 @@ export function useAuthorityOperationGuard(
       begin: () => {
         const captured = epochRef.current;
         let active = true;
+        const operationListeners = new Set<() => void>();
+        const notifyOperationInvalidated = () => {
+          const listeners = [...operationListeners];
+          operationListeners.clear();
+          // Scope replacement can happen during render. Promise resolution is
+          // safe there, but arbitrary subscribers must not synchronously set
+          // React state, so deliver on the immediately following microtask.
+          for (const listener of listeners) queueMicrotask(listener);
+        };
+        const epochListener = () => {
+          active = false;
+          notifyOperationInvalidated();
+        };
         return {
           isCurrent: () =>
             active && !!captured?.valid && captured.parts !== null && epochRef.current === captured,
+          onInvalidate: (listener: () => void) => {
+            let subscribed = true;
+            const guardedListener = () => {
+              if (subscribed) listener();
+            };
+            operationListeners.add(guardedListener);
+            if (captured && active && captured.valid && epochRef.current === captured) {
+              captured.invalidationListeners.add(epochListener);
+            } else {
+              active = false;
+              notifyOperationInvalidated();
+            }
+            return () => {
+              subscribed = false;
+              operationListeners.delete(guardedListener);
+              if (operationListeners.size === 0) {
+                captured?.invalidationListeners.delete(epochListener);
+              }
+            };
+          },
           cancel: () => {
+            if (!active) return;
             active = false;
+            captured?.invalidationListeners.delete(epochListener);
+            notifyOperationInvalidated();
           },
         };
       },

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
@@ -1,4 +1,6 @@
+import type { AgorClient } from '@agor-live/client';
 import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useOptionalConnectionState } from '@/contexts/ConnectionContext';
 
 interface AuthorityEpoch {
   parts: readonly unknown[] | null;
@@ -17,6 +19,41 @@ export interface AuthorityOperationGuard {
   begin: () => AuthorityOperation;
   /** Whether this rendered authority epoch may start an action at all. */
   isCurrent: () => boolean;
+}
+
+export interface AuthenticatedAuthorityScope {
+  /** Identity-stable key for erasing caller-private drafts only on identity/role change. */
+  identityKey: string | null;
+  /** Ready, generation-bound scope for async operations. Null fails closed. */
+  operationScope: readonly unknown[] | null;
+  connectionReady: boolean;
+  authGeneration: number;
+}
+
+/**
+ * Split caller identity lifecycle from socket authority lifecycle.
+ *
+ * Components erase drafts on `identityKey`, while guards consume
+ * `operationScope`; a same-user reconnect therefore preserves input but
+ * synchronously invalidates every older continuation. Independently mounted
+ * leaf surfaces have no ConnectionProvider, so their supplied identity is the
+ * explicit readiness contract and generation zero is used.
+ */
+export function useAuthenticatedAuthorityScope(
+  client: AgorClient | null,
+  identityKey: string | null
+): AuthenticatedAuthorityScope {
+  const connection = useOptionalConnectionState();
+  const connectionReady = connection
+    ? connection.connected && !connection.connecting
+    : identityKey !== null;
+  const authGeneration = connection?.authGeneration ?? 0;
+  const operationScope = useMemo(
+    () =>
+      identityKey && connectionReady ? ([identityKey, client, authGeneration] as const) : null,
+    [authGeneration, client, connectionReady, identityKey]
+  );
+  return { identityKey, operationScope, connectionReady, authGeneration };
 }
 
 function sameScope(left: readonly unknown[] | null, right: readonly unknown[] | null): boolean {

--- a/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
+++ b/apps/agor-ui/src/hooks/useAuthorityOperationGuard.ts
@@ -1,0 +1,79 @@
+import { useLayoutEffect, useMemo, useRef } from 'react';
+
+interface AuthorityEpoch {
+  parts: readonly unknown[] | null;
+  valid: boolean;
+}
+
+export interface AuthorityOperation {
+  /** False as soon as the caller/client/authority scope changes or unmounts. */
+  isCurrent: () => boolean;
+  /** Explicitly end a one-shot operation before its authority epoch ends. */
+  cancel: () => void;
+}
+
+export interface AuthorityOperationGuard {
+  /** Capture the authority epoch that exists at the start of an async action. */
+  begin: () => AuthorityOperation;
+  /** Whether this rendered authority epoch may start an action at all. */
+  isCurrent: () => boolean;
+}
+
+function sameScope(left: readonly unknown[] | null, right: readonly unknown[] | null): boolean {
+  if (left === null || right === null) return left === right;
+  return left.length === right.length && left.every((part, index) => Object.is(part, right[index]));
+}
+
+/**
+ * Synchronous authority fence for caller-private async UI work.
+ *
+ * Passive-effect cleanup is too late for a keyed A -> B replacement: an old
+ * promise continuation can run after B commits but before `useEffect` cleanup.
+ * This hook invalidates during render when any scope part changes, and again in
+ * layout cleanup when a keyed owner is replaced or unmounted. State may remain
+ * mounted across a same-user reconnect, while operations tied to the old auth
+ * generation/client are still cancelled.
+ */
+export function useAuthorityOperationGuard(
+  scopeParts: readonly unknown[] | null
+): AuthorityOperationGuard {
+  const epochRef = useRef<AuthorityEpoch | null>(null);
+  let epoch = epochRef.current;
+  if (!epoch || !sameScope(epoch.parts, scopeParts)) {
+    if (epoch) epoch.valid = false;
+    epoch = {
+      parts: scopeParts === null ? null : [...scopeParts],
+      valid: scopeParts !== null,
+    };
+    epochRef.current = epoch;
+  }
+
+  useLayoutEffect(() => {
+    // React StrictMode deliberately replays layout-effect setup/cleanup on
+    // mount. Re-establish only this still-current epoch during setup so that
+    // replay does not leave every action disabled; a replaced epoch can never
+    // be revived because it no longer equals epochRef.current.
+    if (epochRef.current === epoch && epoch.parts !== null) epoch.valid = true;
+    return () => {
+      epoch.valid = false;
+    };
+  }, [epoch]);
+
+  return useMemo(
+    () => ({
+      begin: () => {
+        const captured = epochRef.current;
+        let active = true;
+        return {
+          isCurrent: () =>
+            active && !!captured?.valid && captured.parts !== null && epochRef.current === captured,
+          cancel: () => {
+            active = false;
+          },
+        };
+      },
+      isCurrent: () => epoch.valid && epoch.parts !== null && epochRef.current === epoch,
+    }),
+    [epoch]
+  );
+}

--- a/apps/agor-ui/src/hooks/useForcedPasswordChangeHandler.ts
+++ b/apps/agor-ui/src/hooks/useForcedPasswordChangeHandler.ts
@@ -1,0 +1,72 @@
+import type { AgorClient, User } from '@agor-live/client';
+import { useCallback } from 'react';
+import { completeForcedPasswordChange } from '../utils/forcePasswordChange';
+import type { CapturedAuthAuthorityCycle } from './useAuth';
+import type { AuthorityOperationGuard } from './useAuthorityOperationGuard';
+
+export type ForcedPasswordChangeHandler = (
+  userId: string,
+  newPassword: string,
+  shouldApply: () => boolean,
+  isSameIdentity: () => boolean
+) => Promise<void>;
+
+interface UseForcedPasswordChangeHandlerOptions {
+  client: AgorClient | null;
+  user: User | null;
+  appAuthorityGuard: AuthorityOperationGuard;
+  captureAuthorityCycle: (shouldApply: () => boolean) => CapturedAuthAuthorityCycle | null;
+  reauthenticate: (
+    email: string,
+    password: string,
+    authorityCycle: CapturedAuthAuthorityCycle
+  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
+  logout: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
+  onCompleted?: (signedIn: boolean) => void;
+}
+
+/**
+ * App-owned forced-password controller.
+ *
+ * The initiating modal owns validation and password-draft lifetime, but it is
+ * intentionally not the owner of post-patch reauthentication: App's loading
+ * gate unmounts that modal. This handler captures the still-mounted App
+ * authority epoch before patching and lets only that exact cycle install or
+ * clear credentials.
+ */
+export function useForcedPasswordChangeHandler({
+  client,
+  user,
+  appAuthorityGuard,
+  captureAuthorityCycle,
+  reauthenticate,
+  logout,
+  onCompleted,
+}: UseForcedPasswordChangeHandlerOptions): ForcedPasswordChangeHandler {
+  return useCallback(
+    async (userId, newPassword, shouldApply, isSameIdentity) => {
+      if (!client) throw new Error('Not connected');
+      if (!user?.email) throw new Error('Current user is unavailable');
+      if (user.user_id !== userId || !shouldApply()) return;
+
+      const appOperation = appAuthorityGuard.begin();
+      const authorityCycle = captureAuthorityCycle(appOperation.isCurrent);
+      if (!authorityCycle || authorityCycle.userId !== userId || !shouldApply()) return;
+
+      const signedIn = await completeForcedPasswordChange({
+        client,
+        userId,
+        email: user.email,
+        newPassword,
+        authorityCycle,
+        shouldApply,
+        reauthenticate,
+        logout,
+      });
+
+      if (signedIn === null || !isSameIdentity()) return;
+      onCompleted?.(signedIn);
+    },
+    [appAuthorityGuard, captureAuthorityCycle, client, logout, onCompleted, reauthenticate, user]
+  );
+}

--- a/apps/agor-ui/src/hooks/useForcedPasswordChangeHandler.ts
+++ b/apps/agor-ui/src/hooks/useForcedPasswordChangeHandler.ts
@@ -1,7 +1,7 @@
 import type { AgorClient, User } from '@agor-live/client';
 import { useCallback } from 'react';
 import { completeForcedPasswordChange } from '../utils/forcePasswordChange';
-import type { CapturedAuthAuthorityCycle } from './useAuth';
+import type { AuthorityCycleLoginResult, CapturedAuthAuthorityCycle } from './useAuth';
 import type { AuthorityOperationGuard } from './useAuthorityOperationGuard';
 
 export type ForcedPasswordChangeHandler = (
@@ -15,12 +15,14 @@ interface UseForcedPasswordChangeHandlerOptions {
   client: AgorClient | null;
   user: User | null;
   appAuthorityGuard: AuthorityOperationGuard;
-  captureAuthorityCycle: (shouldApply: () => boolean) => CapturedAuthAuthorityCycle | null;
+  captureAuthorityCycle: (
+    authorityOperation: ReturnType<AuthorityOperationGuard['begin']>
+  ) => CapturedAuthAuthorityCycle | null;
   reauthenticate: (
     email: string,
     password: string,
     authorityCycle: CapturedAuthAuthorityCycle
-  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
+  ) => Promise<AuthorityCycleLoginResult>;
   logout: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
   onCompleted?: (signedIn: boolean) => void;
 }
@@ -44,16 +46,16 @@ export function useForcedPasswordChangeHandler({
   onCompleted,
 }: UseForcedPasswordChangeHandlerOptions): ForcedPasswordChangeHandler {
   return useCallback(
-    async (userId, newPassword, shouldApply, isSameIdentity) => {
+    async (userId, newPassword, shouldApply, _isSameIdentity) => {
       if (!client) throw new Error('Not connected');
       if (!user?.email) throw new Error('Current user is unavailable');
       if (user.user_id !== userId || !shouldApply()) return;
 
       const appOperation = appAuthorityGuard.begin();
-      const authorityCycle = captureAuthorityCycle(appOperation.isCurrent);
+      const authorityCycle = captureAuthorityCycle(appOperation);
       if (!authorityCycle || authorityCycle.userId !== userId || !shouldApply()) return;
 
-      const signedIn = await completeForcedPasswordChange({
+      const completion = await completeForcedPasswordChange({
         client,
         userId,
         email: user.email,
@@ -64,8 +66,18 @@ export function useForcedPasswordChangeHandler({
         logout,
       });
 
-      if (signedIn === null || !isSameIdentity()) return;
-      onCompleted?.(signedIn);
+      if (!completion) return;
+      if (completion.status === 'signed-in') {
+        // Success establishes a new auth generation and intentionally unmounts
+        // the modal. Its exact installed-authority receipt—not modal lifetime
+        // or the now-obsolete initiating generation—owns notification.
+        if (completion.authority.isCurrent()) onCompleted?.(true);
+        return;
+      }
+      // A guarded logout is the terminal result for a relogin failure. The
+      // initiating modal has also unmounted here, so do not couple the notice
+      // to its identity guard.
+      onCompleted?.(false);
     },
     [appAuthorityGuard, captureAuthorityCycle, client, logout, onCompleted, reauthenticate, user]
   );

--- a/apps/agor-ui/src/hooks/useIdentityGuardedAsync.ts
+++ b/apps/agor-ui/src/hooks/useIdentityGuardedAsync.ts
@@ -51,6 +51,18 @@ export function useIdentityGuardedAsync(
   const lastRunIdentityRef = useRef(0);
   const onIdentityChangeRef = useRef(onIdentityChange);
   onIdentityChangeRef.current = onIdentityChange;
+  const renderedIdentityRef = useRef<DependencyList | null>(null);
+  const renderedIdentity = renderedIdentityRef.current;
+  if (
+    !renderedIdentity ||
+    renderedIdentity.length !== identity.length ||
+    renderedIdentity.some((value, index) => !Object.is(value, identity[index]))
+  ) {
+    // Render-time invalidation closes the commit-to-layout microtask window.
+    // The layout effect below still owns state reset and unmount invalidation.
+    identityGenRef.current += 1;
+    renderedIdentityRef.current = [...identity];
+  }
 
   useLayoutEffect(
     () => {

--- a/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
+++ b/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
@@ -46,28 +46,57 @@ const MEMBER = { user_id: 'member-1', role: 'member' } as const;
 const OTHER_MEMBER = { user_id: 'member-2', role: 'member' } as const;
 
 describe('useMcpMemberPolicy caller scope', () => {
-  it('fails closed immediately on demotion and refetches for the new role', async () => {
+  it('fails closed immediately on demotion and waits for new socket authority', async () => {
     const next = deferred<MCPMemberPolicySetting>();
     const seam = makeClient({ policy: 'allow_crud', can_configure: true });
     seam.answerNext(next.promise);
     const { result, rerender } = renderHook(
-      ({ role }: { role: string }) =>
+      ({ role, authGeneration }: { role: string; authGeneration: number }) =>
         useMcpMemberPolicy(seam.client, {
           connectionReady: true,
           currentUser: { ...MEMBER, role },
-          authGeneration: 1,
+          authGeneration,
         }),
-      { initialProps: { role: 'member' } }
+      { initialProps: { role: 'member', authGeneration: 1 } }
     );
     await waitFor(() => expect(result.current.canConfigure).toBe(true));
 
-    rerender({ role: 'viewer' });
+    rerender({ role: 'viewer', authGeneration: 1 });
 
     expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(1);
+
+    rerender({ role: 'viewer', authGeneration: 2 });
     expect(seam.find).toHaveBeenCalledTimes(2);
     await act(() => next.resolve({ policy: 'allow_crud', can_configure: false }));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.canConfigure).toBe(false);
+  });
+
+  it('does not issue a viewer-to-member policy read before socket reauthentication', async () => {
+    const next = deferred<MCPMemberPolicySetting>();
+    const seam = makeClient({ policy: 'allow_crud', can_configure: false });
+    seam.answerNext(next.promise);
+    const { result, rerender } = renderHook(
+      ({ role, authGeneration }: { role: string; authGeneration: number }) =>
+        useMcpMemberPolicy(seam.client, {
+          connectionReady: true,
+          currentUser: { ...MEMBER, role },
+          authGeneration,
+        }),
+      { initialProps: { role: 'viewer', authGeneration: 1 } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canConfigure).toBe(false);
+
+    rerender({ role: 'member', authGeneration: 1 });
+    expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(1);
+
+    rerender({ role: 'member', authGeneration: 2 });
+    expect(seam.find).toHaveBeenCalledTimes(2);
+    await act(() => next.resolve({ policy: 'allow_crud', can_configure: true }));
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
   });
 
   it('fails closed across identity and token-generation replacement on a stable client', async () => {

--- a/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
+++ b/apps/agor-ui/src/hooks/useMcpMemberPolicy.test.tsx
@@ -1,25 +1,184 @@
-import type { AgorClient } from '@agor-live/client';
+import type { AgorClient, MCPMemberPolicySetting } from '@agor-live/client';
+import { MCP_MEMBER_POLICY_CHANGED_EVENT } from '@agor-live/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useMcpMemberPolicy } from './useMcpMemberPolicy';
 
-describe('useMcpMemberPolicy', () => {
-  it('treats a save response without a capability as withheld', async () => {
-    const find = vi.fn().mockResolvedValue({
-      policy: 'use_existing_only',
-      can_configure: true,
-    });
-    const patch = vi.fn().mockResolvedValue({ policy: 'allow_crud' });
-    const client = {
-      service: () => ({ find, patch }),
-    } as unknown as AgorClient;
+type Listener = () => void;
 
-    const { result } = renderHook(() => useMcpMemberPolicy(client));
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function makeClient(initial: MCPMemberPolicySetting) {
+  const listeners = new Map<string, Listener[]>();
+  const answers: Array<Promise<MCPMemberPolicySetting>> = [Promise.resolve(initial)];
+  const find = vi.fn(() => answers.shift() ?? Promise.resolve(initial));
+  const patch = vi.fn().mockResolvedValue({ policy: 'allow_crud' });
+  const mcpServers = {
+    on: (event: string, listener: Listener) =>
+      listeners.set(event, [...(listeners.get(event) ?? []), listener]),
+    removeListener: (event: string, listener: Listener) =>
+      listeners.set(
+        event,
+        (listeners.get(event) ?? []).filter((candidate) => candidate !== listener)
+      ),
+  };
+  const client = {
+    service: (path: string) => (path === 'mcp-member-policy' ? { find, patch } : mcpServers),
+  } as unknown as AgorClient;
+  return {
+    client,
+    find,
+    patch,
+    answerNext: (answer: Promise<MCPMemberPolicySetting>) => answers.push(answer),
+    emitPolicyChange: () => {
+      for (const listener of listeners.get(MCP_MEMBER_POLICY_CHANGED_EVENT) ?? []) listener();
+    },
+  };
+}
+
+const MEMBER = { user_id: 'member-1', role: 'member' } as const;
+const OTHER_MEMBER = { user_id: 'member-2', role: 'member' } as const;
+
+describe('useMcpMemberPolicy caller scope', () => {
+  it('fails closed immediately on demotion and refetches for the new role', async () => {
+    const next = deferred<MCPMemberPolicySetting>();
+    const seam = makeClient({ policy: 'allow_crud', can_configure: true });
+    seam.answerNext(next.promise);
+    const { result, rerender } = renderHook(
+      ({ role }: { role: string }) =>
+        useMcpMemberPolicy(seam.client, {
+          connectionReady: true,
+          currentUser: { ...MEMBER, role },
+          authGeneration: 1,
+        }),
+      { initialProps: { role: 'member' } }
+    );
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+
+    rerender({ role: 'viewer' });
+
+    expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(2);
+    await act(() => next.resolve({ policy: 'allow_crud', can_configure: false }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.canConfigure).toBe(false);
+  });
+
+  it('fails closed across identity and token-generation replacement on a stable client', async () => {
+    const next = deferred<MCPMemberPolicySetting>();
+    const seam = makeClient({ policy: 'allow_crud', can_configure: true });
+    seam.answerNext(next.promise);
+    const { result, rerender } = renderHook(
+      ({ userId, authGeneration }: { userId: string; authGeneration: number }) =>
+        useMcpMemberPolicy(seam.client, {
+          connectionReady: true,
+          currentUser: { ...OTHER_MEMBER, user_id: userId },
+          authGeneration,
+        }),
+      { initialProps: { userId: MEMBER.user_id, authGeneration: 1 } }
+    );
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+
+    rerender({ userId: OTHER_MEMBER.user_id, authGeneration: 2 });
+
+    expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(2);
+    await act(() => next.resolve({ policy: 'allow_private_only', can_configure: true }));
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+  });
+
+  it('eliminates the permissive disconnect window from render-time state', async () => {
+    const seam = makeClient({ policy: 'allow_crud', can_configure: true });
+    const { result, rerender } = renderHook(
+      ({ ready }: { ready: boolean }) =>
+        useMcpMemberPolicy(seam.client, {
+          connectionReady: ready,
+          currentUser: MEMBER,
+          authGeneration: 1,
+        }),
+      { initialProps: { ready: true } }
+    );
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+
+    rerender({ ready: false });
+
+    expect(result.current).toMatchObject({
+      canConfigure: false,
+      loading: false,
+      error: 'Not connected to the Agor daemon',
+    });
+  });
+
+  it('invalidates on a tenant policy event and withholds until the refetch lands', async () => {
+    const next = deferred<MCPMemberPolicySetting>();
+    const seam = makeClient({ policy: 'allow_crud', can_configure: true });
+    seam.answerNext(next.promise);
+    const { result } = renderHook(() =>
+      useMcpMemberPolicy(seam.client, {
+        connectionReady: true,
+        currentUser: MEMBER,
+        authGeneration: 1,
+      })
+    );
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+
+    act(() => seam.emitPolicyChange());
+
+    expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(2);
+    await act(() => next.resolve({ policy: 'use_existing_only', can_configure: false }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current).toMatchObject({
+      policy: 'use_existing_only',
+      canConfigure: false,
+    });
+  });
+
+  it('requires a new authenticated generation before reconnect capability returns', async () => {
+    const next = deferred<MCPMemberPolicySetting>();
+    const seam = makeClient({ policy: 'allow_private_only', can_configure: true });
+    seam.answerNext(next.promise);
+    const { result, rerender } = renderHook(
+      ({ ready, authGeneration }: { ready: boolean; authGeneration: number }) =>
+        useMcpMemberPolicy(seam.client, {
+          connectionReady: ready,
+          currentUser: MEMBER,
+          authGeneration,
+        }),
+      { initialProps: { ready: true, authGeneration: 1 } }
+    );
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+    rerender({ ready: false, authGeneration: 1 });
+    expect(result.current.canConfigure).toBe(false);
+
+    rerender({ ready: true, authGeneration: 2 });
+
+    expect(result.current).toMatchObject({ canConfigure: false, loading: true });
+    expect(seam.find).toHaveBeenCalledTimes(2);
+    await act(() => next.resolve({ policy: 'allow_private_only', can_configure: true }));
+    await waitFor(() => expect(result.current.canConfigure).toBe(true));
+  });
+
+  it('treats a save response without a capability as withheld', async () => {
+    const seam = makeClient({ policy: 'use_existing_only', can_configure: true });
+    const { result } = renderHook(() =>
+      useMcpMemberPolicy(seam.client, {
+        connectionReady: true,
+        currentUser: MEMBER,
+        authGeneration: 1,
+      })
+    );
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(() => result.current.save('allow_crud'));
 
-    expect(patch).toHaveBeenCalledWith(null, { policy: 'allow_crud' });
+    expect(seam.patch).toHaveBeenCalledWith(null, { policy: 'allow_crud' });
     expect(result.current).toMatchObject({
       policy: 'allow_crud',
       canConfigure: false,

--- a/apps/agor-ui/src/hooks/useMcpMemberPolicy.ts
+++ b/apps/agor-ui/src/hooks/useMcpMemberPolicy.ts
@@ -10,7 +10,7 @@
 
 import type { AgorClient, MCPMemberPolicy, User } from '@agor-live/client';
 import { DEFAULT_MCP_MEMBER_POLICY, MCP_MEMBER_POLICY_CHANGED_EVENT } from '@agor-live/client';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 export interface McpMemberPolicyState {
   policy: MCPMemberPolicy;
@@ -71,13 +71,35 @@ export function useMcpMemberPolicy(
   const identityKey = currentUser
     ? `${currentUser.user_id}:${String(currentUser.role ?? '')}`
     : null;
-  const scopeKey =
-    client && connectionReady && identityKey
-      ? `${identityKey}:${authGeneration}:${policyGeneration}`
-      : null;
+  const establishedAuthorityRef = useRef<{
+    client: AgorClient;
+    identityKey: string;
+    authGeneration: number;
+  } | null>(null);
+  const establishedAuthority = establishedAuthorityRef.current;
+  const authorityMatchesEstablished =
+    !!establishedAuthority &&
+    establishedAuthority.client === client &&
+    establishedAuthority.identityKey === identityKey &&
+    authGeneration >= establishedAuthority.authGeneration;
+  const authorityHasNewAuthentication =
+    !establishedAuthority || authGeneration > establishedAuthority.authGeneration;
+  const callerAuthorityReady =
+    !!client &&
+    connectionReady &&
+    !!identityKey &&
+    (authorityMatchesEstablished || authorityHasNewAuthentication);
+  const scopeKey = callerAuthorityReady
+    ? `${identityKey}:${authGeneration}:${policyGeneration}`
+    : null;
   const [snapshot, setSnapshot] = useState<PolicySnapshot>(() =>
     restrictiveSnapshot(null, null, true)
   );
+
+  useLayoutEffect(() => {
+    if (!callerAuthorityReady || !client || !identityKey) return;
+    establishedAuthorityRef.current = { client, identityKey, authGeneration };
+  }, [authGeneration, callerAuthorityReady, client, identityKey]);
 
   // Policy writes can happen in another tab, browser, or daemon replica. The
   // daemon publishes an empty tenant-scoped invalidation only after commit;

--- a/apps/agor-ui/src/hooks/useMcpMemberPolicy.ts
+++ b/apps/agor-ui/src/hooks/useMcpMemberPolicy.ts
@@ -1,21 +1,22 @@
 /**
- * The tenant-wide MCP member policy, read once for whoever renders it.
+ * Caller-scoped MCP member policy.
  *
- * One value for the whole settings surface: the card that displays it and the
- * table that dims what it forbids read the same state, so the two can never
- * disagree about what the workspace allows.
+ * `can_configure` is not tenant configuration alone: it is the daemon's answer
+ * for one authenticated identity. The socket client survives reconnects and
+ * token replacement, so this hook scopes every answer to client + user + role +
+ * successful authentication generation. A mismatched answer is never exposed,
+ * even for the render before the refetch effect starts.
  */
 
-import type { AgorClient, MCPMemberPolicy } from '@agor-live/client';
-import { DEFAULT_MCP_MEMBER_POLICY } from '@agor-live/client';
-import { useCallback, useEffect, useState } from 'react';
+import type { AgorClient, MCPMemberPolicy, User } from '@agor-live/client';
+import { DEFAULT_MCP_MEMBER_POLICY, MCP_MEMBER_POLICY_CHANGED_EVENT } from '@agor-live/client';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface McpMemberPolicyState {
   policy: MCPMemberPolicy;
   /**
    * The daemon's answer to whether this caller may configure servers at all —
-   * the role floor and the policy in one, so a client does not rebuild it.
-   * False until the read succeeds: an unknown answer withholds.
+   * false until an answer for the current authenticated scope succeeds.
    */
   canConfigure: boolean;
   loading: boolean;
@@ -26,69 +27,172 @@ export interface McpMemberPolicyState {
   save: (next: MCPMemberPolicy) => Promise<void>;
 }
 
+export interface McpMemberPolicyScope {
+  /** Socket is connected, authenticated, and not in reconnect/reauth transition. */
+  connectionReady: boolean;
+  /** Identity whose caller-shaped capability the endpoint will answer. */
+  currentUser?: Pick<User, 'user_id' | 'role'> | null;
+  /** Monotonic successful socket-auth generation from useAgorClient. */
+  authGeneration: number;
+}
+
+interface PolicySnapshot {
+  client: AgorClient | null;
+  scopeKey: string | null;
+  policy: MCPMemberPolicy;
+  canConfigure: boolean;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+const restrictiveSnapshot = (
+  client: AgorClient | null,
+  scopeKey: string | null,
+  loading: boolean
+): PolicySnapshot => ({
+  client,
+  scopeKey,
+  policy: DEFAULT_MCP_MEMBER_POLICY,
+  canConfigure: false,
+  loading,
+  saving: false,
+  error: null,
+});
+
 const describeError = (error: unknown, fallback: string): string =>
   error instanceof Error && error.message ? error.message : fallback;
 
-export function useMcpMemberPolicy(client: AgorClient | null): McpMemberPolicyState {
-  // Start at the restrictive default rather than at "unknown": the value drives
-  // which actions are offered, and a permissive guess would flash affordances
-  // the workspace does not allow.
-  const [policy, setPolicy] = useState<MCPMemberPolicy>(DEFAULT_MCP_MEMBER_POLICY);
-  const [canConfigure, setCanConfigure] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+export function useMcpMemberPolicy(
+  client: AgorClient | null,
+  { connectionReady, currentUser, authGeneration }: McpMemberPolicyScope
+): McpMemberPolicyState {
+  const [policyGeneration, setPolicyGeneration] = useState(0);
+  const identityKey = currentUser
+    ? `${currentUser.user_id}:${String(currentUser.role ?? '')}`
+    : null;
+  const scopeKey =
+    client && connectionReady && identityKey
+      ? `${identityKey}:${authGeneration}:${policyGeneration}`
+      : null;
+  const [snapshot, setSnapshot] = useState<PolicySnapshot>(() =>
+    restrictiveSnapshot(null, null, true)
+  );
+
+  // Policy writes can happen in another tab, browser, or daemon replica. The
+  // daemon publishes an empty tenant-scoped invalidation only after commit;
+  // refetching here preserves the endpoint as the authority for caller-shaped
+  // `can_configure` and avoids broadcasting one user's answer to another.
+  useEffect(() => {
+    if (!client) return;
+    const service = client.service('mcp-servers');
+    const invalidate = () => setPolicyGeneration((generation) => generation + 1);
+    service.on(MCP_MEMBER_POLICY_CHANGED_EVENT, invalidate);
+    return () => service.removeListener(MCP_MEMBER_POLICY_CHANGED_EVENT, invalidate);
+  }, [client]);
 
   useEffect(() => {
-    if (!client) {
-      // Disconnected is a knowable state, not a pending one: settle so callers
-      // fall back to the restrictive default instead of waiting forever.
-      setLoading(false);
-      setError('Not connected to the Agor daemon');
-      return;
-    }
+    if (!client || !scopeKey) return;
+
     let active = true;
-    setLoading(true);
+    setSnapshot(restrictiveSnapshot(client, scopeKey, true));
     client
       .service('mcp-member-policy')
       .find()
       .then((result) => {
         if (!active) return;
-        setPolicy(result.policy);
-        // An answer without the field is not an answer: coerce rather than let
-        // a non-boolean sit in this state and read as one.
-        setCanConfigure(result.can_configure === true);
-        setError(null);
+        setSnapshot({
+          client,
+          scopeKey,
+          policy: result.policy,
+          // An answer without the field is not an answer: coerce rather than
+          // let an undefined/non-boolean value read as a capability.
+          canConfigure: result.can_configure === true,
+          loading: false,
+          saving: false,
+          error: null,
+        });
       })
       .catch((loadError: unknown) => {
         if (!active) return;
-        setError(describeError(loadError, 'Failed to load the MCP member policy'));
-      })
-      .finally(() => {
-        if (active) setLoading(false);
+        setSnapshot({
+          ...restrictiveSnapshot(client, scopeKey, false),
+          error: describeError(loadError, 'Failed to load the MCP member policy'),
+        });
       });
+
     return () => {
       active = false;
     };
-  }, [client]);
+  }, [client, scopeKey]);
+
+  // Compare scope in render, not in an effect. On disconnect, demotion,
+  // identity replacement, token reauth, reconnect, or policy invalidation the
+  // previous permissive snapshot becomes unusable in this very render.
+  const currentSnapshot =
+    client && scopeKey && snapshot.client === client && snapshot.scopeKey === scopeKey
+      ? snapshot
+      : null;
+
+  const effective = useMemo(() => {
+    if (!client || !connectionReady) {
+      return {
+        ...restrictiveSnapshot(client, null, false),
+        error: 'Not connected to the Agor daemon',
+      };
+    }
+    if (!identityKey || !scopeKey || !currentSnapshot) {
+      return restrictiveSnapshot(client, scopeKey, true);
+    }
+    return currentSnapshot;
+  }, [client, connectionReady, currentSnapshot, identityKey, scopeKey]);
 
   const save = useCallback(
     async (next: MCPMemberPolicy) => {
-      if (!client) return;
-      setSaving(true);
+      if (!client || !connectionReady || !scopeKey) return;
+
+      const saveClient = client;
+      const saveScopeKey = scopeKey;
+      setSnapshot((current) =>
+        current.client === saveClient && current.scopeKey === saveScopeKey
+          ? { ...current, saving: true }
+          : current
+      );
       try {
-        const result = await client.service('mcp-member-policy').patch(null, { policy: next });
-        setPolicy(result.policy);
-        setCanConfigure(result.can_configure === true);
-        setError(null);
+        const result = await saveClient.service('mcp-member-policy').patch(null, { policy: next });
+        setSnapshot((current) =>
+          current.client === saveClient && current.scopeKey === saveScopeKey
+            ? {
+                ...current,
+                policy: result.policy,
+                canConfigure: result.can_configure === true,
+                saving: false,
+                error: null,
+              }
+            : current
+        );
       } catch (saveError: unknown) {
-        setError(describeError(saveError, 'Failed to change the MCP member policy'));
-      } finally {
-        setSaving(false);
+        setSnapshot((current) =>
+          current.client === saveClient && current.scopeKey === saveScopeKey
+            ? {
+                ...current,
+                canConfigure: false,
+                saving: false,
+                error: describeError(saveError, 'Failed to change the MCP member policy'),
+              }
+            : current
+        );
       }
     },
-    [client]
+    [client, connectionReady, scopeKey]
   );
 
-  return { policy, canConfigure, loading, saving, error, save };
+  return {
+    policy: effective.policy,
+    canConfigure: effective.canConfigure,
+    loading: effective.loading,
+    saving: effective.saving,
+    error: effective.error,
+    save,
+  };
 }

--- a/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
+++ b/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
@@ -67,6 +67,7 @@ export const MarketingScreenshotPage = () => {
           value={{
             connected: true,
             connecting: false,
+            authGeneration: 1,
             outOfSync: false,
             capturedSha: null,
             currentSha: null,

--- a/apps/agor-ui/src/pages/MarketplacePage.tsx
+++ b/apps/agor-ui/src/pages/MarketplacePage.tsx
@@ -1,9 +1,9 @@
 /**
  * Marketplace surface: browse the MCP catalog and connect a server.
  *
- * A standalone surface rather than a workspace route — it reads the global
- * catalog table and does not need the tenant's boards, sessions or canvas, so
- * it keeps the same lightweight chrome as Knowledge.
+ * A standalone surface rather than a workspace route — it reads the checked-in
+ * curated catalog and does not need the tenant's boards, sessions or canvas,
+ * so it keeps the same lightweight chrome as Knowledge.
  *
  * The Catalog is the only tab in this slice. My Servers, Sessions and
  * Credentials arrive with the data models behind them.
@@ -99,7 +99,7 @@ export const MarketplacePage: React.FC<MarketplacePageProps> = ({
           <Paragraph type="secondary" style={{ marginBottom: token.margin }}>
             Attach tools to your agents — browse, review permissions, connect.
           </Paragraph>
-          <CatalogTab client={client} connected={connected} currentUserId={currentUser?.user_id} />
+          <CatalogTab client={client} connected={connected} currentUser={currentUser} />
         </div>
       </Content>
     </Layout>

--- a/apps/agor-ui/src/pages/MarketplacePage.tsx
+++ b/apps/agor-ui/src/pages/MarketplacePage.tsx
@@ -34,6 +34,10 @@ export interface MarketplacePageProps {
    * surface renders immediately and has to carry the distinction itself.
    */
   connected: boolean;
+  /** True during disconnect grace and in-place token authentication. */
+  connecting: boolean;
+  /** Successful socket-auth generation from useAgorClient. */
+  authGeneration: number;
   currentUser?: User | null;
   onUserSettingsClick?: () => void;
   onLogout?: () => void;
@@ -42,6 +46,8 @@ export interface MarketplacePageProps {
 export const MarketplacePage: React.FC<MarketplacePageProps> = ({
   client,
   connected,
+  connecting,
+  authGeneration,
   currentUser,
   onUserSettingsClick,
   onLogout,
@@ -99,7 +105,13 @@ export const MarketplacePage: React.FC<MarketplacePageProps> = ({
           <Paragraph type="secondary" style={{ marginBottom: token.margin }}>
             Attach tools to your agents — browse, review permissions, connect.
           </Paragraph>
-          <CatalogTab client={client} connected={connected} currentUser={currentUser} />
+          <CatalogTab
+            client={client}
+            connected={connected}
+            connecting={connecting}
+            authGeneration={authGeneration}
+            currentUser={currentUser}
+          />
         </div>
       </Content>
     </Layout>

--- a/apps/agor-ui/src/pages/marketing/MarketingVideoPage.tsx
+++ b/apps/agor-ui/src/pages/marketing/MarketingVideoPage.tsx
@@ -473,6 +473,7 @@ export const MarketingVideoPage = () => {
           value={{
             connected: true,
             connecting: false,
+            authGeneration: 1,
             outOfSync: false,
             capturedSha: null,
             currentSha: null,

--- a/apps/agor-ui/src/store/realtimeBatch.test.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.test.ts
@@ -6,9 +6,12 @@ import {
   discardRealtimeNow,
   enqueueSessionPatch,
   flushRealtimeNow,
+  setRealtimeAuthorityScope,
   tombstoneSession,
   untombstoneSession,
 } from './realtimeBatch';
+
+const AUTHORITY = 'user-a:member:1';
 
 // The keyed session-patch queue writes through the real store, so these are
 // small integration tests: seed the store, drive the queue, assert the maps.
@@ -36,10 +39,12 @@ beforeEach(() => {
   agorStore.getState().reset();
   resetHydrationRevisions();
   discardRealtimeNow();
+  setRealtimeAuthorityScope(AUTHORITY);
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  setRealtimeAuthorityScope(null);
   discardRealtimeNow();
   agorStore.getState().reset();
   resetHydrationRevisions();
@@ -50,11 +55,11 @@ describe('realtimeBatch — keyed session-patch queue', () => {
     seedSession(makeSession({ status: 'idle' }));
 
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
     // Not applied synchronously.
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
 
-    flushRealtimeNow();
+    flushRealtimeNow(AUTHORITY);
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'running' });
   });
 
@@ -67,15 +72,16 @@ describe('realtimeBatch — keyed session-patch queue', () => {
     });
 
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'thinking' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'thinking' }));
     bumpRevision('sessions');
     enqueueSessionPatch(
+      AUTHORITY,
       makeSession({ status: 'idle', ready_for_prompt: true } as Partial<Session>)
     );
 
-    flushRealtimeNow();
+    flushRealtimeNow(AUTHORITY);
     unsub();
 
     // Only the latest payload lands, and the whole frame is a single notify.
@@ -91,9 +97,9 @@ describe('realtimeBatch — keyed session-patch queue', () => {
 
     // patched arrives (queued), then removed applies synchronously.
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
 
-    tombstoneSession('s-1');
+    tombstoneSession(AUTHORITY, 's-1');
     agorStore.getState().applyMaps((prev) => {
       const sessionById = new Map(prev.sessionById);
       sessionById.delete('s-1');
@@ -102,7 +108,7 @@ describe('realtimeBatch — keyed session-patch queue', () => {
       return { ...prev, sessionById, sessionsByBranch };
     });
 
-    flushRealtimeNow();
+    flushRealtimeNow(AUTHORITY);
 
     // The tombstoned id is skipped — no resurrection in either map.
     expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
@@ -111,14 +117,14 @@ describe('realtimeBatch — keyed session-patch queue', () => {
 
   it('created clears a tombstone so a same-frame recreate+patch applies', () => {
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
-    tombstoneSession('s-1'); // remove
-    untombstoneSession('s-1'); // create clears the tombstone
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
+    tombstoneSession(AUTHORITY, 's-1'); // remove
+    untombstoneSession(AUTHORITY, 's-1'); // create clears the tombstone
     seedSession(makeSession({ status: 'running' }));
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'thinking' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'thinking' }));
 
-    flushRealtimeNow();
+    flushRealtimeNow(AUTHORITY);
 
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'thinking' });
   });
@@ -135,7 +141,7 @@ describe('realtimeBatch — keyed session-patch queue', () => {
       seedSession(makeSession({ status: 'idle' }));
 
       bumpRevision('sessions');
-      enqueueSessionPatch(makeSession({ status: 'running' }));
+      enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
       // rAF would pause in a hidden tab; nothing applied yet.
       expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
 
@@ -151,13 +157,13 @@ describe('realtimeBatch — keyed session-patch queue', () => {
 
     // A patch is enqueued (stamped with the current revision)...
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
 
     // ...then a hydration applies a fresher snapshot proven quiet at-or-after
     // that revision. The queued patch is now stale.
     recordHydrationApply(['sessions'], [1]);
 
-    flushRealtimeNow();
+    flushRealtimeNow(AUTHORITY);
 
     // The stale patch is dropped — the hydrated (idle) state stands.
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
@@ -167,15 +173,41 @@ describe('realtimeBatch — keyed session-patch queue', () => {
     seedSession(makeSession({ status: 'idle' }));
 
     bumpRevision('sessions');
-    enqueueSessionPatch(makeSession({ status: 'running' }));
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
 
     discardRealtimeNow();
-    flushRealtimeNow(); // nothing left to apply
+    flushRealtimeNow(AUTHORITY); // nothing left to apply
 
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
   });
 
   it('flushRealtimeNow is a no-op when the queue is empty', () => {
-    expect(() => flushRealtimeNow()).not.toThrow();
+    expect(() => flushRealtimeNow(AUTHORITY)).not.toThrow();
+  });
+
+  it('discards the previous authority queue and makes its delayed cleanup a no-op', () => {
+    seedSession(makeSession({ status: 'idle' }));
+    bumpRevision('sessions');
+    enqueueSessionPatch(AUTHORITY, makeSession({ status: 'running' }));
+
+    const replacementAuthority = 'user-b:admin:2';
+    setRealtimeAuthorityScope(replacementAuthority);
+    agorStore.getState().resetMaps();
+
+    // This is the old subscription's passive cleanup. It must neither apply A's
+    // payload nor cancel/flush any work that B queues before its own cleanup.
+    flushRealtimeNow(AUTHORITY);
+    bumpRevision('sessions');
+    enqueueSessionPatch(
+      replacementAuthority,
+      makeSession({ session_id: 's-b', status: 'thinking' })
+    );
+    flushRealtimeNow(AUTHORITY);
+
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-b')).toBe(false);
+
+    flushRealtimeNow(replacementAuthority);
+    expect(agorStore.getState().sessionById.get('s-b')).toMatchObject({ status: 'thinking' });
   });
 });

--- a/apps/agor-ui/src/store/realtimeBatch.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.ts
@@ -14,7 +14,7 @@
  * and goes through the quiet first-paint gate.
  *
  * Design — a KEYED latest-payload-per-session queue with tombstones, NOT a FIFO
- * thunk queue. Two properties fall out of the shape:
+ * thunk queue. Four properties fall out of the shape:
  *
  *  1. Ordering safety. `session:created`/`removed` apply SYNCHRONOUSLY (see the
  *     wiring in `useAgorData`), while `patched`/`updated` defer to the next
@@ -26,13 +26,18 @@
  *     genuine remove-then-recreate within one frame still applies. Tombstones
  *     live only until the flush that clears them — a later-frame patch can't be
  *     stale against a same-frame remove, and cross-fetch staleness is handled by
- *     (3). Memory is bounded to one entry per session, so a burst collapses.
+ *     (4). Memory is bounded to one entry per session, so a burst collapses.
  *
  *  2. Bounded flush work. At most one (the latest) payload per id is applied,
  *     composed into a SINGLE `applyMaps` pass — O(1) store notifies per frame
  *     regardless of how many patches arrived.
  *
- *  3. Hydration ordering. Each queued entry is stamped with the sessions
+ *  3. Authority ordering. Each queued entry is stamped with the authenticated
+ *     identity/role/auth generation that received it. Moving to another
+ *     authority discards the old queue before map reset, and an old listener
+ *     or passive cleanup cannot enqueue/flush after that move.
+ *
+ *  4. Hydration ordering. Each queued entry is stamped with the sessions
  *     revision at enqueue time. A background hydration records the revision its
  *     last quiet-window apply was proven against (`getLastAppliedRevision`); the
  *     flush DROPS any queued entry stamped at-or-below it, because the applied
@@ -54,6 +59,11 @@ import { agorStore } from './agorStore';
 
 interface PendingPatch {
   session: Session;
+  // The authenticated UI authority that received this socket event. The
+  // socket client is intentionally long-lived across launch-auth replacement,
+  // role changes, and reconnects, so a sessions revision alone cannot prove
+  // that a deferred patch still belongs to the current caller.
+  authorityScope: string;
   // Sessions revision captured right after the synchronous bump at enqueue —
   // used by the flush to discard entries a fresher hydration already subsumed.
   revision: number;
@@ -63,9 +73,13 @@ interface PendingPatch {
 // flush (tombstones). Both are module-global singletons: `useAgorData` mounts
 // once, and tests reset via `discardRealtimeNow`.
 let pending = new Map<string, PendingPatch>();
-let tombstones = new Set<string>();
+let tombstones = new Map<string, string>();
 let handle: number | ReturnType<typeof setTimeout> | null = null;
 let handleIsRaf = false;
+// Set from useAgorData's layout phase before any authority-transition map
+// reset. Old passive subscription cleanups therefore cannot flush caller A's
+// queue after caller B has become current.
+let activeAuthorityScope: string | null = null;
 
 // Cadence for the hidden-tab / no-rAF fallback. Browsers throttle background
 // timers to ~1s regardless; a short nominal interval keeps a foreground no-rAF
@@ -110,14 +124,16 @@ function flush(): void {
   // stale patch can outlive them (a later-frame patch is not stale against a
   // same-frame remove; cross-fetch staleness is caught by the revision guard).
   pending = new Map();
-  tombstones = new Set();
+  tombstones = new Map();
 
-  if (batch.size === 0) return;
+  const flushAuthorityScope = activeAuthorityScope;
+  if (!flushAuthorityScope || batch.size === 0) return;
 
   const lastApplied = getLastAppliedRevision('sessions');
   const sessions: Session[] = [];
   for (const [id, entry] of batch) {
-    if (graves.has(id)) continue; // removed synchronously this frame
+    if (entry.authorityScope !== flushAuthorityScope) continue;
+    if (graves.get(id) === flushAuthorityScope) continue; // removed synchronously this frame
     if (entry.revision <= lastApplied) continue; // subsumed by a fresher hydration apply
     sessions.push(entry.session);
   }
@@ -150,8 +166,16 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
  * bumps synchronously first, so the stamp reflects this event). Applied on the
  * next coalesced flush.
  */
-export function enqueueSessionPatch(session: Session): void {
-  pending.set(session.session_id, { session, revision: getRevision('sessions') });
+export function enqueueSessionPatch(authorityScope: string, session: Session): void {
+  // A listener from the previous subscription can remain attached until its
+  // passive cleanup runs. Reject it synchronously once the layout phase has
+  // moved the queue to a replacement authority.
+  if (authorityScope !== activeAuthorityScope) return;
+  pending.set(session.session_id, {
+    session,
+    authorityScope,
+    revision: getRevision('sessions'),
+  });
   scheduleFlush();
 }
 
@@ -160,9 +184,10 @@ export function enqueueSessionPatch(session: Session): void {
  * for it and mark it so a same-frame queued patch can't resurrect it at flush.
  * Schedules a flush so the tombstone is cleared even if no patch is queued.
  */
-export function tombstoneSession(sessionId: string): void {
+export function tombstoneSession(authorityScope: string, sessionId: string): void {
+  if (authorityScope !== activeAuthorityScope) return;
   pending.delete(sessionId);
-  tombstones.add(sessionId);
+  tombstones.set(sessionId, authorityScope);
   scheduleFlush();
 }
 
@@ -170,15 +195,36 @@ export function tombstoneSession(sessionId: string): void {
  * Clear a session id's tombstone on synchronous `session:created` so a genuine
  * remove-then-recreate within one frame lets subsequent patches apply.
  */
-export function untombstoneSession(sessionId: string): void {
-  tombstones.delete(sessionId);
+export function untombstoneSession(authorityScope: string, sessionId: string): void {
+  if (authorityScope !== activeAuthorityScope) return;
+  if (tombstones.get(sessionId) === authorityScope) tombstones.delete(sessionId);
 }
 
 /**
- * Apply any queued patches immediately. Call on teardown so the last streamed
- * update isn't dropped when the subscription effect re-runs or unmounts.
+ * Move the singleton queue to the currently authenticated authority.
+ *
+ * Changing authority always discards queued work. It is not safe to preserve a
+ * deferred entity payload across identity, role, token-auth generation, or
+ * connection transitions: caller-shaped rows and redactions may differ even
+ * when the entity ID is the same. This runs in useAgorData's layout phase,
+ * before its map reset and before the previous subscription's passive cleanup.
  */
-export function flushRealtimeNow(): void {
+export function setRealtimeAuthorityScope(authorityScope: string | null): void {
+  if (activeAuthorityScope === authorityScope) return;
+  activeAuthorityScope = authorityScope;
+  discardRealtimeNow();
+}
+
+/**
+ * Apply any queued patches immediately for a same-authority subscription
+ * teardown. A true owner unmount first activates a null scope in layout cleanup,
+ * making its later passive cleanup a no-op instead of retaining private rows.
+ */
+export function flushRealtimeNow(authorityScope: string): void {
+  // A previous effect's cleanup must not cancel or flush the replacement
+  // authority's queue. Same-authority resubscriptions still preserve the last
+  // streamed update, which is why this is scoped rather than always discarded.
+  if (authorityScope !== activeAuthorityScope) return;
   cancelHandle();
   flush();
 }
@@ -190,5 +236,5 @@ export function flushRealtimeNow(): void {
 export function discardRealtimeNow(): void {
   cancelHandle();
   pending = new Map();
-  tombstones = new Set();
+  tombstones = new Map();
 }

--- a/apps/agor-ui/src/surfaces/SharedUserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/surfaces/SharedUserSettingsModal.test.tsx
@@ -1,0 +1,133 @@
+import type { AgorClient, UpdateUserInput, User } from '@agor-live/client';
+import { act, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../contexts/ConnectionContext';
+
+type CapturedProps = {
+  onUpdate: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => Promise<void>;
+  onRestartOnboarding?: (shouldApply?: () => boolean) => Promise<void>;
+};
+
+let captured: CapturedProps | null = null;
+vi.mock('../components/SettingsModal', () => ({
+  UserSettingsModal: (props: CapturedProps) => {
+    captured = props;
+    return null;
+  },
+}));
+
+import { SharedUserSettingsModal } from './SharedUserSettingsModal';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const user = {
+  user_id: 'member-a',
+  email: 'member-a@example.test',
+  role: 'member',
+} as User;
+const client = {} as AgorClient;
+
+function view(generation: number, children: ReactNode) {
+  return (
+    <ConnectionProvider
+      value={{
+        connected: true,
+        connecting: false,
+        authGeneration: generation,
+        outOfSync: false,
+        capturedSha: null,
+        currentSha: null,
+      }}
+    >
+      {children}
+    </ConnectionProvider>
+  );
+}
+
+describe('SharedUserSettingsModal authority fencing', () => {
+  beforeEach(() => {
+    captured = null;
+  });
+
+  it('drops refresh and restart continuations from the previous auth generation', async () => {
+    const updatePending = deferred();
+    const restartPending = deferred();
+    const onUpdateUser = vi.fn(() => updatePending.promise);
+    const onRefreshCurrentUser = vi.fn(async (_shouldApply: () => boolean) => {});
+    const onRestartOnboarding = vi.fn(() => restartPending.promise);
+    const modal = (
+      <SharedUserSettingsModal
+        open
+        user={user}
+        client={client}
+        onClose={vi.fn()}
+        onUpdateUser={onUpdateUser}
+        onRefreshCurrentUser={onRefreshCurrentUser}
+        onRestartOnboarding={onRestartOnboarding}
+      />
+    );
+    const rendered = render(view(3, modal));
+    const pendingUpdate = captured!.onUpdate('member-a', { name: 'A draft' }, () => true);
+    const pendingRestart = captured!.onRestartOnboarding!(() => true);
+    expect(onUpdateUser).toHaveBeenCalledOnce();
+    expect(onRestartOnboarding).toHaveBeenCalledOnce();
+
+    rendered.rerender(view(4, modal));
+    await act(async () => {
+      updatePending.resolve();
+      restartPending.resolve();
+      await Promise.all([pendingUpdate, pendingRestart]);
+    });
+
+    expect(onRefreshCurrentUser).not.toHaveBeenCalled();
+    const updateGuard = onUpdateUser.mock.calls[0]?.[2];
+    const restartGuard = onRestartOnboarding.mock.calls[0]?.[0];
+    expect(updateGuard?.()).toBe(false);
+    expect(restartGuard?.()).toBe(false);
+  });
+
+  it('passes the exact operation guard through an in-flight current-user refresh', async () => {
+    const refreshPending = deferred();
+    let refreshGuard: (() => boolean) | undefined;
+    const onRefreshCurrentUser = vi.fn((shouldApply: () => boolean) => {
+      refreshGuard = shouldApply;
+      return refreshPending.promise;
+    });
+    const modal = (
+      <SharedUserSettingsModal
+        open
+        user={user}
+        client={client}
+        onClose={vi.fn()}
+        onUpdateUser={vi.fn(async () => {})}
+        onRefreshCurrentUser={onRefreshCurrentUser}
+      />
+    );
+    const rendered = render(view(8, modal));
+    const pendingUpdate = captured!.onUpdate('member-a', { name: 'A draft' }, () => true);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onRefreshCurrentUser).toHaveBeenCalledOnce();
+    expect(refreshGuard?.()).toBe(true);
+
+    rendered.rerender(view(9, modal));
+    expect(refreshGuard?.()).toBe(false);
+    await act(async () => {
+      refreshPending.resolve();
+      await pendingUpdate;
+    });
+  });
+});

--- a/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
+++ b/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
@@ -1,14 +1,22 @@
 import type { AgorClient, UpdateUserInput, User } from '@agor-live/client';
 import { UserSettingsModal } from '../components/SettingsModal';
+import {
+  useAuthenticatedAuthorityScope,
+  useAuthorityOperationGuard,
+} from '../hooks/useAuthorityOperationGuard';
 
 export interface SharedUserSettingsModalProps {
   open: boolean;
   user: User | null;
   client: AgorClient | null;
   onClose: () => void;
-  onUpdateUser: (userId: string, updates: UpdateUserInput) => Promise<void>;
-  onRefreshCurrentUser: () => Promise<unknown>;
-  onRestartOnboarding?: () => void | Promise<void>;
+  onUpdateUser: (
+    userId: string,
+    updates: UpdateUserInput,
+    shouldApply?: () => boolean
+  ) => Promise<void>;
+  onRefreshCurrentUser: (shouldApply: () => boolean) => Promise<unknown>;
+  onRestartOnboarding?: (shouldApply?: () => boolean) => void | Promise<void>;
   initialTab?: string;
 }
 
@@ -30,18 +38,42 @@ export const SharedUserSettingsModal: React.FC<SharedUserSettingsModalProps> = (
   onRefreshCurrentUser,
   onRestartOnboarding,
   initialTab,
-}) => (
-  <UserSettingsModal
-    open={open}
-    onClose={onClose}
-    user={user}
-    currentUser={user}
-    client={client}
-    onUpdate={async (userId, updates) => {
-      await onUpdateUser(userId, updates);
-      await onRefreshCurrentUser();
-    }}
-    onRestartOnboarding={onRestartOnboarding}
-    initialTab={initialTab}
-  />
-);
+}) => {
+  const authority = useAuthenticatedAuthorityScope(
+    client,
+    user ? `${user.user_id}:${user.role}` : null
+  );
+  const operationGuard = useAuthorityOperationGuard(authority.operationScope);
+  return (
+    <UserSettingsModal
+      open={open}
+      onClose={onClose}
+      user={user}
+      currentUser={user}
+      client={client}
+      onUpdate={async (userId, updates, childShouldApply) => {
+        const operation = operationGuard.begin();
+        const shouldApply = () =>
+          operation.isCurrent() && (childShouldApply ? childShouldApply() : true);
+        if (!shouldApply()) return;
+        await onUpdateUser(userId, updates, shouldApply);
+        if (!shouldApply()) return;
+        await onRefreshCurrentUser(shouldApply);
+        if (!shouldApply()) return;
+      }}
+      onRestartOnboarding={
+        onRestartOnboarding
+          ? async (childShouldApply) => {
+              const operation = operationGuard.begin();
+              const shouldApply = () =>
+                operation.isCurrent() && (childShouldApply ? childShouldApply() : true);
+              if (!shouldApply()) return;
+              await onRestartOnboarding(shouldApply);
+              if (!shouldApply()) return;
+            }
+          : undefined
+      }
+      initialTab={initialTab}
+    />
+  );
+};

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -76,9 +76,9 @@ export const MARKETPLACE_SURFACE = defineSurface({
   id: 'marketplace',
   label: 'Marketplace',
   routePaths: MARKETPLACE_ROUTE_PATHS,
-  // Browsing the catalog reads a paginated global table, not the tenant's
-  // boards and sessions, so the workspace store stays cold until connect
-  // navigates into a session.
+  // Browsing the catalog reads the checked-in curated file the daemon serves
+  // whole, not the tenant's boards and sessions, so the workspace store stays
+  // cold until connect navigates into a session.
   startsWorkspaceRuntime: false,
   usesDeviceRouter: false,
   usesSharedUserSettings: true,

--- a/apps/agor-ui/src/types/ui.ts
+++ b/apps/agor-ui/src/types/ui.ts
@@ -22,4 +22,6 @@ export interface CreateRepoOptions {
   silent?: boolean;
   /** Still surface failures while suppressing loading/success toasts. */
   showErrors?: boolean;
+  /** Suppress continuations once the initiating authenticated authority changes. */
+  shouldApply?: () => boolean;
 }

--- a/apps/agor-ui/src/utils/currentUserAuthority.test.ts
+++ b/apps/agor-ui/src/utils/currentUserAuthority.test.ts
@@ -1,0 +1,59 @@
+import { hasMinimumRole, ROLES, type User } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { canAddMcpServer } from '../components/MCPServer/memberPolicy';
+import { enrichAuthenticatedUser } from './currentUserAuthority';
+
+const user = (role: User['role'], name: string): User =>
+  ({
+    user_id: 'user-1',
+    email: 'fresh@example.com',
+    name,
+    role,
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date(),
+  }) as User;
+
+describe('enrichAuthenticatedUser', () => {
+  it('keeps an admin-to-member authentication change authoritative without a users event', () => {
+    const authenticated = user('member', 'Fresh auth name');
+    const staleDirectory = { ...user('admin', 'Directory display name'), email: 'old@example.com' };
+
+    const effective = enrichAuthenticatedUser(authenticated, staleDirectory);
+    expect(effective).toMatchObject({
+      user_id: 'user-1',
+      role: 'member',
+      email: 'fresh@example.com',
+      name: 'Directory display name',
+    });
+    expect(
+      canAddMcpServer({
+        connectionReady: true,
+        role: effective?.role,
+        isAdmin: hasMinimumRole(effective?.role, ROLES.ADMIN),
+        policy: 'allow_crud',
+        userId: effective?.user_id,
+        canConfigure: false,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps a member-to-admin launch-auth change authoritative without a users event', () => {
+    const authenticated = user('admin', 'Fresh auth name');
+    const staleDirectory = user('member', 'Directory display name');
+
+    const effective = enrichAuthenticatedUser(authenticated, staleDirectory);
+    expect(effective).toMatchObject({
+      role: 'admin',
+      name: 'Directory display name',
+    });
+    expect(hasMinimumRole(effective?.role, ROLES.ADMIN)).toBe(true);
+  });
+
+  it('does not enrich from a cached row belonging to another identity', () => {
+    const authenticated = user('member', 'Fresh auth name');
+    const other = { ...user('admin', 'Other'), user_id: 'user-2' } as User;
+
+    expect(enrichAuthenticatedUser(authenticated, other)).toBe(authenticated);
+  });
+});

--- a/apps/agor-ui/src/utils/currentUserAuthority.ts
+++ b/apps/agor-ui/src/utils/currentUserAuthority.ts
@@ -1,0 +1,33 @@
+import type { User } from '@agor-live/client';
+
+/**
+ * Enrich the freshly authenticated user with directory display data without
+ * allowing an older directory snapshot to become authorization authority.
+ *
+ * Launch auth can update the database directly and return the new role without
+ * a `users` event. Likewise, a token replacement can establish a different
+ * role while `userById` still contains the prior row. Display fields may lag;
+ * identity, role, and login gates may not.
+ */
+export function enrichAuthenticatedUser(
+  authenticated: User | null | undefined,
+  directory: User | null | undefined
+): User | null {
+  if (!authenticated) return null;
+  if (!directory || directory.user_id !== authenticated.user_id) return authenticated;
+
+  return {
+    ...authenticated,
+    ...directory,
+    // Authentication response is the caller authority. Keep these after the
+    // directory spread so stale admin/member rows and launch-auth direct DB
+    // updates cannot be reversed by cached enrichment.
+    user_id: authenticated.user_id,
+    email: authenticated.email,
+    role: authenticated.role,
+    must_change_password: authenticated.must_change_password,
+    onboarding_completed: authenticated.onboarding_completed,
+    unix_username: authenticated.unix_username,
+    filesystem_home: authenticated.filesystem_home,
+  };
+}

--- a/apps/agor-ui/src/utils/forcePasswordChange.test.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.test.ts
@@ -16,12 +16,22 @@ function makeClient(patch = vi.fn().mockResolvedValue({})) {
   } as unknown as Parameters<typeof completeForcedPasswordChange>[0]['client'];
 }
 
+function authorityCycle(isCurrent: () => boolean = () => true) {
+  return {
+    userId: 'user-a',
+    role: 'admin',
+    accessToken: 'user-a-access',
+    isCurrent,
+  };
+}
+
 function options(overrides: Partial<Parameters<typeof completeForcedPasswordChange>[0]> = {}) {
   return {
     client: makeClient(),
     userId: 'user-a',
     email: 'a@example.test',
     newPassword: 'new-password-1234',
+    authorityCycle: authorityCycle(),
     shouldApply: () => true,
     reauthenticate: vi.fn().mockResolvedValue('signed-in' as const),
     logout: vi.fn().mockResolvedValue(true),
@@ -41,7 +51,7 @@ describe('completeForcedPasswordChange', () => {
     expect(reauthenticate).toHaveBeenCalledWith(
       'a@example.test',
       'new-password-1234',
-      expect.any(Function)
+      expect.objectContaining({ userId: 'user-a', role: 'admin' })
     );
     expect(logout).not.toHaveBeenCalled();
   });
@@ -55,6 +65,7 @@ describe('completeForcedPasswordChange', () => {
       options({
         client: makeClient(vi.fn(() => pendingPatch.promise)),
         shouldApply: () => current,
+        authorityCycle: authorityCycle(() => current),
         reauthenticate,
         logout,
       })
@@ -73,6 +84,7 @@ describe('completeForcedPasswordChange', () => {
     const result = completeForcedPasswordChange(
       options({
         shouldApply: () => current,
+        authorityCycle: authorityCycle(() => current),
         reauthenticate: vi.fn(() => pendingLogin.promise),
         logout,
       })
@@ -108,7 +120,9 @@ describe('completeForcedPasswordChange', () => {
       )
     ).resolves.toBe(false);
     expect(logout).toHaveBeenCalledOnce();
-    expect(logout).toHaveBeenCalledWith(expect.any(Function));
+    expect(logout).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-a', role: 'admin' })
+    );
   });
 });
 

--- a/apps/agor-ui/src/utils/forcePasswordChange.test.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.test.ts
@@ -142,7 +142,8 @@ describe('completeForcedPasswordChange', () => {
 describe('completeLocalPasswordChange', () => {
   it('patches all settings and reauthenticates with the post-change email', async () => {
     const patch = vi.fn().mockResolvedValue({});
-    const login = vi.fn().mockResolvedValue(true);
+    const reauthenticate = vi.fn().mockResolvedValue(signedInReceipt());
+    const cycle = authorityCycle();
     const updates = {
       email: 'new@example.test',
       password: 'new-password-1234',
@@ -155,17 +156,18 @@ describe('completeLocalPasswordChange', () => {
       emailAfterChange: updates.email,
       newPassword: updates.password,
       updates,
-      login,
-      logout: vi.fn(),
+      authorityCycle: cycle,
+      reauthenticate,
+      logout: vi.fn().mockResolvedValue(true),
     });
 
     expect(patch).toHaveBeenCalledWith('user-1', updates);
-    expect(login).toHaveBeenCalledWith('new@example.test', 'new-password-1234');
+    expect(reauthenticate).toHaveBeenCalledWith('new@example.test', 'new-password-1234', cycle);
   });
 
-  it('logs out when reauthentication rejects after the credential write', async () => {
-    const loginError = new Error('authentication transport failed');
-    const logout = vi.fn().mockResolvedValue(undefined);
+  it('logs out only when guarded reauthentication fails after the credential write', async () => {
+    const cycle = authorityCycle();
+    const logout = vi.fn().mockResolvedValue(true);
 
     await expect(
       completeLocalPasswordChange({
@@ -174,10 +176,34 @@ describe('completeLocalPasswordChange', () => {
         emailAfterChange: 'person@example.test',
         newPassword: 'new-password-1234',
         updates: { password: 'new-password-1234' },
-        login: vi.fn().mockRejectedValue(loginError),
+        authorityCycle: cycle,
+        reauthenticate: vi.fn().mockResolvedValue({ status: 'failed' }),
         logout,
       })
-    ).rejects.toBe(loginError);
-    expect(logout).toHaveBeenCalledTimes(1);
+    ).resolves.toEqual({ status: 'signed-out' });
+    expect(logout).toHaveBeenCalledWith(cycle);
+  });
+
+  it('does not reauthenticate or log out a replacement authority after a delayed patch', async () => {
+    const pendingPatch = deferred<Record<string, never>>();
+    let current = true;
+    const reauthenticate = vi.fn();
+    const logout = vi.fn();
+    const result = completeLocalPasswordChange({
+      client: makeClient(vi.fn(() => pendingPatch.promise)),
+      userId: 'user-1',
+      emailAfterChange: 'person@example.test',
+      newPassword: 'new-password-1234',
+      updates: { password: 'new-password-1234' },
+      authorityCycle: authorityCycle(() => current),
+      reauthenticate,
+      logout,
+    });
+
+    current = false;
+    pendingPatch.resolve({});
+    await expect(result).resolves.toBeNull();
+    expect(reauthenticate).not.toHaveBeenCalled();
+    expect(logout).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/utils/forcePasswordChange.test.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.test.ts
@@ -22,6 +22,19 @@ function authorityCycle(isCurrent: () => boolean = () => true) {
     role: 'admin',
     accessToken: 'user-a-access',
     isCurrent,
+    onInvalidate: () => () => {},
+  };
+}
+
+function signedInReceipt(isCurrent: () => boolean = () => true) {
+  return {
+    status: 'signed-in' as const,
+    authority: {
+      userId: 'user-a',
+      role: 'admin',
+      accessToken: 'user-a-new-access',
+      isCurrent,
+    },
   };
 }
 
@@ -33,7 +46,7 @@ function options(overrides: Partial<Parameters<typeof completeForcedPasswordChan
     newPassword: 'new-password-1234',
     authorityCycle: authorityCycle(),
     shouldApply: () => true,
-    reauthenticate: vi.fn().mockResolvedValue('signed-in' as const),
+    reauthenticate: vi.fn().mockResolvedValue(signedInReceipt()),
     logout: vi.fn().mockResolvedValue(true),
     ...overrides,
   };
@@ -42,11 +55,11 @@ function options(overrides: Partial<Parameters<typeof completeForcedPasswordChan
 describe('completeForcedPasswordChange', () => {
   it('patches then establishes the same exact authority cycle', async () => {
     const patch = vi.fn().mockResolvedValue({});
-    const reauthenticate = vi.fn().mockResolvedValue('signed-in');
+    const reauthenticate = vi.fn().mockResolvedValue(signedInReceipt());
     const logout = vi.fn().mockResolvedValue(true);
     await expect(
       completeForcedPasswordChange(options({ client: makeClient(patch), reauthenticate, logout }))
-    ).resolves.toBe(true);
+    ).resolves.toMatchObject({ status: 'signed-in' });
     expect(patch).toHaveBeenCalledWith('user-a', { password: 'new-password-1234' });
     expect(reauthenticate).toHaveBeenCalledWith(
       'a@example.test',
@@ -78,7 +91,7 @@ describe('completeForcedPasswordChange', () => {
   });
 
   it('does not apply a delayed A relogin failure continuation or log out B', async () => {
-    const pendingLogin = deferred<'signed-in' | 'failed' | 'obsolete'>();
+    const pendingLogin = deferred<{ status: 'failed' }>();
     let current = true;
     const logout = vi.fn().mockResolvedValue(true);
     const result = completeForcedPasswordChange(
@@ -91,7 +104,7 @@ describe('completeForcedPasswordChange', () => {
     );
     await Promise.resolve();
     current = false;
-    pendingLogin.resolve('failed');
+    pendingLogin.resolve({ status: 'failed' });
     await expect(result).resolves.toBeNull();
     expect(logout).not.toHaveBeenCalled();
   });
@@ -104,11 +117,11 @@ describe('completeForcedPasswordChange', () => {
       // Installing A's new tokens is the operation's intended terminal
       // authority transition, so the old generation becomes stale here.
       current = false;
-      return 'signed-in' as const;
+      return signedInReceipt();
     });
     await expect(
       completeForcedPasswordChange(options({ shouldApply: () => current, reauthenticate, logout }))
-    ).resolves.toBe(true);
+    ).resolves.toMatchObject({ status: 'signed-in' });
     expect(logout).not.toHaveBeenCalled();
   });
 
@@ -116,9 +129,9 @@ describe('completeForcedPasswordChange', () => {
     const logout = vi.fn().mockResolvedValue(true);
     await expect(
       completeForcedPasswordChange(
-        options({ reauthenticate: vi.fn().mockResolvedValue('failed'), logout })
+        options({ reauthenticate: vi.fn().mockResolvedValue({ status: 'failed' }), logout })
       )
-    ).resolves.toBe(false);
+    ).resolves.toEqual({ status: 'signed-out' });
     expect(logout).toHaveBeenCalledOnce();
     expect(logout).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'user-a', role: 'admin' })

--- a/apps/agor-ui/src/utils/forcePasswordChange.test.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { completeForcedPasswordChange, completeLocalPasswordChange } from './forcePasswordChange';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
 function makeClient(patch = vi.fn().mockResolvedValue({})) {
   return {
     service: vi.fn((name: string) => {
@@ -10,42 +16,99 @@ function makeClient(patch = vi.fn().mockResolvedValue({})) {
   } as unknown as Parameters<typeof completeForcedPasswordChange>[0]['client'];
 }
 
+function options(overrides: Partial<Parameters<typeof completeForcedPasswordChange>[0]> = {}) {
+  return {
+    client: makeClient(),
+    userId: 'user-a',
+    email: 'a@example.test',
+    newPassword: 'new-password-1234',
+    shouldApply: () => true,
+    reauthenticate: vi.fn().mockResolvedValue('signed-in' as const),
+    logout: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
 describe('completeForcedPasswordChange', () => {
-  it('patches the password then signs in with the new password', async () => {
+  it('patches then establishes the same exact authority cycle', async () => {
     const patch = vi.fn().mockResolvedValue({});
-    const login = vi.fn().mockResolvedValue(true);
-    const logout = vi.fn().mockResolvedValue(undefined);
-
-    const result = await completeForcedPasswordChange({
-      client: makeClient(patch),
-      userId: 'user-1',
-      email: 'person@example.test',
-      newPassword: 'new-password-1234',
-      login,
-      logout,
-    });
-
-    expect(result).toBe(true);
-    expect(patch).toHaveBeenCalledWith('user-1', { password: 'new-password-1234' });
-    expect(login).toHaveBeenCalledWith('person@example.test', 'new-password-1234');
+    const reauthenticate = vi.fn().mockResolvedValue('signed-in');
+    const logout = vi.fn().mockResolvedValue(true);
+    await expect(
+      completeForcedPasswordChange(options({ client: makeClient(patch), reauthenticate, logout }))
+    ).resolves.toBe(true);
+    expect(patch).toHaveBeenCalledWith('user-a', { password: 'new-password-1234' });
+    expect(reauthenticate).toHaveBeenCalledWith(
+      'a@example.test',
+      'new-password-1234',
+      expect.any(Function)
+    );
     expect(logout).not.toHaveBeenCalled();
   });
 
-  it('clears stale local state when the fresh sign-in fails', async () => {
-    const login = vi.fn().mockResolvedValue(false);
-    const logout = vi.fn().mockResolvedValue(undefined);
+  it('does not reauthenticate A when authority changes during the password patch', async () => {
+    const pendingPatch = deferred<Record<string, never>>();
+    let current = true;
+    const reauthenticate = vi.fn();
+    const logout = vi.fn();
+    const result = completeForcedPasswordChange(
+      options({
+        client: makeClient(vi.fn(() => pendingPatch.promise)),
+        shouldApply: () => current,
+        reauthenticate,
+        logout,
+      })
+    );
+    current = false;
+    pendingPatch.resolve({});
+    await expect(result).resolves.toBeNull();
+    expect(reauthenticate).not.toHaveBeenCalled();
+    expect(logout).not.toHaveBeenCalled();
+  });
 
-    const result = await completeForcedPasswordChange({
-      client: makeClient(),
-      userId: 'user-1',
-      email: 'person@example.test',
-      newPassword: 'new-password-1234',
-      login,
-      logout,
+  it('does not apply a delayed A relogin failure continuation or log out B', async () => {
+    const pendingLogin = deferred<'signed-in' | 'failed' | 'obsolete'>();
+    let current = true;
+    const logout = vi.fn().mockResolvedValue(true);
+    const result = completeForcedPasswordChange(
+      options({
+        shouldApply: () => current,
+        reauthenticate: vi.fn(() => pendingLogin.promise),
+        logout,
+      })
+    );
+    await Promise.resolve();
+    current = false;
+    pendingLogin.resolve('failed');
+    await expect(result).resolves.toBeNull();
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it('accepts the guarded signed-in receipt when that exact install advances generation', async () => {
+    let current = true;
+    const logout = vi.fn();
+    const reauthenticate = vi.fn(async () => {
+      expect(current).toBe(true);
+      // Installing A's new tokens is the operation's intended terminal
+      // authority transition, so the old generation becomes stale here.
+      current = false;
+      return 'signed-in' as const;
     });
+    await expect(
+      completeForcedPasswordChange(options({ shouldApply: () => current, reauthenticate, logout }))
+    ).resolves.toBe(true);
+    expect(logout).not.toHaveBeenCalled();
+  });
 
-    expect(result).toBe(false);
-    expect(logout).toHaveBeenCalledTimes(1);
+  it('logs out only when relogin fails while the captured authority is still exact', async () => {
+    const logout = vi.fn().mockResolvedValue(true);
+    await expect(
+      completeForcedPasswordChange(
+        options({ reauthenticate: vi.fn().mockResolvedValue('failed'), logout })
+      )
+    ).resolves.toBe(false);
+    expect(logout).toHaveBeenCalledOnce();
+    expect(logout).toHaveBeenCalledWith(expect.any(Function));
   });
 });
 

--- a/apps/agor-ui/src/utils/forcePasswordChange.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.ts
@@ -1,4 +1,5 @@
 import type { AgorClient, UpdateUserInput, User } from '@agor-live/client';
+import type { CapturedAuthAuthorityCycle } from '../hooks/useAuth';
 
 interface CompleteLocalPasswordChangeOptions {
   client: AgorClient;
@@ -15,13 +16,14 @@ interface CompleteForcedPasswordChangeOptions {
   userId: string;
   email: string;
   newPassword: string;
+  authorityCycle: CapturedAuthAuthorityCycle;
   shouldApply: () => boolean;
   reauthenticate: (
     email: string,
     password: string,
-    shouldApply: () => boolean
+    authorityCycle: CapturedAuthAuthorityCycle
   ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
-  logout: (shouldApply: () => boolean) => Promise<boolean>;
+  logout: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
 }
 
 /**
@@ -62,29 +64,30 @@ export async function completeForcedPasswordChange({
   userId,
   email,
   newPassword,
+  authorityCycle,
   shouldApply,
   reauthenticate,
   logout,
 }: CompleteForcedPasswordChangeOptions): Promise<boolean | null> {
-  if (!shouldApply()) return null;
+  if (!shouldApply() || !authorityCycle.isCurrent()) return null;
   await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
-  if (!shouldApply()) return null;
+  if (!shouldApply() || !authorityCycle.isCurrent()) return null;
 
   // The password patch revokes A's old tokens, so establishing A with the new
   // password is the terminal step of this same captured authority operation.
   // Authentication happens on a disposable REST client and installs tokens
-  // only if `shouldApply` is still exact at the point of application.
-  const result = await reauthenticate(email, newPassword, shouldApply);
+  // only if the App-owned captured authority is still exact at the point of
+  // application. The initiating modal may unmount while auth loading is shown.
+  const result = await reauthenticate(email, newPassword, authorityCycle);
   if (result === 'obsolete') return null;
   // `signed-in` is a guarded authority-establishment receipt: useAuth checks
   // shouldApply immediately before synchronously installing the new tokens and
   // identity. That installation is expected to advance authGeneration, so the
   // old generation must not invalidate its own successful terminal result.
   if (result === 'signed-in') return true;
-  if (!shouldApply()) return null;
   if (result === 'failed') {
-    if (!shouldApply()) return null;
-    await logout(shouldApply);
+    if (!authorityCycle.isCurrent()) return null;
+    await logout(authorityCycle);
     return false;
   }
 

--- a/apps/agor-ui/src/utils/forcePasswordChange.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.ts
@@ -1,5 +1,13 @@
 import type { AgorClient, UpdateUserInput, User } from '@agor-live/client';
-import type { CapturedAuthAuthorityCycle } from '../hooks/useAuth';
+import type {
+  AuthorityCycleLoginResult,
+  CapturedAuthAuthorityCycle,
+  EstablishedAuthAuthorityReceipt,
+} from '../hooks/useAuth';
+
+export type ForcedPasswordCompletion =
+  | { status: 'signed-in'; authority: EstablishedAuthAuthorityReceipt }
+  | { status: 'signed-out' };
 
 interface CompleteLocalPasswordChangeOptions {
   client: AgorClient;
@@ -22,7 +30,7 @@ interface CompleteForcedPasswordChangeOptions {
     email: string,
     password: string,
     authorityCycle: CapturedAuthAuthorityCycle
-  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
+  ) => Promise<AuthorityCycleLoginResult>;
   logout: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
 }
 
@@ -68,7 +76,7 @@ export async function completeForcedPasswordChange({
   shouldApply,
   reauthenticate,
   logout,
-}: CompleteForcedPasswordChangeOptions): Promise<boolean | null> {
+}: CompleteForcedPasswordChangeOptions): Promise<ForcedPasswordCompletion | null> {
   if (!shouldApply() || !authorityCycle.isCurrent()) return null;
   await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
   if (!shouldApply() || !authorityCycle.isCurrent()) return null;
@@ -79,17 +87,19 @@ export async function completeForcedPasswordChange({
   // only if the App-owned captured authority is still exact at the point of
   // application. The initiating modal may unmount while auth loading is shown.
   const result = await reauthenticate(email, newPassword, authorityCycle);
-  if (result === 'obsolete') return null;
+  if (result.status === 'obsolete') return null;
   // `signed-in` is a guarded authority-establishment receipt: useAuth checks
   // shouldApply immediately before synchronously installing the new tokens and
   // identity. That installation is expected to advance authGeneration, so the
   // old generation must not invalidate its own successful terminal result.
-  if (result === 'signed-in') return true;
-  if (result === 'failed') {
+  if (result.status === 'signed-in') {
+    return { status: 'signed-in', authority: result.authority };
+  }
+  if (result.status === 'failed') {
     if (!authorityCycle.isCurrent()) return null;
-    await logout(authorityCycle);
-    return false;
+    if (!(await logout(authorityCycle))) return null;
+    return { status: 'signed-out' };
   }
 
-  return false;
+  return null;
 }

--- a/apps/agor-ui/src/utils/forcePasswordChange.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.ts
@@ -15,8 +15,13 @@ interface CompleteForcedPasswordChangeOptions {
   userId: string;
   email: string;
   newPassword: string;
-  login: (email: string, password: string) => Promise<boolean>;
-  logout: () => Promise<void>;
+  shouldApply: () => boolean;
+  reauthenticate: (
+    email: string,
+    password: string,
+    shouldApply: () => boolean
+  ) => Promise<'signed-in' | 'failed' | 'obsolete'>;
+  logout: (shouldApply: () => boolean) => Promise<boolean>;
 }
 
 /**
@@ -44,22 +49,44 @@ export async function completeLocalPasswordChange({
   }
 }
 
-/** Complete the forced-password-change flow through the shared reauth contract. */
+/**
+ * Completes the forced-password-change flow.
+ *
+ * The password patch intentionally invalidates all existing browser tokens. To
+ * keep the initiating user from getting stuck with now-stale tokens, immediately
+ * sign in with the new password. If that fresh sign-in fails, clear the stale
+ * local session so the user lands on the login screen.
+ */
 export async function completeForcedPasswordChange({
   client,
   userId,
   email,
   newPassword,
-  login,
+  shouldApply,
+  reauthenticate,
   logout,
-}: CompleteForcedPasswordChangeOptions): Promise<boolean> {
-  return completeLocalPasswordChange({
-    client,
-    userId,
-    emailAfterChange: email,
-    newPassword,
-    updates: { password: newPassword },
-    login,
-    logout,
-  });
+}: CompleteForcedPasswordChangeOptions): Promise<boolean | null> {
+  if (!shouldApply()) return null;
+  await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
+  if (!shouldApply()) return null;
+
+  // The password patch revokes A's old tokens, so establishing A with the new
+  // password is the terminal step of this same captured authority operation.
+  // Authentication happens on a disposable REST client and installs tokens
+  // only if `shouldApply` is still exact at the point of application.
+  const result = await reauthenticate(email, newPassword, shouldApply);
+  if (result === 'obsolete') return null;
+  // `signed-in` is a guarded authority-establishment receipt: useAuth checks
+  // shouldApply immediately before synchronously installing the new tokens and
+  // identity. That installation is expected to advance authGeneration, so the
+  // old generation must not invalidate its own successful terminal result.
+  if (result === 'signed-in') return true;
+  if (!shouldApply()) return null;
+  if (result === 'failed') {
+    if (!shouldApply()) return null;
+    await logout(shouldApply);
+    return false;
+  }
+
+  return false;
 }

--- a/apps/agor-ui/src/utils/forcePasswordChange.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.ts
@@ -15,8 +15,13 @@ interface CompleteLocalPasswordChangeOptions {
   emailAfterChange: string;
   newPassword: string;
   updates: UpdateUserInput & { password: string };
-  login: (email: string, password: string) => Promise<boolean>;
-  logout: () => Promise<void>;
+  authorityCycle: CapturedAuthAuthorityCycle;
+  reauthenticate: (
+    email: string,
+    password: string,
+    authorityCycle: CapturedAuthAuthorityCycle
+  ) => Promise<AuthorityCycleLoginResult>;
+  logout: (authorityCycle: CapturedAuthAuthorityCycle) => Promise<boolean>;
 }
 
 interface CompleteForcedPasswordChangeOptions {
@@ -38,6 +43,8 @@ interface CompleteForcedPasswordChangeOptions {
  * Apply a current user's local-password patch and immediately replace the
  * browser credentials that the server revoked. `updates` may include an email
  * change, but the caller must provide the post-patch email used for login.
+ * The same captured-authority rules as the forced-password flow prevent a
+ * delayed login or logout continuation from replacing a newer principal.
  */
 export async function completeLocalPasswordChange({
   client,
@@ -45,18 +52,22 @@ export async function completeLocalPasswordChange({
   emailAfterChange,
   newPassword,
   updates,
-  login,
+  authorityCycle,
+  reauthenticate,
   logout,
-}: CompleteLocalPasswordChangeOptions): Promise<boolean> {
+}: CompleteLocalPasswordChangeOptions): Promise<ForcedPasswordCompletion | null> {
+  if (!authorityCycle.isCurrent()) return null;
   await client.service('users').patch(userId, updates as Partial<User>);
+  if (!authorityCycle.isCurrent()) return null;
 
-  let signedIn = false;
-  try {
-    signedIn = await login(emailAfterChange, newPassword);
-    return signedIn;
-  } finally {
-    if (!signedIn) await logout();
+  const result = await reauthenticate(emailAfterChange, newPassword, authorityCycle);
+  if (result.status === 'obsolete') return null;
+  if (result.status === 'signed-in') {
+    return { status: 'signed-in', authority: result.authority };
   }
+  if (!authorityCycle.isCurrent()) return null;
+  if (!(await logout(authorityCycle))) return null;
+  return { status: 'signed-out' };
 }
 
 /**

--- a/apps/agor-ui/src/utils/mcpOAuthAttempt.test.ts
+++ b/apps/agor-ui/src/utils/mcpOAuthAttempt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { agorStore } from '@/store/agorStore';
 import {
   oauthAttemptFailureMessage,
@@ -6,6 +6,18 @@ import {
   refreshAndRefetchMCPOAuthGrant,
   waitForMCPOAuthAttempt,
 } from './mcpOAuthAttempt';
+
+beforeEach(() => {
+  agorStore.getState().reset();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 describe('waitForMCPOAuthAttempt', () => {
   it('uses repeated durable gets rather than a realtime event as completion proof', async () => {
@@ -48,7 +60,7 @@ describe('waitForMCPOAuthAttempt', () => {
       service: vi.fn((path: keyof typeof services) => services[path]),
     } as never;
 
-    await refetchMCPOAuthDurableState(client, 'server-1');
+    await refetchMCPOAuthDurableState(client, 'server-1', () => true);
 
     expect(agorStore.getState().userAuthenticatedMcpServerIds).toEqual(new Set(['server-1']));
     expect(agorStore.getState().mcpServerById.get('server-1')).toMatchObject({
@@ -75,7 +87,7 @@ describe('waitForMCPOAuthAttempt', () => {
       service: vi.fn((path: keyof typeof services) => services[path]),
     } as never;
 
-    await expect(refreshAndRefetchMCPOAuthGrant(client, 'server-1')).resolves.toEqual({
+    await expect(refreshAndRefetchMCPOAuthGrant(client, 'server-1', () => true)).resolves.toEqual({
       success: false,
       error: 'needs_reauth',
     });
@@ -107,8 +119,108 @@ describe('waitForMCPOAuthAttempt', () => {
       service: vi.fn((path: keyof typeof services) => services[path]),
     } as never;
 
-    await expect(refreshAndRefetchMCPOAuthGrant(client, 'server-1')).rejects.toBe(createError);
+    await expect(refreshAndRefetchMCPOAuthGrant(client, 'server-1', () => true)).rejects.toBe(
+      createError
+    );
     expect(find).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['status-first', 'server-first'] as const)(
+    'does not apply caller-private durable rows when authority is lost after the %s read',
+    async (firstRead) => {
+      agorStore.getState().applyMaps((prev) => ({
+        ...prev,
+        userAuthenticatedMcpServerIds: new Set(['current-server']),
+        mcpServerById: new Map(prev.mcpServerById).set('current-server', {
+          mcp_server_id: 'current-server',
+          name: 'current',
+          transport: 'http',
+        } as never),
+      }));
+      const status = deferred<{ authenticated_server_ids: string[] }>();
+      const server = deferred<{
+        mcp_server_id: string;
+        name: string;
+        transport: string;
+        auth: { type: string; oauth_access_token: string };
+      }>();
+      const services = {
+        'mcp-servers/oauth-status': { find: vi.fn(() => status.promise) },
+        'mcp-servers': { get: vi.fn(() => server.promise) },
+      };
+      const client = {
+        service: vi.fn((path: keyof typeof services) => services[path]),
+      } as never;
+      let currentAuthority = true;
+
+      const refetch = refetchMCPOAuthDurableState(
+        client,
+        'previous-private-server',
+        () => currentAuthority
+      );
+      if (firstRead === 'status-first') {
+        status.resolve({ authenticated_server_ids: ['previous-private-server'] });
+        await status.promise;
+        currentAuthority = false;
+        server.resolve({
+          mcp_server_id: 'previous-private-server',
+          name: 'private-to-previous-user',
+          transport: 'http',
+          auth: { type: 'oauth', oauth_access_token: 'redacted-shape' },
+        });
+      } else {
+        server.resolve({
+          mcp_server_id: 'previous-private-server',
+          name: 'private-to-previous-user',
+          transport: 'http',
+          auth: { type: 'oauth', oauth_access_token: 'redacted-shape' },
+        });
+        await server.promise;
+        currentAuthority = false;
+        status.resolve({ authenticated_server_ids: ['previous-private-server'] });
+      }
+      await refetch;
+
+      expect(agorStore.getState().userAuthenticatedMcpServerIds).toEqual(
+        new Set(['current-server'])
+      );
+      expect(agorStore.getState().mcpServerById.has('previous-private-server')).toBe(false);
+      expect(agorStore.getState().mcpServerById.get('current-server')).toMatchObject({
+        name: 'current',
+      });
+    }
+  );
+
+  it('threads authority loss through refresh into the durable refetch application', async () => {
+    const status = deferred<{ authenticated_server_ids: string[] }>();
+    const get = vi.fn().mockResolvedValue({
+      mcp_server_id: 'server-1',
+      name: 'previous-private-server',
+      transport: 'http',
+      auth: { type: 'oauth' },
+    });
+    const services = {
+      'mcp-servers/oauth-refresh': {
+        create: vi.fn().mockResolvedValue({ success: true, expires_at: 123 }),
+      },
+      'mcp-servers/oauth-status': { find: vi.fn(() => status.promise) },
+      'mcp-servers': { get },
+    };
+    const client = {
+      service: vi.fn((path: keyof typeof services) => services[path]),
+    } as never;
+    let currentAuthority = true;
+
+    const refresh = refreshAndRefetchMCPOAuthGrant(client, 'server-1', () => currentAuthority);
+    await vi.waitFor(() =>
+      expect(services['mcp-servers/oauth-status'].find).toHaveBeenCalledOnce()
+    );
+    currentAuthority = false;
+    status.resolve({ authenticated_server_ids: ['server-1'] });
+
+    await expect(refresh).resolves.toEqual({ success: true, expires_at: 123 });
+    expect(agorStore.getState().userAuthenticatedMcpServerIds).toEqual(new Set());
+    expect(agorStore.getState().mcpServerById.has('server-1')).toBe(false);
   });
 });

--- a/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
+++ b/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
@@ -61,12 +61,14 @@ export function oauthAttemptFailureMessage(status: MCPOAuthAttemptStatus): strin
 /** Refetch and atomically apply both durable OAuth UI authorities. */
 export async function refetchMCPOAuthDurableState(
   client: AgorClient,
-  mcpServerId: string
+  mcpServerId: string,
+  shouldApply: () => boolean = () => true
 ): Promise<void> {
   const [status, fresh] = await Promise.all([
     client.service('mcp-servers/oauth-status').find(),
     client.service('mcp-servers').get(mcpServerId),
   ]);
+  if (!shouldApply()) return;
   const ids = (status as Partial<MCPOAuthStatusResult>)?.authenticated_server_ids ?? [];
   const server = fresh as MCPServer;
   agorStore.getState().applyMaps((prev) => {

--- a/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
+++ b/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
@@ -62,8 +62,13 @@ export function oauthAttemptFailureMessage(status: MCPOAuthAttemptStatus): strin
 export async function refetchMCPOAuthDurableState(
   client: AgorClient,
   mcpServerId: string,
-  shouldApply: () => boolean = () => true
+  shouldApply: () => boolean
 ): Promise<void> {
+  // Avoid starting caller-private reads when the initiating authority already
+  // disappeared. The second check is still the security boundary: identity,
+  // role, connection, or auth generation can change while either request is in
+  // flight.
+  if (!shouldApply()) return;
   const [status, fresh] = await Promise.all([
     client.service('mcp-servers/oauth-status').find(),
     client.service('mcp-servers').get(mcpServerId),
@@ -89,7 +94,8 @@ export async function refetchMCPOAuthDurableState(
  */
 export async function refreshAndRefetchMCPOAuthGrant(
   client: AgorClient,
-  mcpServerId: string
+  mcpServerId: string,
+  shouldApply: () => boolean
 ): Promise<MCPOAuthRefreshResult> {
   let result: MCPOAuthRefreshResult | undefined;
   let refreshError: unknown;
@@ -102,7 +108,7 @@ export async function refreshAndRefetchMCPOAuthGrant(
   }
 
   try {
-    await refetchMCPOAuthDurableState(client, mcpServerId);
+    await refetchMCPOAuthDurableState(client, mcpServerId, shouldApply);
   } catch (refetchError) {
     if (!refreshError) throw refetchError;
   }

--- a/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
+++ b/docs/internal/mcp-tool-permission-enforcement-audit-2026-08-18.md
@@ -256,9 +256,9 @@ Roughly in order of value:
    list, so it cannot be mechanically turned into permissions. Making the
    disclosure enforceable would mean adding a structured field to
    `curated.yaml` — e.g. `default_denied_tools` — and seeding from it at connect
-   time. That is a curation cost across 48 entries and a change to the connect
-   path; worth it only if the product intends the disclosure to be a contract
-   rather than a description.
+   time. That is a curation cost across every catalog entry and a change to the
+   connect path; worth it only if the product intends the disclosure to be a
+   contract rather than a description.
 
 Until at least (1) lands, the disclosure remains a description of what a
 connected server may do, and the enforcement machinery stays a correct engine

--- a/packages/core/src/tools/mcp/jwt-auth.test.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.test.ts
@@ -55,6 +55,46 @@ describe('resolveMCPAuthHeaders OAuth authority', () => {
       )
     ).resolves.toEqual({ Authorization: 'Bearer bound-token' });
   });
+
+  it('propagates authority loss during client-credential fetch instead of falling back', async () => {
+    let signalRequest!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      signalRequest = resolve;
+    });
+    let releaseResponse!: () => void;
+    const responseReleased = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    const tokenUrl = await listen(async (_request, response) => {
+      signalRequest();
+      await responseReleased;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"access_token":"must-not-return","token_type":"bearer"}');
+    });
+    let current = true;
+    const resolving = resolveMCPAuthHeaders(
+      {
+        type: 'oauth',
+        oauth_token_url: tokenUrl,
+        oauth_client_id: 'client',
+        oauth_client_secret: 'secret',
+      },
+      'http://127.0.0.1/mcp',
+      {
+        allowLocalhostHttp: true,
+        disableProcessTokenCache: true,
+        assertCurrent: () => {
+          if (!current) throw new Error('request authority replaced');
+        },
+      }
+    );
+
+    await requestStarted;
+    current = false;
+    releaseResponse();
+
+    await expect(resolving).rejects.toThrow('request authority replaced');
+  });
 });
 
 describe('JWT discovery authentication outbound policy', () => {

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -30,6 +30,8 @@ export interface JWTTokenFetchOptions {
   cacheNamespace?: string;
   /** PostgreSQL/hosted callers disable process-local bearer caching. */
   cache?: boolean;
+  /** Optional live request authority for secret-bearing provider work. */
+  assertCurrent?: () => void;
 }
 
 // Cache tokens per unique credential set to avoid cross-tenant leakage
@@ -63,6 +65,7 @@ export async function fetchJWTToken(
   config: JWTConfig,
   options: JWTTokenFetchOptions = {}
 ): Promise<string> {
+  options.assertCurrent?.();
   const { api_url, api_token, api_secret } = config;
   const shouldCache = options.cache !== false;
   const cacheKey = getCacheKey(config, options.cacheNamespace ?? '<standalone>');
@@ -70,6 +73,7 @@ export async function fetchJWTToken(
   // Check cache first
   const cached = shouldCache ? tokenCache.get(cacheKey) : undefined;
   if (cached && cached.expiresAt > Date.now()) {
+    options.assertCurrent?.();
     return cached.token;
   }
 
@@ -87,6 +91,7 @@ export async function fetchJWTToken(
       name: api_token,
       secret: api_secret,
     }),
+    assertCurrent: options.assertCurrent,
   });
 
   if (!response.ok) {
@@ -99,8 +104,10 @@ export async function fetchJWTToken(
   try {
     data = (await response.json()) as typeof data;
   } catch {
+    options.assertCurrent?.();
     throw new Error('JWT token fetch failed (invalid_response)');
   }
+  options.assertCurrent?.();
 
   // Handle different response formats
   const token = data.access_token || data.payload?.access_token;
@@ -182,8 +189,11 @@ export async function resolveMCPAuthHeaders(
     allowLocalhostHttp?: boolean;
     cacheNamespace?: string;
     disableProcessTokenCache?: boolean;
+    /** Optional live request authority for provider/token use. */
+    assertCurrent?: () => void;
   } = {}
 ): Promise<Record<string, string> | undefined> {
+  options.assertCurrent?.();
   if (!auth || auth.type === 'none') {
     return undefined;
   }
@@ -216,6 +226,7 @@ export async function resolveMCPAuthHeaders(
         allowLocalhostHttp: options.allowLocalhostHttp ?? true,
         cacheNamespace: options.cacheNamespace,
         cache: options.disableProcessTokenCache !== true,
+        assertCurrent: options.assertCurrent,
       }
     );
 
@@ -269,12 +280,16 @@ export async function resolveMCPAuthHeaders(
         allowLocalhostHttp: options.allowLocalhostHttp ?? true,
         cacheNamespace: options.cacheNamespace,
         cache: options.disableProcessTokenCache !== true,
+        assertCurrent: options.assertCurrent,
       });
 
       return {
         Authorization: `Bearer ${token}`,
       };
     } catch (error) {
+      // Never downgrade identity/authority loss into an unauthenticated MCP
+      // fallback after client credentials crossed the provider boundary.
+      options.assertCurrent?.();
       console.warn('[OAuth] Token fetch failed:', error instanceof Error ? error.message : error);
       return undefined;
     }

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -7,7 +7,7 @@
 
 import { createHash } from 'node:crypto';
 import type { MCPAuth } from '../../types/mcp';
-import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import { type OutboundDnsLookup, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import { fetchOAuthToken, inferOAuthTokenUrl } from './oauth-auth';
 
 interface JWTConfig {
@@ -32,6 +32,8 @@ export interface JWTTokenFetchOptions {
   cache?: boolean;
   /** Optional live request authority for secret-bearing provider work. */
   assertCurrent?: () => void;
+  /** Injectable DNS boundary for deterministic authority-race tests. */
+  resolveDns?: OutboundDnsLookup;
 }
 
 // Cache tokens per unique credential set to avoid cross-tenant leakage
@@ -92,6 +94,7 @@ export async function fetchJWTToken(
       secret: api_secret,
     }),
     assertCurrent: options.assertCurrent,
+    resolveDns: options.resolveDns,
   });
 
   if (!response.ok) {

--- a/packages/core/src/tools/mcp/oauth-auth.ts
+++ b/packages/core/src/tools/mcp/oauth-auth.ts
@@ -24,6 +24,8 @@ export interface OAuthConfig {
   cacheNamespace?: string;
   /** Durable daemon paths disable this process-local bearer cache. */
   cache?: boolean;
+  /** Optional live request authority for secret-bearing provider work. */
+  assertCurrent?: () => void;
 }
 
 export interface OAuthTokenResponse {
@@ -139,6 +141,7 @@ export async function fetchOAuthToken(
   config: OAuthConfig,
   debug: boolean = false
 ): Promise<{ token: string; debugInfo?: OAuthDebugInfo }> {
+  config.assertCurrent?.();
   const debugSteps: OAuthDebugStep[] = [];
   const startTime = Date.now();
 
@@ -191,6 +194,7 @@ export async function fetchOAuthToken(
   const cached = cacheEnabled ? oauthTokenCache.get(cacheKey) : undefined;
 
   if (cached && cached.expiresAt > Date.now()) {
+    config.assertCurrent?.();
     const ttlRemaining = Math.floor((cached.expiresAt - Date.now()) / 1000);
     addDebugStep('check_cache', 'success', `Cache hit! Token still valid for ${ttlRemaining}s`, {
       fetchedAt: new Date(cached.fetchedAt).toISOString(),
@@ -260,6 +264,7 @@ export async function fetchOAuthToken(
       redirect: 'error',
       timeoutMs: 15_000,
       allowLocalhostHttp: config.allowLocalhostHttp,
+      assertCurrent: config.assertCurrent,
     });
 
     addDebugStep('fetch_token', 'info', `Received response with status ${response.status}`, {
@@ -270,6 +275,9 @@ export async function fetchOAuthToken(
       },
     });
   } catch (error: unknown) {
+    // Preserve caller authority errors rather than wrapping them as a generic
+    // provider failure that an outer compatibility layer may swallow.
+    config.assertCurrent?.();
     const errorMessage = error instanceof Error ? error.message : String(error);
     addDebugStep('fetch_token', 'error', `Network error: ${errorMessage}`, {
       error: errorMessage,
@@ -304,6 +312,7 @@ export async function fetchOAuthToken(
   let data: OAuthTokenResponse;
   try {
     data = (await response.json()) as OAuthTokenResponse;
+    config.assertCurrent?.();
     addDebugStep('parse_response', 'success', 'Successfully parsed OAuth response', {
       token_type: data.token_type,
       expires_in: data.expires_in,
@@ -311,6 +320,7 @@ export async function fetchOAuthToken(
       scope: data.scope,
     });
   } catch (error: unknown) {
+    config.assertCurrent?.();
     const errorMessage = error instanceof Error ? error.message : String(error);
     addDebugStep('parse_response', 'error', `Failed to parse JSON response: ${errorMessage}`);
     throw new Error(`OAuth response is not valid JSON: ${errorMessage}`);

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -809,6 +809,32 @@ describe('resolveMCPOAuthDiscovery', () => {
     expect(result).toBeNull();
   });
 
+  it('stops between well-known candidates when the authority deadline expires', async () => {
+    let current = true;
+    const fetchMock = vi.fn(async () => {
+      // The first path-aware candidate began while current, but its held
+      // response crossed the reservation deadline. The post-await assertion
+      // must abort rather than issuing the root fallback request.
+      current = false;
+      return { ok: false, status: 404 };
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      resolveMCPOAuthDiscovery(null, 'https://example.com/mcp', {
+        compatibilityMode: 'legacy',
+        assertCurrent: () => {
+          if (!current) throw new Error('reservation expired');
+        },
+      })
+    ).rejects.toThrow('reservation expired');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/.well-known/oauth-protected-resource/mcp',
+      expect.anything()
+    );
+  });
+
   it('prefers RFC 9728 well-known over AS-direct when both succeed', async () => {
     // If a server publishes both RFC 9728 *and* serves AS metadata at its
     // origin, RFC 9728 should win — it's the spec-compliant indirection that

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -207,6 +207,7 @@ export async function discoverResourceMetadataUrl(
         redirect: 'follow',
         timeoutMs: 10_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
+        assertCurrent: options.assertCurrent,
       });
     } catch {
       // Keep the authority/deadline check outside the provider-error catch:
@@ -330,6 +331,7 @@ export async function discoverAuthorizationServerFromMcpOrigin(
         redirect: 'follow',
         timeoutMs: 10_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
+        assertCurrent: options.assertCurrent,
       });
     } catch {
       options.assertCurrent?.();
@@ -450,6 +452,7 @@ async function fetchResourceMetadata(
       redirect: 'follow',
       timeoutMs: 15_000,
       allowLocalhostHttp: options.allowLocalhostHttp,
+      assertCurrent: options.assertCurrent,
     });
   } catch (error) {
     options.assertCurrent?.();
@@ -617,6 +620,7 @@ async function registerDynamicClient(
       timeoutMs: 15_000,
       maxResponseBytes: MAX_DCR_RESPONSE_BYTES,
       allowLocalhostHttp,
+      assertCurrent,
     });
   } catch (error) {
     assertCurrent?.();
@@ -796,6 +800,7 @@ export async function fetchAuthorizationServerMetadata(
         redirect: 'follow',
         timeoutMs: 15_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
+        assertCurrent: options.assertCurrent,
       });
     } catch {
       options.assertCurrent?.();

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -1406,6 +1406,8 @@ async function startMCPOAuthFlowWithAS(opts: {
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
   dcrMode: MCPOAuthDCRMode;
   allowLocalhostHttp: boolean;
+  /** Daemon-owned authority/deadline assertion around provider side effects. */
+  assertCurrent?: () => void;
 }): Promise<OAuthFlowContext> {
   const {
     authServerMetadata,
@@ -1424,6 +1426,7 @@ async function startMCPOAuthFlowWithAS(opts: {
   } = opts;
 
   const hasFullOverrides = !!(authorizationUrlOverride && tokenUrlOverride);
+  opts.assertCurrent?.();
 
   // PKCE
   const pkce = generatePKCE();
@@ -1514,6 +1517,7 @@ async function startMCPOAuthFlowWithAS(opts: {
       authServerMetadata?.registration_endpoint ||
       (dcrMode === 'fallback' ? fallbackRegistrationEndpoint : undefined);
     if (registrationEndpoint) {
+      opts.assertCurrent?.();
       console.log('[MCP OAuth] Using Dynamic Client Registration');
       const registrationEndpointSource = authServerMetadata?.registration_endpoint
         ? 'metadata'
@@ -1537,6 +1541,8 @@ async function startMCPOAuthFlowWithAS(opts: {
           registration_endpoint_source: registrationEndpointSource,
         });
       }
+      // Keep authority/deadline failures out of the DCR diagnostic wrapper.
+      opts.assertCurrent?.();
     } else if (hasFullOverrides) {
       throw new Error(
         'OAuth client_id is required when using manual OAuth URL overrides.\n\n' +
@@ -1566,6 +1572,7 @@ async function startMCPOAuthFlowWithAS(opts: {
     authUrl.searchParams.set('scope', scopeString);
   }
 
+  opts.assertCurrent?.();
   return {
     metadataUrl: cacheKey,
     resourceUri,
@@ -1627,6 +1634,11 @@ export async function startMCPOAuthFlow(
     dcrMode?: MCPOAuthDCRMode;
     /** Exact loopback HTTP exception for standalone development only. */
     allowLocalhostHttp?: boolean;
+    /**
+     * Optional daemon authority/deadline assertion. Called before and after
+     * discovery and DCR boundaries; standalone/CLI callers omit it.
+     */
+    assertCurrent?: () => void;
   }
 ): Promise<OAuthFlowContext> {
   console.log('[MCP OAuth] Starting two-phase OAuth 2.1 flow');
@@ -1634,6 +1646,7 @@ export async function startMCPOAuthFlow(
   const dcrMode = options?.dcrMode ?? 'advertised';
   const allowLocalhostHttp = options?.allowLocalhostHttp === true;
   const resourceUri = options?.resourceUri;
+  options?.assertCurrent?.();
   if (!resourceUri) throw new Error('MCP OAuth requires an exact protected resource URI');
   assertSafeOAuthUrl(resourceUri, { allowLocalhostHttp });
 
@@ -1683,6 +1696,7 @@ export async function startMCPOAuthFlow(
       compatibilityMode,
       dcrMode,
       allowLocalhostHttp,
+      assertCurrent: options.assertCurrent,
     });
   }
 
@@ -1698,7 +1712,9 @@ export async function startMCPOAuthFlow(
   console.log('[MCP OAuth] Resource metadata resolved');
 
   // Step 2: Fetch Protected Resource Metadata (RFC 9728)
+  options?.assertCurrent?.();
   const resourceMetadata = await fetchResourceMetadata(metadataUrl, { allowLocalhostHttp });
+  options?.assertCurrent?.();
 
   if (
     compatibilityMode === 'strict'
@@ -1731,6 +1747,7 @@ export async function startMCPOAuthFlow(
     console.log('[MCP OAuth] Skipping auth server metadata fetch — manual overrides provided');
   } else {
     try {
+      options?.assertCurrent?.();
       authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl, {
         compatibilityMode,
         allowLocalhostHttp,
@@ -1747,6 +1764,10 @@ export async function startMCPOAuthFlow(
         throw metadataError;
       }
     }
+    // This is deliberately outside the metadata fallback catch: authority or
+    // reservation expiry must never be treated as a recoverable legacy
+    // discovery failure.
+    options?.assertCurrent?.();
   }
 
   // Steps 4-7: Delegate PKCE / DCR / endpoint resolution / auth URL build to
@@ -1773,6 +1794,7 @@ export async function startMCPOAuthFlow(
     compatibilityMode,
     dcrMode,
     allowLocalhostHttp,
+    assertCurrent: options?.assertCurrent,
   });
 }
 

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -184,8 +184,9 @@ function parseWWWAuthenticate(header: string): string | null {
  */
 export async function discoverResourceMetadataUrl(
   mcpUrl: string,
-  options: { allowLocalhostHttp?: boolean } = {}
+  options: { allowLocalhostHttp?: boolean; assertCurrent?: () => void } = {}
 ): Promise<string | null> {
+  options.assertCurrent?.();
   const url = new URL(mcpUrl);
   const origin = url.origin;
   const path = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
@@ -199,25 +200,41 @@ export async function discoverResourceMetadataUrl(
   candidates.push(`${origin}/.well-known/oauth-protected-resource`);
 
   for (const candidate of candidates) {
+    options.assertCurrent?.();
+    let response: Response;
     try {
-      const response = await safeOutboundFetch(candidate, {
+      response = await safeOutboundFetch(candidate, {
         redirect: 'follow',
         timeoutMs: 10_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
       });
-      if (response.ok) {
-        // Validate it looks like proper metadata
-        const data = (await response.json()) as Record<string, unknown>;
-        if (data.authorization_servers && Array.isArray(data.authorization_servers)) {
-          console.log('[MCP OAuth] Resource metadata discovered');
-          return candidate;
-        }
-      }
     } catch {
+      // Keep the authority/deadline check outside the provider-error catch:
+      // an expired daemon reservation is terminal, never another discovery
+      // candidate to try.
+      options.assertCurrent?.();
       console.log('[MCP OAuth] Resource metadata discovery candidate failed');
+      continue;
+    }
+    options.assertCurrent?.();
+    if (response.ok) {
+      let data: Record<string, unknown>;
+      try {
+        data = (await response.json()) as Record<string, unknown>;
+      } catch {
+        options.assertCurrent?.();
+        console.log('[MCP OAuth] Resource metadata discovery candidate failed');
+        continue;
+      }
+      options.assertCurrent?.();
+      if (data.authorization_servers && Array.isArray(data.authorization_servers)) {
+        console.log('[MCP OAuth] Resource metadata discovered');
+        return candidate;
+      }
     }
   }
 
+  options.assertCurrent?.();
   return null;
 }
 
@@ -235,8 +252,9 @@ export async function discoverResourceMetadataUrl(
 export async function resolveResourceMetadataUrl(
   wwwAuthenticateHeader: string | null,
   mcpUrl: string,
-  options: { allowLocalhostHttp?: boolean } = {}
+  options: { allowLocalhostHttp?: boolean; assertCurrent?: () => void } = {}
 ): Promise<{ metadataUrl: string; source: 'header' | 'well-known' } | null> {
+  options.assertCurrent?.();
   // Strategy 1: Parse from WWW-Authenticate header
   if (wwwAuthenticateHeader) {
     const parsed = parseWWWAuthenticate(wwwAuthenticateHeader);
@@ -247,6 +265,7 @@ export async function resolveResourceMetadataUrl(
 
   // Strategy 2: Auto-discover via .well-known endpoint
   const discovered = await discoverResourceMetadataUrl(mcpUrl, options);
+  options.assertCurrent?.();
   if (discovered) {
     return { metadataUrl: discovered, source: 'well-known' };
   }
@@ -281,8 +300,9 @@ export async function resolveResourceMetadataUrl(
  */
 export async function discoverAuthorizationServerFromMcpOrigin(
   mcpUrl: string,
-  options: { allowLocalhostHttp?: boolean } = {}
+  options: { allowLocalhostHttp?: boolean; assertCurrent?: () => void } = {}
 ): Promise<{ metadata: AuthorizationServerMetadata; discoveredAt: string } | null> {
+  options.assertCurrent?.();
   const url = new URL(mcpUrl);
   const origin = url.origin;
   const path = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
@@ -303,30 +323,44 @@ export async function discoverAuthorizationServerFromMcpOrigin(
   const unique = Array.from(new Set(candidates));
 
   for (const candidate of unique) {
+    options.assertCurrent?.();
+    let response: Response;
     try {
-      const response = await safeOutboundFetch(candidate, {
+      response = await safeOutboundFetch(candidate, {
         redirect: 'follow',
         timeoutMs: 10_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
       });
-      if (!response.ok) continue;
-      const data = (await response.json()) as Partial<AuthorizationServerMetadata>;
-      // Minimal validation: must have authorization_endpoint + token_endpoint
-      if (
-        typeof data.authorization_endpoint === 'string' &&
-        typeof data.token_endpoint === 'string'
-      ) {
-        console.log('[MCP OAuth] Authorization-server metadata discovered');
-        return {
-          metadata: data as AuthorizationServerMetadata,
-          discoveredAt: candidate,
-        };
-      }
     } catch {
+      options.assertCurrent?.();
       console.log('[MCP OAuth] Authorization-server discovery candidate failed');
+      continue;
+    }
+    options.assertCurrent?.();
+    if (!response.ok) continue;
+    let data: Partial<AuthorizationServerMetadata>;
+    try {
+      data = (await response.json()) as Partial<AuthorizationServerMetadata>;
+    } catch {
+      options.assertCurrent?.();
+      console.log('[MCP OAuth] Authorization-server discovery candidate failed');
+      continue;
+    }
+    options.assertCurrent?.();
+    // Minimal validation: must have authorization_endpoint + token_endpoint
+    if (
+      typeof data.authorization_endpoint === 'string' &&
+      typeof data.token_endpoint === 'string'
+    ) {
+      console.log('[MCP OAuth] Authorization-server metadata discovered');
+      return {
+        metadata: data as AuthorizationServerMetadata,
+        discoveredAt: candidate,
+      };
     }
   }
 
+  options.assertCurrent?.();
   return null;
 }
 
@@ -375,10 +409,14 @@ export async function resolveMCPOAuthDiscovery(
   options: {
     compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     allowLocalhostHttp?: boolean;
+    /** Daemon-owned authority/deadline assertion between discovery requests. */
+    assertCurrent?: () => void;
   } = {}
 ): Promise<MCPOAuthDiscoveryResult | null> {
+  options.assertCurrent?.();
   // Strategies 1 + 2: RFC 9728 (header hint, then well-known fallback)
   const rfc9728 = await resolveResourceMetadataUrl(wwwAuthenticateHeader, mcpUrl, options);
+  options.assertCurrent?.();
   if (rfc9728) {
     return { kind: 'resource-metadata', ...rfc9728 };
   }
@@ -386,6 +424,7 @@ export async function resolveMCPOAuthDiscovery(
   // Strategies 3 + 4: AS metadata directly at MCP origin (RFC 8414 / OIDC)
   if ((options.compatibilityMode ?? 'strict') === 'strict') return null;
   const asDirect = await discoverAuthorizationServerFromMcpOrigin(mcpUrl, options);
+  options.assertCurrent?.();
   if (asDirect) {
     return {
       kind: 'authorization-server',
@@ -402,13 +441,21 @@ export async function resolveMCPOAuthDiscovery(
  */
 async function fetchResourceMetadata(
   metadataUrl: string,
-  options: { allowLocalhostHttp?: boolean } = {}
+  options: { allowLocalhostHttp?: boolean; assertCurrent?: () => void } = {}
 ): Promise<OAuthMetadata> {
-  const response = await safeOutboundFetch(metadataUrl, {
-    redirect: 'follow',
-    timeoutMs: 15_000,
-    allowLocalhostHttp: options.allowLocalhostHttp,
-  });
+  options.assertCurrent?.();
+  let response: Response;
+  try {
+    response = await safeOutboundFetch(metadataUrl, {
+      redirect: 'follow',
+      timeoutMs: 15_000,
+      allowLocalhostHttp: options.allowLocalhostHttp,
+    });
+  } catch (error) {
+    options.assertCurrent?.();
+    throw error;
+  }
+  options.assertCurrent?.();
   if (!response.ok) {
     throw new Error(
       `Failed to fetch OAuth resource metadata from ${metadataUrl} (${response.status}). ` +
@@ -416,7 +463,9 @@ async function fetchResourceMetadata(
         `This indicates an incomplete OAuth implementation on the server side.`
     );
   }
-  return (await response.json()) as OAuthMetadata;
+  const metadata = (await response.json()) as OAuthMetadata;
+  options.assertCurrent?.();
+  return metadata;
 }
 
 // Cache for dynamically registered clients (per authorization server)
@@ -526,8 +575,10 @@ async function registerDynamicClient(
   scope?: string,
   reuseLocalCache = true,
   allowLocalhostHttp = false,
-  registrationEndpointSource: 'metadata' | 'legacy_fallback' = 'metadata'
+  registrationEndpointSource: 'metadata' | 'legacy_fallback' = 'metadata',
+  assertCurrent?: () => void
 ): Promise<DynamicClientRegistrationResponse> {
+  assertCurrent?.();
   // Check cache first
   const cacheKey = registrationEndpoint;
   const cached = reuseLocalCache ? dynamicClientCache.get(cacheKey) : undefined;
@@ -553,25 +604,34 @@ async function registerDynamicClient(
     registrationRequest.scope = scope;
   }
 
-  const response = await safeOutboundFetch(registrationEndpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify(registrationRequest),
-    redirect: 'error',
-    timeoutMs: 15_000,
-    maxResponseBytes: MAX_DCR_RESPONSE_BYTES,
-    allowLocalhostHttp,
-  });
+  let response: Response;
+  try {
+    response = await safeOutboundFetch(registrationEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(registrationRequest),
+      redirect: 'error',
+      timeoutMs: 15_000,
+      maxResponseBytes: MAX_DCR_RESPONSE_BYTES,
+      allowLocalhostHttp,
+    });
+  } catch (error) {
+    assertCurrent?.();
+    throw error;
+  }
+  assertCurrent?.();
 
   if (!response.ok) {
     throw registrationFailure(registrationDiagnostic(response.status, registrationEndpointSource));
   }
 
   const diagnostic = registrationDiagnostic(response.status, registrationEndpointSource);
-  const parsed = dynamicClientRegistrationSchema.safeParse(await response.json().catch(() => null));
+  const responseBody = await response.json().catch(() => null);
+  assertCurrent?.();
+  const parsed = dynamicClientRegistrationSchema.safeParse(responseBody);
   if (!parsed.success) {
     throw registrationFailure(
       diagnostic,
@@ -622,6 +682,7 @@ async function registerDynamicClient(
   }
 
   if (reuseLocalCache) {
+    assertCurrent?.();
     dynamicClientCache.set(cacheKey, {
       client_id: result.client_id,
       client_secret: result.client_secret,
@@ -696,8 +757,11 @@ export async function fetchAuthorizationServerMetadata(
   options: {
     compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     allowLocalhostHttp?: boolean;
+    /** Daemon-owned authority/deadline assertion between discovery requests. */
+    assertCurrent?: () => void;
   } = {}
 ): Promise<AuthorizationServerMetadata> {
+  options.assertCurrent?.();
   const cleanUrl = authServerUrl.replace(/\/$/, '');
   const urlsToTry: { url: string; label: string }[] = [];
 
@@ -725,33 +789,47 @@ export async function fetchAuthorizationServerMetadata(
 
   const errors: string[] = [];
   for (const { url, label } of urlsToTry) {
+    options.assertCurrent?.();
+    let response: Response;
     try {
-      const response = await safeOutboundFetch(url, {
+      response = await safeOutboundFetch(url, {
         redirect: 'follow',
         timeoutMs: 15_000,
         allowLocalhostHttp: options.allowLocalhostHttp,
       });
-      if (response.ok) {
-        console.log(`[MCP OAuth] ✓ Fetched metadata via ${label}`);
-        const metadata = (await response.json()) as AuthorizationServerMetadata;
-        if (
-          compatibilityMode === 'strict'
-            ? metadata.issuer !== authServerUrl
-            : compatibilityMode === 'marketplace' &&
-              !oauthIssuerIdentifiersMatch(metadata.issuer, authServerUrl)
-        ) {
-          throw new Error(
-            'Authorization server metadata issuer does not match the advertised issuer'
-          );
-        }
-        return metadata;
-      }
-      errors.push(`${label}: HTTP ${response.status}`);
     } catch {
+      options.assertCurrent?.();
       errors.push(`${label}: request failed`);
+      continue;
     }
+    options.assertCurrent?.();
+    if (!response.ok) {
+      errors.push(`${label}: HTTP ${response.status}`);
+      continue;
+    }
+    let metadata: AuthorizationServerMetadata;
+    try {
+      metadata = (await response.json()) as AuthorizationServerMetadata;
+    } catch {
+      options.assertCurrent?.();
+      errors.push(`${label}: request failed`);
+      continue;
+    }
+    options.assertCurrent?.();
+    if (
+      compatibilityMode === 'strict'
+        ? metadata.issuer !== authServerUrl
+        : compatibilityMode === 'marketplace' &&
+          !oauthIssuerIdentifiersMatch(metadata.issuer, authServerUrl)
+    ) {
+      errors.push(`${label}: request failed`);
+      continue;
+    }
+    console.log(`[MCP OAuth] ✓ Fetched metadata via ${label}`);
+    return metadata;
   }
 
+  options.assertCurrent?.();
   throw new Error(
     'Failed to fetch authorization server metadata.\n' +
       `Tried:\n${errors.map((e) => `  - ${e}`).join('\n')}\n\n` +
@@ -1530,11 +1608,15 @@ async function startMCPOAuthFlowWithAS(opts: {
           scopeString,
           opts.reuseDynamicClientRegistration !== false,
           allowLocalhostHttp,
-          registrationEndpointSource
+          registrationEndpointSource,
+          opts.assertCurrent
         );
         actualClientId = registration.client_id;
         resolvedClientSecret = registration.client_secret;
       } catch (error) {
+        // An authority/deadline assertion is not a provider DCR diagnostic.
+        // Reassert first so it escapes this compatibility wrapper unchanged.
+        opts.assertCurrent?.();
         if (error instanceof OAuthDCRFailure) throw error;
         throw registrationFailure({
           stage: 'dcr_registration',
@@ -1713,7 +1795,10 @@ export async function startMCPOAuthFlow(
 
   // Step 2: Fetch Protected Resource Metadata (RFC 9728)
   options?.assertCurrent?.();
-  const resourceMetadata = await fetchResourceMetadata(metadataUrl, { allowLocalhostHttp });
+  const resourceMetadata = await fetchResourceMetadata(metadataUrl, {
+    allowLocalhostHttp,
+    assertCurrent: options?.assertCurrent,
+  });
   options?.assertCurrent?.();
 
   if (
@@ -1751,6 +1836,7 @@ export async function startMCPOAuthFlow(
       authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl, {
         compatibilityMode,
         allowLocalhostHttp,
+        assertCurrent: options?.assertCurrent,
       });
       console.log('[MCP OAuth] Authorization server metadata resolved');
     } catch (metadataError) {

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -203,6 +203,16 @@ export type MCPMemberPolicy = (typeof MCP_MEMBER_POLICIES)[number];
 export const DEFAULT_MCP_MEMBER_POLICY: MCPMemberPolicy = 'use_existing_only';
 
 /**
+ * Realtime invalidation emitted on the tenant-scoped `mcp-servers` service
+ * after an administrator changes the member policy.
+ *
+ * The event deliberately carries no policy value: `can_configure` is derived
+ * for the authenticated caller, so every browser must refetch its own answer
+ * from `mcp-member-policy` rather than accepting another caller's payload.
+ */
+export const MCP_MEMBER_POLICY_CHANGED_EVENT = 'member-policy:changed' as const;
+
+/**
  * The payload of the `mcp-member-policy` endpoint, read and written.
  *
  * A wrapper rather than the bare value so the setting can gain a field — who

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -200,6 +200,23 @@ export const MCP_MEMBER_POLICIES = [
 
 export type MCPMemberPolicy = (typeof MCP_MEMBER_POLICIES)[number];
 
+/**
+ * Caller-generated correlation for the compatibility browser hint emitted by
+ * blocking MCP discovery. The daemon derives `caller_user_id` from auth; the
+ * generation is an opaque browser authority epoch echoed only to the exact
+ * initiating socket.
+ */
+export interface MCPOAuthBrowserEventRequest {
+  operation_id: string;
+  auth_generation: number;
+}
+
+export interface MCPOAuthOpenBrowserEvent extends MCPOAuthBrowserEventRequest {
+  authUrl: string;
+  attempt_id: MCPOAuthAttemptID;
+  caller_user_id: UserID;
+}
+
 export const DEFAULT_MCP_MEMBER_POLICY: MCPMemberPolicy = 'use_existing_only';
 
 /**

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -200,15 +200,29 @@ export const MCP_MEMBER_POLICIES = [
 
 export type MCPMemberPolicy = (typeof MCP_MEMBER_POLICIES)[number];
 
+export const MCP_OAUTH_BROWSER_OPERATIONS = ['discover', 'test-oauth'] as const;
+export type MCPOAuthBrowserOperation = (typeof MCP_OAUTH_BROWSER_OPERATIONS)[number];
+
 /**
- * Caller-generated correlation for the compatibility browser hint emitted by
- * blocking MCP discovery. The daemon derives `caller_user_id` from auth; the
- * generation is an opaque browser authority epoch echoed only to the exact
- * initiating socket.
+ * Request/response contract for a short-lived browser-event reservation.
+ *
+ * The request names only what the caller intends to do. The opaque token in
+ * the response is minted by the daemon and bound there to the authenticated
+ * tenant, caller, socket, operation and saved server (when present).
  */
+export interface MCPOAuthBrowserReservationRequest {
+  operation: MCPOAuthBrowserOperation;
+  mcp_server_id?: MCPServerID;
+}
+
+export interface MCPOAuthBrowserReservation {
+  reservation_token: string;
+  expires_at: number;
+}
+
+/** One-shot reservation presented to blocking discovery/test. */
 export interface MCPOAuthBrowserEventRequest {
-  operation_id: string;
-  auth_generation: number;
+  reservation_token: string;
 }
 
 export interface MCPOAuthOpenBrowserEvent extends MCPOAuthBrowserEventRequest {

--- a/packages/core/src/utils/safe-outbound-fetch.test.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.test.ts
@@ -182,6 +182,44 @@ describe('safe OAuth outbound URL policy', () => {
     expect(targetReached).toBe(true);
   });
 
+  it('rechecks authority between redirect hops and never dispatches the next request', async () => {
+    let releaseFirstHop!: () => void;
+    const firstHopHeld = new Promise<void>((resolve) => {
+      releaseFirstHop = resolve;
+    });
+    let firstHopReached!: () => void;
+    const firstHopStarted = new Promise<void>((resolve) => {
+      firstHopReached = resolve;
+    });
+    let targetReached = false;
+    const target = await listen((_request, response) => {
+      targetReached = true;
+      response.writeHead(200);
+      response.end('must not be reached');
+    });
+    const source = await listen(async (_request, response) => {
+      firstHopReached();
+      await firstHopHeld;
+      response.writeHead(302, { location: `${target.url}/metadata` });
+      response.end();
+    });
+    let current = true;
+    const request = safeOutboundFetch(source.url, {
+      redirect: 'follow',
+      allowLocalhostHttp: true,
+      assertCurrent: () => {
+        if (!current) throw new Error('request authority replaced');
+      },
+    });
+
+    await firstHopStarted;
+    current = false;
+    releaseFirstHop();
+
+    await expect(request).rejects.toThrow('request authority replaced');
+    expect(targetReached).toBe(false);
+  });
+
   it('bounds response bodies before parsing provider-controlled content', async () => {
     const { url } = await listen((_request, response) => {
       response.writeHead(200);

--- a/packages/core/src/utils/safe-outbound-fetch.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.ts
@@ -63,6 +63,11 @@ export interface SafeOutboundFetchOptions extends Omit<RequestInit, 'redirect' |
   maxResponseBytes?: number;
   /** Exact localhost/loopback HTTP exception for standalone development. */
   allowLocalhostHttp?: boolean;
+  /**
+   * Optional caller-owned authority fence for credential-bearing requests.
+   * Checked around every physical dispatch, response/error, and redirect hop.
+   */
+  assertCurrent?: () => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -223,6 +228,10 @@ async function requestOnce(
   const maxBytes = options.maxResponseBytes ?? 1024 * 1024;
   const pinnedLookup = createPinnedLookup(pinned);
 
+  // DNS validation may itself have awaited. Re-ask immediately before opening
+  // the socket so a caller cannot lose authority during lookup and still send
+  // the captured headers/body.
+  options.assertCurrent?.();
   return new Promise<Response>((resolve, reject) => {
     let settled = false;
     let responseStream: http.IncomingMessage | undefined;
@@ -315,7 +324,20 @@ export async function safeOutboundFetch(
     const redirectMode = options.redirect ?? 'error';
     const maxRedirects = options.maxRedirects ?? 3;
     for (let hop = 0; ; hop += 1) {
-      const response = await requestOnce(url, options, deadline.signal);
+      // This assertion is intentionally per hop rather than only around the
+      // aggregate fetch. Redirect handling is an internal request loop, and
+      // each destination is a distinct external side effect.
+      options.assertCurrent?.();
+      let response: Response;
+      try {
+        response = await requestOnce(url, options, deadline.signal);
+      } catch (error) {
+        // Authority/expiry wins over a simultaneous network error and prevents
+        // callers from treating it as a retryable provider failure.
+        options.assertCurrent?.();
+        throw error;
+      }
+      options.assertCurrent?.();
       if (![301, 302, 303, 307, 308].includes(response.status)) return response;
       if (redirectMode !== 'follow' || hop >= maxRedirects) {
         throw new UnsafeOutboundUrlError('Outbound OAuth redirect is not allowed');

--- a/packages/core/src/utils/safe-outbound-fetch.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.ts
@@ -68,7 +68,14 @@ export interface SafeOutboundFetchOptions extends Omit<RequestInit, 'redirect' |
    * Checked around every physical dispatch, response/error, and redirect hop.
    */
   assertCurrent?: () => void;
+  /** Injectable DNS boundary for deterministic authority-race tests. */
+  resolveDns?: OutboundDnsLookup;
 }
+
+export type OutboundDnsLookup = (
+  hostname: string,
+  options: { all: true; verbatim: true }
+) => Promise<Array<{ address: string; family: number }>>;
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_TIMER_MS = 2_147_483_647;
@@ -155,14 +162,15 @@ function assertSafeParsedUrl(url: URL, allowLocalhostHttp: boolean): void {
 async function resolvePinnedAddress(
   url: URL,
   allowLocalhostHttp: boolean,
-  signal: AbortSignal
+  signal: AbortSignal,
+  resolveDns: OutboundDnsLookup
 ): Promise<{ address: string; family: 4 | 6 }> {
   throwIfAborted(signal);
   const hostname = normalizedHostname(url);
   const literalFamily = isIP(hostname);
   const addresses = literalFamily
     ? [{ address: hostname, family: literalFamily as 4 | 6 }]
-    : await withAbort(lookup(hostname, { all: true, verbatim: true }), signal);
+    : await withAbort(resolveDns(hostname, { all: true, verbatim: true }), signal);
   throwIfAborted(signal);
   if (addresses.length === 0) throw new UnsafeOutboundUrlError('OAuth destination did not resolve');
   for (const candidate of addresses) {
@@ -218,7 +226,12 @@ async function requestOnce(
 ): Promise<Response> {
   throwIfAborted(signal);
   assertSafeParsedUrl(url, options.allowLocalhostHttp === true);
-  const pinned = await resolvePinnedAddress(url, options.allowLocalhostHttp === true, signal);
+  const pinned = await resolvePinnedAddress(
+    url,
+    options.allowLocalhostHttp === true,
+    signal,
+    options.resolveDns ?? lookup
+  );
   const body = requestBody(options.body);
   const headers = new Headers(options.headers);
   if (body != null && !headers.has('content-length')) {


### PR DESCRIPTION
## Summary

This PR now covers the complete authority/capability hardening needed to make Marketplace and Settings safe across viewer, member, admin, reconnect, token-refresh, and in-place identity transitions.

### Marketplace navigation and capability gating

- Restores Marketplace as a top-level navigation destination for every authenticated user who can browse the catalog, including viewers.
- Makes viewer workspace bootstrap independent of the member-only Users directory so the real header/workspace can render instead of failing before navigation.
- Derives Connect/create/edit/test/OAuth affordances from current server policy, role, identity, authentication generation, and connection readiness; capability loss fails closed while dialogs are open.
- Keeps catalog/saved-row/auth policy and API-key/OAuth/reuse behavior server-authoritative, preserving merged Marketplace and modal-lifecycle behavior, including #2481 and #2482.

### Settings and caller-private state

- Gates Users, MCP, Gateway, Agentic Tools, uploads, API keys, repos, avatars, and deep-linked sections to the same capabilities enforced by the daemon.
- Prevents member self-edits from submitting admin-only role or execution-home fields.
- Adds shared identity/authority operation guards around secret-bearing asynchronous saves and post-await continuations.
- Erases caller-private dialogs, forms, bearer/JWT/OAuth credentials, consent, selections, and errors on identity replacement while preserving same-user reconnect drafts where safe.
- Makes forced-password completion, reauthentication, loading release, and notification ownership generation-safe at App scope.

### Realtime and authentication authority

- Enforces viewer role floors at the canonical realtime publication boundary for tenant/branch mutation events.
- Tags/discards queued realtime batches across authority transitions and makes workspace resync generation-safe under delayed responses, promotion, demotion, reconnect, and socket reauthentication ordering.
- Separates authenticated identity/role authority from stale directory enrichment.
- Keeps token refresh/reconnect authentication single-flight and advances authority generation only on actual authority establishment.

### MCP OAuth and outbound request hardening

- Uses server-issued, one-shot OAuth browser reservations bound to tenant, caller, physical socket, operation/server, token authority, TTL, and fair per-socket/user/tenant/global quotas.
- Carries authority assertions through saved-row/policy/lock/repository work, discovery candidate cascades, redirects, DCR, provider probes, SDK multi-request connect, callback token use, and all success/error fallback paths.
- Revalidates immediately before and after every outbound request/redirect hop so captured credentials or headers cannot continue after replacement or expiry.
- Correlates browser-open events to authoritative attempts; malformed, nullish, unrelated, duplicate, expired, or replaced-caller events are ignored.
- Adds an immutable, non-enumerable server-derived Socket.IO authority identifier to the real `socket.feathers` connection and verifies exact live-socket ownership. Socket requests fail closed if it is absent; REST/internal requests retain their own authority models.
- Cleans socket-bound reservations on disconnect and fixes the adjacent legacy session-token assumption about the Feathers connection shape.

## Base and rebase

The 13 reviewer-approved feature commits are rebased onto current `origin/main` at `7c8b85ec79cac23c1ebfd307ed2c1445fb0c1008`, preserving the merged #2481/#2482 behavior and the cumulative authority fixes. A fourteenth, test-only commit scopes longer time allowances to the real antd MCP form integration suites after hosted full-suite worker contention caused otherwise-passing safety assertions to exceed the global jsdom timeout.

Range-diff against the approved `52d91a8e` stack shows 10 patch-equivalent commits and three narrow base-integration resolutions:

- keep the fresh authenticated `currentUser` authority and current viewer onboarding gate while retaining Marketplace capability checks;
- compose the upstream onboarding gate with the existing operation guard;
- retain the redesigned upstream onboarding wizard/resume flow while adding its authority guard.

Final SHA: `0875a2540141d2527b7ab5f171760f552d5be7c0`.

No catalog-size claims are made here. Marketplace API-key Connect, OAuth, grant reuse, catalog authority, and server-side authorization remain intact.

## Validation

Post-rebase validation:

- Focused UI authority/Marketplace/Settings suites: **13 files, 254 tests passed**. Three MCP table cases hit the 15-second timeout only under the parallel focused run; the complete MCP table file then passed in isolation (**33/33**) without code or timeout changes.
- Focused daemon OAuth/realtime/socket/policy suites: **11 files passed, 321 tests passed**.
- Focused core auth/outbound-fetch suites: **5 files, 208 tests passed**.
- Monorepo typecheck: **21/21 tasks passed**.
- Multitenancy, daemon-filesystem, realtime, and short-ID boundary checks: passed.
- Biome checks on the rebase-resolved UI files: passed.
- MCP table suite after the CI-only timeout scoping: **33/33 passed**; UI typecheck and commit hooks passed.
- Hosted checks passed: **CI**, **PostgreSQL integration (non-superuser RLS)**, **Build & push**, **immutable release artifacts**, and **packaged install smoke**. The two main-only/aggregate jobs were expected skips.

The reviewer-approved pre-rebase stack also passed the full daemon suite (**248 files, 3,251 tests**), full core suite (**153 files, 3,743 tests**), monorepo lint (**2,380 files**), frontend design fixtures (**330**), and commit hooks.

The local PostgreSQL pending-flow suite is conditional on `AGOR_DB_DIALECT=postgresql` plus `AGOR_TEST_POSTGRES_URL`; those **12 cases were skipped locally** because that environment was not configured. SQLite integration and PostgreSQL control-flow/transaction-boundary tests passed. The dedicated hosted PostgreSQL integration check **passed** in its configured environment.
