### PR TITLE
Exp 2: landing page copy for problem/solution messaging test

### DIFF
--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -11,6 +11,9 @@ import styles from './LandingPage.module.css';
  */
 export type HeroVariantKey =
   | 'technical-collaboration'
+  // Exp 2 framing variant — problem-sell counterpart to
+  // technical-collaboration (solution-sell), for the messaging A/B test.
+  | 'technical-collaboration-problem'
   | 'governance'
   | 'business-builders'
   | 'outcomes'
@@ -21,6 +24,9 @@ export type HeroVariantKey =
   | 'selfware'
   | 'dev-team'
   | 'cost-control'
+  // Exp 2 framing variant — solution-sell counterpart to cost-control
+  // (problem-sell), for the messaging A/B test.
+  | 'cost-control-solution'
   // Shelved (not a hit in review) — copy kept here rather than deleted so
   // it can be reinstated cheaply if wanted later. Has no routed page; add
   // back a content/agentify-everyone.mdx stub (see git history for the
@@ -43,7 +49,14 @@ export interface HeroVariant {
 export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
   'technical-collaboration': {
     headline: 'Raise a team\nof [AI teammates]',
-    subheadline: '{Build} together, {learn} together. No lonely {terminals}.',
+    subheadline: '{Build} together on one [multiplayer canvas]. No lonely {terminals}.',
+    ctaLabel: 'Start building together',
+  },
+  // Exp 2 framing variant — problem-sell counterpart to
+  // technical-collaboration (solution-sell) above.
+  'technical-collaboration-problem': {
+    headline: 'Your AI coding agents\nare working [alone]',
+    subheadline: 'Siloed {terminals}, no shared {context}, no team {oversight}.',
     ctaLabel: 'Start building together',
   },
   governance: {
@@ -77,8 +90,15 @@ export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
     ctaLabel: 'Enable your dev team',
   },
   'cost-control': {
-    headline: 'Keep your [AI costs] under control',
-    subheadline: '{Governance}, {observability}, and {model agnosticism}.',
+    headline: 'Locked into [one AI vendor]\nas costs climb?',
+    subheadline: 'No way to {switch models} or keep agent {spend} in view.',
+    ctaLabel: 'Control your AI costs',
+  },
+  // Exp 2 framing variant — solution-sell counterpart to cost-control
+  // (problem-sell) above.
+  'cost-control-solution': {
+    headline: 'AI costs under control.\nNo [frontier lock-in].',
+    subheadline: 'Run {Claude}, {Codex}, {Gemini} & {Copilot}. Switch models anytime.',
     ctaLabel: 'Control your AI costs',
   },
   // Shelved — see HeroVariantKey comment above. Not routed to a live page.

--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -108,8 +108,8 @@ export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
     ctaLabel: 'Enable your dev team',
   },
   'cost-control': {
-    headline: 'Locked into [one AI vendor]\nas costs climb?',
-    subheadline: 'No way to {switch models} or keep agent {spend} in view.',
+    headline: 'Locked into one vendor.\n[Locked into their price.]',
+    subheadline: 'Run [any model] across multiple agents, while keeping {spend} in check.',
     ctaLabel: 'Control your AI costs',
   },
   // Exp 2 framing variant — solution-sell counterpart to cost-control

--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -67,7 +67,7 @@ export interface HeroVariant {
 export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
   'technical-collaboration': {
     headline: 'Raise a team\nof [AI teammates]',
-    subheadline: '{Build} together on one [multiplayer canvas]. No lonely {terminals}.',
+    subheadline: '{Build} together on a shared [multiplayer canvas]. No lonely {terminals}.',
     ctaLabel: 'Start building together',
   },
   // Exp 2 framing variant — problem-sell counterpart to

--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -67,7 +67,7 @@ export interface HeroVariant {
 export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
   'technical-collaboration': {
     headline: 'Raise a team\nof [AI teammates]',
-    subheadline: '{Build} together on a shared [multiplayer canvas]. No lonely {terminals}.',
+    subheadline: '{Build} together on a [multiplayer canvas]. No lonely {terminals}.',
     ctaLabel: 'Start building together',
   },
   // Exp 2 framing variant — problem-sell counterpart to

--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -74,7 +74,7 @@ export const HERO_VARIANTS: Record<HeroVariantKey, HeroVariant> = {
   // technical-collaboration (solution-sell) above.
   'technical-collaboration-problem': {
     headline: 'Your AI coding agents\nare working [alone]',
-    subheadline: 'Siloed {terminals}, no shared {context}, no team {oversight}.',
+    subheadline: 'Bring every session onto one [board] your whole team can see.',
     ctaLabel: 'Start building together',
   },
   governance: {

--- a/apps/agor-docs/components/heroVariants.tsx
+++ b/apps/agor-docs/components/heroVariants.tsx
@@ -8,6 +8,24 @@ import styles from './LandingPage.module.css';
  * (infra-forward vs. relatable/outcome language) intentionally varies by
  * audience per the messaging thread; everything below the hero is shared
  * and unchanged so the test isolates the hero thesis, not the page.
+ *
+ * Exp 2 (Aug 2026) — problem-sell vs. solution-sell framing test. Each of
+ * the two Phase-1 conversion winners gained a counterpart page, so the
+ * theme is held constant while only the framing varies. Pairing:
+ * /not-alone <-> /not-alone-problem hold the collaboration theme;
+ * /costs-under-control <-> /costs-under-control-solution hold the
+ * cost / no-lock-in theme. Page column below is the /<slug> route.
+ *
+ * | Page | Variant key | Framing | Changed |
+ * | --- | --- | --- | --- |
+ * | not-alone | technical-collaboration | solution | sub-only¹ |
+ * | not-alone-problem | technical-collaboration-problem | problem | new |
+ * | costs-under-control | cost-control | problem | reframed² |
+ * | costs-under-control-solution | cost-control-solution | solution | new |
+ *
+ * ¹ headline unchanged (proven high-converting); only subheadline changed.
+ * ² reframed to vendor lock-in + spend; dropped the old "governance,
+ *   observability, model agnosticism" line.
  */
 export type HeroVariantKey =
   | 'technical-collaboration'

--- a/apps/agor-docs/content/_meta.ts
+++ b/apps/agor-docs/content/_meta.ts
@@ -19,6 +19,7 @@ export default {
     },
   },
   'not-alone': heroVariantMeta,
+  'not-alone-problem': heroVariantMeta,
   'beyond-the-sandbox': heroVariantMeta,
   'not-just-a-tool': heroVariantMeta,
   'right-where-you-work': heroVariantMeta,
@@ -26,6 +27,7 @@ export default {
   'selfware-is-dead': heroVariantMeta,
   'dev-team': heroVariantMeta,
   'costs-under-control': heroVariantMeta,
+  'costs-under-control-solution': heroVariantMeta,
   // Agor Cloud marketing landing page. Reached via the navbar "Agor Cloud"
   // link (see NavbarCloudCTA); hidden from the sidebar and rendered full-bleed
   // like the homepage via `theme.layout: 'full'`. The request-invite form

--- a/apps/agor-docs/content/costs-under-control-solution.mdx
+++ b/apps/agor-docs/content/costs-under-control-solution.mdx
@@ -1,0 +1,9 @@
+---
+title: AI costs under control. No frontier lock-in.
+description: Run Claude, Codex, Gemini, and Copilot from one command center. Switch models anytime and keep coding-agent spend in view.
+noindex: true
+---
+
+import { LandingPage } from '../components';
+
+<LandingPage heroVariant="cost-control-solution" />

--- a/apps/agor-docs/content/costs-under-control.mdx
+++ b/apps/agor-docs/content/costs-under-control.mdx
@@ -1,6 +1,6 @@
 ---
-title: Keep your AI costs under control. Governance, observability, and model agnosticism.
-description: Governance, observability, and model agnosticism.
+title: Locked into one AI vendor as costs climb?
+description: Single-vendor lock-in means climbing coding-agent costs with no way to switch models or keep spend in view.
 noindex: true
 ---
 

--- a/apps/agor-docs/content/costs-under-control.mdx
+++ b/apps/agor-docs/content/costs-under-control.mdx
@@ -1,6 +1,6 @@
 ---
-title: Locked into one AI vendor as costs climb?
-description: Single-vendor lock-in means climbing coding-agent costs with no way to switch models or keep spend in view.
+title: Locked into one vendor. Locked into their price.
+description: Single-vendor lock-in means climbing AI costs. Run any model across multiple agents while keeping spend in check.
 noindex: true
 ---
 

--- a/apps/agor-docs/content/not-alone-problem.mdx
+++ b/apps/agor-docs/content/not-alone-problem.mdx
@@ -1,6 +1,6 @@
 ---
 title: Your AI coding agents are working alone.
-description: Coding agents running solo in siloed terminals leave your team with no shared context and no oversight. Bring every agent onto one board.
+description: Coding agents running solo in siloed terminals leave your team with no shared context. Bring every session onto one board your whole team can see.
 noindex: true
 ---
 

--- a/apps/agor-docs/content/not-alone-problem.mdx
+++ b/apps/agor-docs/content/not-alone-problem.mdx
@@ -1,0 +1,9 @@
+---
+title: Your AI coding agents are working alone.
+description: Coding agents running solo in siloed terminals leave your team with no shared context and no oversight. Bring every agent onto one board.
+noindex: true
+---
+
+import { LandingPage } from '../components';
+
+<LandingPage heroVariant="technical-collaboration-problem" />

--- a/apps/agor-docs/content/not-alone.mdx
+++ b/apps/agor-docs/content/not-alone.mdx
@@ -1,6 +1,6 @@
 ---
-title: Raise a team of AI teammates. Build together on one multiplayer canvas. No lonely terminals.
-description: One shared board for every Claude Code, Codex, and Gemini session, so your team builds together on one multiplayer canvas instead of coding solo.
+title: Raise a team of AI teammates. Build together on a shared multiplayer canvas. No lonely terminals.
+description: A single board for every Claude Code, Codex, and Gemini session, so your team builds together on a shared multiplayer canvas instead of coding solo.
 noindex: true
 ---
 

--- a/apps/agor-docs/content/not-alone.mdx
+++ b/apps/agor-docs/content/not-alone.mdx
@@ -1,6 +1,6 @@
 ---
-title: Raise a team of AI teammates. Build together, learn together. No lonely terminals.
-description: One shared board for every Claude Code, Codex, and Gemini session, so your team builds and learns together instead of coding solo.
+title: Raise a team of AI teammates. Build together on one multiplayer canvas. No lonely terminals.
+description: One shared board for every Claude Code, Codex, and Gemini session, so your team builds together on one multiplayer canvas instead of coding solo.
 noindex: true
 ---
 

--- a/apps/agor-docs/content/not-alone.mdx
+++ b/apps/agor-docs/content/not-alone.mdx
@@ -1,6 +1,6 @@
 ---
-title: Raise a team of AI teammates. Build together on a shared multiplayer canvas. No lonely terminals.
-description: A single board for every Claude Code, Codex, and Gemini session, so your team builds together on a shared multiplayer canvas instead of coding solo.
+title: Raise a team of AI teammates. Build together on a multiplayer canvas. No lonely terminals.
+description: One shared board for every Claude Code, Codex, and Gemini session, so your team builds together on a multiplayer canvas instead of coding solo.
 noindex: true
 ---
 

--- a/apps/agor-docs/next-sitemap.config.cjs
+++ b/apps/agor-docs/next-sitemap.config.cjs
@@ -22,6 +22,7 @@ module.exports = {
     '/_document',
     '/guide/assistants',
     '/not-alone',
+    '/not-alone-problem',
     '/beyond-the-sandbox',
     '/not-just-a-tool',
     '/right-where-you-work',
@@ -29,6 +30,7 @@ module.exports = {
     '/selfware-is-dead',
     '/dev-team',
     '/costs-under-control',
+    '/costs-under-control-solution',
   ],
 
   // Include static LLM-related files


### PR DESCRIPTION
## What

Copy-only hero changes for **Phase 2** of the Google Ads messaging experiment. Phase 1 identified two winning themes — **Not Alone** (collaboration) and **Costs Under Control**. Phase 2 tests a **2×2**: each theme × two framings (**problem-sell** vs **solution-sell**), giving four landing pages.

| URL | Cell | Variant key | Framing |
| --- | --- | --- | --- |
| `/not-alone` | Not Alone | `technical-collaboration` | Solution |
| `/not-alone-problem` | Not Alone | `technical-collaboration-problem` | Problem |
| `/costs-under-control` | Costs Under Control | `cost-control` | Problem |
| `/costs-under-control-solution` | Costs Under Control | `cost-control-solution` | Solution |

Two pages already existed (re-pointed to one framing each); two are new.

## Scope

- **Hero copy is the only change.** Everything below the hero is shared and untouched — no layout, component, or style changes.
- **All four pages remain `noindex: true`** and stay excluded from the sitemap.
- **`/not-alone`'s headline was deliberately left unchanged** — it is proven, high-converting copy. Only its subheadline was updated.
- The `cost-control` (problem) variant deliberately **drops** the old "Governance, observability, and model agnosticism" line — the weakest-converting asset in the ad account.

## Changes

- `components/heroVariants.tsx` — updated `technical-collaboration` (subheadline) and `cost-control` (problem-framed headline/subheadline); added `technical-collaboration-problem` and `cost-control-solution` to the `HeroVariantKey` union and `HERO_VARIANTS`.
- `content/not-alone.mdx`, `content/costs-under-control.mdx` — frontmatter title/description updated to match new hero copy.
- `content/not-alone-problem.mdx`, `content/costs-under-control-solution.mdx` — new stub pages.
- `content/_meta.ts`, `next-sitemap.config.cjs` — registered the two new routes (hidden nav + sitemap exclusion).

## Verification

- `pnpm typecheck` (agor-docs) — passes; new `HeroVariantKey` entries typecheck against `Record<HeroVariantKey, HeroVariant>`.
- `next build` — passes (66 pages); all four routes export and render their intended hero copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)