### PR TITLE
fix(ui): keep board switcher edit pencil from overlapping the board name

### DIFF
--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -136,6 +136,14 @@ describe('BoardSwitcher current-board edit shortcut', () => {
     expect(edit.closest('span[style*="position: absolute"]')).toHaveStyle({ right: '28px' });
   });
 
+  it('reserves room in the name row so a long name never underlaps the edit action', async () => {
+    renderSwitcher();
+    const edit = await screen.findByRole('button', { name: /Edit current board:/ });
+    const trigger = edit.closest('div')?.querySelector('button.ant-dropdown-trigger');
+    // controlHeightSM (24) + paddingSM (12) with the default antd seed token.
+    expect(trigger?.querySelector('.ant-flex')).toHaveStyle({ marginRight: '36px' });
+  });
+
   it('keeps the action keyboard reachable and reveals it on focus-within', async () => {
     renderSwitcher();
     const edit = await screen.findByRole('button', { name: /Edit current board:/ });

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -227,6 +227,13 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
     </Tooltip>
   );
 
+  // The edit button is overlaid absolutely (it can't be a DOM child of the
+  // trigger <button>), so it reserves no layout width. Reserve matching room at
+  // the end of the name row so the ellipsized board name truncates *before* the
+  // pencil instead of rendering underneath it. Only reserve when the action can
+  // actually appear, so boards without an edit shortcut keep the full width.
+  const editActionReserve = editButton ? token.controlHeightSM + token.paddingSM : 0;
+
   return (
     <>
       <div
@@ -321,7 +328,11 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
               alignItems: 'center',
             }}
           >
-            <Flex align="center" gap={8} style={{ flex: 1, minWidth: 0 }}>
+            <Flex
+              align="center"
+              gap={8}
+              style={{ flex: 1, minWidth: 0, marginRight: editActionReserve }}
+            >
               {currentBoard ? (
                 <BoardTile emoji={getBoardEmoji(currentBoard, branchById)} size={24} />
               ) : (


### PR DESCRIPTION
## Problem

Reported via Slack #agor: on the board switcher / select menu, the pencil/edit icon sometimes **overlaps the board name**.

## Root cause

`apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx`

The trigger renders the current board name in a flex `Space` with `ellipsis`, plus the dropdown caret at the far right. The edit/pencil action is a **separate `<button>`** that cannot be a DOM child of the trigger `<button>`, so it is rendered as an **absolutely-positioned overlay** at `right: 28px` (`token.paddingLG + token.sizeUnit`).

Because the overlay reserves **no layout width**, the ellipsized name truncated only at the caret — so for long names its last characters rendered *underneath* the pencil. This was visible on hover (desktop, where the pencil fades in) and permanently on coarse/touch pointers (where the pencil is always shown).

## Fix

Reserve matching room at the end of the name row so the name's ellipsis stops **before** the pencil zone:

```ts
const editActionReserve = editButton ? token.controlHeightSM + token.paddingSM : 0;
// applied as marginRight on the name <Space>
```

- Only reserves when the edit action can actually appear (`editButton` truthy), so boards without an edit shortcut keep the full width.
- The **trigger width, caret position, and overlay position are unchanged** — this preserves the existing *"overlay the action without reserving trigger width"* design contract (the pencil still sits at `28px`, trigger padding stays `8px 12px`).
- Robust for any name length and any state (hover / touch / focus-within), because the reservation is unconditional whenever the pencil could show.

### Before / After

- **Before:** long current-board name → last characters render under the pencil icon.
- **After:** name truncates with `…` before the pencil, leaving a clean gap; pencil and name never overlap.

## Tests

- Added a test asserting the name row reserves `36px` (`controlHeightSM 24 + paddingSM 12`, default antd seed) when the edit action is present.
- All 7 `BoardSwitcher` tests pass, including the preserved `overlays the edit action without reserving trigger width` contract test.
- `biome check` and `tsc` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)