### PR TITLE
fix(daemon): default-deny the realtime publisher

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -93,6 +93,7 @@ import { deepFreezeClone } from './utils/deep-freeze.js';
 import { ensureOpenSourceTelemetryEnvEnabledConfig } from './utils/open-source-telemetry-config.js';
 import { shouldEmitOpenSourceTelemetryDaemonActive } from './utils/open-source-telemetry-heartbeat.js';
 import { startOpenSourceTelemetryUsageSummaryInterval } from './utils/open-source-telemetry-usage.js';
+import { assertRealtimePublishPolicyCoverage } from './utils/realtime-publish-policy.js';
 import { resolveSandboxProtectedDataRoots } from './utils/sandbox-context.js';
 import { configureDaemonUrl, configureExecutor } from './utils/spawn-executor.js';
 import { configureUploadStagingStoreFromConfig } from './utils/upload-staging.js';
@@ -870,6 +871,15 @@ async function startDaemonWithOwnedMetrics(
     sessionEnvSelectionsService: services.sessionEnvSelectionsService,
     terminalsService: services.terminalsService,
   });
+
+  // --------------------------------------------------------------------------
+  // Phase 3.5: Every registered service must have declared its realtime
+  // audience. Undeclared services publish to nobody, which is the safe failure
+  // but an invisible one — so refuse to boot rather than let realtime for a new
+  // service quietly do nothing. Deterministic: it reads the registration table,
+  // not request data.
+  // --------------------------------------------------------------------------
+  assertRealtimePublishPolicyCoverage(app);
 
   // --------------------------------------------------------------------------
   // Phase 4: Startup (orphan cleanup, health, scheduler, listen, shutdown)

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -667,6 +667,66 @@ export function protectFilesystemHomeWrite(context: HookContext, config: AgorCon
 }
 
 /**
+ * Strip the owner-only fields from one user row. Pure.
+ *
+ * `agentic_tools_public_values` is decrypted plaintext that `rowToUser` fills
+ * in ONLY when `requesterId === row.user_id` (`services/users.ts`). The
+ * contract on `AGENTIC_TOOLS_PUBLIC_FIELDS` is explicit that it goes to the
+ * field's owner and to nobody else — not even to an admin reading someone
+ * else's profile — because a base URL can name an internal host.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: hook results are untyped payloads
+function redactUserOwnerOnlyFields(user: any): any {
+  if (!user || typeof user !== 'object' || user.agentic_tools_public_values === undefined) {
+    return user;
+  }
+  const { agentic_tools_public_values: _ownerOnly, ...rest } = user;
+  return rest;
+}
+
+/** Apply the user redaction to whatever shape the payload arrived in. */
+// biome-ignore lint/suspicious/noExplicitAny: hook results are untyped payloads
+function redactUserPayload(result: any): any {
+  if (Array.isArray(result)) return result.map(redactUserOwnerOnlyFields);
+  if (result?.data && Array.isArray(result.data)) {
+    return { ...result, data: result.data.map(redactUserOwnerOnlyFields) };
+  }
+  if (result?.user_id) return redactUserOwnerOnlyFields(result);
+  return result;
+}
+
+/**
+ * Keep owner-only user fields out of the realtime broadcast.
+ *
+ * `users` is a tenant-wide fan-out path — `useAgorData` keeps the whole
+ * directory current so any row can be named in attribution — and Feathers
+ * dispatches `context.dispatch ?? context.result`. Without this hook a
+ * SELF-patch satisfies `requesterId === row.user_id`, so the result carries
+ * decrypted `agentic_tools_public_values`, and that object is what every other
+ * socket in the tenant receives. `GET /users/:id` by those same users returns
+ * the field as `undefined`, so the socket was handing over precisely what the
+ * REST path withholds.
+ *
+ * Same split as `redactMCPServerSecretFields`: `context.result` is the CALLER's
+ * copy and stays intact, because the caller is the owner and legitimately asked
+ * for their own value. `context.dispatch` is by definition everyone else, so
+ * redacting it is unconditional.
+ *
+ * Keyed off `context.event` so it only fires for the methods Feathers actually
+ * broadcasts (`created`/`updated`/`patched`/`removed`; `null` for find/get) —
+ * leaving find/get alone keeps the owner's own reads working.
+ *
+ * Module scope rather than a closure inside `registerHooks` so tests can drive
+ * the real hook instead of reproducing its body.
+ */
+export const redactUserOwnerOnlyFieldsForBroadcast = async (context: HookContext) => {
+  if (context.event) {
+    context.dispatch = redactUserPayload(context.result);
+  }
+  return context;
+};
+
+/**
  * Redact every MCP server row in a service payload, whatever shape it arrived
  * in. Pure — callers decide what to do with the copy.
  */
@@ -2374,6 +2434,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [requireMinimumRole(ROLES.ADMIN, 'delete users')],
     },
     after: {
+      // Registered on `all`, not a method list: Feathers composes
+      // `collectedAll.after` outermost, so this gets the LAST word on
+      // `context.dispatch` after the avatar hooks have run. It is also what
+      // keeps this from drifting the way the mcp-servers redaction did when it
+      // was pinned to a method list that omitted `remove` (#2374) — the hook
+      // itself no-ops on find/get by keying off `context.event`.
+      all: [redactUserOwnerOnlyFieldsForBroadcast],
       // Refresh derived profile presentation after user creation or update.
       create: [
         async (context: HookContext) => {

--- a/apps/agor-daemon/src/register-hooks.users-broadcast-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.users-broadcast-redaction.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from 'node:fs';
+import { feathers } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { redactUserOwnerOnlyFieldsForBroadcast } from './register-hooks';
+
+/**
+ * `users` is a tenant-wide realtime fan-out path, and `rowToUser` decides one
+ * of its fields PER REQUESTER: `agentic_tools_public_values` holds decrypted
+ * plaintext and is populated only when `requesterId === row.user_id`
+ * (`services/users.ts`). A self-patch satisfies that, so without redaction the
+ * `patched` broadcast hands every other socket in the tenant a value that
+ * `GET /users/:id` deliberately returns as `undefined` for them.
+ *
+ * These drive the real hook through real Feathers hook composition and the
+ * real transport payload rule, so a change to any of the three fails here.
+ */
+
+const OWNER_ONLY = {
+  'claude-code': { ANTHROPIC_BASE_URL: 'https://llm.internal.corp.example/v1' },
+};
+
+const ownerRow = () => ({
+  user_id: 'u-owner',
+  email: 'owner@example.com',
+  name: 'Owner',
+  agentic_tools_public_values: structuredClone(OWNER_ONLY),
+});
+
+/**
+ * What a socket other than the caller actually receives. Mirrors
+ * `getDispatcher` in `@feathersjs/transport-commons`: `channel.dataFor()`, then
+ * `context.dispatch`, then `context.result`.
+ */
+function broadcastPayload(context: Partial<HookContext>): unknown {
+  return context.dispatch !== undefined ? context.dispatch : context.result;
+}
+
+describe('users owner-only field redaction', () => {
+  it('keeps the decrypted value in the result the caller gets', async () => {
+    const context = { event: 'patched', result: ownerRow() } as unknown as HookContext;
+
+    await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+    // The caller IS the owner — they asked for their own value and keep it.
+    expect((context.result as Record<string, unknown>).agentic_tools_public_values).toEqual(
+      OWNER_ONLY
+    );
+  });
+
+  it('strips the decrypted value from what every other socket receives', async () => {
+    const context = { event: 'patched', result: ownerRow() } as unknown as HookContext;
+
+    await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+    const broadcast = broadcastPayload(context) as Record<string, unknown>;
+    expect(broadcast).not.toHaveProperty('agentic_tools_public_values');
+    expect(JSON.stringify(broadcast)).not.toContain('llm.internal.corp.example');
+    // Redaction must not gut the directory entry the broadcast exists to carry.
+    expect(broadcast.user_id).toBe('u-owner');
+    expect(broadcast.email).toBe('owner@example.com');
+    expect(broadcast.name).toBe('Owner');
+  });
+
+  it.each(['created', 'updated', 'patched', 'removed'])(
+    'redacts the %s broadcast, not just patched',
+    async (event) => {
+      const context = { event, result: ownerRow() } as unknown as HookContext;
+
+      await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+      expect(broadcastPayload(context)).not.toHaveProperty('agentic_tools_public_values');
+    }
+  );
+
+  it('leaves find/get alone so the owner can still read their own value', async () => {
+    // `context.event` is null for find/get — those broadcast nothing, and a
+    // redacted dispatch there would only strip the value out of the owner's own
+    // socket reads.
+    const context = { event: null, result: ownerRow() } as unknown as HookContext;
+
+    await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+    expect(context.dispatch).toBeUndefined();
+    expect((context.result as Record<string, unknown>).agentic_tools_public_values).toEqual(
+      OWNER_ONLY
+    );
+  });
+
+  it.each([
+    ['a list result', () => [ownerRow(), ownerRow()]],
+    ['a paginated result', () => ({ total: 2, data: [ownerRow(), ownerRow()] })],
+  ])('redacts %s', async (_label, build) => {
+    const context = { event: 'patched', result: build() } as unknown as HookContext;
+
+    await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+    expect(JSON.stringify(broadcastPayload(context))).not.toContain('llm.internal.corp.example');
+  });
+
+  it('passes through a row that never had the field', async () => {
+    const context = {
+      event: 'patched',
+      result: { user_id: 'u-other', email: 'other@example.com' },
+    } as unknown as HookContext;
+
+    await redactUserOwnerOnlyFieldsForBroadcast(context);
+
+    expect(broadcastPayload(context)).toEqual({
+      user_id: 'u-other',
+      email: 'other@example.com',
+    });
+  });
+});
+
+describe('users redaction under real Feathers hook composition', () => {
+  /**
+   * The hook body being right is not enough — it has to actually run, last,
+   * on the event-emitting methods. This stands up a real Feathers app with the
+   * real hook registered the way `registerHooks` registers it (`after.all`,
+   * alongside a method-specific `after.patch` standing in for the avatar hook)
+   * and reads the context off the service event emit — the same
+   * `(data, context)` pair `@feathersjs/transport-commons` hands the publisher.
+   */
+  async function patchThroughRealFeathers() {
+    const app = feathers();
+    let broadcast: unknown;
+
+    app.use('users', {
+      async patch(_id: string, _data: unknown) {
+        // Stands in for rowToUser with requesterId === row.user_id.
+        return ownerRow();
+      },
+    } as never);
+
+    app.service('users').hooks({
+      after: {
+        all: [redactUserOwnerOnlyFieldsForBroadcast],
+        // Listed after `all` in source order but composed INNER by Feathers,
+        // so this must not be able to reinstate the field on the broadcast.
+        patch: [
+          (context: HookContext) => {
+            (context.result as Record<string, unknown>).agentic_tools_public_values =
+              structuredClone(OWNER_ONLY);
+            return context;
+          },
+        ],
+      },
+    } as never);
+
+    app.service('users').on('patched', (_data: unknown, context: HookContext) => {
+      broadcast = broadcastPayload(context);
+    });
+
+    await app.service('users').patch('u-owner', { name: 'Owner' } as never);
+    return broadcast;
+  }
+
+  it('redacts the broadcast even when a later after-hook re-adds the field', async () => {
+    const published = await patchThroughRealFeathers();
+
+    expect(published).toBeDefined();
+    expect(published).not.toHaveProperty('agentic_tools_public_values');
+    expect(JSON.stringify(published)).not.toContain('llm.internal.corp.example');
+  });
+});
+
+describe('users redaction wiring', () => {
+  const source = readFileSync(new URL('./register-hooks.ts', import.meta.url), 'utf8');
+
+  it('registers the redaction on the users service', () => {
+    // Behaviour tests above cover the hook itself; this pins that it is
+    // actually attached, and attached to `all` rather than a method list —
+    // the omission that let mcp-servers `remove` broadcast unredacted (#2374).
+    const start = source.indexOf("app.service('users').hooks({");
+    expect(start, 'users hooks block not found').toBeGreaterThan(-1);
+    // Bound the block at the next service registration rather than the first
+    // `});`, which closes a nested hook long before the block ends.
+    const next = source.indexOf("app.service('", start + 1);
+    const block = source.slice(start, next > -1 ? next : undefined);
+    const afterBlock = block.slice(block.indexOf('after:'));
+    expect(afterBlock).toMatch(/all:\s*\[redactUserOwnerOnlyFieldsForBroadcast\]/);
+  });
+});

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  assertRealtimePublishPolicyCoverage,
+  isRealtimePublishAllowed,
+  NON_SERVICE_REGISTERED_PATHS,
+  REALTIME_PUBLISH_POLICY,
+  RealtimePublishPolicyCoverageError,
+  realtimePublishPolicyFor,
+} from './realtime-publish-policy';
+
+const DAEMON_SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('realtimePublishPolicyFor', () => {
+  it('denies a path that was never declared', () => {
+    expect(realtimePublishPolicyFor('some-brand-new-service')).toBeUndefined();
+    expect(isRealtimePublishAllowed('some-brand-new-service')).toBe(false);
+  });
+
+  it('denies a missing path rather than treating it as unscoped', () => {
+    expect(isRealtimePublishAllowed(undefined)).toBe(false);
+    expect(isRealtimePublishAllowed(null)).toBe(false);
+    expect(isRealtimePublishAllowed('')).toBe(false);
+  });
+
+  it('resolves a declared path with or without the leading slash Feathers strips', () => {
+    expect(realtimePublishPolicyFor('sessions')?.audience).toBe('branch-or-session');
+    expect(realtimePublishPolicyFor('/sessions')?.audience).toBe('branch-or-session');
+    expect(realtimePublishPolicyFor('/kb/documents')?.audience).toBe('knowledge');
+  });
+
+  it('treats an explicit none declaration as not allowed', () => {
+    expect(realtimePublishPolicyFor('mcp-catalog/connect')?.audience).toBe('none');
+    expect(isRealtimePublishAllowed('mcp-catalog/connect')).toBe(false);
+  });
+
+  it('requires every entry to explain itself', () => {
+    for (const [path, policy] of Object.entries(REALTIME_PUBLISH_POLICY)) {
+      expect(policy.why.length, `${path} has no rationale`).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('assertRealtimePublishPolicyCoverage', () => {
+  it('accepts an app whose services are all declared', () => {
+    const app = { services: { sessions: {}, 'mcp-catalog/connect': {}, '/branches': {} } };
+    expect(() => assertRealtimePublishPolicyCoverage(app)).not.toThrow();
+  });
+
+  it('throws and names every undeclared service', () => {
+    const app = { services: { sessions: {}, 'shiny-new-thing': {}, 'another-one': {} } };
+    let error: unknown;
+    try {
+      assertRealtimePublishPolicyCoverage(app);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(RealtimePublishPolicyCoverageError);
+    expect((error as RealtimePublishPolicyCoverageError).missingPaths).toEqual([
+      'another-one',
+      'shiny-new-thing',
+    ]);
+    expect((error as Error).message).toContain('shiny-new-thing');
+  });
+
+  it('ignores the Express mounts that are not services', () => {
+    const app = {
+      services: Object.fromEntries([...NON_SERVICE_REGISTERED_PATHS].map((p) => [p, {}])),
+    };
+    expect(() => assertRealtimePublishPolicyCoverage(app)).not.toThrow();
+  });
+});
+
+/**
+ * The startup assertion is authoritative but only fires for services that are
+ * actually registered, so a flag-gated service could reach production before
+ * anyone boots with its flag on. This scan reads the source instead, so a
+ * missing declaration fails in CI at the pull request that adds it.
+ *
+ * It over-matches by design (Express middleware mounts look like service
+ * registrations), which is why `NON_SERVICE_REGISTERED_PATHS` and the literals
+ * below exist — an entry there is a deliberate "this is not a service", not a
+ * silencer.
+ */
+describe('source scan: every registered path is declared', () => {
+  /** String literals that reach a registration call site but are not paths. */
+  const NOT_A_PATH = new Set([
+    '10mb', // express.json({ limit: '10mb' })
+    'application/csp-report', // express.json({ type: … })
+    'gz', // expressStaticGzip extension
+    'index.html', // static-assets fallback
+    'string', // a typeof comparison
+  ]);
+
+  const REGISTRATION_CALL =
+    /(?:\bapp\.use|\brouteApp\.use|\bctx\.app\.use|registerAuthenticatedRoute|registerLongAuthenticatedRoute|registerAuthenticatedRouteBase)\(/;
+
+  function registeredPathsInSource(): Map<string, string> {
+    const files = execFileSync(
+      'grep',
+      [
+        '-rlE',
+        'app\\.use\\(|registerAuthenticatedRoute|registerLongAuthenticatedRoute',
+        DAEMON_SRC,
+        '--include=*.ts',
+      ],
+      { encoding: 'utf8' }
+    )
+      .trim()
+      .split('\n')
+      .filter((file) => file && !file.endsWith('.test.ts'));
+
+    const found = new Map<string, string>();
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, index) => {
+        const start = line.search(REGISTRATION_CALL);
+        if (start < 0) return;
+        // The path is the first string literal of the call. It sits on the same
+        // line for `app.use('/x', …)` and a line or two down for the multi-line
+        // `registerAuthenticatedRoute(\n  app,\n  '/x',` form.
+        const window = [line.slice(start), ...lines.slice(index + 1, index + 5)].join('\n');
+        const literal = window.match(/['"]([^'"\n]*)['"]/);
+        if (!literal) return;
+        const path = literal[1].replace(/^\/+/, '').replace(/\/+$/, '');
+        if (!found.has(path)) found.set(path, `${relative(DAEMON_SRC, file)}:${index + 1}`);
+      });
+    }
+    return found;
+  }
+
+  it('finds the registration call sites at all', () => {
+    // Guards the scan itself: a refactor that renames the helpers would
+    // otherwise turn this whole describe into a silent pass.
+    const found = registeredPathsInSource();
+    expect(found.has('sessions')).toBe(true);
+    expect(found.has('mcp-catalog/connect')).toBe(true);
+    expect(found.size).toBeGreaterThan(100);
+  });
+
+  it('declares a realtime audience for each one', () => {
+    const undeclared: string[] = [];
+    for (const [path, where] of registeredPathsInSource()) {
+      if (NOT_A_PATH.has(path)) continue;
+      if (NON_SERVICE_REGISTERED_PATHS.has(path)) continue;
+      if (path.includes('${')) continue; // interpolated mount, e.g. the UI path
+      if (!realtimePublishPolicyFor(path)) undeclared.push(`${path} (${where})`);
+    }
+    expect(undeclared).toEqual([]);
+  });
+
+  it('has no declaration for a path that is no longer registered', () => {
+    // Catches a typo in a policy key, which the runtime assertion cannot see:
+    // a key that matches nothing silently leaves the real path denied.
+    const registered = new Set(registeredPathsInSource().keys());
+    const stale = Object.keys(REALTIME_PUBLISH_POLICY).filter((path) => !registered.has(path));
+    expect(stale).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.test.ts
@@ -95,18 +95,46 @@ describe('source scan: every registered path is declared', () => {
     'string', // a typeof comparison
   ]);
 
-  const REGISTRATION_CALL =
-    /(?:\bapp\.use|\brouteApp\.use|\bctx\.app\.use|registerAuthenticatedRoute|registerLongAuthenticatedRoute|registerAuthenticatedRouteBase)\(/;
+  /**
+   * Match on the CALL, never on the receiver.
+   *
+   * `.use(` catches `app.use`, `routeApp.use`, `ctx.app.use`, `this.app.use`,
+   * `feathersApp.use`, `(app as any).use` and anything else a future helper
+   * names its Feathers application — including one built on the generic
+   * `app.use(path, service)` inside `registerAuthenticatedRoute`
+   * (`utils/authorization.ts`). Anchoring on a list of receiver identifiers
+   * made a registration through any other name invisible to this scan, and if
+   * such a service were also flag-gated the startup assertion would not see it
+   * either.
+   *
+   * `\.use\(\s*['"\`]` requires a string literal to open the argument list,
+   * which drops `app.use(cors(...))`-style middleware without a path while
+   * keeping every path-first registration.
+   */
+  const REGISTRATION_CALL = /\.use\(\s*['"`]|\bregister\w*AuthenticatedRoute\w*\(|\.use\($/;
+
+  /** Extract every registered path from one file's source. Pure, so it can be driven against a fixture. */
+  function extractRegisteredPaths(source: string): Array<{ path: string; line: number }> {
+    const lines = source.split('\n');
+    const found: Array<{ path: string; line: number }> = [];
+    lines.forEach((line, index) => {
+      const start = line.search(REGISTRATION_CALL);
+      if (start < 0) return;
+      // The path is the first string literal of the call. It sits on the same
+      // line for `app.use('/x', …)` and a line or two down for the multi-line
+      // `registerAuthenticatedRoute(\n  app,\n  '/x',` form.
+      const window = [line.slice(start), ...lines.slice(index + 1, index + 5)].join('\n');
+      const literal = window.match(/['"]([^'"\n]*)['"]/);
+      if (!literal) return;
+      found.push({ path: literal[1].replace(/^\/+/, '').replace(/\/+$/, ''), line: index + 1 });
+    });
+    return found;
+  }
 
   function registeredPathsInSource(): Map<string, string> {
     const files = execFileSync(
       'grep',
-      [
-        '-rlE',
-        'app\\.use\\(|registerAuthenticatedRoute|registerLongAuthenticatedRoute',
-        DAEMON_SRC,
-        '--include=*.ts',
-      ],
+      ['-rlE', '\\.use\\(|register\\w*AuthenticatedRoute', DAEMON_SRC, '--include=*.ts'],
       { encoding: 'utf8' }
     )
       .trim()
@@ -115,22 +143,50 @@ describe('source scan: every registered path is declared', () => {
 
     const found = new Map<string, string>();
     for (const file of files) {
-      const lines = readFileSync(file, 'utf8').split('\n');
-      lines.forEach((line, index) => {
-        const start = line.search(REGISTRATION_CALL);
-        if (start < 0) return;
-        // The path is the first string literal of the call. It sits on the same
-        // line for `app.use('/x', …)` and a line or two down for the multi-line
-        // `registerAuthenticatedRoute(\n  app,\n  '/x',` form.
-        const window = [line.slice(start), ...lines.slice(index + 1, index + 5)].join('\n');
-        const literal = window.match(/['"]([^'"\n]*)['"]/);
-        if (!literal) return;
-        const path = literal[1].replace(/^\/+/, '').replace(/\/+$/, '');
-        if (!found.has(path)) found.set(path, `${relative(DAEMON_SRC, file)}:${index + 1}`);
-      });
+      for (const { path, line } of extractRegisteredPaths(readFileSync(file, 'utf8'))) {
+        if (!found.has(path)) found.set(path, `${relative(DAEMON_SRC, file)}:${line}`);
+      }
     }
     return found;
   }
+
+  it('catches a registration through any receiver, not just `app`', () => {
+    // The whole point of matching on `.use(` rather than a list of receiver
+    // names. Each of these is a real Feathers service registration that the
+    // receiver-anchored matcher missed; a flag-gated one would then have been
+    // invisible to BOTH this scan and the startup assertion.
+    const fixture = [
+      "  feathersApp.use('/renamed-receiver', svc);",
+      "  (app as any).use('/cast-receiver', svc);",
+      "  this.app.use('/this-receiver', svc);",
+      "  server.app.use('/nested-receiver', svc);",
+      '  someApp.use(',
+      "    '/multiline-receiver',",
+      '    svc',
+      '  );',
+      "  registerLongAuthenticatedRoute(app, '/long-route', svc);",
+    ].join('\n');
+
+    expect(extractRegisteredPaths(fixture).map((entry) => entry.path)).toEqual([
+      'renamed-receiver',
+      'cast-receiver',
+      'this-receiver',
+      'nested-receiver',
+      'multiline-receiver',
+      'long-route',
+    ]);
+  });
+
+  it('ignores middleware mounted without a path', () => {
+    // `.use(` alone would sweep these in and force junk into the ignore lists.
+    const fixture = [
+      '  app.use(cors({ origin: true }));',
+      '  app.use(express.json({ limit: someLimit }));',
+      '  app.use(createDynamicCompressionMiddleware() as never);',
+    ].join('\n');
+
+    expect(extractRegisteredPaths(fixture)).toEqual([]);
+  });
 
   it('finds the registration call sites at all', () => {
     // Guards the scan itself: a refactor that renames the helpers would

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -152,7 +152,7 @@ export const REALTIME_PUBLISH_POLICY = {
   repos: { audience: 'tenant', why: 'useAgorData and App.tsx track repo rows and clone progress.' },
   users: {
     audience: 'tenant',
-    why: 'useAgorData keeps the user directory current for attribution.',
+    why: 'useAgorData keeps the user directory current for attribution. rowToUser computes agentic_tools_public_values PER REQUESTER (decrypted plaintext, owner only), so redactUserOwnerOnlyFieldsForBroadcast strips it from context.dispatch — the audience is tenant-wide, so the payload must carry nothing the row owner alone may see.',
   },
   'mcp-servers': {
     audience: 'tenant',

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -1,0 +1,471 @@
+/**
+ * The allowlist that decides which services may fan out over the socket at all.
+ *
+ * Feathers' default is the opposite of what a multi-tenant product wants. The
+ * app-level publisher registered by `configureRealtimePublish` is the LAST
+ * fallback in `@feathersjs/transport-commons`' precedence chain, so it runs for
+ * EVERY service that emits an event — including the dozens of RPC-shaped custom
+ * routes (`sessions/:id/fork`, `repos/clone`, `mcp-catalog/connect`, …) whose
+ * authors never thought of themselves as publishing anything. A `create()` on
+ * one of those emits `created` with its response body, and before this file
+ * that body went to the whole tenant unless somebody remembered to write
+ * `.publish(() => [])`.
+ *
+ * That default produced two real leaks: `mcp-catalog/connect` broadcasting a
+ * `{ mcp_server, session }` pair whose server row can carry the caller's API
+ * key, and `mcp-servers` `remove` broadcasting an unredacted row. Both were
+ * fixed one at a time. The class is fixed here: a path with no entry below
+ * reaches NOBODY.
+ *
+ * Two rules keep it that way:
+ *
+ *  1. `realtimePublishPolicyFor` returns `undefined` for an unlisted path and
+ *     the publisher suppresses the event — locally and on the Redis relay.
+ *  2. `assertRealtimePublishPolicyCoverage` runs at startup over the services
+ *     actually registered on the app and throws if any of them is missing.
+ *     So the safe outcome (silence) is automatic, and the DANGEROUS outcome —
+ *     realtime quietly not working because a developer forgot the entry — is a
+ *     boot failure with the path in the message, not a bug report.
+ *
+ * Adding a service therefore means adding a line here. Choosing `'none'` is a
+ * perfectly good answer and is the right one for anything RPC-shaped; the point
+ * is that somebody had to write it down.
+ */
+
+/**
+ * Who may receive an event from a service.
+ *
+ * The branch-flavoured audiences differ only in where the branch id is read
+ * from; all of them resolve to "connections whose user currently holds at least
+ * `view` on that branch" when branch RBAC is on, and to the tenant channel when
+ * it is off (there is no visibility model to enforce in that mode).
+ */
+export type RealtimePublishAudience =
+  /** No realtime fan-out at all. Not relayed to other replicas either. */
+  | 'none'
+  /** Every authenticated connection in the event's tenant. */
+  | 'tenant'
+  /** Branch-scoped; branch id read from the row (`branch_id`), or `context.id`. */
+  | 'branch'
+  /** Branch-scoped; branch id read from `params.route.id` of a `/branches/:id/…` route. */
+  | 'branch-route'
+  /** Branch-scoped; branch id read from the row, else resolved via its `session_id`. */
+  | 'branch-or-session'
+  /** Branch-scoped when a branch/session/task/message is attached, tenant-wide when not. */
+  | 'branch-optional'
+  /** Branch-scoped when the artifact has a branch, else its creator + admins, else service-only. */
+  | 'artifact'
+  /** Per-document / per-namespace reader set, resolved by `knowledge-realtime-publish`. */
+  | 'knowledge';
+
+export type RealtimePublishPolicy = {
+  audience: RealtimePublishAudience;
+  /**
+   * Why this audience. For a fan-out audience, name the consumer that breaks
+   * without it; for `'none'`, say what makes silence correct. Reviewers read
+   * this column, so "no consumer" is a real answer and "unknown" is not.
+   */
+  why: string;
+};
+
+const NO_CONSUMER = 'RPC-shaped route: the caller reads the response, nobody subscribes.';
+
+/**
+ * Every Feathers service path registered by the daemon, and who hears its
+ * events. Keys are normalized paths (no leading slash), exactly as Feathers
+ * reports them in `context.path`.
+ */
+export const REALTIME_PUBLISH_POLICY = {
+  // ---------------------------------------------------------------------------
+  // Session-scoped resources. `useAgorData` / `useMessages` / `SessionPanel`
+  // drive the whole live transcript off these, and the executor's private
+  // control events (`tasks termination_requested`, `messages
+  // permission_resolved`) ride the same two paths before scope resolution.
+  // ---------------------------------------------------------------------------
+  sessions: {
+    audience: 'branch-or-session',
+    why: 'useAgorData + BranchModal SessionsTab track session rows live.',
+  },
+  tasks: {
+    audience: 'branch-or-session',
+    why: 'SessionPanel (queued/patched/removed) and useTaskCompletionChime; also carries the executor control + streaming events.',
+  },
+  messages: {
+    audience: 'branch-or-session',
+    why: 'useMessages renders the transcript from these; also carries streaming chunks and permission_resolved.',
+  },
+  'session-mcp-servers': {
+    audience: 'branch-or-session',
+    why: 'useAgorData tracks per-session MCP attachment.',
+  },
+  'session-env-selections': {
+    audience: 'branch-or-session',
+    why: 'No browser subscriber today, but the row is session-scoped and was already scoped here; kept so a consumer can be added without a security decision.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Branch-scoped resources.
+  // ---------------------------------------------------------------------------
+  branches: {
+    audience: 'branch',
+    why: 'useAgorData, BoardBranchList, EnvironmentTab and App.tsx all track branch rows; health-monitor also listens in-process.',
+  },
+  schedules: {
+    audience: 'branch',
+    why: 'BranchModal ScheduleTab lists schedules live.',
+  },
+  'branches/:id/owners': {
+    audience: 'branch-route',
+    why: 'BoardTeammatePanel refetches owners on created/removed — owner edits never patch the branch row, so this is its only signal.',
+  },
+  'branches/:id/group-grants': {
+    audience: 'branch-route',
+    why: 'Grant rows carry no secret and were already branch-scoped; kept so the permissions UI can subscribe without re-deciding the audience.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Board-attached resources that may or may not hang off a branch.
+  // ---------------------------------------------------------------------------
+  'board-objects': {
+    audience: 'branch-optional',
+    why: 'useAgorData and BoardBranchList track card/zone placement live.',
+  },
+  'board-comments': {
+    audience: 'branch-optional',
+    why: 'useAgorData renders comment threads live.',
+  },
+  artifacts: {
+    audience: 'artifact',
+    why: 'useAgorData and ArtifactFullscreenPage track artifact rows and the agor-query runtime request.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Tenant-wide catalogs. These rows are already visible to any authenticated
+  // member through an unscoped `find`, so the event adds no reach.
+  // ---------------------------------------------------------------------------
+  boards: {
+    audience: 'tenant',
+    why: 'useAgorData tracks boards and board-object mutations emitted as boards.patched.',
+  },
+  cards: { audience: 'tenant', why: 'useAgorData tracks cards.' },
+  'card-types': { audience: 'tenant', why: 'useAgorData tracks card type definitions.' },
+  repos: { audience: 'tenant', why: 'useAgorData and App.tsx track repo rows and clone progress.' },
+  users: {
+    audience: 'tenant',
+    why: 'useAgorData keeps the user directory current for attribution.',
+  },
+  'mcp-servers': {
+    audience: 'tenant',
+    why: 'useAgorData tracks server rows. Secrets are stripped from context.dispatch unconditionally by redactMCPServerSecretFields — the audience is tenant-wide, so the payload must never carry credentials.',
+  },
+  'gateway-channels': {
+    audience: 'tenant',
+    why: 'useAgorData tracks Slack/GitHub channel config.',
+  },
+  'agentic-tool-settings': {
+    audience: 'tenant',
+    why: 'useAgorData upserts tenant tool settings from created/patched.',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Knowledge base. Audience is the per-document / per-namespace reader set
+  // computed by `resolveKnowledgeRealtimeUserIds`, which owns these paths
+  // wholesale — including suppressing `created` on the three search/edit/reindex
+  // paths. Listed individually so a new kb/* service still has to declare itself.
+  // ---------------------------------------------------------------------------
+  'kb/documents': { audience: 'knowledge', why: 'Readers of the document.' },
+  'kb/namespaces': { audience: 'knowledge', why: 'Users holding a permission on the namespace.' },
+  'kb/versions': { audience: 'knowledge', why: 'Readers of the document the version belongs to.' },
+  'kb/graph': { audience: 'knowledge', why: 'Readers of the documents the edge connects.' },
+  'kb/settings': { audience: 'knowledge', why: 'Knowledge admins only.' },
+  'kb/indexing/status': { audience: 'knowledge', why: 'Knowledge admins only.' },
+  'kb/search': {
+    audience: 'knowledge',
+    why: 'created is suppressed outright — a query result is per-caller.',
+  },
+  'kb/document-edits': { audience: 'knowledge', why: 'created is suppressed outright.' },
+  'kb/indexing/reindex': { audience: 'knowledge', why: 'created is suppressed outright.' },
+
+  // ---------------------------------------------------------------------------
+  // Silent: services that already opted out with their own `.publish(() => [])`.
+  // Their service-level publisher wins over the app-level one, so these entries
+  // are documentation plus coverage — but they must agree with the code.
+  // ---------------------------------------------------------------------------
+  'session-streams': {
+    audience: 'none',
+    why: 'Subscription control plane. Joining a room must not tell the tenant who is watching what.',
+  },
+  'messages/streaming': {
+    audience: 'none',
+    why: 'Executor ingest for message chunks; the fan-out is the messages service.',
+  },
+  'tasks/streaming': {
+    audience: 'none',
+    why: 'Executor ingest for task chunks; the fan-out is the tasks service.',
+  },
+  'gateway-channels/test': {
+    audience: 'none',
+    why: 'Connectivity probe result belongs to the caller.',
+  },
+  'gateway-channels/app-info': { audience: 'none', why: 'Probe result belongs to the caller.' },
+  'opencode-auth': { audience: 'none', why: 'Credential control plane.' },
+  'opencode-models': { audience: 'none', why: 'Per-caller model list.' },
+
+  // ---------------------------------------------------------------------------
+  // Silent: authentication and credential control planes. These are the paths
+  // whose results must never reach a second connection under any circumstance;
+  // most are also named in REDIS_FEATHERS_DENIED_PATHS as a second barrier.
+  // ---------------------------------------------------------------------------
+  authentication: { audience: 'none', why: 'Issues the caller a JWT.' },
+  'authentication/refresh': { audience: 'none', why: 'Issues the caller a JWT.' },
+  'authentication/impersonate': { audience: 'none', why: 'Issues a JWT for another identity.' },
+  'auth/launch': { audience: 'none', why: 'Exchanges a launch token for a session.' },
+  'check-auth': { audience: 'none', why: 'Echoes back the API key it was asked to validate.' },
+  'config/resolve-api-key': { audience: 'none', why: 'Returns a provider API key.' },
+  'api/v1/user/api-keys': { audience: 'none', why: 'Returns a freshly minted user API key.' },
+  terminals: {
+    audience: 'none',
+    why: 'Shell control plane; output rides native terminal:* socket packets.',
+  },
+  'codex-auth/device': { audience: 'none', why: 'OAuth device flow for one caller.' },
+  'codex-auth/import': {
+    audience: 'none',
+    why: 'Imports Codex credentials belonging to the caller.',
+  },
+  'codex-auth/logout': { audience: 'none', why: 'Credential control plane.' },
+  'mcp-servers/oauth-start': { audience: 'none', why: 'OAuth control plane.' },
+  'mcp-servers/oauth-callback': {
+    audience: 'none',
+    why: 'OAuth redirect handler (Express middleware, listed defensively).',
+  },
+  'mcp-servers/oauth-complete': {
+    audience: 'none',
+    why: 'OAuth control plane; completion is signalled by the native oauth:completed packet.',
+  },
+  'mcp-servers/oauth-disconnect': {
+    audience: 'none',
+    why: 'Signalled by the native oauth:disconnected packet.',
+  },
+  'mcp-servers/oauth-status': { audience: 'none', why: 'Per-user token status.' },
+  'mcp-servers/oauth-attempt-status': {
+    audience: 'none',
+    why: 'Per-attempt status polled by the initiating tab.',
+  },
+  'mcp-servers/oauth-auth-headers': { audience: 'none', why: 'Returns bearer headers.' },
+  'mcp-servers/oauth-refresh': { audience: 'none', why: 'Returns refreshed tokens.' },
+  'mcp-servers/test-oauth': { audience: 'none', why: 'Probe result belongs to the caller.' },
+  'mcp-servers/test-jwt': { audience: 'none', why: 'Probe result belongs to the caller.' },
+  'mcp-servers/discover': {
+    audience: 'none',
+    why: 'Capability probe run with credentials belonging to the caller; its result is per-caller.',
+  },
+  'mcp-catalog/connect': {
+    audience: 'none',
+    why: 'Returns { mcp_server, session } where an api-key entry carries a credential belonging to the caller. This is the leak that motivated the allowlist.',
+  },
+  'mcp-catalog': { audience: 'none', why: 'find/get only — a static curated catalog, no events.' },
+  'mcp-member-policy': { audience: 'none', why: 'Policy read for the caller.' },
+
+  // ---------------------------------------------------------------------------
+  // Silent: CRUD services with no realtime consumer. Denying costs nothing
+  // today; a future consumer flips the entry deliberately.
+  // ---------------------------------------------------------------------------
+  groups: { audience: 'none', why: 'Group admin UI refetches; no socket subscriber.' },
+  'group-memberships': { audience: 'none', why: 'Group admin UI refetches; no socket subscriber.' },
+  'agentic-tool-presets': { audience: 'none', why: 'Read-mostly presets; no socket subscriber.' },
+  templates: { audience: 'none', why: 'Static template list.' },
+  leaderboard: { audience: 'none', why: 'Analytics rollup, polled.' },
+  'thread-session-map': { audience: 'none', why: 'Gateway-internal thread bookkeeping.' },
+  gateway: { audience: 'none', why: 'Inbound/outbound message routing; no socket subscriber.' },
+  file: { audience: 'none', why: 'Reads a file out of a branch worktree for the caller.' },
+  files: { audience: 'none', why: 'Lists files for the caller.' },
+  'claude-models': { audience: 'none', why: 'Per-caller model list.' },
+  'copilot-models': { audience: 'none', why: 'Per-caller model list.' },
+  'cursor-models': { audience: 'none', why: 'Per-caller model list.' },
+  health: { audience: 'none', why: 'Liveness probe.' },
+  'boards/:id/owners': {
+    audience: 'none',
+    why: 'Board owner edits; the panel refetches, no subscriber.',
+  },
+  'boards/:id/group-grants': {
+    audience: 'none',
+    why: 'Board grant edits; the panel refetches, no subscriber.',
+  },
+  'boards/:id/aligned-branches': { audience: 'none', why: 'Query route.' },
+  'branches/:id/effective-access': { audience: 'none', why: 'Query route.' },
+  'branches/:id/fs-access-users': { audience: 'none', why: 'Query route.' },
+  'me/artifact-trust-grants': { audience: 'none', why: 'Trust grants belonging to the caller.' },
+
+  // ---------------------------------------------------------------------------
+  // Silent: RPC routes. Each of these emits `created`/`patched` carrying its own
+  // response body purely because Feathers treats every `app.use` as a service.
+  // Their durable effects reach the UI through the CRUD service they mutate
+  // (a fork emits `sessions created`; a start emits `branches patched`).
+  // ---------------------------------------------------------------------------
+  'sessions/:id/fork': {
+    audience: 'none',
+    why: `${NO_CONSUMER} The new session arrives as sessions.created.`,
+  },
+  'sessions/:id/spawn': {
+    audience: 'none',
+    why: `${NO_CONSUMER} The new session arrives as sessions.created.`,
+  },
+  'sessions/:id/prompt': {
+    audience: 'none',
+    why: `${NO_CONSUMER} The task arrives as tasks.created/queued.`,
+  },
+  'sessions/:id/spawn-prompt': { audience: 'none', why: NO_CONSUMER },
+  'sessions/:id/stop': { audience: 'none', why: `${NO_CONSUMER} Stop lands as tasks.patched.` },
+  'sessions/:id/archive': { audience: 'none', why: `${NO_CONSUMER} Lands as sessions.patched.` },
+  'sessions/:id/unarchive': { audience: 'none', why: `${NO_CONSUMER} Lands as sessions.patched.` },
+  'sessions/:id/genealogy': { audience: 'none', why: NO_CONSUMER },
+  'sessions/:id/env-selections': {
+    audience: 'none',
+    why: `${NO_CONSUMER} Lands as session-env-selections.`,
+  },
+  'sessions/:id/mcp-servers': {
+    audience: 'none',
+    why: `${NO_CONSUMER} Lands as session-mcp-servers.`,
+  },
+  'sessions/:id/permission-decision': {
+    audience: 'none',
+    why: 'The decision reaches the executor as messages.permission_resolved on its private task room.',
+  },
+  'sessions/:id/restart-cli': { audience: 'none', why: NO_CONSUMER },
+  'sessions/:id/tasks/queue': { audience: 'none', why: `${NO_CONSUMER} Lands as tasks.queued.` },
+  'tasks/:id/run': { audience: 'none', why: `${NO_CONSUMER} Lands as tasks.patched.` },
+  'tasks/:id/complete': { audience: 'none', why: `${NO_CONSUMER} Lands as tasks.patched.` },
+  'tasks/:id/fail': { audience: 'none', why: `${NO_CONSUMER} Lands as tasks.patched.` },
+  'branches/:id/start': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.patched.` },
+  'branches/:id/stop': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.patched.` },
+  'branches/:id/restart': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.patched.` },
+  'branches/:id/nuke': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.patched.` },
+  'branches/:id/health': { audience: 'none', why: NO_CONSUMER },
+  'branches/:id/render-environment': {
+    audience: 'none',
+    why: 'Renders the environment template, which can interpolate secrets.',
+  },
+  'branches/logs': {
+    audience: 'none',
+    why: 'Environment logs can contain secrets echoed by a dev server.',
+  },
+  'branches/:id/archive-or-delete': {
+    audience: 'none',
+    why: `${NO_CONSUMER} Lands as branches.patched/removed.`,
+  },
+  'branches/:id/unarchive': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.patched.` },
+  'branches/:id/execute-schedule-now': { audience: 'none', why: NO_CONSUMER },
+  'branches/:id/fire-zone-trigger': { audience: 'none', why: NO_CONSUMER },
+  'schedules/:id/run-now': { audience: 'none', why: `${NO_CONSUMER} Lands as schedules.patched.` },
+  'boards/:id/archive': { audience: 'none', why: `${NO_CONSUMER} Lands as boards.patched.` },
+  'boards/:id/unarchive': { audience: 'none', why: `${NO_CONSUMER} Lands as boards.patched.` },
+  'boards/:id/sessions': { audience: 'none', why: NO_CONSUMER },
+  'board-comments/:id/reply': {
+    audience: 'none',
+    why: `${NO_CONSUMER} Lands as board-comments.created.`,
+  },
+  'board-comments/:id/toggle-reaction': {
+    audience: 'none',
+    why: `${NO_CONSUMER} Lands as board-comments.patched.`,
+  },
+  'repos/local': { audience: 'none', why: `${NO_CONSUMER} Lands as repos.created.` },
+  'repos/clone': { audience: 'none', why: `${NO_CONSUMER} Clone URLs can embed credentials.` },
+  'repos/:id/branches': { audience: 'none', why: `${NO_CONSUMER} Lands as branches.created.` },
+  'repos/:id/branches/:name': { audience: 'none', why: NO_CONSUMER },
+  'repos/:id/import-agor-yml': { audience: 'none', why: NO_CONSUMER },
+  'repos/:id/export-agor-yml': { audience: 'none', why: NO_CONSUMER },
+  'artifacts/:id/payload': { audience: 'none', why: `${NO_CONSUMER} Lands as artifacts.patched.` },
+  'artifacts/:id/console': {
+    audience: 'none',
+    why: 'Artifact console output is fetched by the viewing tab.',
+  },
+  'artifacts/:id/sandpack-error': { audience: 'none', why: NO_CONSUMER },
+  'artifacts/:id/runtime-response/:requestId': {
+    audience: 'none',
+    why: 'The DOM answer goes back to the one agent that asked, in-process.',
+  },
+  'artifacts/:id/trust': { audience: 'none', why: `${NO_CONSUMER} Lands as artifacts.patched.` },
+  'widgets/:id/submit': {
+    audience: 'none',
+    why: 'Widget input is deliberately kept out of broadcast.',
+  },
+  'widgets/:id/dismiss': {
+    audience: 'none',
+    why: 'Widget input is deliberately kept out of broadcast.',
+  },
+} as const satisfies Record<string, RealtimePublishPolicy>;
+
+export type RealtimePublishPolicyPath = keyof typeof REALTIME_PUBLISH_POLICY;
+
+const POLICY: ReadonlyMap<string, RealtimePublishPolicy> = new Map(
+  Object.entries(REALTIME_PUBLISH_POLICY as Record<string, RealtimePublishPolicy>)
+);
+
+/**
+ * Normalize a Feathers path for lookup. Feathers strips slashes when it
+ * registers a service, but `emitServiceEvent` call sites and the Redis relay
+ * envelope both carry a hand-written string, so normalize on both sides rather
+ * than trusting them to match.
+ */
+export function normalizeRealtimePublishPath(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * The declared policy for a path, or `undefined` when the path was never
+ * declared. `undefined` means DENY — callers must not treat it as "no opinion".
+ */
+export function realtimePublishPolicyFor(
+  path: string | null | undefined
+): RealtimePublishPolicy | undefined {
+  if (!path) return undefined;
+  return POLICY.get(normalizeRealtimePublishPath(path));
+}
+
+/** Convenience for the publisher's gate. */
+export function isRealtimePublishAllowed(path: string | null | undefined): boolean {
+  const policy = realtimePublishPolicyFor(path);
+  return policy !== undefined && policy.audience !== 'none';
+}
+
+/**
+ * Paths that are registered on the Feathers app but are Express middleware
+ * rather than services, so they never emit an event and never reach the
+ * publisher. They are listed so the source-scan coverage test can tell
+ * "deliberately not a service" apart from "somebody forgot".
+ */
+export const NON_SERVICE_REGISTERED_PATHS: ReadonlySet<string> = new Set([
+  '', // SPA fallback
+  'static', // express.static
+]);
+
+export class RealtimePublishPolicyCoverageError extends Error {
+  constructor(public readonly missingPaths: string[]) {
+    super(
+      `Realtime publish policy is missing an entry for: ${missingPaths.join(', ')}.\n` +
+        `Every Feathers service must declare who may receive its events in ` +
+        `apps/agor-daemon/src/utils/realtime-publish-policy.ts. Events from an ` +
+        `undeclared service are suppressed, so realtime for it would silently ` +
+        `do nothing. Add { audience: 'none', why: '…' } if that is what you want.`
+    );
+    this.name = 'RealtimePublishPolicyCoverageError';
+  }
+}
+
+type ServiceRegistry = { services?: Record<string, unknown> };
+
+/**
+ * Throw unless every service registered on `app` has declared an audience.
+ *
+ * Called once at startup after all three registration phases. Deterministic —
+ * it reads the registration table, not request data — so a deployment that
+ * boots in CI boots in production.
+ */
+export function assertRealtimePublishPolicyCoverage(app: unknown): void {
+  const registered = Object.keys((app as ServiceRegistry).services ?? {});
+  const missing = registered
+    .map(normalizeRealtimePublishPath)
+    .filter((path) => !POLICY.has(path) && !NON_SERVICE_REGISTERED_PATHS.has(path))
+    .sort();
+  if (missing.length > 0) throw new RealtimePublishPolicyCoverageError(missing);
+}

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -26,6 +26,7 @@ import {
   REDIS_FEATHERS_DENIED_PATHS,
   setBranchRemovalRealtimeVisibility,
 } from './realtime-publish';
+import { isRealtimePublishAllowed, realtimePublishPolicyFor } from './realtime-publish-policy';
 
 class FakeChannel {
   constructor(public connections: unknown[]) {}
@@ -2265,5 +2266,337 @@ describe('leaveAllSessionStreamChannels', () => {
       ['session-stream:s1', connection],
       ['session-stream:s2', connection],
     ]);
+  });
+});
+
+/**
+ * The allowlist inverts Feathers' default: the app-level publisher runs for
+ * every service that has no publisher of its own, so a path nobody declared
+ * used to broadcast tenant-wide. These drive the real publisher rather than
+ * inspecting the policy table, so a table entry that the publisher does not
+ * actually honour still fails.
+ */
+describe('configureRealtimePublish default-deny allowlist', () => {
+  const allowlistApp = (connections: unknown[]) =>
+    makeApp(connections, { tasks: { get: vi.fn(async () => ({ session_id: 's1' })) } });
+
+  const rbacRepos = () =>
+    repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+
+  /** runPublish returns a channel, or an array of them, or [] for a denial. */
+  const delivered = (result: unknown): unknown[] => {
+    const channels = (Array.isArray(result) ? result : [result]) as (FakeChannel | undefined)[];
+    return [...new Set(channels.flatMap((channel) => channel?.connections ?? []))];
+  };
+
+  it('publishes an undeclared service to nobody, with branch RBAC off', async () => {
+    const app = allowlistApp([{ user: user('u1') }, { user: user('u2') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      ...repos({ branch: branch('b1'), permissions: {} }),
+    });
+
+    const result = await app.runPublish(
+      { branch_id: 'b1', secret: 'sk-live-leak' },
+      { path: 'a-service-nobody-declared', method: 'create', event: 'created', params: {} }
+    );
+
+    expect(delivered(result)).toEqual([]);
+  });
+
+  it('publishes an undeclared service to nobody, with branch RBAC on', async () => {
+    const app = allowlistApp([{ user: user('allowed') }, { user: user('denied') }]);
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...rbacRepos() });
+
+    const result = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'a-service-nobody-declared', method: 'create', event: 'created', params: {} }
+    );
+
+    expect(delivered(result)).toEqual([]);
+  });
+
+  it('publishes an undeclared service to nobody even on a service connection', async () => {
+    // Service accounts are the escape hatch every other suppression path keeps
+    // open. An undeclared path has none: nobody decided, so nobody hears it.
+    const executor = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = allowlistApp([executor, { user: user('u1') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      ...repos({ branch: branch('b1'), permissions: {} }),
+    });
+
+    const result = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'a-service-nobody-declared', method: 'patch', event: 'patched', params: {} }
+    );
+
+    expect(delivered(result)).toEqual([]);
+  });
+
+  it('suppresses an event with no path at all', async () => {
+    const app = allowlistApp([{ user: user('u1') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      ...repos({ branch: branch('b1'), permissions: {} }),
+    });
+
+    const result = await app.runPublish(
+      { branch_id: 'b1' },
+      { method: 'create', event: 'created' }
+    );
+
+    expect(delivered(result)).toEqual([]);
+  });
+
+  it.each([
+    // The RPC route that leaked a credential-bearing mcp_server row (PR #2451).
+    ['mcp-catalog/connect', { mcp_server: { api_key: 'sk-live-leak' }, session: {} }],
+    // The rest of the credential control plane, each of which emits `created`
+    // with its own response body purely because Feathers registers it.
+    ['config/resolve-api-key', { api_key: 'sk-live-leak' }],
+    ['api/v1/user/api-keys', { key: 'agor_pat_leak' }],
+    ['check-auth', { apiKey: 'sk-live-leak' }],
+    ['mcp-servers/oauth-auth-headers', { Authorization: 'Bearer leak' }],
+    ['mcp-servers/discover', { tools: [] }],
+    ['branches/logs', { logs: 'DATABASE_URL=postgres://user:pw@host/db' }],
+    ['repos/clone', { url: 'https://token@github.com/org/repo' }],
+    ['sessions/:id/fork', { session_id: 's1', branch_id: 'b1' }],
+    ['terminals', { terminal_id: 't1' }],
+  ])('publishes %s to nobody', async (path, data) => {
+    const app = allowlistApp([{ user: user('u1') }, { user: user('u2') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      ...repos({ branch: branch('b1'), permissions: {} }),
+    });
+
+    const result = await app.runPublish(data, {
+      path,
+      method: 'create',
+      event: 'created',
+      params: {},
+    });
+
+    expect(delivered(result)).toEqual([]);
+  });
+
+  it('keeps an undeclared event off the Redis relay', async () => {
+    // A denied path must not reach other replicas either — otherwise the leak
+    // just moves one hop and re-enters through the relay handler.
+    const relayed: unknown[] = [];
+    const app = allowlistApp([{ user: user('u1') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+      realtimeRelay: {
+        relay: (envelope) => relayed.push(envelope),
+        setRelayHandler: () => {},
+      },
+      ...repos({ branch: branch('b1'), permissions: {} }),
+    });
+
+    await app.runPublish(
+      { mcp_server: { api_key: 'sk-live-leak' } },
+      { path: 'mcp-catalog/connect', method: 'create', event: 'created', params: {} }
+    );
+    // A declared path on the same publisher still relays, so this asserts the
+    // gate rather than a relay that never fires.
+    await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'branches', method: 'patch', event: 'patched', params: {} }
+    );
+
+    expect(relayed).toHaveLength(1);
+    expect((relayed[0] as { path: string }).path).toBe('branches');
+  });
+
+  describe('declared services still reach their audience', () => {
+    // One case per declared fan-out path. Branch RBAC is ON and only `allowed`
+    // can see branch b1, so a path that silently fell back to a tenant-wide
+    // broadcast — or to nobody — fails here rather than passing by accident.
+    const branchScoped: Array<[string, Record<string, unknown>]> = [
+      ['sessions', { session_id: 's1' }],
+      ['tasks', { session_id: 's1' }],
+      ['messages', { session_id: 's1' }],
+      ['session-mcp-servers', { session_id: 's1' }],
+      ['session-env-selections', { session_id: 's1' }],
+      ['branches', { branch_id: 'b1' }],
+      ['schedules', { branch_id: 'b1' }],
+      ['board-objects', { branch_id: 'b1' }],
+      ['board-comments', { session_id: 's1' }],
+      ['artifacts', { branch_id: 'b1' }],
+    ];
+
+    it.each(branchScoped)('%s reaches the users who can see the branch', async (path, data) => {
+      const allowed = { user: user('allowed') };
+      const denied = { user: user('denied') };
+      const app = allowlistApp([allowed, denied]);
+      configureRealtimePublish({ app, branchRbacEnabled: true, ...rbacRepos() });
+
+      const result = await app.runPublish(data, {
+        path,
+        method: 'patch',
+        event: 'patched',
+        params: {},
+      });
+
+      expect(delivered(result)).toEqual([allowed]);
+    });
+
+    it('branches/:id/owners reaches the branch audience via the route id', async () => {
+      const allowed = { user: user('allowed') };
+      const denied = { user: user('denied') };
+      const app = allowlistApp([allowed, denied]);
+      configureRealtimePublish({ app, branchRbacEnabled: true, ...rbacRepos() });
+
+      // The payload is a bare User with no branch id — the route param is the
+      // only thing that can scope it.
+      const result = await app.runPublish(
+        { user_id: 'allowed' },
+        {
+          path: 'branches/:id/owners',
+          method: 'create',
+          event: 'created',
+          params: { route: { id: 'b1' } },
+        }
+      );
+
+      expect(delivered(result)).toEqual([allowed]);
+    });
+
+    it('branches/:id/group-grants reaches the branch audience via the route id', async () => {
+      const allowed = { user: user('allowed') };
+      const denied = { user: user('denied') };
+      const app = allowlistApp([allowed, denied]);
+      configureRealtimePublish({ app, branchRbacEnabled: true, ...rbacRepos() });
+
+      const result = await app.runPublish(
+        { group_id: 'g1' },
+        {
+          path: 'branches/:id/group-grants',
+          method: 'create',
+          event: 'created',
+          params: { route: { id: 'b1' } },
+        }
+      );
+
+      expect(delivered(result)).toEqual([allowed]);
+    });
+
+    it.each([
+      'boards',
+      'cards',
+      'card-types',
+      'repos',
+      'users',
+      'mcp-servers',
+      'gateway-channels',
+      'agentic-tool-settings',
+    ])('%s reaches the whole tenant', async (path) => {
+      const u1 = { user: user('u1') };
+      const u2 = { user: user('u2') };
+      const app = allowlistApp([u1, u2]);
+      configureRealtimePublish({
+        app,
+        branchRbacEnabled: true,
+        ...repos({ branch: branch('b1'), permissions: {} }),
+      });
+
+      const result = await app.runPublish(
+        { some_id: 'x1' },
+        { path, method: 'patch', event: 'patched', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([u1, u2]);
+    });
+
+    it('board-objects with no branch attachment still reaches the whole tenant', async () => {
+      const u1 = { user: user('u1') };
+      const u2 = { user: user('u2') };
+      const app = allowlistApp([u1, u2]);
+      configureRealtimePublish({ app, branchRbacEnabled: true, ...rbacRepos() });
+
+      const result = await app.runPublish(
+        { board_object_id: 'o1' },
+        { path: 'board-objects', method: 'patch', event: 'patched', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([u1, u2]);
+    });
+
+    it.each([
+      'kb/documents',
+      'kb/namespaces',
+      'kb/versions',
+      'kb/graph',
+      'kb/settings',
+      'kb/indexing/status',
+    ])('%s is routed to the Knowledge resolver, not to the tenant', async (path) => {
+      // Without a database the Knowledge resolver can authorize nobody, so it
+      // returns an empty reader set and only service connections receive. What
+      // matters here is that the path is neither denied outright nor allowed to
+      // fall through to the tenant-wide branch — the seeded dbTests above pin
+      // the real reader sets.
+      const service = { user: { _isServiceAccount: true, role: 'service' } };
+      const member = { user: user('u1') };
+      const app = allowlistApp([service, member]);
+      configureRealtimePublish({
+        app,
+        branchRbacEnabled: false,
+        ...repos({ branch: branch('b1'), permissions: {} }),
+      });
+
+      const result = await app.runPublish(
+        { document_id: 'd1' },
+        { path, method: 'patch', event: 'patched', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([service]);
+    });
+
+    it('still routes executor task control to the private room', async () => {
+      // tasks/messages carry the executor control events, which resolve before
+      // branch scoping. The gate must not swallow them.
+      const browser = { user: user('browser') };
+      const executor = { user: user('executor') };
+      const room = executorTaskChannelName('tenant-a', 'task-1');
+      const app = makeApp([browser, executor], {}, { [room]: [executor] });
+      configureRealtimePublish({
+        app,
+        branchRbacEnabled: false,
+        multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+        ...repos({ branch: branch('b1'), permissions: {} }),
+      });
+
+      const result = await app.runPublish(
+        { task_id: 'task-1', status: 'stopping' },
+        { path: 'tasks', method: 'patch', event: 'termination_requested', params: {} }
+      );
+
+      expect(delivered(result)).toEqual([executor]);
+    });
+  });
+
+  it('declares an audience for every path the publisher special-cases', () => {
+    // The publisher names these paths directly (streaming, executor control,
+    // Redis denial). If one were dropped from the policy the gate would deny it
+    // before that special case ever ran.
+    for (const path of ['messages', 'tasks', 'branches', 'artifacts', 'messages/streaming']) {
+      expect(realtimePublishPolicyFor(path), `${path} is not declared`).toBeDefined();
+    }
+    // Conversely, everything the Redis denylist protects must be denied here
+    // too — the allowlist is meant to be the stricter of the two.
+    for (const path of REDIS_FEATHERS_DENIED_PATHS) {
+      expect(isRealtimePublishAllowed(path), `${path} may publish`).toBe(false);
+    }
   });
 });

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -36,6 +36,11 @@ import {
   RealtimeAccessCache,
   type RealtimeAccessSessionRepository,
 } from './realtime-access-cache.js';
+import {
+  isRealtimePublishAllowed,
+  type RealtimePublishAudience,
+  realtimePublishPolicyFor,
+} from './realtime-publish-policy.js';
 
 export const BRANCH_REMOVAL_VISIBILITY_PARAM = '_agorRealtimeBranchRemovalVisibility';
 
@@ -236,15 +241,15 @@ type PublishScope =
   | { kind: 'users'; userIds: Set<string> }
   | { kind: 'serviceOnly' };
 
-const BRANCH_ID_SCOPED_PATHS = new Set(['branches', 'schedules']);
-const ROUTE_BRANCH_ID_SCOPED_PATHS = new Set(['branches/:id/owners', 'branches/:id/group-grants']);
-const SESSION_ID_SCOPED_PATHS = new Set([
-  'tasks',
-  'messages',
-  'session-mcp-servers',
-  'session-env-selections',
-]);
-const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
+/**
+ * The declared audience for a path, or `undefined` when it was never declared.
+ * `undefined` is a DENY here, not a default — see `realtime-publish-policy.ts`.
+ * Every scoping decision below reads from that one table so the audiences a
+ * reviewer sees listed are the audiences the publisher actually applies.
+ */
+function audienceFor(path: string | null | undefined): RealtimePublishAudience | undefined {
+  return realtimePublishPolicyFor(path)?.audience;
+}
 
 // Authentication and credential control-plane results must never enter shared
 // Redis, even if a future service accidentally enables publication for them.
@@ -340,7 +345,7 @@ function extractBranchId(data: unknown, context: PublishContext): string | undef
   const record = asRecord(data);
   const routeBranchId = (context.params as { route?: { id?: unknown } } | undefined)?.route?.id;
   if (
-    ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path ?? '') &&
+    audienceFor(context.path) === 'branch-route' &&
     typeof routeBranchId === 'string' &&
     routeBranchId.length > 0
   ) {
@@ -491,53 +496,53 @@ async function resolvePublishScope(
   context: PublishContext,
   accessCache: RealtimeAccessCache
 ): Promise<PublishScope> {
-  if (!context.path) return { kind: 'global' };
+  switch (audienceFor(context.path)) {
+    case 'branch':
+    case 'branch-route': {
+      const branchId = extractBranchId(data, context);
+      return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
+    }
 
-  if (BRANCH_ID_SCOPED_PATHS.has(context.path) || ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
-    const branchId = extractBranchId(data, context);
-    return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
+    case 'branch-or-session': {
+      // Hot session/message/task paths must carry branch_id or session_id —
+      // custom `sessions` events carry camelCase `sessionId` rather than the
+      // row's `branch_id`. Avoid message/task fallback lookups here so
+      // malformed streaming events fail closed instead of doing DB work per
+      // chunk.
+      const branchId = await resolveBranchIdFromBranchOrSession(data, context, accessCache);
+      return { kind: 'branch', branchId: branchId ?? null };
+    }
+
+    case 'branch-optional': {
+      const resolvedBranchId = await resolveBranchIdFromSessionTaskOrMessage(
+        data,
+        context,
+        accessCache
+      );
+      if (resolvedBranchId !== undefined) return { kind: 'branch', branchId: resolvedBranchId };
+
+      // These services can also emit global/card/board rows with no branch,
+      // session, task, or message attachment.
+      return { kind: 'global' };
+    }
+
+    case 'artifact': {
+      const branchId = extractBranchId(data, context);
+      if (branchId) return { kind: 'branch', branchId: branchId as BranchID };
+
+      // Null-branch artifacts are not covered by branch visibility. Keep
+      // delivery narrow to the creator/admins when the creator is known,
+      // otherwise service connections only.
+      const createdBy = extractCreatedBy(data);
+      return createdBy ? { kind: 'users', userIds: new Set([createdBy]) } : { kind: 'serviceOnly' };
+    }
+
+    // 'knowledge' never reaches here — resolveKnowledgeRealtimeUserIds answers
+    // for every `kb/*` path earlier in resolveDelivery. 'tenant' is the only
+    // remaining declared audience, and 'none'/undefined were denied at the gate.
+    default:
+      return { kind: 'global' };
   }
-
-  if (context.path === 'sessions') {
-    // Custom sessions events carry camelCase `sessionId` instead of the
-    // session row's `branch_id`.
-    const resolvedBranchId = await resolveBranchIdFromBranchOrSession(data, context, accessCache);
-    return { kind: 'branch', branchId: resolvedBranchId ?? null };
-  }
-
-  if (SESSION_ID_SCOPED_PATHS.has(context.path)) {
-    // Hot message/task paths must carry branch_id or session_id. Avoid
-    // message/task fallback lookups here so malformed streaming events fail
-    // closed instead of doing DB work per chunk.
-    const branchId = await resolveBranchIdFromBranchOrSession(data, context, accessCache);
-    return { kind: 'branch', branchId: branchId ?? null };
-  }
-
-  if (OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS.has(context.path)) {
-    const resolvedBranchId = await resolveBranchIdFromSessionTaskOrMessage(
-      data,
-      context,
-      accessCache
-    );
-    if (resolvedBranchId !== undefined) return { kind: 'branch', branchId: resolvedBranchId };
-
-    // These services can also emit global/card/board rows with no branch,
-    // session, task, or message attachment.
-    return { kind: 'global' };
-  }
-
-  if (context.path === 'artifacts') {
-    const branchId = extractBranchId(data, context);
-    if (branchId) return { kind: 'branch', branchId: branchId as BranchID };
-
-    // Null-branch artifacts are not covered by branch visibility. Keep delivery
-    // narrow to the creator/admins when the creator is known, otherwise service
-    // connections only.
-    const createdBy = extractCreatedBy(data);
-    return createdBy ? { kind: 'users', userIds: new Set([createdBy]) } : { kind: 'serviceOnly' };
-  }
-
-  return { kind: 'global' };
 }
 
 function filterToServiceConnections(authenticated: PublishChannel): PublishChannel {
@@ -739,11 +744,17 @@ function resolveRealtimeTenantId(
 /**
  * Register the single global Feathers publish handler.
  *
- * In open-access mode this preserves the legacy behavior: every authenticated
- * socket receives every service event. When branch RBAC is enabled, events for
- * branch/session-scoped resources are reduced to authenticated connections whose
- * user currently has at least `view` permission for the event's branch. Service
- * executor sockets remain trusted so prompt/permission plumbing keeps working.
+ * Nothing publishes unless `realtime-publish-policy.ts` says who may hear it.
+ * That gate runs first and is independent of branch RBAC: an undeclared path
+ * reaches nobody at all, service connections included, and never enters the
+ * Redis relay.
+ *
+ * For a path that IS declared, the audience is then narrowed as before. In
+ * open-access mode a declared service reaches every authenticated socket in the
+ * tenant. When branch RBAC is enabled, events for branch/session-scoped
+ * resources are reduced to authenticated connections whose user currently has
+ * at least `view` permission for the event's branch. Service executor sockets
+ * remain trusted so prompt/permission plumbing keeps working.
  */
 export function configureRealtimePublish(options: RealtimePublishOptions): void {
   const {
@@ -762,6 +773,15 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
   } = options;
 
   const resolveLocalDelivery = async (data: unknown, context: HookContext) => {
+    // Default-deny. Feathers routes EVERY service event that has no publisher
+    // of its own through this handler, so an undeclared path is one nobody
+    // decided about — including the RPC routes that emit their own response
+    // body as `created`. Suppressing here also keeps the event off the Redis
+    // relay below, because `tenantId` stays undefined.
+    if (!isRealtimePublishAllowed(context.path)) {
+      return { delivery: [] as PublishChannel[], tenantId: undefined };
+    }
+
     const authenticated = app.channel('authenticated');
     if (context.path && isKnowledgeRealtimeSuppressedEvent(context.path, context.event)) {
       return { delivery: authenticated.filter(() => false), tenantId: undefined };

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -496,7 +496,8 @@ async function resolvePublishScope(
   context: PublishContext,
   accessCache: RealtimeAccessCache
 ): Promise<PublishScope> {
-  switch (audienceFor(context.path)) {
+  const audience = audienceFor(context.path);
+  switch (audience) {
     case 'branch':
     case 'branch-route': {
       const branchId = extractBranchId(data, context);
@@ -537,12 +538,44 @@ async function resolvePublishScope(
       return createdBy ? { kind: 'users', userIds: new Set([createdBy]) } : { kind: 'serviceOnly' };
     }
 
-    // 'knowledge' never reaches here — resolveKnowledgeRealtimeUserIds answers
-    // for every `kb/*` path earlier in resolveDelivery. 'tenant' is the only
-    // remaining declared audience, and 'none'/undefined were denied at the gate.
-    default:
+    case 'tenant':
+    // 'knowledge' should not reach here — resolveKnowledgeRealtimeUserIds
+    // answers for every `kb/*` path earlier in resolveDelivery. It is listed
+    // explicitly anyway: if that call ever stops covering a kb path, the
+    // tenant channel is the same answer it had before, not a silent widening
+    // through a catch-all.
+    case 'knowledge':
       return { kind: 'global' };
+
+    case 'none':
+    case undefined:
+      // Unreachable: the gate in resolveLocalDelivery denied both before this
+      // ran. Answering serviceOnly rather than falling through keeps the two
+      // in agreement if the gate is ever moved.
+      return { kind: 'serviceOnly' };
+
+    default:
+      return unhandledAudienceScope(audience, context);
   }
+}
+
+/**
+ * Fail closed on an audience nobody wrote a case for.
+ *
+ * The `never` parameter is the real mechanism: adding a member to
+ * `RealtimePublishAudience` without a case above stops compiling, so
+ * `turbo run typecheck` catches it before anyone can ship it. This body is the
+ * belt to that braces — if the type is ever widened through a cast, delivery
+ * narrows to service connections instead of quietly reaching the whole tenant,
+ * which is the failure this whole file exists to prevent.
+ */
+function unhandledAudienceScope(audience: never, context: PublishContext): PublishScope {
+  console.warn('[realtime] Suppressing event with an unhandled publish audience', {
+    audience,
+    path: context.path,
+    event: context.event,
+  });
+  return { kind: 'serviceOnly' };
 }
 
 function filterToServiceConnections(authenticated: PublishChannel): PublishChannel {

--- a/apps/agor-daemon/src/utils/realtime-publish.unhandled-audience.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.unhandled-audience.test.ts
@@ -1,0 +1,171 @@
+import type { Branch, User } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RealtimeAccessBranchRepository,
+  RealtimeAccessSessionRepository,
+} from './realtime-access-cache';
+
+/**
+ * `RealtimePublishAudience` is an eight-member union and will grow. The
+ * compile-time guard against forgetting a case is the `never` parameter on
+ * `unhandledAudienceScope` — `turbo run typecheck` fails on a new member with
+ * no case, which is the primary protection and cannot be exercised at runtime.
+ *
+ * This is the runtime half: it simulates a future audience (say
+ * `'creator-only'`) that reached `resolvePublishScope` without a case — through
+ * a cast, a bad merge, or a policy table loaded from somewhere else — and pins
+ * that delivery narrows to service connections rather than widening to the
+ * whole tenant. In a file whose thesis is fail-closed, the residual branch has
+ * to fail closed too.
+ *
+ * The policy module is mocked rather than the real table edited, so the real
+ * table stays the single source of truth for every other test.
+ */
+vi.mock('./realtime-publish-policy', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./realtime-publish-policy')>();
+  const FUTURE_PATH = 'a-future-service';
+  return {
+    ...actual,
+    isRealtimePublishAllowed: (path: string | null | undefined) =>
+      path === FUTURE_PATH || actual.isRealtimePublishAllowed(path),
+    realtimePublishPolicyFor: (path: string | null | undefined) =>
+      path === FUTURE_PATH
+        ? // Deliberately not a member of the union — this is the shape of a
+          // member added to the type without a case in the switch.
+          ({ audience: 'creator-only', why: 'a future audience nobody handled' } as never)
+        : actual.realtimePublishPolicyFor(path),
+  };
+});
+
+const { configureRealtimePublish } = await import('./realtime-publish');
+
+class FakeChannel {
+  constructor(public connections: unknown[]) {}
+  get length() {
+    return this.connections.length;
+  }
+  filter(fn: (connection: unknown) => boolean) {
+    return new FakeChannel(this.connections.filter(fn));
+  }
+}
+
+function makeApp(connections: unknown[]) {
+  let publishFn: ((data: unknown, context: unknown) => unknown) | undefined;
+  const app = {
+    get channels() {
+      return ['authenticated'];
+    },
+    channel: vi.fn(() => new FakeChannel(connections)),
+    publish: vi.fn((fn) => {
+      publishFn = fn;
+    }),
+    emit: vi.fn(),
+    service: vi.fn(() => {
+      throw new Error('no services');
+    }),
+    async runPublish(data: unknown, context: Record<string, unknown>) {
+      if (!publishFn) throw new Error('publish not configured');
+      return await publishFn(data, { ...context, app });
+    },
+  } as any;
+  return app;
+}
+
+const user = (id: string, role = ROLES.MEMBER): User => ({ user_id: id, role }) as User;
+
+function repos() {
+  return {
+    branchRepository: {
+      findRealtimeVisibilityBranch: vi.fn(async () => ({ branch_id: 'b1' }) as Branch),
+      findExplicitViewUserIds: vi.fn(async () => []),
+    } as unknown as RealtimeAccessBranchRepository,
+    sessionsRepository: {
+      findBranchIdBySessionId: vi.fn(async () => null),
+      findCreatedByBySessionId: vi.fn(async () => null),
+    } as unknown as RealtimeAccessSessionRepository,
+  } as {
+    branchRepository: RealtimeAccessBranchRepository;
+    sessionsRepository: RealtimeAccessSessionRepository;
+  };
+}
+
+const delivered = (result: unknown): unknown[] => {
+  const channels = (Array.isArray(result) ? result : [result]) as (FakeChannel | undefined)[];
+  return [...new Set(channels.flatMap((channel) => channel?.connections ?? []))];
+};
+
+describe('resolvePublishScope residual audience', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('does not reach the tenant when an audience has no case', async () => {
+    const member = { user: user('u1') };
+    const other = { user: user('u2') };
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([member, other, service]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      ...(repos() as unknown as {
+        branchRepository: never;
+        sessionsRepository: never;
+      }),
+    });
+
+    const result = await app.runPublish(
+      { some_id: 'x1', secret: 'should-not-fan-out' },
+      { path: 'a-future-service', method: 'patch', event: 'patched', params: {} }
+    );
+
+    // Fails closed to service connections — NOT [member, other, service].
+    expect(delivered(result)).toEqual([service]);
+  });
+
+  it('warns so the unhandled audience is visible rather than silent', async () => {
+    const app = makeApp([{ user: user('u1') }]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      ...(repos() as unknown as {
+        branchRepository: never;
+        sessionsRepository: never;
+      }),
+    });
+
+    await app.runPublish(
+      { some_id: 'x1' },
+      { path: 'a-future-service', method: 'patch', event: 'patched', params: {} }
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      '[realtime] Suppressing event with an unhandled publish audience',
+      expect.objectContaining({ audience: 'creator-only', path: 'a-future-service' })
+    );
+  });
+
+  it('still resolves a declared audience normally through the same switch', async () => {
+    // Guards the mock: if the passthrough broke, the test above would pass for
+    // the wrong reason.
+    const member = { user: user('u1') };
+    const app = makeApp([member]);
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      ...(repos() as unknown as {
+        branchRepository: never;
+        sessionsRepository: never;
+      }),
+    });
+
+    const result = await app.runPublish(
+      { board_id: 'bd1' },
+      { path: 'boards', method: 'patch', event: 'patched', params: {} }
+    );
+
+    expect(delivered(result)).toEqual([member]);
+  });
+});


### PR DESCRIPTION
## The class of bug

The daemon's global publisher had no path allowlist. Feathers' app-level publisher is the **last** fallback in `@feathersjs/transport-commons`' precedence chain (service-event publisher → service ALL_EVENTS → app event → app ALL_EVENTS → no-op), so it ran for **every** service that emits an event and has no publisher of its own.

That includes the ~90 RPC-shaped custom routes registered via `app.use` / `registerAuthenticatedRoute`. Feathers treats each as a service, so a `create()` on `sessions/:id/fork`, `repos/clone`, `config/resolve-api-key` or `mcp-catalog/connect` emits `created` **carrying its own response body**, tenant-wide, unless somebody remembered to write `.publish(() => [])`.

Two real leaks came out of that default and were each fixed as an instance:

1. `mcp-catalog/connect` broadcasting `{ mcp_server, session }` whose api-key row carries the caller's credential (#2451 — **not yet on main**).
2. `mcp-servers` `remove` broadcasting an unredacted row (#2374, merged).

## What this does

**Inverts the default.** `apps/agor-daemon/src/utils/realtime-publish-policy.ts` declares an audience for all 126 registered service paths. `realtimePublishPolicyFor` returns `undefined` for anything else, and the publisher suppresses it — locally *and* on the Redis relay, **service connections included**. An undeclared path is one nobody decided about, so it gets no escape hatch.

The three ad-hoc scoping `Set`s in `realtime-publish.ts` (`BRANCH_ID_SCOPED_PATHS`, `ROUTE_BRANCH_ID_SCOPED_PATHS`, `SESSION_ID_SCOPED_PATHS`, `OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS`) are gone. Branch / route / session / artifact scoping now reads the same table, so the audiences a reviewer sees listed are the audiences the publisher actually applies — no parallel list to drift.

**Makes omission loud.** Silence is now the automatic outcome, so the failure that needs to be noisy is the other one: realtime quietly doing nothing because someone forgot the entry.

- `assertRealtimePublishPolicyCoverage(app)` runs at startup (new Phase 3.5, after all three registration phases) over `Object.keys(app.services)` and **refuses to boot**, naming the missing paths. Deterministic — it reads the registration table, not request data.
- A source-scan test covers the same ground at PR time, so a **flag-gated** service can't reach production undeclared (the runtime check only sees services whose flag is on). It also asserts the reverse: a policy key matching no real registration is a typo that would silently leave the real path denied.

## Audiences

| Audience | Paths |
|---|---|
| `branch-or-session` | `sessions`, `tasks`, `messages`, `session-mcp-servers`, `session-env-selections` |
| `branch` | `branches`, `schedules` |
| `branch-route` | `branches/:id/owners`, `branches/:id/group-grants` |
| `branch-optional` | `board-objects`, `board-comments` |
| `artifact` | `artifacts` |
| `tenant` | `boards`, `cards`, `card-types`, `repos`, `users`, `mcp-servers`, `gateway-channels`, `agentic-tool-settings` |
| `knowledge` | `kb/documents`, `kb/namespaces`, `kb/versions`, `kb/graph`, `kb/settings`, `kb/indexing/status`, `kb/search`, `kb/document-edits`, `kb/indexing/reindex` |
| `none` | the other 94 — every auth/credential control plane, every RPC route, and the CRUD services with no socket subscriber |

Every entry carries a `why` naming the consumer that breaks without it, or what makes silence correct. Behaviour for the fan-out paths is unchanged; the tightening is confined to paths with no consumer.

## Tests

- A service with no declaration emits to nobody — RBAC off, RBAC on, and on a service connection; plus a pathless event.
- Ten named leak-shaped paths (including `mcp-catalog/connect` with a credential in the payload) publish to nobody.
- A denied event stays off the Redis relay, asserted against a declared path on the same publisher that still relays.
- Every declared fan-out path is driven through the **real publisher** with branch RBAC on and a branch only one user can see, so a path that silently fell back to tenant-wide — or to nobody — fails. Executor task-control routing is re-asserted through the gate.
- `REDIS_FEATHERS_DENIED_PATHS` is cross-checked: everything Redis refuses is also denied here.

**Mutation-verified.** Neutering the gate fails 15 tests. Dropping one registry entry fails the coverage scan.

## Gate

Baseline taken on clean `main` (`5e5b141f`), compared after.

| | Baseline | After |
|---|---|---|
| `apps/agor-daemon` | 234 files / 2933 tests, 0 fail | **235 / 2988, 0 fail** |
| `packages/core` | 149 / 3606, 0 fail | 149 / 3606, 0 fail |
| `turbo run typecheck` | 22/22 | 22/22 |
| `biome check --error-on-warnings .` | 0 errors, 6 infos | 0 errors, 6 infos |
| `apps/agor-ui` | 3 fail | 5 fail |

Two notes, both **fails on THIS HOST**:

- `pnpm --filter @agor/core build` fails at the `tsc --emitDeclarationOnly` step on `dev-fixtures.ts` (`cloneRepo` / `createBranch` no longer exported from `git/exec`). **Pre-existing on main** — this branch touches no file in `packages/core`. `tsup` still emits `dist`, so downstream builds work.
- The UI failures are the known 15s-timeout flakes under parallel load. All 5 pass when re-run in isolation (`5 passed / 32 tests`), and this branch changes no UI code.

## Scope

Confined to the publishing layer: `realtime-publish.ts`, the new policy module and its test, and one call in `index.ts`. **`mcp-catalog-connect.ts` and the executor handlers are untouched** — `mcp-catalog/connect` is disarmed here by its `'none'` declaration, without editing the file another session is working in. When #2451 lands, its `.publish(() => [])` and this entry agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
