### PR TITLE
feat(auth): support external user authority

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -37,6 +37,20 @@ function baseConfig(): AgorConfig {
   };
 }
 
+function externalAuthorityConfig(): AgorConfig {
+  return {
+    ...baseConfig(),
+    identity: {
+      user_lifecycle: 'external',
+      role_authority: 'claims',
+      local_auth: 'disabled',
+      external: { provider: 'external_launch', provisioning: 'jit' },
+    },
+    external_launch: { ...baseConfig().external_launch, allow_admin_roles: true },
+    execution: { allow_superadmin: true },
+  };
+}
+
 function signClaims(overrides: Record<string, unknown> = {}) {
   return jwt.sign(
     {
@@ -293,6 +307,79 @@ describe('one-time launch auth service', () => {
 
     expect(second.user.user_id).toBe(first.user.user_id);
     expect(second.user.name).toBe('Updated Name');
+  });
+
+  it('synchronizes claim-owned fields on each externally authoritative launch', async () => {
+    mockExchange(
+      signClaims({
+        email: 'first@example.test',
+        name: 'First Name',
+        role: 'admin',
+        avatar: 'https://cdn.example.test/first.png',
+        unix_username: 'first-home',
+      })
+    );
+    const first = await service(externalAuthorityConfig()).create({ launchCode: 'first' });
+    await update(db, users)
+      .set({
+        data: {
+          ...((await select(db).from(users).where(eq(users.user_id, first.user.user_id)).one())!
+            .data as Record<string, unknown>),
+          preferences: { audio: { enabled: false } },
+          default_mcp_server_ids: ['mcp-1'],
+        },
+      })
+      .where(eq(users.user_id, first.user.user_id))
+      .run();
+
+    mockExchange(
+      signClaims({
+        email: 'second@example.test',
+        name: 'Second Name',
+        role: 'viewer',
+        avatar: 'https://cdn.example.test/second.png',
+        unix_username: null,
+      })
+    );
+    const second = await service(externalAuthorityConfig()).create({ launchCode: 'second' });
+
+    expect(second.user.user_id).toBe(first.user.user_id);
+    expect(second.user).toMatchObject({
+      email: 'second@example.test',
+      name: 'Second Name',
+      role: 'viewer',
+    });
+    const row = await select(db).from(users).where(eq(users.user_id, first.user.user_id)).one();
+    expect(row).toMatchObject({
+      email: 'second@example.test',
+      name: 'Second Name',
+      role: 'viewer',
+      unix_username: null,
+    });
+    expect(row?.data).toMatchObject({
+      avatar_url: 'https://cdn.example.test/second.png',
+      preferences: { audio: { enabled: false } },
+      default_mcp_server_ids: ['mcp-1'],
+    });
+  });
+
+  it('requires a recognized role before externally authoritative JIT creation', async () => {
+    mockExchange(
+      signClaims({ sub: 'missing-role', email: 'missing-role@example.test', role: undefined })
+    );
+
+    await expect(
+      service(externalAuthorityConfig()).create({ launchCode: 'missing-role' })
+    ).rejects.toThrow(/role/);
+    expect(await select(db).from(users).all()).toHaveLength(0);
+
+    mockExchange(
+      signClaims({ sub: 'unknown-role', email: 'unknown-role@example.test', role: 'root' })
+    );
+    await expect(
+      service(externalAuthorityConfig()).create({ launchCode: 'unknown-role' })
+    ).rejects.toThrow(/role/);
+    expect(await select(db).from(users).all()).toHaveLength(0);
   });
 
   it('uses token invalidation metadata for launch tokens without returning it', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -12,6 +12,7 @@ import {
   insert,
   select,
   update,
+  userExternalIdentities,
   users,
 } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
@@ -235,6 +236,15 @@ describe('one-time launch auth service', () => {
     }) as { sub: string; type: string };
     expect(decoded.sub).toBe(result.user.user_id);
     expect(decoded.type).toBe('access');
+
+    const binding = await select(db).from(userExternalIdentities).all();
+    expect(binding).toEqual([
+      expect.objectContaining({
+        user_id: result.user.user_id,
+        provider: 'https://issuer.example.test',
+        subject: 'external-user-1',
+      }),
+    ]);
   });
 
   it('scopes launch auth with the configured tenant claim', async () => {
@@ -298,6 +308,28 @@ describe('one-time launch auth service', () => {
     expect(relaunched.user.unix_username).toBe('jose_garcia');
   });
 
+  it('rejects malformed and duplicate authoritative execution-home claims', async () => {
+    mockExchange(
+      signClaims({ sub: 'invalid-home', email: 'invalid-home@example.test', unix_username: '../x' })
+    );
+    await expect(
+      service(externalAuthorityConfig()).create({ launchCode: 'invalid-home' })
+    ).rejects.toThrow(/execution home/);
+
+    mockExchange(
+      signClaims({ sub: 'home-owner', email: 'home-owner@example.test', unix_username: 'shared' })
+    );
+    await service(externalAuthorityConfig()).create({ launchCode: 'home-owner' });
+
+    mockExchange(
+      signClaims({ sub: 'home-other', email: 'home-other@example.test', unix_username: 'shared' })
+    );
+    await expect(
+      service(externalAuthorityConfig()).create({ launchCode: 'home-other' })
+    ).rejects.toThrow(/already assigned/);
+    expect(await select(db).from(users).all()).toHaveLength(1);
+  });
+
   it('repeat login maps the same external identity to the same local user', async () => {
     mockExchange(signClaims());
     const first = await service().create({ launchCode: 'first' });
@@ -307,6 +339,22 @@ describe('one-time launch auth service', () => {
 
     expect(second.user.user_id).toBe(first.user.user_id);
     expect(second.user.name).toBe('Updated Name');
+  });
+
+  it('serializes concurrent JIT projection for the same external subject', async () => {
+    mockExchange(
+      signClaims({ sub: 'concurrent-user', email: 'concurrent@example.test', name: 'Concurrent' })
+    );
+
+    const auth = service();
+    const [first, second] = await Promise.all([
+      auth.create({ launchCode: 'concurrent-1' }),
+      auth.create({ launchCode: 'concurrent-2' }),
+    ]);
+
+    expect(second.user.user_id).toBe(first.user.user_id);
+    expect(await select(db).from(users).all()).toHaveLength(1);
+    expect(await select(db).from(userExternalIdentities).all()).toHaveLength(1);
   });
 
   it('synchronizes claim-owned fields on each externally authoritative launch', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { AgorConfig } from '@agor/core/config';
+import { type AgorConfig, resolveExternalLaunchSettings } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import {
   createDatabase,
@@ -36,6 +36,11 @@ function baseConfig(): AgorConfig {
       service_credential: 'exchange-credential',
     },
   };
+}
+
+function publicLaunchAuthSettings(config: AgorConfig) {
+  const { settings } = resolveExternalLaunchSettings(config);
+  return resolvePublicLaunchAuthSettings(settings);
 }
 
 function externalAuthorityConfig(): AgorConfig {
@@ -127,9 +132,11 @@ describe('one-time launch auth service', () => {
   });
 
   function service(config = baseConfig(), usersService = makeUsersService(db)) {
+    const { settings } = resolveExternalLaunchSettings(config);
     return createLaunchAuthService({
       db,
       config,
+      provider: settings,
       jwtSecret: RUNTIME_JWT_SECRET,
       accessTokenTtl: '15m',
       refreshTokenTtl: '30d',
@@ -784,7 +791,7 @@ describe('public one-time launch auth settings', () => {
   });
 
   it('returns only the public external launch shape', () => {
-    const result = resolvePublicLaunchAuthSettings({
+    const result = publicLaunchAuthSettings({
       external_launch: {
         ...baseConfig().external_launch,
         login_redirect_url: 'https://workspace.example.test/open',
@@ -803,7 +810,7 @@ describe('public one-time launch auth settings', () => {
   });
 
   it('exposes a default return-host param alongside a login redirect', () => {
-    const result = resolvePublicLaunchAuthSettings({
+    const result = publicLaunchAuthSettings({
       external_launch: {
         ...baseConfig().external_launch,
         login_redirect_url: 'https://console.example.test/launch-init',
@@ -813,7 +820,7 @@ describe('public one-time launch auth settings', () => {
   });
 
   it('honors a configured return-host param name', () => {
-    const result = resolvePublicLaunchAuthSettings({
+    const result = publicLaunchAuthSettings({
       external_launch: {
         ...baseConfig().external_launch,
         login_redirect_url: 'https://console.example.test/launch-init',
@@ -824,14 +831,14 @@ describe('public one-time launch auth settings', () => {
   });
 
   it('does not expose a return-host param without a login redirect', () => {
-    const result = resolvePublicLaunchAuthSettings({
+    const result = publicLaunchAuthSettings({
       external_launch: { ...baseConfig().external_launch },
     });
     expect(result).not.toHaveProperty('returnHostParam');
   });
 
   it('never exposes the exchange service credential in public settings', () => {
-    const result = resolvePublicLaunchAuthSettings({
+    const result = publicLaunchAuthSettings({
       external_launch: {
         ...baseConfig().external_launch,
         service_credential: 'exchange-only-credential',
@@ -843,7 +850,7 @@ describe('public one-time launch auth settings', () => {
 
   it('does not expose an inactive login redirect URL', () => {
     expect(
-      resolvePublicLaunchAuthSettings({
+      publicLaunchAuthSettings({
         external_launch: {
           ...baseConfig().external_launch,
           enabled: false,

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -541,10 +541,9 @@ async function verifyLaunchAssertion(
   }
 
   const key = await resolveVerificationKey(decoded.header, settings);
-  // Production verification is asymmetric and must pin an explicit algorithm
-  // allow-list. Defaulting to RS256 for the non-dev path prevents algorithm
-  // confusion (e.g. a public key coerced into HS256). The dev symmetric path
-  // stays HS256-only. An operator may still narrow/extend via `algorithms`.
+  // The shared config parser supplies a key-compatible algorithm allow-list.
+  // These fallbacks are defensive for callers constructing resolved settings
+  // outside that parser; they preserve the historical JWKS/dev defaults.
   const algorithms = settings.algorithms ?? (settings.devSharedSecret ? ['HS256'] : ['RS256']);
   const claims = jwt.verify(assertion, key, {
     issuer: settings.issuer,

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -4,8 +4,7 @@ import {
   type AgorConfig,
   AgorRoleAuthority,
   AgorUserLifecycleAuthority,
-  type ResolvedExternalLaunchSettings,
-  resolveExternalLaunchSettings,
+  type ResolvedExternalLaunchProvider,
   resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveTenantContext,
@@ -83,42 +82,36 @@ export interface LaunchAuthResult {
 export interface LaunchAuthServiceOptions {
   db: TenantScopeAwareDatabase;
   config: AgorConfig;
+  provider: ResolvedExternalLaunchProvider;
   jwtSecret: string;
   accessTokenTtl: SignOptions['expiresIn'];
   refreshTokenTtl: SignOptions['expiresIn'];
   usersService: { get(id: UserID, params?: Params): Promise<User> };
 }
 
-export function resolveLaunchSettings(config: AgorConfig): ResolvedExternalLaunchSettings {
-  return resolveExternalLaunchSettings(config).settings;
-}
-
-export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunchAuthSettings {
-  const { settings, error } = resolveExternalLaunchSettings(config);
-  const enabled = settings.enabled && !error;
+export function resolvePublicLaunchAuthSettings(
+  provider: ResolvedExternalLaunchProvider
+): PublicLaunchAuthSettings {
+  const enabled = provider.enabled;
 
   return {
     enabled,
-    ...(enabled && settings.loginRedirectUrl
-      ? { loginRedirectUrl: settings.loginRedirectUrl }
+    ...(enabled && provider.loginRedirectUrl
+      ? { loginRedirectUrl: provider.loginRedirectUrl }
       : {}),
-    ...(enabled && settings.returnHostParam ? { returnHostParam: settings.returnHostParam } : {}),
+    ...(enabled && provider.returnHostParam ? { returnHostParam: provider.returnHostParam } : {}),
   };
 }
 
-function assertConfigured(
-  settings: ResolvedExternalLaunchSettings,
-  configurationError?: string
-): void {
+function assertConfigured(settings: ResolvedExternalLaunchProvider): void {
   const rejectConfig = (reason: string): never => {
     console.warn(`[auth/launch] ${reason}`);
     throw new NotAuthenticated('One-time launch authentication is unavailable');
   };
 
   if (!settings.enabled) {
-    rejectConfig(configurationError ?? 'disabled');
+    rejectConfig('disabled');
   }
-  if (configurationError) rejectConfig(configurationError);
 }
 
 function identityKey(provider: string, issuer: string, subject: string): string {
@@ -183,7 +176,7 @@ function normalizeLaunchEmail(value: string | undefined): string | undefined {
 
 function mapRole(
   claimedRole: string | undefined,
-  settings: ResolvedExternalLaunchSettings,
+  settings: ResolvedExternalLaunchProvider,
   allowSuperadmin: boolean | undefined,
   existingRole?: UserRole,
   roleAuthority: AgorRoleAuthority = AgorRoleAuthority.INTERNAL
@@ -248,7 +241,7 @@ async function findUserByTrustedEmail(
   db: TenantScopedDatabase,
   email: string | undefined,
   key: string,
-  settings: ResolvedExternalLaunchSettings,
+  settings: ResolvedExternalLaunchProvider,
   claims: LaunchClaims
 ): Promise<typeof users.$inferSelect | null> {
   if (!settings.trustVerifiedEmailForLinking || claims.email_verified !== true || !email) {
@@ -277,7 +270,7 @@ async function projectLaunchUser(
   const { config } = options;
   const issuer = claims.iss;
   const subject = claims.sub;
-  const settings = resolveLaunchSettings(config);
+  const settings = options.provider;
   const identityAuthority = resolveIdentityAuthority(config);
   const provider = claims.provider || settings.providerId || issuer;
   const key = identityKey(provider, issuer, subject);
@@ -440,7 +433,7 @@ async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Pro
  * when forwarding is enabled but no unambiguous host is available.
  */
 export function resolveRequestHost(
-  settings: ResolvedExternalLaunchSettings,
+  settings: ResolvedExternalLaunchProvider,
   headers: Record<string, unknown> | undefined
 ): string | undefined {
   if (!settings.forwardRequestHost) return undefined;
@@ -472,7 +465,7 @@ export function resolveRequestHost(
 
 async function exchangeLaunchCode(
   launchCode: string,
-  settings: ResolvedExternalLaunchSettings,
+  settings: ResolvedExternalLaunchProvider,
   requestHost: string | undefined
 ): Promise<LaunchExchangeResponse> {
   const headers: Record<string, string> = {
@@ -504,7 +497,7 @@ async function exchangeLaunchCode(
 
 async function resolveVerificationKey(
   header: JwtHeader,
-  settings: ResolvedExternalLaunchSettings
+  settings: ResolvedExternalLaunchProvider
 ): Promise<string | KeyObject> {
   if (settings.devSharedSecret) return settings.devSharedSecret;
   if (settings.publicKey) return settings.publicKey;
@@ -528,7 +521,7 @@ async function resolveVerificationKey(
 
 async function verifyLaunchAssertion(
   assertion: string,
-  settings: ResolvedExternalLaunchSettings
+  settings: ResolvedExternalLaunchProvider
 ): Promise<LaunchClaims> {
   const decoded = jwt.decode(assertion, { complete: true });
   if (!decoded || typeof decoded !== 'object') {
@@ -544,7 +537,9 @@ async function verifyLaunchAssertion(
   // The shared config parser supplies a key-compatible algorithm allow-list.
   // These fallbacks are defensive for callers constructing resolved settings
   // outside that parser; they preserve the historical JWKS/dev defaults.
-  const algorithms = settings.algorithms ?? (settings.devSharedSecret ? ['HS256'] : ['RS256']);
+  const algorithms = [
+    ...(settings.algorithms ?? (settings.devSharedSecret ? ['HS256'] : ['RS256'])),
+  ];
   const claims = jwt.verify(assertion, key, {
     issuer: settings.issuer,
     audience: settings.audience,
@@ -557,7 +552,7 @@ async function verifyLaunchAssertion(
 
 function validateLaunchClaims(
   claims: LaunchClaims,
-  settings: ResolvedExternalLaunchSettings
+  settings: ResolvedExternalLaunchProvider
 ): void {
   if (!claims.iss || claims.iss !== settings.issuer) {
     throw new NotAuthenticated('Invalid one-time launch assertion issuer');
@@ -715,9 +710,8 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
         throw new BadRequest('launchCode is too long');
       }
 
-      const resolvedSettings = resolveExternalLaunchSettings(options.config);
-      const settings = resolvedSettings.settings;
-      assertConfigured(settings, resolvedSettings.error);
+      const settings = options.provider;
+      assertConfigured(settings);
 
       try {
         // Resolve the browser Host from the trusted local request context BEFORE

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -2,6 +2,8 @@ import type { JsonWebKey, KeyObject } from 'node:crypto';
 import { createHash, createPublicKey, randomBytes } from 'node:crypto';
 import {
   type AgorConfig,
+  AgorRoleAuthority,
+  AgorUserLifecycleAuthority,
   resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveTenantContext,
@@ -269,9 +271,9 @@ function mapRole(
   settings: ResolvedLaunchSettings,
   allowSuperadmin: boolean | undefined,
   existingRole?: UserRole,
-  roleAuthority: 'internal' | 'claims' = 'internal'
+  roleAuthority: AgorRoleAuthority = AgorRoleAuthority.INTERNAL
 ): UserRole {
-  if (roleAuthority === 'claims') {
+  if (roleAuthority === AgorRoleAuthority.CLAIMS) {
     if (
       typeof claimedRole !== 'string' ||
       !['viewer', 'member', 'admin', 'superadmin', 'owner'].includes(claimedRole)
@@ -359,7 +361,11 @@ async function upsertLaunchUser(
   const now = new Date();
   const nowIso = now.toISOString();
   const email = normalizeLaunchEmail(claims.email);
-  if (identityAuthority.userLifecycle === 'external' && claims.email !== undefined && !email) {
+  if (
+    identityAuthority.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL &&
+    claims.email !== undefined &&
+    !email
+  ) {
     throw new NotAuthenticated('Invalid one-time launch assertion email');
   }
   const name = claims.name?.trim() || undefined;
@@ -398,13 +404,15 @@ async function upsertLaunchUser(
     await update(db, users)
       .set({
         email:
-          identityAuthority.userLifecycle === 'external' && email !== undefined
+          identityAuthority.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL &&
+          email !== undefined
             ? email
             : existing.email,
         name: name ?? existing.name,
         role,
         unix_username:
-          identityAuthority.userLifecycle === 'external' && claims.unix_username !== undefined
+          identityAuthority.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL &&
+          claims.unix_username !== undefined
             ? unixUsername
             : (unixUsername ?? existing.unix_username),
         updated_at: now,

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -4,7 +4,8 @@ import {
   type AgorConfig,
   AgorRoleAuthority,
   AgorUserLifecycleAuthority,
-  externalLaunchConfigurationError,
+  type ResolvedExternalLaunchSettings,
+  resolveExternalLaunchSettings,
   resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveTenantContext,
@@ -33,29 +34,6 @@ import { safeLaunchDiagnostic } from './launch-redaction.js';
 import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
 import { authTokenIssuedAtClaim } from './token-invalidation.js';
 import { redactUserAuthMetadata } from './user-redaction.js';
-
-const DEFAULT_TIMEOUT_MS = 10_000;
-const DEFAULT_TRUSTED_HOST_HEADER = 'host';
-const DEFAULT_RETURN_HOST_PARAM = 'return_host';
-
-interface ResolvedLaunchSettings {
-  enabled: boolean;
-  exchangeUrl?: string;
-  audience?: string;
-  issuer?: string;
-  instanceId?: string;
-  providerId?: string;
-  jwksUrl?: string;
-  publicKey?: string;
-  devSharedSecret?: string;
-  serviceCredential?: string;
-  allowAdminRoles: boolean;
-  trustVerifiedEmailForLinking: boolean;
-  requestTimeoutMs: number;
-  algorithms?: string[];
-  forwardRequestHost: boolean;
-  trustedHostHeader: string;
-}
 
 export interface PublicLaunchAuthSettings {
   enabled: boolean;
@@ -111,56 +89,35 @@ export interface LaunchAuthServiceOptions {
   usersService: { get(id: UserID, params?: Params): Promise<User> };
 }
 
-export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSettings {
-  const raw = config.external_launch;
-
-  return {
-    enabled: raw?.enabled === true,
-    exchangeUrl: raw?.exchange_url,
-    audience: raw?.audience,
-    issuer: raw?.issuer,
-    instanceId: raw?.instance_id,
-    providerId: raw?.provider_id,
-    jwksUrl: raw?.jwks_url,
-    publicKey: raw?.public_key,
-    devSharedSecret: raw?.dev_shared_secret,
-    serviceCredential: raw?.service_credential,
-    allowAdminRoles: raw?.allow_admin_roles === true,
-    trustVerifiedEmailForLinking: raw?.trust_verified_email_for_linking === true,
-    requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
-    algorithms: raw?.algorithms,
-    forwardRequestHost: raw?.forward_request_host === true,
-    trustedHostHeader: (raw?.trusted_host_header || DEFAULT_TRUSTED_HOST_HEADER).toLowerCase(),
-  };
+export function resolveLaunchSettings(config: AgorConfig): ResolvedExternalLaunchSettings {
+  return resolveExternalLaunchSettings(config).settings;
 }
 
 export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunchAuthSettings {
-  const raw = config.external_launch;
-  const enabled = raw?.enabled === true;
-  // Only advertise a return-host param when a launch-init redirect exists to
-  // append it to; the param name itself is public routing metadata, not a secret.
-  const returnHostParam =
-    enabled && raw?.login_redirect_url
-      ? raw?.return_host_param || DEFAULT_RETURN_HOST_PARAM
-      : undefined;
+  const { settings, error } = resolveExternalLaunchSettings(config);
+  const enabled = settings.enabled && !error;
 
   return {
     enabled,
-    ...(enabled && raw?.login_redirect_url ? { loginRedirectUrl: raw.login_redirect_url } : {}),
-    ...(returnHostParam ? { returnHostParam } : {}),
+    ...(enabled && settings.loginRedirectUrl
+      ? { loginRedirectUrl: settings.loginRedirectUrl }
+      : {}),
+    ...(enabled && settings.returnHostParam ? { returnHostParam: settings.returnHostParam } : {}),
   };
 }
 
-function assertConfigured(config: AgorConfig, settings: ResolvedLaunchSettings): void {
+function assertConfigured(
+  settings: ResolvedExternalLaunchSettings,
+  configurationError?: string
+): void {
   const rejectConfig = (reason: string): never => {
     console.warn(`[auth/launch] ${reason}`);
     throw new NotAuthenticated('One-time launch authentication is unavailable');
   };
 
   if (!settings.enabled) {
-    rejectConfig('disabled');
+    rejectConfig(configurationError ?? 'disabled');
   }
-  const configurationError = externalLaunchConfigurationError(config);
   if (configurationError) rejectConfig(configurationError);
 }
 
@@ -226,7 +183,7 @@ function normalizeLaunchEmail(value: string | undefined): string | undefined {
 
 function mapRole(
   claimedRole: string | undefined,
-  settings: ResolvedLaunchSettings,
+  settings: ResolvedExternalLaunchSettings,
   allowSuperadmin: boolean | undefined,
   existingRole?: UserRole,
   roleAuthority: AgorRoleAuthority = AgorRoleAuthority.INTERNAL
@@ -291,7 +248,7 @@ async function findUserByTrustedEmail(
   db: TenantScopedDatabase,
   email: string | undefined,
   key: string,
-  settings: ResolvedLaunchSettings,
+  settings: ResolvedExternalLaunchSettings,
   claims: LaunchClaims
 ): Promise<typeof users.$inferSelect | null> {
   if (!settings.trustVerifiedEmailForLinking || claims.email_verified !== true || !email) {
@@ -483,7 +440,7 @@ async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Pro
  * when forwarding is enabled but no unambiguous host is available.
  */
 export function resolveRequestHost(
-  settings: ResolvedLaunchSettings,
+  settings: ResolvedExternalLaunchSettings,
   headers: Record<string, unknown> | undefined
 ): string | undefined {
   if (!settings.forwardRequestHost) return undefined;
@@ -515,7 +472,7 @@ export function resolveRequestHost(
 
 async function exchangeLaunchCode(
   launchCode: string,
-  settings: ResolvedLaunchSettings,
+  settings: ResolvedExternalLaunchSettings,
   requestHost: string | undefined
 ): Promise<LaunchExchangeResponse> {
   const headers: Record<string, string> = {
@@ -547,7 +504,7 @@ async function exchangeLaunchCode(
 
 async function resolveVerificationKey(
   header: JwtHeader,
-  settings: ResolvedLaunchSettings
+  settings: ResolvedExternalLaunchSettings
 ): Promise<string | KeyObject> {
   if (settings.devSharedSecret) return settings.devSharedSecret;
   if (settings.publicKey) return settings.publicKey;
@@ -571,7 +528,7 @@ async function resolveVerificationKey(
 
 async function verifyLaunchAssertion(
   assertion: string,
-  settings: ResolvedLaunchSettings
+  settings: ResolvedExternalLaunchSettings
 ): Promise<LaunchClaims> {
   const decoded = jwt.decode(assertion, { complete: true });
   if (!decoded || typeof decoded !== 'object') {
@@ -599,7 +556,10 @@ async function verifyLaunchAssertion(
   return claims;
 }
 
-function validateLaunchClaims(claims: LaunchClaims, settings: ResolvedLaunchSettings): void {
+function validateLaunchClaims(
+  claims: LaunchClaims,
+  settings: ResolvedExternalLaunchSettings
+): void {
   if (!claims.iss || claims.iss !== settings.issuer) {
     throw new NotAuthenticated('Invalid one-time launch assertion issuer');
   }
@@ -756,8 +716,9 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
         throw new BadRequest('launchCode is too long');
       }
 
-      const settings = resolveLaunchSettings(options.config);
-      assertConfigured(options.config, settings);
+      const resolvedSettings = resolveExternalLaunchSettings(options.config);
+      const settings = resolvedSettings.settings;
+      assertConfigured(settings, resolvedSettings.error);
 
       try {
         // Resolve the browser Host from the trusted local request context BEFORE

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -2,6 +2,7 @@ import type { JsonWebKey, KeyObject } from 'node:crypto';
 import { createHash, createPublicKey, randomBytes } from 'node:crypto';
 import {
   type AgorConfig,
+  resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveTenantContext,
   TenantResolutionError,
@@ -267,8 +268,29 @@ function mapRole(
   claimedRole: string | undefined,
   settings: ResolvedLaunchSettings,
   allowSuperadmin: boolean | undefined,
-  existingRole?: UserRole
+  existingRole?: UserRole,
+  roleAuthority: 'internal' | 'claims' = 'internal'
 ): UserRole {
+  if (roleAuthority === 'claims') {
+    if (
+      typeof claimedRole !== 'string' ||
+      !['viewer', 'member', 'admin', 'superadmin', 'owner'].includes(claimedRole)
+    ) {
+      throw new NotAuthenticated('Invalid one-time launch assertion role');
+    }
+    const authoritativeRole = normalizeRole(claimedRole);
+    if (
+      (authoritativeRole === ROLES.ADMIN || authoritativeRole === ROLES.SUPERADMIN) &&
+      !settings.allowAdminRoles
+    ) {
+      throw new NotAuthenticated('One-time launch assertion role is not enabled');
+    }
+    if (authoritativeRole === ROLES.SUPERADMIN && !allowSuperadmin) {
+      throw new NotAuthenticated('One-time launch assertion superadmin role is not enabled');
+    }
+    return authoritativeRole;
+  }
+
   const role = normalizeRole(claimedRole);
   const allowedRoles: UserRole[] = settings.allowAdminRoles
     ? [ROLES.VIEWER, ROLES.MEMBER, ROLES.ADMIN, ROLES.SUPERADMIN]
@@ -327,6 +349,7 @@ async function upsertLaunchUser(
   const issuer = claims.iss;
   const subject = claims.sub;
   const settings = resolveLaunchSettings(config);
+  const identityAuthority = resolveIdentityAuthority(config);
   const userLookupParams = {
     provider: undefined,
     ...(tenant ? { tenant } : {}),
@@ -336,6 +359,9 @@ async function upsertLaunchUser(
   const now = new Date();
   const nowIso = now.toISOString();
   const email = normalizeLaunchEmail(claims.email);
+  if (identityAuthority.userLifecycle === 'external' && claims.email !== undefined && !email) {
+    throw new NotAuthenticated('Invalid one-time launch assertion email');
+  }
   const name = claims.name?.trim() || undefined;
   const unixUsername = claims.unix_username?.trim() || null;
   const avatar = claims.avatar || claims.picture;
@@ -357,7 +383,8 @@ async function upsertLaunchUser(
       claims.role,
       settings,
       config.execution?.allow_superadmin,
-      normalizeRole(existing.role ?? undefined)
+      normalizeRole(existing.role ?? undefined),
+      identityAuthority.roleAuthority
     );
     const data = (existing.data ?? {}) as UserDataWithExternalIdentities;
     const identities = getExternalIdentities(data);
@@ -370,9 +397,16 @@ async function upsertLaunchUser(
 
     await update(db, users)
       .set({
+        email:
+          identityAuthority.userLifecycle === 'external' && email !== undefined
+            ? email
+            : existing.email,
         name: name ?? existing.name,
         role,
-        unix_username: unixUsername ?? existing.unix_username,
+        unix_username:
+          identityAuthority.userLifecycle === 'external' && claims.unix_username !== undefined
+            ? unixUsername
+            : (unixUsername ?? existing.unix_username),
         updated_at: now,
         data: {
           ...data,
@@ -388,7 +422,13 @@ async function upsertLaunchUser(
     return usersService.get(existing.user_id as UserID, userLookupParams);
   }
 
-  const role = mapRole(claims.role, settings, config.execution?.allow_superadmin);
+  const role = mapRole(
+    claims.role,
+    settings,
+    config.execution?.allow_superadmin,
+    undefined,
+    identityAuthority.roleAuthority
+  );
   const localEmail = await chooseLocalEmail(db, email, key, provider, issuer, subject);
   const userId = generateId() as UserID;
   const password = await hash(randomBytes(32).toString('hex'), 10);
@@ -628,6 +668,16 @@ const KNOWN_LAUNCH_FAILURE_REASONS: ReadonlyMap<string, string> = new Map([
   ['Invalid one-time launch assertion instance', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
   ['Invalid one-time launch assertion id', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
   ['Invalid one-time launch assertion nonce', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion role', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion email', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  [
+    'One-time launch assertion role is not enabled',
+    LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID,
+  ],
+  [
+    'One-time launch assertion superadmin role is not enabled',
+    LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID,
+  ],
   ['Ambiguous launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],
   ['Missing launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],
   ['Invalid launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -4,6 +4,7 @@ import {
   type AgorConfig,
   AgorRoleAuthority,
   AgorUserLifecycleAuthority,
+  externalLaunchConfigurationError,
   resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveTenantContext,
@@ -14,23 +15,19 @@ import {
   generateId,
   hash,
   insert,
+  isExecutionHomeKeyAvailable,
   reattributeLegacyAnonymousRows,
-  runWithTenantDatabaseScope,
+  runWithTenantDatabaseTransaction,
   select,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+  UserExternalIdentitiesRepository,
   update,
   users,
 } from '@agor/core/db';
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
-import type {
-  Params,
-  TenantContext,
-  User,
-  UserExternalIdentity,
-  UserID,
-  UserRole,
-} from '@agor/core/types';
-import { normalizeRole, ROLES } from '@agor/core/types';
+import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor/core/types';
+import { isValidExecutionHomeKey, normalizeRole, ROLES } from '@agor/core/types';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
 import { safeLaunchDiagnostic } from './launch-redaction.js';
 import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
@@ -38,13 +35,6 @@ import { authTokenIssuedAtClaim } from './token-invalidation.js';
 import { redactUserAuthMetadata } from './user-redaction.js';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
-const DEFAULT_SERVICE_TOKEN_ENV = 'AGOR_EXTERNAL_LAUNCH_SERVICE_TOKEN';
-const DEFAULT_SHARED_SECRET_ENV = 'AGOR_EXTERNAL_LAUNCH_SHARED_SECRET';
-const DEFAULT_EXCHANGE_URL_ENV = 'AGOR_EXTERNAL_LAUNCH_EXCHANGE_URL';
-const DEFAULT_ISSUER_ENV = 'AGOR_EXTERNAL_LAUNCH_ISSUER';
-const DEFAULT_AUDIENCE_ENV = 'AGOR_EXTERNAL_LAUNCH_AUDIENCE';
-const DEFAULT_INSTANCE_ID_ENV = 'AGOR_EXTERNAL_LAUNCH_INSTANCE_ID';
-const DEFAULT_FORWARD_REQUEST_HOST_ENV = 'AGOR_EXTERNAL_LAUNCH_FORWARD_REQUEST_HOST';
 const DEFAULT_TRUSTED_HOST_HEADER = 'host';
 const DEFAULT_RETURN_HOST_PARAM = 'return_host';
 
@@ -121,40 +111,32 @@ export interface LaunchAuthServiceOptions {
   usersService: { get(id: UserID, params?: Params): Promise<User> };
 }
 
-function envFlag(value: string | undefined): boolean | undefined {
-  if (value === undefined) return undefined;
-  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
-}
-
 export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSettings {
   const raw = config.external_launch;
-  const serviceTokenEnv = raw?.service_credential_env || DEFAULT_SERVICE_TOKEN_ENV;
-  const sharedSecretEnv = raw?.dev_shared_secret_env || DEFAULT_SHARED_SECRET_ENV;
 
   return {
-    enabled: envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true,
-    exchangeUrl: process.env[DEFAULT_EXCHANGE_URL_ENV] || raw?.exchange_url,
-    audience: process.env[DEFAULT_AUDIENCE_ENV] || raw?.audience,
-    issuer: process.env[DEFAULT_ISSUER_ENV] || raw?.issuer,
-    instanceId: process.env[DEFAULT_INSTANCE_ID_ENV] || raw?.instance_id,
+    enabled: raw?.enabled === true,
+    exchangeUrl: raw?.exchange_url,
+    audience: raw?.audience,
+    issuer: raw?.issuer,
+    instanceId: raw?.instance_id,
     providerId: raw?.provider_id,
     jwksUrl: raw?.jwks_url,
     publicKey: raw?.public_key,
-    devSharedSecret: process.env[sharedSecretEnv] || raw?.dev_shared_secret,
-    serviceCredential: process.env[serviceTokenEnv] || raw?.service_credential,
+    devSharedSecret: raw?.dev_shared_secret,
+    serviceCredential: raw?.service_credential,
     allowAdminRoles: raw?.allow_admin_roles === true,
     trustVerifiedEmailForLinking: raw?.trust_verified_email_for_linking === true,
     requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
     algorithms: raw?.algorithms,
-    forwardRequestHost:
-      envFlag(process.env[DEFAULT_FORWARD_REQUEST_HOST_ENV]) ?? raw?.forward_request_host === true,
+    forwardRequestHost: raw?.forward_request_host === true,
     trustedHostHeader: (raw?.trusted_host_header || DEFAULT_TRUSTED_HOST_HEADER).toLowerCase(),
   };
 }
 
 export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunchAuthSettings {
   const raw = config.external_launch;
-  const enabled = envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true;
+  const enabled = raw?.enabled === true;
   // Only advertise a return-host param when a launch-init redirect exists to
   // append it to; the param name itself is public routing metadata, not a secret.
   const returnHostParam =
@@ -169,7 +151,7 @@ export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunc
   };
 }
 
-function assertConfigured(settings: ResolvedLaunchSettings): void {
+function assertConfigured(config: AgorConfig, settings: ResolvedLaunchSettings): void {
   const rejectConfig = (reason: string): never => {
     console.warn(`[auth/launch] ${reason}`);
     throw new NotAuthenticated('One-time launch authentication is unavailable');
@@ -178,32 +160,8 @@ function assertConfigured(settings: ResolvedLaunchSettings): void {
   if (!settings.enabled) {
     rejectConfig('disabled');
   }
-  if (!settings.exchangeUrl) {
-    rejectConfig('missing exchange_url');
-  }
-  if (!settings.issuer || !settings.audience) {
-    rejectConfig('missing issuer or audience');
-  }
-  const configuredKeyCount = [
-    settings.jwksUrl,
-    settings.publicKey,
-    settings.devSharedSecret,
-  ].filter(Boolean).length;
-  if (configuredKeyCount === 0) {
-    rejectConfig('missing assertion verification key');
-  }
-  if (configuredKeyCount > 1) {
-    rejectConfig('multiple assertion verification methods configured');
-  }
-  // Asymmetric verification (jwks_url/public_key) must never be paired with a
-  // symmetric HS* algorithm. Pinning this makes the algorithm-confusion defense
-  // independent of the jsonwebtoken default allow-list: even if an operator
-  // overrides `algorithms`, an asymmetric public key can never be coerced into
-  // an HMAC secret. The RS256 default for asymmetric methods is preserved.
-  const usesAsymmetricKey = Boolean(settings.jwksUrl || settings.publicKey);
-  if (usesAsymmetricKey && settings.algorithms?.some((alg) => /^hs/i.test(alg))) {
-    rejectConfig('asymmetric verification cannot be configured with HS* algorithms');
-  }
+  const configurationError = externalLaunchConfigurationError(config);
+  if (configurationError) rejectConfig(configurationError);
 }
 
 function identityKey(provider: string, issuer: string, subject: string): string {
@@ -225,7 +183,7 @@ function derivedEmail(provider: string, issuer: string, subject: string): string
 }
 
 async function chooseLocalEmail(
-  db: TenantScopeAwareDatabase,
+  db: TenantScopedDatabase,
   requestedEmail: string | undefined,
   key: string,
   provider: string,
@@ -306,9 +264,21 @@ function mapRole(
 }
 
 async function findUserByExternalIdentity(
-  db: TenantScopeAwareDatabase,
+  db: TenantScopedDatabase,
+  repository: UserExternalIdentitiesRepository,
   key: string
 ): Promise<typeof users.$inferSelect | null> {
+  const binding = await repository.findByKey(key);
+  if (binding) {
+    const boundUser = await select(db).from(users).where(eq(users.user_id, binding.user_id)).one();
+    if (!boundUser) {
+      throw new NotAuthenticated('Invalid external identity binding');
+    }
+    return boundUser;
+  }
+
+  // Compatibility path for users projected before the relation existed. The
+  // caller binds the discovered user transactionally before completing login.
   const rows = await select(db).from(users).all();
   for (const row of rows) {
     const identities = getExternalIdentities(row.data as UserDataWithExternalIdentities);
@@ -318,7 +288,7 @@ async function findUserByExternalIdentity(
 }
 
 async function findUserByTrustedEmail(
-  db: TenantScopeAwareDatabase,
+  db: TenantScopedDatabase,
   email: string | undefined,
   key: string,
   settings: ResolvedLaunchSettings,
@@ -342,20 +312,16 @@ async function findUserByTrustedEmail(
   return existing;
 }
 
-async function upsertLaunchUser(
+async function projectLaunchUser(
+  db: TenantScopedDatabase,
   options: LaunchAuthServiceOptions,
-  claims: LaunchClaims,
-  tenant?: TenantContext
-): Promise<User> {
-  const { db, config, usersService } = options;
+  claims: LaunchClaims
+): Promise<UserID> {
+  const { config } = options;
   const issuer = claims.iss;
   const subject = claims.sub;
   const settings = resolveLaunchSettings(config);
   const identityAuthority = resolveIdentityAuthority(config);
-  const userLookupParams = {
-    provider: undefined,
-    ...(tenant ? { tenant } : {}),
-  };
   const provider = claims.provider || settings.providerId || issuer;
   const key = identityKey(provider, issuer, subject);
   const now = new Date();
@@ -370,6 +336,13 @@ async function upsertLaunchUser(
   }
   const name = claims.name?.trim() || undefined;
   const unixUsername = claims.unix_username?.trim() || null;
+  if (
+    claims.unix_username !== undefined &&
+    unixUsername !== null &&
+    !isValidExecutionHomeKey(unixUsername)
+  ) {
+    throw new NotAuthenticated('Invalid one-time launch assertion execution home');
+  }
   const avatar = claims.avatar || claims.picture;
   const identity: StoredExternalIdentity = {
     key,
@@ -381,8 +354,12 @@ async function upsertLaunchUser(
     last_login_at: nowIso,
   };
 
+  const identityRepository = new UserExternalIdentitiesRepository(db);
+  await identityRepository.lockProvisioningKey(`identity:${key}`);
+  if (email) await identityRepository.lockProvisioningKey(`email:${email}`);
+
   const existing =
-    (await findUserByExternalIdentity(db, key)) ??
+    (await findUserByExternalIdentity(db, identityRepository, key)) ??
     (await findUserByTrustedEmail(db, email, key, settings, claims));
   if (existing) {
     const role = mapRole(
@@ -401,6 +378,18 @@ async function upsertLaunchUser(
       nextIdentities.push(identity);
     }
 
+    const nextUnixUsername =
+      identityAuthority.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL &&
+      claims.unix_username !== undefined
+        ? unixUsername
+        : (unixUsername ?? existing.unix_username);
+    if (
+      nextUnixUsername &&
+      !(await isExecutionHomeKeyAvailable(db, nextUnixUsername, existing.user_id))
+    ) {
+      throw new NotAuthenticated('External execution home is already assigned');
+    }
+
     await update(db, users)
       .set({
         email:
@@ -410,11 +399,7 @@ async function upsertLaunchUser(
             : existing.email,
         name: name ?? existing.name,
         role,
-        unix_username:
-          identityAuthority.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL &&
-          claims.unix_username !== undefined
-            ? unixUsername
-            : (unixUsername ?? existing.unix_username),
+        unix_username: nextUnixUsername,
         updated_at: now,
         data: {
           ...data,
@@ -425,9 +410,10 @@ async function upsertLaunchUser(
       })
       .where(eq(users.user_id, existing.user_id))
       .run();
+    await identityRepository.bind(existing.user_id as UserID, identity, now);
     await reattributeLegacyAnonymousRows(db, existing.user_id);
 
-    return usersService.get(existing.user_id as UserID, userLookupParams);
+    return existing.user_id as UserID;
   }
 
   const role = mapRole(
@@ -440,6 +426,9 @@ async function upsertLaunchUser(
   const localEmail = await chooseLocalEmail(db, email, key, provider, issuer, subject);
   const userId = generateId() as UserID;
   const password = await hash(randomBytes(32).toString('hex'), 10);
+  if (unixUsername && !(await isExecutionHomeKeyAvailable(db, unixUsername))) {
+    throw new NotAuthenticated('External execution home is already assigned');
+  }
 
   await insert(db, users)
     .values({
@@ -463,9 +452,10 @@ async function upsertLaunchUser(
       } as UserDataWithExternalIdentities,
     })
     .run();
+  await identityRepository.bind(userId, identity, now);
   await reattributeLegacyAnonymousRows(db, userId);
 
-  return usersService.get(userId, userLookupParams);
+  return userId;
 }
 
 async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Promise<unknown> {
@@ -731,6 +721,26 @@ function issueRuntimeTokens(
 export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
   const multiTenancy = resolveMultiTenancyConfig(options.config);
   const tenantClaim = multiTenancy.auth_claim ?? 'tenant_id';
+  // SQLite uses one process-local connection and cannot begin two IMMEDIATE
+  // transactions concurrently. PostgreSQL additionally takes the repository's
+  // advisory lock, which extends the same identity serialization across HA
+  // replicas. Failed projections release the queue so a later launch can retry.
+  const projectionTails = new Map<string, Promise<void>>();
+  const serializeProjection = async <T>(key: string, work: () => Promise<T>): Promise<T> => {
+    const previous = projectionTails.get(key) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(work);
+    const tail = next.then(
+      () => undefined,
+      () => undefined
+    );
+    projectionTails.set(key, tail);
+    try {
+      return await next;
+    } finally {
+      if (projectionTails.get(key) === tail) projectionTails.delete(key);
+    }
+  };
+
   return {
     async create(data: { launchCode?: string; launch_code?: string }, params?: Params) {
       const launchCode =
@@ -747,7 +757,7 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
       }
 
       const settings = resolveLaunchSettings(options.config);
-      assertConfigured(settings);
+      assertConfigured(options.config, settings);
 
       try {
         // Resolve the browser Host from the trusted local request context BEFORE
@@ -772,17 +782,26 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
         // resolver so `required_from_auth` cannot fall back to a trusted_header
         // or an explicit params tenant; an absent claim fails closed below.
         const tenant = resolveTenantContext(multiTenancy, { authPayload: claims });
-        return await runWithTenantDatabaseScope(options.db, tenant.tenant_id, async () => {
-          const user = await upsertLaunchUser(options, claims, tenant);
-          return issueRuntimeTokens(
-            user,
-            options.jwtSecret,
-            options.accessTokenTtl,
-            options.refreshTokenTtl,
-            tenantClaim,
-            tenant.tenant_id
-          );
-        });
+        const provider = claims.provider || settings.providerId || claims.iss;
+        const projectionKey = `${tenant.tenant_id}\0${provider}\0${claims.iss}\0${claims.sub}`;
+        const userId = await serializeProjection(projectionKey, () =>
+          runWithTenantDatabaseTransaction(options.db, tenant.tenant_id, async (scopedDb) =>
+            projectLaunchUser(scopedDb, options, claims)
+          )
+        );
+        const userLookupParams = {
+          provider: undefined,
+          tenant,
+        };
+        const user = await options.usersService.get(userId, userLookupParams);
+        return issueRuntimeTokens(
+          user,
+          options.jwtSecret,
+          options.accessTokenTtl,
+          options.refreshTokenTtl,
+          tenantClaim,
+          tenant.tenant_id
+        );
       } catch (error) {
         // Every launch failure — expected or unexpected — emits exactly one
         // coarse operator diagnostic before rethrowing. Only a static reason

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -37,6 +37,7 @@ import {
 import type { AgorConfig, ResolvedSecurity } from '@agor/core/config';
 import {
   assertValidEffectiveExecutionConfig,
+  assertValidEffectiveIdentityConfig,
   getConfigPath,
   loadConfig,
   loadConfigFromFile,
@@ -192,6 +193,7 @@ async function startDaemonWithOwnedMetrics(
   config = resolveEffectiveConfig(config);
   const deploymentId = requireDeploymentId(config);
   assertValidEffectiveExecutionConfig(config);
+  assertValidEffectiveIdentityConfig(config);
   const databaseUrl = resolveDatabaseUrl({ config, env: process.env });
 
   // Deployment package availability is instance-global. Validate it before

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -37,6 +37,7 @@ import {
 import type { AgorConfig, ResolvedSecurity } from '@agor/core/config';
 import {
   assertValidEffectiveExecutionConfig,
+  assertValidEffectiveExternalLaunchConfig,
   assertValidEffectiveIdentityConfig,
   getConfigPath,
   loadConfig,
@@ -47,6 +48,7 @@ import {
   resolveDeploymentConfig,
   resolveEffectiveConfig,
   resolveGitConfigParameters,
+  resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveSecurity,
 } from '@agor/core/config';
@@ -193,6 +195,7 @@ async function startDaemonWithOwnedMetrics(
   config = resolveEffectiveConfig(config);
   const deploymentId = requireDeploymentId(config);
   assertValidEffectiveExecutionConfig(config);
+  assertValidEffectiveExternalLaunchConfig(config);
   assertValidEffectiveIdentityConfig(config);
   const databaseUrl = resolveDatabaseUrl({ config, env: process.env });
 
@@ -734,7 +737,8 @@ async function startDaemonWithOwnedMetrics(
   const { db } = await initializeDatabase(databaseUrl, {
     tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
     requireTenantScope: multiTenancy.mode === 'required_from_auth',
-    skipFirstRunAdminBootstrap: effectiveConfig.external_launch?.enabled === true,
+    skipFirstRunAdminBootstrap:
+      !resolveIdentityAuthority(effectiveConfig).capabilities.users.create,
     // The URL may come from DATABASE_URL, but operators still need to size the
     // per-replica pool from config.yaml. Keep this deliberately limited to max:
     // the public idleTimeout setting is documented in milliseconds while the

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -39,6 +39,7 @@ import {
   assertValidEffectiveExecutionConfig,
   assertValidEffectiveExternalLaunchConfig,
   assertValidEffectiveIdentityConfig,
+  assertValidRawConfig,
   getConfigPath,
   loadConfig,
   loadConfigFromFile,
@@ -189,6 +190,10 @@ async function startDaemonWithOwnedMetrics(
     : options?.configPath
       ? await loadConfigFromFile(options.configPath)
       : await loadConfig();
+
+  // Programmatic startup must cross the same untrusted config boundary as
+  // YAML before environment projection reads nested scalar values.
+  assertValidRawConfig(config);
 
   // Deployment environment overrides are resolved in memory. Container and
   // Kubernetes entrypoints must never materialize them back into config.yaml.

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -37,7 +37,6 @@ import {
 import type { AgorConfig, ResolvedSecurity } from '@agor/core/config';
 import {
   assertValidEffectiveExecutionConfig,
-  assertValidEffectiveExternalLaunchConfig,
   assertValidEffectiveIdentityConfig,
   assertValidRawConfig,
   getConfigPath,
@@ -52,6 +51,7 @@ import {
   resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveSecurity,
+  resolveValidExternalLaunchProvider,
 } from '@agor/core/config';
 import { generateId, resolveDatabaseUrl } from '@agor/core/db';
 import {
@@ -200,7 +200,7 @@ async function startDaemonWithOwnedMetrics(
   config = resolveEffectiveConfig(config);
   const deploymentId = requireDeploymentId(config);
   assertValidEffectiveExecutionConfig(config);
-  assertValidEffectiveExternalLaunchConfig(config);
+  const externalLaunchProvider = resolveValidExternalLaunchProvider(config);
   assertValidEffectiveIdentityConfig(config);
   const databaseUrl = resolveDatabaseUrl({ config, env: process.env });
 
@@ -860,6 +860,7 @@ async function startDaemonWithOwnedMetrics(
     db,
     app,
     config: effectiveConfig,
+    externalLaunchProvider,
     jwtSecret,
     branchRbacEnabled,
     requireAuth,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -12,6 +12,7 @@ import {
   type ResolvedDeploymentConfig,
   requireDeploymentId,
   resolveBranchStorageConfig,
+  resolveIdentityAuthority,
   resolveMultiTenancyConfig,
   resolveSdkWatchdogConfig,
   resolveTeammateFrameworkRepoUrl,
@@ -4471,6 +4472,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   app.use('/health', {
     async find(params?: AuthenticatedParams) {
       const publicLaunchAuth = resolvePublicLaunchAuthSettings(config);
+      const identityAuthority = resolveIdentityAuthority(config);
       // `/health` stays 200 always (pre-login UI fetches must not throw), so the
       // DB signal rides on `status`: ok | degraded. /readyz is the one that 503s.
       // Only { ok, latencyMs } is public; the raw error is authenticated-only below.
@@ -4498,6 +4500,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         auth: {
           requireAuth: true,
           externalLaunch: publicLaunchAuth,
+          identity: identityAuthority,
         },
         instance: {
           label: config.daemon?.instanceLabel,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -10,6 +10,7 @@ import { Transform } from 'node:stream';
 import {
   type AgorConfig,
   type ResolvedDeploymentConfig,
+  type ResolvedExternalLaunchProvider,
   requireDeploymentId,
   resolveBranchStorageConfig,
   resolveIdentityAuthority,
@@ -267,6 +268,7 @@ export interface RegisterRoutesContext {
   db: TenantScopeAwareDatabase;
   app: Application & { io?: import('socket.io').Server };
   config: AgorConfig;
+  externalLaunchProvider: ResolvedExternalLaunchProvider;
   jwtSecret: string;
   branchRbacEnabled: boolean;
   requireAuth: (context: HookContext) => Promise<HookContext>;
@@ -473,6 +475,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     db,
     app,
     config,
+    externalLaunchProvider,
     jwtSecret,
     branchRbacEnabled,
     requireAuth,
@@ -498,6 +501,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   } = ctx;
 
   registerExecutorResponseRoutes(app);
+
+  // Health and launch auth share the exact startup-resolved provider. The
+  // public DTO is immutable and contains no verification or exchange secrets.
+  const publicLaunchAuth = Object.freeze(resolvePublicLaunchAuthSettings(externalLaunchProvider));
 
   const usersService = app.service('users');
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
@@ -718,6 +725,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     createLaunchAuthService({
       db,
       config,
+      provider: externalLaunchProvider,
       jwtSecret,
       accessTokenTtl: ACCESS_TOKEN_TTL,
       refreshTokenTtl: REFRESH_TOKEN_TTL,
@@ -4471,7 +4479,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   app.use('/health', {
     async find(params?: AuthenticatedParams) {
-      const publicLaunchAuth = resolvePublicLaunchAuthSettings(config);
       const identityAuthority = resolveIdentityAuthority(config);
       // `/health` stays 200 always (pre-login UI fetches must not throw), so the
       // DB signal rides on `status`: ok | degraded. /readyz is the one that 503s.

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -7,11 +7,22 @@
  * shaped bytes cannot persist in the database.
  */
 
+import type { AgorConfig } from '@agor/core/config';
 import { AgenticToolPresetRepository } from '@agor/core/db';
-import type { UserID } from '@agor/core/types';
+import type { Params, UserID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
-import { UsersService } from './users';
+import { markLocalAuthenticationLookup, UsersService } from './users';
+
+const externalIdentityConfig: AgorConfig = {
+  identity: {
+    user_lifecycle: 'external',
+    role_authority: 'claims',
+    local_auth: 'disabled',
+    external: { provider: 'external_launch', provisioning: 'jit' },
+  },
+  external_launch: { enabled: true },
+};
 
 async function makeUser(service: UsersService): Promise<UserID> {
   const user = await service.create({
@@ -113,6 +124,108 @@ describe('UsersService — delegated execution home key validation', () => {
       unix_username: '_alice-1',
     });
     expect(user.unix_username).toBe('_alice-1');
+  });
+});
+
+describe('UsersService — external identity authority', () => {
+  dbTest('rejects ordinary create and delete with a stable capability error', async ({ db }) => {
+    const local = new UsersService(db);
+    const userId = await makeUser(local);
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+
+    await expect(
+      external.create({ email: 'created-locally@test.local', password: 'test-password-1234' })
+    ).rejects.toMatchObject({
+      code: 403,
+      data: {
+        code: 'IDENTITY_EXTERNALLY_MANAGED',
+        capability: 'users.create',
+        authority: 'external',
+      },
+    });
+    await expect(external.remove(userId)).rejects.toMatchObject({
+      code: 403,
+      data: {
+        code: 'IDENTITY_EXTERNALLY_MANAGED',
+        capability: 'users.delete',
+        authority: 'external',
+      },
+    });
+  });
+
+  dbTest('rejects claim-owned fields atomically while preserving preferences', async ({ db }) => {
+    const local = new UsersService(db);
+    const userId = await makeUser(local);
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+
+    await expect(
+      external.patch(userId, {
+        email: 'drift@test.local',
+        preferences: { audio: { enabled: false } },
+      })
+    ).rejects.toMatchObject({
+      code: 403,
+      data: {
+        code: 'IDENTITY_EXTERNALLY_MANAGED',
+        capability: 'users.identity.write',
+      },
+    });
+
+    const unchanged = await external.get(userId);
+    expect(unchanged.email).not.toBe('drift@test.local');
+    expect(unchanged.preferences).toEqual({});
+  });
+
+  dbTest('rejects claim-owned role and password writes', async ({ db }) => {
+    const local = new UsersService(db);
+    const userId = await makeUser(local);
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+
+    await expect(external.patch(userId, { role: 'admin' })).rejects.toMatchObject({
+      data: { capability: 'users.role.write', authority: 'claims' },
+    });
+    await expect(
+      external.patch(userId, { password: 'replacement-password' })
+    ).rejects.toMatchObject({
+      data: { capability: 'users.password.write', authority: 'external' },
+    });
+  });
+
+  dbTest('keeps Agor-owned settings editable', async ({ db }) => {
+    const local = new UsersService(db);
+    const userId = await makeUser(local);
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+
+    const updated = await external.patch(userId, {
+      emoji: '🛠️',
+      onboarding_completed: true,
+      preferences: { audio: { enabled: false } },
+      default_mcp_server_ids: [],
+    });
+
+    expect(updated.emoji).toBe('🛠️');
+    expect(updated.onboarding_completed).toBe(true);
+    expect(updated.preferences).toEqual({ audio: { enabled: false } });
+    expect(updated.default_mcp_server_ids).toEqual([]);
+  });
+
+  dbTest('disables local password lookup and avatar mutation surfaces', async ({ db }) => {
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+    const params = { provider: 'rest', query: { email: 'person@test.local' } } as Params;
+    markLocalAuthenticationLookup(params);
+
+    await expect(external.find(params)).rejects.toMatchObject({
+      code: 401,
+      data: { code: 'LOCAL_AUTH_DISABLED' },
+    });
+    await expect(external.updateAvatarSettings({})).rejects.toMatchObject({
+      code: 403,
+      data: { capability: 'users.avatar-settings.write' },
+    });
+    await expect(external.syncAvatars()).rejects.toMatchObject({
+      code: 403,
+      data: { capability: 'users.avatar-settings.write' },
+    });
   });
 });
 

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -9,7 +9,7 @@
 
 import type { AgorConfig } from '@agor/core/config';
 import { AgenticToolPresetRepository } from '@agor/core/db';
-import type { Params, UserID } from '@agor/core/types';
+import type { AuthenticatedParams, Params, UserID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { markLocalAuthenticationLookup, UsersService } from './users';
@@ -223,6 +223,46 @@ describe('UsersService — external identity authority', () => {
     expect(updated.onboarding_completed).toBe(true);
     expect(updated.preferences).toEqual({ audio: { enabled: false } });
     expect(updated.default_mcp_server_ids).toEqual([]);
+  });
+
+  dbTest('composes external capabilities with actor role authority', async ({ db }) => {
+    const local = new UsersService(db);
+    const superadmin = await local.create({
+      email: 'external-superadmin@test.local',
+      password: 'test-password-1234',
+      role: 'superadmin',
+    });
+    const member = await local.create({
+      email: 'external-member@test.local',
+      password: 'test-password-1234',
+      role: 'member',
+    });
+    const params = {
+      provider: 'rest',
+      user: {
+        user_id: superadmin.user_id,
+        email: superadmin.email,
+        role: superadmin.role,
+      },
+    } as AuthenticatedParams;
+    const external = new UsersService(db, undefined, externalIdentityConfig);
+
+    await expect(
+      external.create(
+        { email: 'external-created@test.local', password: 'test-password-1234' },
+        params
+      )
+    ).rejects.toMatchObject({ data: { capability: 'users.create' } });
+    await expect(
+      external.patch(member.user_id as UserID, { role: 'admin' }, params)
+    ).rejects.toMatchObject({ data: { capability: 'users.role.write' } });
+    await expect(external.remove(member.user_id as UserID, params)).rejects.toMatchObject({
+      data: { capability: 'users.delete' },
+    });
+
+    await expect(
+      external.patch(member.user_id as UserID, { preferences: { theme: 'dark' } }, params)
+    ).resolves.toMatchObject({ preferences: { theme: 'dark' } });
   });
 
   dbTest('disables local password lookup and avatar mutation surfaces', async ({ db }) => {

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -125,6 +125,22 @@ describe('UsersService — delegated execution home key validation', () => {
     });
     expect(user.unix_username).toBe('_alice-1');
   });
+
+  dbTest('rejects a duplicate execution-home key across users', async ({ db }) => {
+    const service = new UsersService(db);
+    await service.create({
+      email: 'first-home-key@test.local',
+      password: 'test-password-1234',
+      unix_username: 'shared-home',
+    });
+    await expect(
+      service.create({
+        email: 'second-home-key@test.local',
+        password: 'test-password-1234',
+        unix_username: 'shared-home',
+      })
+    ).rejects.toThrow(/already in use/);
+  });
 });
 
 describe('UsersService — external identity authority', () => {

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -10,11 +10,19 @@ import {
   normalizeAgenticToolModelConfiguration,
 } from '@agor/agentic-tools/config';
 import {
+  type AgorConfig,
+  type AgorIdentityCapability,
+  AgorLocalAuthMode,
+  AgorRoleAuthority,
+  AgorUserLifecycleAuthority,
   assertInlineAgenticConfigurationAllowed,
   assertV05Scope,
   getEnvVarBlockReason,
+  AgorIdentityCapability as IdentityCapability,
   isEnvVarAllowed,
   normalizeStoredEnvMap,
+  type ResolvedIdentityAuthority,
+  resolveIdentityAuthority,
   resolveUserEnvironment,
   type StoredEnvVar,
   validateEnvVar,
@@ -29,6 +37,7 @@ import {
   generateId,
   hash,
   insert,
+  isExecutionHomeKeyAvailable,
   select,
   sql,
   type TenantScopeAwareDatabase,
@@ -353,13 +362,84 @@ function assertValidExecutionHomeKeyWrite(value: string | undefined): void {
  */
 export class UsersService {
   private avatarSync?: UserAvatarSyncManager;
+  private readonly identityAuthority: ResolvedIdentityAuthority;
 
   constructor(
     protected db: TenantScopeAwareDatabase,
-    app?: Application
+    app?: Application,
+    config?: AgorConfig
   ) {
+    const effectiveConfig = config ?? (app?.get('config') as AgorConfig | undefined) ?? {};
+    this.identityAuthority = resolveIdentityAuthority(effectiveConfig);
     if (app) {
       this.avatarSync = new UserAvatarSyncManager(db, app);
+    }
+  }
+
+  private externallyManaged(
+    capability: AgorIdentityCapability,
+    authority: typeof AgorUserLifecycleAuthority.EXTERNAL | typeof AgorRoleAuthority.CLAIMS
+  ): never {
+    throw new Forbidden('This user field is managed by the configured identity provider', {
+      code: 'IDENTITY_EXTERNALLY_MANAGED',
+      capability,
+      authority,
+    });
+  }
+
+  private assertCreateAllowed(): void {
+    if (!this.identityAuthority.capabilities.users.create) {
+      this.externallyManaged(IdentityCapability.USER_CREATE, AgorUserLifecycleAuthority.EXTERNAL);
+    }
+  }
+
+  private assertDeleteAllowed(): void {
+    if (!this.identityAuthority.capabilities.users.delete) {
+      this.externallyManaged(IdentityCapability.USER_DELETE, AgorUserLifecycleAuthority.EXTERNAL);
+    }
+  }
+
+  private assertPatchAllowed(data: UpdateUserData): void {
+    if (data.role !== undefined && !this.identityAuthority.capabilities.users.roleWrite) {
+      this.externallyManaged(IdentityCapability.USER_ROLE_WRITE, AgorRoleAuthority.CLAIMS);
+    }
+
+    const identityFields: Array<keyof UpdateUserData> = [
+      'email',
+      'name',
+      'unix_username',
+      'avatar_url',
+      'avatar',
+      'avatar_source',
+      'avatar_source_id',
+      'avatar_synced_at',
+    ];
+    if (
+      identityFields.some((field) => data[field] !== undefined) &&
+      !this.identityAuthority.capabilities.users.identityWrite
+    ) {
+      this.externallyManaged(
+        IdentityCapability.USER_IDENTITY_WRITE,
+        AgorUserLifecycleAuthority.EXTERNAL
+      );
+    }
+
+    if (
+      (data.password !== undefined || data.must_change_password !== undefined) &&
+      !this.identityAuthority.capabilities.users.passwordWrite
+    ) {
+      this.externallyManaged(
+        IdentityCapability.USER_PASSWORD_WRITE,
+        AgorUserLifecycleAuthority.EXTERNAL
+      );
+    }
+  }
+
+  private assertLocalAuthenticationAllowed(): void {
+    if (this.identityAuthority.localAuth === AgorLocalAuthMode.DISABLED) {
+      throw new NotAuthenticated('Local authentication is disabled', {
+        code: 'LOCAL_AUTH_DISABLED',
+      });
     }
   }
 
@@ -542,6 +622,7 @@ export class UsersService {
    *   `offset` for MCP/client ergonomics
    */
   async find(params?: Params): Promise<Paginated<User>> {
+    if (isLocalAuthenticationLookup(params)) this.assertLocalAuthenticationAllowed();
     const rawQuery = (params?.query ?? {}) as Record<string, unknown>;
 
     // Check if filtering by email (for authentication)
@@ -631,11 +712,14 @@ export class UsersService {
    */
   async create(data: CreateUserData, params?: Params): Promise<User> {
     assertSingleUserMutation(data);
+    this.assertCreateAllowed();
     assertValidExecutionHomeKeyWrite(data.unix_username);
+    if (data.unix_username && !(await isExecutionHomeKeyAvailable(this.db, data.unix_username))) {
+      throw new BadRequest(`Execution home key "${data.unix_username}" is already in use`);
+    }
     if (Object.hasOwn(data, 'role')) data.role = canonicalizeRoleWrite(data.role);
     await lockUserAuthorityMutation(this.db, params);
     await this.authorizeCreate(data, params);
-
     // Check if email already exists
     const existing = await select(this.db)
       .from(users)
@@ -693,7 +777,14 @@ export class UsersService {
       throw new BadRequest('Bulk user mutations are not supported');
     }
     assertSingleUserMutation(data);
+    this.assertPatchAllowed(data);
     assertValidExecutionHomeKeyWrite(data.unix_username);
+    if (
+      data.unix_username &&
+      !(await isExecutionHomeKeyAvailable(this.db, data.unix_username, id))
+    ) {
+      throw new BadRequest(`Execution home key "${data.unix_username}" is already in use`);
+    }
     await lockUserAuthorityMutation(this.db, params);
     const authority = await this.authorizePatch(id, data, params);
     if (
@@ -704,7 +795,6 @@ export class UsersService {
     ) {
       await this.assertNotLastSuperadmin(authority.target, params);
     }
-
     const now = new Date();
     const updates: Record<string, unknown> = { updated_at: now };
 
@@ -990,6 +1080,7 @@ export class UsersService {
     if (typeof id !== 'string' || !id) {
       throw new BadRequest('Bulk user mutations are not supported');
     }
+    this.assertDeleteAllowed();
     await lockUserAuthorityMutation(this.db, params);
     const authority = await this.authorizeRemove(id, params);
     await this.assertNotLastSuperadmin(authority.target, params);
@@ -1165,6 +1256,12 @@ export class UsersService {
     data: Partial<UserAvatarSettings>,
     params?: Params
   ): Promise<UserAvatarSettings> {
+    if (!this.identityAuthority.capabilities.users.avatarSettingsWrite) {
+      this.externallyManaged(
+        IdentityCapability.USER_AVATAR_SETTINGS_WRITE,
+        AgorUserLifecycleAuthority.EXTERNAL
+      );
+    }
     return this.requireAvatarSync().updateSettings(data, params);
   }
 
@@ -1172,10 +1269,17 @@ export class UsersService {
     data: UserAvatarSyncRequest = {},
     params?: Params
   ): Promise<UserAvatarSyncResult> {
+    if (!this.identityAuthority.capabilities.users.avatarSettingsWrite) {
+      this.externallyManaged(
+        IdentityCapability.USER_AVATAR_SETTINGS_WRITE,
+        AgorUserLifecycleAuthority.EXTERNAL
+      );
+    }
     return this.requireAvatarSync().syncAvatars(data, params);
   }
 
   async refreshAvatarFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
+    if (!this.identityAuthority.capabilities.users.avatarSettingsWrite) return null;
     return this.requireAvatarSync().refreshUserFromSettings(userId);
   }
 

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -40,6 +40,13 @@ external_launch:
   # Optional: allow role claims above member. Defaults to false.
   allow_admin_roles: false
 
+  # Optional backchannel timeout, 1-120000 ms. Defaults to 10000.
+  request_timeout_ms: 10000
+
+  # Optional non-empty allow-list. HS* is symmetric-only; RS*/PS*/ES* is
+  # asymmetric-only. Defaults to HS256 for a dev secret and RS256 otherwise.
+  algorithms: [RS256]
+
   # Optional: primary action shown when launch sign-in cannot continue.
   # Must be http:// or https://.
   login_redirect_url: https://workspace.example.com/open

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -176,9 +176,10 @@ credential is never returned to the browser, exposed in the public `/health`
 settings, or written to logs.
 
 Production verification fails closed: the `none` algorithm is always rejected;
-`jwks_url` / `public_key` verification defaults to an `RS256` allow-list to
-prevent algorithm confusion; and a missing issuer, audience, `exp`, `sub`, or
-required tenant claim creates no session.
+`jwks_url` verification defaults to an `RS256` allow-list, while a static
+`public_key` derives a compatible default from its key type and EC curve. An
+explicit allow-list must match that key. A missing issuer, audience, `exp`,
+`sub`, or required tenant claim creates no session.
 
 The exchange endpoint should consume the launch code exactly once and return:
 
@@ -210,12 +211,13 @@ Required when `external_launch.instance_id` is configured:
 
 ## Compatibility and upgrade notes
 
-- **Non-RS256 asymmetric signing must be declared before upgrading.** Asymmetric
-  verification (`jwks_url` / `public_key`) defaults to an `RS256`-only allow-list
-  and refuses HS\* algorithms. If your issuer signs assertions with another
-  asymmetric algorithm (`RS384`, `ES256`, `PS256`, …) and previously relied on
-  library defaults, set `algorithms` explicitly to the intended asymmetric
-  algorithm **before** upgrading, or assertions will stop verifying.
+- **Non-RS256 JWKS signing must be declared before upgrading.** `jwks_url`
+  verification defaults to an `RS256`-only allow-list and refuses HS\*
+  algorithms. Static `public_key` verification instead derives `RS256` for RSA
+  or the matching ES algorithm for a supported EC curve; an explicit
+  `algorithms` list must be compatible with the key. If a JWKS issuer signs with
+  another asymmetric algorithm (`RS384`, `ES256`, `PS256`, …), set
+  `algorithms` explicitly **before** upgrading.
 - **`login_redirect_url` deployments begin receiving a return-host parameter.**
   When `login_redirect_url` is enabled, direct-host entry appends the configured
   `return_host_param` (default `return_host`) to that URL. Existing deployments

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -82,6 +82,12 @@ Agor-owned preferences, onboarding state, AI-provider credentials and defaults,
 environment variables, personal API keys, and MCP selections/OAuth grants stay
 editable.
 
+The trusted `(tenant, provider, issuer, subject)` binding is stored in a
+tenant-owned relation with database uniqueness enforcement. PostgreSQL JIT
+projection is one tenant-scoped transaction and serializes the same subject
+across replicas. Execution-home keys are also unique per tenant, preventing two
+users from sharing one delegated credential context.
+
 The role claim is required and exact in this mode. Administrative claims still
 require `external_launch.allow_admin_roles`; a `superadmin` claim also requires
 `execution.allow_superadmin`. A disabled role fails authentication rather than
@@ -91,6 +97,12 @@ Omitting `identity` preserves normal local user, role, and password authority.
 The current contract does not synchronize external deactivation or revoke
 already-issued Agor credentials: the external provider can prevent a new
 launch, while cleanup and revocation remain a separate lifecycle concern.
+
+Before enabling this profile, apply the external-identity migration and upgrade
+every daemon replica. The migration fails closed if legacy external bindings or
+non-null execution-home keys conflict. New daemons can bind a legacy JSON link
+on the next successful launch, but old daemons do not maintain the new binding
+relation.
 
 For local development only, a symmetric assertion secret can be used:
 

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -57,6 +57,41 @@ external_launch:
   return_host_param: return_host
 ```
 
+### External user and role authority
+
+External launch authentication does not disable Agor user administration by
+itself. A deployment whose launch provider is also authoritative for user
+lifecycle, profile fields, and roles must opt into the identity contract:
+
+```yaml
+identity:
+  user_lifecycle: external
+  role_authority: claims
+  local_auth: disabled
+  external:
+    provider: external_launch
+    provisioning: jit
+```
+
+With this profile, verified launches may still create a missing local user and
+synchronize JWT-owned email, name, avatar, execution-home key, and role. Those
+fields update when the next external launch succeeds; the daemon does not call
+the provider on every request. User and administrator calls through REST,
+Socket.IO, CLI, and MCP cannot create or delete users or edit those fields.
+Agor-owned preferences, onboarding state, AI-provider credentials and defaults,
+environment variables, personal API keys, and MCP selections/OAuth grants stay
+editable.
+
+The role claim is required and exact in this mode. Administrative claims still
+require `external_launch.allow_admin_roles`; a `superadmin` claim also requires
+`execution.allow_superadmin`. A disabled role fails authentication rather than
+being silently downgraded.
+
+Omitting `identity` preserves normal local user, role, and password authority.
+The current contract does not synchronize external deactivation or revoke
+already-issued Agor credentials: the external provider can prevent a new
+launch, while cleanup and revocation remain a separate lifecycle concern.
+
 For local development only, a symmetric assertion secret can be used:
 
 ```yaml
@@ -80,7 +115,7 @@ fresh launch link from the external workspace. The button appends a `return_to`
 query parameter containing the current Agor path, allowing the launcher to
 preserve deep links such as `/ui/s/<session>/` when it issues a fresh
 `launch_code`. Local username/password login is still available as a secondary
-fallback.
+fallback unless external identity authority disables it.
 
 If `login_redirect_url` is omitted, the normal local login screen is unchanged.
 

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { AgorLocalAuthMode } from '@agor/core/config/browser';
 import type {
   AgenticToolName,
   AgorClient,
@@ -894,7 +895,7 @@ function AppContent() {
             ? authConfig.externalLaunch.returnHostParam
             : undefined
         }
-        localLoginEnabled={authConfig?.identity?.localAuth !== 'disabled'}
+        localLoginEnabled={authConfig?.identity?.localAuth !== AgorLocalAuthMode.DISABLED}
       />
     );
   }

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -894,6 +894,7 @@ function AppContent() {
             ? authConfig.externalLaunch.returnHostParam
             : undefined
         }
+        localLoginEnabled={authConfig?.identity?.localAuth !== 'disabled'}
       />
     );
   }

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -30,7 +30,7 @@ import {
   ROLES,
   sessionPath,
 } from '@agor-live/client';
-import { Alert, ConfigProvider, theme } from 'antd';
+import { Alert, Button, ConfigProvider, theme } from 'antd';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AVAILABLE_AGENTS } from './components/AgentSelectionGrid';
@@ -49,6 +49,7 @@ import { CanvasNavigationProvider } from './contexts/CanvasNavigationContext';
 import { ConnectionProvider } from './contexts/ConnectionContext';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
 import {
+  IdentityContractState,
   useAgorClient,
   useAgorData,
   useAuth,
@@ -319,6 +320,8 @@ function AppContent() {
     featuresConfig,
     loading: authConfigLoading,
     error: authConfigError,
+    identityContractState,
+    retry: retryAuthConfig,
   } = useAuthConfig();
 
   // Authentication
@@ -845,6 +848,7 @@ function AppContent() {
   // Show auth config error ONLY if we don't have a config yet (first load)
   // If we already have a config cached, continue with that even if there's an error
   if (authConfigError && !authConfig) {
+    const unsupportedIdentityContract = identityContractState === IdentityContractState.UNSUPPORTED;
     return (
       <div
         style={{
@@ -857,16 +861,27 @@ function AppContent() {
       >
         <Alert
           type="warning"
-          title="Could not fetch daemon configuration"
+          title={
+            unsupportedIdentityContract
+              ? 'Incompatible daemon configuration contract'
+              : 'Could not fetch daemon configuration'
+          }
           description={
             <div>
               <p>{authConfigError.message}</p>
-              <p>Defaulting to requiring authentication. Start the daemon with:</p>
-              <p>
-                <code>cd apps/agor-daemon && pnpm dev</code>
-              </p>
+              {unsupportedIdentityContract ? (
+                <p>Deploy compatible Agor UI and daemon versions, then retry.</p>
+              ) : (
+                <>
+                  <p>Make sure the daemon is running:</p>
+                  <p>
+                    <code>cd apps/agor-daemon && pnpm dev</code>
+                  </p>
+                </>
+              )}
             </div>
           }
+          action={<Button onClick={retryAuthConfig}>Retry</Button>}
           showIcon
         />
       </div>

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -102,6 +102,29 @@ describe('LoginPage external launch redirect', () => {
     expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
   });
 
+  it('does not offer a local-login fallback when identity authority disables it', () => {
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open"
+        localLoginEnabled={false}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'Return to workspace' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Use local login instead' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Email address')).not.toBeInTheDocument();
+  });
+
+  it('explains externally managed sign-in when no return URL is configured', () => {
+    render(<LoginPage onLogin={vi.fn()} localLoginEnabled={false} />);
+
+    expect(screen.getByText('Sign-in is managed by your workspace')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Email address')).not.toBeInTheDocument();
+  });
+
   it('pairs launch errors with the external return action', () => {
     render(
       <LoginPage

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -22,6 +22,7 @@ interface LoginPageProps {
   error?: string | null;
   externalLaunchLoginRedirectUrl?: string;
   externalLaunchReturnHostParam?: string;
+  localLoginEnabled?: boolean;
 }
 
 export function LoginPage({
@@ -30,6 +31,7 @@ export function LoginPage({
   error,
   externalLaunchLoginRedirectUrl,
   externalLaunchReturnHostParam,
+  localLoginEnabled = true,
 }: LoginPageProps) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
@@ -39,7 +41,7 @@ export function LoginPage({
   const externalLaunchHref = externalLaunchLoginRedirectUrl
     ? buildLaunchInitUrl(externalLaunchLoginRedirectUrl, externalLaunchReturnHostParam)
     : undefined;
-  const showLoginForm = !useExternalLaunch || showLocalLogin;
+  const showLoginForm = localLoginEnabled && (!useExternalLaunch || showLocalLogin);
   const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;
 
   const handleSubmit = async (values: { email: string; password: string }) => {
@@ -126,12 +128,21 @@ export function LoginPage({
             >
               Return to workspace
             </Button>
-            {!showLocalLogin && (
+            {localLoginEnabled && !showLocalLogin && (
               <Button type="link" block onClick={() => setShowLocalLogin(true)}>
                 Use local login instead
               </Button>
             )}
           </Space>
+        )}
+
+        {!localLoginEnabled && !useExternalLaunch && (
+          <Alert
+            type="info"
+            title="Sign-in is managed by your workspace"
+            description="Open Agor from your workspace to start a new session."
+            showIcon
+          />
         )}
 
         {/* Login Form */}

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp, ConfigProvider, type FormInstance } from 'antd';
 import { type ReactNode, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { agorStore } from '../../store/agorStore';
 import { UserSettingsModal } from './UserSettingsModal';
 
@@ -404,6 +405,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
   });
 
   it('keeps externally managed identity read-only while saving Agor preferences', async () => {
+    __resetAuthConfigForTests();
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -1244,6 +1246,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 // every tool enabled) before each test so provider panels render, and clear any
 // per-test override afterwards so visibility never leaks between tests.
 beforeEach(() => {
+  __setAuthConfigForTests({ requireAuth: true });
   agorStore.getState().setAgenticToolSettings([]);
 });
 afterEach(() => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -418,6 +418,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
               userLifecycle: 'external',
               roleAuthority: 'claims',
               localAuth: 'disabled',
+              external: { provider: 'external_launch', provisioning: 'jit' },
               capabilities: {
                 users: {
                   create: false,

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -403,6 +403,72 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps externally managed identity read-only while saving Agor preferences', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          auth: {
+            requireAuth: true,
+            identity: {
+              contractVersion: 1,
+              userLifecycle: 'external',
+              roleAuthority: 'claims',
+              localAuth: 'disabled',
+              capabilities: {
+                users: {
+                  create: false,
+                  delete: false,
+                  identityWrite: false,
+                  roleWrite: false,
+                  passwordWrite: false,
+                  avatarSettingsWrite: false,
+                  selfConfigurationWrite: true,
+                },
+              },
+            },
+          },
+        }),
+      })
+    );
+    const user = makeUser({ role: 'admin' });
+    const onUpdate = vi.fn(async () => {});
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={user}
+        currentUser={user}
+        client={null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    await screen.findByText('Identity and role are managed by your workspace');
+    expect(screen.getByPlaceholderText('John Doe')).toBeDisabled();
+    expect(screen.getByPlaceholderText('user@example.com')).toBeDisabled();
+    expect(screen.queryByRole('menuitem', { name: /security/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /preferences/i }));
+    await screen.findByRole('heading', { name: 'Preferences' });
+    const enableChimes = document.querySelector<HTMLInputElement>(
+      'input[aria-label="Enable chimes"]'
+    );
+    expect(enableChimes).not.toBeNull();
+    fireEvent.click(enableChimes as HTMLInputElement);
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled(), ASYNC);
+    const patch = onUpdate.mock.calls[0][1];
+    expect(patch.preferences?.audio?.enabled).toBe(true);
+    expect(patch).not.toHaveProperty('email');
+    expect(patch).not.toHaveProperty('name');
+    expect(patch).not.toHaveProperty('role');
+    expect(patch).not.toHaveProperty('password');
+  });
+
   it('keeps the modal open when saving Profile settings fails', async () => {
     const user = makeUser();
     const onUpdate = vi.fn(async () => {
@@ -1182,4 +1248,5 @@ beforeEach(() => {
 });
 afterEach(() => {
   agorStore.getState().setAgenticToolSettings([]);
+  vi.unstubAllGlobals();
 });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -453,6 +453,9 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(screen.getByPlaceholderText('John Doe')).toBeDisabled();
     expect(screen.getByPlaceholderText('user@example.com')).toBeDisabled();
     expect(screen.queryByRole('menuitem', { name: /security/i })).not.toBeInTheDocument();
+    const useSlackAvatar = screen.getByRole('switch');
+    expect(useSlackAvatar).toBeEnabled();
+    fireEvent.click(useSlackAvatar);
 
     fireEvent.click(screen.getByRole('menuitem', { name: /preferences/i }));
     await screen.findByRole('heading', { name: 'Preferences' });
@@ -466,6 +469,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     await waitFor(() => expect(onUpdate).toHaveBeenCalled(), ASYNC);
     const patch = onUpdate.mock.calls[0][1];
     expect(patch.preferences?.audio?.enabled).toBe(true);
+    expect(patch.preferences?.use_slack_avatar).toBe(false);
     expect(patch).not.toHaveProperty('email');
     expect(patch).not.toHaveProperty('name');
     expect(patch).not.toHaveProperty('role');

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1,5 +1,6 @@
 import { AGENTIC_TOOL_CAPABILITIES, AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
 import { type AgenticToolReadiness, getAgenticToolUIIntegration } from '@agor/agentic-tools/ui';
+import { AgorUserLifecycleAuthority } from '@agor/core/config/browser';
 import { EXECUTION_HOME_KEY_PATTERN } from '@agor/core/types';
 import type {
   AgenticAuthMethod,
@@ -58,6 +59,7 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById } from '../../store/selectors';
 import { buildAgenticToolCredentialPatch } from '../../utils/agenticToolCredentials';
@@ -260,6 +262,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   initialTab,
 }) => {
   const { token } = theme.useToken();
+  const { config: authConfig, identityContractState } = useAuthConfig();
 
   // Entity maps are read from the store rather than drilled through props so
   // the App shell doesn't have to forward them into every modal.
@@ -292,11 +295,37 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     null
   );
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  const externallyManaged =
+    authConfig?.identity?.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL;
+  const identityWriteAvailable = isIdentityCapabilityAvailable(
+    authConfig,
+    identityContractState,
+    'identityWrite'
+  );
+  const roleWriteAvailable = isIdentityCapabilityAvailable(
+    authConfig,
+    identityContractState,
+    'roleWrite'
+  );
+  const passwordWriteAvailable = isIdentityCapabilityAvailable(
+    authConfig,
+    identityContractState,
+    'passwordWrite'
+  );
   const isEditingOther = !!user && !!currentUser && user.user_id !== currentUser.user_id;
   const isSelf = !!user && !!currentUser && user.user_id === currentUser.user_id;
   const canEditTarget =
     !isEditingOther || (isAdmin && hasRoleAuthorityOver(currentUser?.role, user?.role));
   const canAdministerTarget = isAdmin && canEditTarget;
+  const canWriteIdentity = canEditTarget && identityWriteAvailable;
+  const canWriteRole = canAdministerTarget && !isSelf && roleWriteAvailable;
+  const canWritePassword = canEditTarget && passwordWriteAvailable;
+  const canWriteExecutionHome = canAdministerTarget && identityWriteAvailable;
+  const identityWriteHelp = !identityWriteAvailable
+    ? 'Managed by your identity provider'
+    : canWriteIdentity
+      ? undefined
+      : 'You do not have authority to edit this user';
   const assignableRoleOptions = ROLE_OPTIONS.filter((option) =>
     canAssignUserRole(currentUser?.role, option.value)
   );
@@ -319,6 +348,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         ? rawActiveKey
         : 'profile';
     }
+    if (rawActiveKey === 'security' && !canWriteExecutionHome && !canWritePassword)
+      return 'profile';
     if ((rawActiveKey === 'tokens' || rawActiveKey === 'uploads') && isEditingOther)
       return 'profile';
     if (rawActiveKey === 'access' && !canAdministerTarget) return 'profile';
@@ -684,8 +715,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     try {
       const toValidate: string[] = [];
-      if (panels.has('profile')) toValidate.push('email', 'name', 'role');
-      if (panels.has('security')) toValidate.push('unix_username');
+      if (panels.has('profile') && canWriteIdentity) toValidate.push('email', 'name');
+      if (panels.has('profile') && canWriteRole) toValidate.push('role');
+      if (panels.has('security') && canWriteExecutionHome) toValidate.push('unix_username');
       if (toValidate.length) await form.validateFields(toValidate);
 
       const updates: UpdateUserInput = {};
@@ -694,21 +726,23 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
       if (panels.has('profile')) {
         const values = form.getFieldsValue(['email', 'name', 'role', 'useSlackAvatar']);
-        updates.email = values.email;
-        updates.name = values.name;
-        updates.role = values.role;
+        if (canWriteIdentity) {
+          updates.email = values.email;
+          updates.name = values.name;
+        }
         if (values.useSlackAvatar === false) {
           nextPreferences.use_slack_avatar = false;
         } else {
           delete nextPreferences.use_slack_avatar;
         }
         preferencesTouched = true;
+        if (canWriteRole) updates.role = values.role;
       }
 
       if (panels.has('security')) {
         const values = form.getFieldsValue(['unix_username', 'password']);
-        updates.unix_username = values.unix_username;
-        if (values.password?.trim()) updates.password = values.password;
+        if (canWriteExecutionHome) updates.unix_username = values.unix_username;
+        if (canWritePassword && values.password?.trim()) updates.password = values.password;
       }
 
       if (panels.has('preferences')) {
@@ -723,7 +757,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         preferencesTouched = true;
       }
 
-      if (panels.has('access') && canAdministerTarget && isEditingOther) {
+      if (panels.has('access') && canAdministerTarget && isEditingOther && canWritePassword) {
         updates.must_change_password = form.getFieldValue('must_change_password');
       }
 
@@ -1026,7 +1060,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         children: [
           { key: 'profile', ...PANEL_META.profile },
           { key: 'preferences', ...PANEL_META.preferences },
-          { key: 'security', ...PANEL_META.security },
+          ...(!canWriteExecutionHome && !canWritePassword
+            ? []
+            : [{ key: 'security', ...PANEL_META.security }]),
           // Personal API tokens and uploads are scoped to the signed-in caller,
           // so they are meaningless (and misleading) when an admin edits another
           // user.
@@ -1062,7 +1098,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       });
     }
     return groups;
-  }, [canAdministerTarget, canEditTarget, visibleAgenticToolTabs, isEditingOther, resolveProvider]);
+  }, [
+    canAdministerTarget,
+    canEditTarget,
+    canWriteExecutionHome,
+    canWritePassword,
+    isEditingOther,
+    resolveProvider,
+    visibleAgenticToolTabs,
+  ]);
 
   const menuItems: MenuProps['items'] = useMemo(
     () =>
@@ -1123,18 +1167,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         panelKey: 'profile',
       },
       {
-        label: 'Password',
-        kind: 'setting',
-        keywords: 'credentials security',
-        panelKey: 'security',
-      },
-      {
-        label: 'Execution home key',
-        kind: 'setting',
-        keywords: 'impersonation os process user',
-        panelKey: 'security',
-      },
-      {
         label: 'Enable chimes',
         kind: 'setting',
         keywords: 'sound audio notification',
@@ -1165,6 +1197,22 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         panelKey: 'preferences',
       },
     ];
+    if (canWritePassword) {
+      entries.push({
+        label: 'Password',
+        kind: 'setting',
+        keywords: 'credentials security',
+        panelKey: 'security',
+      });
+    }
+    if (canWriteExecutionHome) {
+      entries.push({
+        label: 'Execution home key',
+        kind: 'setting',
+        keywords: 'impersonation os process user',
+        panelKey: 'security',
+      });
+    }
     if (isSelf && onRestartOnboarding) {
       entries.push({
         label: 'Restart onboarding',
@@ -1181,7 +1229,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         panelKey: 'tokens',
       });
     }
-    if (isAdmin) {
+    if (canAdministerTarget) {
       entries.push({
         label: 'Groups',
         kind: 'setting',
@@ -1189,7 +1237,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         panelKey: 'access',
       });
     }
-    if (isAdmin && isEditingOther) {
+    if (canAdministerTarget && isEditingOther && canWritePassword) {
       entries.push({
         label: 'Force password change on next login',
         kind: 'setting',
@@ -1328,10 +1376,12 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     navGroups,
     visibleAgenticToolTabs,
     resolveProvider,
-    isAdmin,
+    canAdministerTarget,
     isEditingOther,
     isSelf,
     onRestartOnboarding,
+    canWriteExecutionHome,
+    canWritePassword,
   ]);
 
   const searchActive = search.trim().length > 0;
@@ -1462,9 +1512,18 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const renderProfilePanel = () => (
     <>
       <PanelHeader title={PANEL_META.profile.title} />
+      {externallyManaged && (
+        <Alert
+          type="info"
+          showIcon
+          title="Identity and role are managed by your workspace"
+          description="Changes appear after the next workspace sign-in. Your Agor preferences and connections remain editable."
+          style={{ marginBottom: 20 }}
+        />
+      )}
       <Form form={form} layout="vertical" onValuesChange={() => markMainPanelDirty('profile')}>
-        <FieldRow label="Name" name="name">
-          <Input placeholder="John Doe" disabled={!canEditTarget} />
+        <FieldRow label="Name" name="name" help={identityWriteHelp}>
+          <Input placeholder="John Doe" disabled={!canWriteIdentity} />
         </FieldRow>
 
         <FieldRow
@@ -1475,8 +1534,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
             { required: true, message: 'Please enter an email' },
             { type: 'email', message: 'Please enter a valid email' },
           ]}
+          help={identityWriteHelp}
         >
-          <Input placeholder="user@example.com" disabled={!canEditTarget} />
+          <Input placeholder="user@example.com" disabled={!canWriteIdentity} />
         </FieldRow>
 
         <FieldRow
@@ -1493,10 +1553,16 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           required
           name="role"
           rules={[{ required: true, message: 'Please select a role' }]}
-          help={canAdministerTarget ? undefined : 'Maintained by administrators'}
+          help={
+            !roleWriteAvailable
+              ? 'Managed by your identity provider'
+              : canWriteRole
+                ? undefined
+                : 'Maintained by administrators'
+          }
         >
           <Select
-            disabled={!canAdministerTarget || isSelf}
+            disabled={!canWriteRole}
             style={{ maxWidth: 320 }}
             options={assignableRoleOptions.map((opt) => ({
               value: opt.value,
@@ -1540,29 +1606,29 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     <>
       <PanelHeader title={PANEL_META.security.title} />
       <Form form={form} layout="vertical" onValuesChange={() => markMainPanelDirty('security')}>
-        <FieldRow label="Password" name="password" help="Leave blank to keep current password">
-          <Input.Password placeholder="••••••••" disabled={!canEditTarget} />
-        </FieldRow>
+        {canWritePassword && (
+          <FieldRow label="Password" name="password" help="Leave blank to keep current password">
+            <Input.Password placeholder="••••••••" />
+          </FieldRow>
+        )}
 
-        <FieldRow
-          label="Execution home key"
-          name="unix_username"
-          help={
-            canAdministerTarget
-              ? 'Transitional home key used only by delegated execution'
-              : 'Maintained by administrators'
-          }
-          rules={[
-            {
-              pattern: EXECUTION_HOME_KEY_PATTERN,
-              message:
-                'Start with a lowercase letter or underscore; then use lowercase letters, numbers, hyphens, or underscores',
-            },
-            { max: 32, message: 'Execution home key must be 32 characters or less' },
-          ]}
-        >
-          <Input placeholder="johnsmith" maxLength={32} disabled={!canAdministerTarget} />
-        </FieldRow>
+        {canWriteExecutionHome && (
+          <FieldRow
+            label="Execution home key"
+            name="unix_username"
+            help="Transitional home key used only by delegated execution"
+            rules={[
+              {
+                pattern: EXECUTION_HOME_KEY_PATTERN,
+                message:
+                  'Start with a lowercase letter or underscore; then use lowercase letters, numbers, hyphens, or underscores',
+              },
+              { max: 32, message: 'Execution home key must be 32 characters or less' },
+            ]}
+          >
+            <Input placeholder="johnsmith" maxLength={32} />
+          </FieldRow>
+        )}
       </Form>
     </>
   );
@@ -1640,7 +1706,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           />
         </FieldRow>
 
-        {canAdministerTarget && isEditingOther && (
+        {canAdministerTarget && isEditingOther && canWritePassword && (
           <>
             <SectionDivider label="Danger zone" />
             <Form.Item

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
@@ -1,7 +1,8 @@
 import type { User } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { App as AntApp, ConfigProvider } from 'antd';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { UsersTable } from './UsersTable';
 
 function user(user_id: string, role: User['role']): User {
@@ -33,6 +34,12 @@ function renderTable(currentUser: User, users: User[]) {
 }
 
 describe('UsersTable role authority', () => {
+  beforeEach(() => {
+    // Legacy/local authority is permissive; individual tests override this
+    // retained health snapshot when exercising delegated capabilities.
+    __setAuthConfigForTests({ requireAuth: true });
+  });
+
   it('hides superadmin mutation actions from admins but keeps member actions', () => {
     const admin = user('admin', 'admin');
     const superadmin = user('superadmin', 'superadmin');
@@ -58,5 +65,37 @@ describe('UsersTable role authority', () => {
 
     expect(await screen.findByText('Admin')).toBeInTheDocument();
     expect(screen.queryByText('Superadmin')).not.toBeInTheDocument();
+  });
+
+  it('composes external lifecycle capabilities with role authority', () => {
+    __setAuthConfigForTests({
+      requireAuth: true,
+      identity: {
+        contractVersion: 1,
+        userLifecycle: 'external',
+        roleAuthority: 'claims',
+        localAuth: 'disabled',
+        external: { provider: 'external_launch', provisioning: 'jit' },
+        capabilities: {
+          users: {
+            create: false,
+            delete: false,
+            identityWrite: false,
+            roleWrite: false,
+            passwordWrite: false,
+            avatarSettingsWrite: false,
+            selfConfigurationWrite: true,
+          },
+        },
+      },
+    });
+    const admin = user('admin', 'admin');
+    const member = user('member', 'member');
+    renderTable(admin, [admin, member]);
+
+    expect(screen.queryByRole('button', { name: /new user/i })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Edit admin@example.test')).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit member@example.test')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete member@example.test')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -1,3 +1,4 @@
+import { AgorUserLifecycleAuthority } from '@agor/core/config/browser';
 import { EXECUTION_HOME_KEY_PATTERN } from '@agor/core/types';
 import type {
   AgorClient,
@@ -33,6 +34,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
+import { isIdentityCapabilityAvailable, useAuthConfig } from '../../hooks/useAuthConfig';
 import { useThemedMessage } from '../../utils/message';
 import { HighlightMatch } from '../HighlightMatch';
 import { UserIdentityAvatar } from '../UserIdentityAvatar';
@@ -60,6 +62,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   onDelete,
 }) => {
   const { showError } = useThemedMessage();
+  const { config: authConfig, identityContractState } = useAuthConfig();
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [groups, setGroups] = useState<Group[]>([]);
@@ -67,6 +70,14 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  const externallyManaged =
+    authConfig?.identity?.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL;
+  const canCreateUsers =
+    isAdmin && isIdentityCapabilityAvailable(authConfig, identityContractState, 'create');
+  const canDeleteUsers = isIdentityCapabilityAvailable(authConfig, identityContractState, 'delete');
+  const canManageAvatarSettings =
+    isAdmin &&
+    isIdentityCapabilityAvailable(authConfig, identityContractState, 'avatarSettingsWrite');
   const assignableRoleOptions = ROLE_OPTIONS.filter((option) =>
     canAssignUserRole(currentUser?.role, option.value)
   );
@@ -79,6 +90,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     !!currentUser &&
     currentUser.user_id !== target.user_id &&
     isAdmin &&
+    canDeleteUsers &&
     hasRoleAuthorityOver(currentUser.role, target.role);
 
   const loadGroups = useCallback(async () => {
@@ -283,7 +295,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           alignItems: 'center',
         }}
       >
-        <Typography.Text type="secondary">Manage user accounts and permissions.</Typography.Text>
+        <Typography.Text type="secondary">
+          {externallyManaged
+            ? 'User accounts and roles are managed by your identity provider.'
+            : 'Manage user accounts and permissions.'}
+        </Typography.Text>
         <Space>
           <Input
             allowClear
@@ -292,7 +308,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
             onChange={(event) => setSearchTerm(event.target.value)}
             style={{ width: 320 }}
           />
-          {isAdmin && (
+          {canCreateUsers && (
             <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
               New User
             </Button>
@@ -309,80 +325,82 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       />
 
       {/* Create User Modal */}
-      <Modal
-        title="Create User"
-        open={createModalOpen}
-        onOk={handleCreate}
-        onCancel={() => {
-          form.resetFields();
-          setCreateModalOpen(false);
-        }}
-        okText="Create"
-        width={800}
-      >
-        <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
-          <Form.Item label="Name" name="name" style={{ marginBottom: 24 }}>
-            <Input placeholder="John Doe" />
-          </Form.Item>
+      {canCreateUsers && (
+        <Modal
+          title="Create User"
+          open={createModalOpen}
+          onOk={handleCreate}
+          onCancel={() => {
+            form.resetFields();
+            setCreateModalOpen(false);
+          }}
+          okText="Create"
+          width={800}
+        >
+          <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+            <Form.Item label="Name" name="name" style={{ marginBottom: 24 }}>
+              <Input placeholder="John Doe" />
+            </Form.Item>
 
-          <Form.Item
-            label="Email"
-            name="email"
-            rules={[
-              { required: true, message: 'Please enter an email' },
-              { type: 'email', message: 'Please enter a valid email' },
-            ]}
-          >
-            <Input placeholder="user@example.com" />
-          </Form.Item>
+            <Form.Item
+              label="Email"
+              name="email"
+              rules={[
+                { required: true, message: 'Please enter an email' },
+                { type: 'email', message: 'Please enter a valid email' },
+              ]}
+            >
+              <Input placeholder="user@example.com" />
+            </Form.Item>
 
-          <Form.Item
-            label="Execution Home Key"
-            name="unix_username"
-            help="Optional transitional home key for delegated execution"
-            rules={[
-              {
-                pattern: EXECUTION_HOME_KEY_PATTERN,
-                message:
-                  'Start with a lowercase letter or underscore; then use lowercase letters, numbers, hyphens, or underscores',
-              },
-              { max: 32, message: 'Execution home key must be 32 characters or less' },
-            ]}
-          >
-            <Input placeholder="johnsmith" maxLength={32} />
-          </Form.Item>
+            <Form.Item
+              label="Execution Home Key"
+              name="unix_username"
+              help="Optional transitional home key for delegated execution"
+              rules={[
+                {
+                  pattern: EXECUTION_HOME_KEY_PATTERN,
+                  message:
+                    'Start with a lowercase letter or underscore; then use lowercase letters, numbers, hyphens, or underscores',
+                },
+                { max: 32, message: 'Execution home key must be 32 characters or less' },
+              ]}
+            >
+              <Input placeholder="johnsmith" maxLength={32} />
+            </Form.Item>
 
-          <Form.Item
-            label="Password"
-            name="password"
-            rules={[
-              { required: true, message: 'Please enter a password' },
-              { min: 8, message: 'Password must be at least 8 characters' },
-            ]}
-          >
-            <Input.Password placeholder="••••••••" />
-          </Form.Item>
+            <Form.Item
+              label="Password"
+              name="password"
+              rules={[
+                { required: true, message: 'Please enter a password' },
+                { min: 8, message: 'Password must be at least 8 characters' },
+              ]}
+            >
+              <Input.Password placeholder="••••••••" />
+            </Form.Item>
 
-          <Form.Item
-            label="Role"
-            name="role"
-            initialValue={ROLES.MEMBER}
-            rules={[{ required: true, message: 'Please select a role' }]}
-          >
-            <Select
-              options={assignableRoleOptions.map((opt) => ({
-                value: opt.value,
-                label: opt.label,
-                title: opt.description,
-              }))}
-            />
-          </Form.Item>
+            <Form.Item
+              label="Role"
+              name="role"
+              initialValue={ROLES.MEMBER}
+              rules={[{ required: true, message: 'Please select a role' }]}
+            >
+              <Select
+                options={assignableRoleOptions.map((opt) => ({
+                  value: opt.value,
+                  label: opt.label,
+                  title: opt.description,
+                }))}
+              />
+            </Form.Item>
 
-          <Form.Item name="must_change_password" valuePropName="checked" initialValue={false}>
-            <Checkbox>Force password change on first login</Checkbox>
-          </Form.Item>
-        </Form>
-      </Modal>
+            <Form.Item name="must_change_password" valuePropName="checked" initialValue={false}>
+              <Checkbox>Force password change on first login</Checkbox>
+            </Form.Item>
+          </Form>
+        </Modal>
+      )}
 
       {/* Edit User Modal - reuses UserSettingsModal */}
       <UserSettingsModal
@@ -404,7 +422,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       defaultActiveKey="users"
       items={[
         { key: 'users', label: 'Users', children: usersTable },
-        ...(isAdmin
+        ...(canManageAvatarSettings
           ? [
               {
                 key: 'avatars',

--- a/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { __resetAuthConfigForTests, useAuthConfig } from './useAuthConfig';
+import { __resetAuthConfigForTests, IdentityContractState, useAuthConfig } from './useAuthConfig';
 
 describe('useAuthConfig', () => {
   afterEach(() => {
@@ -25,6 +25,7 @@ describe('useAuthConfig', () => {
               userLifecycle: 'external',
               roleAuthority: 'claims',
               localAuth: 'disabled',
+              external: { provider: 'external_launch', provisioning: 'jit' },
               capabilities: {
                 users: {
                   create: false,
@@ -62,7 +63,78 @@ describe('useAuthConfig', () => {
       userLifecycle: 'external',
       roleAuthority: 'claims',
       localAuth: 'disabled',
+      external: { provider: 'external_launch', provisioning: 'jit' },
       capabilities: { users: { create: false, selfConfigurationWrite: true } },
     });
+    expect(result.current[0].identityContractState).toBe(IdentityContractState.SUPPORTED);
+  });
+
+  it('permits a legacy health response only when the identity contract is absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ auth: { requireAuth: true } }),
+      }))
+    );
+
+    const { result } = renderHook(() => useAuthConfig());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config).toEqual({ requireAuth: true });
+    expect(result.current.error).toBeNull();
+    expect(result.current.identityContractState).toBe(IdentityContractState.LEGACY);
+  });
+
+  it.each([
+    ['future', { contractVersion: 2 }],
+    [
+      'malformed',
+      {
+        contractVersion: 1,
+        userLifecycle: 'external',
+        roleAuthority: 'claims',
+        localAuth: 'disabled',
+        capabilities: { users: { create: false } },
+      },
+    ],
+  ])('fails closed for a %s identity capability contract', async (_label, identity) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ auth: { requireAuth: true, identity } }),
+      }))
+    );
+
+    const { result } = renderHook(() => useAuthConfig());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config).toBeNull();
+    expect(result.current.error?.message).toMatch(/identity capability contract/i);
+    expect(result.current.identityContractState).toBe(IdentityContractState.UNSUPPORTED);
+  });
+
+  it('retries after a failed singleton fetch without synthesizing local-login config', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, statusText: 'Unavailable' })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ auth: { requireAuth: true } }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = renderHook(() => useAuthConfig());
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.config).toBeNull();
+    expect(first.result.current.error).not.toBeNull();
+    first.unmount();
+
+    const second = renderHook(() => useAuthConfig());
+    await waitFor(() => expect(second.result.current.config).toEqual({ requireAuth: true }));
+    expect(second.result.current.config).toEqual({ requireAuth: true });
+    expect(second.result.current.identityContractState).toBe(IdentityContractState.LEGACY);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
@@ -1,9 +1,10 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useAuthConfig } from './useAuthConfig';
+import { __resetAuthConfigForTests, useAuthConfig } from './useAuthConfig';
 
 describe('useAuthConfig', () => {
   afterEach(() => {
+    __resetAuthConfigForTests();
     vi.unstubAllGlobals();
   });
 
@@ -45,15 +46,18 @@ describe('useAuthConfig', () => {
       }))
     );
 
-    const { result } = renderHook(() => useAuthConfig());
+    const fetchMock = vi.mocked(fetch);
+    const { result } = renderHook(() => [useAuthConfig(), useAuthConfig()] as const);
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current[0].loading).toBe(false));
 
-    expect(result.current.config?.externalLaunch).toEqual({
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toBe(result.current[1]);
+    expect(result.current[0].config?.externalLaunch).toEqual({
       enabled: true,
       loginRedirectUrl: 'https://workspace.example.com/open',
     });
-    expect(result.current.config?.identity).toMatchObject({
+    expect(result.current[0].config?.identity).toMatchObject({
       contractVersion: 1,
       userLifecycle: 'external',
       roleAuthority: 'claims',

--- a/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { __resetAuthConfigForTests, IdentityContractState, useAuthConfig } from './useAuthConfig';
 
@@ -115,7 +115,7 @@ describe('useAuthConfig', () => {
     expect(result.current.identityContractState).toBe(IdentityContractState.UNSUPPORTED);
   });
 
-  it('retries after a failed singleton fetch without synthesizing local-login config', async () => {
+  it('retries in the mounted app shell without synthesizing local-login config', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: false, statusText: 'Unavailable' })
@@ -125,16 +125,16 @@ describe('useAuthConfig', () => {
       });
     vi.stubGlobal('fetch', fetchMock);
 
-    const first = renderHook(() => useAuthConfig());
-    await waitFor(() => expect(first.result.current.loading).toBe(false));
-    expect(first.result.current.config).toBeNull();
-    expect(first.result.current.error).not.toBeNull();
-    first.unmount();
+    const { result } = renderHook(() => useAuthConfig());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.config).toBeNull();
+    expect(result.current.error).not.toBeNull();
 
-    const second = renderHook(() => useAuthConfig());
-    await waitFor(() => expect(second.result.current.config).toEqual({ requireAuth: true }));
-    expect(second.result.current.config).toEqual({ requireAuth: true });
-    expect(second.result.current.identityContractState).toBe(IdentityContractState.LEGACY);
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(result.current.config).toEqual({ requireAuth: true }));
+    expect(result.current.error).toBeNull();
+    expect(result.current.identityContractState).toBe(IdentityContractState.LEGACY);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
@@ -19,6 +19,23 @@ describe('useAuthConfig', () => {
           database: 'sqlite',
           auth: {
             requireAuth: true,
+            identity: {
+              contractVersion: 1,
+              userLifecycle: 'external',
+              roleAuthority: 'claims',
+              localAuth: 'disabled',
+              capabilities: {
+                users: {
+                  create: false,
+                  delete: false,
+                  identityWrite: false,
+                  roleWrite: false,
+                  passwordWrite: false,
+                  avatarSettingsWrite: false,
+                  selfConfigurationWrite: true,
+                },
+              },
+            },
             externalLaunch: {
               enabled: true,
               loginRedirectUrl: 'https://workspace.example.com/open',
@@ -35,6 +52,13 @@ describe('useAuthConfig', () => {
     expect(result.current.config?.externalLaunch).toEqual({
       enabled: true,
       loginRedirectUrl: 'https://workspace.example.com/open',
+    });
+    expect(result.current.config?.identity).toMatchObject({
+      contractVersion: 1,
+      userLifecycle: 'external',
+      roleAuthority: 'claims',
+      localAuth: 'disabled',
+      capabilities: { users: { create: false, selfConfigurationWrite: true } },
     });
   });
 });

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -5,7 +5,15 @@
  * Used on app startup to determine if login page should be shown and display instance label.
  */
 
-import type { ResolvedIdentityAuthority } from '@agor/core/config/browser';
+import {
+  AgorExternalIdentityProvider,
+  AgorExternalIdentityProvisioning,
+  AgorLocalAuthMode,
+  AgorRoleAuthority,
+  AgorUserLifecycleAuthority,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  type ResolvedIdentityAuthority,
+} from '@agor/core/config/browser';
 import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { UploadIngressPolicy } from '@agor/core/types';
 import { useEffect, useSyncExternalStore } from 'react';
@@ -74,17 +82,27 @@ interface HealthResponse {
   timestamp: number;
   version: string;
   database: string;
-  auth: AuthConfig;
+  auth: unknown;
   instance?: InstanceConfig;
   features?: FeaturesConfig;
 }
 
-interface AuthConfigState {
+export const IdentityContractState = {
+  UNKNOWN: 'unknown',
+  LEGACY: 'legacy',
+  SUPPORTED: 'supported',
+  UNSUPPORTED: 'unsupported',
+} as const;
+export type IdentityContractState =
+  (typeof IdentityContractState)[keyof typeof IdentityContractState];
+
+export interface AuthConfigState {
   config: AuthConfig | null;
   instanceConfig: InstanceConfig | null;
   featuresConfig: FeaturesConfig | undefined;
   loading: boolean;
   error: Error | null;
+  identityContractState: IdentityContractState;
 }
 
 let snapshot: AuthConfigState = {
@@ -93,6 +111,7 @@ let snapshot: AuthConfigState = {
   featuresConfig: undefined,
   loading: true,
   error: null,
+  identityContractState: IdentityContractState.UNKNOWN,
 };
 let request: Promise<void> | null = null;
 const listeners = new Set<() => void>();
@@ -105,18 +124,28 @@ export function __resetAuthConfigForTests(): void {
     featuresConfig: undefined,
     loading: true,
     error: null,
+    identityContractState: IdentityContractState.UNKNOWN,
   };
   request = null;
 }
 
 /** Seed the already-loaded app-shell snapshot for isolated component tests. */
 export function __setAuthConfigForTests(config: AuthConfig): void {
+  const identityContractState = config.identity
+    ? isResolvedIdentityAuthority(config.identity)
+      ? IdentityContractState.SUPPORTED
+      : IdentityContractState.UNSUPPORTED
+    : IdentityContractState.LEGACY;
   snapshot = {
-    config,
+    config: identityContractState === IdentityContractState.UNSUPPORTED ? null : config,
     instanceConfig: null,
     featuresConfig: undefined,
     loading: false,
-    error: null,
+    error:
+      identityContractState === IdentityContractState.UNSUPPORTED
+        ? new Error('Unsupported daemon identity capability contract')
+        : null,
+    identityContractState,
   };
   request = Promise.resolve();
 }
@@ -131,9 +160,115 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+type UserIdentityCapability = keyof ResolvedIdentityAuthority['capabilities']['users'];
+
+const USER_IDENTITY_CAPABILITIES = {
+  create: true,
+  delete: true,
+  identityWrite: true,
+  roleWrite: true,
+  passwordWrite: true,
+  avatarSettingsWrite: true,
+  selfConfigurationWrite: true,
+} as const satisfies Record<UserIdentityCapability, true>;
+
+function isEnumValue<T extends string>(values: readonly T[], value: unknown): value is T {
+  return typeof value === 'string' && values.includes(value as T);
+}
+
+function isResolvedIdentityAuthority(value: unknown): value is ResolvedIdentityAuthority {
+  if (!isRecord(value)) return false;
+  if (value.contractVersion !== IDENTITY_AUTHORITY_CONTRACT_VERSION) return false;
+  if (!isEnumValue(Object.values(AgorUserLifecycleAuthority), value.userLifecycle)) {
+    return false;
+  }
+  if (!isEnumValue(Object.values(AgorRoleAuthority), value.roleAuthority)) return false;
+  if (!isEnumValue(Object.values(AgorLocalAuthMode), value.localAuth)) return false;
+
+  const capabilities = value.capabilities;
+  if (!isRecord(capabilities) || !isRecord(capabilities.users)) return false;
+  const users = capabilities.users;
+  for (const capability of Object.keys(USER_IDENTITY_CAPABILITIES)) {
+    if (typeof users[capability] !== 'boolean') return false;
+  }
+  if (users.selfConfigurationWrite !== true) return false;
+
+  const externallyManaged = value.userLifecycle === AgorUserLifecycleAuthority.EXTERNAL;
+  if (externallyManaged) {
+    if (value.roleAuthority !== AgorRoleAuthority.CLAIMS) return false;
+    if (value.localAuth !== AgorLocalAuthMode.DISABLED) return false;
+    if (!isRecord(value.external)) return false;
+    if (value.external.provider !== AgorExternalIdentityProvider.EXTERNAL_LAUNCH) return false;
+    if (value.external.provisioning !== AgorExternalIdentityProvisioning.JIT) return false;
+  } else {
+    if (value.roleAuthority !== AgorRoleAuthority.INTERNAL) return false;
+    if (value.localAuth !== AgorLocalAuthMode.ENABLED) return false;
+    if (value.external !== undefined) return false;
+  }
+
+  return (
+    users.create === !externallyManaged &&
+    users.delete === !externallyManaged &&
+    users.identityWrite === !externallyManaged &&
+    users.roleWrite === (value.roleAuthority === AgorRoleAuthority.INTERNAL) &&
+    users.passwordWrite === (value.localAuth === AgorLocalAuthMode.ENABLED && !externallyManaged) &&
+    users.avatarSettingsWrite === !externallyManaged
+  );
+}
+
+function parseAuthConfig(value: unknown): {
+  config: AuthConfig | null;
+  identityContractState: IdentityContractState;
+  error: Error | null;
+} {
+  if (!isRecord(value) || typeof value.requireAuth !== 'boolean') {
+    throw new Error('Daemon returned an invalid authentication configuration');
+  }
+
+  const identity = value.identity;
+  if (identity === undefined) {
+    // A pre-contract daemon is intentionally permissive for mixed-version
+    // rollout. Server authorization remains authoritative.
+    return {
+      config: value as unknown as AuthConfig,
+      identityContractState: IdentityContractState.LEGACY,
+      error: null,
+    };
+  }
+  if (!isResolvedIdentityAuthority(identity)) {
+    return {
+      config: null,
+      identityContractState: IdentityContractState.UNSUPPORTED,
+      error: new Error('Unsupported or malformed daemon identity capability contract'),
+    };
+  }
+  return {
+    config: value as unknown as AuthConfig,
+    identityContractState: IdentityContractState.SUPPORTED,
+    error: null,
+  };
+}
+
+/** Legacy daemons remain permissive; unknown or invalid contracts fail closed. */
+export function isIdentityCapabilityAvailable(
+  config: AuthConfig | null,
+  contractState: IdentityContractState,
+  capability: UserIdentityCapability
+): boolean {
+  if (contractState === IdentityContractState.LEGACY) return true;
+  return (
+    contractState === IdentityContractState.SUPPORTED &&
+    config?.identity?.capabilities.users[capability] === true
+  );
+}
+
 function fetchAuthConfigOnce(): Promise<void> {
   if (request) return request;
-  request = (async () => {
+  const currentRequest = (async () => {
     try {
       const response = await fetch(`${getDaemonUrl()}/health`);
       if (!response.ok) {
@@ -141,26 +276,35 @@ function fetchAuthConfigOnce(): Promise<void> {
       }
 
       const health: HealthResponse = await response.json();
+      const parsed = parseAuthConfig(health.auth);
       publish({
-        config: health.auth,
+        config: parsed.config,
         instanceConfig: health.instance ?? null,
         featuresConfig: health.features,
         loading: false,
-        error: null,
+        error: parsed.error,
+        identityContractState: parsed.identityContractState,
       });
     } catch (err) {
       publish({
-        // Default to requiring auth on error (secure by default). Capability
-        // consumers also inspect `error` and keep mutation controls disabled.
-        config: { requireAuth: true },
+        // Keep config absent so the app shell shows its configuration-error
+        // state rather than synthesizing a potentially wrong login policy.
+        config: null,
         instanceConfig: null,
         featuresConfig: undefined,
         loading: false,
         error: err instanceof Error ? err : new Error(String(err)),
+        identityContractState: IdentityContractState.UNKNOWN,
       });
     }
   })();
-  return request;
+  request = currentRequest;
+  void currentRequest.finally(() => {
+    // Successful health remains cached for the app lifetime. A transient
+    // failure is retryable on the next mount instead of poisoning the singleton.
+    if (snapshot.error && request === currentRequest) request = null;
+  });
+  return currentRequest;
 }
 
 /** One shared health snapshot for the whole UI; consumers never refetch or drift. */

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -103,6 +103,8 @@ export interface AuthConfigState {
   loading: boolean;
   error: Error | null;
   identityContractState: IdentityContractState;
+  /** Retry a failed or unsupported health-contract load without remounting. */
+  retry: () => void;
 }
 
 let snapshot: AuthConfigState = {
@@ -112,6 +114,7 @@ let snapshot: AuthConfigState = {
   loading: true,
   error: null,
   identityContractState: IdentityContractState.UNKNOWN,
+  retry: retryAuthConfig,
 };
 let request: Promise<void> | null = null;
 const listeners = new Set<() => void>();
@@ -125,6 +128,7 @@ export function __resetAuthConfigForTests(): void {
     loading: true,
     error: null,
     identityContractState: IdentityContractState.UNKNOWN,
+    retry: retryAuthConfig,
   };
   request = null;
 }
@@ -146,6 +150,7 @@ export function __setAuthConfigForTests(config: AuthConfig): void {
         ? new Error('Unsupported daemon identity capability contract')
         : null,
     identityContractState,
+    retry: retryAuthConfig,
   };
   request = Promise.resolve();
 }
@@ -284,6 +289,7 @@ function fetchAuthConfigOnce(): Promise<void> {
         loading: false,
         error: parsed.error,
         identityContractState: parsed.identityContractState,
+        retry: retryAuthConfig,
       });
     } catch (err) {
       publish({
@@ -295,16 +301,31 @@ function fetchAuthConfigOnce(): Promise<void> {
         loading: false,
         error: err instanceof Error ? err : new Error(String(err)),
         identityContractState: IdentityContractState.UNKNOWN,
+        retry: retryAuthConfig,
       });
     }
   })();
   request = currentRequest;
   void currentRequest.finally(() => {
     // Successful health remains cached for the app lifetime. A transient
-    // failure is retryable on the next mount instead of poisoning the singleton.
+    // failure releases the singleton so the mounted shell's action can retry.
     if (snapshot.error && request === currentRequest) request = null;
   });
   return currentRequest;
+}
+
+/** Retry in place so the app-shell error state can recover without a reload. */
+export function retryAuthConfig(): void {
+  if (snapshot.loading || !snapshot.error) return;
+  request = null;
+  publish({
+    ...snapshot,
+    loading: true,
+    error: null,
+    identityContractState: IdentityContractState.UNKNOWN,
+    retry: retryAuthConfig,
+  });
+  void fetchAuthConfigOnce();
 }
 
 /** One shared health snapshot for the whole UI; consumers never refetch or drift. */

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -8,7 +8,7 @@
 import type { ResolvedIdentityAuthority } from '@agor/core/config/browser';
 import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { UploadIngressPolicy } from '@agor/core/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { getDaemonUrl } from '../config/daemon';
 import type { BranchStorageConfig } from '../utils/branchStorage';
 
@@ -79,45 +79,99 @@ interface HealthResponse {
   features?: FeaturesConfig;
 }
 
-export function useAuthConfig() {
-  const [config, setConfig] = useState<AuthConfig | null>(null);
-  const [instanceConfig, setInstanceConfig] = useState<InstanceConfig | null>(null);
-  const [featuresConfig, setFeaturesConfig] = useState<FeaturesConfig | undefined>(undefined);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+interface AuthConfigState {
+  config: AuthConfig | null;
+  instanceConfig: InstanceConfig | null;
+  featuresConfig: FeaturesConfig | undefined;
+  loading: boolean;
+  error: Error | null;
+}
 
-  useEffect(() => {
-    async function fetchAuthConfig() {
-      try {
-        const response = await fetch(`${getDaemonUrl()}/health`);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch auth config: ${response.statusText}`);
-        }
+let snapshot: AuthConfigState = {
+  config: null,
+  instanceConfig: null,
+  featuresConfig: undefined,
+  loading: true,
+  error: null,
+};
+let request: Promise<void> | null = null;
+const listeners = new Set<() => void>();
 
-        const health: HealthResponse = await response.json();
-        setConfig(health.auth);
-        setInstanceConfig(health.instance ?? null);
-        setFeaturesConfig(health.features);
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-        // Default to requiring auth on error (secure by default)
-        setConfig({ requireAuth: true });
-        setInstanceConfig(null);
-        setFeaturesConfig(undefined);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchAuthConfig();
-  }, []);
-
-  return {
-    config,
-    instanceConfig,
-    featuresConfig,
-    loading,
-    error,
+/** Reset the module cache between isolated component tests. */
+export function __resetAuthConfigForTests(): void {
+  snapshot = {
+    config: null,
+    instanceConfig: null,
+    featuresConfig: undefined,
+    loading: true,
+    error: null,
   };
+  request = null;
+}
+
+/** Seed the already-loaded app-shell snapshot for isolated component tests. */
+export function __setAuthConfigForTests(config: AuthConfig): void {
+  snapshot = {
+    config,
+    instanceConfig: null,
+    featuresConfig: undefined,
+    loading: false,
+    error: null,
+  };
+  request = Promise.resolve();
+}
+
+function publish(next: AuthConfigState): void {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function fetchAuthConfigOnce(): Promise<void> {
+  if (request) return request;
+  request = (async () => {
+    try {
+      const response = await fetch(`${getDaemonUrl()}/health`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch auth config: ${response.statusText}`);
+      }
+
+      const health: HealthResponse = await response.json();
+      publish({
+        config: health.auth,
+        instanceConfig: health.instance ?? null,
+        featuresConfig: health.features,
+        loading: false,
+        error: null,
+      });
+    } catch (err) {
+      publish({
+        // Default to requiring auth on error (secure by default). Capability
+        // consumers also inspect `error` and keep mutation controls disabled.
+        config: { requireAuth: true },
+        instanceConfig: null,
+        featuresConfig: undefined,
+        loading: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+  })();
+  return request;
+}
+
+/** One shared health snapshot for the whole UI; consumers never refetch or drift. */
+export function useAuthConfig(): AuthConfigState {
+  const state = useSyncExternalStore(
+    subscribe,
+    () => snapshot,
+    () => snapshot
+  );
+  useEffect(() => {
+    void fetchAuthConfigOnce();
+  }, []);
+  return state;
 }

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -11,8 +11,27 @@ import { useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
 import type { BranchStorageConfig } from '../utils/branchStorage';
 
-interface AuthConfig {
+export interface IdentityAuthorityConfig {
+  contractVersion: 1;
+  userLifecycle: 'internal' | 'external';
+  roleAuthority: 'internal' | 'claims';
+  localAuth: 'enabled' | 'disabled';
+  capabilities: {
+    users: {
+      create: boolean;
+      delete: boolean;
+      identityWrite: boolean;
+      roleWrite: boolean;
+      passwordWrite: boolean;
+      avatarSettingsWrite: boolean;
+      selfConfigurationWrite: boolean;
+    };
+  };
+}
+
+export interface AuthConfig {
   requireAuth: boolean;
+  identity?: IdentityAuthorityConfig;
   externalLaunch?: {
     enabled?: boolean;
     loginRedirectUrl?: string;

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -5,33 +5,16 @@
  * Used on app startup to determine if login page should be shown and display instance label.
  */
 
+import type { ResolvedIdentityAuthority } from '@agor/core/config/browser';
 import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { UploadIngressPolicy } from '@agor/core/types';
 import { useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
 import type { BranchStorageConfig } from '../utils/branchStorage';
 
-export interface IdentityAuthorityConfig {
-  contractVersion: 1;
-  userLifecycle: 'internal' | 'external';
-  roleAuthority: 'internal' | 'claims';
-  localAuth: 'enabled' | 'disabled';
-  capabilities: {
-    users: {
-      create: boolean;
-      delete: boolean;
-      identityWrite: boolean;
-      roleWrite: boolean;
-      passwordWrite: boolean;
-      avatarSettingsWrite: boolean;
-      selfConfigurationWrite: boolean;
-    };
-  };
-}
-
 export interface AuthConfig {
   requireAuth: boolean;
-  identity?: IdentityAuthorityConfig;
+  identity?: ResolvedIdentityAuthority;
   externalLaunch?: {
     enabled?: boolean;
     loginRedirectUrl?: string;

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -89,6 +89,13 @@ or edit those fields. Preferences, onboarding, agentic-tool credentials and
 defaults, environment variables, API keys, and MCP selection/OAuth remain
 Agor-owned.
 
+The daemon stores the trusted `(tenant, provider, issuer, subject)` binding in
+a tenant-owned relation with database uniqueness enforcement. PostgreSQL JIT
+projection runs in one tenant-scoped transaction and serializes a subject
+across replicas; the JSON copy on `users.data.external_identities` remains a
+compatibility and audit cache. Execution-home keys are also unique per tenant,
+so a claim cannot route two users into the same delegated credential context.
+
 Claims roles are required and exact in this mode. `allow_admin_roles` and
 `execution.allow_superadmin` remain explicit acceptance gates; disallowed roles
 fail the launch rather than being downgraded. Omitting `identity` preserves
@@ -216,6 +223,15 @@ Production verification is asymmetric and fails closed:
 
 ## Compatibility and upgrade notes
 
+- **Migrate before enabling external authority.** The external-identity
+  migration creates the binding relation and makes execution-home keys unique
+  per tenant. It fails closed if legacy rows already contain conflicting
+  bindings or duplicate non-null execution-home keys; resolve that data before
+  retrying. Apply the migration before starting the new daemon binary, and
+  enable the `identity` profile only after every daemon replica runs a version
+  that maintains the binding. New daemons can discover legacy JSON links and
+  bind them transactionally on the next successful launch, but old daemons do
+  not write the new relation.
 - **Non-RS256 asymmetric signing must be declared before upgrading.** Asymmetric
   verification (`jwks_url` / `public_key`) now defaults to an `RS256`-only
   allow-list and refuses HS\* algorithms outright. A deployment that signs

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -208,9 +208,10 @@ workspace host:
 Production verification is asymmetric and fails closed:
 
 - The `none` algorithm is always rejected.
-- When verifying with `jwks_url` or `public_key`, the algorithm allow-list
-  defaults to `RS256` (override with `algorithms`), preventing algorithm
-  confusion (e.g. a public key coerced into an HS256 secret). The dev
+- `jwks_url` verification defaults to an `RS256` allow-list. Static
+  `public_key` verification derives `RS256` for RSA or the matching ES
+  algorithm for a supported EC curve; an explicit `algorithms` list must match
+  that key. Both asymmetric paths refuse HS\* algorithms, and the dev
   `dev_shared_secret` path stays HS256-only.
 - JWKS assertions must carry a `kid` that matches a signing key. A key that
   omits `use`/`alg` metadata is accepted; when either is present it must be
@@ -232,13 +233,12 @@ Production verification is asymmetric and fails closed:
   that maintains the binding. New daemons can discover legacy JSON links and
   bind them transactionally on the next successful launch, but old daemons do
   not write the new relation.
-- **Non-RS256 asymmetric signing must be declared before upgrading.** Asymmetric
-  verification (`jwks_url` / `public_key`) now defaults to an `RS256`-only
-  allow-list and refuses HS\* algorithms outright. A deployment that signs
-  assertions with a different asymmetric algorithm (e.g. `RS384`, `ES256`,
-  `PS256`) and previously relied on library defaults must set `algorithms`
-  explicitly to the intended asymmetric algorithm **before** upgrading, or its
-  assertions will stop verifying.
+- **Non-RS256 JWKS signing must be declared before upgrading.** `jwks_url`
+  verification defaults to an `RS256`-only allow-list and refuses HS\*
+  algorithms outright. Static `public_key` verification derives a compatible
+  RSA/EC default. A JWKS deployment that signs assertions with a different
+  asymmetric algorithm (e.g. `RS384`, `ES256`, `PS256`) must set `algorithms`
+  explicitly before upgrading.
 - **`login_redirect_url` deployments begin receiving a return-host query
   parameter.** When `login_redirect_url` is enabled, direct-host entry appends
   the configured `return_host_param` (default `return_host`) to that URL. This is

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -19,7 +19,8 @@ workspace and open a fresh launch link. The UI appends a `return_to` query
 parameter containing the current Agor path, so launch providers can preserve
 deep links such as `/ui/s/<session>/` when issuing a fresh launch code. If the
 field is omitted, the normal local username/password login screen remains
-unchanged.
+unchanged. When external identity authority disables local authentication, no
+local-login fallback is offered.
 
 ## Configuration
 
@@ -63,6 +64,37 @@ external_launch:
   # an opaque return context for direct-host entry. Default: return_host.
   return_host_param: return_host
 ```
+
+### External user and role authority
+
+`external_launch` is only an authentication/provisioning mechanism by default.
+Deployments whose issuer also owns users and roles opt into the separate,
+fail-closed authority contract:
+
+```yaml
+identity:
+  user_lifecycle: external
+  role_authority: claims
+  local_auth: disabled
+  external:
+    provider: external_launch
+    provisioning: jit
+```
+
+Verified launches remain able to JIT-create a missing local projection and
+synchronize JWT-owned email, name, avatar, execution-home key, and role. The
+sync happens at successful launch, not on every request. Ordinary REST,
+Socket.IO, CLI, MCP, admin, and local-password paths cannot create/delete users
+or edit those fields. Preferences, onboarding, agentic-tool credentials and
+defaults, environment variables, API keys, and MCP selection/OAuth remain
+Agor-owned.
+
+Claims roles are required and exact in this mode. `allow_admin_roles` and
+`execution.allow_superadmin` remain explicit acceptance gates; disallowed roles
+fail the launch rather than being downgraded. Omitting `identity` preserves
+local behavior. External deactivation/revocation is not part of this first
+contract: the provider can prevent a new launch, but existing Agor credentials
+are not synchronized or revoked yet.
 
 For local development only, a symmetric assertion secret can be used:
 

--- a/packages/core/drizzle/postgres/0090_external_user_identities.sql
+++ b/packages/core/drizzle/postgres/0090_external_user_identities.sql
@@ -60,11 +60,5 @@ WHERE identity.value->>'key' IS NOT NULL
 ALTER TABLE "user_external_identities" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "user_external_identities" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
 CREATE POLICY "tenant_isolation_user_external_identities" ON "user_external_identities"
-	USING (
-		COALESCE(current_setting('agor.system_scope', true), '') = ''
-		AND "tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default')
-	)
-	WITH CHECK (
-		COALESCE(current_setting('agor.system_scope', true), '') = ''
-		AND "tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default')
-	);
+	USING ("tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default'))
+	WITH CHECK ("tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default'));

--- a/packages/core/drizzle/postgres/0090_external_user_identities.sql
+++ b/packages/core/drizzle/postgres/0090_external_user_identities.sql
@@ -1,0 +1,70 @@
+SET LOCAL lock_timeout = '3s';--> statement-breakpoint
+-- Execution-home keys route delegated execution and credentials, so two users
+-- in one tenant must never share one. NULL remains available for users without
+-- a delegated execution home.
+CREATE UNIQUE INDEX "users_tenant_unix_username_unique"
+	ON "users" ("tenant_id", "unix_username");--> statement-breakpoint
+CREATE TABLE "user_external_identities" (
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"identity_key" varchar(64) NOT NULL,
+	"user_id" varchar(36) NOT NULL,
+	"provider" text NOT NULL,
+	"issuer" text NOT NULL,
+	"subject" text NOT NULL,
+	"email" text,
+	"name" text,
+	"last_login_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "user_external_identities_tenant_id_identity_key_pk"
+		PRIMARY KEY("tenant_id", "identity_key"),
+	CONSTRAINT "user_external_identities_tenant_user_fk"
+		FOREIGN KEY ("tenant_id", "user_id")
+		REFERENCES "public"."users"("tenant_id", "user_id")
+		ON DELETE cascade ON UPDATE no action DEFERRABLE INITIALLY IMMEDIATE
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "user_external_identities_provider_subject_unique"
+	ON "user_external_identities" ("tenant_id", "provider", "issuer", "subject");--> statement-breakpoint
+CREATE INDEX "user_external_identities_tenant_user_idx"
+	ON "user_external_identities" ("tenant_id", "user_id");--> statement-breakpoint
+-- Backfill the compatibility JSON projection. Conflicting legacy bindings fail
+-- the migration instead of letting a login select an arbitrary user.
+INSERT INTO "user_external_identities" (
+	"tenant_id", "identity_key", "user_id", "provider", "issuer", "subject",
+	"email", "name", "last_login_at", "created_at", "updated_at"
+)
+SELECT
+	u."tenant_id",
+	identity.value->>'key',
+	u."user_id",
+	identity.value->>'provider',
+	identity.value->>'issuer',
+	identity.value->>'subject',
+	identity.value->>'email',
+	identity.value->>'name',
+	COALESCE((identity.value->>'last_login_at')::timestamp with time zone, u."updated_at", u."created_at"),
+	u."created_at",
+	COALESCE(u."updated_at", u."created_at")
+FROM "users" u
+CROSS JOIN LATERAL jsonb_array_elements(
+	CASE
+		WHEN jsonb_typeof(u."data"->'external_identities') = 'array'
+		THEN u."data"->'external_identities'
+		ELSE '[]'::jsonb
+	END
+) AS identity(value)
+WHERE identity.value->>'key' IS NOT NULL
+	AND identity.value->>'provider' IS NOT NULL
+	AND identity.value->>'issuer' IS NOT NULL
+	AND identity.value->>'subject' IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_external_identities" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "user_external_identities" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "tenant_isolation_user_external_identities" ON "user_external_identities"
+	USING (
+		COALESCE(current_setting('agor.system_scope', true), '') = ''
+		AND "tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default')
+	)
+	WITH CHECK (
+		COALESCE(current_setting('agor.system_scope', true), '') = ''
+		AND "tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default')
+	);

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1787270400000,
       "tag": "0089_mcp_catalog_install_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1787270400001,
+      "tag": "0090_external_user_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0093_external_user_identities.sql
+++ b/packages/core/drizzle/sqlite/0093_external_user_identities.sql
@@ -1,0 +1,55 @@
+-- Execution-home keys route delegated execution and credentials, so two users
+-- must never share one. NULL remains available for users without a delegated
+-- execution home.
+CREATE UNIQUE INDEX `users_unix_username_unique` ON `users` (`unix_username`);--> statement-breakpoint
+CREATE TABLE `user_external_identities` (
+	`identity_key` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`issuer` text NOT NULL,
+	`subject` text NOT NULL,
+	`email` text,
+	`name` text,
+	`last_login_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_external_identities_provider_subject_unique`
+	ON `user_external_identities` (`provider`, `issuer`, `subject`);--> statement-breakpoint
+CREATE INDEX `user_external_identities_user_idx`
+	ON `user_external_identities` (`user_id`);--> statement-breakpoint
+-- Backfill the compatibility JSON projection. Conflicting legacy bindings fail
+-- the migration instead of letting a login select an arbitrary user.
+INSERT INTO `user_external_identities` (
+	`identity_key`, `user_id`, `provider`, `issuer`, `subject`, `email`, `name`,
+	`last_login_at`, `created_at`, `updated_at`
+)
+SELECT
+	json_extract(identity.value, '$.key'),
+	u.`user_id`,
+	json_extract(identity.value, '$.provider'),
+	json_extract(identity.value, '$.issuer'),
+	json_extract(identity.value, '$.subject'),
+	json_extract(identity.value, '$.email'),
+	json_extract(identity.value, '$.name'),
+	COALESCE(
+		CAST(strftime('%s', json_extract(identity.value, '$.last_login_at')) AS integer) * 1000,
+		u.`updated_at`,
+		u.`created_at`
+	),
+	u.`created_at`,
+	COALESCE(u.`updated_at`, u.`created_at`)
+FROM `users` u
+JOIN json_each(
+	CASE
+		WHEN json_valid(u.`data`) AND json_type(u.`data`, '$.external_identities') = 'array'
+		THEN json_extract(u.`data`, '$.external_identities')
+		ELSE '[]'
+	END
+) identity
+WHERE json_extract(identity.value, '$.key') IS NOT NULL
+	AND json_extract(identity.value, '$.provider') IS NOT NULL
+	AND json_extract(identity.value, '$.issuer') IS NOT NULL
+	AND json_extract(identity.value, '$.subject') IS NOT NULL;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -638,6 +638,13 @@
       "when": 1787270400000,
       "tag": "0092_mcp_catalog_install_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "6",
+      "when": 1787270400001,
+      "tag": "0093_external_user_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -956,6 +956,14 @@ describe('loadConfig', () => {
 
     await fs.writeFile(configPath, 'external_launch: enabled\n', 'utf-8');
     await expect(loadConfig()).rejects.toThrow(/external_launch must be an object/);
+
+    __resetConfigCacheForTests();
+    await fs.writeFile(configPath, 'identity: 2026-08-20\n', 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/identity must be an object/);
+
+    __resetConfigCacheForTests();
+    await fs.writeFile(configPath, 'external_launch: 2026-08-20\n', 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/external_launch must be an object/);
   });
 
   it('accepts an HTTP(S) external launch login redirect URL', async () => {
@@ -975,7 +983,8 @@ describe('loadConfig', () => {
     );
 
     const loaded = await loadConfig();
-    expect(loaded.external_launch?.login_redirect_url).toBe('https://workspace.example.com/open');
+    // Validation is non-mutating; startup's retained provider owns normalization.
+    expect(loaded.external_launch?.login_redirect_url).toBe(' https://workspace.example.com/open ');
   });
 
   it('rejects a non-HTTP(S) external launch login redirect URL', async () => {

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -906,6 +906,46 @@ describe('loadConfig', () => {
     expect(loaded.external_launch?.login_redirect_url).toBeUndefined();
   });
 
+  it('loads the explicit external identity authority contract', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        identity: {
+          user_lifecycle: 'external',
+          role_authority: 'claims',
+          local_auth: 'disabled',
+          external: { provider: 'external_launch', provisioning: 'jit' },
+        },
+      }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).resolves.toMatchObject({
+      identity: {
+        user_lifecycle: 'external',
+        role_authority: 'claims',
+        local_auth: 'disabled',
+        external: { provider: 'external_launch', provisioning: 'jit' },
+      },
+    });
+  });
+
+  it('rejects unknown identity keys and unsupported authority values', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({ identity: { user_lifecycle: 'remote', surprise: true } }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/identity\.user_lifecycle|identity\.surprise/);
+  });
+
   it('accepts an HTTP(S) external launch login redirect URL', async () => {
     const agorDir = path.join(tempDir, '.agor');
     const configPath = path.join(agorDir, 'config.yaml');

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -946,6 +946,18 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow(/identity\.user_lifecycle|identity\.surprise/);
   });
 
+  it('rejects scalar identity and external launch sections', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { recursive: true });
+
+    await fs.writeFile(configPath, 'identity: external\n', 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/identity must be an object/);
+
+    await fs.writeFile(configPath, 'external_launch: enabled\n', 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/external_launch must be an object/);
+  });
+
   it('accepts an HTTP(S) external launch login redirect URL', async () => {
     const agorDir = path.join(tempDir, '.agor');
     const configPath = path.join(agorDir, 'config.yaml');

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -23,7 +23,10 @@ import {
   resolveSdkWatchdogConfig,
 } from './executor-heartbeat';
 import { resolveExecutorResponseConfig } from './executor-response';
-import { resolveEffectiveExternalLaunchConfig } from './external-launch';
+import {
+  assertValidRawExternalLaunchConfig,
+  resolveEffectiveExternalLaunchConfig,
+} from './external-launch';
 import { assertValidMultiTenancyConfig } from './multitenancy';
 import {
   type AgorConfig,
@@ -683,6 +686,7 @@ function validateConfig(config: AgorConfig): void {
     'trusted_host_header',
     'return_host_param',
   ]);
+  assertValidRawExternalLaunchConfig(config.external_launch);
   only(config.identity, 'identity', ['user_lifecycle', 'role_authority', 'local_auth', 'external']);
   only(config.identity?.external, 'identity.external', ['provider', 'provisioning']);
   if (
@@ -1023,6 +1027,14 @@ function validateConfig(config: AgorConfig): void {
   );
 
   validateExternalLaunchReturnHostParam(config);
+}
+
+/**
+ * Validate a preloaded/programmatic config through the same raw boundary used
+ * for YAML. Daemon startup calls this before applying environment overrides.
+ */
+export function assertValidRawConfig(config: AgorConfig): void {
+  validateConfig(config);
 }
 
 /** Return the deployment identity after enforcing the daemon startup invariant. */

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -23,6 +23,7 @@ import {
   resolveSdkWatchdogConfig,
 } from './executor-heartbeat';
 import { resolveExecutorResponseConfig } from './executor-response';
+import { resolveEffectiveExternalLaunchConfig } from './external-launch';
 import { assertValidMultiTenancyConfig } from './multitenancy';
 import {
   type AgorConfig,
@@ -518,6 +519,11 @@ function validateConfig(config: AgorConfig): void {
   }
 
   const unknownPaths: string[] = [];
+  const requireObject = (value: unknown, path: string) => {
+    if (value !== undefined && (!value || typeof value !== 'object' || Array.isArray(value))) {
+      throw new Error(`Config error: ${path} must be an object`);
+    }
+  };
   const only = (value: unknown, path: string, allowed: readonly string[]) => {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return;
     for (const key of Object.keys(value)) {
@@ -652,6 +658,9 @@ function validateConfig(config: AgorConfig): void {
   ]);
   only(config.ui, 'ui', ['base_url', 'port', 'host']);
   only(config.uploads, 'uploads', ['location', 'max_age_days', 'max_file_size_mb']);
+  requireObject(config.external_launch, 'external_launch');
+  requireObject(config.identity, 'identity');
+  requireObject(config.identity?.external, 'identity.external');
   only(config.external_launch, 'external_launch', [
     'enabled',
     'exchange_url',
@@ -1421,6 +1430,7 @@ export function resolveEffectiveConfig(
     'AGOR_STATSD_ENABLED'
   );
   const statsdPort = parseOptionalPortEnvironmentValue(env.AGOR_STATSD_PORT, 'AGOR_STATSD_PORT');
+  const externalLaunch = resolveEffectiveExternalLaunchConfig(config.external_launch, env);
 
   // Resolve the effective Unix isolation mode (env override wins) so the
   // `sandbox` mode can imply the rest of its machinery.
@@ -1491,6 +1501,7 @@ export function resolveEffectiveConfig(
       ...(env.INSTANCE_LABEL ? { instanceLabel: env.INSTANCE_LABEL } : {}),
     },
     ui: { ...defaults.ui, ...config.ui },
+    ...(externalLaunch ? { external_launch: externalLaunch } : {}),
     execution: {
       ...defaults.execution,
       ...config.execution,

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -28,6 +28,7 @@ import {
   resolveEffectiveExternalLaunchConfig,
 } from './external-launch';
 import { assertValidMultiTenancyConfig } from './multitenancy';
+import { isPlainConfigRecord } from './plain-record';
 import {
   type AgorConfig,
   AgorExternalIdentityProvider,
@@ -415,7 +416,14 @@ function resolveUnknownConfigKeyPolicy(): UnknownConfigKeyPolicy {
   );
 }
 
+function requirePlainConfigRecord(value: unknown, path: string): void {
+  if (!isPlainConfigRecord(value)) {
+    throw new Error(`Config error: ${path} must be an object`);
+  }
+}
+
 function validateConfig(config: AgorConfig): void {
+  requirePlainConfigRecord(config, 'config');
   const configuredAnalyticsPlugins = (config.analytics as { plugins?: unknown[] } | undefined)
     ?.plugins;
   const removedModulePluginIndex = configuredAnalyticsPlugins?.findIndex(
@@ -522,14 +530,11 @@ function validateConfig(config: AgorConfig): void {
   }
 
   const unknownPaths: string[] = [];
-  const requireObject = (value: unknown, path: string) => {
-    if (value !== undefined && (!value || typeof value !== 'object' || Array.isArray(value))) {
-      throw new Error(`Config error: ${path} must be an object`);
-    }
-  };
   const only = (value: unknown, path: string, allowed: readonly string[]) => {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) return;
-    for (const key of Object.keys(value)) {
+    if (value === undefined) return;
+    requirePlainConfigRecord(value, path);
+    const record = value as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
       if (!allowed.includes(key)) unknownPaths.push(`${path}.${key}`);
     }
   };
@@ -661,9 +666,6 @@ function validateConfig(config: AgorConfig): void {
   ]);
   only(config.ui, 'ui', ['base_url', 'port', 'host']);
   only(config.uploads, 'uploads', ['location', 'max_age_days', 'max_file_size_mb']);
-  requireObject(config.external_launch, 'external_launch');
-  requireObject(config.identity, 'identity');
-  requireObject(config.identity?.external, 'identity.external');
   only(config.external_launch, 'external_launch', [
     'enabled',
     'exchange_url',
@@ -1019,14 +1021,6 @@ function validateConfig(config: AgorConfig): void {
   }
 
   assertValidMultiTenancyConfig(config);
-
-  validateOptionalHttpUrl(
-    config.external_launch as Record<string, unknown> | undefined,
-    'login_redirect_url',
-    'external_launch.login_redirect_url'
-  );
-
-  validateExternalLaunchReturnHostParam(config);
 }
 
 /**
@@ -1047,55 +1041,6 @@ export function requireDeploymentId(config: AgorConfig): string {
     throw new Error("Config error: 'daemon.deployment_id' is required and must be a valid UUID");
   }
   return deploymentId;
-}
-
-/**
- * Query-parameter name the UI reserves for the relative deep-link it forwards
- * to the launch-init endpoint (see apps/agor-ui/src/utils/launchInitUrl.ts). The
- * host param must never reuse this name: the UI sets `return_to` first and then
- * the host param, so an equal name would overwrite the deep-link with the host.
- */
-const RESERVED_RETURN_TO_PARAM = 'return_to';
-
-function validateExternalLaunchReturnHostParam(config: AgorConfig): void {
-  const raw = config.external_launch?.return_host_param;
-  if (raw === undefined) return;
-  if (typeof raw !== 'string') {
-    throw new Error('Config error: external_launch.return_host_param must be a string');
-  }
-  // An empty value intentionally falls back to the default (`return_host`) at
-  // resolve time, so it is left untouched here.
-  if (raw === '') return;
-  if (raw === RESERVED_RETURN_TO_PARAM) {
-    throw new Error(
-      `Config error: external_launch.return_host_param must not be "${RESERVED_RETURN_TO_PARAM}" — ` +
-        'that name is reserved for the relative deep-link the UI forwards to the launch-init ' +
-        'endpoint, and reusing it would overwrite the deep-link with the return host.'
-    );
-  }
-  // Conservative query-parameter-name charset: the value becomes a URL query
-  // key, so restrict it to opaque identifier characters and reject separators.
-  if (!/^[A-Za-z0-9_.-]+$/.test(raw)) {
-    throw new Error(
-      'Config error: external_launch.return_host_param may only contain letters, digits, ' +
-        'underscore, hyphen, and dot'
-    );
-  }
-}
-
-function validateOptionalHttpUrl(
-  container: Record<string, unknown> | undefined,
-  key: string,
-  configPath: string
-): void {
-  if (!container || container[key] === undefined) return;
-
-  const raw = container[key];
-  if (typeof raw !== 'string') {
-    throw new Error(`Config error: ${configPath} must be an HTTP(S) URL string`);
-  }
-
-  container[key] = validateHttpUrlString(raw, configPath);
 }
 
 function validateHttpUrlString(

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -26,7 +26,12 @@ import { resolveExecutorResponseConfig } from './executor-response';
 import { assertValidMultiTenancyConfig } from './multitenancy';
 import {
   type AgorConfig,
+  AgorExternalIdentityProvider,
+  AgorExternalIdentityProvisioning,
+  AgorLocalAuthMode,
+  AgorRoleAuthority,
   type AgorStatsDSettings,
+  AgorUserLifecycleAuthority,
   BRANCH_STORAGE_MODES,
   type BranchStorageMode,
   DEFAULT_BRANCH_STORAGE_MODE,
@@ -673,31 +678,31 @@ function validateConfig(config: AgorConfig): void {
   only(config.identity?.external, 'identity.external', ['provider', 'provisioning']);
   if (
     config.identity?.user_lifecycle !== undefined &&
-    !['internal', 'external'].includes(config.identity.user_lifecycle)
+    !Object.values(AgorUserLifecycleAuthority).includes(config.identity.user_lifecycle)
   ) {
     throw new Error('Config error: identity.user_lifecycle must be internal or external');
   }
   if (
     config.identity?.role_authority !== undefined &&
-    !['internal', 'claims'].includes(config.identity.role_authority)
+    !Object.values(AgorRoleAuthority).includes(config.identity.role_authority)
   ) {
     throw new Error('Config error: identity.role_authority must be internal or claims');
   }
   if (
     config.identity?.local_auth !== undefined &&
-    !['enabled', 'disabled'].includes(config.identity.local_auth)
+    !Object.values(AgorLocalAuthMode).includes(config.identity.local_auth)
   ) {
     throw new Error('Config error: identity.local_auth must be enabled or disabled');
   }
   if (
     config.identity?.external?.provider !== undefined &&
-    config.identity.external.provider !== 'external_launch'
+    config.identity.external.provider !== AgorExternalIdentityProvider.EXTERNAL_LAUNCH
   ) {
     throw new Error('Config error: identity.external.provider must be external_launch');
   }
   if (
     config.identity?.external?.provisioning !== undefined &&
-    config.identity.external.provisioning !== 'jit'
+    config.identity.external.provisioning !== AgorExternalIdentityProvisioning.JIT
   ) {
     throw new Error('Config error: identity.external.provisioning must be jit');
   }

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -491,6 +491,7 @@ function validateConfig(config: AgorConfig): void {
     'ui',
     'database',
     'external_launch',
+    'identity',
     'execution',
     'security',
     'branches',
@@ -668,6 +669,38 @@ function validateConfig(config: AgorConfig): void {
     'trusted_host_header',
     'return_host_param',
   ]);
+  only(config.identity, 'identity', ['user_lifecycle', 'role_authority', 'local_auth', 'external']);
+  only(config.identity?.external, 'identity.external', ['provider', 'provisioning']);
+  if (
+    config.identity?.user_lifecycle !== undefined &&
+    !['internal', 'external'].includes(config.identity.user_lifecycle)
+  ) {
+    throw new Error('Config error: identity.user_lifecycle must be internal or external');
+  }
+  if (
+    config.identity?.role_authority !== undefined &&
+    !['internal', 'claims'].includes(config.identity.role_authority)
+  ) {
+    throw new Error('Config error: identity.role_authority must be internal or claims');
+  }
+  if (
+    config.identity?.local_auth !== undefined &&
+    !['enabled', 'disabled'].includes(config.identity.local_auth)
+  ) {
+    throw new Error('Config error: identity.local_auth must be enabled or disabled');
+  }
+  if (
+    config.identity?.external?.provider !== undefined &&
+    config.identity.external.provider !== 'external_launch'
+  ) {
+    throw new Error('Config error: identity.external.provider must be external_launch');
+  }
+  if (
+    config.identity?.external?.provisioning !== undefined &&
+    config.identity.external.provisioning !== 'jit'
+  ) {
+    throw new Error('Config error: identity.external.provisioning must be jit');
+  }
   if (config.uploads !== undefined) {
     if (
       typeof config.uploads.location !== 'undefined' &&

--- a/packages/core/src/config/external-launch.test.ts
+++ b/packages/core/src/config/external-launch.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import {
   assertValidEffectiveExternalLaunchConfig,
@@ -13,6 +14,16 @@ const completeProvider = {
   audience: 'runtime:test',
   jwks_url: 'https://issuer.example.test/jwks',
 } as const;
+
+function publicKeyPem(type: 'rsa' | 'ec' | 'ed25519', namedCurve?: string): string {
+  const { publicKey } =
+    type === 'rsa'
+      ? generateKeyPairSync('rsa', { modulusLength: 2_048 })
+      : type === 'ec'
+        ? generateKeyPairSync('ec', { namedCurve: namedCurve ?? 'P-256' })
+        : generateKeyPairSync('ed25519');
+  return publicKey.export({ type: 'spki', format: 'pem' }).toString();
+}
 
 function unsafeConfig(externalLaunch: Record<string, unknown>): AgorConfig {
   return { external_launch: externalLaunch } as unknown as AgorConfig;
@@ -92,7 +103,17 @@ describe('external launch effective config', () => {
 
   it.each([
     ['non-HTTP exchange URL', { exchange_url: 'not-a-url' }, /exchange_url.*HTTP/i],
+    [
+      'credentials in the exchange URL',
+      { exchange_url: 'https://user:secret@issuer.example.test/exchange' },
+      /exchange_url.*URL credentials/i,
+    ],
     ['non-HTTP JWKS URL', { jwks_url: 'file:///tmp/jwks.json' }, /jwks_url.*HTTP/i],
+    [
+      'credentials in the JWKS URL',
+      { jwks_url: 'https://user:secret@issuer.example.test/jwks' },
+      /jwks_url.*URL credentials/i,
+    ],
     ['zero timeout', { request_timeout_ms: 0 }, /request_timeout_ms.*1/i],
     ['excessive timeout', { request_timeout_ms: 120_001 }, /request_timeout_ms.*120000/i],
     ['empty algorithms', { algorithms: [] }, /algorithms.*non-empty/i],
@@ -122,6 +143,56 @@ describe('external launch effective config', () => {
         })
       )
     ).toThrow(/symmetric verification.*HS/i);
+  });
+
+  it('derives a curve-compatible default for an EC public key', () => {
+    const result = resolveExternalLaunchSettings(
+      unsafeConfig({
+        ...completeProvider,
+        jwks_url: undefined,
+        public_key: publicKeyPem('ec', 'P-256'),
+      })
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.settings.algorithms).toEqual(['ES256']);
+  });
+
+  it.each([
+    [
+      'an EC key with an RSA algorithm',
+      publicKeyPem('ec', 'P-256'),
+      ['RS256'],
+      /curve.*requires.*ES256/i,
+    ],
+    [
+      'an EC key with the wrong curve algorithm',
+      publicKeyPem('ec', 'P-256'),
+      ['ES384'],
+      /curve.*requires.*ES256/i,
+    ],
+    ['an RSA key with an EC algorithm', publicKeyPem('rsa'), ['ES256'], /RSA.*RS\* or PS\*/i],
+    ['an unsupported key type', publicKeyPem('ed25519'), ['RS256'], /unsupported key type/i],
+  ])('rejects %s', (_label, publicKey, algorithms, expected) => {
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig(
+        unsafeConfig({
+          ...completeProvider,
+          jwks_url: undefined,
+          public_key: publicKey,
+          algorithms,
+        })
+      )
+    ).toThrow(expected);
+  });
+
+  it('rejects malformed raw env selectors with a stable config error', () => {
+    expect(() =>
+      resolveEffectiveExternalLaunchConfig(
+        unsafeConfig({ service_credential_env: 42 }).external_launch,
+        {}
+      )
+    ).toThrow(/Config error: external_launch\.service_credential_env must be a non-empty string/i);
   });
 
   it('returns the normalized settings consumed by request handling', () => {

--- a/packages/core/src/config/external-launch.test.ts
+++ b/packages/core/src/config/external-launch.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidEffectiveExternalLaunchConfig,
+  resolveEffectiveExternalLaunchConfig,
+} from './external-launch';
+
+describe('external launch effective config', () => {
+  it('materializes supported environment overrides once', () => {
+    const resolved = resolveEffectiveExternalLaunchConfig(
+      {
+        enabled: false,
+        service_credential_env: 'CUSTOM_LAUNCH_TOKEN',
+        dev_shared_secret_env: 'CUSTOM_LAUNCH_SECRET',
+      },
+      {
+        AGOR_EXTERNAL_LAUNCH_ENABLED: 'true',
+        AGOR_EXTERNAL_LAUNCH_EXCHANGE_URL: 'https://issuer.example.test/exchange',
+        AGOR_EXTERNAL_LAUNCH_ISSUER: 'https://issuer.example.test',
+        AGOR_EXTERNAL_LAUNCH_AUDIENCE: 'runtime:test',
+        AGOR_EXTERNAL_LAUNCH_INSTANCE_ID: 'runtime-1',
+        AGOR_EXTERNAL_LAUNCH_FORWARD_REQUEST_HOST: 'on',
+        CUSTOM_LAUNCH_TOKEN: 'service-token',
+        CUSTOM_LAUNCH_SECRET: 'assertion-secret',
+      }
+    );
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      exchange_url: 'https://issuer.example.test/exchange',
+      issuer: 'https://issuer.example.test',
+      audience: 'runtime:test',
+      instance_id: 'runtime-1',
+      forward_request_host: true,
+      service_credential: 'service-token',
+      dev_shared_secret: 'assertion-secret',
+    });
+  });
+
+  it('rejects invalid environment booleans instead of silently disabling auth', () => {
+    expect(() =>
+      resolveEffectiveExternalLaunchConfig(undefined, {
+        AGOR_EXTERNAL_LAUNCH_ENABLED: 'sometimes',
+      })
+    ).toThrow(/AGOR_EXTERNAL_LAUNCH_ENABLED/);
+  });
+
+  it('fails startup for incomplete or ambiguous enabled providers', () => {
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig({ external_launch: { enabled: true } })
+    ).toThrow(/exchange_url/);
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig({
+        external_launch: {
+          enabled: true,
+          exchange_url: 'https://issuer.example.test/exchange',
+          issuer: 'https://issuer.example.test',
+          audience: 'runtime:test',
+          jwks_url: 'https://issuer.example.test/jwks',
+          public_key: 'also-configured',
+        },
+      })
+    ).toThrow(/multiple assertion verification methods/);
+  });
+
+  it('accepts one complete effective provider configuration', () => {
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig({
+        external_launch: {
+          enabled: true,
+          exchange_url: 'https://issuer.example.test/exchange',
+          issuer: 'https://issuer.example.test',
+          audience: 'runtime:test',
+          jwks_url: 'https://issuer.example.test/jwks',
+        },
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/config/external-launch.test.ts
+++ b/packages/core/src/config/external-launch.test.ts
@@ -2,7 +2,21 @@ import { describe, expect, it } from 'vitest';
 import {
   assertValidEffectiveExternalLaunchConfig,
   resolveEffectiveExternalLaunchConfig,
+  resolveExternalLaunchSettings,
 } from './external-launch';
+import type { AgorConfig } from './types';
+
+const completeProvider = {
+  enabled: true,
+  exchange_url: 'https://issuer.example.test/exchange',
+  issuer: 'https://issuer.example.test',
+  audience: 'runtime:test',
+  jwks_url: 'https://issuer.example.test/jwks',
+} as const;
+
+function unsafeConfig(externalLaunch: Record<string, unknown>): AgorConfig {
+  return { external_launch: externalLaunch } as unknown as AgorConfig;
+}
 
 describe('external launch effective config', () => {
   it('materializes supported environment overrides once', () => {
@@ -74,5 +88,60 @@ describe('external launch effective config', () => {
         },
       })
     ).not.toThrow();
+  });
+
+  it.each([
+    ['non-HTTP exchange URL', { exchange_url: 'not-a-url' }, /exchange_url.*HTTP/i],
+    ['non-HTTP JWKS URL', { jwks_url: 'file:///tmp/jwks.json' }, /jwks_url.*HTTP/i],
+    ['zero timeout', { request_timeout_ms: 0 }, /request_timeout_ms.*1/i],
+    ['excessive timeout', { request_timeout_ms: 120_001 }, /request_timeout_ms.*120000/i],
+    ['empty algorithms', { algorithms: [] }, /algorithms.*non-empty/i],
+    ['unsupported algorithm', { algorithms: ['none'] }, /algorithms.*only contain/i],
+    [
+      'malformed public key',
+      { jwks_url: undefined, public_key: 'not-a-public-key' },
+      /public_key.*valid public key/i,
+    ],
+    ['numeric trusted header', { trusted_host_header: 42 }, /trusted_host_header.*string/i],
+    ['invalid trusted header', { trusted_host_header: 'host header' }, /HTTP header name/i],
+    ['non-boolean host forwarding', { forward_request_host: 'yes' }, /must be a boolean/i],
+  ])('fails startup for an enabled provider with %s', (_label, override, expected) => {
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig(unsafeConfig({ ...completeProvider, ...override }))
+    ).toThrow(expected);
+  });
+
+  it('requires configured algorithms to match the verification key family', () => {
+    expect(() =>
+      assertValidEffectiveExternalLaunchConfig(
+        unsafeConfig({
+          ...completeProvider,
+          jwks_url: undefined,
+          dev_shared_secret: 'secret',
+          algorithms: ['ES256'],
+        })
+      )
+    ).toThrow(/symmetric verification.*HS/i);
+  });
+
+  it('returns the normalized settings consumed by request handling', () => {
+    const result = resolveExternalLaunchSettings(
+      unsafeConfig({
+        ...completeProvider,
+        algorithms: ['ES256'],
+        trusted_host_header: 'X-Forwarded-Host',
+        request_timeout_ms: 5_000,
+      })
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.settings).toMatchObject({
+      enabled: true,
+      exchangeUrl: completeProvider.exchange_url,
+      jwksUrl: completeProvider.jwks_url,
+      algorithms: ['ES256'],
+      trustedHostHeader: 'x-forwarded-host',
+      requestTimeoutMs: 5_000,
+    });
   });
 });

--- a/packages/core/src/config/external-launch.test.ts
+++ b/packages/core/src/config/external-launch.test.ts
@@ -1,9 +1,10 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import {
-  assertValidEffectiveExternalLaunchConfig,
+  assertValidRawExternalLaunchConfig,
   resolveEffectiveExternalLaunchConfig,
   resolveExternalLaunchSettings,
+  resolveValidExternalLaunchProvider,
 } from './external-launch';
 import type { AgorConfig } from './types';
 
@@ -71,10 +72,10 @@ describe('external launch effective config', () => {
 
   it('fails startup for incomplete or ambiguous enabled providers', () => {
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig({ external_launch: { enabled: true } })
+      resolveValidExternalLaunchProvider({ external_launch: { enabled: true } })
     ).toThrow(/exchange_url/);
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig({
+      resolveValidExternalLaunchProvider({
         external_launch: {
           enabled: true,
           exchange_url: 'https://issuer.example.test/exchange',
@@ -89,7 +90,7 @@ describe('external launch effective config', () => {
 
   it('accepts one complete effective provider configuration', () => {
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig({
+      resolveValidExternalLaunchProvider({
         external_launch: {
           enabled: true,
           exchange_url: 'https://issuer.example.test/exchange',
@@ -128,13 +129,13 @@ describe('external launch effective config', () => {
     ['non-boolean host forwarding', { forward_request_host: 'yes' }, /must be a boolean/i],
   ])('fails startup for an enabled provider with %s', (_label, override, expected) => {
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig(unsafeConfig({ ...completeProvider, ...override }))
+      resolveValidExternalLaunchProvider(unsafeConfig({ ...completeProvider, ...override }))
     ).toThrow(expected);
   });
 
   it('requires configured algorithms to match the verification key family', () => {
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig(
+      resolveValidExternalLaunchProvider(
         unsafeConfig({
           ...completeProvider,
           jwks_url: undefined,
@@ -146,7 +147,7 @@ describe('external launch effective config', () => {
   });
 
   it('derives a curve-compatible default for an EC public key', () => {
-    const result = resolveExternalLaunchSettings(
+    const settings = resolveValidExternalLaunchProvider(
       unsafeConfig({
         ...completeProvider,
         jwks_url: undefined,
@@ -154,8 +155,11 @@ describe('external launch effective config', () => {
       })
     );
 
-    expect(result.error).toBeUndefined();
-    expect(result.settings.algorithms).toEqual(['ES256']);
+    expect(settings.algorithms).toEqual(['ES256']);
+    expect(settings.publicKey).toMatchObject({ type: 'public', asymmetricKeyType: 'ec' });
+    expect(typeof settings.publicKey).not.toBe('string');
+    expect(Object.isFrozen(settings)).toBe(true);
+    expect(Object.isFrozen(settings.algorithms)).toBe(true);
   });
 
   it.each([
@@ -175,7 +179,7 @@ describe('external launch effective config', () => {
     ['an unsupported key type', publicKeyPem('ed25519'), ['RS256'], /unsupported key type/i],
   ])('rejects %s', (_label, publicKey, algorithms, expected) => {
     expect(() =>
-      assertValidEffectiveExternalLaunchConfig(
+      resolveValidExternalLaunchProvider(
         unsafeConfig({
           ...completeProvider,
           jwks_url: undefined,
@@ -193,6 +197,20 @@ describe('external launch effective config', () => {
         {}
       )
     ).toThrow(/Config error: external_launch\.service_credential_env must be a non-empty string/i);
+  });
+
+  it('validates raw launch settings without mutating caller-owned config', () => {
+    const configured = {
+      login_redirect_url: ' https://workspace.example.test/open ',
+      return_host_param: ' workspace_host ',
+    };
+
+    assertValidRawExternalLaunchConfig(configured);
+
+    expect(configured).toEqual({
+      login_redirect_url: ' https://workspace.example.test/open ',
+      return_host_param: ' workspace_host ',
+    });
   });
 
   it('returns the normalized settings consumed by request handling', () => {

--- a/packages/core/src/config/external-launch.ts
+++ b/packages/core/src/config/external-launch.ts
@@ -1,4 +1,4 @@
-import { createPublicKey } from 'node:crypto';
+import { createPublicKey, type KeyObject } from 'node:crypto';
 import {
   type AgorConfig,
   AgorExternalLaunchAlgorithm,
@@ -69,7 +69,11 @@ function optionalBoolean(
   return value;
 }
 
-function httpUrl(value: string | undefined, path: string): string | undefined {
+function httpUrl(
+  value: string | undefined,
+  path: string,
+  options: { rejectUserinfo?: boolean } = {}
+): string | undefined {
   if (value === undefined) return undefined;
   let parsed: URL;
   try {
@@ -79,6 +83,9 @@ function httpUrl(value: string | undefined, path: string): string | undefined {
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`${path} must be a valid HTTP(S) URL`);
+  }
+  if (options.rejectUserinfo && (parsed.username || parsed.password)) {
+    throw new Error(`${path} must not include URL credentials`);
   }
   return value;
 }
@@ -98,7 +105,57 @@ function parseAlgorithms(
   return algorithms as ResolvedExternalLaunchSettings['algorithms'];
 }
 
-function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunchSettings {
+const DEFAULT_HMAC_ALGORITHMS = [AgorExternalLaunchAlgorithm.HS256];
+const DEFAULT_RSA_ALGORITHMS = [AgorExternalLaunchAlgorithm.RS256];
+
+const EC_CURVE_ALGORITHM = new Map<string, AgorExternalLaunchAlgorithm>([
+  ['prime256v1', AgorExternalLaunchAlgorithm.ES256],
+  ['secp256r1', AgorExternalLaunchAlgorithm.ES256],
+  ['P-256', AgorExternalLaunchAlgorithm.ES256],
+  ['secp384r1', AgorExternalLaunchAlgorithm.ES384],
+  ['P-384', AgorExternalLaunchAlgorithm.ES384],
+  ['secp521r1', AgorExternalLaunchAlgorithm.ES512],
+  ['P-521', AgorExternalLaunchAlgorithm.ES512],
+]);
+
+function publicKeyAlgorithms(
+  key: KeyObject,
+  configured: ResolvedExternalLaunchSettings['algorithms']
+): ResolvedExternalLaunchSettings['algorithms'] {
+  if (key.asymmetricKeyType === 'rsa') {
+    const algorithms = configured ?? DEFAULT_RSA_ALGORITHMS;
+    if (
+      algorithms.some((algorithm) => !algorithm.startsWith('RS') && !algorithm.startsWith('PS'))
+    ) {
+      throw new Error('external_launch RSA public keys may only use RS* or PS* algorithms');
+    }
+    return algorithms;
+  }
+
+  if (key.asymmetricKeyType === 'ec') {
+    const curve = key.asymmetricKeyDetails?.namedCurve;
+    const expected = curve ? EC_CURVE_ALGORITHM.get(curve) : undefined;
+    if (!expected) {
+      throw new Error('external_launch.public_key uses an unsupported elliptic curve');
+    }
+    const algorithms = configured ?? [expected];
+    if (algorithms.some((algorithm) => algorithm !== expected)) {
+      throw new Error(
+        `external_launch EC public key curve ${curve} requires the ${expected} algorithm`
+      );
+    }
+    return algorithms;
+  }
+
+  throw new Error(
+    `external_launch.public_key uses unsupported key type ${key.asymmetricKeyType ?? 'unknown'}`
+  );
+}
+
+function parseExternalLaunchSettings(
+  config: AgorConfig,
+  options: { requireCompleteProvider?: boolean } = {}
+): ResolvedExternalLaunchSettings {
   const rawValue = config.external_launch as unknown;
   if (rawValue !== undefined && !isObject(rawValue)) {
     throw new Error('external_launch must be an object');
@@ -106,12 +163,16 @@ function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunch
   const raw = rawValue ?? {};
 
   const enabled = optionalBoolean(raw, 'enabled');
-  const exchangeUrl = httpUrl(requiredString(raw, 'exchange_url'), 'external_launch.exchange_url');
+  const exchangeUrl = httpUrl(requiredString(raw, 'exchange_url'), 'external_launch.exchange_url', {
+    rejectUserinfo: true,
+  });
   const issuer = requiredString(raw, 'issuer');
   const audience = requiredString(raw, 'audience');
   const instanceId = requiredString(raw, 'instance_id');
   const providerId = requiredString(raw, 'provider_id');
-  const jwksUrl = httpUrl(requiredString(raw, 'jwks_url'), 'external_launch.jwks_url');
+  const jwksUrl = httpUrl(requiredString(raw, 'jwks_url'), 'external_launch.jwks_url', {
+    rejectUserinfo: true,
+  });
   const publicKey = requiredString(raw, 'public_key', { preserveWhitespace: true });
   const devSharedSecret = requiredString(raw, 'dev_shared_secret', { preserveWhitespace: true });
   const serviceCredential = requiredString(raw, 'service_credential', {
@@ -139,7 +200,7 @@ function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunch
       `external_launch.request_timeout_ms must be an integer from 1 to ${EXTERNAL_LAUNCH_MAX_TIMEOUT_MS}`
     );
   }
-  const algorithms = parseAlgorithms(raw);
+  let algorithms = parseAlgorithms(raw);
   const allowAdminRoles = optionalBoolean(raw, 'allow_admin_roles');
   const trustVerifiedEmailForLinking = optionalBoolean(raw, 'trust_verified_email_for_linking');
   const forwardRequestHost = optionalBoolean(raw, 'forward_request_host');
@@ -177,28 +238,31 @@ function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunch
   }
 
   const verificationMethods = [jwksUrl, publicKey, devSharedSecret].filter(Boolean);
-  if (enabled && !exchangeUrl) {
+  const requireCompleteProvider = options.requireCompleteProvider ?? true;
+  if (requireCompleteProvider && enabled && !exchangeUrl) {
     throw new Error('external_launch.exchange_url is required when external launch is enabled');
   }
-  if (enabled && (!issuer || !audience)) {
+  if (requireCompleteProvider && enabled && (!issuer || !audience)) {
     throw new Error(
       'external_launch.issuer and external_launch.audience are required when external launch is enabled'
     );
   }
-  if (enabled && verificationMethods.length === 0) {
+  if (requireCompleteProvider && enabled && verificationMethods.length === 0) {
     throw new Error('external_launch requires exactly one assertion verification method');
   }
-  if (enabled && verificationMethods.length > 1) {
+  if (verificationMethods.length > 1) {
     throw new Error('external_launch must not configure multiple assertion verification methods');
   }
-  if (enabled && publicKey) {
+  if (publicKey) {
+    let key: KeyObject;
     try {
-      createPublicKey(publicKey);
+      key = createPublicKey(publicKey);
     } catch {
       throw new Error('external_launch.public_key must be a valid public key');
     }
+    algorithms = publicKeyAlgorithms(key, algorithms);
   }
-  if (enabled && algorithms) {
+  if (algorithms) {
     const hasHsAlgorithm = algorithms.some((algorithm) => algorithm.startsWith('HS'));
     const hasNonHsAlgorithm = algorithms.some((algorithm) => !algorithm.startsWith('HS'));
     if (devSharedSecret && hasNonHsAlgorithm) {
@@ -208,6 +272,8 @@ function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunch
       throw new Error('external_launch asymmetric verification cannot use HS* algorithms');
     }
   }
+  if (!algorithms && devSharedSecret) algorithms = DEFAULT_HMAC_ALGORITHMS;
+  if (!algorithms && jwksUrl) algorithms = DEFAULT_RSA_ALGORITHMS;
 
   return {
     enabled,
@@ -274,9 +340,7 @@ export function resolveEffectiveExternalLaunchConfig(
   configured: AgorConfig['external_launch'],
   env: NodeJS.ProcessEnv = process.env
 ): AgorExternalLaunchSettings | undefined {
-  if (configured !== undefined && !isObject(configured)) {
-    throw new Error('Config error: external_launch must be an object');
-  }
+  assertValidRawExternalLaunchConfig(configured);
 
   const raw: AgorExternalLaunchSettings = configured ?? {};
   const enabled = booleanEnvironmentValue(
@@ -326,6 +390,24 @@ export function resolveEffectiveExternalLaunchConfig(
       : {}),
     ...(forwardRequestHost !== undefined ? { forward_request_host: forwardRequestHost } : {}),
   };
+}
+
+/**
+ * Validate file- or API-provided values before environment projection. This
+ * keeps programmatic daemon startup on the same raw config boundary as YAML
+ * loading while allowing required secrets to arrive from their named env vars.
+ */
+export function assertValidRawExternalLaunchConfig(configured: unknown): void {
+  try {
+    parseExternalLaunchSettings(
+      { external_launch: configured as AgorConfig['external_launch'] },
+      { requireCompleteProvider: false }
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'external_launch configuration is invalid';
+    throw new Error(`Config error: ${message}`);
+  }
 }
 
 /**

--- a/packages/core/src/config/external-launch.ts
+++ b/packages/core/src/config/external-launch.ts
@@ -1,9 +1,9 @@
 import { createPublicKey, type KeyObject } from 'node:crypto';
+import { isPlainConfigRecord } from './plain-record';
 import {
   type AgorConfig,
   AgorExternalLaunchAlgorithm,
   type AgorExternalLaunchSettings,
-  type ResolvedExternalLaunchSettings,
 } from './types';
 
 export const EXTERNAL_LAUNCH_DEFAULT_TIMEOUT_MS = 10_000;
@@ -37,10 +37,6 @@ function booleanEnvironmentValue(value: string | undefined, name: string): boole
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
   if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
   throw new Error(`Config error: ${name} must be one of: true, false, 1, 0, yes, no, on, off`);
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function requiredString(
@@ -90,9 +86,7 @@ function httpUrl(
   return value;
 }
 
-function parseAlgorithms(
-  raw: Record<string, unknown>
-): ResolvedExternalLaunchSettings['algorithms'] {
+function parseAlgorithms(raw: Record<string, unknown>): AgorExternalLaunchAlgorithm[] | undefined {
   const algorithms = raw.algorithms;
   if (algorithms === undefined) return undefined;
   if (!Array.isArray(algorithms) || algorithms.length === 0) {
@@ -102,7 +96,7 @@ function parseAlgorithms(
   if (algorithms.some((algorithm) => typeof algorithm !== 'string' || !supported.has(algorithm))) {
     throw new Error(`external_launch.algorithms may only contain: ${[...supported].join(', ')}`);
   }
-  return algorithms as ResolvedExternalLaunchSettings['algorithms'];
+  return [...algorithms] as AgorExternalLaunchAlgorithm[];
 }
 
 const DEFAULT_HMAC_ALGORITHMS = [AgorExternalLaunchAlgorithm.HS256];
@@ -120,8 +114,8 @@ const EC_CURVE_ALGORITHM = new Map<string, AgorExternalLaunchAlgorithm>([
 
 function publicKeyAlgorithms(
   key: KeyObject,
-  configured: ResolvedExternalLaunchSettings['algorithms']
-): ResolvedExternalLaunchSettings['algorithms'] {
+  configured: AgorExternalLaunchAlgorithm[] | undefined
+): AgorExternalLaunchAlgorithm[] {
   if (key.asymmetricKeyType === 'rsa') {
     const algorithms = configured ?? DEFAULT_RSA_ALGORITHMS;
     if (
@@ -152,12 +146,35 @@ function publicKeyAlgorithms(
   );
 }
 
+/** Node-only provider model retained for the daemon's full process lifetime. */
+export interface ResolvedExternalLaunchProvider {
+  readonly enabled: boolean;
+  readonly exchangeUrl?: string;
+  readonly audience?: string;
+  readonly issuer?: string;
+  readonly instanceId?: string;
+  readonly providerId?: string;
+  readonly jwksUrl?: string;
+  /** Parsed once after environment projection; the PEM is not retained. */
+  readonly publicKey?: KeyObject;
+  readonly devSharedSecret?: string;
+  readonly serviceCredential?: string;
+  readonly allowAdminRoles: boolean;
+  readonly trustVerifiedEmailForLinking: boolean;
+  readonly requestTimeoutMs: number;
+  readonly algorithms?: readonly AgorExternalLaunchAlgorithm[];
+  readonly forwardRequestHost: boolean;
+  readonly trustedHostHeader: string;
+  readonly loginRedirectUrl?: string;
+  readonly returnHostParam?: string;
+}
+
 function parseExternalLaunchSettings(
   config: AgorConfig,
-  options: { requireCompleteProvider?: boolean } = {}
-): ResolvedExternalLaunchSettings {
+  options: { requireCompleteProvider?: boolean; resolvePublicKey?: boolean } = {}
+): ResolvedExternalLaunchProvider {
   const rawValue = config.external_launch as unknown;
-  if (rawValue !== undefined && !isObject(rawValue)) {
+  if (rawValue !== undefined && !isPlainConfigRecord(rawValue)) {
     throw new Error('external_launch must be an object');
   }
   const raw = rawValue ?? {};
@@ -173,7 +190,7 @@ function parseExternalLaunchSettings(
   const jwksUrl = httpUrl(requiredString(raw, 'jwks_url'), 'external_launch.jwks_url', {
     rejectUserinfo: true,
   });
-  const publicKey = requiredString(raw, 'public_key', { preserveWhitespace: true });
+  const publicKeyPem = requiredString(raw, 'public_key', { preserveWhitespace: true });
   const devSharedSecret = requiredString(raw, 'dev_shared_secret', { preserveWhitespace: true });
   const serviceCredential = requiredString(raw, 'service_credential', {
     preserveWhitespace: true,
@@ -237,7 +254,7 @@ function parseExternalLaunchSettings(
     );
   }
 
-  const verificationMethods = [jwksUrl, publicKey, devSharedSecret].filter(Boolean);
+  const verificationMethods = [jwksUrl, publicKeyPem, devSharedSecret].filter(Boolean);
   const requireCompleteProvider = options.requireCompleteProvider ?? true;
   if (requireCompleteProvider && enabled && !exchangeUrl) {
     throw new Error('external_launch.exchange_url is required when external launch is enabled');
@@ -253,14 +270,14 @@ function parseExternalLaunchSettings(
   if (verificationMethods.length > 1) {
     throw new Error('external_launch must not configure multiple assertion verification methods');
   }
-  if (publicKey) {
-    let key: KeyObject;
+  let publicKey: KeyObject | undefined;
+  if (publicKeyPem && (options.resolvePublicKey ?? true)) {
     try {
-      key = createPublicKey(publicKey);
+      publicKey = createPublicKey(publicKeyPem);
     } catch {
       throw new Error('external_launch.public_key must be a valid public key');
     }
-    algorithms = publicKeyAlgorithms(key, algorithms);
+    algorithms = publicKeyAlgorithms(publicKey, algorithms);
   }
   if (algorithms) {
     const hasHsAlgorithm = algorithms.some((algorithm) => algorithm.startsWith('HS'));
@@ -268,7 +285,7 @@ function parseExternalLaunchSettings(
     if (devSharedSecret && hasNonHsAlgorithm) {
       throw new Error('external_launch symmetric verification may only use HS* algorithms');
     }
-    if ((jwksUrl || publicKey) && hasHsAlgorithm) {
+    if ((jwksUrl || publicKeyPem) && hasHsAlgorithm) {
       throw new Error('external_launch asymmetric verification cannot use HS* algorithms');
     }
   }
@@ -300,11 +317,11 @@ function parseExternalLaunchSettings(
 }
 
 export interface ExternalLaunchSettingsResolution {
-  settings: ResolvedExternalLaunchSettings;
+  settings: ResolvedExternalLaunchProvider;
   error?: string;
 }
 
-const DISABLED_LAUNCH_SETTINGS: ResolvedExternalLaunchSettings = {
+const DISABLED_LAUNCH_SETTINGS: ResolvedExternalLaunchProvider = {
   enabled: false,
   allowAdminRoles: false,
   trustVerifiedEmailForLinking: false,
@@ -314,9 +331,8 @@ const DISABLED_LAUNCH_SETTINGS: ResolvedExternalLaunchSettings = {
 };
 
 /**
- * Parse the complete provider profile once through the same fail-closed
- * contract used by startup and request handling. Invalid raw values never
- * escape into auth code as partially trusted settings.
+ * Parse one provider profile through the canonical fail-closed contract.
+ * Daemon startup promotes a successful result into its retained runtime model.
  */
 export function resolveExternalLaunchSettings(
   config: AgorConfig
@@ -401,7 +417,7 @@ export function assertValidRawExternalLaunchConfig(configured: unknown): void {
   try {
     parseExternalLaunchSettings(
       { external_launch: configured as AgorConfig['external_launch'] },
-      { requireCompleteProvider: false }
+      { requireCompleteProvider: false, resolvePublicKey: false }
     );
   } catch (error) {
     const message =
@@ -410,17 +426,14 @@ export function assertValidRawExternalLaunchConfig(configured: unknown): void {
   }
 }
 
-/**
- * Return the single startup/request-time validation result used by both the
- * config boundary and launch service. Keeping this pure prevents the two
- * enforcement points from accepting different provider configurations.
- */
-export function externalLaunchConfigurationError(config: AgorConfig): string | undefined {
-  return resolveExternalLaunchSettings(config).error;
-}
-
-/** Fail startup before database initialization when enabled launch auth is unusable. */
-export function assertValidEffectiveExternalLaunchConfig(config: AgorConfig): void {
-  const error = externalLaunchConfigurationError(config);
+/** Resolve and retain the one validated Node runtime provider model. */
+export function resolveValidExternalLaunchProvider(
+  config: AgorConfig
+): ResolvedExternalLaunchProvider {
+  const { settings, error } = resolveExternalLaunchSettings(config);
   if (error) throw new Error(`Config error: ${error}`);
+  const algorithms = settings.algorithms
+    ? (Object.freeze([...settings.algorithms]) as AgorExternalLaunchAlgorithm[])
+    : undefined;
+  return Object.freeze({ ...settings, algorithms });
 }

--- a/packages/core/src/config/external-launch.ts
+++ b/packages/core/src/config/external-launch.ts
@@ -1,0 +1,141 @@
+import type { AgorConfig, AgorExternalLaunchSettings } from './types';
+
+export const EXTERNAL_LAUNCH_ENV = {
+  ENABLED: 'AGOR_EXTERNAL_LAUNCH_ENABLED',
+  EXCHANGE_URL: 'AGOR_EXTERNAL_LAUNCH_EXCHANGE_URL',
+  ISSUER: 'AGOR_EXTERNAL_LAUNCH_ISSUER',
+  AUDIENCE: 'AGOR_EXTERNAL_LAUNCH_AUDIENCE',
+  INSTANCE_ID: 'AGOR_EXTERNAL_LAUNCH_INSTANCE_ID',
+  FORWARD_REQUEST_HOST: 'AGOR_EXTERNAL_LAUNCH_FORWARD_REQUEST_HOST',
+  SERVICE_CREDENTIAL: 'AGOR_EXTERNAL_LAUNCH_SERVICE_TOKEN',
+  DEV_SHARED_SECRET: 'AGOR_EXTERNAL_LAUNCH_SHARED_SECRET',
+} as const;
+
+function nonEmptyEnvironmentValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function booleanEnvironmentValue(value: string | undefined, name: string): boolean | undefined {
+  const normalized = nonEmptyEnvironmentValue(value)?.toLowerCase();
+  if (normalized === undefined) return undefined;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  throw new Error(`Config error: ${name} must be one of: true, false, 1, 0, yes, no, on, off`);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Fold the supported launch-auth environment overrides into the daemon's
+ * immutable effective configuration snapshot. Runtime auth code must not
+ * re-read process.env after startup.
+ */
+export function resolveEffectiveExternalLaunchConfig(
+  configured: AgorConfig['external_launch'],
+  env: NodeJS.ProcessEnv = process.env
+): AgorExternalLaunchSettings | undefined {
+  if (configured !== undefined && !isObject(configured)) {
+    throw new Error('Config error: external_launch must be an object');
+  }
+
+  const raw: AgorExternalLaunchSettings = configured ?? {};
+  const enabled = booleanEnvironmentValue(
+    env[EXTERNAL_LAUNCH_ENV.ENABLED],
+    EXTERNAL_LAUNCH_ENV.ENABLED
+  );
+  const forwardRequestHost = booleanEnvironmentValue(
+    env[EXTERNAL_LAUNCH_ENV.FORWARD_REQUEST_HOST],
+    EXTERNAL_LAUNCH_ENV.FORWARD_REQUEST_HOST
+  );
+  const hasLaunchEnvironment = [
+    enabled,
+    forwardRequestHost,
+    nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.EXCHANGE_URL]),
+    nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.ISSUER]),
+    nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.AUDIENCE]),
+    nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.INSTANCE_ID]),
+  ].some((value) => value !== undefined);
+
+  if (configured === undefined && !hasLaunchEnvironment) return undefined;
+
+  const serviceCredentialEnv =
+    nonEmptyEnvironmentValue(raw.service_credential_env) ?? EXTERNAL_LAUNCH_ENV.SERVICE_CREDENTIAL;
+  const sharedSecretEnv =
+    nonEmptyEnvironmentValue(raw.dev_shared_secret_env) ?? EXTERNAL_LAUNCH_ENV.DEV_SHARED_SECRET;
+
+  return {
+    ...raw,
+    ...(enabled !== undefined ? { enabled } : {}),
+    ...(nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.EXCHANGE_URL])
+      ? { exchange_url: nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.EXCHANGE_URL]) }
+      : {}),
+    ...(nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.ISSUER])
+      ? { issuer: nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.ISSUER]) }
+      : {}),
+    ...(nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.AUDIENCE])
+      ? { audience: nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.AUDIENCE]) }
+      : {}),
+    ...(nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.INSTANCE_ID])
+      ? { instance_id: nonEmptyEnvironmentValue(env[EXTERNAL_LAUNCH_ENV.INSTANCE_ID]) }
+      : {}),
+    ...(nonEmptyEnvironmentValue(env[serviceCredentialEnv])
+      ? { service_credential: nonEmptyEnvironmentValue(env[serviceCredentialEnv]) }
+      : {}),
+    ...(nonEmptyEnvironmentValue(env[sharedSecretEnv])
+      ? { dev_shared_secret: nonEmptyEnvironmentValue(env[sharedSecretEnv]) }
+      : {}),
+    ...(forwardRequestHost !== undefined ? { forward_request_host: forwardRequestHost } : {}),
+  };
+}
+
+/**
+ * Return the single startup/request-time validation result used by both the
+ * config boundary and launch service. Keeping this pure prevents the two
+ * enforcement points from accepting different provider configurations.
+ */
+export function externalLaunchConfigurationError(config: AgorConfig): string | undefined {
+  const raw = config.external_launch as unknown;
+  if (raw !== undefined && !isObject(raw)) return 'external_launch must be an object';
+  if (raw === undefined) return undefined;
+
+  const settings = raw as unknown as AgorExternalLaunchSettings;
+  if (settings.enabled !== undefined && typeof settings.enabled !== 'boolean') {
+    return 'external_launch.enabled must be a boolean';
+  }
+  if (settings.enabled !== true) return undefined;
+  if (!nonEmptyEnvironmentValue(settings.exchange_url)) {
+    return 'external_launch.exchange_url is required when external launch is enabled';
+  }
+  if (!nonEmptyEnvironmentValue(settings.issuer) || !nonEmptyEnvironmentValue(settings.audience)) {
+    return 'external_launch.issuer and external_launch.audience are required when external launch is enabled';
+  }
+
+  const configuredKeyCount = [
+    settings.jwks_url,
+    settings.public_key,
+    settings.dev_shared_secret,
+  ].filter((value) => nonEmptyEnvironmentValue(value) !== undefined).length;
+  if (configuredKeyCount === 0) {
+    return 'external_launch requires exactly one assertion verification method';
+  }
+  if (configuredKeyCount > 1) {
+    return 'external_launch must not configure multiple assertion verification methods';
+  }
+
+  const usesAsymmetricKey = Boolean(
+    nonEmptyEnvironmentValue(settings.jwks_url) || nonEmptyEnvironmentValue(settings.public_key)
+  );
+  if (usesAsymmetricKey && settings.algorithms?.some((algorithm) => /^hs/i.test(algorithm))) {
+    return 'external_launch asymmetric verification cannot use HS* algorithms';
+  }
+  return undefined;
+}
+
+/** Fail startup before database initialization when enabled launch auth is unusable. */
+export function assertValidEffectiveExternalLaunchConfig(config: AgorConfig): void {
+  const error = externalLaunchConfigurationError(config);
+  if (error) throw new Error(`Config error: ${error}`);
+}

--- a/packages/core/src/config/external-launch.ts
+++ b/packages/core/src/config/external-launch.ts
@@ -1,4 +1,19 @@
-import type { AgorConfig, AgorExternalLaunchSettings } from './types';
+import { createPublicKey } from 'node:crypto';
+import {
+  type AgorConfig,
+  AgorExternalLaunchAlgorithm,
+  type AgorExternalLaunchSettings,
+  type ResolvedExternalLaunchSettings,
+} from './types';
+
+export const EXTERNAL_LAUNCH_DEFAULT_TIMEOUT_MS = 10_000;
+export const EXTERNAL_LAUNCH_MAX_TIMEOUT_MS = 120_000;
+export const EXTERNAL_LAUNCH_DEFAULT_TRUSTED_HOST_HEADER = 'host';
+export const EXTERNAL_LAUNCH_DEFAULT_RETURN_HOST_PARAM = 'return_host';
+
+const RESERVED_RETURN_TO_PARAM = 'return_to';
+const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const ENVIRONMENT_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export const EXTERNAL_LAUNCH_ENV = {
   ENABLED: 'AGOR_EXTERNAL_LAUNCH_ENABLED',
@@ -26,6 +41,228 @@ function booleanEnvironmentValue(value: string | undefined, name: string): boole
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requiredString(
+  raw: Record<string, unknown>,
+  key: keyof AgorExternalLaunchSettings,
+  options: { preserveWhitespace?: boolean } = {}
+): string | undefined {
+  const value = raw[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`external_launch.${key} must be a non-empty string`);
+  }
+  return options.preserveWhitespace ? value : value.trim();
+}
+
+function optionalBoolean(
+  raw: Record<string, unknown>,
+  key: keyof AgorExternalLaunchSettings,
+  fallback = false
+): boolean {
+  const value = raw[key];
+  if (value === undefined) return fallback;
+  if (typeof value !== 'boolean') {
+    throw new Error(`external_launch.${key} must be a boolean`);
+  }
+  return value;
+}
+
+function httpUrl(value: string | undefined, path: string): string | undefined {
+  if (value === undefined) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${path} must be a valid HTTP(S) URL`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${path} must be a valid HTTP(S) URL`);
+  }
+  return value;
+}
+
+function parseAlgorithms(
+  raw: Record<string, unknown>
+): ResolvedExternalLaunchSettings['algorithms'] {
+  const algorithms = raw.algorithms;
+  if (algorithms === undefined) return undefined;
+  if (!Array.isArray(algorithms) || algorithms.length === 0) {
+    throw new Error('external_launch.algorithms must be a non-empty array');
+  }
+  const supported = new Set<string>(Object.values(AgorExternalLaunchAlgorithm));
+  if (algorithms.some((algorithm) => typeof algorithm !== 'string' || !supported.has(algorithm))) {
+    throw new Error(`external_launch.algorithms may only contain: ${[...supported].join(', ')}`);
+  }
+  return algorithms as ResolvedExternalLaunchSettings['algorithms'];
+}
+
+function parseExternalLaunchSettings(config: AgorConfig): ResolvedExternalLaunchSettings {
+  const rawValue = config.external_launch as unknown;
+  if (rawValue !== undefined && !isObject(rawValue)) {
+    throw new Error('external_launch must be an object');
+  }
+  const raw = rawValue ?? {};
+
+  const enabled = optionalBoolean(raw, 'enabled');
+  const exchangeUrl = httpUrl(requiredString(raw, 'exchange_url'), 'external_launch.exchange_url');
+  const issuer = requiredString(raw, 'issuer');
+  const audience = requiredString(raw, 'audience');
+  const instanceId = requiredString(raw, 'instance_id');
+  const providerId = requiredString(raw, 'provider_id');
+  const jwksUrl = httpUrl(requiredString(raw, 'jwks_url'), 'external_launch.jwks_url');
+  const publicKey = requiredString(raw, 'public_key', { preserveWhitespace: true });
+  const devSharedSecret = requiredString(raw, 'dev_shared_secret', { preserveWhitespace: true });
+  const serviceCredential = requiredString(raw, 'service_credential', {
+    preserveWhitespace: true,
+  });
+  const devSharedSecretEnv = requiredString(raw, 'dev_shared_secret_env');
+  const serviceCredentialEnv = requiredString(raw, 'service_credential_env');
+  for (const [path, value] of [
+    ['external_launch.dev_shared_secret_env', devSharedSecretEnv],
+    ['external_launch.service_credential_env', serviceCredentialEnv],
+  ] as const) {
+    if (value !== undefined && !ENVIRONMENT_VARIABLE_NAME.test(value)) {
+      throw new Error(`${path} must be a valid environment variable name`);
+    }
+  }
+
+  const timeoutValue = raw.request_timeout_ms;
+  if (
+    timeoutValue !== undefined &&
+    (!Number.isSafeInteger(timeoutValue) ||
+      (timeoutValue as number) <= 0 ||
+      (timeoutValue as number) > EXTERNAL_LAUNCH_MAX_TIMEOUT_MS)
+  ) {
+    throw new Error(
+      `external_launch.request_timeout_ms must be an integer from 1 to ${EXTERNAL_LAUNCH_MAX_TIMEOUT_MS}`
+    );
+  }
+  const algorithms = parseAlgorithms(raw);
+  const allowAdminRoles = optionalBoolean(raw, 'allow_admin_roles');
+  const trustVerifiedEmailForLinking = optionalBoolean(raw, 'trust_verified_email_for_linking');
+  const forwardRequestHost = optionalBoolean(raw, 'forward_request_host');
+
+  const configuredHeader = requiredString(raw, 'trusted_host_header');
+  if (configuredHeader !== undefined && !HTTP_HEADER_NAME.test(configuredHeader)) {
+    throw new Error('external_launch.trusted_host_header must be a valid HTTP header name');
+  }
+  const trustedHostHeader = (
+    configuredHeader ?? EXTERNAL_LAUNCH_DEFAULT_TRUSTED_HOST_HEADER
+  ).toLowerCase();
+
+  const loginRedirectUrl = httpUrl(
+    requiredString(raw, 'login_redirect_url'),
+    'external_launch.login_redirect_url'
+  );
+  const returnHostParamValue = raw.return_host_param;
+  if (returnHostParamValue !== undefined && typeof returnHostParamValue !== 'string') {
+    throw new Error('external_launch.return_host_param must be a string');
+  }
+  // Preserve the existing explicit-empty behavior: it selects the default.
+  const configuredReturnHostParam = returnHostParamValue?.trim() || undefined;
+  if (configuredReturnHostParam === RESERVED_RETURN_TO_PARAM) {
+    throw new Error(
+      `external_launch.return_host_param must not be "${RESERVED_RETURN_TO_PARAM}" because that name is reserved`
+    );
+  }
+  if (
+    configuredReturnHostParam !== undefined &&
+    !/^[A-Za-z0-9_.-]+$/.test(configuredReturnHostParam)
+  ) {
+    throw new Error(
+      'external_launch.return_host_param may only contain letters, digits, underscore, hyphen, and dot'
+    );
+  }
+
+  const verificationMethods = [jwksUrl, publicKey, devSharedSecret].filter(Boolean);
+  if (enabled && !exchangeUrl) {
+    throw new Error('external_launch.exchange_url is required when external launch is enabled');
+  }
+  if (enabled && (!issuer || !audience)) {
+    throw new Error(
+      'external_launch.issuer and external_launch.audience are required when external launch is enabled'
+    );
+  }
+  if (enabled && verificationMethods.length === 0) {
+    throw new Error('external_launch requires exactly one assertion verification method');
+  }
+  if (enabled && verificationMethods.length > 1) {
+    throw new Error('external_launch must not configure multiple assertion verification methods');
+  }
+  if (enabled && publicKey) {
+    try {
+      createPublicKey(publicKey);
+    } catch {
+      throw new Error('external_launch.public_key must be a valid public key');
+    }
+  }
+  if (enabled && algorithms) {
+    const hasHsAlgorithm = algorithms.some((algorithm) => algorithm.startsWith('HS'));
+    const hasNonHsAlgorithm = algorithms.some((algorithm) => !algorithm.startsWith('HS'));
+    if (devSharedSecret && hasNonHsAlgorithm) {
+      throw new Error('external_launch symmetric verification may only use HS* algorithms');
+    }
+    if ((jwksUrl || publicKey) && hasHsAlgorithm) {
+      throw new Error('external_launch asymmetric verification cannot use HS* algorithms');
+    }
+  }
+
+  return {
+    enabled,
+    exchangeUrl,
+    issuer,
+    audience,
+    instanceId,
+    providerId,
+    jwksUrl,
+    publicKey,
+    devSharedSecret,
+    serviceCredential,
+    allowAdminRoles,
+    trustVerifiedEmailForLinking,
+    requestTimeoutMs: (timeoutValue as number | undefined) ?? EXTERNAL_LAUNCH_DEFAULT_TIMEOUT_MS,
+    algorithms,
+    forwardRequestHost,
+    trustedHostHeader,
+    loginRedirectUrl,
+    returnHostParam: loginRedirectUrl
+      ? (configuredReturnHostParam ?? EXTERNAL_LAUNCH_DEFAULT_RETURN_HOST_PARAM)
+      : undefined,
+  };
+}
+
+export interface ExternalLaunchSettingsResolution {
+  settings: ResolvedExternalLaunchSettings;
+  error?: string;
+}
+
+const DISABLED_LAUNCH_SETTINGS: ResolvedExternalLaunchSettings = {
+  enabled: false,
+  allowAdminRoles: false,
+  trustVerifiedEmailForLinking: false,
+  requestTimeoutMs: EXTERNAL_LAUNCH_DEFAULT_TIMEOUT_MS,
+  forwardRequestHost: false,
+  trustedHostHeader: EXTERNAL_LAUNCH_DEFAULT_TRUSTED_HOST_HEADER,
+};
+
+/**
+ * Parse the complete provider profile once through the same fail-closed
+ * contract used by startup and request handling. Invalid raw values never
+ * escape into auth code as partially trusted settings.
+ */
+export function resolveExternalLaunchSettings(
+  config: AgorConfig
+): ExternalLaunchSettingsResolution {
+  try {
+    return { settings: parseExternalLaunchSettings(config) };
+  } catch (error) {
+    return {
+      settings: DISABLED_LAUNCH_SETTINGS,
+      error: error instanceof Error ? error.message : 'external_launch configuration is invalid',
+    };
+  }
 }
 
 /**
@@ -97,41 +334,7 @@ export function resolveEffectiveExternalLaunchConfig(
  * enforcement points from accepting different provider configurations.
  */
 export function externalLaunchConfigurationError(config: AgorConfig): string | undefined {
-  const raw = config.external_launch as unknown;
-  if (raw !== undefined && !isObject(raw)) return 'external_launch must be an object';
-  if (raw === undefined) return undefined;
-
-  const settings = raw as unknown as AgorExternalLaunchSettings;
-  if (settings.enabled !== undefined && typeof settings.enabled !== 'boolean') {
-    return 'external_launch.enabled must be a boolean';
-  }
-  if (settings.enabled !== true) return undefined;
-  if (!nonEmptyEnvironmentValue(settings.exchange_url)) {
-    return 'external_launch.exchange_url is required when external launch is enabled';
-  }
-  if (!nonEmptyEnvironmentValue(settings.issuer) || !nonEmptyEnvironmentValue(settings.audience)) {
-    return 'external_launch.issuer and external_launch.audience are required when external launch is enabled';
-  }
-
-  const configuredKeyCount = [
-    settings.jwks_url,
-    settings.public_key,
-    settings.dev_shared_secret,
-  ].filter((value) => nonEmptyEnvironmentValue(value) !== undefined).length;
-  if (configuredKeyCount === 0) {
-    return 'external_launch requires exactly one assertion verification method';
-  }
-  if (configuredKeyCount > 1) {
-    return 'external_launch must not configure multiple assertion verification methods';
-  }
-
-  const usesAsymmetricKey = Boolean(
-    nonEmptyEnvironmentValue(settings.jwks_url) || nonEmptyEnvironmentValue(settings.public_key)
-  );
-  if (usesAsymmetricKey && settings.algorithms?.some((algorithm) => /^hs/i.test(algorithm))) {
-    return 'external_launch asymmetric verification cannot use HS* algorithms';
-  }
-  return undefined;
+  return resolveExternalLaunchSettings(config).error;
 }
 
 /** Fail startup before database initialization when enabled launch auth is unusable. */

--- a/packages/core/src/config/identity-authority.test.ts
+++ b/packages/core/src/config/identity-authority.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { assertValidEffectiveIdentityConfig, resolveIdentityAuthority } from './identity-authority';
+import type { AgorConfig } from './types';
+
+function externalConfig(overrides: Partial<AgorConfig> = {}): AgorConfig {
+  return {
+    identity: {
+      user_lifecycle: 'external',
+      role_authority: 'claims',
+      local_auth: 'disabled',
+      external: { provider: 'external_launch', provisioning: 'jit' },
+    },
+    external_launch: { enabled: true },
+    ...overrides,
+  };
+}
+
+describe('identity authority', () => {
+  it('defaults omitted config to local authority', () => {
+    expect(resolveIdentityAuthority({})).toEqual({
+      contractVersion: 1,
+      userLifecycle: 'internal',
+      roleAuthority: 'internal',
+      localAuth: 'enabled',
+      capabilities: {
+        users: {
+          create: true,
+          delete: true,
+          identityWrite: true,
+          roleWrite: true,
+          passwordWrite: true,
+          avatarSettingsWrite: true,
+          selfConfigurationWrite: true,
+        },
+      },
+    });
+  });
+
+  it('derives externally managed capabilities from the coherent external profile', () => {
+    const config = externalConfig();
+    expect(() => assertValidEffectiveIdentityConfig(config, {})).not.toThrow();
+    expect(resolveIdentityAuthority(config)).toMatchObject({
+      userLifecycle: 'external',
+      roleAuthority: 'claims',
+      localAuth: 'disabled',
+      external: { provider: 'external_launch', provisioning: 'jit' },
+      capabilities: {
+        users: {
+          create: false,
+          delete: false,
+          identityWrite: false,
+          roleWrite: false,
+          passwordWrite: false,
+          avatarSettingsWrite: false,
+          selfConfigurationWrite: true,
+        },
+      },
+    });
+  });
+
+  it('rejects partial or contradictory external authority profiles', () => {
+    expect(() =>
+      assertValidEffectiveIdentityConfig({
+        identity: { user_lifecycle: 'external' },
+        external_launch: { enabled: true },
+      })
+    ).toThrow(/role_authority 'claims'/);
+    expect(() =>
+      assertValidEffectiveIdentityConfig({
+        identity: {
+          user_lifecycle: 'external',
+          role_authority: 'claims',
+          local_auth: 'enabled',
+          external: { provider: 'external_launch', provisioning: 'jit' },
+        },
+        external_launch: { enabled: true },
+      })
+    ).toThrow(/local_auth 'disabled'/);
+    expect(() =>
+      assertValidEffectiveIdentityConfig({
+        identity: {
+          user_lifecycle: 'external',
+          role_authority: 'claims',
+          local_auth: 'disabled',
+        },
+        external_launch: { enabled: true },
+      })
+    ).toThrow(/identity\.external\.provider/);
+  });
+
+  it('requires the external launch provisioner and rejects bootstrap role mutation', () => {
+    expect(() =>
+      assertValidEffectiveIdentityConfig(
+        externalConfig({ external_launch: { enabled: false } }),
+        {}
+      )
+    ).toThrow(/external_launch\.enabled/);
+
+    expect(() =>
+      assertValidEffectiveIdentityConfig(
+        externalConfig({
+          execution: { bootstrap_superadmin_users: ['user-1'] },
+        }),
+        {}
+      )
+    ).toThrow(/bootstrap_superadmin_users/);
+  });
+
+  it('accepts the documented environment override for external launch enablement', () => {
+    const config = externalConfig({ external_launch: { enabled: false } });
+    expect(() =>
+      assertValidEffectiveIdentityConfig(config, { AGOR_EXTERNAL_LAUNCH_ENABLED: 'true' })
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/config/identity-authority.test.ts
+++ b/packages/core/src/config/identity-authority.test.ts
@@ -52,6 +52,11 @@ describe('identity authority', () => {
     expect(() => assertValidRawConfig(scalarExternal)).toThrow(
       /Config error: identity\.external must be an object/i
     );
+
+    class IdentitySettings {}
+    expect(() =>
+      assertValidRawConfig({ identity: new IdentitySettings() } as unknown as AgorConfig)
+    ).toThrow(/Config error: identity must be an object/i);
   });
 
   it('derives externally managed capabilities from the coherent external profile', () => {

--- a/packages/core/src/config/identity-authority.test.ts
+++ b/packages/core/src/config/identity-authority.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { resolveEffectiveConfig } from './config-manager';
 import { assertValidEffectiveIdentityConfig, resolveIdentityAuthority } from './identity-authority';
 import type { AgorConfig } from './types';
 
@@ -38,7 +39,7 @@ describe('identity authority', () => {
 
   it('derives externally managed capabilities from the coherent external profile', () => {
     const config = externalConfig();
-    expect(() => assertValidEffectiveIdentityConfig(config, {})).not.toThrow();
+    expect(() => assertValidEffectiveIdentityConfig(config)).not.toThrow();
     expect(resolveIdentityAuthority(config)).toMatchObject({
       userLifecycle: 'external',
       roleAuthority: 'claims',
@@ -90,26 +91,21 @@ describe('identity authority', () => {
 
   it('requires the external launch provisioner and rejects bootstrap role mutation', () => {
     expect(() =>
-      assertValidEffectiveIdentityConfig(
-        externalConfig({ external_launch: { enabled: false } }),
-        {}
-      )
+      assertValidEffectiveIdentityConfig(externalConfig({ external_launch: { enabled: false } }))
     ).toThrow(/external_launch\.enabled/);
 
     expect(() =>
       assertValidEffectiveIdentityConfig(
         externalConfig({
           execution: { bootstrap_superadmin_users: ['user-1'] },
-        }),
-        {}
+        })
       )
     ).toThrow(/bootstrap_superadmin_users/);
   });
 
   it('accepts the documented environment override for external launch enablement', () => {
     const config = externalConfig({ external_launch: { enabled: false } });
-    expect(() =>
-      assertValidEffectiveIdentityConfig(config, { AGOR_EXTERNAL_LAUNCH_ENABLED: 'true' })
-    ).not.toThrow();
+    const effective = resolveEffectiveConfig(config, { AGOR_EXTERNAL_LAUNCH_ENABLED: 'true' });
+    expect(() => assertValidEffectiveIdentityConfig(effective)).not.toThrow();
   });
 });

--- a/packages/core/src/config/identity-authority.test.ts
+++ b/packages/core/src/config/identity-authority.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveEffectiveConfig } from './config-manager';
+import { assertValidRawConfig, resolveEffectiveConfig } from './config-manager';
 import { assertValidEffectiveIdentityConfig, resolveIdentityAuthority } from './identity-authority';
 import type { AgorConfig } from './types';
 
@@ -35,6 +35,23 @@ describe('identity authority', () => {
         },
       },
     });
+  });
+
+  it('rejects malformed programmatic identity sections before projection', () => {
+    const scalarIdentity = { identity: 'external' } as unknown as AgorConfig;
+    expect(() => assertValidRawConfig(scalarIdentity)).toThrow(
+      /Config error: identity must be an object/i
+    );
+    expect(() => assertValidEffectiveIdentityConfig(scalarIdentity)).toThrow(
+      /identity must be an object/i
+    );
+
+    const scalarExternal = {
+      identity: { external: 'external_launch' },
+    } as unknown as AgorConfig;
+    expect(() => assertValidRawConfig(scalarExternal)).toThrow(
+      /Config error: identity\.external must be an object/i
+    );
   });
 
   it('derives externally managed capabilities from the coherent external profile', () => {

--- a/packages/core/src/config/identity-authority.ts
+++ b/packages/core/src/config/identity-authority.ts
@@ -1,0 +1,122 @@
+import type { AgorConfig } from './types';
+
+export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1 as const;
+
+export interface ResolvedIdentityAuthority {
+  contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+  userLifecycle: 'internal' | 'external';
+  roleAuthority: 'internal' | 'claims';
+  localAuth: 'enabled' | 'disabled';
+  external?: {
+    provider: 'external_launch';
+    provisioning: 'jit';
+  };
+  capabilities: {
+    users: {
+      create: boolean;
+      delete: boolean;
+      identityWrite: boolean;
+      roleWrite: boolean;
+      passwordWrite: boolean;
+      avatarSettingsWrite: boolean;
+      selfConfigurationWrite: true;
+    };
+  };
+}
+
+/** Resolve the omitted-config local default into one transport-neutral policy. */
+export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAuthority {
+  const userLifecycle = config.identity?.user_lifecycle ?? 'internal';
+  const roleAuthority = config.identity?.role_authority ?? 'internal';
+  const localAuth = config.identity?.local_auth ?? 'enabled';
+  const externallyManaged = userLifecycle === 'external';
+  const external = config.identity?.external;
+
+  return {
+    contractVersion: IDENTITY_AUTHORITY_CONTRACT_VERSION,
+    userLifecycle,
+    roleAuthority,
+    localAuth,
+    ...(external?.provider === 'external_launch' && external.provisioning === 'jit'
+      ? {
+          external: {
+            provider: external.provider,
+            provisioning: external.provisioning,
+          },
+        }
+      : {}),
+    capabilities: {
+      users: {
+        create: !externallyManaged,
+        delete: !externallyManaged,
+        identityWrite: !externallyManaged,
+        roleWrite: roleAuthority === 'internal',
+        passwordWrite: localAuth === 'enabled' && !externallyManaged,
+        avatarSettingsWrite: !externallyManaged,
+        selfConfigurationWrite: true,
+      },
+    },
+  };
+}
+
+function externalLaunchEnabled(config: AgorConfig, env: NodeJS.ProcessEnv): boolean {
+  const override = env.AGOR_EXTERNAL_LAUNCH_ENABLED?.trim().toLowerCase();
+  if (override !== undefined && override !== '') {
+    return ['1', 'true', 'yes', 'on'].includes(override);
+  }
+  return config.external_launch?.enabled === true;
+}
+
+/**
+ * Validate the resolved authority profile before database initialization.
+ * Invalid partial profiles fail closed rather than producing combinations
+ * whose create, role, password, and JIT behavior disagree.
+ */
+export function assertValidEffectiveIdentityConfig(
+  config: AgorConfig,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  const identity = config.identity;
+  if (!identity) return;
+
+  const resolved = resolveIdentityAuthority(config);
+  if (resolved.userLifecycle === 'internal') {
+    if (resolved.roleAuthority !== 'internal') {
+      throw new Error(
+        "identity.role_authority 'claims' requires identity.user_lifecycle 'external'"
+      );
+    }
+    if (resolved.localAuth !== 'enabled') {
+      throw new Error("identity.local_auth 'disabled' requires identity.user_lifecycle 'external'");
+    }
+    if (identity.external !== undefined) {
+      throw new Error('identity.external is only valid when identity.user_lifecycle is external');
+    }
+    return;
+  }
+
+  if (resolved.roleAuthority !== 'claims') {
+    throw new Error("identity.user_lifecycle 'external' requires identity.role_authority 'claims'");
+  }
+  if (resolved.localAuth !== 'disabled') {
+    throw new Error("identity.user_lifecycle 'external' requires identity.local_auth 'disabled'");
+  }
+  if (
+    identity.external?.provider !== 'external_launch' ||
+    identity.external.provisioning !== 'jit'
+  ) {
+    throw new Error(
+      "identity.user_lifecycle 'external' requires identity.external.provider 'external_launch' and provisioning 'jit'"
+    );
+  }
+  if (!externalLaunchEnabled(config, env)) {
+    throw new Error(
+      'identity external authority requires external_launch.enabled or AGOR_EXTERNAL_LAUNCH_ENABLED'
+    );
+  }
+  if ((config.execution?.bootstrap_superadmin_users?.length ?? 0) > 0) {
+    throw new Error(
+      'execution.bootstrap_superadmin_users is incompatible with claim-authoritative roles'
+    );
+  }
+}

--- a/packages/core/src/config/identity-authority.ts
+++ b/packages/core/src/config/identity-authority.ts
@@ -51,8 +51,19 @@ export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAu
  * whose create, role, password, and JIT behavior disagree.
  */
 export function assertValidEffectiveIdentityConfig(config: AgorConfig): void {
-  const identity = config.identity;
-  if (!identity) return;
+  const identityValue = config.identity as unknown;
+  if (identityValue === undefined) return;
+  if (!identityValue || typeof identityValue !== 'object' || Array.isArray(identityValue)) {
+    throw new Error('identity must be an object');
+  }
+  const identity = identityValue as NonNullable<AgorConfig['identity']>;
+  const externalValue = identity.external as unknown;
+  if (
+    externalValue !== undefined &&
+    (!externalValue || typeof externalValue !== 'object' || Array.isArray(externalValue))
+  ) {
+    throw new Error('identity.external must be an object');
+  }
 
   const resolved = resolveIdentityAuthority(config);
   if (resolved.userLifecycle === AgorUserLifecycleAuthority.INTERNAL) {

--- a/packages/core/src/config/identity-authority.ts
+++ b/packages/core/src/config/identity-authority.ts
@@ -45,23 +45,12 @@ export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAu
   };
 }
 
-function externalLaunchEnabled(config: AgorConfig, env: NodeJS.ProcessEnv): boolean {
-  const override = env.AGOR_EXTERNAL_LAUNCH_ENABLED?.trim().toLowerCase();
-  if (override !== undefined && override !== '') {
-    return ['1', 'true', 'yes', 'on'].includes(override);
-  }
-  return config.external_launch?.enabled === true;
-}
-
 /**
  * Validate the resolved authority profile before database initialization.
  * Invalid partial profiles fail closed rather than producing combinations
  * whose create, role, password, and JIT behavior disagree.
  */
-export function assertValidEffectiveIdentityConfig(
-  config: AgorConfig,
-  env: NodeJS.ProcessEnv = process.env
-): void {
+export function assertValidEffectiveIdentityConfig(config: AgorConfig): void {
   const identity = config.identity;
   if (!identity) return;
 
@@ -95,10 +84,8 @@ export function assertValidEffectiveIdentityConfig(
       "identity.user_lifecycle 'external' requires identity.external.provider 'external_launch' and provisioning 'jit'"
     );
   }
-  if (!externalLaunchEnabled(config, env)) {
-    throw new Error(
-      'identity external authority requires external_launch.enabled or AGOR_EXTERNAL_LAUNCH_ENABLED'
-    );
+  if (config.external_launch?.enabled !== true) {
+    throw new Error('identity external authority requires external_launch.enabled');
   }
   if ((config.execution?.bootstrap_superadmin_users?.length ?? 0) > 0) {
     throw new Error(

--- a/packages/core/src/config/identity-authority.ts
+++ b/packages/core/src/config/identity-authority.ts
@@ -1,35 +1,20 @@
-import type { AgorConfig } from './types';
-
-export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1 as const;
-
-export interface ResolvedIdentityAuthority {
-  contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
-  userLifecycle: 'internal' | 'external';
-  roleAuthority: 'internal' | 'claims';
-  localAuth: 'enabled' | 'disabled';
-  external?: {
-    provider: 'external_launch';
-    provisioning: 'jit';
-  };
-  capabilities: {
-    users: {
-      create: boolean;
-      delete: boolean;
-      identityWrite: boolean;
-      roleWrite: boolean;
-      passwordWrite: boolean;
-      avatarSettingsWrite: boolean;
-      selfConfigurationWrite: true;
-    };
-  };
-}
+import {
+  type AgorConfig,
+  AgorExternalIdentityProvider,
+  AgorExternalIdentityProvisioning,
+  AgorLocalAuthMode,
+  AgorRoleAuthority,
+  AgorUserLifecycleAuthority,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  type ResolvedIdentityAuthority,
+} from './types';
 
 /** Resolve the omitted-config local default into one transport-neutral policy. */
 export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAuthority {
-  const userLifecycle = config.identity?.user_lifecycle ?? 'internal';
-  const roleAuthority = config.identity?.role_authority ?? 'internal';
-  const localAuth = config.identity?.local_auth ?? 'enabled';
-  const externallyManaged = userLifecycle === 'external';
+  const userLifecycle = config.identity?.user_lifecycle ?? AgorUserLifecycleAuthority.INTERNAL;
+  const roleAuthority = config.identity?.role_authority ?? AgorRoleAuthority.INTERNAL;
+  const localAuth = config.identity?.local_auth ?? AgorLocalAuthMode.ENABLED;
+  const externallyManaged = userLifecycle === AgorUserLifecycleAuthority.EXTERNAL;
   const external = config.identity?.external;
 
   return {
@@ -37,7 +22,8 @@ export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAu
     userLifecycle,
     roleAuthority,
     localAuth,
-    ...(external?.provider === 'external_launch' && external.provisioning === 'jit'
+    ...(external?.provider === AgorExternalIdentityProvider.EXTERNAL_LAUNCH &&
+    external.provisioning === AgorExternalIdentityProvisioning.JIT
       ? {
           external: {
             provider: external.provider,
@@ -50,8 +36,8 @@ export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAu
         create: !externallyManaged,
         delete: !externallyManaged,
         identityWrite: !externallyManaged,
-        roleWrite: roleAuthority === 'internal',
-        passwordWrite: localAuth === 'enabled' && !externallyManaged,
+        roleWrite: roleAuthority === AgorRoleAuthority.INTERNAL,
+        passwordWrite: localAuth === AgorLocalAuthMode.ENABLED && !externallyManaged,
         avatarSettingsWrite: !externallyManaged,
         selfConfigurationWrite: true,
       },
@@ -80,13 +66,13 @@ export function assertValidEffectiveIdentityConfig(
   if (!identity) return;
 
   const resolved = resolveIdentityAuthority(config);
-  if (resolved.userLifecycle === 'internal') {
-    if (resolved.roleAuthority !== 'internal') {
+  if (resolved.userLifecycle === AgorUserLifecycleAuthority.INTERNAL) {
+    if (resolved.roleAuthority !== AgorRoleAuthority.INTERNAL) {
       throw new Error(
         "identity.role_authority 'claims' requires identity.user_lifecycle 'external'"
       );
     }
-    if (resolved.localAuth !== 'enabled') {
+    if (resolved.localAuth !== AgorLocalAuthMode.ENABLED) {
       throw new Error("identity.local_auth 'disabled' requires identity.user_lifecycle 'external'");
     }
     if (identity.external !== undefined) {
@@ -95,15 +81,15 @@ export function assertValidEffectiveIdentityConfig(
     return;
   }
 
-  if (resolved.roleAuthority !== 'claims') {
+  if (resolved.roleAuthority !== AgorRoleAuthority.CLAIMS) {
     throw new Error("identity.user_lifecycle 'external' requires identity.role_authority 'claims'");
   }
-  if (resolved.localAuth !== 'disabled') {
+  if (resolved.localAuth !== AgorLocalAuthMode.DISABLED) {
     throw new Error("identity.user_lifecycle 'external' requires identity.local_auth 'disabled'");
   }
   if (
-    identity.external?.provider !== 'external_launch' ||
-    identity.external.provisioning !== 'jit'
+    identity.external?.provider !== AgorExternalIdentityProvider.EXTERNAL_LAUNCH ||
+    identity.external.provisioning !== AgorExternalIdentityProvisioning.JIT
   ) {
     throw new Error(
       "identity.user_lifecycle 'external' requires identity.external.provider 'external_launch' and provisioning 'jit'"

--- a/packages/core/src/config/identity-authority.ts
+++ b/packages/core/src/config/identity-authority.ts
@@ -1,3 +1,4 @@
+import { isPlainConfigRecord } from './plain-record';
 import {
   type AgorConfig,
   AgorExternalIdentityProvider,
@@ -53,15 +54,12 @@ export function resolveIdentityAuthority(config: AgorConfig): ResolvedIdentityAu
 export function assertValidEffectiveIdentityConfig(config: AgorConfig): void {
   const identityValue = config.identity as unknown;
   if (identityValue === undefined) return;
-  if (!identityValue || typeof identityValue !== 'object' || Array.isArray(identityValue)) {
+  if (!isPlainConfigRecord(identityValue)) {
     throw new Error('identity must be an object');
   }
   const identity = identityValue as NonNullable<AgorConfig['identity']>;
   const externalValue = identity.external as unknown;
-  if (
-    externalValue !== undefined &&
-    (!externalValue || typeof externalValue !== 'object' || Array.isArray(externalValue))
-  ) {
+  if (externalValue !== undefined && !isPlainConfigRecord(externalValue)) {
     throw new Error('identity.external must be an object');
   }
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,6 +16,7 @@ export * from './env-vars';
 export * from './executor-credential-storage';
 export * from './executor-heartbeat';
 export * from './executor-response';
+export * from './external-launch';
 export * from './identity-authority';
 export * from './initial-deployment-config';
 export * from './key-resolver';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,6 +16,7 @@ export * from './env-vars';
 export * from './executor-credential-storage';
 export * from './executor-heartbeat';
 export * from './executor-response';
+export * from './identity-authority';
 export * from './initial-deployment-config';
 export * from './key-resolver';
 export * from './multitenancy';

--- a/packages/core/src/config/plain-record.ts
+++ b/packages/core/src/config/plain-record.ts
@@ -1,0 +1,6 @@
+/** True only for ordinary configuration mappings, never Dates or class instances. */
+export function isPlainConfigRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -274,28 +274,6 @@ export const AgorExternalLaunchAlgorithm = {
 export type AgorExternalLaunchAlgorithm =
   (typeof AgorExternalLaunchAlgorithm)[keyof typeof AgorExternalLaunchAlgorithm];
 
-/** Fully normalized launch settings consumed by startup and request handling. */
-export interface ResolvedExternalLaunchSettings {
-  enabled: boolean;
-  exchangeUrl?: string;
-  audience?: string;
-  issuer?: string;
-  instanceId?: string;
-  providerId?: string;
-  jwksUrl?: string;
-  publicKey?: string;
-  devSharedSecret?: string;
-  serviceCredential?: string;
-  allowAdminRoles: boolean;
-  trustVerifiedEmailForLinking: boolean;
-  requestTimeoutMs: number;
-  algorithms?: AgorExternalLaunchAlgorithm[];
-  forwardRequestHost: boolean;
-  trustedHostHeader: string;
-  loginRedirectUrl?: string;
-  returnHostParam?: string;
-}
-
 /** Which system may create and remove user projections in this daemon. */
 export const AgorUserLifecycleAuthority = {
   INTERNAL: 'internal',

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -202,11 +202,11 @@ export interface AgorExternalLaunchSettings {
   /** Environment variable that contains the exchange endpoint bearer credential. */
   service_credential_env?: string;
 
-  /** Backchannel request timeout in milliseconds (default: 10000). */
+  /** Backchannel request timeout in milliseconds, from 1 to 120000 (default: 10000). */
   request_timeout_ms?: number;
 
-  /** Optional allow-list of JWT algorithms for returned launch assertions. */
-  algorithms?: string[];
+  /** Optional non-empty allow-list of supported JWT algorithms for returned assertions. */
+  algorithms?: AgorExternalLaunchAlgorithm[];
 
   /** Allow launch assertions to assign admin/superadmin roles (default: false). */
   allow_admin_roles?: boolean;
@@ -254,6 +254,46 @@ export interface AgorExternalLaunchSettings {
    * the deep-link with the host. Rejected during config validation.
    */
   return_host_param?: string;
+}
+
+/** Algorithms accepted by the launch assertion verifier. `none` is never valid. */
+export const AgorExternalLaunchAlgorithm = {
+  HS256: 'HS256',
+  HS384: 'HS384',
+  HS512: 'HS512',
+  RS256: 'RS256',
+  RS384: 'RS384',
+  RS512: 'RS512',
+  ES256: 'ES256',
+  ES384: 'ES384',
+  ES512: 'ES512',
+  PS256: 'PS256',
+  PS384: 'PS384',
+  PS512: 'PS512',
+} as const;
+export type AgorExternalLaunchAlgorithm =
+  (typeof AgorExternalLaunchAlgorithm)[keyof typeof AgorExternalLaunchAlgorithm];
+
+/** Fully normalized launch settings consumed by startup and request handling. */
+export interface ResolvedExternalLaunchSettings {
+  enabled: boolean;
+  exchangeUrl?: string;
+  audience?: string;
+  issuer?: string;
+  instanceId?: string;
+  providerId?: string;
+  jwksUrl?: string;
+  publicKey?: string;
+  devSharedSecret?: string;
+  serviceCredential?: string;
+  allowAdminRoles: boolean;
+  trustVerifiedEmailForLinking: boolean;
+  requestTimeoutMs: number;
+  algorithms?: AgorExternalLaunchAlgorithm[];
+  forwardRequestHost: boolean;
+  trustedHostHeader: string;
+  loginRedirectUrl?: string;
+  returnHostParam?: string;
 }
 
 /** Which system may create and remove user projections in this daemon. */

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -257,20 +257,47 @@ export interface AgorExternalLaunchSettings {
 }
 
 /** Which system may create and remove user projections in this daemon. */
-export type AgorUserLifecycleAuthority = 'internal' | 'external';
+export const AgorUserLifecycleAuthority = {
+  INTERNAL: 'internal',
+  EXTERNAL: 'external',
+} as const;
+export type AgorUserLifecycleAuthority =
+  (typeof AgorUserLifecycleAuthority)[keyof typeof AgorUserLifecycleAuthority];
 
 /** Which system owns the effective Agor role. */
-export type AgorRoleAuthority = 'internal' | 'claims';
+export const AgorRoleAuthority = {
+  INTERNAL: 'internal',
+  CLAIMS: 'claims',
+} as const;
+export type AgorRoleAuthority = (typeof AgorRoleAuthority)[keyof typeof AgorRoleAuthority];
 
 /** Whether password-based authentication is available on this daemon. */
-export type AgorLocalAuthMode = 'enabled' | 'disabled';
+export const AgorLocalAuthMode = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+} as const;
+export type AgorLocalAuthMode = (typeof AgorLocalAuthMode)[keyof typeof AgorLocalAuthMode];
+
+/** Supported external projection providers. */
+export const AgorExternalIdentityProvider = {
+  EXTERNAL_LAUNCH: 'external_launch',
+} as const;
+export type AgorExternalIdentityProvider =
+  (typeof AgorExternalIdentityProvider)[keyof typeof AgorExternalIdentityProvider];
+
+/** Supported external projection provisioning strategies. */
+export const AgorExternalIdentityProvisioning = {
+  JIT: 'jit',
+} as const;
+export type AgorExternalIdentityProvisioning =
+  (typeof AgorExternalIdentityProvisioning)[keyof typeof AgorExternalIdentityProvisioning];
 
 /** External identity provisioning settings. */
 export interface AgorExternalIdentitySettings {
   /** Verified authentication handoff that provisions users. */
-  provider?: 'external_launch';
+  provider?: AgorExternalIdentityProvider;
   /** Create/update a local projection when a verified external login succeeds. */
-  provisioning?: 'jit';
+  provisioning?: AgorExternalIdentityProvisioning;
 }
 
 /**
@@ -286,6 +313,31 @@ export interface AgorIdentitySettings {
   role_authority?: AgorRoleAuthority;
   local_auth?: AgorLocalAuthMode;
   external?: AgorExternalIdentitySettings;
+}
+
+export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1 as const;
+
+/** Resolved identity policy and client capability contract exposed by the daemon. */
+export interface ResolvedIdentityAuthority {
+  contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+  userLifecycle: AgorUserLifecycleAuthority;
+  roleAuthority: AgorRoleAuthority;
+  localAuth: AgorLocalAuthMode;
+  external?: {
+    provider: AgorExternalIdentityProvider;
+    provisioning: AgorExternalIdentityProvisioning;
+  };
+  capabilities: {
+    users: {
+      create: boolean;
+      delete: boolean;
+      identityWrite: boolean;
+      roleWrite: boolean;
+      passwordWrite: boolean;
+      avatarSettingsWrite: boolean;
+      selfConfigurationWrite: true;
+    };
+  };
 }
 
 /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -317,6 +317,19 @@ export interface AgorIdentitySettings {
 
 export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1 as const;
 
+/** Stable identifiers returned in externally-managed mutation errors. */
+export const AgorIdentityCapability = {
+  USER_CREATE: 'users.create',
+  USER_DELETE: 'users.delete',
+  USER_IDENTITY_WRITE: 'users.identity.write',
+  USER_ROLE_WRITE: 'users.role.write',
+  USER_PASSWORD_WRITE: 'users.password.write',
+  USER_AVATAR_SETTINGS_WRITE: 'users.avatar-settings.write',
+  USER_SELF_CONFIGURATION_WRITE: 'users.self-configuration.write',
+} as const;
+export type AgorIdentityCapability =
+  (typeof AgorIdentityCapability)[keyof typeof AgorIdentityCapability];
+
 /** Resolved identity policy and client capability contract exposed by the daemon. */
 export interface ResolvedIdentityAuthority {
   contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -256,6 +256,38 @@ export interface AgorExternalLaunchSettings {
   return_host_param?: string;
 }
 
+/** Which system may create and remove user projections in this daemon. */
+export type AgorUserLifecycleAuthority = 'internal' | 'external';
+
+/** Which system owns the effective Agor role. */
+export type AgorRoleAuthority = 'internal' | 'claims';
+
+/** Whether password-based authentication is available on this daemon. */
+export type AgorLocalAuthMode = 'enabled' | 'disabled';
+
+/** External identity provisioning settings. */
+export interface AgorExternalIdentitySettings {
+  /** Verified authentication handoff that provisions users. */
+  provider?: 'external_launch';
+  /** Create/update a local projection when a verified external login succeeds. */
+  provisioning?: 'jit';
+}
+
+/**
+ * Deployment-owned authority contract for user identity.
+ *
+ * The section is optional. Omitting it preserves Agor's normal local user,
+ * role, and password authority. The only external profile supported in v1 is
+ * deliberately coherent: external lifecycle, claim-owned roles, disabled
+ * local login, and verified launch-time JIT provisioning.
+ */
+export interface AgorIdentitySettings {
+  user_lifecycle?: AgorUserLifecycleAuthority;
+  role_authority?: AgorRoleAuthority;
+  local_auth?: AgorLocalAuthMode;
+  external?: AgorExternalIdentitySettings;
+}
+
 /**
  * Database configuration settings
  */
@@ -1272,6 +1304,9 @@ export interface AgorConfig {
   /** Generic external one-time launch-code authentication. */
   external_launch?: AgorExternalLaunchSettings;
 
+  /** User identity, lifecycle, role, and local-login authority. */
+  identity?: AgorIdentitySettings;
+
   /** Execution isolation settings */
   execution?: AgorExecutionSettings;
 
@@ -1310,6 +1345,7 @@ export type ConfigKey =
   | `ui.${keyof AgorUISettings}`
   | `database.${keyof AgorDatabaseSettings}`
   | `external_launch.${keyof AgorExternalLaunchSettings}`
+  | `identity.${keyof AgorIdentitySettings}`
   | `execution.${keyof AgorExecutionSettings}`
   | `security.${keyof AgorSecuritySettings}`
   | `teammates.${keyof AgorTeammateSettings}`

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -51,11 +51,7 @@ export * from './pending-migrations';
 export * from './repositories';
 export * from './sanitize-error';
 export * from './schema';
-export {
-  type DatabaseDialect,
-  detectDialectFromUrl,
-  getDatabaseDialect,
-} from './schema-factory';
+export { type DatabaseDialect, detectDialectFromUrl, getDatabaseDialect } from './schema-factory';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';
 // Tenant database lifecycle primitives. Filesystem-backed portability operations
@@ -71,5 +67,6 @@ export * from './tenant-scope';
 export * from './tenant-unit-of-work';
 // Tenant write gate (generation-bound per-tenant write freeze)
 export * from './tenant-write-gate';
+export * from './user-execution-home';
 // User utilities
 export * from './user-utils';

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -46,6 +46,9 @@ function migrationTenantTables(): string[] {
   const githubInstallStateMigration = readRepoFile(
     'packages/core/drizzle/postgres/0082_github_install_state.sql'
   );
+  const externalIdentitiesMigration = readRepoFile(
+    'packages/core/drizzle/postgres/0090_external_user_identities.sql'
+  );
   const retiredTables = retiredTenantTables();
   return [
     ...new Set(
@@ -57,6 +60,7 @@ function migrationTenantTables(): string[] {
         ...gatewayHaMigration.matchAll(/CREATE TABLE "([^"]+)" \([\s\S]*?"tenant_id"/g),
         ...mcpOauthMigration.matchAll(/CREATE TABLE "([^"]+)" \([\s\S]*?"tenant_id"/g),
         ...githubInstallStateMigration.matchAll(/CREATE TABLE "([^"]+)" \([\s\S]*?"tenant_id"/g),
+        ...externalIdentitiesMigration.matchAll(/CREATE TABLE "([^"]+)" \([\s\S]*?"tenant_id"/g),
       ]
         .map((m) => m[1])
         .filter((table) => !retiredTables.has(table))
@@ -73,6 +77,7 @@ function rlsPolicyTables(): string[] {
     readRepoFile('packages/core/drizzle/postgres/0076_gateway_listener_ha.sql'),
     readRepoFile('packages/core/drizzle/postgres/0078_mcp_oauth_pending_flows.sql'),
     readRepoFile('packages/core/drizzle/postgres/0082_github_install_state.sql'),
+    readRepoFile('packages/core/drizzle/postgres/0090_external_user_identities.sql'),
   ].join('\n');
   const retiredTables = retiredTenantTables();
   return [

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -40,5 +40,6 @@ export * from './tenant-agentic-tools';
 export * from './thread-session-map';
 export * from './uploads';
 export * from './user-api-keys';
+export * from './user-external-identities';
 export * from './user-mcp-oauth-tokens';
 export * from './users';

--- a/packages/core/src/db/repositories/user-external-identities.postgres.test.ts
+++ b/packages/core/src/db/repositories/user-external-identities.postgres.test.ts
@@ -1,0 +1,111 @@
+/**
+ * PostgreSQL integration proof for tenant-stamped external identity projection.
+ *
+ * Run with, e.g.:
+ *   AGOR_DB_DIALECT=postgresql \
+ *   AGOR_TEST_POSTGRES_URL=postgresql://user:pw@host:5432/db \
+ *   pnpm --filter @agor/core exec vitest run \
+ *     src/db/repositories/user-external-identities.postgres.test.ts
+ */
+
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { UserExternalIdentity, UserID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { deleteFrom, insert, isPostgresDatabase, select } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import * as pg from '../schema.postgres';
+import { runWithTenantDatabaseScope, runWithTenantDatabaseTransaction } from '../tenant-scope';
+import { UserExternalIdentitiesRepository } from './user-external-identities';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+async function closePostgresDatabase(db: Database): Promise<void> {
+  await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'external identity projection (PostgreSQL)',
+  () => {
+    let db: Database;
+
+    beforeAll(async () => {
+      db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(db);
+      if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+    });
+
+    afterAll(async () => {
+      if (db) await closePostgresDatabase(db);
+    });
+
+    it('stamps the scoped tenant on JIT-style inserts and hides the projection from other tenants', async () => {
+      const tenantA = `external-identity-a-${generateId()}`;
+      const tenantB = `external-identity-b-${generateId()}`;
+      const userId = generateId() as UserID;
+      const identity: UserExternalIdentity = {
+        key: 'a'.repeat(64),
+        provider: 'external-launch-test',
+        issuer: `https://issuer.example.test/${generateId()}`,
+        subject: generateId(),
+        email: `${generateId()}@example.test`,
+        name: 'External Identity Test',
+        last_login_at: new Date().toISOString(),
+      };
+      const now = new Date();
+
+      await runWithTenantDatabaseTransaction(db, tenantA, async (scoped) => {
+        // This intentionally mirrors launch-auth: tenant_id is omitted and the
+        // tenant-aware insert wrapper stamps it from the trusted DB scope.
+        await insert(scoped, pg.users)
+          .values({
+            user_id: userId,
+            created_at: now,
+            updated_at: now,
+            email: identity.email!,
+            password: 'not-used-for-external-auth',
+            name: identity.name,
+            emoji: '👤',
+            role: 'member',
+            onboarding_completed: false,
+            must_change_password: false,
+            data: { external_identities: [identity] },
+          })
+          .run();
+
+        const repository = new UserExternalIdentitiesRepository(scoped);
+        await repository.lockProvisioningKey(`identity:${identity.key}`);
+        await repository.bind(userId, identity, now);
+
+        expect(
+          await select(scoped).from(pg.users).where(eq(pg.users.user_id, userId)).one()
+        ).toMatchObject({
+          tenant_id: tenantA,
+          user_id: userId,
+        });
+        expect(await repository.findByKey(identity.key)).toMatchObject({
+          tenant_id: tenantA,
+          user_id: userId,
+        });
+      });
+
+      await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+        expect(
+          await select(scoped).from(pg.users).where(eq(pg.users.user_id, userId)).one()
+        ).toBeNull();
+        expect(
+          await select(scoped)
+            .from(pg.userExternalIdentities)
+            .where(eq(pg.userExternalIdentities.identity_key, identity.key))
+            .one()
+        ).toBeNull();
+      });
+
+      await runWithTenantDatabaseTransaction(db, tenantA, async (scoped) => {
+        await deleteFrom(scoped, pg.users).where(eq(pg.users.user_id, userId)).run();
+      });
+    });
+  }
+);

--- a/packages/core/src/db/repositories/user-external-identities.ts
+++ b/packages/core/src/db/repositories/user-external-identities.ts
@@ -1,0 +1,88 @@
+import type { UserExternalIdentity, UserID } from '@agor/core/types';
+import { eq, sql } from 'drizzle-orm';
+import type { Database } from '../client';
+import { executeRaw, insert, isPostgresDatabase, select, update } from '../database-wrapper';
+import { userExternalIdentities } from '../schema';
+import { getCurrentTenantId } from '../tenant-context';
+import { RepositoryError } from './base';
+
+export class UserExternalIdentityBindingConflictError extends RepositoryError {
+  constructor(readonly identityKey: string) {
+    super('External identity is already bound to a different user');
+    this.name = 'UserExternalIdentityBindingConflictError';
+  }
+}
+
+/**
+ * Tenant-scoped persistence authority for trusted external identity bindings.
+ * Callers own claim verification and user-field projection; this repository
+ * owns uniqueness, serialization, and the relation's audit metadata.
+ */
+export class UserExternalIdentitiesRepository {
+  constructor(private readonly db: Database) {}
+
+  /** Serialize JIT projection for one subject on PostgreSQL; SQLite uses IMMEDIATE transactions. */
+  async lockProvisioningKey(key: string): Promise<void> {
+    if (!isPostgresDatabase(this.db)) return;
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) {
+      throw new RepositoryError('External identity provisioning requires a tenant database scope');
+    }
+    const scopedKey = `${tenantId}\0${key}`;
+    await executeRaw(this.db, sql`SELECT pg_advisory_xact_lock(hashtextextended(${scopedKey}, 0))`);
+  }
+
+  async findByKey(key: string): Promise<typeof userExternalIdentities.$inferSelect | null> {
+    return select(this.db)
+      .from(userExternalIdentities)
+      .where(eq(userExternalIdentities.identity_key, key))
+      .one();
+  }
+
+  /**
+   * Bind or refresh one verified subject. A conflicting user binding is never
+   * reassigned implicitly: resolving that requires an explicit administrative
+   * migration rather than an authentication side effect.
+   */
+  async bind(
+    userId: UserID,
+    identity: UserExternalIdentity,
+    now: Date = new Date()
+  ): Promise<typeof userExternalIdentities.$inferSelect> {
+    await insert(this.db, userExternalIdentities)
+      .values({
+        identity_key: identity.key,
+        user_id: userId,
+        provider: identity.provider,
+        issuer: identity.issuer,
+        subject: identity.subject,
+        email: identity.email,
+        name: identity.name,
+        last_login_at: new Date(identity.last_login_at),
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflictDoNothing()
+      .run();
+
+    const bound = await this.findByKey(identity.key);
+    if (!bound || bound.user_id !== userId) {
+      throw new UserExternalIdentityBindingConflictError(identity.key);
+    }
+
+    await update(this.db, userExternalIdentities)
+      .set({
+        provider: identity.provider,
+        issuer: identity.issuer,
+        subject: identity.subject,
+        email: identity.email,
+        name: identity.name,
+        last_login_at: new Date(identity.last_login_at),
+        updated_at: now,
+      })
+      .where(eq(userExternalIdentities.identity_key, identity.key))
+      .run();
+
+    return (await this.findByKey(identity.key)) ?? bound;
+  }
+}

--- a/packages/core/src/db/repositories/user-external-identities.ts
+++ b/packages/core/src/db/repositories/user-external-identities.ts
@@ -28,7 +28,9 @@ export class UserExternalIdentitiesRepository {
     if (!tenantId) {
       throw new RepositoryError('External identity provisioning requires a tenant database scope');
     }
-    const scopedKey = `${tenantId}\0${key}`;
+    // PostgreSQL text values cannot contain NUL. JSON encodes this tuple
+    // unambiguously while keeping the advisory-lock input portable.
+    const scopedKey = JSON.stringify([tenantId, key]);
     await executeRaw(this.db, sql`SELECT pg_advisory_xact_lock(hashtextextended(${scopedKey}, 0))`);
   }
 

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -24,6 +24,7 @@ import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { decryptApiKey, encryptApiKey } from '../encryption';
 import { type UserInsert as SchemaUserInsert, type UserRow, users } from '../schema';
+import { isExecutionHomeKeyAvailable } from '../user-execution-home';
 import {
   type BaseRepository,
   EntityNotFoundError,
@@ -175,30 +176,6 @@ export class UsersRepository implements BaseRepository<InternalUser, Partial<Int
   }
 
   /**
-   * Check if unix_username is already taken by another user
-   */
-  private async isUnixUsernameTaken(
-    unixUsername: string,
-    excludeUserId?: string
-  ): Promise<boolean> {
-    const result = await select(this.db)
-      .from(users)
-      .where(eq(users.unix_username, unixUsername))
-      .one();
-
-    if (!result) {
-      return false;
-    }
-
-    // If excluding a user ID (for updates), check if it's a different user
-    if (excludeUserId && result.user_id === excludeUserId) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
    * Create a new user
    */
   async create(data: Partial<InternalUser>): Promise<InternalUser> {
@@ -207,8 +184,7 @@ export class UsersRepository implements BaseRepository<InternalUser, Partial<Int
     }
     // Validate unix_username uniqueness if provided
     if (data.unix_username) {
-      const isTaken = await this.isUnixUsernameTaken(data.unix_username);
-      if (isTaken) {
+      if (!(await isExecutionHomeKeyAvailable(this.db, data.unix_username))) {
         throw new RepositoryError(
           `Execution home key "${data.unix_username}" is already in use by another user`
         );
@@ -332,8 +308,7 @@ export class UsersRepository implements BaseRepository<InternalUser, Partial<Int
 
     // Validate unix_username uniqueness if being changed
     if (updates.unix_username && updates.unix_username !== current.unix_username) {
-      const isTaken = await this.isUnixUsernameTaken(updates.unix_username, fullId);
-      if (isTaken) {
+      if (!(await isExecutionHomeKeyAvailable(this.db, updates.unix_username, fullId))) {
         throw new RepositoryError(
           `Execution home key "${updates.unix_username}" is already in use by another user`
         );

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1022,7 +1022,7 @@ export const users = pgTable(
       .notNull()
       .default('member'),
 
-    // Opaque execution-home key (optional, app-enforced tenant uniqueness)
+    // Opaque execution-home key (optional, database-enforced per-tenant uniqueness)
     unix_username: text('unix_username'),
 
     // Absolute host home dir used as the per-user sandbox overlay SOURCE under

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1160,6 +1160,47 @@ export const users = pgTable(
     tenantIdx: index('users_tenant_id_idx').on(table.tenant_id),
     emailIdx: index('users_email_idx').on(table.email),
     emailTenantUnique: uniqueIndex('users_tenant_email_unique').on(table.tenant_id, table.email),
+    executionHomeTenantUnique: uniqueIndex('users_tenant_unix_username_unique').on(
+      table.tenant_id,
+      table.unix_username
+    ),
+  })
+);
+
+/**
+ * Database-enforced binding between one trusted external subject and its local
+ * user projection. The JSON copy on users remains a compatibility/audit cache;
+ * this relation is the lookup and uniqueness authority.
+ */
+export const userExternalIdentities = pgTable(
+  'user_external_identities',
+  {
+    tenant_id: text('tenant_id').notNull().default('default'),
+    identity_key: varchar('identity_key', { length: 64 }).notNull(),
+    user_id: varchar('user_id', { length: 36 }).notNull(),
+    provider: text('provider').notNull(),
+    issuer: text('issuer').notNull(),
+    subject: text('subject').notNull(),
+    email: text('email'),
+    name: text('name'),
+    last_login_at: t.timestamp('last_login_at').notNull(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.tenant_id, table.identity_key] }),
+    tenantUserFk: foreignKey({
+      columns: [table.tenant_id, table.user_id],
+      foreignColumns: [users.tenant_id, users.user_id],
+      name: 'user_external_identities_tenant_user_fk',
+    }).onDelete('cascade'),
+    providerSubjectUnique: uniqueIndex('user_external_identities_provider_subject_unique').on(
+      table.tenant_id,
+      table.provider,
+      table.issuer,
+      table.subject
+    ),
+    userIdx: index('user_external_identities_tenant_user_idx').on(table.tenant_id, table.user_id),
   })
 );
 
@@ -2746,6 +2787,8 @@ export type ScheduleRow = typeof schedules.$inferSelect;
 export type ScheduleInsert = typeof schedules.$inferInsert;
 export type UserRow = typeof users.$inferSelect;
 export type UserInsert = typeof users.$inferInsert;
+export type UserExternalIdentityRow = typeof userExternalIdentities.$inferSelect;
+export type UserExternalIdentityInsert = typeof userExternalIdentities.$inferInsert;
 export type AppVariableRow = typeof appVariables.$inferSelect;
 export type AppVariableInsert = typeof appVariables.$inferInsert;
 export type AgenticToolPresetRow = typeof agenticToolPresets.$inferSelect;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1115,6 +1115,37 @@ export const users = sqliteTable(
   },
   (table) => ({
     emailIdx: index('users_email_idx').on(table.email),
+    executionHomeUnique: uniqueIndex('users_unix_username_unique').on(table.unix_username),
+  })
+);
+
+/**
+ * Database-enforced binding between one trusted external subject and its local
+ * user projection. SQLite is single-tenant, so identity_key is globally unique.
+ */
+export const userExternalIdentities = sqliteTable(
+  'user_external_identities',
+  {
+    identity_key: text('identity_key', { length: 64 }).primaryKey(),
+    user_id: text('user_id', { length: 36 })
+      .notNull()
+      .references(() => users.user_id, { onDelete: 'cascade' }),
+    provider: text('provider').notNull(),
+    issuer: text('issuer').notNull(),
+    subject: text('subject').notNull(),
+    email: text('email'),
+    name: text('name'),
+    last_login_at: t.timestamp('last_login_at').notNull(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+  },
+  (table) => ({
+    providerSubjectUnique: uniqueIndex('user_external_identities_provider_subject_unique').on(
+      table.provider,
+      table.issuer,
+      table.subject
+    ),
+    userIdx: index('user_external_identities_user_idx').on(table.user_id),
   })
 );
 
@@ -2577,6 +2608,8 @@ export type ScheduleRow = typeof schedules.$inferSelect;
 export type ScheduleInsert = typeof schedules.$inferInsert;
 export type UserRow = typeof users.$inferSelect;
 export type UserInsert = typeof users.$inferInsert;
+export type UserExternalIdentityRow = typeof userExternalIdentities.$inferSelect;
+export type UserExternalIdentityInsert = typeof userExternalIdentities.$inferInsert;
 export type AppVariableRow = typeof appVariables.$inferSelect;
 export type AppVariableInsert = typeof appVariables.$inferInsert;
 export type AgenticToolPresetRow = typeof agenticToolPresets.$inferSelect;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -977,7 +977,7 @@ export const users = sqliteTable(
       .notNull()
       .default('member'),
 
-    // Opaque execution-home key (optional, app-enforced tenant uniqueness)
+    // Opaque execution-home key (optional, database-enforced uniqueness)
     unix_username: text('unix_username'),
 
     // Absolute host home dir used as the per-user sandbox overlay SOURCE under

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -36,6 +36,7 @@ export const branchGroupGrants = schema.branchGroupGrants;
 export const boardGroupGrants = schema.boardGroupGrants;
 export const schedules = schema.schedules;
 export const users = schema.users;
+export const userExternalIdentities = schema.userExternalIdentities;
 export const appVariables = schema.appVariables;
 export const agenticToolPresets = schema.agenticToolPresets;
 export const mcpServers = schema.mcpServers;

--- a/packages/core/src/db/tenant-portability-manifest.test.ts
+++ b/packages/core/src/db/tenant-portability-manifest.test.ts
@@ -62,7 +62,7 @@ describe('buildTenantInsertOrder', () => {
 describe('tenantPortabilityForeignKeys', () => {
   it('freezes the exact schema-derived movable FK set', () => {
     const foreignKeys = tenantPortabilityForeignKeys();
-    expect(foreignKeys).toHaveLength(92);
+    expect(foreignKeys).toHaveLength(93);
     expect(Object.isFrozen(foreignKeys)).toBe(true);
     const structuralKeys = foreignKeys.map((foreignKey) =>
       [
@@ -83,6 +83,20 @@ describe('tenantPortabilityForeignKeys', () => {
   it('does not classify deployment-bound MCP OAuth grant relations as movable', () => {
     expect(tenantPortabilityForeignKeys()).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ childTable: 'user_mcp_oauth_tokens' })])
+    );
+  });
+
+  it('moves external identity bindings with their projected users', () => {
+    expect(tenantPortabilityForeignKeys()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          childTable: 'user_external_identities',
+          childColumns: ['tenant_id', 'user_id'],
+          parentTable: 'users',
+          parentColumns: ['tenant_id', 'user_id'],
+          onDelete: 'cascade',
+        }),
+      ])
     );
   });
 

--- a/packages/core/src/db/user-execution-home.ts
+++ b/packages/core/src/db/user-execution-home.ts
@@ -1,0 +1,21 @@
+import { and, eq, ne } from 'drizzle-orm';
+import type { Database } from './client';
+import { select } from './database-wrapper';
+import { users } from './schema';
+
+/** Tenant-scoped execution-home uniqueness check shared by every user writer. */
+export async function isExecutionHomeKeyAvailable(
+  db: Database,
+  executionHomeKey: string,
+  excludeUserId?: string
+): Promise<boolean> {
+  const existing = await select(db)
+    .from(users)
+    .where(
+      excludeUserId
+        ? and(eq(users.unix_username, executionHomeKey), ne(users.user_id, excludeUserId))
+        : eq(users.unix_username, executionHomeKey)
+    )
+    .one();
+  return !existing;
+}


### PR DESCRIPTION
## Summary

- add a generic, explicit identity-authority contract instead of a Cloud-specific mode or independent mutation flags
- preserve today's local user/role/password authority when `identity` is omitted
- allow verified external-launch authentication to JIT-create a local user projection through its existing internal database seam
- synchronize claim-owned email, name, avatar, execution-home key, and exact role on successful launches
- reject ordinary/admin user creation, deletion, identity edits, role edits, password writes, and avatar-source writes when authority is external
- keep Agor-owned preferences, onboarding, agentic-tool configuration/credentials, environment variables, API keys, and MCP selections/OAuth editable
- publish the resolved capability contract through `/health` and use it to hide or disable unsupported login and user-management UI

## Configuration contract

```yaml
identity:
  user_lifecycle: external
  role_authority: claims
  local_auth: disabled
  external:
    provider: external_launch
    provisioning: jit
```

The daemon validates this as one coherent v1 profile at startup. External authority also requires an enabled `external_launch` provider and rejects `execution.bootstrap_superadmin_users`. Contradictory or partial combinations fail startup rather than falling back to local authority.

No `identity` section means:

- internal user lifecycle
- internal role authority
- enabled local password authentication

## Runtime behavior

### External launch / JIT

The existing verified launch path remains the privileged provisioning seam and does not call public user CRUD. On each successful launch it:

- resolves the existing tenant-scoped external identity, or creates a missing local projection
- requires a recognized role in claims-authoritative mode
- applies exact role promotions and demotions, subject to `allow_admin_roles` and `execution.allow_superadmin`
- refreshes supplied email, name, avatar, and execution-home claims
- preserves Agor-owned data in the user blob

Claim changes are therefore eventually consistent at the next successful workspace launch; there is no provider lookup on every request.

### Server enforcement

`UsersService` is the common enforcement point for REST, Socket.IO, CLI, MCP, and ordinary internal service callers:

- forbidden externally managed writes return HTTP/Feathers `403` with `data.code = IDENTITY_EXTERNALLY_MANAGED` and a stable capability name
- local password authentication returns `401` with `data.code = LOCAL_AUTH_DISABLED`
- mixed patches are rejected before any allowed preference changes are applied

The UI consumes `/health.auth.identity` (contract version 1) for capability discovery, but server enforcement remains authoritative.

## Deliberately deferred

- external deletion/deactivation synchronization
- revocation of already-issued Agor sessions or API tokens when a user disappears externally
- a background/SCIM-like reconciliation mechanism
- dedicated claim-change audit events beyond existing stored external-identity provenance and launch logs
- a local break-glass account while the external profile disables local authentication

For this phase, Cloud prevents a removed user from obtaining a new launch. Existing local projections remain dormant until a later lifecycle-sync design handles them.

## Rollout

1. deploy this daemon/UI version while omitting `identity` (no behavior change)
2. update Agor Cloud deployment configuration to render the complete external profile
3. enable it only after every serving daemon understands contract version 1

This PR adds PostgreSQL migration `0090_external_user_identities.sql` and SQLite migration `0093_external_user_identities.sql`. They create the normalized external-identity binding and enforce non-null execution-home uniqueness; conflicting legacy bindings or duplicate keys fail migration and must be repaired before retrying. Apply the migration before starting the new daemon binary, and enable `identity` only after every replica writes the normalized binding. Older daemons neither write that relation nor accept the new top-level config key, so do not mix old daemons with an enabled external-authority profile.

## Security and tenancy

- invalid authority combinations fail before database initialization
- the JIT path retains the existing trusted tenant context and tenant-scoped database behavior
- public/admin CRUD cannot bypass external authority
- all HA replicas derive the same immutable capability contract from effective config
- role gates fail authentication rather than silently downgrading authoritative claims

## Tests

- `pnpm check`
- `pnpm exec vitest run src/config/identity-authority.test.ts src/config/config-manager.test.ts` (from `packages/core`)
- `pnpm exec vitest run src/auth/launch-auth.test.ts src/services/users.security.test.ts` (from `apps/agor-daemon`)
- focused LoginPage, `useAuthConfig`, and `UserSettingsModal` Vitest suites (from `apps/agor-ui`)

## Design

[Early external-user-authority design draft](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/architecture/external-user-authority-2026-08.md)


## Companion deployment PR

- [preset-io/agor-cloud#383](https://github.com/preset-io/agor-cloud/pull/383) renders this authority profile for managed launch-enabled Cells.


