### PR TITLE
fix(mcp): harden Marketplace OAuth policy and session accessibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,14 +431,17 @@ endpoint still challenges for OAuth.
 An endpoint the probe finds behind a non-OAuth challenge is installed with a key
 the user pastes into the marketplace drawer. The key never goes in
 `curated.yaml` — that file is checked in, public, and byte-identical for every
-tenant. It arrives as `api_key` on the connect request, the only field on that
+tenant. It arrives as `bearer_token` on the connect request, the only field on that
 request that is the caller's rather than the catalog's: URL, transport, and the
 kind of credential still derive server-side from the entry, so a client holding
 a key cannot name where it is sent. It is stored as `auth.token` on the
 installed `mcp_servers` row, which is where every bearer credential in Agor
-lives and therefore what `redactMCPAuthSecrets` already covers on read. Connect
-tries the key against the endpoint before writing anything (`probeRemoteBearerToken`)
-rather than installing a server whose every tool would fail. Reuse of a row that
+lives and therefore what `redactMCPAuthSecrets` already covers on read. Before
+the authenticated probe, Connect durably claims the caller's generation for
+that catalog install so an older concurrent request cannot later overwrite a
+newer key. It then tries the key against the endpoint (`probeRemoteBearerToken`)
+and writes the server/session only after acceptance, rather than installing a
+server whose every tool would fail. Reuse of a row that
 keeps a secret in its own columns is restricted to the row's owner, so two users
 connecting the same entry get two rows and two keys; re-connecting with a new
 key rotates the one row rather than leaving the old key live beside it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,7 +380,7 @@ There is no catalog table and no ingestion job: the marketplace offers exactly
 what that file names, so adding a server is a pull request and removing one
 takes it off the shelf on the next deploy.
 
-The file lists ~50 entries across two keys. `entries:` are servers the public
+The file lists reviewed entries across two keys. `entries:` are servers the public
 [MCP registry](https://registry.modelcontextprotocol.io) publishes under exactly
 that `name`; `unpublished:` are vendor-run endpoints whose reverse-DNS name Agor
 inferred. The split is a curation record only — both lists are offered on one
@@ -390,7 +390,7 @@ written down, since parsing flattens the two.
 `name` is the identity. It is what an installed server records in
 `catalog_entry_name`, so renaming an entry orphans every install of it.
 
-The read path is one endpoint. `find` takes no query and returns all ~50 entries
+The read path is one endpoint. `find` takes no query and returns every entry
 at once; the Marketplace holds them and does its own searching, filtering,
 sorting and paging. So there is no server-side filter to add a case to —
 narrowing lives in `packages/core/src/mcp-catalog/query.ts`, which the browser
@@ -403,13 +403,30 @@ how connect turns a `catalog_key` into a URL and transport.
 Each entry states an `auth_type` (`none` / `oauth` / `credentials`), or omits it
 where nobody has established the answer. It decides what the marketplace tells a
 user before they press Connect, and nothing else: `mcp-catalog-connect.ts`
-probes the endpoint on every connect, whatever the entry says, and installs only
-on a valid JSON-RPC `initialize` result. Each of the three verdicts installs
-something — open, configured-for-OAuth, or key-bearing — so no stated auth type
-is a dead end. When the probe contradicts the entry, the daemon logs it at
+probes the endpoint on every connect, whatever the entry says. A valid JSON-RPC
+`initialize` result installs the server open. An OAuth challenge installs a
+`per_user` OAuth row; a non-OAuth challenge installs only when the entry carries
+a reviewed bearer-credential recipe and the caller supplies a key that passes a
+second `initialize`. When the probe contradicts the entry, the daemon logs it at
 `warn` with the stated and probed values; that log is the only thing that can
 catch a stale `auth_type`, because nothing else compares the file against the
 servers it describes.
+
+OAuth entries that omit `oauth.compatibility_mode` use an internal,
+non-persistable `marketplace` profile. This is not a general relaxed default: it
+is derived only while the saved row remains a canonical install of the current
+OAuth catalog entry (provenance, endpoint, transport, auth prescription, and
+empty custom headers all match). It admits only the reviewed interoperability
+differences implemented in `oauth-mcp-transport.ts`, while retaining
+same-origin bounds on those fallbacks, resource/issuer binding, the exact MCP
+URL as the RFC 8707 resource, PKCE S256, and callback issuer validation. An
+explicit saved-row `strict` or `legacy` mode always wins. The catalog explicitly
+keeps Monday, Cloudflare, and ClickUp on `strict`; an edited/imported install, a
+removed entry, or any catalog configuration drift falls back to `strict`.
+GitHub, Prisma, MongoDB, Box, HubSpot, Slack, PagerDuty, and Kagi were removed
+from the shelf because the review could not establish a safely bound
+client-registration or issuer path; do not re-add one merely because its
+endpoint still challenges for OAuth.
 
 An endpoint the probe finds behind a non-OAuth challenge is installed with a key
 the user pastes into the marketplace drawer. The key never goes in
@@ -420,11 +437,28 @@ kind of credential still derive server-side from the entry, so a client holding
 a key cannot name where it is sent. It is stored as `auth.token` on the
 installed `mcp_servers` row, which is where every bearer credential in Agor
 lives and therefore what `redactMCPAuthSecrets` already covers on read. Connect
-tries the key against the endpoint before writing anything (`probeRemoteApiKey`)
+tries the key against the endpoint before writing anything (`probeRemoteBearerToken`)
 rather than installing a server whose every tool would fail. Reuse of a row that
 keeps a secret in its own columns is restricted to the row's owner, so two users
 connecting the same entry get two rows and two keys; re-connecting with a new
 key rotates the one row rather than leaving the old key live beside it.
+
+OAuth Connect also looks for a credential the caller already holds. It may reuse
+or refresh a live `per_user` grant only when the row is a credential peer for the
+same catalog endpoint, requested scope, compatibility/DCR/client policy, and
+recorded protected resource. Shared grants, another user's grants, routing
+overrides, custom headers, stale bindings, and mismatched resources are not
+eligible. This can reuse a user-configured peer without converting its
+provenance or lifecycle into a catalog install.
+
+Every successful Connect creates and attaches a new idle session, then the UI
+navigates there. Open, bearer-key, and already-authenticated OAuth results stage
+the entry's starter prompt. A fresh OAuth result with no reusable grant does
+not: the session instead shows the dismissible disconnected notice and warning
+MCP badge, and the user opens the badge and activates the server pill to sign
+in. The OAuth window is deliberately not auto-started after navigation because
+the navigation and async start request no longer have the transient user
+activation browsers require for a reliable popup.
 
 Both probes go through `createPinnedFetch`
 (`packages/core/src/utils/pinned-fetch.ts`), which resolves the hostname,

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -1012,6 +1012,44 @@ describe('mcp-catalog/connect — endpoints that sign the user in', () => {
     });
   });
 
+  it.each(['strict', 'legacy'] as const)(
+    'preserves an owned install’s explicit %s override when reconnecting a catalog-default entry',
+    async (mode) => {
+      const existing = installOf({
+        auth: {
+          type: 'oauth',
+          oauth_mode: 'per_user',
+          oauth_compatibility_mode: mode,
+        },
+      });
+      const { app, patched, deps } = buildApp(OAUTH_ENTRY, [existing]);
+
+      const result = await createMCPCatalogConnectService(app, deps).create(request, params);
+
+      expect(result.reuse_kind).toBe('catalog_install');
+      expect((patched.at(-1)!.data.auth as MCPAuth).oauth_compatibility_mode).toBe(mode);
+      expect(result.mcp_server.auth?.oauth_compatibility_mode).toBe(mode);
+      expect(result.effective_oauth_policy).toEqual({
+        effective_mode: mode,
+        managed_by_catalog: false,
+      });
+    }
+  );
+
+  it('keeps the derived Marketplace policy when reconnecting an unmodified catalog-default row', async () => {
+    const existing = installOf({ auth: { type: 'oauth', oauth_mode: 'per_user' } });
+    const { app, patched, deps } = buildApp(OAUTH_ENTRY, [existing]);
+
+    const result = await createMCPCatalogConnectService(app, deps).create(request, params);
+
+    expect(patched).toHaveLength(0);
+    expect(result.mcp_server.auth?.oauth_compatibility_mode).toBeUndefined();
+    expect(result.effective_oauth_policy).toEqual({
+      effective_mode: 'marketplace',
+      managed_by_catalog: true,
+    });
+  });
+
   it('reuses the install the caller has already signed into', async () => {
     // The OAuth flow never writes to the server row — the token lives in
     // `user_mcp_oauth_tokens` — but the `mcp-servers` read hook hydrates the
@@ -1594,13 +1632,19 @@ describe('mcp-catalog/connect — endpoints that take an API key', () => {
     expect(result.session.session_id).toBe('session-1');
   });
 
-  it('tries the key against the catalog endpoint before writing anything', async () => {
+  it('claims its generation, then tries the key before creating the server or session', async () => {
     // A key that is wrong at install time produces a server whose every tool
     // fails, reported by the agent as a broken tool rather than a bad
     // credential. One extra handshake is what buys the difference.
-    const { app } = buildApp(KEY_ENTRY);
+    const built = buildApp(KEY_ENTRY);
+    probeRemoteBearerToken.mockImplementationOnce(async () => {
+      expect(built.generationClaims).toHaveLength(1);
+      expect(built.created.mcpServers).toHaveLength(0);
+      expect(built.created.sessions).toHaveLength(0);
+      return 'accepted';
+    });
 
-    await createMCPCatalogConnectService(app).create(keyRequest, params);
+    await createMCPCatalogConnectService(built.app).create(keyRequest, params);
 
     expect(probeRemoteBearerToken).toHaveBeenCalledWith('https://mcp.linear.app/mcp', PASTED_KEY);
   });

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -139,8 +139,10 @@ function isCredentialPeerOf(
  * would silently turn an explicit Strict row back into Marketplace whenever
  * the catalog omits `compatibility_mode` (and similarly erase Legacy).
  *
- * Preserve only those two known-safe values. A malformed database value is not
- * carried forward through reconciliation.
+ * Preserve only those two validated public values: Strict retains the narrow
+ * policy, while Legacy remains the explicit, deliberately broader operator
+ * override. A malformed database value is not carried forward through
+ * reconciliation.
  */
 function preserveExplicitOAuthCompatibility(server: MCPServer, prescribed: MCPAuth): MCPAuth {
   if (server.auth?.type !== 'oauth' || prescribed.type !== 'oauth') return prescribed;

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -26,8 +26,8 @@
  * is installed ready to use; one that answers with an OAuth challenge is
  * installed configured-but-unauthenticated, for the user to complete through
  * the OAuth flow that already exists in Settings → MCP Servers; one that asks
- * for an bearer access token is installed with the key the caller pasted, after that key
- * has been tried against the endpoint.
+ * for a bearer access token is installed with the key the caller pasted after
+ * that key has been tried against the endpoint.
  */
 
 import { isDatabaseUniqueConstraintError } from '@agor/core/db';
@@ -125,6 +125,28 @@ function isCredentialPeerOf(
     sameCatalogEndpoint(server.url, entry.remote_url) &&
     Object.keys(server.headers ?? {}).length === 0
   );
+}
+
+/**
+ * Reconcile catalog-owned configuration without erasing the owner's explicit
+ * OAuth compatibility choice.
+ *
+ * Endpoint, transport, scope, headers, and every other auth field still come
+ * from the current catalog prescription. `strict` and `legacy` are different:
+ * they are the two validated public overrides the Settings UI can persist, and
+ * the OAuth resolver treats either as authoritative over the derived
+ * Marketplace profile. Replacing the whole auth object with `prescribed`
+ * would silently turn an explicit Strict row back into Marketplace whenever
+ * the catalog omits `compatibility_mode` (and similarly erase Legacy).
+ *
+ * Preserve only those two known-safe values. A malformed database value is not
+ * carried forward through reconciliation.
+ */
+function preserveExplicitOAuthCompatibility(server: MCPServer, prescribed: MCPAuth): MCPAuth {
+  if (server.auth?.type !== 'oauth' || prescribed.type !== 'oauth') return prescribed;
+  const explicitMode = server.auth.oauth_compatibility_mode;
+  if (explicitMode !== 'strict' && explicitMode !== 'legacy') return prescribed;
+  return { ...prescribed, oauth_compatibility_mode: explicitMode };
 }
 
 async function hasCatalogCredentialPolicy(
@@ -825,6 +847,9 @@ export function createMCPCatalogConnectService(
     params: AuthenticatedParams,
     generation?: { ownerUserId: string; catalogEntryName: string; value: number }
   ): Promise<MCPServer> => {
+    const reconciledAuth = reconcile
+      ? preserveExplicitOAuthCompatibility(server, prescribed)
+      : prescribed;
     const updates = reconcile
       ? {
           enabled: true,
@@ -832,7 +857,7 @@ export function createMCPCatalogConnectService(
           scope: createInput.scope,
           url: createInput.url,
           headers: {},
-          auth: prescribed,
+          auth: reconciledAuth,
         }
       : { auth: prescribed };
     if (!generation) {
@@ -936,6 +961,15 @@ export function createMCPCatalogConnectService(
           !isCurrentCatalogInstall(mcpServer, entry, auth, {
             reconcileMissingCompatibilityMode: true,
           }));
+      const preservedCompatibilityOverride =
+        selection?.kind === 'catalog_install' &&
+        mcpServer.auth?.type === 'oauth' &&
+        auth.type === 'oauth' &&
+        (mcpServer.auth.oauth_compatibility_mode === 'strict' ||
+          mcpServer.auth.oauth_compatibility_mode === 'legacy') &&
+        mcpServer.auth.oauth_compatibility_mode !== auth.oauth_compatibility_mode
+          ? mcpServer.auth.oauth_compatibility_mode
+          : undefined;
 
       // Four writes across three services, so there is no transaction to lean
       // on. What this request created, it takes back on failure: a server or a
@@ -1010,8 +1044,13 @@ export function createMCPCatalogConnectService(
           effective_oauth_policy:
             auth.type === 'oauth'
               ? {
-                  effective_mode: entry.oauth?.compatibility_mode ?? 'marketplace',
-                  managed_by_catalog: !selection || selection.kind === 'catalog_install',
+                  effective_mode:
+                    preservedCompatibilityOverride ??
+                    entry.oauth?.compatibility_mode ??
+                    'marketplace',
+                  managed_by_catalog:
+                    (!selection || selection.kind === 'catalog_install') &&
+                    preservedCompatibilityOverride === undefined,
                 }
               : undefined,
         };

--- a/apps/agor-daemon/src/services/mcp-catalog.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog.ts
@@ -6,7 +6,8 @@
  * file in this repository, so the way to change them is a pull request.
  *
  * This does not extend `DrizzleService`. There is no table behind it — the
- * catalog is loaded once into the process and every read is served from there.
+ * catalog is parsed lazily on its first read, cached in the process, and every
+ * later read is served from there.
  *
  * Two methods, for two different callers: `find` hands the Marketplace the
  * whole catalog to filter in the browser, and `get` resolves one entry by name
@@ -27,9 +28,9 @@ export class MCPCatalogService {
   /**
    * The whole catalog, every time.
    *
-   * There is nothing to narrow here and no page to take. The catalog is ~50
-   * entries — tens of kilobytes, a few over the wire once — so the browser is
-   * handed all of it and filters, orders and pages what it holds. That makes
+   * There is nothing to narrow here and no page to take. The current static
+   * catalog is bounded and small enough to hand to the browser in one response,
+   * so it filters, orders and pages what it holds. That makes
    * search a keystroke instead of a debounced round trip, and it is why this
    * takes no query: a `search=` or `$skip=` that reached this method would have
    * to be implemented twice to mean the same thing in both places.

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -391,11 +391,19 @@ function assertScopeUnchangedOrAllowed(
  * Refuse a write the tenant's policy does not permit.
  *
  * The marketplace gets its own sentence. Installing a curated entry is a much
- * narrower thing than configuring a server — the entry is chosen from a list,
- * remote, and unauthenticated — so somebody who clicked Connect and is told
- * their organization "does not allow members to configure MCP servers" is being
- * answered about a capability they did not ask for, and reasonably reads it as
- * the marketplace being broken.
+ * narrower thing than configuring an arbitrary server: the entry, endpoint,
+ * transport, and auth recipe come from the checked-in catalog and live probe.
+ * A pasted bearer token can go only to that pinned catalog endpoint and is
+ * stored on the caller-owned row; OAuth is fixed to `per_user`, and credential
+ * reuse can select only a live caller grant bound to the same resource and
+ * catalog policy. The internal `marketplace` compatibility policy is derived,
+ * never stored or accepted from this request, and survives only while the row
+ * still matches the current catalog prescription; explicit saved-row modes and
+ * configuration drift take the strict/general path instead. So somebody who
+ * clicked Connect and is told their
+ * organization "does not allow members to configure MCP servers" is being
+ * answered about a broader capability than they asked for, and reasonably
+ * reads it as the marketplace being broken.
  *
  * Neither sentence promises the grant is coming. `use_existing_only` refusing
  * the marketplace is the deliberate current state, not a gap waiting on a fix:

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -370,9 +370,9 @@ AGOR_CONFIG_PATH=/etc/agor/config.yaml agor daemon start
 
 ## MCP catalog
 
-Agor ships a browsable catalog of MCP servers. It is a reviewed file in the repository, loaded by
-the daemon at startup, so browsing the marketplace requires no catalog service and there is nothing
-to configure.
+Agor ships a browsable catalog of MCP servers. It is a reviewed file in the repository, parsed lazily
+on the daemon's first catalog read and then cached for the life of the process, so browsing the
+marketplace requires no external catalog service and there is nothing to configure.
 
 What the catalog offers is therefore a function of the deployed binary: rolling
 back to an older release withdraws entries added since, until you roll forward
@@ -381,9 +381,10 @@ again. That is intended, but it is not something to discover during an incident.
 Each entry records whether its endpoint needs an account, but Connect checks the live endpoint rather
 than trusting that record. A completed MCP handshake is installed ready to use. An OAuth challenge is
 installed as a per-user connection. A non-OAuth challenge can be installed when the catalog includes a
-reviewed bearer-token recipe: the drawer asks for the token, tests it against the catalog URL before
-writing anything, and stores it on a connection owned by that user. A stale catalog auth label therefore
-does not silently install a connection that the live endpoint will reject.
+reviewed bearer-token recipe: the drawer asks for the token, and the daemon first durably claims this
+user's connect generation so a slower, older reconnect cannot overwrite a newer token. It then tests the
+token against the catalog URL and writes the server/session only after the probe accepts it. A stale
+catalog auth label therefore does not silently install a connection that the live endpoint will reject.
 
 Marketplace OAuth uses a bounded compatibility profile for current, unmodified catalog installs. It
 accepts only reviewed discovery differences while retaining same-origin bounds on those fallbacks,

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -370,27 +370,57 @@ AGOR_CONFIG_PATH=/etc/agor/config.yaml agor daemon start
 
 ## MCP catalog
 
-Agor ships a browsable catalog of MCP servers. It is a file in the repository —
-around fifty reviewed entries — loaded by the daemon at startup, so the
-marketplace works with no network access and there is nothing to configure.
+Agor ships a browsable catalog of MCP servers. It is a reviewed file in the repository, loaded by
+the daemon at startup, so browsing the marketplace requires no catalog service and there is nothing
+to configure.
 
 What the catalog offers is therefore a function of the deployed binary: rolling
 back to an older release withdraws entries added since, until you roll forward
 again. That is intended, but it is not something to discover during an incident.
 
-Each entry records whether its endpoint needs an account. Only servers that need
-none can be connected from the marketplace today; the rest are shown with what
-they would ask for, and Connect is not offered. Connecting always checks the
-endpoint first, so an entry whose vendor has since started requiring an account
-is refused rather than installed broken.
+Each entry records whether its endpoint needs an account, but Connect checks the live endpoint rather
+than trusting that record. A completed MCP handshake is installed ready to use. An OAuth challenge is
+installed as a per-user connection. A non-OAuth challenge can be installed when the catalog includes a
+reviewed bearer-token recipe: the drawer asks for the token, tests it against the catalog URL before
+writing anything, and stores it on a connection owned by that user. A stale catalog auth label therefore
+does not silently install a connection that the live endpoint will reject.
+
+Marketplace OAuth uses a bounded compatibility profile for current, unmodified catalog installs. It
+accepts only reviewed discovery differences while retaining same-origin bounds on those fallbacks,
+resource and issuer binding, the exact MCP URL in authorization and token requests, PKCE S256, and
+callback issuer checks. This profile is derived by the daemon; it cannot be selected or persisted as a
+general OAuth mode. An explicit **Strict** or **Legacy** choice on the saved connection remains
+authoritative; Legacy is the deliberately broader operator override. Entries that have passed the
+strict boundary can require it in the catalog — Monday, Cloudflare, and ClickUp currently do — and an
+edited or imported connection, a removed entry, or catalog-configuration drift falls back to Strict.
+
+Agor removed GitHub, Prisma, MongoDB, Box, HubSpot, Slack, PagerDuty, and Kagi from the catalog. The
+review could not establish a safely bound client-registration or issuer path for those endpoints. Their
+absence is not the earlier state where OAuth cards were offered but failed after Connect; unsupported
+providers are removed from the shelf instead.
+
+Connect may reuse an OAuth credential the caller already holds when it is a live per-user grant for the
+same endpoint, protected resource, requested scope, and catalog OAuth policy. It never reuses another
+user's or a shared grant, and declines rows with custom headers, credential-routing overrides, or stale
+configuration. An expired matching grant may be refreshed before reuse. Reconnecting a bearer-token
+entry reuses only that user's catalog connection and rotates the token after the new session and
+attachment have succeeded.
+
+Every successful Connect creates a new idle session, attaches the server, and opens that session. For an
+open server, a bearer-token server, or OAuth with a reusable live grant, the starter prompt is loaded in
+the composer. A new OAuth connection that still needs sign-in lands in the same session without the
+starter prompt. The dismissible notice above the composer and the warning MCP badge identify the
+unfinished connection; open the badge and activate the server pill to sign in. Agor does not auto-open
+OAuth after navigation because browsers require a short-lived user activation for a reliable popup.
 
 If you previously set an `mcp_catalog:` block in `~/.agor/config.yaml`, leave it
 or delete it — either works. The daemon still accepts the section so an upgrade
 cannot fail on it, and ignores every setting in it.
 
-That connect-time check is a single request, to the entry's own URL and nowhere
-else, and it only connects to public addresses: the hostname is resolved first
-and refused unless every resolved address is globally reachable.
+The unauthenticated connect-time check is a single request to the entry's own URL. A bearer token adds
+one authenticated check to that same URL. Both resolve the hostname first, require every resolved
+address to be globally reachable, pin the checked address, bound the response, and refuse redirects so
+a credential is never forwarded to a destination the catalog did not name.
 
 ---
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -31,6 +31,10 @@ export interface MCPServerEditModalProps {
   /** The scopes this editor may switch to, on the same terms. */
   offeredScopes?: MCPScope[];
   onClose: () => void;
+  /** Runs after the portal has finished closing (for example, to restore focus). */
+  afterClose?: () => void;
+  /** Delegates focus restoration to an owner when the original trigger was unmounted. */
+  focusTriggerAfterClose?: boolean;
 }
 
 interface TestResult {
@@ -49,7 +53,8 @@ interface TestResult {
  *
  * Hydrates its own form from `server`, owns transport/authType/test state,
  * and persists updates via the `mcp-servers` Feathers service. Used by
- * both `MCPServersTable` (settings) and `MCPServerPill` (admin shortcut).
+ * both `MCPServersTable` (settings) and `SessionMcpFooterControl` (admin
+ * shortcut).
  */
 export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   server,
@@ -58,6 +63,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   offeredTransports,
   offeredScopes,
   onClose,
+  afterClose,
+  focusTriggerAfterClose,
 }) => {
   const { showSuccess, showError } = useThemedMessage();
   const [form] = Form.useForm();
@@ -309,6 +316,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       title="Edit MCP Server"
       open={open}
       onCancel={closeAndReset}
+      afterClose={afterClose}
+      focusable={focusTriggerAfterClose === undefined ? undefined : { focusTriggerAfterClose }}
       width={600}
       destroyOnHidden
       footer={

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
@@ -69,6 +69,7 @@ describe('MCPServerPill OAuth recovery', () => {
 
   it('names the admin edit action for the server it edits', () => {
     permissionState.isAdmin = true;
+    const onEdit = vi.fn();
     const server = {
       mcp_server_id: '01900000-0000-7000-8000-000000000005',
       name: 'oauth-server',
@@ -79,11 +80,12 @@ describe('MCPServerPill OAuth recovery', () => {
       auth: { type: 'oauth' },
     } as MCPServer;
 
-    render(<MCPServerPill server={server} needsAuth client={null} />);
+    render(<MCPServerPill server={server} needsAuth client={null} onEdit={onEdit} />);
 
-    expect(
-      screen.getByRole('button', { name: 'Edit OAuth Server MCP server' })
-    ).toBeInTheDocument();
+    const edit = screen.getByRole('button', { name: 'Edit OAuth Server MCP server' });
+    expect(edit).toBeInTheDocument();
+    fireEvent.click(edit);
+    expect(onEdit).toHaveBeenCalledWith(server);
   });
 
   it('exposes authenticated OAuth refresh as a named native button', async () => {

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
@@ -1,5 +1,5 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPServerPill } from './MCPServerPill';
 
@@ -54,7 +54,7 @@ describe('MCPServerPill OAuth recovery', () => {
 
     const signIn = screen.getByRole('button', { name: 'Sign in to OAuth Server' });
     expect(signIn.tagName).toBe('BUTTON');
-    signIn.focus();
+    act(() => signIn.focus());
     expect(signIn).toHaveFocus();
     fireEvent.click(signIn);
 
@@ -105,7 +105,7 @@ describe('MCPServerPill OAuth recovery', () => {
       name: 'Refresh OAuth credentials for OAuth Server',
     });
     expect(refresh.tagName).toBe('BUTTON');
-    refresh.focus();
+    act(() => refresh.focus());
     expect(refresh).toHaveFocus();
     fireEvent.click(refresh);
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
@@ -3,13 +3,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPServerPill } from './MCPServerPill';
 
+const permissionState = vi.hoisted(() => ({ isAdmin: false }));
+const refreshAndRefetchMCPOAuthGrant = vi.hoisted(() => vi.fn());
 const showError = vi.fn();
 const showInfo = vi.fn();
 const showSuccess = vi.fn();
 const showWarning = vi.fn();
 
 vi.mock('@/hooks/usePermissions', () => ({
-  usePermissions: () => ({ isAdmin: false }),
+  usePermissions: () => permissionState,
 }));
 
 vi.mock('@/utils/message', () => ({
@@ -17,13 +19,16 @@ vi.mock('@/utils/message', () => ({
 }));
 
 vi.mock('@/utils/mcpOAuthAttempt', () => ({
-  refreshAndRefetchMCPOAuthGrant: vi.fn(),
+  refreshAndRefetchMCPOAuthGrant,
   refetchMCPOAuthDurableState: vi.fn(),
   waitForMCPOAuthAttempt: vi.fn(),
 }));
 
 describe('MCPServerPill OAuth recovery', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionState.isAdmin = false;
+  });
 
   it('uses the shared OAuth start path and exposes DCR diagnostics', async () => {
     const startOAuth = vi.fn().mockResolvedValue({
@@ -47,7 +52,11 @@ describe('MCPServerPill OAuth recovery', () => {
 
     render(<MCPServerPill server={server} needsAuth client={client} />);
 
-    fireEvent.click(screen.getByText('OAuth Server'));
+    const signIn = screen.getByRole('button', { name: 'Sign in to OAuth Server' });
+    expect(signIn.tagName).toBe('BUTTON');
+    signIn.focus();
+    expect(signIn).toHaveFocus();
+    fireEvent.click(signIn);
 
     await waitFor(() => expect(startOAuth).toHaveBeenCalledOnce());
     expect(startOAuth).toHaveBeenCalledWith({
@@ -56,5 +65,55 @@ describe('MCPServerPill OAuth recovery', () => {
     expect(await screen.findByText('OAuth setup needs attention')).toBeVisible();
     expect(screen.getByText(/HTTP 404/)).toBeVisible();
     expect(screen.getByText(/mcp-servers\/oauth-callback/)).toBeVisible();
+  });
+
+  it('names the admin edit action for the server it edits', () => {
+    permissionState.isAdmin = true;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000005',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      transport: 'http',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+
+    render(<MCPServerPill server={server} needsAuth client={null} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Edit OAuth Server MCP server' })
+    ).toBeInTheDocument();
+  });
+
+  it('exposes authenticated OAuth refresh as a named native button', async () => {
+    refreshAndRefetchMCPOAuthGrant.mockResolvedValue({ success: true });
+    const client = {} as AgorClient;
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000006',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      transport: 'http',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+
+    render(<MCPServerPill server={server} needsAuth={false} client={client} />);
+
+    const refresh = screen.getByRole('button', {
+      name: 'Refresh OAuth credentials for OAuth Server',
+    });
+    expect(refresh.tagName).toBe('BUTTON');
+    refresh.focus();
+    expect(refresh).toHaveFocus();
+    fireEvent.click(refresh);
+
+    await waitFor(() =>
+      expect(refreshAndRefetchMCPOAuthGrant).toHaveBeenCalledWith(
+        client,
+        '01900000-0000-7000-8000-000000000006'
+      )
+    );
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -9,13 +9,14 @@ import { formatAbsoluteTime } from '../../utils/time';
 import { ENTITY_PILL_COLORS } from '../Pill';
 import { Tag } from '../Tag';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
-import { MCPServerEditModal } from './MCPServerEditModal';
 import { useMCPServerOAuthStart } from './useMCPServerOAuthStart';
 
 interface MCPServerPillProps {
   server: MCPServer;
   needsAuth: boolean;
   client: AgorClient | null;
+  /** Lets an overlay owner open an editor without nesting its lifecycle in this pill. */
+  onEdit?: (server: MCPServer) => void;
 }
 
 /**
@@ -68,14 +69,19 @@ function formatRefreshError(error?: string): string {
  *   - Authenticated:   purple + API icon, tooltip shows human-readable expiry,
  *                      activation force-refreshes the token (even before it's due)
  *                      so operators can probe per-provider refresh policy.
- *   - Admin only: a small pencil icon at the end opens the MCP edit modal
- *                 so operators can fix config without leaving the session view.
+ *   - Admin only: when the overlay owner supplies `onEdit`, a small pencil icon
+ *                 requests the MCP editor so operators can fix config without
+ *                 leaving the session view.
  */
-export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth, client }) => {
+export const MCPServerPill: React.FC<MCPServerPillProps> = ({
+  server,
+  needsAuth,
+  client,
+  onEdit,
+}) => {
   const { showSuccess, showInfo, showWarning, showError } = useThemedMessage();
   const { isAdmin } = usePermissions();
   const [refreshing, setRefreshing] = useState(false);
-  const [editModalOpen, setEditModalOpen] = useState(false);
   // Local override so the tooltip reflects a just-refreshed expiry without
   // waiting for a full MCPServer re-fetch from the parent.
   const [expiresAtOverride, setExpiresAtOverride] = useState<number | undefined>(undefined);
@@ -230,7 +236,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
           ) : (
             label
           )}
-          {isAdmin && (
+          {isAdmin && onEdit && (
             // Real <button> for keyboard focus + screen-reader semantics.
             // Native `title` (not <Tooltip>) so we don't stack a second
             // AntD tooltip on top of the parent expiry/auth tooltip.
@@ -240,7 +246,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
               title={`Edit ${label} MCP server`}
               onClick={(e) => {
                 e.stopPropagation();
-                setEditModalOpen(true);
+                onEdit(server);
               }}
               style={{
                 marginLeft: 8,
@@ -274,14 +280,6 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
         </Tag>
       </Tooltip>
       {oauthFailure && <MCPOAuthRecoveryAlert failure={oauthFailure} />}
-      {isAdmin && (
-        <MCPServerEditModal
-          server={server}
-          open={editModalOpen}
-          client={client}
-          onClose={() => setEditModalOpen(false)}
-        />
-      )}
     </>
   );
 };

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -64,9 +64,9 @@ function formatRefreshError(error?: string): string {
 /**
  * Clickable MCP server pill.
  *
- *   - Unauthenticated: error/red + login icon, click starts OAuth.
+ *   - Unauthenticated: warning + login icon, activation starts OAuth.
  *   - Authenticated:   purple + API icon, tooltip shows human-readable expiry,
- *                      click force-refreshes the token (even before it's due)
+ *                      activation force-refreshes the token (even before it's due)
  *                      so operators can probe per-provider refresh policy.
  *   - Admin only: a small pencil icon at the end opens the MCP edit modal
  *                 so operators can fix config without leaving the session view.
@@ -135,7 +135,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
           {verb} {phrase}
         </div>
         <div style={{ opacity: 0.75, fontSize: 12 }}>{formatAbsoluteTime(date)}</div>
-        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
+        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Activate to refresh now</div>
       </>
     );
   } else {
@@ -152,16 +152,29 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
         <div style={{ opacity: 0.75, fontSize: 12 }}>
           Provider returned no expiry. Token is used until it stops working.
         </div>
-        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
+        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Activate to refresh now</div>
       </>
     );
   }
 
-  const needsAuthTooltip = `${server.display_name || server.name} isn’t connected. Click to connect.`;
+  const needsAuthTooltip = `${server.display_name || server.name} isn’t connected. Activate to sign in.`;
+
+  const label = server.display_name || server.name;
+  // The pill's own action, or nothing for a non-OAuth server. Named here
+  // because both the Tag's pointer target and the label button need to agree on
+  // whether there is one.
+  const primaryAction = needsAuth
+    ? () => void handleStartOAuthFlow()
+    : isOAuthServer
+      ? handleRefreshClick
+      : undefined;
 
   return (
     <>
       <Tooltip
+        // The label is a button for actionable pills, so the same explanation
+        // keyboard users receive on focus is available to pointer users on hover.
+        trigger={['hover', 'focus']}
         title={
           needsAuth
             ? startingOAuthFlow
@@ -173,29 +186,58 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
         <Tag
           color={needsAuth ? 'warning' : ENTITY_PILL_COLORS.mcp}
           icon={
-            needsAuth ? <LoginOutlined /> : refreshing ? <ReloadOutlined spin /> : <ApiOutlined />
+            needsAuth ? (
+              <LoginOutlined aria-hidden />
+            ) : refreshing ? (
+              <ReloadOutlined spin aria-hidden />
+            ) : (
+              <ApiOutlined aria-hidden />
+            )
           }
           style={{
             cursor:
               refreshing || startingOAuthFlow ? 'wait' : isOAuthServer ? 'pointer' : 'default',
           }}
-          onClick={
-            needsAuth
-              ? () => void handleStartOAuthFlow()
-              : isOAuthServer
-                ? handleRefreshClick
-                : undefined
-          }
+          onClick={primaryAction}
         >
-          {server.display_name || server.name}
+          {primaryAction ? (
+            // Tag is a span. Keep the whole visual pill as the pointer target,
+            // but give its primary action a native keyboard/focus target. Stop
+            // propagation so activating the button does not also fire Tag's
+            // pointer handler.
+            <button
+              type="button"
+              aria-label={
+                needsAuth ? `Sign in to ${label}` : `Refresh OAuth credentials for ${label}`
+              }
+              aria-busy={startingOAuthFlow || refreshing}
+              onClick={(event) => {
+                event.stopPropagation();
+                void primaryAction();
+              }}
+              style={{
+                margin: 0,
+                padding: 0,
+                background: 'transparent',
+                border: 'none',
+                color: 'inherit',
+                font: 'inherit',
+                cursor: 'inherit',
+              }}
+            >
+              {label}
+            </button>
+          ) : (
+            label
+          )}
           {isAdmin && (
             // Real <button> for keyboard focus + screen-reader semantics.
             // Native `title` (not <Tooltip>) so we don't stack a second
             // AntD tooltip on top of the parent expiry/auth tooltip.
             <button
               type="button"
-              aria-label="Edit MCP server"
-              title="Edit MCP server"
+              aria-label={`Edit ${label} MCP server`}
+              title={`Edit ${label} MCP server`}
               onClick={(e) => {
                 e.stopPropagation();
                 setEditModalOpen(true);
@@ -218,13 +260,15 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
                 (e.currentTarget as HTMLElement).style.opacity = '0.55';
               }}
               onFocus={(e) => {
+                e.stopPropagation();
                 (e.currentTarget as HTMLElement).style.opacity = '1';
               }}
               onBlur={(e) => {
+                e.stopPropagation();
                 (e.currentTarget as HTMLElement).style.opacity = '0.55';
               }}
             >
-              <EditOutlined />
+              <EditOutlined aria-hidden />
             </button>
           )}
         </Tag>

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -411,15 +411,14 @@ describe('connect', () => {
   });
 
   /**
-   * 42 of the 48 catalog entries are OAuth, and an OAuth install lands with no
-   * credentials — the row is written before anyone signs in. A starter prompt
-   * is written to exercise the server it ships with, so arming the composer
-   * with one here means the modal outcome of pressing Connect is a loaded
-   * prompt whose only result is a tool-less answer.
+   * A new OAuth install with no reusable grant lands without credentials. A
+   * starter prompt is written to exercise the server it ships with, so arming
+   * the composer with one here means pressing Connect produces a loaded prompt
+   * whose only result is a tool-less answer.
    *
    * These pin the split. Landing in the session is unchanged: the session is
-   * where the sign-in lives (the alert above the composer, the red MCP badge,
-   * the pill that starts OAuth on click). Only the loaded gun is withheld.
+   * where the sign-in lives (the notice above the composer, the warning MCP badge,
+   * the pill that starts OAuth on activation). Only the loaded gun is withheld.
    */
   async function connectAndLand(mcpServer: Record<string, unknown>) {
     connectImpl = async () => ({

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.tsx
@@ -201,12 +201,12 @@ export const CatalogTab: React.FC<CatalogTabProps> = ({ client, connected }) => 
         rememberConnectBranchId(branchId);
         // A starter prompt is written to exercise the server it ships with, so
         // it is only worth arming the composer with once that server can answer
-        // it. Most of the catalog is OAuth, and an OAuth install lands with no
+        // it. A new OAuth install with no reusable grant lands without
         // credentials: staging the prompt there hands the user a loaded
         // composer whose only outcome is a tool-less answer, turning a
         // recoverable state into an invitation to hit the failure. The session
-        // says what is missing instead — see the unauthenticated-server alert
-        // above the composer and the red MCP badge beside it.
+        // says what is missing instead — see the unauthenticated-server notice
+        // above the composer and the warning MCP badge beside it.
         if (
           result.starter_prompt &&
           !mcpServerNeedsAuth(result.mcp_server, userAuthenticatedMcpServerIds)

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -306,7 +306,33 @@ describe('SessionFooter', () => {
     const disclosure = screen.getByRole('button', {
       name: 'MCP servers. OAuth Server isn’t connected. Open to connect.',
     });
-    disclosure.focus();
+    act(() => disclosure.focus());
+    expect(disclosure).toHaveFocus();
+  });
+
+  it('exposes dialog popup state and restores disclosure focus when Escape dismisses it', () => {
+    render(<SessionFooter {...baseProps} client={{} as never} />, { wrapper: Wrapper });
+    const disclosure = screen.getByRole('button', {
+      name: 'MCP servers. No MCP servers attached. Open to add or change MCP servers.',
+    });
+
+    expect(disclosure).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    act(() => disclosure.focus());
+    fireEvent.click(disclosure);
+
+    const popup = screen.getByRole('dialog', { name: 'Session MCP servers' });
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+    expect(disclosure).toHaveAttribute('aria-controls', popup.id);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    const selector = within(popup).getByRole('combobox');
+    act(() => selector.focus());
+    expect(selector).toHaveFocus();
+    fireEvent.keyDown(selector, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Session MCP servers' })).not.toBeInTheDocument();
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
     expect(disclosure).toHaveFocus();
   });
 
@@ -387,11 +413,42 @@ describe('SessionFooter', () => {
       { wrapper: Wrapper }
     );
     const notice = screen.getByTestId('mcp-disconnected-notice');
+    expect(notice).toHaveAttribute('role', 'status');
+    expect(notice).toHaveAttribute('aria-live', 'polite');
+    expect(notice).toHaveAttribute('aria-atomic', 'true');
     expect(notice).toHaveTextContent(/2 MCP servers aren.t connected/);
     expect(notice).toHaveTextContent(/Open the MCP badge/);
     expect(
       screen.getByRole('button', { name: 'Dismiss MCP connection notice' })
     ).toBeInTheDocument();
+  });
+
+  it('reveals the advertised MCP recovery badge while Tools is unpinned', () => {
+    const disconnected = {
+      ...mcpServer('a', 'Alpha'),
+      transport: 'http',
+      scope: 'session',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+    localStorage.setItem('agor-footer-prefs', JSON.stringify({ pinnedChips: ['model'] }));
+
+    render(
+      <SessionFooter
+        {...baseProps}
+        sessionMcpServerIds={[disconnected.mcp_server_id]}
+        unauthedMcpServers={[disconnected]}
+        mcpServerById={new Map([[disconnected.mcp_server_id, disconnected]])}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(/Open the MCP badge/);
+    const disclosure = screen.getByRole('button', {
+      name: 'MCP servers. Alpha isn’t connected. Open to connect.',
+    });
+    fireEvent.click(disclosure);
+    expect(screen.getByRole('dialog', { name: 'Session MCP servers' })).toBeInTheDocument();
   });
 
   it('hides the notice after dismissal and keeps it hidden across re-renders', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -3,6 +3,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  MCPServer,
   PermissionMode,
   Session,
 } from '@agor-live/client';
@@ -264,8 +265,11 @@ describe('SessionFooter', () => {
 
   it('MCP chip shows 0 count when no MCP servers are attached', () => {
     render(<SessionFooter {...baseProps} sessionMcpServerIds={[]} />, { wrapper: Wrapper });
-    const chip = screen.getByTitle(/No MCP servers attached/);
+    const chip = screen.getByRole('button', {
+      name: 'MCP servers. No MCP servers attached. Open to add or change MCP servers.',
+    });
     expect(chip).toBeInTheDocument();
+    expect(chip.tagName).toBe('BUTTON');
     expect(chip.textContent).toContain('0');
   });
 
@@ -277,6 +281,33 @@ describe('SessionFooter', () => {
     const chip = screen.getByTitle(/3 MCP servers need attention/);
     expect(chip).toBeInTheDocument();
     expect(chip.textContent).toContain('3');
+  });
+
+  it('names the disconnected server in the MCP disclosure control', () => {
+    const oauthServer = {
+      mcp_server_id: 'oauth-server-id',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      transport: 'http',
+      scope: 'session',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+
+    render(
+      <SessionFooter
+        {...baseProps}
+        sessionMcpServerIds={[oauthServer.mcp_server_id]}
+        mcpServerById={new Map([[oauthServer.mcp_server_id, oauthServer]])}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const disclosure = screen.getByRole('button', {
+      name: 'MCP servers. OAuth Server isn’t connected. Open to connect.',
+    });
+    disclosure.focus();
+    expect(disclosure).toHaveFocus();
   });
 
   it('tones the MCP badge count as a warning (not an error) when servers need attention', () => {
@@ -330,7 +361,11 @@ describe('SessionFooter', () => {
       wrapper: Wrapper,
     });
 
-    fireEvent.click(screen.getByTitle(/No MCP servers attached/));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'MCP servers. No MCP servers attached. Open to add or change MCP servers.',
+      })
+    );
 
     expect(await screen.findByText('Session MCP servers')).toBeInTheDocument();
     expect(screen.queryByText('Open session settings')).not.toBeInTheDocument();
@@ -353,6 +388,7 @@ describe('SessionFooter', () => {
     );
     const notice = screen.getByTestId('mcp-disconnected-notice');
     expect(notice).toHaveTextContent(/2 MCP servers aren.t connected/);
+    expect(notice).toHaveTextContent(/Open the MCP badge/);
     expect(
       screen.getByRole('button', { name: 'Dismiss MCP connection notice' })
     ).toBeInTheDocument();

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -247,6 +247,11 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   );
   const showMcpNotice =
     unauthedMcpServers.length > 0 && dismissedMcpSignature !== unauthedSignature;
+  // A disconnected install needs a working recovery control even when the
+  // user previously unpinned Tools. Reveal the MCP badge for as long as any
+  // attached server needs authentication; once recovered, the saved pin
+  // preference takes effect again.
+  const showMcpControl = pinnedChips.includes('tools') || unauthedMcpServers.length > 0;
   const mcpNoticeMessage =
     unauthedMcpServers.length === 1
       ? `${unauthedMcpServers[0].display_name || unauthedMcpServers[0].name} isn’t connected. Open the MCP badge to connect it.`
@@ -1343,7 +1348,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
 
       <div style={{ position: 'relative', zIndex: 1 }}>
         {/* Row 1 — Info bar */}
-        {(pinnedChips.includes('tools') ||
+        {(showMcpControl ||
           (footerTimerTask && pinnedChips.includes('timer')) ||
           (modelName && pinnedChips.includes('model')) ||
           (tokenDisplay !== null && pinnedChips.includes('tokens')) ||
@@ -1380,7 +1385,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
               </div>
             )}
 
-            {pinnedChips.includes('tools') && (
+            {showMcpControl && (
               <SessionMcpFooterControl
                 client={client}
                 sessionId={session.session_id}
@@ -1544,6 +1549,9 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
             align="center"
             gap={token.sizeXS}
             data-testid="mcp-disconnected-notice"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
             style={{
               marginBottom: token.sizeUnit * 2,
               padding: `${token.sizeXXS}px ${token.sizeSM}px`,

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -249,8 +249,8 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
     unauthedMcpServers.length > 0 && dismissedMcpSignature !== unauthedSignature;
   const mcpNoticeMessage =
     unauthedMcpServers.length === 1
-      ? `${unauthedMcpServers[0].display_name || unauthedMcpServers[0].name} isn’t connected. Click the MCP badge to connect it.`
-      : `${unauthedMcpServers.length} MCP servers aren’t connected. Click the MCP badge to connect them.`;
+      ? `${unauthedMcpServers[0].display_name || unauthedMcpServers[0].name} isn’t connected. Open the MCP badge to connect it.`
+      : `${unauthedMcpServers.length} MCP servers aren’t connected. Open the MCP badge to connect them.`;
 
   const composerAttachmentActionTooltip = 'Attachments are only supported for normal Send for now';
   const composerUploadTooltip = 'Uploading files...';

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.test.tsx
@@ -1,0 +1,105 @@
+import type { AgorClient, MCPServer } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App, ConfigProvider } from 'antd';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionMcpFooterControl } from './SessionMcpFooterControl';
+
+const permissionState = vi.hoisted(() => ({ isAdmin: true }));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => permissionState,
+}));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ConfigProvider>
+    <App>{children}</App>
+  </ConfigProvider>
+);
+
+const server = {
+  mcp_server_id: '01900000-0000-7000-8000-000000000020',
+  name: 'portal-server',
+  display_name: 'Portal Server',
+  description: 'Before',
+  transport: 'http',
+  url: 'https://mcp.example.com/mcp',
+  scope: 'global',
+  enabled: true,
+  auth: { type: 'none' },
+} as MCPServer;
+
+const client = {
+  service: vi.fn(() => ({ patch: vi.fn(), create: vi.fn() })),
+  io: { on: vi.fn(), off: vi.fn() },
+} as unknown as AgorClient;
+
+describe('SessionMcpFooterControl overlay lifecycle', () => {
+  beforeEach(() => {
+    permissionState.isAdmin = true;
+    vi.clearAllMocks();
+  });
+
+  it('keeps the portaled editor usable and restores disclosure behavior and focus', async () => {
+    render(
+      <SessionMcpFooterControl
+        client={client}
+        sessionId="session-id"
+        sessionMcpServerIds={[server.mcp_server_id]}
+        mcpServerById={new Map([[server.mcp_server_id, server]])}
+        userAuthenticatedMcpServerIds={new Set()}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const disclosure = screen.getByRole('button', {
+      name: 'MCP servers. 1 MCP server attached. Open to add or change MCP servers.',
+    });
+    fireEvent.click(disclosure);
+
+    const mcpDialog = screen.getByRole('dialog', { name: 'Session MCP servers' });
+    fireEvent.click(
+      within(mcpDialog).getByRole('button', { name: 'Edit Portal Server MCP server' })
+    );
+
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('dialog', { name: 'Session MCP servers' })).not.toBeInTheDocument();
+
+    const editDialog = await screen.findByRole('dialog', { name: 'Edit MCP Server' });
+    const displayName = await within(editDialog).findByLabelText('Display Name');
+    act(() => displayName.focus());
+    fireEvent.pointerDown(displayName);
+    fireEvent.change(displayName, { target: { value: 'Portal Server Edited' } });
+
+    expect(editDialog).toBeInTheDocument();
+    expect(displayName).toHaveValue('Portal Server Edited');
+
+    const cancel = within(editDialog).getByRole('button', { name: 'Cancel' });
+    fireEvent.pointerDown(cancel);
+    expect(editDialog).toBeInTheDocument();
+    fireEvent.click(cancel);
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit MCP Server' })).not.toBeInTheDocument()
+    );
+    await waitFor(() => expect(disclosure).toHaveFocus());
+
+    fireEvent.click(disclosure);
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Session MCP servers' })).getByRole('button', {
+        name: 'Edit Portal Server MCP server',
+      })
+    );
+    await screen.findByRole('dialog', { name: 'Edit MCP Server' });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit MCP Server' })).not.toBeInTheDocument()
+    );
+    await waitFor(() => expect(disclosure).toHaveFocus());
+
+    fireEvent.click(disclosure);
+    expect(screen.getByRole('dialog', { name: 'Session MCP servers' })).toBeInTheDocument();
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole('dialog', { name: 'Session MCP servers' })).not.toBeInTheDocument();
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -54,7 +54,8 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
       ? `${unauthedServers[0].display_name || unauthedServers[0].name} isn’t connected. Open to connect.`
       : unauthedServers.length > 1
         ? `${unauthedServers.length} MCP servers aren’t connected. Open to connect.`
-        : `${summary.tooltip}. Click to add or change MCP servers.`;
+        : `${summary.tooltip}. Open to add or change MCP servers.`;
+  const badgeAccessibleName = `MCP servers. ${badgeTitle}`;
 
   const handleChange = async (nextIds: string[]) => {
     if (!client) return;
@@ -115,47 +116,69 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
       title={null}
       content={content}
     >
-      <Tag
-        icon={<ApiOutlined />}
-        color="default"
+      {/* Tag renders a span, but this popover contains the only in-session
+          sign-in action for a fresh Marketplace OAuth install. Keep the Tag's
+          appearance inside a native disclosure control so Enter/Space, focus,
+          and the stateful accessible name do not depend on click handlers on a
+          span. */}
+      <button
+        type="button"
+        aria-label={badgeAccessibleName}
         title={badgeTitle}
-        style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
-        // antd nests children in a content span, so the root's align-items never reaches the chip.
-        styles={{ content: { display: 'inline-flex', alignItems: 'center' } }}
+        style={{
+          margin: 0,
+          padding: 0,
+          border: 'none',
+          background: 'transparent',
+          color: 'inherit',
+          font: 'inherit',
+          lineHeight: 1,
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+        }}
       >
-        <span>MCP</span>
-        <AntTag
-          style={{
-            marginInlineStart: token.sizeUnit,
-            marginInlineEnd: 0,
-            // Round notification counter: a 16px circle at one digit
-            // (minWidth === height), growing into a pill for 2+ digits. The
-            // large radius fully rounds the ends (clamped to height/2) in both.
-            boxSizing: 'border-box',
-            minWidth: 16,
-            height: 16,
-            paddingInline: 4,
-            borderRadius: 999,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            lineHeight: 1,
-            fontSize: 10,
-            textAlign: 'center',
-            fontVariantNumeric: 'tabular-nums',
-            // Recolor the count amber via semantic tokens only — the neutral chip's
-            // geometry (size, radius, shape) is untouched, so the not-connected
-            // state differs from the healthy state purely in color, theme-aware
-            // in light and dark. Avoids AntD's `color="warning"` preset, whose own
-            // fill/border/radius would shift the box vs. the neutral chip.
-            ...(summary.tone === 'warning'
-              ? { backgroundColor: token.colorWarningBg, color: token.colorWarning }
-              : {}),
-          }}
+        <Tag
+          icon={<ApiOutlined aria-hidden />}
+          color="default"
+          style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+          // antd nests children in a content span, so the root's align-items never reaches the chip.
+          styles={{ content: { display: 'inline-flex', alignItems: 'center' } }}
         >
-          {summary.attachedCount}
-        </AntTag>
-      </Tag>
+          <span>MCP</span>
+          <AntTag
+            style={{
+              marginInlineStart: token.sizeUnit,
+              marginInlineEnd: 0,
+              // Round notification counter: a 16px circle at one digit
+              // (minWidth === height), growing into a pill for 2+ digits. The
+              // large radius fully rounds the ends (clamped to height/2) in both.
+              boxSizing: 'border-box',
+              minWidth: 16,
+              height: 16,
+              paddingInline: 4,
+              borderRadius: 999,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              lineHeight: 1,
+              fontSize: 10,
+              textAlign: 'center',
+              fontVariantNumeric: 'tabular-nums',
+              // Recolor the count amber via semantic tokens only — the neutral chip's
+              // geometry (size, radius, shape) is untouched, so the not-connected
+              // state differs from the healthy state purely in color, theme-aware
+              // in light and dark. Avoids AntD's `color="warning"` preset, whose own
+              // fill/border/radius would shift the box vs. the neutral chip.
+              ...(summary.tone === 'warning'
+                ? { backgroundColor: token.colorWarningBg, color: token.colorWarning }
+                : {}),
+            }}
+          >
+            {summary.attachedCount}
+          </AntTag>
+        </Tag>
+      </button>
     </Popover>
   );
 };

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { updateSessionMcpServers } from '../../utils/sessionMcpServers';
-import { MCPServerPill } from '../MCPServer';
+import { MCPServerEditModal, MCPServerPill } from '../MCPServer';
 import { summarizeSessionMcpServers } from '../MCPServer/mcp-session-summary';
 import { MCPServerSelect } from '../MCPServerSelect';
 import { Tag } from '../Tag';
@@ -29,6 +29,8 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
   const { showSuccess, showError } = useThemedMessage();
   const [saving, setSaving] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const [editingServer, setEditingServer] = React.useState<MCPServer | null>(null);
+  const [editModalOpen, setEditModalOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const popupRef = React.useRef<HTMLDivElement>(null);
@@ -62,6 +64,21 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
       dismissAndRestoreFocus();
     }
   };
+
+  const handleEditServer = React.useCallback((server: MCPServer) => {
+    // AntD Modal portals to document.body. Close this disclosure deliberately
+    // before opening the modal, and keep the modal's state at this overlay
+    // owner, so interacting with the portal cannot be mistaken for an outside
+    // click or unmount the editor with the disclosure contents.
+    setOpen(false);
+    setEditingServer(server);
+    setEditModalOpen(true);
+  }, []);
+
+  const finishEditModalClose = React.useCallback(() => {
+    setEditingServer(null);
+    triggerRef.current?.focus();
+  }, []);
 
   const summary = React.useMemo(
     () =>
@@ -108,7 +125,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
 
   const content = (
     <div style={{ width: 340, maxWidth: 'min(340px, 80vw)' }}>
-      <Space direction="vertical" size={10} style={{ width: '100%' }}>
+      <Space orientation="vertical" size={10} style={{ width: '100%' }}>
         <div>
           <Typography.Text id={headingId} strong>
             Session MCP servers
@@ -126,6 +143,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
                 server={server}
                 needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
                 client={client}
+                onEdit={handleEditServer}
               />
             ))}
           </Space>
@@ -242,6 +260,16 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
         >
           {content}
         </div>
+      )}
+      {editingServer && (
+        <MCPServerEditModal
+          server={editingServer}
+          open={editModalOpen}
+          client={client}
+          onClose={() => setEditModalOpen(false)}
+          afterClose={finishEditModalClose}
+          focusTriggerAfterClose={false}
+        />
       )}
     </div>
   );

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
 import { ApiOutlined } from '@ant-design/icons';
-import { Tag as AntTag, Popover, Space, Typography, theme } from 'antd';
+import { Tag as AntTag, Space, Typography, theme } from 'antd';
 import React from 'react';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -28,6 +28,40 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const [saving, setSaving] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const popupRef = React.useRef<HTMLDivElement>(null);
+  const generatedId = React.useId().replaceAll(':', '');
+  const popupId = `session-mcp-popup-${generatedId}`;
+  const headingId = `${popupId}-heading`;
+
+  React.useEffect(() => {
+    if (!open) return;
+    const dismissOutside = (event: PointerEvent) => {
+      if (
+        rootRef.current &&
+        event.target instanceof Node &&
+        !rootRef.current.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', dismissOutside);
+    return () => document.removeEventListener('pointerdown', dismissOutside);
+  }, [open]);
+
+  const dismissAndRestoreFocus = React.useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+  const handleEscape = (event: React.KeyboardEvent) => {
+    if (open && event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      dismissAndRestoreFocus();
+    }
+  };
 
   const summary = React.useMemo(
     () =>
@@ -76,7 +110,9 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
     <div style={{ width: 340, maxWidth: 'min(340px, 80vw)' }}>
       <Space direction="vertical" size={10} style={{ width: '100%' }}>
         <div>
-          <Typography.Text strong>Session MCP servers</Typography.Text>
+          <Typography.Text id={headingId} strong>
+            Session MCP servers
+          </Typography.Text>
           <Typography.Paragraph type="secondary" style={{ margin: `${token.sizeUnit}px 0 0` }}>
             Attach tools/connectors that the agent can use in this conversation.
           </Typography.Paragraph>
@@ -103,28 +139,31 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           loading={saving}
           disabled={!client || saving}
           style={{ width: '100%' }}
+          getPopupContainer={(trigger) =>
+            popupRef.current ?? trigger.parentElement ?? document.body
+          }
         />
       </Space>
     </div>
   );
 
   return (
-    <Popover
-      trigger="click"
-      placement="top"
-      getPopupContainer={(trigger) => trigger.parentElement ?? document.body}
-      title={null}
-      content={content}
-    >
+    <div ref={rootRef} style={{ position: 'relative', display: 'inline-flex' }}>
       {/* Tag renders a span, but this popover contains the only in-session
           sign-in action for a fresh Marketplace OAuth install. Keep the Tag's
           appearance inside a native disclosure control so Enter/Space, focus,
           and the stateful accessible name do not depend on click handlers on a
           span. */}
       <button
+        ref={triggerRef}
         type="button"
         aria-label={badgeAccessibleName}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={popupId}
         title={badgeTitle}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={handleEscape}
         style={{
           margin: 0,
           padding: 0,
@@ -179,6 +218,31 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           </AntTag>
         </Tag>
       </button>
-    </Popover>
+
+      {open && (
+        <div
+          ref={popupRef}
+          id={popupId}
+          role="dialog"
+          aria-labelledby={headingId}
+          onKeyDown={handleEscape}
+          style={{
+            position: 'absolute',
+            bottom: `calc(100% + ${token.sizeXS}px)`,
+            left: 0,
+            zIndex: token.zIndexPopupBase,
+            padding: token.paddingSM,
+            background: token.colorBgElevated,
+            borderWidth: token.lineWidth,
+            borderStyle: 'solid',
+            borderColor: token.colorBorderSecondary,
+            borderRadius: token.borderRadiusLG,
+            boxShadow: token.boxShadowSecondary,
+          }}
+        >
+          {content}
+        </div>
+      )}
+    </div>
   );
 };

--- a/packages/core/src/mcp-catalog/catalog.test.ts
+++ b/packages/core/src/mcp-catalog/catalog.test.ts
@@ -45,12 +45,27 @@ describe('loadCatalog', () => {
   it('hands out entries nothing can corrupt for the next reader', async () => {
     const entries = await loadCatalog();
     const [first] = entries;
+    const oauthEntry = entries.find((candidate) => candidate.oauth);
+    const credentialEntry = entries.find((candidate) => candidate.credentials);
 
     // Every caller shares these objects, so a mutation would outlive the
     // request that made it and nothing would point back here.
     expect(Object.isFrozen(entries)).toBe(true);
     expect(Object.isFrozen(first)).toBe(true);
     expect(Object.isFrozen(first?.capabilities)).toBe(true);
+    expect(oauthEntry?.oauth).toBeDefined();
+    expect(credentialEntry?.credentials).toBeDefined();
+    expect(Object.isFrozen(oauthEntry?.oauth)).toBe(true);
+    expect(Object.isFrozen(credentialEntry?.credentials)).toBe(true);
+
+    expect(() => {
+      (oauthEntry?.oauth as { compatibility_mode?: string }).compatibility_mode = 'marketplace';
+    }).toThrow(TypeError);
+    expect(() => {
+      (credentialEntry?.credentials as { scheme: string }).scheme = 'basic';
+    }).toThrow(TypeError);
+    expect(oauthEntry?.oauth?.compatibility_mode).not.toBe('marketplace');
+    expect(credentialEntry?.credentials?.scheme).toBe('bearer');
   });
 
   it('does not serve the held catalog to a caller that named its own file', async () => {

--- a/packages/core/src/mcp-catalog/catalog.ts
+++ b/packages/core/src/mcp-catalog/catalog.ts
@@ -1,9 +1,9 @@
 /**
  * The catalog itself: the parsed contents of `curated.yaml`.
  *
- * The whole catalog is a few dozen entries of authored text, identical for
- * every caller and unchanged for the life of the process. So it is parsed once
- * and held, and every read is served from there.
+ * The whole catalog is a bounded set of authored text, identical for every
+ * caller and unchanged for the life of the process. So it is parsed once on
+ * first use and held, and every later read is served from there.
  *
  * Narrowing lives in `query.ts`, which has no filesystem in it and so can be
  * imported from the browser bundle that now does the narrowing.
@@ -32,6 +32,8 @@ let loaded: Promise<readonly MCPCatalogEntry[]> | null = null;
  */
 function freezeEntry(entry: MCPCatalogEntry): MCPCatalogEntry {
   Object.freeze(entry.capabilities);
+  if (entry.oauth) Object.freeze(entry.oauth);
+  if (entry.credentials) Object.freeze(entry.credentials);
   return Object.freeze(entry);
 }
 

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -341,6 +341,23 @@ ${block}
     );
   });
 
+  it('refuses dcr_mode: disabled with no client_id, which can never start a flow', () => {
+    // Registration off and no client stated leaves the flow with no client ID
+    // to send, and `startOAuthFlow` throws on exactly that pair. Caught here it
+    // is a diff a reviewer can fix; caught there it is a per-user dead end.
+    expect(() => parseCuratedCatalog(withOAuth('      dcr_mode: disabled'))).toThrow(
+      CuratedCatalogError
+    );
+  });
+
+  it.each(['advertised', 'fallback'] as const)(
+    'accepts dcr_mode: %s with no client_id, because registration mints one',
+    (dcrMode) => {
+      const [entry] = parseCuratedCatalog(withOAuth(`      dcr_mode: ${dcrMode}`));
+      expect(entry.oauth).toEqual({ dcr_mode: dcrMode });
+    }
+  );
+
   it('leaves the block absent when an entry states nothing', () => {
     const [entry] = parseCuratedCatalog(VALID_ENTRY);
     expect(entry.oauth).toBeUndefined();

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -351,12 +351,20 @@ ${block}
   });
 
   it.each(['advertised', 'fallback'] as const)(
-    'accepts dcr_mode: %s with no client_id, because registration mints one',
+    'accepts dcr_mode: %s with no client_id, because registration can supply one',
     (dcrMode) => {
       const [entry] = parseCuratedCatalog(withOAuth(`      dcr_mode: ${dcrMode}`));
       expect(entry.oauth).toEqual({ dcr_mode: dcrMode });
     }
   );
+
+  it('accepts dcr_mode: disabled with the client_id it requires', () => {
+    const [entry] = parseCuratedCatalog(
+      withOAuth(`      client_id: public-client-123
+      dcr_mode: disabled`)
+    );
+    expect(entry.oauth).toEqual({ client_id: 'public-client-123', dcr_mode: 'disabled' });
+  });
 
   it('leaves the block absent when an entry states nothing', () => {
     const [entry] = parseCuratedCatalog(VALID_ENTRY);

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -71,8 +71,8 @@ const catalogEntryOAuthSchema = z
     message: 'must state at least one setting, or be omitted entirely',
   })
   // `disabled` is the one mode that has to bring its own client. The other two
-  // reach a registration endpoint and mint one, so an absent `client_id` there
-  // is the ordinary case; with registration off, nothing else can supply it and
+  // allow registration to supply one, so an absent `client_id` there is the
+  // ordinary case; with registration off, nothing else can supply it and
   // `startOAuthFlow` refuses the pair. That refusal lands per-user at sign-in,
   // long after the entry was reviewed, which is the wrong place to learn that a
   // combination could never have worked.

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -51,9 +51,9 @@ const httpUrl = z.url().refine((value) => /^https?:\/\//i.test(value), {
  * is pasting a whole OAuth client configuration into an entry, and the
  * dangerous halves of one — `client_secret`, `token_url`, `authorization_url` —
  * are exactly the keys someone would reach for. Under `.strict()` any of them
- * fails the load loudly at review time and at daemon start, rather than being
- * dropped in silence: a published client secret that nobody was told about is
- * strictly worse than a catalog that will not parse. See
+ * fails the load loudly at review time and on the first catalog read, rather
+ * than being dropped in silence: a published client secret that nobody was
+ * told about is strictly worse than a catalog that will not parse. See
  * {@link MCPCatalogEntryOAuth} for why each accepted key is accepted.
  */
 const catalogEntryOAuthSchema = z

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -69,6 +69,15 @@ const catalogEntryOAuthSchema = z
   // it all", and there should be exactly one way to say that.
   .refine((value) => Object.values(value).some((field) => field !== undefined), {
     message: 'must state at least one setting, or be omitted entirely',
+  })
+  // `disabled` is the one mode that has to bring its own client. The other two
+  // reach a registration endpoint and mint one, so an absent `client_id` there
+  // is the ordinary case; with registration off, nothing else can supply it and
+  // `startOAuthFlow` refuses the pair. That refusal lands per-user at sign-in,
+  // long after the entry was reviewed, which is the wrong place to learn that a
+  // combination could never have worked.
+  .refine((value) => value.dcr_mode !== 'disabled' || value.client_id !== undefined, {
+    message: 'must state a client_id when dcr_mode is disabled, since nothing else can supply one',
   });
 
 const catalogEntryCredentialsSchema = z

--- a/packages/core/src/mcp-catalog/query.test.ts
+++ b/packages/core/src/mcp-catalog/query.test.ts
@@ -210,9 +210,8 @@ describe('filterCatalog A–Z over the shipped catalog', () => {
   });
 
   it('puts Airtable before Exa, whose identifiers order the other way', async () => {
-    // `ai.exa/exa` sorts first of all 50 by identifier and 17th by display name;
-    // `com.airtable/mcp` is 4th by identifier and 1st by display name. This is
-    // the case reported from the marketplace.
+    // The identifiers sort Exa before Airtable, while the display names sort
+    // Airtable before Exa. This is the case reported from the marketplace.
     const sorted = filterCatalog(await loadCatalog(), { sort: 'name' });
     const position = (name: string) => sorted.findIndex((entry) => entry.name === name);
 

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -266,8 +266,8 @@ const GENERIC_CATALOG_NAME_LABELS = new Set(['mcp', 'mcp-server', 'server', 'api
  *
  * Shared because both sides of the wire need this and disagreed: the catalog
  * UI derived the publisher while connect took the last path segment, so the
- * server name the agent saw was the word "mcp" for 38 of 50 entries. One rule,
- * two formattings — never two rules.
+ * server name the agent saw was often the word "mcp". One rule, two
+ * formattings — never two rules.
  *
  * The publisher identifies the server only while every name is hand-reviewed.
  * `io.github.<user>/<repo>` inverts it — every server one GitHub user publishes
@@ -336,10 +336,11 @@ export type MCPCatalogSort = 'popularity' | 'name';
 /**
  * What the Marketplace narrows the catalog by.
  *
- * These are exactly the toolbar's controls. The catalog is a few dozen frozen
- * objects the browser already holds, so applying them is a pass over an array,
- * not a request — which is why there is no `limit`/`offset` here: paging a list
- * you hold is a `slice`, and it is the grid's business rather than a filter's.
+ * These are exactly the toolbar's controls. The catalog is a bounded set of
+ * frozen objects the browser already holds, so applying them is a pass over an
+ * array, not a request — which is why there is no `limit`/`offset` here: paging
+ * a list you hold is a `slice`, and it is the grid's business rather than a
+ * filter's.
  */
 export interface MCPCatalogFilters {
   /** Case-insensitive substring match over name, title, and description. */


### PR DESCRIPTION
Post-#2377 follow-ups, reconciled with the current Marketplace implementation and the merged session handoff/notice work. Changes that current `main` already owns were dropped rather than duplicated.

## Retained scope

### Catalog schema and cache integrity

- Reject catalog OAuth entries that set `dcr_mode: disabled` without a `client_id`; with registration disabled, no later step can supply a client.
- Apply the invariant through the shared schema for both published and unpublished entries.
- Deep-freeze catalog entries, including nested `oauth`, `credentials`, and capability objects, so the lazy-loaded cache cannot be mutated into an invalid state.

### Marketplace OAuth and credential policy

- Document the bounded catalog-managed Marketplace compatibility profile that applies only while an install remains a canonical match for the current static catalog entry.
- Keep explicit **Strict** and **Legacy** saved-row overrides authoritative during catalog reconnect/reconciliation. Strict remains narrow; Legacy is an explicit, deliberately broader operator override. Invalid persisted values are not preserved.
- Document strict fallback for removed/edited/drifted entries, the current unsupported-provider removals, and explicit per-entry strict prescriptions.
- Describe API-key Connect using the public `bearer_token` request field, the durable generation claim before the authenticated probe, owner-scoped credential rotation, and pinned/no-redirect probes.
- Describe safe reuse of compatible per-user OAuth credentials without changing the peer row's provenance or lifecycle.
- Describe current handoff behavior: successful open/key/reused-OAuth connects stage the starter prompt; a fresh OAuth grant lands in the new session with the dismissible disconnected notice and requires user-activated sign-in from the MCP control.
- Correct authorization and catalog comments for lazy first-read loading and the authenticated catalog install policy.

### Session MCP accessibility and recovery

- Use native, accurately named controls for the MCP disclosure, sign-in/refresh pill, and admin Edit action.
- Expose `aria-haspopup`, `aria-expanded`, and `aria-controls`; use dialog rather than tooltip semantics for the interactive popup.
- Support Escape dismissal, outside-pointer dismissal, keyboard focus, and trigger focus restoration without React `act` warnings.
- Keep the disconnected notice dismissible while adding status/live-region semantics and ensuring the advertised MCP control remains available when Tools is unpinned.
- Move edit-modal ownership above the conditionally rendered disclosure. AntD's body-portaled modal remains usable for field/button interaction, closes independently, and restores focus to the MCP trigger after Cancel or Escape.

## Validation

Re-run after rebasing onto current `origin/main` (`d957dead`, including #2494 and #2495):

- Core MCP catalog: **126 passed** (4 files)
- Daemon catalog/connect/compatibility/authorization: **226 passed** (6 files)
- UI MCP/footer/modal: **42 passed** (4 files)
- Biome on the affected implementation/tests: passed
- Core/client standard type checks: passed
- Daemon/UI source-mode type checks: passed (local package `dist` artifacts were not rebuilt)
- Managed Chromium/Puppeteer: real body-portal field/button interaction, Cancel/Escape focus restoration, disclosure Escape/outside dismissal, popup semantics, and disconnected-notice semantics passed
- Commit hooks: passed

Remote required checks passed on the force-with-lease updated PR head (`e5973e01`). Expected non-main publish/integration jobs were skipped.
