### PR TITLE
fix(mcp): restore marketplace OAuth compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Every release-version bump PR must include its finalized changelog section; a ve
 ### Fixes
 
 - **Local CLI inspection no longer requires login** — `agor open` and `agor version` now target the local deployment by default, retain `--local` as a compatibility alias, and use the connected deployment only with `--remote`. ([#2468](https://github.com/preset-io/agor/pull/2468))
+- **Curated marketplace OAuth works across reviewed provider variations** — marketplace installs use a bounded interoperability profile while preserving PKCE S256 and issuer/resource binding; explicit strict and legacy policies remain available. Compatibility is re-evaluated against the current curated endpoint and auth policy, so imported, removed, or edited installs fail closed. ([#2377](https://github.com/preset-io/agor/pull/2377))
+  - GitHub, MongoDB, Box, HubSpot, Slack, Prisma, PagerDuty, and Kagi are no longer advertised because the read-only OAuth audit could not reach a safely bound client-registration boundary. Existing saved rows are not deleted.
+  - Existing strict grants retain their binding. Moving an install into or out of marketplace compatibility invalidates the old grant and requires authorization again.
 
 ## 0.25.2 (2026-08-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Every release-version bump PR must include its finalized changelog section; a ve
 - **Curated marketplace OAuth works across reviewed provider variations** — marketplace installs use a bounded interoperability profile while preserving PKCE S256 and issuer/resource binding; explicit strict and legacy policies remain available. Compatibility is re-evaluated against the current curated endpoint and auth policy, so imported, removed, or edited installs fail closed. ([#2377](https://github.com/preset-io/agor/pull/2377))
   - GitHub, MongoDB, Box, HubSpot, Slack, Prisma, PagerDuty, and Kagi are no longer advertised because the read-only OAuth audit could not reach a safely bound client-registration boundary. Existing saved rows are not deleted.
   - Existing strict grants retain their binding. Moving an install into or out of marketplace compatibility invalidates the old grant and requires authorization again.
+  - Standalone SQLite callbacks now bind the saved server through provider exchange, and Settings shows catalog-managed Marketplace policy instead of labeling it Strict.
 
 ## 0.25.2 (2026-08-18)
 

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
@@ -1,0 +1,267 @@
+import {
+  createDatabaseAsync,
+  MCPServerRepository,
+  runMigrations,
+  type TenantScopeAwareDatabase,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { type Application, feathers } from '@agor/core/feathers';
+import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
+import type { MCPServerID, UserID } from '@agor/core/types';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from '../../register-hooks.js';
+import {
+  fingerprintMCPOAuthGrantConfiguration,
+  isMCPOAuthGrantBoundToServer,
+  type MCPOAuthResolvedGrantBinding,
+} from '../../services/mcp-oauth-grant-binding.js';
+import { createMCPServersService } from '../../services/mcp-servers.js';
+import { listAttachedMcpServers, registerMcpServerTools } from './mcp-servers.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+describe('MCP OAuth status through Feathers response hooks', () => {
+  let previousMasterSecret: string | undefined;
+  let rawDb: Awaited<ReturnType<typeof createDatabaseAsync>> | undefined;
+
+  beforeEach(() => {
+    previousMasterSecret = process.env.AGOR_MASTER_SECRET;
+    process.env.AGOR_MASTER_SECRET = 'b'.repeat(64);
+  });
+
+  afterEach(() => {
+    (rawDb as unknown as { $client?: { close(): void } } | undefined)?.$client?.close();
+    rawDb = undefined;
+    if (previousMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
+    else process.env.AGOR_MASTER_SECRET = previousMasterSecret;
+  });
+
+  it('reports a valid v4 grant in list, auth status, and attached summaries', async () => {
+    rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+    await runMigrations(rawDb);
+    const db = rawDb as unknown as TenantScopeAwareDatabase;
+    const user = await new UsersRepository(rawDb).create({
+      email: 'mcp-hook-oauth@example.com',
+      role: 'member',
+    });
+    const server = await new MCPServerRepository(rawDb).create({
+      name: 'mcp-hook-oauth',
+      display_name: 'MCP Hook OAuth',
+      transport: 'http',
+      url: 'https://resource.example.test/mcp',
+      scope: 'global',
+      source: 'user',
+      owner_user_id: user.user_id as UserID,
+      enabled: true,
+      headers: { 'X-Route': 'configured-route' },
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_compatibility_mode: 'strict',
+        oauth_client_id: 'configured-client',
+        oauth_client_secret: 'configured-client-secret',
+        oauth_access_token: 'configured-static-access',
+        oauth_refresh_token: 'configured-static-refresh',
+        oauth_token_expires_at: Date.now() + 7_200_000,
+      },
+    });
+    const resolved = {
+      resourceUri: server.url!,
+      metadataUrl: 'https://resource.example.test/.well-known/oauth-protected-resource',
+      issuer: 'https://auth.example.test',
+      authorizationEndpoint: 'https://auth.example.test/authorize',
+      tokenEndpoint: 'https://auth.example.test/token',
+      redirectUri: 'https://agor.example.test/mcp-servers/oauth-callback',
+      clientId: 'configured-client',
+      clientSecret: 'configured-client-secret',
+      compatibilityMode: 'strict',
+    } satisfies MCPOAuthResolvedGrantBinding;
+    const fingerprint = fingerprintMCPOAuthGrantConfiguration(
+      process.env.AGOR_MASTER_SECRET!,
+      server,
+      resolved,
+      4
+    );
+    await new UserMCPOAuthTokenRepository(rawDb).saveToken(
+      user.user_id as UserID,
+      server.mcp_server_id as MCPServerID,
+      {
+        accessToken: 'durable-grant-access',
+        refreshToken: 'durable-grant-refresh',
+        clientId: resolved.clientId,
+        clientSecret: resolved.clientSecret,
+        expiresAt: new Date(Date.now() + 3_600_000),
+        grantBinding: {
+          generation: 1,
+          version: 4,
+          fingerprint,
+          metadataUri: resolved.metadataUrl,
+          resourceUri: resolved.resourceUri,
+          issuer: resolved.issuer,
+          authorizationEndpoint: resolved.authorizationEndpoint,
+          tokenEndpoint: resolved.tokenEndpoint,
+          redirectUri: resolved.redirectUri,
+        },
+      }
+    );
+    const savedGrant = await new UserMCPOAuthTokenRepository(rawDb).getToken(
+      user.user_id as UserID,
+      server.mcp_server_id as MCPServerID
+    );
+    const savedServer = await new MCPServerRepository(rawDb).findById(server.mcp_server_id);
+    expect(savedGrant).not.toBeNull();
+    expect(savedServer).not.toBeNull();
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        process.env.AGOR_MASTER_SECRET!,
+        savedServer!,
+        savedGrant!,
+        'strict'
+      )
+    ).toBe(true);
+
+    const app = feathers() as Application;
+    (app as Application & { publish: (publisher: unknown) => Application }).publish = () => app;
+    app.use('mcp-servers', createMCPServersService(db));
+    const placeholderService = () => ({
+      async find() {
+        return [];
+      },
+      async get() {
+        return {};
+      },
+      async create(data: unknown) {
+        return data;
+      },
+      async update(_id: unknown, data: unknown) {
+        return data;
+      },
+      async patch(_id: unknown, data: unknown) {
+        return data;
+      },
+      async remove() {
+        return {};
+      },
+    });
+    // `registerHooks` wires the whole daemon and has a few intentionally
+    // mandatory services. They are inert here; only mcp-servers is exercised.
+    for (const path of [
+      'users',
+      'messages',
+      'repos',
+      'branches',
+      'sessions',
+      'leaderboard',
+      'schedules',
+      'tasks',
+    ]) {
+      app.use(path, placeholderService() as never);
+    }
+    registerHooks({
+      db,
+      app,
+      config: {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'default' },
+        execution: { branch_rbac: false, unix_user_mode: 'simple' },
+      } as RegisterHooksContext['config'],
+      jwtSecret: 'mcp-hook-integration-secret',
+      requireAuth: async (context) => context,
+      superadminOpts: { allowSuperadmin: false },
+      sessionsService: {} as RegisterHooksContext['sessionsService'],
+      messagesService: {} as RegisterHooksContext['messagesService'],
+      boardsService: undefined,
+      branchRepository: {} as RegisterHooksContext['branchRepository'],
+      usersRepository: {} as RegisterHooksContext['usersRepository'],
+      sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+      deployment: { mode: 'standalone' } as RegisterHooksContext['deployment'],
+    });
+
+    const sessionId = '00000000-0000-7000-8000-000000000123';
+    app.use('session-mcp-servers', {
+      async find() {
+        return {
+          total: 1,
+          limit: 100,
+          skip: 0,
+          data: [{ mcp_server_id: server.mcp_server_id, enabled: true }],
+        };
+      },
+    } as never);
+
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user,
+      tenant: { tenant_id: 'default', source: 'static' },
+    } as const;
+    const context = {
+      app,
+      db,
+      userId: user.user_id as UserID,
+      sessionId,
+      authenticatedUser: user,
+      baseServiceParams,
+    };
+
+    // Prove the actual Feathers boundary handed the tool an enriched/redacted
+    // projection which cannot itself reproduce the v4 fingerprint.
+    const projected = await app
+      .service('mcp-servers')
+      .get(server.mcp_server_id, baseServiceParams as never);
+    expect(projected.auth?.oauth_access_token).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(projected)).not.toContain('configured-client-secret');
+    expect(JSON.stringify(projected)).not.toContain('durable-grant-access');
+
+    const handlers = new Map<string, ToolHandler>();
+    const mcp = {
+      registerTool(name: string, _config: unknown, handler: ToolHandler) {
+        handlers.set(name, handler);
+      },
+    } as unknown as McpServer;
+    registerMcpServerTools(mcp, context as never);
+
+    const listResult = await handlers.get('agor_mcp_servers_list')!({});
+    const listed = JSON.parse(listResult.content[0]!.text) as {
+      mcp_servers: Array<{ mcp_server_id: string; oauth_authenticated: boolean }>;
+    };
+    expect(listed.mcp_servers).toContainEqual(
+      expect.objectContaining({
+        mcp_server_id: server.mcp_server_id,
+        oauth_authenticated: true,
+      })
+    );
+
+    const statusResult = await handlers.get('agor_mcp_servers_auth_status')!({
+      mcpServerId: server.mcp_server_id,
+    });
+    expect(JSON.parse(statusResult.content[0]!.text)).toMatchObject({
+      mcp_server_id: server.mcp_server_id,
+      oauth_authenticated: true,
+    });
+
+    const attachedContext = {
+      ...context,
+      app: {
+        service(path: string) {
+          if (path === 'sessions') {
+            return { get: async () => ({ session_id: sessionId, created_by: user.user_id }) };
+          }
+          return app.service(path);
+        },
+      },
+    };
+    await expect(
+      listAttachedMcpServers(attachedContext as never, sessionId)
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        mcp_server_id: server.mcp_server_id,
+        oauth_authenticated: true,
+      })
+    );
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
@@ -10,8 +10,13 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetOAuthToken, mockGrantAuthority } = vi.hoisted(() => ({
+const { mockGetOAuthToken, mockFindMCPServer, mockGrantAuthority } = vi.hoisted(() => ({
   mockGetOAuthToken: vi.fn(async () => null),
+  mockFindMCPServer: vi.fn(async (mcpServerId: string) => ({
+    mcp_server_id: mcpServerId,
+    enabled: true,
+    auth: { type: 'oauth', oauth_mode: 'per_user' },
+  })),
   mockGrantAuthority: vi.fn(async () => true),
 }));
 
@@ -24,6 +29,9 @@ vi.mock('../resolve-ids.js', () => ({
 
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class FakeBranchRepository {},
+  MCPServerRepository: class FakeMCPServerRepository {
+    findById = mockFindMCPServer;
+  },
   UserMCPOAuthTokenRepository: class FakeUserMCPOAuthTokenRepository {
     getToken = mockGetOAuthToken;
   },
@@ -35,6 +43,11 @@ vi.mock('../../services/mcp-oauth-grant-authority.js', () => ({
 
 beforeEach(() => {
   mockGetOAuthToken.mockReset().mockResolvedValue(null);
+  mockFindMCPServer.mockReset().mockImplementation(async (mcpServerId: string) => ({
+    mcp_server_id: mcpServerId,
+    enabled: true,
+    auth: { type: 'oauth', oauth_mode: 'per_user' },
+  }));
   mockGrantAuthority.mockReset().mockResolvedValue(true);
 });
 

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
@@ -8,7 +8,12 @@
  */
 
 import type { McpServer } from '@modelcontextprotocol/server';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetOAuthToken, mockGrantAuthority } = vi.hoisted(() => ({
+  mockGetOAuthToken: vi.fn(async () => null),
+  mockGrantAuthority: vi.fn(async () => true),
+}));
 
 vi.mock('../resolve-ids.js', () => ({
   resolveBoardId: async (_ctx: unknown, id: string) => id,
@@ -20,11 +25,18 @@ vi.mock('../resolve-ids.js', () => ({
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class FakeBranchRepository {},
   UserMCPOAuthTokenRepository: class FakeUserMCPOAuthTokenRepository {
-    getToken = vi.fn(async () => null);
+    getToken = mockGetOAuthToken;
   },
 }));
 
-import { vi } from 'vitest';
+vi.mock('../../services/mcp-oauth-grant-authority.js', () => ({
+  isMCPOAuthGrantAuthorizedForServer: mockGrantAuthority,
+}));
+
+beforeEach(() => {
+  mockGetOAuthToken.mockReset().mockResolvedValue(null);
+  mockGrantAuthority.mockReset().mockResolvedValue(true);
+});
 
 type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
 function makeFakeApp(services: Record<string, ServiceStub>) {
@@ -341,6 +353,37 @@ describe('agor_mcp_servers_list', () => {
       mcp_server_id: 'owned-server',
       oauth_authenticated: false,
     });
+  });
+
+  it('does not report raw token presence when the authoritative binding is invalid', async () => {
+    mockGetOAuthToken.mockResolvedValue({
+      oauth_access_token: 'raw-but-mismatched',
+      oauth_token_expires_at: new Date(Date.now() + 60_000),
+      refresh_status: 'idle',
+    });
+    mockGrantAuthority.mockResolvedValue(false);
+    const app = makeFakeApp({
+      'mcp-servers': {
+        get: async () => ({
+          mcp_server_id: 'owned-server',
+          name: 'private-owned',
+          transport: 'http',
+          scope: 'session',
+          source: 'user',
+          owner_user_id: 'user-1',
+          enabled: true,
+          auth: { type: 'oauth' },
+        }),
+      },
+    });
+    const authStatus = await captureTool(
+      { app, userId: 'user-1', sessionId: 'sess-1' },
+      'agor_mcp_servers_auth_status'
+    );
+
+    const result = await authStatus({ mcpServerId: 'owned-server' });
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ oauth_authenticated: false });
+    expect(mockGrantAuthority).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -53,23 +53,29 @@ async function getOAuthStatus(
   mcpServer: MCPServer
 ): Promise<{ authenticated: boolean; tokenExpiresAt?: number }> {
   const authType = mcpServer.auth?.type || 'none';
-  const oauthMode = mcpServer.auth?.oauth_mode || 'per_user';
 
   if (authType !== 'oauth') {
     return { authenticated: true };
   }
 
   // Both shared and per_user live in `user_mcp_oauth_tokens` — shared rows use
-  // `user_id = NULL`. See migration 0038 (sqlite) / 0027 (postgres).
-  const { UserMCPOAuthTokenRepository } = await import('@agor/core/db');
-  const lookupUserId = oauthMode === 'shared' ? null : ctx.userId;
+  // `user_id = NULL`. See migration 0038 (sqlite) / 0027 (postgres). MCP
+  // service responses have already passed through token injection + secret
+  // redaction hooks, so binding authority must come from the raw stored row.
+  const { MCPServerRepository, UserMCPOAuthTokenRepository } = await import('@agor/core/db');
   const tokenData = await runWithMcpTenantDatabaseScope(ctx, async (db) => {
+    const authoritativeServer = await new MCPServerRepository(db).findById(mcpServer.mcp_server_id);
+    if (!authoritativeServer?.enabled || authoritativeServer.auth?.type !== 'oauth') return null;
+    const lookupUserId =
+      (authoritativeServer.auth.oauth_mode ?? 'per_user') === 'shared' ? null : ctx.userId;
     const grant = await new UserMCPOAuthTokenRepository(db).getToken(
       lookupUserId,
       mcpServer.mcp_server_id
     );
     if (!grant) return null;
-    return (await isMCPOAuthGrantAuthorizedForServer(db, mcpServer, grant)) ? grant : null;
+    return (await isMCPOAuthGrantAuthorizedForServer(db, authoritativeServer, grant))
+      ? grant
+      : null;
   });
   if (tokenData) {
     if (

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -1,5 +1,6 @@
 import { NotFound } from '@agor/core/feathers';
 import {
+  findDuplicateMCPCustomHeaderName,
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
 } from '@agor/core/tools/mcp/http-headers';
@@ -12,6 +13,7 @@ import type {
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
+import { isMCPOAuthGrantAuthorizedForServer } from '../../services/mcp-oauth-grant-authority.js';
 import { isMcpServerUsableByCaller } from '../../utils/mcp-server-authorization.js';
 import { resolveMcpServerId, resolveSessionId } from '../resolve-ids.js';
 import {
@@ -61,11 +63,19 @@ async function getOAuthStatus(
   // `user_id = NULL`. See migration 0038 (sqlite) / 0027 (postgres).
   const { UserMCPOAuthTokenRepository } = await import('@agor/core/db');
   const lookupUserId = oauthMode === 'shared' ? null : ctx.userId;
-  const tokenData = await runWithMcpTenantDatabaseScope(ctx, (db) =>
-    new UserMCPOAuthTokenRepository(db).getToken(lookupUserId, mcpServer.mcp_server_id)
-  );
+  const tokenData = await runWithMcpTenantDatabaseScope(ctx, async (db) => {
+    const grant = await new UserMCPOAuthTokenRepository(db).getToken(
+      lookupUserId,
+      mcpServer.mcp_server_id
+    );
+    if (!grant) return null;
+    return (await isMCPOAuthGrantAuthorizedForServer(db, mcpServer, grant)) ? grant : null;
+  });
   if (tokenData) {
-    if (!tokenData.oauth_token_expires_at || tokenData.oauth_token_expires_at > new Date()) {
+    if (
+      tokenData.refresh_status === 'idle' &&
+      (!tokenData.oauth_token_expires_at || tokenData.oauth_token_expires_at > new Date())
+    ) {
       return {
         authenticated: true,
         tokenExpiresAt: tokenData.oauth_token_expires_at?.getTime(),
@@ -482,6 +492,14 @@ const mcpServerUpdateSchema = z
 
 function validateHeaders(headers: Record<string, string> | undefined, issue: z.RefinementCtx) {
   if (!headers) return;
+  const duplicate = findDuplicateMCPCustomHeaderName(headers);
+  if (duplicate) {
+    issue.addIssue({
+      code: 'custom',
+      path: ['headers', duplicate.duplicate],
+      message: `Duplicate case-insensitive HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`,
+    });
+  }
   for (const [key, value] of Object.entries(headers)) {
     const name = key.trim();
     if (!name) {

--- a/apps/agor-daemon/src/oauth-cache.sqlite.test.ts
+++ b/apps/agor-daemon/src/oauth-cache.sqlite.test.ts
@@ -105,6 +105,7 @@ describe('standalone OAuth token persistence', () => {
           db,
           userId: user.user_id as UserID,
           mcpServerId: server.mcp_server_id as MCPServerID,
+          validateGrant: async () => true,
         })
       ).resolves.toBe('refreshed-access');
       expect(new URLSearchParams(refreshBody).get('resource')).toBe(resourceUri);

--- a/apps/agor-daemon/src/oauth-cache.sqlite.test.ts
+++ b/apps/agor-daemon/src/oauth-cache.sqlite.test.ts
@@ -105,6 +105,11 @@ describe('standalone OAuth token persistence', () => {
           db,
           userId: user.user_id as UserID,
           mcpServerId: server.mcp_server_id as MCPServerID,
+          observedRefreshVersion: {
+            grantGeneration: stored!.grant_generation,
+            grantBindingFingerprint: stored!.grant_binding_fingerprint,
+            refreshGeneration: stored!.refresh_generation,
+          },
           validateGrant: async () => true,
         })
       ).resolves.toBe('refreshed-access');

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -109,5 +109,8 @@ export async function persistOAuthToken(
     grantBinding: pendingFlow.grantBinding,
   });
 
-  console.log(`[${logPrefix}] OAuth token persisted mode=${oauthMode} expiry=${expiry.source}`);
+  console.log(
+    `[${logPrefix}] OAuth token persisted mode=${oauthMode} ` +
+      `binding_version=${pendingFlow.grantBinding?.version ?? 'legacy_unbound'} expiry=${expiry.source}`
+  );
 }

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -39,7 +39,9 @@ describe('register-hooks MCP server secret redaction', () => {
     // writes rather than the `all` chain alone. That gate is no longer a role
     // check: `authorizeMcpServerWriteHook` decides on `mcp_member_policy` plus
     // ownership, which is what lets a member hold a server of their own at all.
-    expect(source).toMatch(/update:\s*\[authorizeMcpServerWriteHook\]/);
+    expect(source).toMatch(
+      /update:\s*\[validateMcpServerOAuthCompatibility,\s*authorizeMcpServerWriteHook\]/
+    );
   });
 
   it('redacts session MCP server route responses that bypass service hooks', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -83,6 +83,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import {
+  assertPublicMCPOAuthCompatibilityMode,
   GATEWAY_CHANNEL_WRITE_FIELDS,
   GATEWAY_REDACTED_SENTINEL,
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
@@ -116,6 +117,7 @@ import type { RedisRealtimeRuntime } from './realtime/redis-realtime.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
+import { resolveMCPOAuthCompatibilityPolicy } from './services/mcp-oauth-compatibility.js';
 import { isMCPOAuthGrantBoundToServer } from './services/mcp-oauth-grant-binding.js';
 import {
   isRemoteRelationshipsEnrichedResult,
@@ -1762,9 +1764,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         if (!row) {
           return server;
         }
+        const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
         if (
           isPostgresDatabaseHandle(db) &&
-          !isMCPOAuthGrantBoundToServer(process.env.AGOR_MASTER_SECRET!, server, row)
+          !isMCPOAuthGrantBoundToServer(
+            process.env.AGOR_MASTER_SECRET!,
+            server,
+            row,
+            compatibilityMode
+          )
         ) {
           console.warn('[MCP OAuth] grant_rejected category=binding_mismatch');
           return server;
@@ -1820,6 +1828,22 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     context: HookContext
   ) => Promise<HookContext>;
 
+  const validateMcpServerOAuthCompatibility = async (
+    context: HookContext
+  ): Promise<HookContext> => {
+    const items = Array.isArray(context.data) ? context.data : [context.data];
+    try {
+      for (const item of items) {
+        assertPublicMCPOAuthCompatibilityMode(
+          item && typeof item === 'object' ? (item as { auth?: unknown }).auth : undefined
+        );
+      }
+    } catch (error) {
+      throw new BadRequest(error instanceof Error ? error.message : 'Invalid MCP OAuth policy');
+    }
+    return context;
+  };
+
   const scopeMcpServerFindToUsable = async (context: HookContext): Promise<HookContext> => {
     if (!context.params.provider) return context;
     const user = context.params.user;
@@ -1857,9 +1881,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [typedValidateQuery(mcpServerQueryValidator), requireAuth],
       find: [scopeMcpServerFindToUsable],
-      create: [authorizeMcpServerWriteHook],
-      update: [authorizeMcpServerWriteHook],
-      patch: [authorizeMcpServerWriteHook],
+      create: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
+      update: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
+      patch: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
       remove: [authorizeMcpServerWriteHook],
     },
     after: {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -117,8 +117,14 @@ import type { RedisRealtimeRuntime } from './realtime/redis-realtime.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
-import { resolveMCPOAuthCompatibilityPolicy } from './services/mcp-oauth-compatibility.js';
-import { isMCPOAuthGrantBoundToServer } from './services/mcp-oauth-grant-binding.js';
+import {
+  presentMCPOAuthCompatibilityPolicy,
+  resolveMCPOAuthCompatibilityPolicy,
+} from './services/mcp-oauth-compatibility.js';
+import {
+  isMCPOAuthGrantBoundToServer,
+  shouldVerifyMCPOAuthGrantBinding,
+} from './services/mcp-oauth-grant-binding.js';
 import {
   isRemoteRelationshipsEnrichedResult,
   markRemoteRelationshipsEnrichedResult,
@@ -1741,14 +1747,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       authPayloadType,
       callerUserId: context.params?.user?.user_id,
     });
-    if (!userId) {
-      return context;
-    }
-
     const injectToken = async (server: MCPServer) => {
       if (server.auth?.type !== 'oauth') {
         return server;
       }
+
+      const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(server);
+      const serverWithPolicy: MCPServer = {
+        ...server,
+        oauth_compatibility_policy: presentMCPOAuthCompatibilityPolicy(compatibilityPolicy),
+      };
+      if (!userId) return serverWithPolicy;
 
       // Tokens for both modes live in user_mcp_oauth_tokens:
       //   - per_user  → row keyed by (userId, serverId)
@@ -1762,11 +1771,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         const row = await userTokenRepo.getToken(tokenUserId, server.mcp_server_id);
 
         if (!row) {
-          return server;
+          return serverWithPolicy;
         }
-        const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
+        const compatibilityMode = compatibilityPolicy.mode;
         if (
-          isPostgresDatabaseHandle(db) &&
+          shouldVerifyMCPOAuthGrantBinding(
+            isPostgresDatabaseHandle(db),
+            row.grant_binding_version
+          ) &&
           !isMCPOAuthGrantBoundToServer(
             process.env.AGOR_MASTER_SECRET!,
             server,
@@ -1775,7 +1787,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           )
         ) {
           console.warn('[MCP OAuth] grant_rejected category=binding_mismatch');
-          return server;
+          return serverWithPolicy;
         }
 
         // Response enrichment is a durable read only. Refresh is coordinated
@@ -1785,13 +1797,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           row.refresh_status !== 'idle' ||
           (row.oauth_token_expires_at && row.oauth_token_expires_at <= new Date())
         ) {
-          return server;
+          return serverWithPolicy;
         }
         const accessToken = row.oauth_access_token;
         const expiresAt = row.oauth_token_expires_at;
 
         return {
-          ...server,
+          ...serverWithPolicy,
           auth: {
             ...server.auth,
             oauth_access_token: accessToken,
@@ -1805,7 +1817,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         console.warn('[MCP OAuth] grant_resolution_failed category=local_error');
       }
 
-      return server;
+      return serverWithPolicy;
     };
 
     // Handle both single result and array/paginated results

--- a/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-capability-role.test.ts
@@ -149,15 +149,17 @@ describe('MCP caller floor wiring', () => {
     }
   });
 
-  it('re-checks the flow initiator ahead of the durable-only branch', () => {
+  it('re-checks the flow initiator ahead of SQLite and durable server authority', () => {
     // The callback gap was not the check being absent but unreachable: it sat
     // behind `if (!record) return`, which is every SQLite deployment.
     const guardAt = source.indexOf('const assertPendingFlowStillAuthorized');
-    const body = source.slice(guardAt, guardAt + 1200);
+    const body = source.slice(guardAt, guardAt + 5000);
     const initiatorAt = body.indexOf('assertFlowInitiatorStillEntitled(');
-    const durableReturnAt = body.indexOf('if (!record) return;');
+    const localAuthorityAt = body.indexOf('if (!record) {');
     expect(initiatorAt).toBeGreaterThan(-1);
-    expect(durableReturnAt).toBeGreaterThan(-1);
-    expect(initiatorAt).toBeLessThan(durableReturnAt);
+    expect(localAuthorityAt).toBeGreaterThan(-1);
+    expect(initiatorAt).toBeLessThan(localAuthorityAt);
+    expect(body).toContain('savedServerAuthority');
+    expect(body).toContain('localGrantBinding');
   });
 });

--- a/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
@@ -19,13 +19,11 @@ describe('register-services /mcp-servers/discover custom headers wiring', () => 
     expect(discoverBlock).toContain('serverConfig.headers = resolution.resolved.headers');
   });
 
-  it('restores redacted edit-form auth/header values from the saved server before probing', () => {
-    expect(discoverBlock).toContain('restoreRedactedMCPAuthSecrets');
-    expect(discoverBlock).toContain('current: server.auth');
-    expect(discoverBlock).toContain('next: data.auth');
-    expect(discoverBlock).toContain('restoreRedactedMCPCustomHeaders');
-    expect(discoverBlock).toContain('current: server.headers');
-    expect(discoverBlock).toContain('next: data.headers');
+  it('uses saved auth/header values rather than a transient edit-form snapshot', () => {
+    expect(discoverBlock).toContain('auth: server.auth');
+    expect(discoverBlock).toContain('headers: server.headers');
+    expect(discoverBlock).not.toContain('restoreRedactedMCPAuthSecrets');
+    expect(discoverBlock).not.toContain('restoreRedactedMCPCustomHeaders');
   });
 
   it('passes merged custom/auth headers to Streamable HTTP transport', () => {

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -85,7 +85,8 @@ describe('register-services /mcp-servers/discover wiring', () => {
     const firstOutboundIdx = discoverBlock.indexOf('oauthFetch(');
     expect(validationIdx).toBeGreaterThan(-1);
     expect(validationIdx).toBeLessThan(firstOutboundIdx);
-    expect(discoverBlock).toMatch(/if\s*\(durableOAuthFlows\)[\s\S]*url:\s*server\.url/);
+    expect(discoverBlock).toMatch(/serverConfig\s*=\s*\{[\s\S]*url:\s*server\.url/);
+    expect(discoverBlock).not.toContain('restoreRedactedMCPAuthSecrets');
     expect(discoverBlock).toMatch(
       /resolveMCPOAuthCompatibilityPolicy\s*\(\s*authoritativeServer\s*\?\?/
     );

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -80,6 +80,17 @@ describe('register-services /mcp-servers/discover wiring', () => {
     expect(discoverBlock).toContain('disableProcessTokenCache: !!durableOAuthFlows');
   });
 
+  it('rejects transient compatibility values and uses the durable row for grant-producing discovery', () => {
+    const validationIdx = discoverBlock.indexOf('assertPublicMCPOAuthCompatibilityMode(data.auth)');
+    const firstOutboundIdx = discoverBlock.indexOf('oauthFetch(');
+    expect(validationIdx).toBeGreaterThan(-1);
+    expect(validationIdx).toBeLessThan(firstOutboundIdx);
+    expect(discoverBlock).toMatch(/if\s*\(durableOAuthFlows\)[\s\S]*url:\s*server\.url/);
+    expect(discoverBlock).toMatch(
+      /resolveMCPOAuthCompatibilityPolicy\s*\(\s*authoritativeServer\s*\?\?/
+    );
+  });
+
   it('skips pre-resolution URL validation for templated URLs', () => {
     // `new URL("https://{{ user.env.HOST }}/mcp")` throws because of the
     // whitespace inside `{{ }}`, and `new URL("{{ user.env.MCP_URL }}")`

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -93,6 +93,41 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/reuseDynamicClientRegistration:\s*false/);
   });
 
+  it('binds durable pending flows to the authoritative compatibility policy', () => {
+    const flowHelper = codeOnly.slice(
+      codeOnly.indexOf('async function startTwoPhaseMCPOAuthFlowInternal'),
+      codeOnly.indexOf('const tenantIdFromParams')
+    );
+    expect(flowHelper).toMatch(/resolveMCPOAuthCompatibilityPolicy\s*\(\s*server\s*\)/);
+    expect(flowHelper).toMatch(/effectiveClientId\s*=\s*server\.auth\.oauth_client_id/);
+    expect(flowHelper).toMatch(/effectiveCompatibilityMode\s*=\s*compatibilityPolicy\.mode/);
+    expect(flowHelper).toMatch(/compatibilityMode:\s*context\.compatibilityMode/);
+
+    const callbackAuthority = codeOnly.slice(
+      codeOnly.indexOf('const assertPendingFlowStillAuthorized'),
+      codeOnly.indexOf('const persistOAuthTokenForPendingFlow')
+    );
+    expect(callbackAuthority).toMatch(
+      /compatibilityPolicy\?\.mode\s*!==\s*pendingFlow\.context\.compatibilityMode/
+    );
+    expect(callbackAuthority).toMatch(
+      /compatibilityMode:\s*pendingFlow\.context\.compatibilityMode/
+    );
+  });
+
+  it('validates test-oauth transient policy before outbound work and reloads saved authority', () => {
+    const testOauth = codeOnly.slice(
+      codeOnly.indexOf("app.use('/mcp-servers/test-oauth'"),
+      codeOnly.indexOf("app.service('mcp-servers/test-oauth').hooks")
+    );
+    expect(testOauth.indexOf('assertPublicMCPOAuthCompatibilityMode')).toBeLessThan(
+      testOauth.indexOf('oauthFetch(')
+    );
+    expect(testOauth).toMatch(/effectiveMcpUrl\s*=\s*authoritativeServer\?\.url/);
+    expect(testOauth).toMatch(/compatibilityPolicy\?\.mode\s*\?\?/);
+    expect(testOauth).toMatch(/effectiveClientId\s*=\s*authoritativeServer/);
+  });
+
   it('uses durable hashed state claims on PostgreSQL and never broadcasts raw flow state', () => {
     expect(codeOnly).toMatch(/durableOAuthFlows\.claimForCallback\s*\(\s*state\s*\)/);
     expect(codeOnly).toMatch(/cacheToken:\s*false/);

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -55,6 +55,8 @@ type TestProvider = {
   tokenRequested: Deferred<void>;
   refreshRequested: Deferred<void>;
   releaseToken: () => void;
+  releaseTokenRequest: (requestNumber: number) => void;
+  waitForTokenRequest: (requestNumber: number) => Promise<void>;
   releaseRefresh: () => void;
   close: () => Promise<void>;
 };
@@ -69,8 +71,23 @@ async function createTestProvider(
   } = {}
 ): Promise<TestProvider> {
   const requests: TestProvider['requests'] = [];
-  const tokenRequested = deferred<void>();
-  const release = deferred<void>();
+  const tokenRequestMilestones = new Map<number, Deferred<void>>();
+  const tokenReleaseGates = new Map<number, Deferred<void>>();
+  const tokenRequestMilestone = (requestNumber: number): Deferred<void> => {
+    const existing = tokenRequestMilestones.get(requestNumber);
+    if (existing) return existing;
+    const created = deferred<void>();
+    tokenRequestMilestones.set(requestNumber, created);
+    return created;
+  };
+  const tokenReleaseGate = (requestNumber: number): Deferred<void> => {
+    const existing = tokenReleaseGates.get(requestNumber);
+    if (existing) return existing;
+    const created = deferred<void>();
+    tokenReleaseGates.set(requestNumber, created);
+    return created;
+  };
+  const tokenRequested = tokenRequestMilestone(1);
   const refreshRequested = deferred<void>();
   const releaseRefresh = deferred<void>();
   let tokenRequestCount = 0;
@@ -135,9 +152,10 @@ async function createTestProvider(
         return;
       }
       tokenRequestCount += 1;
-      tokenRequested.resolve();
+      const requestRelease = tokenReleaseGate(tokenRequestCount);
+      tokenRequestMilestone(tokenRequestCount).resolve();
       if (options.holdToken || options.holdTokenRequests?.includes(tokenRequestCount)) {
-        await release.promise;
+        await requestRelease.promise;
       }
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(
@@ -206,10 +224,14 @@ async function createTestProvider(
     requests,
     tokenRequested,
     refreshRequested,
-    releaseToken: () => release.resolve(),
+    releaseToken: () => {
+      for (const gate of tokenReleaseGates.values()) gate.resolve();
+    },
+    releaseTokenRequest: (requestNumber: number) => tokenReleaseGate(requestNumber).resolve(),
+    waitForTokenRequest: (requestNumber: number) => tokenRequestMilestone(requestNumber).promise,
     releaseRefresh: () => releaseRefresh.resolve(),
     close: () => {
-      release.resolve();
+      for (const gate of tokenReleaseGates.values()) gate.resolve();
       releaseRefresh.resolve();
       return new Promise<void>((resolve) => {
         server.close(() => resolve());
@@ -622,6 +644,154 @@ describe('SQLite saved-row OAuth authority', () => {
       grant_generation: generation,
       oauth_access_token: 'new-authorization-access-token',
     });
+  });
+
+  it.each([
+    {
+      mode: 'per_user' as const,
+      name: 'lower generation commits first',
+      order: 'lower-first' as const,
+    },
+    {
+      mode: 'per_user' as const,
+      name: 'higher generation commits first',
+      order: 'higher-first' as const,
+    },
+    { mode: 'per_user' as const, name: 'both empty-row writes race', order: 'concurrent' as const },
+    {
+      mode: 'shared' as const,
+      name: 'lower generation commits first',
+      order: 'lower-first' as const,
+    },
+    {
+      mode: 'shared' as const,
+      name: 'higher generation commits first',
+      order: 'higher-first' as const,
+    },
+    { mode: 'shared' as const, name: 'both empty-row writes race', order: 'concurrent' as const },
+  ])('keeps the higher first-time $mode callback when $name', async ({ mode, order }) => {
+    const provider = await createTestProvider({
+      holdTokenRequests: [1, 2],
+      numberedTokenResponses: true,
+    });
+    providers.push(provider);
+    const harness = await createHarness(provider, mode);
+    databases.push(harness.rawDb);
+
+    const start = async (): Promise<string> => {
+      const result = (await harness.app
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+        authorizationUrl: string;
+      };
+      return new URL(result.authorizationUrl).searchParams.get('state')!;
+    };
+
+    // Both one-shot callbacks are claimed and blocked inside their provider
+    // exchanges while the grant subject is still empty.
+    const callbackA = harness.callback(await start());
+    await provider.waitForTokenRequest(1);
+    const callbackB = harness.callback(await start());
+    await provider.waitForTokenRequest(2);
+
+    let emptyReadBarrierSpy: ReturnType<typeof vi.spyOn> | undefined;
+    if (order === 'concurrent') {
+      // Deterministically reproduce the old read-then-insert race: if callback
+      // persistence performs an empty-row read, hold the first until both have
+      // observed null. The atomic upsert correctly performs no such read.
+      const originalGetToken = UserMCPOAuthTokenRepository.prototype.getToken;
+      const bothEmptyReads = deferred<void>();
+      let emptyReadCount = 0;
+      emptyReadBarrierSpy = vi
+        .spyOn(UserMCPOAuthTokenRepository.prototype, 'getToken')
+        .mockImplementation(async function (userId, serverId) {
+          const row = await originalGetToken.call(this, userId, serverId);
+          if (row) return row;
+          emptyReadCount += 1;
+          if (emptyReadCount === 2) bothEmptyReads.resolve();
+          await bothEmptyReads.promise;
+          return null;
+        });
+    }
+
+    let resultA: { status: number; body: string };
+    let resultB: { status: number; body: string };
+    try {
+      if (order === 'lower-first') {
+        provider.releaseTokenRequest(1);
+        resultA = await callbackA;
+        provider.releaseTokenRequest(2);
+        resultB = await callbackB;
+      } else if (order === 'higher-first') {
+        provider.releaseTokenRequest(2);
+        resultB = await callbackB;
+        provider.releaseTokenRequest(1);
+        resultA = await callbackA;
+      } else {
+        provider.releaseTokenRequest(1);
+        provider.releaseTokenRequest(2);
+        [resultA, resultB] = await Promise.all([callbackA, callbackB]);
+      }
+    } finally {
+      emptyReadBarrierSpy?.mockRestore();
+    }
+
+    expect(resultB.status).toBe(200);
+    if (order === 'lower-first') expect(resultA.status).toBe(200);
+
+    const repository = new UserMCPOAuthTokenRepository(harness.rawDb);
+    const subjectUserId = mode === 'per_user' ? (harness.user.user_id as UserID) : null;
+    const durable = await repository.getToken(
+      subjectUserId,
+      harness.server.mcp_server_id as MCPServerID
+    );
+    expect(durable).toMatchObject({
+      user_id: subjectUserId,
+      mcp_server_id: harness.server.mcp_server_id,
+      grant_generation: 2,
+      grant_binding_version: 4,
+      oauth_access_token: 'sqlite-access-token-2',
+      oauth_refresh_token: 'refresh-2',
+      oauth_client_id: 'saved-client-id',
+      oauth_resource_uri: provider.savedMcpUrl,
+    });
+    expect(durable?.grant_binding_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+
+    const attemptReplacement = (generation: number, accessToken: string) =>
+      repository.saveToken(subjectUserId, harness.server.mcp_server_id as MCPServerID, {
+        accessToken,
+        refreshToken: `${accessToken}-refresh`,
+        clientId: durable!.oauth_client_id,
+        grantBinding: {
+          generation,
+          version: 4,
+          fingerprint: durable!.grant_binding_fingerprint!,
+          metadataUri: durable!.oauth_metadata_uri!,
+          resourceUri: durable!.oauth_resource_uri!,
+          issuer: durable!.oauth_issuer!,
+          authorizationEndpoint: durable!.oauth_authorization_endpoint!,
+          tokenEndpoint: durable!.oauth_token_endpoint!,
+          redirectUri: durable!.oauth_redirect_uri!,
+        },
+      });
+    await expect(attemptReplacement(1, 'lower-generation')).rejects.toThrow(
+      'A newer MCP OAuth grant superseded this attempt'
+    );
+    await expect(attemptReplacement(2, 'equal-generation')).rejects.toThrow(
+      'A newer MCP OAuth grant superseded this attempt'
+    );
+    await expect(
+      repository.getToken(subjectUserId, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toMatchObject({
+      grant_generation: 2,
+      oauth_access_token: 'sqlite-access-token-2',
+    });
+    await expect(
+      repository.getToken(
+        mode === 'per_user' ? null : (harness.user.user_id as UserID),
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toBeNull();
   });
 
   it('never reuses a released generation while an older callback is exchanging', async () => {

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -60,13 +60,20 @@ type TestProvider = {
 };
 
 async function createTestProvider(
-  options: { holdToken?: boolean; holdRefresh?: boolean; invalidRefresh?: boolean } = {}
+  options: {
+    holdToken?: boolean;
+    holdTokenRequests?: number[];
+    numberedTokenResponses?: boolean;
+    holdRefresh?: boolean;
+    invalidRefresh?: boolean;
+  } = {}
 ): Promise<TestProvider> {
   const requests: TestProvider['requests'] = [];
   const tokenRequested = deferred<void>();
   const release = deferred<void>();
   const refreshRequested = deferred<void>();
   const releaseRefresh = deferred<void>();
+  let tokenRequestCount = 0;
   let baseUrl = '';
 
   const server = http.createServer(async (request, response) => {
@@ -127,13 +134,20 @@ async function createTestProvider(
         );
         return;
       }
+      tokenRequestCount += 1;
       tokenRequested.resolve();
-      if (options.holdToken) await release.promise;
+      if (options.holdToken || options.holdTokenRequests?.includes(tokenRequestCount)) {
+        await release.promise;
+      }
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(
         JSON.stringify({
-          access_token: 'sqlite-access-token',
-          refresh_token: 'refresh',
+          access_token: options.numberedTokenResponses
+            ? `sqlite-access-token-${tokenRequestCount}`
+            : 'sqlite-access-token',
+          refresh_token: options.numberedTokenResponses
+            ? `refresh-${tokenRequestCount}`
+            : 'refresh',
           expires_in: 3600,
         })
       );
@@ -212,6 +226,7 @@ type SQLiteHarness = {
   server: MCPServer;
   nextAuthorizationUrl: () => Promise<string>;
   callback: (state: string) => Promise<{ status: number; body: string }>;
+  deny: (state: string) => Promise<{ status: number; body: string }>;
 };
 
 async function createHarness(provider: TestProvider, oauthMode?: 'per_user' | 'shared') {
@@ -264,6 +279,29 @@ async function createHarness(provider: TestProvider, oauthMode?: 'per_user' | 's
     deployment: {} as RegisterServicesContext['deployment'],
   });
 
+  const invokeCallback = async (
+    query: Record<string, string>
+  ): Promise<{ status: number; body: string }> => {
+    let status = 200;
+    let body = '';
+    const response = {
+      setHeader: vi.fn(),
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      send(value: string) {
+        body = value;
+        return this;
+      },
+    };
+    await (oauthCallbackHandler as unknown as (req: unknown, res: unknown) => Promise<void>)(
+      { query },
+      response
+    );
+    return { status, body };
+  };
+
   return {
     app,
     db,
@@ -275,26 +313,9 @@ async function createHarness(provider: TestProvider, oauthMode?: 'per_user' | 's
       nextUrl = deferred<string>();
       return value;
     },
-    callback: async (state: string) => {
-      let status = 200;
-      let body = '';
-      const response = {
-        setHeader: vi.fn(),
-        status(code: number) {
-          status = code;
-          return this;
-        },
-        send(value: string) {
-          body = value;
-          return this;
-        },
-      };
-      await (oauthCallbackHandler as unknown as (req: unknown, res: unknown) => Promise<void>)(
-        { query: { code: 'authorization-code', state, iss: provider.baseUrl } },
-        response
-      );
-      return { status, body };
-    },
+    callback: (state: string) =>
+      invokeCallback({ code: 'authorization-code', state, iss: provider.baseUrl }),
+    deny: (state: string) => invokeCallback({ error: 'access_denied', state }),
   } satisfies SQLiteHarness;
 }
 
@@ -600,6 +621,102 @@ describe('SQLite saved-row OAuth authority', () => {
     ).resolves.toMatchObject({
       grant_generation: generation,
       oauth_access_token: 'new-authorization-access-token',
+    });
+  });
+
+  it('never reuses a released generation while an older callback is exchanging', async () => {
+    const provider = await createTestProvider({
+      holdTokenRequests: [1],
+      numberedTokenResponses: true,
+    });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+
+    const start = async (): Promise<string> => {
+      const result = (await harness.app
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+        authorizationUrl: string;
+      };
+      return new URL(result.authorizationUrl).searchParams.get('state')!;
+    };
+
+    // A owns generation 1 and has already been claimed/removed from pending
+    // state, but its provider exchange remains active.
+    const stateA = await start();
+    const callbackA = harness.callback(stateA);
+    await provider.tokenRequested.promise;
+
+    // B owns generation 2, then fails and releases only its own reservation.
+    const stateB = await start();
+    expect((await harness.deny(stateB)).status).toBe(400);
+
+    // C must allocate generation 3, never reuse generation 1 after B releases.
+    const stateC = await start();
+    expect((await harness.callback(stateC)).status).toBe(200);
+    const repository = new UserMCPOAuthTokenRepository(harness.rawDb);
+    await expect(
+      repository.getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({
+      grant_generation: 3,
+      oauth_access_token: 'sqlite-access-token-2',
+      oauth_refresh_token: 'refresh-2',
+    });
+
+    // When A eventually completes, older/equal-generation update fencing and
+    // exact deletion must leave C's grant untouched.
+    provider.releaseToken();
+    expect((await callbackA).status).not.toBe(200);
+    await expect(
+      repository.getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({
+      grant_generation: 3,
+      oauth_access_token: 'sqlite-access-token-2',
+      oauth_refresh_token: 'refresh-2',
+    });
+
+    const grantC = await repository.getToken(
+      harness.user.user_id as UserID,
+      harness.server.mcp_server_id as MCPServerID
+    );
+    expect(grantC?.grant_binding_fingerprint).toBeTruthy();
+    await expect(
+      repository.saveToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID,
+        {
+          accessToken: 'same-generation-different-attempt',
+          refreshToken: 'must-not-replace-c',
+          clientId: grantC!.oauth_client_id,
+          grantBinding: {
+            generation: 3,
+            version: 4,
+            fingerprint: grantC!.grant_binding_fingerprint!,
+            metadataUri: grantC!.oauth_metadata_uri!,
+            resourceUri: grantC!.oauth_resource_uri!,
+            issuer: grantC!.oauth_issuer!,
+            authorizationEndpoint: grantC!.oauth_authorization_endpoint!,
+            tokenEndpoint: grantC!.oauth_token_endpoint!,
+            redirectUri: grantC!.oauth_redirect_uri!,
+          },
+        }
+      )
+    ).rejects.toThrow('A newer MCP OAuth grant superseded this attempt');
+    await expect(
+      repository.getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({
+      grant_generation: 3,
+      oauth_access_token: 'sqlite-access-token-2',
     });
   });
 });

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -53,14 +53,20 @@ type TestProvider = {
   transientMcpUrl: string;
   requests: Array<{ path: string; authorization?: string; transientHeader?: string }>;
   tokenRequested: Deferred<void>;
+  refreshRequested: Deferred<void>;
   releaseToken: () => void;
+  releaseRefresh: () => void;
   close: () => Promise<void>;
 };
 
-async function createTestProvider(options: { holdToken?: boolean } = {}): Promise<TestProvider> {
+async function createTestProvider(
+  options: { holdToken?: boolean; holdRefresh?: boolean; invalidRefresh?: boolean } = {}
+): Promise<TestProvider> {
   const requests: TestProvider['requests'] = [];
   const tokenRequested = deferred<void>();
   const release = deferred<void>();
+  const refreshRequested = deferred<void>();
+  const releaseRefresh = deferred<void>();
   let baseUrl = '';
 
   const server = http.createServer(async (request, response) => {
@@ -99,6 +105,28 @@ async function createTestProvider(options: { holdToken?: boolean } = {}): Promis
       return;
     }
     if (url.pathname === '/token') {
+      let body = '';
+      for await (const chunk of request) body += String(chunk);
+      const isRefresh = new URLSearchParams(body).get('grant_type') === 'refresh_token';
+      if (isRefresh) {
+        refreshRequested.resolve();
+        if (options.holdRefresh) await releaseRefresh.promise;
+        response.writeHead(options.invalidRefresh ? 400 : 200, {
+          'content-type': 'application/json',
+        });
+        response.end(
+          JSON.stringify(
+            options.invalidRefresh
+              ? { error: 'invalid_grant' }
+              : {
+                  access_token: 'stale-refreshed-access-token',
+                  refresh_token: 'stale-rotated-refresh-token',
+                  expires_in: 3600,
+                }
+          )
+        );
+        return;
+      }
       tokenRequested.resolve();
       if (options.holdToken) await release.promise;
       response.writeHead(200, { 'content-type': 'application/json' });
@@ -163,9 +191,12 @@ async function createTestProvider(options: { holdToken?: boolean } = {}): Promis
     transientMcpUrl: `${baseUrl}/transient/mcp`,
     requests,
     tokenRequested,
+    refreshRequested,
     releaseToken: () => release.resolve(),
+    releaseRefresh: () => releaseRefresh.resolve(),
     close: () => {
       release.resolve();
+      releaseRefresh.resolve();
       return new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
@@ -270,8 +301,66 @@ async function createHarness(provider: TestProvider, oauthMode?: 'per_user' | 's
 function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: { id: string } } {
   return {
     user: harness.user,
+    tenant: { tenant_id: 'default', source: 'static' },
     connection: { id: 'sqlite-test-socket' },
   } as AuthenticatedParams & { connection: { id: string } };
+}
+
+async function authorizeSavedServer(harness: SQLiteHarness): Promise<void> {
+  const started = (await harness.app
+    .service('mcp-servers/oauth-start')
+    .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+    success: boolean;
+    authorizationUrl: string;
+  };
+  expect(started.success).toBe(true);
+  const state = new URL(started.authorizationUrl).searchParams.get('state');
+  expect(state).toBeTruthy();
+  expect((await harness.callback(state!)).status).toBe(200);
+}
+
+async function replaceWithNewAuthorization(harness: SQLiteHarness): Promise<number> {
+  const repository = new UserMCPOAuthTokenRepository(harness.rawDb);
+  const previous = await repository.getToken(
+    harness.user.user_id as UserID,
+    harness.server.mcp_server_id as MCPServerID
+  );
+  if (
+    !previous?.grant_binding_fingerprint ||
+    !previous.oauth_metadata_uri ||
+    !previous.oauth_resource_uri ||
+    !previous.oauth_issuer ||
+    !previous.oauth_authorization_endpoint ||
+    !previous.oauth_token_endpoint ||
+    !previous.oauth_redirect_uri ||
+    !previous.oauth_client_id
+  ) {
+    throw new Error('Expected a complete bound SQLite grant fixture');
+  }
+  const generation = previous.grant_generation + 1;
+  await repository.saveToken(
+    harness.user.user_id as UserID,
+    harness.server.mcp_server_id as MCPServerID,
+    {
+      accessToken: 'new-authorization-access-token',
+      refreshToken: 'new-authorization-refresh-token',
+      clientId: previous.oauth_client_id,
+      clientSecret: previous.oauth_client_secret,
+      expiresAt: new Date(Date.now() + 3_600_000),
+      grantBinding: {
+        generation,
+        version: 4,
+        fingerprint: previous.grant_binding_fingerprint,
+        metadataUri: previous.oauth_metadata_uri,
+        resourceUri: previous.oauth_resource_uri,
+        issuer: previous.oauth_issuer,
+        authorizationEndpoint: previous.oauth_authorization_endpoint,
+        tokenEndpoint: previous.oauth_token_endpoint,
+        redirectUri: previous.oauth_redirect_uri,
+      },
+    }
+  );
+  return generation;
 }
 
 const providers: TestProvider[] = [];
@@ -415,5 +504,102 @@ describe('SQLite saved-row OAuth authority', () => {
         harness.server.mcp_server_id as MCPServerID
       )
     ).toBeNull();
+  });
+
+  it('does not resurrect a grant deleted by a Settings mutation during refresh', async () => {
+    const provider = await createTestProvider({ holdRefresh: true });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const refresh = harness.app
+      .service('mcp-servers/oauth-refresh')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await Promise.race([
+      provider.refreshRequested.promise,
+      refresh.then((result) => {
+        throw new Error(`Refresh returned before provider exchange: ${JSON.stringify(result)}`);
+      }),
+    ]);
+    await harness.app
+      .service('mcp-servers')
+      .patch(
+        harness.server.mcp_server_id,
+        { headers: { 'X-Saved-Config': 'mutated-during-refresh' } },
+        paramsFor(harness)
+      );
+    provider.releaseRefresh();
+
+    await expect(refresh).resolves.toMatchObject({ success: false, error: 'needs_reauth' });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('does not let an old refresh overwrite a newer authorization generation', async () => {
+    const provider = await createTestProvider({ holdRefresh: true });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const refresh = harness.app
+      .service('mcp-servers/oauth-refresh')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await Promise.race([
+      provider.refreshRequested.promise,
+      refresh.then((result) => {
+        throw new Error(`Refresh returned before provider exchange: ${JSON.stringify(result)}`);
+      }),
+    ]);
+    const generation = await replaceWithNewAuthorization(harness);
+    provider.releaseRefresh();
+
+    await expect(refresh).resolves.toMatchObject({ success: false, error: 'needs_reauth' });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({
+      grant_generation: generation,
+      oauth_access_token: 'new-authorization-access-token',
+      oauth_refresh_token: 'new-authorization-refresh-token',
+    });
+  });
+
+  it('does not let stale invalid_grant delete a newer authorization', async () => {
+    const provider = await createTestProvider({ holdRefresh: true, invalidRefresh: true });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const refresh = harness.app
+      .service('mcp-servers/oauth-refresh')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    await Promise.race([
+      provider.refreshRequested.promise,
+      refresh.then((result) => {
+        throw new Error(`Refresh returned before provider exchange: ${JSON.stringify(result)}`);
+      }),
+    ]);
+    const generation = await replaceWithNewAuthorization(harness);
+    provider.releaseRefresh();
+
+    await expect(refresh).resolves.toMatchObject({ success: false, error: 'needs_reauth' });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({
+      grant_generation: generation,
+      oauth_access_token: 'new-authorization-access-token',
+    });
   });
 });

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1,0 +1,419 @@
+import http from 'node:http';
+import {
+  createDatabaseAsync,
+  MCPServerRepository,
+  runMigrations,
+  type TenantScopeAwareDatabase,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { type Application, feathers } from '@agor/core/feathers';
+import type { AuthenticatedParams, MCPServer, MCPServerID, User, UserID } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
+
+// The boundary under test is daemon discovery/OAuth authority, not the MCP
+// SDK's stream parser. Mock only the post-grant capability client so Vitest
+// does not try to type-strip eventsource-parser's published TypeScript file.
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    async connect() {}
+    async close() {}
+    async listTools() {
+      return { tools: [] };
+    }
+    async listResources() {
+      return { resources: [] };
+    }
+    async listPrompts() {
+      return { prompts: [] };
+    }
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {},
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+type TestProvider = {
+  baseUrl: string;
+  savedMcpUrl: string;
+  transientMcpUrl: string;
+  requests: Array<{ path: string; authorization?: string; transientHeader?: string }>;
+  tokenRequested: Deferred<void>;
+  releaseToken: () => void;
+  close: () => Promise<void>;
+};
+
+async function createTestProvider(options: { holdToken?: boolean } = {}): Promise<TestProvider> {
+  const requests: TestProvider['requests'] = [];
+  const tokenRequested = deferred<void>();
+  const release = deferred<void>();
+  let baseUrl = '';
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', baseUrl);
+    requests.push({
+      path: url.pathname,
+      authorization: request.headers.authorization,
+      transientHeader:
+        typeof request.headers['x-transient-config'] === 'string'
+          ? request.headers['x-transient-config']
+          : undefined,
+    });
+
+    if (url.pathname === '/.well-known/oauth-protected-resource') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          resource: `${baseUrl}/saved/mcp`,
+          authorization_servers: [baseUrl],
+        })
+      );
+      return;
+    }
+    if (url.pathname === '/.well-known/oauth-authorization-server') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          issuer: baseUrl,
+          authorization_endpoint: `${baseUrl}/authorize`,
+          token_endpoint: `${baseUrl}/token`,
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256'],
+          authorization_response_iss_parameter_supported: true,
+        })
+      );
+      return;
+    }
+    if (url.pathname === '/token') {
+      tokenRequested.resolve();
+      if (options.holdToken) await release.promise;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          access_token: 'sqlite-access-token',
+          refresh_token: 'refresh',
+          expires_in: 3600,
+        })
+      );
+      return;
+    }
+    if (url.pathname === '/saved/mcp') {
+      if (request.headers.authorization !== 'Bearer sqlite-access-token') {
+        response.writeHead(401, {
+          'www-authenticate': `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
+        });
+        response.end();
+        return;
+      }
+
+      let body = '';
+      for await (const chunk of request) body += String(chunk);
+      const rpc = body ? (JSON.parse(body) as { id?: unknown; method?: string }) : {};
+      const result =
+        rpc.method === 'initialize'
+          ? {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              serverInfo: { name: 'sqlite-oauth-test', version: '1.0.0' },
+            }
+          : rpc.method === 'tools/list'
+            ? { tools: [] }
+            : rpc.method === 'resources/list'
+              ? { resources: [] }
+              : rpc.method === 'prompts/list'
+                ? { prompts: [] }
+                : {};
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id ?? 1, result }));
+      return;
+    }
+    if (url.pathname === '/transient/mcp') {
+      response.writeHead(418);
+      response.end('transient configuration must not be contacted');
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl,
+    savedMcpUrl: `${baseUrl}/saved/mcp`,
+    transientMcpUrl: `${baseUrl}/transient/mcp`,
+    requests,
+    tokenRequested,
+    releaseToken: () => release.resolve(),
+    close: () => {
+      release.resolve();
+      return new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+type SQLiteHarness = {
+  app: Application & { io: unknown };
+  db: TenantScopeAwareDatabase;
+  rawDb: Awaited<ReturnType<typeof createDatabaseAsync>>;
+  user: User;
+  server: MCPServer;
+  nextAuthorizationUrl: () => Promise<string>;
+  callback: (state: string) => Promise<{ status: number; body: string }>;
+};
+
+async function createHarness(provider: TestProvider, oauthMode?: 'per_user' | 'shared') {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const db = rawDb as unknown as TenantScopeAwareDatabase;
+  const user = await new UsersRepository(rawDb).create({
+    email: `sqlite-oauth-${Math.random()}@example.com`,
+    role: 'admin',
+  });
+  const server = await new MCPServerRepository(rawDb).create({
+    name: 'sqlite-oauth-authority',
+    transport: 'http',
+    url: provider.savedMcpUrl,
+    headers: { 'X-Saved-Config': 'true' },
+    scope: 'global',
+    owner_user_id: user.user_id as UserID,
+    auth: {
+      type: 'oauth',
+      oauth_client_id: 'saved-client-id',
+      ...(oauthMode ? { oauth_mode: oauthMode } : {}),
+    },
+  });
+
+  let nextUrl = deferred<string>();
+  const io = {
+    local: {
+      to: () => ({
+        emit: (event: string, value: { authUrl?: string }) => {
+          if (event === 'oauth:open_browser' && value.authUrl) nextUrl.resolve(value.authUrl);
+        },
+      }),
+    },
+    to: () => ({ emit: vi.fn() }),
+  };
+  const app = feathers() as Application & { io: typeof io };
+  app.io = io;
+  const { oauthCallbackHandler } = await registerMCPServices({
+    db,
+    app,
+    config: {} as RegisterServicesContext['config'],
+    jwtSecret: 'test-jwt',
+    daemonUrl: 'http://127.0.0.1:3030',
+    bundledUiAvailable: false,
+    DAEMON_PORT: 3030,
+    UI_PORT: 5173,
+    branchRbacEnabled: false,
+    allowSuperadmin: false,
+    requireAuth: async (context) => context,
+    deployment: {} as RegisterServicesContext['deployment'],
+  });
+
+  return {
+    app,
+    db,
+    rawDb,
+    user,
+    server,
+    nextAuthorizationUrl: async () => {
+      const value = await nextUrl.promise;
+      nextUrl = deferred<string>();
+      return value;
+    },
+    callback: async (state: string) => {
+      let status = 200;
+      let body = '';
+      const response = {
+        setHeader: vi.fn(),
+        status(code: number) {
+          status = code;
+          return this;
+        },
+        send(value: string) {
+          body = value;
+          return this;
+        },
+      };
+      await (oauthCallbackHandler as unknown as (req: unknown, res: unknown) => Promise<void>)(
+        { query: { code: 'authorization-code', state, iss: provider.baseUrl } },
+        response
+      );
+      return { status, body };
+    },
+  } satisfies SQLiteHarness;
+}
+
+function paramsFor(harness: SQLiteHarness): AuthenticatedParams & { connection: { id: string } } {
+  return {
+    user: harness.user,
+    connection: { id: 'sqlite-test-socket' },
+  } as AuthenticatedParams & { connection: { id: string } };
+}
+
+const providers: TestProvider[] = [];
+const databases: SQLiteHarness['rawDb'][] = [];
+let previousBaseUrl: string | undefined;
+let previousMasterSecret: string | undefined;
+
+beforeEach(() => {
+  previousBaseUrl = process.env.AGOR_BASE_URL;
+  previousMasterSecret = process.env.AGOR_MASTER_SECRET;
+  process.env.AGOR_BASE_URL = 'https://agor.example.test';
+  process.env.AGOR_MASTER_SECRET = 'a'.repeat(64);
+});
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.close()));
+  for (const db of databases.splice(0)) {
+    (db as unknown as { $client?: { close(): void } }).$client?.close();
+  }
+  if (previousBaseUrl === undefined) delete process.env.AGOR_BASE_URL;
+  else process.env.AGOR_BASE_URL = previousBaseUrl;
+  if (previousMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
+  else process.env.AGOR_MASTER_SECRET = previousMasterSecret;
+});
+
+describe('SQLite saved-row OAuth authority', () => {
+  it('ignores a transient Settings Test Connection snapshot and binds the saved row', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+
+    const discover = harness.app.service('mcp-servers/discover').create(
+      {
+        mcp_server_id: harness.server.mcp_server_id,
+        url: provider.transientMcpUrl,
+        transport: 'sse',
+        headers: { 'X-Transient-Config': 'must-not-leave-daemon' },
+        auth: {
+          type: 'oauth',
+          oauth_client_id: 'transient-client-id',
+          oauth_compatibility_mode: 'legacy',
+        },
+      },
+      paramsFor(harness)
+    );
+
+    const authorizationUrl = new URL(
+      await Promise.race([
+        harness.nextAuthorizationUrl(),
+        discover.then((result) => {
+          throw new Error(`Discover returned before OAuth start: ${JSON.stringify(result)}`);
+        }),
+      ])
+    );
+    expect(authorizationUrl.searchParams.get('client_id')).toBe('saved-client-id');
+    expect(authorizationUrl.searchParams.get('resource')).toBe(provider.savedMcpUrl);
+    expect(provider.requests.some((request) => request.path === '/transient/mcp')).toBe(false);
+    expect(provider.requests.some((request) => request.transientHeader)).toBe(false);
+
+    const callback = await harness.callback(authorizationUrl.searchParams.get('state')!);
+    expect(callback.status).toBe(200);
+    await discover;
+
+    const grant = await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+      harness.user.user_id as UserID,
+      harness.server.mcp_server_id as MCPServerID
+    );
+    expect(grant?.oauth_resource_uri).toBe(provider.savedMcpUrl);
+    expect(grant?.grant_binding_version).toBe(4);
+    expect(
+      await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        null,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).toBeNull();
+  });
+
+  it('rejects a saved-row mutation that lands while the provider token exchange is running', async () => {
+    const provider = await createTestProvider({ holdToken: true });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+
+    const started = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+      success: boolean;
+      authorizationUrl: string;
+    };
+    expect(started.success).toBe(true);
+    const authorizationUrl = new URL(started.authorizationUrl);
+
+    const callback = harness.callback(authorizationUrl.searchParams.get('state')!);
+    await provider.tokenRequested.promise;
+    await harness.app
+      .service('mcp-servers')
+      .patch(
+        harness.server.mcp_server_id,
+        { headers: { 'X-Saved-Config': 'mutated-during-exchange' } },
+        paramsFor(harness)
+      );
+    provider.releaseToken();
+
+    expect((await callback).status).not.toBe(200);
+    expect(
+      await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).toBeNull();
+  });
+
+  it('/test-oauth defaults an omitted oauth_mode to a per-user grant', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+
+    const testRequest = harness.app.service('mcp-servers/test-oauth').create(
+      {
+        mcp_url: provider.savedMcpUrl,
+        mcp_server_id: harness.server.mcp_server_id,
+        start_browser_flow: true,
+      },
+      paramsFor(harness)
+    );
+    const authorizationUrl = new URL(await harness.nextAuthorizationUrl());
+    expect((await harness.callback(authorizationUrl.searchParams.get('state')!)).status).toBe(200);
+    await expect(testRequest).resolves.toMatchObject({ success: true });
+
+    expect(
+      await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).not.toBeNull();
+    expect(
+      await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        null,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).toBeNull();
+  });
+});

--- a/apps/agor-daemon/src/register-services.oauth-status.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-status.test.ts
@@ -19,7 +19,8 @@ describe('register-services durable OAuth status authority', () => {
   // route asks it rather than deciding for itself.
   it('resolves durable status through the one place that decides it', () => {
     expect(statusBlock).toContain('resolveAuthenticatedServerIds');
-    expect(statusBlock).toContain('requireGrantBinding: isPostgresDatabaseHandle(db)');
+    expect(statusBlock).toContain('requireGrantBinding: true');
+    expect(statusBlock).toContain('shouldVerifyMCPOAuthGrantBinding(');
   });
 
   it('gives the refresh owner and observer the same retryable known-failure response', () => {

--- a/apps/agor-daemon/src/register-services.oauth-status.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-status.test.ts
@@ -20,7 +20,7 @@ describe('register-services durable OAuth status authority', () => {
   it('resolves durable status through the one place that decides it', () => {
     expect(statusBlock).toContain('resolveAuthenticatedServerIds');
     expect(statusBlock).toContain('requireGrantBinding: true');
-    expect(statusBlock).toContain('shouldVerifyMCPOAuthGrantBinding(');
+    expect(statusBlock).toContain('isMCPOAuthGrantAuthorizedForServer(');
   });
 
   it('gives the refresh owner and observer the same retryable known-failure response', () => {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -72,7 +72,13 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { hasMinimumRole, isMCPOAuthGrantBindingVersion, ROLES, TaskStatus } from '@agor/core/types';
+import {
+  assertPublicMCPOAuthCompatibilityMode,
+  hasMinimumRole,
+  isMCPOAuthGrantBindingVersion,
+  ROLES,
+  TaskStatus,
+} from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import { safeOutboundFetch } from '@agor/core/utils/safe-outbound-fetch';
 import type express from 'express';
@@ -158,7 +164,10 @@ import { createKnowledgeSettingsService } from './services/knowledge-settings.js
 import { createKnowledgeVersionsService } from './services/knowledge-versions.js';
 import { createLeaderboardService } from './services/leaderboard.js';
 import { createMCPCatalogService } from './services/mcp-catalog.js';
-import { resolveMCPOAuthCompatibilityMode } from './services/mcp-oauth-compatibility.js';
+import {
+  logMCPOAuthCompatibilityPolicy,
+  resolveMCPOAuthCompatibilityPolicy,
+} from './services/mcp-oauth-compatibility.js';
 import {
   classifyMCPOAuthCompletionFailure,
   OAuthFlowAuthorizationChangedError,
@@ -1653,6 +1662,14 @@ async function registerMCPServices(
     }
 
     let durableServer: import('@agor/core/types').MCPServer | undefined;
+    let effectiveMcpUrl = opts.mcpUrl;
+    let effectiveClientId = opts.clientId;
+    let effectiveClientSecret = opts.clientSecret;
+    let effectiveAuthorizationUrlOverride = opts.authorizationUrlOverride;
+    let effectiveTokenUrlOverride = opts.tokenUrlOverride;
+    let effectiveScope = opts.scope;
+    let effectiveCompatibilityMode = opts.compatibilityMode ?? 'strict';
+    let effectiveDcrMode = opts.dcrMode;
     let durableBinding:
       | {
           tenantId: string;
@@ -1675,6 +1692,19 @@ async function registerMCPServices(
           'The saved MCP server no longer matches this OAuth request. Save changes, then restart OAuth.'
         );
       }
+      const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(server);
+      logMCPOAuthCompatibilityPolicy('flow-start', server.mcp_server_id, compatibilityPolicy);
+      // The row reloaded in the tenant scope is the only durable authority.
+      // Callers may have discovered metadata from a transient form snapshot,
+      // but no grant may bind values that differ from the saved definition.
+      effectiveMcpUrl = server.url;
+      effectiveClientId = server.auth.oauth_client_id;
+      effectiveClientSecret = server.auth.oauth_client_secret;
+      effectiveAuthorizationUrlOverride = server.auth.oauth_authorization_url;
+      effectiveTokenUrlOverride = server.auth.oauth_token_url;
+      effectiveScope = server.auth.oauth_scope;
+      effectiveCompatibilityMode = compatibilityPolicy.mode;
+      effectiveDcrMode = server.auth.oauth_dcr_mode;
       if ((server.auth.oauth_mode ?? 'per_user') === 'shared') {
         const initiatingUser = await runInOAuthTenantScope(db, opts.tenantId, () =>
           new UsersRepository(db).findById(opts.userId!)
@@ -1692,23 +1722,23 @@ async function registerMCPServices(
       };
     }
 
-    const context = await startMCPOAuthFlow(opts.wwwAuthenticate, opts.clientId, redirectUri, {
-      authorizationUrlOverride: opts.authorizationUrlOverride,
-      tokenUrlOverride: opts.tokenUrlOverride,
-      clientSecret: opts.clientSecret,
-      scope: opts.scope,
+    const context = await startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
+      authorizationUrlOverride: effectiveAuthorizationUrlOverride,
+      tokenUrlOverride: effectiveTokenUrlOverride,
+      clientSecret: effectiveClientSecret,
+      scope: effectiveScope,
       resourceMetadataUrl: opts.resourceMetadataUrl,
       prefetchedAuthServerMetadata: opts.prefetchedAuthServerMetadata,
       // The core helper still needs a stable metadata key for its standalone
       // flow context. Daemon callers never read or populate its origin-only
       // bearer cache.
-      cacheKey: opts.prefetchedAuthServerMetadata ? opts.mcpUrl : undefined,
+      cacheKey: opts.prefetchedAuthServerMetadata ? effectiveMcpUrl : undefined,
       // Process-global DCR credentials are not a tenant/user/server namespace.
       // Daemon flows never share them, including in SQLite deployments.
       reuseDynamicClientRegistration: false,
-      resourceUri: opts.mcpUrl,
-      compatibilityMode: opts.compatibilityMode,
-      dcrMode: opts.dcrMode,
+      resourceUri: effectiveMcpUrl,
+      compatibilityMode: effectiveCompatibilityMode,
+      dcrMode: effectiveDcrMode,
       allowLocalhostHttp: !durableOAuthFlows,
     });
 
@@ -1745,6 +1775,7 @@ async function registerMCPServices(
                 redirectUri: context.redirectUri,
                 clientId: context.clientId,
                 clientSecret: context.clientSecret,
+                compatibilityMode: context.compatibilityMode,
               }
             ),
           });
@@ -1954,11 +1985,15 @@ async function registerMCPServices(
       if (!record) return;
       await runInOAuthTenantScope(db, record.tenantId, async () => {
         const server = await new MCPServerRepository(db).findById(record.mcpServerId);
+        const compatibilityPolicy = server
+          ? await resolveMCPOAuthCompatibilityPolicy(server)
+          : undefined;
         if (
           !server?.enabled ||
           server.auth?.type !== 'oauth' ||
           (server.auth.oauth_mode ?? 'per_user') !== record.oauthMode ||
           server.url !== pendingFlow.context.resourceUri ||
+          compatibilityPolicy?.mode !== pendingFlow.context.compatibilityMode ||
           !isMCPOAuthGrantBindingVersion(record.configFingerprintVersion)
         ) {
           throw new Error('MCP OAuth server configuration changed; restart authorization');
@@ -1975,6 +2010,7 @@ async function registerMCPServices(
             redirectUri: pendingFlow.context.redirectUri,
             clientId: pendingFlow.context.clientId,
             clientSecret: pendingFlow.context.clientSecret,
+            compatibilityMode: pendingFlow.context.compatibilityMode,
           },
           record.configFingerprintVersion
         );
@@ -2445,28 +2481,78 @@ async function registerMCPServices(
       params?: AuthenticatedParams & { connection?: { id?: string } }
     ) {
       try {
+        assertPublicMCPOAuthCompatibilityMode({
+          oauth_compatibility_mode: data.compatibility_mode,
+        });
         // Completing this flow writes a shared token onto the named row and
         // backfills its token endpoint, so the same rule the other flow-start
         // endpoints apply has to apply here. Testing a not-yet-created server
         // passes no id and is unaffected.
-        if (data.mcp_server_id) {
-          await runInOAuthTenantScope(
-            db,
-            tenantIdFromParams(params as AuthenticatedParams | undefined),
-            () =>
-              loadMcpServerForCaller(
-                db,
-                data.mcp_server_id as string,
-                params as AuthenticatedParams | undefined
-              )
+        const authoritativeServer = data.mcp_server_id
+          ? await runInOAuthTenantScope(
+              db,
+              tenantIdFromParams(params as AuthenticatedParams | undefined),
+              () =>
+                loadMcpServerForCaller(
+                  db,
+                  data.mcp_server_id as string,
+                  params as AuthenticatedParams | undefined
+                )
+            )
+          : undefined;
+        if (
+          authoritativeServer &&
+          (!authoritativeServer.enabled ||
+            !authoritativeServer.url ||
+            authoritativeServer.auth?.type !== 'oauth')
+        ) {
+          return {
+            success: false,
+            error:
+              'OAuth testing requires an enabled OAuth server. Save changes, then retry the test.',
+          };
+        }
+        if (authoritativeServer?.url && authoritativeServer.url !== data.mcp_url) {
+          return {
+            success: false,
+            error:
+              'The saved MCP server URL no longer matches this test. Save changes, then retry.',
+          };
+        }
+
+        const effectiveMcpUrl = authoritativeServer?.url ?? data.mcp_url;
+        const effectiveAuth = authoritativeServer?.auth;
+        const compatibilityPolicy = authoritativeServer
+          ? await resolveMCPOAuthCompatibilityPolicy(authoritativeServer)
+          : undefined;
+        const compatibilityMode = compatibilityPolicy?.mode ?? data.compatibility_mode ?? 'strict';
+        if (compatibilityPolicy) {
+          logMCPOAuthCompatibilityPolicy(
+            'test-oauth',
+            authoritativeServer?.mcp_server_id,
+            compatibilityPolicy
           );
         }
+        const effectiveClientId = authoritativeServer
+          ? effectiveAuth?.oauth_client_id
+          : data.client_id;
+        const effectiveClientSecret = authoritativeServer
+          ? effectiveAuth?.oauth_client_secret
+          : data.client_secret;
+        const effectiveScope = authoritativeServer ? effectiveAuth?.oauth_scope : data.scope;
+        const effectiveGrantType = authoritativeServer
+          ? effectiveAuth?.oauth_grant_type
+          : data.grant_type;
+        const effectiveDcrMode = authoritativeServer
+          ? effectiveAuth?.oauth_dcr_mode
+          : data.dcr_mode;
+        const effectiveOAuthMode = effectiveAuth?.oauth_mode ?? 'shared';
 
         console.log('[OAuth Test] Probing configured MCP server');
 
         let probeResponse: Response;
         try {
-          probeResponse = await oauthFetch(data.mcp_url, {
+          probeResponse = await oauthFetch(effectiveMcpUrl, {
             method: 'POST',
             headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
             body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
@@ -2480,7 +2566,7 @@ async function registerMCPServices(
         }
 
         if (probeResponse.status !== 401) {
-          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(data.mcp_url);
+          const fallbackProbe = await probeMcpAuthViaReadOnlyToolCall(effectiveMcpUrl);
           if (fallbackProbe) {
             console.log(
               '[OAuth Test] Handshake-level probe returned no auth requirement; ' +
@@ -2497,7 +2583,6 @@ async function registerMCPServices(
         });
         console.log(`[OAuth Test] Probe response status=${probeResponse.status}`);
 
-        const compatibilityMode = data.compatibility_mode ?? 'strict';
         let metadataUrl: string | null = null;
         let prefetchedAuthServerMetadata:
           | import('@agor/core/tools/mcp/oauth-mcp-transport').AuthorizationServerMetadata
@@ -2507,7 +2592,7 @@ async function registerMCPServices(
           const { resolveMCPOAuthDiscovery } = await import(
             '@agor/core/tools/mcp/oauth-mcp-transport'
           );
-          const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, data.mcp_url, {
+          const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, effectiveMcpUrl, {
             compatibilityMode,
             allowLocalhostHttp: !durableOAuthFlows,
           });
@@ -2526,7 +2611,10 @@ async function registerMCPServices(
           console.log('[OAuth Test] OAuth 2.1 auto-discovery detected');
 
           if (data.start_browser_flow) {
-            if (!hasMinimumRole((params as AuthenticatedParams)?.user?.role, ROLES.ADMIN)) {
+            if (
+              effectiveOAuthMode === 'shared' &&
+              !hasMinimumRole((params as AuthenticatedParams)?.user?.role, ROLES.ADMIN)
+            ) {
               throw new Forbidden('Shared MCP OAuth grants can only be started by an admin');
             }
             console.log('[OAuth Test] Starting browser-based OAuth 2.1 flow...');
@@ -2543,7 +2631,7 @@ async function registerMCPServices(
               let started: StartTwoPhaseOAuthAndAwaitResult;
               try {
                 started = await startTwoPhaseMCPOAuthFlowAndAwaitToken({
-                  mcpUrl: data.mcp_url,
+                  mcpUrl: effectiveMcpUrl,
                   wwwAuthenticate: wwwAuthenticate || '',
                   resourceMetadataUrl: metadataUrl ?? undefined,
                   prefetchedAuthServerMetadata: prefetchedAuthServerMetadata ?? undefined,
@@ -2551,14 +2639,14 @@ async function registerMCPServices(
                   userId: (params as AuthenticatedParams)?.user?.user_id,
                   // Test endpoint mirrors the previous saveOAuth21TokenToDB
                   // call (writes to the shared MCP server row, not per-user).
-                  oauthMode: 'shared',
-                  clientId: data.client_id,
+                  oauthMode: effectiveOAuthMode,
+                  clientId: effectiveClientId,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
                   socketId: connection?.id,
-                  clientSecret: data.client_secret,
-                  scope: data.scope,
+                  clientSecret: effectiveClientSecret,
+                  scope: effectiveScope,
                   compatibilityMode,
-                  dcrMode: data.dcr_mode,
+                  dcrMode: effectiveDcrMode,
                 });
               } catch (err) {
                 if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -2569,7 +2657,7 @@ async function registerMCPServices(
 
               const tokenResponse = await started.awaitToken();
 
-              const testResponse = await oauthFetch(data.mcp_url, {
+              const testResponse = await oauthFetch(effectiveMcpUrl, {
                 method: 'POST',
                 headers: {
                   Authorization: `Bearer ${tokenResponse.access_token}`,
@@ -2720,15 +2808,15 @@ async function registerMCPServices(
             /* Ignore */
           }
 
-          if (data.client_id && data.client_secret) {
+          if (effectiveClientId && effectiveClientSecret) {
             console.log('[OAuth Test] Using Client Credentials flow');
             const { fetchOAuthToken, inferOAuthTokenUrl } = await import(
               '@agor/core/tools/mcp/oauth-auth'
             );
-            let tokenUrl = data.token_url;
+            let tokenUrl = authoritativeServer ? effectiveAuth?.oauth_token_url : data.token_url;
             let tokenUrlSource: 'provided' | 'auto-detected' = 'provided';
             if (!tokenUrl) {
-              tokenUrl = inferOAuthTokenUrl(data.mcp_url);
+              tokenUrl = inferOAuthTokenUrl(effectiveMcpUrl);
               tokenUrlSource = 'auto-detected';
               if (!tokenUrl)
                 return {
@@ -2740,10 +2828,10 @@ async function registerMCPServices(
             const { token, debugInfo } = await fetchOAuthToken(
               {
                 token_url: tokenUrl,
-                client_id: data.client_id,
-                client_secret: data.client_secret,
-                scope: data.scope,
-                grant_type: data.grant_type || 'client_credentials',
+                client_id: effectiveClientId,
+                client_secret: effectiveClientSecret,
+                scope: effectiveScope,
+                grant_type: effectiveGrantType || 'client_credentials',
                 allowLocalhostHttp: !durableOAuthFlows,
                 cacheNamespace: [
                   tenantIdFromParams(params as AuthenticatedParams | undefined) ?? '<standalone>',
@@ -2757,7 +2845,7 @@ async function registerMCPServices(
             let mcpStatus: number | undefined;
             let mcpStatusText: string | undefined;
             try {
-              const mcpResponse = await oauthFetch(data.mcp_url, {
+              const mcpResponse = await oauthFetch(effectiveMcpUrl, {
                 method: 'POST',
                 headers: {
                   Authorization: `Bearer ${token}`,
@@ -2885,7 +2973,13 @@ async function registerMCPServices(
           clientIdFromConfig = savedServer.auth.oauth_client_id;
           clientSecretOverride = savedServer.auth.oauth_client_secret;
           scopeOverride = savedServer.auth.oauth_scope;
-          compatibilityMode = resolveMCPOAuthCompatibilityMode(savedServer);
+          const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(savedServer);
+          compatibilityMode = compatibilityPolicy.mode;
+          logMCPOAuthCompatibilityPolicy(
+            'oauth-start',
+            savedServer.mcp_server_id,
+            compatibilityPolicy
+          );
           dcrMode = savedServer.auth.oauth_dcr_mode;
           if (oauthMode === 'shared') {
             const currentUser =
@@ -3179,8 +3273,13 @@ async function registerMCPServices(
           listShared: () => userTokenRepo.listShared(),
           findServer: (serverId) => serverRepo.findById(serverId),
           requireGrantBinding: isPostgresDatabaseHandle(db),
-          isGrantBoundToServer: (server, grant) =>
-            isMCPOAuthGrantBoundToServer(process.env.AGOR_MASTER_SECRET!, server, grant),
+          isGrantBoundToServer: async (server, grant) =>
+            isMCPOAuthGrantBoundToServer(
+              process.env.AGOR_MASTER_SECRET!,
+              server,
+              grant,
+              (await resolveMCPOAuthCompatibilityPolicy(server)).mode
+            ),
         });
         return { authenticated_server_ids: authenticatedServerIds };
       } catch (error) {
@@ -3399,9 +3498,15 @@ async function registerMCPServices(
               headers[serverId] = { error: 'needs_reauth' };
               return;
             }
+            const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
             if (
               isPostgresDatabaseHandle(db) &&
-              !isMCPOAuthGrantBoundToServer(process.env.AGOR_MASTER_SECRET!, server, row)
+              !isMCPOAuthGrantBoundToServer(
+                process.env.AGOR_MASTER_SECRET!,
+                server,
+                row,
+                compatibilityMode
+              )
             ) {
               await runInOAuthTenantWriteScope(db, tenantId, () =>
                 new UserMCPOAuthTokenRepository(db).deleteGrantVersion(
@@ -3587,9 +3692,15 @@ async function registerMCPServices(
           const currentGrant = await runInOAuthTenantScope(db, tenantId, () =>
             new UserMCPOAuthTokenRepository(db).getToken(tokenUserId, serverId as MCPServerID)
           );
+          const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
           if (
             !currentGrant ||
-            !isMCPOAuthGrantBoundToServer(process.env.AGOR_MASTER_SECRET!, server, currentGrant)
+            !isMCPOAuthGrantBoundToServer(
+              process.env.AGOR_MASTER_SECRET!,
+              server,
+              currentGrant,
+              compatibilityMode
+            )
           ) {
             if (currentGrant) {
               await runInOAuthTenantWriteScope(db, tenantId, () =>
@@ -3722,12 +3833,15 @@ async function registerMCPServices(
           oauth_scope?: string;
           oauth_grant_type?: string;
           oauth_mode?: 'per_user' | 'shared';
+          oauth_compatibility_mode?: 'strict' | 'legacy';
+          oauth_dcr_mode?: MCPOAuthDCRMode;
         };
         headers?: Record<string, string>;
       },
       params?: AuthenticatedParams
     ) {
       try {
+        assertPublicMCPOAuthCompatibilityMode(data.auth);
         const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
         const { StreamableHTTPClientTransport } = await import(
           '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -3774,6 +3888,7 @@ async function registerMCPServices(
           catalog_entry_name?: string;
         };
         let serverId: string | undefined;
+        let authoritativeServer: MCPServer | undefined;
 
         if (hasInlineConfig) {
           if (!isTemplated(data.url!)) {
@@ -3793,16 +3908,34 @@ async function registerMCPServices(
             );
             const denial = denyDiscoverOfAnotherUsersServer(server, params);
             if (denial) return denial;
-            serverConfig.auth = restoreRedactedMCPAuthSecrets({
-              current: server.auth,
-              next: data.auth,
-            });
-            serverConfig.headers = restoreRedactedMCPCustomHeaders({
-              current: server.headers,
-              next: data.headers,
-            });
-            serverConfig.source = server.source;
-            serverConfig.catalog_entry_name = server.catalog_entry_name;
+            authoritativeServer = server;
+            if (durableOAuthFlows) {
+              // A PostgreSQL discover may create a durable grant. Ignore the
+              // mutable form snapshot and use the row that the eventual
+              // pending flow and grant are bound to.
+              serverConfig = {
+                url: server.url || '',
+                transport: (server.transport as 'http' | 'sse') || (server.url ? 'http' : 'stdio'),
+                auth: server.auth,
+                headers: server.headers,
+                name: server.name,
+                scope: server.scope,
+                owner_user_id: server.owner_user_id,
+                source: server.source,
+                catalog_entry_name: server.catalog_entry_name,
+              };
+            } else {
+              serverConfig.auth = restoreRedactedMCPAuthSecrets({
+                current: server.auth,
+                next: data.auth,
+              });
+              serverConfig.headers = restoreRedactedMCPCustomHeaders({
+                current: server.headers,
+                next: data.headers,
+              });
+              serverConfig.source = server.source;
+              serverConfig.catalog_entry_name = server.catalog_entry_name;
+            }
             serverId = data.mcp_server_id;
           }
         } else if (data.mcp_server_id) {
@@ -3811,6 +3944,7 @@ async function registerMCPServices(
           );
           const denial = denyDiscoverOfAnotherUsersServer(server, params);
           if (denial) return denial;
+          authoritativeServer = server;
           if (server.url && !isTemplated(server.url)) {
             const urlValidation = validateUrl(server.url);
             if (!urlValidation.valid) return { success: false, error: urlValidation.error };
@@ -3912,7 +4046,14 @@ async function registerMCPServices(
             const { resolveMCPOAuthDiscovery } = await import(
               '@agor/core/tools/mcp/oauth-mcp-transport'
             );
-            const compatibilityMode = resolveMCPOAuthCompatibilityMode(serverConfig);
+            const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(
+              authoritativeServer ?? {
+                ...serverConfig,
+                source: serverConfig.source ?? 'user',
+              }
+            );
+            const compatibilityMode = compatibilityPolicy.mode;
+            logMCPOAuthCompatibilityPolicy('discover', serverId, compatibilityPolicy);
             const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, mcpUrl, {
               compatibilityMode,
               allowLocalhostHttp: !durableOAuthFlows,
@@ -4000,7 +4141,15 @@ async function registerMCPServices(
                     catalog_entry_name: serverConfig.catalog_entry_name,
                     auth: serverConfig.auth,
                   },
-                  grant
+                  grant,
+                  (
+                    await resolveMCPOAuthCompatibilityPolicy(
+                      authoritativeServer ?? {
+                        ...serverConfig,
+                        source: serverConfig.source ?? 'user',
+                      }
+                    )
+                  ).mode
                 )
               ) {
                 return undefined;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -62,6 +62,7 @@ import type {
   MCPOAuthAttemptID,
   MCPOAuthDCRMode,
   MCPOAuthPendingFlowStatus,
+  MCPOAuthRuntimeCompatibilityMode,
   MCPOAuthStartFailure,
   MCPServer,
   MCPServerID,
@@ -157,6 +158,7 @@ import { createKnowledgeSettingsService } from './services/knowledge-settings.js
 import { createKnowledgeVersionsService } from './services/knowledge-versions.js';
 import { createLeaderboardService } from './services/leaderboard.js';
 import { createMCPCatalogService } from './services/mcp-catalog.js';
+import { resolveMCPOAuthCompatibilityMode } from './services/mcp-oauth-compatibility.js';
 import {
   classifyMCPOAuthCompletionFailure,
   OAuthFlowAuthorizationChangedError,
@@ -1599,7 +1601,7 @@ async function registerMCPServices(
     authorizationUrlOverride?: string;
     tokenUrlOverride?: string;
     scope?: string;
-    compatibilityMode?: 'strict' | 'legacy';
+    compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     dcrMode?: MCPOAuthDCRMode;
     socketId?: string;
   };
@@ -2826,7 +2828,7 @@ async function registerMCPServices(
         let clientSecretOverride: string | undefined;
         let clientIdFromConfig: string | undefined;
         let scopeOverride: string | undefined;
-        let compatibilityMode: 'strict' | 'legacy' = 'strict';
+        let compatibilityMode: MCPOAuthRuntimeCompatibilityMode = 'strict';
         let dcrMode: MCPOAuthDCRMode | undefined;
         const savedServerId = data.mcp_server_id;
         // Its stored OAuth client configuration belongs to whoever owns the
@@ -2883,7 +2885,7 @@ async function registerMCPServices(
           clientIdFromConfig = savedServer.auth.oauth_client_id;
           clientSecretOverride = savedServer.auth.oauth_client_secret;
           scopeOverride = savedServer.auth.oauth_scope;
-          compatibilityMode = savedServer.auth.oauth_compatibility_mode ?? 'strict';
+          compatibilityMode = resolveMCPOAuthCompatibilityMode(savedServer);
           dcrMode = savedServer.auth.oauth_dcr_mode;
           if (oauthMode === 'shared') {
             const currentUser =
@@ -3768,6 +3770,8 @@ async function registerMCPServices(
           name?: string;
           scope?: string;
           owner_user_id?: string;
+          source?: MCPServer['source'];
+          catalog_entry_name?: string;
         };
         let serverId: string | undefined;
 
@@ -3797,6 +3801,8 @@ async function registerMCPServices(
               current: server.headers,
               next: data.headers,
             });
+            serverConfig.source = server.source;
+            serverConfig.catalog_entry_name = server.catalog_entry_name;
             serverId = data.mcp_server_id;
           }
         } else if (data.mcp_server_id) {
@@ -3817,6 +3823,8 @@ async function registerMCPServices(
             name: server.name,
             scope: server.scope,
             owner_user_id: server.owner_user_id,
+            source: server.source,
+            catalog_entry_name: server.catalog_entry_name,
           };
           serverId = data.mcp_server_id;
         } else {
@@ -3904,7 +3912,7 @@ async function registerMCPServices(
             const { resolveMCPOAuthDiscovery } = await import(
               '@agor/core/tools/mcp/oauth-mcp-transport'
             );
-            const compatibilityMode = serverConfig.auth?.oauth_compatibility_mode ?? 'strict';
+            const compatibilityMode = resolveMCPOAuthCompatibilityMode(serverConfig);
             const discovery = await resolveMCPOAuthDiscovery(wwwAuthenticate, mcpUrl, {
               compatibilityMode,
               allowLocalhostHttp: !durableOAuthFlows,
@@ -3988,6 +3996,8 @@ async function registerMCPServices(
                     enabled: true,
                     transport: serverConfig.transport,
                     url: serverConfig.url,
+                    source: serverConfig.source ?? 'user',
+                    catalog_entry_name: serverConfig.catalog_entry_name,
                     auth: serverConfig.auth,
                   },
                   grant

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -36,6 +36,7 @@ import {
   RepoRepository,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
+  type SaveTokenInput,
   SessionMCPServerRepository,
   SessionRepository,
   select,
@@ -174,9 +175,11 @@ import {
 } from './services/mcp-oauth-exchange-classification.js';
 import {
   fingerprintMCPOAuthGrantConfiguration,
+  grantBindingVersionForCompatibilityMode,
   hasMCPOAuthRelevantServerConfigurationChanged,
   isMCPOAuthGrantBoundToServer,
   lockMCPOAuthGrantConfiguration,
+  shouldVerifyMCPOAuthGrantBinding,
 } from './services/mcp-oauth-grant-binding.js';
 import { MCPOAuthPendingFlowAuthority } from './services/mcp-oauth-pending-flow-authority.js';
 import { resolveAuthenticatedServerIds } from './services/mcp-oauth-status.js';
@@ -594,7 +597,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   // The OAuth callback middleware is registered in boot.ts; here we set the handler
   {
-    const mcpResult = await registerMCPServices(ctx, sessionsService);
+    const mcpResult = await registerMCPServices(ctx);
     oauthCallbackHandler = isConstrainedHa(ctx.deployment)
       ? (_req, res) => {
           res.status(503).json({
@@ -1415,9 +1418,8 @@ function createExecuteHandler(
 // MCP Services Registration (large block extracted for readability)
 // ============================================================================
 
-async function registerMCPServices(
-  ctx: RegisterServicesContext,
-  sessionsService: SessionsServiceImpl
+export async function registerMCPServices(
+  ctx: RegisterServicesContext
 ): Promise<{ oauthCallbackHandler: (req: express.Request, res: express.Response) => void }> {
   const { db, app } = ctx;
   const sessionsRepository = new SessionRepository(db);
@@ -1469,10 +1471,23 @@ async function registerMCPServices(
     tokenReject?: (err: Error) => void;
     /** Present only for a PostgreSQL one-shot claim. */
     durableRecord?: MCPOAuthPendingFlowRecord;
+    /**
+     * Exact saved row that authorized a standalone/SQLite flow. The callback
+     * re-reads and compares this authority both before and after the provider
+     * exchange, so consuming the in-memory state cannot detach the grant from
+     * a concurrent Settings edit.
+     */
+    savedServerAuthority?: MCPServer;
+    /** Bound grant envelope issued for new standalone flows. */
+    localGrantBinding?: NonNullable<SaveTokenInput['grantBinding']>;
   };
 
   // Store pending OAuth flow contexts
   const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
+  // SQLite has no cross-process flow, but callbacks and Settings mutations can
+  // interleave within this daemon. A monotonic per-subject generation prevents
+  // an older exchange from replacing a newer completed authorization.
+  const localOAuthGrantGenerations = new Map<string, number>();
   const localOAuthAttemptStatuses = new Map<
     MCPOAuthAttemptID,
     {
@@ -1661,7 +1676,7 @@ async function registerMCPServices(
       );
     }
 
-    let durableServer: import('@agor/core/types').MCPServer | undefined;
+    let savedServerAuthority: MCPServer | undefined;
     let effectiveMcpUrl = opts.mcpUrl;
     let effectiveClientId = opts.clientId;
     let effectiveClientSecret = opts.clientSecret;
@@ -1670,6 +1685,7 @@ async function registerMCPServices(
     let effectiveScope = opts.scope;
     let effectiveCompatibilityMode = opts.compatibilityMode ?? 'strict';
     let effectiveDcrMode = opts.dcrMode;
+    let effectiveOAuthMode = opts.oauthMode ?? 'per_user';
     let durableBinding:
       | {
           tenantId: string;
@@ -1678,10 +1694,15 @@ async function registerMCPServices(
           oauthMode: 'per_user' | 'shared';
         }
       | undefined;
-    if (durableOAuthFlows) {
-      if (!opts.tenantId || !opts.userId || !opts.mcpServerId) {
+    if (durableOAuthFlows && (!opts.tenantId || !opts.userId || !opts.mcpServerId)) {
+      throw new Error(
+        'PostgreSQL OAuth requires a saved MCP server and authenticated tenant/user binding. Save the server, then restart OAuth.'
+      );
+    }
+    if (opts.mcpServerId) {
+      if (!opts.userId) {
         throw new Error(
-          'PostgreSQL OAuth requires a saved MCP server and authenticated tenant/user binding. Save the server, then restart OAuth.'
+          'Saved MCP OAuth requires an authenticated user binding. Sign in, then restart OAuth.'
         );
       }
       const server = await runInOAuthTenantScope(db, opts.tenantId, () =>
@@ -1705,7 +1726,8 @@ async function registerMCPServices(
       effectiveScope = server.auth.oauth_scope;
       effectiveCompatibilityMode = compatibilityPolicy.mode;
       effectiveDcrMode = server.auth.oauth_dcr_mode;
-      if ((server.auth.oauth_mode ?? 'per_user') === 'shared') {
+      effectiveOAuthMode = server.auth.oauth_mode ?? 'per_user';
+      if (effectiveOAuthMode === 'shared') {
         const initiatingUser = await runInOAuthTenantScope(db, opts.tenantId, () =>
           new UsersRepository(db).findById(opts.userId!)
         );
@@ -1713,13 +1735,17 @@ async function registerMCPServices(
           throw new Forbidden('Shared MCP OAuth grants can only be started by an admin');
         }
       }
-      durableServer = server;
-      durableBinding = {
-        tenantId: opts.tenantId,
-        userId: opts.userId as UserID,
-        mcpServerId: opts.mcpServerId as MCPServerID,
-        oauthMode: server.auth.oauth_mode ?? 'per_user',
-      };
+      // Clone the row so later repository/service mutations cannot change the
+      // in-memory authority captured by a standalone pending flow.
+      savedServerAuthority = structuredClone(server);
+      if (durableOAuthFlows) {
+        durableBinding = {
+          tenantId: opts.tenantId!,
+          userId: opts.userId as UserID,
+          mcpServerId: opts.mcpServerId as MCPServerID,
+          oauthMode: effectiveOAuthMode,
+        };
+      }
     }
 
     const context = await startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
@@ -1742,6 +1768,76 @@ async function registerMCPServices(
       allowLocalhostHttp: !durableOAuthFlows,
     });
 
+    const resolvedGrantBinding = {
+      resourceUri: context.resourceUri,
+      metadataUrl: context.metadataUrl,
+      issuer: context.issuer,
+      authorizationEndpoint: context.authorizationEndpoint,
+      tokenEndpoint: context.tokenEndpoint,
+      redirectUri: context.redirectUri,
+      clientId: context.clientId,
+      clientSecret: context.clientSecret,
+      compatibilityMode: context.compatibilityMode,
+    } satisfies import('./services/mcp-oauth-grant-binding.js').MCPOAuthResolvedGrantBinding;
+
+    let localGrantBinding: NonNullable<SaveTokenInput['grantBinding']> | undefined;
+    if (savedServerAuthority && !durableOAuthFlows) {
+      localGrantBinding = await runInOAuthTenantScope(db, opts.tenantId, async () => {
+        const currentServer = await new MCPServerRepository(db).findById(
+          savedServerAuthority!.mcp_server_id
+        );
+        const currentPolicy = currentServer
+          ? await resolveMCPOAuthCompatibilityPolicy(currentServer)
+          : undefined;
+        if (
+          !currentServer?.enabled ||
+          currentServer.auth?.type !== 'oauth' ||
+          currentServer.url !== context.resourceUri ||
+          (currentServer.auth.oauth_mode ?? 'per_user') !== effectiveOAuthMode ||
+          currentPolicy?.mode !== context.compatibilityMode ||
+          hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
+        ) {
+          throw new Error(
+            'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
+          );
+        }
+
+        const subjectUserId = effectiveOAuthMode === 'per_user' ? (opts.userId as UserID) : null;
+        const subjectKey = [
+          currentServer.mcp_server_id,
+          effectiveOAuthMode,
+          subjectUserId ?? '<shared>',
+        ].join('\u001f');
+        const existingGrant = await new UserMCPOAuthTokenRepository(db).getToken(
+          subjectUserId,
+          currentServer.mcp_server_id
+        );
+        const generation =
+          Math.max(
+            existingGrant?.grant_generation ?? 0,
+            localOAuthGrantGenerations.get(subjectKey) ?? 0
+          ) + 1;
+        localOAuthGrantGenerations.set(subjectKey, generation);
+        const version = grantBindingVersionForCompatibilityMode(context.compatibilityMode);
+        return {
+          generation,
+          version,
+          fingerprint: fingerprintMCPOAuthGrantConfiguration(
+            process.env.AGOR_MASTER_SECRET!,
+            currentServer,
+            resolvedGrantBinding,
+            version
+          ),
+          metadataUri: context.metadataUrl,
+          resourceUri: context.resourceUri,
+          issuer: context.issuer,
+          authorizationEndpoint: context.authorizationEndpoint,
+          tokenEndpoint: context.tokenEndpoint,
+          redirectUri: context.redirectUri,
+        };
+      });
+    }
+
     const attemptId = durableBinding
       ? await runInOAuthTenantWriteScope(db, durableBinding.tenantId, async () => {
           await lockMCPOAuthGrantConfiguration(
@@ -1754,7 +1850,7 @@ async function registerMCPServices(
           );
           if (
             !currentServer ||
-            hasMCPOAuthRelevantServerConfigurationChanged(durableServer, currentServer)
+            hasMCPOAuthRelevantServerConfigurationChanged(savedServerAuthority, currentServer)
           ) {
             throw new Error(
               'The MCP server changed while OAuth metadata was being resolved. Restart OAuth.'
@@ -1766,17 +1862,7 @@ async function registerMCPServices(
             configFingerprint: fingerprintMCPOAuthGrantConfiguration(
               process.env.AGOR_MASTER_SECRET!,
               currentServer,
-              {
-                resourceUri: context.resourceUri,
-                metadataUrl: context.metadataUrl,
-                issuer: context.issuer,
-                authorizationEndpoint: context.authorizationEndpoint,
-                tokenEndpoint: context.tokenEndpoint,
-                redirectUri: context.redirectUri,
-                clientId: context.clientId,
-                clientSecret: context.clientSecret,
-                compatibilityMode: context.compatibilityMode,
-              }
+              resolvedGrantBinding
             ),
           });
         })
@@ -1810,7 +1896,7 @@ async function registerMCPServices(
                 userId: opts.userId,
                 tenantId: opts.tenantId,
                 mcpServerId: opts.mcpServerId,
-                oauthMode: opts.oauthMode,
+                oauthMode: effectiveOAuthMode,
                 failureCode: 'authorization_timed_out',
                 updatedAt: Date.now(),
               });
@@ -1831,8 +1917,8 @@ async function registerMCPServices(
         const sameSubject =
           older.tenantId === (opts.tenantId ?? getCurrentTenantId()) &&
           older.mcpServerId === opts.mcpServerId &&
-          (older.oauthMode ?? 'per_user') === (opts.oauthMode ?? 'per_user') &&
-          ((opts.oauthMode ?? 'per_user') === 'shared' || older.userId === opts.userId);
+          (older.oauthMode ?? 'per_user') === effectiveOAuthMode &&
+          (effectiveOAuthMode === 'shared' || older.userId === opts.userId);
         if (!sameSubject) continue;
         pendingOAuthFlows.delete(olderState);
         markLocalOAuthAttempt(older, 'failed', 'superseded_by_newer_attempt');
@@ -1843,19 +1929,21 @@ async function registerMCPServices(
         context,
         mcpServerId: opts.mcpServerId,
         userId: opts.userId,
-        oauthMode: opts.oauthMode,
+        oauthMode: effectiveOAuthMode,
         tenantId: opts.tenantId ?? getCurrentTenantId(),
         socketId: opts.socketId,
         createdAt: Date.now(),
         tokenResolve,
         tokenReject,
+        savedServerAuthority,
+        localGrantBinding,
       });
       localOAuthAttemptStatuses.set(attemptId, {
         status: 'pending',
         userId: opts.userId,
         tenantId: opts.tenantId,
         mcpServerId: opts.mcpServerId,
-        oauthMode: opts.oauthMode,
+        oauthMode: effectiveOAuthMode,
         updatedAt: Date.now(),
       });
     }
@@ -1982,7 +2070,53 @@ async function registerMCPServices(
         record?.tenantId ?? pendingFlow.tenantId,
         record?.oauthMode ?? pendingFlow.oauthMode ?? 'per_user'
       );
-      if (!record) return;
+      if (!record) {
+        if (!pendingFlow.mcpServerId) return;
+        const savedAuthority = pendingFlow.savedServerAuthority;
+        const grantBinding = pendingFlow.localGrantBinding;
+        if (!savedAuthority || !grantBinding) {
+          throw new Error('Saved standalone OAuth flow is missing its server authority');
+        }
+        await runInOAuthTenantScope(db, pendingFlow.tenantId, async () => {
+          const server = await new MCPServerRepository(db).findById(
+            pendingFlow.mcpServerId as MCPServerID
+          );
+          const compatibilityPolicy = server
+            ? await resolveMCPOAuthCompatibilityPolicy(server)
+            : undefined;
+          if (
+            !server?.enabled ||
+            server.auth?.type !== 'oauth' ||
+            (server.auth.oauth_mode ?? 'per_user') !== (pendingFlow.oauthMode ?? 'per_user') ||
+            server.url !== pendingFlow.context.resourceUri ||
+            compatibilityPolicy?.mode !== pendingFlow.context.compatibilityMode ||
+            hasMCPOAuthRelevantServerConfigurationChanged(savedAuthority, server) ||
+            !isMCPOAuthGrantBindingVersion(grantBinding.version)
+          ) {
+            throw new Error('MCP OAuth server configuration changed; restart authorization');
+          }
+          const fingerprint = fingerprintMCPOAuthGrantConfiguration(
+            process.env.AGOR_MASTER_SECRET!,
+            server,
+            {
+              resourceUri: pendingFlow.context.resourceUri,
+              metadataUrl: pendingFlow.context.metadataUrl,
+              issuer: pendingFlow.context.issuer,
+              authorizationEndpoint: pendingFlow.context.authorizationEndpoint,
+              tokenEndpoint: pendingFlow.context.tokenEndpoint,
+              redirectUri: pendingFlow.context.redirectUri,
+              clientId: pendingFlow.context.clientId,
+              clientSecret: pendingFlow.context.clientSecret,
+              compatibilityMode: pendingFlow.context.compatibilityMode,
+            },
+            grantBinding.version
+          );
+          if (fingerprint !== grantBinding.fingerprint) {
+            throw new Error('MCP OAuth grant binding changed; restart authorization');
+          }
+        });
+        return;
+      }
       await runInOAuthTenantScope(db, record.tenantId, async () => {
         const server = await new MCPServerRepository(db).findById(record.mcpServerId);
         const compatibilityPolicy = server
@@ -2038,6 +2172,19 @@ async function registerMCPServices(
           return version;
         })()
       : undefined;
+    const grantBinding = pendingFlow.durableRecord
+      ? {
+          generation: pendingFlow.durableRecord.grantGeneration,
+          version: durableGrantBindingVersion!,
+          fingerprint: pendingFlow.durableRecord.configFingerprint,
+          metadataUri: pendingFlow.context.metadataUrl,
+          resourceUri: pendingFlow.context.resourceUri,
+          issuer: pendingFlow.context.issuer,
+          authorizationEndpoint: pendingFlow.context.authorizationEndpoint,
+          tokenEndpoint: pendingFlow.context.tokenEndpoint,
+          redirectUri: pendingFlow.context.redirectUri,
+        }
+      : pendingFlow.localGrantBinding;
     const work = () =>
       persistOAuthToken(
         db,
@@ -2048,21 +2195,7 @@ async function registerMCPServices(
           clientSecret: pendingFlow.context.clientSecret,
           tokenEndpoint: pendingFlow.context.tokenEndpoint,
           resourceUri: pendingFlow.context.resourceUri,
-          ...(pendingFlow.durableRecord
-            ? {
-                grantBinding: {
-                  generation: pendingFlow.durableRecord.grantGeneration,
-                  version: durableGrantBindingVersion!,
-                  fingerprint: pendingFlow.durableRecord.configFingerprint,
-                  metadataUri: pendingFlow.context.metadataUrl,
-                  resourceUri: pendingFlow.context.resourceUri,
-                  issuer: pendingFlow.context.issuer,
-                  authorizationEndpoint: pendingFlow.context.authorizationEndpoint,
-                  tokenEndpoint: pendingFlow.context.tokenEndpoint,
-                  redirectUri: pendingFlow.context.redirectUri,
-                },
-              }
-            : {}),
+          ...(grantBinding ? { grantBinding } : {}),
         },
         logPrefix
       );
@@ -2079,6 +2212,29 @@ async function registerMCPServices(
       }
       await assertPendingFlowStillAuthorized(pendingFlow, true);
       await work();
+      if (!pendingFlow.durableRecord && pendingFlow.localGrantBinding) {
+        try {
+          // SQLite cannot hold PostgreSQL's transaction-scoped advisory lock.
+          // Recheck after the write as well: a Settings mutation interleaved
+          // after the pre-write check either invalidates the row itself or is
+          // detected here, where only this exact generation is removed.
+          await assertPendingFlowStillAuthorized(pendingFlow, true);
+        } catch (error) {
+          const tokenUserId =
+            (pendingFlow.oauthMode ?? 'per_user') === 'per_user'
+              ? (pendingFlow.userId as UserID)
+              : null;
+          if (pendingFlow.mcpServerId) {
+            await new UserMCPOAuthTokenRepository(db).deleteGrantVersion(
+              tokenUserId,
+              pendingFlow.mcpServerId as MCPServerID,
+              pendingFlow.localGrantBinding.generation,
+              pendingFlow.localGrantBinding.fingerprint
+            );
+          }
+          throw error;
+        }
+      }
       if (pendingFlow.durableRecord) {
         const transitioned = await durableOAuthFlows!.finish(
           pendingFlow.durableRecord,
@@ -2484,10 +2640,10 @@ async function registerMCPServices(
         assertPublicMCPOAuthCompatibilityMode({
           oauth_compatibility_mode: data.compatibility_mode,
         });
-        // Completing this flow writes a shared token onto the named row and
-        // backfills its token endpoint, so the same rule the other flow-start
-        // endpoints apply has to apply here. Testing a not-yet-created server
-        // passes no id and is unaffected.
+        // Completing this flow writes a per-user or explicitly shared token
+        // onto the named row and backfills its token endpoint, so the same
+        // saved-row authority as every other flow-start endpoint applies.
+        // Testing a not-yet-created server passes no id and is unaffected.
         const authoritativeServer = data.mcp_server_id
           ? await runInOAuthTenantScope(
               db,
@@ -2546,7 +2702,11 @@ async function registerMCPServices(
         const effectiveDcrMode = authoritativeServer
           ? effectiveAuth?.oauth_dcr_mode
           : data.dcr_mode;
-        const effectiveOAuthMode = effectiveAuth?.oauth_mode ?? 'shared';
+        // Match oauth-start, hydration, refresh, and persistence: omission is
+        // per-user. `/test-oauth` must never widen a legacy/default row into a
+        // tenant-shared NULL-subject grant merely because this endpoint was
+        // used to begin the browser flow.
+        const effectiveOAuthMode = effectiveAuth?.oauth_mode ?? 'per_user';
 
         console.log('[OAuth Test] Probing configured MCP server');
 
@@ -2637,8 +2797,8 @@ async function registerMCPServices(
                   prefetchedAuthServerMetadata: prefetchedAuthServerMetadata ?? undefined,
                   mcpServerId: data.mcp_server_id,
                   userId: (params as AuthenticatedParams)?.user?.user_id,
-                  // Test endpoint mirrors the previous saveOAuth21TokenToDB
-                  // call (writes to the shared MCP server row, not per-user).
+                  // The saved row selects the grant subject; omission is the
+                  // product-wide per-user default.
                   oauthMode: effectiveOAuthMode,
                   clientId: effectiveClientId,
                   tenantId: tenantIdFromParams(params as AuthenticatedParams | undefined),
@@ -3272,14 +3432,25 @@ async function registerMCPServices(
           listForUser: (id) => userTokenRepo.listForUser(id),
           listShared: () => userTokenRepo.listShared(),
           findServer: (serverId) => serverRepo.findById(serverId),
-          requireGrantBinding: isPostgresDatabaseHandle(db),
-          isGrantBoundToServer: async (server, grant) =>
-            isMCPOAuthGrantBoundToServer(
+          requireGrantBinding: true,
+          isGrantBoundToServer: async (server, grant) => {
+            // Existing standalone grants predate binding and remain usable.
+            // Every newly issued SQLite grant is v4-bound and must verify.
+            if (
+              !shouldVerifyMCPOAuthGrantBinding(
+                isPostgresDatabaseHandle(db),
+                grant.grant_binding_version
+              )
+            ) {
+              return true;
+            }
+            return isMCPOAuthGrantBoundToServer(
               process.env.AGOR_MASTER_SECRET!,
               server,
               grant,
               (await resolveMCPOAuthCompatibilityPolicy(server)).mode
-            ),
+            );
+          },
         });
         return { authenticated_server_ids: authenticatedServerIds };
       } catch (error) {
@@ -3500,7 +3671,10 @@ async function registerMCPServices(
             }
             const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
             if (
-              isPostgresDatabaseHandle(db) &&
+              shouldVerifyMCPOAuthGrantBinding(
+                isPostgresDatabaseHandle(db),
+                row.grant_binding_version
+              ) &&
               !isMCPOAuthGrantBoundToServer(
                 process.env.AGOR_MASTER_SECRET!,
                 server,
@@ -3688,10 +3862,15 @@ async function registerMCPServices(
         let observedRefreshVersion:
           | { grantGeneration: number; refreshGeneration: number }
           | undefined;
-        if (isPostgresDatabaseHandle(db)) {
-          const currentGrant = await runInOAuthTenantScope(db, tenantId, () =>
-            new UserMCPOAuthTokenRepository(db).getToken(tokenUserId, serverId as MCPServerID)
-          );
+        const currentGrant = await runInOAuthTenantScope(db, tenantId, () =>
+          new UserMCPOAuthTokenRepository(db).getToken(tokenUserId, serverId as MCPServerID)
+        );
+        if (
+          shouldVerifyMCPOAuthGrantBinding(
+            isPostgresDatabaseHandle(db),
+            currentGrant?.grant_binding_version
+          )
+        ) {
           const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
           if (
             !currentGrant ||
@@ -3846,11 +4025,8 @@ async function registerMCPServices(
         const { StreamableHTTPClientTransport } = await import(
           '@modelcontextprotocol/sdk/client/streamableHttp.js'
         );
-        const { restoreRedactedMCPAuthSecrets } = await import('@agor/core/tools/mcp/auth-secrets');
         const { resolveMCPAuthHeaders } = await import('@agor/core/tools/mcp/jwt-auth');
-        const { mergeMCPRemoteHeaders, restoreRedactedMCPCustomHeaders } = await import(
-          '@agor/core/tools/mcp/http-headers'
-        );
+        const { mergeMCPRemoteHeaders } = await import('@agor/core/tools/mcp/http-headers');
         const tenantId = tenantIdFromParams(params);
 
         const validateUrl = (url: string): { valid: boolean; error?: string } => {
@@ -3909,33 +4085,22 @@ async function registerMCPServices(
             const denial = denyDiscoverOfAnotherUsersServer(server, params);
             if (denial) return denial;
             authoritativeServer = server;
-            if (durableOAuthFlows) {
-              // A PostgreSQL discover may create a durable grant. Ignore the
-              // mutable form snapshot and use the row that the eventual
-              // pending flow and grant are bound to.
-              serverConfig = {
-                url: server.url || '',
-                transport: (server.transport as 'http' | 'sse') || (server.url ? 'http' : 'stdio'),
-                auth: server.auth,
-                headers: server.headers,
-                name: server.name,
-                scope: server.scope,
-                owner_user_id: server.owner_user_id,
-                source: server.source,
-                catalog_entry_name: server.catalog_entry_name,
-              };
-            } else {
-              serverConfig.auth = restoreRedactedMCPAuthSecrets({
-                current: server.auth,
-                next: data.auth,
-              });
-              serverConfig.headers = restoreRedactedMCPCustomHeaders({
-                current: server.headers,
-                next: data.headers,
-              });
-              serverConfig.source = server.source;
-              serverConfig.catalog_entry_name = server.catalog_entry_name;
-            }
+            // Supplying a saved ID makes the row authoritative on every
+            // database. Settings may submit an unsaved form snapshot for a
+            // connection test, but a grant-producing OAuth probe must never
+            // authorize that transient URL/auth/header configuration and then
+            // persist the token under a different saved row.
+            serverConfig = {
+              url: server.url || '',
+              transport: (server.transport as 'http' | 'sse') || (server.url ? 'http' : 'stdio'),
+              auth: server.auth,
+              headers: server.headers,
+              name: server.name,
+              scope: server.scope,
+              owner_user_id: server.owner_user_id,
+              source: server.source,
+              catalog_entry_name: server.catalog_entry_name,
+            };
             serverId = data.mcp_server_id;
           }
         } else if (data.mcp_server_id) {
@@ -4081,8 +4246,9 @@ async function registerMCPServices(
                   : undefined,
               mcpServerId: serverId,
               userId: params?.user?.user_id,
-              // PostgreSQL requires this saved server binding. SQLite retains
-              // the historical inline/standalone path for compatibility.
+              // A saved ID always binds discovery and any resulting grant to
+              // the authoritative row. Only an unsaved standalone probe may
+              // use inline configuration, and that path cannot persist a grant.
               oauthMode: serverConfig.auth?.oauth_mode ?? 'per_user',
               clientId: serverConfig.auth?.oauth_client_id,
               clientSecret: serverConfig.auth?.oauth_client_secret,
@@ -4129,7 +4295,10 @@ async function registerMCPServices(
               const grant = await tokenRepo.getToken(lookupUserId, serverId as MCPServerID);
               if (!grant) return undefined;
               if (
-                isPostgresDatabaseHandle(db) &&
+                shouldVerifyMCPOAuthGrantBinding(
+                  isPostgresDatabaseHandle(db),
+                  grant.grant_binding_version
+                ) &&
                 !isMCPOAuthGrantBoundToServer(
                   process.env.AGOR_MASTER_SECRET!,
                   {
@@ -4139,6 +4308,7 @@ async function registerMCPServices(
                     url: serverConfig.url,
                     source: serverConfig.source ?? 'user',
                     catalog_entry_name: serverConfig.catalog_entry_name,
+                    headers: serverConfig.headers,
                     auth: serverConfig.auth,
                   },
                   grant,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -45,6 +45,7 @@ import {
   shortId,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
+  type UserMCPOAuthToken,
   UserMCPOAuthTokenRepository,
   UsersRepository,
   visibleSessionReferenceAccessExists,
@@ -56,6 +57,7 @@ import type {
   OAuthTokenResponse,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import { OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import type { RefreshAndPersistDeps } from '@agor/core/tools/mcp/oauth-refresh';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -173,6 +175,10 @@ import {
   classifyMCPOAuthCompletionFailure,
   OAuthFlowAuthorizationChangedError,
 } from './services/mcp-oauth-exchange-classification.js';
+import {
+  isCurrentMCPOAuthGrantAuthorized,
+  isMCPOAuthGrantAuthorizedForServer,
+} from './services/mcp-oauth-grant-authority.js';
 import {
   fingerprintMCPOAuthGrantConfiguration,
   grantBindingVersionForCompatibilityMode,
@@ -1450,6 +1456,24 @@ export async function registerMCPServices(
       allowLocalhostHttp: !durableOAuthFlows,
     });
   };
+  const refreshGrantValidator =
+    (tenantId: string | undefined, serverId: MCPServerID) =>
+    async (
+      grant: UserMCPOAuthToken,
+      refreshDb: Parameters<RefreshAndPersistDeps['validateGrant']>[1]
+    ): Promise<boolean> =>
+      isCurrentMCPOAuthGrantAuthorized({
+        // Core accepts a raw repository-compatible handle for standalone
+        // tests, but daemon refreshes always enter here with the long-lived
+        // tenant-aware proxy or a short-lived tenant-scoped transaction.
+        db: refreshDb as TenantScopeAwareDatabase | TenantScopedDatabase,
+        serverId,
+        grant,
+        tenantId,
+        // PostgreSQL Settings mutations use the same advisory lock. SQLite
+        // relies on exact-generation/fingerprint CAS plus its serialized writer.
+        lockConfiguration: true,
+      });
 
   type PendingOAuthFlow = {
     attemptId: MCPOAuthAttemptID;
@@ -1480,6 +1504,8 @@ export async function registerMCPServices(
     savedServerAuthority?: MCPServer;
     /** Bound grant envelope issued for new standalone flows. */
     localGrantBinding?: NonNullable<SaveTokenInput['grantBinding']>;
+    /** Subject key whose temporary generation reservation this flow owns. */
+    localGrantSubjectKey?: string;
   };
 
   // Store pending OAuth flow contexts
@@ -1487,7 +1513,16 @@ export async function registerMCPServices(
   // SQLite has no cross-process flow, but callbacks and Settings mutations can
   // interleave within this daemon. A monotonic per-subject generation prevents
   // an older exchange from replacing a newer completed authorization.
-  const localOAuthGrantGenerations = new Map<string, number>();
+  const localOAuthGrantGenerations = new Map<string, { generation: number; reservedAt: number }>();
+  const releaseLocalGrantGeneration = (flow: PendingOAuthFlow): void => {
+    if (!flow.localGrantSubjectKey || !flow.localGrantBinding) return;
+    const reserved = localOAuthGrantGenerations.get(flow.localGrantSubjectKey);
+    // A newer in-flight attempt for the same subject owns a higher reservation.
+    // Never let an older callback release that fence.
+    if (reserved?.generation === flow.localGrantBinding.generation) {
+      localOAuthGrantGenerations.delete(flow.localGrantSubjectKey);
+    }
+  };
   const localOAuthAttemptStatuses = new Map<
     MCPOAuthAttemptID,
     {
@@ -1539,7 +1574,17 @@ export async function registerMCPServices(
           failureCode: 'authorization_timed_out',
           updatedAt: now,
         });
+        releaseLocalGrantGeneration(flow);
         flow.tokenReject?.(new Error('OAuth flow expired before callback was received'));
+      }
+    }
+    // Defense-in-depth for a callback which was claimed and then abandoned by
+    // an unexpected local failure before its terminal-status path ran. OAuth
+    // provider exchanges are bounded to seconds; after the full flow TTL no
+    // live exchange can safely depend on the process-local reservation.
+    for (const [subjectKey, reservation] of localOAuthGrantGenerations) {
+      if (now - reservation.reservedAt > LOCAL_OAUTH_FLOW_TTL_MS) {
+        localOAuthGrantGenerations.delete(subjectKey);
       }
     }
     for (const [attemptId, attempt] of localOAuthAttemptStatuses) {
@@ -1781,6 +1826,7 @@ export async function registerMCPServices(
     } satisfies import('./services/mcp-oauth-grant-binding.js').MCPOAuthResolvedGrantBinding;
 
     let localGrantBinding: NonNullable<SaveTokenInput['grantBinding']> | undefined;
+    let localGrantSubjectKey: string | undefined;
     if (savedServerAuthority && !durableOAuthFlows) {
       localGrantBinding = await runInOAuthTenantScope(db, opts.tenantId, async () => {
         const currentServer = await new MCPServerRepository(db).findById(
@@ -1815,9 +1861,10 @@ export async function registerMCPServices(
         const generation =
           Math.max(
             existingGrant?.grant_generation ?? 0,
-            localOAuthGrantGenerations.get(subjectKey) ?? 0
+            localOAuthGrantGenerations.get(subjectKey)?.generation ?? 0
           ) + 1;
-        localOAuthGrantGenerations.set(subjectKey, generation);
+        localOAuthGrantGenerations.set(subjectKey, { generation, reservedAt: Date.now() });
+        localGrantSubjectKey = subjectKey;
         const version = grantBindingVersionForCompatibilityMode(context.compatibilityMode);
         return {
           generation,
@@ -1891,6 +1938,7 @@ export async function registerMCPServices(
             const pending = pendingOAuthFlows.get(context.state);
             if (pending) {
               pendingOAuthFlows.delete(context.state);
+              releaseLocalGrantGeneration(pending);
               localOAuthAttemptStatuses.set(attemptId, {
                 status: 'expired',
                 userId: opts.userId,
@@ -1937,6 +1985,7 @@ export async function registerMCPServices(
         tokenReject,
         savedServerAuthority,
         localGrantBinding,
+        localGrantSubjectKey,
       });
       localOAuthAttemptStatuses.set(attemptId, {
         status: 'pending',
@@ -2279,6 +2328,9 @@ export async function registerMCPServices(
       failureCode,
       updatedAt: Date.now(),
     });
+    if (status !== 'pending' && status !== 'exchanging') {
+      releaseLocalGrantGeneration(pendingFlow);
+    }
   };
 
   const emitOAuthCompletion = (pendingFlow: PendingOAuthFlow, success: boolean) => {
@@ -3433,24 +3485,8 @@ export async function registerMCPServices(
           listShared: () => userTokenRepo.listShared(),
           findServer: (serverId) => serverRepo.findById(serverId),
           requireGrantBinding: true,
-          isGrantBoundToServer: async (server, grant) => {
-            // Existing standalone grants predate binding and remain usable.
-            // Every newly issued SQLite grant is v4-bound and must verify.
-            if (
-              !shouldVerifyMCPOAuthGrantBinding(
-                isPostgresDatabaseHandle(db),
-                grant.grant_binding_version
-              )
-            ) {
-              return true;
-            }
-            return isMCPOAuthGrantBoundToServer(
-              process.env.AGOR_MASTER_SECRET!,
-              server,
-              grant,
-              (await resolveMCPOAuthCompatibilityPolicy(server)).mode
-            );
-          },
+          isGrantBoundToServer: (server, grant) =>
+            isMCPOAuthGrantAuthorizedForServer(db, server, grant),
         });
         return { authenticated_server_ids: authenticatedServerIds };
       } catch (error) {
@@ -3736,8 +3772,10 @@ export async function registerMCPServices(
                   mcpServerId: serverId as MCPServerID,
                   observedRefreshVersion: {
                     grantGeneration: row.grant_generation,
+                    grantBindingFingerprint: row.grant_binding_fingerprint,
                     refreshGeneration: row.refresh_generation,
                   },
+                  validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
                 });
                 headers[serverId] = { authorization: `Bearer ${observed}` };
               } catch {
@@ -3756,8 +3794,10 @@ export async function registerMCPServices(
                   mcpServerId: serverId as MCPServerID,
                   observedRefreshVersion: {
                     grantGeneration: row.grant_generation,
+                    grantBindingFingerprint: row.grant_binding_fingerprint,
                     refreshGeneration: row.refresh_generation,
                   },
+                  validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
                 });
               } catch (refreshErr) {
                 if (refreshErr instanceof InvalidGrantError) {
@@ -3838,6 +3878,7 @@ export async function registerMCPServices(
         MissingClientIdError,
         AmbiguousRefreshError,
         FailedRefreshError,
+        GrantConfigurationChangedError,
       } = await import('@agor/core/tools/mcp/oauth-refresh');
 
       try {
@@ -3859,45 +3900,26 @@ export async function registerMCPServices(
         }
         const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
-        let observedRefreshVersion:
-          | { grantGeneration: number; refreshGeneration: number }
-          | undefined;
         const currentGrant = await runInOAuthTenantScope(db, tenantId, () =>
           new UserMCPOAuthTokenRepository(db).getToken(tokenUserId, serverId as MCPServerID)
         );
-        if (
-          shouldVerifyMCPOAuthGrantBinding(
-            isPostgresDatabaseHandle(db),
-            currentGrant?.grant_binding_version
-          )
-        ) {
-          const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
-          if (
-            !currentGrant ||
-            !isMCPOAuthGrantBoundToServer(
-              process.env.AGOR_MASTER_SECRET!,
-              server,
-              currentGrant,
-              compatibilityMode
+        if (!currentGrant) return { success: false, error: 'needs_reauth' };
+        if (!(await isMCPOAuthGrantAuthorizedForServer(db, server, currentGrant))) {
+          await runInOAuthTenantWriteScope(db, tenantId, () =>
+            new UserMCPOAuthTokenRepository(db).deleteGrantVersion(
+              tokenUserId,
+              serverId as MCPServerID,
+              currentGrant.grant_generation,
+              currentGrant.grant_binding_fingerprint
             )
-          ) {
-            if (currentGrant) {
-              await runInOAuthTenantWriteScope(db, tenantId, () =>
-                new UserMCPOAuthTokenRepository(db).deleteGrantVersion(
-                  tokenUserId,
-                  serverId as MCPServerID,
-                  currentGrant.grant_generation,
-                  currentGrant.grant_binding_fingerprint
-                )
-              );
-            }
-            return { success: false, error: 'needs_reauth' };
-          }
-          observedRefreshVersion = {
-            grantGeneration: currentGrant.grant_generation,
-            refreshGeneration: currentGrant.refresh_generation,
-          };
+          );
+          return { success: false, error: 'needs_reauth' };
         }
+        const observedRefreshVersion = {
+          grantGeneration: currentGrant.grant_generation,
+          grantBindingFingerprint: currentGrant.grant_binding_fingerprint,
+          refreshGeneration: currentGrant.refresh_generation,
+        };
 
         await refreshAndPersistToken({
           db,
@@ -3905,6 +3927,7 @@ export async function registerMCPServices(
           userId: tokenUserId,
           mcpServerId: serverId as MCPServerID,
           observedRefreshVersion,
+          validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
         });
 
         const fresh = await runInOAuthTenantScope(db, tenantId, () =>
@@ -3920,7 +3943,8 @@ export async function registerMCPServices(
         if (
           err instanceof InvalidGrantError ||
           err instanceof MissingRefreshTokenError ||
-          err instanceof AmbiguousRefreshError
+          err instanceof AmbiguousRefreshError ||
+          err instanceof GrantConfigurationChangedError
         ) {
           return { success: false, error: 'needs_reauth' };
         }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1511,16 +1511,25 @@ export async function registerMCPServices(
   // Store pending OAuth flow contexts
   const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
   // SQLite has no cross-process flow, but callbacks and Settings mutations can
-  // interleave within this daemon. A monotonic per-subject generation prevents
-  // an older exchange from replacing a newer completed authorization.
-  const localOAuthGrantGenerations = new Map<string, { generation: number; reservedAt: number }>();
+  // interleave within this daemon. Keep every active attempt represented and
+  // allocate from a process-lifetime monotonic high-water mark: releasing a
+  // newer failed attempt must never make an older generation reusable (ABA).
+  const localOAuthGrantReservations = new Map<
+    string,
+    Map<MCPOAuthAttemptID, { generation: number; reservedAt: number }>
+  >();
+  let localOAuthGrantGenerationHighWater = 0;
   const releaseLocalGrantGeneration = (flow: PendingOAuthFlow): void => {
     if (!flow.localGrantSubjectKey || !flow.localGrantBinding) return;
-    const reserved = localOAuthGrantGenerations.get(flow.localGrantSubjectKey);
-    // A newer in-flight attempt for the same subject owns a higher reservation.
-    // Never let an older callback release that fence.
+    const subjectReservations = localOAuthGrantReservations.get(flow.localGrantSubjectKey);
+    const reserved = subjectReservations?.get(flow.attemptId);
+    // Release only this attempt. A different attempt may never free or replace
+    // an exchanging callback's active generation authority.
     if (reserved?.generation === flow.localGrantBinding.generation) {
-      localOAuthGrantGenerations.delete(flow.localGrantSubjectKey);
+      subjectReservations!.delete(flow.attemptId);
+      if (subjectReservations!.size === 0) {
+        localOAuthGrantReservations.delete(flow.localGrantSubjectKey);
+      }
     }
   };
   const localOAuthAttemptStatuses = new Map<
@@ -1582,9 +1591,14 @@ export async function registerMCPServices(
     // an unexpected local failure before its terminal-status path ran. OAuth
     // provider exchanges are bounded to seconds; after the full flow TTL no
     // live exchange can safely depend on the process-local reservation.
-    for (const [subjectKey, reservation] of localOAuthGrantGenerations) {
-      if (now - reservation.reservedAt > LOCAL_OAUTH_FLOW_TTL_MS) {
-        localOAuthGrantGenerations.delete(subjectKey);
+    for (const [subjectKey, reservations] of localOAuthGrantReservations) {
+      for (const [attemptId, reservation] of reservations) {
+        if (now - reservation.reservedAt > LOCAL_OAUTH_FLOW_TTL_MS) {
+          reservations.delete(attemptId);
+        }
+      }
+      if (reservations.size === 0) {
+        localOAuthGrantReservations.delete(subjectKey);
       }
     }
     for (const [attemptId, attempt] of localOAuthAttemptStatuses) {
@@ -1793,6 +1807,11 @@ export async function registerMCPServices(
       }
     }
 
+    // Local reservations are attempt-aware, so establish identity before
+    // allocating a generation. PostgreSQL obtains its durable attempt ID from
+    // the pending-flow authority below instead.
+    const localAttemptId = durableOAuthFlows ? undefined : (generateId() as MCPOAuthAttemptID);
+
     const context = await startMCPOAuthFlow(opts.wwwAuthenticate, effectiveClientId, redirectUri, {
       authorizationUrlOverride: effectiveAuthorizationUrlOverride,
       tokenUrlOverride: effectiveTokenUrlOverride,
@@ -1859,11 +1878,16 @@ export async function registerMCPServices(
           currentServer.mcp_server_id
         );
         const generation =
-          Math.max(
-            existingGrant?.grant_generation ?? 0,
-            localOAuthGrantGenerations.get(subjectKey)?.generation ?? 0
-          ) + 1;
-        localOAuthGrantGenerations.set(subjectKey, { generation, reservedAt: Date.now() });
+          Math.max(existingGrant?.grant_generation ?? 0, localOAuthGrantGenerationHighWater) + 1;
+        if (!Number.isSafeInteger(generation)) {
+          throw new Error('Standalone OAuth grant generation authority is exhausted');
+        }
+        localOAuthGrantGenerationHighWater = generation;
+        const subjectReservations =
+          localOAuthGrantReservations.get(subjectKey) ??
+          new Map<MCPOAuthAttemptID, { generation: number; reservedAt: number }>();
+        subjectReservations.set(localAttemptId!, { generation, reservedAt: Date.now() });
+        localOAuthGrantReservations.set(subjectKey, subjectReservations);
         localGrantSubjectKey = subjectKey;
         const version = grantBindingVersionForCompatibilityMode(context.compatibilityMode);
         return {
@@ -1913,7 +1937,7 @@ export async function registerMCPServices(
             ),
           });
         })
-      : (generateId() as MCPOAuthAttemptID);
+      : localAttemptId!;
 
     let tokenPromise: Promise<OAuthTokenResponse> | undefined;
     let tokenResolve: ((t: OAuthTokenResponse) => void) | undefined;

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -2153,6 +2153,60 @@ describe('GatewayService MCP resolution', () => {
     });
     expect(emitted).toHaveBeenCalledOnce();
   });
+
+  it('warns when raw OAuth tokens exist but their authoritative binding is invalid', async () => {
+    const channel = {
+      ...slackChannel,
+      mcp_server_ids: [channelMcpId],
+    } as unknown as GatewayChannel;
+    const { service, promptCreate } = makeGatewayHarness({ channel, existingMapping: null });
+    Object.assign(service as unknown as Record<string, unknown>, {
+      mcpServerRepo: {
+        findById: vi.fn(async () => ({
+          mcp_server_id: channelMcpId,
+          name: 'bound-oauth',
+          display_name: 'Bound OAuth',
+          transport: 'http',
+          scope: 'global',
+          enabled: true,
+          source: 'user',
+          url: 'https://mcp.example.test',
+          auth: { type: 'oauth', oauth_mode: 'per_user' },
+        })),
+      },
+      userTokenRepo: {
+        getToken: vi.fn(async () => ({
+          user_id: user.user_id,
+          mcp_server_id: channelMcpId,
+          oauth_access_token: 'raw-token-must-not-suppress-warning',
+          oauth_refresh_token: 'raw-refresh-must-not-suppress-warning',
+          grant_generation: 1,
+          grant_binding_version: 5,
+          refresh_status: 'idle',
+          refresh_generation: 0,
+          refresh_success_generation: 0,
+          created_at: new Date(),
+        })),
+      },
+    });
+
+    await service.create({
+      channel_key: channel.channel_key,
+      thread_id: 'C123-100.000000',
+      text: 'start',
+      metadata: {
+        channel: 'C123',
+        channel_type: 'channel',
+        slack_has_mention: true,
+        slack_message_ts: '100.000000',
+      },
+    });
+
+    expect(promptCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining('Bound OAuth') }),
+      expect.anything()
+    );
+  });
 });
 
 describe('GatewayService Slack system message routing', () => {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -101,6 +101,7 @@ import {
   ingestInboundAttachments,
 } from '../utils/gateway-attachments.js';
 import { deferWithTenantContext } from '../utils/tenant-db-scope.js';
+import { isMCPOAuthGrantAuthorizedForServer } from './mcp-oauth-grant-authority.js';
 import type { SessionParams } from './sessions.js';
 
 /**
@@ -2478,11 +2479,19 @@ export class GatewayService {
               // before handing it to the executor. This avoids spurious
               // "not authenticated" warnings for users who are one refresh away.
               const row = await this.userTokenRepo.getToken(tokenUserId, serverId as MCPServerID);
+              const bindingValid =
+                !!row && (await isMCPOAuthGrantAuthorizedForServer(this.db, server, row));
               const accessValid = !!(
-                row?.oauth_access_token &&
+                bindingValid &&
+                row?.refresh_status === 'idle' &&
+                row.oauth_access_token &&
                 (!row.oauth_token_expires_at || row.oauth_token_expires_at > new Date())
               );
-              const refreshable = !!row?.oauth_refresh_token;
+              const refreshable = !!(
+                bindingValid &&
+                row?.refresh_status !== 'ambiguous' &&
+                row?.oauth_refresh_token
+              );
               if (!accessValid && !refreshable) {
                 unauthedMcpNames.push(server.display_name || server.name);
               }

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -237,17 +237,26 @@ describe('marketplace install, as it lands in the database', () => {
  * `around`, and `after` hooks on `mcp-servers` too, and none of them are the
  * claim under test.
  */
-function captureRegisteredMcpServerCreateHooks(
-  db: TenantScopeAwareDatabase
-): Array<(context: McpServerWriteHookContext) => Promise<unknown>> {
-  const captured: Array<(context: McpServerWriteHookContext) => Promise<unknown>> = [];
+function captureRegisteredMcpServerCreateHooks(db: TenantScopeAwareDatabase): {
+  create: Array<(context: McpServerWriteHookContext) => Promise<unknown>>;
+  patch: Array<(context: McpServerWriteHookContext) => Promise<unknown>>;
+} {
+  const captured = {
+    create: [] as Array<(context: McpServerWriteHookContext) => Promise<unknown>>,
+    patch: [] as Array<(context: McpServerWriteHookContext) => Promise<unknown>>,
+  };
   const app = {
     service(path: string) {
       return {
-        hooks(hooks: { before?: { create?: unknown[] } }) {
+        hooks(hooks: { before?: { create?: unknown[]; patch?: unknown[] } }) {
           if (path.replace(/^\//, '') !== 'mcp-servers') return;
-          captured.push(
+          captured.create.push(
             ...((hooks.before?.create ?? []) as Array<
+              (context: McpServerWriteHookContext) => Promise<unknown>
+            >)
+          );
+          captured.patch.push(
+            ...((hooks.before?.patch ?? []) as Array<
               (context: McpServerWriteHookContext) => Promise<unknown>
             >)
           );
@@ -319,11 +328,25 @@ describe('the write hook this seam depends on', () => {
           user: { user_id: caller.user_id, role: 'member' },
         } as unknown as AuthenticatedParams,
       } satisfies McpServerWriteHookContext;
-      for (const hook of registeredHooks) await hook(context);
+      for (const hook of registeredHooks.create) await hook(context);
       return context;
     };
 
-    return { bob, mallory, createAs };
+    const patchAs = async (caller: User, data: Record<string, unknown>) => {
+      const context = {
+        method: 'patch',
+        id: '01900000-0000-7000-8000-000000000099',
+        data,
+        params: {
+          provider: 'rest',
+          user: { user_id: caller.user_id, role: 'member' },
+        } as unknown as AuthenticatedParams,
+      } satisfies McpServerWriteHookContext;
+      for (const hook of registeredHooks.patch) await hook(context);
+      return context;
+    };
+
+    return { bob, mallory, createAs, patchAs };
   };
 
   it('is registered on mcp-servers create by registerHooks, not just constructible', async () => {
@@ -345,4 +368,18 @@ describe('the write hook this seam depends on', () => {
 
     expect((context.data as { owner_user_id?: string }).owner_user_id).toBe(bob.user_id);
   });
+
+  it.each(['marketplace', 'future-mode'])(
+    'rejects public create and patch compatibility mode %s before authorization',
+    async (mode) => {
+      const { bob, createAs, patchAs } = await standUpDaemonHooks();
+      const data = {
+        transport: 'http',
+        auth: { type: 'oauth', oauth_compatibility_mode: mode },
+      };
+
+      await expect(createAs(bob, data)).rejects.toThrow(/must be either strict or legacy/);
+      await expect(patchAs(bob, data)).rejects.toThrow(/must be either strict or legacy/);
+    }
+  );
 });

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -33,6 +33,7 @@ const CURATED: MCPCatalogEntry = {
 function installOf(overrides: Record<string, unknown> = {}) {
   return {
     mcp_server_id: 'server-existing',
+    source: 'catalog',
     catalog_entry_name: LINEAR,
     transport: 'http',
     url: 'https://mcp.linear.app/mcp',

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -605,12 +605,13 @@ describe('mcp-catalog/connect — endpoints that sign the user in', () => {
 
     const result = await createMCPCatalogConnectService(app).create(request, params);
 
-    // `oauth-start` reads exactly three things off the row: the endpoint, that
-    // the row is enabled, and that it is an OAuth row. Everything else it needs
-    // it discovers from the endpoint at the moment the user signs in.
+    // `oauth-start` reads the endpoint, enabled/OAuth state, and trusted catalog
+    // provenance. Everything provider-specific is still discovered from the
+    // endpoint at the moment the user signs in.
     expect(created.mcpServers[0]).toMatchObject({
       url: 'https://mcp.linear.app/mcp',
       transport: 'http',
+      source: 'catalog',
       auth: { type: 'oauth', oauth_mode: 'per_user' },
     });
     expect(result.reused_existing_server).toBe(false);
@@ -659,8 +660,8 @@ describe('mcp-catalog/connect — endpoints that sign the user in', () => {
   });
 
   it('carries the entry’s stated settings onto the row', async () => {
-    // The escape hatch for servers that fall short of the discovery spec. No
-    // curated entry states these today; the plumbing is what is asserted.
+    // The reviewed escape hatch for a provider-specific exception or strict
+    // opt-in; the plumbing is what is asserted.
     const { app, created } = buildApp({
       ...OAUTH_ENTRY,
       oauth: {

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -32,133 +32,15 @@ import type {
   MCPCatalogEntry,
   MCPCatalogProbedAuthType,
   MCPServer,
-  MCPTransport,
   Session,
   UserID,
 } from '@agor/core/types';
 import { catalogDisplayName, catalogServerSlug } from '@agor/core/types';
-
-/** Catalog transports, as `mcp_servers` names them. */
-function toServerTransport(entry: MCPCatalogEntry): MCPTransport {
-  return entry.transport === 'sse' ? 'sse' : 'http';
-}
-
-/**
- * Whether two endpoint URLs name the same place.
- *
- * Normalised through `URL` so a trailing slash, a default port, or a
- * differently-cased host does not read as a different server and cost somebody
- * their install. Anything unparseable falls back to an exact comparison rather
- * than guessing.
- */
-function sameEndpoint(a: string | undefined, b: string): boolean {
-  if (!a) return false;
-  const normalize = (value: string): string => {
-    try {
-      const url = new URL(value.trim());
-      url.pathname = url.pathname.replace(/\/+$/, '');
-      return url.href;
-    } catch {
-      return value.trim();
-    }
-  };
-  return normalize(a) === normalize(b);
-}
-
-/**
- * Auth fields a read of an `mcp_servers` row can carry without anyone having
- * configured them.
- *
- * The OAuth flow never writes to the server row: an access token, its refresh
- * token, and its expiry belong to one user and live in `user_mcp_oauth_tokens`,
- * keyed by `(user_id, mcp_server_id)`. But `mcp-servers` has a read hook that
- * hydrates the caller's own token onto the payload it returns, and
- * {@link MCPCatalogConnectService} finds existing installs through that service
- * — so these three arrive on exactly the rows that reuse is most important for,
- * the ones the caller already authenticated. Comparing them would make every
- * successful authentication look like drift and mint a second row beside the
- * working one.
- */
-const RUNTIME_HYDRATED_AUTH_FIELDS = [
-  'oauth_access_token',
-  'oauth_refresh_token',
-  'oauth_token_expires_at',
-] as const satisfies readonly (keyof MCPAuth)[];
-
-/**
- * Whether `auth` is the configuration `prescribed` describes, ignoring what the
- * read hook hydrated.
- *
- * Compared by difference rather than field by field: every key on the row that
- * is not runtime-hydrated must appear in the prescription with the same value,
- * and vice versa. A named-fields comparison would silently stop covering any
- * field later added to {@link MCPAuth} — and the fields most worth adding to an
- * auth block are the ones that route a credential. This way an unrecognised key
- * on the row is a mismatch, so a new field is excluded from reuse until someone
- * decides otherwise, rather than being waved through by omission.
- */
-function isPrescribedAuth(auth: MCPAuth | undefined, prescribed: MCPAuth): boolean {
-  const significant = (value: MCPAuth | undefined): Record<string, unknown> => {
-    const entries = Object.entries(value ?? { type: 'none' }).filter(
-      ([key, field]) =>
-        field !== undefined && !(RUNTIME_HYDRATED_AUTH_FIELDS as readonly string[]).includes(key)
-    );
-    return Object.fromEntries(entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
-  };
-  return JSON.stringify(significant(auth)) === JSON.stringify(significant(prescribed));
-}
-
-/**
- * Whether `server` still carries the configuration the catalog described.
- *
- * The stamp records where a row came from; this asks whether it is still that.
- * The two come apart because a member may edit their own server — which is
- * theirs to do — so a stamp on its own would let an edited row stand in for
- * the catalog's, and reuse would hand the next caller something the catalog
- * never described. A stamp nobody but the install path can write (see
- * `authorizeMcpServerWrite`) closes the forged half; this closes the half
- * where a legitimately stamped row is changed afterwards.
- *
- * What is compared is everything that decides where the session's traffic goes
- * and what it carries: the endpoint, and the credential routing. `prescribed`
- * is the auth block this same connect just derived from the entry and the
- * probe, so the comparison is against what installing right now would produce
- * rather than against a fixed shape — which is what lets an OAuth entry be
- * reused at all, and what makes a row whose owner has since pointed
- * `oauth_token_url` at their own host fail to match. That field, and
- * `oauth_authorization_url` and `oauth_client_secret` with it, are ones connect
- * never sets, so on a catalog row their mere presence is the drift: they are
- * where an authorization code and a client credential get sent.
- *
- * It also means an entry whose endpoint has changed sides — installed while it
- * was open, now answering with an OAuth challenge — does not match its old
- * unauthenticated row, and the caller gets one configured the way the endpoint
- * now answers instead of a row that can no longer work.
- *
- * Custom headers are refused wholesale rather than screened for the
- * dangerous-looking ones. Agor redacts every custom header value on read and
- * documents them as secret-bearing; the only names it classifies are the
- * reserved ones it refuses to store at all. There is no notion of a harmless
- * header anywhere in the codebase, and reuse is the wrong place to invent one
- * — a rule that has to guess which headers carry secrets is a rule that will
- * eventually guess wrong.
- *
- * Genuinely cosmetic fields stay the owner's: name, labels, description, and
- * scope. A second row for a benign edit would be its own bug.
- */
-function isInstallOf(
-  server: MCPServer,
-  entry: MCPCatalogEntry & { remote_url: string },
-  prescribed: MCPAuth
-): boolean {
-  return (
-    server.catalog_entry_name === entry.name &&
-    server.transport === toServerTransport(entry) &&
-    sameEndpoint(server.url, entry.remote_url) &&
-    isPrescribedAuth(server.auth, prescribed) &&
-    Object.keys(server.headers ?? {}).length === 0
-  );
-}
+import {
+  catalogOAuthConfig,
+  catalogServerTransport,
+  isCurrentCatalogInstall,
+} from './mcp-catalog-install-policy.js';
 
 function assertConnectableEntry(entry: MCPCatalogEntry): asserts entry is MCPCatalogEntry & {
   remote_url: string;
@@ -251,18 +133,6 @@ function logProbeDisagreement(entry: MCPCatalogEntry, probed: MCPCatalogProbedAu
  * block above and not a row full of `undefined` that would then have to be
  * compared around.
  */
-function catalogOAuthConfig(entry: MCPCatalogEntry): MCPAuth {
-  const stated = entry.oauth;
-  return {
-    type: 'oauth',
-    oauth_mode: 'per_user',
-    ...(stated?.scope ? { oauth_scope: stated.scope } : {}),
-    ...(stated?.client_id ? { oauth_client_id: stated.client_id } : {}),
-    ...(stated?.dcr_mode ? { oauth_dcr_mode: stated.dcr_mode } : {}),
-    ...(stated?.compatibility_mode ? { oauth_compatibility_mode: stated.compatibility_mode } : {}),
-  };
-}
-
 /**
  * Decide how the entry's endpoint wants to be talked to, and produce the auth
  * block to install it with — or refuse.
@@ -333,7 +203,8 @@ export function createMCPCatalogConnectService(
    * the entry is unique on, so there is no second normalisation to keep in
    * step and an install survives every edit to the entry except a rename.
    *
-   * The name alone does not settle it, though: see {@link isInstallOf}. A row
+   * The name alone does not settle it, though: see
+   * {@link isCurrentCatalogInstall}. A row
    * that no longer carries the entry's configuration is passed over rather
    * than handed back, so a caller who has one of those and a real install gets
    * the real one.
@@ -358,7 +229,13 @@ export function createMCPCatalogConnectService(
       query: { ...(userId ? { usableByUserId: userId } : {}), $limit: 1000 },
     });
     const servers = (Array.isArray(result) ? result : result.data) as MCPServer[];
-    return servers.find((server) => server.enabled && isInstallOf(server, entry, prescribed));
+    return servers.find(
+      (server) =>
+        server.enabled &&
+        isCurrentCatalogInstall(server, entry, prescribed, {
+          reconcileMissingCompatibilityMode: true,
+        })
+    );
   };
 
   return {
@@ -391,7 +268,7 @@ export function createMCPCatalogConnectService(
         name: catalogServerSlug(entry.name),
         display_name: catalogDisplayName(entry),
         description: entry.benefit ?? entry.description,
-        transport: toServerTransport(entry),
+        transport: catalogServerTransport(entry),
         url: entry.remote_url,
         auth,
         // Session scope: an install is for the session it launched, not

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -246,10 +246,10 @@ function logProbeDisagreement(entry: MCPCatalogEntry, probed: MCPCatalogProbedAu
  * either.
  *
  * The rest is {@link MCPCatalogEntryOAuth} — the non-secret settings an entry
- * may state for a server that falls short of the spec. `curated.yaml` states
- * none of them today; each is spread only when present, so an entry that says
- * nothing produces the two-key block above and not a row full of `undefined`
- * that would then have to be compared around.
+ * may state after the production discovery boundary is reviewed. Each is
+ * spread only when present, so an entry that says nothing produces the two-key
+ * block above and not a row full of `undefined` that would then have to be
+ * compared around.
  */
 function catalogOAuthConfig(entry: MCPCatalogEntry): MCPAuth {
   const stated = entry.oauth;

--- a/apps/agor-daemon/src/services/mcp-catalog-install-policy.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-install-policy.ts
@@ -1,0 +1,92 @@
+import type { MCPAuth, MCPCatalogEntry, MCPServer, MCPTransport } from '@agor/core/types';
+
+/** Catalog transports, as `mcp_servers` names them. */
+export function catalogServerTransport(entry: MCPCatalogEntry): MCPTransport {
+  return entry.transport === 'sse' ? 'sse' : 'http';
+}
+
+function sameCatalogEndpoint(a: string | undefined, b: string): boolean {
+  if (!a) return false;
+  const normalize = (value: string): string => {
+    try {
+      const url = new URL(value.trim());
+      url.pathname = url.pathname.replace(/\/+$/, '');
+      return url.href;
+    } catch {
+      return value.trim();
+    }
+  };
+  return normalize(a) === normalize(b);
+}
+
+const RUNTIME_HYDRATED_AUTH_FIELDS = [
+  'oauth_access_token',
+  'oauth_refresh_token',
+  'oauth_token_expires_at',
+] as const satisfies readonly (keyof MCPAuth)[];
+
+function significantAuth(value: MCPAuth | undefined): Record<string, unknown> {
+  const entries = Object.entries(value ?? { type: 'none' }).filter(
+    ([key, field]) =>
+      field !== undefined && !(RUNTIME_HYDRATED_AUTH_FIELDS as readonly string[]).includes(key)
+  );
+  return Object.fromEntries(entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}
+
+function isPrescribedCatalogAuth(
+  auth: MCPAuth | undefined,
+  prescribed: MCPAuth,
+  reconcileMissingCompatibilityMode: boolean
+): boolean {
+  const actual = significantAuth(auth);
+  const expected = significantAuth(prescribed);
+  // Compatibility policy is evaluated from the current catalog. This one
+  // reconciliation lets installs created before an entry acquired an explicit
+  // strict policy remain the same install without mutating their row.
+  if (reconcileMissingCompatibilityMode && actual.oauth_compatibility_mode === undefined) {
+    delete expected.oauth_compatibility_mode;
+  }
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+/** The OAuth configuration a current catalog entry prescribes. */
+export function catalogOAuthConfig(entry: MCPCatalogEntry): MCPAuth {
+  const stated = entry.oauth;
+  return {
+    type: 'oauth',
+    oauth_mode: 'per_user',
+    ...(stated?.scope ? { oauth_scope: stated.scope } : {}),
+    ...(stated?.client_id ? { oauth_client_id: stated.client_id } : {}),
+    ...(stated?.dcr_mode ? { oauth_dcr_mode: stated.dcr_mode } : {}),
+    ...(stated?.compatibility_mode ? { oauth_compatibility_mode: stated.compatibility_mode } : {}),
+  };
+}
+
+/**
+ * Canonical current-install predicate shared by Connect reuse and OAuth policy.
+ * Historical source/stamp alone is never authority: the row must still match
+ * the current entry's endpoint, transport, credential routing, and no-header
+ * policy. Imported/edited/removed rows therefore fail closed.
+ */
+export function isCurrentCatalogInstall(
+  server: Pick<
+    MCPServer,
+    'source' | 'catalog_entry_name' | 'transport' | 'url' | 'auth' | 'headers'
+  >,
+  entry: MCPCatalogEntry & { remote_url: string },
+  prescribed: MCPAuth,
+  options: { reconcileMissingCompatibilityMode?: boolean } = {}
+): boolean {
+  return (
+    server.source === 'catalog' &&
+    server.catalog_entry_name === entry.name &&
+    server.transport === catalogServerTransport(entry) &&
+    sameCatalogEndpoint(server.url, entry.remote_url) &&
+    isPrescribedCatalogAuth(
+      server.auth,
+      prescribed,
+      options.reconcileMissingCompatibilityMode === true
+    ) &&
+    Object.keys(server.headers ?? {}).length === 0
+  );
+}

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
@@ -1,6 +1,9 @@
 import type { MCPCatalogEntry, MCPServer } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { resolveMCPOAuthCompatibilityPolicy } from './mcp-oauth-compatibility.js';
+import {
+  presentMCPOAuthCompatibilityPolicy,
+  resolveMCPOAuthCompatibilityPolicy,
+} from './mcp-oauth-compatibility.js';
 
 const entry = {
   name: 'com.example/provider',
@@ -48,6 +51,18 @@ describe('resolveMCPOAuthCompatibilityPolicy', () => {
     await expect(
       resolveMCPOAuthCompatibilityPolicy(catalogServer(), [strictEntry])
     ).resolves.toMatchObject({ mode: 'strict', reason: 'current_catalog_strict' });
+  });
+
+  it('projects current catalog policy as managed without making marketplace persisted input', () => {
+    expect(
+      presentMCPOAuthCompatibilityPolicy({
+        mode: 'marketplace',
+        reason: 'current_catalog_marketplace',
+      })
+    ).toEqual({ effective_mode: 'marketplace', managed_by_catalog: true });
+    expect(
+      presentMCPOAuthCompatibilityPolicy({ mode: 'strict', reason: 'explicit_strict' })
+    ).toEqual({ effective_mode: 'strict', managed_by_catalog: false });
   });
 
   it('retains explicit public strict and legacy opt-ins', async () => {

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
@@ -1,38 +1,125 @@
-import type { MCPAuth, MCPSource } from '@agor/core/types';
+import type { MCPCatalogEntry, MCPServer } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { resolveMCPOAuthCompatibilityMode } from './mcp-oauth-compatibility.js';
+import { resolveMCPOAuthCompatibilityPolicy } from './mcp-oauth-compatibility.js';
 
-function server(source: MCPSource, compatibility?: 'strict' | 'legacy') {
+const entry = {
+  name: 'com.example/provider',
+  title: 'Provider',
+  description: 'Provider',
+  remote_url: 'https://provider.example/mcp',
+  transport: 'streamable-http',
+  has_remote: true,
+  category: 'developer-tools',
+  capabilities: [],
+  benefit: 'Test',
+  starter_prompt: 'Test',
+  permission_disclosure: 'Test',
+  auth_type: 'oauth',
+} as MCPCatalogEntry;
+
+function catalogServer(overrides: Partial<MCPServer> = {}): MCPServer {
   return {
-    source,
-    ...(source === 'catalog' ? { catalog_entry_name: 'com.example/provider' } : {}),
-    auth: {
-      type: 'oauth',
-      ...(compatibility ? { oauth_compatibility_mode: compatibility } : {}),
-    } satisfies MCPAuth,
+    mcp_server_id: '01900000-0000-7000-8000-000000000001' as MCPServer['mcp_server_id'],
+    name: 'provider',
+    transport: 'http',
+    scope: 'global',
+    enabled: true,
+    source: 'catalog',
+    catalog_entry_name: entry.name,
+    url: entry.remote_url,
+    auth: { type: 'oauth', oauth_mode: 'per_user' },
+    created_at: new Date(0),
+    updated_at: new Date(0),
+    ...overrides,
   };
 }
 
-describe('resolveMCPOAuthCompatibilityMode', () => {
-  it('uses the bounded interoperability profile only for an unstated catalog install', () => {
-    expect(resolveMCPOAuthCompatibilityMode(server('catalog'))).toBe('marketplace');
+describe('resolveMCPOAuthCompatibilityPolicy', () => {
+  it('derives marketplace only from a canonical install of a current OAuth entry', async () => {
+    await expect(resolveMCPOAuthCompatibilityPolicy(catalogServer(), [entry])).resolves.toEqual({
+      mode: 'marketplace',
+      reason: 'current_catalog_marketplace',
+      catalogEntryName: entry.name,
+    });
   });
 
-  it('retains explicit strict and legacy catalog opt-ins', () => {
-    expect(resolveMCPOAuthCompatibilityMode(server('catalog', 'strict'))).toBe('strict');
-    expect(resolveMCPOAuthCompatibilityMode(server('catalog', 'legacy'))).toBe('legacy');
+  it('reconciles an existing install with a newly explicit current strict policy', async () => {
+    const strictEntry = { ...entry, oauth: { compatibility_mode: 'strict' as const } };
+    await expect(
+      resolveMCPOAuthCompatibilityPolicy(catalogServer(), [strictEntry])
+    ).resolves.toMatchObject({ mode: 'strict', reason: 'current_catalog_strict' });
   });
 
-  it('does not trust a caller-forgeable source value without the protected catalog stamp', () => {
-    expect(resolveMCPOAuthCompatibilityMode({ source: 'catalog', auth: { type: 'oauth' } })).toBe(
-      'strict'
+  it('retains explicit public strict and legacy opt-ins', async () => {
+    await expect(
+      resolveMCPOAuthCompatibilityPolicy(
+        catalogServer({
+          auth: { type: 'oauth', oauth_mode: 'per_user', oauth_compatibility_mode: 'strict' },
+        }),
+        [entry]
+      )
+    ).resolves.toMatchObject({ mode: 'strict', reason: 'explicit_strict' });
+    await expect(
+      resolveMCPOAuthCompatibilityPolicy(
+        catalogServer({
+          auth: { type: 'oauth', oauth_mode: 'per_user', oauth_compatibility_mode: 'legacy' },
+        }),
+        [entry]
+      )
+    ).resolves.toMatchObject({ mode: 'legacy', reason: 'explicit_legacy' });
+  });
+
+  it.each([
+    ['user provenance', { source: 'user' as const }, [entry], 'general_default_strict'],
+    ['imported provenance', { source: 'imported' as const }, [entry], 'general_default_strict'],
+    [
+      'missing protected stamp',
+      { catalog_entry_name: undefined },
+      [entry],
+      'general_default_strict',
+    ],
+    ['removed entry', {}, [], 'catalog_entry_removed'],
+    [
+      'edited endpoint',
+      { url: 'https://attacker.example/mcp' },
+      [entry],
+      'catalog_configuration_drift',
+    ],
+    ['edited transport', { transport: 'sse' as const }, [entry], 'catalog_configuration_drift'],
+    [
+      'edited auth routing',
+      {
+        auth: {
+          type: 'oauth' as const,
+          oauth_mode: 'per_user' as const,
+          oauth_token_url: 'https://attacker.example/token',
+        },
+      },
+      [entry],
+      'catalog_configuration_drift',
+    ],
+    [
+      'custom header',
+      { headers: { 'X-Route': 'elsewhere' } },
+      [entry],
+      'catalog_configuration_drift',
+    ],
+  ] as const)('fails closed for %s', async (_label, overrides, entries, reason) => {
+    await expect(
+      resolveMCPOAuthCompatibilityPolicy(catalogServer(overrides as Partial<MCPServer>), entries)
+    ).resolves.toMatchObject({ mode: 'strict', reason });
+  });
+
+  it.each(['marketplace', 'unknown'])('rejects public/persisted mode %s', async (mode) => {
+    const server = catalogServer({
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_compatibility_mode: mode,
+      } as never,
+    });
+    await expect(resolveMCPOAuthCompatibilityPolicy(server, [entry])).rejects.toThrow(
+      /must be either strict or legacy/
     );
   });
-
-  it.each(['user', 'imported', 'agor'] as const)(
-    'keeps the general %s server default strict',
-    (source) => {
-      expect(resolveMCPOAuthCompatibilityMode(server(source))).toBe('strict');
-    }
-  );
 });

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
@@ -1,0 +1,38 @@
+import type { MCPAuth, MCPSource } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { resolveMCPOAuthCompatibilityMode } from './mcp-oauth-compatibility.js';
+
+function server(source: MCPSource, compatibility?: 'strict' | 'legacy') {
+  return {
+    source,
+    ...(source === 'catalog' ? { catalog_entry_name: 'com.example/provider' } : {}),
+    auth: {
+      type: 'oauth',
+      ...(compatibility ? { oauth_compatibility_mode: compatibility } : {}),
+    } satisfies MCPAuth,
+  };
+}
+
+describe('resolveMCPOAuthCompatibilityMode', () => {
+  it('uses the bounded interoperability profile only for an unstated catalog install', () => {
+    expect(resolveMCPOAuthCompatibilityMode(server('catalog'))).toBe('marketplace');
+  });
+
+  it('retains explicit strict and legacy catalog opt-ins', () => {
+    expect(resolveMCPOAuthCompatibilityMode(server('catalog', 'strict'))).toBe('strict');
+    expect(resolveMCPOAuthCompatibilityMode(server('catalog', 'legacy'))).toBe('legacy');
+  });
+
+  it('does not trust a caller-forgeable source value without the protected catalog stamp', () => {
+    expect(resolveMCPOAuthCompatibilityMode({ source: 'catalog', auth: { type: 'oauth' } })).toBe(
+      'strict'
+    );
+  });
+
+  it.each(['user', 'imported', 'agor'] as const)(
+    'keeps the general %s server default strict',
+    (source) => {
+      expect(resolveMCPOAuthCompatibilityMode(server(source))).toBe('strict');
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
@@ -22,6 +22,17 @@ export interface MCPOAuthCompatibilityPolicy {
   catalogEntryName?: string;
 }
 
+/** Public, non-persisted projection used by Settings to show effective policy. */
+export function presentMCPOAuthCompatibilityPolicy(
+  policy: MCPOAuthCompatibilityPolicy
+): NonNullable<MCPServer['oauth_compatibility_policy']> {
+  return {
+    effective_mode: policy.mode,
+    managed_by_catalog:
+      policy.reason === 'current_catalog_marketplace' || policy.reason === 'current_catalog_strict',
+  };
+}
+
 /**
  * Resolve one saved server against the CURRENT curated catalog.
  *

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
@@ -1,0 +1,24 @@
+import type { MCPAuth, MCPOAuthRuntimeCompatibilityMode, MCPSource } from '@agor/core/types';
+
+/**
+ * Resolve the policy the OAuth transport must enforce for one saved server.
+ *
+ * The public/user-authored configuration surface still has exactly two
+ * choices and still defaults to `strict`. `marketplace` is an internal policy
+ * selected only by trusted provenance: both the catalog source and protected
+ * `catalog_entry_name` stamp must be present. The daemon install path writes
+ * that stamp, and request payloads cannot forge it. A catalog entry can retain
+ * strict behavior explicitly by stating `compatibility_mode: strict`; legacy
+ * remains an explicit, broader escape hatch rather than the marketplace
+ * default.
+ */
+export function resolveMCPOAuthCompatibilityMode(server: {
+  source?: MCPSource;
+  catalog_entry_name?: string;
+  auth?: MCPAuth;
+}): MCPOAuthRuntimeCompatibilityMode {
+  return (
+    server.auth?.oauth_compatibility_mode ??
+    (server.source === 'catalog' && server.catalog_entry_name ? 'marketplace' : 'strict')
+  );
+}

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.ts
@@ -1,24 +1,100 @@
-import type { MCPAuth, MCPOAuthRuntimeCompatibilityMode, MCPSource } from '@agor/core/types';
+import { findCatalogEntry, loadCatalog } from '@agor/core/mcp-catalog';
+import type {
+  MCPCatalogEntry,
+  MCPOAuthRuntimeCompatibilityMode,
+  MCPServer,
+} from '@agor/core/types';
+import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
+import { catalogOAuthConfig, isCurrentCatalogInstall } from './mcp-catalog-install-policy.js';
+
+export type MCPOAuthCompatibilityPolicyReason =
+  | 'explicit_strict'
+  | 'explicit_legacy'
+  | 'current_catalog_strict'
+  | 'current_catalog_marketplace'
+  | 'catalog_entry_removed'
+  | 'catalog_configuration_drift'
+  | 'general_default_strict';
+
+export interface MCPOAuthCompatibilityPolicy {
+  mode: MCPOAuthRuntimeCompatibilityMode;
+  reason: MCPOAuthCompatibilityPolicyReason;
+  catalogEntryName?: string;
+}
 
 /**
- * Resolve the policy the OAuth transport must enforce for one saved server.
+ * Resolve one saved server against the CURRENT curated catalog.
  *
- * The public/user-authored configuration surface still has exactly two
- * choices and still defaults to `strict`. `marketplace` is an internal policy
- * selected only by trusted provenance: both the catalog source and protected
- * `catalog_entry_name` stamp must be present. The daemon install path writes
- * that stamp, and request payloads cannot forge it. A catalog entry can retain
- * strict behavior explicitly by stating `compatibility_mode: strict`; legacy
- * remains an explicit, broader escape hatch rather than the marketplace
- * default.
+ * Public/persisted input is validated before any derivation. An explicit
+ * strict/legacy choice remains authoritative. Omission can become marketplace
+ * only when the durable row is still a canonical install of a current OAuth
+ * entry; a historical stamp, removed entry, edited endpoint/auth/header, or
+ * imported row falls back to strict.
  */
-export function resolveMCPOAuthCompatibilityMode(server: {
-  source?: MCPSource;
-  catalog_entry_name?: string;
-  auth?: MCPAuth;
-}): MCPOAuthRuntimeCompatibilityMode {
-  return (
-    server.auth?.oauth_compatibility_mode ??
-    (server.source === 'catalog' && server.catalog_entry_name ? 'marketplace' : 'strict')
+export async function resolveMCPOAuthCompatibilityPolicy(
+  server: Pick<
+    MCPServer,
+    'source' | 'catalog_entry_name' | 'transport' | 'url' | 'auth' | 'headers'
+  >,
+  catalogEntries?: readonly MCPCatalogEntry[]
+): Promise<MCPOAuthCompatibilityPolicy> {
+  assertPublicMCPOAuthCompatibilityMode(server.auth);
+  const configured = server.auth?.oauth_compatibility_mode;
+  if (configured) {
+    return {
+      mode: configured,
+      reason: configured === 'strict' ? 'explicit_strict' : 'explicit_legacy',
+      ...(server.catalog_entry_name ? { catalogEntryName: server.catalog_entry_name } : {}),
+    };
+  }
+
+  if (server.source !== 'catalog' || !server.catalog_entry_name) {
+    return { mode: 'strict', reason: 'general_default_strict' };
+  }
+
+  const entries = catalogEntries ?? (await loadCatalog());
+  const entry = findCatalogEntry(entries, server.catalog_entry_name);
+  if (!entry?.remote_url || entry.auth_type !== 'oauth') {
+    return {
+      mode: 'strict',
+      reason: 'catalog_entry_removed',
+      catalogEntryName: server.catalog_entry_name,
+    };
+  }
+
+  if (
+    !isCurrentCatalogInstall(
+      server,
+      entry as MCPCatalogEntry & { remote_url: string },
+      catalogOAuthConfig(entry),
+      {
+        reconcileMissingCompatibilityMode: true,
+      }
+    )
+  ) {
+    return {
+      mode: 'strict',
+      reason: 'catalog_configuration_drift',
+      catalogEntryName: server.catalog_entry_name,
+    };
+  }
+
+  const mode = entry.oauth?.compatibility_mode ?? 'marketplace';
+  return {
+    mode,
+    reason: mode === 'strict' ? 'current_catalog_strict' : 'current_catalog_marketplace',
+    catalogEntryName: entry.name,
+  };
+}
+
+/** Secret-free, stable policy evidence at the flow boundary. */
+export function logMCPOAuthCompatibilityPolicy(
+  operation: string,
+  serverId: string | undefined,
+  policy: MCPOAuthCompatibilityPolicy
+): void {
+  console.info(
+    `[MCP OAuth] compatibility operation=${operation} mode=${policy.mode} reason=${policy.reason} ` +
+      `server=${serverId ?? '<unsaved>'} catalog_entry=${policy.catalogEntryName ?? '<none>'}`
   );
 }

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-authority.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-authority.test.ts
@@ -1,0 +1,86 @@
+import type { TenantScopeAwareDatabase, UserMCPOAuthToken } from '@agor/core/db';
+import type { MCPServer, MCPServerID } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { isMCPOAuthGrantAuthorizedForServer } from './mcp-oauth-grant-authority.js';
+import { fingerprintMCPOAuthGrantConfiguration } from './mcp-oauth-grant-binding.js';
+
+const db = { run: () => undefined } as unknown as TenantScopeAwareDatabase;
+const masterSecret = 'grant-authority-test-master-secret';
+const server: MCPServer = {
+  mcp_server_id: 'authority-server' as MCPServerID,
+  name: 'authority-server',
+  transport: 'http',
+  scope: 'global',
+  enabled: true,
+  source: 'user',
+  url: 'https://mcp.example.test',
+  auth: { type: 'oauth', oauth_mode: 'per_user', oauth_compatibility_mode: 'strict' },
+  created_at: new Date(0),
+  updated_at: new Date(0),
+};
+const resolved = {
+  resourceUri: server.url!,
+  metadataUrl: 'https://mcp.example.test/.well-known/oauth-protected-resource',
+  issuer: 'https://auth.example.test',
+  authorizationEndpoint: 'https://auth.example.test/authorize',
+  tokenEndpoint: 'https://auth.example.test/token',
+  redirectUri: 'https://agor.example.test/mcp-servers/oauth-callback',
+  clientId: 'client',
+  compatibilityMode: 'strict' as const,
+};
+
+function grant(version: number | undefined): UserMCPOAuthToken {
+  return {
+    user_id: 'user-1' as never,
+    mcp_server_id: server.mcp_server_id,
+    oauth_access_token: 'access',
+    oauth_client_id: resolved.clientId,
+    oauth_metadata_uri: resolved.metadataUrl,
+    oauth_resource_uri: resolved.resourceUri,
+    oauth_issuer: resolved.issuer,
+    oauth_authorization_endpoint: resolved.authorizationEndpoint,
+    oauth_token_endpoint: resolved.tokenEndpoint,
+    oauth_redirect_uri: resolved.redirectUri,
+    grant_generation: version === undefined ? 0 : 1,
+    grant_binding_version: version,
+    grant_binding_fingerprint:
+      version === 4
+        ? fingerprintMCPOAuthGrantConfiguration(masterSecret, server, resolved, 4)
+        : undefined,
+    refresh_status: 'idle',
+    refresh_generation: 0,
+    refresh_success_generation: 0,
+    created_at: new Date(0),
+  };
+}
+
+describe('MCP OAuth grant authority', () => {
+  it('grandfathers only an absent SQLite binding and accepts a valid current binding', async () => {
+    const previous = process.env.AGOR_MASTER_SECRET;
+    process.env.AGOR_MASTER_SECRET = masterSecret;
+    try {
+      await expect(isMCPOAuthGrantAuthorizedForServer(db, server, grant(undefined))).resolves.toBe(
+        true
+      );
+      await expect(isMCPOAuthGrantAuthorizedForServer(db, server, grant(4))).resolves.toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.AGOR_MASTER_SECRET;
+      else process.env.AGOR_MASTER_SECRET = previous;
+    }
+  });
+
+  it.each([0, 5, Number.NaN])(
+    'rejects unsupported non-null binding version %s',
+    async (version) => {
+      await expect(isMCPOAuthGrantAuthorizedForServer(db, server, grant(version))).resolves.toBe(
+        false
+      );
+    }
+  );
+
+  it('rejects a grant subject inconsistent with the current OAuth mode', async () => {
+    await expect(
+      isMCPOAuthGrantAuthorizedForServer(db, server, { ...grant(undefined), user_id: null })
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-authority.ts
@@ -1,0 +1,60 @@
+import {
+  isPostgresDatabaseHandle,
+  MCPServerRepository,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+  type UserMCPOAuthToken,
+} from '@agor/core/db';
+import type { MCPServer, MCPServerID } from '@agor/core/types';
+import { resolveMCPOAuthCompatibilityPolicy } from './mcp-oauth-compatibility.js';
+import {
+  isMCPOAuthGrantBoundToServer,
+  lockMCPOAuthGrantConfiguration,
+  shouldVerifyMCPOAuthGrantBinding,
+} from './mcp-oauth-grant-binding.js';
+
+type GrantAuthorityDatabase = TenantScopeAwareDatabase | TenantScopedDatabase;
+
+/**
+ * Shared authoritative grant decision used by execution, status, refresh, and
+ * gateway warning surfaces. Only an actually absent standalone binding is
+ * grandfathered; any present unsupported version reaches the verifier and is
+ * rejected.
+ */
+export async function isMCPOAuthGrantAuthorizedForServer(
+  db: GrantAuthorityDatabase,
+  server: MCPServer,
+  grant: UserMCPOAuthToken
+): Promise<boolean> {
+  if (!server.enabled || server.auth?.type !== 'oauth') return false;
+  const mode = server.auth.oauth_mode ?? 'per_user';
+  if ((mode === 'shared') !== (grant.user_id === null)) return false;
+
+  if (
+    !shouldVerifyMCPOAuthGrantBinding(isPostgresDatabaseHandle(db), grant.grant_binding_version)
+  ) {
+    return true;
+  }
+  return isMCPOAuthGrantBoundToServer(
+    process.env.AGOR_MASTER_SECRET!,
+    server,
+    grant,
+    (await resolveMCPOAuthCompatibilityPolicy(server)).mode
+  );
+}
+
+/** Re-read the saved row, optionally fencing a PostgreSQL refresh completion. */
+export async function isCurrentMCPOAuthGrantAuthorized(options: {
+  db: GrantAuthorityDatabase;
+  serverId: MCPServerID;
+  grant: UserMCPOAuthToken;
+  tenantId?: string;
+  lockConfiguration?: boolean;
+}): Promise<boolean> {
+  if (options.lockConfiguration && isPostgresDatabaseHandle(options.db)) {
+    if (!options.tenantId) return false;
+    await lockMCPOAuthGrantConfiguration(options.db, options.tenantId, options.serverId);
+  }
+  const server = await new MCPServerRepository(options.db).findById(options.serverId);
+  return !!server && isMCPOAuthGrantAuthorizedForServer(options.db, server, options.grant);
+}

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -11,12 +11,16 @@ import {
 
 const masterSecret = 'test-master-secret-that-is-not-a-provider-secret';
 
-type ServerBinding = Pick<MCPServer, 'mcp_server_id' | 'enabled' | 'transport' | 'url' | 'auth'>;
+type ServerBinding = Pick<
+  MCPServer,
+  'mcp_server_id' | 'enabled' | 'transport' | 'url' | 'source' | 'catalog_entry_name' | 'auth'
+>;
 
 const server: ServerBinding = {
   mcp_server_id: '019f-server-a' as MCPServerID,
   enabled: true,
   transport: 'http',
+  source: 'user',
   url: 'https://resource.example/mcp',
   auth: {
     type: 'oauth',
@@ -100,6 +104,24 @@ describe('MCP OAuth grant configuration binding', () => {
         tokenFor(legacyFingerprint(withoutPolicy), 1)
       )
     ).toBe(true);
+  });
+
+  it('binds the marketplace-derived profile and an explicit strict opt-in differently', () => {
+    const catalogDefault: ServerBinding = {
+      ...server,
+      source: 'catalog',
+      catalog_entry_name: 'com.example/provider',
+      auth: { ...server.auth, oauth_compatibility_mode: undefined },
+    };
+    const catalogStrict: ServerBinding = {
+      ...catalogDefault,
+      auth: { ...catalogDefault.auth, oauth_compatibility_mode: 'strict' },
+    };
+
+    expect(fingerprintMCPOAuthGrantConfiguration(masterSecret, catalogDefault, resolved)).not.toBe(
+      fingerprintMCPOAuthGrantConfiguration(masterSecret, catalogStrict, resolved)
+    );
+    expect(hasMCPOAuthRelevantServerConfigurationChanged(catalogDefault, catalogStrict)).toBe(true);
   });
 
   it('binds every provider, client, callback, server, mode, and version input', () => {

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -8,13 +8,21 @@ import {
   isMCPOAuthGrantBoundToServer,
   MCP_OAUTH_GRANT_BINDING_VERSION,
   type MCPOAuthResolvedGrantBinding,
+  shouldVerifyMCPOAuthGrantBinding,
 } from './mcp-oauth-grant-binding.js';
 
 const masterSecret = 'test-master-secret-that-is-not-a-provider-secret';
 
 type ServerBinding = Pick<
   MCPServer,
-  'mcp_server_id' | 'enabled' | 'transport' | 'url' | 'source' | 'catalog_entry_name' | 'auth'
+  | 'mcp_server_id'
+  | 'enabled'
+  | 'transport'
+  | 'url'
+  | 'source'
+  | 'catalog_entry_name'
+  | 'headers'
+  | 'auth'
 >;
 
 const server: ServerBinding = {
@@ -51,7 +59,7 @@ const resolved = {
 
 function tokenFor(
   fingerprint: string,
-  version: UserMCPOAuthToken['grant_binding_version'] = 2
+  version: UserMCPOAuthToken['grant_binding_version'] = MCP_OAUTH_GRANT_BINDING_VERSION
 ): UserMCPOAuthToken {
   return {
     user_id: null,
@@ -76,6 +84,11 @@ function tokenFor(
 }
 
 describe('MCP OAuth grant configuration binding', () => {
+  it('grandfathers only historical standalone unbound grants', () => {
+    expect(shouldVerifyMCPOAuthGrantBinding(false, undefined)).toBe(false);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, 4)).toBe(true);
+    expect(shouldVerifyMCPOAuthGrantBinding(true, undefined)).toBe(true);
+  });
   it('records advertised as the effective default while preserving version-1 fingerprints', () => {
     const withoutPolicy: ServerBinding = {
       ...server,
@@ -133,9 +146,9 @@ describe('MCP OAuth grant configuration binding', () => {
       marketplaceResolved
     );
     expect(strictFingerprint).not.toBe(marketplaceFingerprint);
-    expect(grantBindingVersionForCompatibilityMode('strict')).toBe(2);
-    expect(grantBindingVersionForCompatibilityMode('legacy')).toBe(2);
-    expect(grantBindingVersionForCompatibilityMode('marketplace')).toBe(3);
+    expect(grantBindingVersionForCompatibilityMode('strict')).toBe(4);
+    expect(grantBindingVersionForCompatibilityMode('legacy')).toBe(4);
+    expect(grantBindingVersionForCompatibilityMode('marketplace')).toBe(4);
     // A pre-marketplace v2 strict grant cannot silently cross into the new
     // policy even though both formats share the historical version number.
     expect(
@@ -166,11 +179,17 @@ describe('MCP OAuth grant configuration binding', () => {
         'marketplace'
       )
     ).toBe(true);
+    const marketplaceV3Fingerprint = fingerprintMCPOAuthGrantConfiguration(
+      masterSecret,
+      catalogDefault,
+      marketplaceResolved,
+      3
+    );
     expect(
       isMCPOAuthGrantBoundToServer(
         masterSecret,
         catalogDefault,
-        tokenFor(marketplaceFingerprint, 3),
+        tokenFor(marketplaceV3Fingerprint, 3),
         'marketplace'
       )
     ).toBe(true);
@@ -178,7 +197,7 @@ describe('MCP OAuth grant configuration binding', () => {
       isMCPOAuthGrantBoundToServer(
         masterSecret,
         catalogDefault,
-        tokenFor(marketplaceFingerprint, 3),
+        tokenFor(marketplaceV3Fingerprint, 3),
         'strict'
       )
     ).toBe(false);
@@ -192,6 +211,9 @@ describe('MCP OAuth grant configuration binding', () => {
       ['resource URL', { ...server, url: 'https://other-resource.example/mcp' }, resolved],
       ['enabled state', { ...server, enabled: false }, resolved],
       ['transport', { ...server, transport: 'sse' }, resolved],
+      ['custom headers', { ...server, headers: { 'X-Resource': 'other' } }, resolved],
+      ['catalog provenance', { ...server, source: 'catalog' }, resolved],
+      ['insecure auth', { ...server, auth: { ...server.auth, insecure: true } }, resolved],
       ['auth mode', { ...server, auth: { ...server.auth, oauth_mode: 'shared' } }, resolved],
       [
         'compatibility mode',
@@ -239,7 +261,7 @@ describe('MCP OAuth grant configuration binding', () => {
         label
       ).not.toBe(original);
     }
-    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(3);
+    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(4);
   });
 
   it('revalidates a stored grant and rejects a configuration change', () => {
@@ -310,6 +332,19 @@ describe('MCP OAuth grant configuration binding', () => {
       hasMCPOAuthRelevantServerConfigurationChanged(server, {
         ...server,
         url: 'https://replacement.example/mcp',
+      })
+    ).toBe(true);
+    expect(
+      hasMCPOAuthRelevantServerConfigurationChanged(server, {
+        ...server,
+        headers: { 'X-Resource': 'changed' },
+      })
+    ).toBe(true);
+    expect(
+      hasMCPOAuthRelevantServerConfigurationChanged(server, {
+        ...server,
+        source: 'catalog',
+        catalog_entry_name: 'com.example/provider',
       })
     ).toBe(true);
   });

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -3,6 +3,7 @@ import type { MCPServer, MCPServerID } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
   fingerprintMCPOAuthGrantConfiguration,
+  grantBindingVersionForCompatibilityMode,
   hasMCPOAuthRelevantServerConfigurationChanged,
   isMCPOAuthGrantBoundToServer,
   MCP_OAUTH_GRANT_BINDING_VERSION,
@@ -45,11 +46,12 @@ const resolved = {
   redirectUri: 'https://agor.example/oauth/callback',
   clientId: 'registered-client',
   clientSecret: 'registered-secret',
+  compatibilityMode: 'strict',
 } satisfies MCPOAuthResolvedGrantBinding;
 
 function tokenFor(
   fingerprint: string,
-  version: UserMCPOAuthToken['grant_binding_version'] = MCP_OAUTH_GRANT_BINDING_VERSION
+  version: UserMCPOAuthToken['grant_binding_version'] = 2
 ): UserMCPOAuthToken {
   return {
     user_id: null,
@@ -101,12 +103,13 @@ describe('MCP OAuth grant configuration binding', () => {
       isMCPOAuthGrantBoundToServer(
         masterSecret,
         withoutPolicy,
-        tokenFor(legacyFingerprint(withoutPolicy), 1)
+        tokenFor(legacyFingerprint(withoutPolicy), 1),
+        'strict'
       )
     ).toBe(true);
   });
 
-  it('binds the marketplace-derived profile and an explicit strict opt-in differently', () => {
+  it('versions and binds a marketplace policy transition explicitly', () => {
     const catalogDefault: ServerBinding = {
       ...server,
       source: 'catalog',
@@ -118,9 +121,67 @@ describe('MCP OAuth grant configuration binding', () => {
       auth: { ...catalogDefault.auth, oauth_compatibility_mode: 'strict' },
     };
 
-    expect(fingerprintMCPOAuthGrantConfiguration(masterSecret, catalogDefault, resolved)).not.toBe(
-      fingerprintMCPOAuthGrantConfiguration(masterSecret, catalogStrict, resolved)
+    const marketplaceResolved = { ...resolved, compatibilityMode: 'marketplace' as const };
+    const strictFingerprint = fingerprintMCPOAuthGrantConfiguration(
+      masterSecret,
+      catalogStrict,
+      resolved
     );
+    const marketplaceFingerprint = fingerprintMCPOAuthGrantConfiguration(
+      masterSecret,
+      catalogDefault,
+      marketplaceResolved
+    );
+    expect(strictFingerprint).not.toBe(marketplaceFingerprint);
+    expect(grantBindingVersionForCompatibilityMode('strict')).toBe(2);
+    expect(grantBindingVersionForCompatibilityMode('legacy')).toBe(2);
+    expect(grantBindingVersionForCompatibilityMode('marketplace')).toBe(3);
+    // A pre-marketplace v2 strict grant cannot silently cross into the new
+    // policy even though both formats share the historical version number.
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        catalogDefault,
+        tokenFor(
+          fingerprintMCPOAuthGrantConfiguration(masterSecret, catalogDefault, resolved, 2),
+          2
+        ),
+        'marketplace'
+      )
+    ).toBe(false);
+    // A v2 grant actually issued by the merged #2377 implementation did bind
+    // marketplace into its HMAC. Keep it when the row still satisfies today's
+    // canonical catalog policy; edited/removed rows resolve strict upstream.
+    const mergedPrFingerprint = fingerprintMCPOAuthGrantConfiguration(
+      masterSecret,
+      catalogDefault,
+      marketplaceResolved,
+      2
+    );
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        catalogDefault,
+        tokenFor(mergedPrFingerprint, 2),
+        'marketplace'
+      )
+    ).toBe(true);
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        catalogDefault,
+        tokenFor(marketplaceFingerprint, 3),
+        'marketplace'
+      )
+    ).toBe(true);
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        catalogDefault,
+        tokenFor(marketplaceFingerprint, 3),
+        'strict'
+      )
+    ).toBe(false);
     expect(hasMCPOAuthRelevantServerConfigurationChanged(catalogDefault, catalogStrict)).toBe(true);
   });
 
@@ -135,7 +196,7 @@ describe('MCP OAuth grant configuration binding', () => {
       [
         'compatibility mode',
         { ...server, auth: { ...server.auth, oauth_compatibility_mode: 'legacy' } },
-        resolved,
+        { ...resolved, compatibilityMode: 'legacy' },
       ],
       ['DCR policy', { ...server, auth: { ...server.auth, oauth_dcr_mode: 'fallback' } }, resolved],
       [
@@ -169,6 +230,7 @@ describe('MCP OAuth grant configuration binding', () => {
       ['redirect contract', server, { ...resolved, redirectUri: 'https://other-agor.example/cb' }],
       ['resolved client id', server, { ...resolved, clientId: 'other-registered-client' }],
       ['resolved client secret', server, { ...resolved, clientSecret: 'other-registered-secret' }],
+      ['effective compatibility mode', server, { ...resolved, compatibilityMode: 'marketplace' }],
     ];
 
     for (const [label, changedServer, changedResolved] of variants) {
@@ -177,21 +239,46 @@ describe('MCP OAuth grant configuration binding', () => {
         label
       ).not.toBe(original);
     }
-    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(2);
+    expect(MCP_OAUTH_GRANT_BINDING_VERSION).toBe(3);
   });
 
   it('revalidates a stored grant and rejects a configuration change', () => {
     const fingerprint = fingerprintMCPOAuthGrantConfiguration(masterSecret, server, resolved);
     const grant = tokenFor(fingerprint);
-    expect(isMCPOAuthGrantBoundToServer(masterSecret, server, grant)).toBe(true);
+    expect(isMCPOAuthGrantBoundToServer(masterSecret, server, grant, 'strict')).toBe(true);
     expect(
       isMCPOAuthGrantBoundToServer(
         masterSecret,
         { ...server, url: 'https://replacement.example/mcp' },
-        grant
+        grant,
+        'strict'
       )
     ).toBe(false);
-    expect(isMCPOAuthGrantBoundToServer('other-master', server, grant)).toBe(false);
+    expect(isMCPOAuthGrantBoundToServer('other-master', server, grant, 'strict')).toBe(false);
+  });
+
+  it('keeps a v2 strict grant for an existing catalog row whose stored mode was absent', () => {
+    const existingStrictCatalogServer: ServerBinding = {
+      ...server,
+      source: 'catalog',
+      catalog_entry_name: 'com.example/strict-provider',
+      auth: { ...server.auth, oauth_compatibility_mode: undefined },
+    };
+    const fingerprint = fingerprintMCPOAuthGrantConfiguration(
+      masterSecret,
+      existingStrictCatalogServer,
+      resolved,
+      2
+    );
+
+    expect(
+      isMCPOAuthGrantBoundToServer(
+        masterSecret,
+        existingStrictCatalogServer,
+        tokenFor(fingerprint, 2),
+        'strict'
+      )
+    ).toBe(true);
   });
 
   it('detects all server-side OAuth configuration changes for invalidation', () => {

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.test.ts
@@ -86,8 +86,40 @@ function tokenFor(
 describe('MCP OAuth grant configuration binding', () => {
   it('grandfathers only historical standalone unbound grants', () => {
     expect(shouldVerifyMCPOAuthGrantBinding(false, undefined)).toBe(false);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, null)).toBe(false);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, 0)).toBe(true);
     expect(shouldVerifyMCPOAuthGrantBinding(false, 4)).toBe(true);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, 5)).toBe(true);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, Number.NaN)).toBe(true);
+    expect(shouldVerifyMCPOAuthGrantBinding(false, 'malformed')).toBe(true);
     expect(shouldVerifyMCPOAuthGrantBinding(true, undefined)).toBe(true);
+
+    const fingerprint = fingerprintMCPOAuthGrantConfiguration(masterSecret, server, resolved);
+    for (const version of [0, 5, Number.NaN]) {
+      expect(
+        isMCPOAuthGrantBoundToServer(masterSecret, server, tokenFor(fingerprint, version), 'strict')
+      ).toBe(false);
+    }
+  });
+
+  it('uses one case-insensitive header representation for wire, mutation, and binding', () => {
+    const ordered = { ...server, headers: { 'X-Route': 'a', 'X-Tenant': 'b' } };
+    const reorderedAndRecased = {
+      ...server,
+      headers: { 'x-tenant': 'b', 'x-route': 'a' },
+    };
+    expect(fingerprintMCPOAuthGrantConfiguration(masterSecret, ordered, resolved)).toBe(
+      fingerprintMCPOAuthGrantConfiguration(masterSecret, reorderedAndRecased, resolved)
+    );
+    expect(hasMCPOAuthRelevantServerConfigurationChanged(ordered, reorderedAndRecased)).toBe(false);
+
+    const duplicate = { ...server, headers: { 'X-Route': 'a', 'x-route': 'b' } };
+    expect(() => fingerprintMCPOAuthGrantConfiguration(masterSecret, duplicate, resolved)).toThrow(
+      /Duplicate custom HTTP header names/
+    );
+    expect(() => hasMCPOAuthRelevantServerConfigurationChanged(server, duplicate)).toThrow(
+      /Duplicate custom HTTP header names/
+    );
   });
   it('records advertised as the effective default while preserving version-1 fingerprints', () => {
     const withoutPolicy: ServerBinding = {

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -6,6 +6,7 @@ import {
   type TenantScopedDatabase,
   type UserMCPOAuthToken,
 } from '@agor/core/db';
+import { canonicalMCPCustomHeaderEntries } from '@agor/core/tools/mcp/http-headers';
 import type {
   MCPAuth,
   MCPOAuthGrantBindingVersion,
@@ -23,7 +24,10 @@ export const MCP_OAUTH_GRANT_BINDING_VERSION = 4 as const;
  * unbound grants usable, while every newly issued versioned grant verifies.
  */
 export function shouldVerifyMCPOAuthGrantBinding(requireAll: boolean, version: unknown): boolean {
-  return requireAll || isMCPOAuthGrantBindingVersion(version);
+  // Only a truly absent standalone/SQLite version is historical. Any present
+  // but unsupported value (0, a future version, NaN/malformed storage) must
+  // reach the verifier and fail closed rather than masquerade as unbound.
+  return requireAll || (version !== null && version !== undefined);
 }
 
 export function grantBindingVersionForCompatibilityMode(
@@ -134,14 +138,7 @@ export function fingerprintMCPOAuthGrantConfiguration(
       ? {
           source: server.source,
           catalogEntryName: server.catalog_entry_name ?? null,
-          // Header names are case-insensitive on the wire. Sorting makes the
-          // fingerprint independent of JSON object insertion order without
-          // accepting any value or duplicate-header change.
-          headers: Object.entries(server.headers ?? {})
-            .map(([name, value]) => [name.toLowerCase(), value] as const)
-            .sort(([aName, aValue], [bName, bValue]) =>
-              aName === bName ? aValue.localeCompare(bValue) : aName.localeCompare(bName)
-            ),
+          headers: canonicalMCPCustomHeaderEntries(server.headers),
         }
       : {}),
     auth: authBinding(server, version, compatibilityMode),
@@ -162,11 +159,7 @@ function relevantServerConfiguration(server: Partial<MCPServer> | null | undefin
     url: server.url ?? null,
     source: server.source ?? null,
     catalogEntryName: server.catalog_entry_name ?? null,
-    headers: Object.entries(server.headers ?? {})
-      .map(([name, value]) => [name.toLowerCase(), value] as const)
-      .sort(([aName, aValue], [bName, bValue]) =>
-        aName === bName ? aValue.localeCompare(bValue) : aName.localeCompare(bName)
-      ),
+    headers: canonicalMCPCustomHeaderEntries(server.headers),
     // Mutation invalidation compares public row data. Current catalog policy
     // is independently re-resolved at start, callback, and grant-use time.
     auth: authBinding(server, 4, server.auth?.oauth_compatibility_mode ?? 'strict'),

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -15,17 +15,25 @@ import type {
 } from '@agor/core/types';
 import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
 
-/** Latest format; only the derived marketplace policy needs the v3 envelope. */
-export const MCP_OAUTH_GRANT_BINDING_VERSION = 3 as const;
+/** Latest format; v4 binds the complete saved remote-server authority. */
+export const MCP_OAUTH_GRANT_BINDING_VERSION = 4 as const;
+
+/**
+ * PostgreSQL requires binding for every row. Standalone keeps historical
+ * unbound grants usable, while every newly issued versioned grant verifies.
+ */
+export function shouldVerifyMCPOAuthGrantBinding(requireAll: boolean, version: unknown): boolean {
+  return requireAll || isMCPOAuthGrantBindingVersion(version);
+}
 
 export function grantBindingVersionForCompatibilityMode(
-  mode: MCPOAuthRuntimeCompatibilityMode
+  _mode: MCPOAuthRuntimeCompatibilityMode
 ): MCPOAuthGrantBindingVersion {
-  // Keeping strict/legacy on v2 preserves every historically valid fingerprint.
-  // New marketplace grants use v3 so their derived policy is explicit in the
-  // envelope. A #2377-era v2 marketplace HMAC can still be verified below;
-  // pre-marketplace v2 strict HMACs cannot silently cross the policy change.
-  return mode === 'marketplace' ? 3 : 2;
+  // Existing v1/v2 strict/legacy and v3 marketplace fingerprints remain
+  // verifiable with their own stored version, so issuing v4 never forces
+  // reauthorization. New grants bind headers and current catalog provenance
+  // in addition to the v3 effective-policy envelope.
+  return MCP_OAUTH_GRANT_BINDING_VERSION;
 }
 
 /**
@@ -84,6 +92,14 @@ function authBinding(
     configuredClientSecret: auth?.oauth_client_secret ?? null,
     scope: auth?.oauth_scope ?? null,
     grantType: auth?.oauth_grant_type ?? null,
+    ...(version >= 4
+      ? {
+          insecure: auth?.insecure ?? false,
+          configuredAccessToken: auth?.oauth_access_token ?? null,
+          configuredAccessTokenExpiresAt: auth?.oauth_token_expires_at ?? null,
+          configuredRefreshToken: auth?.oauth_refresh_token ?? null,
+        }
+      : {}),
   };
 }
 
@@ -92,7 +108,14 @@ export function fingerprintMCPOAuthGrantConfiguration(
   masterSecret: string,
   server: Pick<
     MCPServer,
-    'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
+    | 'mcp_server_id'
+    | 'transport'
+    | 'url'
+    | 'enabled'
+    | 'source'
+    | 'catalog_entry_name'
+    | 'headers'
+    | 'auth'
   >,
   resolved: MCPOAuthResolvedGrantBinding,
   version: MCPOAuthGrantBindingVersion = grantBindingVersionForCompatibilityMode(
@@ -107,6 +130,20 @@ export function fingerprintMCPOAuthGrantConfiguration(
     enabled: server.enabled,
     transport: server.transport,
     serverUrl: server.url ?? null,
+    ...(version >= 4
+      ? {
+          source: server.source,
+          catalogEntryName: server.catalog_entry_name ?? null,
+          // Header names are case-insensitive on the wire. Sorting makes the
+          // fingerprint independent of JSON object insertion order without
+          // accepting any value or duplicate-header change.
+          headers: Object.entries(server.headers ?? {})
+            .map(([name, value]) => [name.toLowerCase(), value] as const)
+            .sort(([aName, aValue], [bName, bValue]) =>
+              aName === bName ? aValue.localeCompare(bValue) : aName.localeCompare(bName)
+            ),
+        }
+      : {}),
     auth: authBinding(server, version, compatibilityMode),
     resolved: version >= 3 ? resolved : historicalResolved,
   });
@@ -123,9 +160,16 @@ function relevantServerConfiguration(server: Partial<MCPServer> | null | undefin
     enabled: server.enabled,
     transport: server.transport,
     url: server.url ?? null,
-    // Mutation invalidation compares public row data, not a catalog-derived
-    // policy. Catalog policy changes are caught by v3 fingerprint checks.
-    auth: authBinding(server, 2, server.auth?.oauth_compatibility_mode ?? 'strict'),
+    source: server.source ?? null,
+    catalogEntryName: server.catalog_entry_name ?? null,
+    headers: Object.entries(server.headers ?? {})
+      .map(([name, value]) => [name.toLowerCase(), value] as const)
+      .sort(([aName, aValue], [bName, bValue]) =>
+        aName === bName ? aValue.localeCompare(bValue) : aName.localeCompare(bName)
+      ),
+    // Mutation invalidation compares public row data. Current catalog policy
+    // is independently re-resolved at start, callback, and grant-use time.
+    auth: authBinding(server, 4, server.auth?.oauth_compatibility_mode ?? 'strict'),
     configuredCompatibility: server.auth?.oauth_compatibility_mode ?? null,
   });
 }
@@ -146,7 +190,14 @@ export function isMCPOAuthGrantBoundToServer(
   masterSecret: string,
   server: Pick<
     MCPServer,
-    'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
+    | 'mcp_server_id'
+    | 'transport'
+    | 'url'
+    | 'enabled'
+    | 'source'
+    | 'catalog_entry_name'
+    | 'headers'
+    | 'auth'
   >,
   grant: UserMCPOAuthToken,
   effectiveMode: MCPOAuthRuntimeCompatibilityMode

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -13,6 +13,7 @@ import type {
   MCPServerID,
 } from '@agor/core/types';
 import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
+import { resolveMCPOAuthCompatibilityMode } from './mcp-oauth-compatibility.js';
 
 export const MCP_OAUTH_GRANT_BINDING_VERSION = 2 as const;
 
@@ -47,13 +48,14 @@ export interface MCPOAuthResolvedGrantBinding {
 }
 
 function authBinding(
-  auth: MCPAuth | undefined,
+  server: { source?: MCPServer['source']; auth?: MCPAuth },
   version: MCPOAuthGrantBindingVersion
 ): Record<string, unknown> {
+  const auth = server.auth;
   return {
     type: auth?.type ?? 'none',
     mode: auth?.oauth_mode ?? 'per_user',
-    compatibility: auth?.oauth_compatibility_mode ?? 'strict',
+    compatibility: resolveMCPOAuthCompatibilityMode(server),
     // Preserve version 1 for existing grants and pending flows. New bindings
     // record the effective default so an explicit switch to disabled revokes a
     // DCR-created grant just like any other relevant policy change.
@@ -70,7 +72,10 @@ function authBinding(
 /** HMAC prevents a fingerprint from becoming a client-secret guessing oracle. */
 export function fingerprintMCPOAuthGrantConfiguration(
   masterSecret: string,
-  server: Pick<MCPServer, 'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'auth'>,
+  server: Pick<
+    MCPServer,
+    'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
+  >,
   resolved: MCPOAuthResolvedGrantBinding,
   version: MCPOAuthGrantBindingVersion = MCP_OAUTH_GRANT_BINDING_VERSION
 ): string {
@@ -81,7 +86,7 @@ export function fingerprintMCPOAuthGrantConfiguration(
     enabled: server.enabled,
     transport: server.transport,
     serverUrl: server.url ?? null,
-    auth: authBinding(server.auth, version),
+    auth: authBinding(server, version),
     resolved,
   });
   return createHmac('sha256', masterSecret)
@@ -97,7 +102,7 @@ function relevantServerConfiguration(server: Partial<MCPServer> | null | undefin
     enabled: server.enabled,
     transport: server.transport,
     url: server.url ?? null,
-    auth: authBinding(server.auth, MCP_OAUTH_GRANT_BINDING_VERSION),
+    auth: authBinding(server, MCP_OAUTH_GRANT_BINDING_VERSION),
   });
 }
 
@@ -115,7 +120,10 @@ export function hasMCPOAuthRelevantServerConfigurationChanged(
  */
 export function isMCPOAuthGrantBoundToServer(
   masterSecret: string,
-  server: Pick<MCPServer, 'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'auth'>,
+  server: Pick<
+    MCPServer,
+    'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
+  >,
   grant: UserMCPOAuthToken
 ): boolean {
   if (

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-binding.ts
@@ -9,13 +9,24 @@ import {
 import type {
   MCPAuth,
   MCPOAuthGrantBindingVersion,
+  MCPOAuthRuntimeCompatibilityMode,
   MCPServer,
   MCPServerID,
 } from '@agor/core/types';
 import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
-import { resolveMCPOAuthCompatibilityMode } from './mcp-oauth-compatibility.js';
 
-export const MCP_OAUTH_GRANT_BINDING_VERSION = 2 as const;
+/** Latest format; only the derived marketplace policy needs the v3 envelope. */
+export const MCP_OAUTH_GRANT_BINDING_VERSION = 3 as const;
+
+export function grantBindingVersionForCompatibilityMode(
+  mode: MCPOAuthRuntimeCompatibilityMode
+): MCPOAuthGrantBindingVersion {
+  // Keeping strict/legacy on v2 preserves every historically valid fingerprint.
+  // New marketplace grants use v3 so their derived policy is explicit in the
+  // envelope. A #2377-era v2 marketplace HMAC can still be verified below;
+  // pre-marketplace v2 strict HMACs cannot silently cross the policy change.
+  return mode === 'marketplace' ? 3 : 2;
+}
 
 /**
  * Serialize an MCP server's OAuth configuration with grant creation and
@@ -45,17 +56,24 @@ export interface MCPOAuthResolvedGrantBinding {
   redirectUri: string;
   clientId: string;
   clientSecret?: string;
+  /** Exact runtime policy used to produce this authorization grant. */
+  compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
 }
 
 function authBinding(
-  server: { source?: MCPServer['source']; auth?: MCPAuth },
-  version: MCPOAuthGrantBindingVersion
+  server: { auth?: MCPAuth },
+  version: MCPOAuthGrantBindingVersion,
+  effectiveMode: MCPOAuthRuntimeCompatibilityMode
 ): Record<string, unknown> {
   const auth = server.auth;
   return {
     type: auth?.type ?? 'none',
     mode: auth?.oauth_mode ?? 'per_user',
-    compatibility: resolveMCPOAuthCompatibilityMode(server),
+    // Version 1 predates derived marketplace policy. Version 2 was emitted by
+    // both the pre-marketplace strict implementation and the merged #2377
+    // implementation; the HMAC itself disambiguates those values. Version 3
+    // additionally records the effective mode in `resolved` for auditability.
+    compatibility: version >= 2 ? effectiveMode : (auth?.oauth_compatibility_mode ?? 'strict'),
     // Preserve version 1 for existing grants and pending flows. New bindings
     // record the effective default so an explicit switch to disabled revokes a
     // DCR-created grant just like any other relevant policy change.
@@ -77,17 +95,20 @@ export function fingerprintMCPOAuthGrantConfiguration(
     'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
   >,
   resolved: MCPOAuthResolvedGrantBinding,
-  version: MCPOAuthGrantBindingVersion = MCP_OAUTH_GRANT_BINDING_VERSION
+  version: MCPOAuthGrantBindingVersion = grantBindingVersionForCompatibilityMode(
+    resolved.compatibilityMode
+  )
 ): string {
   if (!masterSecret) throw new Error('MCP OAuth grant binding requires AGOR_MASTER_SECRET');
+  const { compatibilityMode, ...historicalResolved } = resolved;
   const canonical = JSON.stringify({
     version,
     serverId: server.mcp_server_id,
     enabled: server.enabled,
     transport: server.transport,
     serverUrl: server.url ?? null,
-    auth: authBinding(server, version),
-    resolved,
+    auth: authBinding(server, version, compatibilityMode),
+    resolved: version >= 3 ? resolved : historicalResolved,
   });
   return createHmac('sha256', masterSecret)
     .update(`agor:mcp-oauth:grant-configuration:v${version}\0`, 'utf8')
@@ -102,7 +123,10 @@ function relevantServerConfiguration(server: Partial<MCPServer> | null | undefin
     enabled: server.enabled,
     transport: server.transport,
     url: server.url ?? null,
-    auth: authBinding(server, MCP_OAUTH_GRANT_BINDING_VERSION),
+    // Mutation invalidation compares public row data, not a catalog-derived
+    // policy. Catalog policy changes are caught by v3 fingerprint checks.
+    auth: authBinding(server, 2, server.auth?.oauth_compatibility_mode ?? 'strict'),
+    configuredCompatibility: server.auth?.oauth_compatibility_mode ?? null,
   });
 }
 
@@ -124,7 +148,8 @@ export function isMCPOAuthGrantBoundToServer(
     MCPServer,
     'mcp_server_id' | 'transport' | 'url' | 'enabled' | 'source' | 'catalog_entry_name' | 'auth'
   >,
-  grant: UserMCPOAuthToken
+  grant: UserMCPOAuthToken,
+  effectiveMode: MCPOAuthRuntimeCompatibilityMode
 ): boolean {
   if (
     !isMCPOAuthGrantBindingVersion(grant.grant_binding_version) ||
@@ -153,6 +178,7 @@ export function isMCPOAuthGrantBoundToServer(
           redirectUri: grant.oauth_redirect_uri,
           clientId: grant.oauth_client_id,
           clientSecret: grant.oauth_client_secret,
+          compatibilityMode: effectiveMode,
         },
         grant.grant_binding_version
       ) === grant.grant_binding_fingerprint

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
@@ -67,6 +67,7 @@ function flowContext(label: string): DurableMCPOAuthFlowContext {
     state: `state-capability-${label}`,
     authorizationUrl: `https://provider.example.test/${label}/authorize?state=state-capability-${label}`,
     compatibilityMode: 'strict',
+    authorizationResponseIssuerParameterSupported: true,
     allowLocalhostHttp: false,
   };
 }

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -29,7 +29,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
-import { MCP_OAUTH_GRANT_BINDING_VERSION } from './mcp-oauth-grant-binding.js';
+import { grantBindingVersionForCompatibilityMode } from './mcp-oauth-grant-binding.js';
 
 const FLOW_TTL_MS = 10 * 60 * 1000;
 
@@ -136,7 +136,9 @@ export class MCPOAuthPendingFlowAuthority {
         mcpServerId: input.mcpServerId,
         oauthMode: input.oauthMode,
         grantGeneration,
-        configFingerprintVersion: MCP_OAUTH_GRANT_BINDING_VERSION,
+        configFingerprintVersion: grantBindingVersionForCompatibilityMode(
+          input.context.compatibilityMode
+        ),
         configFingerprint: input.configFingerprint,
         resourceUri: input.context.resourceUri,
         issuer: input.context.issuer,
@@ -174,7 +176,7 @@ export class MCPOAuthPendingFlowAuthority {
         oauthMode: input.oauthMode,
         subjectUserId,
         grantGeneration,
-        configFingerprintVersion: MCP_OAUTH_GRANT_BINDING_VERSION,
+        configFingerprintVersion: material.configFingerprintVersion,
         configFingerprint: input.configFingerprint,
         envelopeVersion: MCP_OAUTH_SECRET_ENVELOPE_VERSION,
         sealedMaterial,

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -75,7 +75,11 @@ function hasOnlyExpectedMaterialShape(value: unknown): value is MCPOAuthPendingF
     typeof material.pkceVerifier === 'string' &&
     typeof material.clientId === 'string' &&
     (material.clientSecret === undefined || typeof material.clientSecret === 'string') &&
-    (material.compatibilityMode === 'strict' || material.compatibilityMode === 'legacy') &&
+    (material.compatibilityMode === 'strict' ||
+      material.compatibilityMode === 'legacy' ||
+      material.compatibilityMode === 'marketplace') &&
+    (material.authorizationResponseIssuerParameterSupported === undefined ||
+      typeof material.authorizationResponseIssuerParameterSupported === 'boolean') &&
     typeof material.allowLocalhostHttp === 'boolean'
   );
 }
@@ -144,6 +148,8 @@ export class MCPOAuthPendingFlowAuthority {
         clientId: input.context.clientId,
         ...(input.context.clientSecret ? { clientSecret: input.context.clientSecret } : {}),
         compatibilityMode: input.context.compatibilityMode,
+        authorizationResponseIssuerParameterSupported:
+          input.context.authorizationResponseIssuerParameterSupported,
         allowLocalhostHttp: input.context.allowLocalhostHttp,
       };
       const sealedMaterial = sealMCPOAuthSecret(
@@ -281,6 +287,12 @@ export class MCPOAuthPendingFlowAuthority {
         // secret-bearing authorization URL after the browser has opened it.
         authorizationUrl: '',
         compatibilityMode: material.compatibilityMode,
+        // Older version-2 envelopes predate this explicit bit. Strict starts
+        // could only succeed when the AS advertised RFC 9207, while legacy
+        // never required it, so the mode reconstructs the old contract.
+        authorizationResponseIssuerParameterSupported:
+          material.authorizationResponseIssuerParameterSupported ??
+          material.compatibilityMode === 'strict',
         allowLocalhostHttp: material.allowLocalhostHttp,
       },
     };

--- a/apps/agor-daemon/src/services/mcp-oauth-status.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.ts
@@ -3,9 +3,10 @@
  *
  * The answer drives an auth badge in the UI, so it is a read of durable state
  * rather than of whatever a realtime hint last said: a grant is advertised only
- * if it has not expired, is not mid-refresh in an ambiguous state, and — on
- * Postgres, where durable flows live — still binds to the server it was issued
- * against.
+ * if it has not expired, is not mid-refresh in an ambiguous state, and still
+ * binds to the server it was issued against. Historical standalone grants
+ * predate binding and are intentionally grandfathered; newly issued SQLite
+ * grants carry the same versioned configuration envelope.
  *
  * Grants come from two places and only one of them is the caller's. Shared
  * grants belong to a server, not to a user, so the set they contribute is
@@ -30,7 +31,8 @@ export interface OAuthStatusDeps {
   findServer(serverId: string): Promise<MCPServer | null>;
   /**
    * Whether to recompute each grant's binding to its server's configuration.
-   * Only durable (Postgres) flows carry the fields that makes this answerable.
+   * The daemon may keep this false for a legacy caller; production enables it
+   * and lets the verifier grandfather only historical unbound SQLite rows.
    */
   requireGrantBinding: boolean;
   isGrantBoundToServer(server: MCPServer, grant: UserMCPOAuthToken): boolean | Promise<boolean>;

--- a/apps/agor-daemon/src/services/mcp-oauth-status.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.ts
@@ -33,7 +33,7 @@ export interface OAuthStatusDeps {
    * Only durable (Postgres) flows carry the fields that makes this answerable.
    */
   requireGrantBinding: boolean;
-  isGrantBoundToServer(server: MCPServer, grant: UserMCPOAuthToken): boolean;
+  isGrantBoundToServer(server: MCPServer, grant: UserMCPOAuthToken): boolean | Promise<boolean>;
   now?: Date;
 }
 
@@ -67,7 +67,7 @@ export async function resolveAuthenticatedServerIds(deps: OAuthStatusDeps): Prom
 
     // Durable status is authoritative. A realtime hint or stale row must never
     // make the UI advertise a grant which the request path would refuse to use.
-    if (deps.requireGrantBinding && !deps.isGrantBoundToServer(server, token)) continue;
+    if (deps.requireGrantBinding && !(await deps.isGrantBoundToServer(server, token))) continue;
 
     authenticatedServerIds.add(token.mcp_server_id);
   }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -90,6 +90,41 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     expect(showError).not.toHaveBeenCalled();
   });
 
+  it.each(['Save', 'Start OAuth Flow'])(
+    'hydrates and preserves a catalog-managed Marketplace policy during %s',
+    async (action) => {
+      const patch = vi.fn().mockResolvedValue({});
+      const client = {
+        service: vi.fn().mockReturnValue({ patch }),
+        io: { on: vi.fn(), off: vi.fn() },
+      } as unknown as AgorClient;
+      const server = {
+        mcp_server_id: '01900000-0000-7000-8000-000000000010',
+        name: 'catalog-oauth',
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        scope: 'global',
+        source: 'catalog',
+        catalog_entry_name: 'com.example/mcp',
+        enabled: true,
+        auth: { type: 'oauth' },
+        oauth_compatibility_policy: {
+          effective_mode: 'marketplace',
+          managed_by_catalog: true,
+        },
+      } as MCPServer;
+
+      render(<MCPServerEditModal server={server} open client={client} onClose={vi.fn()} />);
+
+      expect(await screen.findByLabelText('OAuth Compatibility')).toHaveValue('marketplace');
+      fireEvent.click(screen.getByRole('button', { name: action }));
+
+      await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
+      const updates = patch.mock.calls[0]?.[1] as { auth?: Record<string, unknown> };
+      expect(updates.auth).not.toHaveProperty('oauth_compatibility_mode');
+    }
+  );
+
   it('persists edited OAuth client credentials before the first OAuth start', async () => {
     const patch = vi.fn().mockResolvedValue({});
     const onClose = vi.fn();

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -84,6 +84,8 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     await waitFor(() => expect(patch).toHaveBeenCalledTimes(1));
     const updates = patch.mock.calls[0]?.[1] as { auth?: Record<string, unknown> };
     expect(updates.auth).not.toHaveProperty('oauth_dcr_mode');
+    expect(updates.auth).not.toHaveProperty('oauth_compatibility_mode');
+    expect(updates.auth).not.toHaveProperty('oauth_grant_type');
     expect(showSuccess).toHaveBeenCalled();
     expect(showError).not.toHaveBeenCalled();
   });
@@ -128,6 +130,8 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       oauth_client_id: 'fresh-client-id',
       oauth_client_secret: 'fresh-client-secret',
     });
+    expect(updates.auth).not.toHaveProperty('oauth_compatibility_mode');
+    expect(updates.auth).not.toHaveProperty('oauth_grant_type');
     expect(onClose).not.toHaveBeenCalled();
     expect(showError).not.toHaveBeenCalled();
   });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -66,6 +66,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [preserveAbsentDcrMode, setPreserveAbsentDcrMode] = useState(false);
+  const [preserveAbsentCompatibilityMode, setPreserveAbsentCompatibilityMode] = useState(false);
+  const [preserveAbsentGrantType, setPreserveAbsentGrantType] = useState(false);
   // The form is filled in an effect, so its fields read blank on the first
   // render. Gating on this keeps Save from flashing disabled while the modal
   // animates in.
@@ -90,6 +92,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
 
     setTestResult(null);
     setPreserveAbsentDcrMode(false);
+    setPreserveAbsentCompatibilityMode(false);
+    setPreserveAbsentGrantType(false);
     const serverAuthType = (server.auth?.type as 'none' | 'bearer' | 'jwt' | 'oauth') || 'none';
     setAuthType(serverAuthType);
     setTransport(server.transport || (server.url ? 'http' : 'stdio'));
@@ -121,6 +125,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       formValues.jwt_api_secret = server.auth?.api_secret;
     } else if (serverAuthType === 'oauth') {
       setPreserveAbsentDcrMode(server.auth?.oauth_dcr_mode === undefined);
+      setPreserveAbsentCompatibilityMode(server.auth?.oauth_compatibility_mode === undefined);
+      setPreserveAbsentGrantType(server.auth?.oauth_grant_type === undefined);
       formValues.oauth_authorization_url = server.auth?.oauth_authorization_url;
       formValues.oauth_token_url = server.auth?.oauth_token_url;
       formValues.oauth_client_id = server.auth?.oauth_client_id;
@@ -143,6 +149,8 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
     setAuthType('none');
     setTestResult(null);
     setPreserveAbsentDcrMode(false);
+    setPreserveAbsentCompatibilityMode(false);
+    setPreserveAbsentGrantType(false);
     setFormHydrated(false);
     onClose();
   };
@@ -181,7 +189,11 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         mcp_server_id: server.mcp_server_id,
         url: values.url,
         transport: values.transport || 'http',
-        auth: buildAuthFromValues(values),
+        auth: buildAuthFromValues(values, {
+          preserveAbsentDcrMode,
+          preserveAbsentCompatibilityMode,
+          preserveAbsentGrantType,
+        }),
         headers: parseHeadersJSON(values.headers),
       })) as {
         success: boolean;
@@ -251,7 +263,11 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       const env = parseEnvJSON(values.env);
       if (env) updates.env = env;
 
-      updates.auth = buildAuthFromValues(values, { preserveAbsentDcrMode });
+      updates.auth = buildAuthFromValues(values, {
+        preserveAbsentDcrMode,
+        preserveAbsentCompatibilityMode,
+        preserveAbsentGrantType,
+      });
 
       await client.service('mcp-servers').patch(server.mcp_server_id, updates);
       return true;
@@ -305,6 +321,10 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         style={{ marginTop: 16 }}
         onValuesChange={(changedValues) => {
           if ('oauth_dcr_mode' in changedValues) setPreserveAbsentDcrMode(false);
+          if ('oauth_compatibility_mode' in changedValues) {
+            setPreserveAbsentCompatibilityMode(false);
+          }
+          if ('oauth_grant_type' in changedValues) setPreserveAbsentGrantType(false);
           bumpFormRevision();
         }}
       >

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -124,6 +124,9 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       formValues.jwt_api_token = server.auth?.api_token;
       formValues.jwt_api_secret = server.auth?.api_secret;
     } else if (serverAuthType === 'oauth') {
+      const managedCompatibilityMode = server.oauth_compatibility_policy?.managed_by_catalog
+        ? server.oauth_compatibility_policy.effective_mode
+        : undefined;
       setPreserveAbsentDcrMode(server.auth?.oauth_dcr_mode === undefined);
       setPreserveAbsentCompatibilityMode(server.auth?.oauth_compatibility_mode === undefined);
       setPreserveAbsentGrantType(server.auth?.oauth_grant_type === undefined);
@@ -134,14 +137,21 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       formValues.oauth_scope = server.auth?.oauth_scope;
       formValues.oauth_grant_type = server.auth?.oauth_grant_type || 'client_credentials';
       formValues.oauth_mode = server.auth?.oauth_mode || 'per_user';
-      formValues.oauth_compatibility_mode = server.auth?.oauth_compatibility_mode || 'strict';
+      formValues.oauth_compatibility_mode =
+        managedCompatibilityMode ?? server.auth?.oauth_compatibility_mode ?? 'strict';
       formValues.oauth_dcr_mode = server.auth?.oauth_dcr_mode || 'advertised';
     }
 
     form.setFieldsValue(formValues);
     setFormHydrated(true);
     bumpFormRevision();
-  }, [open, server?.mcp_server_id, form]);
+  }, [
+    open,
+    server?.mcp_server_id,
+    server?.oauth_compatibility_policy?.effective_mode,
+    server?.oauth_compatibility_policy?.managed_by_catalog,
+    form,
+  ]);
 
   const closeAndReset = () => {
     form.resetFields();
@@ -344,6 +354,13 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
           testResult={testResult}
           onPrepareOAuthStart={prepareOAuthStart}
           formRevision={formRevision}
+          managedOAuthCompatibilityMode={
+            server?.oauth_compatibility_policy?.managed_by_catalog &&
+            (server.oauth_compatibility_policy.effective_mode === 'strict' ||
+              server.oauth_compatibility_policy.effective_mode === 'marketplace')
+              ? server.oauth_compatibility_policy.effective_mode
+              : undefined
+          }
         />
       </Form>
     </Modal>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -201,4 +201,47 @@ describe('MCPServerFormFields OAuth start', () => {
     await waitFor(() => expect(onPrepareOAuthStart).toHaveBeenCalledTimes(1));
     expect(startOAuth).not.toHaveBeenCalled();
   });
+
+  it('shows a catalog-managed Marketplace policy read-only', async () => {
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn().mockReturnValue({ create: vi.fn() }),
+    } as unknown as AgorClient;
+
+    const Harness = () => {
+      const [form] = Form.useForm();
+      useEffect(() => {
+        form.setFieldsValue({
+          name: 'catalog-server',
+          url: 'https://mcp.example/mcp',
+          auth_type: 'oauth',
+          oauth_compatibility_mode: 'marketplace',
+        });
+      }, [form]);
+      return (
+        <Form form={form}>
+          <MCPServerFormFields
+            mode="edit"
+            transport="http"
+            authType="oauth"
+            form={form}
+            client={client}
+            serverId="saved-server"
+            onPrepareOAuthStart={vi.fn().mockResolvedValue('saved-server')}
+            managedOAuthCompatibilityMode="marketplace"
+          />
+        </Form>
+      );
+    };
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText('Advanced — OAuth settings'));
+    expect(await screen.findByText('Marketplace compatibility (catalog managed)')).toBeVisible();
+    const compatibility = screen.getByLabelText('OAuth Compatibility');
+    expect(compatibility).toBeDisabled();
+    expect(
+      screen.getByText(/current Marketplace catalog manages this server's interoperability/i)
+    ).toBeVisible();
+  });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -84,6 +84,8 @@ export interface MCPServerFormFieldsProps {
    * `useFormRevision`.
    */
   formRevision?: number;
+  /** Effective catalog-managed policy shown read-only in Settings. */
+  managedOAuthCompatibilityMode?: 'strict' | 'marketplace';
 }
 
 /**
@@ -115,6 +117,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   onPrepareOAuthStart,
   // Consumed by re-rendering, not by reading — see `formRevision` above.
   formRevision: _formRevision,
+  managedOAuthCompatibilityMode,
 }) => {
   const { showSuccess, showError, showWarning, showInfo } = useThemedMessage();
   const [testingAuth, setTestingAuth] = useState(false);
@@ -255,7 +258,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           showError(data.error || 'JWT authentication failed');
         }
       } else if (currentAuthType === 'oauth') {
-        const requestData = extractOAuthConfigForTesting(values);
+        const requestData = extractOAuthConfigForTesting({
+          ...values,
+          ...(serverId && managedOAuthCompatibilityMode ? { mcp_server_id: serverId } : {}),
+        });
         if (!requestData) {
           showWarning('Please enter MCP URL first to test OAuth authentication');
           return;
@@ -747,8 +753,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     description={
                       <ul style={{ margin: 0, paddingLeft: 20, fontSize: 12 }}>
                         <li>
-                          Strict MCP OAuth discovery, protected-resource binding, PKCE S256, and
-                          issuer checks are enabled by default.
+                          {managedOAuthCompatibilityMode
+                            ? `The current Marketplace catalog manages this server's ${managedOAuthCompatibilityMode === 'marketplace' ? 'interoperability' : 'strict'} discovery policy.`
+                            : 'Strict MCP OAuth discovery is enabled by default.'}{' '}
+                          Protected-resource binding, PKCE S256, and issuer checks remain enabled.
                         </li>
                         <li>
                           Set Client ID / Client Secret only for servers that require a
@@ -794,10 +802,22 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     label="OAuth Compatibility"
                     name="oauth_compatibility_mode"
                     initialValue="strict"
-                    tooltip="Legacy mode narrowly permits older discovery and metadata deviations. It never relaxes outbound network protections."
+                    tooltip={
+                      managedOAuthCompatibilityMode
+                        ? 'This effective policy is managed by the current curated Marketplace entry. Editing the endpoint or authentication configuration makes that catalog policy stop applying.'
+                        : 'Legacy mode narrowly permits older discovery and metadata deviations. It never relaxes outbound network protections.'
+                    }
                   >
-                    <Select>
-                      <Select.Option value="strict">Strict current MCP OAuth</Select.Option>
+                    <Select disabled={!!managedOAuthCompatibilityMode}>
+                      {managedOAuthCompatibilityMode === 'marketplace' && (
+                        <Select.Option value="marketplace">
+                          Marketplace compatibility (catalog managed)
+                        </Select.Option>
+                      )}
+                      <Select.Option value="strict">
+                        Strict current MCP OAuth
+                        {managedOAuthCompatibilityMode === 'strict' ? ' (catalog managed)' : ''}
+                      </Select.Option>
                       <Select.Option value="legacy">Legacy provider compatibility</Select.Option>
                     </Select>
                   </Form.Item>

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -361,5 +361,8 @@ describe('validateHeadersJSON', () => {
     expect(validateHeadersJSON('{"X-Count": 42}')).toBe(
       'Custom HTTP header values must be strings'
     );
+    expect(validateHeadersJSON('{"X-Route": "a", "x-route": "b"}')).toMatch(
+      /Duplicate case-insensitive custom HTTP header names/
+    );
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -169,6 +169,26 @@ describe('extractOAuthConfigForTesting', () => {
     expect(result).not.toBeNull();
     expect(result!.token_url).toBe('{{ env.TOKEN_URL }}');
   });
+
+  it('binds a managed Marketplace test to the saved row without submitting the internal mode', () => {
+    expect(
+      extractOAuthConfigForTesting({
+        url: 'https://mcp.example.com',
+        mcp_server_id: 'saved-server',
+        oauth_compatibility_mode: 'marketplace',
+      })
+    ).toMatchObject({
+      mcp_url: 'https://mcp.example.com',
+      mcp_server_id: 'saved-server',
+    });
+    expect(
+      extractOAuthConfigForTesting({
+        url: 'https://mcp.example.com',
+        mcp_server_id: 'saved-server',
+        oauth_compatibility_mode: 'marketplace',
+      })
+    ).not.toHaveProperty('compatibility_mode');
+  });
 });
 
 describe('buildAuthFromValues', () => {
@@ -200,6 +220,19 @@ describe('buildAuthFromValues', () => {
         {
           auth_type: 'oauth',
           oauth_compatibility_mode: 'strict',
+          oauth_scope: 'unchanged',
+        },
+        { preserveAbsentCompatibilityMode: true }
+      )
+    ).not.toHaveProperty('oauth_compatibility_mode');
+  });
+
+  it('never persists the read-only managed Marketplace display value', () => {
+    expect(
+      buildAuthFromValues(
+        {
+          auth_type: 'oauth',
+          oauth_compatibility_mode: 'marketplace',
           oauth_scope: 'unchanged',
         },
         { preserveAbsentCompatibilityMode: true }

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -194,6 +194,37 @@ describe('buildAuthFromValues', () => {
     ).toMatchObject({ oauth_dcr_mode: 'fallback' });
   });
 
+  it('preserves a derived compatibility mode across an unrelated edit', () => {
+    expect(
+      buildAuthFromValues(
+        {
+          auth_type: 'oauth',
+          oauth_compatibility_mode: 'strict',
+          oauth_scope: 'unchanged',
+        },
+        { preserveAbsentCompatibilityMode: true }
+      )
+    ).not.toHaveProperty('oauth_compatibility_mode');
+  });
+
+  it('materializes compatibility after the operator changes the policy', () => {
+    expect(
+      buildAuthFromValues(
+        { auth_type: 'oauth', oauth_compatibility_mode: 'legacy' },
+        { preserveAbsentCompatibilityMode: true }
+      )
+    ).toMatchObject({ oauth_compatibility_mode: 'legacy' });
+  });
+
+  it('preserves an absent OAuth grant type across an unrelated edit', () => {
+    expect(
+      buildAuthFromValues(
+        { auth_type: 'oauth', oauth_grant_type: 'client_credentials' },
+        { preserveAbsentGrantType: true }
+      )
+    ).not.toHaveProperty('oauth_grant_type');
+  });
+
   it('returns undefined when auth_type is none / missing / unrecognized', () => {
     expect(buildAuthFromValues({})).toBeUndefined();
     expect(buildAuthFromValues({ auth_type: 'none' })).toBeUndefined();

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -84,6 +84,7 @@ export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig
 
 export interface TestConfig {
   mcp_url: string;
+  mcp_server_id?: string;
   token_url?: string;
   client_id?: string;
   client_secret?: string;
@@ -105,6 +106,10 @@ export function extractOAuthConfigForTesting(values: Record<string, unknown>): T
   const config: TestConfig = {
     mcp_url: values.url,
   };
+
+  if (typeof values.mcp_server_id === 'string') {
+    config.mcp_server_id = values.mcp_server_id;
+  }
 
   // Include token URL even if it's a template (will be resolved server-side or auto-detected)
   if (values.oauth_token_url && typeof values.oauth_token_url === 'string') {
@@ -137,7 +142,12 @@ export function extractOAuthConfigForTesting(values: Record<string, unknown>): T
   if (values.oauth_grant_type && typeof values.oauth_grant_type === 'string') {
     config.grant_type = values.oauth_grant_type;
   }
-  config.compatibility_mode = values.oauth_compatibility_mode === 'legacy' ? 'legacy' : 'strict';
+  // `marketplace` is a read-only form display value. A saved-row test asks
+  // the daemon to re-derive it from current catalog policy; it is never sent
+  // as caller-selectable public data.
+  if (values.oauth_compatibility_mode !== 'marketplace') {
+    config.compatibility_mode = values.oauth_compatibility_mode === 'legacy' ? 'legacy' : 'strict';
+  }
   config.dcr_mode =
     values.oauth_dcr_mode === 'disabled' || values.oauth_dcr_mode === 'fallback'
       ? values.oauth_dcr_mode
@@ -197,7 +207,11 @@ export function buildAuthFromValues(
     if (options.preserveAbsentDcrMode && values.oauth_dcr_mode === 'advertised') {
       delete auth.oauth_dcr_mode;
     }
-    if (options.preserveAbsentCompatibilityMode && values.oauth_compatibility_mode === 'strict') {
+    if (
+      options.preserveAbsentCompatibilityMode &&
+      (values.oauth_compatibility_mode === 'strict' ||
+        values.oauth_compatibility_mode === 'marketplace')
+    ) {
       delete auth.oauth_compatibility_mode;
     }
     if (options.preserveAbsentGrantType && values.oauth_grant_type === 'client_credentials') {

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -176,7 +176,11 @@ export interface BuiltAuth {
  */
 export function buildAuthFromValues(
   values: Record<string, unknown>,
-  options: { preserveAbsentDcrMode?: boolean } = {}
+  options: {
+    preserveAbsentDcrMode?: boolean;
+    preserveAbsentCompatibilityMode?: boolean;
+    preserveAbsentGrantType?: boolean;
+  } = {}
 ): BuiltAuth | undefined {
   const authType = values.auth_type;
   if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') return undefined;
@@ -192,6 +196,12 @@ export function buildAuthFromValues(
     Object.assign(auth, extractOAuthConfig(values));
     if (options.preserveAbsentDcrMode && values.oauth_dcr_mode === 'advertised') {
       delete auth.oauth_dcr_mode;
+    }
+    if (options.preserveAbsentCompatibilityMode && values.oauth_compatibility_mode === 'strict') {
+      delete auth.oauth_compatibility_mode;
+    }
+    if (options.preserveAbsentGrantType && values.oauth_grant_type === 'client_credentials') {
+      delete auth.oauth_grant_type;
     }
   }
   return auth;

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -1,4 +1,5 @@
 import {
+  findDuplicateMCPCustomHeaderName,
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
 } from '@agor/core/tools/mcp/http-headers';
@@ -266,6 +267,11 @@ export function validateHeadersJSON(headersValue: unknown): string | undefined {
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return 'Custom HTTP headers must be a JSON object';
+  }
+
+  const duplicate = findDuplicateMCPCustomHeaderName(parsed as Record<string, unknown>);
+  if (duplicate) {
+    return `Duplicate case-insensitive custom HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`;
   }
 
   for (const [key, value] of Object.entries(parsed)) {

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -447,6 +447,14 @@ function wrapQuery(
         db,
         table
       ),
+    onConflictDoUpdate: (...args: unknown[]) =>
+      wrapQuery(
+        (query as { onConflictDoUpdate: (...args: unknown[]) => DrizzleQuery }).onConflictDoUpdate(
+          ...args
+        ),
+        db,
+        table
+      ),
   };
 }
 

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -91,6 +91,19 @@ describe('MCPServerRepository.create', () => {
 
     expect(created.enabled).toBe(true);
   });
+
+  dbTest('rejects internal and unknown OAuth compatibility modes on create', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    for (const mode of ['marketplace', 'future-mode']) {
+      await expect(
+        repo.create(
+          createMCPServerData({
+            auth: { type: 'oauth', oauth_compatibility_mode: mode } as never,
+          })
+        )
+      ).rejects.toThrow(/must be either strict or legacy/);
+    }
+  });
 });
 
 // ============================================================================
@@ -234,6 +247,19 @@ describe('MCPServerRepository.update', () => {
     await expect(repo.update(nonExistentId, { enabled: false })).rejects.toThrow(
       EntityNotFoundError
     );
+  });
+
+  dbTest('rejects internal OAuth compatibility mode on patch/update', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({ auth: { type: 'oauth', oauth_compatibility_mode: 'strict' } })
+    );
+
+    await expect(
+      repo.update(created.mcp_server_id, {
+        auth: { type: 'oauth', oauth_compatibility_mode: 'marketplace' } as never,
+      })
+    ).rejects.toThrow(/must be either strict or legacy/);
   });
 });
 

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -423,6 +423,20 @@ describe('MCPServerRepository custom headers', () => {
     expect(found?.headers).toBeUndefined();
   });
 
+  dbTest('should reject case-insensitive duplicate custom headers', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    await expect(
+      repo.create(
+        createMCPServerData({
+          name: 'ambiguous-headers',
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          headers: { 'X-Route': 'a', 'x-route': 'b' },
+        })
+      )
+    ).rejects.toThrow(/Duplicate custom HTTP header names/);
+  });
+
   dbTest(
     'should preserve existing header values when update sends redacted sentinel',
     async ({ db }) => {

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -13,6 +13,7 @@ import type {
   UpdateMCPServerInput,
   UserID,
 } from '@agor/core/types';
+import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
 import { and, eq, isNull, like, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import { restoreRedactedMCPAuthSecrets } from '../../tools/mcp/auth-secrets';
@@ -86,6 +87,7 @@ export class MCPServerRepository
    * Convert MCPServer to database insert format
    */
   private mcpServerToInsert(data: CreateMCPServerInput | Partial<MCPServer>): MCPServerInsert {
+    assertPublicMCPOAuthCompatibilityMode('auth' in data ? data.auth : undefined);
     const now = Date.now();
     const serverId =
       'mcp_server_id' in data && data.mcp_server_id ? data.mcp_server_id : generateId();

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -117,6 +117,8 @@ export type MCPOAuthRefreshClaimResult =
 
 export interface MCPOAuthRefreshVersion {
   grantGeneration: number;
+  /** Exact configuration HMAC observed with the grant; null for historical unbound SQLite rows. */
+  grantBindingFingerprint?: string;
   refreshGeneration: number;
 }
 
@@ -466,6 +468,45 @@ export class UserMCPOAuthTokenRepository {
   }
 
   /**
+   * Commit a standalone/SQLite refresh only onto the exact grant which was
+   * verified before the provider exchange. This is deliberately update-only:
+   * a Settings mutation or disconnect which deleted the grant must never be
+   * resurrected as an unbound generation-0 row.
+   */
+  async completeStandaloneRefresh(
+    userId: UserID | null,
+    serverId: MCPServerID,
+    expected: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>,
+    input: { accessToken: string; refreshToken?: string; expiresAt: Date | null }
+  ): Promise<boolean> {
+    if (this.postgres) {
+      throw new RepositoryError('Standalone refresh completion is only available on SQLite');
+    }
+    try {
+      const fingerprint = expected.grantBindingFingerprint ?? null;
+      const result = await update(this.db, userMcpOauthTokens)
+        .set({
+          oauth_access_token: input.accessToken,
+          oauth_token_expires_at: input.expiresAt,
+          ...(input.refreshToken !== undefined ? { oauth_refresh_token: input.refreshToken } : {}),
+          updated_at: new Date(),
+        })
+        .where(
+          and(
+            matchKey(userId, serverId),
+            eq(userMcpOauthTokens.grant_generation, expected.grantGeneration),
+            sql`${userMcpOauthTokens.grant_binding_fingerprint} IS NOT DISTINCT FROM ${fingerprint}`
+          )
+        )
+        .run();
+      return result.rowsAffected === 1;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      throw new RepositoryError('Failed to complete exact standalone MCP OAuth refresh', error);
+    }
+  }
+
+  /**
    * PostgreSQL database-time refresh claim. A stale owner is not replayed:
    * the row becomes ambiguous because a rotating refresh token may have been
    * consumed before the owner died.
@@ -507,6 +548,7 @@ export class UserMCPOAuthTokenRepository {
           WHERE mcp_server_id = ${serverId}
             AND ${userPredicate}
             AND grant_generation = ${expected.grantGeneration}
+            AND grant_binding_fingerprint IS NOT DISTINCT FROM ${expected.grantBindingFingerprint ?? null}
             AND refresh_generation = ${expected.refreshGeneration}
             AND refresh_status = 'idle'
             AND oauth_refresh_token IS NOT NULL

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -12,7 +12,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { MCPOAuthGrantBindingVersion, MCPServerID, UserID } from '@agor/core/types';
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, lt, sql } from 'drizzle-orm';
 import type { Database } from '../client';
 import { deleteFrom, executeRaw, insert, select, update } from '../database-wrapper';
 import { openMCPOAuthSecret, sealMCPOAuthSecret } from '../oauth-secret-envelope';
@@ -417,7 +417,7 @@ export class UserMCPOAuthTokenRepository {
             binding
               ? and(
                   matchKey(userId, serverId),
-                  sql`${userMcpOauthTokens.grant_generation} <= ${binding.generation}`
+                  lt(userMcpOauthTokens.grant_generation, binding.generation)
                 )
               : matchKey(userId, serverId)
           )

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -12,7 +12,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { MCPOAuthGrantBindingVersion, MCPServerID, UserID } from '@agor/core/types';
-import { and, eq, isNull, lt, sql } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull, lt, sql } from 'drizzle-orm';
 import type { Database } from '../client';
 import { deleteFrom, executeRaw, insert, select, update } from '../database-wrapper';
 import { openMCPOAuthSecret, sealMCPOAuthSecret } from '../oauth-secret-envelope';
@@ -329,7 +329,6 @@ export class UserMCPOAuthTokenRepository {
           )`
         );
       }
-      const existing = await this.getToken(userId, serverId);
       const binding = input.grantBinding;
       if (this.postgres && !binding) {
         throw new RepositoryError('PostgreSQL MCP OAuth grant save requires configuration binding');
@@ -337,6 +336,10 @@ export class UserMCPOAuthTokenRepository {
       if (binding && !input.clientId) {
         throw new RepositoryError('Bound MCP OAuth grant requires a client ID');
       }
+      // A bound SQLite grant uses a single INSERT ... ON CONFLICT statement
+      // below. Do not decide insert/update from a preceding read: concurrent
+      // first-time callbacks may both observe an empty subject.
+      const existing = this.postgres || !binding ? await this.getToken(userId, serverId) : null;
       const generation = binding?.generation ?? existing?.grant_generation ?? 0;
       if (binding && (!Number.isSafeInteger(binding.generation) || binding.generation <= 0)) {
         throw new RepositoryError('MCP OAuth grant generation is invalid');
@@ -356,6 +359,91 @@ export class UserMCPOAuthTokenRepository {
         );
       };
       const sealedAccessToken = seal(input.accessToken, 'access-token', 'access')!;
+      const boundReplacement = binding
+        ? {
+            oauth_refresh_token: seal(input.refreshToken, 'refresh-token', 'refresh') ?? null,
+            oauth_client_id: seal(input.clientId, 'client-id', 'client-id') ?? null,
+            oauth_client_secret: seal(input.clientSecret, 'client-secret', 'client-secret') ?? null,
+            grant_generation: binding.generation,
+            grant_binding_version: binding.version,
+            grant_binding_fingerprint: binding.fingerprint,
+            oauth_metadata_uri: binding.metadataUri,
+            oauth_resource_uri: binding.resourceUri,
+            oauth_issuer: binding.issuer,
+            oauth_authorization_endpoint: binding.authorizationEndpoint,
+            oauth_token_endpoint: binding.tokenEndpoint,
+            oauth_redirect_uri: binding.redirectUri,
+            refresh_status: 'idle' as const,
+            refresh_generation: 0,
+            refresh_success_generation: 0,
+            refresh_claim_id: null,
+            refresh_claimed_at: null,
+          }
+        : undefined;
+      const newToken: UserMCPOAuthTokenInsert = {
+        user_id: userId,
+        mcp_server_id: serverId,
+        oauth_access_token: sealedAccessToken,
+        // On insert, `null` and `undefined` both write a missing column
+        // (Drizzle treats `undefined` on insert as "use default", which for
+        // a nullable column is NULL). Coerce to `undefined` to keep the
+        // insert payload uniform regardless of which the caller passed.
+        oauth_token_expires_at: expiresAtField ?? undefined,
+        oauth_refresh_token:
+          boundReplacement?.oauth_refresh_token ??
+          seal(input.refreshToken, 'refresh-token', 'refresh'),
+        oauth_client_id:
+          boundReplacement?.oauth_client_id ?? seal(input.clientId, 'client-id', 'client-id'),
+        oauth_client_secret:
+          boundReplacement?.oauth_client_secret ??
+          seal(input.clientSecret, 'client-secret', 'client-secret'),
+        grant_generation: generation,
+        grant_binding_version: binding?.version,
+        grant_binding_fingerprint: binding?.fingerprint,
+        oauth_metadata_uri: binding?.metadataUri,
+        oauth_resource_uri: binding?.resourceUri ?? input.resourceUri,
+        oauth_issuer: binding?.issuer,
+        oauth_authorization_endpoint: binding?.authorizationEndpoint,
+        oauth_token_endpoint: binding?.tokenEndpoint ?? input.tokenEndpoint,
+        oauth_redirect_uri: binding?.redirectUri,
+        refresh_status: 'idle',
+        refresh_generation: 0,
+        refresh_success_generation: 0,
+        ...(tenantId ? { tenant_id: tenantId } : {}),
+        created_at: now,
+      };
+
+      if (!this.postgres && binding) {
+        // SQLite's subject uniqueness is expressed as two partial indexes.
+        // Match the applicable index exactly, while never updating either
+        // subject key. The set predicate makes both insert and replacement a
+        // single atomic statement and rejects lower/equal-generation attempts.
+        const result = await insert(this.db, userMcpOauthTokens)
+          .values(newToken)
+          .onConflictDoUpdate({
+            target:
+              userId === null
+                ? userMcpOauthTokens.mcp_server_id
+                : [userMcpOauthTokens.user_id, userMcpOauthTokens.mcp_server_id],
+            targetWhere:
+              userId === null
+                ? isNull(userMcpOauthTokens.user_id)
+                : isNotNull(userMcpOauthTokens.user_id),
+            set: {
+              oauth_access_token: sealedAccessToken,
+              ...(expiresAtField !== undefined ? { oauth_token_expires_at: expiresAtField } : {}),
+              ...boundReplacement,
+              updated_at: now,
+            },
+            setWhere: lt(userMcpOauthTokens.grant_generation, binding.generation),
+          })
+          .run();
+        if (result.rowsAffected !== 1) {
+          throw new RepositoryError('A newer MCP OAuth grant superseded this attempt');
+        }
+        console.log('[MCP OAuth Grant] grant_saved category=atomic_upsert');
+        return;
+      }
 
       if (existing) {
         const result = await update(this.db, userMcpOauthTokens)
@@ -364,12 +452,7 @@ export class UserMCPOAuthTokenRepository {
             // Spread so `undefined` ⇒ omit field (preserve), but `null` ⇒ write NULL.
             ...(expiresAtField !== undefined ? { oauth_token_expires_at: expiresAtField } : {}),
             ...(binding
-              ? {
-                  oauth_refresh_token: seal(input.refreshToken, 'refresh-token', 'refresh') ?? null,
-                  oauth_client_id: seal(input.clientId, 'client-id', 'client-id') ?? null,
-                  oauth_client_secret:
-                    seal(input.clientSecret, 'client-secret', 'client-secret') ?? null,
-                }
+              ? boundReplacement
               : {
                   ...(input.refreshToken != null
                     ? {
@@ -393,24 +476,6 @@ export class UserMCPOAuthTokenRepository {
                     : {}),
                   ...(input.resourceUri != null ? { oauth_resource_uri: input.resourceUri } : {}),
                 }),
-            ...(binding
-              ? {
-                  grant_generation: binding.generation,
-                  grant_binding_version: binding.version,
-                  grant_binding_fingerprint: binding.fingerprint,
-                  oauth_metadata_uri: binding.metadataUri,
-                  oauth_resource_uri: binding.resourceUri,
-                  oauth_issuer: binding.issuer,
-                  oauth_authorization_endpoint: binding.authorizationEndpoint,
-                  oauth_token_endpoint: binding.tokenEndpoint,
-                  oauth_redirect_uri: binding.redirectUri,
-                  refresh_status: 'idle',
-                  refresh_generation: 0,
-                  refresh_success_generation: 0,
-                  refresh_claim_id: null,
-                  refresh_claimed_at: null,
-                }
-              : {}),
             updated_at: now,
           })
           .where(
@@ -427,34 +492,6 @@ export class UserMCPOAuthTokenRepository {
         }
         console.log('[MCP OAuth Grant] grant_saved category=replacement');
       } else {
-        const newToken: UserMCPOAuthTokenInsert = {
-          user_id: userId,
-          mcp_server_id: serverId,
-          oauth_access_token: sealedAccessToken,
-          // On insert, `null` and `undefined` both write a missing column
-          // (Drizzle treats `undefined` on insert as "use default", which for
-          // a nullable column is NULL). Coerce to `undefined` to keep the
-          // insert payload uniform regardless of which the caller passed.
-          oauth_token_expires_at: expiresAtField ?? undefined,
-          oauth_refresh_token: seal(input.refreshToken, 'refresh-token', 'refresh'),
-          oauth_client_id: seal(input.clientId, 'client-id', 'client-id'),
-          oauth_client_secret: seal(input.clientSecret, 'client-secret', 'client-secret'),
-          grant_generation: generation,
-          grant_binding_version: binding?.version,
-          grant_binding_fingerprint: binding?.fingerprint,
-          oauth_metadata_uri: binding?.metadataUri,
-          oauth_resource_uri: binding?.resourceUri ?? input.resourceUri,
-          oauth_issuer: binding?.issuer,
-          oauth_authorization_endpoint: binding?.authorizationEndpoint,
-          oauth_token_endpoint: binding?.tokenEndpoint ?? input.tokenEndpoint,
-          oauth_redirect_uri: binding?.redirectUri,
-          refresh_status: 'idle',
-          refresh_generation: 0,
-          refresh_success_generation: 0,
-          ...(tenantId ? { tenant_id: tenantId } : {}),
-          created_at: now,
-        };
-
         await insert(this.db, userMcpOauthTokens).values(newToken).run();
 
         console.log('[MCP OAuth Grant] grant_saved category=new');

--- a/packages/core/src/db/tenant-database-io.ts
+++ b/packages/core/src/db/tenant-database-io.ts
@@ -84,8 +84,19 @@ function joinJsonlLines(lines: string[]): string {
  * by restore (populate + insert) and re-home derivation (populate + re-emit) so
  * the transformed bytes each produces cannot drift.
  */
-function rewrittenRowJsonb(elem: SQL, destinationTenantId: string): SQL {
-  return sql`pg_catalog.jsonb_set(${elem}, ${TENANT_ID_JSONB_PATH}::pg_catalog.text[], pg_catalog.to_jsonb(${destinationTenantId}::pg_catalog.text))`;
+function rewrittenRowJsonb(elem: SQL, destinationTenantId: string, tableName: string): SQL {
+  const tenantRewritten = sql`pg_catalog.jsonb_set(${elem}, ${TENANT_ID_JSONB_PATH}::pg_catalog.text[], pg_catalog.to_jsonb(${destinationTenantId}::pg_catalog.text))`;
+  if (tableName !== 'mcp_servers') return tenantRewritten;
+
+  // A catalog stamp proves that this deployment's marketplace install path
+  // created a row. It cannot survive an archive crossing the import boundary:
+  // the destination must treat the restored definition like any other imported
+  // server and re-establish catalog trust only through Connect.
+  return sql`pg_catalog.jsonb_set(
+    (${tenantRewritten} #- '{data,catalog_entry_name}'::pg_catalog.text[]),
+    '{source}'::pg_catalog.text[],
+    '"imported"'::pg_catalog.jsonb
+  )`;
 }
 
 /**
@@ -290,7 +301,7 @@ async function rewriteRowsToCanonicalText(
       SELECT pg_catalog.to_jsonb(
         pg_catalog.jsonb_populate_record(
           NULL::${qualifiedTable(tableName)},
-          ${rewrittenRowJsonb(sql`element.value`, destinationTenantId)}
+          ${rewrittenRowJsonb(sql`element.value`, destinationTenantId, tableName)}
         )
       )::pg_catalog.text AS row
       FROM pg_catalog.jsonb_array_elements(${arrayText}::pg_catalog.jsonb)
@@ -326,7 +337,7 @@ export async function insertTenantTableRows(
           NULL::${qualifiedTable(tableName)},
           (
             SELECT pg_catalog.jsonb_agg(
-              ${rewrittenRowJsonb(sql`element.value`, destinationTenantId)}
+              ${rewrittenRowJsonb(sql`element.value`, destinationTenantId, tableName)}
             )
             FROM pg_catalog.jsonb_array_elements(${arrayText}::pg_catalog.jsonb) AS element(value)
           )

--- a/packages/core/src/db/tenant-import.test.ts
+++ b/packages/core/src/db/tenant-import.test.ts
@@ -7,7 +7,7 @@
  * access: if the escaping link is caught first, that proxy is never touched.
  */
 
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -19,11 +19,12 @@ import {
   sha256Hex,
   TENANT_ARCHIVE_MANIFEST_VERSION,
   type TenantArchiveManifest,
+  tableJsonlPath,
   writeManifest,
 } from './tenant-archive';
 import type { TenantDatabaseIdentity } from './tenant-catalog';
 import { UnsafeArchivePathError } from './tenant-filesystem';
-import { importTenant } from './tenant-import';
+import { importTenant, validateArchivedMCPCompatibilityModes } from './tenant-import';
 
 let scratch: string;
 
@@ -115,5 +116,47 @@ describe('importTenant pre-mutation validation ordering', () => {
     await expect(importTenant(untouchableDb(), { archivePath: scratch })).rejects.toThrow(
       /database was accessed/
     );
+  });
+});
+
+describe('importTenant MCP OAuth public policy boundary', () => {
+  async function archivedMcpManifest(mode: unknown): Promise<TenantArchiveManifest> {
+    const line = `${JSON.stringify({ data: { auth: { type: 'oauth', oauth_compatibility_mode: mode } } })}\n`;
+    await mkdir(databaseDir(scratch), { recursive: true });
+    await writeFile(tableJsonlPath(scratch, 'mcp_servers'), line, 'utf8');
+    return {
+      manifestVersion: TENANT_ARCHIVE_MANIFEST_VERSION,
+      tenantId: 'acme',
+      operationId: 'op-oauth-policy',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      contentFingerprint: 'not-used-by-direct-validator',
+      database: {
+        identity,
+        tables: [
+          {
+            name: 'mcp_servers',
+            rowCount: 1,
+            sha256: sha256Hex(line),
+            bytes: Buffer.byteLength(line),
+          },
+        ],
+      },
+      filesystem: { included: false, entries: [], skippedSpecialCount: 0, unsafeSymlinkCount: 0 },
+    };
+  }
+
+  it.each(['marketplace', 'future-mode'])(
+    'rejects archived public compatibility mode %s',
+    async (mode) => {
+      await expect(
+        validateArchivedMCPCompatibilityModes(scratch, await archivedMcpManifest(mode))
+      ).rejects.toThrow(/must be either strict or legacy/);
+    }
+  );
+
+  it.each([undefined, 'strict', 'legacy'])('accepts archived public mode %s', async (mode) => {
+    await expect(
+      validateArchivedMCPCompatibilityModes(scratch, await archivedMcpManifest(mode))
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/db/tenant-import.test.ts
+++ b/packages/core/src/db/tenant-import.test.ts
@@ -120,8 +120,13 @@ describe('importTenant pre-mutation validation ordering', () => {
 });
 
 describe('importTenant MCP OAuth public policy boundary', () => {
-  async function archivedMcpManifest(mode: unknown): Promise<TenantArchiveManifest> {
-    const line = `${JSON.stringify({ data: { auth: { type: 'oauth', oauth_compatibility_mode: mode } } })}\n`;
+  async function archivedMcpManifest(
+    mode: unknown,
+    headers?: Record<string, string>
+  ): Promise<TenantArchiveManifest> {
+    const line = `${JSON.stringify({
+      data: { auth: { type: 'oauth', oauth_compatibility_mode: mode }, headers },
+    })}\n`;
     await mkdir(databaseDir(scratch), { recursive: true });
     await writeFile(tableJsonlPath(scratch, 'mcp_servers'), line, 'utf8');
     return {
@@ -158,5 +163,14 @@ describe('importTenant MCP OAuth public policy boundary', () => {
     await expect(
       validateArchivedMCPCompatibilityModes(scratch, await archivedMcpManifest(mode))
     ).resolves.toBeUndefined();
+  });
+
+  it('rejects case-insensitive duplicate custom headers before import writes', async () => {
+    await expect(
+      validateArchivedMCPCompatibilityModes(
+        scratch,
+        await archivedMcpManifest('strict', { 'X-Route': 'a', 'x-route': 'b' })
+      )
+    ).rejects.toThrow(/Duplicate custom HTTP header names/);
   });
 });

--- a/packages/core/src/db/tenant-import.ts
+++ b/packages/core/src/db/tenant-import.ts
@@ -34,6 +34,7 @@
 
 import { rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
 import { sql } from 'drizzle-orm';
 import type { Database } from './client';
 import { executeRaw, isPostgresDatabase } from './database-wrapper';
@@ -96,6 +97,35 @@ export interface TenantImportOptions {
 }
 
 type PortionState = 'empty' | 'matches' | 'conflict';
+
+/**
+ * Catalog trust is deployment-local review authority, not portable tenant
+ * data. Validate archived public OAuth values before any write; the database
+ * rewrite later marks every restored MCP row `imported` and removes its
+ * catalog stamp.
+ */
+export async function validateArchivedMCPCompatibilityModes(
+  archivePath: string,
+  manifest: TenantArchiveManifest
+): Promise<void> {
+  const table = manifest.database.tables.find((candidate) => candidate.name === 'mcp_servers');
+  if (!table || table.rowCount === 0) return;
+  const lines = splitTenantJsonlLines(await readTableJsonl(archivePath, table.name));
+  for (const line of lines) {
+    const row = JSON.parse(line) as { data?: unknown };
+    const data = row.data;
+    const auth = data && typeof data === 'object' ? (data as { auth?: unknown }).auth : undefined;
+    try {
+      assertPublicMCPOAuthCompatibilityMode(auth);
+    } catch (error) {
+      throw new MalformedArchiveError(
+        `Refusing to import mcp_servers: ${
+          error instanceof Error ? error.message : 'invalid OAuth compatibility policy'
+        }`
+      );
+    }
+  }
+}
 
 /**
  * Classify the live database for the destination tenant relative to the archive:
@@ -250,6 +280,8 @@ export async function importTenant(
   // The archive must carry exactly the live catalog's movable tenant tables —
   // no missing, extra, or duplicate — before we read or restore any of them.
   assertManifestTablesMatchCatalog(manifest, identity.tenantTables);
+
+  await validateArchivedMCPCompatibilityModes(options.archivePath, manifest);
 
   // Derive the exact per-table snapshots the destination will hold once the
   // archive's rows are rewritten to `tenantId` and restored. Comparing the live

--- a/packages/core/src/db/tenant-import.ts
+++ b/packages/core/src/db/tenant-import.ts
@@ -34,9 +34,9 @@
 
 import { rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { findDuplicateMCPCustomHeaderName } from '@agor/core/tools/mcp/http-headers';
 import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
 import { sql } from 'drizzle-orm';
+import { findDuplicateMCPCustomHeaderName } from '../tools/mcp/http-headers';
 import type { Database } from './client';
 import { executeRaw, isPostgresDatabase } from './database-wrapper';
 import { isDatabaseUniqueConstraintError } from './sanitize-error';

--- a/packages/core/src/db/tenant-import.ts
+++ b/packages/core/src/db/tenant-import.ts
@@ -34,6 +34,7 @@
 
 import { rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { findDuplicateMCPCustomHeaderName } from '@agor/core/tools/mcp/http-headers';
 import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
 import { sql } from 'drizzle-orm';
 import type { Database } from './client';
@@ -100,9 +101,9 @@ type PortionState = 'empty' | 'matches' | 'conflict';
 
 /**
  * Catalog trust is deployment-local review authority, not portable tenant
- * data. Validate archived public OAuth values before any write; the database
- * rewrite later marks every restored MCP row `imported` and removes its
- * catalog stamp.
+ * data. Validate archived public OAuth values and header identity before any
+ * write; the database rewrite later marks every restored MCP row `imported`
+ * and removes its catalog stamp.
  */
 export async function validateArchivedMCPCompatibilityModes(
   archivePath: string,
@@ -114,9 +115,20 @@ export async function validateArchivedMCPCompatibilityModes(
   for (const line of lines) {
     const row = JSON.parse(line) as { data?: unknown };
     const data = row.data;
-    const auth = data && typeof data === 'object' ? (data as { auth?: unknown }).auth : undefined;
+    const publicData = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
+    const auth = publicData.auth;
     try {
       assertPublicMCPOAuthCompatibilityMode(auth);
+      const headers = publicData.headers;
+      const duplicate =
+        headers && typeof headers === 'object' && !Array.isArray(headers)
+          ? findDuplicateMCPCustomHeaderName(headers as Record<string, unknown>)
+          : undefined;
+      if (duplicate) {
+        throw new Error(
+          `Duplicate custom HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`
+        );
+      }
     } catch (error) {
       throw new MalformedArchiveError(
         `Refusing to import mcp_servers: ${

--- a/packages/core/src/db/tenant-portability.postgres.test.ts
+++ b/packages/core/src/db/tenant-portability.postgres.test.ts
@@ -161,8 +161,12 @@ async function seedNonPortableOAuthGrant(
         transport: 'http',
         scope: 'global',
         enabled: true,
-        source: 'user',
-        data: { url: 'https://mcp.example.test', auth: { type: 'oauth' } },
+        source: 'catalog',
+        data: {
+          url: 'https://mcp.example.test',
+          catalog_entry_name: 'com.example/portable-oauth',
+          auth: { type: 'oauth' },
+        },
         created_at: new Date(),
       })
       .run();
@@ -777,6 +781,10 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant portability (Postgr
         .where(eq(pg.mcpServers.mcp_server_id, serverId))
         .all();
       expect(servers).toHaveLength(1);
+      expect(servers[0]?.source).toBe('imported');
+      expect(
+        (servers[0]?.data as { catalog_entry_name?: string } | undefined)?.catalog_entry_name
+      ).toBeUndefined();
       await expect(
         new UserMCPOAuthTokenRepository(
           scoped,

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -337,14 +337,35 @@ ${block}
 });
 
 describe('the shipped catalog', () => {
-  it('states no oauth settings, because discovery covers every entry', async () => {
-    // Not a style rule: each of these is an authored claim about somebody
-    // else's endpoint that nothing in the running system can contradict, so an
-    // entry acquiring one should be a deliberate, reviewed exception rather
-    // than something that accumulates. Delete this expectation with the PR that
-    // adds the first justified one.
+  it('opts the providers that pass the strict production boundary into strict mode', async () => {
+    // Marketplace installs with no statement use the daemon's bounded
+    // interoperability profile. These three publish the exact PRM/issuer,
+    // S256 and RFC 9207 contracts, so keep the stronger policy explicit and
+    // make any later expansion a reviewed curation change.
     const entries = await loadCuratedCatalog();
-    expect(entries.filter((entry) => entry.oauth !== undefined)).toEqual([]);
+    expect(
+      entries.filter((entry) => entry.oauth !== undefined).map((entry) => [entry.name, entry.oauth])
+    ).toEqual([
+      ['com.monday/monday.com', { compatibility_mode: 'strict' }],
+      ['com.cloudflare/mcp', { compatibility_mode: 'strict' }],
+      ['com.clickup/mcp', { compatibility_mode: 'strict' }],
+    ]);
+  });
+
+  it('does not advertise OAuth endpoints that cannot reach a safely bound client-registration boundary', async () => {
+    const entries = await loadCuratedCatalog();
+    const unsupported = [
+      'io.github.github/github-mcp-server',
+      'io.prisma/mcp',
+      'com.mongodb/mcp',
+      'com.box/mcp',
+      'com.hubspot/mcp',
+      'com.slack/mcp',
+      'com.pagerduty/mcp',
+      'com.kagi/mcp',
+    ];
+
+    expect(entries.filter((entry) => unsupported.includes(entry.name))).toEqual([]);
   });
 
   it('carries no secret-shaped value anywhere in the file', async () => {

--- a/packages/core/src/mcp-catalog/curated.yaml
+++ b/packages/core/src/mcp-catalog/curated.yaml
@@ -37,18 +37,6 @@
 
 # Entries the registry publishes under exactly this `name`.
 entries:
-  - name: io.github.github/github-mcp-server
-    category: dev-tools
-    capabilities: [code-repos, issues, pull-requests, code-search, automations]
-    benefit: Let an agent read your repos, triage issues, and open pull requests without leaving the session.
-    starter_prompt: Summarise the open pull requests on my most active repository and flag any that have been waiting on review for more than a week.
-    permission_disclosure: Reads and writes repositories, issues, pull requests, and Actions runs for every organisation your GitHub account can reach.
-    icon_url: https://api.smithery.ai/servers/github/icon
-    popularity_rank: 1
-    remote_url: https://api.githubcopilot.com/mcp/
-    transport: streamable-http
-    auth_type: oauth
-
   - name: app.linear/linear
     category: dev-tools
     capabilities: [issues, projects, notes]
@@ -134,18 +122,6 @@ entries:
     transport: streamable-http
     auth_type: oauth
 
-  - name: io.prisma/mcp
-    category: data-storage
-    capabilities: [schema, databases]
-    benefit: Keep an agent's migrations honest by giving it the live Prisma schema and database state.
-    starter_prompt: Read my Prisma schema and draft a migration that adds the field I describe.
-    permission_disclosure: Reads and modifies schema and data in the Prisma Postgres databases you authorise.
-    icon_url: https://api.smithery.ai/servers/prisma/icon
-    popularity_rank: 18
-    remote_url: https://mcp.prisma.io/mcp
-    transport: streamable-http
-    auth_type: oauth
-
   - name: com.airtable/mcp
     category: data-storage
     capabilities: [databases, schema]
@@ -205,6 +181,8 @@ entries:
     remote_url: https://mcp.monday.com/mcp
     transport: streamable-http
     auth_type: oauth
+    oauth:
+      compatibility_mode: strict
 
   - name: com.zapier/mcp
     category: productivity
@@ -404,6 +382,8 @@ unpublished:
     remote_url: https://mcp.cloudflare.com/mcp
     transport: streamable-http
     auth_type: oauth
+    oauth:
+      compatibility_mode: strict
 
   - name: com.semgrep/mcp
     category: dev-tools
@@ -426,18 +406,6 @@ unpublished:
     icon_url: https://api.smithery.ai/servers/buildkite/icon
     popularity_rank: 31
     remote_url: https://mcp.buildkite.com/mcp
-    transport: streamable-http
-    auth_type: oauth
-
-  - name: com.mongodb/mcp
-    category: data-storage
-    capabilities: [files, databases, schema, sql]
-    benefit: Explore collections and run aggregations without hand-writing shell commands.
-    starter_prompt: List my collections, describe the shape of the largest one, and suggest an index for my slowest query.
-    permission_disclosure: Reads and writes documents, collections, and indexes in the MongoDB clusters you authorise.
-    icon_url: https://www.google.com/s2/favicons?domain=mongodb.com&sz=64
-    popularity_rank: 16
-    remote_url: https://mcp.mongodb.com/mcp
     transport: streamable-http
     auth_type: oauth
 
@@ -465,18 +433,6 @@ unpublished:
     transport: streamable-http
     auth_type: oauth
 
-  - name: com.box/mcp
-    category: data-storage
-    capabilities: [files, web-search]
-    benefit: Search and read Box content so an agent can work from the documents your team already keeps there.
-    starter_prompt: Search my Box account for documents about the project I name and summarise what they cover.
-    permission_disclosure: Reads and writes files, folders, and metadata in the Box accounts you authorise.
-    icon_url: https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/box.svg
-    popularity_rank: 40
-    remote_url: https://mcp.box.com/mcp
-    transport: streamable-http
-    auth_type: oauth
-
   - name: com.asana/mcp
     category: productivity
     capabilities: [tasks, projects, notes]
@@ -500,6 +456,8 @@ unpublished:
     remote_url: https://mcp.clickup.com/mcp
     transport: streamable-http
     auth_type: oauth
+    oauth:
+      compatibility_mode: strict
 
   - name: com.squareup/mcp
     category: productivity
@@ -510,18 +468,6 @@ unpublished:
     icon_url: https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master//squareup.svg
     popularity_rank: 43
     remote_url: https://mcp.squareup.com/mcp
-    transport: streamable-http
-    auth_type: oauth
-
-  - name: com.hubspot/mcp
-    category: productivity
-    capabilities: [crm]
-    benefit: Query the CRM in plain language instead of building a report for every question.
-    starter_prompt: Summarise the deals in my pipeline that have not moved in two weeks.
-    permission_disclosure: Reads and writes contacts, companies, deals, and tickets in the HubSpot portals you authorise.
-    icon_url: https://api.smithery.ai/servers/hubspot/icon
-    popularity_rank: 27
-    remote_url: https://mcp.hubspot.com/anthropic
     transport: streamable-http
     auth_type: oauth
 
@@ -546,18 +492,6 @@ unpublished:
     icon_url: https://cdn.jsdelivr.net/gh/ComposioHQ/open-logos@master/canva.jpeg
     popularity_rank: 42
     remote_url: https://mcp.canva.com/mcp
-    transport: streamable-http
-    auth_type: oauth
-
-  - name: com.slack/mcp
-    category: messaging
-    capabilities: [messages, channels, web-search]
-    benefit: Search channel history for the decision nobody wrote down, and post results where the team will see them.
-    starter_prompt: Search my Slack for discussion about the feature I name and summarise what was decided.
-    permission_disclosure: Reads and posts messages in the Slack channels you authorise, including their history.
-    icon_url: https://api.smithery.ai/servers/node2flow/slack/icon
-    popularity_rank: 13
-    remote_url: https://mcp.slack.com/mcp
     transport: streamable-http
     auth_type: oauth
 
@@ -586,18 +520,6 @@ unpublished:
     transport: streamable-http
     auth_type: credentials
 
-  - name: com.pagerduty/mcp
-    category: observability
-    capabilities: [incidents, deployments]
-    benefit: Read incident history and on-call state so an agent knows who was paged and what changed.
-    starter_prompt: Summarise the incidents from the last week and identify which service caused the most pages.
-    permission_disclosure: Reads and writes incidents, schedules, and service configuration in the PagerDuty accounts you authorise.
-    icon_url: https://logos.composio.dev/api/pagerduty
-    popularity_rank: 46
-    remote_url: https://mcp.pagerduty.com/mcp
-    transport: streamable-http
-    auth_type: oauth
-
   - name: com.firecrawl/mcp
     category: search
     capabilities: [web-scrape]
@@ -610,14 +532,7 @@ unpublished:
     transport: streamable-http
     auth_type: none
 
-  - name: com.kagi/mcp
-    category: search
-    capabilities: [web-search]
-    benefit: Search with an ad-free, publisher-ranked index when result quality matters more than breadth.
-    starter_prompt: Search for recent authoritative coverage of the topic I name and summarise the consensus.
-    permission_disclosure: Sends your search queries to Kagi under the account you authorise, which may consume search credits.
-    icon_url: https://www.google.com/s2/favicons?domain=kagi.com&sz=64
-    popularity_rank: 50
-    remote_url: https://mcp.kagi.com/mcp
-    transport: streamable-http
-    auth_type: oauth
+# OAuth endpoints intentionally not offered after the 2026-08-19 read-only audit:
+# - GitHub, MongoDB, Box, HubSpot, and Slack publish no DCR endpoint or reviewed public client for Agor.
+# - Prisma and PagerDuty publish authorization-server issuer chains that do not bind safely.
+# - Kagi challenges with Bearer but publishes neither protected-resource nor authorization-server metadata.

--- a/packages/core/src/tools/mcp/auth-secrets.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.ts
@@ -9,7 +9,7 @@ import {
   isUserEnvPlaceholder,
   TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS,
 } from '../../mcp/template-resolver';
-import type { MCPAuth } from '../../types/mcp';
+import { assertPublicMCPOAuthCompatibilityMode, type MCPAuth } from '../../types/mcp';
 import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
 
 export const MCP_AUTH_SECRET_FIELDS = [
@@ -67,6 +67,7 @@ export function restoreRedactedMCPAuthSecrets(options: {
   next?: MCPAuth;
 }): MCPAuth | undefined {
   if (!options.next) return undefined;
+  assertPublicMCPOAuthCompatibilityMode(options.next);
 
   const restored: MCPAuth = { ...options.next };
   const record = restored as unknown as Record<string, unknown>;

--- a/packages/core/src/tools/mcp/http-headers.test.ts
+++ b/packages/core/src/tools/mcp/http-headers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canonicalMCPCustomHeaderEntries,
+  findDuplicateMCPCustomHeaderName,
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
   MCP_HEADER_REDACTED_SENTINEL,
@@ -28,6 +30,24 @@ describe('MCP HTTP header helpers', () => {
         '': 'empty',
       })
     ).toEqual({ 'DD-API-KEY': 'dummy-api-key' });
+  });
+
+  it('rejects case-insensitive duplicate names before persistence or Fetch merging', () => {
+    const headers = { ' X-Route ': 'first', 'x-route': 'second' };
+    expect(findDuplicateMCPCustomHeaderName(headers)).toEqual({
+      first: ' X-Route ',
+      duplicate: 'x-route',
+    });
+    expect(() => normalizeMCPCustomHeaders(headers)).toThrow(/Duplicate custom HTTP header names/);
+    expect(() => mergeMCPRemoteHeaders({ custom: headers })).toThrow(
+      /Duplicate custom HTTP header names/
+    );
+  });
+
+  it('canonicalizes non-duplicate ordering and name case identically', () => {
+    expect(canonicalMCPCustomHeaderEntries({ 'X-B': '2', 'X-A': '1' })).toEqual(
+      canonicalMCPCustomHeaderEntries({ 'x-a': '1', 'x-b': '2' })
+    );
   });
 
   it('merges base, custom, and auth headers with auth taking precedence', () => {

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -37,10 +37,44 @@ export function isReservedMCPCustomHeaderName(name: string): boolean {
   return RESERVED_MCP_CUSTOM_HEADER_NAMES.has(name.toLowerCase());
 }
 
+export interface DuplicateMCPCustomHeaderName {
+  first: string;
+  duplicate: string;
+}
+
+/**
+ * Find a pair of names which Fetch would collapse into one case-insensitive
+ * header. Keeping both would make JSON insertion order security-relevant: the
+ * wire value becomes a comma-joined sequence whose order can change while a
+ * naively sorted fingerprint stays the same.
+ */
+export function findDuplicateMCPCustomHeaderName(
+  headers?: Record<string, unknown>
+): DuplicateMCPCustomHeaderName | undefined {
+  if (!headers) return undefined;
+  const names = new Map<string, string>();
+  for (const rawName of Object.keys(headers)) {
+    const name = rawName.trim();
+    if (!name) continue;
+    const canonicalName = name.toLowerCase();
+    const first = names.get(canonicalName);
+    if (first !== undefined) return { first, duplicate: rawName };
+    names.set(canonicalName, rawName);
+  }
+  return undefined;
+}
+
 export function normalizeMCPCustomHeaders(
   headers?: Record<string, string>
 ): Record<string, string> | undefined {
   if (!headers) return undefined;
+
+  const duplicate = findDuplicateMCPCustomHeaderName(headers);
+  if (duplicate) {
+    throw new Error(
+      `Duplicate custom HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`
+    );
+  }
 
   const normalized: Record<string, string> = {};
   for (const [rawName, rawValue] of Object.entries(headers)) {
@@ -52,6 +86,20 @@ export function normalizeMCPCustomHeaders(
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+/**
+ * Canonical representation shared by outbound normalization, configuration
+ * mutation detection, and OAuth grant fingerprints.
+ */
+export function canonicalMCPCustomHeaderEntries(
+  headers?: Record<string, string>
+): ReadonlyArray<readonly [string, string]> {
+  return Object.entries(normalizeMCPCustomHeaders(headers) ?? {})
+    .map(([name, value]) => [name.toLowerCase(), value] as const)
+    .sort(([aName, aValue], [bName, bValue]) =>
+      aName === bName ? aValue.localeCompare(bValue) : aName.localeCompare(bName)
+    );
 }
 
 export function redactMCPCustomHeaders(

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -89,6 +89,7 @@ describe('completeMCPOAuthFlow token exchange', () => {
     state: 'state',
     authorizationUrl: 'https://provider.example.test/authorize',
     compatibilityMode: 'legacy' as const,
+    authorizationResponseIssuerParameterSupported: false,
     allowLocalhostHttp: false,
   };
 
@@ -115,6 +116,7 @@ describe('completeMCPOAuthFlow token exchange', () => {
         state: 'state',
         authorizationUrl: 'https://github.com/login/oauth/authorize',
         compatibilityMode: 'legacy',
+        authorizationResponseIssuerParameterSupported: false,
         allowLocalhostHttp: true,
       },
       'authorization-code',
@@ -167,6 +169,7 @@ describe('completeMCPOAuthFlow token exchange', () => {
         state: sentinels.state,
         authorizationUrl: `https://provider.example.test/authorize?state=${sentinels.state}`,
         compatibilityMode: 'legacy',
+        authorizationResponseIssuerParameterSupported: false,
         allowLocalhostHttp: false,
       },
       sentinels.code,
@@ -213,7 +216,11 @@ describe('completeMCPOAuthFlow token exchange', () => {
       const fetchSpy = vi.fn();
       globalThis.fetch = fetchSpy as unknown as typeof fetch;
       const failure = await completeMCPOAuthFlow(
-        { ...context, compatibilityMode: 'strict' },
+        {
+          ...context,
+          compatibilityMode: 'strict',
+          authorizationResponseIssuerParameterSupported: true,
+        },
         'single-use-code',
         state,
         { cacheToken: false, issuer }
@@ -1027,6 +1034,286 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     await expect(startMCPOAuthFlow('', undefined, redirectUri, prefetchedOptions)).rejects.toThrow(
       'Dynamic Client Registration failed'
     );
+  });
+});
+
+describe('marketplace oauth-start production boundary', () => {
+  const originalFetch = globalThis.fetch;
+  const redirectUri = 'https://agor.example.com/mcp-servers/oauth-callback';
+
+  beforeEach(() => {
+    clearAuthCodeTokenCache();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  it('takes an Airtable-style origin-scoped resource through discovery and advertised DCR', async () => {
+    const mcpUrl = 'https://mcp.airtable.example/mcp';
+    const metadataUrl = 'https://mcp.airtable.example/.well-known/oauth-protected-resource';
+    const issuer = 'https://airtable.example/oauth2/v1';
+    globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === `${metadataUrl}/mcp`) return json({}, 404);
+      if (url === metadataUrl) {
+        return json({
+          resource: 'https://mcp.airtable.example',
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === 'https://airtable.example/.well-known/oauth-authorization-server/oauth2/v1') {
+        return json({
+          issuer,
+          authorization_endpoint: `${issuer}/authorize`,
+          token_endpoint: `${issuer}/token`,
+          registration_endpoint: `${issuer}/register`,
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      if (url === `${issuer}/register` && init?.method === 'POST') {
+        return json(
+          {
+            client_id: 'airtable-dcr-client',
+            redirect_uris: [redirectUri],
+            token_endpoint_auth_method: 'none',
+          },
+          201
+        );
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const discovery = await resolveMCPOAuthDiscovery('Bearer', mcpUrl, {
+      compatibilityMode: 'marketplace',
+    });
+    expect(discovery).toEqual({
+      kind: 'resource-metadata',
+      metadataUrl,
+      source: 'well-known',
+    });
+    const context = await startMCPOAuthFlow('Bearer', undefined, redirectUri, {
+      resourceMetadataUrl: metadataUrl,
+      resourceUri: mcpUrl,
+      compatibilityMode: 'marketplace',
+    });
+
+    const authorizationUrl = new URL(context.authorizationUrl);
+    expect(context.clientId).toBe('airtable-dcr-client');
+    expect(context.authorizationResponseIssuerParameterSupported).toBe(false);
+    expect(authorizationUrl.searchParams.get('resource')).toBe(mcpUrl);
+    expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('takes Atlassian-style AS-direct discovery through the same oauth-start path', async () => {
+    const mcpUrl = 'https://mcp.atlassian.example/v1/mcp';
+    const issuer = 'https://mcp.atlassian.example';
+    const registrationEndpoint = `${issuer}/v1/register`;
+    globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/.well-known/oauth-protected-resource')) return json({}, 404);
+      if (url === `${issuer}/.well-known/oauth-authorization-server`) {
+        return json({
+          issuer,
+          authorization_endpoint: `${issuer}/v1/authorize`,
+          token_endpoint: `${issuer}/v1/token`,
+          registration_endpoint: registrationEndpoint,
+          code_challenge_methods_supported: ['plain', 'S256'],
+        });
+      }
+      if (url === registrationEndpoint && init?.method === 'POST') {
+        return json(
+          {
+            client_id: 'atlassian-dcr-client',
+            redirect_uris: [redirectUri],
+            token_endpoint_auth_method: 'none',
+          },
+          201
+        );
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    const discovery = await resolveMCPOAuthDiscovery('Bearer', mcpUrl, {
+      compatibilityMode: 'marketplace',
+    });
+    expect(discovery?.kind).toBe('authorization-server');
+    if (discovery?.kind !== 'authorization-server') throw new Error('expected AS-direct');
+
+    const context = await startMCPOAuthFlow('Bearer', undefined, redirectUri, {
+      prefetchedAuthServerMetadata: discovery.authServerMetadata,
+      cacheKey: mcpUrl,
+      resourceUri: mcpUrl,
+      compatibilityMode: 'marketplace',
+    });
+    expect(context.clientId).toBe('atlassian-dcr-client');
+    expect(new URL(context.authorizationUrl).pathname).toBe('/v1/authorize');
+  });
+
+  it('rejects a cross-origin issuer from AS-direct discovery before DCR', async () => {
+    const mcpUrl = 'https://mcp.example.com/mcp';
+    const registrationEndpoint = 'https://attacker.example/register';
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      startMCPOAuthFlow('Bearer', undefined, redirectUri, {
+        prefetchedAuthServerMetadata: {
+          issuer: 'https://attacker.example',
+          authorization_endpoint: 'https://attacker.example/authorize',
+          token_endpoint: 'https://attacker.example/token',
+          registration_endpoint: registrationEndpoint,
+          code_challenge_methods_supported: ['S256'],
+        },
+        cacheKey: mcpUrl,
+        resourceUri: mcpUrl,
+        compatibilityMode: 'marketplace',
+      })
+    ).rejects.toThrow('does not match the MCP resource origin');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  function linearFetch(options: { callbackIssuer?: boolean; metadataIssuer?: string } = {}) {
+    const mcpUrl = 'https://mcp.linear.example/mcp';
+    const metadataUrl = 'https://mcp.linear.example/.well-known/oauth-protected-resource/mcp';
+    const issuer = 'https://mcp.linear.example';
+    return {
+      mcpUrl,
+      metadataUrl,
+      issuer,
+      fetch: vi.fn(async (input: string | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === metadataUrl) {
+          return json({ resource: mcpUrl, authorization_servers: [issuer] });
+        }
+        if (url === `${issuer}/.well-known/oauth-authorization-server`) {
+          return json({
+            issuer: options.metadataIssuer ?? issuer,
+            authorization_endpoint: `${issuer}/authorize`,
+            token_endpoint: `${issuer}/token`,
+            registration_endpoint: `${issuer}/register`,
+            code_challenge_methods_supported: ['S256'],
+            ...(options.callbackIssuer
+              ? { authorization_response_iss_parameter_supported: true }
+              : {}),
+          });
+        }
+        if (url === `${issuer}/register` && init?.method === 'POST') {
+          return json(
+            {
+              client_id: 'linear-dcr-client',
+              redirect_uris: [redirectUri],
+              token_endpoint_auth_method: 'none',
+            },
+            201
+          );
+        }
+        if (url === `${issuer}/token` && init?.method === 'POST') {
+          return json({ access_token: 'linear-access-token' });
+        }
+        return json({}, 404);
+      }),
+    };
+  }
+
+  it('does not require Linear-style optional RFC 9207 declarations, but rejects a supplied wrong issuer', async () => {
+    const fixture = linearFetch();
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    const context = await startMCPOAuthFlow(
+      `Bearer resource_metadata="${fixture.metadataUrl}"`,
+      undefined,
+      redirectUri,
+      {
+        resourceUri: fixture.mcpUrl,
+        compatibilityMode: 'marketplace',
+      }
+    );
+    expect(context.authorizationResponseIssuerParameterSupported).toBe(false);
+
+    await expect(
+      completeMCPOAuthFlow(context, 'code', context.state, {
+        cacheToken: false,
+        issuer: 'https://attacker.example',
+      })
+    ).rejects.toMatchObject({ failureCode: 'callback_issuer_mismatch' });
+    await expect(
+      completeMCPOAuthFlow(context, 'code', context.state, { cacheToken: false })
+    ).resolves.toMatchObject({ access_token: 'linear-access-token' });
+  });
+
+  it('retains explicit strict opt-in and validates it before DCR', async () => {
+    const fixture = linearFetch();
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${fixture.metadataUrl}"`,
+        undefined,
+        redirectUri,
+        { resourceUri: fixture.mcpUrl, compatibilityMode: 'strict' }
+      )
+    ).rejects.toThrow('required callback issuer');
+    expect(fixture.fetch).not.toHaveBeenCalledWith(
+      `${fixture.issuer}/register`,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('rejects cross-origin protected-resource metadata instead of relaxing validation wholesale', async () => {
+    const mcpUrl = 'https://mcp.example.com/mcp';
+    const metadataUrl = 'https://metadata.attacker.example/oauth-protected-resource';
+    const issuer = 'https://issuer.example.com';
+    globalThis.fetch = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === metadataUrl) {
+        return json({
+          resource: 'https://mcp.example.com',
+          authorization_servers: [issuer],
+        });
+      }
+      return json({}, 404);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      startMCPOAuthFlow(`Bearer resource_metadata="${metadataUrl}"`, 'client-id', redirectUri, {
+        resourceUri: mcpUrl,
+        compatibilityMode: 'marketplace',
+      })
+    ).rejects.toThrow('Protected resource metadata does not match');
+  });
+
+  it('rejects an authorization-server issuer alias that crosses origins', async () => {
+    const fixture = linearFetch({ metadataIssuer: 'https://attacker.example' });
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${fixture.metadataUrl}"`,
+        'client-id',
+        redirectUri,
+        { resourceUri: fixture.mcpUrl, compatibilityMode: 'marketplace' }
+      )
+    ).rejects.toThrow('Failed to fetch authorization server metadata');
+  });
+
+  it('requires the callback issuer when a marketplace authorization server advertises RFC 9207', async () => {
+    const fixture = linearFetch({ callbackIssuer: true });
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    const context = await startMCPOAuthFlow(
+      `Bearer resource_metadata="${fixture.metadataUrl}"`,
+      undefined,
+      redirectUri,
+      { resourceUri: fixture.mcpUrl, compatibilityMode: 'marketplace' }
+    );
+    await expect(
+      completeMCPOAuthFlow(context, 'code', context.state, { cacheToken: false })
+    ).rejects.toMatchObject({ failureCode: 'callback_issuer_missing' });
   });
 });
 

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -1302,6 +1302,40 @@ describe('marketplace oauth-start production boundary', () => {
     ).rejects.toThrow('Failed to fetch authorization server metadata');
   });
 
+  it('accepts exactly one trailing-slash spelling difference for a marketplace issuer', async () => {
+    const fixture = linearFetch({ metadataIssuer: 'https://mcp.linear.example/' });
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${fixture.metadataUrl}"`,
+        'pre-registered-client',
+        redirectUri,
+        { resourceUri: fixture.mcpUrl, compatibilityMode: 'marketplace' }
+      )
+    ).resolves.toMatchObject({
+      issuer: 'https://mcp.linear.example/',
+      compatibilityMode: 'marketplace',
+    });
+  });
+
+  it.each([
+    'https://MCP.linear.example',
+    'https://mcp.linear.example:443',
+    'https://mcp.linear.example/a/../',
+    'https://mcp.linear.example//',
+  ])('does not accept URL canonicalization of marketplace issuer %s', async (metadataIssuer) => {
+    const fixture = linearFetch({ metadataIssuer });
+    globalThis.fetch = fixture.fetch as unknown as typeof fetch;
+    await expect(
+      startMCPOAuthFlow(
+        `Bearer resource_metadata="${fixture.metadataUrl}"`,
+        'pre-registered-client',
+        redirectUri,
+        { resourceUri: fixture.mcpUrl, compatibilityMode: 'marketplace' }
+      )
+    ).rejects.toThrow('Failed to fetch authorization server metadata');
+  });
+
   it('requires the callback issuer when a marketplace authorization server advertises RFC 9207', async () => {
     const fixture = linearFetch({ callbackIssuer: true });
     globalThis.fetch = fixture.fetch as unknown as typeof fetch;

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -660,12 +660,17 @@ function oauthIssuerIdentifiersMatch(left: unknown, right: unknown): boolean {
   if (typeof left !== 'string' || typeof right !== 'string') return false;
   if (left === right) return true;
   try {
-    const normalize = (value: string): string => {
-      const url = new URL(value);
-      if (url.pathname.length > 1) url.pathname = url.pathname.replace(/\/+$/, '');
-      return url.toString();
-    };
-    return normalize(left) === normalize(right);
+    // Parse only to reject non-URL issuer identifiers. Do not compare the
+    // parsed values: URL serialization also folds host case, removes default
+    // ports, and resolves dot segments, none of which this reviewed exception
+    // intends to accept.
+    new URL(left);
+    new URL(right);
+    const differsByOneTrailingSlash = (withSlash: string, withoutSlash: string): boolean =>
+      withSlash.endsWith('/') &&
+      !withSlash.slice(0, -1).endsWith('/') &&
+      withSlash.slice(0, -1) === withoutSlash;
+    return differsByOneTrailingSlash(left, right) || differsByOneTrailingSlash(right, left);
   } catch {
     return false;
   }

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -9,13 +9,18 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
 import { z } from 'zod';
-import type { MCPOAuthDCRDiagnostic, MCPOAuthDCRMode } from '../../types/mcp.js';
+import type {
+  MCPOAuthDCRDiagnostic,
+  MCPOAuthDCRMode,
+  MCPOAuthRuntimeCompatibilityMode,
+} from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import type { OAuthTokenResponse } from './oauth-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
 export interface OAuthMetadata {
-  resource?: string;
+  /** RFC 9728 says string; marketplace compatibility also recognizes one observed singleton array. */
+  resource?: string | string[];
   authorization_servers: string[];
   scopes_supported?: string[];
   bearer_methods_supported?: string[];
@@ -367,7 +372,10 @@ export type MCPOAuthDiscoveryResult =
 export async function resolveMCPOAuthDiscovery(
   wwwAuthenticateHeader: string | null,
   mcpUrl: string,
-  options: { compatibilityMode?: 'strict' | 'legacy'; allowLocalhostHttp?: boolean } = {}
+  options: {
+    compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
+    allowLocalhostHttp?: boolean;
+  } = {}
 ): Promise<MCPOAuthDiscoveryResult | null> {
   // Strategies 1 + 2: RFC 9728 (header hint, then well-known fallback)
   const rfc9728 = await resolveResourceMetadataUrl(wwwAuthenticateHeader, mcpUrl, options);
@@ -376,7 +384,7 @@ export async function resolveMCPOAuthDiscovery(
   }
 
   // Strategies 3 + 4: AS metadata directly at MCP origin (RFC 8414 / OIDC)
-  if ((options.compatibilityMode ?? 'strict') !== 'legacy') return null;
+  if ((options.compatibilityMode ?? 'strict') === 'strict') return null;
   const asDirect = await discoverAuthorizationServerFromMcpOrigin(mcpUrl, options);
   if (asDirect) {
     return {
@@ -643,6 +651,36 @@ function buildWellKnownUrl(issuerUrl: string, wellKnownSuffix: string): string {
 }
 
 /**
+ * A few reviewed providers disagree only about a trailing slash on an issuer.
+ * Treat that spelling difference as equivalent in the marketplace profile,
+ * while preserving strict RFC 8414 string comparison everywhere else. Host,
+ * scheme, port, path, query, username and password must still agree.
+ */
+function oauthIssuerIdentifiersMatch(left: unknown, right: unknown): boolean {
+  if (typeof left !== 'string' || typeof right !== 'string') return false;
+  if (left === right) return true;
+  try {
+    const normalize = (value: string): string => {
+      const url = new URL(value);
+      if (url.pathname.length > 1) url.pathname = url.pathname.replace(/\/+$/, '');
+      return url.toString();
+    };
+    return normalize(left) === normalize(right);
+  } catch {
+    return false;
+  }
+}
+
+function oauthIssuerOriginMatchesResource(issuer: unknown, resourceUri: string): boolean {
+  if (typeof issuer !== 'string') return false;
+  try {
+    return new URL(issuer).origin === new URL(resourceUri).origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fetch Authorization Server Metadata (RFC 8414)
  *
  * Implements path-aware discovery per RFC 8414 Section 3.
@@ -650,7 +688,10 @@ function buildWellKnownUrl(issuerUrl: string, wellKnownSuffix: string): string {
  */
 export async function fetchAuthorizationServerMetadata(
   authServerUrl: string,
-  options: { compatibilityMode?: 'strict' | 'legacy'; allowLocalhostHttp?: boolean } = {}
+  options: {
+    compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
+    allowLocalhostHttp?: boolean;
+  } = {}
 ): Promise<AuthorizationServerMetadata> {
   const cleanUrl = authServerUrl.replace(/\/$/, '');
   const urlsToTry: { url: string; label: string }[] = [];
@@ -659,20 +700,21 @@ export async function fetchAuthorizationServerMetadata(
   const rfc8414Url = buildWellKnownUrl(cleanUrl, 'oauth-authorization-server');
   urlsToTry.push({ url: rfc8414Url, label: 'RFC 8414 (path-aware)' });
 
-  const legacy = options.compatibilityMode === 'legacy';
+  const compatibilityMode = options.compatibilityMode ?? 'strict';
+  const compatibilityProbes = compatibilityMode !== 'strict';
   // Narrow opt-in legacy probes for non-compliant issuers.
   const naiveUrl = `${cleanUrl}/.well-known/oauth-authorization-server`;
-  if (legacy && naiveUrl !== rfc8414Url) {
+  if (compatibilityProbes && naiveUrl !== rfc8414Url) {
     urlsToTry.push({ url: naiveUrl, label: 'RFC 8414 (naive append)' });
   }
 
   // 3. OIDC discovery — path-aware
   const oidcUrl = buildWellKnownUrl(cleanUrl, 'openid-configuration');
-  if (legacy) urlsToTry.push({ url: oidcUrl, label: 'OIDC (path-aware)' });
+  if (compatibilityProbes) urlsToTry.push({ url: oidcUrl, label: 'OIDC (path-aware)' });
 
   // 4. OIDC discovery — naive append
   const naiveOidcUrl = `${cleanUrl}/.well-known/openid-configuration`;
-  if (legacy && naiveOidcUrl !== oidcUrl) {
+  if (compatibilityProbes && naiveOidcUrl !== oidcUrl) {
     urlsToTry.push({ url: naiveOidcUrl, label: 'OIDC (naive append)' });
   }
 
@@ -687,7 +729,12 @@ export async function fetchAuthorizationServerMetadata(
       if (response.ok) {
         console.log(`[MCP OAuth] ✓ Fetched metadata via ${label}`);
         const metadata = (await response.json()) as AuthorizationServerMetadata;
-        if (!legacy && metadata.issuer !== authServerUrl) {
+        if (
+          compatibilityMode === 'strict'
+            ? metadata.issuer !== authServerUrl
+            : compatibilityMode === 'marketplace' &&
+              !oauthIssuerIdentifiersMatch(metadata.issuer, authServerUrl)
+        ) {
           throw new Error(
             'Authorization server metadata issuer does not match the advertised issuer'
           );
@@ -1126,7 +1173,7 @@ export async function performMCPOAuthFlow(
       pkce.verifier,
       actualClientId,
       clientSecret,
-      resourceMetadata.resource,
+      typeof resourceMetadata.resource === 'string' ? resourceMetadata.resource : undefined,
       true
     );
 
@@ -1252,9 +1299,59 @@ export interface OAuthFlowContext {
   clientSecret?: string;
   state: string;
   authorizationUrl: string;
-  compatibilityMode: 'strict' | 'legacy';
+  compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
+  /** Require `iss` when the AS advertised RFC 9207 support for this flow. */
+  authorizationResponseIssuerParameterSupported: boolean;
   /** Narrow standalone-development exception; durable daemon flows leave this false. */
   allowLocalhostHttp: boolean;
+}
+
+/**
+ * Bounded RFC 9728 compatibility for reviewed marketplace endpoints.
+ *
+ * Exact equality remains the strict/default rule. The marketplace may also
+ * accept an origin-level (or parent-path) resource identifier, but only when
+ * both the metadata document and that identifier are served by the exact MCP
+ * origin. This covers providers that publish one origin-scoped PRM for
+ * `/mcp`, without accepting a cross-origin metadata document or resource that
+ * could redirect a grant to an attacker. The authorization and token requests
+ * still carry the exact MCP URL as their RFC 8707 `resource` value.
+ *
+ * One provider currently emits the singular RFC field as a singleton array;
+ * accepting exactly one string preserves the same unambiguous binding. A list
+ * of alternatives is rejected rather than guessing which resource was meant.
+ */
+function marketplaceResourceMetadataMatches(
+  metadataUrl: string,
+  statedResource: OAuthMetadata['resource'],
+  resourceUri: string
+): boolean {
+  const identifiers =
+    typeof statedResource === 'string'
+      ? [statedResource]
+      : Array.isArray(statedResource) &&
+          statedResource.length === 1 &&
+          typeof statedResource[0] === 'string'
+        ? statedResource
+        : [];
+  if (identifiers.length !== 1) return false;
+  const [identifier] = identifiers;
+  if (identifier === resourceUri) return true;
+
+  try {
+    const metadata = new URL(metadataUrl);
+    const stated = new URL(identifier);
+    const requested = new URL(resourceUri);
+    if (metadata.origin !== requested.origin || stated.origin !== requested.origin) return false;
+    if (stated.search || stated.hash) return false;
+    const basePath = stated.pathname.replace(/\/+$/, '') || '/';
+    const requestedPath = requested.pathname.replace(/\/+$/, '') || '/';
+    return (
+      requestedPath === basePath || basePath === '/' || requestedPath.startsWith(`${basePath}/`)
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1301,7 +1398,7 @@ async function startMCPOAuthFlowWithAS(opts: {
   reuseDynamicClientRegistration?: boolean;
   resourceUri: string;
   issuer: string;
-  compatibilityMode: 'strict' | 'legacy';
+  compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
   dcrMode: MCPOAuthDCRMode;
   allowLocalhostHttp: boolean;
 }): Promise<OAuthFlowContext> {
@@ -1364,17 +1461,30 @@ async function startMCPOAuthFlowWithAS(opts: {
 
   assertSafeOAuthUrl(tokenEndpoint, { allowLocalhostHttp });
   assertSafeOAuthUrl(authorizationEndpoint, { allowLocalhostHttp });
-  if (compatibilityMode === 'strict') {
+  if (compatibilityMode !== 'legacy') {
     if (!authServerMetadata) {
-      throw new Error('Strict MCP OAuth requires authorization-server metadata');
+      throw new Error('MCP OAuth issuer validation requires authorization-server metadata');
     }
-    if (authServerMetadata.issuer !== issuer) {
+    assertSafeOAuthUrl(authServerMetadata.issuer, { allowLocalhostHttp });
+    const issuerMatches =
+      compatibilityMode === 'strict'
+        ? authServerMetadata.issuer === issuer
+        : oauthIssuerIdentifiersMatch(authServerMetadata.issuer, issuer);
+    if (!issuerMatches) {
       throw new Error('Authorization server issuer mismatch');
     }
-    if (!authServerMetadata.code_challenge_methods_supported?.includes('S256')) {
+    const advertisedPKCEMethods = authServerMetadata.code_challenge_methods_supported;
+    if (
+      compatibilityMode === 'strict'
+        ? !advertisedPKCEMethods?.includes('S256')
+        : advertisedPKCEMethods !== undefined && !advertisedPKCEMethods.includes('S256')
+    ) {
       throw new Error('Authorization server does not advertise required PKCE S256 support');
     }
-    if (authServerMetadata.authorization_response_iss_parameter_supported !== true) {
+    if (
+      compatibilityMode === 'strict' &&
+      authServerMetadata.authorization_response_iss_parameter_supported !== true
+    ) {
       throw new Error(
         'Authorization server does not advertise the required callback issuer parameter'
       );
@@ -1383,10 +1493,10 @@ async function startMCPOAuthFlowWithAS(opts: {
       authorizationUrlOverride &&
       authorizationUrlOverride !== authServerMetadata.authorization_endpoint
     ) {
-      throw new Error('Strict MCP OAuth authorization endpoint override does not match metadata');
+      throw new Error('MCP OAuth authorization endpoint override does not match metadata');
     }
     if (tokenUrlOverride && tokenUrlOverride !== authServerMetadata.token_endpoint) {
-      throw new Error('Strict MCP OAuth token endpoint override does not match metadata');
+      throw new Error('MCP OAuth token endpoint override does not match metadata');
     }
   }
 
@@ -1454,7 +1564,11 @@ async function startMCPOAuthFlowWithAS(opts: {
   return {
     metadataUrl: cacheKey,
     resourceUri,
-    issuer,
+    // RFC 8414 metadata is the callback issuer authority. Marketplace mode
+    // admits only a trailing-slash spelling difference from the resource's
+    // advertised AS identifier; persist the metadata spelling so an `iss`
+    // callback is compared with the value the AS itself promised to send.
+    issuer: authServerMetadata?.issuer ?? issuer,
     authorizationEndpoint,
     tokenEndpoint,
     redirectUri: actualRedirectUri,
@@ -1464,6 +1578,8 @@ async function startMCPOAuthFlowWithAS(opts: {
     state,
     authorizationUrl: authUrl.toString(),
     compatibilityMode,
+    authorizationResponseIssuerParameterSupported:
+      authServerMetadata?.authorization_response_iss_parameter_supported === true,
     allowLocalhostHttp,
   };
 }
@@ -1502,7 +1618,7 @@ export async function startMCPOAuthFlow(
     reuseDynamicClientRegistration?: boolean;
     /** Exact protected resource identifier sent to authorization/token endpoints. */
     resourceUri?: string;
-    compatibilityMode?: 'strict' | 'legacy';
+    compatibilityMode?: MCPOAuthRuntimeCompatibilityMode;
     dcrMode?: MCPOAuthDCRMode;
     /** Exact loopback HTTP exception for standalone development only. */
     allowLocalhostHttp?: boolean;
@@ -1520,8 +1636,10 @@ export async function startMCPOAuthFlow(
   // 9728 resource metadata to fetch. Take the short path and skip directly to
   // PKCE / DCR / auth-URL construction.
   if (options?.prefetchedAuthServerMetadata) {
-    if (compatibilityMode !== 'legacy') {
-      throw new Error('Authorization-server-direct discovery requires explicit legacy mode');
+    if (compatibilityMode === 'strict') {
+      throw new Error(
+        'Authorization-server-direct discovery requires explicit marketplace or legacy mode'
+      );
     }
     if (!options.cacheKey) {
       // Without it there is no `context.metadataUrl` to carry through the
@@ -1530,6 +1648,18 @@ export async function startMCPOAuthFlow(
       throw new Error(
         'startMCPOAuthFlow: cacheKey is required when prefetchedAuthServerMetadata is provided ' +
           '(typically pass the MCP server URL).'
+      );
+    }
+    // With no RFC 9728 document there is no independently advertised AS
+    // identifier to bind. The marketplace fallback is therefore safe only
+    // when the directly discovered issuer remains on the protected resource's
+    // origin. Legacy mode retains its explicitly broader behavior.
+    if (
+      compatibilityMode === 'marketplace' &&
+      !oauthIssuerOriginMatchesResource(options.prefetchedAuthServerMetadata.issuer, resourceUri)
+    ) {
+      throw new Error(
+        'Authorization-server-direct discovery issuer does not match the MCP resource origin'
       );
     }
     console.log('[MCP OAuth] Using prefetched AS metadata (RFC 9728 skipped)');
@@ -1565,7 +1695,12 @@ export async function startMCPOAuthFlow(
   // Step 2: Fetch Protected Resource Metadata (RFC 9728)
   const resourceMetadata = await fetchResourceMetadata(metadataUrl, { allowLocalhostHttp });
 
-  if (compatibilityMode === 'strict' && resourceMetadata.resource !== resourceUri) {
+  if (
+    compatibilityMode === 'strict'
+      ? resourceMetadata.resource !== resourceUri
+      : compatibilityMode === 'marketplace' &&
+        !marketplaceResourceMetadataMatches(metadataUrl, resourceMetadata.resource, resourceUri)
+  ) {
     throw new Error('Protected resource metadata does not match the MCP resource URI');
   }
 
@@ -1659,10 +1794,14 @@ export async function completeMCPOAuthFlow(
   if (state !== context.state) {
     throw new OAuthCallbackValidationError('callback_state_mismatch');
   }
-  if (context.compatibilityMode === 'strict' && options.issuer == null) {
+  if (context.authorizationResponseIssuerParameterSupported && options.issuer == null) {
     throw new OAuthCallbackValidationError('callback_issuer_missing');
   }
-  if (context.compatibilityMode === 'strict' && options.issuer !== context.issuer) {
+  if (
+    context.compatibilityMode !== 'legacy' &&
+    options.issuer != null &&
+    options.issuer !== context.issuer
+  ) {
     throw new OAuthCallbackValidationError('callback_issuer_mismatch');
   }
 

--- a/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
@@ -23,6 +23,7 @@ import type { MCPServerID, UserID } from '../../types';
 import {
   AmbiguousRefreshError,
   FailedRefreshError,
+  GrantConfigurationChangedError,
   OAuthRefreshExchangeError,
   refreshAndPersistToken,
 } from './oauth-refresh';
@@ -109,14 +110,14 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       };
     }
 
-    async function nextGeneration(db: TenantScopeAwareDatabase, tenantId: string) {
-      return runWithTenantDatabaseScope(db, tenantId, (scoped) => {
+    async function nextGeneration(db: TenantScopeAwareDatabase, seed: Seed) {
+      return runWithTenantDatabaseScope(db, seed.tenantId, (scoped) => {
         const repository = new MCPOAuthPendingFlowRepository(scoped);
         return repository.allocateGrantGeneration({
-          tenantId,
-          mcpServerId: 'refresh-test-generation-subject' as MCPServerID,
-          oauthMode: 'shared',
-          subjectUserId: null,
+          tenantId: seed.tenantId,
+          mcpServerId: seed.serverId,
+          oauthMode: 'per_user',
+          subjectUserId: seed.userId,
         });
       });
     }
@@ -187,7 +188,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       accessToken: string,
       refreshToken: string
     ): Promise<number> {
-      const generation = await nextGeneration(db, seed.tenantId);
+      const generation = await nextGeneration(db, seed);
       await runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
         new UserMCPOAuthTokenRepository(scoped, masterSecret).saveToken(
           seed.userId,
@@ -215,7 +216,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
     }
 
     function initialRefreshVersion(seed: Seed) {
-      return { grantGeneration: seed.generation, refreshGeneration: 0 };
+      return {
+        grantGeneration: seed.generation,
+        grantBindingFingerprint: 'a'.repeat(64),
+        refreshGeneration: 0,
+      };
     }
 
     it('allows one daemon to rotate while a peer observes the committed result', async () => {
@@ -241,6 +246,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           tenantId: bound.tenantId,
           userId: bound.userId,
           mcpServerId: bound.serverId,
+          validateGrant: async () => true,
           observedRefreshVersion: initialRefreshVersion(bound),
           allowLocalhostHttpDevelopment: true,
         }),
@@ -249,6 +255,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           tenantId: bound.tenantId,
           userId: bound.userId,
           mcpServerId: bound.serverId,
+          validateGrant: async () => true,
           observedRefreshVersion: initialRefreshVersion(bound),
           allowLocalhostHttpDevelopment: true,
         }),
@@ -285,6 +292,50 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       ).toBe(true);
     });
 
+    it('refuses completion when authoritative server configuration changes during exchange', async () => {
+      let configurationStillValid = true;
+      const tokenProvider = await provider((_body, response) => {
+        // The refresh owner already validated the saved row before sending
+        // the request. Model a Settings mutation landing while the provider
+        // owns the rotating refresh token.
+        configurationStillValid = false;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(
+          JSON.stringify({
+            access_token: 'must-not-commit-after-settings-change',
+            refresh_token: 'must-not-rotate-after-settings-change',
+            expires_in: 3600,
+          })
+        );
+      });
+      const bound = await seed('settings-mutation', tokenProvider.url);
+      const validateGrant = vi.fn(async () => configurationStillValid);
+
+      await expect(
+        refreshAndPersistToken({
+          db: dbA,
+          tenantId: bound.tenantId,
+          userId: bound.userId,
+          mcpServerId: bound.serverId,
+          validateGrant,
+          observedRefreshVersion: initialRefreshVersion(bound),
+          allowLocalhostHttpDevelopment: true,
+        })
+      ).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+
+      expect(validateGrant).toHaveBeenCalledTimes(2);
+      const current = await runWithTenantDatabaseScope(dbB, bound.tenantId, (scoped) =>
+        new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(bound.userId, bound.serverId)
+      );
+      expect(current).toMatchObject({
+        oauth_access_token: 'expired-access-settings-mutation',
+        oauth_refresh_token: 'refresh-settings-mutation-0',
+        refresh_status: 'ambiguous',
+        refresh_generation: 1,
+        refresh_success_generation: 0,
+      });
+    });
+
     it('makes a delayed stale caller observe the committed rotation instead of refreshing twice', async () => {
       const tokenProvider = await provider((_body, response) => {
         response.writeHead(200, { 'content-type': 'application/json' });
@@ -305,6 +356,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           tenantId: bound.tenantId,
           userId: bound.userId,
           mcpServerId: bound.serverId,
+          validateGrant: async () => true,
           observedRefreshVersion: staleVersion,
           allowLocalhostHttpDevelopment: true,
         })
@@ -318,6 +370,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           tenantId: bound.tenantId,
           userId: bound.userId,
           mcpServerId: bound.serverId,
+          validateGrant: async () => true,
           observedRefreshVersion: staleVersion,
           allowLocalhostHttpDevelopment: true,
         })
@@ -347,6 +400,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         tenantId: bound.tenantId,
         userId: bound.userId,
         mcpServerId: bound.serverId,
+        validateGrant: async () => true,
         observedRefreshVersion: observed,
         allowLocalhostHttpDevelopment: true,
       });
@@ -356,6 +410,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         tenantId: bound.tenantId,
         userId: bound.userId,
         mcpServerId: bound.serverId,
+        validateGrant: async () => true,
         observedRefreshVersion: observed,
         allowLocalhostHttpDevelopment: true,
       });
@@ -409,6 +464,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           tenantId: bound.tenantId,
           userId: bound.userId,
           mcpServerId: bound.serverId,
+          validateGrant: async () => true,
           observedRefreshVersion: initialRefreshVersion(bound),
           allowLocalhostHttpDevelopment: true,
         })
@@ -438,6 +494,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         tenantId: bound.tenantId,
         userId: bound.userId,
         mcpServerId: bound.serverId,
+        validateGrant: async () => true,
         observedRefreshVersion: initialRefreshVersion(bound),
         onInvalidGrant: invalidGrantNotice,
         allowLocalhostHttpDevelopment: true,
@@ -452,7 +509,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       );
       releaseResponse();
 
-      await expect(oldRefresh).resolves.toBe('new-account-access');
+      await expect(oldRefresh).rejects.toBeInstanceOf(GrantConfigurationChangedError);
       expect(invalidGrantNotice).not.toHaveBeenCalled();
       const current = await runWithTenantDatabaseScope(dbA, bound.tenantId, (scoped) =>
         new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(bound.userId, bound.serverId)
@@ -462,6 +519,58 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         oauth_access_token: 'new-account-access',
         oauth_refresh_token: 'new-account-refresh',
         refresh_status: 'idle',
+      });
+    });
+
+    it('does not return or overwrite a newer authorization after an old refresh succeeds', async () => {
+      let requestArrived!: () => void;
+      const arrived = new Promise<void>((resolve) => {
+        requestArrived = resolve;
+      });
+      let releaseResponse!: () => void;
+      const release = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const tokenProvider = await provider(async (_body, response) => {
+        requestArrived();
+        await release;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(
+          JSON.stringify({
+            access_token: 'stale-refresh-access',
+            refresh_token: 'stale-refresh-rotation',
+            expires_in: 3600,
+          })
+        );
+      });
+      const bound = await seed('losing-successful-refresh', tokenProvider.url);
+      const oldRefresh = refreshAndPersistToken({
+        db: dbA,
+        tenantId: bound.tenantId,
+        userId: bound.userId,
+        mcpServerId: bound.serverId,
+        validateGrant: async () => true,
+        observedRefreshVersion: initialRefreshVersion(bound),
+        allowLocalhostHttpDevelopment: true,
+      });
+      await arrived;
+      const newerGeneration = await replaceGrant(
+        dbB,
+        bound,
+        tokenProvider.url,
+        'new-authorization-access',
+        'new-authorization-refresh'
+      );
+      releaseResponse();
+
+      await expect(oldRefresh).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+      const current = await runWithTenantDatabaseScope(dbA, bound.tenantId, (scoped) =>
+        new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(bound.userId, bound.serverId)
+      );
+      expect(current).toMatchObject({
+        grant_generation: newerGeneration,
+        oauth_access_token: 'new-authorization-access',
+        oauth_refresh_token: 'new-authorization-refresh',
       });
     });
 

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -25,6 +25,7 @@ import type { MCPServerID, UserID } from '../../types';
 import {
   __refreshMutexSizeForTests,
   __resetRefreshMutexForTests,
+  GrantConfigurationChangedError,
   InvalidGrantError,
   MissingClientIdError,
   MissingRefreshTokenError,
@@ -44,26 +45,30 @@ import {
 // plain `function` constructors (not arrow factories) so `new X()` works.
 // ---------------------------------------------------------------------------
 
-const { mockGetToken, mockSaveToken, mockDeleteToken, mockFindById, mockUserFindById } = vi.hoisted(
-  () => ({
-    mockGetToken: vi.fn(),
-    mockSaveToken: vi.fn(),
-    mockDeleteToken: vi.fn(),
-    mockFindById: vi.fn(),
-    // Persisting a refreshed token now requires the grant's subject to still be
-    // entitled to hold it (`assertMcpGrantSubjectEntitled`), so these
-    // orchestration tests need a subject who is. The refusal itself is covered
-    // where it is enforced — see the daemon's `mcp-capability-role` tests.
-    mockUserFindById: vi.fn(async () => ({ user_id: 'user-1', role: 'member' })),
-  })
-);
+const {
+  mockGetToken,
+  mockCompleteStandaloneRefresh,
+  mockDeleteGrantVersion,
+  mockFindById,
+  mockUserFindById,
+} = vi.hoisted(() => ({
+  mockGetToken: vi.fn(),
+  mockCompleteStandaloneRefresh: vi.fn(),
+  mockDeleteGrantVersion: vi.fn(),
+  mockFindById: vi.fn(),
+  // Persisting a refreshed token now requires the grant's subject to still be
+  // entitled to hold it (`assertMcpGrantSubjectEntitled`), so these
+  // orchestration tests need a subject who is. The refusal itself is covered
+  // where it is enforced — see the daemon's `mcp-capability-role` tests.
+  mockUserFindById: vi.fn(async () => ({ user_id: 'user-1', role: 'member' })),
+}));
 
 vi.mock('../../db/repositories', () => ({
   UserMCPOAuthTokenRepository: function UserMCPOAuthTokenRepositoryMock() {
     return {
       getToken: mockGetToken,
-      saveToken: mockSaveToken,
-      deleteToken: mockDeleteToken,
+      completeStandaloneRefresh: mockCompleteStandaloneRefresh,
+      deleteGrantVersion: mockDeleteGrantVersion,
     };
   },
   MCPServerRepository: function MCPServerRepositoryMock() {
@@ -265,8 +270,8 @@ describe('refreshAndPersistToken', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     mockGetToken.mockReset();
-    mockSaveToken.mockReset();
-    mockDeleteToken.mockReset();
+    mockCompleteStandaloneRefresh.mockReset().mockResolvedValue(true);
+    mockDeleteGrantVersion.mockReset();
     mockFindById.mockReset();
 
     __resetRefreshMutexForTests();
@@ -299,23 +304,28 @@ describe('refreshAndPersistToken', () => {
       url: 'https://srv.example.com/mcp',
       auth: { oauth_token_url: 'https://auth.example.com/token' },
     });
-    mockSaveToken.mockResolvedValue(undefined);
     mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
 
     const token = await refreshAndPersistToken({
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     expect(token).toBe('new-a');
-    expect(mockSaveToken).toHaveBeenCalledWith(USER_ID, SERVER_ID, {
-      accessToken: 'new-a',
-      expiresAt: expect.any(Date), // resolved from expires_in: 3600 → ~now+1h
-      refreshToken: undefined, // provider omitted — repo preserves existing
-    });
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
+      USER_ID,
+      SERVER_ID,
+      { grantGeneration: 0, grantBindingFingerprint: undefined },
+      {
+        accessToken: 'new-a',
+        expiresAt: expect.any(Date), // resolved from expires_in: 3600 → ~now+1h
+        refreshToken: undefined, // provider omitted — repo preserves existing
+      }
+    );
     // Spot-check the resolved expiry is roughly +1h from now (within 5s slop).
-    const call = mockSaveToken.mock.calls[0]?.[2] as { expiresAt: Date };
+    const call = mockCompleteStandaloneRefresh.mock.calls[0]?.[3] as { expiresAt: Date };
     const deltaSec = (call.expiresAt.getTime() - Date.now()) / 1000;
     expect(deltaSec).toBeGreaterThan(3595);
     expect(deltaSec).toBeLessThanOrEqual(3600);
@@ -343,12 +353,47 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
-    expect(mockSaveToken).toHaveBeenCalledWith(
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
       USER_ID,
       SERVER_ID,
+      expect.any(Object),
       expect.objectContaining({ refreshToken: 'rt-2' })
+    );
+  });
+
+  it('fails closed when the exact SQLite grant disappears before refresh commit', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      grant_generation: 7,
+      grant_binding_fingerprint: 'binding-7',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ access_token: 'stale-refresh-result', expires_in: 3600 });
+    mockCompleteStandaloneRefresh.mockResolvedValue(false);
+
+    await expect(
+      refreshAndPersistToken({
+        db: { run: () => undefined } as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
+      })
+    ).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
+      USER_ID,
+      SERVER_ID,
+      { grantGeneration: 7, grantBindingFingerprint: 'binding-7' },
+      expect.objectContaining({ accessToken: 'stale-refresh-result' })
     );
   });
 
@@ -365,7 +410,7 @@ describe('refreshAndPersistToken', () => {
       auth: { oauth_token_url: 'https://auth.example.com/token' },
     });
     mockFetchJson({ error: 'invalid_grant' }, 400);
-    mockDeleteToken.mockResolvedValue(true);
+    mockDeleteGrantVersion.mockResolvedValue(true);
 
     const onInvalidGrant = vi.fn();
 
@@ -374,16 +419,48 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
         onInvalidGrant,
       })
     ).rejects.toBeInstanceOf(InvalidGrantError);
 
-    expect(mockDeleteToken).toHaveBeenCalledWith(USER_ID, SERVER_ID);
+    expect(mockDeleteGrantVersion).toHaveBeenCalledWith(USER_ID, SERVER_ID, 0, undefined);
     expect(onInvalidGrant).toHaveBeenCalledWith({
       userId: USER_ID,
       mcpServerId: SERVER_ID,
     });
-    expect(mockSaveToken).not.toHaveBeenCalled();
+    expect(mockCompleteStandaloneRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does not report or delete invalid_grant when the exact grant was replaced', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-revoked',
+      oauth_client_id: 'cid',
+      grant_generation: 3,
+      grant_binding_fingerprint: 'old-binding',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ error: 'invalid_grant' }, 400);
+    mockDeleteGrantVersion.mockResolvedValue(false);
+    const onInvalidGrant = vi.fn();
+
+    await expect(
+      refreshAndPersistToken({
+        db: { run: () => undefined } as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
+        onInvalidGrant,
+      })
+    ).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+    expect(mockDeleteGrantVersion).toHaveBeenCalledWith(USER_ID, SERVER_ID, 3, 'old-binding');
+    expect(onInvalidGrant).not.toHaveBeenCalled();
   });
 
   it('throws MissingRefreshTokenError when row has no refresh_token', async () => {
@@ -400,6 +477,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingRefreshTokenError);
   });
@@ -412,6 +490,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingRefreshTokenError);
   });
@@ -435,6 +514,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     expect(token).toBe('new-a');
@@ -459,6 +539,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingTokenEndpointError);
   });
@@ -486,6 +567,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -514,6 +596,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingClientIdError);
 
@@ -546,11 +629,13 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
     const p2 = refreshAndPersistToken({
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     // Wait for the fetch mock to be invoked before resolving — the mock's
@@ -569,7 +654,7 @@ describe('refreshAndPersistToken', () => {
     expect(t1).toBe('shared-new-a');
     expect(t2).toBe('shared-new-a');
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(mockSaveToken).toHaveBeenCalledTimes(1);
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('mutex: different keys refresh independently', async () => {
@@ -603,11 +688,13 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       }),
       refreshAndPersistToken({
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID_2,
+        validateGrant: async () => true,
       }),
     ]);
 
@@ -632,6 +719,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     expect(__refreshMutexSizeForTests()).toBe(0);
@@ -650,13 +738,14 @@ describe('refreshAndPersistToken', () => {
       auth: { oauth_token_url: 'https://auth.example.com/token' },
     });
     mockFetchJson({ error: 'invalid_grant' }, 400);
-    mockDeleteToken.mockResolvedValue(true);
+    mockDeleteGrantVersion.mockResolvedValue(true);
 
     await expect(
       refreshAndPersistToken({
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(InvalidGrantError);
 
@@ -681,11 +770,17 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: null,
       mcpServerId: SERVER_ID,
+      validateGrant: async () => true,
     });
 
     expect(token).toBe('shared-new');
     expect(mockGetToken).toHaveBeenCalledWith(null, SERVER_ID);
-    expect(mockSaveToken).toHaveBeenCalledWith(null, SERVER_ID, expect.any(Object));
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
+      null,
+      SERVER_ID,
+      expect.any(Object),
+      expect.any(Object)
+    );
   });
 });
 

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -263,6 +263,11 @@ describe('refreshAndPersistToken', () => {
   const originalFetch = globalThis.fetch;
   const USER_ID = 'user-1' as UserID;
   const SERVER_ID = 'srv-1' as MCPServerID;
+  const observedVersion = (grantGeneration = 0, grantBindingFingerprint?: string) => ({
+    grantGeneration,
+    grantBindingFingerprint,
+    refreshGeneration: 0,
+  });
 
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -310,6 +315,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -353,6 +359,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -386,6 +393,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(7, 'binding-7'),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(GrantConfigurationChangedError);
@@ -419,6 +427,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
         onInvalidGrant,
       })
@@ -455,6 +464,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(3, 'old-binding'),
         validateGrant: async () => true,
         onInvalidGrant,
       })
@@ -477,6 +487,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingRefreshTokenError);
@@ -490,6 +501,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingRefreshTokenError);
@@ -514,6 +526,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -539,6 +552,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingTokenEndpointError);
@@ -567,6 +581,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -596,6 +611,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(MissingClientIdError);
@@ -629,12 +645,14 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
     const p2 = refreshAndPersistToken({
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -655,6 +673,96 @@ describe('refreshAndPersistToken', () => {
     expect(t2).toBe('shared-new-a');
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(mockCompleteStandaloneRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a stale caller before it can adopt a replacement SQLite grant', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'replacement-access',
+      oauth_refresh_token: 'replacement-refresh',
+      oauth_client_id: 'cid',
+      grant_generation: 12,
+      grant_binding_fingerprint: 'replacement-binding',
+    });
+    globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
+    const validateGrant = vi.fn(async () => true);
+
+    await expect(
+      refreshAndPersistToken({
+        db: { run: () => undefined } as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(11, 'stale-binding'),
+        validateGrant,
+      })
+    ).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+
+    expect(validateGrant).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(__refreshMutexSizeForTests()).toBe(0);
+  });
+
+  it('does not share a user/server mutex result across grant versions', async () => {
+    const oldGrant = {
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-access',
+      oauth_refresh_token: 'old-refresh',
+      oauth_client_id: 'cid',
+      grant_generation: 21,
+      grant_binding_fingerprint: 'old-binding',
+    };
+    const replacementGrant = {
+      ...oldGrant,
+      oauth_access_token: 'replacement-access',
+      oauth_refresh_token: 'replacement-refresh',
+      grant_generation: 22,
+      grant_binding_fingerprint: 'replacement-binding',
+    };
+    mockGetToken.mockResolvedValue(oldGrant);
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    let resolveFetch!: (response: Response) => void;
+    globalThis.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    ) as typeof globalThis.fetch;
+
+    const oldCaller = refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(21, 'old-binding'),
+      validateGrant: async () => true,
+    });
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    // Reauthorization replaced the row while the old exchange owns the mutex.
+    mockGetToken.mockResolvedValue(replacementGrant);
+    const replacementCaller = refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(22, 'replacement-binding'),
+      validateGrant: async () => true,
+    });
+
+    await expect(replacementCaller).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    resolveFetch(
+      new Response(JSON.stringify({ access_token: 'old-refresh-result', expires_in: 3600 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    await expect(oldCaller).rejects.toBeInstanceOf(GrantConfigurationChangedError);
+    expect(__refreshMutexSizeForTests()).toBe(0);
   });
 
   it('mutex: different keys refresh independently', async () => {
@@ -688,12 +796,14 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       }),
       refreshAndPersistToken({
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID_2,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       }),
     ]);
@@ -719,6 +829,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: USER_ID,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 
@@ -745,6 +856,7 @@ describe('refreshAndPersistToken', () => {
         db: { run: () => undefined } as any,
         userId: USER_ID,
         mcpServerId: SERVER_ID,
+        observedRefreshVersion: observedVersion(),
         validateGrant: async () => true,
       })
     ).rejects.toBeInstanceOf(InvalidGrantError);
@@ -770,6 +882,7 @@ describe('refreshAndPersistToken', () => {
       db: { run: () => undefined } as any,
       userId: null,
       mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
       validateGrant: async () => true,
     });
 

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -166,7 +166,11 @@ export async function refreshMCPToken(
 }
 
 type MutexKey = string;
-const _inFlightRefreshes = new Map<MutexKey, Promise<string>>();
+interface StandaloneRefreshFlight {
+  version: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>;
+  promise: Promise<string>;
+}
+const _inFlightRefreshes = new Map<MutexKey, StandaloneRefreshFlight>();
 export function __resetRefreshMutexForTests(): void {
   _inFlightRefreshes.clear();
 }
@@ -183,11 +187,11 @@ export interface RefreshAndPersistDeps {
   userId: UserID | null;
   mcpServerId: MCPServerID;
   /**
-   * Version read by the caller when it decided a PostgreSQL refresh was
-   * needed. Required at runtime for PostgreSQL so a delayed caller cannot
-   * refresh a peer's newly rotated token.
+   * Exact version read by the caller when it decided a refresh was needed.
+   * Both database implementations fence the exchange and any joined refresh
+   * result to this version so a stale caller cannot adopt a replacement grant.
    */
-  observedRefreshVersion?: MCPOAuthRefreshVersion;
+  observedRefreshVersion: MCPOAuthRefreshVersion;
   /**
    * Re-resolve the authoritative saved server and verify this exact grant's
    * binding inside the supplied database unit. Daemon callers acquire the
@@ -209,6 +213,16 @@ function exactGrantMatches(
   return (
     (token.grant_generation ?? 0) === expected.grantGeneration &&
     (token.grant_binding_fingerprint ?? undefined) === expected.grantBindingFingerprint
+  );
+}
+
+function exactGrantVersionsMatch(
+  left: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>,
+  right: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+): boolean {
+  return (
+    left.grantGeneration === right.grantGeneration &&
+    left.grantBindingFingerprint === right.grantBindingFingerprint
   );
 }
 
@@ -436,15 +450,31 @@ async function assertGrantSubjectForRefresh(
   });
 }
 
-async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
+async function loadObservedStandaloneGrant(
+  deps: RefreshAndPersistDeps,
+  expected: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+): Promise<UserMCPOAuthToken> {
   const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db as Database);
   const row = await userTokenRepo.getToken(deps.userId, deps.mcpServerId);
-  if (!row?.oauth_refresh_token) throw new MissingRefreshTokenError();
-  const exactGrantVersion = {
-    grantGeneration: row.grant_generation ?? 0,
-    grantBindingFingerprint: row.grant_binding_fingerprint,
-  };
+  if (!row) throw new MissingRefreshTokenError();
+  if (!exactGrantMatches(row, expected)) throw new GrantConfigurationChangedError();
   await assertGrantStillAuthorized(deps, row, deps.db);
+  return row;
+}
+
+async function refreshStandalone(
+  deps: RefreshAndPersistDeps,
+  observedVersion: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+): Promise<string> {
+  const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db as Database);
+  const exactGrantVersion = {
+    grantGeneration: observedVersion.grantGeneration,
+    grantBindingFingerprint: observedVersion.grantBindingFingerprint,
+  };
+  // Repeat the caller-bound check inside the mutex owner. The saved row may
+  // have changed after the pre-mutex validation but before this promise ran.
+  const row = await loadObservedStandaloneGrant(deps, exactGrantVersion);
+  if (!row.oauth_refresh_token) throw new MissingRefreshTokenError();
   const server = await new MCPServerRepository(deps.db as Database).findById(deps.mcpServerId);
   const clientId = row.oauth_client_id ?? server?.auth?.oauth_client_id;
   if (!clientId) throw new MissingClientIdError();
@@ -496,15 +526,39 @@ async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
 
 export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promise<string> {
   if (isPostgresDatabaseHandle(deps.db)) return refreshPostgres(deps);
+  const expected = deps.observedRefreshVersion;
+  if (!expected) {
+    throw new Error('Standalone MCP OAuth refresh requires an observed grant version');
+  }
+
+  // Validate the caller's exact observation before it may create or join a
+  // user/server mutex. A caller authorized against an old row must not learn,
+  // refresh, or invalidate the replacement row occupying the same subject.
+  await loadObservedStandaloneGrant(deps, expected);
   const key = mutexKey(deps.userId, deps.mcpServerId);
   const existing = _inFlightRefreshes.get(key);
-  if (existing) return existing;
-  const refresh = refreshStandalone(deps);
-  _inFlightRefreshes.set(key, refresh);
+  if (existing) {
+    if (!exactGrantVersionsMatch(existing.version, expected)) {
+      throw new GrantConfigurationChangedError();
+    }
+    const result = await existing.promise;
+    // A Settings mutation or replacement may have landed while this caller
+    // was awaiting another request's exchange. Fence the shared result too.
+    await loadObservedStandaloneGrant(deps, expected);
+    return result;
+  }
+  const flight: StandaloneRefreshFlight = {
+    version: {
+      grantGeneration: expected.grantGeneration,
+      grantBindingFingerprint: expected.grantBindingFingerprint,
+    },
+    promise: refreshStandalone(deps, expected),
+  };
+  _inFlightRefreshes.set(key, flight);
   try {
-    return await refresh;
+    return await flight.promise;
   } finally {
-    _inFlightRefreshes.delete(key);
+    if (_inFlightRefreshes.get(key) === flight) _inFlightRefreshes.delete(key);
   }
 }
 

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -66,6 +66,14 @@ export class FailedRefreshError extends Error {
   }
 }
 
+export class GrantConfigurationChangedError extends Error {
+  readonly code = 'grant_configuration_changed';
+  constructor(message = 'MCP OAuth grant or server configuration changed during refresh') {
+    super(message);
+    this.name = 'GrantConfigurationChangedError';
+  }
+}
+
 export class OAuthRefreshExchangeError extends Error {
   constructor(
     readonly category: 'provider_rejected' | 'transport_ambiguous' | 'response_ambiguous',
@@ -180,9 +188,49 @@ export interface RefreshAndPersistDeps {
    * refresh a peer's newly rotated token.
    */
   observedRefreshVersion?: MCPOAuthRefreshVersion;
+  /**
+   * Re-resolve the authoritative saved server and verify this exact grant's
+   * binding inside the supplied database unit. Daemon callers acquire the
+   * server-configuration lock here on PostgreSQL before refresh completion.
+   */
+  validateGrant: (
+    grant: UserMCPOAuthToken,
+    db: Database | TenantScopeAwareDatabase
+  ) => boolean | Promise<boolean>;
   onInvalidGrant?: (info: { userId: UserID | null; mcpServerId: MCPServerID }) => void;
   /** Internal test/development seam; daemon PostgreSQL callers leave this false. */
   allowLocalhostHttpDevelopment?: boolean;
+}
+
+function exactGrantMatches(
+  token: UserMCPOAuthToken,
+  expected: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+): boolean {
+  return (
+    (token.grant_generation ?? 0) === expected.grantGeneration &&
+    (token.grant_binding_fingerprint ?? undefined) === expected.grantBindingFingerprint
+  );
+}
+
+async function assertGrantStillAuthorized(
+  deps: RefreshAndPersistDeps,
+  grant: UserMCPOAuthToken,
+  db: Database | TenantScopeAwareDatabase
+): Promise<void> {
+  if (!(await deps.validateGrant(grant, db))) throw new GrantConfigurationChangedError();
+}
+
+async function loadExactAuthorizedGrant(
+  deps: RefreshAndPersistDeps,
+  expected: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+): Promise<UserMCPOAuthToken> {
+  return tenantWork(deps, async (db) => {
+    const token = await new UserMCPOAuthTokenRepository(db).getToken(deps.userId, deps.mcpServerId);
+    if (!token) throw new InvalidGrantError();
+    if (!exactGrantMatches(token, expected)) throw new GrantConfigurationChangedError();
+    await assertGrantStillAuthorized(deps, token, db);
+    return token;
+  });
 }
 
 function resolveTenantId(deps: RefreshAndPersistDeps): string {
@@ -218,14 +266,11 @@ async function observeCommittedRefresh(
       new UserMCPOAuthTokenRepository(db).getToken(deps.userId, deps.mcpServerId)
     );
     if (!token) throw new InvalidGrantError();
+    if (!exactGrantMatches(token, expected)) throw new GrantConfigurationChangedError();
     if (token.refresh_status === 'ambiguous') throw new AmbiguousRefreshError();
     if (token.refresh_status === 'idle') {
-      // A newer authorization replaced the old grant atomically and is valid
-      // independently of the old refresh attempt.
-      if (token.grant_generation !== expected.grantGeneration) {
-        return token.oauth_access_token;
-      }
       if (token.refresh_success_generation >= expected.refreshGeneration) {
+        await tenantWork(deps, (db) => assertGrantStillAuthorized(deps, token, db));
         return token.oauth_access_token;
       }
       // `idle` alone is not success: a known provider rejection releases the
@@ -239,13 +284,16 @@ async function observeCommittedRefresh(
 
 async function settleObservedRefresh(
   deps: RefreshAndPersistDeps,
-  token: UserMCPOAuthToken | null
+  token: UserMCPOAuthToken | null,
+  expected: MCPOAuthRefreshVersion
 ): Promise<string> {
   if (!token) throw new InvalidGrantError();
+  if (!exactGrantMatches(token, expected)) throw new GrantConfigurationChangedError();
   if (token.refresh_status === 'ambiguous') throw new AmbiguousRefreshError();
   if (token.refresh_status === 'refreshing') {
     return observeCommittedRefresh(deps, {
       grantGeneration: token.grant_generation,
+      grantBindingFingerprint: token.grant_binding_fingerprint,
       refreshGeneration: token.refresh_generation,
     });
   }
@@ -255,6 +303,7 @@ async function settleObservedRefresh(
   }
   // A stale caller lost its expected-version CAS to a successfully refreshed
   // row or to a newer atomic grant replacement. It must observe, not exchange.
+  await tenantWork(deps, (db) => assertGrantStillAuthorized(deps, token, db));
   return token.oauth_access_token;
 }
 
@@ -263,11 +312,16 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
   if (!expected) {
     throw new Error('PostgreSQL MCP OAuth refresh requires an observed grant version');
   }
+  if (!expected.grantBindingFingerprint) {
+    throw new GrantConfigurationChangedError(
+      'PostgreSQL MCP OAuth refresh requires the observed grant fingerprint'
+    );
+  }
   const claim = await tenantWork(deps, (db) =>
     new UserMCPOAuthTokenRepository(db).claimRefresh(deps.userId, deps.mcpServerId, expected)
   );
   if (claim.outcome === 'observed') {
-    return settleObservedRefresh(deps, claim.token);
+    return settleObservedRefresh(deps, claim.token, expected);
   }
 
   const row = claim.token;
@@ -275,6 +329,7 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
     claimId: claim.claimId,
     refreshGeneration: claim.refreshGeneration,
     grantGeneration: claim.grantGeneration,
+    grantBindingFingerprint: row.grant_binding_fingerprint,
   };
   const releaseUnstartedClaim = async (error: Error): Promise<never> => {
     await tenantWork(deps, (db) =>
@@ -295,6 +350,13 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
     return releaseUnstartedClaim(new MissingTokenEndpointError());
   }
   try {
+    await tenantWork(deps, (db) => assertGrantStillAuthorized(deps, row, db));
+  } catch (error) {
+    return releaseUnstartedClaim(
+      error instanceof Error ? error : new GrantConfigurationChangedError()
+    );
+  }
+  try {
     const result = await refreshMCPToken({
       tokenEndpoint: row.oauth_token_endpoint,
       refreshToken: row.oauth_refresh_token,
@@ -310,6 +372,7 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       // transaction the write commits in. See `assertMcpGrantSubjectEntitled`
       // for the residual window this still leaves open.
       await assertGrantSubjectForRefresh(deps, db);
+      await assertGrantStillAuthorized(deps, row, db);
       return new UserMCPOAuthTokenRepository(db).completeClaimedRefresh(
         deps.userId,
         deps.mcpServerId,
@@ -323,7 +386,7 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
     });
     if (!committed) return observeCommittedRefresh(deps, fence);
     console.log('[MCP OAuth Refresh] refresh_succeeded category=committed');
-    return result.access_token;
+    return (await loadExactAuthorizedGrant(deps, fence)).oauth_access_token;
   } catch (error) {
     if (error instanceof InvalidGrantError) {
       const deleted = await tenantWork(deps, (db) =>
@@ -377,6 +440,11 @@ async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
   const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db as Database);
   const row = await userTokenRepo.getToken(deps.userId, deps.mcpServerId);
   if (!row?.oauth_refresh_token) throw new MissingRefreshTokenError();
+  const exactGrantVersion = {
+    grantGeneration: row.grant_generation ?? 0,
+    grantBindingFingerprint: row.grant_binding_fingerprint,
+  };
+  await assertGrantStillAuthorized(deps, row, deps.db);
   const server = await new MCPServerRepository(deps.db as Database).findById(deps.mcpServerId);
   const clientId = row.oauth_client_id ?? server?.auth?.oauth_client_id;
   if (!clientId) throw new MissingClientIdError();
@@ -394,16 +462,33 @@ async function refreshStandalone(deps: RefreshAndPersistDeps): Promise<string> {
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
     await assertGrantSubjectForRefresh(deps, deps.db);
-    await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
-      accessToken: result.access_token,
-      refreshToken: result.refresh_token,
-      expiresAt: expiry.expiresAt,
-    });
+    await assertGrantStillAuthorized(deps, row, deps.db);
+    const committed = await userTokenRepo.completeStandaloneRefresh(
+      deps.userId,
+      deps.mcpServerId,
+      exactGrantVersion,
+      {
+        accessToken: result.access_token,
+        refreshToken: result.refresh_token,
+        expiresAt: expiry.expiresAt,
+      }
+    );
+    if (!committed) throw new GrantConfigurationChangedError();
+    const current = await userTokenRepo.getToken(deps.userId, deps.mcpServerId);
+    if (!current) throw new InvalidGrantError();
+    if (!exactGrantMatches(current, exactGrantVersion)) throw new GrantConfigurationChangedError();
+    await assertGrantStillAuthorized(deps, current, deps.db);
     return result.access_token;
   } catch (error) {
     if (error instanceof InvalidGrantError) {
-      await userTokenRepo.deleteToken(deps.userId, deps.mcpServerId);
-      notifyInvalidGrant(deps);
+      const deleted = await userTokenRepo.deleteGrantVersion(
+        deps.userId,
+        deps.mcpServerId,
+        exactGrantVersion.grantGeneration,
+        exactGrantVersion.grantBindingFingerprint
+      );
+      if (deleted) notifyInvalidGrant(deps);
+      else throw new GrantConfigurationChangedError();
     }
     throw error;
   }

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -181,9 +181,11 @@ export interface MCPCatalogEntry {
  * metadata (RFC 9728), that names its authorization server, that publishes its
  * endpoints and registration endpoint (RFC 8414), and Dynamic Client
  * Registration (RFC 7591) mints the client. Connect declares none of that, and
- * every entry in `curated.yaml` today states nothing here, because a fact
- * fetched from the vendor at the moment of use cannot go stale and an authored
- * one silently can — and nothing sweeps this file for rot.
+ * entries should normally state nothing here, because a fact fetched from the
+ * vendor at the moment of use cannot go stale and an authored one silently can
+ * — and nothing sweeps this file for rot. A reviewed explicit `strict` opt-in
+ * is useful when the production discovery boundary proves a provider supports
+ * the complete strict contract.
  *
  * So this is an escape hatch for the servers that fall short of that, not a
  * place to restate what discovery already returns. Each field is here because
@@ -200,8 +202,10 @@ export interface MCPCatalogEntry {
  *   in the browser's address bar during the flow.
  * - `dcr_mode` decides whether registration may fall back to an unadvertised
  *   `/register`, for a server that runs DCR without publishing the endpoint.
- * - `compatibility_mode` decides whether authorization-server metadata may be
- *   fetched straight from the MCP origin, for a server that predates RFC 9728.
+ * - `compatibility_mode` is an explicit `strict` or `legacy` opt-in. Omission
+ *   uses the daemon's marketplace-only interoperability profile: standard and
+ *   OIDC discovery fallbacks with same-origin resource binding, issuer
+ *   validation, and PKCE S256 retained.
  *
  * What is deliberately absent is as load-bearing as what is here:
  *
@@ -228,7 +232,7 @@ export interface MCPCatalogEntryOAuth {
   client_id?: string;
   /** Dynamic Client Registration policy; defaults to `advertised`. */
   dcr_mode?: MCPOAuthDCRMode;
-  /** Authorization-metadata discovery strictness; defaults to `strict`. */
+  /** Explicit authorization-metadata policy; omission uses marketplace interoperability. */
   compatibility_mode?: MCPOAuthCompatibilityMode;
 }
 

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -71,6 +71,26 @@ export const MCP_OAUTH_COMPATIBILITY_MODES = ['strict', 'legacy'] as const;
 
 export type MCPOAuthCompatibilityMode = (typeof MCP_OAUTH_COMPATIBILITY_MODES)[number];
 
+/** Runtime guard for every public/persisted OAuth compatibility input. */
+export function isMCPOAuthCompatibilityMode(value: unknown): value is MCPOAuthCompatibilityMode {
+  return (
+    typeof value === 'string' &&
+    MCP_OAUTH_COMPATIBILITY_MODES.includes(value as MCPOAuthCompatibilityMode)
+  );
+}
+
+/**
+ * Reject internal or unknown compatibility policies at public/storage
+ * boundaries. `marketplace` is deliberately absent: it is a runtime decision,
+ * never data a caller or archive may provide.
+ */
+export function assertPublicMCPOAuthCompatibilityMode(auth: unknown): void {
+  if (!auth || typeof auth !== 'object' || Array.isArray(auth)) return;
+  const value = (auth as Record<string, unknown>).oauth_compatibility_mode;
+  if (value === undefined || isMCPOAuthCompatibilityMode(value)) return;
+  throw new Error('oauth_compatibility_mode must be either strict or legacy');
+}
+
 /**
  * Effective OAuth discovery policy while a flow is running.
  *
@@ -102,7 +122,7 @@ export interface MCPOAuthStartFailure {
   redirect_uri?: string;
 }
 
-export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2] as const;
+export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2, 3] as const;
 export type MCPOAuthGrantBindingVersion = (typeof MCP_OAUTH_GRANT_BINDING_VERSIONS)[number];
 
 export function isMCPOAuthGrantBindingVersion(
@@ -228,7 +248,10 @@ export type MCPScope = (typeof MCP_SCOPES)[number];
  * - `catalog`: installed from the marketplace; `catalog_entry_name` records
  *   which entry, the way `import_path` records which file
  *
- * This is provenance, not authorization — nothing reads it to decide access.
+ * This is not an access-control decision. Catalog provenance is one required
+ * input to the daemon's current-entry OAuth policy, but never grants access or
+ * relaxation by itself: the protected stamp and complete current catalog
+ * endpoint/transport/auth prescription must also match.
  */
 export type MCPSource = 'user' | 'imported' | 'agor' | 'catalog';
 

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -122,7 +122,7 @@ export interface MCPOAuthStartFailure {
   redirect_uri?: string;
 }
 
-export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2, 3] as const;
+export const MCP_OAUTH_GRANT_BINDING_VERSIONS = [1, 2, 3, 4] as const;
 export type MCPOAuthGrantBindingVersion = (typeof MCP_OAUTH_GRANT_BINDING_VERSIONS)[number];
 
 export function isMCPOAuthGrantBindingVersion(
@@ -380,6 +380,17 @@ export interface MCPServer {
 
   // Authentication (for HTTP/SSE transports)
   auth?: MCPAuth;
+
+  /**
+   * Read-only effective policy resolved by the daemon for Settings and other
+   * operator surfaces. This is never accepted as persisted MCP server input:
+   * `marketplace` remains an internal runtime policy derived only from the
+   * current curated catalog entry.
+   */
+  oauth_compatibility_policy?: {
+    effective_mode: MCPOAuthRuntimeCompatibilityMode;
+    managed_by_catalog: boolean;
+  };
 
   // Scope
   scope: MCPScope;

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -72,6 +72,18 @@ export const MCP_OAUTH_COMPATIBILITY_MODES = ['strict', 'legacy'] as const;
 export type MCPOAuthCompatibilityMode = (typeof MCP_OAUTH_COMPATIBILITY_MODES)[number];
 
 /**
+ * Effective OAuth discovery policy while a flow is running.
+ *
+ * `marketplace` is deliberately not an {@link MCPOAuthCompatibilityMode} and
+ * therefore cannot be submitted in an MCP server payload. The daemon derives
+ * it only for reviewed catalog installs whose row did not explicitly opt into
+ * `strict` or `legacy`. This keeps the default for every user/admin configured
+ * server strict while giving the marketplace a bounded interoperability
+ * profile that still enforces issuer/resource binding and PKCE S256.
+ */
+export type MCPOAuthRuntimeCompatibilityMode = MCPOAuthCompatibilityMode | 'marketplace';
+
+/**
  * Safe diagnostics for a failed OAuth Dynamic Client Registration attempt.
  *
  * This closed shape classifies recovery without carrying provider response
@@ -128,7 +140,9 @@ export interface MCPOAuthPendingFlowSealedMaterial {
   pkceVerifier: string;
   clientId: string;
   clientSecret?: string;
-  compatibilityMode: 'strict' | 'legacy';
+  compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
+  /** Whether RFC 9207 says this AS will return `iss` on the callback. */
+  authorizationResponseIssuerParameterSupported?: boolean;
   allowLocalhostHttp: boolean;
 }
 


### PR DESCRIPTION
## Linked issue

Refs #2377

## Summary

- Add a bounded marketplace OAuth interoperability mode for current canonical catalog installs while keeping ordinary MCP OAuth strict by default.
- Preserve PKCE S256 and issuer/resource mix-up defenses, but tolerate reviewed provider variations around resource metadata paths, RFC 9207 issuer advertisement, and authorization-server discovery.
- Bind pending flows, callbacks, grants, refreshes, and status surfaces to the authoritative saved server configuration and compatibility policy in both SQLite and PostgreSQL.
- Remove eight OAuth entries whose audited metadata could not reach a safely bound registration boundary, and show catalog-managed Marketplace policy accurately in Settings.

## Why / context

The merged marketplace work advertised Connect for curated OAuth servers, but 39 of 42 audited OAuth entries failed before dynamic client registration because they inherited strict discovery requirements. Row-shape CI did not exercise the real OAuth start boundary.

This follow-up keeps strict behavior available and unchanged for non-marketplace servers while making compatibility a current-catalog-derived policy rather than a public caller-controlled value.

## Implementation notes

- Public create, patch, import, and transient payloads accept only the closed 'strict | legacy' compatibility enum; internal 'marketplace' is derived after validation.
- Catalog relaxation requires the durable row to match the current curated endpoint, transport, and auth policy. Removed, imported, or edited rows fail closed.
- Security-relevant configuration is fingerprinted into pending flows and grants. Callback and refresh completion revalidate binding and generation.
- SQLite grant persistence uses generation-fenced atomic upserts so concurrent first authorization, reauthorization, refresh, deletion, and invalid-grant races cannot overwrite newer grants.
- Custom HTTP header names reject case-insensitive duplicates, and normalization and fingerprints share the same canonical representation.
- Existing strict grants remain valid. Effective policy changes intentionally require reauthorization.
- GitHub, MongoDB, Box, HubSpot, Slack, Prisma, PagerDuty, and Kagi are no longer advertised; existing saved rows are not deleted.

## Validation / test plan

- [x] pnpm i
- [x] pnpm check
- [x] Focused core OAuth/repository suites
- [x] Focused daemon OAuth, SQLite race, MCP hook, status, and gateway suites
- [x] Focused Settings UI suites
- [x] Read-only discovery audit through OAuth start, excluding provider-side DCR state

## Screenshots / demos

Settings behavior is covered by component tests; no screenshot is included because the change is a managed policy label/disabled-state correction rather than a new interaction.

## Risks / rollout / rollback

- Catalog installs whose effective policy changes must reauthorize; this is required to prevent grants from crossing security-policy fingerprints.
- Provider metadata can change independently. Compatibility is intentionally bounded to canonical curated installs and emits the effective mode/reason for observability.
- Rollback restores strict discovery behavior and would make the affected marketplace Connect flows fail again.
